### PR TITLE
add %id% token for topic names

### DIFF
--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -55,6 +55,7 @@ typedef unsigned long power_t;              // Power (Relay) type
 
 #define MQTT_TOKEN_PREFIX      "%prefix%"   // To be substituted by mqtt_prefix[x]
 #define MQTT_TOKEN_TOPIC       "%topic%"    // To be substituted by mqtt_topic, mqtt_grptopic, mqtt_buttontopic, mqtt_switchtopic
+#define MQTT_TOKEN_ID          "%id%"       // To be substituted by mqtt_topic, mqtt_grptopic, mqtt_buttontopic, mqtt_switchtopic
 
 #define WIFI_HOSTNAME          "%s-%04d"    // Expands to <MQTT_TOPIC>-<last 4 decimal chars of MAC address>
 

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -269,6 +269,12 @@ void GetTopic_P(char *stopic, byte prefix, char *topic, const char* subtopic)
     }
     fulltopic.replace(F(MQTT_TOKEN_PREFIX), Settings.mqtt_prefix[prefix]);
     fulltopic.replace(F(MQTT_TOKEN_TOPIC), topic);
+
+    uint8_t mac[6];
+    char macStr[13] = { 0 };
+    WiFi.macAddress(mac);
+    snprintf_P(macStr, sizeof macStr, PSTR("%02x%02x%02x%02x%02x%02x"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    fulltopic.replace(F(MQTT_TOKEN_ID), macStr);
   }
   fulltopic.replace(F("#"), "");
   fulltopic.replace(F("//"), "/");


### PR DESCRIPTION
This patch adds the ability to use `%id%` in the fulltopic path, which is replaced with the device's full MAC address.  This allows for a great deal of auto-configuration with a few firmware changes (attach to WiFi, define the mqtt server, flash many devices, and each gets an automatic distinct fulltopic for control)
