### PR TITLE
Add support for sensor discovery

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -455,16 +455,18 @@ void RulesEvery50ms(void)
   }
 }
 
+uint8_t rules_xsns_index = 0;
+
 void RulesEvery100ms(void)
 {
   if (Settings.rule_enabled && (uptime > 4)) {  // Any rule enabled and allow 4 seconds start-up time for sensors (#3811)
     mqtt_data[0] = '\0';
     int tele_period_save = tele_period;
-    tele_period = 2;                 // Do not allow HA updates during next function call
-    XsnsNextCall(FUNC_JSON_APPEND);  // ,"INA219":{"Voltage":4.494,"Current":0.020,"Power":0.089}
+    tele_period = 2;                                   // Do not allow HA updates during next function call
+    XsnsNextCall(FUNC_JSON_APPEND, rules_xsns_index);  // ,"INA219":{"Voltage":4.494,"Current":0.020,"Power":0.089}
     tele_period = tele_period_save;
     if (strlen(mqtt_data)) {
-      mqtt_data[0] = '{';            // {"INA219":{"Voltage":4.494,"Current":0.020,"Power":0.089}
+      mqtt_data[0] = '{';                              // {"INA219":{"Voltage":4.494,"Current":0.020,"Power":0.089}
       snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
       RulesProcess();
     }

--- a/sonoff/xsns_interface.ino
+++ b/sonoff/xsns_interface.ino
@@ -263,13 +263,12 @@ boolean (* const xsns_func_ptr[])(byte) = {  // Sensor Function Pointers for sim
 };
 
 const uint8_t xsns_present = sizeof(xsns_func_ptr) / sizeof(xsns_func_ptr[0]);  // Number of External Sensors found
-uint8_t xsns_index = 0;
 
 /*********************************************************************************************\
  * Function call to all xsns
 \*********************************************************************************************/
 
-boolean XsnsNextCall(byte Function)
+boolean XsnsNextCall(byte Function, uint8_t &xsns_index)
 {
 
   xsns_index++;


### PR DESCRIPTION
Add support for Hass sensor discovery.

All sensors except for temperature and humidity sensors are announced as "Generic sensor".

Example, Sonoff set up with an AM2301 + Counter sensor:
![image](https://user-images.githubusercontent.com/14281572/48861326-97717180-edc3-11e8-96e9-6aff432c7a2a.png)

Note:
Hass also knows about the following type of sensors:
- battery: Percentage of battery that is left.
- illuminance: The current light level in lx or lm.
- pressure: Pressure in hPa or mbar.

Support for this can be added as well if requested.

