### PR TITLE
ignore user_config_override.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .piolibdeps
 .clang_complete
 .gcc-flags.json
+sonoff/user_config_override.h


### PR DESCRIPTION
I always forget to PR this - this should optimize usual stash + pull + stash pop, process and just turn it into pull, when getting new versions of Tasmota. 

  