### PR TITLE
platformio script to remove _printf_float and _scanf_float

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -1,0 +1,15 @@
+Import('env')
+
+#
+# Dump build environment (for debug)
+#print env.Dump()
+#
+
+flags = " ".join(env['LINKFLAGS'])
+flags = flags.replace("-u _printf_float", "")
+flags = flags.replace("-u _scanf_float", "")
+newflags = flags.split()
+
+env.Replace(
+  LINKFLAGS=newflags
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ src_dir = sonoff
 ;env_default = sonoff-ds18x20
 
 [env:sonoff]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -47,6 +48,7 @@ monitor_baud = 115200
 ;extra_scripts = pio/http-uploader.py
 
 [env:sonoff-DE]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -58,6 +60,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-ES]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -69,6 +72,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-FR]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -80,6 +84,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-IT]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -91,6 +96,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-NL]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -102,6 +108,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-PL]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -113,6 +120,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-CN]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -124,6 +132,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-minimal]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m
@@ -135,6 +144,7 @@ lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
 monitor_baud = 115200
 
 [env:sonoff-ds18x20]
+extra_scripts = extra_script.py
 platform = espressif8266
 framework = arduino
 board = esp01_1m


### PR DESCRIPTION
Platformio script to remove _printf_float and _scanf_float

Note: Linkoptions come from .platformio\platforms\espressif8266\builder\main.py:
```
LINKFLAGS=[
        "-Os",
        "-nostdlib",
        "-Wl,--no-check-sections",
        "-u", "call_user_start",
        "-u", "_printf_float",
        "-u", "_scanf_float",
        "-Wl,-static",
        "-Wl,--gc-sections"
    ]
```