### PR TITLE
Allow IR messages with a data payload of zero.

### DIFF
--- a/sonoff/xdrv_02_irremote.ino
+++ b/sonoff/xdrv_02_irremote.ino
@@ -298,7 +298,7 @@ boolean IrSendCommand()
         protocol = root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_PROTOCOL))];
         bits = root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_BITS))];
         data = strtoul(root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_DATA))], NULL, 0);
-        if (protocol && bits && data) {
+        if (protocol && bits) {
           int protocol_code = GetCommandCode(protocol_text, sizeof(protocol_text), protocol, kIrRemoteProtocols);
 
           snprintf_P(log_data, sizeof(log_data), PSTR("IRS: protocol_text %s, protocol %s, bits %d, data %u (0x%lX), protocol_code %d"),


### PR DESCRIPTION
Ref: Issue #2751

Incorrect assumption that if the result of `strtoul()` is zero (0) it is a parse failure. That's incorrect as the "data" payload could actually be 0.

Ref: https://github.com/markszabo/IRremoteESP8266/issues/447#issuecomment-389745404