### PR TITLE
Add tested Beta Arduino Core 2.5.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,8 @@ platform = espressif8266@1.5.0
 ;platform = espressif8266@1.7.3
 ; *** Esp8266 core for Arduino version 2.4.2
 ;platform = espressif8266@1.8.0
+; *** Esp8266 core for Arduino version Core 2.5.0 beta tested for Tasmota
+;platform = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
 ; *** Esp8266 core for Arduino version latest beta
 ;platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 ; *** Esp8266 core for Arduino current version (located in %USERPROFILE%\.platformio\platforms\espressif8266)


### PR DESCRIPTION
Add tested and known working Beta Arduino Core 2.5.0 for Tasmota. Unchanged Fork from Original https://github.com/esp8266/Arduino
New commits to Beta core 2.5.0 will only be added if known to be working with Tasmota