### PR TITLE
Rolling Shutters with Sonoff Dual

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1643,7 +1643,6 @@ void do_cmnd_power(byte device, byte state)
       /// a new module type is defined in sonoff_template.h as Shutter (fairly the same as Sonoff Dual)
       /// set pulsetime a bit higher than the shutter rising time (in my case 40 sec. - in web console: "pulsetime 140")
       /// PowerOnState should be 0 (console: "PowerOnState 0")
-/// progmem 480516 Bytes (46%), data 43308 Bytes (52%)
 
     if (SHUTTER == sysCfg.module) {
       setRelay(0);            /// both relays off first

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -145,6 +145,7 @@ enum module_t {
   SONOFF_DEV,
   H801,
   SONOFF_SC,
+  SHUTTER,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -431,6 +432,18 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      0, 0, 0, 0, 0, 0, // Flash connection
      0,
      GPIO_LED1_INV,    // GPIO13 Green Led (0 = On, 1 = Off)
+     0, 0, 0, 0
+  },
+  { "Shutter",         // Sonoff Dual as Shutter Switch (ESP8266)
+     0,
+     GPIO_TXD,         // GPIO01 Relay control
+     0,
+     GPIO_RXD,         // GPIO03 Relay control
+     GPIO_USER,        // GPIO04 Optional sensor
+     0,
+     0, 0, 0, 0, 0, 0, // Flash connection
+     0,
+     GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)
      0, 0, 0, 0
   }
 };


### PR DESCRIPTION
There were already some requests for a shutter enhancement here.
I use a Sonoff Dual (or Ch4) as switch for my rolling shutters.
My shutter motors have 3 connectors: N, Motor UP, Motor down and provide internal end switches.

The code here should use not more than 300 bytes of flash space and provides this functionnality:
Using the Wemo emulation, each ON/OFF command first shuts both relays off for 10 ms, then for a period of "pulsetime" relay 1 (ON command) or relay 2 (OFF command) switches on.
So I can tell my echo dot "Alexa Shutters On" and the shutters go up.
The motor can also be controlled with buttons at the internal pin header of the Dual: UP = button0 /
DOWN = button1. The top button (button2) should work as normal, i.e. toggle.
Any command during pulsetime stops the motor.

A new module type is defined in sonoff_template.h as "Shutter" (fairly the same as Sonoff Dual).
Set pulsetime a bit higher than the shutter rising time (in my case 40 sec. - in web console: "pulsetime 140"). PowerOnState should be 0 (console: "PowerOnState 0") .

Warning!
The code is not so much testet, I tried to avoid any side effects for the other moduls, but no one knows... 