### PR TITLE
Changed CounterType 1 to micros() and implemented stall detection

### DIFF
--- a/sonoff/xsns_01_counter.ino
+++ b/sonoff/xsns_01_counter.ino
@@ -21,13 +21,13 @@
  * Counter sensors (water meters, electricity meters etc.)
 \*********************************************************************************************/
 
-unsigned long last_counter_timer[MAX_COUNTERS]; // Last counter time in milli seconds
+unsigned long last_counter_timer[MAX_COUNTERS]; // Last counter time in micro seconds
 
 void CounterUpdate(byte index)
 {
-  unsigned long counter_debounce_time = millis() - last_counter_timer[index -1];
-  if (counter_debounce_time > Settings.pulse_counter_debounce) {
-    last_counter_timer[index -1] = millis();
+  unsigned long counter_debounce_time = micros() - last_counter_timer[index -1];
+  if (counter_debounce_time > Settings.pulse_counter_debounce * 1000) {
+    last_counter_timer[index -1] = micros();
     if (bitRead(Settings.pulse_counter_type, index -1)) {
       RtcSettings.pulse_counter[index -1] = counter_debounce_time;
     } else {
@@ -98,7 +98,7 @@ void CounterShow(boolean json)
   for (byte i = 0; i < MAX_COUNTERS; i++) {
     if (pin[GPIO_CNTR1 +i] < 99) {
       if (bitRead(Settings.pulse_counter_type, i)) {
-        dtostrfd((double)RtcSettings.pulse_counter[i] / 1000, 3, counter);
+        dtostrfd((double)RtcSettings.pulse_counter[i] / 1000000, 6, counter);
       } else {
         dsxflg++;
         dtostrfd(RtcSettings.pulse_counter[i], 0, counter);
@@ -124,6 +124,7 @@ void CounterShow(boolean json)
 #endif  // USE_WEBSERVER
       }
     }
+    if(bitRead(Settings.pulse_counter_type, i)) RtcSettings.pulse_counter[i]=0xFFFFFFFF; // Set Timer to max in case of no more interrupts due to stall of measured device
   }
   if (json) {
     if (header) {


### PR DESCRIPTION
Hi,

I was in need of a time in flight measurement for a fan so I tried CounterType 1 on a GPIO. Due to the usage of millis this was not very accurate why I changed millis to micros. Now the max. time difference is 71 seconds what would make a rather slow fan. Also recognized that a stalled fan isn't detected. CounterShow always reports the last value and if the device stalls there are no new interrupts and so no change of the Time in Flight. Fixed this by setting RtcSettingsPulseCount to max. in case of counter type 1 after show. Maybe 0 would be better so feel free to use what you prefer. Would also like to have a shorter telemetry periode maybe down to 1 second but this is not part of this pull request.

Greetings,

         Heiko.