### PR TITLE
Add gpio1 and gpio3 back to sonoff pow.

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -287,7 +287,10 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
   },
   { "Sonoff Pow",      // Sonoff Pow (ESP8266)
      GPIO_KEY1,        // GPIO00 Button
-     0, 0, 0, 0,
+     GPIO_USER,        // GPIO01 Serial RXD and Optional sensor
+     0,                // GPIO02
+     GPIO_USER,        // GPIO03 Serial TXD and Optional sensor
+     0,
      GPIO_HLW_SEL,     // GPIO05 HLW8012 Sel output
      0, 0, 0, 0, 0, 0, // Flash connection
      GPIO_REL1,        // GPIO12 Red Led and Relay (0 = Off, 1 = On)


### PR DESCRIPTION
see issue #920. No reason or hw issue why these ports should be not available.

Reasons that are given are only a risk when connecting it to a pc or other device with a own power supply