### PR TITLE
Support for LC Technology WiFi Relay

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -313,6 +313,20 @@ void SetDevicePower(power_t rpower)
     Serial.write('\n');
     Serial.flush();
   }
+  else if (LCTECH == Settings.module) {
+    Serial.write(0xA0);
+    Serial.write(0x01);
+    if ( rpower )
+    {
+      Serial.write(0x01);
+      Serial.write(0xA2);      
+    }
+    else
+    {
+      Serial.write(0x00);    
+      Serial.write(0xA1);
+    }    
+  }  
   else if (EXS_RELAY == Settings.module) {
     SetLatchingRelay(rpower, 1);
   }
@@ -2539,6 +2553,10 @@ void GpioInit()
     devices_present = 2;
     baudrate = 19200;
   }
+  else if (LCTECH == Settings.module) {
+    devices_present = 1;
+    baudrate = 9600;
+  }  
   else if (CH4 == Settings.module) {
     devices_present = 4;
     baudrate = 19200;

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -197,6 +197,7 @@ enum SupportedModules {
   ARILUX_LC01,
   ARILUX_LC11,
   SONOFF_DUAL_R2,
+  LCTECH
   MAXMODULE };
 
 /********************************************************************************************/
@@ -778,7 +779,20 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL1,        // GPIO12 Relay 1 (0 = Off, 1 = On)
      GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)
      0, 0, 0, 0
-  }
+  },
+  { "LCTECH Relay",     // LC Technology WiFi Relay
+     0,
+     GPIO_TXD,          // GPIO01 Relay control
+     0,
+     GPIO_RXD,          // GPIO03 Relay control
+     0,                 
+     0,
+     0, 0, 0, 0, 0, 0,  // Flash connection
+     0,
+     0,                
+     0,                
+     0, 0, 0
+  }  
 };
 
 #endif  // _SONOFF_TEMPLATE_H_

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -197,7 +197,7 @@ enum SupportedModules {
   ARILUX_LC01,
   ARILUX_LC11,
   SONOFF_DUAL_R2,
-  LCTECH
+  LCTECH,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -792,7 +792,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      0,                
      0,                
      0, 0, 0
-  }  
+  }
 };
 
 #endif  // _SONOFF_TEMPLATE_H_

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -254,7 +254,8 @@ const uint8_t kNiceList[MAXMODULE] PROGMEM = {
   KMC_70011,
   AILIGHT,
   WEMOS,
-  WITTY
+  WITTY,
+  LCTECH
 };
 
 // Default module settings


### PR DESCRIPTION
No buttons. ESP-01s is used to control one relay via STC15F104W PIC ( just like Sonoff Dual ).
Blue LED is connected directly to relay.
[http://www.chinalctech.com/index.php?_m=mod_product&_a=view&p_id=1204](url)