### PR TITLE
Enable user mode for GPIO2 and GPIO5 on the Sonoff Dual

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -308,10 +308,10 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
   { "Sonoff Dual",     // Sonoff Dual (ESP8266)
      0,
      GPIO_TXD,         // GPIO01 Relay control
-     0,
+     GPIO_USER,        // GPIO02 Optional sensor
      GPIO_RXD,         // GPIO03 Relay control
      GPIO_USER,        // GPIO04 Optional sensor
-     0,
+     GPIO_USER,        // GPIO05 Optional sensor
      0, 0, 0, 0, 0, 0, // Flash connection
      0,
      GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -313,10 +313,12 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_USER,        // GPIO04 Optional sensor
      GPIO_USER,        // GPIO05 Optional sensor
      0, 0, 0, 0, 0, 0, // Flash connection
-     0,
+     GPIO_USER,        // GPIO12 Optional sensor
      GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)
      GPIO_USER,        // GPIO14 Optional sensor
-     0, 0, 0
+     GPIO_USER,        // GPIO15 Optional sensor
+     GPIO_USER,        // GPIO16 Optional sensor
+     0
   },
   { "Sonoff Pow",      // Sonoff Pow (ESP8266)
      GPIO_KEY1,        // GPIO00 Button


### PR DESCRIPTION
GPIO 2 and 5 on the Sonoff Dual are unused, so the pads can be routed out and used for senor connection.