### PR TITLE
Move LM75ADDetect and MCP230xx_Detect

### DIFF
--- a/sonoff/xsns_26_lm75ad.ino
+++ b/sonoff/xsns_26_lm75ad.ino
@@ -108,7 +108,7 @@ boolean Xsns26(byte function)
 
   if (i2c_flg) {
     switch (function) {
-      case FUNC_PREP_BEFORE_TELEPERIOD:
+      case FUNC_EVERY_SECOND:
         LM75ADDetect();
         break;
       case FUNC_JSON_APPEND:

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -437,7 +437,7 @@ boolean Xsns29(byte function)
 
   if (i2c_flg) {
     switch (function) {
-      case FUNC_PREP_BEFORE_TELEPERIOD:
+      case FUNC_EVERY_SECOND:
         MCP230xx_Detect();
         break;
       case FUNC_EVERY_50_MSECOND:


### PR DESCRIPTION
Move LM75ADDetect() and MCP230xx_Detect() from FUNC_PREP_BEFORE_TELEPERIOD to FUNC_EVERY_SECOND