### PR TITLE
tuya: reset wifi status LED

### DIFF
--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -221,6 +221,21 @@ boolean TuyaModuleSelected()
   return true;
 }
 
+void TuyaResetWifiLed(){
+    snprintf_P(log_data, sizeof(log_data), "TYA: Reset WiFi LED");
+    AddLog(LOG_LEVEL_DEBUG);
+
+    TuyaSerial->write((uint8_t)0x55); // header 55AA
+    TuyaSerial->write((uint8_t)0xAA);
+    TuyaSerial->write((uint8_t)0x00); // version 00
+    TuyaSerial->write((uint8_t)0x03); // command 03 - set wifi state
+    TuyaSerial->write((uint8_t)0x00);
+    TuyaSerial->write((uint8_t)0x01); // following data length 0x01
+    TuyaSerial->write((uint8_t)0x03); // wifi state 4 (configured and connected)
+    TuyaSerial->write((uint8_t)0x06); // checksum:sum of all bytes in packet mod 256
+    TuyaSerial->flush();
+}
+
 void TuyaInit()
 {
   if (!Settings.param[P_TUYA_DIMMER_ID]) {
@@ -241,16 +256,6 @@ void TuyaInit()
     TuyaSerial->write((uint8_t)0x00);
     TuyaSerial->write((uint8_t)0x00); // following data length 0x00
     TuyaSerial->write((uint8_t)0x07); // checksum:sum of all bytes in packet mod 256
-    TuyaSerial->flush();
-
-    TuyaSerial->write((uint8_t)0x55); // header 55AA
-    TuyaSerial->write((uint8_t)0xAA);
-    TuyaSerial->write((uint8_t)0x00); // version 00
-    TuyaSerial->write((uint8_t)0x03); // command 03 - set wifi state
-    TuyaSerial->write((uint8_t)0x00);
-    TuyaSerial->write((uint8_t)0x01); // following data length 0x01
-    TuyaSerial->write((uint8_t)0x03); // wifi state 4 (configured and connected)
-    TuyaSerial->write((uint8_t)0x06); // checksum:sum of all bytes in packet mod 256
     TuyaSerial->flush();
   }
 }
@@ -298,6 +303,8 @@ boolean Xdrv16(byte function)
       case FUNC_BUTTON_PRESSED:
         result = TuyaButtonPressed();
         break;
+      case FUNC_EVERY_SECOND:
+        if(TuyaSerial) { TuyaResetWifiLed(); }
     }
   }
   return result;

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -242,6 +242,16 @@ void TuyaInit()
     TuyaSerial->write((uint8_t)0x00); // following data length 0x00
     TuyaSerial->write((uint8_t)0x07); // checksum:sum of all bytes in packet mod 256
     TuyaSerial->flush();
+
+    TuyaSerial->write((uint8_t)0x55); // header 55AA
+    TuyaSerial->write((uint8_t)0xAA);
+    TuyaSerial->write((uint8_t)0x00); // version 00
+    TuyaSerial->write((uint8_t)0x03); // command 03 - set wifi state
+    TuyaSerial->write((uint8_t)0x00);
+    TuyaSerial->write((uint8_t)0x01); // following data length 0x01
+    TuyaSerial->write((uint8_t)0x03); // wifi state 4 (configured and connected)
+    TuyaSerial->write((uint8_t)0x06); // checksum:sum of all bytes in packet mod 256
+    TuyaSerial->flush();
   }
 }
 

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -305,6 +305,7 @@ boolean Xdrv16(byte function)
         break;
       case FUNC_EVERY_SECOND:
         if(TuyaSerial) { TuyaResetWifiLed(); }
+        break;
     }
   }
   return result;


### PR DESCRIPTION
Some of the tuya-modules don't allow direct control of the status-led via GPIO.
Instead a serial packet indicating wifi-status must be sent to the MCU.
To keep the status-led from blinking annoyingly, just always turn it off for now.
Might implement proper indication of wifi-status at a later time.

See #469 for further details.