### PR TITLE
Revert "Fix ccs811 begin result check"

### DIFF
--- a/sonoff/xsns_31_ccs811.ino
+++ b/sonoff/xsns_31_ccs811.ino
@@ -47,12 +47,13 @@ void CCS811Update()  // Perform every n second
     tcnt = 0;
     CCS811_ready = 0;
     if (!CCS811_type) {
-      if (ccs.begin(CCS811_ADDRESS)) { // ccs.begin returns true in case of success
+      sint8_t res = ccs.begin(CCS811_ADDRESS);
+      if (!res) {
         CCS811_type = 1;
         snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, "CCS811", 0x5A);
         AddLog(LOG_LEVEL_DEBUG);
       } else {
-        //snprintf_P(log_data, sizeof(log_data), "CCS811 init failed");
+        //snprintf_P(log_data, sizeof(log_data), "CCS811 init failed: %d",res);
         //AddLog(LOG_LEVEL_DEBUG);
       }
     } else {


### PR DESCRIPTION
Reverts arendst/Sonoff-Tasmota#3666
Sorry, had installed official adafruit ccs811 1.0.1 library installed and there begin returns bool.
But library from tasmota repo have some custom version of ccs811, where begin returns some error codes...
