### PR TITLE
tuya: autoconfig and other updates

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -354,7 +354,7 @@
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10                // Set the startup volume on init, the range can be 0..30(max)
 #define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
-  #define TUYA_DIMMER_ID       3                 // Default dimmer Id
+  #define TUYA_DIMMER_ID       0                 // Default dimmer Id
 
 // Power monitoring sensors -----------------------
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -104,7 +104,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #define USE_MP3_PLAYER                        // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10             // Set the startup volume on init, the range can be 0..30(max)
 #define USE_TUYA_DIMMER                       // Add support for Tuya Serial Dimmer
-  #define TUYA_DIMMER_ID       3              // Default dimmer Id
+  #define TUYA_DIMMER_ID       0              // Default dimmer Id
 #define USE_PZEM004T                          // Add support for PZEM004T Energy monitor (+2k code)
 #define USE_PZEM_AC                           // Add support for PZEM014,016 Energy monitor (+1k1 code)
 #define USE_PZEM_DC                           // Add support for PZEM003,017 Energy monitor (+1k1 code)

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1154,7 +1154,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
   },
   { "Tuya Dimmer",     // Tuya Dimmer (ESP8266 w/ separate MCU dimmer)
                        // https://www.amazon.com/gp/product/B07CTNSZZ8/ref=oh_aui_detailpage_o00_s00?ie=UTF8&psc=1
-     GPIO_KEY1,        // Virtual Button (controlled by MCU)
+     GPIO_USER,        // Virtual Button (controlled by MCU)
      GPIO_USER,        // GPIO01 MCU serial control
      GPIO_USER,
      GPIO_USER,        // GPIO03 MCU serial control
@@ -1163,7 +1163,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      0, 0, 0, 0, 0, 0, // Flash connection
      GPIO_USER,
      GPIO_USER,
-     GPIO_LED1,        // GPIO14 Green Led
+     GPIO_USER,        // GPIO14 Green Led
      GPIO_USER,
      GPIO_USER,
      0

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -153,7 +153,7 @@ void TuyaPacketProcess()
       ExecuteCommand(scmnd, SRC_SWITCH);
     }
   }
-  else if (tuya_byte_counter == 8 && tuya_buffer[3] == 5 && tuya_buffer[5] == 1 && tuya_buffer[7] == 5 ) {  // reset WiFi settings packet
+  else if (tuya_byte_counter == 8 && tuya_buffer[3] == 5 && tuya_buffer[5] == 1) {  // reset WiFi settings packet
 
     AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: WiFi Reset Rcvd"));
     TuyaResetWifi();

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -310,6 +310,9 @@ void TuyaRequestState(){
 
 void TuyaInit()
 {
+  if (!Settings.param[P_TUYA_DIMMER_ID]) {
+    Settings.param[P_TUYA_DIMMER_ID] = TUYA_DIMMER_ID;
+  }
   TuyaSerial = new TasmotaSerial(pin[GPIO_TUYA_RX], pin[GPIO_TUYA_TX], 1);
   if (TuyaSerial->begin(9600)) {
     if (TuyaSerial->hardwareSerial()) { ClaimSerial(); }

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -20,7 +20,7 @@
 #ifdef USE_TUYA_DIMMER
 
 #ifndef TUYA_DIMMER_ID
-#define TUYA_DIMMER_ID    3
+#define TUYA_DIMMER_ID    0
 #endif
 #define TUYA_BUFFER_SIZE  256
 
@@ -127,6 +127,12 @@ void TuyaPacketProcess()
 
     snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Rcvd Dim State=%d"), tuya_buffer[13]);
     AddLog(LOG_LEVEL_DEBUG);
+
+    if (!Settings.param[P_TUYA_DIMMER_ID]) {
+      snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Autoconfiguring Dimmer ID %d"), tuya_buffer[6]);
+      AddLog(LOG_LEVEL_DEBUG);
+      Settings.param[P_TUYA_DIMMER_ID] = tuya_buffer[6];
+    }
 
     tuya_new_dim = round(tuya_buffer[13] * (100. / 255.));
     if((power) && (tuya_new_dim > 0) && (abs(tuya_new_dim - Settings.light_dimmer) > 2)) {


### PR DESCRIPTION
This implements some autoconfig magic for the tuya dimmers 

- Uses TUYA_DIMMER_ID 0 as default and autodetects the ID. (can still bit set manually)
- Frees up GPIO_0 and GPIO_14 for user-configuration.
- Autoconfigures GPIOs used for Reset and WiFi-LED (GPIO_0 and GPIO_14 in my case).
- Dimmers using software-serial still need to manually configure serial-GPIOs

check #469 for further info