### PR TITLE
xdrv_06_snfbridge: Remove whitespace from RfRaw for SerialSendRaw()

### DIFF
--- a/sonoff/xdrv_06_snfbridge.ino
+++ b/sonoff/xdrv_06_snfbridge.ino
@@ -557,7 +557,7 @@ boolean SonoffBridgeCommand()
           break;
         }
       } else {
-        char rawsend[XdrvMailbox.data_len];
+        char rawsend[XdrvMailbox.data_len+1];
         sprintf(rawsend,"%s",charclean(XdrvMailbox.data));
         SerialSendRaw(rawsend, strlen(rawsend));
         sonoff_bridge_receive_raw_flag = 1;

--- a/sonoff/xdrv_06_snfbridge.ino
+++ b/sonoff/xdrv_06_snfbridge.ino
@@ -411,6 +411,22 @@ void SonoffBridgeLearn(uint8_t key)
   Serial.write(0x55);  // End of Text
 }
 
+char* charclean(char *in)
+{
+  uint8_t i;
+  uint8_t x;
+  char *out = in;
+  for (i=0,x=0;i<strlen(in);i++,x++) {
+    if (in[i] != ' ') {
+      out[x] = in[i];
+    } else {
+      x--;
+    }
+  }
+  out[x] = 0; // null terminate the new char array
+  return out;
+}
+
 /*********************************************************************************************\
  * Commands
 \*********************************************************************************************/
@@ -541,7 +557,9 @@ boolean SonoffBridgeCommand()
           break;
         }
       } else {
-        SerialSendRaw(XdrvMailbox.data, XdrvMailbox.data_len);
+        char rawsend[XdrvMailbox.data_len];
+        sprintf(rawsend,"%s",charclean(XdrvMailbox.data));
+        SerialSendRaw(rawsend, strlen(rawsend));
         sonoff_bridge_receive_raw_flag = 1;
       }
     }
@@ -584,4 +602,3 @@ boolean Xdrv06(byte function)
   }
   return result;
 }
-


### PR DESCRIPTION
This PR solves issue https://github.com/arendst/Sonoff-Tasmota/issues/4020 when user sends RFRaw command that results in SerialSendRaw() when first character does not match any of the use cases selected by switch (XdrvMailbox.payload).

So user can send easy to copy/read commands like
```
RfRaw AA B0 3C 04 14 01E1 042F 0BE0 1C70 2301101001011010011001010101101010011010011010010123011010010101011001100101101010010101011010100101 55
```

resulting in an actual SerialSendRaw() as

```
AAB03C041401E1042F0BE01C70230110100101101001100101010110101001101001101001012301101001010101100110010110101001010101101010010155
```

sent to the RF chip.
