### PR TITLE
Move LM75ADDetect() to FUNC_EVERY_SECOND

### DIFF
--- a/sonoff/xsns_26_lm75ad.ino
+++ b/sonoff/xsns_26_lm75ad.ino
@@ -108,7 +108,7 @@ boolean Xsns26(byte function)
 
   if (i2c_flg) {
     switch (function) {
-      case FUNC_PREP_BEFORE_TELEPERIOD:
+      case FUNC_EVERY_SECOND:
         LM75ADDetect();
         break;
       case FUNC_JSON_APPEND:


### PR DESCRIPTION
Move LM75ADDetect() from FUNC_PREP_BEFORE_TELEPERIOD to FUNC_EVERY_SECOND to comply with FUNC_PREP_BEFORE_TELEPERIOD marked as deprecated.