### PR TITLE
Fix XSS-Vulnerability in configuration page

### DIFF
--- a/sonoff/xdrv_02_webserver.ino
+++ b/sonoff/xdrv_02_webserver.ino
@@ -789,6 +789,17 @@ void HandleWifiConfiguration()
   HandleWifi(false);
 }
 
+String htmlEscape(String s)
+{
+    s.replace("&", "&amp;");
+    s.replace("<", "&lt;");
+    s.replace(">", "&gt;");
+    s.replace("\"", "&quot;");
+    s.replace("'", "&#x27;");
+    s.replace("/", "&#x2F;");
+    return s;
+}
+
 void HandleWifi(boolean scan)
 {
   if (HttpUser()) { return; }
@@ -854,7 +865,7 @@ void HandleWifi(boolean scan)
           String item = FPSTR(HTTP_LNK_ITEM);
           String rssiQ;
           rssiQ += quality;
-          item.replace(F("{v}"), WiFi.SSID(indices[i]));
+          item.replace(F("{v}"), htmlEscape(WiFi.SSID(indices[i])));
           item.replace(F("{w}"), String(WiFi.channel(indices[i])));
           item.replace(F("{r}"), rssiQ);
           uint8_t auth = WiFi.encryptionType(indices[i]);


### PR DESCRIPTION
Add HTML entity encoding to the SSID of networks that can be found using the "Scan for wifi networks" function of the configuration page. This is necessary because a malicious actor could create a wifi-network using a SSID like "<script>javascript_code</script>". The code will then be executed in the browser of the victim.

As a proof-of-Concept one could create a wifi network using the SSID <script>alert(1)</script>. Visit the initial configuration page and click on "Scan for wifi networks". If the network with the above SSID is found the message "1" will be displayed in your browser.