### PR TITLE
KNX: Automatic Multicast Library Selection

### DIFF
--- a/lib/ESPAsyncUDP-master/src/AsyncUDP.cpp
+++ b/lib/ESPAsyncUDP-master/src/AsyncUDP.cpp
@@ -1,3 +1,6 @@
+#include <core_version.h>         // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_3_0)
+#ifndef ARDUINO_ESP8266_RELEASE_2_3_0 // This Library will only work with ARDUINO_ESP8266_RELEASE_2_4_0 and up
+
 #include "Arduino.h"
 #include "ESPAsyncUDP.h"
 
@@ -425,3 +428,5 @@ size_t AsyncUDP::broadcast(AsyncUDPMessage &message)
     }
     return broadcast(message.data(), message.length());
 }
+
+#endif

--- a/lib/esp-knx-ip-0.5.1/esp-knx-ip.h
+++ b/lib/esp-knx-ip-0.5.1/esp-knx-ip.h
@@ -7,14 +7,6 @@
 #ifndef ESP_KNX_IP_H
 #define ESP_KNX_IP_H
 
-//#define USE_ASYNC_UDP     // UDP WIFI Library Selection for Multicast
-                          //   If commented out, the esp-knx-ip library will use WIFI_UDP Library that is compatible with ESP8266 Library Version 2.3.0 and up
-                          //   If not commented out, the esp-knx-ip library will use ESPAsyncUDP Library that is compatible with ESP8266 Library Version 2.4.0 and up
-                          //     The ESPAsyncUDP Library have a more reliable multicast communication
-                          //     Please Use it with Patch (https://github.com/me-no-dev/ESPAsyncUDP/pull/21) )
-                          //     check line 57 on esp-knx-ip.h file is uncommented: #include <ESPAsyncUDP.h>
-                          //       Comment out that line when using UDP WIFI to avoid compiling issues on PlatformIO with ESP8266 Library Version 2.3.0
-
 /**
  * CONFIG
  * All MAX_ values must not exceed 255 (1 byte, except MAC_CONFIG_SPACE which can go up to 2 bytes, so 0xffff in theory) and must not be negative!
@@ -54,8 +46,13 @@
 #include <EEPROM.h>
 #include <ESP8266WiFi.h>
 
+#include <core_version.h>         // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_3_0)
+#ifndef ARDUINO_ESP8266_RELEASE_2_3_0
+#define USE_ASYNC_UDP             // UDP WIFI Library Selection for Multicast
+#endif
+
 #ifdef USE_ASYNC_UDP
-//#include <ESPAsyncUDP.h>
+#include <ESPAsyncUDP.h>
 #else
 #include <WiFiUdp.h>
 #endif


### PR DESCRIPTION
With this PR, the selection of the Wifi Multicast Library used by the ESP-KNX-IP Library for KNX Tasmota Driver is automatic, using the ESP8266 Board Library Version:

If you compile using v2.3.0 will use WIFIUDP Library
If you compile using v2.4.0 and up (recommended v2.4.2) will use ESPAsyncUDP Library.

Both Libraries were modified in order to compile under Arduino or Platformio with any ESP8266 Board Library.