### PR TITLE
Add support for inverted PWM

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -285,6 +285,7 @@ mytmplt my_module;                    // Active copy of GPIOs
 uint8_t pin[GPIO_MAX];                // Possible pin configurations
 uint8_t rel_inverted[4] = { 0 };      // Relay inverted flag (1 = (0 = On, 1 = Off))
 uint8_t led_inverted[4] = { 0 };      // LED inverted flag (1 = (0 = On, 1 = Off))
+uint8_t pwm_inverted[4] = { 0 };      // PWM inverted flag (1 = (0 = On, 1 = Off))
 uint8_t dht_flg = 0;                  // DHT configured
 uint8_t hlw_flg = 0;                  // Power monitor configured
 uint8_t i2c_flg = 0;                  // I2C configured
@@ -1253,7 +1254,7 @@ void mqttDataCb(char* topic, byte* data, unsigned int data_len)
     else if (!strcasecmp_P(type, PSTR(D_CMND_PWM)) && (index > pwm_idxoffset) && (index <= 5)) {
       if ((payload >= 0) && (payload <= PWM_RANGE) && (pin[GPIO_PWM1 + index -1] < 99)) {
         sysCfg.pwmvalue[index -1] = payload;
-        analogWrite(pin[GPIO_PWM1 + index -1], payload);
+        analogWrite(pin[GPIO_PWM1 + index -1], pwm_inverted[index-1]?PWM_RANGE-payload:payload);
       }
       snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_PWM "\":{"));
       bool first = true;
@@ -2597,6 +2598,10 @@ void GPIO_init()
         led_inverted[mpin - GPIO_LED1_INV] = 1;
         mpin -= 4;
       }
+      else if ((mpin >= GPIO_PWM1_INV) && (mpin <= GPIO_PWM5_INV)) {
+        pwm_inverted[mpin - GPIO_PWM1_INV] = 1;
+        mpin -= 5;
+      }
 #ifdef USE_DHT
       else if ((mpin >= GPIO_DHT11) && (mpin <= GPIO_DHT22)) {
         if (dht_setup(i, mpin)) {
@@ -2704,7 +2709,7 @@ void GPIO_init()
     if (pin[GPIO_PWM1 +i] < 99) {
       pwm_flg = 1;
       pinMode(pin[GPIO_PWM1 +i], OUTPUT);
-      analogWrite(pin[GPIO_PWM1 +i], sysCfg.pwmvalue[i]);
+      analogWrite(pin[GPIO_PWM1 +i], pwm_inverted[i]?PWM_RANGE-sysCfg.pwmvalue[i]:sysCfg.pwmvalue[i]);
     }
   }
 

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -57,6 +57,11 @@ enum upins_t {
   GPIO_PWM3,           // RGB   Blue
   GPIO_PWM4,           // RGBW  (Cold) White
   GPIO_PWM5,           // RGBCW Warm White
+  GPIO_PWM1_INV,       // RGB   Red   or C  Cold White
+  GPIO_PWM2_INV,       // RGB   Green or CW Warm White
+  GPIO_PWM3_INV,       // RGB   Blue
+  GPIO_PWM4_INV,       // RGBW  (Cold) White
+  GPIO_PWM5_INV,       // RGBCW Warm White
   GPIO_CNTR1,
   GPIO_CNTR2,
   GPIO_CNTR3,
@@ -103,6 +108,11 @@ const char sensors[GPIO_SENSOR_END][9] PROGMEM = {
   D_SENSOR_PWM "3",
   D_SENSOR_PWM "4",
   D_SENSOR_PWM "5",
+  D_SENSOR_PWM "1I",
+  D_SENSOR_PWM "2I",
+  D_SENSOR_PWM "3I",
+  D_SENSOR_PWM "4I",
+  D_SENSOR_PWM "5I",
   D_SENSOR_COUNTER "1",
   D_SENSOR_COUNTER "2",
   D_SENSOR_COUNTER "3",

--- a/sonoff/xdrv_snfled.ino
+++ b/sonoff/xdrv_snfled.ino
@@ -408,7 +408,8 @@ void sl_animate()
         cur_col[i] = (sysCfg.led_table) ? ledTable[sl_lcolor[i]] : sl_lcolor[i];
         if (sfl_flg < 6) {
           if (pin[GPIO_PWM1 +i] < 99) {
-            analogWrite(pin[GPIO_PWM1 +i], cur_col[i] * (PWM_RANGE / 255));
+            int pwmvalue = cur_col[i] * (PWM_RANGE / 255);
+            analogWrite(pin[GPIO_PWM1 +i], pwm_inverted[i]?PWM_RANGE-pwmvalue:pwmvalue);
           }
         }
       }


### PR DESCRIPTION
Add support for inverted PWM control, for example when P-channel MOSFET is used to drive LED.

Note:
Default state of PWM needs to be implemented.
What works for me for dimmer control is to simply set sl_any to 1 instead of 0 at the end of sl_init, but maybe this has some side effect?
See also #955