### PR TITLE
MQTT - Serial bridge

### DIFF
--- a/lib/TasmotaSerial-1.1.0/src/TasmotaSerial.h
+++ b/lib/TasmotaSerial-1.1.0/src/TasmotaSerial.h
@@ -20,12 +20,12 @@
 #ifndef TasmotaSerial_h
 #define TasmotaSerial_h
 /*********************************************************************************************\
- * TasmotaSerial supports up to 9600 baud with fixed buffer size of 64 bytes using optional no iram
+ * TasmotaSerial supports up to 115200 baud with fixed buffer size of 64 bytes using optional no iram
  *
  * Based on EspSoftwareSerial v3.3.1 by Peter Lerup (https://github.com/plerup/espsoftwareserial)
 \*********************************************************************************************/
 
-#define TM_SERIAL_BAUDRATE           9600   // Max supported baudrate
+#define TM_SERIAL_BAUDRATE           115200 // Max supported baudrate
 #define TM_SERIAL_BUFFER_SIZE        64     // Receive buffer size
 
 #include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_3_0)
@@ -60,6 +60,7 @@ class TasmotaSerial : public Stream {
     int m_rx_pin;
     int m_tx_pin;
     unsigned long m_bit_time;
+    bool m_high_speed;
     unsigned int m_in_pos;
     unsigned int m_out_pos;
     uint8_t *m_buffer;

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -341,7 +341,7 @@
 #define D_CMND_DISP_TEXT "Text"
 
 // Commands xdrv_08_serial_bridge.ino
-#define D_CMND_SET_SBR_BAUDRATE "SBrBaudDivFour"
+#define D_CMND_SET_SBR_BAUDRATE "SBrBaud"
 
 /********************************************************************************************/
 

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -342,6 +342,7 @@
 
 // Commands xdrv_08_serial_bridge.ino
 #define D_CMND_SET_SBR_BAUDRATE "SBrBaud"
+#define D_CMND_SET_SBR_DELIMITER "SBrDelim"
 
 /********************************************************************************************/
 

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -341,7 +341,7 @@
 #define D_CMND_DISP_TEXT "Text"
 
 // Commands xdrv_08_serial_bridge.ino
-#define D_CMND_SET_SBR_BAUDRATE "SBrBaud"
+#define D_CMND_SET_SBR_BAUDRATE "SBrBaudDivFour"
 
 /********************************************************************************************/
 

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -340,6 +340,9 @@
 #define D_CMND_DISP_SIZE "Size"
 #define D_CMND_DISP_TEXT "Text"
 
+// Commands xdrv_08_serial_bridge.ino
+#define D_CMND_SET_SBR_BAUDRATE "SBrBaud"
+
 /********************************************************************************************/
 
 #ifndef MY_LANGUAGE

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/es-AR.h
+++ b/sonoff/language/es-AR.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "Háttérvil"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "Luz negra"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -412,6 +412,8 @@
 #define D_SENSOR_BACKLIGHT "BkLight"
 #define D_SENSOR_PMS5003  "PMS5003"
 #define D_SENSOR_SDS0X1   "SDS0X1"
+#define D_SENSOR_SBR_RX   "SerBr Rx"
+#define D_SENSOR_SBR_TX   "SerBr Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -227,8 +227,7 @@ struct SYSCFG {
   uint16_t      pulse_timer[MAX_PULSETIMERS]; // 532
 
   uint8_t       serial_br_baudrate_div1200; // 542
-
-  byte          free_543[1];               // 543
+  char          serial_br_delimiter;       // 543
 
   uint32_t      ip_address[4];             // 544
   unsigned long energy_kWhtotal;              // 554

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -226,7 +226,9 @@ struct SYSCFG {
   byte          ina219_mode;               // 531
   uint16_t      pulse_timer[MAX_PULSETIMERS]; // 532
 
-  uint16_t      serial_br_baudrate_div4;   // 542
+  uint8_t       serial_br_baudrate_div1200; // 542
+
+  byte          free_543[1];               // 543
 
   uint32_t      ip_address[4];             // 544
   unsigned long energy_kWhtotal;              // 554

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -226,7 +226,7 @@ struct SYSCFG {
   byte          ina219_mode;               // 531
   uint16_t      pulse_timer[MAX_PULSETIMERS]; // 532
 
-  byte          free_542[2];               // 542
+  uint16_t      serial_br_baudrate_div4;   // 542
 
   uint32_t      ip_address[4];             // 544
   unsigned long energy_kWhtotal;              // 554

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -549,6 +549,7 @@ void SettingsDefaultSet2()
   Settings.pulse_timer[0] = APP_PULSETIME;
 
   Settings.serial_br_baudrate_div1200 = 32;
+  Settings.serial_br_delimiter = 0xff;
 
   // 4.0.7
 //  for (byte i = 0; i < MAX_PWMS; i++) Settings.pwm_value[i] = 0;
@@ -908,6 +909,7 @@ void SettingsDelta()
 
     if (Settings.version < 0x050C0008) {
       Settings.serial_br_baudrate_div1200 = 32;
+      Settings.serial_br_delimiter = 0xff;
     }
 
     Settings.version = VERSION;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -548,6 +548,8 @@ void SettingsDefaultSet2()
   SettingsDefaultSet_4_0_4();
   Settings.pulse_timer[0] = APP_PULSETIME;
 
+  Settings.serial_br_baudrate_div4 = 9600;
+
   // 4.0.7
 //  for (byte i = 0; i < MAX_PWMS; i++) Settings.pwm_value[i] = 0;
 
@@ -902,6 +904,10 @@ void SettingsDelta()
     }
     if (Settings.version < 0x050C0007) {
       Settings.baudrate = APP_BAUDRATE / 1200;
+    }
+
+    if (Settings.version < 0x050C0008) {
+      Settings.serial_br_baudrate_div4 = 9600;
     }
 
     Settings.version = VERSION;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -548,7 +548,7 @@ void SettingsDefaultSet2()
   SettingsDefaultSet_4_0_4();
   Settings.pulse_timer[0] = APP_PULSETIME;
 
-  Settings.serial_br_baudrate_div4 = 9600;
+  Settings.serial_br_baudrate_div1200 = 32;
 
   // 4.0.7
 //  for (byte i = 0; i < MAX_PWMS; i++) Settings.pwm_value[i] = 0;
@@ -907,7 +907,7 @@ void SettingsDelta()
     }
 
     if (Settings.version < 0x050C0008) {
-      Settings.serial_br_baudrate_div4 = 9600;
+      Settings.serial_br_baudrate_div1200 = 32;
     }
 
     Settings.version = VERSION;

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -89,6 +89,8 @@ enum UserSelectablePins {
   GPIO_BACKLIGHT,      // Display backlight control
   GPIO_PMS5003,        // Plantower PMS5003 Serial interface
   GPIO_SDS0X1,         // Nova Fitness SDS011 Serial interface
+  GPIO_SBR_TX,         // Serial Bridge Serial interface
+  GPIO_SBR_RX,         // Serial Bridge Serial interface
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality offset by user selectable GPIOs
@@ -130,7 +132,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_PZEM_TX "|" D_SENSOR_PZEM_RX "|"
   D_SENSOR_SAIR_TX "|" D_SENSOR_SAIR_RX "|"
   D_SENSOR_SPI_CS "|" D_SENSOR_SPI_DC "|" D_SENSOR_BACKLIGHT "|"
-  D_SENSOR_PMS5003 "|" D_SENSOR_SDS0X1;
+  D_SENSOR_PMS5003 "|" D_SENSOR_SDS0X1 "|"
+  D_SENSOR_SBR_RX "|" D_SENSOR_SBR_TX;
 
 /********************************************************************************************/
 

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -220,7 +220,7 @@
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
-#define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k4 code, +0k1 mem)
+#define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k5 code, +0k1 mem)
 
 // -- Low level interface devices -----------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -220,7 +220,8 @@
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
-#define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k5 code, +0k1 mem)
+#define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k6 code)
+  #define USE_SERIAL_BRIDGE_DELIMITER            // Add delimiter support for Serial port MQTT bridge (+0k1 mem)
 
 // -- Low level interface devices -----------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -220,6 +220,7 @@
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
+#define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k4 code, +0k1 mem)
 
 // -- Low level interface devices -----------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -222,6 +222,7 @@
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
 #define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k6 code)
   #define USE_SERIAL_BRIDGE_DELIMITER            // Add delimiter support for Serial port MQTT bridge (+0k1 code, +0k1 mem)
+  #define USE_SERIAL_BRIDGE_ESCAPE_WS            // Add support to send whitespace characters by escaping them (+0k2 code)
 
 // -- Low level interface devices -----------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -221,7 +221,7 @@
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
 #define USE_SERIAL_BRIDGE                        // Add support for Serial port MQTT bridge (+0k6 code)
-  #define USE_SERIAL_BRIDGE_DELIMITER            // Add delimiter support for Serial port MQTT bridge (+0k1 mem)
+  #define USE_SERIAL_BRIDGE_DELIMITER            // Add delimiter support for Serial port MQTT bridge (+0k1 code, +0k1 mem)
 
 // -- Low level interface devices -----------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -118,8 +118,8 @@ boolean SerialBridgeCommand()
     return true;
   }
   else if (CMND_SET_SBR_DELIMITER == command_code) {
-    if (XdrvMailbox.data_len > 0) {
-      Settings.serial_br_delimiter = XdrvMailbox.data[0];
+    if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 255)) {
+      Settings.serial_br_delimiter = XdrvMailbox.payload;
     }
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_NVALUE, command, Settings.serial_br_delimiter);
     return true;

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -34,7 +34,7 @@ void SerialBridgeInit(void)
   if ((pin[GPIO_SBR_RX] < 99) && (pin[GPIO_SBR_TX] < 99)) {
     GetTopic_P(SerialBridgeTopic, CMND, Settings.mqtt_topic, PSTR("serialbr"));
     SerialBridgeSerial = new TasmotaSerial(pin[GPIO_SBR_RX], pin[GPIO_SBR_TX]);
-    SerialBridgeSerial->begin(4 * Settings.serial_br_baudrate_div4); // Baud rate is stored div 4 so it fits into 2 bytes
+    SerialBridgeSerial->begin(1200 * Settings.serial_br_baudrate_div1200); // Baud rate is stored div 1200 so it fits into one byte
     SerialBridgeSerial->flush();
   }
 }
