### PR TITLE
Add Console Commands for KNX

### DIFF
--- a/sonoff/_releasenotes.ino
+++ b/sonoff/_releasenotes.ino
@@ -1,4 +1,22 @@
 /* 5.14.0b
+* Added Console Commands to send KNX Commands
+  usage: KnxTx_Cmnd[slot] command
+  where [slot] is any of the 5 slots on the KNX Menu and command is 0 or 1
+  example: KnxTx_Cmnd1 0
+* Added Console Commands to send KNX Values
+  usage: KnxTx_Val[slot] value
+  where [slot] is any of the 5 slots on the KNX Menu and value is a number
+  example: KnxTx_Val1 35
+* Added Slots on the KNX Web Menu to select Group Addess to send data from console commands
+* Added Events to trigger rules when received data from KNX
+  usage on rules as: event#KnxRx_Val[slot]
+  where [slot] is any of the 5 slots on the KNX Menu
+  example: rule on event#KnxRx_Val1 do VAR1 %value% endon
+* Added Events to trigger rules when received read requests from KNX
+  usage on rules as: event#KnxRx_Req[slot]
+  where [slot] is any of the 5 slots on the KNX Menu
+  example: rule on event#KnxRx_Req1 do KnxTx_Val1 35 endon
+ * Added Slots on the KNX Web Menu to select Group Addess to receive data to trigger rules
  * Add two rule sets of 511 characters using commands rule1, rule2 and rule3
  * Add Ukranian language file
  * Add rule support for IrReceive and RfReceive (#2758)

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "изпратен до"
 #define D_KNX_WARNING "Груповият адрес ( 0 / 0 / 0 ) е резервиран и не може да бъде използван."
 #define D_KNX_ENHANCEMENT "Подобрена комуникация"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Използвана енергия днес"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "pošli"
 #define D_KNX_WARNING "Skupinová adresa ( 0 / 0 / 0 ) je rezervována a nemůže být použita."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Spotřeba Dnes"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energie heute"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "αποστολή σε"
 #define D_KNX_WARNING "Η Ομάδα Διευθύνσεων ( 0 / 0 / 0 ) είναι δεσμευμένη και δεν μπορεί να χρησιμοποιηθεί."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energy Σήμερα"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.14.0a
+ * Updated until v5.14.0b
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energy Today"

--- a/sonoff/language/es-AR.h
+++ b/sonoff/language/es-AR.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.14.0a
+ * Updated until v5.14.0b
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -402,6 +402,8 @@
 #define D_SENT_TO "enviada a"
 #define D_KNX_WARNING "La dirección de grupo ( 0 / 0 / 0 ) está reservada y no puede ser utilizada."
 #define D_KNX_ENHANCEMENT "Mejora de Comunicación"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energía Hoy"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "envoyé à"
 #define D_KNX_WARNING "L'Adresse de Groupe ( 0 / 0 / 0 ) est réservée et ne peut être utilisée."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xsns_03_energy.ino
 #define D_ENERGY_TODAY "Énergie aujourd'hui"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Mai Energia"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "invia a"
 #define D_KNX_WARNING "L'indirizzo del gruppo ( 0 / 0 / 0 ) è riservato e non può essere usato."
 #define D_KNX_ENHANCEMENT "Miglioramento Comunicazione"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energia Oggi"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "verzend naar"
 #define D_KNX_WARNING "Groep adres (0/0/0) is gereserveerd en mag niet worden gebruikt."
 #define D_KNX_ENHANCEMENT "Verbeter verbinding"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Verbruik vandaag"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energia Dzisiaj"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "Enviar para"
 #define D_KNX_WARNING "O endereço ( 0 / 0 / 0 ) é reservado e não pode ser usado."
 #define D_KNX_ENHANCEMENT "Melhoria da comunicação"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Consumo energético de hoje"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Consumo energético de hoje"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Энергия Сегодня"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "надіслати до"
 #define D_KNX_WARNING "Адреса групи (0/0/0) зарезервована і не може бути використана."
 #define D_KNX_ENHANCEMENT "Підвищення зв'язку"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Енергія Сьогодні"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "今日用电量"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -402,6 +402,8 @@
 #define D_SENT_TO "sent to"
 #define D_KNX_WARNING "The group address ( 0 / 0 / 0 ) is reserved and can not be used."
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
+#define D_KNX_TX_SLOT "KNX TX"
+#define D_KNX_RX_SLOT "KNX RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "今日用電量"

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -147,7 +147,12 @@ typedef unsigned long power_t;              // Power (Relay) type
 #define KNX_ENERGY_DAILY       23
 #define KNX_ENERGY_START       24
 #define KNX_ENERGY_TOTAL       25
-#define KNX_MAX_device_param   25
+#define KNX_SLOT1              26
+#define KNX_SLOT2              27
+#define KNX_SLOT3              28
+#define KNX_SLOT4              29
+#define KNX_SLOT5              30
+#define KNX_MAX_device_param   30
 
 /*********************************************************************************************\
  * Enumeration

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -137,7 +137,7 @@ typedef unsigned long power_t;              // Power (Relay) type
 #define DAWN_NAUTIC            -12.0
 #define DAWN_ASTRONOMIC        -18.0
 
-// Sensor definition for KNX Driver
+// Sensor and Commands definition for KNX Driver
 #define KNX_TEMPERATURE        17
 #define KNX_HUMIDITY           18
 #define KNX_ENERGY_VOLTAGE     19
@@ -153,6 +153,7 @@ typedef unsigned long power_t;              // Power (Relay) type
 #define KNX_SLOT4              29
 #define KNX_SLOT5              30
 #define KNX_MAX_device_param   30
+#define MAX_KNXTX_CMNDS        5
 
 /*********************************************************************************************\
  * Enumeration

--- a/sonoff/xdrv_11_knx.ino
+++ b/sonoff/xdrv_11_knx.ino
@@ -115,6 +115,11 @@ device_parameters_t device_param[] = {
   { KNX_ENERGY_DAILY   , false, false, KNX_Empty },
   { KNX_ENERGY_START   , false, false, KNX_Empty },
   { KNX_ENERGY_TOTAL   , false, false, KNX_Empty },
+  { KNX_SLOT1 , false, false, KNX_Empty },
+  { KNX_SLOT2 , false, false, KNX_Empty },
+  { KNX_SLOT3 , false, false, KNX_Empty },
+  { KNX_SLOT4 , false, false, KNX_Empty },
+  { KNX_SLOT5 , false, false, KNX_Empty },
   { KNX_Empty, false, false, KNX_Empty}
 };
 
@@ -145,6 +150,11 @@ const char * device_param_ga[] = {
   D_ENERGY_TODAY      ,
   D_ENERGY_YESTERDAY  ,
   D_ENERGY_TOTAL      ,
+  D_KNX_TX_SLOT   " 1",
+  D_KNX_TX_SLOT   " 2",
+  D_KNX_TX_SLOT   " 3",
+  D_KNX_TX_SLOT   " 4",
+  D_KNX_TX_SLOT   " 5",
   nullptr
 };
 
@@ -175,8 +185,19 @@ const char *device_param_cb[] = {
   D_REPLY " " D_ENERGY_TODAY      ,
   D_REPLY " " D_ENERGY_YESTERDAY  ,
   D_REPLY " " D_ENERGY_TOTAL      ,
+  D_KNX_RX_SLOT   " 1",
+  D_KNX_RX_SLOT   " 2",
+  D_KNX_RX_SLOT   " 3",
+  D_KNX_RX_SLOT   " 4",
+  D_KNX_RX_SLOT   " 5",
   nullptr
 };
+
+// Commands
+#define D_CMND_KNXTXCMND "KnxTx_Cmnd"
+#define D_CMND_KNXTXVAL "KnxTx_Val"
+enum KnxCommands { CMND_KNXTXCMND, CMND_KNXTXVAL };
+const char kKnxCommands[] PROGMEM = D_CMND_KNXTXCMND "|" D_CMND_KNXTXVAL ;
 
 
 byte KNX_GA_Search( byte param, byte start = 0 )
@@ -377,11 +398,19 @@ bool KNX_CONFIG_NOT_MATCH()
   {
     if ( !device_param[i].show ) { // device has this parameter ?
       // if not, search for all registered group address to this parameter for deletion
+
+      // Checks all GA
       if ( KNX_GA_Search(i+1) != KNX_Empty ) { return true; }
-      if ( (i < 8) || (i > 15) ) // check relays and sensors (i from 8 to 16 are toggle relays parameters)
+
+      // Check all CB
+      if ( i < 8 ) // check relays (i from 8 to 15 are toggle relays parameters)
       {
         if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
         if ( KNX_CB_Search(i+9) != KNX_Empty ) { return true; }
+      }
+      if ( i > 15 ) // check sensors and others
+      {
+        if ( KNX_CB_Search(i+1) != KNX_Empty ) { return true; }
       }
     }
   }
@@ -448,6 +477,14 @@ void KNX_INIT()
     device_param[KNX_ENERGY_POWERFACTOR-1].show = true;
   }
 
+#ifdef USE_RULES
+  device_param[KNX_SLOT1-1].show = true;
+  device_param[KNX_SLOT2-1].show = true;
+  device_param[KNX_SLOT3-1].show = true;
+  device_param[KNX_SLOT4-1].show = true;
+  device_param[KNX_SLOT5-1].show = true;
+#endif
+
   // Delete from KNX settings all configuration is not anymore related to this device
   if (KNX_CONFIG_NOT_MATCH()) {
     Settings.knx_GA_registered = 0;
@@ -505,7 +542,21 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           }
         }
       }
+#ifdef USE_RULES
+      else if ((chan->type >= KNX_SLOT1) && (chan->type <= KNX_SLOT5)) // KNX RX SLOTs (write command)
+      {
+        if (!toggle_inhibit) {
+          char command[25];
+          snprintf_P(command, sizeof(command), PSTR("event KNXRX_VAL%d=%d"), ((chan->type) - KNX_SLOT1 + 1 ), msg.data[0]);
+          ExecuteCommand(command, SRC_KNX);
+          if (Settings.flag.knx_enable_enhancement) {
+            toggle_inhibit = TOGGLE_INHIBIT_TIME;
+          }
+        }
+      }
+#endif
       break;
+
     case KNX_CT_READ:
       if (chan->type < 9) // reply Relays status
       {
@@ -531,6 +582,19 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           knx.answer_2byte_float(msg.received_on, last_hum);
         }
       }
+#ifdef USE_RULES
+      else if ((chan->type >= KNX_SLOT1) && (chan->type <= KNX_SLOT5)) // KNX RX SLOTs (read command)
+      {
+        if (!toggle_inhibit) {
+          char command[25];
+          snprintf_P(command, sizeof(command), PSTR("event KNXRX_REQ%d"), ((chan->type) - KNX_SLOT1 + 1 ) );
+          ExecuteCommand(command, SRC_KNX);
+          if (Settings.flag.knx_enable_enhancement) {
+            toggle_inhibit = TOGGLE_INHIBIT_TIME;
+          }
+        }
+      }
+#endif
       break;
   }
 }
@@ -939,6 +1003,71 @@ void KNX_Save_Settings()
 #endif  // USE_WEBSERVER
 
 
+boolean KnxCommand()
+{
+  char command[CMDSZ];
+  uint8_t index = XdrvMailbox.index;
+  int command_code = GetCommandCode(command, sizeof(command), XdrvMailbox.topic, kKnxCommands);
+
+  if (!(Settings.flag.knx_enabled)) { return false; }
+
+  if (-1 == command_code) { return false; } // Unknown command
+
+  else if ((CMND_KNXTXCMND == command_code) && (index > 0) && (index <= MAX_KNXTX_CMNDS) && (XdrvMailbox.data_len > 0)) {
+    // index <- KNX SLOT to use
+    // XdrvMailbox.payload <- data to send
+
+    // Search all the registered GA that has that output (variable: KNX SLOTx) as parameter
+    byte i = KNX_GA_Search(index + KNX_SLOT1 -1);
+    while ( i != KNX_Empty ) {
+      KNX_addr.value = Settings.knx_GA_addr[i];
+      knx.write_1bit(KNX_addr, !(XdrvMailbox.payload == 0));
+      if (Settings.flag.knx_enable_enhancement) {
+        knx.write_1bit(KNX_addr, !(XdrvMailbox.payload == 0));
+        knx.write_1bit(KNX_addr, !(XdrvMailbox.payload == 0));
+      }
+
+      snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_KNX "%s = %d " D_SENT_TO " %d.%d.%d"),
+       device_param_ga[index + KNX_SLOT1 -2], !(XdrvMailbox.payload == 0),
+       KNX_addr.ga.area, KNX_addr.ga.line, KNX_addr.ga.member);
+      AddLog(LOG_LEVEL_INFO);
+
+      i = KNX_GA_Search(index + KNX_SLOT1 -1, i + 1);
+    }
+  }
+
+  else if ((CMND_KNXTXVAL == command_code) && (index > 0) && (index <= MAX_KNXTX_CMNDS) && (XdrvMailbox.data_len > 0)) {
+    // index <- KNX SLOT to use
+    // XdrvMailbox.payload <- data to send
+
+    // Search all the registered GA that has that output (variable: KNX SLOTx) as parameter
+    byte i = KNX_GA_Search(index + KNX_SLOT1 -1);
+    while ( i != KNX_Empty ) {
+      KNX_addr.value = Settings.knx_GA_addr[i];
+      knx.write_2byte_float(KNX_addr, XdrvMailbox.payload);
+      if (Settings.flag.knx_enable_enhancement) {
+        knx.write_2byte_float(KNX_addr, XdrvMailbox.payload);
+        knx.write_2byte_float(KNX_addr, XdrvMailbox.payload);
+      }
+
+      snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_KNX "%s = %d " D_SENT_TO " %d.%d.%d"),
+       device_param_ga[index + KNX_SLOT1 -2], XdrvMailbox.payload,
+       KNX_addr.ga.area, KNX_addr.ga.line, KNX_addr.ga.member);
+      AddLog(LOG_LEVEL_INFO);
+
+      i = KNX_GA_Search(index + KNX_SLOT1 -1, i + 1);
+    }
+  }
+
+  else { return false; }  // Incomplete command
+
+  snprintf_P (mqtt_data, sizeof(mqtt_data), PSTR("{\"%s%d\":\"%d\"}"),
+    command, index, XdrvMailbox.payload );
+
+  return true;
+}
+
+
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/
@@ -960,9 +1089,9 @@ boolean Xdrv11(byte function)
           toggle_inhibit--;
         }
         break;
-//      case FUNC_COMMAND:
-//        result = KNXCommand();
-//        break;
+      case FUNC_COMMAND:
+        result = KnxCommand();
+        break;
 //      case FUNC_SET_POWER:
 //        break;
     }


### PR DESCRIPTION
Hi,

To add some flexibility for KNX, TX commands and RX events were added to be used in rules.

* Added Console Command to send KNX Commands
  usage: `KnxTx_Cmnd[slot] command`
  where `[slot]` is any of the 5 slots on the KNX Menu and command is 0 or 1
  example: `KnxTx_Cmnd1 0`

* Added Console Command to send KNX Values
  usage: `KnxTx_Val[slot] value`
  where `[slot]` is any of the 5 slots on the KNX Menu and value is a number
  example: `KnxTx_Val1 35`

* Added Slots on the KNX Web Menu to select Group Addess to send data from console commands

* Added Events to trigger rules when data is received from KNX
  usage on rules as: `event#KnxRx_Val[slot]`
  where `[slot]` is any of the 5 slots on the KNX Menu
  example: `rule on event#KnxRx_Val1 do VAR1 %value% endon`

* Added Events to trigger rules when a read request is received from KNX
  usage on rules as: `event#KnxRx_Req[slot]`
  where `[slot]` is any of the 5 slots on the KNX Menu
  example: `rule on event#KnxRx_Req1 do KnxTx_Val1 35 endon`

* Added Slots on the KNX Web Menu to select Group Addess to receive data to trigger rules
