### PR TITLE
Add basic support for color calibration

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -317,6 +317,7 @@
 #define D_CMND_LEDTABLE "LedTable"
 #define D_CMND_FADE "Fade"
 #define D_CMND_PIXELS "Pixels"
+#define D_CMND_RGBWWTABLE "RGBWWTable"
 #define D_CMND_ROTATION "Rotation"
 #define D_CMND_SCHEME "Scheme"
 #define D_CMND_SPEED "Speed"

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -324,7 +324,7 @@ struct SYSCFG {
 
   uint8_t       rgbwwTable[5];             // 71A
 
-  byte          free_71A[169];             // 71F
+  byte          free_71F[169];             // 71F
 
   unsigned long energy_frequency_calibration;  // 7C8
 

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -322,7 +322,9 @@ struct SYSCFG {
 
   uint16_t      mcp230xx_int_timer;        // 718
 
-  byte          free_71A[174];             // 71A
+  uint8_t       rgbwwTable[5];             // 71A
+
+  byte          free_71A[169];             // 71F
 
   unsigned long energy_frequency_calibration;  // 7C8
 

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -624,6 +624,10 @@ void SettingsDefaultSet2()
 
   Settings.button_debounce = KEY_DEBOUNCE_TIME;
   Settings.switch_debounce = SWITCH_DEBOUNCE_TIME;
+
+  for (byte j = 0; j < 5; j++) {
+    Settings.rgbwwTable[j] = 255;
+  }
 }
 
 /********************************************************************************************/
@@ -826,6 +830,11 @@ void SettingsDelta()
     if (Settings.version < 0x0601010C) {
       Settings.button_debounce = KEY_DEBOUNCE_TIME;
       Settings.switch_debounce = SWITCH_DEBOUNCE_TIME;
+    }
+    if (Settings.version < 0x0602010A) {
+      for (byte j = 0; j < 5; j++) {
+        Settings.rgbwwTable[j] = 255;
+      }
     }
 
     Settings.version = VERSION;

--- a/sonoff/sonoff_version.h
+++ b/sonoff/sonoff_version.h
@@ -20,7 +20,7 @@
 #ifndef _SONOFF_VERSION_H_
 #define _SONOFF_VERSION_H_
 
-#define VERSION            0x06020109
+#define VERSION            0x0602010A
 
 #define D_PROGRAMNAME      "Sonoff-Tasmota"
 #define D_AUTHOR           "Theo Arends"


### PR DESCRIPTION
Add new command `RGBWWTable` primarily to allow rudimentary compensation of unbalanced RGB channels.

With this, the very unbalanced colors on for example the Sonoff B1 can be adjusted such that unsaturated colors are no longer dominated by the blue, and to a lesser extent the green channel.

Example for Sonoff B1 with RGB board marking "LED-RGB-CTRL_V1.1" which gives acceptable colors:
```
LEDTable 1
RGBWWTable 255,135,70,255,255
```