@@ -74,10 +74,12 @@ boolean SerialBridgeCommand()
   int command_code = GetCommandCode(command, sizeof(command), XdrvMailbox.topic, kSerialBridgeCommands);
 
   if (CMND_SET_SBR_BAUDRATE == command_code) {
-    if ((XdrvMailbox.payload >= 300) && (XdrvMailbox.payload <= 28800)) {
-      Settings.serial_br_baudrate_div4 = XdrvMailbox.payload;
+    char *p;
+    uint32_t baud = strtol(XdrvMailbox.data, &p, 10);
+    if ((baud >= 1200) && (baud <= 115200)) {
+      Settings.serial_br_baudrate_div1200 = baud / 1200;
     }
-    snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_NVALUE, command, Settings.serial_br_baudrate_div4);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_LVALUE, command, 1200 * Settings.serial_br_baudrate_div1200);
     return true;
   }
 

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -76,8 +76,8 @@ boolean SerialBridgeCommand()
   if (CMND_SET_SBR_BAUDRATE == command_code) {
     if ((XdrvMailbox.payload >= 300) && (XdrvMailbox.payload <= 28800)) {
       Settings.serial_br_baudrate_div4 = XdrvMailbox.payload;
-      snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_NVALUE, command, Settings.serial_br_baudrate_div4);
     }
