### PR TITLE
MQTT TSL fingerprint ignored

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -558,7 +558,9 @@ void MqttReconnect()
     if (EspClient.verify(Settings.mqtt_fingerprint, Settings.mqtt_host)) {
       AddLog_P(LOG_LEVEL_INFO, S_LOG_MQTT, PSTR(D_VERIFIED));
     } else {
-      AddLog_P(LOG_LEVEL_DEBUG, S_LOG_MQTT, PSTR(D_INSECURE));
+      AddLog_P(LOG_LEVEL_INFO, S_LOG_MQTT, PSTR(D_INSECURE));
+      EspClient.stop();
+      return;
     }
     EspClient.stop();
     yield();


### PR DESCRIPTION
Just figured out that Tasmota ignores MQTT TLS fingerprint and continues connection: 

```
00:00:03 MQT: Verify TLS fingerprint...
00:00:04 MQT: Insecure connection due to invalid Fingerprint
00:00:06 MQT: Attempting connection...
00:00:06 MQT: Connected
```

To add insult to injury, message about invalid fingerprint is not at `INFO` loglevel, but only at `DEBUG` which is not on by default, so it's easily missed. 

I added a message to `INFO` and broke the connection loop to retry. Not sure if this is the best way to handle it so please propose better one.
