### PR TITLE
MCP230xx - Make space for more config options

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -154,16 +154,16 @@ typedef union {
 typedef union {
   uint16_t data;
   struct {
-    uint8_t pinmode : 3;                   // Pin mode (1 through 6)
-    uint8_t pullup : 1;                    // Enable internal weak pull-up resistor
-    uint8_t saved_state : 1;               // Save output state, if used.
-    uint8_t int_report_mode : 2;           // Interrupt reporting mode 0 = immediate telemetry & event, 1 = immediate event only, 2 = immediate telemetry only
-    uint8_t int_report_defer : 4;          // Number of interrupts to ignore until reporting (default 0, max 15)
-    uint8_t int_count_sec : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND callback if more than 0 occured (overrides int_report_mode if enabled)
-    uint8_t int_count_min : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND*60 callback if more than 0 occured (overrides int_report_mode if enabled)
-    uint8_t spare13 : 1;
-    uint8_t spare14 : 1;
-    uint8_t spare15 : 1;
+    uint16_t pinmode : 3;                   // Pin mode (1 through 6)
+    uint16_t pullup : 1;                    // Enable internal weak pull-up resistor
+    uint16_t saved_state : 1;               // Save output state, if used.
+    uint16_t int_report_mode : 2;           // Interrupt reporting mode 0 = immediate telemetry & event, 1 = immediate event only, 2 = immediate telemetry only
+    uint16_t int_report_defer : 4;          // Number of interrupts to ignore until reporting (default 0, max 15)
+    uint16_t int_count_sec : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND callback if more than 0 occured (overrides int_report_mode if enabled)
+    uint16_t int_count_min : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND*60 callback if more than 0 occured (overrides int_report_mode if enabled)
+    uint16_t spare13 : 1;
+    uint16_t spare14 : 1;
+    uint16_t spare15 : 1;
   };
 } Mcp230xxCfg;
 

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -152,13 +152,18 @@ typedef union {
 } Timer;
 
 typedef union {
-  uint8_t data;
+  uint16_t data;
   struct {
     uint8_t pinmode : 3;                   // Pin mode (1 through 6)
     uint8_t pullup : 1;                    // Enable internal weak pull-up resistor
     uint8_t saved_state : 1;               // Save output state, if used.
     uint8_t int_report_mode : 2;           // Interrupt reporting mode 0 = immediate telemetry & event, 1 = immediate event only, 2 = immediate telemetry only
-    uint8_t b7 : 1;
+    uint8_t int_report_defer : 4;          // Number of interrupts to ignore until reporting (default 0, max 15)
+    uint8_t int_count_sec : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND callback if more than 0 occured (overrides int_report_mode if enabled)
+    uint8_t int_count_min : 1;             // 0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND*60 callback if more than 0 occured (overrides int_report_mode if enabled)
+    uint8_t spare13 : 1;
+    uint8_t spare14 : 1;
+    uint8_t spare15 : 1;
   };
 } Mcp230xxCfg;
 
@@ -317,8 +322,9 @@ struct SYSCFG {
   byte          knx_GA_param[MAX_KNX_GA];  // 6E2  Type of Input (relay changed, button pressed, sensor read <-teleperiod)
   byte          knx_CB_param[MAX_KNX_CB];  // 6EC  Type of Output (set relay, toggle relay, reply sensor value)
   Mcp230xxCfg   mcp230xx_config[16];       // 6F6
+  uint8_t       mcp230xx_int_prio;         // 716
 
-  byte          free_6f6[200];             // 706
+  byte          free_717[183];             // 717
 
   char          mems[RULES_MAX_MEMS][10];  // 7CE
                                            // 800 Full - no more free locations

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -350,8 +350,14 @@ void MCP230xx_Reset(uint8_t pinmode) {
     } else {
       Settings.mcp230xx_config[pinx].int_report_mode=3; // Disabled for pinmode 1, 5 and 6 (No interrupts there)
     }
-    Settings.mcp230xx_config[pinx].b7=0;
+    Settings.mcp230xx_config[pinx].int_report_defer=0; // Disabled
+    Settings.mcp230xx_config[pinx].int_count_sec; // Disabled
+    Settings.mcp230xx_config[pinx].int_count_min; // Disabled
+    Settings.mcp230xx_config[pinx].spare13=0;
+    Settings.mcp230xx_config[pinx].spare14=0;
+    Settings.mcp230xx_config[pinx].spare15=0;
   }
+  Settings.mcp230xx_int_prio=0; // Once per FUNC_EVERY_50_MSECOND callback
   MCP230xx_ApplySettings();
   char pulluptxt[7];
   char intmodetxt[9];


### PR DESCRIPTION
Updated mcp230xx_config from 8bit to 16bit to support additional
configuration options to be added.

`uint8_t int_report_defer : 4;`
Number of interrupts to ignore until reporting (default 0, max 15)
Will cause driver telemetry and/or event output until required number
of interrupts have occurred.

`uint8_t int_count_sec : 1;`
0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND callback 
if more than 0 occured (overrides int_report_mode if enabled)


`uint8_t int_count_min : 1;`
0 = Not, 1 = Report number of interrupts since last FUNC_EVERY_SECOND*60 callback
if more than 0 occured (overrides int_report_mode if enabled)

In the two cases above the plan is to implement a counter like configuration so
FUNC_EVERY_50_MSECOND will still run but will not report immediate telemetry or event
but report the number of interrupts which occurred either in the last 20 FUNC_EVERY_SECOND (1 second)
callbacks, or in the last 60 FUNC_EVERY_SECOND callbacks (1 minute)

Also added uint8_t mcp230xx_int_prio which will allow future configuration of
interrupt priority. Currently, interrupts are polled using the FUNC_EVERY_50_MSECOND
callback - Functionality will be added to implement multiples of FUNC_EVERY_50_MSECOND
in low power applications where the user may require interrupt polling only once per second
for example, then interrupt priority would be set to 20 (20*50ms = 1 second)



