### PR TITLE
Added support for Zengee WF017 LED Strip controller

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2115,6 +2115,9 @@ void GpioInit()
   else if (SONOFF_B1 == Settings.module) {   // RGBWC led
     light_type = LT_RGBWC;
   }
+  else if (ZENGGE_ZF_WF017 == Settings.module) {   // RGB led
+    light_type = LT_PWM3;
+  }
   else {
     if (!light_type) devices_present = 0;
     for (byte i = 0; i < MAX_RELAYS; i++) {

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -177,6 +177,7 @@ enum SupportedModules {
   SONOFF_DUAL_R2,
   ARILUX_LC06,
   SONOFF_S31,
+  ZENGGE_ZF_WF017,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -235,7 +236,8 @@ const uint8_t kNiceList[MAXMODULE] PROGMEM = {
   KMC_70011,
   AILIGHT,
   WEMOS,
-  WITTY
+  WITTY,
+  ZENGGE_ZF_WF017
 };
 
 // Default module settings
@@ -786,7 +788,21 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL1,        // GPIO12 Red Led and Relay (0 = Off, 1 = On)
      GPIO_LED1_INV,    // GPIO13 Green Led (0 = On, 1 = Off)
      0, 0, 0, 0
-  }
+  },
+  {  "Zengge WF017",     // Zenggee ZJ-WF017-A (ESP12S)) - https://www.ebay.com/p/Smartphone-Android-IOS-WiFi-Music-Controller-for-RGB-5050-3528-LED-Strip-Light/534446632?_trksid=p2047675.l2644
+     GPIO_KEY1,        // GPIO00 Optional Button
+     0,
+     GPIO_USER,        // GPIO02 Empty pad
+     0,
+     GPIO_USER,        // GPIO04 W2 - PWM5
+     0,
+     0, 0, 0, 0, 0, 0, // Flash connection
+     GPIO_PWM2,        // GPIO12 RGB LED Green
+     GPIO_PWM1,        // GPIO13 RGB LED Red
+     GPIO_PWM3,        // GPIO14 RGB LED Blue
+     0,
+     0, 0
+    }
 };
 
 /*


### PR DESCRIPTION
Added Support for Zenggee ZJ-WF017-A (ESP12S))

https://www.ebay.com/p/Smartphone-Android-IOS-WiFi-Music-Controller-for-RGB-5050-3528-LED-Strip-Light/534446632?_trksid=p2047675.l2644

This pull request adds patch to force it to be recognised as RGB light by default.