### PR TITLE
Enable use of GPIO16

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2679,13 +2679,13 @@ void GPIO_init()
         Maxdevice++;
       }
 //      if (pin[GPIO_KEY1 +i] < 99) {
-//        pinMode(pin[GPIO_KEY1 +i], INPUT_PULLUP);
+//        pinMode(pin[GPIO_KEY1 +i], pin[GPIO_KEY1 +i] == 16 ? INPUT_PULLDOWN_16 : INPUT_PULLUP);
 //      }
     }
   }
   for (byte i = 0; i < 4; i++) {
     if (pin[GPIO_KEY1 +i] < 99) {
-      pinMode(pin[GPIO_KEY1 +i], INPUT_PULLUP);
+      pinMode(pin[GPIO_KEY1 +i], pin[GPIO_KEY1 +i] == 16 ? INPUT_PULLDOWN_16 : INPUT_PULLUP);
     }
     if (pin[GPIO_LED1 +i] < 99) {
       pinMode(pin[GPIO_LED1 +i], OUTPUT);
@@ -2693,7 +2693,7 @@ void GPIO_init()
     }
     if (pin[GPIO_SWT1 +i] < 99) {
       swt_flg = 1;
-      pinMode(pin[GPIO_SWT1 +i], INPUT_PULLUP);
+      pinMode(pin[GPIO_SWT1 +i], pin[GPIO_SWT1 +i] == 16 ? INPUT_PULLDOWN_16 : INPUT_PULLUP);
       lastwallswitch[i] = digitalRead(pin[GPIO_SWT1 +i]);  // set global now so doesn't change the saved power state on first switch check
     }
   }


### PR DESCRIPTION
GPIO16 only has a pull-down option, not a pull-up and the underlying code for
initializing GPIO16 does not respond to the INPUT_PULLUP option. Whilst the
official devices don't use GPIO16 at present, custom devices and perhaps some
in the future would use them.