### PR TITLE
Updated for B1 light: Use Option 21 to unlink power

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -46,7 +46,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t light_signal : 1;             // bit 18 (v5.10.0c)
     uint32_t hass_discovery : 1;           // bit 19 (v5.11.1a)
     uint32_t voltage_resolution : 1;       // Replaced by below
-    uint32_t spare21 : 1;
+    uint32_t not_power_linked : 1;         // Bit 21 : Don't link power to dimmer in light
     uint32_t spare22 : 1;
     uint32_t spare23 : 1;
     uint32_t spare24 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1027,6 +1027,7 @@ void MqttDataCallback(char* topic, byte* data, unsigned int data_len)
               case 16:  // ws_clock_reverse
               case 17:  // decimal_text
               case 18:  // light_signal
+              case 21:  // not_power_linked
                 bitWrite(Settings.flag.data, index, payload);
             }
             if (12 == index) {  // stop_flash_rotate

--- a/sonoff/xdrv_01_light.ino
+++ b/sonoff/xdrv_01_light.ino
@@ -568,7 +568,9 @@ void LightState(uint8_t append)
 void LightPreparePower()
 {
   if (Settings.light_dimmer && !(light_power)) {
-    ExecuteCommandPower(light_device, POWER_ON_NO_STATE);
+    if (!Settings.flag.not_power_linked) {
+      ExecuteCommandPower(light_device, POWER_ON_NO_STATE);
+    }
   }
   else if (!Settings.light_dimmer && light_power) {
     ExecuteCommandPower(light_device, POWER_OFF_NO_STATE);


### PR DESCRIPTION
Setting Option21 = 1 will stop the POWER being automatically turned on when a dimmer, colour or CT command is sent.

This is useful when using the wakeup light as you can set the desired target colour or CT without the lighting coming on before issuing the wakeup command.