### PR TITLE
Major performace Improvements for WS2812 pixels

### DIFF
--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1118,6 +1118,7 @@ boolean LightCommand()
     if (XdrvMailbox.data_len > 0) {
       char *p;
       uint16_t idx = XdrvMailbox.index;
+      Ws2812ForceSuspend();
       for (char *color = strtok_r(XdrvMailbox.data, " ", &p); color; color = strtok_r(NULL, " ", &p)) {
         if (LightColorEntry(color, strlen(color))) {
           Ws2812SetColor(idx, light_entry_color[0], light_entry_color[1], light_entry_color[2], light_entry_color[3]);
@@ -1127,6 +1128,8 @@ boolean LightCommand()
           break;
         }
       }
+
+      Ws2812ForceUpdate();
     }
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_INDEX_SVALUE, command, XdrvMailbox.index, Ws2812GetColor(XdrvMailbox.index, scolor));
   }

--- a/sonoff/xplg_ws2812.ino
+++ b/sonoff/xplg_ws2812.ino
@@ -93,7 +93,7 @@ uint8_t kRepeat[5] = {
     1 };   // All
 
 uint8_t ws_show_next = 1;
-
+bool ws_suspend_update = false;
 /********************************************************************************************/
 
 void Ws2812StripShow()
@@ -365,6 +365,19 @@ void Ws2812SetColor(uint16_t led, uint8_t red, uint8_t green, uint8_t blue, uint
       strip->SetPixelColor(i, lcolor);
     }
   }
+
+  if (!ws_suspend_update) {
+    strip->Show();
+    ws_show_next = 1;
+  }
+}
+
+void Ws2812ForceSuspend () {
+  ws_suspend_update = true;
+}
+
+void Ws2812ForceUpdate () {
+  ws_suspend_update = false;
   strip->Show();
   ws_show_next = 1;
 }


### PR DESCRIPTION
When passing values for multiple WS2812 LEDs at once, updating is very slow because after each LED is set, the strip is updated. The update was so slow that it was visible with the eye. For me, it took approx 0.5 seconds to update an 28 pixel long strip.

This patch suspends updates to the strip while procesing the passed LEDs, enabling the updates afterwards.

How to reproduce prior the patch:

- Connect a sufficient long WS2812 strip to the device (I used 28 pixels)
- Send the command `"Led1 17,10,18 14,7,15 10,3,11 11,1,9 15,4,12 21,5,15 22,5,15 24,4,15 18,3,8 18,0,7 25,4,13 25,5,14 12,0,6 9,0,5 10,4,6 9,0,3 17,0,6 45,2,22 53,0,26 229,221,232 88,86,91 73,64,67 115,130,125 33,22,28 1,0,2 0,1,4 127,0,50 212,0,80"` to the strip
- You'll notice that the changes in each LED occur delayed

Now apply the patch. Updating and displaying the LEDs should now be near instant (apart from the usual delay for `strip->Show();`

