### PR TITLE
Resolved unhandled exception when posting commands to web console containing %s

### DIFF
--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -702,13 +702,12 @@ void CFG_Delta()
       sysCfg.blinkcount = APP_BLINKCOUNT;
     }
     if (sysCfg.version < 0x03011000) {  // 3.1.16 - Add parameter
-      getClient(sysCfg.friendlyname[0], sysCfg.mqtt_client, sizeof(sysCfg.friendlyname[0]));
+      snprintf_P(sysCfg.friendlyname[0], sizeof(sysCfg.friendlyname[0]), sysCfg.mqtt_client, ESP.getChipId());
     }
     if (sysCfg.version < 0x03020400) {  // 3.2.4 - Add parameter
       CFG_DefaultSet_3_2_4();
     }
     if (sysCfg.version < 0x03020500) {  // 3.2.5 - Add parameter
-      getClient(sysCfg.friendlyname[0], sysCfg.mqtt_client, sizeof(sysCfg.friendlyname[0]));
       strlcpy(sysCfg.friendlyname[1], FRIENDLY_NAME"2", sizeof(sysCfg.friendlyname[1]));
       strlcpy(sysCfg.friendlyname[2], FRIENDLY_NAME"3", sizeof(sysCfg.friendlyname[2]));
       strlcpy(sysCfg.friendlyname[3], FRIENDLY_NAME"4", sizeof(sysCfg.friendlyname[3]));

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -29,6 +29,8 @@
 #define WIFI_CONFIG_TOOL       WIFI_WPSCONFIG    // [WifiConfig] Default tool if wifi fails to connect
                                                  //   (WIFI_RESTART, WIFI_SMARTCONFIG, WIFI_MANAGER, WIFI_WPSCONFIG, WIFI_RETRY)
                                                  
+#define WIFI_HOSTNAME          "%s-%06X"         // Expands to <MQTT_TOPIC>-<last 6 characters of MAC address>
+                                                 
 // -- Syslog --------------------------------------
 #define SYS_LOG_HOST           "domus1"          // [LogHost] (Linux) syslog host
 #define SYS_LOG_PORT           514               // [LogPort] default syslog UDP port

--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -103,7 +103,7 @@ const char HTTP_SCRIPT_CONSOL[] PROGMEM =
     "t=document.getElementById('t1');"
     "if(p==1){"
       "c=document.getElementById('c1');"
-      "o='&c1='+c.value;"
+      "o='&c1='+encodeURI(c.value);"
       "c.value='';"
       "t.scrollTop=sn;"
     "}"
@@ -685,9 +685,7 @@ void handleMqtt()
   String page = FPSTR(HTTP_HEAD);
   page.replace("{v}", "Configure MQTT");
   page += FPSTR(HTTP_FORM_MQTT);
-  char str[sizeof(sysCfg.mqtt_client)];
-  getClient(str, MQTT_CLIENT_ID, sizeof(sysCfg.mqtt_client));
-  page.replace("{m0}", str);
+  page.replace("{m0}", MQTTClient);
   page.replace("{m1}", sysCfg.mqtt_host);
   page.replace("{m2}", String(sysCfg.mqtt_port));
   page.replace("{m3}", sysCfg.mqtt_client);
@@ -1152,7 +1150,7 @@ void handleCmnd()
   if (valid) {
     byte curridx = logidx;
     if (strlen(webServer->arg("cmnd").c_str())) {
-      snprintf_P(svalue, sizeof(svalue), webServer->arg("cmnd").c_str());
+      snprintf_P(svalue, sizeof(svalue), PSTR("%s"), webServer->arg("cmnd").c_str());
       byte syslog_now = syslog_level;
       syslog_level = 0;  // Disable UDP syslog to not trigger hardware WDT
       do_cmnd(svalue);
@@ -1174,7 +1172,7 @@ void handleCmnd()
           }
         }
         counter++;
-        if (counter > MAX_LOG_LINES -1) counter = 0;
+		if (counter > MAX_LOG_LINES -1) counter = 0;
       } while (counter != logidx);
     } else {
       message = F("Enable weblog 2 if response expected\n");
@@ -1211,7 +1209,7 @@ void handleAjax()
   byte cflg = 1, counter = 99;
 
   if (strlen(webServer->arg("c1").c_str())) {
-    snprintf_P(svalue, sizeof(svalue), webServer->arg("c1").c_str());
+    snprintf_P(svalue, sizeof(svalue), PSTR("%s"), webServer->arg("c1").c_str());
     snprintf_P(log, sizeof(log), PSTR("CMND: %s"), svalue);
     addLog(LOG_LEVEL_INFO, log);
     byte syslog_now = syslog_level;


### PR DESCRIPTION
Resolved unhandled exception when posting any command with a %s character to the web console.
Encoded web commands to allow for special chars (especially % when setting hostname or MQTTclient).
Enabled support for custom wifihost names with dynamic parameters.
Changed default wifi hostname to include last 6 of mac address to match mqtt default and allow simplification of formatting code.
Moved Wifi hostname to user_config.
Simplified and removed formatting code.