### PR TITLE
Add support for different variants of TUYA-dimmer

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -246,6 +246,7 @@
 #define D_CMND_SERIALDELIMITER "SerialDelimiter"
 #define D_CMND_BAUDRATE "Baudrate"
 #define D_LOG_SOME_SETTINGS_RESET "Some settings have been reset"
+#define D_CMND_TUYA_DIMMER_ID "TuyaDimmerId"
 
 // Commands xdrv_01_mqtt.ino
 #define D_CMND_MQTTHOST "MqttHost"

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -334,6 +334,7 @@ struct SYSCFG {
   uint16_t      web_refresh;               // 7CC
   char          mems[MAX_RULE_MEMS][10];   // 7CE
   char          rules[MAX_RULE_SETS][MAX_RULE_SIZE]; // 800 uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
+  uint8_t       tuya_dimmer_id;
                                            // E00 - FFF free locations
 } Settings;
 

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -419,6 +419,11 @@ void SettingsDefaultSet2()
   // Module
 //  Settings.flag.interlock = 0;
   Settings.module = MODULE;
+#ifdef TUYA_DIMMER_ID
+  Settings.tuya_dimmer_id = TUYA_DIMMER_ID;
+#else
+  Settings.tuya_dimmer_id = 3;
+#endif
 //  for (byte i = 0; i < MAX_GPIO_PIN; i++) { Settings.my_gp.io[i] = 0; }
   strlcpy(Settings.friendlyname[0], FRIENDLY_NAME, sizeof(Settings.friendlyname[0]));
   strlcpy(Settings.friendlyname[1], FRIENDLY_NAME"2", sizeof(Settings.friendlyname[1]));

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -202,6 +202,9 @@ char web_log[WEB_LOG_SIZE] = {'\0'};        // Web log buffer
 String backlog[MAX_BACKLOG];                // Command backlog
 uint8_t tuya_new_dim = 0;                   // Tuya dimmer value temp
 boolean tuya_ignore_dim = false;            // Flag to skip serial send to prevent looping when processing inbound states from the faceplate interaction
+uint8_t tuya_cmd_status = 0;                // Current status of serial-read
+uint8_t tuya_cmd_checksum = 0;              // Checksum of tuya command
+uint8_t tuya_data_len = 0;                  // Data lenght of command
 
 /********************************************************************************************/
 
@@ -2259,35 +2262,28 @@ void TuyaPacketProcess()
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Heartbeat"));
   }
   if (serial_in_byte_counter == 12 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 5) {  // on/off packet
-    if (serial_in_buffer[10] == 0) {
-      AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Rcvd - Off State"));
-      ExecuteCommandPower(1, 0, SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
-    } else
-    {
-      AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Rcvd - On State"));
-      ExecuteCommandPower(1, 1, SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
+    snprintf_P(log_data, sizeof(log_data),PSTR("TYA: Rcvd - %s State"),serial_in_buffer[10]?"On":"Off");
+    AddLog(LOG_LEVEL_DEBUG);
+    if((power || Settings.light_dimmer > 0) && (power != serial_in_buffer[10])) {
+      ExecuteCommandPower(1, serial_in_buffer[10], SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
     }
-    serial_in_byte_counter = 0;
-    serial_in_buffer[serial_in_byte_counter] = 0;  // serial data completed
   }
   if (serial_in_byte_counter == 15 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 8) {  // dim packet
     snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Rcvd Dim State=%d"), serial_in_buffer[13]);
     AddLog(LOG_LEVEL_DEBUG);
     tuya_new_dim = round(serial_in_buffer[13] * (100. / 255.));
-    snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Send CMND_DIMMER=%d"), tuya_new_dim );
-    AddLog(LOG_LEVEL_DEBUG);
-    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_DIMMER " %d"), tuya_new_dim );
-    snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Send CMND_DIMMER_STR=%s"), scmnd );
-    AddLog(LOG_LEVEL_DEBUG);
-    tuya_ignore_dim = true;
-    ExecuteCommand(scmnd, SRC_SWITCH);
-    serial_in_byte_counter = 0;
-    serial_in_buffer[serial_in_byte_counter] = 0;  // serial data completed
+    if((power || !Settings.light_dimmer ) && (tuya_new_dim > 0) && (abs(tuya_new_dim - Settings.light_dimmer) > 2)) {
+      snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Send CMND_DIMMER=%d"), tuya_new_dim );
+      AddLog(LOG_LEVEL_DEBUG);
+      snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_DIMMER " %d"), tuya_new_dim );
+      snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Send CMND_DIMMER_STR=%s"), scmnd );
+      AddLog(LOG_LEVEL_DEBUG);
+      tuya_ignore_dim = true;
+      ExecuteCommand(scmnd, SRC_SWITCH);
+    }
   }
