### PR TITLE
First step into Wiring an Adafruit Featherwing as build target

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,3 +23,14 @@ board_flash_mode = qio
 
 build_flags = -Wl,-Tesp8266.flash.1m64.ld -DMQTT_MAX_PACKET_SIZE=512
 lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
+
+[env:touch]
+platform = espressif8266
+framework = arduino
+board = esp12e
+upload_speed = 460800
+board_flash_mode = qio
+build_flags = -Wl,-Tesp8266.flash.4m1m.ld -DMQTT_MAX_PACKET_SIZE=512
+
+lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
+  Adafruit GFX Library, Adafruit ILI9341, Adafruit STMPE610

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ framework = arduino
 board = esp12e
 upload_speed = 460800
 board_flash_mode = qio
-build_flags = -Wl,-Tesp8266.flash.4m1m.ld -DMQTT_MAX_PACKET_SIZE=512
+build_flags = -Wl,-Tesp8266.flash.4m1m.ld -DMQTT_MAX_PACKET_SIZE=512 -DUSE_TOUCHSCREEN
 
 lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
   Adafruit GFX Library, Adafruit ILI9341, Adafruit STMPE610

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -413,6 +413,9 @@ void mqtt_publish_sec(const char* topic, const char* data, boolean retained)
   char log[TOPSZ + MESSZ];
 
   if (sysCfg.mqtt_enabled) {
+#ifdef USE_TOUCHSCREEN
+    if (touchscreen) touchscreen->NetworkSend();
+#endif // USE_TOUCHSCREEN
     if (mqttClient.publish(topic, data, retained)) {
       snprintf_P(log, sizeof(log), PSTR("MQTT: %s = %s%s"), topic, data, (retained) ? " (retained)" : "");
 //      mqttClient.loop();  // Do not use here! Will block previous publishes
@@ -757,6 +760,10 @@ boolean mqtt_command(boolean grpflg, char *type, uint16_t index, char *dataBuf, 
 void mqttDataCb(char* topic, byte* data, unsigned int data_len)
 {
   char *str;
+
+#ifdef USE_TOUCHSCREEN
+    if (touchscreen) touchscreen->NetworkRecv();
+#endif // USE_TOUCHSCREEN
 
   if (!strcmp(sysCfg.mqtt_prefix[0],sysCfg.mqtt_prefix[1])) {
     str = strstr(topic,sysCfg.mqtt_prefix[0]);

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -26,6 +26,11 @@ enum emul_t  {EMUL_NONE, EMUL_WEMO, EMUL_HUE, EMUL_MAX};
 #include "user_config.h"
 #include "user_config_override.h"
 
+#ifdef USE_TOUCHSCREEN
+#include "touchscreen.h"
+#endif // USE_TOUCHSCREEN
+
+
 /*********************************************************************************************\
  * No user configurable items below
 \*********************************************************************************************/
@@ -2207,6 +2212,10 @@ void setup()
   snprintf_P(log, sizeof(log), PSTR("APP: Project %s %s (Topic %s, Fallback %s, GroupTopic %s) Version %s"),
     PROJECT, sysCfg.friendlyname[0], sysCfg.mqtt_topic, MQTTClient, sysCfg.mqtt_grptopic, Version);
   addLog(LOG_LEVEL_INFO, log);
+
+#ifdef USE_TOUCHSCREEN
+  touchscreen_setup();
+#endif // USE_TOUCHSCREEN
 }
 
 void loop()
@@ -2224,6 +2233,10 @@ void loop()
   if (millis() >= timerxs) stateloop();
   if (sysCfg.mqtt_enabled) mqttClient.loop();
   if (Serial.available()) serial();
+
+#ifdef USE_TOUCHSCREEN
+  touchscreen_handle();
+#endif // USE_TOUCHSCREEN
 
 //  yield();     // yield == delay(0), delay contains yield, auto yield in loop
   delay(sleep);  // https://github.com/esp8266/Arduino/issues/2021

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -27,7 +27,8 @@ enum emul_t  {EMUL_NONE, EMUL_WEMO, EMUL_HUE, EMUL_MAX};
 #include "user_config_override.h"
 
 #ifdef USE_TOUCHSCREEN
-#include "touchscreen.h"
+  #include "touchscreen.h"
+  extern TouchScreen *touchscreen;
 #endif // USE_TOUCHSCREEN
 
 
@@ -2214,7 +2215,7 @@ void setup()
   addLog(LOG_LEVEL_INFO, log);
 
 #ifdef USE_TOUCHSCREEN
-  touchscreen_setup();
+  touchscreen = new TouchScreen();
 #endif // USE_TOUCHSCREEN
 }
 
@@ -2235,7 +2236,7 @@ void loop()
   if (Serial.available()) serial();
 
 #ifdef USE_TOUCHSCREEN
-  touchscreen_handle();
+  if (touchscreen) touchscreen->handle();
 #endif // USE_TOUCHSCREEN
 
 //  yield();     // yield == delay(0), delay contains yield, auto yield in loop

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -341,6 +341,9 @@ void setRelay(uint8_t power)
     for (byte i = 0; i < Maxdevice; i++) {
       state = power &1;
       if (pin[GPIO_REL1 +i] < 99) digitalWrite(pin[GPIO_REL1 +i], rel_inverted[i] ? !state : state);
+#ifdef USE_TOUCHSCREEN
+      if (touchscreen) touchscreen->RelayState(state != 0);
+#endif // USE_TOUCHSCREEN
       power >>= 1;
     }
   }

--- a/sonoff/touchscreen.h
+++ b/sonoff/touchscreen.h
@@ -49,6 +49,7 @@ class TouchScreen
 
   void NetworkSend();           // Activate Up-Arrow icon, will clear in 100ms
   void NetworkRecv();           // Activate Down-Arrow icon, will clear in 100ms
+  void RelayState(bool);        // Activate Relay icon
   
   private:
   ScreenTouch_t _touch_last_type;
@@ -66,6 +67,7 @@ class TouchScreen
   void _handleWidget_Network(int period=100);
   void _handleWidget_NetworkSend(int color);
   void _handleWidget_NetworkRecv(int color);
+  void _handleWidget_RelayState(int color);
 };
 
 #endif // USE_TOUCHSCREEN

--- a/sonoff/touchscreen.h
+++ b/sonoff/touchscreen.h
@@ -34,9 +34,6 @@
 #define SCREEN_MAX_BUTTONS 10
 typedef enum { TOUCH_NONE, TOUCH_DOWN, TOUCH_UP } ScreenTouch_t;
 
-void touchscreen_setup();
-void touchscreen_handle();
-
 class TouchScreen
 {
   public:

--- a/sonoff/touchscreen.h
+++ b/sonoff/touchscreen.h
@@ -1,0 +1,76 @@
+#ifndef __TOUCHSCREEN_H
+#define __TOUCHSCREEN_H
+
+#include "user_config.h"
+
+#ifdef USE_TOUCHSCREEN
+
+#include <Arduino.h>
+#include <inttypes.h>
+#include <SPI.h>
+#include <Wire.h>                  // this is needed even tho we aren't using it
+
+#include <Adafruit_GFX.h>         // Core graphics library
+#include <Adafruit_ILI9341.h>     // Hardware-specific library
+#include <SD.h>
+#include <Adafruit_STMPE610.h>
+
+// Pinout specific to Adafruit Huzzah Feather:
+// ESP8266 - https://www.adafruit.com/product/2821
+// TFT     - https://www.adafruit.com/product/3315
+#define STMPE_CS 16
+#define TFT_CS   0
+#define TFT_DC   15
+#define SD_CS    2
+
+// This is calibration data for the raw touch data to the screen coordinates
+#define TS_MINX 250
+#define TS_MINY 150
+#define TS_MAXX 3750
+#define TS_MAXY 3750
+
+#define PENRADIUS 2
+
+#define SCREEN_MAX_BUTTONS 10
+typedef enum { TOUCH_NONE, TOUCH_DOWN, TOUCH_UP } ScreenTouch_t;
+
+void touchscreen_setup();
+void touchscreen_handle();
+
+class TouchScreen
+{
+  public:
+  TouchScreen();
+  ~TouchScreen();
+
+  void handle();
+  
+  Adafruit_ILI9341 *_tft;
+  Adafruit_STMPE610 *_ts;
+  TS_Point _touch_last_down;    // Last TOUCH_DOWN (x,y)
+  TS_Point _touch_last_up;      // Last TOUCH_UP (x,y)
+
+  void NetworkSend();           // Activate Up-Arrow icon, will clear in 100ms
+  void NetworkRecv();           // Activate Down-Arrow icon, will clear in 100ms
+  
+  private:
+  ScreenTouch_t _touch_last_type;
+  TS_Point _touch_last;         // Last (x,y) registered touch
+  unsigned long _millis_now;
+  unsigned long _millis_network_send_clear;
+  unsigned long _millis_network_recv_clear;
+
+  void handleTouch();
+  void handleTop();
+  void _handleWidget_Time(int period=1000);
+  void _handleWidget_Wifi(int period=5000, int wifi_signal_strength=0);
+  void _handleWidget_Alarm(int period=1000);
+  void _handleWidget_Name(int period=60000);
+  void _handleWidget_Network(int period=100);
+  void _handleWidget_NetworkSend(int color);
+  void _handleWidget_NetworkRecv(int color);
+};
+
+#endif // USE_TOUCHSCREEN
+
+#endif // __TOUCHSCREEN_H

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -145,8 +145,6 @@
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial TXD) (+1k mem)
                                                  //   When USE_WS2812_DMA is enabled expect Exceptions on Pow
 
-#define USE_TOUCHSCREEN                          // Adafruit TFT TouchScreen (+14.6k code, +1.3k mem) - Diable by //
-
 /*********************************************************************************************\
  * Compile a minimal version if upgrade memory gets tight ONLY TO BE USED FOR UPGRADE STEP 1!
  *   To be used as step 1 during upgrade. 

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -145,6 +145,8 @@
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial TXD) (+1k mem)
                                                  //   When USE_WS2812_DMA is enabled expect Exceptions on Pow
 
+#define USE_TOUCHSCREEN                          // Adafruit TFT TouchScreen (+14.6k code, +1.3k mem) - Diable by //
+
 /*********************************************************************************************\
  * Compile a minimal version if upgrade memory gets tight ONLY TO BE USED FOR UPGRADE STEP 1!
  *   To be used as step 1 during upgrade. 

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -36,7 +36,6 @@ void TouchScreen::handle()
 void TouchScreen::_handleWidget_Time(int period)
 {
   static unsigned long _last = 0;
-  unsigned long time_in_seconds;
   char _timestring[9]; // HH:MM:SS\0
   
   if ((_millis_now < _last+period) && _last > 0) 
@@ -44,8 +43,7 @@ void TouchScreen::_handleWidget_Time(int period)
 
   _last = _millis_now;
 
-  time_in_seconds = (_millis_now / 1000) % (24*60*60);
-  sprintf(_timestring, "%02d:%02d:%02d", (time_in_seconds/(60*60))%24, (time_in_seconds/(60))%60, time_in_seconds%60);
+  sprintf(_timestring, "%02d:%02d:%02d", rtcTime.Hour, rtcTime.Minute, rtcTime.Second);
   _tft->setCursor(320-4-9*5,8);
   _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
   _tft->setTextSize(1);

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -141,7 +141,7 @@ void TouchScreen::_handleWidget_Name(int period)
 void TouchScreen::handleTop()
 {
   _handleWidget_Time(1000);
-  _handleWidget_Wifi(1800, random(100));
+  _handleWidget_Wifi(1800, (WiFi.status() != WL_CONNECTED) ? 0 : WIFI_getRSSIasQuality(WiFi.RSSI()));
   _handleWidget_Alarm(1000);
   _handleWidget_Network();
   _handleWidget_Name(1300);

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -130,8 +130,7 @@ void TouchScreen::_handleWidget_Name(int period)
     return;
   _last = _millis_now;
 
-  const char names[7][21] = { "Livingroom", "Attic", "Basement", "1234", "", "TestSetup", "01234567890123456789" };
-  sprintf(_namestring, "%-20s", names[random(7)]);
+  sprintf(_namestring, "%-20s", sysCfg.friendlyname[0]);
   _tft->setCursor(4,8);
   _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
   _tft->setTextSize(1);

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -4,39 +4,23 @@
 
 TouchScreen *touchscreen = NULL;
 
-void touchscreen_setup()
-{
-  touchscreen = new TouchScreen();
-  
-  touchscreen->_tft->fillScreen(ILI9341_BLUE);
-  
-  touchscreen->_tft->drawRoundRect(24, 48, 80, 80, 8, ILI9341_GREEN);
-  touchscreen->_tft->drawRoundRect(120, 48, 80, 80, 8, ILI9341_GREEN);
-  touchscreen->_tft->drawRoundRect(216, 48, 80, 176, 8, ILI9341_GREEN);
-  touchscreen->_tft->drawRoundRect(24, 144, 176, 80, 8, ILI9341_GREEN);
-
-  touchscreen->_tft->drawFastHLine(0, 24, 320, ILI9341_WHITE);
-  touchscreen->_tft->drawFastHLine(0, 25, 320, ILI9341_WHITE);
-
-  /*
-  Serial.print("Initializing SD card...");
-  if (!SD.begin(SD_CS)) {
-    Serial.println("failed!");
-  }
-  Serial.println("OK!");
-  */
-}
-
-void touchscreen_handle() 
-{
-  touchscreen->handle();
-}
-
 TouchScreen::TouchScreen()
 {
   _tft = new Adafruit_ILI9341(TFT_CS, TFT_DC);
   _tft->begin();
   _tft->setRotation(1);
+
+  /* Temporary setup of the screen */
+  _tft->fillScreen(ILI9341_BLUE);
+  
+  _tft->drawRoundRect(24, 48, 80, 80, 8, ILI9341_GREEN);
+  _tft->drawRoundRect(120, 48, 80, 80, 8, ILI9341_GREEN);
+  _tft->drawRoundRect(216, 48, 80, 176, 8, ILI9341_GREEN);
+  _tft->drawRoundRect(24, 144, 176, 80, 8, ILI9341_GREEN);
+
+  _tft->drawFastHLine(0, 24, 320, ILI9341_WHITE);
+  _tft->drawFastHLine(0, 25, 320, ILI9341_WHITE);
+  /* END(temp setup) */
 
   _ts = new Adafruit_STMPE610(STMPE_CS);
   _ts->begin();

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -1,0 +1,225 @@
+#include "touchscreen.h"
+
+#ifdef USE_TOUCHSCREEN
+
+TouchScreen *touchscreen = NULL;
+
+void touchscreen_setup()
+{
+  touchscreen = new TouchScreen();
+  
+  touchscreen->_tft->fillScreen(ILI9341_BLUE);
+  
+  touchscreen->_tft->drawRoundRect(24, 48, 80, 80, 8, ILI9341_GREEN);
+  touchscreen->_tft->drawRoundRect(120, 48, 80, 80, 8, ILI9341_GREEN);
+  touchscreen->_tft->drawRoundRect(216, 48, 80, 176, 8, ILI9341_GREEN);
+  touchscreen->_tft->drawRoundRect(24, 144, 176, 80, 8, ILI9341_GREEN);
+
+  touchscreen->_tft->drawFastHLine(0, 24, 320, ILI9341_WHITE);
+  touchscreen->_tft->drawFastHLine(0, 25, 320, ILI9341_WHITE);
+
+  /*
+  Serial.print("Initializing SD card...");
+  if (!SD.begin(SD_CS)) {
+    Serial.println("failed!");
+  }
+  Serial.println("OK!");
+  */
+}
+
+void touchscreen_handle() 
+{
+  touchscreen->handle();
+}
+
+TouchScreen::TouchScreen()
+{
+  _tft = new Adafruit_ILI9341(TFT_CS, TFT_DC);
+  _tft->begin();
+  _tft->setRotation(1);
+
+  _ts = new Adafruit_STMPE610(STMPE_CS);
+  _ts->begin();
+}
+
+void TouchScreen::handle()
+{
+  _millis_now = millis();
+  handleTop();
+  handleTouch();
+}
+
+void TouchScreen::_handleWidget_Time(int period)
+{
+  static unsigned long _last = 0;
+  unsigned long time_in_seconds;
+  char _timestring[9]; // HH:MM:SS\0
+  
+  if ((_millis_now < _last+period) && _last > 0) 
+    return;
+
+  _last = _millis_now;
+
+  time_in_seconds = (_millis_now / 1000) % (24*60*60);
+  sprintf(_timestring, "%02d:%02d:%02d", (time_in_seconds/(60*60))%24, (time_in_seconds/(60))%60, time_in_seconds%60);
+  _tft->setCursor(320-4-9*5,8);
+  _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
+  _tft->setTextSize(1);
+  _tft->print(_timestring);
+}
+
+// wifi_signal_strength in [0..100]
+void TouchScreen::_handleWidget_Wifi(int period, int wifi_signal_strength)
+{
+  static unsigned long _last = 0;
+  int w;
+  
+  if ((_millis_now < _last+period) && _last > 0) 
+    return;
+  _last = _millis_now;
+  _tft->fillTriangle(248, 18, 264, 18, 264, 2, ILI9341_DARKGREY);
+  // Map signal strength from [0..100] to [0..16]
+  w = map(wifi_signal_strength, 0, 100, 0, 16);
+  if (w>0)
+    _tft->fillTriangle(248, 18, 248+w, 18, 248+w, 18-w, ILI9341_WHITE);
+  else {
+  _tft->setCursor(248+10,10);
+  _tft->setTextColor(ILI9341_RED, ILI9341_DARKGREY);
+  _tft->setTextSize(1);
+  _tft->print("X");
+  }
+}
+
+void TouchScreen::NetworkSend()
+{
+  _handleWidget_NetworkSend(ILI9341_GREEN);
+  _millis_network_send_clear = millis()+100;
+}
+
+void TouchScreen::NetworkRecv()
+{
+  _handleWidget_NetworkRecv(ILI9341_GREEN);
+  _millis_network_recv_clear = millis()+100;
+}
+
+
+void TouchScreen::_handleWidget_Alarm(int period)
+{
+  static unsigned long _last;
+  if ((_millis_now < _last+period) && _last > 0) 
+    return;
+  _last = _millis_now;  
+}
+
+void TouchScreen::_handleWidget_NetworkSend(int color)
+{
+  _tft->fillTriangle(224,10, 232, 10, 228, 2, color);
+  _tft->fillRect(227, 10, 3, 8, color);
+}
+
+void TouchScreen::_handleWidget_NetworkRecv(int color)
+{
+  _tft->fillTriangle(232, 10, 240, 10, 236, 18, color);
+  _tft->fillRect(235, 2, 3, 8, color);
+}
+
+void TouchScreen::_handleWidget_Network(int period)
+{
+  static unsigned long _last = 0;
+  if ((_millis_now < _last+period) && _last > 0) 
+    return;
+
+  if (random(100) < 3)
+    NetworkSend();
+  if (random(100) < 10)
+    NetworkRecv();
+
+  if ((_millis_now > _millis_network_send_clear && _millis_network_send_clear != 0) || _last==0) {
+    _millis_network_send_clear=0;
+    _handleWidget_NetworkSend(ILI9341_DARKGREY);
+  }
+  if ((_millis_now > _millis_network_recv_clear && _millis_network_recv_clear != 0) || _last==0) {
+    _millis_network_recv_clear=0;
+    _handleWidget_NetworkRecv(ILI9341_DARKGREY);
+  }
+  _last = _millis_now;  
+}
+
+void TouchScreen::_handleWidget_Name(int period)
+{
+  char _namestring[21];
+  static unsigned long _last = 0;
+  if ((_millis_now < _last+period) && _last > 0) 
+    return;
+  _last = _millis_now;
+
+  const char names[7][21] = { "Livingroom", "Attic", "Basement", "1234", "", "TestSetup", "01234567890123456789" };
+  sprintf(_namestring, "%-20s", names[random(7)]);
+  _tft->setCursor(4,8);
+  _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
+  _tft->setTextSize(1);
+  _tft->print(_namestring);
+}
+
+void TouchScreen::handleTop()
+{
+  _handleWidget_Time(1000);
+  _handleWidget_Wifi(1800, random(100));
+  _handleWidget_Alarm(1000);
+  _handleWidget_Network();
+  _handleWidget_Name(1300);
+}
+
+void TouchScreen::handleTouch()
+{
+  // Handle buffered touchscreen
+  if (!_ts->touched()) {
+    if (_touch_last_type == TOUCH_DOWN) {
+      _touch_last_type = TOUCH_UP;
+      _touch_last_up = _touch_last;
+      // Callback TOUCH_UP
+      Serial.printf("TouchScreen:: TOUCH_UP on (%u,%u)\r\n", _touch_last_up.x, _touch_last_up.y);
+      if (((_touch_last_up.y-PENRADIUS) > 0) && ((_touch_last_up.y+PENRADIUS) < _tft->height())) {
+        _tft->fillCircle(_touch_last_up.x, _touch_last_up.y, PENRADIUS, ILI9341_RED);
+      }
+    }
+    _touch_last_type = TOUCH_NONE;
+    return;
+  }
+
+  TS_Point p = _ts->getPoint();
+  if (p.z == 0) {
+    _touch_last_type = TOUCH_NONE;
+    return;
+  }
+
+  // The TouchScreen hardware yields a number between 0..4000
+  // but is a bit noisy at the edges. First, constrain outliers
+  // into [TS_MINX,TS_MAXX] and [TS_MINY,TS_MAXY] respectively.
+  p.x=constrain(p.x,TS_MINX, TS_MAXX);
+  p.y=constrain(p.y,TS_MINY, TS_MAXY);
+
+  // Then, map the raw coordinates to the screen dimension,
+  // making the rotation mapping along the way.
+  // PS will have values from [0,tftwidth) and [0,tftheight)
+  TS_Point ps;
+  ps.x = map(p.y, TS_MINY, TS_MAXY, 0, _tft->width()-1);
+  ps.y = map(p.x, TS_MINX, TS_MAXX, 0, _tft->height()-1);
+  ps.z = p.z;
+  
+  if (ps == _touch_last) {
+    return;
+  }
+  _touch_last = ps;
+  if (_touch_last_type != TOUCH_DOWN) {
+    _touch_last_type = TOUCH_DOWN;
+    _touch_last_down = _touch_last;
+    // Callback TOUCH_DOWN
+    Serial.printf("TouchScreen:: TOUCH_DOWN on (%u,%u)\r\n", _touch_last_down.x, _touch_last_down.y);
+    if (((_touch_last_down.y-PENRADIUS) > 0) && ((_touch_last_down.y+PENRADIUS) < _tft->height())) {
+      _tft->fillCircle(_touch_last_down.x, _touch_last_down.y, PENRADIUS, ILI9341_WHITE);
+    }
+  }
+}
+
+#endif // USE_TOUCHSCREEN

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -113,11 +113,6 @@ void TouchScreen::_handleWidget_Network(int period)
   if ((_millis_now < _last+period) && _last > 0) 
     return;
 
-  if (random(100) < 3)
-    NetworkSend();
-  if (random(100) < 10)
-    NetworkRecv();
-
   if ((_millis_now > _millis_network_send_clear && _millis_network_send_clear != 0) || _last==0) {
     _millis_network_send_clear=0;
     _handleWidget_NetworkSend(ILI9341_DARKGREY);

--- a/sonoff/xdrv_touchscreen.ino
+++ b/sonoff/xdrv_touchscreen.ino
@@ -2,6 +2,8 @@
 
 #ifdef USE_TOUCHSCREEN
 
+#define TOUCHSCREEN_BGCOLOR ILI9341_BLUE
+
 TouchScreen *touchscreen = NULL;
 
 TouchScreen::TouchScreen()
@@ -11,7 +13,7 @@ TouchScreen::TouchScreen()
   _tft->setRotation(1);
 
   /* Temporary setup of the screen */
-  _tft->fillScreen(ILI9341_BLUE);
+  _tft->fillScreen(TOUCHSCREEN_BGCOLOR);
   
   _tft->drawRoundRect(24, 48, 80, 80, 8, ILI9341_GREEN);
   _tft->drawRoundRect(120, 48, 80, 80, 8, ILI9341_GREEN);
@@ -20,6 +22,7 @@ TouchScreen::TouchScreen()
 
   _tft->drawFastHLine(0, 24, 320, ILI9341_WHITE);
   _tft->drawFastHLine(0, 25, 320, ILI9341_WHITE);
+  RelayState(power!=0);
   /* END(temp setup) */
 
   _ts = new Adafruit_STMPE610(STMPE_CS);
@@ -45,7 +48,7 @@ void TouchScreen::_handleWidget_Time(int period)
 
   sprintf(_timestring, "%02d:%02d:%02d", rtcTime.Hour, rtcTime.Minute, rtcTime.Second);
   _tft->setCursor(320-4-9*5,8);
-  _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
+  _tft->setTextColor(ILI9341_WHITE, TOUCHSCREEN_BGCOLOR);
   _tft->setTextSize(1);
   _tft->print(_timestring);
 }
@@ -70,6 +73,19 @@ void TouchScreen::_handleWidget_Wifi(int period, int wifi_signal_strength)
   _tft->setTextSize(1);
   _tft->print("X");
   }
