### PR TITLE
Move subStr() Function to Support.ino

### DIFF
--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -130,6 +130,24 @@ size_t strchrspn(const char *str1, int character)
   return ret;
 }
 
+// Function to return a substring defined by a delimiter at an index
+char* subStr(char* dest, char* str, const char *delim, int index)
+{
+  char *act;
+  char *sub;
+  char *ptr;
+  int i;
+
+  // Since strtok consumes the first arg, make a copy
+  strncpy(dest, str, strlen(str));
+  for (i = 1, act = dest; i <= index; i++, act = NULL) {
+    sub = strtok_r(act, delim, &ptr);
+    if (sub == NULL) break;
+  }
+  sub = Trim(sub);
+  return sub;
+}
+
 double CharToDouble(char *str)
 {
   // simple ascii to double, because atof or strtod are too large

--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -603,24 +603,6 @@ double map_double(double x, double in_min, double in_max, double out_min, double
  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
-// Function to return a substring defined by a delimiter at an index
-char* subStr(char* dest, char* str, const char *delim, int index)
-{
-  char *act;
-  char *sub;
-  char *ptr;
-  int i;
-
-  // Since strtok consumes the first arg, make a copy
-  strncpy(dest, str, strlen(str));
-  for (i = 1, act = dest; i <= index; i++, act = NULL) {
-    sub = strtok_r(act, delim, &ptr);
-    if (sub == NULL) break;
-  }
-  sub = Trim(sub);
-  return sub;
-}
-
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/


### PR DESCRIPTION
Please, Move subStr() Function to Support.ino due it is usefull for splitting command arguments (like scale 2,0,10,0,100) for other drivers too.