### PR TITLE
missing "" around UV Index text in json

### DIFF
--- a/sonoff/xsns_11_veml6070.ino
+++ b/sonoff/xsns_11_veml6070.ino
@@ -31,6 +31,9 @@
   Version Date      Action    Description
   --------------------------------------------------------------------------------------------
 
+  1.0.0.3 20181006  fixed     - missing "" around the UV Index text 
+                              - thanks to Lisa she had tested it on here mqtt system.
+  --
   1.0.0.2 20180928  tests     - same as in version 1.0.0.1
                     cleaned   - source code
                     changed   - snprintf_P for json and web server output
@@ -77,9 +80,9 @@
                               - show not only the UV Power value in W/m2, possible a @define value to show it as joule value
                               - add a #define to select how many characters are shown benhind the decimal point for the UV Index
   ---
-  1.0.0.0 20180912  started - further development by mike2nl  - https://github.com/mike2nl/Sonoff-Tasmota
-                    forked  - from arendst/tasmota            - https://github.com/arendst/Sonoff-Tasmota
-                    base    - code base from arendst too
+  1.0.0.0 20180912  started   - further development by mike2nl  - https://github.com/mike2nl/Sonoff-Tasmota
+                    forked    - from arendst/tasmota            - https://github.com/arendst/Sonoff-Tasmota
+                    base      - code base from arendst too
 
 */
 
@@ -168,11 +171,11 @@ void Veml6070EverySecond(void)
 {
   // all = 10..15[ms]
   if (11 == (uptime %100)) {
-    Veml6070ModeCmd(1);			      // on = 1[ms], wakeup the UV sensor
+    Veml6070ModeCmd(1);			                  // on = 1[ms], wakeup the UV sensor
     Veml6070Detect();                         // 1[ms], check for sensor and init with IT time
     Veml6070ModeCmd(0);                       // off = 5[ms], suspend the UV sensor
   } else {
-    Veml6070ModeCmd(1);			      // 1[ms], wakeup the UV sensor
+    Veml6070ModeCmd(1);			                  // 1[ms], wakeup the UV sensor
     uvlevel = Veml6070ReadUv();               // 1..2[ms], get UV raw values
     uvrisk  = Veml6070UvRiskLevel(uvlevel);   // 0..1[ms], get UV risk level
     uvpower = Veml6070UvPower(uvrisk);        // 2[ms], get UV power in W/m2
@@ -277,10 +280,10 @@ void Veml6070Show(boolean json)
     dtostrfd(uvpower, 3, str_uvpower);
     if (json) {
 #ifdef USE_VEML6070_SHOW_RAW
-      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":{\"" D_JSON_UV_LEVEL "\":%s,\"" D_JSON_UV_INDEX "\":%s,\"" D_JSON_UV_INDEX_TEXT "\":%s,\"" D_JSON_UV_POWER "\":%s}"),
+      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":{\"" D_JSON_UV_LEVEL "\":%s,\"" D_JSON_UV_INDEX "\":%s,\"" D_JSON_UV_INDEX_TEXT "\":\"%s\",\"" D_JSON_UV_POWER "\":%s}"),
         mqtt_data, veml6070_name, str_uvlevel, str_uvrisk, str_uvrisk_text, str_uvpower);
 #else
-      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":{\"" D_JSON_UV_INDEX "\":%s,\"" D_JSON_UV_INDEX_TEXT "\":%s,\"" D_JSON_UV_POWER "\":%s}"),
+      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":{\"" D_JSON_UV_INDEX "\":%s,\"" D_JSON_UV_INDEX_TEXT "\":\"%s\",\"" D_JSON_UV_POWER "\":%s}"),
         mqtt_data, veml6070_name, str_uvrisk, str_uvrisk_text, str_uvpower);
 #endif  // USE_VEML6070_SHOW_RAW
 #ifdef USE_DOMOTICZ


### PR DESCRIPTION
Found out with the help of Lisa an UK user that i missed the "" around the UV Index text in json output.
Fixed now and i have tested with and without the raw values on two systems.

Driver history is updated too