### PR TITLE
tuya: properly indicate wifi-status

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1110,7 +1110,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
         wifi_state_flag = Settings.sta_config;
         snprintf_P(stemp1, sizeof(stemp1), kWifiConfig[Settings.sta_config]);
         snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_CMND_WIFICONFIG "\":\"%s " D_JSON_SELECTED "\"}"), stemp1);
-        if (WifiState() != WIFI_RESTART) {
+        if (WifiState() > WIFI_RESTART) {
 //          snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s after restart"), mqtt_data);
           restart_flag = 2;
         }
@@ -1795,7 +1795,7 @@ void ButtonHandler()
                 // Success
               } else {
                 if (multipress[button_index] < 3) {            // Single or Double press
-                  if (WifiState()) {                           // WPSconfig, Smartconfig or Wifimanager active
+                  if (WifiState() > WIFI_RESTART) {            // WPSconfig, Smartconfig or Wifimanager active
                     restart_flag = 1;
                   } else {
                     ExecuteCommandPower(button_index + multipress[button_index], POWER_TOGGLE, SRC_BUTTON);  // Execute Toggle command internally

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -1613,7 +1613,7 @@ void WifiCheck(uint8_t param)
 
 int WifiState()
 {
-  int state;
+  int state = -1;
 
   if ((WL_CONNECTED == WiFi.status()) && (static_cast<uint32_t>(WiFi.localIP()) != 0)) {
     state = WIFI_RESTART;

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -235,11 +235,13 @@ void TuyaSetWifiLed(){
       case WIFI_WPSCONFIG:
         wifi_state = 0x01;
         break;
-      case WIFI_WAIT:
-      case WIFI_RETRY:
-        wifi_state = 0x02;
       case WIFI_RESTART:
         wifi_state =  0x03;
+        break;
+      case WIFI_WAIT:
+      case WIFI_RETRY:
+      default:
+        wifi_state = 0x02;
         break;
     }
 

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -151,7 +151,7 @@ void TuyaPacketProcess()
   else if (tuya_byte_counter == 7 && tuya_buffer[3] == 3 && tuya_buffer[6] == 2) {  // WiFi LED has been sucessfully set.
 
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi LED set ACK"));
-    tuya_wifi_state = TuyaWifiState();
+    tuya_wifi_state = WifiState();
   }
 }
 
@@ -225,20 +225,9 @@ boolean TuyaModuleSelected()
   return true;
 }
 
-int TuyaWifiState()
-{
-  int state = -1;
-
-  if ((WL_CONNECTED == WiFi.status()) && (static_cast<uint32_t>(WiFi.localIP()) != 0)) {
-    state = WIFI_RESTART;
-  }
-  if (wifi_config_type) { state = wifi_config_type; }
-  return state;
-}
-
 void TuyaSetWifiLed(){
     uint8_t wifi_state = 0x02;
-    switch(TuyaWifiState()){
+    switch(WifiState()){
       case WIFI_SMARTCONFIG:
         wifi_state = 0x00;
         break;
@@ -254,7 +243,7 @@ void TuyaSetWifiLed(){
         break;
     }
 
-    snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", wifi_state, TuyaWifiState());
+    snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", wifi_state, WifiState());
     AddLog(LOG_LEVEL_DEBUG);
 
     TuyaSerial->write((uint8_t)0x55); // header 55AA
@@ -342,7 +331,7 @@ boolean Xdrv16(byte function)
         result = TuyaButtonPressed();
         break;
       case FUNC_EVERY_SECOND:
-        if(TuyaSerial && tuya_wifi_state!=TuyaWifiState()) { TuyaSetWifiLed(); }
+        if(TuyaSerial && tuya_wifi_state!=WifiState()) { TuyaSetWifiLed(); }
         break;
     }
   }

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -238,9 +238,6 @@ void TuyaSetWifiLed(){
       case WIFI_RESTART:
         wifi_state =  0x03;
         break;
-      default:
-        wifi_state = 0x02;
-        break;
     }
 
     snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", wifi_state, WifiState());

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -33,7 +33,7 @@ boolean tuya_ignore_dim = false;            // Flag to skip serial send to preve
 uint8_t tuya_cmd_status = 0;                // Current status of serial-read
 uint8_t tuya_cmd_checksum = 0;              // Checksum of tuya command
 uint8_t tuya_data_len = 0;                  // Data lenght of command
-bool tuya_wifi_state = false;
+uint8_t tuya_wifi_state = 0xFF;
 
 char tuya_buffer[TUYA_BUFFER_SIZE];         // Serial receive buffer
 int tuya_byte_counter = 0;                  // Index in serial receive buffer
@@ -148,10 +148,10 @@ void TuyaPacketProcess()
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi Reset Rcvd"));
     TuyaResetWifi();
   }
-  else if (tuya_byte_counter == 7 && tuya_buffer[3] == 3 && tuya_buffer[6] == 2) {  // WiFi LED has been sucessfully reset.
+  else if (tuya_byte_counter == 7 && tuya_buffer[3] == 3 && tuya_buffer[6] == 2) {  // WiFi LED has been sucessfully set.
 
-    AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi LED reset ACK"));
-    tuya_wifi_state = true;
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi LED set ACK"));
+    tuya_wifi_state = WifiState();
   }
 }
 
@@ -225,8 +225,25 @@ boolean TuyaModuleSelected()
   return true;
 }
 
-void TuyaResetWifiLed(){
-    snprintf_P(log_data, sizeof(log_data), "TYA: Reset WiFi LED");
+void TuyaSetWifiLed(){
+    uint8_t wifi_state = 0x02;
+    switch(WifiState()){
+      case WIFI_SMARTCONFIG:
+        wifi_state = 0x00;
+        break;
+      case WIFI_MANAGER:
+      case WIFI_WPSCONFIG:
+        wifi_state = 0x01;
+        break;
+      case WIFI_WAIT:
+      case WIFI_RETRY:
+        wifi_state = 0x02;
+      case WIFI_RESTART:
+        wifi_state =  0x03;
+        break;
+    }
+
+    snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", WifiState(), wifi_state);
     AddLog(LOG_LEVEL_DEBUG);
 
     TuyaSerial->write((uint8_t)0x55); // header 55AA
@@ -235,8 +252,8 @@ void TuyaResetWifiLed(){
     TuyaSerial->write((uint8_t)0x03); // command 03 - set wifi state
     TuyaSerial->write((uint8_t)0x00);
     TuyaSerial->write((uint8_t)0x01); // following data length 0x01
-    TuyaSerial->write((uint8_t)0x03); // wifi state 4 (configured and connected)
-    TuyaSerial->write((uint8_t)0x06); // checksum:sum of all bytes in packet mod 256
+    TuyaSerial->write((uint8_t)wifi_state); // wifi state (0x00 == smartconfig, 0x01 == AP, 0x02 == not connected, 0x03 == connected) 
+    TuyaSerial->write((uint8_t)(0x03 + wifi_state)); // checksum:sum of all bytes in packet mod 256
     TuyaSerial->flush();
 }
 
@@ -268,9 +285,9 @@ void TuyaResetWifi()
 {
   if (!Settings.flag.button_restrict) {
     char scmnd[20];
+    tuya_wifi_state = 0xFF;
     snprintf_P(scmnd, sizeof(scmnd), D_CMND_WIFICONFIG " %d", 2);
     ExecuteCommand(scmnd, SRC_BUTTON);
-    tuya_wifi_state = false;
   }
 }
 
@@ -314,7 +331,7 @@ boolean Xdrv16(byte function)
         result = TuyaButtonPressed();
         break;
       case FUNC_EVERY_SECOND:
-        if(TuyaSerial && !tuya_wifi_state) { TuyaResetWifiLed(); }
+        if(TuyaSerial && tuya_wifi_state!=WifiState()) { TuyaSetWifiLed(); }
         break;
     }
   }

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -245,7 +245,7 @@ void TuyaSetWifiLed(){
         break;
     }
 
-    snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", WifiState(), wifi_state);
+    snprintf_P(log_data, sizeof(log_data), "TYA: Set WiFi LED to state %d (%d)", wifi_state, WifiState());
     AddLog(LOG_LEVEL_DEBUG);
 
     TuyaSerial->write((uint8_t)0x55); // header 55AA


### PR DESCRIPTION
Implement proper indication of wifi-status for the tuya-dimmers that don't allow direct control of the LED via GPIO.
This also modifies WifiState() in support.ino to also reflect not connected status (using -1) and updates the calls to it, so they work as before.
See #469 for further discussion