### PR TITLE
Use c-string methods in xplg_wemohue.ino to save memory

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -186,10 +186,6 @@ uint8_t light_type = 0;                     // Light types
 
 boolean mdns_begun = false;
 
-uint8_t xdrv_present = 0;                   // Number of drivers found
-boolean (*xdrv_func_ptr[XDRV_MAX])(byte);   // Driver Function Pointers
-uint8_t xsns_present = 0;                   // Number of External Sensors found
-boolean (*xsns_func_ptr[XSNS_MAX])(byte);   // External Sensor Function Pointers for simple implementation of sensors
 char my_version[33];                        // Composed version string
 char my_hostname[33];                       // Composed Wifi hostname
 char mqtt_client[33];                        // Composed MQTT Clientname

--- a/sonoff/xdrv_01_light.ino
+++ b/sonoff/xdrv_01_light.ino
@@ -891,18 +891,18 @@ void LightHsbToRgb()
 
 /********************************************************************************************/
 
-void LightReplaceHsb(String *response)
+void LightGetHsbFixedPoint(uint16_t *hue, uint8_t *sat, uint8_t *bri)
 {
   if (light_subtype > LST_COLDWARM) {
     LightRgbToHsb();
-    response->replace("{h}", String((uint16_t)(65535.0f * light_hue)));
-    response->replace("{s}", String((uint8_t)(254.0f * light_saturation)));
-    response->replace("{b}", String((uint8_t)(254.0f * light_brightness)));
+    *hue = (uint16_t)(65535.0f * light_hue);
+    *sat = (uint8_t)(254.0f * light_saturation);
+    *bri = (uint8_t)(254.0f * light_brightness);
   } else {
-    response->replace("{h}", "0");
-    response->replace("{s}", "0");
-//    response->replace("{b}", String((uint8_t)(2.54f * (float)Settings.light_dimmer)));
-    response->replace("{b}", String((uint8_t)(0.01f * (float)Settings.light_dimmer)));
+    *hue = 0;
+    *sat = 0;
+//    *sat = (uint8_t)(2.54f * (float)Settings.light_dimmer);
+    *sat = (uint8_t)(0.01f * (float)Settings.light_dimmer);
   }
 }
 

