### PR TITLE
Support send / receive of binary serial data

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -48,7 +48,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t not_power_linked : 1;         // bit 20 (v5.11.1f)
     uint32_t no_power_on_check : 1;        // bit 21 (v5.11.1i)
     uint32_t mqtt_serial : 1;              // bit 22 (v5.12.0f)
-    uint32_t rules_enabled : 1;            // bit 23 (v5.12.0j) - free since v5.14.0b
+    uint32_t mqtt_serial_raw : 1;          // bit 23 (vTDB)
     uint32_t rules_once : 1;               // bit 24 (v5.12.0k) - free since v5.14.0b
     uint32_t knx_enabled : 1;              // bit 25 (v5.12.0l) KNX
     uint32_t device_index_enable : 1;      // bit 26 (v5.13.1a)

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -756,7 +756,7 @@ void SettingsDelta()
     }
     if (Settings.version < 0x050E0002) {
       for (byte i = 1; i < MAX_RULE_SETS; i++) { Settings.rules[i][0] = '\0'; }
-      Settings.rule_enabled = Settings.flag.rules_enabled;
+      Settings.rule_enabled = Settings.flag.mqtt_serial_raw;
       Settings.rule_once = Settings.flag.rules_once;
     }
     if (Settings.version < 0x06000000) {
@@ -778,7 +778,7 @@ void SettingsDelta()
       }
     }
     if (Settings.version < 0x06000003) {
-      Settings.flag.rules_enabled = 0;
+      Settings.flag.mqtt_serial_raw = 0;
       Settings.flag.rules_once = 0;
       Settings.flag3.data = 0;
     }


### PR DESCRIPTION
Add command serialsend4 which supports sending and receiving raw binary data, including NUL character.
Sending of data is done with binary data in the mqtt message

Received data is sent as hex-strings, example:
`tasmota/sonoff_0FAC39/tele/RESULT:{"SerialReceived":"403f10003c0304430000948583120d"}`
Another option could be to send the received data in a non JSON-endoded message.

The changes can be included also in the softserial bridge in xdrv_08_serial_bridge.ino, please let me know and I'll update the PR with sames changes there.