### PR TITLE
MCP230xx - Fix millisecond counter reset placement

### DIFF
--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -280,7 +280,9 @@ void MCP230xx_CheckForInterrupt(void) {
                 if (report_int) {
                   bool int_tele = false;
                   bool int_event = false;
-                  unsigned long millis_since_last_int = millis() - int_millis[intp+(mcp230xx_port*8)];
+                  unsigned long millis_now = millis();
+                  unsigned long millis_since_last_int = millis_now - int_millis[intp+(mcp230xx_port*8)];
+                  int_millis[intp+(mcp230xx_port*8)]=millis_now;
                   switch (Settings.mcp230xx_config[intp+(mcp230xx_port*8)].int_report_mode) {
                     case 0:
                       int_tele=true;
@@ -304,7 +306,6 @@ void MCP230xx_CheckForInterrupt(void) {
                     sprintf(command,"event MCPINT_D%i=%i",intp+(mcp230xx_port*8),((mcp230xx_intcap >> intp) & 0x01));
                     ExecuteCommand(command, SRC_RULE);
                   }
-                  int_millis[intp+(mcp230xx_port*8)]=millis();
                 }
               }
             }


### PR DESCRIPTION
Resetting of millis() was done at end of loop causing up to 10ms offset that is unaccounted for so I moved the resetting of last millis() when interrupt was raised to further up to where it should be. This was discovered whilst debugging and doing proof of concept for https://github.com/arendst/Sonoff-Tasmota/issues/3802