### PR TITLE
Increase delays before web ui is refreshed

### DIFF
--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -95,7 +95,12 @@ const char HTTP_SCRIPT_WIFI[] PROGMEM =
   "}";
 
 const char HTTP_SCRIPT_RELOAD[] PROGMEM =
-  "setTimeout(function(){location.href='.';},5000);"
+  "setTimeout(function(){location.href='.';},10000);"
+  "</script>";
+
+// Local OTA upgrade requires more time to complete cp: before web ui should be reloaded
+const char HTTP_SCRIPT_RELOAD_OTA[] PROGMEM =
+  "setTimeout(function(){location.href='.';},20000);"
   "</script>";
 
 const char HTTP_SCRIPT_CONSOL[] PROGMEM =
@@ -1463,7 +1468,7 @@ void HandleUploadDone(void)
   } else {
     page += F("green'>" D_SUCCESSFUL "</font></b><br/>");
     page += FPSTR(HTTP_MSG_RSTRT);
-    page.replace(F("</script>"), FPSTR(HTTP_SCRIPT_RELOAD));
+    page.replace(F("</script>"), FPSTR(HTTP_SCRIPT_RELOAD_OTA)); // Refesh main web ui after OTA upgrade
     ShowWebSource(SRC_WEBGUI);
     restart_flag = 2;  // Always restart to re-enable disabled features during update
   }

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -95,7 +95,7 @@ const char HTTP_SCRIPT_WIFI[] PROGMEM =
   "}";
 
 const char HTTP_SCRIPT_RELOAD[] PROGMEM =
-  "setTimeout(function(){location.href='.';},5000);"
+  "setTimeout(function(){location.href='.';},9000);"
   "</script>";
 
 // Local OTA upgrade requires more time to complete cp: before web ui should be reloaded

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -95,7 +95,7 @@ const char HTTP_SCRIPT_WIFI[] PROGMEM =
   "}";
 
 const char HTTP_SCRIPT_RELOAD[] PROGMEM =
-  "setTimeout(function(){location.href='.';},10000);"
+  "setTimeout(function(){location.href='.';},5000);"
   "</script>";
 
 // Local OTA upgrade requires more time to complete cp: before web ui should be reloaded


### PR DESCRIPTION
The current 5-second delay before refreshing web ui after settings were changed is not always sufficient as wifi can take up to 10 seconds to re-connect and be available on some wireless networks, depending on the device's RSSI.

This change increases the delay from 5 seconds to 10 seconds which have been tested down to RSSI levels of 25 to be sufficient.

This change also increases the refresh delay when a local OTA is uploaded to 20 seconds which allows enough time for the cp: process to complete and the device to reconnected to wifi under >= 25 RSSI conditions.