### PR TITLE
Added additional features for improving light handling (Status/Channels/Hue-Sat-Brightness)

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -64,6 +64,7 @@
 #define D_JSON_HEAPSIZE "Heap"
 #define D_JSON_HIGH "High"
 #define D_JSON_HUMIDITY "Humidity"
+#define D_JSON_HSBCOLOR "HSBColor"
 #define D_JSON_I2CSCAN_DEVICES_FOUND_AT "Device(s) found at"
 #define D_JSON_I2CSCAN_UNKNOWN_ERROR_AT "Unknown error at"
 #define D_JSON_I2CSCAN_NO_DEVICES_FOUND "No devices found"
@@ -259,6 +260,8 @@
 #define D_CMND_WAKEUP "Wakeup"
 #define D_CMND_WAKEUPDURATION "WakeUpDuration"
 #define D_CMND_WIDTH "Width"
+#define D_CMND_CHANNEL "Channel"
+#define D_CMND_COLOR_HSB "HSBColor"
 
 // Commands xdrv_02_irremote.ino
 #define D_CMND_IRSEND "IRSend"

--- a/sonoff/xdrv_01_light.ino
+++ b/sonoff/xdrv_01_light.ino
@@ -55,10 +55,13 @@
 
 enum LightCommands {
   CMND_COLOR, CMND_COLORTEMPERATURE, CMND_DIMMER, CMND_LED, CMND_LEDTABLE, CMND_FADE,
-  CMND_PIXELS, CMND_ROTATION, CMND_SCHEME, CMND_SPEED, CMND_WAKEUP, CMND_WAKEUPDURATION, CMND_WIDTH, CMND_UNDOCA };
+  CMND_PIXELS, CMND_ROTATION, CMND_SCHEME, CMND_SPEED, CMND_WAKEUP, CMND_WAKEUPDURATION, CMND_WIDTH, CMND_UNDOCA,
+  CMND_CHANNEL, CMND_COLOR_HSB
+};
 const char kLightCommands[] PROGMEM =
   D_CMND_COLOR "|" D_CMND_COLORTEMPERATURE "|" D_CMND_DIMMER "|" D_CMND_LED "|" D_CMND_LEDTABLE "|" D_CMND_FADE "|"
-  D_CMND_PIXELS "|" D_CMND_ROTATION "|" D_CMND_SCHEME "|" D_CMND_SPEED "|" D_CMND_WAKEUP "|" D_CMND_WAKEUPDURATION "|" D_CMND_WIDTH "|UNDOCA" ;
+  D_CMND_PIXELS "|" D_CMND_ROTATION "|" D_CMND_SCHEME "|" D_CMND_SPEED "|" D_CMND_WAKEUP "|" D_CMND_WAKEUPDURATION "|" D_CMND_WIDTH "|UNDOCA" "|"
+  D_CMND_CHANNEL "|" D_CMND_COLOR_HSB;
 
 struct LRgbColor {
   uint8_t R, G, B;
@@ -1053,6 +1056,59 @@ boolean LightCommand()
       snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_INDEX_SVALUE, command, XdrvMailbox.index, scolor);
     }
   }
+  else if ((CMND_CHANNEL == command_code) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= light_subtype ) ) {
+    //  Implement "Channel" command to allow for direct setting of each color channel
+    if (XdrvMailbox.data_len > 0) {
+      uint8_t level = atoi(XdrvMailbox.data);
+      if ( level > 100 ) {
+        level = 100;
+      }
+      light_current_color[XdrvMailbox.index-1] = round (level * 2.55);
+      LightSetColor();
+      coldim=true;
+    }
+    scolor[0] = '\0';
+    snprintf_P(scolor, 25, PSTR("%s%d"), scolor, round (light_current_color[XdrvMailbox.index -1 ] / 2.55));
+    snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_INDEX_SVALUE, command, XdrvMailbox.index, scolor);
+
+  }
+  else if ((CMND_CHANNEL == command_code) && light_subtype >= LST_RGB) {
+    //  Implement method to "direct set" color by HSB (HSB is passed comma separated, 0<H<360 0<S<100 0<B<100 )
+    if ( (XdrvMailbox.index == 1) ) {
+       uint16_t HSB[3];
+       bool validHSB = true;
+
+       for (int i=0; i<3; i++) {
+          char *substr;
+
+          if ( i == 0 ) {
+            substr = strtok (XdrvMailbox.data, ",");
+          } else {
+            substr = strtok (NULL, ",");
+          }
+          if ( substr != NULL) {
+             HSB[i] = atoi(substr);
+          } else {
+            validHSB = false;
+          }
+       }
+
+       if (validHSB) {
+         //  Translate to fractional elements as required by LightHsbToRgb
+         //  Keep the results <=1 in the event someone passes something
+         //  out of range.
+         light_hue        = ( (HSB[0]>360) ? (HSB[0] % 360) : HSB[0] ) /360.0;
+         light_saturation = ( (HSB[1]>100) ? (HSB[1] % 100) : HSB[1] ) /100.0;
+         light_brightness = ( (HSB[2]>100) ? (HSB[2] % 100) : HSB[2] ) /100.0;
+
+         LightHsbToRgb();
+         LightSetColor();
+         coldim = true;
+       }
+    }
+
+}
+
 #ifdef USE_WS2812  //  ***********************************************************************
   else if ((CMND_LED == command_code) && (LT_WS2812 == light_type) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= Settings.light_pixels)) {
     if (XdrvMailbox.data_len > 0) {


### PR DESCRIPTION
* Added a series of improvements for light handling.

   *  new command 'HSBColor' with parameters H,S,B where:
         *  H = Hue:         0 < H < 360
         *  S = Saturation:  0 < S < 100
         *  B = Brightness:  0 < B < 100

   *  Altered status report for xdrv_01_light.ino to include info
      relating to HSBColor in the format H,S,B.

   *  When SetOption15 = 0 and direct PWM driving is configured
      the status now returns PWM state for each PWM channel.

   *  Added feature to Light object that allows a CHANNEL command
      this command allows direct setting of each color/light
      channel.   Syntax is CHANNEL[X]  [Y]   where X is the color
      channel (Red is 1, Green is 2, Blue is 3 etc) and Y is the
      amplitude to set the channel to (0-100).



