### PR TITLE
Support sending tele/STATUS as state/RESULT

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -72,7 +72,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t use_wifi_scan : 1;            // bit 6 (v6.3.0.10)
     uint32_t use_wifi_rescan : 1;          // bit 7 (v6.3.0.10)
     uint32_t receive_raw : 1;              // bit 8 (v6.3.0.11)
-    uint32_t spare09 : 1;
+    uint32_t hass_tele_as_result : 1;      // bit 9
     uint32_t spare10 : 1;
     uint32_t spare11 : 1;
     uint32_t spare12 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1681,7 +1681,11 @@ void PerformEverySecond(void)
 
       mqtt_data[0] = '\0';
       MqttShowState();
-      MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
+      if (Settings.flag3.hass_tele_as_result) {
+        MqttPublishPrefixTopic_P(STAT, S_RSLT_RESULT, MQTT_TELE_RETAIN);
+      } else {
+        MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
+      }
 
       mqtt_data[0] = '\0';
       if (MqttShowSensor()) {

--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -424,8 +424,9 @@ void HAssDiscovery(uint8_t mode)
 {
   // Configure Tasmota for default Home Assistant parameters to keep discovery message as short as possible
   if (Settings.flag.hass_discovery) {
-    Settings.flag.mqtt_response = 0;     // Response always as RESULT and not as uppercase command
-    Settings.flag.decimal_text = 1;      // Respond with decimal color values
+    Settings.flag.mqtt_response = 0;        // Response always as RESULT and not as uppercase command
+    Settings.flag.decimal_text = 1;         // Respond with decimal color values
+    Settings.flag3.hass_tele_as_result = 1; // send tele/STATE message as stat/RESULT
 //    Settings.light_scheme = 0;           // To just control color it needs to be Scheme 0
     if (!string_ends_with(Settings.mqtt_fulltopic, "%prefix%/"))
       strncpy_P(Settings.mqtt_fulltopic, PSTR("%topic%/%prefix%/"), sizeof(Settings.mqtt_fulltopic));


### PR DESCRIPTION
Improve Hass support by sending tele/STATUS as state/RESULT.
This make sure Hass state is synchronized with the Sonoffs after Hass restart.
See also: home-assistant/home-assistant#18703

The option will be automatically enabled if hass discovery is enabled.