### PR TITLE
IR receiver

### DIFF
--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -383,14 +383,15 @@
 // xdrv_ir-send.ino
 #define D_INVALID_JSON "Invalid JSON"
 #define D_PROTOCOL_NOT_SUPPORTED "Protocol not supported"
-#define D_IRSEND_PROTOCOL "PROTOCOL"
-#define D_IRSEND_BITS "BITS"
-#define D_IRSEND_DATA "DATA"
+#define D_IR_PROTOCOL "PROTOCOL"
+#define D_IR_BITS "BITS"
+#define D_IR_DATA "DATA"
 #define D_IRHVAC_VENDOR "VENDOR"
 #define D_IRHVAC_POWER "POWER"
 #define D_IRHVAC_MODE "MODE"
 #define D_IRHVAC_FANSPEED "FANSPEED"
 #define D_IRHVAC_TEMP "TEMP"
+#define D_IRRECEIVED "IRReceived"
 
 // xdrv_snfbridge.ino
 #define D_RFRECEIVED "RfReceived"
@@ -456,7 +457,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
-#define D_SENSOR_IRREMOTE "IRremote"
+#define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"
 #define D_SENSOR_RELAY    "Relay"    // Suffix "1I"
@@ -466,6 +467,7 @@
 #define D_SENSOR_SPI_CS   "SPI CS"
 #define D_SENSOR_SPI_DC   "SPI DC"
 #define D_SENSOR_BACKLIGHT "BLight"
+#define D_SENSOR_IRRECV   "IRrecv"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -383,14 +383,16 @@
 // xdrv_ir-send.ino
 #define D_INVALID_JSON "Ongeldig JSON"
 #define D_PROTOCOL_NOT_SUPPORTED "Protocol wordt niet ondersteund"
-#define D_IRSEND_PROTOCOL "PROTOCOL"
-#define D_IRSEND_BITS "BITS"
-#define D_IRSEND_DATA "DATA"
+#define D_IR_PROTOCOL "PROTOCOL"
+#define D_IR_BITS "BITS"
+#define D_IR_DATA "DATA"
 #define D_IRHVAC_VENDOR "VENDOR"
 #define D_IRHVAC_POWER "POWER"
 #define D_IRHVAC_MODE "MODE"
 #define D_IRHVAC_FANSPEED "FANSPEED"
 #define D_IRHVAC_TEMP "TEMP"
+#define D_IRRECEIVED "IRReceived"
+
 
 // xdrv_snfbridge.ino
 #define D_RFRECEIVED "RfReceived"
@@ -456,7 +458,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
-#define D_SENSOR_IRREMOTE "IRremote"
+#define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"  // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"  // Suffix "1"
 #define D_SENSOR_RELAY    "Relais"  // Suffix "1I"
@@ -466,6 +468,7 @@
 #define D_SENSOR_SPI_CS   "SPI CS"
 #define D_SENSOR_SPI_DC   "SPI DC"
 #define D_SENSOR_BACKLIGHT "BLight"
+#define D_SENSOR_IRRECV   "IRrecv"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2315,6 +2315,11 @@ void stateloop()
 */
       blogptr &= 0xF;
     }
+#ifdef USE_IR_REMOTE
+    if (pin[GPIO_IRRECV] < 99) {
+      ir_recv_check();  // check if there's anything on IR side
+    }
+#endif
   }
 
 /*-------------------------------------------------------------------------------------------*\
@@ -2702,6 +2707,9 @@ void GPIO_init()
 #ifdef USE_IR_REMOTE
   if (pin[GPIO_IRSEND] < 99) {
     ir_send_init();
+  }
+  if (pin[GPIO_IRRECV] < 99) {
+    ir_recv_init();
   }
 #endif // USE_IR_REMOTE
 

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -61,6 +61,7 @@ enum upins_t {
   GPIO_CNTR2,
   GPIO_CNTR3,
   GPIO_CNTR4,
+  GPIO_IRRECV,
   GPIO_SENSOR_END };
 
 // Text in webpage Module Parameters and commands GPIOS and GPIO
@@ -73,7 +74,7 @@ const char sensors[GPIO_SENSOR_END][9] PROGMEM = {
   D_SENSOR_I2C_SCL,
   D_SENSOR_I2C_SDA,
   D_SENSOR_WS2812,
-  D_SENSOR_IRREMOTE,
+  D_SENSOR_IRSEND,
   D_SENSOR_SWITCH "1",
   D_SENSOR_SWITCH "2",
   D_SENSOR_SWITCH "3",
@@ -106,7 +107,8 @@ const char sensors[GPIO_SENSOR_END][9] PROGMEM = {
   D_SENSOR_COUNTER "1",
   D_SENSOR_COUNTER "2",
   D_SENSOR_COUNTER "3",
-  D_SENSOR_COUNTER "4"
+  D_SENSOR_COUNTER "4",
+  D_SENSOR_IRRECV
   };
 
 // Programmer selectable GPIO functionality offset by user selectable GPIOs
@@ -666,4 +668,3 @@ const mytmplt modules[MAXMODULE] PROGMEM = {
      0, 0, 0
   }
 };
-


### PR DESCRIPTION
Initial commit for IR Receiver code, tested on MagicHome with IR receiver.

Quite easy to use - just enable IRRecv on a GPIO where you have your IR receiver connected. 
If you don't have MagicHome with IR receiver, you can get one of these and use them with any other Module with free GPIO: 
https://www.aliexpress.com/item/1PCS-Digital-38KHz-IR-Receiver-Sensors-Switch-Detector-Module-Infrared-Transducer-Boards-Active-Components-38KHz-IR/32711118446.html

My first experience is not that great - my receiver is placed next to a  LED strip and it seems that light from LED strip is influencing receiver sensitivity, so I hardly get any code. In a debug version (that I didn't commit), I get a lot of type=unknown, data=random garbage, which I filtered out.
With lights off, I get a decent reading and I got all of my remotes decoded (around 10 that I could find around the house).

@arendst - I placed a check for IR code in 0.1sec loop. I have no way of telling if this is killing CPU or not, but I didn't noticed any hickups on MagicHome. Feel free to move the check to 0.2 or even 0.5sec loop, if you feel it's too much.
