### PR TITLE
Fix regression for nrg and dsp interface delays

### DIFF
--- a/sonoff/xdsp_interface.ino
+++ b/sonoff/xdsp_interface.ino
@@ -117,7 +117,6 @@ boolean XdspCall(byte Function)
   boolean result = false;
 
   for (byte x = 0; x < xdsp_present; x++) {
-    if (global_state.wifi_down) { delay(DRIVER_BOOT_DELAY); }
     result = xdsp_func_ptr[x](Function);
     if (result) break;
   }

--- a/sonoff/xnrg_interface.ino
+++ b/sonoff/xnrg_interface.ino
@@ -90,7 +90,6 @@ int XnrgCall(byte Function)
   int result = 0;
 
   for (byte x = 0; x < xnrg_present; x++) {
-    if (global_state.wifi_down) { delay(DRIVER_BOOT_DELAY); }
     result = xnrg_func_ptr[x](Function);
     if (result) break;
   }


### PR DESCRIPTION
**URGENT**

After testing on POW and POW2 I find that the delay in combination with the wifi status check prevents a POW or POW2 from being set to that module type for some reason.

So reverting back to what @ascillato originally committed except for the addition of the #define for the value