### PR TITLE
Use color2 command (HASS sends normalized RGB)

### DIFF
--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -50,7 +50,7 @@ const char HASS_DISCOVER_LIGHT_DIMMER[] PROGMEM =
   "\"brightness_value_template\":\"{{value_json." D_CMND_DIMMER "}}\"";
 
 const char HASS_DISCOVER_LIGHT_COLOR[] PROGMEM =
-  "%s,\"rgb_command_topic\":\"%s\","               // cmnd/led2/Color
+  "%s,\"rgb_command_topic\":\"%s2\","              // cmnd/led2/Color2
   "\"rgb_state_topic\":\"%s\","                    // stat/led2/RESULT
   "\"rgb_value_template\":\"{{value_json." D_CMND_COLOR "}}\"";
 //  "\"rgb_value_template\":\"{{value_json." D_CMND_COLOR " | join(',')}}\"";


### PR DESCRIPTION
Home-assistant sends normalized (full brightness) RGB color if a brightness_command_topic is set.
This causes the light to flicker when changing color if Tasmota `color` command is used.
Use Tasmota `color2` command instead which will adjust the received color according to previously set brightness.