### PR TITLE
Fix Alexa for Core 2.5.0 (also backwards compatible)

### DIFF
--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -660,11 +660,11 @@ void HueLights(String *path)
     if ((device < 1) || (device > maxhue)) {
       device = 1;
     }
-    if (1 == WebServer->args()) {
+    if (WebServer->args()) {
       response = "[";
 
       StaticJsonBuffer<400> jsonBuffer;
-      JsonObject &hue_json = jsonBuffer.parseObject(WebServer->arg(0));
+      JsonObject &hue_json = jsonBuffer.parseObject(WebServer->arg((WebServer->args())-1));
       if (hue_json.containsKey("on")) {
 
         response += FPSTR(HUE_LIGHT_RESPONSE_JSON);


### PR DESCRIPTION
Alexa uses Phillips Hue Emulation to control Tasmota.

In the Arduino Esp8266 Core v2.3.0 all works fine.
In the Arduino Esp8266 Core v2.4.0, 2.4.1 and 2.4.2, a modification in the core is needed in order to make phillips hue work.
In the Arduino Esp8266 Core v2.5.0 (actual Stage version), the webserver parsing was modified and this PR fix this modification.

The new parsing of the core works fine for a standard phillips hue messages, but for Alexa it splits the command in 2 args. The first arg is empty and the second contains the correct phillips hue commands.

Tested ok