--- a/sonoff/xdrv_interface.ino
+++ b/sonoff/xdrv_interface.ino
@@ -17,52 +17,51 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void XDrvInit()
-{
-  for (byte i = 0; i < XDRV_MAX; i++) {
-    xdrv_func_ptr[i] = NULL;
-  }
-  xdrv_present = 0;
-
+boolean (* const xdrv_func_ptr[])(byte) PROGMEM = {   // Driver Function Pointers
 #ifdef XDRV_01
-  xdrv_func_ptr[xdrv_present++] = &Xdrv01;
+  &Xdrv01,
 #endif
 
 #ifdef XDRV_02
-  xdrv_func_ptr[xdrv_present++] = &Xdrv02;
+  &Xdrv02,
 #endif
 
 #ifdef XDRV_03
-  xdrv_func_ptr[xdrv_present++] = &Xdrv03;
+  &Xdrv03,
 #endif
 
 #ifdef XDRV_04
-  xdrv_func_ptr[xdrv_present++] = &Xdrv04;
+  &Xdrv04,
 #endif
 
 #ifdef XDRV_05
-  xdrv_func_ptr[xdrv_present++] = &Xdrv05;
+  &Xdrv05,
 #endif
 
 #ifdef XDRV_06
-  xdrv_func_ptr[xdrv_present++] = &Xdrv06;
+  &Xdrv06,
 #endif
 
 #ifdef XDRV_07
-  xdrv_func_ptr[xdrv_present++] = &Xdrv07;
+  &Xdrv07,
 #endif
 
 #ifdef XDRV_08
-  xdrv_func_ptr[xdrv_present++] = &Xdrv08;
+  &Xdrv08,
 #endif
 
 #ifdef XDRV_09
-  xdrv_func_ptr[xdrv_present++] = &Xdrv09;
+  &Xdrv09,
 #endif
 
 #ifdef XDRV_10
-  xdrv_func_ptr[xdrv_present++] = &Xdrv10;
+  &Xdrv10,
 #endif
+};
+const uint8_t xdrv_present = sizeof(xdrv_func_ptr)/sizeof(xdrv_func_ptr[0]); // Number of drivers found
+
+void XDrvInit()
+{
 
 //  snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_DEBUG "Drivers %d"), xdrv_present);
 //  AddLog(LOG_LEVEL_DEBUG);

--- a/sonoff/xsns_interface.ino
+++ b/sonoff/xsns_interface.ino
@@ -17,92 +17,91 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-void XSnsInit()
-{
-  for (byte i = 0; i < XSNS_MAX; i++) {
-    xsns_func_ptr[i] = NULL;
-  }
-  xsns_present = 0;
-
+boolean (* const xsns_func_ptr[])(byte) PROGMEM = { // External Sensor Function Pointers for simple implementation of sensors
 #ifdef XSNS_01
-  xsns_func_ptr[xsns_present++] = &Xsns01;
+  &Xsns01,
 #endif
 
 #ifdef XSNS_02
-  xsns_func_ptr[xsns_present++] = &Xsns02;
+  &Xsns02,
 #endif
 
 #ifdef XSNS_03
-  xsns_func_ptr[xsns_present++] = &Xsns03;
+  &Xsns03,
 #endif
 
 #ifdef XSNS_04
-  xsns_func_ptr[xsns_present++] = &Xsns04;
+  &Xsns04,
 #endif
 
 #ifdef XSNS_05
-  xsns_func_ptr[xsns_present++] = &Xsns05;
+  &Xsns05,
 #endif
 
 #ifdef XSNS_06
-  xsns_func_ptr[xsns_present++] = &Xsns06;
+  &Xsns06,
 #endif
 
 #ifdef XSNS_07
-  xsns_func_ptr[xsns_present++] = &Xsns07;
+  &Xsns07,
 #endif
 
 #ifdef XSNS_08
-  xsns_func_ptr[xsns_present++] = &Xsns08;
+  &Xsns08,
 #endif
 
 #ifdef XSNS_09
-  xsns_func_ptr[xsns_present++] = &Xsns09;
+  &Xsns09,
 #endif
 
 #ifdef XSNS_10
-  xsns_func_ptr[xsns_present++] = &Xsns10;
+  &Xsns10,
 #endif
 
 #ifdef XSNS_11
-  xsns_func_ptr[xsns_present++] = &Xsns11;
+  &Xsns11,
 #endif
 
 #ifdef XSNS_12
-  xsns_func_ptr[xsns_present++] = &Xsns12;
+  &Xsns12,
 #endif
 
 #ifdef XSNS_13
-  xsns_func_ptr[xsns_present++] = &Xsns13;
+  &Xsns13,
 #endif
 
 #ifdef XSNS_14
-  xsns_func_ptr[xsns_present++] = &Xsns14;
+  &Xsns14,
 #endif
 
 #ifdef XSNS_15
-  xsns_func_ptr[xsns_present++] = &Xsns15;
+  &Xsns15,
 #endif
 
 #ifdef XSNS_16
-  xsns_func_ptr[xsns_present++] = &Xsns16;
+  &Xsns16,
 #endif
 
 #ifdef XSNS_17
-  xsns_func_ptr[xsns_present++] = &Xsns17;
+  &Xsns17,
 #endif
 
 #ifdef XSNS_18
-  xsns_func_ptr[xsns_present++] = &Xsns18;
+  &Xsns18,
 #endif
 
 #ifdef XSNS_19
-  xsns_func_ptr[xsns_present++] = &Xsns19;
+  &Xsns19,
 #endif
 
 #ifdef XSNS_20
-  xsns_func_ptr[xsns_present++] = &Xsns20;
+  &Xsns20,
 #endif
+};
+const uint8_t xsns_present = sizeof(xsns_func_ptr)/sizeof(xsns_func_ptr[0]); // Number of External Sensors found
+
+void XSnsInit()
+{
 
 //  snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_DEBUG "Sensors found %d"), xsns_present);
 //  AddLog(LOG_LEVEL_DEBUG);


### PR DESCRIPTION
Use c-string methods in xplg_wemohue.ino (-1k flash)
Move sensor and extension jump tableto flash (-70 byte RAM)

Note: I have verified the changes xplg_wemohue.ino only by accessing the API through browser (valid JSON, seems fully aligned with before change). Let me know if this functionality can be tested with Domoticz.