### PR TITLE
Fix bug in MCP230xx_CheckForInterrupt()

### DIFF
--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -146,7 +146,7 @@ bool MCP230xx_CheckForInterrupt(void) {
             if ((intf >> intp) & 0x01) { // we know which pin caused interrupt
               report_int = 0;
               if (Settings.mcp230xx_config[intp+(mcp230xx_port*8)].pinmode > 1) {
-                switch (Settings.mcp230xx_config[+(mcp230xx_port*8)].pinmode) {
+                switch (Settings.mcp230xx_config[intp+(mcp230xx_port*8)].pinmode) {
                   case 2:
                     report_int = 1;
                     break;


### PR DESCRIPTION
Fix bug in MCP230xx_CheckForInterrupt() where incorrect setting register was referenced due to math in loop missing intp for index reference to "Settings.mcp230xx_config[intp+(mcp230xx_port*8)].pinmode"