### PR TITLE
Add reset-button-handler vor tuya-dimmer

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1723,7 +1723,20 @@ void ButtonHandler()
             ExecuteCommandPower(button_index +1, POWER_TOGGLE, SRC_BUTTON);  // Execute Toggle command internally
           }
         }
-      } else {
+      }
+#ifdef USE_TUYA_DIMMER
+      else if (TUYA_DIMMER == Settings.module) {
+        if ((PRESSED == button) && (NOT_PRESSED == lastbutton[button_index])) {
+          snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_LEVEL_10), button_index +1);
+          AddLog(LOG_LEVEL_DEBUG);
+          if (!Settings.flag.button_restrict) {
+            snprintf_P(scmnd, sizeof(scmnd), D_CMND_WIFICONFIG " %d", 2);
+            ExecuteCommand(scmnd, SRC_BUTTON);
+          }
+        }
+      }
+#endif
+      else {
         if ((PRESSED == button) && (NOT_PRESSED == lastbutton[button_index])) {
           if (Settings.flag.button_single) {                   // Allow only single button press for immediate action
             snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_IMMEDIATE), button_index +1);


### PR DESCRIPTION
Some of the TUYA-Dimmers use GPIO_0 to tell the ESP that wifi-configuration should be reset.
The Procedure to trigger this is as follows:
- Turn of the dimmer
- Hold Arrow-down-button for +-15 Seconds
- The MCU will pull down GPIO_0
This code mimics 4 short presses as described here:
https://github.com/arendst/Sonoff-Tasmota/wiki/Button-usage

Without this there is no way to trigger wifi-configuration.