### PR TITLE
Fix the alignment of emulation radio buttons.

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -227,7 +227,7 @@ const char HTTP_FORM_OTHER2[] PROGMEM =
 const char HTTP_FORM_OTHER3a[] PROGMEM =
   "<br/><fieldset><legend><b>&nbsp;" D_EMULATION "&nbsp;</b></legend>";
 const char HTTP_FORM_OTHER3b[] PROGMEM =
-  "<br/><input style='width:10%;float:left' id='b2' name='b2' type='radio' value='{1'{2><b>{3</b>{4";
+  "<br/><input style='width:10%;' id='b2' name='b2' type='radio' value='{1'{2><b>{3</b>{4";
 #endif  // USE_EMULATION
 const char HTTP_FORM_END[] PROGMEM =
   "<br/><button type='submit'>" D_SAVE "</button></form></fieldset>";


### PR DESCRIPTION
Current emulation box has weirdly aligned radio buttons, every button indented the right from the previous one. 
![sonoff-alignment-01](https://user-images.githubusercontent.com/29731130/30983815-ce7c16ee-a48b-11e7-8653-14eca9e6824d.png)

Fix realigns the radio buttons:
![sonoff-alignment-02](https://user-images.githubusercontent.com/29731130/30983857-ef6ae51a-a48b-11e7-9782-e730c4cc8f58.png)

