### PR TITLE
Fix logic for forced light discovery

### DIFF
--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -76,7 +76,7 @@ void HAssDiscoverRelay()
 
   for (int i = 1; i <= MAX_RELAYS; i++) {
     is_light = ((i == devices_present) && (light_type));
-    is_topic_light = Settings.flag.hass_light;
+    is_topic_light = Settings.flag.hass_light || is_light;
 
     mqtt_data[0] = '\0';  // Clear retained message
 


### PR DESCRIPTION
In home-assistant, a switch can be turned on/off and a light can be turned on/off but may also have additional capabilities such as brightness, color etc.

Home-assistant can handle simple relays announced as light, but it can't handle a light announced as a switch.
Fix handling of setoption30 to reflect this.

Suggested wiki update:

| Command | Payload | Description |
| --- | --- | --- |
| SetOption30 | 0 / off | Automatic announcement as 'switch' for relays and 'light' for PWM in Home-Assistant MQTT discovery message. |
| SetOption30 | 1 / on | Enforce Home-Assistant discovery as 'light' platform also for relays. |

