### PR TITLE
Module Title in a Multi-language way for web pages

### DIFF
--- a/sonoff/webserver.ino
+++ b/sonoff/webserver.ino
@@ -98,11 +98,7 @@ const char HTTP_HEAD_STYLE[] PROGMEM =
 #ifdef BE_MINIMAL
   "<div style='text-align:center;color:red;'><h3>" D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "</h3></div>"
 #endif
-#ifdef LANGUAGE_MODULE_NAME
-  "<div style='text-align:center;'><h3>" D_MODULE " {ha</h3><h2>{h}</h2></div>";
-#else
-  "<div style='text-align:center;'><h3>{ha " D_MODULE "</h3><h2>{h}</h2></div>";
-#endif
+  "<div style='text-align:center;'><h3>" D_MODULE ": {ha</h3><h2>{h}</h2></div>";
 const char HTTP_SCRIPT_CONSOL[] PROGMEM =
   "var sn=0;"                    // Scroll position
   "var id=0;"                    // Get most of weblog initially


### PR DESCRIPTION
With this PR, it is proposed to change the way that the title of the module is expressed on the web pages.

At this moment is: 

  **[module type] module**

So, as example, for Generic was **Generic Module** but in Spanish (_Generic Módulo_), Italian (_Generic Modulo_) and French (_Generic Module_), the words are in wrong order.

So, the idea is to be:

   **Module: [module type]**

So, for example, Generic module title should be: **Module: Generic**