### PR TITLE
Support for MagicHome LED controllers

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -159,6 +159,7 @@ enum module_t {
   SUPLA1,
   WITTY,
   YUNSHAN,
+  MAGICHOME,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -206,6 +207,7 @@ const uint8_t nicelist[MAXMODULE] PROGMEM = {
   H801,
   HUAFAN_SS,
   AILIGHT,
+  MAGICHOME,
   WEMOS,
   WITTY
 };
@@ -650,6 +652,17 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      GPIO_KEY1,        // GPIO05 Blue Led and OptoCoupler input - Module Pin 9
      0, 0, 0, 0, 0, 0, // Flash connection
      0, 0, 0, 0, 0
-  }
+  },
+  { "MagicHome LED",  // Magic Home (aka Flux-light) (ESP8266) - https://www.aliexpress.com/item/Magic-Home-Mini-RGB-RGBW-Wifi-Controller-For-Led-Strip-Panel-light-Timing-Function-16million-colors/32686853650.html
+     0, 0,
+     GPIO_LED1_INV,   // GPIO02, Blue onboard LED
+     0,               // GPIO03
+     GPIO_USER,       // GPIO04, IR receiver (optional)
+     GPIO_PWM4,       // GPIO05 - Green
+     0, 0, 0, 0, 0, 0,
+     GPIO_PWM5,       // GPIO12 - Blue
+     GPIO_USER,       // GPIO13 - White (optional - set to PWM1 for Cold White or PWM2 for Warm White)
+     GPIO_PWM3,       // GPIO14 - Red
+     0, 0, 0
+  },
 };
-


### PR DESCRIPTION
### MagicHome LED controllers (aka Flux-Led)

I got quite a few of these nice little boxes from AliExpress. Out of the box, they have a stock firmware that requires separate application on your phone. 

![img_0303](https://user-images.githubusercontent.com/29731130/31029721-23312a68-a553-11e7-9bd9-0a45f38d3375.jpg)
![img_0304](https://user-images.githubusercontent.com/29731130/31029726-269589f6-a553-11e7-95ed-aecb334d3aa3.jpg)


https://www.aliexpress.com/item/Magic-Home-Mini-RGB-RGBW-Wifi-Controller-For-Led-Strip-Panel-light-Timing-Function-16million-colors/32686853650.html

It's essentially a ESP-12S with necessary voltage converters, little bit of flash, 3 or 4 MOSFETs to drive LED strip, connector for LED strip and optional IR receiver. It's powered by 12V that is used to power LED strip as well.

Board comes in (at least) 3 variants:
- RGB
- RGBW
- RGBW + IR receiver

I happen to have 2 variants (RGBW and RGBW+IR) and internally they use same PCB and almost the same housing. IR variant, obviously, has a IR Receiver soldered, but non-IR has pins for it, so it's easy to "upgrade".

Application uses some binary protocol over UDP and is generally not open. People have reverse engineered the protocol (see flux-led python library) but I wasn't happy with it as it's still not MQTT enabled and it works very slow/unreliable with Home Assistant.
Sonoff-Tasmota to the rescue ;)

### Configuration 

Some GPIO are preconfigured with the board: 
- GPIO05 - Green color on the led strip, first pin from the GND
- GPIO14 - Red color on the LED strip, second pin from the GND
- GPIO12 - Blue color on the LED strip, third pin from the GND

Due to variants, I left the option of choosing how would you like to use:
- GPIO04 - on non-IR boards, it's open pin you can use for Onewire, button or something else. On IR-enabled boards, IR receiver is connected there so maybe we will add IR receiver support to Sonoff-Tasmota.
- GPIO13  -  This pin is not used on RGB board (so you'll leave it as "None"), but on RGBW, it's driving another channel for LED strip. Depending on the strip type, you can set it to PWM1 (for RGB+Cold White) or PWM2 (for RGB+Warm White).

btw, I'm actually driving 4 different white (single-color) strips with this board. Just make sure GND is common for all of them.

### How to flash
Original firmware doesn't even have OTA update option, so trying to do something like SonOTA wouldn't work. 

Board has RX, TX, GND and GPIO00 pads exposed on the bottom side of the PCB. You can use those pads to program the board either by:
- holding programmer pins directly (ugly and imprecise - you might need someone's help to press the buttons while you juggle with pins),
- using putty (a bit better, but still frustrating) or 
- temporary soldering wires to pads.

![img_0307](https://user-images.githubusercontent.com/29731130/31029735-2f99db9c-a553-11e7-896c-2f71c3d04551.jpg)


You should also connect VCC from the MagicHome to VCC on the programmer, but for me, this didn't work. I used the VCC pin of the IR Receiver, so some resistors/capacitors/diodes might have gotten in the way. Other explanation might be that programmer didn't supply enough power for the whole board (maybe MOSFETs are drawing something).

In either case, I needed to power the board while keeping it connected to the programmer.

With all Sonoff boards that works with AC, this is a big no-no that will fry your programmer, your Sonoff and might even get you killed.
In this case, you'd be dealing with 12V, so the only thing that matters is to connect the GND of your programmer to GND of the board before you supply the 12V. Not doing so might fry your board and/or programmer, but would definitely not hurt you.

Steps I used: 
1. Connect your programmer to a breadboard and notice the locations of GND, TX and RX columns.
1. Open the MagicHome controller box and expose bottom side of PCB
1. Solder 4 jumper wires to 4 exposed pads.
1. **FIRST** connect GND to your programmer (and make sure they are connected well!)
1. Connect RX from the MagicHome to TX on the programmer. TX from the board goes to RX on the programmer.
1. Connect GPIO00 to GND (best to use same column on the breadboard)
1. Connect the 12V power supply to MagicHome. As GPIO00 is connected to GND, board will go into flash mode. I usually disconnect GPIO00 after few seconds, but not sure if this is mandatory or optional.
1. Upload Sonoff-Tasmota like it would be any other board.
1. Once upload is complete, disconnect power from the MagicHome controller
1. Disconnect RX and TX and then only then GND. GND gets disconnected **LAST.**

You can then connect the power back to the board and Sonoff-Tasmota should be running on it. Once you verify that board is up and you can access it over the Web, you can unsolder temporary wires and update subsequent firmware versions using OTA.


