### PR TITLE
Ignore Visual Studio Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 .gcc-flags.json
 sonoff/user_config_override.h
 build
+
+## Visual Studio Code specific ######
+.vscode


### PR DESCRIPTION
Ignore local Visual Studio Code settings files.

It doesn't hurt having more files / folders in .gitignore file. Rather not having them is irritating for users that use Visual Studio Code, because files from .vscode folder will appear every time as uncommitted changes in git.