### PR TITLE
Remove assumption of 100% to report correctly

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2799,9 +2799,5 @@ void loop(void)
       delay(my_activity /2); // If wifi down and my_activity > setoption36 then force loop delay to 1/3 of my_activity period
     }
   }
- if (my_activity < (uint32_t)Settings.param[P_LOOP_SLEEP_DELAY]) {
-   UpdateLoopLoadAvg(my_activity);
- } else {
-   UpdateLoopLoadAvg((uint32_t)Settings.param[P_LOOP_SLEEP_DELAY]); // Assume 100% loop cycle ratio
- }
+  UpdateLoopLoadAvg(my_activity);
 }


### PR DESCRIPTION
Remove the assumption of 100% loop duty cycle as we want an accurate loop load average and not a percentage as such - so if it overshoots the value stored for setoption36 this should be known by looking at the load average and not be distorted by reducing it to 100 basis points on the assumption that my_acitivity took as long as setoption36.