### PR TITLE
Enable user mode for GPIO2, GPIO5 and GPIO16 on the Sonoff RF/Basic 

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -256,10 +256,10 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
   { "Sonoff Basic",    // Sonoff Basic (ESP8266)
      GPIO_KEY1,        // GPIO00 Button
      GPIO_USER,        // GPIO01 Serial RXD and Optional sensor
-     0,                // GPIO02
+     GPIO_USER,        // GPIO02 Optional sensor
      GPIO_USER,        // GPIO03 Serial TXD and Optional sensor
      GPIO_USER,        // GPIO04 Optional sensor
-     0,                // GPIO05
+     GPIO_USER,        // GPIO05 Optional sensor
      0,                // GPIO06 (SD_CLK   Flash)
      0,                // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
      0,                // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
@@ -270,21 +270,23 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_LED1_INV,    // GPIO13 Green Led (0 = On, 1 = Off)
      GPIO_USER,        // GPIO14 Optional sensor
      0,                // GPIO15
-     0,                // GPIO16
+     GPIO_USER,        // GPIO16 Optional sensor
      0                 // ADC0 Analog input
   },
   { "Sonoff RF",       // Sonoff RF (ESP8266)
      GPIO_KEY1,        // GPIO00 Button
      GPIO_USER,        // GPIO01 Serial RXD and Optional sensor
-     0,
+     GPIO_USER,        // GPIO02 Optional sensor
      GPIO_USER,        // GPIO03 Serial TXD and Optional sensor
      GPIO_USER,        // GPIO04 Optional sensor
-     0,
+     GPIO_USER,        // GPIO05 Optional sensor
      0, 0, 0, 0, 0, 0, // Flash connection
      GPIO_REL1,        // GPIO12 Red Led and Relay (0 = Off, 1 = On)
      GPIO_LED1_INV,    // GPIO13 Green Led (0 = On, 1 = Off)
      GPIO_USER,        // GPIO14 Optional sensor
-     0, 0, 0
+     0,                // GPIO15
+     GPIO_USER,        // GPIO16 Optional sensor
+     0                 // ADC0 Analog input
   },
   { "Sonoff SV",       // Sonoff SV (ESP8266)
      GPIO_KEY1,        // GPIO00 Button


### PR DESCRIPTION
Hello,
not a big deal but if GPIO4 is in the List why not make it complete and put all usable GPIOs in the list.

Related to:
https://github.com/arendst/Sonoff-Tasmota/issues/2650
https://github.com/arendst/Sonoff-Tasmota/pull/2258