### PR TITLE
Allow Cross-Origin (removed by ESP Update)

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -407,6 +407,7 @@ void SetHeader()
   WebServer->sendHeader(F("Cache-Control"), F("no-cache, no-store, must-revalidate"));
   WebServer->sendHeader(F("Pragma"), F("no-cache"));
   WebServer->sendHeader(F("Expires"), F("-1"));
+  WebServer->sendHeader(F("Access-Control-Allow-Origin"), F("*"));
 }
 
 void ShowPage(String &page)
@@ -1375,6 +1376,7 @@ void HandleHttpCommand()
   } else {
     message += F(D_NEED_USER_AND_PASSWORD "\"}");
   }
+  SetHeader();
   WebServer->send(200, FPSTR(HDR_CTYPE_JSON), message);
 }
 


### PR DESCRIPTION
Default Cross Origin was allowed before 2.4.0

Now its not in the headers anymore (check here: http://www.esp8266.com/viewtopic.php?f=6&t=16679 )

Im working on a Webinterface (https://github.com/reloxx13/SonWEB) to manage all sonoffs in network, i cannot executes commands without this.

coud break other communications too

> 
> Failed to load http://192.168.10.53/cm?cmnd=Power1: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://192.168.10.180' is therefore not allowed access.
> 
> 
> Failed to load http://192.168.10.53/cm?cmnd=Status%202: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://192.168.10.180' is therefore not allowed access.