### PR TITLE
Fix issue when using together Emulation, PWM and Serial Communication

### DIFF
--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -210,6 +210,7 @@ boolean UdpDisconnect()
 boolean UdpConnect()
 {
   if (!udp_connected) {
+    delay(0); // Fix issue when using Emulation, PWM and Serial Communication
     if (PortUdp.beginMulticast(WiFi.localIP(), ipMulticast, port_multicast)) {
       AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_UPNP D_MULTICAST_REJOINED));
       udp_response_mutex = false;


### PR DESCRIPTION
This fix applies to Core 2.5.0 (Stage), for older cores, this fix do nothing.

The issue is that the ESP8266 becomes unresponsive and after some time it hungs and restart with hardware watchdog.

This fix solves that.