### PR TITLE
MCP23008/MCP23017 - Add event command when interrupt is detected

### DIFF
--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -164,6 +164,9 @@ bool MCP230xx_CheckForInterrupt(void) {
                   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"MCP230XX_INT\":{\"D%i\":%i}"), mqtt_data, intp+(mcp230xx_port*8), ((mcp230xx_intcap >> intp) & 0x01));
                   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
                   MqttPublishPrefixTopic_P(RESULT_OR_STAT, mqtt_data);
+                  char command[13];
+                  sprintf(command,"event MCPINTD%i=%i",intp+(mcp230xx_port*8),((mcp230xx_intcap >> intp) & 0x01));
+                  ExecuteCommand(command, SRC_RULE);
                 }
               }
             }

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -164,7 +164,7 @@ bool MCP230xx_CheckForInterrupt(void) {
                   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"MCP230XX_INT\":{\"D%i\":%i}"), mqtt_data, intp+(mcp230xx_port*8), ((mcp230xx_intcap >> intp) & 0x01));
                   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
                   MqttPublishPrefixTopic_P(RESULT_OR_STAT, mqtt_data);
-                  char command[13];
+                  char command[18];
                   sprintf(command,"event MCPINTD%i=%i",intp+(mcp230xx_port*8),((mcp230xx_intcap >> intp) & 0x01));
                   ExecuteCommand(command, SRC_RULE);
                 }


### PR DESCRIPTION
Currently there is no way for rules to respond to interrupts - currently, only interaction is for rules to get pin state from telemetry data and process accordingly, but this will lead to missed interrupts causing time critical rules not to be run/detected.

Code was added to MCP230xx_CheckForInterrupt() to send a command
`event MCPINTDxx=y`
where xx = pin number on which interrupt was detected and
y = state of the pin as captured by the interrupt register on the MCP23008/MCP23017 chip.

This results in the Tasmota firmware receiving something like this:

```
MQT: stat/sonoff/RESULT = {"Time":"2018-08-01T17:53:34","MCP230XX_INT":{"D0":0}}
SRC: Rule
RSL: Group 0, Index 1, Command EVENT, Data MCPINTD0=0
MQT: stat/sonoff/RESULT = {"Event":"Done"}
```

This output may then be immediately processed by a rule, for example as the following:

`rule on event#MCPINTD0=1 do power on endon on event#MCPINTD0=0 do power off endon`

So if the interrupt was registered 1/HIGH for input pin 0 on the MCP chip the rule will cause "power on" command to be run whilst also in this example "power off" will be executed if pin 0 raised an interrupt and the captured state of the pin was low.

The events will only be executed/sent based on the interrupt configuration... i.e. on CHANGE, on LOW, or on HIGH.

Needless to say any other commands may be substituted so it could cause any other behaviour required based on what the "on event#MCPINTx=x" has been told to respond to.
