### PR TITLE
Fix PIO Linter Warning

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -48,7 +48,7 @@
 
 // -- Project -------------------------------------
 #define PROJECT                "sonoff"          // PROJECT is used as the default topic delimiter
-#define MODULE                 SONOFF_BASIC      // [Module] Select default model from sonoff_template.h (Should not be changed)
+//#define MODULE                 SONOFF_BASIC      // [Module] Select default model from sonoff_template.h. If none is selected the default will be SONOFF_BASIC
 
 #define SAVE_DATA              1                 // [SaveData] Save changed parameters to Flash (0 = disable, 1 - 3600 seconds)
 #define SAVE_STATE             1                 // [SetOption0] Save changed power state to Flash (0 = disable, 1 = enable)


### PR DESCRIPTION
This fixes the linter warning for Platformio due to module is defined in _platformio.ini_ and also _my_user_config.h_

If module is not defined in _my_user_config.h_ nor in _platformio.ini_, _sonoff_post.h_ will make `SONOFF_BASIC` as the default.

This works for both **Arduino** and **Platformio**

This will work as the same as `#define MY_LANGUAGE` works. If you define it in _my_user_config.h_, the compiler will use that language, if not defined, the compiler will use `en-GB` as the default language.