### PR TITLE
optionally append timezone to timestamp in JSON messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 
 ## Visual Studio Code specific ######
 .vscode
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -170,7 +170,7 @@ enum WeekInMonthOptions {Last, First, Second, Third, Fourth};
 enum DayOfTheWeekOptions {Sun=1, Mon, Tue, Wed, Thu, Fri, Sat};
 enum MonthNamesOptions {Jan=1, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec};
 enum HemisphereOptions {North, South};
-enum GetDateAndTimeOptions { DT_LOCAL, DT_UTC, DT_RESTART, DT_UPTIME };
+enum GetDateAndTimeOptions { DT_LOCAL, DT_UTC, DT_RESTART };
 
 enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE, LOG_LEVEL_ALL};
 

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1418,7 +1418,7 @@ void PublishStatus(uint8_t payload)
 
   if ((0 == payload) || (1 == payload)) {
     snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_STATUS D_STATUS1_PARAMETER "\":{\"" D_JSON_BAUDRATE "\":%d,\"" D_CMND_GROUPTOPIC "\":\"%s\",\"" D_CMND_OTAURL "\":\"%s\",\"" D_JSON_RESTARTREASON "\":\"%s\",\"" D_JSON_UPTIME "\":\"%s\",\"" D_JSON_STARTUPUTC "\":\"%s\",\"" D_CMND_SLEEP "\":%d,\"" D_JSON_BOOTCOUNT "\":%d,\"" D_JSON_SAVECOUNT "\":%d,\"" D_JSON_SAVEADDRESS "\":\"%X\"}}"),
-      baudrate, Settings.mqtt_grptopic, Settings.ota_url, GetResetReason().c_str(), GetDateAndTime(DT_UPTIME).c_str(), GetDateAndTime(DT_RESTART).c_str(), Settings.sleep, Settings.bootcount, Settings.save_flag, GetSettingsAddress());
+      baudrate, Settings.mqtt_grptopic, Settings.ota_url, GetResetReason().c_str(), GetUptime().c_str(), GetDateAndTime(DT_RESTART).c_str(), Settings.sleep, Settings.bootcount, Settings.save_flag, GetSettingsAddress());
     MqttPublishPrefixTopic_P(option, PSTR(D_CMND_STATUS "1"));
   }
 
@@ -1509,7 +1509,7 @@ void MqttShowState()
 {
   char stemp1[33];
 
-  snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s{\"" D_JSON_TIME "\":\"%s\",\"" D_JSON_UPTIME "\":\"%s\""), mqtt_data, GetDateAndTime(DT_LOCAL).c_str(), GetDateAndTime(DT_UPTIME).c_str());
+  snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s{\"" D_JSON_TIME "\":\"%s\",\"" D_JSON_UPTIME "\":\"%s\""), mqtt_data, GetDateAndTime(DT_LOCAL).c_str(), GetUptime().c_str());
 #ifdef USE_ADC_VCC
   dtostrfd((double)ESP.getVcc()/1000, 3, stemp1);
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"" D_JSON_VCC "\":%s"), mqtt_data, stemp1);
@@ -1626,7 +1626,7 @@ void PerformEverySecond()
 
   if ((2 == RtcTime.minute) && latest_uptime_flag) {
     latest_uptime_flag = false;
-    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_TIME "\":\"%s\",\"" D_JSON_UPTIME "\":\"%s\"}"), GetDateAndTime(DT_LOCAL).c_str(), GetDateAndTime(DT_UPTIME).c_str());
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_TIME "\":\"%s\",\"" D_JSON_UPTIME "\":\"%s\"}"), GetDateAndTime(DT_LOCAL).c_str(), GetUptime().c_str());
     MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_UPTIME));
   }
   if ((3 == RtcTime.minute) && !latest_uptime_flag) latest_uptime_flag = true;

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -152,6 +152,9 @@
 #define TIME_STD_HOUR          3                  // Hour (0 to 23)
 #define TIME_STD_OFFSET        +60                // Offset from UTC in minutes (-780 to +780)
 
+// -- Time - formatting options
+#define TIME_APPEND_TIMEZONE   0                   // for local timestamps: 0 = no timezone in string, 1 = append numeric timezone (e.g. "+1:00" or "-7:00")
+
 // -- Location ------------------------------------
 #define LATITUDE               48.858360         // [Latitude] Your location to be used with sunrise and sunset
 #define LONGITUDE              2.294442          // [Longitude] Your location to be used with sunrise and sunset

--- a/sonoff/xdrv_02_webserver.ino
+++ b/sonoff/xdrv_02_webserver.ino
@@ -1291,7 +1291,7 @@ void HandleInformation()
   func += F(D_PROGRAM_VERSION "}2"); func += my_version;
   func += F("}1" D_BUILD_DATE_AND_TIME "}2"); func += GetBuildDateAndTime();
   func += F("}1" D_CORE_AND_SDK_VERSION "}2" ARDUINO_ESP8266_RELEASE "/"); func += String(ESP.getSdkVersion());
