### PR TITLE
decode-config.py v2.0.0000: add full backup/restore capability

### DIFF
--- a/tools/decode-config.html
+++ b/tools/decode-config.html
@@ -1,0 +1,230 @@
+<h1 id="decode-config-py">decode-config.py</h1>
+<p><em>decode-config.py</em> backup and restore Sonoff-Tasmota configuration.</p>
+<p>Comparing backup files created by <em>decode-config.py</em> and *.dmp files created by Tasmota &quot;Backup/Restore Configuration&quot;:  </p>
+<table>
+<thead>
+<tr>
+<th>&nbsp;</th>
+<th style="text-align:center">decode-config.py<br />*.json file</th>
+<th style="text-align:center">Sonoff-Tasmota<br />*.dmp file</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Encrypted</td>
+<td style="text-align:center">No</td>
+<td style="text-align:center">Yes</td>
+</tr>
+<tr>
+<td>Readable</td>
+<td style="text-align:center">Yes</td>
+<td style="text-align:center">No</td>
+</tr>
+<tr>
+<td>Simply editable</td>
+<td style="text-align:center">Yes</td>
+<td style="text-align:center">No</td>
+</tr>
+<tr>
+<td>Simply batch processing</td>
+<td style="text-align:center">Yes</td>
+<td style="text-align:center">No</td>
+</tr>
+</tbody>
+</table>
+<p><em>decode-config.py</em> handles Tasmota configurations for release version since 5.10.0 up to now.</p>
+<h1 id="content">Content</h1>
+<ul>
+<li><a href="decode-config.html#prerequisite">Prerequisite</a></li>
+<li><a href="decode-config.html#file-types">File Types</a><ul>
+<li><a href="decode-config.html#-dmp-file-format">.dmp File Format</a></li>
+<li><a href="decode-config.html#-json-file-format">.json File Format</a></li>
+<li><a href="decode-config.html#-bin-file-format">.bin File Format</a><ul>
+<li><a href="decode-config.html#file-extensions">File extensions</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="decode-config.html#usage">Usage</a><ul>
+<li><a href="decode-config.html#basics">Basics</a></li>
+<li><a href="decode-config.html#save-backup-file">Save backup file</a></li>
+<li><a href="decode-config.html#restore-backup-file">Restore backup file</a></li>
+<li><a href="decode-config.html#configuration-file">Configuration file</a></li>
+<li><a href="decode-config.html#more-program-arguments">More program arguments</a></li>
+<li><a href="decode-config.html#examples">Examples</a><ul>
+<li><a href="decode-config.html#config-file">Config file</a></li>
+<li><a href="decode-config.html#using-tasmota-binary-configuration-files">Using Tasmota binary configuration files</a></li>
+<li><a href="decode-config.html#use-batch-processing">Use batch processing</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<h2 id="prerequisite">Prerequisite</h2>
+<ul>
+<li><a href="https://en.wikipedia.org/wiki/Python_(programming_language">Python</a>)<br>This program is written in <a href="https://en.wikipedia.org/wiki/Python_(programming_language">Python</a>) so you need to install a python environment (for details see <a href="https://docs.python.org/2.7/using/index.html">Python Setup and Usage</a>)</li>
+<li><a href="https://github.com/arendst/Sonoff-Tasmota">Sonoff-Tasmota</a> <a href="https://github.com/arendst/Sonoff-Tasmota/releases">Firmware</a> with enabled Web-Server<br>To backup or restore configurations from/to a Sonoff-Tasmota device you need a firmare with enabled web-server in admin mode (command <a href="https://github.com/arendst/Sonoff-Tasmota/wiki/Commands#wifi">WebServer 2</a>).
+<br />Only self compiled firmware may do not have a web-server sod if you use your own compiled firmware be aware to enable the web-server, otherwise you can only use the <code>--file</code> parameter as source.</li>
+</ul>
+<h2 id="file-types">File Types</h2>
+<p><em>decode-config.py</em> can handle the following backup file types:  </p>
+<h3 id="-dmp-format">.dmp Format</h3>
+<p>Configuration data as used by Tasmota &quot;Backup/Restore Configuration&quot; web interface.<br>This format is binary and encrypted.</p>
+<h3 id="-json-format">.json Format</h3>
+<p>Configuration data in <a href="http://www.json.org/">JSON</a>-format.<br>This format is decrypted, human readable and editable and can also be used for the <code>--restore-file</code> command.<br>This file will becreated by <em>decode-config.py</em> using <code>--backup-file</code> with <code>--backup-type json</code> parameter (default).</p>
+<h3 id="-bin-format">.bin Format</h3>
+<p>Configuration data in binary format.<br>This format is binary decryptet, editable (e.g. using a hex editor) and can also be used for <code>--restore-file</code> command.<br>It will be created by <em>decode-config.py</em> using <code>--backup-file</code> with <code>--backup-type bin</code>.<br>Note:<br>This file is 4 byte longer than an original .dmp file due to an prefix header at the beginning. The file data starting at address position 4 are containing the same as the <strong>struct SYSCFG</strong> from Tasmota <a href="https://github.com/arendst/Sonoff-Tasmota/blob/master/sonoff/settings.h">settings.h</a> in decrypted format.</p>
+<h4 id="file-extensions">File extensions</h4>
+<p><em>decode-config.py</em> uses auto extension as default for backup filenames; you don&#39;t need to append extensions to your backup file, it will be selected based on <code>--backup-type</code> argument.<br>If you want using your own extension use the <code>--no-extension</code> argument.</p>
+<h2 id="usage">Usage</h2>
+<p>After download don&#39;t forget to set exec flag under linux with <code>chmod +x decode-config.py</code> or call the program using <code>python decode-config.py...</code>.</p>
+<h3 id="basics">Basics</h3>
+<p>At least pass a source where you want to read the configuration data from using <code>-f &lt;filename&gt;</code> or <code>-d &lt;host&gt;</code>:</p>
+<p>The source can be either </p>
+<ul>
+<li>a Tasmota device hostname or IP by passing it using the <code>-d &lt;host&gt;</code> arg</li>
+<li>or a previously stored Tasmota *.dmp<code>configuration file by passing the filename using</code>-f <filename>` arg</li>
+</ul>
+<p>Example:  </p>
+<pre><code>decode-config<span class="hljs-selector-class">.py</span> -d sonoff-<span class="hljs-number">4281</span>
+</code></pre><p>will output a human readable configuration in <a href="http://www.json.org/">JSON</a>-format:</p>
+<pre><code>{
+  <span class="hljs-string">"altitude"</span>: <span class="hljs-number">112</span>, 
+  <span class="hljs-string">"baudrate"</span>: <span class="hljs-number">115200</span>, 
+  <span class="hljs-string">"blinkcount"</span>: <span class="hljs-number">10</span>, 
+  <span class="hljs-string">"blinktime"</span>: <span class="hljs-number">10</span>, 
+...
+  <span class="hljs-string">"ws_width"</span>: [
+    <span class="hljs-number">1</span>, 
+    <span class="hljs-number">3</span>, 
+    <span class="hljs-number">5</span>
+  ]
+}
+</code></pre><h3 id="save-backup-file">Save backup file</h3>
+<p>To save the output as backup file <code>--backup-file &lt;filename&gt;</code>, you can use placeholder for Version, Friendlyname and Hostname:  </p>
+<pre><code><span class="hljs-selector-tag">decode-config</span><span class="hljs-selector-class">.py</span> <span class="hljs-selector-tag">-d</span> <span class="hljs-selector-tag">sonoff-4281</span> <span class="hljs-selector-tag">--backup-file</span> <span class="hljs-selector-tag">Config_</span>@<span class="hljs-keyword">f_</span>@<span class="hljs-keyword">v</span>
+</code></pre><p>If you have setup a WebPassword within Tasmota, use</p>
+<pre><code>decode-config<span class="hljs-selector-class">.py</span> -d sonoff-<span class="hljs-number">4281</span> -<span class="hljs-selector-tag">p</span> &lt;yourpassword&gt; --backup-file Config_@f_@v
+</code></pre><p>will create a file like <code>Config_Sonoff_x.x.x.json</code>. Because it is in JSON format, you can read and edit the file with any raw text editor.</p>
+<h3 id="restore-backup-file">Restore backup file</h3>
+<p>Reading back a saved (and possible changed) backup file use the <code>--restore-file &lt;filename&gt;</code> arg. This will read the (changed) configuration data from this file and send it back to the source device or filename.</p>
+<p>To restore the previously save backup file <code>Config_Sonoff_6.2.1.json</code> to device <code>sonoff-4281</code> use:  </p>
+<pre><code><span class="hljs-selector-tag">decode-config</span><span class="hljs-selector-class">.py</span> <span class="hljs-selector-tag">-d</span> <span class="hljs-selector-tag">sonoff-4281</span> <span class="hljs-selector-tag">--restore-file</span> <span class="hljs-selector-tag">Config_Sonoff_6</span><span class="hljs-selector-class">.2</span><span class="hljs-selector-class">.1</span><span class="hljs-selector-class">.json</span>
+</code></pre><p>with password set by WebPassword:</p>
+<pre><code><span class="hljs-selector-tag">decode-config</span><span class="hljs-selector-class">.py</span> <span class="hljs-selector-tag">-d</span> <span class="hljs-selector-tag">sonoff-4281</span> <span class="hljs-selector-tag">-p</span> &lt;<span class="hljs-selector-tag">yourpassword</span>&gt; <span class="hljs-selector-tag">--restore-file</span> <span class="hljs-selector-tag">Config_Sonoff_6</span><span class="hljs-selector-class">.2</span><span class="hljs-selector-class">.1</span><span class="hljs-selector-class">.json</span>
+</code></pre><h3 id="configuration-file">Configuration file</h3>
+<p>Each argument that start with <code>--</code> (eg. <code>--file</code>) can also be set in a config file (specified via -c). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at <a href="https://pypi.org/project/ConfigArgParse/">https://pypi.org/project/ConfigArgParse</a>).</p>
+<p>If an argument is specified in more than one place, then commandline values override config file values which override defaults. This is usefull if you always use the same argument or a basic set of arguments.</p>
+<p>The http authentication credentials <code>--username</code> and <code>--password</code> is predestinated to store it in a file instead using it on your command line as argument:</p>
+<p>e.g. my.conf:</p>
+<pre><code><span class="hljs-section">[source]</span>
+<span class="hljs-attr">username</span> = admin
+<span class="hljs-attr">password</span> = myPaszxwo!z
+</code></pre><p>To make a backup file from example above you can now pass the config file instead using the password on command line:</p>
+<pre><code><span class="hljs-selector-tag">decode-config</span><span class="hljs-selector-class">.py</span> <span class="hljs-selector-tag">-d</span> <span class="hljs-selector-tag">sonoff-4281</span> <span class="hljs-selector-tag">-c</span> <span class="hljs-selector-tag">my</span><span class="hljs-selector-class">.conf</span> <span class="hljs-selector-tag">--backup-file</span> <span class="hljs-selector-tag">Config_</span>@<span class="hljs-keyword">f_</span>@<span class="hljs-keyword">v</span>
+</code></pre><h3 id="more-program-arguments">More program arguments</h3>
+<p>For better reading your porgram arguments each short written arg (minus sign <code>-</code>) has a corresponding readable long version (two minus signs <code>--</code>), eg. <code>--device</code> for <code>-d</code> or <code>--file</code> for <code>-f</code> (note: not even all <code>--</code> arg has a corresponding <code>-</code> one).</p>
+<p>A short list of possible program args is displayed using <code>-h</code> or <code>--help</code>.</p>
+<p>For advanced help use <code>-H</code> or <code>--full-help</code>:</p>
+<pre><code>usage: decode-config.py [-f &lt;filename&gt;] [-d &lt;host&gt;] [-P &lt;<span class="hljs-keyword">port</span>&gt;]
+                        [-u &lt;username&gt;] [-p &lt;password&gt;] [-i &lt;filename&gt;]
+                        [-o &lt;filename&gt;] [-F json|bin|dmp] [-E] [-e]
+                        [<span class="hljs-comment">--json-indent &lt;indent&gt;] [--json-compact]</span>
+                        [<span class="hljs-comment">--json-hide-pw] [--json-unhide-pw] [-h] [-H] [-v]</span>
+                        [-V] [-c &lt;filename&gt;] [<span class="hljs-comment">--ignore-warnings]</span>
+
+Backup/Restore Sonoff-Tasmota <span class="hljs-keyword">configuration</span> data. Args that start <span class="hljs-keyword">with</span> '<span class="hljs-comment">--'</span>
+(eg. -f) can also be set <span class="hljs-keyword">in</span> a config <span class="hljs-keyword">file</span> (specified via -c). Config <span class="hljs-keyword">file</span>
+syntax allows: key=value, flag=<span class="hljs-literal">true</span>, stuff=[a,b,c] (<span class="hljs-keyword">for</span> details, see syntax at
+https://goo.gl/R74nmi). <span class="hljs-keyword">If</span> an arg <span class="hljs-keyword">is</span> specified <span class="hljs-keyword">in</span> more than one place, <span class="hljs-keyword">then</span>
+commandline values override config <span class="hljs-keyword">file</span> values which override defaults.
+
+optional arguments:
+  -c, <span class="hljs-comment">--config &lt;filename&gt;</span>
+                        program config <span class="hljs-keyword">file</span> - can be used <span class="hljs-keyword">to</span> set <span class="hljs-keyword">default</span>
+                        command args (<span class="hljs-keyword">default</span>: None)
+  <span class="hljs-comment">--ignore-warnings     do not exit on warnings. Not recommended, used by your</span>
+                        own responsibility!
+
+Source:
+  Read/Write Tasmota <span class="hljs-keyword">configuration</span> from/<span class="hljs-keyword">to</span>
+
+  -f, <span class="hljs-comment">--file, --tasmota-file &lt;filename&gt;</span>
+                        <span class="hljs-keyword">file</span> <span class="hljs-keyword">to</span> retrieve/write Tasmota <span class="hljs-keyword">configuration</span> from/<span class="hljs-keyword">to</span>
+                        (<span class="hljs-keyword">default</span>: None)'
+  -d, <span class="hljs-comment">--device, --host &lt;host&gt;</span>
+                        hostname <span class="hljs-keyword">or</span> IP address <span class="hljs-keyword">to</span> retrieve/send Tasmota
+                        <span class="hljs-keyword">configuration</span> from/<span class="hljs-keyword">to</span> (<span class="hljs-keyword">default</span>: None)
+  -P, <span class="hljs-comment">--port &lt;port&gt;     TCP/IP port number to use for the host connection</span>
+                        (<span class="hljs-keyword">default</span>: <span class="hljs-number">80</span>)
+  -u, <span class="hljs-comment">--username &lt;username&gt;</span>
+                        host HTTP <span class="hljs-keyword">access</span> username (<span class="hljs-keyword">default</span>: admin)
+  -p, <span class="hljs-comment">--password &lt;password&gt;</span>
+                        host HTTP <span class="hljs-keyword">access</span> password (<span class="hljs-keyword">default</span>: None)
+
+Backup/Restore:
+  Backup/Restore <span class="hljs-keyword">configuration</span> <span class="hljs-keyword">file</span> specification
+
+  -i, <span class="hljs-comment">--restore-file &lt;filename&gt;</span>
+                        <span class="hljs-keyword">file</span> <span class="hljs-keyword">to</span> restore <span class="hljs-keyword">configuration</span> from (<span class="hljs-keyword">default</span>: None).
+                        Replacements: @v=firmware version, @f=device friendly
+                        name, @h=device hostname
+  -o, <span class="hljs-comment">--backup-file &lt;filename&gt;</span>
+                        <span class="hljs-keyword">file</span> <span class="hljs-keyword">to</span> backup <span class="hljs-keyword">configuration</span> <span class="hljs-keyword">to</span> (<span class="hljs-keyword">default</span>: None).
+                        Replacements: @v=firmware version, @f=device friendly
+                        name, @h=device hostname
+  -F, <span class="hljs-comment">--backup-type json|bin|dmp</span>
+                        backup filetype (<span class="hljs-keyword">default</span>: <span class="hljs-symbol">'json</span>')
+  -E, <span class="hljs-comment">--extension       append filetype extension for -i and -o filename</span>
+                        (<span class="hljs-keyword">default</span>)
+  -e, <span class="hljs-comment">--no-extension    do not append filetype extension, use -i and -o</span>
+                        filename as passed
+
+JSON:
+  JSON backup format specification
+
+  <span class="hljs-comment">--json-indent &lt;indent&gt;</span>
+                        pretty-printed JSON output using indent level
+                        (<span class="hljs-keyword">default</span>: <span class="hljs-symbol">'None</span>'). -<span class="hljs-number">1</span> disables indent.
+  <span class="hljs-comment">--json-compact        compact JSON output by eliminate whitespace</span>
+  <span class="hljs-comment">--json-hide-pw        hide passwords (default)</span>
+  <span class="hljs-comment">--json-unhide-pw      unhide passwords</span>
+
+Info:
+  additional information
+
+  -h, <span class="hljs-comment">--help            show usage help message and exit</span>
+  -H, <span class="hljs-comment">--full-help       show full help message and exit</span>
+  -v, <span class="hljs-comment">--verbose         produce more output about what the program does</span>
+  -V, <span class="hljs-comment">--version         show program's version number and exit</span>
+
+Either argument -d &lt;host&gt; <span class="hljs-keyword">or</span> -f &lt;filename&gt; must be given.
+</code></pre><h3 id="examples">Examples</h3>
+<p>The most of the examples are for linux command line. Under Windows call the program using <code>python decode-config.py ...</code>.</p>
+<h4 id="config-file">Config file</h4>
+<p>Note: The example contains .ini style sections <code>[...]</code>. Sections are always treated as comment and serves as clarity only.
+For further details of config file syntax see <a href="https://pypi.org/project/ConfigArgParse/">https://pypi.org/project/ConfigArgParse</a>.</p>
+<p><em>my.conf</em></p>
+<pre><code><span class="hljs-string">[Source]</span>
+username = admin
+password = myPaszxwo!z
+
+<span class="hljs-string">[JSON]</span>
+json-indent <span class="hljs-number">2</span>
+</code></pre><h4 id="using-tasmota-binary-configuration-files">Using Tasmota binary configuration files</h4>
+<ol>
+<li><p>Restore a Tasmota configuration file</p>
+<p> <code>decode-config.py -c my.conf -d sonoff --restore-file Config_Sonoff_6.2.1.dmp</code></p>
+</li>
+<li><p>Backup device using Tasmota configuration compatible format</p>
+<p>a) use file extension to choice the file format</p>
+<p> <code>decode-config.py -c my.conf -d sonoff --backup-file Config_@f_@v.dmp</code></p>
+<p>b) use args to choice the file format</p>
+<p> <code>decode-config.py -c my.conf -d sonoff --backup-type dmp --backup-file Config_@f_@v</code></p>
+</li>
+</ol>
+<h4 id="use-batch-processing">Use batch processing</h4>
+<pre><code><span class="hljs-keyword">for</span> device <span class="hljs-keyword">in</span> sonoff1 sonoff2 sonoff3; <span class="hljs-keyword">do</span> ./decode-config.py -c my.conf -d <span class="hljs-variable">$device</span> -o Config<span class="hljs-number">_</span><span class="hljs-variable">@f_</span><span class="hljs-variable">@v</span>
+</code></pre><p>or under windows</p>
+<pre><code><span class="hljs-keyword">for</span> device <span class="hljs-keyword">in</span> (sonoff1 sonoff2 sonoff3) <span class="hljs-keyword">do</span> <span class="hljs-keyword">python</span> decode-config.py -c my.conf -d %device -o Config_@f_@v
+</code></pre><p>will produce JSON configuration files for host sonoff1, sonoff2 and sonoff3 using friendly name and Tasmota firmware version for backup filenames.</p>

--- a/tools/decode-config.md
+++ b/tools/decode-config.md
@@ -1,0 +1,253 @@
+# decode-config.py
+_decode-config.py_ backup and restore Sonoff-Tasmota configuration.
+
+Comparing backup files created by *decode-config.py* and *.dmp files created by Tasmota "Backup/Restore Configuration":  
+
+| &nbsp;                  | decode-config.py<br />*.json file | Sonoff-Tasmota<br />*.dmp file |
+|-------------------------|:-------------------------------:|:-----------------------------------:|
+| Encrypted               |                No               |                 Yes                 |
+| Readable                |               Yes               |                  No                 |
+| Simply editable         |               Yes               |                  No                 |
+| Simply batch processing |               Yes               |                  No                 |
+
+_decode-config.py_ handles Tasmota configurations for release version since 5.10.0 up to now.
+
+# Content
+* [Prerequisite](decode-config.md#prerequisite)
+* [File Types](decode-config.md#file-types)
+  * [.dmp File Format](decode-config.md#-dmp-file-format)
+  * [.json File Format](decode-config.md#-json-file-format)
+  * [.bin File Format](decode-config.md#-bin-file-format)
+    * [File extensions](decode-config.md#file-extensions)
+* [Usage](decode-config.md#usage)
+  * [Basics](decode-config.md#basics)
+  * [Save backup file](decode-config.md#save-backup-file)
+  * [Restore backup file](decode-config.md#restore-backup-file)
+  * [Configuration file](decode-config.md#configuration-file)
+  * [More program arguments](decode-config.md#more-program-arguments)
+  * [Examples](decode-config.md#examples)
+    * [Config file](decode-config.md#config-file)
+    * [Using Tasmota binary configuration files](decode-config.md#using-tasmota-binary-configuration-files)
+    * [Use batch processing](decode-config.md#use-batch-processing)
+
+## Prerequisite
+* [Python](https://en.wikipedia.org/wiki/Python_(programming_language))  
+  This program is written in [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) so you need to install a python environment (for details see [Python Setup and Usage](https://docs.python.org/2.7/using/index.html))
+* [Sonoff-Tasmota](https://github.com/arendst/Sonoff-Tasmota) [Firmware](https://github.com/arendst/Sonoff-Tasmota/releases) with enabled Web-Server  
+  To backup or restore configurations from/to a Sonoff-Tasmota device you need a firmare with enabled web-server in admin mode (command [WebServer 2](https://github.com/arendst/Sonoff-Tasmota/wiki/Commands#wifi)).
+  <br />Only self compiled firmware may do not have a web-server sod if you use your own compiled firmware be aware to enable the web-server, otherwise you can only use the `--file` parameter as source.
+
+## File Types
+_decode-config.py_ can handle the following backup file types:  
+### .dmp Format
+Configuration data as used by Tasmota "Backup/Restore Configuration" web interface.  
+This format is binary and encrypted.
+### .json Format
+Configuration data in [JSON](http://www.json.org/)-format.  
+This format is decrypted, human readable and editable and can also be used for the `--restore-file` command.  
+This file will becreated by _decode-config.py_ using `--backup-file` with `--backup-type json` parameter (default).
+### .bin Format
+Configuration data in binary format.  
+This format is binary decryptet, editable (e.g. using a hex editor) and can also be used for `--restore-file` command.  
+It will be created by _decode-config.py_ using `--backup-file` with `--backup-type bin`.  
+Note:  
+This file is 4 byte longer than an original .dmp file due to an prefix header at the beginning. The file data starting at address position 4 are containing the same as the **struct SYSCFG** from Tasmota [settings.h](https://github.com/arendst/Sonoff-Tasmota/blob/master/sonoff/settings.h) in decrypted format.
+
+#### File extensions
+_decode-config.py_ uses auto extension as default for backup filenames; you don't need to append extensions to your backup file, it will be selected based on `--backup-type` argument.  
+If you want using your own extension use the `--no-extension` argument.
+
+## Usage
+After download don't forget to set exec flag under linux with `chmod +x decode-config.py` or call the program using `python decode-config.py...`.
+
+### Basics
+At least pass a source where you want to read the configuration data from using `-f <filename>` or `-d <host>`:
+
+The source can be either 
+* a Tasmota device hostname or IP by passing it using the `-d <host>` arg
+* or a previously stored Tasmota *.dmp` configuration file by passing the filename using `-f <filename>` arg
+
+Example:  
+
+    decode-config.py -d sonoff-4281
+
+will output a human readable configuration in [JSON](http://www.json.org/)-format:
+
+    {
+      "altitude": 112, 
+      "baudrate": 115200, 
+      "blinkcount": 10, 
+      "blinktime": 10, 
+    ...
+      "ws_width": [
+        1, 
+        3, 
+        5
+      ]
+    }
+
+
+### Save backup file
+To save the output as backup file `--backup-file <filename>`, you can use placeholder for Version, Friendlyname and Hostname:  
+
+    decode-config.py -d sonoff-4281 --backup-file Config_@f_@v
+    
+If you have setup a WebPassword within Tasmota, use
+
+    decode-config.py -d sonoff-4281 -p <yourpassword> --backup-file Config_@f_@v
+
+will create a file like `Config_Sonoff_x.x.x.json`. Because it is in JSON format, you can read and edit the file with any raw text editor.
+
+### Restore backup file
+Reading back a saved (and possible changed) backup file use the `--restore-file <filename>` arg. This will read the (changed) configuration data from this file and send it back to the source device or filename.
+
+To restore the previously save backup file `Config_Sonoff_6.2.1.json` to device `sonoff-4281` use:  
+
+    decode-config.py -d sonoff-4281 --restore-file Config_Sonoff_6.2.1.json
+    
+with password set by WebPassword:
+
+    decode-config.py -d sonoff-4281 -p <yourpassword> --restore-file Config_Sonoff_6.2.1.json
+
+### Configuration file
+Each argument that start with `--` (eg. `--file`) can also be set in a config file (specified via -c). Config file syntax allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at [https://pypi.org/project/ConfigArgParse](https://pypi.org/project/ConfigArgParse/)).
+
+If an argument is specified in more than one place, then commandline values override config file values which override defaults. This is usefull if you always use the same argument or a basic set of arguments.
+
+The http authentication credentials `--username` and `--password` is predestinated to store it in a file instead using it on your command line as argument:
+
+e.g. my.conf:
+
+    [source]
+    username = admin
+    password = myPaszxwo!z
+
+To make a backup file from example above you can now pass the config file instead using the password on command line:
+
+    decode-config.py -d sonoff-4281 -c my.conf --backup-file Config_@f_@v
+
+
+
+### More program arguments
+For better reading your porgram arguments each short written arg (minus sign `-`) has a corresponding readable long version (two minus signs `--`), eg. `--device` for `-d` or `--file` for `-f` (note: not even all `--` arg has a corresponding `-` one).
+
+A short list of possible program args is displayed using `-h` or `--help`.
+
+For advanced help use `-H` or `--full-help`:
+
+    usage: decode-config.py [-f <filename>] [-d <host>] [-P <port>]
+                            [-u <username>] [-p <password>] [-i <filename>]
+                            [-o <filename>] [-F json|bin|dmp] [-E] [-e]
+                            [--json-indent <indent>] [--json-compact]
+                            [--json-hide-pw] [--json-unhide-pw] [-h] [-H] [-v]
+                            [-V] [-c <filename>] [--ignore-warnings]
+
+    Backup/Restore Sonoff-Tasmota configuration data. Args that start with '--'
+    (eg. -f) can also be set in a config file (specified via -c). Config file
+    syntax allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at
+    https://goo.gl/R74nmi). If an arg is specified in more than one place, then
+    commandline values override config file values which override defaults.
+
+    optional arguments:
+      -c, --config <filename>
+                            program config file - can be used to set default
+                            command args (default: None)
+      --ignore-warnings     do not exit on warnings. Not recommended, used by your
+                            own responsibility!
+
+    Source:
+      Read/Write Tasmota configuration from/to
+
+      -f, --file, --tasmota-file <filename>
+                            file to retrieve/write Tasmota configuration from/to
+                            (default: None)'
+      -d, --device, --host <host>
+                            hostname or IP address to retrieve/send Tasmota
+                            configuration from/to (default: None)
+      -P, --port <port>     TCP/IP port number to use for the host connection
+                            (default: 80)
+      -u, --username <username>
+                            host HTTP access username (default: admin)
+      -p, --password <password>
+                            host HTTP access password (default: None)
+
+    Backup/Restore:
+      Backup/Restore configuration file specification
+
+      -i, --restore-file <filename>
+                            file to restore configuration from (default: None).
+                            Replacements: @v=firmware version, @f=device friendly
+                            name, @h=device hostname
+      -o, --backup-file <filename>
+                            file to backup configuration to (default: None).
+                            Replacements: @v=firmware version, @f=device friendly
+                            name, @h=device hostname
+      -F, --backup-type json|bin|dmp
+                            backup filetype (default: 'json')
+      -E, --extension       append filetype extension for -i and -o filename
+                            (default)
+      -e, --no-extension    do not append filetype extension, use -i and -o
+                            filename as passed
+
+    JSON:
+      JSON backup format specification
+
+      --json-indent <indent>
+                            pretty-printed JSON output using indent level
+                            (default: 'None'). -1 disables indent.
+      --json-compact        compact JSON output by eliminate whitespace
+      --json-hide-pw        hide passwords (default)
+      --json-unhide-pw      unhide passwords
+
+    Info:
+      additional information
+
+      -h, --help            show usage help message and exit
+      -H, --full-help       show full help message and exit
+      -v, --verbose         produce more output about what the program does
+      -V, --version         show program's version number and exit
+
+    Either argument -d <host> or -f <filename> must be given.
+
+
+### Examples
+The most of the examples are for linux command line. Under Windows call the program using `python decode-config.py ...`.
+
+#### Config file
+Note: The example contains .ini style sections `[...]`. Sections are always treated as comment and serves as clarity only.
+For further details of config file syntax see [https://pypi.org/project/ConfigArgParse](https://pypi.org/project/ConfigArgParse/).
+
+*my.conf*
+
+    [Source]
+    username = admin
+    password = myPaszxwo!z
+
+    [JSON]
+    json-indent 2
+
+#### Using Tasmota binary configuration files
+
+1. Restore a Tasmota configuration file
+
+    `decode-config.py -c my.conf -d sonoff --restore-file Config_Sonoff_6.2.1.dmp`
+
+2. Backup device using Tasmota configuration compatible format
+
+   a) use file extension to choice the file format
+
+    `decode-config.py -c my.conf -d sonoff --backup-file Config_@f_@v.dmp`
+
+   b) use args to choice the file format
+
+    `decode-config.py -c my.conf -d sonoff --backup-type dmp --backup-file Config_@f_@v`
+
+#### Use batch processing
+
+    for device in sonoff1 sonoff2 sonoff3; do ./decode-config.py -c my.conf -d $device -o Config_@f_@v
+
+or under windows
+
+    for device in (sonoff1 sonoff2 sonoff3) do python decode-config.py -c my.conf -d %device -o Config_@f_@v
+
+will produce JSON configuration files for host sonoff1, sonoff2 and sonoff3 using friendly name and Tasmota firmware version for backup filenames.


### PR DESCRIPTION
- add full backup/restore capability
- add Tasmota .dmp format to be able to upload previously save Tasmota files
- add help files decode-config.md
- add Tasmota *.dmp format for backup
- new args:
    --restore-file, --extension, --no-extension,
    --full-help, --verbose
- changed args:
    --exit-on-error-only to --ignore-warnings
    --output-file        to --backup-file
    --output-file-format to --backup-type
    --hide-pw            to --json-hide-pw
    --unhide-pw          to --json-unhide-pw
- removed (hidden) args:
    --sort, --unsort, --raw-values, --no-raw-values
    -raw-keys, -no-raw-keys
    defaults are no raw keys/values and sort