### PR TITLE
MCP23008/MCP23017 - Remove web config & extend sensor29 command

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -155,11 +155,9 @@ typedef union {
 typedef union {
   uint8_t data;
   struct {
-    uint8_t enable : 1;                    // Enable INPUT
+    uint8_t pinmode : 3;                    // Enable INPUT
     uint8_t pullup : 1;                    // Enable internal weak pull-up resistor
-    uint8_t inten : 1;                     // Enable Interrupt on PIN
-    uint8_t intmode : 1;                   // Change on STATE or match COMPARATOR
-    uint8_t intcomp : 1;                   // Interrupt COMPARATOR
+    uint8_t b4 : 1;
     uint8_t b5 : 1;
     uint8_t b6 : 1;
     uint8_t b7 : 1;

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -288,8 +288,6 @@
   #define USE_LM75AD                             // Enable LM75AD sensor (I2C addresses 0x48 - 0x4F) (+0k5 code)
 //  #define USE_APDS9960                           // Enable APDS9960 Proximity Sensor (I2C address 0x39). Disables SHT and VEML6070 (+4k7 code)
 //  #define USE_MCP230xx                           // Enable MCP23008/MCP23017 for GP INPUT ONLY (I2C addresses 0x20 - 0x27) providing command Sensor29 for configuration (+2k2 code)
-//    #define USE_MCP230xx_displaymain             // Display pin status on Tasmota main page (+0k2 code)
-//    #define USE_MCP230xx_webconfig               // Enable web config button and form to Tasmota web interface (+2k1 code)
 //  #define USE_MPR121                             // Enable MPR121 controller (I2C addresses 0x5A, 0x5B, 0x5C and 0x5D) in input mode for touch buttons (+1k3 code)
 #endif  // USE_I2C
 

--- a/sonoff/xdrv_02_webserver.ino
+++ b/sonoff/xdrv_02_webserver.ino
@@ -190,10 +190,6 @@ const char HTTP_BTN_RSTRT[] PROGMEM =
   "<br/><form action='rb' method='get' onsubmit='return confirm(\"" D_CONFIRM_RESTART "\");'><button class='button bred'>" D_RESTART "</button></form>";
 const char HTTP_BTN_MENU_MODULE[] PROGMEM =
   "<br/><form action='md' method='get'><button>" D_CONFIGURE_MODULE "</button></form>";
-#if defined(USE_I2C) && defined(USE_MCP230xx) && defined(USE_MCP230xx_webconfig)
-const char HTTP_BTN_MCP230XX[] PROGMEM =
-  "<br/><form action='mc' method='get'><button>" D_CONFIGURE_MCP230XX "</button></form>";
-#endif  // USE_I2C and USE_MCP230xx and USE_MCP230xx_webconfig
 #if defined(USE_TIMERS) && defined(USE_TIMERS_WEB)
 const char HTTP_BTN_MENU_TIMER[] PROGMEM =
   "<br/><form action='tm' method='get'><button>" D_CONFIGURE_TIMER "</button></form>";
@@ -383,9 +379,6 @@ void StartWebserver(int type, IPAddress ipweb)
 #ifndef BE_MINIMAL
       WebServer->on("/cn", HandleConfiguration);
       WebServer->on("/md", HandleModuleConfiguration);
-#if defined(USE_I2C) && defined(USE_MCP230xx) && defined(USE_MCP230xx_webconfig)
-      WebServer->on("/mc", HandleMCP230xxConfiguration);
-#endif  // USE_I2C and USE_MCP230xx and USE_MCP230xx_webconfig
 #if defined(USE_TIMERS) && defined(USE_TIMERS_WEB)
       WebServer->on("/tm", HandleTimerConfiguration);
 #endif  // USE_TIMERS and USE_TIMERS_WEB
@@ -693,11 +686,6 @@ void HandleConfiguration()
   page.replace(F("{v}"), FPSTR(S_CONFIGURATION));
   page += FPSTR(HTTP_HEAD_STYLE);
   page += FPSTR(HTTP_BTN_MENU_MODULE);
-#if defined(USE_I2C) && defined(USE_MCP230xx) && defined(USE_MCP230xx_webconfig)
-  if (MCP230xx_Type()) {	// Configuration button will only show if MCP23008/MCP23017 was detected on I2C
-    page += FPSTR(HTTP_BTN_MCP230XX);
-  }
-#endif  // USE_I2C and USE_MCP230xx and USE_MCP230xx_webconfig
 #if defined(USE_TIMERS) && defined(USE_TIMERS_WEB)
 #ifdef USE_RULES
   page += FPSTR(HTTP_BTN_MENU_TIMER);
@@ -1136,11 +1124,6 @@ void HandleSaveSettings()
     }
     AddLog(LOG_LEVEL_INFO);
     break;
-#if defined(USE_I2C) && defined(USE_MCP230xx) && defined(USE_MCP230xx_webconfig)
-  case 8:
-    MCP230xx_SaveSettings();
-    break;
-#endif  // USE_I2C and USE_MCP230xx and USE_MCP230xx_webconfig
   case 6:
     WebGetArg("g99", tmp, sizeof(tmp));
     byte new_module = (!strlen(tmp)) ? MODULE : atoi(tmp);

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -68,14 +68,19 @@ void MCP230xx_ApplySettings(void) {
   uint8_t reg_gpinten = 0;
   uint8_t reg_iodir = 0xFF;
   for (uint8_t idx = 0; idx < 8; idx++) {
-    if (Settings.mcp230xx_config[idx].pinmode > 0) {
-      reg_iodir |= (1 << idx);                   // Force pin to input state if enabled
-      if (Settings.mcp230xx_config[idx].pinmode > 1) { // Int is enabled in some form or another
+    switch (Settings.mcp230xx_config[idx].pinmode) {
+      case 0 ... 1:
+        reg_iodir |= (1 << idx);
+        break;
+      case 2 ... 4:
+        reg_iodir |= (1 << idx);
         reg_gpinten |= (1 << idx);
-      }
-      if (Settings.mcp230xx_config[idx].pullup) {
-        reg_gppu |= (1 << idx);
-      }
+        break;
+      default:
+        break;
+    }
+    if (Settings.mcp230xx_config[idx].pullup) {
+      reg_gppu |= (1 << idx);
     }
   }
   I2cWrite8(mcp230xx_address, MCP230xx_GPPU, reg_gppu);
@@ -86,14 +91,19 @@ void MCP230xx_ApplySettings(void) {
     reg_gpinten = 0;
     reg_iodir = 0xFF;
     for (uint8_t idx = 8; idx < 16; idx++) {
-      if (Settings.mcp230xx_config[idx].pinmode > 0) {
-        reg_iodir |= (1 << idx - 8);               // Force pin to input state if enabled
-        if (Settings.mcp230xx_config[idx].pinmode > 1) { // Int is enabled in some form or another
+      switch (Settings.mcp230xx_config[idx].pinmode) {
+        case 0 ... 1:
+          reg_iodir |= (1 << idx - 8);
+          break;
+        case 2 ... 4:
+          reg_iodir |= (1 << idx - 8);
           reg_gpinten |= (1 << idx - 8);
-        }
-        if (Settings.mcp230xx_config[idx].pullup) {
-          reg_gppu |= (1 << idx - 8);
-        }
+          break;
+        default:
+          break;
+      }
+      if (Settings.mcp230xx_config[idx].pullup) {
+        reg_gppu |= (1 << idx - 8);
       }
     }
     I2cWrite8(mcp230xx_address, MCP230xx_GPPU + 1, reg_gppu);


### PR DESCRIPTION
1. Removed web configuration option as it uses too much ram in relation to benefit
2. Updated the config structure to use a single pinmode 3 bit value to determine the mode of an input pin which makes it easier to implement in the code
3. Extended the sensor29 command as follows:

`sensor29 reset` - Will reset all pins to input without internal pull-up resistors

`MQT: stat/sonoff/RESULT = {"Sensor29":{"D":99,"MODE":99,"PULL-UP":99}}`

Note the 99's are returned in all values due to the reset confirmation

`sensor29 pin,?` - Will send a response as follows showing the current configuration of a pin

`MQT: stat/sonoff/RESULT = {"Sensor29":{"D":0,"MODE":1,"PULL-UP":0}}`

Existing sensor29 commands for configuration persist as follows, to configure pin 0 as input with pull-up:

`sensor29 0,1,1`

`Response receive: MQT: stat/sonoff/RESULT = {"Sensor29":{"D":0,"MODE":1,"PULL-UP":1}}`

Configure pin 8 (Pin B0 on the chip) as input with interrupt on LOW with pull-up using the command
`sensor29 8,3,1`

And interrupt is reported when the pin goes low as follows

`MQT: stat/sonoff/RESULT = {"Time":"2018-07-21T17:12:08","MCP230XX_INT":{"Pin":"D8", "State":0}}`
