### PR TITLE
Add support for mapping ADC input to PWM output with new USE_ADC_PWM

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -370,6 +370,9 @@
 #define D_CMND_LATITUDE "Latitude"
 #define D_CMND_LONGITUDE "Longitude"
 
+// Commands xdrv_12_adc.ino
+#define D_CMND_ADCPWM "AdcPwm"
+
 /********************************************************************************************/
 
 #ifndef MY_LANGUAGE

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -258,7 +258,11 @@ struct SYSCFG {
   byte          knx_GA_param[MAX_KNX_GA];  // 6E2  Type of Input (relay changed, button pressed, sensor read <-teleperiod)
   byte          knx_CB_param[MAX_KNX_CB];  // 6EC  Type of Output (set relay, toggle relay, reply sensor value)
 
-  byte          free_6f6[266];             // 6F6
+  uint8_t       adc_pwm_target;            // 6F6
+  int16_t       adc_pwm_map_lo;            // 6F7
+  int16_t       adc_pwm_map_hi;            // 6F9
+
+  byte          free_6fb[261];             // 6FB
 
   char          rules[MAX_RULE_SIZE];      // 800 uses 512 bytes in v5.12.0m
 

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -521,6 +521,11 @@ void SettingsDefaultSet2()
 
   Settings.latitude = (int)((double)LATITUDE * 1000000);
   Settings.longitude = (int)((double)LONGITUDE * 1000000);
+
+  // 5.12.0n
+  //Settings.adc_pwm_targe = 0;
+  //Settings.adc_pwm_map_lo = 0;
+  Settings.adc_pwm_map_hi = 1023;
 }
 
 /********************************************************************************************/
@@ -850,6 +855,11 @@ void SettingsDelta()
       Settings.knx_GA_registered = 0;
       Settings.knx_CB_registered = 0;
       memset(&Settings.knx_physsical_addr, 0x00, 0x800 - 0x6b8);  // Reset until 0x800 for future use
+    }
+    if (Settings.version < 0x050C000E) {
+      //Settings.adc_pwm_targe = 0;
+      //Settings.adc_pwm_map_lo = 0;
+      Settings.adc_pwm_map_hi = 1023;
     }
 
     Settings.version = VERSION;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -25,7 +25,7 @@
     - Select IDE Tools - Flash Size: "1M (no SPIFFS)"
   ====================================================*/
 
-#define VERSION                0x050C000D   // 5.12.0m
+#define VERSION                0x050C000E   // 5.12.0n
 
 // Location specific includes
 #include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_3_0)

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -1379,55 +1379,6 @@ void RtcInit()
   TickerRtc.attach(1, RtcSecond);
 }
 
