### PR TITLE
Enable /RESULT to be customized via user_config.h

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -462,7 +462,7 @@ void mqtt_publishPowerState(byte device)
 
   if ((device < 1) || (device > Maxdevice)) device = 1;
   snprintf_P(sdevice, sizeof(sdevice), PSTR("%d"), device);
-  snprintf_P(stopic, sizeof(stopic), PSTR("%s/%s/RESULT"), PUB_PREFIX, sysCfg.mqtt_topic);
+  snprintf_P(stopic, sizeof(stopic), PSTR("%s/%s/%s"), PUB_PREFIX, sysCfg.mqtt_topic, PUB_RESULT);
   snprintf_P(svalue, sizeof(svalue), PSTR("{\"%s%s\":\"%s\"}"),
     sysCfg.mqtt_subtopic, (Maxdevice > 1) ? sdevice : "", (power & (0x01 << (device -1))) ? MQTT_STATUS_ON : MQTT_STATUS_OFF);
   mqtt_publish(stopic, svalue);

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -63,6 +63,8 @@
 #define PUB_PREFIX             "stat"            // Sonoff devices publish to:- PUB_PREFIX/MQTT_TOPIC
 #define PUB_PREFIX2            "tele"            // Sonoff devices publish telemetry data to:- PUB_PREFIX2/MQTT_TOPIC/UPTIME, POWER/LIGHT and TIME
                                                  //   May be named the same as PUB_PREFIX
+#define PUB_RESULT             "result"          // Sonoff devices publish POWER result to:- PUB_PREFIX/MQTT_TOPIC/PUB_RESULT
+
 #define MQTT_TOPIC             PROJECT           // [Topic] (unique) MQTT device topic
 #define MQTT_GRPTOPIC          "sonoffs"         // [GroupTopic] MQTT Group topic
 #define MQTT_BUTTON_RETAIN     0                 // [ButtonRetain] Button may send retain flag (0 = off, 1 = on)


### PR DESCRIPTION
This MQTT subscribers that are only limited/hardcoded to a single topic to listen to both telemetry as well as result feedback since both are using similar JSON payload.