### PR TITLE
Add OTA "push" method

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -65,14 +65,11 @@
 #endif  // USE_SPI
 
 
-
 #ifdef USE_ARDUINO_OTA
 #include <ArduinoOTA.h>
 #include <ESP8266mDNS.h>
 bool ArduinoOTAtriggered=false;
 #endif
-
-
 
 // Structs
 #include "settings.h"
@@ -2817,6 +2814,7 @@ void setup()
   RtcInit();
   XsnsCall(FUNC_INIT);
 
+
 #ifdef USE_ARDUINO_OTA
     ArduinoOTAInit();
 #endif
@@ -2865,12 +2863,10 @@ void loop()
 
 
 
-
-
 #ifdef USE_ARDUINO_OTA
 /********************************************************************************************\
   Allow updating via the Arduino OTA-protocol. (this allows you to upload directly from platformio)
-  \*********************************************************************************************/
+\*********************************************************************************************/
 
 void ArduinoOTAInit(){
 
@@ -2884,33 +2880,32 @@ void ArduinoOTAInit(){
 	ArduinoOTA.onStart([]() {
 		Serial.println("OTA: Start");
 		ArduinoOTAtriggered=true;
-		//SPIFFS.end(); //important, otherwise it fails
 	});
 
 	ArduinoOTA.onEnd([]() {
-		Serial.println("\nOTA: End");
-		Serial.println("OTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE.");
+		//Serial.println("\nOTA: End");
+		//Serial.println("OTA  : DO NOT RESET OR POWER OFF UNTIL BOOT+FLASH IS COMPLETE.");
 		delay(100);
 		ESP.reset();
 	});
 	ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
-		Serial.printf("OTA: Progress %u%%\r", (progress / (total / 100)));
+		//Serial.printf("OTA: Progress %u%%\r", (progress / (total / 100)));
 	});
 
 	ArduinoOTA.onError([](ota_error_t error) {
+		/*
 		Serial.print(F("\nOTA	 : Error (will reboot): "));
-		if (error == OTA_AUTH_ERROR) Serial.println(F("Auth Failed"));
-		else if (error == OTA_BEGIN_ERROR) Serial.println(F("Begin Failed"));
-		else if (error == OTA_CONNECT_ERROR) Serial.println(F("Connect Failed"));
-		else if (error == OTA_RECEIVE_ERROR) Serial.println(F("Receive Failed"));
-		else if (error == OTA_END_ERROR) Serial.println(F("End Failed"));
-
+		if (error == OTA_AUTH_ERROR) 		{Serial.println(F("Auth Failed"));}
+		else if (error == OTA_BEGIN_ERROR)	{Serial.println(F("Begin Failed"));}
+		else if (error == OTA_CONNECT_ERROR){Serial.println(F("Connect Failed"));}
+		else if (error == OTA_RECEIVE_ERROR){Serial.println(F("Receive Failed"));}
+		else if (error == OTA_END_ERROR)	{Serial.println(F("End Failed"));}
+		*/
 		delay(100);
 		ESP.reset();
 	});
 
 	ArduinoOTA.begin();
-
 	snprintf_P(log_data, sizeof(log_data), PSTR("OTA: Arduino OTA enabled on port 8266"));
 	AddLog(LOG_LEVEL_INFO);
 }

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -68,7 +68,8 @@
 #define WEB_LOG_LEVEL          LOG_LEVEL_INFO    // [WebLog]
 
 // -- Ota -----------------------------------------
-#define OTA_URL                "http://sonoff.maddox.co.uk/tasmota/sonoff.ino.bin"  // [OtaUrl]
+#define OTA_URL                "http://sonoff.maddox.co.uk/tasmota/sonoff.ino.bin"  // [OtaUrl] for OTA "pull" requests
+//#define USE_ARDUINO_OTA															//uncomment to listen to OTA "push" requests
 
 // -- MQTT ----------------------------------------
 #define MQTT_USE               1                 // [SetOption3] Select default MQTT use (0 = Off, 1 = On)


### PR DESCRIPTION
This PR implements the ability to receive OTA updates. This allows the "Two Steps Update" method as successfully implemented by ESPEasy or Espurna ([learn more](https://github.com/xoseperez/espurna/wiki/TwoStepUpdates)). 

When using this method : 
- (1) one can first upload a very small special Uploader Firmare that retains the wifi/network settings (I've successfully compiled one [there](https://github.com/soif/EspBuddy/blob/master/firmwares/TasmotaUploader.OTA-0x20161209.bin), with sources [here](https://github.com/soif/EspBuddy/tree/master/sketches/TasmotaUploader.OTA))
- (2) then Upload a bigger firmware  (up to near 700k). :-)

These 2 steps can be performed from the web interface (very simple for most users) OR directly in platformio or espota.py that are able to make direct OTA updates. 

I've even build a nice [EspBuddy](https://github.com/soif/EspBuddy) wrapper script that make use of this to allow (among many others features) to  update OTA one (or more in batch) ESP firmware in a single simple command.... 👍 

BTW As I've added this as a _#ifdef USE_ARDUINO_OTA_, it should not add a single octet of memory is not activated, but when used it paves the way to be able to *easely* release larger firmwares ...

HTH