### PR TITLE
Allow calibration of HuaFan devices (and other hardware)

### DIFF
--- a/sonoff/xsns_hlw8012.ino
+++ b/sonoff/xsns_hlw8012.ino
@@ -517,6 +517,24 @@ boolean hlw_command(char *type, uint16_t index, char *dataBuf, uint16_t data_len
     }
     snprintf_P(svalue, ssvalue, PSTR("{\"HlwIcal\":\"%d%s\"}"), sysCfg.hlw_ical, (sysCfg.flag.value_units) ? " uS" : "");
   }
+  else if (!strcmp_P(type,PSTR("HLWPSET"))) {
+    if ((payload > 0) && (payload < 3601) && hlw_cf_plen) {
+      sysCfg.hlw_pcal = (payload * 10 * hlw_cf_plen) / HLW_PREF;
+    }
+    snprintf_P(svalue, ssvalue, PSTR("(\"HlwPcal\":\"%d%s\"}"), sysCfg.hlw_pcal, (sysCfg.flag.value_units) ? " uS" : "");
+  }
+  else if (!strcmp_P(type,PSTR("HLWUSET"))) {
+    if ((payload > 0) && (payload < 501) && hlw_cf1u_plen) {
+      sysCfg.hlw_ucal = (payload * 10 * hlw_cf1u_plen) / HLW_UREF;
+    }
+    snprintf_P(svalue, ssvalue, PSTR("(\"HlwUcal\":\"%d%s\"}"), sysCfg.hlw_ucal, (sysCfg.flag.value_units) ? " uS" : "");
+  }
+  else if (!strcmp_P(type,PSTR("HLWISET"))) {
+    if ((payload > 0) && (payload < 16001) && hlw_cf1i_plen) {
+      sysCfg.hlw_ical = (payload * hlw_cf1i_plen) / HLW_IREF;
+    }
+    snprintf_P(svalue, ssvalue, PSTR("(\"HlwIcal\":\"%d%s\"}"), sysCfg.hlw_ical, (sysCfg.flag.value_units) ? " uS" : "");
+  }
 #if FEATURE_POWER_LIMIT
   else if (!strcmp_P(type,PSTR("MAXPOWER"))) {
     if ((payload >= 0) && (payload < 3601)) {


### PR DESCRIPTION
The calibration limits hardcoded into xsns_hlw8012.ino are too high for calibrating the HuaFan devices. The HuaFan's shunt resistor is double the Sonoff's and there are only 4 voltage divider resistors rather than 5. For example, to calibrate the Huafan required the following values: HLWPCAL: 4,750, HLWUCAL: 1,525, HLWICAL: 1,680 (the first and last are below the hardcoded limits).

This PR proposes an alternative calibration approach allowing the user to provide known power, voltage and current values with the software auto-calibrating to these values. This would also allow the HuaFan to be calibrated as well as devices with other hardware. The PR adds the following three commands:
- HLWPSET x: where x is the expected power in watts i.e. 60 for a 60 watt bulb
- HLWUSET x: where x is the expected voltage in volts i.e. 240 for a 240 volt supply
- HLWISET x: where x is the expected current in milliamps i.e. 250 for 0.250mA 

The use cases for calibration are either:
- a user connects up a known appliance, i.e. 60W bulb, and assumes 240V and 0.25A for voltage and current and enters these into the console
- a user  connects a load and uses a multimeter to determine all three values

This approach seems more consistent with the guidelines provided in the wiki pages for preparation and simplifies the calibration process.