### PR TITLE
Add optional sensor to GPIO4 for Sonoff Dual

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -155,7 +155,8 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      GPIO_TXD,         // GPIO01 Relay control
      0,
      GPIO_RXD,         // GPIO03 Relay control
-     0, 0, 0, 0, 0, 0, 0, 0, 0,
+     GPIO_USER,        // GPIO04 Optional sensor
+     0, 0, 0, 0, 0, 0, 0, 0,
      GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)
      0, 0, 0
   },


### PR DESCRIPTION
GPIO4 is not used on the Dual board, so it is possible to use it for a sensor. Some soldering skills required.