-#ifndef USE_ADC_VCC
-/*********************************************************************************************\
- * ADC support
-\*********************************************************************************************/
-
-void AdcShow(boolean json)
-{
-  uint16_t analog = 0;
-  for (byte i = 0; i < 32; i++) {
-    analog += analogRead(A0);
-    delay(1);
-  }
-  analog >>= 5;
-
-  if (json) {
-    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"" D_JSON_ANALOG_INPUT "0\":%d"), mqtt_data, analog);
-#ifdef USE_WEBSERVER
-  } else {
-    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_ANALOG, mqtt_data, "", 0, analog);
-#endif  // USE_WEBSERVER
-  }
-}
-
-/*********************************************************************************************\
- * Interface
-\*********************************************************************************************/
-
-#define XSNS_02
-
-boolean Xsns02(byte function)
-{
-  boolean result = false;
-
-  if (pin[GPIO_ADC0] < 99) {
-    switch (function) {
-      case FUNC_JSON_APPEND:
-        AdcShow(1);
-        break;
-#ifdef USE_WEBSERVER
-      case FUNC_WEB_APPEND:
-        AdcShow(0);
-        break;
-#endif  // USE_WEBSERVER
-    }
-  }
-  return result;
-}
-#endif  // USE_ADC_VCC
-
 /*********************************************************************************************\
  * Syslog
  *

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -234,6 +234,9 @@
 
 // -- Internal Analog input -----------------------
 #define USE_ADC_VCC                              // Display Vcc in Power status. Disable for use as Analog input on selected devices
+#ifndef USE_ADC_VCC
+  #define USE_ADC_PWM                            // Map ADC value to a PWM output (+0k5 code)
+#endif
 
 // -- One wire sensors ----------------------------
                                                  // WARNING: Select none for default one DS18B20 sensor or enable one of the following two options for multiple sensors

--- a/sonoff/xdrv_12_adc.ino
+++ b/sonoff/xdrv_12_adc.ino
@@ -1,0 +1,195 @@
+/*
+xsns_02_adc.ino - ADC analog input and output mapping for Sonoff-Tasmota
+
+Copyright (C) 2018 Bryan Mayland
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef USE_ADC_VCC
+
+#ifdef USE_ADC_PWM
+
+enum AdcCommands {
+  CMND_ADCPWM
+};
+
+const char kAdcCommands[] PROGMEM =
+  D_CMND_ADCPWM
+;
+
+static struct tagAdcState {
+  uint8_t fast_reads_remaining;
+  uint16_t last_val;
+} adc_state;
+
+static void AdcInit(void)
+{
+  adc_state.fast_reads_remaining = 1;
+}
+
+/*
+  Functionaly equivalent to:
+  constrain(map(x, in_lo, in_hi, 0, out_hi), 0, out_hi);
+*/
+static inline uint16_t constrain_map(long x, int16_t in_lo, int16_t in_hi, int16_t out_hi)
+{
+  // Prevent divide by zero
+  int16_t in_range = in_hi - in_lo;
+  if (in_range == 0)
+    in_range = 1;
+
+  long retVal;
+  retVal = (x - in_lo) * out_hi / in_range;
+  if (retVal > out_hi)
+    return out_hi;
+  if (retVal < 0)
+    return 0;
+  return retVal;
+}
+
+static void AdcRead(boolean force)
+{
+  if (Settings.adc_pwm_target == 0)
+    return;
+
+  if (force || adc_state.fast_reads_remaining > 0)
+  {
+    uint16_t adc = analogRead(A0);
+    /* If the difference between the last stored value and the new one is more
+       than 1% of range (10 ticks), then start a fast read session */
+    if (adc_state.last_val - adc + 10U >= (10U * 10U))
+      adc_state.fast_reads_remaining = 20 * 10; // 20 times a second for 10 seconds
+
+    if (adc_state.fast_reads_remaining > 0)
+    {
+      uint16_t range = Settings.pwm_range;
+      uint16_t newpwm = constrain_map(adc, Settings.adc_pwm_map_lo, Settings.adc_pwm_map_hi, range);
+      uint8_t index = Settings.adc_pwm_target;
+      analogWrite(pin[GPIO_PWM1 + index - 1], bitRead(pwm_inverted, index - 1) ? range - newpwm : newpwm);
+      adc_state.last_val = adc;
+      adc_state.fast_reads_remaining--;
+    }
+  }
+}
+
+static boolean AdcCommand()
+{
+  char command[CMDSZ];
+  int command_code = GetCommandCode(command, sizeof(command), XdrvMailbox.topic, kAdcCommands);
+  if (CMND_ADCPWM == command_code)
+  {
+    // "AdcRange pwmtarget,lo,hi"
+    char *buf = XdrvMailbox.data;
+    if (strlen(buf) > 0)
+    {
+      Settings.adc_pwm_target = atoi(buf);
+      uint8_t i = 0;
+      while ((buf = strchr(buf, ',')))
+      {
+        ++buf;
+        switch (++i)
+        {
+        case 1: Settings.adc_pwm_map_lo = atoi(buf); break;
+        case 2: Settings.adc_pwm_map_hi = atoi(buf); break;
+        }
+      }
+      // Force next read to update with new parameters
+      adc_state.fast_reads_remaining = 1;
+    }
+
+    char newvals[16];
+    snprintf_P(newvals, sizeof(newvals), PSTR("%u,%d,%d"),
+      Settings.adc_pwm_target, Settings.adc_pwm_map_lo, Settings.adc_pwm_map_hi);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, command, newvals);
+
+    return true;
+  }
+  else
+    return false;
+}
+
+#endif // USE_ADC_PWM
+
+void AdcShow(boolean json)
+{
+  uint16_t analog = 0;
+  for (byte i = 0; i < 32; i++) {
+    analog += analogRead(A0);
+    delay(1);
+  }
+  analog >>= 5;
+
+  if (json) {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"" D_JSON_ANALOG_INPUT "0\":%d"), mqtt_data, analog);
+#ifdef USE_WEBSERVER
+  }
+  else {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_ANALOG, mqtt_data, "", 0, analog);
+#endif  // USE_WEBSERVER
+  }
+}
+
+/*********************************************************************************************\
+* Interface
+\*********************************************************************************************/
+
+#ifdef USE_ADC_PWM
+
+#define XDRV_12
+
+boolean Xdrv12(byte function)
+{
+  boolean result = false;
+
+  switch (function) {
+  case FUNC_INIT:
+    AdcInit();
+    break;
+  case FUNC_EVERY_50_MSECOND:
+    AdcRead(false);
+    break;
+  case FUNC_EVERY_SECOND:
+    AdcRead(true);
+    break;
+  case FUNC_COMMAND:
+    result = AdcCommand();
+    break;
+  }
+  return result;
+}
+
+#endif 
+
+#define XSNS_02
+
+boolean Xsns02(byte function)
+{
+  boolean result = false;
+
+  if (pin[GPIO_ADC0] < 99) {
+    switch (function) {
+    case FUNC_JSON_APPEND:
+      AdcShow(1);
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_APPEND:
+      AdcShow(0);
+      break;
+#endif  // USE_WEBSERVER
+    }
+  }
+  return result;
+}
+#endif  // USE_ADC_VCC


