### PR TITLE
Rename mcp230xx_config[].b4 to mcp230xx_config[].saved_state

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -154,9 +154,9 @@ typedef union {
 typedef union {
   uint8_t data;
   struct {
-    uint8_t pinmode : 3;                   // Enable INPUT
+    uint8_t pinmode : 3;                   // Pin mode (1 through 5)
     uint8_t pullup : 1;                    // Enable internal weak pull-up resistor
-    uint8_t b4 : 1;
+    uint8_t saved_state : 1;               // Save output state, if used.
     uint8_t b5 : 1;
     uint8_t b6 : 1;
     uint8_t b7 : 1;

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -95,7 +95,7 @@ void MCP230xx_ApplySettings(void) {
         case 5:
           reg_iodir &= ~(1 << idx);
           if (Settings.flag.save_state) { // Firmware configuration wants us to use the last pin state
-            reg_portpins |= (Settings.mcp230xx_config[idx+(mcp230xx_port*8)].b4 << idx);
+            reg_portpins |= (Settings.mcp230xx_config[idx+(mcp230xx_port*8)].saved_state << idx);
           } else {
             if (Settings.mcp230xx_config[idx+(mcp230xx_port*8)].pullup) {
               reg_portpins |= (1 << idx);
@@ -128,11 +128,11 @@ void MCP230xx_ApplySettings(void) {
 
 void MCP230xx_Detect()
 {
-  uint8_t buffer;
-
   if (mcp230xx_type) {
     return;
   }
+
+  uint8_t buffer;
 
   for (byte i = 0; i < sizeof(mcp230xx_addresses); i++) {
     mcp230xx_address = mcp230xx_addresses[i];
@@ -243,7 +243,7 @@ void MCP230xx_SetOutPin(uint8_t pin,uint8_t pinstate) {
   }
   I2cWrite8(mcp230xx_address, MCP230xx_GPIO + port, portpins);
   if (Settings.flag.save_state) { // Firmware configured to save last known state in settings
-    Settings.mcp230xx_config[pin].b4=portpins>>(pin-(port*8))&1;
+    Settings.mcp230xx_config[pin].saved_state=portpins>>(pin-(port*8))&1;
   }
   switch (pinstate) {
     case 0:
@@ -269,7 +269,7 @@ void MCP230xx_Reset(uint8_t pinmode) {
   for (uint8_t pinx=0;pinx<16;pinx++) {
     Settings.mcp230xx_config[pinx].pinmode=pinmode;
     Settings.mcp230xx_config[pinx].pullup=pullup;
-    Settings.mcp230xx_config[pinx].b4=0;
+    Settings.mcp230xx_config[pinx].saved_state=0;
     Settings.mcp230xx_config[pinx].b5=0;
     Settings.mcp230xx_config[pinx].b6=0;
     Settings.mcp230xx_config[pinx].b7=0;


### PR DESCRIPTION
Rename bit4 field to correctly represent its purpose, which is used when setoption0 = 1 is enabled in Tasmota firmware to store the last known state of an output pin for setting during reset/power-up.

Also moved construction of uint8_t buffer; to after return if already detected as it doesn't need to be constructed if function  MCP230xx_Detect() is going to return without doing anything with it.