### PR TITLE
Fix 'vars' on Rules

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -88,6 +88,8 @@ uint32_t rules_triggers = 0;
 uint8_t rules_trigger_count = 0;
 uint8_t rules_teleperiod = 0;
 
+char vars[RULES_MAX_VARS][10] = { 0 };
+
 /*******************************************************************************************/
 
 long TimeDifference(unsigned long prev, unsigned long next)
@@ -243,7 +245,6 @@ bool RulesRuleMatch(String &event, String &rule)
 bool RulesProcess()
 {
   bool serviced = false;
-  char vars[RULES_MAX_VARS][10] = { 0 };
   char stemp[10];
 
   delay(0);                                               // Prohibit possible loop software watchdog


### PR DESCRIPTION
The 'vars' were not working from one rule to another because the declaration of the variable was not global and was being lost.

Problem shows when trying to make a thermostat as follows.

**Inital config:**

* available physical button as button2
* relay1 as controller
* relay2 any unused pin (will be used as toggle memory for the status ON/StandBy of the thermostat)
* button1 any unused pin
* led1 as thermostat status (ON or StandBy)

**On console:**

Turn on rules
`rule 1 ` 
check temp every minute
`teleperiod 60` 
use power1 on mqtt messages
`setoption26 1 `
dont save relay status on eeprom
`setoption0 0`  
start all relays off
`poweronstate 0` 

**Rule:**

On boot enable thermostat and enable start check of temp sensor connection
`rule on system#boot do backlog event enabled=1; ruletimer1 70 endon`

Set thermostat enable variable
`on event#enabled do backlog var1; power2 %value%; ledpower %var% endon`

An available button is configured as button2 and set also a relay 2 on any unused pin (to be used as a toggle memory to turn on and off the thermostat)
`on power2#state do event enabled=%value% endon`

check temp sensor connection. If fails, set to off and turn off thermostat. Also continue checking
`on rules#timer=1 do backlog event enabled=0; ruletimer1 70; power1 0 endon`

Resets checking timer if temperature is connected
`on tele-am2301-12#temperature do ruletimer1 70 endon`

Thermostat control - upper limit and lower limit
`on tele-am2301-12#temperature>25 do power1 0 endon`
`on tele-am2301-12#temperature<24 do power1 %var1% endon`

Thermostat can be turned on by:

* pushing button2
* by command on local console: `event enabled=1`
* by command on any console: `publish cmnd/topic/EVENT ENABLED=1`
* or MQTT at: `publish cmnd/topic/EVENT ENABLED=1`

Thermostat can be turned Off or by 

* pushing button2
* by command on local console: `event enabled=0`
* by command on any console: `publish cmnd/topic/EVENT ENABLED=0`
* or MQTT at: `publish cmnd/topic/EVENT ENABLED=0`

**Everything together:**

INITIAL CONFIG:

`backlog rule 1; teleperiod 60; setoption26 1; setoption0 0; poweronstate 0`

RULES:

`rule on system#boot do backlog event enabled=1; ruletimer1 70 endon on on event#enabled do backlog var1; power2 %value%; ledpower %var% endon on power2#state do event enabled=%value% endon on rules#timer=1 do backlog event enabled=0; ruletimer1 70; power1 0 endon on tele-am2301-12#temperature do ruletimer1 70 endon on tele-am2301-12#temperature>25 do power1 0 endon on tele-am2301-12#temperature<24 do power1 %var1% endon`
