### PR TITLE
Added DFPlayer Mini MP3 Player

### DIFF
--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Ключ"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Бутон"   // Suffix "1"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Spínač"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Tlačítko"   // Suffix "1"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRSend"
 #define D_SENSOR_SWITCH   "Switch "   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button "   // Suffix "1"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Διακόπτης"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Κουμπί"   // Suffix "1"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -456,7 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
-#define D_SENSOR_MP3_DFR562 "MP3 Player"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_MP3_DFR562 "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/language/es-AR.h
+++ b/sonoff/language/es-AR.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IR TX"
 #define D_SENSOR_SWITCH   "Llave"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Botón"   // Suffix "1"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "ÉmetIR"
 #define D_SENSOR_SWITCH   "Inter."     // Suffix "1"
 #define D_SENSOR_BUTTON   "Bouton"     // Suffix "1"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRadó"
 #define D_SENSOR_SWITCH   "Kapcsoló"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Gomb"   // Suffix "1"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Speler"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"  // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"  // Suffix "1"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Przela"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Przyci"   // Suffix "1"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Interruptor"	// Suffix "1"
 #define D_SENSOR_BUTTON   "Botão"   	// Suffix "1"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Interruptor"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Botão"   // Suffix "1"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Свич"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Кнопка"   // Suffix "1"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Перемикач"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Кнопка"   // Suffix "1"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -456,6 +456,7 @@
 #define D_SENSOR_I2C_SCL  "I2C SCL"
 #define D_SENSOR_I2C_SDA  "I2C SDA"
 #define D_SENSOR_WS2812   "WS2812"
