### PR TITLE
PlatformIO custom uploaded - scp

### DIFF
--- a/pio/sftp-uploader.py
+++ b/pio/sftp-uploader.py
@@ -1,0 +1,6 @@
+Import("env")
+from base64 import b64decode
+
+env.Replace(UPLOADER="echo scp")
+env.Replace(UPLOADERFLAGS="")
+env.Replace(UPLOADCMD="$UPLOADER $SOURCES " + b64decode(ARGUMENTS.get("UPLOAD_PORT")))

--- a/pio/sftp-uploader.py
+++ b/pio/sftp-uploader.py
@@ -1,6 +1,6 @@
 Import("env")
 from base64 import b64decode
 
-env.Replace(UPLOADER="echo scp")
+env.Replace(UPLOADER="scp")
 env.Replace(UPLOADERFLAGS="")
-env.Replace(UPLOADCMD="$UPLOADER $SOURCES " + b64decode(ARGUMENTS.get("UPLOAD_PORT")))
+env.Replace(UPLOADCMD="$UPLOADER $SOURCES " + b64decode(ARGUMENTS.get("UPLOAD_PORT")) + "/" + b64decode(ARGUMENTS.get("PIOENV")) + ".bin")

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,8 @@ board = esp01_1m
 board_flash_mode = dout
 build_flags = -Wl,-Tesp8266.flash.1m0.ld -DMQTT_MAX_PACKET_SIZE=512
 lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
+upload_port = user@host:/path
+extra_scripts = pio/sftp-uploader.py
 
 ; Serial Monitor options
 monitor_baud = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,8 +24,8 @@ board = esp01_1m
 board_flash_mode = dout
 build_flags = -Wl,-Tesp8266.flash.1m0.ld -DMQTT_MAX_PACKET_SIZE=512
 lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
-upload_port = user@host:/path
-extra_scripts = pio/sftp-uploader.py
+; upload_port = user@host:/path
+; extra_scripts = pio/sftp-uploader.py
 
 ; Serial Monitor options
 monitor_baud = 115200


### PR DESCRIPTION
This patch implements custom PlatformIO uploader that pushes .bin files to remote OTA server using SCP. Images can be served to Sonoff-Tasmotas from there.

### Configuration
To upload .bin images to OTA server using SCP, one has to add following lines under target environment:

```
[env:sonoff]
...
extra_scripts = pio/sftp-uploader.py
upload_port = user@host:/path

```
upload_port should be modified to reflect user, host and path on the host where images should be uploaded.

### Requirements
SSH communication between the build server and OTA server should be pre-configured so that it doesn't require password (pre-shared keys) - http://lmgtfy.com/?q=ssh+pre+shared+key

### Future enhancements
Custom uploader framework can be used for uploads over HTTP / HTTPS or simply moving files to another folder on the same machine.