### PR TITLE
Domoticz RSSI and Battery Quality

### DIFF
--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -1,6 +1,9 @@
 /* 
- * 5.11.1b-DomoticzQuality
- * Add support for Battery and RSSI quality in Domoticz
+ * 5.11.1b2
+ * Add Domoticz "RSSI" and "Battery" to sensor
+ *
+ * 5.11.1b1
+ * Add support for Battery and RSSI quality in Domoticz switch command
  *
  * 5.11.1b
  * Add command PowerOnState option 5 which inverts PulseTime and allows for delayed always on after power on

--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -1,4 +1,8 @@
-/* 5.11.1b
+/* 
+ * 5.11.1b-DomoticzQuality
+ * Added support for Battery and RSSI quality in Domoticz
+ *
+ * 5.11.1b
  * Add command PowerOnState option 5 which inverts PulseTime and allows for delayed always on after power on
  * Changed OSWATCH_RESET_TIME (Blocked loop) from 30 to 120 seconds to allow slow networks (#1556)
  * Add French language file (#1561)

--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -1,6 +1,6 @@
 /* 
  * 5.11.1b-DomoticzQuality
- * Added support for Battery and RSSI quality in Domoticz
+ * Add support for Battery and RSSI quality in Domoticz
  *
  * 5.11.1b
  * Add command PowerOnState option 5 which inverts PulseTime and allows for delayed always on after power on

--- a/sonoff/xdrv_05_domoticz.ino
+++ b/sonoff/xdrv_05_domoticz.ino
@@ -316,7 +316,7 @@ uint8_t DomoticzHumidityState(char *hum)
 void DomoticzSensor(byte idx, char *data)
 {
   if (Settings.domoticz_sensor_idx[idx]) {
-    char dmess[64]; //64 + 24 extra data
+    char dmess[88]; //64 + 24 extra data
 
     memcpy(dmess, mqtt_data, sizeof(dmess));
     if (DZ_AIRQUALITY == idx) {

--- a/sonoff/xdrv_05_domoticz.ino
+++ b/sonoff/xdrv_05_domoticz.ino
@@ -316,13 +316,13 @@ uint8_t DomoticzHumidityState(char *hum)
 void DomoticzSensor(byte idx, char *data)
 {
   if (Settings.domoticz_sensor_idx[idx]) {
-    char dmess[64];
+    char dmess[64]; //64 + 24 extra data
 
     memcpy(dmess, mqtt_data, sizeof(dmess));
     if (DZ_AIRQUALITY == idx) {
-      snprintf_P(mqtt_data, sizeof(dmess), PSTR("{\"idx\":%d,\"nvalue\":%s}"), Settings.domoticz_sensor_idx[idx], data);
+      snprintf_P(mqtt_data, sizeof(dmess), PSTR("{\"idx\":%d,\"nvalue\":%s,\"Battery\":%d,\"RSSI\":%d}"), Settings.domoticz_sensor_idx[idx], data, SystemGetVoltageAsDomoticzQuality(ESP.getVcc()), WifiGetRssiAsDomoticzQuality(WiFi.RSSI()));
     } else {
-      snprintf_P(mqtt_data, sizeof(dmess), PSTR("{\"idx\":%d,\"nvalue\":0,\"svalue\":\"%s\"}"), Settings.domoticz_sensor_idx[idx], data);
+      snprintf_P(mqtt_data, sizeof(dmess), PSTR("{\"idx\":%d,\"nvalue\":0,\"svalue\":\"%s\",\"Battery\":%d,\"RSSI\":%d}"), Settings.domoticz_sensor_idx[idx], data, SystemGetVoltageAsDomoticzQuality(ESP.getVcc()), WifiGetRssiAsDomoticzQuality(WiFi.RSSI()));
     }
     MqttPublish(domoticz_in_topic);
     memcpy(mqtt_data, dmess, sizeof(dmess));


### PR DESCRIPTION
Hello,

I added support for Battery and RSSI quality in Domoticz. 

RSSI range: 0% to 10% (12 means disable RSSI in Domoticz)
Battery range: 0% to 200% (255 means disable Battery in Domoticz)

Battery 0%: ESP 2.6V (minimum operating voltage is 2.5)
Battery 100%: ESP 3.6V (maximum operating voltage is 3.6)
Battery 101% to 200%: ESP over 3.6V (means over maximum operating voltage)

**How to use:**
Enable `DomoticzStatusUpdate`

Greetings Fabi

![quality](https://user-images.githubusercontent.com/6533600/34923383-a1ffe158-f99b-11e7-8779-d427cb92c686.jpg)

![quality2](https://user-images.githubusercontent.com/6533600/34923414-fecaef72-f99b-11e7-89a0-668ec2941550.jpg)