### PR DESCRIPTION
A new ADC driver reads from the ADC input once per second, if the new value is more than 1% changed from the previous value, a fast read session begins, and the ADC is sampled every 50ms for 10s. The 1% change requirement allows Pwm# to be set in software without the ADC resetting the software-set value on each read.

The input ADC value is mapped to a PWM output (0-PwmRange) using the ADC low/high range set using the command AdcPwm target,lo,hi where target is the PWM output (1-MAX_PWM) and lo and hi are the ADC values to LERP between. Examples (assumes PwmRange 1023)

```
# Set a 1-to-1 mapping of the ADC input value onto Pwm2
AdcPwm 2,0,1023
# Disable mapping ADC value to any Pwm
AdcPwm 0
# ADC input values of 0-100 are mapped to Pwm1 (0-PwmRange)
AdcPwm 1,0,100
# Negative values are ok, a 10 ADC value becomes 0 Pwm3 output
AdcPwm 3,-10,1013
# Inverted ranges are ok, regardless of Pwm4's inverted-ness
AdcPwm 4,1000,-50
```

A typical use would be to attach a potentiometer to the ADC input (properly scaled down to the ADC input max voltage) and have it drive a PWM dimmer. I wasn't sure if this should drive a LIGHT or PWM driver but the light driver is pretty complicated so I could imagine way too many ways a user might want to directly change a value (overall brightness, a single RGB channel, color temperature, etc) so I decided to make it a simple PWM which might work more generally for more cases.

NOTE: I intentionally do not store the Pwm output value in Settings to persist between reboots. The first ADC forced read 50ms after startup will set the intensity. 

Requires USE_ADC_VCC not be defined.