### PR TITLE
Fix comments to reflect correct file name

### DIFF
--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -275,6 +275,7 @@
 //  #define USE_INA219                             // Add I2C code for INA219 Low voltage and current sensor (+1k code)
 //  #define USE_MGS                                // Add I2C code for Xadow and Grove Mutichannel Gas sensor using library Multichannel_Gas_Sensor (+10k code)
     #define MGS_SENSOR_ADDR    0x04              // Default Mutichannel Gas sensor i2c address
+//    #define USE_LM75AD                           // Add I2C code for LM75AD Temperature Sensor (+0k6 code)
 #endif  // USE_I2C
 
 // -- SPI sensors ---------------------------------

--- a/sonoff/xsns_26_lm75ad.ino
+++ b/sonoff/xsns_26_lm75ad.ino
@@ -1,5 +1,5 @@
 /*
-  xdrv_26_lm75ad.ino - Support for I2C LM75AD Temperature Sensor
+  xsns_26_lm75ad.ino - Support for I2C LM75AD Temperature Sensor
 
   Copyright (C) 2018  Theo Arends
 


### PR DESCRIPTION
Fix comments at top of the file to reflect correct file name to xsns_26_lm75ad.ino