### PR TITLE
Language Support for Title (ES, IT, FR)

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -98,7 +98,7 @@ const char HTTP_HEAD_STYLE[] PROGMEM =
 #ifdef BE_MINIMAL
   "<div style='text-align:center;color:red;'><h3>" D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "</h3></div>"
 #endif
-#ifdef LANGUAGE_MODULE_NAME
+#if MY_LANGUAGE == es-AR || MY_LANGUAGE == fr-FR || MY_LANGUAGE == it-IT
   "<div style='text-align:center;'><h3>" D_MODULE " {ha</h3><h2>{h}</h2></div>";
 #else
   "<div style='text-align:center;'><h3>{ha " D_MODULE "</h3><h2>{h}</h2></div>";


### PR DESCRIPTION
Added language support on the web page title for spanish, french and italian.

Tested Ok.

if you use spanish, french or italian the title will be displayed [MODULE] [NAME]
if you use others the title will be displayed [NAME] [MODULE]