### PR TITLE
Fix warning when compiling sonoff-sensors.bin

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -107,7 +107,9 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #define USE_MP3_PLAYER                        // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10             // Set the startup volume on init, the range can be 0..30(max)
 #define USE_TUYA_DIMMER                       // Add support for Tuya Serial Dimmer
+#ifndef TUYA_DIMMER_ID
   #define TUYA_DIMMER_ID       0              // Default dimmer Id
+#endif
 #define USE_PZEM004T                          // Add support for PZEM004T Energy monitor (+2k code)
 #define USE_PZEM_AC                           // Add support for PZEM014,016 Energy monitor (+1k1 code)
 #define USE_PZEM_DC                           // Add support for PZEM003,017 Energy monitor (+1k1 code)


### PR DESCRIPTION
The `#define TUYA_DIMMER_ID` is in _my_user_config.h_ and also in _sonoff_post.h_ when using `USE_SENSORS `for building **sonoff_sensors.bin**.

This fixes the warning of dupplicated defines.