### PR TITLE
Add PWM Freq Limits Config at Compile time

### DIFF
--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -80,6 +80,10 @@ typedef unsigned long power_t;              // Power (Relay) type
 //#define PWM_FREQ               1000         // 100..1000 Hz led refresh
 //#define PWM_FREQ               910          // 100..1000 Hz led refresh (iTead value)
 #define PWM_FREQ               880          // 100..1000 Hz led refresh (BN-SZ01 value)
+#define PWM_MAX                4000         // [PWM_MAX] Maximum frequency - Default: 4000
+#define PWM_MIN                100          // [PWM_MIN] Minimum frequency - Default: 100
+                                            //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
+                                            //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
 
 #define DEFAULT_POWER_DELTA    80           // Power change percentage
 #define MAX_POWER_HOLD         10           // Time in SECONDS to allow max agreed power

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -914,7 +914,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
       snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
     }
     else if (CMND_PWMFREQUENCY == command_code) {
-      if ((1 == payload) || ((payload >= 100) && (payload <= 4000))) {
+      if ((1 == payload) || ((payload >= PWM_MIN) && (payload <= PWM_MAX))) {
         Settings.pwm_frequency = (1 == payload) ? PWM_FREQ : payload;
         analogWriteFreq(Settings.pwm_frequency);   // Default is 1000 (core_esp8266_wiring_pwm.c)
       }


### PR DESCRIPTION
The keys PWM_MAX and PWM_MIN are added with explanation comments in order to let a user, who wants to use a Servo, to config these values. Not added at runtime in order to avoid issues with dimmers.

#3997