### PR TITLE
rf receive HEX DEC setting

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ env_default = sonoff
 
 [common] ; ************************************************************
 ; *** Esp8266 core for Arduino version 2.3.0
-platform = espressif8266@1.5.0
+;platform = espressif8266@1.5.0
 ; *** Esp8266 core for Arduino version 2.4.0
 ;platform = espressif8266@1.6.0
 ; *** Esp8266 core for Arduino version 2.4.1
@@ -43,7 +43,7 @@ platform = espressif8266@1.5.0
 ; *** Esp8266 core for Arduino version latest beta
 ;platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 ; *** Esp8266 core for Arduino current version
-;platform = espressif8266
+platform = espressif8266
 
 framework = arduino
 board = esp01_1m
@@ -62,10 +62,10 @@ build_flags =
 monitor_speed = 115200
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
-;upload_speed = 115200
-upload_speed = 512000
+upload_speed = 115200
+;upload_speed = 512000
 upload_resetmethod = nodemcu
-upload_port = COM5
+upload_port = /dev/cu.usbserial-A800GHMR
 ; *** Fix Esp/Arduino core 2.4.x induced Tasmota unused floating point includes
 extra_scripts = pio/strip-floats.py
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ env_default = sonoff
 
 [common] ; ************************************************************
 ; *** Esp8266 core for Arduino version 2.3.0
-;platform = espressif8266@1.5.0
+platform = espressif8266@1.5.0
 ; *** Esp8266 core for Arduino version 2.4.0
 ;platform = espressif8266@1.6.0
 ; *** Esp8266 core for Arduino version 2.4.1
@@ -43,7 +43,7 @@ env_default = sonoff
 ; *** Esp8266 core for Arduino version latest beta
 ;platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 ; *** Esp8266 core for Arduino current version
-platform = espressif8266
+;platform = espressif8266
 
 framework = arduino
 board = esp01_1m
@@ -62,10 +62,10 @@ build_flags =
 monitor_speed = 115200
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
-upload_speed = 115200
-;upload_speed = 512000
+;upload_speed = 115200
+upload_speed = 512000
 upload_resetmethod = nodemcu
-upload_port = /dev/cu.usbserial-A800GHMR
+upload_port = COM5
 ; *** Fix Esp/Arduino core 2.4.x induced Tasmota unused floating point includes
 extra_scripts = pio/strip-floats.py
 

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -53,7 +53,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t knx_enabled : 1;              // bit 25 (v5.12.0l) KNX
     uint32_t device_index_enable : 1;      // bit 26 (v5.13.1a)
     uint32_t knx_enable_enhancement : 1;   // bit 27 (v5.14.0a) KNX
-    uint32_t spare28 : 1;
+    uint32_t rf_receive_dec : 1;           // bit 28
     uint32_t spare29 : 1;
     uint32_t spare30 : 1;
     uint32_t spare31 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -569,7 +569,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
       XsnsCall(FUNC_COMMAND);
 //      if (!XsnsCall(FUNC_COMMAND)) type = NULL;
     }
-    else if ((CMND_SETOPTION == command_code) && ((index <= 26) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
+    else if ((CMND_SETOPTION == command_code) && ((index <= 28) || ((index > 31) && (index <= P_MAX_PARAM8 + 31)))) {
       if (index <= 31) {
         ptype = 0;   // SetOption0 .. 31
       } else {
@@ -604,6 +604,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
 //              case 24:  // rules_once
 //              case 25:  // knx_enabled
               case 26:  // device_index_enable
+              case 28:  // rf receive_ dec
                 bitWrite(Settings.flag.data, index, payload);
             }
             if (12 == index) {  // stop_flash_rotate

--- a/sonoff/xdrv_06_snfbridge.ino
+++ b/sonoff/xdrv_06_snfbridge.ino
@@ -295,8 +295,12 @@ void SonoffBridgeReceived()
             }
           }
         }
-        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_RFRECEIVED "\":{\"" D_JSON_SYNC "\":%d,\"" D_JSON_LOW "\":%d,\"" D_JSON_HIGH "\":%d,\"" D_JSON_DATA "\":\"%06X\",\"" D_CMND_RFKEY "\":%s}}"),
-          sync_time, low_time, high_time, received_id, rfkey);
+        if(Settings.flag.rf_receive_dec == 1){
+          snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_RFRECEIVED "\":{\"" D_JSON_SYNC "\":%d,\"" D_JSON_LOW "\":%d,\"" D_JSON_HIGH "\":%d,\"" D_JSON_DATA "\":%d,\"" D_CMND_RFKEY "\":%s}}"), sync_time, low_time, high_time, received_id, rfkey);
+        }
+        else if(Settings.flag.rf_receive_dec == 0){
+          snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_RFRECEIVED "\":{\"" D_JSON_SYNC "\":%d,\"" D_JSON_LOW "\":%d,\"" D_JSON_HIGH "\":%d,\"" D_JSON_DATA "\":\"%06X\",\"" D_CMND_RFKEY "\":%s}}"), sync_time, low_time, high_time, received_id, rfkey);
+        }
         MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_RFRECEIVED));
         XdrvRulesProcess();
   #ifdef USE_DOMOTICZ
@@ -583,4 +587,3 @@ boolean Xdrv06(byte function)
   }
   return result;
 }
-


### PR DESCRIPTION
hi arendst,
created a setting in setoption to switch between HEX and DEC data in the json object when an RF signal is recieved on the sonoff bridge.

i have used setoption 28 as it was labeled as spare.
i have tested this and all seems to be working as it should.

in sonoff.ino i have changed the CMND_SETOPTION index from 26 to 28 which may enable the setting for knx_enable_enhancement. 
this may have to be looked at. maybe by adding ||(index == 28) instead.

thanks for all your great work.
sam