### PR TITLE
Add CPU LOAD Measurement

### DIFF
--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -72,6 +72,8 @@
 #define SYS_LOG_LEVEL          LOG_LEVEL_NONE    // [SysLog] (LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE)
 #define SERIAL_LOG_LEVEL       LOG_LEVEL_INFO    // [SerialLog] (LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE)
 #define WEB_LOG_LEVEL          LOG_LEVEL_INFO    // [WebLog] (LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE)
+//#define USE_CPU_LOAD                             // CPU LOAD log
+  #define CPU_LOAD_CHECK       1                 // Seconds between each CPU_LOAD log
 
 // -- Ota -----------------------------------------
 #define OTA_URL                "http://sonoff.maddox.co.uk/tasmota/sonoff.bin"  // [OtaUrl]


### PR DESCRIPTION
Hi,

This is a small code to check the amount of cycles that Tasmota is performing on its main loop. This is more a developer feature for debugging and checking than an user one, but it is a way to measure the CPU usage of different configurations and sets of features.

The log can be seen only with `weblog 3` command.

For example, using the esp8266 at 80Mhz, Tasmota has about 20,000 cycles per second. 
```
15:52:01 APP: osWatch FreeRam 11704, rssi 52, CPU 64%(80MHz), Loops/sec 14736
15:52:02 APP: osWatch FreeRam 11824, rssi 52, CPU 46%(80MHz), Loops/sec 21696
15:52:03 APP: osWatch FreeRam 11704, rssi 52, CPU 50%(80MHz), Loops/sec 20347
15:52:04 APP: osWatch FreeRam 11824, rssi 52, CPU 46%(80MHz), Loops/sec 21719
15:52:05 APP: osWatch FreeRam 11824, rssi 52, CPU 46%(80MHz), Loops/sec 21683
15:52:06 APP: osWatch FreeRam 11824, rssi 52, CPU 61%(80MHz), Loops/sec 15842
15:52:07 APP: osWatch FreeRam 11824, rssi 52, CPU 46%(80MHz), Loops/sec 21709
15:52:08 APP: osWatch FreeRam 11824, rssi 52, CPU 61%(80MHz), Loops/sec 15954
```
But when using sleep at 100, it goes down to about 10 cycles per second. So, it is a good measure of what things can be done or not while using sleep. (remember that each cycle will be at 80Mhz of speed but just 10 of those per second)
```
15:53:27 APP: osWatch FreeRam 11648, rssi 46, CPU 55%(80MHz), Loops/sec 6
15:53:28 APP: osWatch FreeRam 11768, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:29 APP: osWatch FreeRam 11688, rssi 46, CPU 40%(80MHz), Loops/sec 8
15:53:30 APP: osWatch FreeRam 11808, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:31 APP: osWatch FreeRam 11808, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:32 APP: osWatch FreeRam 11808, rssi 46, CPU 40%(80MHz), Loops/sec 8
15:53:33 APP: osWatch FreeRam 12648, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:34 APP: osWatch FreeRam 12648, rssi 46, CPU 40%(80MHz), Loops/sec 8
15:53:35 APP: osWatch FreeRam 12648, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:36 APP: osWatch FreeRam 12648, rssi 46, CPU 40%(80MHz), Loops/sec 8
15:53:37 APP: osWatch FreeRam 12648, rssi 44, CPU 25%(80MHz), Loops/sec 10
15:53:38 APP: osWatch FreeRam 12528, rssi 46, CPU 33%(80MHz), Loops/sec 9
15:53:39 APP: osWatch FreeRam 11808, rssi 46, CPU 25%(80MHz), Loops/sec 10
15:53:40 APP: osWatch FreeRam 11808, rssi 46, CPU 25%(80MHz), Loops/sec 10
```

Using the esp8266 at 160Mhz, Tasmota has about 60,000 cycles per second.
```
16:00:11 APP: osWatch FreeRam 12344, rssi 54, CPU 40%(160MHz), Loops/sec 48608
16:00:12 APP: osWatch FreeRam 12464, rssi 54, CPU 25%(160MHz), Loops/sec 60235
16:00:13 APP: osWatch FreeRam 11896, rssi 58, CPU 25%(160MHz), Loops/sec 60237
16:00:14 APP: osWatch FreeRam 11624, rssi 56, CPU 52%(160MHz), Loops/sec 38434
16:00:15 APP: osWatch FreeRam 11624, rssi 56, CPU 26%(160MHz), Loops/sec 59995
16:00:16 APP: osWatch FreeRam 11624, rssi 56, CPU 58%(160MHz), Loops/sec 33811
16:00:17 APP: osWatch FreeRam 11624, rssi 56, CPU 25%(160MHz), Loops/sec 60205
16:00:18 APP: osWatch FreeRam 11624, rssi 56, CPU 32%(160MHz), Loops/sec 54795
16:00:19 APP: osWatch FreeRam 11952, rssi 56, CPU 25%(160MHz), Loops/sec 60009
16:00:20 APP: osWatch FreeRam 12360, rssi 56, CPU 25%(160MHz), Loops/sec 60478
16:00:21 APP: osWatch FreeRam 12360, rssi 56, CPU 45%(160MHz), Loops/sec 44099
```
But when using sleep at 100, it goes down to about 10 cycles per second.
```
16:02:02 APP: osWatch FreeRam 11736, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:03 APP: osWatch FreeRam 11768, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:04 APP: osWatch FreeRam 11808, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:05 APP: osWatch FreeRam 11808, rssi 54, CPU 70%(160MHz), Loops/sec 8
16:02:06 APP: osWatch FreeRam 11808, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:07 APP: osWatch FreeRam 11808, rssi 54, CPU 70%(160MHz), Loops/sec 8
16:02:08 APP: osWatch FreeRam 11808, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:09 APP: osWatch FreeRam 12648, rssi 54, CPU 70%(160MHz), Loops/sec 8
16:02:10 APP: osWatch FreeRam 12648, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:12 APP: osWatch FreeRam 12424, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:13 APP: osWatch FreeRam 12648, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:14 APP: osWatch FreeRam 12648, rssi 54, CPU 63%(160MHz), Loops/sec 10
16:02:15 APP: osWatch FreeRam 11808, rssi 54, CPU 74%(160MHz), Loops/sec 7
16:02:16 APP: osWatch FreeRam 11808, rssi 56, CPU 63%(160MHz), Loops/sec 10
```

Also, more demanding features as schemes in led strips use nearly 90% of CPU usage if it is also open a web console. So, it is expected for a scheme 6 to hung a bit if a web browser is opened.

Another information that can be taken from this, is that those free cycles are not steady (because of wifi handling), so features like streaming sound ( request # 2873 ) are not possible without glitches in Tasmota.

By Default, this feature is disabled. ( `//#define USE_CPU_LOAD` in _user_config.h_ )
Also can be set the time between log ( `#define CPU_LOAD_CHECK       1     // Seconds between each CPU_LOAD log`  )
