### PR TITLE
Added support for multiple (up to 3) DHT sensors.

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -483,8 +483,10 @@ void handleAjax2()
   }
 #endif  // USE_DS18x20
 #ifdef USE_DHT
-  if (dht_type) {
-    tpage += dht_webPresent();
+  for (byte i = 0; i < 3; i++) {
+    if (dht_type[i]) {
+      tpage += dht_webPresent(i);
+    }
   }
 #endif  // USE_DHT
 #ifdef USE_I2C


### PR DESCRIPTION
Up to three different or same DHT sensors can be configured in the web interface. The name of each sensor in the transmitted data and on the web page is extended with the number of the IO pin. E.g. DHT22 on pin 04 wiil be "DHT22_04" on the web page. 
![grafik](https://cloud.githubusercontent.com/assets/16901676/25616617/35f0b384-2f3e-11e7-9f75-4e562517fd35.png)
Multiple sensor readings will be transmitted in one line to e.g. the MQTT broker:
`12:50:10 MQTT: tele/sonoff_th10/SENSOR = {"Time":"2017-05-02T12:50:10", "DHT22_04":{"Temperature":18.9, "Humidity":44.8}, "DHT22_14":{"Temperature":18.9, "Humidity":44.8}}`

