### PR TITLE
Format ESP.getChipId as an 8 character hex instead of 7 digit decimal

### DIFF
--- a/sonoff/xdrv_wemohue.ino
+++ b/sonoff/xdrv_wemohue.ino
@@ -52,14 +52,14 @@ const char WEMO_MSEARCH[] PROGMEM =
 
 String wemo_serial()
 {
-  char serial[15];
-  snprintf_P(serial, sizeof(serial), PSTR("201612K%07d"), ESP.getChipId());
+  char serial[16];
+  snprintf_P(serial, sizeof(serial), PSTR("201612K%08X"), ESP.getChipId());
   return String(serial);
 }
 
 String wemo_UUID()
 {
-  char uuid[26];
+  char uuid[27];
   snprintf_P(uuid, sizeof(uuid), PSTR("Socket-1_0-%s"), wemo_serial().c_str());
   return String(uuid);
 }


### PR DESCRIPTION
Copy of https://github.com/arendst/Sonoff-MQTT-OTA-Arduino/pull/289

I have two sonoff duals with chip id's of 15163478 and 15165864. Adding an eighth would work for now, but 10 should be required. Although unlikely, it's possible for UUID collisions. I have two, but as some people have greater numbers of devices, and likely purchased in batches, it's plausible the issue will come up.

ESP.getChipId() returns a 32 bit integer, which can range up to 2,147,483,647. That would require 10 decimal digits. When I was experimenting with simply adding 1 to the UUID for the second channel on a dual, the UUID for both channels would match. They didn't differ as the least significant digit(s) were truncated. My https://github.com/don-willingham/Sonoff-MQTT-OTA-Arduino/tree/dual-wemo branch appends another digit for channel number to the UUID's.