+#define D_SENSOR_DFR562   "MP3 Player"
 #define D_SENSOR_IRSEND   "IRsend"
 #define D_SENSOR_SWITCH   "Switch"   // Suffix "1"
 #define D_SENSOR_BUTTON   "Button"   // Suffix "1"

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -122,6 +122,7 @@ enum UserSelectablePins {
   GPIO_CNTR4_NP,
   GPIO_PZEM2_TX,       // PZEM-003,014,016,017 Serial interface
   GPIO_PZEM2_RX,       // PZEM-003,014,016,017 Serial interface
+  GPIO_MP3_DFR562,     // RB-DFR-562, DFPlayer Mini MP3 Player
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality offset by user selectable GPIOs
@@ -172,7 +173,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_SWITCH "1n|" D_SENSOR_SWITCH "2n|" D_SENSOR_SWITCH "3n|" D_SENSOR_SWITCH "4n|" D_SENSOR_SWITCH "5n|" D_SENSOR_SWITCH "6n|" D_SENSOR_SWITCH "7n|" D_SENSOR_SWITCH "8n|"
   D_SENSOR_BUTTON "1n|" D_SENSOR_BUTTON "2n|" D_SENSOR_BUTTON "3n|" D_SENSOR_BUTTON "4n|"
   D_SENSOR_COUNTER "1n|" D_SENSOR_COUNTER "2n|" D_SENSOR_COUNTER "3n|" D_SENSOR_COUNTER "4n|"
-  D_SENSOR_PZEM_TX "|" D_SENSOR_PZEM_RX "|";
+  D_SENSOR_PZEM_TX "|" D_SENSOR_PZEM_RX "|"
+  D_SENSOR_MP3_DFR562;
 
 /********************************************************************************************/
 

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -174,7 +174,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_BUTTON "1n|" D_SENSOR_BUTTON "2n|" D_SENSOR_BUTTON "3n|" D_SENSOR_BUTTON "4n|"
   D_SENSOR_COUNTER "1n|" D_SENSOR_COUNTER "2n|" D_SENSOR_COUNTER "3n|" D_SENSOR_COUNTER "4n|"
   D_SENSOR_PZEM_TX "|" D_SENSOR_PZEM_RX "|"
-  D_SENSOR_MP3_DFR562;
+  D_SENSOR_DFR562;
 
 /********************************************************************************************/
 

--- a/sonoff/user_config.h
+++ b/sonoff/user_config.h
@@ -268,6 +268,9 @@
 // -- Internal Analog input -----------------------
 #define USE_ADC_VCC                              // Display Vcc in Power status. Disable for use as Analog input on selected devices
 
+// -- MP3 player ----------------------------------
+//#define USE_MP3_PLAYER                         // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
+
 // -- One wire sensors ----------------------------
                                                  // WARNING: Select none for default one DS18B20 sensor or enable one of the following two options for multiple sensors
 #define USE_DS18x20                              // Optional for more than one DS18x20 sensors with id sort, single scan and read retry (+1k3 code)

--- a/sonoff/xdrv_91_mp3.ino
+++ b/sonoff/xdrv_91_mp3.ino
@@ -1,0 +1,117 @@
+/*
+  xdrv_91_mp3.ino - MP3 Player support for Sonoff-Tasmota
+  Player type: RB-DFR-562, DFPlayer Mini MP3 Player
+  Copyright (C) 2018  Theo Arends
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    
+*/
+
+#ifdef USE_MP3_PLAYER
+
+#include <TasmotaSerial.h>
+
+TasmotaSerial *MP3Player;
+
+#define D_CMND_MP3 "MP3"
+const char S_JSON_MP3_COMMAND_NVALUE[] PROGMEM = "{\"" D_CMND_MP3 "%s\":%d}";
+const char S_JSON_MP3_COMMAND[] PROGMEM        = "{\"" D_CMND_MP3 "%s\"}";
+
+enum MP3_Commands { CMND_MP3_PLAY, CMND_MP3_STOP, CMND_MP3_VOLUME};
+const char kMP3_Commands[] PROGMEM = "Play" "|" "Stop" "|" "Volume";
+
+#define MP3_CMD_PLAY 3
+#define MP3_CMD_VOLUME 6
+#define MP3_CMD_STOP 0x0e
+
+uint16_t MP3_Checksum(uint8_t *array)
+{
+  uint16_t checksum = 0;
+  for (uint8_t i = 0; i < 6; i++) {
+    checksum += array[i];
+  }
+  checksum = checksum^0xffff;
+  return checksum+1;
+}
+
+// init player define serial tx port
+void InitMP3Player() {
+  MP3Player = new TasmotaSerial(-1, pin[GPIO_MP3PLAYER]);
+  
+  if (MP3Player->begin(9600)) {
+    //serial_bridge_active = 1;
+    MP3Player->flush();
+  }
+}
+
+void MP3_CMD(uint8_t mp3cmd,uint16_t val) {
+  uint8_t cmd[10] = {0x7e,0xff,6,0,0,0,0,0,0,0xef};
+  cmd[3] = mp3cmd;
+  cmd[5] = val>>8;
+  cmd[6] = val;
+  uint16_t chks = MP3_Checksum(&cmd[1]);								// calculate out
+  cmd[7] = chks>>8;
+  cmd[8] = chks;
+  MP3Player->write(cmd, sizeof(cmd));
+}
+
+boolean MP3PlayerCmd() {
+  char command[CMDSZ];
+  boolean serviced = true;
+  uint8_t disp_len = strlen(D_CMND_MP3);
+  
+  if (!strncasecmp_P(XdrvMailbox.topic, PSTR(D_CMND_MP3), disp_len)) {  // Prefix
+    int command_code = GetCommandCode(command, sizeof(command), XdrvMailbox.topic + disp_len, kMP3_Commands);
+
+    if (CMND_MP3_PLAY == command_code) {
+      if (XdrvMailbox.data_len > 0) {									// play
+        MP3_CMD(MP3_CMD_PLAY, XdrvMailbox.payload);
+      }
+      snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_MP3_COMMAND_NVALUE, command, XdrvMailbox.payload);
+    }
+    else if (CMND_MP3_VOLUME == command_code) {
+      if (XdrvMailbox.data_len > 0) {									// set volume
+        MP3_CMD(MP3_CMD_VOLUME, XdrvMailbox.payload * 30 / 100);
+      }
+      snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_MP3_COMMAND_NVALUE, command, XdrvMailbox.payload);
+    } 
+	else if (CMND_MP3_STOP == command_code) {							// stop
+      MP3_CMD(MP3_CMD_STOP, 0);
+      snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_MP3_COMMAND, command, XdrvMailbox.payload);
+    } else {
+      serviced = false;  												// Unknown command
+    }
+  }
+  return serviced;
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+#define XDRV_91
+
+boolean Xdrv91(byte function)
+{
+  boolean result = false;
+
+  switch (function) {
+    case FUNC_PRE_INIT:
+      InitMP3Player();
+      break;
+    case FUNC_COMMAND:
+      result = MP3PlayerCmd();
+      break;
+  }
+  return result;
+}
+
+#endif  // USE_MP3_PLAYER


### PR DESCRIPTION
Based on the issue Tasmota needs sound !! #3628 from gemu2015 i have added all 
needed changings including the xdrv_91_mp3.ino driver. Renamed it because there 
is a lot of stuff in the range around 96, 97 and 98.  The GPIO is now selectable and
no longer fixed to GPIO 16 as in the original driver xdrv_98_mp3.ino. Formated the 
code a little bit for better and faster reading.

Right now only three commands are prossible:
e.g. MP3Play 001 means first track
e.g. MP3Volume 60 set volume to 60% = (60 * 30 / 100)
e.g. MP3Stop yeah stops the playing

Link to the issue:
-> https://github.com/arendst/Sonoff-Tasmota/issues/3628