### PR TITLE
Added nodeMcu support, added IR control Toshiba HVAC

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1165,6 +1165,11 @@ void mqttDataCb(char* topic, byte* data, unsigned int data_len)
     else if ((pin[GPIO_IRSEND] < 99) && ir_send_command(type, index, dataBufUc, data_len, payload, svalue, sizeof(svalue))) {
       // Serviced
     }
+ #ifdef USE_IR_HVAC
+     else if ((pin[GPIO_IRSEND] < 99) && ir_hvac_command(type, index, dataBufUc, data_len, payload, svalue, sizeof(svalue))) {
+      // Serviced
+    }
+ #endif  //USE_IR_HVAC
 #endif // USE_IR_REMOTE
     else {
       type = NULL;

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -88,6 +88,7 @@ enum module_t {
   ELECTRODRAGON,
   EXS_RELAY,
   USER_TEST,
+  NODEMCU,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -284,6 +285,23 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      GPIO_LED1_INV,    // GPIO13 Green Led (0 = On, 1 = Off)
      GPIO_USER,        // GPIO14 Optional sensor
      0, 0
+  },
+  { "NodeMCU",    // NodeMCU hardware
+     GPIO_KEY1,        // GPIO00 Button
+     GPIO_USER,        // GPIO01
+     GPIO_USER,        // GPIO02
+     GPIO_USER,        // GPIO03 Serial TXD and Optional sensor
+     GPIO_USER,        // GPIO04 Optional sensor
+     GPIO_USER,        // GPIO05
+     0, 0, 0,
+     GPIO_USER,        // GPIO09
+     GPIO_USER,        // GPIO10
+     0,
+     GPIO_USER,        // GPIO12
+     GPIO_USER,        // GPIO13
+     GPIO_USER,        // GPIO14
+     GPIO_USER,        // GPIO15
+     0
   }
 };
 

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -128,6 +128,10 @@
 
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0.3k mem)
 
+#ifdef USE_IR_REMOTE
+ #define USE_IR_HVAC                             //Support for HVAC system using IR
+#endif
+
 #define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+8k code, +1k mem) - Disable by //
   #define USE_WS2812_CTYPE     1                 // WS2812 Color type (0 - RGB, 1 - GRB)
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial TXD) (+1k mem)


### PR DESCRIPTION
Hi,
I've added:
* nodeMCU hardware support
* extension for controlling Toshiba HVAC via IR.

To send IR to HVAC use command IRhvac with parameters (JSON)
IRhvac  {"HVAC_Mode": "<MODE>" , "HVAC_FanMode" : "<FAN_MODE>" , "HVAC_Temp" : <TEMP> , OFF : <0|1>}

Where 
- MODE is  HVAC_HOT, HVAC_COLD, HVAC_DRY, HVAC_AUTO (default)
- FAN_MODE is FAN_SPEED_1, FAN_SPEED_2, FAN_SPEED_3, FAN_SPEED_4, FAN_SPEED_5, FAN_SPEED_AUTO (default), FAN_SPEED_SILENT
- TEMP is temperature from 17 to 30 Celsius degrees
- OFF 1- turn off , 0-turn on (default)  
all parameters are optional, eg.:
IRhvac  {"HVAC_Mode": "HVAC_COLD" , "HVAC_FanMode" : "FAN_SPEED_AUTO" , "HVAC_Temp" : 19 , OFF : 0}
IRhvac  {"HVAC_Mode": "HVAC_HOT" , "HVAC_FanMode" : "FAN_SPEED_AUTO" , "HVAC_Temp" : 24 }
IRhvac  {"OFF" : 1 }

