### PR TITLE
Change C functions with () to explicitly specify (void) for no parameters

### DIFF
--- a/sonoff/core_esp8266_timer.c
+++ b/sonoff/core_esp8266_timer.c
@@ -46,7 +46,7 @@ void ICACHE_RAM_ATTR timer1_isr_handler(void *para){
     }
 }
 
-void ICACHE_RAM_ATTR timer1_isr_init(){
+void ICACHE_RAM_ATTR timer1_isr_init(void){
     ETS_FRC_TIMER1_INTR_ATTACH(timer1_isr_handler, NULL);
 }
 
@@ -55,7 +55,7 @@ void timer1_attachInterrupt(timercallback userFunc) {
     ETS_FRC1_INTR_ENABLE();
 }
 
-void ICACHE_RAM_ATTR timer1_detachInterrupt() {
+void ICACHE_RAM_ATTR timer1_detachInterrupt(void) {
     timer1_user_cb = 0;
     TEIE &= ~TEIE1;//edge int disable
     ETS_FRC1_INTR_DISABLE();
@@ -71,7 +71,7 @@ void ICACHE_RAM_ATTR timer1_write(uint32_t ticks){
     if ((T1C & (1 << TCIT)) == 0) TEIE |= TEIE1;//edge int enable
 }
 
-void ICACHE_RAM_ATTR timer1_disable(){
+void ICACHE_RAM_ATTR timer1_disable(void){
     T1C = 0;
     T1I = 0;
 }
@@ -92,7 +92,7 @@ void ICACHE_RAM_ATTR timer0_isr_handler(void* para){
     }
 }
 
-void timer0_isr_init(){
+void timer0_isr_init(void){
     ETS_CCOMPARE0_INTR_ATTACH(timer0_isr_handler, NULL);
 }
 
@@ -101,7 +101,7 @@ void timer0_attachInterrupt(timercallback userFunc) {
     ETS_CCOMPARE0_ENABLE();
 }
 
-void ICACHE_RAM_ATTR timer0_detachInterrupt() {
+void ICACHE_RAM_ATTR timer0_detachInterrupt(void) {
     timer0_user_cb = NULL;
     ETS_CCOMPARE0_DISABLE();
 }

--- a/sonoff/core_esp8266_wiring_digital.c
+++ b/sonoff/core_esp8266_wiring_digital.c
@@ -188,7 +188,7 @@ extern void ICACHE_RAM_ATTR __detachInterrupt(uint8_t pin) {
   }
 }
 
-void initPins() {
+void initPins(void) {
   //Disable UART interrupts
   system_set_os_print(0);
   U0IE = 0;

--- a/sonoff/core_esp8266_wiring_pwm.c
+++ b/sonoff/core_esp8266_wiring_pwm.c
@@ -84,7 +84,7 @@ uint32_t pwm_get_mask(uint16_t value)
     return mask;
 }
 
-void prep_pwm_steps()
+void prep_pwm_steps(void)
 {
     if(pwm_mask == 0) {
         return;
@@ -123,7 +123,7 @@ void prep_pwm_steps()
     pwm_steps_changed = 1;
 }
 
-void ICACHE_RAM_ATTR pwm_timer_isr() //103-138
+void ICACHE_RAM_ATTR pwm_timer_isr(void) //103-138
 {
     struct pwm_isr_table *table = &(_pwm_isr_data.tables[_pwm_isr_data.active]);
     static uint8_t current_step = 0;
@@ -160,7 +160,7 @@ void ICACHE_RAM_ATTR pwm_timer_isr() //103-138
     TEIE |= TEIE1;//13
 }
 
-void pwm_start_timer()
+void pwm_start_timer(void)
 {
     timer1_disable();
     ETS_FRC_TIMER1_INTR_ATTACH(NULL, NULL);

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -69,7 +69,7 @@
 
 uint32_t rtc_settings_crc = 0;
 
-uint32_t GetRtcSettingsCrc()
+uint32_t GetRtcSettingsCrc(void)
 {
   uint32_t crc = 0;
   uint8_t *bytes = (uint8_t*)&RtcSettings;
@@ -80,7 +80,7 @@ uint32_t GetRtcSettingsCrc()
   return crc;
 }
 
-void RtcSettingsSave()
+void RtcSettingsSave(void)
 {
   if (GetRtcSettingsCrc() != rtc_settings_crc) {
     RtcSettings.valid = RTC_MEM_VALID;
@@ -89,7 +89,7 @@ void RtcSettingsSave()
   }
 }
 
-void RtcSettingsLoad()
+void RtcSettingsLoad(void)
 {
   ESP.rtcUserMemoryRead(100, (uint32_t*)&RtcSettings, sizeof(RTCMEM));  // 0x290
   if (RtcSettings.valid != RTC_MEM_VALID) {
@@ -106,7 +106,7 @@ void RtcSettingsLoad()
   rtc_settings_crc = GetRtcSettingsCrc();
 }
 
-boolean RtcSettingsValid()
+boolean RtcSettingsValid(void)
 {
   return (RTC_MEM_VALID == RtcSettings.valid);
 }
@@ -115,7 +115,7 @@ boolean RtcSettingsValid()
 
 uint32_t rtc_reboot_crc = 0;
 
-uint32_t GetRtcRebootCrc()
+uint32_t GetRtcRebootCrc(void)
 {
   uint32_t crc = 0;
   uint8_t *bytes = (uint8_t*)&RtcReboot;
@@ -126,7 +126,7 @@ uint32_t GetRtcRebootCrc()
   return crc;
 }
 
-void RtcRebootSave()
+void RtcRebootSave(void)
 {
   if (GetRtcRebootCrc() != rtc_reboot_crc) {
     RtcReboot.valid = RTC_MEM_VALID;
@@ -135,7 +135,7 @@ void RtcRebootSave()
   }
 }
 
-void RtcRebootLoad()
+void RtcRebootLoad(void)
 {
   ESP.rtcUserMemoryRead(100 - sizeof(RTCRBT), (uint32_t*)&RtcReboot, sizeof(RTCRBT));  // 0x280
   if (RtcReboot.valid != RTC_MEM_VALID) {
@@ -147,7 +147,7 @@ void RtcRebootLoad()
   rtc_reboot_crc = GetRtcRebootCrc();
 }
 
-boolean RtcRebootValid()
+boolean RtcRebootValid(void)
 {
   return (RTC_MEM_VALID == RtcReboot.valid);
 }
@@ -179,7 +179,7 @@ uint8_t *settings_buffer = NULL;
 /*
  * Based on cores/esp8266/Updater.cpp
  */
-void SetFlashModeDout()
+void SetFlashModeDout(void)
 {
   uint8_t *_buffer;
   uint32_t address;
@@ -198,7 +198,7 @@ void SetFlashModeDout()
   delete[] _buffer;
 }
 
-void SettingsBufferFree()
+void SettingsBufferFree(void)
 {
   if (settings_buffer != NULL) {
     free(settings_buffer);
@@ -206,7 +206,7 @@ void SettingsBufferFree()
   }
 }
 
-bool SettingsBufferAlloc()
+bool SettingsBufferAlloc(void)
 {
   SettingsBufferFree();
   if (!(settings_buffer = (uint8_t *)malloc(sizeof(Settings)))) {
@@ -216,7 +216,7 @@ bool SettingsBufferAlloc()
   return true;
 }
 
-uint16_t GetSettingsCrc()
+uint16_t GetSettingsCrc(void)
 {
   uint16_t crc = 0;
   uint8_t *bytes = (uint8_t*)&Settings;
@@ -227,7 +227,7 @@ uint16_t GetSettingsCrc()
   return crc;
 }
 
-void SettingsSaveAll()
+void SettingsSaveAll(void)
 {
   if (Settings.flag.save_state) {
     Settings.power = power;
@@ -242,7 +242,7 @@ void SettingsSaveAll()
  * Config Save - Save parameters to Flash ONLY if any parameter has changed
 \*********************************************************************************************/
 
-uint32_t GetSettingsAddress()
+uint32_t GetSettingsAddress(void)
 {
   return settings_location * SPI_FLASH_SEC_SIZE;
 }
@@ -294,7 +294,7 @@ void SettingsSave(byte rotate)
   RtcSettingsSave();
 }
 
-void SettingsLoad()
+void SettingsLoad(void)
 {
 /* Load configuration from eeprom or one of 7 slots below if first load does not stop_flash_rotate
  */
@@ -377,7 +377,7 @@ bool SettingsEraseConfig(void) {
   return true;
 }
 
-void SettingsSdkErase()
+void SettingsSdkErase(void)
 {
   WiFi.disconnect(true);    // Delete SDK wifi config
   SettingsErase(1);
@@ -387,7 +387,7 @@ void SettingsSdkErase()
 
 /********************************************************************************************/
 
-void SettingsDefault()
+void SettingsDefault(void)
 {
   AddLog_P(LOG_LEVEL_NONE, PSTR(D_LOG_CONFIG D_USE_DEFAULTS));
   SettingsDefaultSet1();
@@ -395,7 +395,7 @@ void SettingsDefault()
   SettingsSave(2);
 }
 
-void SettingsDefaultSet1()
+void SettingsDefaultSet1(void)
 {
   memset(&Settings, 0x00, sizeof(SYSCFG));
 
@@ -407,7 +407,7 @@ void SettingsDefaultSet1()
 //  Settings.cfg_crc = 0;
 }
 
-void SettingsDefaultSet2()
+void SettingsDefaultSet2(void)
 {
   memset((char*)&Settings +16, 0x00, sizeof(SYSCFG) -16);
 
@@ -641,7 +641,7 @@ void SettingsDefaultSet2()
 
 /********************************************************************************************/
 
-void SettingsDefaultSet_5_8_1()
+void SettingsDefaultSet_5_8_1(void)
 {
 //  Settings.flag.ws_clock_reverse = 0;
   Settings.ws_width[WS_SECOND] = 1;
@@ -658,7 +658,7 @@ void SettingsDefaultSet_5_8_1()
   Settings.ws_color[WS_HOUR][WS_BLUE] = 0;
 }
 
-void SettingsDefaultSet_5_10_1()
+void SettingsDefaultSet_5_10_1(void)
 {
   Settings.display_model = 0;
   Settings.display_mode = 1;
@@ -680,7 +680,7 @@ void SettingsDefaultSet_5_10_1()
   Settings.display_address[7] = MTX_ADDRESS8;
 }
 
-void SettingsResetStd()
+void SettingsResetStd(void)
 {
   Settings.tflag[0].hemis = TIME_STD_HEMISPHERE;
   Settings.tflag[0].week = TIME_STD_WEEK;
@@ -690,7 +690,7 @@ void SettingsResetStd()
   Settings.toffset[0] = TIME_STD_OFFSET;
 }
 
-void SettingsResetDst()
+void SettingsResetDst(void)
 {
   Settings.tflag[1].hemis = TIME_DST_HEMISPHERE;
   Settings.tflag[1].week = TIME_DST_WEEK;
@@ -700,7 +700,7 @@ void SettingsResetDst()
   Settings.toffset[1] = TIME_DST_OFFSET;
 }
 
-void SettingsDefaultSet_5_13_1c()
+void SettingsDefaultSet_5_13_1c(void)
 {
   SettingsResetStd();
   SettingsResetDst();
@@ -708,7 +708,7 @@ void SettingsDefaultSet_5_13_1c()
 
 /********************************************************************************************/
 
-void SettingsDelta()
+void SettingsDelta(void)
 {
   if (Settings.version != VERSION) {      // Fix version dependent changes
 

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -378,7 +378,7 @@ void SetLedPower(uint8_t state)
   digitalWrite(pin[GPIO_LED1], (bitRead(led_inverted, 0)) ? !state : state);
 }
 
-uint8_t GetFanspeed()
+uint8_t GetFanspeed(void)
 {
   uint8_t fanspeed = 0;
 
@@ -1426,7 +1426,7 @@ void ExecuteCommandPower(byte device, byte state, int source)
   if (publish_power) MqttPublishPowerState(device);
 }
 
-void StopAllPowerBlink()
+void StopAllPowerBlink(void)
 {
   power_t mask;
 
@@ -1571,7 +1571,7 @@ void PublishStatus(uint8_t payload)
 
 }
 
-void MqttShowPWMState()
+void MqttShowPWMState(void)
 {
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s\"" D_CMND_PWM "\":{"), mqtt_data);
   bool first = true;
@@ -1584,7 +1584,7 @@ void MqttShowPWMState()
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
 }
 
-void MqttShowState()
+void MqttShowState(void)
 {
   char stemp1[33];
 
@@ -1615,7 +1615,7 @@ void MqttShowState()
     mqtt_data, Settings.sta_active +1, Settings.sta_ssid[Settings.sta_active], WiFi.BSSIDstr().c_str(), WiFi.channel(), WifiGetRssiAsQuality(WiFi.RSSI()));
 }
 
-boolean MqttShowSensor()
+boolean MqttShowSensor(void)
 {
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s{\"" D_JSON_TIME "\":\"%s\""), mqtt_data, GetDateAndTime(DT_LOCAL).c_str());
   int json_data_start = strlen(mqtt_data);
@@ -1645,7 +1645,7 @@ boolean MqttShowSensor()
 
 /********************************************************************************************/
 
-void PerformEverySecond()
+void PerformEverySecond(void)
 {
   uptime++;
 
@@ -1718,7 +1718,7 @@ void PerformEverySecond()
  * Button handler with single press only or multi-press and hold on all buttons
 \*********************************************************************************************/
 
-void ButtonHandler()
+void ButtonHandler(void)
 {
   uint8_t button = NOT_PRESSED;
   uint8_t button_present = 0;
@@ -1956,7 +1956,7 @@ void SwitchHandler(byte mode)
  * Every 0.1 second
 \*-------------------------------------------------------------------------------------------*/
 
-void Every100mSeconds()
+void Every100mSeconds(void)
 {
   // As the max amount of sleep = 250 mSec this loop will shift in time...
   power_t power_now;
@@ -2005,7 +2005,7 @@ void Every100mSeconds()
  * Every 0.25 second
 \*-------------------------------------------------------------------------------------------*/
 
-void Every250mSeconds()
+void Every250mSeconds(void)
 {
 // As the max amount of sleep = 250 mSec this loop should always be taken...
 
@@ -2201,7 +2201,7 @@ void Every250mSeconds()
 bool arduino_ota_triggered = false;
 uint16_t arduino_ota_progress_dot_count = 0;
 
-void ArduinoOTAInit()
+void ArduinoOTAInit(void)
 {
   ArduinoOTA.setPort(8266);
   ArduinoOTA.setHostname(Settings.hostname);
@@ -2270,7 +2270,7 @@ void ArduinoOTAInit()
 
 /********************************************************************************************/
 
-void SerialInput()
+void SerialInput(void)
 {
   while (Serial.available()) {
     yield();
@@ -2398,7 +2398,7 @@ void GpioSwitchPinMode(uint8_t index)
   }
 }
 
-void GpioInit()
+void GpioInit(void)
 {
   uint8_t mpin;
   uint8_t key_no_pullup = 0;
@@ -2599,7 +2599,7 @@ extern "C" {
 extern struct rst_info resetInfo;
 }
 
-void setup()
+void setup(void)
 {
   byte idx;
 
@@ -2751,7 +2751,7 @@ void setup()
   XsnsCall(FUNC_INIT);
 }
 
-void loop()
+void loop(void)
 {
   XdrvCall(FUNC_LOOP);
 

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -39,7 +39,7 @@ byte oswatch_blocked_loop = 0;
 bool knx_started = false;
 #endif  // USE_KNX
 
-void OsWatchTicker()
+void OsWatchTicker(void)
 {
   unsigned long t = millis();
   unsigned long last_run = abs(t - oswatch_last_loop_time);
@@ -57,7 +57,7 @@ void OsWatchTicker()
   }
 }
 
-void OsWatchInit()
+void OsWatchInit(void)
 {
   oswatch_blocked_loop = RtcSettings.oswatch_blocked_loop;
   RtcSettings.oswatch_blocked_loop = 0;
@@ -65,13 +65,13 @@ void OsWatchInit()
   tickerOSWatch.attach_ms(((OSWATCH_RESET_TIME / 3) * 1000), OsWatchTicker);
 }
 
-void OsWatchLoop()
+void OsWatchLoop(void)
 {
   oswatch_last_loop_time = millis();
 //  while(1) delay(1000);  // this will trigger the os watch
 }
 
-String GetResetReason()
+String GetResetReason(void)
 {
   char buff[32];
   if (oswatch_blocked_loop) {
@@ -82,7 +82,7 @@ String GetResetReason()
   }
 }
 
-boolean OsWatchBlockedLoop()
+boolean OsWatchBlockedLoop(void)
 {
   return oswatch_blocked_loop;
 }
@@ -470,7 +470,7 @@ float ConvertTemp(float c)
   return result;
 }
 
-char TempUnit()
+char TempUnit(void)
 {
   return (Settings.flag.temperature_conversion) ? 'F' : 'C';
 }
@@ -485,7 +485,7 @@ float ConvertPressure(float p)
   return result;
 }
 
-String PressureUnit()
+String PressureUnit(void)
 {
   return (Settings.flag.pressure_conversion) ? String(D_UNIT_MILLIMETER_MERCURY) : String(D_UNIT_PRESSURE);
 }
@@ -497,7 +497,7 @@ void SetGlobalValues(float temperature, float humidity)
   global_humidity = humidity;
 }
 
-void ResetGlobalValues()
+void ResetGlobalValues(void)
 {
   if ((uptime - global_update) > GLOBAL_VALUES_VALID) {  // Reset after 5 minutes
     global_update = 0;
@@ -712,7 +712,7 @@ void SetSerialBaudrate(int baudrate)
   }
 }
 
-void ClaimSerial()
+void ClaimSerial(void)
 {
   serial_local = 1;
   AddLog_P(LOG_LEVEL_INFO, PSTR("SNS: Hardware Serial"));
@@ -765,7 +765,7 @@ uint8_t ValidGPIO(uint8_t pin, uint8_t gpio)
   return result;
 }
 
-void AppDelay()
+void AppDelay(void)
 {
   if (APP_BAUDRATE == baudrate) {  // When baudrate too low it will fail on Sonoff Pow R2 and S31 serial interface initialization
     if (global_state.wifi_down) {
@@ -841,7 +841,7 @@ void SetNextTimeInterval(unsigned long& timer, const unsigned long step)
  * Fill feature list
 \*********************************************************************************************/
 
-void GetFeatures()
+void GetFeatures(void)
 {
   feature_drv1 = 0x00000000;   // xdrv_01_mqtt.ino, xdrv_01_light.ino, xdrv_04_snfbridge.ino
 
@@ -1206,7 +1206,7 @@ int WifiGetRssiAsQuality(int rssi)
   return quality;
 }
 
-boolean WifiConfigCounter()
+boolean WifiConfigCounter(void)
 {
   if (wifi_config_counter) {
     wifi_config_counter = WIFI_CONFIG_SEC;
@@ -1310,7 +1310,7 @@ void WifiConfig(uint8_t type)
   }
 }
 
-void WiFiSetSleepMode()
+void WiFiSetSleepMode(void)
 {
 /* Excerpt from the esp8266 non os sdk api reference (v2.2.1):
  * Sets sleep type for power saving. Set WIFI_NONE_SLEEP to disable power saving.
@@ -1387,7 +1387,7 @@ void WifiSetState(uint8_t state)
   global_state.wifi_down = state ^1;
 }
 
-void WifiCheckIp()
+void WifiCheckIp(void)
 {
   if ((WL_CONNECTED == WiFi.status()) && (static_cast<uint32_t>(WiFi.localIP()) != 0)) {
     WifiSetState(1);
@@ -1574,7 +1574,7 @@ void WifiCheck(uint8_t param)
   }
 }
 
-int WifiState()
+int WifiState(void)
 {
   int state = -1;
 
@@ -1583,7 +1583,7 @@ int WifiState()
   return state;
 }
 
-void WifiConnect()
+void WifiConnect(void)
 {
   WifiSetState(0);
   WiFi.persistent(false);     // Solve possible wifi init errors
@@ -1595,7 +1595,7 @@ void WifiConnect()
 
 // Enable from 6.0.0a until 6.1.0a - disabled due to possible cause of bad wifi connect on core 2.3.0
 // Re-enabled from 6.3.0.7 with ESP.restart replaced by ESP.reset
-void WifiDisconnect()
+void WifiDisconnect(void)
 {
   // Courtesy of EspEasy
   WiFi.persistent(true);      // use SDK storage of SSID/WPA parameters
@@ -1605,7 +1605,7 @@ void WifiDisconnect()
   WiFi.persistent(false);     // Do not use SDK storage of SSID/WPA parameters
 }
 
-void EspRestart()
+void EspRestart(void)
 {
   delay(100);                 // Allow time for message xfer - disabled v6.1.0b
   WifiDisconnect();
@@ -1614,7 +1614,7 @@ void EspRestart()
 }
 
 /*
-void EspRestart()
+void EspRestart(void)
 {
   ESP.restart();
 }
@@ -1863,7 +1863,7 @@ int32_t  time_timezone = 0;
 uint8_t  midnight_now = 0;
 uint8_t  ntp_sync_minute = 0;
 
-String GetBuildDateAndTime()
+String GetBuildDateAndTime(void)
 {
   // "2017-03-07T11:08:02" - ISO8601:2004
   char bdt[21];
@@ -1892,7 +1892,7 @@ String GetBuildDateAndTime()
   return String(bdt);  // 2017-03-07T11:08:02
 }
 
-String GetTimeZone()
+String GetTimeZone(void)
 {
   char tz[7];
 
@@ -1966,7 +1966,7 @@ String GetTime(int type)
   return String(stime);  // Thu Nov 01 11:41:02 2018
 }
 
-String GetUptime()
+String GetUptime(void)
 {
   char dt[16];
 
@@ -1988,7 +1988,7 @@ String GetUptime()
   return String(dt);  // 128T14:35:44
 }
 
-uint32_t GetMinutesUptime()
+uint32_t GetMinutesUptime(void)
 {
   TIME_T ut;
 
@@ -2001,7 +2001,7 @@ uint32_t GetMinutesUptime()
   return (ut.days *1440) + (ut.hour *60) + ut.minute;
 }
 
-uint32_t GetMinutesPastMidnight()
+uint32_t GetMinutesPastMidnight(void)
 {
   uint32_t minutes = 0;
 
@@ -2133,24 +2133,24 @@ uint32_t RuleToTime(TimeRule r, int yr)
   return t;
 }
 
-uint32_t LocalTime()
+uint32_t LocalTime(void)
 {
   return local_time;
 }
 
-uint32_t Midnight()
+uint32_t Midnight(void)
 {
   return midnight;
 }
 
-boolean MidnightNow()
+boolean MidnightNow(void)
 {
   boolean mnflg = midnight_now;
   if (mnflg) midnight_now = 0;
   return mnflg;
 }
 
-void RtcSecond()
+void RtcSecond(void)
 {
   TIME_T tmpTime;
 
@@ -2218,7 +2218,7 @@ void RtcSecond()
   RtcTime.year += 1970;
 }
 
-void RtcInit()
+void RtcInit(void)
 {
   sntp_setservername(0, Settings.ntp_server[0]);
   sntp_setservername(1, Settings.ntp_server[1]);
@@ -2273,7 +2273,7 @@ void GetLog(byte idx, char** entry_pp, size_t* len_p)
 }
 #endif  // USE_WEBSERVER
 
-void Syslog()
+void Syslog(void)
 {
   // Destroys log_data
   char syslog_preamble[64];  // Hostname + Id

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -408,7 +408,7 @@ void StartWebserver(int type, IPAddress ipweb)
   if (type) { webserver_state = type; }
 }
 
-void StopWebserver()
+void StopWebserver(void)
 {
   if (webserver_state) {
     WebServer->close();
@@ -417,7 +417,7 @@ void StopWebserver()
   }
 }
 
-void WifiManagerBegin()
+void WifiManagerBegin(void)
 {
   // setup AP
   if (!global_state.wifi_down) {
@@ -440,7 +440,7 @@ void WifiManagerBegin()
   StartWebserver(HTTP_MANAGER, WiFi.softAPIP());
 }
 
-void PollDnsWebserver()
+void PollDnsWebserver(void)
 {
   if (DnsServer) { DnsServer->processNextRequest(); }
   if (WebServer) { WebServer->handleClient(); }
@@ -448,7 +448,7 @@ void PollDnsWebserver()
 
 /*********************************************************************************************/
 
-void SetHeader()
+void SetHeader(void)
 {
   WebServer->sendHeader(F("Cache-Control"), F("no-cache, no-store, must-revalidate"));
   WebServer->sendHeader(F("Pragma"), F("no-cache"));
@@ -555,7 +555,7 @@ void WebRestart(uint8_t type)
 
 /*********************************************************************************************/
 
-void HandleWifiLogin()
+void HandleWifiLogin(void)
 {
   String page = FPSTR(HTTP_HEAD);
   page.replace(F("{v}"), FPSTR( D_CONFIGURE_WIFI ));
@@ -564,7 +564,7 @@ void HandleWifiLogin()
   ShowPage(page, false);  // false means show page no matter if the client has or has not credentials
 }
 
-void HandleRoot()
+void HandleRoot(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, S_MAIN_MENU);
 
@@ -663,7 +663,7 @@ void HandleRoot()
   }
 }
 
-void HandleAjaxStatusRefresh()
+void HandleAjaxStatusRefresh(void)
 {
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
 
@@ -733,7 +733,7 @@ void HandleAjaxStatusRefresh()
   WebServer->send(200, FPSTR(HDR_CTYPE_HTML), mqtt_data);
 }
 
-boolean HttpUser()
+boolean HttpUser(void)
 {
   boolean status = (HTTP_USER == webserver_state);
   if (status) { HandleRoot(); }
@@ -744,7 +744,7 @@ boolean HttpUser()
 
 #ifndef BE_MINIMAL
 
-void HandleConfiguration()
+void HandleConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -767,7 +767,7 @@ void HandleConfiguration()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleModuleConfiguration()
+void HandleModuleConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -836,7 +836,7 @@ void HandleModuleConfiguration()
   ShowPage(page);
 }
 
-void ModuleSaveSettings()
+void ModuleSaveSettings(void)
 {
   char tmp[100];
   char stemp[TOPSZ];
@@ -878,7 +878,7 @@ String htmlEscape(String s)
     return s;
 }
 
-void HandleWifiConfiguration()
+void HandleWifiConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -982,7 +982,7 @@ void HandleWifiConfiguration()
   ShowPage(page, !(HTTP_MANAGER == webserver_state));
 }
 
-void WifiSaveSettings()
+void WifiSaveSettings(void)
 {
   char tmp[100];
 
@@ -1006,7 +1006,7 @@ void WifiSaveSettings()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleLoggingConfiguration()
+void HandleLoggingConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1061,7 +1061,7 @@ void HandleLoggingConfiguration()
   ShowPage(page);
 }
 
-void LoggingSaveSettings()
+void LoggingSaveSettings(void)
 {
   char tmp[100];
 
@@ -1089,7 +1089,7 @@ void LoggingSaveSettings()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleOtherConfiguration()
+void HandleOtherConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1134,7 +1134,7 @@ void HandleOtherConfiguration()
   ShowPage(page);
 }
 
-void OtherSaveSettings()
+void OtherSaveSettings(void)
 {
   char tmp[100];
   char stemp[TOPSZ];
@@ -1160,7 +1160,7 @@ void OtherSaveSettings()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleBackupConfiguration()
+void HandleBackupConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1204,7 +1204,7 @@ void HandleBackupConfiguration()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleResetConfiguration()
+void HandleResetConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1225,7 +1225,7 @@ void HandleResetConfiguration()
   ExecuteWebCommand(svalue, SRC_WEBGUI);
 }
 
-void HandleRestoreConfiguration()
+void HandleRestoreConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1246,7 +1246,7 @@ void HandleRestoreConfiguration()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleInformation()
+void HandleInformation(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1367,7 +1367,7 @@ void HandleInformation()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleUpgradeFirmware()
+void HandleUpgradeFirmware(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1387,7 +1387,7 @@ void HandleUpgradeFirmware()
   upload_file_type = UPL_TASMOTA;
 }
 
-void HandleUpgradeFirmwareStart()
+void HandleUpgradeFirmwareStart(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1416,7 +1416,7 @@ void HandleUpgradeFirmwareStart()
   ExecuteWebCommand(svalue, SRC_WEBGUI);
 }
 
-void HandleUploadDone()
+void HandleUploadDone(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1470,7 +1470,7 @@ void HandleUploadDone()
   ShowPage(page);
 }
 
-void HandleUploadLoop()
+void HandleUploadLoop(void)
 {
   // Based on ESP8266HTTPUpdateServer.cpp uses ESP8266WebServer Parsing.cpp and Cores Updater.cpp (Update)
   boolean _serialoutput = (LOG_LEVEL_DEBUG <= seriallog_level);
@@ -1664,7 +1664,7 @@ void HandleUploadLoop()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandlePreflightRequest()
+void HandlePreflightRequest(void)
 {
   WebServer->sendHeader(F("Access-Control-Allow-Origin"), F("*"));
   WebServer->sendHeader(F("Access-Control-Allow-Methods"), F("GET, POST"));
@@ -1674,7 +1674,7 @@ void HandlePreflightRequest()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleHttpCommand()
+void HandleHttpCommand(void)
 {
   if (HttpUser()) { return; }
 //  if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1734,7 +1734,7 @@ void HandleHttpCommand()
 
 /*-------------------------------------------------------------------------------------------*/
 
-void HandleConsole()
+void HandleConsole(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1750,7 +1750,7 @@ void HandleConsole()
   ShowPage(page);
 }
 
-void HandleAjaxConsoleRefresh()
+void HandleAjaxConsoleRefresh(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -1809,7 +1809,7 @@ void HandleAjaxConsoleRefresh()
 
 /********************************************************************************************/
 
-void HandleNotFound()
+void HandleNotFound(void)
 {
 //  snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_HTTP "Not fount (%s)"), WebServer->uri().c_str());
 //  AddLog(LOG_LEVEL_DEBUG);
@@ -1834,7 +1834,7 @@ void HandleNotFound()
 }
 
 /* Redirect to captive portal if we got a request for another domain. Return true in that case so the page handler do not try to handle the request again. */
-boolean CaptivePortal()
+boolean CaptivePortal(void)
 {
   if ((HTTP_MANAGER == webserver_state) && !ValidIpAddress(WebServer->hostHeader())) {
     AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_HTTP D_REDIRECTED));
@@ -1990,7 +1990,7 @@ enum WebCommands { CMND_WEBSERVER, CMND_WEBPASSWORD, CMND_WEBLOG, CMND_WEBREFRES
 const char kWebCommands[] PROGMEM = D_CMND_WEBSERVER "|" D_CMND_WEBPASSWORD "|" D_CMND_WEBLOG "|" D_CMND_WEBREFRESH "|" D_CMND_WEBSEND "|" D_CMND_EMULATION ;
 const char kWebSendStatus[] PROGMEM = D_JSON_DONE "|" D_JSON_WRONG_PARAMETERS "|" D_JSON_CONNECT_FAILED "|" D_JSON_HOST_NOT_FOUND ;
 
-bool WebCommand()
+bool WebCommand(void)
 {
   char command[CMDSZ];
   bool serviced = true;

--- a/sonoff/xdrv_02_mqtt.ino
+++ b/sonoff/xdrv_02_mqtt.ino
@@ -89,12 +89,12 @@ bool mqtt_connected = false;                // MQTT virtual connection status
 
 PubSubClient MqttClient(EspClient);
 
-bool MqttIsConnected()
+bool MqttIsConnected(void)
 {
   return MqttClient.connected();
 }
 
-void MqttDisconnect()
+void MqttDisconnect(void)
 {
   MqttClient.disconnect();
 }
@@ -112,7 +112,7 @@ bool MqttPublishLib(const char* topic, boolean retained)
   return result;
 }
 
-void MqttLoop()
+void MqttLoop(void)
 {
   MqttClient.loop();
 }
@@ -122,17 +122,17 @@ void MqttLoop()
 #include <TasmotaMqtt.h>
 TasmotaMqtt MqttClient;
 
-bool MqttIsConnected()
+bool MqttIsConnected(void)
 {
   return MqttClient.Connected();
 }
 
-void MqttDisconnect()
+void MqttDisconnect(void)
 {
   MqttClient.Disconnect();
 }
 
-void MqttDisconnectedCb()
+void MqttDisconnectedCb(void)
 {
   MqttDisconnected(MqttClient.State());  // status codes are documented in file mqtt.h as tConnState
 }
@@ -147,7 +147,7 @@ bool MqttPublishLib(const char* topic, boolean retained)
   return MqttClient.Publish(topic, mqtt_data, strlen(mqtt_data), 0, retained);
 }
 
-void MqttLoop()
+void MqttLoop(void)
 {
 }
 
@@ -156,12 +156,12 @@ void MqttLoop()
 #include <MQTTClient.h>
 MQTTClient MqttClient(MQTT_MAX_PACKET_SIZE);
 
-bool MqttIsConnected()
+bool MqttIsConnected(void)
 {
   return MqttClient.connected();
 }
 
-void MqttDisconnect()
+void MqttDisconnect(void)
 {
   MqttClient.disconnect();
 }
@@ -189,7 +189,7 @@ bool MqttPublishLib(const char* topic, boolean retained)
   return MqttClient.publish(topic, mqtt_data, strlen(mqtt_data), retained, 0);
 }
 
-void MqttLoop()
+void MqttLoop(void)
 {
   MqttClient.loop();
 //  delay(10);
@@ -201,7 +201,7 @@ void MqttLoop()
 
 #ifdef USE_DISCOVERY
 #ifdef MQTT_HOST_DISCOVERY
-boolean MqttDiscoverServer()
+boolean MqttDiscoverServer(void)
 {
   if (!mdns_begun) { return false; }
 
@@ -225,7 +225,7 @@ boolean MqttDiscoverServer()
 #endif  // MQTT_HOST_DISCOVERY
 #endif  // USE_DISCOVERY
 
-int MqttLibraryType()
+int MqttLibraryType(void)
 {
   return (int)MQTT_LIBRARY_TYPE;
 }
@@ -372,7 +372,7 @@ void MqttDisconnected(int state)
   rules_flag.mqtt_disconnected = 1;
 }
 
-void MqttConnected()
+void MqttConnected(void)
 {
   char stopic[TOPSZ];
 
@@ -434,7 +434,7 @@ void MqttConnected()
 }
 
 #ifdef USE_MQTT_TLS
-boolean MqttCheckTls()
+boolean MqttCheckTls(void)
 {
   char fingerprint1[60];
   char fingerprint2[60];
@@ -474,7 +474,7 @@ boolean MqttCheckTls()
 }
 #endif  // USE_MQTT_TLS
 
-void MqttReconnect()
+void MqttReconnect(void)
 {
   char stopic[TOPSZ];
 
@@ -559,7 +559,7 @@ void MqttReconnect()
 #endif  // MQTT_LIBRARY_TYPE
 }
 
-void MqttCheck()
+void MqttCheck(void)
 {
   if (Settings.flag.mqtt_enabled) {
     if (!MqttIsConnected()) {
@@ -587,7 +587,7 @@ void MqttCheck()
 
 /*********************************************************************************************/
 
-bool MqttCommand()
+bool MqttCommand(void)
 {
   char command [CMDSZ];
   bool serviced = true;
@@ -841,7 +841,7 @@ const char HTTP_FORM_MQTT[] PROGMEM =
   "<br/><b>" D_TOPIC "</b> = %topic% (" MQTT_TOPIC ")<br/><input id='mt' name='mt' placeholder='" MQTT_TOPIC" ' value='{m6'><br/>"
   "<br/><b>" D_FULL_TOPIC "</b> (" MQTT_FULLTOPIC ")<br/><input id='mf' name='mf' placeholder='" MQTT_FULLTOPIC" ' value='{m7'><br/>";
 
-void HandleMqttConfiguration()
+void HandleMqttConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -873,7 +873,7 @@ void HandleMqttConfiguration()
   ShowPage(page);
 }
 
-void MqttSaveSettings()
+void MqttSaveSettings(void)
 {
   char tmp[100];
   char stemp[TOPSZ];

--- a/sonoff/xdrv_03_energy.ino
+++ b/sonoff/xdrv_03_energy.ino
@@ -87,7 +87,7 @@ Ticker ticker_energy;
 int energy_command_code = 0;
 /********************************************************************************************/
 
-void EnergyUpdateToday()
+void EnergyUpdateToday(void)
 {
   if (energy_kWhtoday_delta > 1000) {
     unsigned long delta = energy_kWhtoday_delta / 1000;
@@ -101,7 +101,7 @@ void EnergyUpdateToday()
 
 /*********************************************************************************************/
 
-void Energy200ms()
+void Energy200ms(void)
 {
   energy_power_on = (power != 0) | Settings.flag.no_power_on_check;
 
@@ -131,7 +131,7 @@ void Energy200ms()
   XnrgCall(FUNC_EVERY_200_MSECOND);
 }
 
-void EnergySaveState()
+void EnergySaveState(void)
 {
   Settings.energy_kWhdoy = (RtcTime.valid) ? RtcTime.day_of_year : 0;
   Settings.energy_kWhtoday = energy_kWhtoday;
@@ -154,12 +154,12 @@ boolean EnergyMargin(byte type, uint16_t margin, uint16_t value, byte &flag, byt
   return (change != save_flag);
 }
 
-void EnergySetPowerSteadyCounter()
+void EnergySetPowerSteadyCounter(void)
 {
   energy_power_steady_cntr = 2;
 }
 
-void EnergyMarginCheck()
+void EnergyMarginCheck(void)
 {
   uint16_t energy_daily_u = 0;
   uint16_t energy_power_u = 0;
@@ -296,7 +296,7 @@ void EnergyMarginCheck()
   if (energy_power_delta) EnergyMqttShow();
 }
 
-void EnergyMqttShow()
+void EnergyMqttShow(void)
 {
 // {"Time":"2017-12-16T11:48:55","ENERGY":{"Total":0.212,"Yesterday":0.000,"Today":0.014,"Period":2.0,"Power":22.0,"Factor":1.00,"Voltage":213.6,"Current":0.100}}
   snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_TIME "\":\"%s\""), GetDateAndTime(DT_LOCAL).c_str());
@@ -313,7 +313,7 @@ void EnergyMqttShow()
  * Commands
 \*********************************************************************************************/
 
-boolean EnergyCommand()
+boolean EnergyCommand(void)
 {
   char command [CMDSZ];
   char sunit[CMDSZ];
@@ -506,13 +506,13 @@ boolean EnergyCommand()
   return serviced;
 }
 
-void EnergyDrvInit()
+void EnergyDrvInit(void)
 {
   energy_flg = ENERGY_NONE;
   XnrgCall(FUNC_PRE_INIT);
 }
 
-void EnergySnsInit()
+void EnergySnsInit(void)
 {
   XnrgCall(FUNC_INIT);
 

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -146,11 +146,11 @@ uint8_t arilux_rf_toggle = 0;
 
 #ifndef ARDUINO_ESP8266_RELEASE_2_3_0
 #ifndef USE_WS2812_DMA  // Collides with Neopixelbus but solves RF misses
-void AriluxRfInterrupt() ICACHE_RAM_ATTR;  // As iram is tight and it works this way too
+void AriluxRfInterrupt(void) ICACHE_RAM_ATTR;  // As iram is tight and it works this way too
 #endif  // USE_WS2812_DMA
 #endif  // ARDUINO_ESP8266_RELEASE_2_3_0
 
-void AriluxRfInterrupt()
+void AriluxRfInterrupt(void)
 {
   unsigned long time = micros();
   unsigned int duration = time - arilux_rf_lasttime;
@@ -184,7 +184,7 @@ void AriluxRfInterrupt()
   arilux_rf_lasttime = time;
 }
 
-void AriluxRfHandler()
+void AriluxRfHandler(void)
 {
   unsigned long now = millis();
   if (arilux_rf_received_value && !((arilux_rf_received_value == arilux_rf_last_received_value) && (now - arilux_rf_last_time < ARILUX_RF_TIME_AVOID_DUPLICATE))) {
@@ -245,7 +245,7 @@ void AriluxRfHandler()
   arilux_rf_received_value = 0;
 }
 
-void AriluxRfInit()
+void AriluxRfInit(void)
 {
   if ((pin[GPIO_ARIRFRCV] < 99) && (pin[GPIO_LED2] < 99)) {
     if (Settings.last_module != Settings.module) {
@@ -259,7 +259,7 @@ void AriluxRfInit()
   }
 }
 
-void AriluxRfDisable()
+void AriluxRfDisable(void)
 {
   if ((pin[GPIO_ARIRFRCV] < 99) && (pin[GPIO_LED2] < 99)) {
     detachInterrupt(pin[GPIO_ARIRFRCV]);
@@ -309,7 +309,7 @@ void LightMy92x1Write(uint8_t data)
   }
 }
 
-void LightMy92x1Init()
+void LightMy92x1Init(void)
 {
   uint8_t chips = light_type -11;       // 1 (AiLight) or 2 (Sonoff B1)
 
@@ -347,7 +347,7 @@ void LightMy92x1Duty(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b, uint8_t dut
 
 /********************************************************************************************/
 
-void LightInit()
+void LightInit(void)
 {
   uint8_t max_scheme = LS_MAX -1;
 
@@ -449,7 +449,7 @@ void LightSetColorTemp(uint16_t ct)
   }
 }
 
-uint16_t LightGetColorTemp()
+uint16_t LightGetColorTemp(void)
 {
   uint8_t ct_idx = 0;
   if (LST_RGBWC == light_subtype) {
@@ -491,7 +491,7 @@ void LightSetDimmer(uint8_t myDimmer)
   }
 }
 
-void LightSetColor()
+void LightSetColor(void)
 {
   uint8_t highest = 0;
 
@@ -551,7 +551,7 @@ char* LightGetColor(uint8_t type, char* scolor)
   return scolor;
 }
 
-void LightPowerOn()
+void LightPowerOn(void)
 {
   if (Settings.light_dimmer && !(light_power)) {
     ExecuteCommandPower(light_device, POWER_ON, SRC_LIGHT);
@@ -606,7 +606,7 @@ void LightState(uint8_t append)
   }
 }
 
-void LightPreparePower()
+void LightPreparePower(void)
 {
   if (Settings.light_dimmer && !(light_power)) {
     if (!Settings.flag.not_power_linked) {
@@ -623,7 +623,7 @@ void LightPreparePower()
   LightState(0);
 }
 
-void LightFade()
+void LightFade(void)
 {
   if (0 == Settings.light_fade) {
     for (byte i = 0; i < light_subtype; i++) {
@@ -686,7 +686,7 @@ void LightCycleColor(int8_t direction)
   memcpy(light_new_color, light_entry_color, sizeof(light_new_color));
 }
 
-void LightRandomColor()
+void LightRandomColor(void)
 {
   uint8_t light_update = 0;
   for (byte i = 0; i < LST_RGB; i++) {
@@ -702,7 +702,7 @@ void LightRandomColor()
   LightFade();
 }
 
-void LightSetPower()
+void LightSetPower(void)
 {
 //  light_power = XdrvMailbox.index;
   light_power = bitRead(XdrvMailbox.index, light_device -1);
@@ -715,7 +715,7 @@ void LightSetPower()
   LightAnimate();
 }
 
-void LightAnimate()
+void LightAnimate(void)
 {
   uint8_t cur_col[5];
   uint16_t light_still_on = 0;
@@ -843,7 +843,7 @@ float light_hue = 0.0;
 float light_saturation = 0.0;
 float light_brightness = 0.0;
 
-void LightRgbToHsb()
+void LightRgbToHsb(void)
 {
   LightSetDimmer(Settings.light_dimmer);
 
@@ -874,7 +874,7 @@ void LightRgbToHsb()
   }
 }
 
-void LightHsbToRgb()
+void LightHsbToRgb(void)
 {
   float r;
   float g;
@@ -1064,7 +1064,7 @@ boolean LightColorEntry(char *buffer, uint8_t buffer_length)
 /********************************************************************************************/
 
 //boolean LightCommand(char *type, uint16_t index, char *dataBuf, uint16_t XdrvMailbox.data_len, int16_t XdrvMailbox.payload)
-boolean LightCommand()
+boolean LightCommand(void)
 {
   char command [CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_05_irremote.ino
+++ b/sonoff/xdrv_05_irremote.ino
@@ -88,7 +88,7 @@ void IrReceiveInit(void)
   //  AddLog_P(LOG_LEVEL_DEBUG, PSTR("IrReceive initialized"));
 }
 
-void IrReceiveCheck()
+void IrReceiveCheck(void)
 {
   char sirtype[14];  // Max is AIWA_RC_T501
   char stemp[16];
@@ -285,7 +285,7 @@ boolean IrHvacMitsubishi(const char *HVAC_Mode, const char *HVAC_FanMode, boolea
 */
 
 //boolean IrSendCommand(char *type, uint16_t index, char *dataBuf, uint16_t data_len, int16_t payload)
-boolean IrSendCommand()
+boolean IrSendCommand(void)
 {
   boolean serviced = true;
   boolean error = false;

--- a/sonoff/xdrv_06_snfbridge.ino
+++ b/sonoff/xdrv_06_snfbridge.ino
@@ -167,7 +167,7 @@ ssize_t rf_search_and_write(uint8_t *buf, size_t size)
   return 0;
 }
 
-uint8_t rf_erase_flash()
+uint8_t rf_erase_flash(void)
 {
   uint8_t err;
 
@@ -190,7 +190,7 @@ uint8_t rf_erase_flash()
   return 0;
 }
 
-uint8_t SnfBrUpdateInit()
+uint8_t SnfBrUpdateInit(void)
 {
   pinMode(PIN_C2CK, OUTPUT);
   pinMode(PIN_C2D, INPUT);
@@ -201,7 +201,7 @@ uint8_t SnfBrUpdateInit()
 
 /********************************************************************************************/
 
-void SonoffBridgeReceivedRaw()
+void SonoffBridgeReceivedRaw(void)
 {
   // Decoding according to https://github.com/Portisch/RF-Bridge-EFM8BB1
   uint8_t buckets = 0;
@@ -225,14 +225,14 @@ void SonoffBridgeReceivedRaw()
 
 /********************************************************************************************/
 
-void SonoffBridgeLearnFailed()
+void SonoffBridgeLearnFailed(void)
 {
   sonoff_bridge_learn_active = 0;
   snprintf_P(mqtt_data, sizeof(mqtt_data), S_JSON_COMMAND_INDEX_SVALUE, D_CMND_RFKEY, sonoff_bridge_learn_key, D_JSON_LEARN_FAILED);
   MqttPublishPrefixTopic_P(RESULT_OR_STAT, PSTR(D_CMND_RFKEY));
 }
 
-void SonoffBridgeReceived()
+void SonoffBridgeReceived(void)
 {
   uint16_t sync_time = 0;
   uint16_t low_time = 0;
@@ -300,7 +300,7 @@ void SonoffBridgeReceived()
   }
 }
 
-boolean SonoffBridgeSerialInput()
+boolean SonoffBridgeSerialInput(void)
 {
   // iTead Rf Universal Transceiver Module Serial Protocol Version 1.0 (20170420)
   static int8_t receive_len = 0;
@@ -359,7 +359,7 @@ void SonoffBridgeSendCommand(byte code)
   Serial.write(0x55);  // End of Text
 }
 
-void SonoffBridgeSendAck()
+void SonoffBridgeSendAck(void)
 {
   Serial.write(0xAA);  // Start of Text
   Serial.write(0xA0);  // Acknowledge
@@ -418,7 +418,7 @@ void SonoffBridgeLearn(uint8_t key)
  * Commands
 \*********************************************************************************************/
 
-boolean SonoffBridgeCommand()
+boolean SonoffBridgeCommand(void)
 {
   char command [CMDSZ];
   boolean serviced = true;
@@ -556,7 +556,7 @@ boolean SonoffBridgeCommand()
 
 /*********************************************************************************************/
 
-void SonoffBridgeInit()
+void SonoffBridgeInit(void)
 {
   sonoff_bridge_receive_raw_flag = 0;
   SonoffBridgeSendCommand(0xA7);  // Stop reading RF signals enabling iTead default RF handling

--- a/sonoff/xdrv_07_domoticz.ino
+++ b/sonoff/xdrv_07_domoticz.ino
@@ -45,7 +45,7 @@ boolean domoticz_subscribe = false;
 int domoticz_update_timer = 0;
 byte domoticz_update_flag = 1;
 
-int DomoticzBatteryQuality()
+int DomoticzBatteryQuality(void)
 {
   // Battery 0%: ESP 2.6V (minimum operating voltage is 2.5)
   // Battery 100%: ESP 3.6V (maximum operating voltage is 3.6)
@@ -64,7 +64,7 @@ int DomoticzBatteryQuality()
   return quality;
 }
 
-int DomoticzRssiQuality()
+int DomoticzRssiQuality(void)
 {
   // RSSI range: 0% to 10% (12 means disable RSSI in Domoticz)
 
@@ -94,7 +94,7 @@ void DomoticzUpdatePowerState(byte device)
   domoticz_update_flag = 1;
 }
 
-void DomoticzMqttUpdate()
+void DomoticzMqttUpdate(void)
 {
   if (domoticz_subscribe && (Settings.domoticz_update_timer || domoticz_update_timer)) {
     domoticz_update_timer--;
@@ -107,7 +107,7 @@ void DomoticzMqttUpdate()
   }
 }
 
-void DomoticzMqttSubscribe()
+void DomoticzMqttSubscribe(void)
 {
   uint8_t maxdev = (devices_present > MAX_DOMOTICZ_IDX) ? MAX_DOMOTICZ_IDX : devices_present;
   for (byte i = 0; i < maxdev; i++) {
@@ -148,7 +148,7 @@ void DomoticzMqttSubscribe()
 }
 */
 
-boolean DomoticzMqttData()
+boolean DomoticzMqttData(void)
 {
   char stemp1[10];
   unsigned long idx = 0;
@@ -234,7 +234,7 @@ boolean DomoticzMqttData()
  * Commands
 \*********************************************************************************************/
 
-boolean DomoticzCommand()
+boolean DomoticzCommand(void)
 {
   char command [CMDSZ];
   boolean serviced = true;
@@ -393,7 +393,7 @@ const char HTTP_FORM_DOMOTICZ_SENSOR[] PROGMEM =
 const char HTTP_FORM_DOMOTICZ_TIMER[] PROGMEM =
   "<tr><td style='width:260px'><b>" D_DOMOTICZ_UPDATE_TIMER "</b> (" STR(DOMOTICZ_UPDATE_TIMER) ")</td><td style='width:70px'><input id='ut' name='ut' placeholder='" STR(DOMOTICZ_UPDATE_TIMER) "' value='{6'</td></tr>";
 
-void HandleDomoticzConfiguration()
+void HandleDomoticzConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -437,7 +437,7 @@ void HandleDomoticzConfiguration()
   ShowPage(page);
 }
 
-void DomoticzSaveSettings()
+void DomoticzSaveSettings(void)
 {
   char stemp[20];
   char ssensor_indices[6 * MAX_DOMOTICZ_SNS_IDX];

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -38,7 +38,7 @@ uint8_t serial_bridge_in_byte_counter = 0;
 unsigned long serial_bridge_polling_window = 0;
 char serial_bridge_buffer[SERIAL_BRIDGE_BUFFER_SIZE];
 
-void SerialBridgeInput()
+void SerialBridgeInput(void)
 {
   while (SerialBridgeSerial->available()) {
     yield();
@@ -87,7 +87,7 @@ void SerialBridgeInit(void)
  * Commands
 \*********************************************************************************************/
 
-boolean SerialBridgeCommand()
+boolean SerialBridgeCommand(void)
 {
   char command [CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_09_timers.ino
+++ b/sonoff/xdrv_09_timers.ino
@@ -64,7 +64,7 @@ const double pi2 = TWO_PI;
 const double pi = PI;
 const double RAD = DEG_TO_RAD;
 
-double JulianischesDatum()
+double JulianischesDatum(void)
 {
   // Gregorianischer Kalender
   int Gregor;
@@ -255,12 +255,12 @@ void TimerSetRandomWindow(byte index)
   }
 }
 
-void TimerSetRandomWindows()
+void TimerSetRandomWindows(void)
 {
   for (byte i = 0; i < MAX_TIMERS; i++) { TimerSetRandomWindow(i); }
 }
 
-void TimerEverySecond()
+void TimerEverySecond(void)
 {
   if (RtcTime.valid) {
     if (!RtcTime.hour && !RtcTime.minute && !RtcTime.second) { TimerSetRandomWindows(); }  // Midnight
@@ -338,7 +338,7 @@ void PrepShowTimer(uint8_t index)
  * Commands
 \*********************************************************************************************/
 
-boolean TimerCommand()
+boolean TimerCommand(void)
 {
   char command[CMDSZ];
   char dataBufUc[XdrvMailbox.data_len];
@@ -681,7 +681,7 @@ const char HTTP_FORM_TIMER1[] PROGMEM =
   "</div><br/>"
   "<div id='ds' name='ds'></div>";
 
-void HandleTimerConfiguration()
+void HandleTimerConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -717,7 +717,7 @@ void HandleTimerConfiguration()
   ShowPage(page);
 }
 
-void TimerSaveSettings()
+void TimerSaveSettings(void)
 {
   char tmp[MAX_TIMERS *12];  // Need space for MAX_TIMERS x 10 digit numbers separated by a comma
   Timer timer;

--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -347,12 +347,12 @@ bool RulesProcessEvent(char *json_event)
   return serviced;
 }
 
-bool RulesProcess()
+bool RulesProcess(void)
 {
   return RulesProcessEvent(mqtt_data);
 }
 
-void RulesInit()
+void RulesInit(void)
 {
   rules_flag.data = 0;
   for (byte i = 0; i < MAX_RULE_SETS; i++) {
@@ -364,7 +364,7 @@ void RulesInit()
   rules_teleperiod = 0;
 }
 
-void RulesEvery50ms()
+void RulesEvery50ms(void)
 {
   if (Settings.rule_enabled) {  // Any rule enabled
     char json_event[120];
@@ -455,7 +455,7 @@ void RulesEvery50ms()
   }
 }
 
-void RulesEvery100ms()
+void RulesEvery100ms(void)
 {
   if (Settings.rule_enabled && (uptime > 4)) {  // Any rule enabled and allow 4 seconds start-up time for sensors (#3811)
     mqtt_data[0] = '\0';
@@ -471,7 +471,7 @@ void RulesEvery100ms()
   }
 }
 
-void RulesEverySecond()
+void RulesEverySecond(void)
 {
   if (Settings.rule_enabled) {  // Any rule enabled
     char json_event[120];
@@ -495,19 +495,19 @@ void RulesEverySecond()
   }
 }
 
-void RulesSetPower()
+void RulesSetPower(void)
 {
   rules_new_power = XdrvMailbox.index;
 }
 
-void RulesTeleperiod()
+void RulesTeleperiod(void)
 {
   rules_teleperiod = 1;
   RulesProcess();
   rules_teleperiod = 0;
 }
 
-boolean RulesCommand()
+boolean RulesCommand(void)
 {
   char command[CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_11_knx.ino
+++ b/sonoff/xdrv_11_knx.ino
@@ -392,7 +392,7 @@ void KNX_DEL_CB( byte CBnum )
 }
 
 
-bool KNX_CONFIG_NOT_MATCH()
+bool KNX_CONFIG_NOT_MATCH(void)
 {
   // Check for configured parameters that the device does not have (module changed)
   for (byte i = 0; i < KNX_MAX_device_param; ++i)
@@ -442,7 +442,7 @@ bool KNX_CONFIG_NOT_MATCH()
 }
 
 
-void KNXStart()
+void KNXStart(void)
 {
   knx.start(nullptr);
   snprintf_P(log_data, sizeof(log_data), PSTR(D_LOG_KNX D_START));
@@ -450,7 +450,7 @@ void KNXStart()
 }
 
 
-void KNX_INIT()
+void KNX_INIT(void)
 {
   // Check for incompatible config
   if (Settings.knx_GA_registered > MAX_KNX_GA) { Settings.knx_GA_registered = MAX_KNX_GA; }
@@ -795,7 +795,7 @@ const char HTTP_FORM_KNX_ADD_TABLE_ROW2[] PROGMEM =
   "<tr><td><b>GAfnum / GAarea / GAfdef -> {optex}</b></td>"
   "<td><button type='submit' name='btn_del_cb' value='{opval}' class='button bred'> " D_DELETE " </button></td></tr>";
 
-void HandleKNXConfiguration()
+void HandleKNXConfiguration(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -994,7 +994,7 @@ void HandleKNXConfiguration()
 }
 
 
-void KNX_Save_Settings()
+void KNX_Save_Settings(void)
 {
   String stmp;
   address_t KNX_addr;
@@ -1047,7 +1047,7 @@ void KNX_Save_Settings()
 #endif  // USE_WEBSERVER
 
 
-boolean KnxCommand()
+boolean KnxCommand(void)
 {
   char command[CMDSZ];
   uint8_t index = XdrvMailbox.index;

--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -69,7 +69,7 @@ const char HASS_DISCOVER_LIGHT_SCHEME[] PROGMEM =
   "\"effect_list\":[\"0\",\"1\",\"2\",\"3\",\"4\"]";  // string list with reference to scheme parameter. Currently only supports numbers 0 to 11 as it make the mqtt string too long
 */
 
-void HAssDiscoverRelay()
+void HAssDiscoverRelay(void)
 {
   char sidx[8];
   char stopic[TOPSZ];
@@ -138,7 +138,7 @@ void HAssDiscoverRelay()
   }
 }
 
-void HAssDiscoverButton()
+void HAssDiscoverButton(void)
 {
   char sidx[8];
   char stopic[TOPSZ];
@@ -215,7 +215,7 @@ void HAssDiscovery(uint8_t mode)
 enum HassCommands { CMND_HASSDISCOVER };
 const char kHassCommands[] PROGMEM = D_CMND_HASSDISCOVER ;
 
-boolean HassCommand()
+boolean HassCommand(void)
 {
   char command[CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_13_display.ino
+++ b/sonoff/xdrv_13_display.ino
@@ -106,7 +106,7 @@ void DisplayInit(uint8_t mode)
   XdspCall(FUNC_DISPLAY_INIT);
 }
 
-void DisplayClear()
+void DisplayClear(void)
 {
   XdspCall(FUNC_DISPLAY_CLEAR);
 }
@@ -177,7 +177,7 @@ void DisplayDrawFilledRectangle(uint16_t x, uint16_t y, uint16_t x2, uint16_t y2
   XdspCall(FUNC_DISPLAY_FILL_RECTANGLE);
 }
 
-void DisplayDrawFrame()
+void DisplayDrawFrame(void)
 {
   XdspCall(FUNC_DISPLAY_DRAW_FRAME);
 }
@@ -254,7 +254,7 @@ uint8_t atoiV(char *cp, uint16_t *res)
 
 #define DISPLAY_BUFFER_COLS    128          // Max number of characters in linebuf
 
-void DisplayText()
+void DisplayText(void)
 {
   uint8_t lpos;
   uint8_t escape = 0;
@@ -487,7 +487,7 @@ void DisplayText()
 
 #ifdef USE_DISPLAY_MODES1TO5
 
-void DisplayClearScreenBuffer()
+void DisplayClearScreenBuffer(void)
 {
   if (disp_screen_buffer_cols) {
     for (byte i = 0; i < disp_screen_buffer_rows; i++) {
@@ -496,7 +496,7 @@ void DisplayClearScreenBuffer()
   }
 }
 
-void DisplayFreeScreenBuffer()
+void DisplayFreeScreenBuffer(void)
 {
   if (disp_screen_buffer != NULL) {
     for (byte i = 0; i < disp_screen_buffer_rows; i++) {
@@ -508,7 +508,7 @@ void DisplayFreeScreenBuffer()
   }
 }
 
-void DisplayAllocScreenBuffer()
+void DisplayAllocScreenBuffer(void)
 {
   if (!disp_screen_buffer_cols) {
     disp_screen_buffer_rows = Settings.display_rows;
@@ -529,7 +529,7 @@ void DisplayAllocScreenBuffer()
   }
 }
 
-void DisplayReAllocScreenBuffer()
+void DisplayReAllocScreenBuffer(void)
 {
   DisplayFreeScreenBuffer();
   DisplayAllocScreenBuffer();
@@ -546,7 +546,7 @@ void DisplayFillScreen(uint8_t line)
 
 /*-------------------------------------------------------------------------------------------*/
 
-void DisplayClearLogBuffer()
+void DisplayClearLogBuffer(void)
 {
   if (disp_log_buffer_cols) {
     for (byte i = 0; i < DISPLAY_LOG_ROWS; i++) {
@@ -555,7 +555,7 @@ void DisplayClearLogBuffer()
   }
 }
 
-void DisplayFreeLogBuffer()
+void DisplayFreeLogBuffer(void)
 {
   if (disp_log_buffer != NULL) {
     for (byte i = 0; i < DISPLAY_LOG_ROWS; i++) {
@@ -566,7 +566,7 @@ void DisplayFreeLogBuffer()
   }
 }
 
-void DisplayAllocLogBuffer()
+void DisplayAllocLogBuffer(void)
 {
   if (!disp_log_buffer_cols) {
     disp_log_buffer = (char**)malloc(sizeof(*disp_log_buffer) * DISPLAY_LOG_ROWS);
@@ -586,7 +586,7 @@ void DisplayAllocLogBuffer()
   }
 }
 
-void DisplayReAllocLogBuffer()
+void DisplayReAllocLogBuffer(void)
 {
   DisplayFreeLogBuffer();
   DisplayAllocLogBuffer();
@@ -617,7 +617,7 @@ char* DisplayLogBuffer(char temp_code)
   return result;
 }
 
-void DisplayLogBufferInit()
+void DisplayLogBufferInit(void)
 {
   if (Settings.display_mode) {
     disp_log_buffer_idx = 0;
@@ -798,7 +798,7 @@ void DisplayAnalyzeJson(char *topic, char *json)
   }
 }
 
-void DisplayMqttSubscribe()
+void DisplayMqttSubscribe(void)
 {
 /* Subscribe to tele messages only
  * Supports the following FullTopic formats
@@ -831,7 +831,7 @@ void DisplayMqttSubscribe()
   }
 }
 
-boolean DisplayMqttData()
+boolean DisplayMqttData(void)
 {
   if (disp_subscribed) {
     char stopic[TOPSZ];
@@ -850,7 +850,7 @@ boolean DisplayMqttData()
   return false;
 }
 
-void DisplayLocalSensor()
+void DisplayLocalSensor(void)
 {
   if ((Settings.display_mode &0x02) && (0 == tele_period)) {
     DisplayAnalyzeJson(mqtt_topic, mqtt_data);
@@ -863,7 +863,7 @@ void DisplayLocalSensor()
  * Public
 \*********************************************************************************************/
 
-void DisplayInitDriver()
+void DisplayInitDriver(void)
 {
   XdspCall(FUNC_DISPLAY_INIT_DRIVER);
 
@@ -882,7 +882,7 @@ void DisplayInitDriver()
   }
 }
 
-void DisplaySetPower()
+void DisplaySetPower(void)
 {
   disp_power = bitRead(XdrvMailbox.index, disp_device -1);
   if (Settings.display_model) {
@@ -894,7 +894,7 @@ void DisplaySetPower()
  * Commands
 \*********************************************************************************************/
 
-boolean DisplayCommand()
+boolean DisplayCommand(void)
 {
   char command [CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -114,7 +114,7 @@ void TuyaSendValue(uint8_t id, uint32_t value){
     TuyaSendState(id, TUYA_TYPE_VALUE, (uint8_t*)(&value));
 }
 
-boolean TuyaSetPower()
+boolean TuyaSetPower(void)
 {
   boolean status = false;
 
@@ -154,7 +154,7 @@ void LightSerialDuty(uint8_t duty)
   }
 }
 
-void TuyaRequestState(){
+void TuyaRequestState(void){
   if(TuyaSerial) {
 
     // Get current status of MCU
@@ -165,7 +165,7 @@ void TuyaRequestState(){
   }
 }
 
-void TuyaResetWifi()
+void TuyaResetWifi(void)
 {
   if (!Settings.flag.button_restrict) {
     char scmnd[20];
@@ -174,7 +174,7 @@ void TuyaResetWifi()
   }
 }
 
-void TuyaPacketProcess()
+void TuyaPacketProcess(void)
 {
   char scmnd[20];
 
@@ -267,7 +267,7 @@ void TuyaPacketProcess()
  * API Functions
 \*********************************************************************************************/
 
-boolean TuyaModuleSelected()
+boolean TuyaModuleSelected(void)
 {
   if (!(pin[GPIO_TUYA_RX] < 99) || !(pin[GPIO_TUYA_TX] < 99)) {  // fallback to hardware-serial if not explicitly selected
     pin[GPIO_TUYA_TX] = 1;
@@ -280,7 +280,7 @@ boolean TuyaModuleSelected()
   return true;
 }
 
-void TuyaInit()
+void TuyaInit(void)
 {
   if (!Settings.param[P_TUYA_DIMMER_ID]) {
     Settings.param[P_TUYA_DIMMER_ID] = TUYA_DIMMER_ID;
@@ -296,7 +296,7 @@ void TuyaInit()
   }
 }
 
-void TuyaSerialInput()
+void TuyaSerialInput(void)
 {
   while (TuyaSerial->available()) {
     yield();
@@ -352,7 +352,7 @@ void TuyaSerialInput()
 }
 
 
-boolean TuyaButtonPressed()
+boolean TuyaButtonPressed(void)
 {
   if (!XdrvMailbox.index && ((PRESSED == XdrvMailbox.payload) && (NOT_PRESSED == lastbutton[XdrvMailbox.index]))) {
     snprintf_P(log_data, sizeof(log_data), PSTR("TYA: Reset GPIO triggered"));
@@ -363,7 +363,7 @@ boolean TuyaButtonPressed()
   return false;   // Don't serve other buttons
 }
 
-void TuyaSetWifiLed(){
+void TuyaSetWifiLed(void){
     uint8_t wifi_state = 0x02;
     switch(WifiState()){
       case WIFI_SMARTCONFIG:

--- a/sonoff/xdrv_17_rcswitch.ino
+++ b/sonoff/xdrv_17_rcswitch.ino
@@ -40,7 +40,7 @@ RCSwitch mySwitch = RCSwitch();
 
 uint32_t rf_lasttime = 0;
 
-void RfReceiveCheck()
+void RfReceiveCheck(void)
 {
   if (mySwitch.available()) {
 
@@ -74,7 +74,7 @@ void RfReceiveCheck()
   }
 }
 
-void RfInit()
+void RfInit(void)
 {
   if (pin[GPIO_RFSEND] < 99) {
     mySwitch.enableTransmit(pin[GPIO_RFSEND]);
@@ -88,7 +88,7 @@ void RfInit()
  * Commands
 \*********************************************************************************************/
 
-boolean RfSendCommand()
+boolean RfSendCommand(void)
 {
   boolean serviced = true;
   boolean error = false;

--- a/sonoff/xdrv_95_debug.ino
+++ b/sonoff/xdrv_95_debug.ino
@@ -131,7 +131,7 @@ Decoding 14 results
 
 /*******************************************************************************************/
 
-void CpuLoadLoop()
+void CpuLoadLoop(void)
 {
   CPU_last_loop_time = millis();
   if (CPU_load_check && CPU_last_millis) {
@@ -164,7 +164,7 @@ extern "C" {
   extern cont_t g_cont;
 }
 
-void DebugFreeMem()
+void DebugFreeMem(void)
 {
   register uint32_t *sp asm("a1");
 
@@ -186,7 +186,7 @@ extern "C" {
   extern cont_t* g_pcont;
 }
 
-void DebugFreeMem()
+void DebugFreeMem(void)
 {
   register uint32_t *sp asm("a1");
 
@@ -408,7 +408,7 @@ void DebugCfgShow(uint8_t more)
 
 /*******************************************************************************************/
 
-boolean DebugCommand()
+boolean DebugCommand(void)
 {
   char command[CMDSZ];
   boolean serviced = true;

--- a/sonoff/xdrv_interface.ino
+++ b/sonoff/xdrv_interface.ino
@@ -216,7 +216,7 @@ boolean XdrvMqttData(char *topicBuf, uint16_t stopicBuf, char *dataBuf, uint16_t
   return XdrvCall(FUNC_MQTT_DATA);
 }
 
-boolean XdrvRulesProcess()
+boolean XdrvRulesProcess(void)
 {
   return XdrvCall(FUNC_RULES_PROCESS);
 }

--- a/sonoff/xdsp_01_lcd.ino
+++ b/sonoff/xdsp_01_lcd.ino
@@ -33,7 +33,7 @@ LiquidCrystal_I2C *lcd;
 
 /*********************************************************************************************/
 
-void LcdInitMode()
+void LcdInitMode(void)
 {
   lcd->init();
   lcd->clear();
@@ -54,7 +54,7 @@ void LcdInit(uint8_t mode)
   }
 }
 
-void LcdInitDriver()
+void LcdInitDriver(void)
 {
   if (!Settings.display_model) {
     if (I2cDevice(LCD_ADDRESS1)) {
@@ -78,7 +78,7 @@ void LcdInitDriver()
   }
 }
 
-void LcdDrawStringAt()
+void LcdDrawStringAt(void)
 {
   lcd->setCursor(dsp_x, dsp_y);
   lcd->print(dsp_str);
@@ -112,7 +112,7 @@ void LcdCenter(byte row, char* txt)
   lcd->print(line);
 }
 
-boolean LcdPrintLog()
+boolean LcdPrintLog(void)
 {
   boolean result = false;
 
@@ -145,7 +145,7 @@ boolean LcdPrintLog()
   return result;
 }
 
-void LcdTime()
+void LcdTime(void)
 {
   char line[Settings.display_cols[0] +1];
 
@@ -155,7 +155,7 @@ void LcdTime()
   LcdCenter(1, line);
 }
 
-void LcdRefresh()  // Every second
+void LcdRefresh(void)  // Every second
 {
   if (Settings.display_mode) {  // Mode 0 is User text
     switch (Settings.display_mode) {

--- a/sonoff/xdsp_02_ssd1306.ino
+++ b/sonoff/xdsp_02_ssd1306.ino
@@ -43,7 +43,7 @@ uint8_t ssd1306_font_y = OLED_FONT_HEIGTH;
 
 /*********************************************************************************************/
 
-void Ssd1306InitMode()
+void Ssd1306InitMode(void)
 {
   oled->setRotation(Settings.display_rotate);  // 0
   oled->invertDisplay(false);
@@ -72,7 +72,7 @@ void Ssd1306Init(uint8_t mode)
   }
 }
 
-void Ssd1306InitDriver()
+void Ssd1306InitDriver(void)
 {
   if (!Settings.display_model) {
     if (I2cDevice(OLED_ADDRESS1)) {
@@ -97,7 +97,7 @@ void Ssd1306InitDriver()
   }
 }
 
-void Ssd1306Clear()
+void Ssd1306Clear(void)
 {
   oled->clearDisplay();
   oled->setCursor(0, 0);
@@ -123,7 +123,7 @@ void Ssd1306DisplayOnOff(uint8_t on)
   }
 }
 
-void Ssd1306OnOff()
+void Ssd1306OnOff(void)
 {
   Ssd1306DisplayOnOff(disp_power);
   oled->display();
@@ -133,7 +133,7 @@ void Ssd1306OnOff()
 
 #ifdef USE_DISPLAY_MODES1TO5
 
-void Ssd1306PrintLog()
+void Ssd1306PrintLog(void)
 {
   disp_refresh--;
   if (!disp_refresh) {
@@ -163,7 +163,7 @@ void Ssd1306PrintLog()
   }
 }
 
-void Ssd1306Time()
+void Ssd1306Time(void)
 {
   char line[12];
 
@@ -177,7 +177,7 @@ void Ssd1306Time()
   oled->display();
 }
 
-void Ssd1306Refresh()  // Every second
+void Ssd1306Refresh(void)  // Every second
 {
   if (Settings.display_mode) {  // Mode 0 is User text
     switch (Settings.display_mode) {

--- a/sonoff/xdsp_03_matrix.ino
+++ b/sonoff/xdsp_03_matrix.ino
@@ -43,14 +43,14 @@ uint8_t mtx_done = 0;
 
 /*********************************************************************************************/
 
-void MatrixWrite()
+void MatrixWrite(void)
 {
   for (byte i = 0; i < mtx_matrices; i++) {
     matrix[i]->writeDisplay();
   }
 }
 
-void MatrixClear()
+void MatrixClear(void)
 {
   for (byte i = 0; i < mtx_matrices; i++) {
     matrix[i]->clear();
@@ -166,7 +166,7 @@ void MatrixScrollUp(char* txt, int loop)
 
 /*********************************************************************************************/
 
-void MatrixInitMode()
+void MatrixInitMode(void)
 {
   for (byte i = 0; i < mtx_matrices; i++) {
     matrix[i]->setRotation(Settings.display_rotate);  // 1
@@ -192,7 +192,7 @@ void MatrixInit(uint8_t mode)
   }
 }
 
-void MatrixInitDriver()
+void MatrixInitDriver(void)
 {
   if (!Settings.display_model) {
     if (I2cDevice(Settings.display_address[1])) {
@@ -215,7 +215,7 @@ void MatrixInitDriver()
   }
 }
 
-void MatrixOnOff()
+void MatrixOnOff(void)
 {
   if (!disp_power) { MatrixClear(); }
 }
@@ -278,7 +278,7 @@ void MatrixPrintLog(uint8_t direction)
 
 #endif  // USE_DISPLAY_MODES1TO5
 
-void MatrixRefresh()  // Every second
+void MatrixRefresh(void)  // Every second
 {
   if (disp_power) {
     switch (Settings.display_mode) {

--- a/sonoff/xdsp_04_ili9341.ino
+++ b/sonoff/xdsp_04_ili9341.ino
@@ -38,7 +38,7 @@ uint16_t tft_scroll;
 
 /*********************************************************************************************/
 
-void Ili9341InitMode()
+void Ili9341InitMode(void)
 {
   tft->setRotation(Settings.display_rotate);  // 0
   tft->invertDisplay(0);
@@ -77,7 +77,7 @@ void Ili9341Init(uint8_t mode)
   }
 }
 
-void Ili9341InitDriver()
+void Ili9341InitDriver(void)
 {
   if (!Settings.display_model) {
     Settings.display_model = XDSP_04;
@@ -97,7 +97,7 @@ void Ili9341InitDriver()
   }
 }
 
-void Ili9341Clear()
+void Ili9341Clear(void)
 {
   tft->fillScreen(ILI9341_BLACK);
   tft->setCursor(0, 0);
@@ -128,7 +128,7 @@ void Ili9341DisplayOnOff(uint8_t on)
   }
 }
 
-void Ili9341OnOff()
+void Ili9341OnOff(void)
 {
   Ili9341DisplayOnOff(disp_power);
 }
@@ -137,7 +137,7 @@ void Ili9341OnOff()
 
 #ifdef USE_DISPLAY_MODES1TO5
 
-void Ili9341PrintLog()
+void Ili9341PrintLog(void)
 {
   disp_refresh--;
   if (!disp_refresh) {
@@ -184,7 +184,7 @@ void Ili9341PrintLog()
   }
 }
 
-void Ili9341Refresh()  // Every second
+void Ili9341Refresh(void)  // Every second
 {
   if (Settings.display_mode) {  // Mode 0 is User text
     char tftdt[Settings.display_cols[0] +1];

--- a/sonoff/xdsp_05_epaper.ino
+++ b/sonoff/xdsp_05_epaper.ino
@@ -41,7 +41,7 @@ sFONT *selected_font;
 
 /*********************************************************************************************/
 
-void EpdInitMode()
+void EpdInitMode(void)
 {
   // whiten display with full update
   epd.Init(lut_full_update);
@@ -72,7 +72,7 @@ void EpdInitMode()
   paint.Clear(UNCOLORED);
 }
 
-void EpdInitPartial()
+void EpdInitPartial(void)
 {
   epd.Init(lut_partial_update);
   //paint.Clear(UNCOLORED);
@@ -80,7 +80,7 @@ void EpdInitPartial()
   delay(500);
 }
 
-void EpdInitFull()
+void EpdInitFull(void)
 {
   epd.Init(lut_full_update);
   //paint.Clear(UNCOLORED);
@@ -104,7 +104,7 @@ void EpdInit(uint8_t mode)
   }
 }
 
-void EpdInitDriver()
+void EpdInitDriver(void)
 {
   if (!Settings.display_model) {
     Settings.display_model = XDSP_05;
@@ -121,7 +121,7 @@ void EpdInitDriver()
 
 /*********************************************************************************************/
 
-void EpdClear()
+void EpdClear(void)
 {
   paint.Clear(UNCOLORED);
 }
@@ -158,7 +158,7 @@ void EpdDisplayOnOff(uint8_t on)
 
 }
 
-void EpdOnOff()
+void EpdOnOff(void)
 {
   EpdDisplayOnOff(disp_power);
 }
@@ -167,7 +167,7 @@ void EpdOnOff()
 
 #ifdef USE_DISPLAY_MODES1TO5
 
-void EpdRefresh()  // Every second
+void EpdRefresh(void)  // Every second
 {
   if (Settings.display_mode) {  // Mode 0 is User text
 

--- a/sonoff/xdsp_interface.ino
+++ b/sonoff/xdsp_interface.ino
@@ -112,7 +112,7 @@ const uint8_t xdsp_present = sizeof(xdsp_func_ptr) / sizeof(xdsp_func_ptr[0]);  
  * FUNC_DISPLAY_ONOFF
 \*********************************************************************************************/
 
-uint8_t XdspPresent()
+uint8_t XdspPresent(void)
 {
   return xdsp_present;
 }

--- a/sonoff/xnrg_01_hlw8012.ino
+++ b/sonoff/xnrg_01_hlw8012.ino
@@ -62,11 +62,11 @@ unsigned long hlw_cf1_voltage_max_pulse_counter;
 unsigned long hlw_cf1_current_max_pulse_counter;
 
 #ifndef USE_WS2812_DMA  // Collides with Neopixelbus but solves exception
-void HlwCfInterrupt() ICACHE_RAM_ATTR;
-void HlwCf1Interrupt() ICACHE_RAM_ATTR;
+void HlwCfInterrupt(void) ICACHE_RAM_ATTR;
+void HlwCf1Interrupt(void) ICACHE_RAM_ATTR;
 #endif  // USE_WS2812_DMA
 
-void HlwCfInterrupt()  // Service Power
+void HlwCfInterrupt(void)  // Service Power
 {
   unsigned long us = micros();
 
@@ -80,7 +80,7 @@ void HlwCfInterrupt()  // Service Power
   }
 }
 
-void HlwCf1Interrupt()  // Service Voltage and Current
+void HlwCf1Interrupt(void)  // Service Voltage and Current
 {
   unsigned long us = micros();
 
@@ -97,7 +97,7 @@ void HlwCf1Interrupt()  // Service Voltage and Current
 
 /********************************************************************************************/
 
-void HlwEvery200ms()
+void HlwEvery200ms(void)
 {
   unsigned long hlw_w = 0;
   unsigned long hlw_u = 0;
@@ -154,7 +154,7 @@ void HlwEvery200ms()
   }
 }
 
-void HlwEverySecond()
+void HlwEverySecond(void)
 {
   unsigned long hlw_len;
 
@@ -168,7 +168,7 @@ void HlwEverySecond()
   }
 }
 
-void HlwSnsInit()
+void HlwSnsInit(void)
 {
   if (!Settings.energy_power_calibration || (4975 == Settings.energy_power_calibration)) {
     Settings.energy_power_calibration = HLW_PREF_PULSE;
@@ -210,7 +210,7 @@ void HlwSnsInit()
   hlw_cf1_timer = 0;
 }
 
-void HlwDrvInit()
+void HlwDrvInit(void)
 {
   if (!energy_flg) {
     hlw_model_type = 0;
@@ -233,7 +233,7 @@ void HlwDrvInit()
   }
 }
 
-boolean HlwCommand()
+boolean HlwCommand(void)
 {
   boolean serviced = true;
 

--- a/sonoff/xnrg_02_cse7766.ino
+++ b/sonoff/xnrg_02_cse7766.ino
@@ -46,7 +46,7 @@ long cf_pulses = 0;
 long cf_pulses_last_time = CSE_PULSES_NOT_INITIALIZED;
 uint8_t cse_power_invalid = CSE_MAX_INVALID_POWER;
 
-void CseReceived()
+void CseReceived(void)
 {
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
   // 55 5A 02 F7 60 00 03 5A 00 40 10 04 8B 9F 51 A6 58 18 72 75 61 AC A1 30 - Power not valid (load below 5W)
@@ -128,7 +128,7 @@ void CseReceived()
   }
 }
 
-bool CseSerialInput()
+bool CseSerialInput(void)
 {
   if (cse_receive_flag) {
     serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
@@ -168,7 +168,7 @@ bool CseSerialInput()
 
 /********************************************************************************************/
 
-void CseEverySecond()
+void CseEverySecond(void)
 {
   long cf_frequency = 0;
 
@@ -188,7 +188,7 @@ void CseEverySecond()
   }
 }
 
-void CseDrvInit()
+void CseDrvInit(void)
 {
   if (!energy_flg) {
     if ((SONOFF_S31 == Settings.module) || (SONOFF_POW_R2 == Settings.module)) {     // Sonoff S31 or Sonoff Pow R2
@@ -199,7 +199,7 @@ void CseDrvInit()
   }
 }
 
-boolean CseCommand()
+boolean CseCommand(void)
 {
   boolean serviced = true;
 

--- a/sonoff/xnrg_03_pzem004t.ino
+++ b/sonoff/xnrg_03_pzem004t.ino
@@ -87,7 +87,7 @@ void PzemSend(uint8_t cmd)
   PzemSerial->write(bytes, sizeof(pzem));
 }
 
-bool PzemReceiveReady()
+bool PzemReceiveReady(void)
 {
   return PzemSerial->available() >= (int)sizeof(PZEMCommand);
 }
@@ -162,7 +162,7 @@ const uint8_t pzem_responses[] { RESP_SET_ADDRESS, RESP_VOLTAGE, RESP_CURRENT, R
 uint8_t pzem_read_state = 0;
 uint8_t pzem_sendRetry = 0;
 
-void PzemEvery200ms()
+void PzemEvery200ms(void)
 {
   bool data_ready = PzemReceiveReady();
 
@@ -200,7 +200,7 @@ void PzemEvery200ms()
   }
 }
 
-void PzemSnsInit()
+void PzemSnsInit(void)
 {
   // Software serial init needs to be done here as earlier (serial) interrupts may lead to Exceptions
   PzemSerial = new TasmotaSerial(pin[GPIO_PZEM004_RX], pin[GPIO_PZEM0XX_TX], 1);
@@ -211,7 +211,7 @@ void PzemSnsInit()
   }
 }
 
-void PzemDrvInit()
+void PzemDrvInit(void)
 {
   if (!energy_flg) {
     if ((pin[GPIO_PZEM004_RX] < 99) && (pin[GPIO_PZEM0XX_TX] < 99)) {  // Any device with a Pzem004T

--- a/sonoff/xnrg_05_pzem_ac.ino
+++ b/sonoff/xnrg_05_pzem_ac.ino
@@ -36,7 +36,7 @@
 #include <TasmotaModbus.h>
 TasmotaModbus *PzemAcModbus;
 
-void PzemAcEverySecond()
+void PzemAcEverySecond(void)
 {
   static uint8_t send_retry = 0;
 
@@ -78,7 +78,7 @@ void PzemAcEverySecond()
   }
 }
 
-void PzemAcSnsInit()
+void PzemAcSnsInit(void)
 {
   PzemAcModbus = new TasmotaModbus(pin[GPIO_PZEM016_RX], pin[GPIO_PZEM0XX_TX]);
   uint8_t result = PzemAcModbus->Begin(9600);
@@ -89,7 +89,7 @@ void PzemAcSnsInit()
   }
 }
 
-void PzemAcDrvInit()
+void PzemAcDrvInit(void)
 {
   if (!energy_flg) {
     if ((pin[GPIO_PZEM016_RX] < 99) && (pin[GPIO_PZEM0XX_TX] < 99)) {

--- a/sonoff/xnrg_06_pzem_dc.ino
+++ b/sonoff/xnrg_06_pzem_dc.ino
@@ -36,7 +36,7 @@
 #include <TasmotaModbus.h>
 TasmotaModbus *PzemDcModbus;
 
-void PzemDcEverySecond()
+void PzemDcEverySecond(void)
 {
   static uint8_t send_retry = 0;
 
@@ -76,7 +76,7 @@ void PzemDcEverySecond()
   }
 }
 
-void PzemDcSnsInit()
+void PzemDcSnsInit(void)
 {
   PzemDcModbus = new TasmotaModbus(pin[GPIO_PZEM017_RX], pin[GPIO_PZEM0XX_TX]);
   uint8_t result = PzemDcModbus->Begin(9600, 2);  // Uses two stop bits!!
@@ -88,7 +88,7 @@ void PzemDcSnsInit()
   }
 }
 
-void PzemDcDrvInit()
+void PzemDcDrvInit(void)
 {
   if (!energy_flg) {
     if ((pin[GPIO_PZEM017_RX] < 99) && (pin[GPIO_PZEM0XX_TX] < 99)) {

--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -59,7 +59,7 @@ const char WEMO_MSEARCH[] PROGMEM =
   "X-User-Agent: redsonic\r\n"
   "\r\n";
 
-String WemoSerialnumber()
+String WemoSerialnumber(void)
 {
   char serial[16];
 
@@ -67,7 +67,7 @@ String WemoSerialnumber()
   return String(serial);
 }
 
-String WemoUuid()
+String WemoUuid(void)
 {
   char uuid[27];
 
@@ -131,7 +131,7 @@ const char HUE_ST3[] PROGMEM =
   "USN: uuid:{r3\r\n"
   "\r\n";
 
-String HueBridgeId()
+String HueBridgeId(void)
 {
   String temp = WiFi.macAddress();
   temp.replace(":", "");
@@ -139,7 +139,7 @@ String HueBridgeId()
   return bridgeid;  // 5CCF7FFFFE139F3D
 }
 
-String HueSerialnumber()
+String HueSerialnumber(void)
 {
   String serial = WiFi.macAddress();
   serial.replace(":", "");
@@ -147,14 +147,14 @@ String HueSerialnumber()
   return serial;  // 5ccf7f139f3d
 }
 
-String HueUuid()
+String HueUuid(void)
 {
   String uuid = F("f6543a06-da50-11ba-8d8f-");
   uuid += HueSerialnumber();
   return uuid;  // f6543a06-da50-11ba-8d8f-5ccf7f139f3d
 }
 
-void HueRespondToMSearch()
+void HueRespondToMSearch(void)
 {
   char message[TOPSZ];
 
@@ -197,7 +197,7 @@ void HueRespondToMSearch()
  * Belkin WeMo and Philips Hue bridge UDP multicast support
 \*********************************************************************************************/
 
-boolean UdpDisconnect()
+boolean UdpDisconnect(void)
 {
   if (udp_connected) {
     WiFiUDP::stopAll();
@@ -207,7 +207,7 @@ boolean UdpDisconnect()
   return udp_connected;
 }
 
-boolean UdpConnect()
+boolean UdpConnect(void)
 {
   if (!udp_connected) {
     if (PortUdp.beginMulticast(WiFi.localIP(), ipMulticast, port_multicast)) {
@@ -222,7 +222,7 @@ boolean UdpConnect()
   return udp_connected;
 }
 
-void PollUdp()
+void PollUdp(void)
 {
   if (udp_connected && !udp_response_mutex) {
     if (PortUdp.parsePacket()) {
@@ -381,7 +381,7 @@ const char WEMO_SETUP_XML[] PROGMEM =
 
 /********************************************************************************************/
 
-void HandleUpnpEvent()
+void HandleUpnpEvent(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_BASIC_EVENT));
 
@@ -408,21 +408,21 @@ void HandleUpnpEvent()
   WebServer->send(200, FPSTR(HDR_CTYPE_XML), state_xml);
 }
 
-void HandleUpnpService()
+void HandleUpnpService(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_EVENT_SERVICE));
 
   WebServer->send(200, FPSTR(HDR_CTYPE_PLAIN), FPSTR(WEMO_EVENTSERVICE_XML));
 }
 
-void HandleUpnpMetaService()
+void HandleUpnpMetaService(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_META_SERVICE));
 
   WebServer->send(200, FPSTR(HDR_CTYPE_PLAIN), FPSTR(WEMO_METASERVICE_XML));
 }
 
-void HandleUpnpSetupWemo()
+void HandleUpnpSetupWemo(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_SETUP));
 
@@ -517,7 +517,7 @@ String GetHueDeviceId(uint8_t id)
   return deviceid;  // 5c:cf:7f:13:9f:3d:00:11-1
 }
 
-String GetHueUserId()
+String GetHueUserId(void)
 {
   char userid[7];
 
@@ -525,7 +525,7 @@ String GetHueUserId()
   return String(userid);
 }
 
-void HandleUpnpSetupHue()
+void HandleUpnpSetupHue(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_HUE_BRIDGE_SETUP));
   String description_xml = FPSTR(HUE_DESCRIPTION_XML);
@@ -841,7 +841,7 @@ void HandleHueApi(String *path)
   else HueGlobalConfig(path);
 }
 
-void HueWemoAddHandlers()
+void HueWemoAddHandlers(void)
 {
   if (EMUL_WEMO == Settings.flag2.emulation) {
     WebServer->on("/upnp/control/basicevent1", HTTP_POST, HandleUpnpEvent);

--- a/sonoff/xplg_ws2812.ino
+++ b/sonoff/xplg_ws2812.ino
@@ -96,7 +96,7 @@ uint8_t ws_show_next = 1;
 bool ws_suspend_update = false;
 /********************************************************************************************/
 
-void Ws2812StripShow()
+void Ws2812StripShow(void)
 {
 #if (USE_WS2812_CTYPE > NEO_3LED)
   RgbwColor c;
@@ -163,7 +163,7 @@ void Ws2812UpdateHand(int position, uint8_t index)
   }
 }
 
-void Ws2812Clock()
+void Ws2812Clock(void)
 {
   strip->ClearTo(0); // Reset strip
   int clksize = 60000 / (int)Settings.light_pixels;
@@ -302,7 +302,7 @@ void Ws2812Bars(uint8_t schemenr)
  * Public
 \*********************************************************************************************/
 
-void Ws2812Init()
+void Ws2812Init(void)
 {
 #ifdef USE_WS2812_DMA
 #if (USE_WS2812_CTYPE == NEO_GRB)
@@ -337,7 +337,7 @@ void Ws2812Init()
   Ws2812Clear();
 }
 
-void Ws2812Clear()
+void Ws2812Clear(void)
 {
   strip->ClearTo(0);
   strip->Show();
@@ -371,11 +371,11 @@ void Ws2812SetColor(uint16_t led, uint8_t red, uint8_t green, uint8_t blue, uint
   }
 }
 
-void Ws2812ForceSuspend () {
+void Ws2812ForceSuspend (void) {
   ws_suspend_update = true;
 }
 
-void Ws2812ForceUpdate () {
+void Ws2812ForceUpdate (void) {
   ws_suspend_update = false;
   strip->Show();
   ws_show_next = 1;

--- a/sonoff/xsns_01_counter.ino
+++ b/sonoff/xsns_01_counter.ino
@@ -41,29 +41,29 @@ void CounterUpdate(byte index)
   }
 }
 
-void CounterUpdate1()
+void CounterUpdate1(void)
 {
   CounterUpdate(1);
 }
 
-void CounterUpdate2()
+void CounterUpdate2(void)
 {
   CounterUpdate(2);
 }
 
-void CounterUpdate3()
+void CounterUpdate3(void)
 {
   CounterUpdate(3);
 }
 
-void CounterUpdate4()
+void CounterUpdate4(void)
 {
   CounterUpdate(4);
 }
 
 /********************************************************************************************/
 
-void CounterSaveState()
+void CounterSaveState(void)
 {
   for (byte i = 0; i < MAX_COUNTERS; i++) {
     if (pin[GPIO_CNTR1 +i] < 99) {
@@ -72,7 +72,7 @@ void CounterSaveState()
   }
 }
 
-void CounterInit()
+void CounterInit(void)
 {
   typedef void (*function) () ;
   function counter_callbacks[] = { CounterUpdate1, CounterUpdate2, CounterUpdate3, CounterUpdate4 };

--- a/sonoff/xsns_02_analog.ino
+++ b/sonoff/xsns_02_analog.ino
@@ -26,7 +26,7 @@
 
 uint16_t adc_last_value = 0;
 
-uint16_t AdcRead()
+uint16_t AdcRead(void)
 {
   uint16_t analog = 0;
   for (byte i = 0; i < 32; i++) {
@@ -38,7 +38,7 @@ uint16_t AdcRead()
 }
 
 #ifdef USE_RULES
-void AdcEvery250ms()
+void AdcEvery250ms(void)
 {
   uint16_t new_value = AdcRead();
   if ((new_value < adc_last_value -10) || (new_value > adc_last_value +10)) {

--- a/sonoff/xsns_04_snfsc.ino
+++ b/sonoff/xsns_04_snfsc.ino
@@ -65,7 +65,7 @@ void SonoffScSend(const char *data)
   AddLog(LOG_LEVEL_DEBUG);
 }
 
-void SonoffScInit()
+void SonoffScInit(void)
 {
 //  SonoffScSend("AT+DEVCONFIG=\"uploadFreq\":1800");
   SonoffScSend("AT+START");

--- a/sonoff/xsns_05_ds18b20.ino
+++ b/sonoff/xsns_05_ds18b20.ino
@@ -37,7 +37,7 @@ char ds18b20_types[] = "DS18B20";
  * Embedded stripped and tuned OneWire library
 \*********************************************************************************************/
 
-uint8_t OneWireReset()
+uint8_t OneWireReset(void)
 {
   uint8_t retries = 125;
 
@@ -75,7 +75,7 @@ void OneWireWriteBit(uint8_t v)
   delayMicroseconds(delay_high[v]);
 }
 
-uint8_t OneWireReadBit()
+uint8_t OneWireReadBit(void)
 {
   //noInterrupts();
   pinMode(ds18x20_pin, OUTPUT);
@@ -96,7 +96,7 @@ void OneWireWrite(uint8_t v)
   }
 }
 
-uint8_t OneWireRead()
+uint8_t OneWireRead(void)
 {
   uint8_t r = 0;
 
@@ -129,7 +129,7 @@ boolean OneWireCrc8(uint8_t *addr)
 
 /********************************************************************************************/
 
-void Ds18b20Convert()
+void Ds18b20Convert(void)
 {
   OneWireReset();
   OneWireWrite(W1_SKIP_ROM);           // Address all Sensors on Bus
@@ -137,7 +137,7 @@ void Ds18b20Convert()
 //  delay(750);                          // 750ms should be enough for 12bit conv
 }
 
-boolean Ds18b20Read()
+boolean Ds18b20Read(void)
 {
   uint8_t data[9];
   int8_t sign = 1;
@@ -173,7 +173,7 @@ boolean Ds18b20Read()
 
 /********************************************************************************************/
 
-void Ds18b20EverySecond()
+void Ds18b20EverySecond(void)
 {
   ds18x20_pin = pin[GPIO_DSB];
   if (uptime &1) {

--- a/sonoff/xsns_05_ds18x20.ino
+++ b/sonoff/xsns_05_ds18x20.ino
@@ -69,7 +69,7 @@ uint8_t onewire_last_family_discrepancy = 0;
 bool onewire_last_device_flag = false;
 unsigned char onewire_rom_id[8] = { 0 };
 
-uint8_t OneWireReset()
+uint8_t OneWireReset(void)
 {
   uint8_t retries = 125;
 
@@ -107,7 +107,7 @@ void OneWireWriteBit(uint8_t v)
   delayMicroseconds(delay_high[v]);
 }
 
-uint8_t OneWireReadBit()
+uint8_t OneWireReadBit(void)
 {
   //noInterrupts();
   pinMode(ds18x20_pin, OUTPUT);
@@ -128,7 +128,7 @@ void OneWireWrite(uint8_t v)
   }
 }
 
-uint8_t OneWireRead()
+uint8_t OneWireRead(void)
 {
   uint8_t r = 0;
 
@@ -148,7 +148,7 @@ void OneWireSelect(const uint8_t rom[8])
   }
 }
 
-void OneWireResetSearch()
+void OneWireResetSearch(void)
 {
   onewire_last_discrepancy = 0;
   onewire_last_device_flag = false;
@@ -254,7 +254,7 @@ boolean OneWireCrc8(uint8_t *addr)
 
 /********************************************************************************************/
 
-void Ds18x20Init()
+void Ds18x20Init(void)
 {
   uint64_t ids[DS18X20_MAX_SENSORS];
 
@@ -289,7 +289,7 @@ void Ds18x20Init()
   AddLog(LOG_LEVEL_DEBUG);
 }
 
-void Ds18x20Convert()
+void Ds18x20Convert(void)
 {
   OneWireReset();
 #ifdef W1_PARASITE_POWER
@@ -389,7 +389,7 @@ void Ds18x20Name(uint8_t sensor)
 
 /********************************************************************************************/
 
-void Ds18x20EverySecond()
+void Ds18x20EverySecond(void)
 {
 #ifdef W1_PARASITE_POWER
   // skip access if there is still an eeprom write ongoing

--- a/sonoff/xsns_05_ds18x20_legacy.ino
+++ b/sonoff/xsns_05_ds18x20_legacy.ino
@@ -43,12 +43,12 @@ uint8_t ds18x20_index[DS18X20_MAX_SENSORS];
 uint8_t ds18x20_sensors = 0;
 char ds18x20_types[9];
 
-void Ds18x20Init()
+void Ds18x20Init(void)
 {
   ds = new OneWire(pin[GPIO_DSB]);
 }
 
-void Ds18x20Search()
+void Ds18x20Search(void)
 {
   uint8_t num_sensors=0;
   uint8_t sensor = 0;
@@ -78,7 +78,7 @@ void Ds18x20Search()
   ds18x20_sensors = num_sensors;
 }
 
-uint8_t Ds18x20Sensors()
+uint8_t Ds18x20Sensors(void)
 {
   return ds18x20_sensors;
 }
@@ -93,7 +93,7 @@ String Ds18x20Addresses(uint8_t sensor)
   return String(address);
 }
 
-void Ds18x20Convert()
+void Ds18x20Convert(void)
 {
   ds->reset();
   ds->write(W1_SKIP_ROM);        // Address all Sensors on Bus

--- a/sonoff/xsns_06_dht.ino
+++ b/sonoff/xsns_06_dht.ino
@@ -45,7 +45,7 @@ struct DHTSTRUCT {
   float    h = NAN;
 } Dht[DHT_MAX_SENSORS];
 
-void DhtReadPrep()
+void DhtReadPrep(void)
 {
   for (byte i = 0; i < dht_sensors; i++) {
     digitalWrite(Dht[i].pin, HIGH);
@@ -177,7 +177,7 @@ boolean DhtSetup(byte pin, byte type)
 
 /********************************************************************************************/
 
-void DhtInit()
+void DhtInit(void)
 {
   dht_max_cycles = microsecondsToClockCycles(1000);  // 1 millisecond timeout for reading pulses from DHT sensor.
 
@@ -192,7 +192,7 @@ void DhtInit()
   }
 }
 
-void DhtEverySecond()
+void DhtEverySecond(void)
 {
   if (uptime &1) {
     // <1mS

--- a/sonoff/xsns_07_sht1x.ino
+++ b/sonoff/xsns_07_sht1x.ino
@@ -44,7 +44,7 @@ uint8_t sht_valid = 0;
 float sht_temperature = 0;
 float sht_humidity = 0;
 
-boolean ShtReset()
+boolean ShtReset(void)
 {
   pinMode(sht_sda_pin, INPUT_PULLUP);
   pinMode(sht_scl_pin, OUTPUT);
@@ -90,7 +90,7 @@ boolean ShtSendCommand(const byte cmd)
   return (!ackerror);
 }
 
-boolean ShtAwaitResult()
+boolean ShtAwaitResult(void)
 {
   // Maximum 320ms for 14 bit measurement
   for (byte i = 0; i < 16; i++) {
@@ -104,7 +104,7 @@ boolean ShtAwaitResult()
   return false;
 }
 
-int ShtReadData()
+int ShtReadData(void)
 {
   int val = 0;
 
@@ -125,7 +125,7 @@ int ShtReadData()
   return val;
 }
 
-boolean ShtRead()
+boolean ShtRead(void)
 {
   if (sht_valid) { sht_valid--; }
   if (!ShtReset()) { return false; }
@@ -157,7 +157,7 @@ boolean ShtRead()
 
 /********************************************************************************************/
 
-void ShtDetect()
+void ShtDetect(void)
 {
   if (sht_type) {
     return;
@@ -174,7 +174,7 @@ void ShtDetect()
   }
 }
 
-void ShtEverySecond()
+void ShtEverySecond(void)
 {
   if (sht_type && !(uptime %4)) {  // Update every 4 seconds
     // 344mS

--- a/sonoff/xsns_08_htu21.ino
+++ b/sonoff/xsns_08_htu21.ino
@@ -133,14 +133,14 @@ void HtuHeater(uint8_t heater)
   I2cWrite8(HTU21_ADDR, HTU21_WRITEREG, current);
 }
 
-void HtuInit()
+void HtuInit(void)
 {
   HtuReset();
   HtuHeater(HTU21_HEATER_OFF);
   HtuSetResolution(HTU21_RES_RH12_T14);
 }
 
-boolean HtuRead()
+boolean HtuRead(void)
 {
   uint8_t  checksum = 0;
   uint16_t sensorval = 0;
@@ -195,7 +195,7 @@ boolean HtuRead()
 
 /********************************************************************************************/
 
-void HtuDetect()
+void HtuDetect(void)
 {
   if (htu_type) { return; }
 
@@ -229,7 +229,7 @@ void HtuDetect()
   }
 }
 
-void HtuEverySecond()
+void HtuEverySecond(void)
 {
   if (92 == (uptime %100)) {
     // 1mS

--- a/sonoff/xsns_09_bmp.ino
+++ b/sonoff/xsns_09_bmp.ino
@@ -417,7 +417,7 @@ void Bme680Read(uint8_t bmp_idx)
 
 /********************************************************************************************/
 
-void BmpDetect()
+void BmpDetect(void)
 {
   if (bmp_count) return;
 
@@ -456,7 +456,7 @@ void BmpDetect()
   }
 }
 
-void BmpRead()
+void BmpRead(void)
 {
   for (byte bmp_idx = 0; bmp_idx < bmp_count; bmp_idx++) {
     switch (bmp_sensors[bmp_idx].bmp_type) {
@@ -477,7 +477,7 @@ void BmpRead()
   SetGlobalValues(ConvertTemp(bmp_sensors[0].bmp_temperature), bmp_sensors[0].bmp_humidity);
 }
 
-void BmpEverySecond()
+void BmpEverySecond(void)
 {
   if (91 == (uptime %100)) {
     // 1mS

--- a/sonoff/xsns_10_bh1750.ino
+++ b/sonoff/xsns_10_bh1750.ino
@@ -39,7 +39,7 @@ uint8_t bh1750_valid = 0;
 uint16_t bh1750_illuminance = 0;
 char bh1750_types[] = "BH1750";
 
-bool Bh1750Read()
+bool Bh1750Read(void)
 {
   if (bh1750_valid) { bh1750_valid--; }
 
@@ -53,7 +53,7 @@ bool Bh1750Read()
 
 /********************************************************************************************/
 
-void Bh1750Detect()
+void Bh1750Detect(void)
 {
   if (bh1750_type) {
     return;
@@ -72,7 +72,7 @@ void Bh1750Detect()
   }
 }
 
-void Bh1750EverySecond()
+void Bh1750EverySecond(void)
 {
   if (90 == (uptime %100)) {
     // 1mS

--- a/sonoff/xsns_12_ads1115.ino
+++ b/sonoff/xsns_12_ads1115.ino
@@ -157,7 +157,7 @@ int16_t Ads1115GetConversion(uint8_t channel)
 
 /********************************************************************************************/
 
-void Ads1115Detect()
+void Ads1115Detect(void)
 {
   uint16_t buffer;
 

--- a/sonoff/xsns_12_ads1115_i2cdev.ino
+++ b/sonoff/xsns_12_ads1115_i2cdev.ino
@@ -75,7 +75,7 @@ int16_t Ads1115GetConversion(byte channel)
 
 /********************************************************************************************/
 
-void Ads1115Detect()
+void Ads1115Detect(void)
 {
   if (ads1115_type) {
     return;

--- a/sonoff/xsns_13_ina219.ino
+++ b/sonoff/xsns_13_ina219.ino
@@ -128,7 +128,7 @@ bool Ina219SetCalibration(uint8_t mode)
   return success;
 }
 
-float Ina219GetShuntVoltage_mV()
+float Ina219GetShuntVoltage_mV(void)
 {
   // raw shunt voltage (16-bit signed integer, so +-32767)
   int16_t value = I2cReadS16(ina219_address, INA219_REG_SHUNTVOLTAGE);
@@ -136,7 +136,7 @@ float Ina219GetShuntVoltage_mV()
   return value * 0.01;
 }
 
-float Ina219GetBusVoltage_V()
+float Ina219GetBusVoltage_V(void)
 {
   // Shift to the right 3 to drop CNVR and OVF and multiply by LSB
   // raw bus voltage (16-bit signed integer, so +-32767)
@@ -145,7 +145,7 @@ float Ina219GetBusVoltage_V()
   return value * 0.001;
 }
 
-float Ina219GetCurrent_mA()
+float Ina219GetCurrent_mA(void)
 {
   // Sometimes a sharp load will reset the INA219, which will reset the cal register,
   // meaning CURRENT and POWER will not be available ... avoid this by always setting
@@ -159,7 +159,7 @@ float Ina219GetCurrent_mA()
   return value;
 }
 
-bool Ina219Read()
+bool Ina219Read(void)
 {
   ina219_voltage = Ina219GetBusVoltage_V() + (Ina219GetShuntVoltage_mV() / 1000);
   ina219_current = Ina219GetCurrent_mA() / 1000;
@@ -175,7 +175,7 @@ bool Ina219Read()
  * 2 - Max 16V 0.4A range
 \*********************************************************************************************/
 
-bool Ina219CommandSensor()
+bool Ina219CommandSensor(void)
 {
   boolean serviced = true;
 
@@ -190,7 +190,7 @@ bool Ina219CommandSensor()
 
 /********************************************************************************************/
 
-void Ina219Detect()
+void Ina219Detect(void)
 {
   if (ina219_type) { return; }
 
@@ -205,7 +205,7 @@ void Ina219Detect()
   }
 }
 
-void Ina219EverySecond()
+void Ina219EverySecond(void)
 {
   if (87 == (uptime %100)) {
     // 2mS

--- a/sonoff/xsns_14_sht3x.ino
+++ b/sonoff/xsns_14_sht3x.ino
@@ -76,7 +76,7 @@ bool Sht3xRead(float &t, float &h, uint8_t sht3x_address)
 
 /********************************************************************************************/
 
-void Sht3xDetect()
+void Sht3xDetect(void)
 {
   if (sht3x_count) return;
 

--- a/sonoff/xsns_15_mhz19.ino
+++ b/sonoff/xsns_15_mhz19.ino
@@ -159,7 +159,7 @@ bool MhzCheckAndApplyFilter(uint16_t ppm, uint8_t s)
   return true;
 }
 
-void MhzEverySecond()
+void MhzEverySecond(void)
 {
   mhz_state++;
   if (8 == mhz_state) {                   // Every 8 sec start a MH-Z19 measuring cycle (which takes 1005 +5% ms)
@@ -253,7 +253,7 @@ void MhzEverySecond()
  * 9 - Reset
 \*********************************************************************************************/
 
-bool MhzCommandSensor()
+bool MhzCommandSensor(void)
 {
   boolean serviced = true;
 
@@ -275,7 +275,7 @@ bool MhzCommandSensor()
 
 /*********************************************************************************************/
 
-void MhzInit()
+void MhzInit(void)
 {
   mhz_type = 0;
   if ((pin[GPIO_MHZ_RXD] < 99) && (pin[GPIO_MHZ_TXD] < 99)) {

--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -38,7 +38,7 @@ uint8_t tsl2561_valid = 0;
 uint32_t tsl2561_milliLux = 0;
 char tsl2561_types[] = "TSL2561";
 
-bool Tsl2561Read()
+bool Tsl2561Read(void)
 {
   if (tsl2561_valid) { tsl2561_valid--; }
 
@@ -63,7 +63,7 @@ bool Tsl2561Read()
   return true;
 }
 
-void Tsl2561Detect()
+void Tsl2561Detect(void)
 {
   if (tsl2561_type) { return; }
 
@@ -77,7 +77,7 @@ void Tsl2561Detect()
   }
 }
 
-void Tsl2561EverySecond()
+void Tsl2561EverySecond(void)
 {
   if (90 == (uptime %100)) {
     // 1mS

--- a/sonoff/xsns_17_senseair.ino
+++ b/sonoff/xsns_17_senseair.ino
@@ -58,7 +58,7 @@ const uint8_t start_addresses[] { 0x1A, 0x00, 0x03, 0x04, 0x05, 0x1C, 0x0A };
 uint8_t senseair_read_state = 0;
 uint8_t senseair_send_retry = 0;
 
-void Senseair250ms()              // Every 250 mSec
+void Senseair250ms(void)              // Every 250 mSec
 {
 //  senseair_state++;
 //  if (6 == senseair_state) {     // Every 300 mSec
@@ -132,7 +132,7 @@ void Senseair250ms()              // Every 250 mSec
 
 /*********************************************************************************************/
 
-void SenseairInit()
+void SenseairInit(void)
 {
   senseair_type = 0;
   if ((pin[GPIO_SAIR_RX] < 99) && (pin[GPIO_SAIR_TX] < 99)) {

--- a/sonoff/xsns_18_pms5003.ino
+++ b/sonoff/xsns_18_pms5003.ino
@@ -45,7 +45,7 @@ struct pms5003data {
 
 /*********************************************************************************************/
 
-boolean PmsReadData()
+boolean PmsReadData(void)
 {
   if (! PmsSerial->available()) {
     return false;
@@ -87,7 +87,7 @@ boolean PmsReadData()
 
 /*********************************************************************************************/
 
-void PmsSecond()                 // Every second
+void PmsSecond(void)                 // Every second
 {
   if (PmsReadData()) {
     pms_valid = 10;
@@ -100,7 +100,7 @@ void PmsSecond()                 // Every second
 
 /*********************************************************************************************/
 
-void PmsInit()
+void PmsInit(void)
 {
   pms_type = 0;
   if (pin[GPIO_PMS5003] < 99) {

--- a/sonoff/xsns_19_mgs.ino
+++ b/sonoff/xsns_19_mgs.ino
@@ -34,11 +34,11 @@
 
 #include "MutichannelGasSensor.h"
 
-void MGSInit() {
+void MGSInit(void) {
   gas.begin(MGS_SENSOR_ADDR);
 }
 
-boolean MGSPrepare()
+boolean MGSPrepare(void)
 {
   gas.begin(MGS_SENSOR_ADDR);
   if (!gas.isError()) {

--- a/sonoff/xsns_20_novasds.ino
+++ b/sonoff/xsns_20_novasds.ino
@@ -48,7 +48,7 @@ struct sds011data {
   uint16_t pm25;
 } novasds_data;
 
-void NovaSdsSetWorkPeriod()
+void NovaSdsSetWorkPeriod(void)
 {
 
   while (NovaSdsSerial->available() > 0) {
@@ -73,7 +73,7 @@ void NovaSdsSetWorkPeriod()
   }
 }
 
-bool NovaSdsReadData()
+bool NovaSdsReadData(void)
 {
   if (! NovaSdsSerial->available()) return false;
 
@@ -104,7 +104,7 @@ bool NovaSdsReadData()
 
 /*********************************************************************************************/
 
-void NovaSdsSecond()                 // Every second
+void NovaSdsSecond(void)                 // Every second
 {
   if (XSNS_20 == (uptime % 100)) {
     if (!novasds_valid) {
@@ -123,7 +123,7 @@ void NovaSdsSecond()                 // Every second
 
 /*********************************************************************************************/
 
-void NovaSdsInit()
+void NovaSdsInit(void)
 {
   novasds_type = 0;
   if (pin[GPIO_SDS0X1_RX] < 99 && pin[GPIO_SDS0X1_TX] < 99) {

--- a/sonoff/xsns_21_sgp30.ino
+++ b/sonoff/xsns_21_sgp30.ino
@@ -38,7 +38,7 @@ uint8_t sgp30_counter = 0;
 
 /********************************************************************************************/
 
-void Sgp30Update()  // Perform every second to ensure proper operation of the baseline compensation algorithm
+void Sgp30Update(void)  // Perform every second to ensure proper operation of the baseline compensation algorithm
 {
   sgp30_ready = 0;
   if (!sgp30_type) {

--- a/sonoff/xsns_22_sr04.ino
+++ b/sonoff/xsns_22_sr04.ino
@@ -46,7 +46,7 @@ uint8_t sr04_trig_pin = 0;
 
 /********************************************************************************************/
 
-void Sr04Init()
+void Sr04Init(void)
 {
   sr04_echo_pin = pin[GPIO_SR04_ECHO];
   sr04_trig_pin = pin[GPIO_SR04_TRIG];

--- a/sonoff/xsns_23_sdm120.ino
+++ b/sonoff/xsns_23_sdm120.ino
@@ -43,7 +43,7 @@ float sdm120_power_factor = 0;
 float sdm120_frequency = 0;
 float sdm120_energy_total = 0;
 
-bool SDM120_ModbusReceiveReady()
+bool SDM120_ModbusReceiveReady(void)
 {
   return (SDM120Serial->available() > 1);
 }
@@ -137,7 +137,7 @@ const uint16_t sdm120_start_addresses[] {
 uint8_t sdm120_read_state = 0;
 uint8_t sdm120_send_retry = 0;
 
-void SDM120250ms()              // Every 250 mSec
+void SDM120250ms(void)              // Every 250 mSec
 {
 //  sdm120_state++;
 //  if (6 == sdm120_state) {     // Every 300 mSec
@@ -203,7 +203,7 @@ void SDM120250ms()              // Every 250 mSec
 //  } // end 300 ms
 }
 
-void SDM120Init()
+void SDM120Init(void)
 {
   sdm120_type = 0;
   if ((pin[GPIO_SDM120_RX] < 99) && (pin[GPIO_SDM120_TX] < 99)) {

--- a/sonoff/xsns_24_si1145.ino
+++ b/sonoff/xsns_24_si1145.ino
@@ -210,12 +210,12 @@ uint8_t Si1145WriteParamData(uint8_t p, uint8_t v)
 
 /********************************************************************************************/
 
-bool Si1145Present()
+bool Si1145Present(void)
 {
   return (Si1145ReadByte(SI114X_PART_ID) == 0X45);
 }
 
-void Si1145Reset()
+void Si1145Reset(void)
 {
   Si1145WriteByte(SI114X_MEAS_RATE0, 0);
   Si1145WriteByte(SI114X_MEAS_RATE1, 0);
@@ -231,7 +231,7 @@ void Si1145Reset()
   delay(10);
 }
 
-void Si1145DeInit()
+void Si1145DeInit(void)
 {
   //ENABLE UV reading
   //these reg must be set to the fixed value
@@ -276,7 +276,7 @@ void Si1145DeInit()
   Si1145WriteByte(SI114X_COMMAND, SI114X_PSALS_AUTO);
 }
 
-boolean Si1145Begin()
+boolean Si1145Begin(void)
 {
   if (!Si1145Present()) { return false; }
 
@@ -286,26 +286,26 @@ boolean Si1145Begin()
 }
 
 // returns the UV index * 100 (divide by 100 to get the index)
-uint16_t Si1145ReadUV()
+uint16_t Si1145ReadUV(void)
 {
   return Si1145ReadHalfWord(SI114X_AUX_DATA0_UVINDEX0);
 }
 
 // returns visible+IR light levels
-uint16_t Si1145ReadVisible()
+uint16_t Si1145ReadVisible(void)
 {
   return Si1145ReadHalfWord(SI114X_ALS_VIS_DATA0);
 }
 
 // returns IR light levels
-uint16_t Si1145ReadIR()
+uint16_t Si1145ReadIR(void)
 {
   return Si1145ReadHalfWord(SI114X_ALS_IR_DATA0);
 }
 
 /********************************************************************************************/
 
-void Si1145Update()
+void Si1145Update(void)
 {
   if (!si1145_type) {
     if (Si1145Begin()) {

--- a/sonoff/xsns_25_sdm630.ino
+++ b/sonoff/xsns_25_sdm630.ino
@@ -41,7 +41,7 @@ float sdm630_reactive_power[] = {0,0,0};
 float sdm630_power_factor[] = {0,0,0};
 float sdm630_energy_total = 0;
 
-bool SDM630_ModbusReceiveReady()
+bool SDM630_ModbusReceiveReady(void)
 {
   return (SDM630Serial->available() > 1);
 }
@@ -143,7 +143,7 @@ const uint16_t sdm630_start_addresses[] {
 uint8_t sdm630_read_state = 0;
 uint8_t sdm630_send_retry = 0;
 
-void SDM630250ms()              // Every 250 mSec
+void SDM630250ms(void)              // Every 250 mSec
 {
 //  sdm630_state++;
 //  if (6 == sdm630_state) {     // Every 300 mSec
@@ -241,7 +241,7 @@ void SDM630250ms()              // Every 250 mSec
 //  } // end 300 ms
 }
 
-void SDM630Init()
+void SDM630Init(void)
 {
   sdm630_type = 0;
   if ((pin[GPIO_SDM630_RX] < 99) && (pin[GPIO_SDM630_TX] < 99)) {

--- a/sonoff/xsns_27_apds9960.ino
+++ b/sonoff/xsns_27_apds9960.ino
@@ -351,7 +351,7 @@ int8_t wireReadDataBlock(   uint8_t reg,
 *            Kelvin
 */
 
-void calculateColorTemperature()
+void calculateColorTemperature(void)
 {
   float X, Y, Z;      /* RGB to XYZ correlation      */
   float xc, yc;       /* Chromaticity co-ordinates   */
@@ -398,7 +398,7 @@ float powf(const float x, const float y)
   *
   * @return lower threshold
   */
- uint8_t getProxIntLowThresh()
+ uint8_t getProxIntLowThresh(void)
  {
      uint8_t val;
 
@@ -422,7 +422,7 @@ float powf(const float x, const float y)
   *
   * @return high threshold
   */
- uint8_t getProxIntHighThresh()
+ uint8_t getProxIntHighThresh(void)
  {
      uint8_t val;
 
@@ -454,7 +454,7 @@ float powf(const float x, const float y)
   *
   * @return the value of the LED drive strength. 0xFF on failure.
   */
- uint8_t getLEDDrive()
+ uint8_t getLEDDrive(void)
  {
      uint8_t val;
 
@@ -506,7 +506,7 @@ float powf(const float x, const float y)
   *
   * @return the value of the proximity gain. 0xFF on failure.
   */
- uint8_t getProximityGain()
+ uint8_t getProximityGain(void)
  {
      uint8_t val;
 
@@ -597,7 +597,7 @@ float powf(const float x, const float y)
   *
   * @return The LED boost value. 0xFF on failure.
   */
- uint8_t getLEDBoost()
+ uint8_t getLEDBoost(void)
  {
      uint8_t val;
 
@@ -642,7 +642,7 @@ float powf(const float x, const float y)
   *
   * @return 1 if compensation is enabled. 0 if not. 0xFF on error.
   */
- uint8_t getProxGainCompEnable()
+ uint8_t getProxGainCompEnable(void)
  {
      uint8_t val;
 
@@ -689,7 +689,7 @@ float powf(const float x, const float y)
   *
   * @return Current proximity mask for photodiodes. 0xFF on error.
   */
- uint8_t getProxPhotoMask()
+ uint8_t getProxPhotoMask(void)
  {
      uint8_t val;
 
@@ -735,7 +735,7 @@ float powf(const float x, const float y)
   *
   * @return Current entry proximity threshold.
   */
- uint8_t getGestureEnterThresh()
+ uint8_t getGestureEnterThresh(void)
  {
      uint8_t val;
 
@@ -761,7 +761,7 @@ float powf(const float x, const float y)
   *
   * @return Current exit proximity threshold.
   */
- uint8_t getGestureExitThresh()
+ uint8_t getGestureExitThresh(void)
  {
      uint8_t val;
 
@@ -792,7 +792,7 @@ float powf(const float x, const float y)
   *
   * @return the current photodiode gain. 0xFF on error.
   */
- uint8_t getGestureGain()
+ uint8_t getGestureGain(void)
  {
      uint8_t val;
 
@@ -844,7 +844,7 @@ float powf(const float x, const float y)
   *
   * @return the LED drive current value. 0xFF on error.
   */
- uint8_t getGestureLEDDrive()
+ uint8_t getGestureLEDDrive(void)
  {
      uint8_t val;
 
@@ -900,7 +900,7 @@ float powf(const float x, const float y)
   *
   * @return the current wait time between gestures. 0xFF on error.
   */
- uint8_t getGestureWaitTime()
+ uint8_t getGestureWaitTime(void)
  {
      uint8_t val;
 
@@ -1087,7 +1087,7 @@ float powf(const float x, const float y)
   *
   * @return 1 if interrupts are enabled, 0 if not. 0xFF on error.
   */
- uint8_t getAmbientLightIntEnable()
+ uint8_t getAmbientLightIntEnable(void)
  {
      uint8_t val;
 
@@ -1127,7 +1127,7 @@ float powf(const float x, const float y)
   *
   * @return 1 if interrupts are enabled, 0 if not. 0xFF on error.
   */
- uint8_t getProximityIntEnable()
+ uint8_t getProximityIntEnable(void)
  {
      uint8_t val;
 
@@ -1167,7 +1167,7 @@ float powf(const float x, const float y)
   *
   * @return 1 if interrupts are enabled, 0 if not. 0xFF on error.
   */
- uint8_t getGestureIntEnable()
+ uint8_t getGestureIntEnable(void)
  {
      uint8_t val;
 
@@ -1206,7 +1206,7 @@ float powf(const float x, const float y)
   * @brief Clears the ambient light interrupt
   *
   */
- void clearAmbientLightInt()
+ void clearAmbientLightInt(void)
  {
      uint8_t throwaway;
      throwaway = I2cRead8(APDS9960_I2C_ADDR, APDS9960_AICLEAR);
@@ -1216,7 +1216,7 @@ float powf(const float x, const float y)
   * @brief Clears the proximity interrupt
   *
   */
- void clearProximityInt()
+ void clearProximityInt(void)
  {
      uint8_t throwaway;
      throwaway = I2cRead8(APDS9960_I2C_ADDR, APDS9960_PICLEAR) ;
@@ -1228,7 +1228,7 @@ float powf(const float x, const float y)
   *
   * @return 1 if gesture state machine is running, 0 if not. 0xFF on error.
   */
- uint8_t getGestureMode()
+ uint8_t getGestureMode(void)
  {
      uint8_t val;
 
@@ -1263,7 +1263,7 @@ float powf(const float x, const float y)
  }
 
 
-bool APDS9960_init()
+bool APDS9960_init(void)
 {
     /* Set default values for ambient light and proximity registers */
 
@@ -1339,7 +1339,7 @@ bool APDS9960_init()
  *
  * @return Contents of the ENABLE register. 0xFF if error.
  */
-uint8_t getMode()
+uint8_t getMode(void)
 {
     uint8_t enable_value;
 
@@ -1388,7 +1388,7 @@ void setMode(uint8_t mode, uint8_t enable)
  *
  * no interrupts
  */
-void enableLightSensor()
+void enableLightSensor(void)
 {
     /* Set default gain, interrupts, enable power, and enable sensor */
     setAmbientLightGain(DEFAULT_AGAIN);
@@ -1401,7 +1401,7 @@ void enableLightSensor()
  * @brief Ends the light sensor on the APDS-9960
  *
  */
-void disableLightSensor()
+void disableLightSensor(void)
 {
     setAmbientLightIntEnable(0) ;
     setMode(AMBIENT_LIGHT, 0) ;
@@ -1412,7 +1412,7 @@ void disableLightSensor()
  *
  * no interrupts
  */
-void enableProximitySensor()
+void enableProximitySensor(void)
 {
     /* Set default gain, LED, interrupts, enable power, and enable sensor */
     setProximityGain(DEFAULT_PGAIN);
@@ -1426,7 +1426,7 @@ void enableProximitySensor()
  * @brief Ends the proximity sensor on the APDS-9960
  *
  */
-void disableProximitySensor()
+void disableProximitySensor(void)
 {
 	setProximityIntEnable(0) ;
   setMode(PROXIMITY, 0) ;
@@ -1437,7 +1437,7 @@ void disableProximitySensor()
  *
  * no interrupts
  */
-void enableGestureSensor()
+void enableGestureSensor(void)
 {
     /* Enable gesture mode
        Set ENABLE to 0 (power off)
@@ -1462,7 +1462,7 @@ void enableGestureSensor()
  * @brief Ends the gesture recognition engine on the APDS-9960
  *
  */
-void disableGestureSensor()
+void disableGestureSensor(void)
 {
     resetGestureParameters();
     setGestureIntEnable(0) ;
@@ -1475,7 +1475,7 @@ void disableGestureSensor()
  *
  * @return True if gesture available. False otherwise.
  */
-bool isGestureAvailable()
+bool isGestureAvailable(void)
 {
     uint8_t val;
 
@@ -1498,7 +1498,7 @@ bool isGestureAvailable()
  *
  * @return Number corresponding to gesture. -1 on error.
  */
-int16_t readGesture()
+int16_t readGesture(void)
 {
     uint8_t fifo_level = 0;
     uint8_t bytes_read = 0;
@@ -1585,7 +1585,7 @@ int16_t readGesture()
  * Turn the APDS-9960 on
  *
  */
-void enablePower()
+void enablePower(void)
 {
     setMode(POWER, 1) ;
 }
@@ -1594,7 +1594,7 @@ void enablePower()
  * Turn the APDS-9960 off
  *
  */
-void disablePower()
+void disablePower(void)
 {
     setMode(POWER, 0) ;
 }
@@ -1608,7 +1608,7 @@ void disablePower()
   *
   */
 
-void readAllColorAndProximityData()
+void readAllColorAndProximityData(void)
 {
   if (I2cReadBuffer(APDS9960_I2C_ADDR, APDS9960_CDATAL, (uint8_t *) &color_data, (uint16_t)9))
   {
@@ -1624,7 +1624,7 @@ void readAllColorAndProximityData()
 /**
  * @brief Resets all the parameters in the gesture data member
  */
-void resetGestureParameters()
+void resetGestureParameters(void)
 {
     gesture_data_.index = 0;
     gesture_data_.total_gestures = 0;
@@ -1644,7 +1644,7 @@ void resetGestureParameters()
  *
  * @return True if near or far state seen. False otherwise.
  */
-bool processGestureData()
+bool processGestureData(void)
 {
     uint8_t u_first = 0;
     uint8_t d_first = 0;
@@ -1748,7 +1748,7 @@ bool processGestureData()
  *
  * @return True if near/far event. False otherwise.
  */
-bool decodeGesture()
+bool decodeGesture(void)
 {
 
     /* Determine swipe direction */
@@ -1791,7 +1791,7 @@ bool decodeGesture()
     return true;
 }
 
-void handleGesture() {
+void handleGesture(void) {
     if (isGestureAvailable() ) {
     char log[LOGSZ];
     switch (readGesture()) {
@@ -1870,7 +1870,7 @@ void APDS9960_adjustATime(void)  // not really used atm
 }
 
 
-void APDS9960_loop()
+void APDS9960_loop(void)
 {
   if (recovery_loop_counter > 0){
     recovery_loop_counter -= 1;
@@ -1993,7 +1993,7 @@ void APDS9960_show(boolean json)
  * Sensor27 | 2 / On  | Enable gesture mode with half gain
 \*********************************************************************************************/
 
-bool APDS9960CommandSensor()
+bool APDS9960CommandSensor(void)
 {
   boolean serviced = true;
 

--- a/sonoff/xsns_28_tm1638.ino
+++ b/sonoff/xsns_28_tm1638.ino
@@ -72,7 +72,7 @@ void TM16XXSendData(byte address, byte data)
   digitalWrite(tm1638_strobe_pin, HIGH);
 }
 
-byte Tm16XXReceive()
+byte Tm16XXReceive(void)
 {
   byte temp = 0;
 
@@ -96,7 +96,7 @@ byte Tm16XXReceive()
 
 /*********************************************************************************************/
 
-void Tm16XXClearDisplay()
+void Tm16XXClearDisplay(void)
 {
   for (int i = 0; i < tm1638_displays; i++) {
     TM16XXSendData(i << 1, 0);
@@ -125,7 +125,7 @@ void Tm1638SetLEDs(word leds)
   }
 }
 
-byte Tm1638GetButtons()
+byte Tm1638GetButtons(void)
 {
   byte keys = 0;
 
@@ -141,7 +141,7 @@ byte Tm1638GetButtons()
 
 /*********************************************************************************************/
 
-void TmInit()
+void TmInit(void)
 {
   tm1638_type = 0;
   if ((pin[GPIO_TM16CLK] < 99) && (pin[GPIO_TM16DIO] < 99) && (pin[GPIO_TM16STB] < 99)) {
@@ -171,7 +171,7 @@ void TmInit()
   }
 }
 
-void TmLoop()
+void TmLoop(void)
 {
   if (tm1638_state) {
     byte buttons = Tm1638GetButtons();

--- a/sonoff/xsns_31_ccs811.ino
+++ b/sonoff/xsns_31_ccs811.ino
@@ -42,7 +42,7 @@ uint8_t ecnt = 0;
 /********************************************************************************************/
 #define EVERYNSECONDS 5
 
-void CCS811Update()  // Perform every n second
+void CCS811Update(void)  // Perform every n second
 {
   tcnt++;
   if (tcnt >= EVERYNSECONDS) {

--- a/sonoff/xsns_32_mpu6050.ino
+++ b/sonoff/xsns_32_mpu6050.ino
@@ -45,7 +45,7 @@ int16_t MPU_6050_temperature = 0;
 #include <MPU6050.h>
 MPU6050 mpu6050;
 
-void MPU_6050PerformReading()
+void MPU_6050PerformReading(void)
 {
   mpu6050.getMotion6(
     &MPU_6050_ax,
@@ -75,7 +75,7 @@ void MPU_6050SetAccelOffsets(int x, int y, int z)
 }
 */
 
-void MPU_6050Detect()
+void MPU_6050Detect(void)
 {
   if (MPU_6050_found)
   {

--- a/sonoff/xsns_33_ds3231.ino
+++ b/sonoff/xsns_33_ds3231.ino
@@ -69,7 +69,7 @@ boolean DS3231chipDetected;
 /*----------------------------------------------------------------------*
   Detect the DS3231 Chip
   ----------------------------------------------------------------------*/
-boolean DS3231Detect()
+boolean DS3231Detect(void)
 {
   if (I2cValidRead(USE_RTC_ADDR, RTC_STATUS, 1))
   {
@@ -104,7 +104,7 @@ uint8_t dec2bcd(uint8_t n)
 /*----------------------------------------------------------------------*
    Read time from DS3231 and return the epoch time (second since 1-1-1970 00:00)
   ----------------------------------------------------------------------*/
-uint32_t ReadFromDS3231()
+uint32_t ReadFromDS3231(void)
 {
   TIME_T tm;
   tm.second = bcd2dec(I2cRead8(USE_RTC_ADDR, RTC_SECONDS));

--- a/sonoff/xsns_34_hx711.ino
+++ b/sonoff/xsns_34_hx711.ino
@@ -116,7 +116,7 @@ long HxRead()
 
 /*********************************************************************************************/
 
-void HxReset()
+void HxReset(void)
 {
   hx_tare_flg = 1;
   hx_sum_weight = 0;
@@ -149,7 +149,7 @@ void HxCalibrationStateTextJson(uint8_t msg_id)
  * Sensor34 6 <weight in decigram> - Set item weight
 \*********************************************************************************************/
 
-bool HxCommand()
+bool HxCommand(void)
 {
   bool serviced = true;
   bool show_parms = false;
@@ -220,7 +220,7 @@ long HxWeight()
   return (hx_calibrate_step < HX_CAL_FAIL) ? hx_weight : 0;
 }
 
-void HxInit()
+void HxInit(void)
 {
   hx_type = 0;
   if ((pin[GPIO_HX711_DAT] < 99) && (pin[GPIO_HX711_SCK] < 99)) {
@@ -245,7 +245,7 @@ void HxInit()
   }
 }
 
-void HxEvery100mSecond()
+void HxEvery100mSecond(void)
 {
   hx_sum_weight += HxRead();
 
@@ -391,7 +391,7 @@ const char HTTP_FORM_HX711[] PROGMEM =
   "<form method='post' action='" WEB_HANDLE_HX711 "'>"
   "<br/><b>" D_ITEM_WEIGHT "</b> (" D_UNIT_KILOGRAM ")<br/><input type='number' max='6.5535' step='0.0001' id='p2' name='p2' placeholder='0.0' value='{2'><br/>";
 
-void HandleHxAction()
+void HandleHxAction(void)
 {
   if (HttpUser()) { return; }
   if (!WebAuthenticate()) { return WebServer->requestAuthentication(); }
@@ -440,7 +440,7 @@ void HandleHxAction()
   ShowPage(page);
 }
 
-void HxSaveSettings()
+void HxSaveSettings(void)
 {
   char tmp[100];
 
@@ -450,7 +450,7 @@ void HxSaveSettings()
   HxLogUpdates();
 }
 
-void HxLogUpdates()
+void HxLogUpdates(void)
 {
   char weigth_ref_chr[10];
   char weigth_item_chr[10];

--- a/sonoff/xsns_35_tx20.ino
+++ b/sonoff/xsns_35_tx20.ino
@@ -80,7 +80,7 @@ uint8_t tx20_wind_direction = 0;
 
 boolean tx20_available = false;
 
-void Tx20StartRead()
+void Tx20StartRead(void)
 {
   /* La Crosse TX20 Anemometer datagram every 2 seconds
    * 0-0 11011 0011 111010101111 0101 1100 000101010000 0-0 - Received pin data at 1200 uSec per bit
@@ -146,7 +146,7 @@ void Tx20StartRead()
   GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << pin[GPIO_TX20_TXD_BLACK]);
 }
 
-void Tx20Read()
+void Tx20Read(void)
 {
   if (!(uptime % TX20_RESET_VALUES)) {
     tx20_count = 0;
@@ -165,7 +165,7 @@ void Tx20Read()
   }
 }
 
-void Tx20Init() {
+void Tx20Init(void) {
   pinMode(pin[GPIO_TX20_TXD_BLACK], INPUT);
   attachInterrupt(pin[GPIO_TX20_TXD_BLACK], Tx20StartRead, RISING);
 }

--- a/sonoff/xsns_interface.ino
+++ b/sonoff/xsns_interface.ino
@@ -542,7 +542,7 @@ boolean XsnsPresent(byte sns_index)
   return false;
 }
 
-String XsnsGetSensors()
+String XsnsGetSensors(void)
 {
   char state[2] = { 0 };
 


### PR DESCRIPTION
Change C functions with () to explicitly specify (void) for no parameters

The Arduino compiler recipe seems to ignore () and substitute (void) anyway, but this does not seem to be the case for PIO.

This PR changes all C functions which have no parameters to explicitly define this by having void as a parameter.