### PR TITLE
Remove faulty Arduino cores

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -40,10 +40,6 @@ env_default = sonoff
 [common] ; ************************************************************
 ; *** Esp8266 core for Arduino version 2.3.0
 platform = espressif8266@1.5.0
-; *** Esp8266 core for Arduino version 2.4.0
-;platform = espressif8266@1.6.0
-; *** Esp8266 core for Arduino version 2.4.1
-;platform = espressif8266@1.7.3
 ; *** Esp8266 core for Arduino version 2.4.2
 ;platform = espressif8266@1.8.0
 ; *** Esp8266 core for Arduino version Core 2.5.0 beta tested for Tasmota


### PR DESCRIPTION
Cores 2.4.0 and 2.4.1 are known to be faulty. Not needed for Tasmota anymore