### PR TITLE
Bugfix MCP230xx driver

### DIFF
--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -213,9 +213,9 @@ void MCP230xx_ApplySettings(void) {
   uint8_t reg_iodir = 0xFF;
   for (uint8_t idx = 0; idx < 8; idx++) {
     if (Settings.mcp230xx_config[idx].enable) {
+      reg_iodir |= (1 << idx);                   // Force pin to input state if enabled
       if (Settings.mcp230xx_config[idx].inten) { // Int is enabled in some form or another
         reg_gpinten |= (1 << idx);
-        reg_iodir |= (1 << idx);                 // Force pin to input state if enabled
       }
       if (Settings.mcp230xx_config[idx].pullup) {
         reg_gppu |= (1 << idx);
@@ -231,9 +231,9 @@ void MCP230xx_ApplySettings(void) {
     reg_iodir = 0xFF;
     for (uint8_t idx = 8; idx < 16; idx++) {
       if (Settings.mcp230xx_config[idx].enable) {
+        reg_iodir |= (1 << idx - 8);               // Force pin to input state if enabled
         if (Settings.mcp230xx_config[idx].inten) { // Int is enabled in some form or another
           reg_gpinten |= (1 << idx - 8);
-          reg_iodir |= (1 << idx - 8);             // Force pin to input state if enabled
         }
         if (Settings.mcp230xx_config[idx].pullup) {
           reg_gppu |= (1 << idx - 8);


### PR DESCRIPTION
1. Force IO direction register to INPUT if pin is enabled
2. Prevent sensor29 from being used on pins outside of valid pins for MCP230xx variant detected... i.e. 0-7 for MCP23008 and 0-17 for MCP23017
