### PR TITLE
Language error in Dutch (airquality) #1721

### DIFF
--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -47,7 +47,7 @@
 
 // Common
 #define D_ADMIN "Admin"
-#define D_AIR_QUALITY "Lucht kwalitiet"
+#define D_AIR_QUALITY "Lucht kwaliteit"
 #define D_AP "AP"                    // Access Point
 #define D_AS "als"
 #define D_AUTO "AUTO"


### PR DESCRIPTION
At the dutch webinterface of the Sonoff SC shows at airquality: Lucht kwalitiet instead of Lucht kwaliteit. (#1721)