-  if (serial_in_byte_counter == 8 && serial_in_buffer[3] == 5 && serial_in_buffer[5] == 1 && serial_in_buffer[7] == 5 ) {  // reset WiFi settings packet - to do: reset red MCU LED after WiFi is up
+  else if (serial_in_byte_counter == 8 && serial_in_buffer[3] == 5 && serial_in_buffer[5] == 1 && serial_in_buffer[7] == 5 ) {  // reset WiFi settings packet - to do: reset red MCU LED after WiFi is up
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi Reset Rcvd"));
-    serial_in_byte_counter = 0;
-    serial_in_buffer[serial_in_byte_counter] = 0;  // serial data completed
     snprintf_P(scmnd, sizeof(scmnd), D_CMND_WIFICONFIG " 2");
     ExecuteCommand(scmnd, SRC_BUTTON);
   }
@@ -2324,23 +2320,52 @@ void SerialInput()
  * Tuya based Dimmer with Serial Communications to MCU dimmer at 9600 baud
 \*-------------------------------------------------------------------------------------------*/
     if (TUYA_DIMMER == Settings.module) {
-      if (serial_in_byte == '\x55') {            // Start TUYA Packet
-        if (serial_in_byte_counter > 0 && serial_in_byte_counter < 11) {
-           TuyaPacketProcess();
-        }
-        AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: 0x55 Packet Start"));
+      //snprintf_P(log_data, sizeof(log_data), PSTR("TYA: serial_in_byte %d, tuya_cmd_status %d, tuya_cmd_checksum %d, tuya_data_len %d, serial_in_byte_counter %d"), serial_in_byte, tuya_cmd_status, tuya_cmd_checksum, tuya_data_len, serial_in_byte_counter);
+      //AddLog(LOG_LEVEL_DEBUG);
+      if (serial_in_byte == 0x55) {            // Start TUYA Packet
+        tuya_cmd_status = 1;
+        serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
+        tuya_cmd_checksum += serial_in_byte;
+      }
+      else if (tuya_cmd_status == 1 && serial_in_byte == 0xAA){ // Only packtes with header 0x55AA are valid
+        tuya_cmd_status = 2;
+        AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: 0x55AA Packet Start"));
         serial_in_byte_counter = 0;
+        serial_in_buffer[serial_in_byte_counter++] = 0x55;
+        serial_in_buffer[serial_in_byte_counter++] = 0xAA;
+        tuya_cmd_checksum = 0xFF;
+      }
+      else if (tuya_cmd_status == 2){
+        if(serial_in_byte_counter == 5){ // Get length of data
+          tuya_cmd_status = 3;
+          tuya_data_len = serial_in_byte;
+        }
+        tuya_cmd_checksum += serial_in_byte;
         serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
-//        return;  // test to see if we need this
-      } else {                                  // read additional packets from TUYA
-      if (serial_in_byte_counter < INPUT_BUFFER_SIZE -1) {  // add char to string if it still fits
+      }
+      else if ((tuya_cmd_status == 3) && (serial_in_byte_counter == (6 + tuya_data_len)) && (tuya_cmd_checksum == serial_in_byte)){ // Compare checksum and process packet
         serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
-        serial_polling_window = millis();
-//        return;  // test to see if we need this
+        snprintf_P(log_data, sizeof(log_data), PSTR("TYA: 0x55 Packet End: \""));
+        for (int i = 0; i < serial_in_byte_counter; i++) {
+          snprintf_P(log_data, sizeof(log_data), PSTR("%s%02x"), log_data, serial_in_buffer[i]);
+        }
+        snprintf_P(log_data, sizeof(log_data), PSTR("%s\""), log_data);
+        AddLog(LOG_LEVEL_DEBUG);
+        TuyaPacketProcess();
+        serial_in_byte_counter = 0;
+        tuya_cmd_status = 0;
+        tuya_cmd_checksum = 0;
+        tuya_data_len = 0;
+      }                               // read additional packets from TUYA
+      else if(serial_in_byte_counter < INPUT_BUFFER_SIZE -1) {  // add char to string if it still fits
+        serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
+        tuya_cmd_checksum += serial_in_byte;
       } else {
         serial_in_byte_counter = 0;
+        tuya_cmd_status = 0;
+        tuya_cmd_checksum = 0;
+        tuya_data_len = 0;
       }
-     }
     }
 
 /*-------------------------------------------------------------------------------------------*/
@@ -2407,17 +2432,7 @@ void SerialInput()
     }
   }
 