-  func += F("}1" D_UPTIME "}2"); func += GetDateAndTime(DT_UPTIME);
+  func += F("}1" D_UPTIME "}2"); func += GetUptime();
   snprintf_P(stopic, sizeof(stopic), PSTR(" at %X"), GetSettingsAddress());
   func += F("}1" D_FLASH_WRITE_COUNT "}2"); func += String(Settings.save_flag); func += stopic;
   func += F("}1" D_BOOT_COUNT "}2"); func += String(Settings.bootcount);


### PR DESCRIPTION
See https://github.com/arendst/Sonoff-Tasmota/issues/3629

This allows one the compile-time choice to explicitly include a timezone offset in JSON timestamp strings, so that clients don't have to guess.

I refactored `GetDateAndTime()` while I was at it, removing the `DT_UPTIME` code that is already duplicated by `GetUptime()`.  This leaves `GetDateAndTime()` less complicated, I think.

-------------------------

**Test Results**

I burned this onto a Sonoff Basic twice, once with the flag on, once with it off.  I wasn't sure exactly how to document tests, so I grabbed console output in various situations.

Timezones were added when expected, and weren't when not, in both cases.

 
**With the flag = 1**

_On startup…_
```
14:29:00 MQT: tele/sonoff-pr-on/STATE = {"Time":"2018-09-05T14:29:00+01:00","Uptime":"0T00:04:15"...
```

_'timezone -7’_

-> status 7 unchanged
```
06:29:30 MQT: stat/sonoff-pr-on/STATUS7 = {"StatusTIM":{"UTC":"Wed Sep 05 13:29:30 2018","Local":"Wed Sep 05 06:29:30 2018","StartDST":"Sun Mar 25 02:00:00 2018","EndDST":"Sun Oct 28 03:00:00 2018","Timezone":-7,"Sunrise":"22:12","Sunset":"11:25"}}
```

-> status 11 ‘time’ has “-07:00", ‘uptime’ not affected
```
06:29:46 MQT: stat/sonoff-pr-on/STATUS11 = {"StatusSTS":{"Time":"2018-09-05T06:29:46-07:00","Uptime":"0T00:05:01”...
```

‘timezone 0'

-> status 11 ‘time’ has “+00:00”, ‘uptime’ not affected
```
13:30:27 MQT: stat/sonoff-pr-on/STATUS11 = {"StatusSTS":{"Time":"2018-09-05T13:30:27+00:00","Uptime":"0T00:05:42”…
```

-> status 1 ‘uptime’ and ‘startuputc’ not affected
```
13:31:22 MQT: stat/sonoff-pr-on/STATUS1 = {"StatusPRM":{"Baudrate":115200...,"Uptime":"0T00:06:37","StartupUTC":"2018-09-05T13:24:45”,...
```

-> status 2 build timestamp not affected
```
13:34:07 MQT: stat/sonoff-pr-on/STATUS2 = {"StatusFWR":{"Version":"6.2.0","BuildDateTime":"2018-09-05T06:23:39”,...
```

-> Info page
```
Uptime 0T00:10:48 
```

-> STATE message - “time” has timezone, uptime not affected
```
13:36:00 MQT: tele/sonoff-pr-on/STATE = {"Time":"2018-09-05T13:36:00+00:00","Uptime":"0T00:11:15”...
```


**With flag = 0**

_timezone -7_

-> status 11 shows current time
```
06:40:42 MQT: stat/sonoff-pr-on/STATUS11 = {"StatusSTS":{"Time":"2018-09-05T06:40:42","Uptime":"0T00:00:43"
```

_timezone +3_

-> status 11 shows current time (10 hours later)
```
16:40:56 MQT: stat/sonoff-pr-on/STATUS11 = {"StatusSTS":{"Time":"2018-09-05T16:40:56","Uptime":"0T00:00:57"
```

-> status 1  ‘uptime’ and ‘startuputc’ not affected
```
16:41:10 MQT: stat/sonoff-pr-on/STATUS1 = {"StatusPRM":{"Baudrate”:115200..."Uptime":"0T00:01:11"
```

-> status 2 build date not affected
```
16:41:12 MQT: stat/sonoff-pr-on/STATUS2 = {"StatusFWR":{"Version":"6.2.0","BuildDateTime":"2018-09-05T06:38:32","Boot":6,"Core":"2_3_0","SDK":"1.5.3(aec24ac9)”}}
```

-> Info page not affected
```
Uptime 0T00:02:06 
```

-> STATE message - 10 hours later, no timezone
```
16:42:12 MQT: tele/sonoff-pr-on/STATE = {"Time":"2018-09-05T16:42:12","Uptime":"0T00:02:13"
```
