### PR TITLE
Add new triggers for rules on boot time

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -376,6 +376,25 @@ void RulesEvery50ms()
             RulesProcessEvent(json_event);
           }
         }
+      } else {
+        // Boot time POWER OUTPUTS (Relays) Status
+        for (byte i = 0; i < devices_present; i++) {
+          uint8_t new_state = (rules_new_power >> i) &1;
+          snprintf_P(json_event, sizeof(json_event), PSTR("{\"Power%d\":{\"Boot\":%d}}"), i +1, new_state);
+          RulesProcessEvent(json_event);
+        }
+        // Boot time SWITCHES Status
+        for (byte i = 0; i < MAX_SWITCHES; i++) {
+#ifdef USE_TM1638
+          if ((pin[GPIO_SWT1 +i] < 99) || ((pin[GPIO_TM16CLK] < 99) && (pin[GPIO_TM16DIO] < 99) && (pin[GPIO_TM16STB] < 99))) {
+#else
+          if (pin[GPIO_SWT1 +i] < 99) {
+#endif // USE_TM1638
+            boolean swm = ((FOLLOW_INV == Settings.switchmode[i]) || (PUSHBUTTON_INV == Settings.switchmode[i]) || (PUSHBUTTONHOLD_INV == Settings.switchmode[i]));
+            snprintf_P(json_event, sizeof(json_event), PSTR("{\"" D_JSON_SWITCH "%d\":{\"Boot\":%d}}"), i +1, (swm ^ lastwallswitch[i]));
+            RulesProcessEvent(json_event);
+          }
+        }
       }
       rules_old_power = rules_new_power;
     }


### PR DESCRIPTION
To make it possible to trigger a rule at boot time with the state of the switches or relays (in order to take decisions), 2 new trigger types are proposed here to be added: 

* `SWITCH1#BOOT`

to be used like:

```
ON SWITCH1#BOOT DO ...  %value% ENDON
ON SWITCH1#BOOT=0 DO .... ENDON
ON SWITCH1#BOOT=1 DO .... ENDON
```

and

* `POWER1#BOOT`

to be used like:

```
ON POWER1#BOOT DO ...  %value% ENDON
ON POWER1#BOOT=0 DO .... ENDON
ON POWER1#BOOT=1 DO .... ENDON
```
-------------------------------------

This solves #3904

Examples where this is needed and where the explained issues can be solved by the use of this new triggers:

* If having two switches on a garage door, one that closes when the door is fully open, one that closes when the door is fully closed. The initial state of the door at boot is an issue. Once the door status changes a rule can pick it up fine and can be seen it’s status and send the proper commands depending on its state. The initial state, (and it could be days with one switch closed), can be seen in the telemetry data but isn’t available to the rules on the device.

* A slide switch to toggle between Heating and Cooling on a typical thermostat... to make a robust device that will work even when MQTT is unavailable the rules would need that value. On Change triggers are great once there is a change... but again, on boot up a rule don’t know the state though it’s value is in the telemetry data.

-----------------------------

Testing the following rule:
```
rule 1
rule rule on switch1#boot do event bootsw1=%value% endon on power1#boot do event bootpo1=%value% endon on switch2#boot do event bootsw2=%value% endon on system#boot do event bootsys endon
```
At startup gives the following output:
```
00:00:00 Proyecto sonoff Living (Topic living, Fallback DVES_591719, GroupTopic sonoffs) Versión 6.2.1.8-2_4_2
00:00:00 RUL: POWER1#BOOT performs "backlog event bootpo1=0"
00:00:00 RUL: SWITCH1#BOOT performs "backlog event bootsw1=1"
00:00:00 RUL: SWITCH2#BOOT performs "backlog event bootsw2=0"
00:00:00 WIF: Connectando a AP1 NetWireless en modo 11N como living-5913...
00:00:00 RSL: stat/living/RESULT = {"Event":"Done"}
00:00:00 RSL: stat/living/RESULT = {"Event":"Done"}
00:00:00 RSL: stat/living/RESULT = {"Event":"Done"}
00:00:04 WIF: Conectado
00:00:04 HTP: Servidor web activo en living-5913 con dirección IP 192.168.1.33
00:00:06 MQT: Intentando conectar...
22:59:19 MQT: Conectado
22:59:19 MQT: tele/living/LWT = Online (Grabado)
22:59:19 MQT: cmnd/living/POWER = 
22:59:19 MQT: tele/living/INFO1 = {"Module":"Generic","Version":"6.2.1.8","FallbackTopic":"DVES_591719","GroupTopic":"sonoffs"}
22:59:19 MQT: tele/living/INFO2 = {"WebServerMode":"Admin","Hostname":"living-5913","IPAddress":"192.168.1.33"}
22:59:19 MQT: tele/living/INFO3 = {"RestartReason":"External System"}
22:59:19 MQT: stat/living/RESULT = {"POWER1":"OFF"}
22:59:19 MQT: stat/living/POWER1 = OFF
22:59:19 RUL: SYSTEM#BOOT performs "backlog event bootsys"
22:59:20 MQT: stat/living/RESULT = {"Event":"Done"}
22:59:28 MQT: tele/living/STATE = {"Time":"2018-09-26T22:59:28","Uptime":"0T00:00:18","Vcc":2.993,"POWER1":"OFF","Wifi":{"AP":1,"SSId":"NetWireless","BSSId":"18:D6:C7:80:38:2C","Channel":1,"RSSI":52}}
22:59:28 MQT: tele/living/SENSOR = {"Time":"2018-09-26T22:59:28","Switch1":"ON","Switch2":"OFF"}
```