### PR TITLE
KNX: Add new event and new commands

### DIFF
--- a/lib/esp-knx-ip-0.5.1/keywords.txt
+++ b/lib/esp-knx-ip-0.5.1/keywords.txt
@@ -1,14 +1,14 @@
 # datatypes
-address_t	DATA_TYPE
-message_t	DATA_TYPE
-callback_id_t	DATA_TYPE
-callback_assignment_id_t	DATA_TYPE
-option_entry_t	DATA_TYPE
-config_id_t	DATA_TYPE
-enable_condition_t	DATA_TYPE
-callback_fptr_t	DATA_TYPE
-feedback_action_fptr_t	DATA_TYPE
-knx_command_type_t	DATA_TYPE
+address_t	KEYWORD1 DATA_TYPE
+message_t	KEYWORD1 DATA_TYPE
+callback_id_t	KEYWORD1 DATA_TYPE
+callback_assignment_id_t KEYWORD1 DATA_TYPE
+option_entry_t KEYWORD1 DATA_TYPE
+config_id_t KEYWORD1 DATA_TYPE
+enable_condition_t KEYWORD1 DATA_TYPE
+callback_fptr_t	KEYWORD1 DATA_TYPE
+feedback_action_fptr_t KEYWORD1 DATA_TYPE
+knx_command_type_t KEYWORD1 DATA_TYPE
 
 # methods
 setup	KEYWORD2
@@ -92,13 +92,13 @@ answer_4byte_int	KEYWORD2
 answer_4byte_uint	KEYWORD2
 answer_4byte_float	KEYWORD2
 
-data_to_1byte_int	KEYWORD 2
-data_to_2byte_int	KEYWORD 2
-data_to_2byte_float	KEYWORD 2
-data_to_4byte_float	KEYWORD 2
-data_to_3byte_color	KEYWORD 2
-data_to_3byte_time	KEYWORD 2
-data_to_3byte_data	KEYWORD 2
+data_to_1byte_int	KEYWORD2
+data_to_2byte_int	KEYWORD2
+data_to_2byte_float	KEYWORD2
+data_to_4byte_float	KEYWORD2
+data_to_3byte_color	KEYWORD2
+data_to_3byte_time	KEYWORD2
+data_to_3byte_data	KEYWORD2
 
 # constants
 knx	LITERAL1

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -238,6 +238,7 @@
 
 // -- KNX IP Protocol -----------------------------
 //#define USE_KNX                                  // Enable KNX IP Protocol Support (+23k code, +3k3 mem)
+  #define USE_KNX_WEB_MENU                       // Enable KNX WEB MENU
 
 // -- HTTP ----------------------------------------
 #define USE_WEBSERVER                            // Enable web server and Wifi Manager (+66k code, +8k mem)

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -237,8 +237,8 @@
 //#define USE_MQTT_TLS                             // Use TLS for MQTT connection (+53k code, +15k mem)
 
 // -- KNX IP Protocol -----------------------------
-//#define USE_KNX                                  // Enable KNX IP Protocol Support (+23k code, +3k3 mem)
-  #define USE_KNX_WEB_MENU                       // Enable KNX WEB MENU
+//#define USE_KNX                                  // Enable KNX IP Protocol Support (+9.4k code, +3k7 mem)
+  #define USE_KNX_WEB_MENU                       // Enable KNX WEB MENU (+8.3k code, +144 mem)
 
 // -- HTTP ----------------------------------------
 #define USE_WEBSERVER                            // Enable web server and Wifi Manager (+66k code, +8k mem)

--- a/sonoff/xdrv_02_webserver.ino
+++ b/sonoff/xdrv_02_webserver.ino
@@ -204,7 +204,9 @@ const char HTTP_BTN_MENU_MQTT[] PROGMEM =
   "";
 const char HTTP_BTN_MENU4[] PROGMEM =
 #ifdef USE_KNX
+#ifdef USE_KNX_WEB_MENU
   "<br/><form action='kn' method='get'><button>" D_CONFIGURE_KNX "</button></form>"
+#endif  // USE_KNX_WEB_MENU
 #endif  // USE_KNX
   "<br/><form action='lg' method='get'><button>" D_CONFIGURE_LOGGING "</button></form>"
   "<br/><form action='co' method='get'><button>" D_CONFIGURE_OTHER "</button></form>"
@@ -391,7 +393,9 @@ void StartWebserver(int type, IPAddress ipweb)
 #endif  // USE_DOMOTICZ
       }
 #ifdef USE_KNX
+#ifdef USE_KNX_WEB_MENU
       WebServer->on("/kn", HandleKNXConfiguration);
+#endif // USE_KNX_WEB_MENU
 #endif // USE_KNX
       WebServer->on("/lg", HandleLoggingConfiguration);
       WebServer->on("/co", HandleOtherConfiguration);

--- a/sonoff/xdrv_11_knx.ino
+++ b/sonoff/xdrv_11_knx.ino
@@ -716,6 +716,7 @@ void KnxSensor(byte sensor_type, float value)
 \*********************************************************************************************/
 
 #ifdef USE_WEBSERVER
+#ifdef USE_KNX_WEB_MENU
 const char S_CONFIGURE_KNX[] PROGMEM = D_CONFIGURE_KNX;
 
 const char HTTP_FORM_KNX[] PROGMEM =
@@ -1020,6 +1021,7 @@ void KNX_Save_Settings()
   }
 }
 
+#endif  // USE_KNX_WEB_MENU
 #endif  // USE_WEBSERVER
 
 


### PR DESCRIPTION
* Added the `EVENT#KNXRX_VAL1...5` when receiving values from the KNX Network or another Tasmota with KNX. Now, sensor values (for example) can be sent from one device to another.

* Added Command `KNX_ENABLED 0 / 1` to enable / disable KNX communication

* Added Command `KNX_ENHANCED 0 / 1` to enable / disable KNX enhanced communication

* Added an optional entry to _user_config.h_ file to include or not the KNX WEB MENU

* Corrections of KEYWORD_TOKENTYPE to the _keywords.txt_ file of the ESP-KNX-IP Library