### PR TITLE
Add W1_PARASITE_POWER optimization for DS18X20

### DIFF
--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -255,6 +255,7 @@
 // -- One wire sensors ----------------------------
                                                  // WARNING: Select none for default one DS18B20 sensor or enable one of the following two options for multiple sensors
 //#define USE_DS18x20                              // Optional for more than one DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
+//#define W1_PARASITE_POWER                        // If using USE_DS18x20 then optimize for parasite powered sensors
 //#define USE_DS18x20_LEGACY                       // Optional for more than one DS18x20 sensors with dynamic scan using library OneWire (+1k5 code)
 
 // -- I2C sensors ---------------------------------


### PR DESCRIPTION
There are additional requirements when using DS18x20 type sensors in parasite power mode:
- keep the data line high for the conversion time
- provide enough power on the data line for the conversion.

The first is accommodated by bookkeeping `w1_power_until` millis until the bus is usable again.

The latter (missing a strong pull-up) by triggering conversion on each sensor round-robin instead of all at once. To that `Ds18x20Convert()` is called with `FUNC_EVERY_SECOND` only and `Ds18x20Read()` is blocked if a conversion is still running.

I tested this with 5 sensors on a 25m bus with a 1k5 pull-up for about 2mA (worst case at 3V) usable power (the sensor can sink up to 4mA, the ESP up to 20mA) with perfectly stable results.

The whole optimization is optional with the `W1_PARASITE_POWER` define.