-  if (TUYA_DIMMER == Settings.module && serial_in_byte_counter > 6 && (millis() > (serial_polling_window + SERIAL_POLLING))) {
-    snprintf_P(log_data, sizeof(log_data), PSTR("TYA: 0x55 Packet End: \""));
-    for (int i = 0; i < serial_in_byte_counter; i++) {
-      snprintf_P(log_data, sizeof(log_data), PSTR("%s%02x"), log_data, serial_in_buffer[i]);
-    }
-    snprintf_P(log_data, sizeof(log_data), PSTR("%s\""), log_data);
-    AddLog(LOG_LEVEL_DEBUG);
-    TuyaPacketProcess();
-    serial_in_buffer[serial_in_byte_counter] = 0;  // serial data completed
-    serial_in_byte_counter = 0;
-  } else {
+  if( TUYA_DIMMER != Settings.module){
     if (Settings.flag.mqtt_serial && serial_in_byte_counter && (millis() > (serial_polling_window + SERIAL_POLLING))) {
       serial_in_buffer[serial_in_byte_counter] = 0;  // serial data completed
       if (!Settings.flag.mqtt_serial_raw) {
@@ -2580,6 +2595,7 @@ void GpioInit()
     Settings.flag.mqtt_serial = 0;
     baudrate = 9600;
     light_type = LT_SERIAL;
+    Serial.setDebugOutput(false);
   }
   else if (SONOFF_BN == Settings.module) {   // PWM Single color led (White)
     light_type = LT_PWM1;
@@ -2734,6 +2750,19 @@ void setup()
   SetSerialBaudrate(baudrate);
 
   WifiConnect();
+
+  if (TUYA_DIMMER == Settings.module) { // Get current status of MCU
+    snprintf_P(log_data, sizeof(log_data), "TYA: Request MCU state");
+    AddLog(LOG_LEVEL_DEBUG);
+    Serial.write(0x55); // header 55AA
+    Serial.write(0xAA);
+    Serial.write(0x00); // version 00
+    Serial.write(0x08); // command 08 - get status
+    Serial.write(0x00);
+    Serial.write(0x00); // following data length 0x00
+    Serial.write(0x07); // checksum:sum of all bytes in packet mod 256
+    Serial.flush();
+  }
 
   if (MOTOR == Settings.module) Settings.poweronstate = POWER_ALL_ON;  // Needs always on else in limbo!
   if (POWER_ALL_ALWAYS_ON == Settings.poweronstate) {

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2261,14 +2261,14 @@ void TuyaPacketProcess()
   if (serial_in_byte_counter == 7 && serial_in_buffer[3] == 14 ) {  // heartbeat packet
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Heartbeat"));
   }
-  if (serial_in_byte_counter == 12 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 5) {  // on/off packet
+  else if (serial_in_byte_counter == 12 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 5) {  // on/off packet
     snprintf_P(log_data, sizeof(log_data),PSTR("TYA: Rcvd - %s State"),serial_in_buffer[10]?"On":"Off");
     AddLog(LOG_LEVEL_DEBUG);
     if((power || Settings.light_dimmer > 0) && (power != serial_in_buffer[10])) {
       ExecuteCommandPower(1, serial_in_buffer[10], SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
     }
   }
-  if (serial_in_byte_counter == 15 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 8) {  // dim packet
+  else if (serial_in_byte_counter == 15 && serial_in_buffer[3] == 7 && serial_in_buffer[5] == 8) {  // dim packet
     snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Rcvd Dim State=%d"), serial_in_buffer[13]);
     AddLog(LOG_LEVEL_DEBUG);
     tuya_new_dim = round(serial_in_buffer[13] * (100. / 255.));

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1137,14 +1137,19 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      0, 0, 0
   },
   { "Tuya Dimmer",     // Tuya Dimmer (ESP8266 w/ separate MCU dimmer)
-                       // https://www.amazon.com/gp/product/B07CTNSZZ8/ref=oh_aui_detailpage_o00_s00?ie=UTF8&psc=1
-     0,
-     GPIO_TXD,         // TX to dimmer MCU
-     0,
-     GPIO_RXD,         // RX from dimmer MCU
-     0, 0,
+     GPIO_KEY1,        // Virtual Button (controlled by MCU)
+     GPIO_TXD,         // GPIO01 MCU serial control
+     GPIO_USER,
+     GPIO_RXD,         // GPIO03 MCU serial control
+     GPIO_USER,
+     GPIO_USER,
      0, 0, 0, 0, 0, 0, // Flash connection
-     0, 0, 0, 0, 0, 0
+     GPIO_USER,
+     GPIO_USER,
+     GPIO_LED1,        // GPIO14 Green Led
+     GPIO_USER,
+     GPIO_USER,
+     0
   }
 };
 

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -343,6 +343,7 @@ void LightMy92x1Duty(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b, uint8_t dut
   os_delay_us(12);                      // TStop > 12us.
 }
 
+
 // *************** Tuya Dimmer Serial Comms
 void LightSerialDuty(uint8_t duty)
 {
@@ -356,7 +357,7 @@ void LightSerialDuty(uint8_t duty)
     Serial.write(0x06); // Tuya command 06 - send order
     Serial.write(0x00);
     Serial.write(0x08); // following data length 0x08
-    Serial.write(0x03); // dimmer id
+    Serial.write(Settings.tuya_dimmer_id); // dimmer id
     Serial.write(0x02); // type=value
     Serial.write(0x00); // length hi
     Serial.write(0x04); // length low
@@ -364,9 +365,9 @@ void LightSerialDuty(uint8_t duty)
     Serial.write(0x00); // 
     Serial.write(0x00); // 
     Serial.write( duty ); // dim value (0-255)
-    Serial.write( byte(22 + duty) ); // checksum:sum of all bytes in packet mod 256
+    Serial.write( byte(Settings.tuya_dimmer_id + 19 + duty) ); // checksum:sum of all bytes in packet mod 256
     Serial.flush();
-    snprintf_P(log_data, sizeof(log_data), PSTR( "TYA: Send Serial Packet Dim Value=%d"), duty);
+    snprintf_P(log_data, sizeof(log_data), PSTR( "TYA: Send Serial Packet Dim Value=%d (id=%d)"), duty, Settings.tuya_dimmer_id);
     AddLog(LOG_LEVEL_DEBUG);
   } else {
     tuya_ignore_dim = false;  // reset flag


### PR DESCRIPTION
There are many Dimmers using the TUYA serial-protocol, they use different configurations for addressing the dimmer, as well as reset-functions (Button-presses) etc.

This adds support for other Dimmers using the TUYA protocol as mentioned in #469 

This patch adds a new option to select the dimmer ID used in the serial communication.
It can either be set at compile-time via:
`#define TUYA_DIMMER_ID <id>`

Or at runtime via:
`TuyaDimmerId <id>`

The ID defaults to **3** to not break stuff.