### PR TITLE
handle preflight requests

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -347,6 +347,7 @@ void StartWebserver(int type, IPAddress ipweb)
       WebServer->on("/up", HandleUpgradeFirmware);
       WebServer->on("/u1", HandleUpgradeFirmwareStart);  // OTA
       WebServer->on("/u2", HTTP_POST, HandleUploadDone, HandleUploadLoop);
+      WebServer->on("/u2", HTTP_OPTIONS, HandlePreflightRequest);
       WebServer->on("/cm", HandleHttpCommand);
       WebServer->on("/cs", HandleConsole);
       WebServer->on("/ax", HandleAjaxConsoleRefresh);
@@ -1415,6 +1416,14 @@ void HandleUploadLoop()
     }
   }
   delay(0);
+}
+
+void HandlePreflightRequest()
+{
+  WebServer->sendHeader(F("Access-Control-Allow-Origin"), F("*"));
+  WebServer->sendHeader(F("Access-Control-Allow-Methods"), F("GET, POST"));
+  WebServer->sendHeader(F("Access-Control-Allow-Headers"), F("authorization"));
+  WebServer->send(200, FPSTR(HDR_CTYPE_HTML), "");
 }
 
 void HandleHttpCommand()


### PR DESCRIPTION
Currently, I'm writing a little web programme to make the batch updating from multiple tasmota devices easier. 

My preferred method to update the devices is to send the firmware directly to the device via a POST request. That is basically the same what the original built-in updater is doing. The problem is that a browser sends before the actual POST request a so-called preflight request (an OPTIONS request). The browser asks the web server whether the request is allowed or not. Currently, the preflight requests are not handled by tasmota and therefore the response is an error 404. 

This pull request implements the correct handling of preflight requests for the firmware update page. 