+    snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_NVALUE, command, Settings.serial_br_baudrate_div4);
     return true;
   }
 

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -46,7 +46,7 @@ void SerialBridge50ms()
     uint8_t sbuf[len+1];
     SerialBridgeSerial->readBytes(sbuf, len);
     sbuf[len] = '\0';
-    snprintf_P(mqtt_data, sizeof(mqtt_data), "%s", sbuf);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s"), sbuf);
     MqttPublishPrefixTopic_P(STAT, PSTR("serialbr"), false);
   }
 }
@@ -78,6 +78,7 @@ boolean SerialBridgeCommand()
     uint32_t baud = strtol(XdrvMailbox.data, &p, 10);
     if ((baud >= 1200) && (baud <= 115200)) {
       Settings.serial_br_baudrate_div1200 = baud / 1200;
+      SerialBridgeSerial->begin(1200 * Settings.serial_br_baudrate_div1200); // Reinitialize serial port with new baud rate
     }
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_LVALUE, command, 1200 * Settings.serial_br_baudrate_div1200);
     return true;

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -1,0 +1,94 @@
+/*
+  xdrv_08_serial_bridge.ino - serial bridge support for Sonoff-Tasmota
+
+  Copyright (C) 2018  Dániel Zoltán Tolnai
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_SERIAL_BRIDGE
+/*********************************************************************************************\
+ * Serial-MQTT Bridge
+\*********************************************************************************************/
+#include <TasmotaSerial.h>
+
+TasmotaSerial *SerialBridgeSerial;
+char SerialBridgeTopic[TOPSZ];
+
+void SerialBridgeInit(void)
+{
+  if ((pin[GPIO_SBR_RX] < 99) && (pin[GPIO_SBR_TX] < 99)) {
+    GetTopic_P(SerialBridgeTopic, CMND, Settings.mqtt_topic, PSTR("serialbr"));
+    SerialBridgeSerial = new TasmotaSerial(pin[GPIO_SBR_RX], pin[GPIO_SBR_TX]);
+    SerialBridgeSerial->begin();
+    SerialBridgeSerial->flush();
+  }
+}
+
+void SerialBridge50ms()
+{
+  if (SerialBridgeSerial->available()) {
+    size_t len = SerialBridgeSerial->available();
+    uint8_t sbuf[len+1];
+    SerialBridgeSerial->readBytes(sbuf, len);
+    sbuf[len] = '\0';
+    snprintf_P(mqtt_data, sizeof(mqtt_data), "%s", sbuf);
+    MqttPublishPrefixTopic_P(STAT, PSTR("serialbr"), false);
+  }
+}
+
+boolean SerialBridgeMqttData()
+{
+  // Do not process irrelevant topics
+  if (strncmp(XdrvMailbox.topic, SerialBridgeTopic, strlen(SerialBridgeTopic))) {
+    return false;
+  }
+
+  // Do not process empty commands
+  if (XdrvMailbox.data_len == 0) {
+    return false;
+  }
+
+  // Send data to serial
+  SerialBridgeSerial->write(XdrvMailbox.data, XdrvMailbox.data_len - 1);
+  return true;
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+#define XDRV_08
+
+boolean Xdrv08(byte function)
+{
+  boolean result = false;
+
+  if ((pin[GPIO_SBR_RX] < 99) && (pin[GPIO_SBR_TX] < 99)) {
+    switch (function) {
+      case FUNC_INIT:
+        SerialBridgeInit();
+        break;
+      case FUNC_EVERY_50_MSECOND:
+        SerialBridge50ms();
+        break;
+      case FUNC_MQTT_DATA:
+        result = SerialBridgeMqttData();
+        break;
+    }
+  }
+  return result;
+}
+
+#endif // USE_SERIAL_BRIDGE


### PR DESCRIPTION
Software serial - MQTT bridge implemented as an xdrv. Useful when interfacing with devices having only a serial port for communication like for example projectors and older AV receivers.

Quick info and usage:
 - Configure pins "SerBr Rx" and "SerBr Tx"
 - Set the baud rate through cmnd/sonoff/SBrBaud (Can be anything from 1200 to 115200)
 - Send data through cmnd/sonoff/serialbr
 - Received data is published to stat/sonoff/SERIALBR
 - Delimiter functionality can be enabled by sending the ASCII code of the delimiter to cmnd/sonoff/SBrDelim
 - Delimiter functionality can be disabled by sending 0xff to cmnd/sonoff/SBrDelim
 - Added support for whitespace characters. It is possible to transmit for example a newline character by putting its escaped version ("\n") in the MQTT message