### PR TITLE
sonoff-basic.bin - Enable sleep = 1 by default

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -229,6 +229,9 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 
 #ifdef USE_BASIC
 
+#undef APP_SLEEP
+#define APP_SLEEP 1                          // Default to sleep = 1 for USE_BASIC
+
 //#undef USE_ENERGY_SENSOR                      // Disable energy sensors
 #undef USE_ARDUINO_OTA                        // Disable support for Arduino OTA
 #undef USE_WPS                                // Disable support for WPS as initial wifi configuration tool


### PR DESCRIPTION
Most of the sonoff basic issues seem to be resolved by either reducing the number of drivers polled during startup or by entering sleep 1 to reduce cpu load and therefore power demand.

This PR enables sleep = 1 by default for the pre-compiled binaries for sonoff-basic.bin