### PR TITLE
Add support for 5 LEDs

### DIFF
--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -34,7 +34,7 @@ typedef unsigned long power_t;              // Power (Relay) type
 // Changes to the following MAX_ defines will impact settings layout
 #define MAX_SWITCHES           8            // Max number of switches
 #define MAX_RELAYS             8            // Max number of relays
-#define MAX_LEDS               4            // Max number of leds
+#define MAX_LEDS               5            // Max number of leds
 #define MAX_KEYS               4            // Max number of keys or buttons
 #define MAX_PWMS               5            // Max number of PWM channels
 #define MAX_COUNTERS           4            // Max number of counter sensors

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -80,10 +80,12 @@ enum UserSelectablePins {
   GPIO_LED2,
   GPIO_LED3,
   GPIO_LED4,
+  GPIO_LED5,
   GPIO_LED1_INV,
   GPIO_LED2_INV,
   GPIO_LED3_INV,
   GPIO_LED4_INV,
+  GPIO_LED5_INV,
   GPIO_MHZ_TXD,        // MH-Z19 Serial interface
   GPIO_MHZ_RXD,        // MH-Z19 Serial interface
   GPIO_PZEM_TX,        // PZEM004T Serial interface
@@ -161,8 +163,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_COUNTER "1|" D_SENSOR_COUNTER "2|" D_SENSOR_COUNTER "3|" D_SENSOR_COUNTER "4|"
   D_SENSOR_PWM "1i|" D_SENSOR_PWM "2i|" D_SENSOR_PWM "3i|" D_SENSOR_PWM "4i|" D_SENSOR_PWM "5i|"
   D_SENSOR_IRRECV "|"
-  D_SENSOR_LED "1|" D_SENSOR_LED "2|" D_SENSOR_LED "3|" D_SENSOR_LED "4|"
-  D_SENSOR_LED "1i|" D_SENSOR_LED "2i|" D_SENSOR_LED "3i|" D_SENSOR_LED "4i|"
+  D_SENSOR_LED "1|" D_SENSOR_LED "2|" D_SENSOR_LED "3|" D_SENSOR_LED "4|" D_SENSOR_LED "5|"
+  D_SENSOR_LED "1i|" D_SENSOR_LED "2i|" D_SENSOR_LED "3i|" D_SENSOR_LED "4i|" D_SENSOR_LED "5i|"
   D_SENSOR_MHZ_TX "|" D_SENSOR_MHZ_RX "|"
   D_SENSOR_PZEM_TX "|" D_SENSOR_PZEM_RX "|"
   D_SENSOR_SAIR_TX "|" D_SENSOR_SAIR_RX "|"
@@ -297,6 +299,8 @@ const uint8_t kGpioNiceList[GPIO_SENSOR_END] PROGMEM = {
   GPIO_LED3_INV,
   GPIO_LED4,
   GPIO_LED4_INV,
+  GPIO_LED5,
+  GPIO_LED5_INV,
   GPIO_PWM1,           // RGB   Red   or C  Cold White
   GPIO_PWM1_INV,
   GPIO_PWM2,           // RGB   Green or CW Warm White


### PR DESCRIPTION
The MJ-SD01 dimmer switch has 5 LEDs each tied to its own GPIO so bump up
the max number of LEDS to 5.

Signed-off-by: Kumar Gala <kumar.gala@gmail.com>