+}
+
+void TouchScreen::_handleWidget_RelayState(int color)
+{
+  _tft->fillCircle(206, 11, 7, color);
+  _tft->fillCircle(206, 11, 5, TOUCHSCREEN_BGCOLOR);
+  _tft->fillRect(202, 2, 8, 8, TOUCHSCREEN_BGCOLOR);
+  _tft->fillRect(205, 3, 3, 8, color);
+}
+
+void TouchScreen::RelayState(bool on)
+{
+  _handleWidget_RelayState(on?ILI9341_GREEN : ILI9341_DARKGREY);
 }
 
 void TouchScreen::NetworkSend()
@@ -132,7 +148,7 @@ void TouchScreen::_handleWidget_Name(int period)
 
   sprintf(_namestring, "%-20s", sysCfg.friendlyname[0]);
   _tft->setCursor(4,8);
-  _tft->setTextColor(ILI9341_WHITE, ILI9341_BLUE);
+  _tft->setTextColor(ILI9341_WHITE, TOUCHSCREEN_BGCOLOR);
   _tft->setTextSize(1);
   _tft->print(_namestring);
 }


### PR DESCRIPTION
Theo, you may recall I pinged you a while ago about adding a touch screen to Sonoff Touch (the device). I have made a little bit of progress in this, and wanted to see if you are OK with the direction.

Using #define USE_TOUCHSCREEN (set in [env:touch] in platformio.ini), I gate the inclusion of xdrv_touchscreen.ino and gate linking against the associated libraries (AdaFruit GFX/ILI9341/STMPE610). It creates an object 'TouchScreen' with a handle() method which is called in the main loop().

[env:sonoff] is unaffected by this change, compiles cleanly and runs on several of my Sonoff devices. I will be using [env:touch] going forward for this new target (which is also an ESP12e w/ 4M flash).

Currently, the mechanics of handle() do some simulated action, which will be replaced with functionality taken from sonoff.ino's internals. It registers touch (TOUCH_DOWN and TOUCH_UP) and currently only prints to serial, intended behavior is to wire this to MQTT message passing.

Could you let me know your thoughts on this, stylistically and any concerns you have? I'm not asking you to merge this for the time being, as I will need to get away from proof-of-concept mode and into a more productive UX. This adds 14.6K of code and 1.3K of memory.