### PR TITLE
Added Support for Lixada H801 Wifi

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -383,13 +383,13 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      GPIO_LED1,        // GPIO01 Green LED
      GPIO_USER,        // GPIO02 RX - Pin next to TX on the PCB
      GPIO_USER,        // GPIO03 TX - Pin next to GND on the PCB
-     GPIO_PWM1,        // GPIO04 W2 - not yet tested
+     GPIO_PWM2,        // GPIO04 W2 
      GPIO_LED2_INV,    // GPIO05 Red LED
      0, 0, 0, 0, 0, 0, // Flash connection
-     GPIO_PWM3,        // GPIO12 Blue - not yet tested
-     GPIO_PWM4,        // GPIO13 Green - not yet tested
-     GPIO_PWM2,        // GPIO14 W1 - not yet tested
-     GPIO_PWM5,        // GPIO15 Red - not yet tested
+     GPIO_PWM3,        // GPIO12 Blue 
+     GPIO_PWM4,        // GPIO13 Green 
+     GPIO_PWM1,        // GPIO14 W1 
+     GPIO_PWM5,        // GPIO15 Red 
      0,                // GPIO16
      0                 // ADC0 A0 Analog input
   }

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -120,6 +120,7 @@ enum module_t {
   WION,
   WEMOS,
   SONOFF_DEV,
+  H801,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -376,6 +377,21 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      0,                // GPIO15
      0,                // GPIO16
      GPIO_ADC0         // ADC0 A0 Analog input
+  },
+  { "H801",            // Lixada H801 Wifi (ESP8266)
+     GPIO_KEY1,        // GPIO00 E-FW Button
+     GPIO_LED1,        // GPIO01 Green LED
+     GPIO_USER,        // GPIO02 RX - Pin next to TX on the PCB
+     GPIO_USER,        // GPIO03 TX - Pin next to GND on the PCB
+     GPIO_PWM1,        // GPIO04 W2 - not yet tested
+     GPIO_LED2_INV,    // GPIO05 Red LED
+     0, 0, 0, 0, 0, 0, // Flash connection
+     GPIO_PWM3,        // GPIO12 Blue - not yet tested
+     GPIO_PWM4,        // GPIO13 Green - not yet tested
+     GPIO_PWM2,        // GPIO14 W1 - not yet tested
+     GPIO_PWM5,        // GPIO15 Red - not yet tested
+     0,                // GPIO16
+     0                 // ADC0 A0 Analog input
   }
 };
 


### PR DESCRIPTION
General Performance is equal to my Sonoff_Basic. No glitches, no crashes. For me it's stable via USB-Power and 5-V-Power-Supply.

I have tested so far:
1. Onboard LED's switch on and off as expected via LED* and LED*_INV.
2. The 2 USER_GPIO can read from an AM2320 as expected. BTW, RX and TX are probably printed on the PCB in an incorrect way, at least you must connect RX to RX and TX to TX with the USB-Serial-Adapter.

Not tested:
The Info for the PWM-GPIO-Connections are taken from the Internet, i.e. https://revspace.nl/H801. I ordered a RGB-Strip and will test ASAP.