### PR TITLE
Build time setting of button and switch topic

### DIFF
--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -458,8 +458,8 @@ void SettingsDefaultSet2()
   strlcpy(Settings.mqtt_user, MQTT_USER, sizeof(Settings.mqtt_user));
   strlcpy(Settings.mqtt_pwd, MQTT_PASS, sizeof(Settings.mqtt_pwd));
   strlcpy(Settings.mqtt_topic, MQTT_TOPIC, sizeof(Settings.mqtt_topic));
-  strlcpy(Settings.button_topic, "0", sizeof(Settings.button_topic));
-  strlcpy(Settings.switch_topic, "0", sizeof(Settings.switch_topic));
+  strlcpy(Settings.button_topic, MQTT_BUTTON_TOPIC, sizeof(Settings.button_topic));
+  strlcpy(Settings.switch_topic, MQTT_SWITCH_TOPIC, sizeof(Settings.switch_topic));
   strlcpy(Settings.mqtt_grptopic, MQTT_GRPTOPIC, sizeof(Settings.mqtt_grptopic));
   strlcpy(Settings.mqtt_fulltopic, MQTT_FULLTOPIC, sizeof(Settings.mqtt_fulltopic));
   Settings.mqtt_retry = MQTT_RETRY_SECS;

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -110,8 +110,10 @@
 #define PUB_PREFIX2            "tele"            // [Prefix3] Sonoff devices publish telemetry data to %prefix%/%topic% being PUB_PREFIX2/MQTT_TOPIC/UPTIME, POWER and TIME
                                                  //   May be named the same as PUB_PREFIX
 // %topic% token options (also ButtonTopic and SwitchTopic)
-#define MQTT_TOPIC             PROJECT           // [Topic] (unique) MQTT device topic
+#define MQTT_TOPIC             PROJECT           // [Topic] (unique) MQTT device topic, set to 'PROJECT "_%06X"' for unique topic including device MAC address
 #define MQTT_GRPTOPIC          "sonoffs"         // [GroupTopic] MQTT Group topic
+#define MQTT_BUTTON_TOPIC      "0"               // [ButtonTopic] MQTT button topic, "0" = same as MQTT_TOPIC, set to 'PROJECT "_BTN_%06X"' for unique topic including device MAC address
+#define MQTT_SWITCH_TOPIC      "0"               // [SwitchTopic] MQTT button topic, "0" = same as MQTT_TOPIC, set to 'PROJECT "_SW_%06X"' for unique topic including device MAC address
 #define MQTT_CLIENT_ID         "DVES_%06X"       // [MqttClient] Also fall back topic using Chip Id = last 6 characters of MAC address
 
 // -- MQTT - Telemetry ----------------------------

--- a/sonoff/xdrv_01_mqtt.ino
+++ b/sonoff/xdrv_01_mqtt.ino
@@ -692,7 +692,10 @@ bool MqttCommand()
     if ((data_len > 0) && (data_len < sizeof(Settings.button_topic))) {
       MakeValidMqtt(0, dataBuf);
       if (!strcmp(dataBuf, mqtt_client)) payload = 1;
-      strlcpy(Settings.button_topic, (!strcmp(dataBuf,"0")) ? "" : (1 == payload) ? mqtt_topic : dataBuf, sizeof(Settings.button_topic));
+      if (!strcmp(dataBuf,"0")) strlcpy(Settings.button_topic, "", sizeof(Settings.button_topic));
+      else if (1 == payload) strlcpy(Settings.button_topic, mqtt_topic, sizeof(Settings.button_topic));
+      else if (2 == payload) strlcpy(Settings.button_topic, MQTT_BUTTON_TOPIC, sizeof(Settings.button_topic));
+      else strlcpy(Settings.button_topic, dataBuf, sizeof(Settings.button_topic));
     }
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, command, Settings.button_topic);
   }
@@ -700,7 +703,10 @@ bool MqttCommand()
     if ((data_len > 0) && (data_len < sizeof(Settings.switch_topic))) {
       MakeValidMqtt(0, dataBuf);
       if (!strcmp(dataBuf, mqtt_client)) payload = 1;
-      strlcpy(Settings.switch_topic, (!strcmp(dataBuf,"0")) ? "" : (1 == payload) ? mqtt_topic : dataBuf, sizeof(Settings.switch_topic));
+      if (!strcmp(dataBuf,"0")) strlcpy(Settings.switch_topic, "", sizeof(Settings.switch_topic));
+      else if (1 == payload) strlcpy(Settings.switch_topic, mqtt_topic, sizeof(Settings.switch_topic));
+      else if (2 == payload) strlcpy(Settings.switch_topic, MQTT_SWITCH_TOPIC, sizeof(Settings.switch_topic));
+      else strlcpy(Settings.switch_topic, dataBuf, sizeof(Settings.switch_topic));
     }
     snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, command, Settings.switch_topic);
   }


### PR DESCRIPTION
Add build time setting of button and switch topic.

Update ButtonTopic and SwitchTopic commands with option 2 to revert back to build time topic:

ButtonTopic |   | Show current MQTT button topic
-- | -- | --
ButtonTopic | 0 / off | Disable use of MQTT button topic
ButtonTopic | 1 | Set MQTT button topic to Topic
**ButtonTopic** | **2** | **Set MQTT button topic to user_config.h(MQTT_BUTTON_TOPIC)**
ButtonTopic | <topic> | Set MQTT button topic (32 chars max)

Note: This is an improved version of similar change in #2277 which was reverted in 914c2929f8afc70e28ba25be7d78337b29cc3652
