### PR TITLE
TasmotaSerial: use Serial.swap to map UART0 to GPIO13 and GPIO15

### DIFF
--- a/lib/TasmotaSerial-2.1.0/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-2.1.0/src/TasmotaSerial.cpp
@@ -80,6 +80,7 @@ TasmotaSerial::TasmotaSerial(int receive_pin, int transmit_pin, bool hardware_fa
 {
   m_valid = false;
   m_hardserial = 0;
+  m_hardswap = 0;
   m_stop_bits = 1;
   if (!((isValidGPIOpin(receive_pin)) && (isValidGPIOpin(transmit_pin) || transmit_pin == 16))) {
     return;
@@ -89,6 +90,9 @@ TasmotaSerial::TasmotaSerial(int receive_pin, int transmit_pin, bool hardware_fa
   m_in_pos = m_out_pos = 0;
   if (hardware_fallback && (((3 == m_rx_pin) && (1 == m_tx_pin)) || ((3 == m_rx_pin) && (-1 == m_tx_pin)) || ((-1 == m_rx_pin) && (1 == m_tx_pin)))) {
     m_hardserial = 1;
+  } else if (hardware_fallback && (((13 == m_rx_pin) && (15 == m_tx_pin)) || ((13 == m_rx_pin) && (-1 == m_tx_pin)) || ((-1 == m_rx_pin) && (15 == m_tx_pin)))) {
+    m_hardserial = 1;
+    m_hardswap = 1;
   } else {
     if (m_rx_pin > -1) {
       m_buffer = (uint8_t*)malloc(TM_SERIAL_BUFFER_SIZE);
@@ -133,6 +137,9 @@ bool TasmotaSerial::begin(long speed, int stop_bits) {
       Serial.begin(speed, SERIAL_8N2);
     } else {
       Serial.begin(speed, SERIAL_8N1);
+    }
+    if(m_hardswap) {
+      Serial.swap();
     }
   } else {
     // Use getCycleCount() loop to get as exact timing as possible

--- a/lib/TasmotaSerial-2.1.0/src/TasmotaSerial.h
+++ b/lib/TasmotaSerial-2.1.0/src/TasmotaSerial.h
@@ -62,6 +62,7 @@ class TasmotaSerial : public Stream {
     // Member variables
     bool m_valid;
     bool m_hardserial;
+    bool m_hardswap;
     bool m_high_speed;
     int m_rx_pin;
     int m_tx_pin;


### PR DESCRIPTION
According to the [documentation](https://github.com/esp8266/Arduino/blob/master/doc/reference.rst#serial) UART0 can be mapped to GPIO13 and GPIO15, thus allowing to use hardware-serial with these pins.
This implements this feature and uses hardware-serial when GPIO13 and GPIO15 are selected as RX and TX respectively and hardware_fallback is enabled.
