### PR TITLE
LM75AD - Force function parameters to be C and C++ compliant

### DIFF
--- a/sonoff/xsns_26_lm75ad.ino
+++ b/sonoff/xsns_26_lm75ad.ino
@@ -46,7 +46,7 @@ uint8_t lm75ad_type = 0;
 uint8_t lm75ad_address;
 uint8_t lm75ad_addresses[] = { LM75AD_ADDRESS1, LM75AD_ADDRESS2, LM75AD_ADDRESS3, LM75AD_ADDRESS4, LM75AD_ADDRESS5, LM75AD_ADDRESS6, LM75AD_ADDRESS7, LM75AD_ADDRESS8 };
 
-void LM75ADDetect()
+void LM75ADDetect(void)
 {
   if (lm75ad_type) { return; }
 
@@ -64,7 +64,7 @@ void LM75ADDetect()
   }
 }
 
-float LM75ADGetTemp() {
+float LM75ADGetTemp(void) {
   int16_t sign = 1;
 
   uint16_t t = I2cRead16(lm75ad_address, LM75_TEMP_REGISTER);

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -181,7 +181,7 @@ void MCP230xx_ApplySettings(void) {
   MCP230xx_CheckForIntCounter(); // update register on whether or not we should be counting interrupts
 }
 
-void MCP230xx_Detect()
+void MCP230xx_Detect(void)
 {
   if (mcp230xx_type) {
     return;


### PR DESCRIPTION
So a bit of a theory.

I was thinking about what we experienced here https://github.com/arendst/Sonoff-Tasmota/issues/3678#issuecomment-419727653 wherein removing the LM75AD driver was changing the behaviour of the code.

In C it is perfectly fine to have a function like

void LM75ADDetect()
{
}

and the C compiler will treat it that this function does not have a parameter.

In C++ this is not acceptable for the case of no parameters because it is intended to allow you to pass any number of unknown variables or types.

My theory is that because we use C and C++ code mixed in the project that perhaps the platformio compiler recipe is not correct insofar that it may be trying to link functions like void LM75ADDetect() with a pointer to a potential parameter being cast to the function - of course there is no handling inside the function for this as would be required in C++ so it leads to a pointer being created that may be pointing to absolutely nothing and could lead to unexpected behaviour.

To explicitly define a function that has no parameters in C++ one has to do

void LM75ADDetect(void)

This, of course, is also valid and accepted by a C compiler and is treated the same as the compiler would treat void LM75ADDetect() during compilation/linking.

So with this theory in mind, I propose these changes to the LM75AD driver and see if someone can reproduce the problems from issue 3678 after compiling on platformio and not getting a reboot loop or other problems.

Either way, it cannot break anything and its probably better to use (void) in all cases anyway.

If this does solve the problem it proves that the recipe imported by the platformio esp8266 core needs to be looked into to make sure that C and C++ are segregated correctly and linked appropriately.

Just a shot in the dark, but worth the try I think.
