### PR TITLE
Fix Alexa

### DIFF
--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -664,7 +664,7 @@ void HueLights(String *path)
       response = "[";
 
       StaticJsonBuffer<400> jsonBuffer;
-      JsonObject &hue_json = jsonBuffer.parseObject(WebServer->arg((WebServer->args())-1));
+      JsonObject &hue_json = jsonBuffer.parseObject(WebServer->arg("1"));
       if (hue_json.containsKey("on")) {
 
         response += FPSTR(HUE_LIGHT_RESPONSE_JSON);


### PR DESCRIPTION
Alexa uses Phillips Hue Emulation to control Tasmota.

With this fix, the webserver arguments are passed to Tasmota as keys instead of args solving the Alexa issue for ALL cores.

Besides, for core 2.6.0 is planned to deprecate the use of args in favor of keys.

This fix makes Alexa to works compiling Tasmota under core 2.3.0, ~2.4.0, 2.4.1, 2.4.2~, 2.5.0 (stage), ~2.6.0 (planned)~

(no need to modify anything on any Arduino core)

Tested Ok.

EDIT: There was a problem with the test devices. Only works for 2.3.0 and stage