### PR TITLE
Fix MQTT Reconnection Bug

### DIFF
--- a/sonoff/xdrv_01_mqtt.ino
+++ b/sonoff/xdrv_01_mqtt.ino
@@ -109,7 +109,6 @@ TasmotaMqtt MqttClient;
 
 bool MqttIsConnected()
 {
-  //return mqtt_connected;
   return MqttClient.Connected();
 }
 

--- a/sonoff/xdrv_01_mqtt.ino
+++ b/sonoff/xdrv_01_mqtt.ino
@@ -109,7 +109,8 @@ TasmotaMqtt MqttClient;
 
 bool MqttIsConnected()
 {
-  return mqtt_connected;
+  //return mqtt_connected;
+  return MqttClient.Connected();
 }
 
 void MqttDisconnect()


### PR DESCRIPTION
If you restart your wifi router, and you have **Tasmota_MQTT Library** with `wificonfig 5`, Tasmota don't realize of this _MQTT disconnection_.

This solves issue #3314