### PR TITLE
Sunrise offset

### DIFF
--- a/sonoff/xdrv_09_timers.ino
+++ b/sonoff/xdrv_09_timers.ino
@@ -464,7 +464,7 @@ const char HTTP_TIMER_SCRIPT[] PROGMEM =
     "if((m==1)||(m==2)){"                                         // Sunrise or sunset is set
       "p=pt[ct]&0x7FF;"                                           // Load stored time for offset calculation
       "q=Math.floor(p/60);"                                       // Parse hours
-      "if(q>12){q-=12;qs('#odr').selectedIndex=1;}"               // Negative offset
+      "if(q>=12){q-=12;qs('#odr').selectedIndex=1;}"               // Negative offset
         "else{qs('#odr').selectedIndex=0;}"
       "if(q<10){q='0'+q;}qs('#oho').value=q;"                     // Set offset hours
       "q=p%60;if(q<10){q='0'+q;}qs('#omi').value=q;"              // Set offset minutes

--- a/sonoff/xdrv_09_timers.ino
+++ b/sonoff/xdrv_09_timers.ino
@@ -464,7 +464,7 @@ const char HTTP_TIMER_SCRIPT[] PROGMEM =
     "if((m==1)||(m==2)){"                                         // Sunrise or sunset is set
       "p=pt[ct]&0x7FF;"                                           // Load stored time for offset calculation
       "q=Math.floor(p/60);"                                       // Parse hours
-      "if(q>12){q-=12;qs('#odr').selectedIndex=1;}"               // Negative offset
+      "if(q>=12){q-=12;qs('#odr').selectedIndex=1;}"              // Negative offset
         "else{qs('#odr').selectedIndex=0;}"
       "if(q<10){q='0'+q;}qs('#oho').value=q;"                     // Set offset hours
       "q=p%60;if(q<10){q='0'+q;}qs('#omi').value=q;"              // Set offset minutes

--- a/sonoff/xdrv_09_timers.ino
+++ b/sonoff/xdrv_09_timers.ino
@@ -611,16 +611,6 @@ void HandleTimerConfiguration()
   page += FPSTR(HTTP_FORM_TIMER);
   for (byte i = 0; i < MAX_TIMERS; i++) {
     if (i > 0) page += F(",");
-//REMOVE:
-// #ifdef USE_SUNRISE
-//     Timer xtimer=Settings.timer[i];
-//     if (xtimer.mode>0) {
-//       ApplyTimerOffsets(Settings.timer[i], &xtimer);
-//     }
-//     page += String(xtimer.data);
-// #else
-//     page += String(Settings.timer[i].data);
-// #endif
     page += String(Settings.timer[i].data);
   }
 #ifdef USE_SUNRISE
@@ -650,26 +640,7 @@ void TimerSaveSettings()
   for (byte i = 0; i < MAX_TIMERS; i++) {
     timer.data = strtol(p, &p, 10);
     p++;  // Skip comma
-    if (timer.time < 1440) {
-//REMOVE:
-// #ifdef USE_SUNRISE
-//       if (timer.mode>0) {
-//         // calculate offset timer for comparison
-//         Timer offsetTimer = Settings.timer[i];
-//         ApplyTimerOffsets(Settings.timer[i], &offsetTimer);
-//         if (timer.time!=offsetTimer.time) {
-//             Settings.timer[i].time=timer.time;     // save time for offset
-//         }
-//         Settings.timer[i].mode=timer.mode;
-//         if (timer.days!=offsetTimer.days) {
-//             Settings.timer[i].days=timer.days;     // days changed, save
-//         }
-//         Settings.timer[i].device=timer.device;
-//         Settings.timer[i].power=timer.power;
-//         Settings.timer[i].repeat=timer.repeat;
-//         Settings.timer[i].arm=timer.arm;
-//       }
-// #endif      
+    if (timer.time < 1440) {    
       Settings.timer[i].data = timer.data;
     }  
     snprintf_P(log_data, sizeof(log_data), PSTR("%s%s0x%08X"), log_data, (i > 0)?",":"", Settings.timer[i].data);


### PR DESCRIPTION
After learning about @gemu2015 's sunrise timer pulled in from #2317 and and instantly loving it , 
I wondered why there was no functionality to add an offset. 

So I did implement it myself.

It exploits the Timer.time field which in sunrise mode is otherwise unused.
This way, the sunrise / sundawn time can be positively or negatively be offset by up to 11h59m.
If a given offset would cause an over- or underflow, the actual days to be considered for firing the
timed event are shifted accordingly.

[However, only the selected (sunrise/sundawn) time + offset and originally choosen day(s) are 
currently displayed]