### PR TITLE
Change kmph to km/h

### DIFF
--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "h"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_INCREMENTS "inc"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "h"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -1,3 +1,4 @@
+
 /*
   el-GR.h - localization for Greek - Greece for Sonoff-Tasmota
 
@@ -537,7 +538,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/es-AR.h
+++ b/sonoff/language/es-AR.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "h"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "ó"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "h"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Godz"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "H"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Ч"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "кОм"
 #define D_UNIT_KILOWATTHOUR "кВт"
 #define D_UNIT_LUX "лк"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -536,7 +536,7 @@
 #define D_UNIT_HOUR "Hr"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kOhm"
 #define D_UNIT_KILOWATTHOUR "kWh"
 #define D_UNIT_LUX "lx"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "Г"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "кОм"
 #define D_UNIT_KILOWATTHOUR "кВт"
 #define D_UNIT_LUX "лк"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -536,7 +536,7 @@
 #define D_UNIT_HOUR "时"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "千欧"
 #define D_UNIT_KILOWATTHOUR "千瓦时"
 #define D_UNIT_LUX "勒克斯"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -537,7 +537,7 @@
 #define D_UNIT_HOUR "時"
 #define D_UNIT_INCREMENTS "inc"
 #define D_UNIT_KILOGRAM "kg"
-#define D_UNIT_KILOMETER_PER_HOUR "kmph"  // or "km/h"
+#define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "千歐"
 #define D_UNIT_KILOWATTHOUR "千瓦時"
 #define D_UNIT_LUX "勒克斯"


### PR DESCRIPTION
SI, and hence the use of "km/h" (or "km h−1" or "km·h−1") has now been adopted around the world 