### PR TITLE
Add command Reset 5

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1156,6 +1156,10 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
         restart_flag = 214;
         snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_RESET "\":\"" D_JSON_ERASE ", " D_JSON_RESET_AND_RESTARTING "\"}"));
         break;
+      case 5:
+        restart_flag = 215;
+        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_RESET "\":\"" D_JSON_ERASE ", " D_JSON_RESET_AND_RESTARTING "\"}"));
+        break;
       default:
         snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_SVALUE, command, D_JSON_ONE_TO_RESET);
       }
@@ -2107,13 +2111,16 @@ void Every250mSeconds()
         SettingsDefault();
         restart_flag = 2;
       }
-      if (214 == restart_flag) {
+      if ((214 == restart_flag) || (215 == restart_flag)) {
         char tmp_sta_ssid[2][33];
         char tmp_sta_pwd[2][65];
         strlcpy(tmp_sta_ssid[0],Settings.sta_ssid[0],sizeof(Settings.sta_ssid[0]));
         strlcpy(tmp_sta_pwd[0],Settings.sta_pwd[0],sizeof(Settings.sta_pwd[0]));
         strlcpy(tmp_sta_ssid[1],Settings.sta_ssid[1],sizeof(Settings.sta_ssid[1]));
         strlcpy(tmp_sta_pwd[1],Settings.sta_pwd[1],sizeof(Settings.sta_pwd[1]));
+        if (215 == restart_flag) {
+          SettingsErase(0);    // Erase all flash from program end to end of physical flash
+        }
         SettingsDefault();
         strlcpy(Settings.sta_ssid[0],tmp_sta_ssid[0],sizeof(Settings.sta_ssid[0]));
         strlcpy(Settings.sta_pwd[0],tmp_sta_pwd[0],sizeof(Settings.sta_pwd[0]));


### PR DESCRIPTION
Adds command Reset 5

Same as reset 4 which erases settings whilst retaining wifi ssid's and passwords, but parameter 5 adds a step to also erase the fash from the end of program used space to the end of flash size using SettingsErase(0) as is the case with "Reset 2"

The main difference is that it retains wifi ssid's and passwords.

This may be useful in future use cases where for some reason the SPI flash of a user's device has garbage in it.

This is also known as a partial @Jason2866 erase solution except that it does not erase the firmware and retains wifi configuration so that user can re-connect without having to access console via cable.