### PR TITLE
Fixed size log buffer

### DIFF
--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -87,15 +87,17 @@ typedef unsigned long power_t;              // Power (Relay) type
 #define TOPSZ                  100          // Max number of characters in topic string
 #define LOGSZ                  400          // Max number of characters in log
 #define MIN_MESSZ              893          // Min number of characters in MQTT message
+
 #ifdef USE_MQTT_TLS
-  #define MAX_LOG_LINES        10           // Max number of lines in weblog
+  #define WEB_LOG_SIZE         2000         // Max number of lines in weblog
 #else
   #ifdef ARDUINO_ESP8266_RELEASE_2_3_0
-    #define MAX_LOG_LINES      20           // Max number of lines in weblog
+    #define WEB_LOG_SIZE       4000         // Max number of lines in weblog
   #else
-    #define MAX_LOG_LINES      13           // Max number of lines in weblog (less due to more memory usage)
+    #define WEB_LOG_SIZE       3000         // Max number of lines in weblog (less due to more memory usage)
   #endif
 #endif
+
 #define MAX_BACKLOG            16           // Max number of commands in backlog (chk backlog_index and backlog_pointer code)
 #define MIN_BACKLOG_DELAY      2            // Minimal backlog delay in 0.1 seconds
 

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -189,11 +189,11 @@ boolean mdns_begun = false;
 
 char my_version[33];                        // Composed version string
 char my_hostname[33];                       // Composed Wifi hostname
-char mqtt_client[33];                        // Composed MQTT Clientname
+char mqtt_client[33];                       // Composed MQTT Clientname
 char serial_in_buffer[INPUT_BUFFER_SIZE + 2]; // Receive buffer
 char mqtt_data[MESSZ];                      // MQTT publish buffer and web page ajax buffer
 char log_data[LOGSZ];                       // Logging
-String web_log[MAX_LOG_LINES];              // Web log buffer
+char web_log[WEB_LOG_SIZE] = {'\0'};        // Web log buffer
 String backlog[MAX_BACKLOG];                // Command backlog
 
 /********************************************************************************************/


### PR DESCRIPTION
Instead of array of dynamically sized strings, allocate fixed chunk of memory for web log.
Main purpose is to have less dynamic memory usage.
Instead of a fixed number of retained log messages, as many log messages as can fit in the chunk of memory are kept (so more messages if they are short, and fewer if they are long).

Also saves some memory, because the array of strings has an overhead of at least 20 byte / entry for the String objects.

The implementation is very simplistic and not very efficient, but there is not a lot of logging going on so should be OK.