### PR TITLE
Prevent sleep and SetOption36 Conflict

### DIFF
--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -857,6 +857,7 @@ void SettingsDelta(void)
     }
     if (Settings.version < 0x0603000A) {
       Settings.param[P_LOOP_SLEEP_DELAY] = LOOP_SLEEP_DELAY;
+      Settings.sleep = 0;                   // We do not want sleep enabled when SetOption36 is active
     }
     if (Settings.version < 0x0603000E) {
       Settings.flag2.calc_resolution = CALC_RESOLUTION;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -587,6 +587,11 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
     }
     else if (CMND_SLEEP == command_code) {
       if ((payload >= 0) && (payload < 251)) {
+        if (payload > 0) {
+          snprintf_P(log_data, sizeof(log_data), PSTR("*** WARNING *** - Disabling SetOption36 (Dynamic Sleep) in favour of sleep"));
+          AddLog(LOG_LEVEL_INFO);
+          Settings.param[P_LOOP_SLEEP_DELAY] = 0; // We do not want SetOption36 to be active along with traditional sleep
+        }
         Settings.sleep = payload;
         sleep = payload;
         WiFiSetSleepMode();
@@ -756,6 +761,12 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
               param_low = 1;
               param_high = 250;
               break;
+            case P_LOOP_SLEEP_DELAY:
+              if (payload > 0) {
+                snprintf_P(log_data, sizeof(log_data), PSTR("*** WARNING *** - Disabling sleep in favour of SetOption36 (Dynamic Sleep)"));
+                AddLog(LOG_LEVEL_INFO);
+                Settings.sleep = 0; // We do not want traditional sleep to be enabled along side SetOption36
+              }
           }
           if ((payload >= param_low) && (payload <= param_high)) {
             Settings.param[pindex] = payload;


### PR DESCRIPTION
Code change to set sleep = 0 when SetOption36 is > 0 is sent by command.

Reverse also, set SetOption36 = 0 when sleep > 0 command is sent.

Users have reported unusual results when a combination of the two is used.