### PR TITLE
RULES: Added BREAK as an alternative ENDON

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -264,6 +264,8 @@ bool RuleSetProcess(byte rule_set, String &event_saved)
 
   rules_trigger_count[rule_set] = 0;
   int plen = 0;
+  int plen2 = 0;
+  bool stop_all_rules = false;
   while (true) {
     rules = rules.substring(plen);                        // Select relative to last rule
     rules.trim();
@@ -278,7 +280,14 @@ bool RuleSetProcess(byte rule_set, String &event_saved)
     String event_trigger = rule.substring(3, pevt);       // "INA219#CURRENT>0.100"
 
     plen = rule.indexOf(" ENDON");
-    if (plen == -1) { return serviced; }                  // Bad syntax - No endon
+    plen2 = rule.indexOf(" BREAK");
+    if ((plen == -1) && (plen2 == -1)) { return serviced; } // Bad syntax - No ENDON neither BREAK
+
+    if (plen == -1) { plen = 9999; }
+    if (plen2 == -1) { plen2 = 9999; }
+    plen = min(plen, plen2);
+    if (plen == plen2) { stop_all_rules = true; }     // If BREAK was used, Stop execution of this rule set
+
     String commands = rules.substring(pevt +4, plen);     // "Backlog Dimmer 10;Color 100000"
     plen += 6;
     rules_event_value = "";
@@ -320,6 +329,7 @@ bool RuleSetProcess(byte rule_set, String &event_saved)
 
       ExecuteCommand(command, SRC_RULE);
       serviced = true;
+      if (stop_all_rules) { return serviced; }     // If BREAK was used, Stop execution of this rule set
     }
     rules_trigger_count[rule_set]++;
   }

--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -285,7 +285,7 @@ bool RuleSetProcess(byte rule_set, String &event_saved)
 
     if (plen == -1) { plen = 9999; }
     if (plen2 == -1) { plen2 = 9999; }
-    plen = min(plen, plen2);
+    plen = tmin(plen, plen2);
     if (plen == plen2) { stop_all_rules = true; }     // If BREAK was used, Stop execution of this rule set
 
     String commands = rules.substring(pevt +4, plen);     // "Backlog Dimmer 10;Color 100000"


### PR DESCRIPTION
RULES: Added `BREAK` as an alternative `ENDON` that will stop the execution for the rules that follows it.

If a rule that ends with `BREAK`, is triggered, then, the following rules of that set will not be executed. This is useful for cases like: https://github.com/arendst/Sonoff-Tasmota/issues/4477

Example:

With the actual rules, if we use a set like the following:

```
rule1
on event#temp>85 do VAR1 more85 endon
on event#temp>83 do VAR1 more83 endon
on event#temp>81 do VAR1 more81 endon
on event#temp=81 do VAR1 equal81 endon
on event#temp<81 do VAR1 less81 endon
```

We will have this output in the console :

```
19:43:18 CMD: rule
19:43:18 MQT: stat/living/RESULT = {"Rule1":"ON","Once":"ON","StopOnError":"OFF","Free":322,"Rules":"on event#temp>85 do VAR1 more85 endon on event#temp>83 do VAR1 more83 endon on event#temp>81 do VAR1 more81 endon on event#temp=81 do VAR1 equal81 endon on event#temp<81 do VAR1 less81 endon"}

19:43:24 CMD: event temp=10
19:43:24 MQT: stat/living/RESULT = {"Event":"Done"}
19:43:24 RUL: EVENT#TEMP<81 performs "VAR1 less81"
19:43:24 MQT: stat/living/RESULT = {"Var1":"less81"}

19:43:36 CMD: event temp=100
19:43:36 MQT: stat/living/RESULT = {"Event":"Done"}
19:43:36 RUL: EVENT#TEMP>85 performs "VAR1 more85"
19:43:36 MQT: stat/living/RESULT = {"Var1":"more85"}
19:43:36 RUL: EVENT#TEMP>83 performs "VAR1 more83"
19:43:36 MQT: stat/living/RESULT = {"Var1":"more83"}
19:43:36 RUL: EVENT#TEMP>81 performs "VAR1 more81"
19:43:36 MQT: stat/living/RESULT = {"Var1":"more81"}
```

So, all the rules where `TEMP>100`, are being triggered. If this scenario is not the desired one, now with this PR the rule set can be changed to:

```
rule
on event#temp>85 do VAR1 more85 break
on event#temp>83 do VAR1 more83 break
on event#temp>81 do VAR1 more81 endon
on event#temp=81 do VAR1 equal81 endon
on event#temp<81 do VAR1 less81 endon
```

So, you can have the following output:

```
18:00:17 CMD: rule
18:00:17 RSL: RESULT = {"Rule1":"ON","Once":"OFF","StopOnError":"OFF","Free":321,"Rules":"on event#temp>85 do VAR1 more85 break on event#temp>83 do VAR1 more83 break on event#temp>81 do VAR1 more81 endon on event#temp=81 do VAR1 equal81 endon on event#temp<81 do VAR1 less81 endon"}

18:00:25 CMD: event temp=10
18:00:25 RSL: RESULT = {"Event":"Done"}
18:00:25 RUL: EVENT#TEMP<81 performs "VAR1 less81"
18:00:25 RSL: RESULT = {"Var1":"less81"}

18:00:36 CMD: event temp=100
18:00:36 RSL: RESULT = {"Event":"Done"}
18:00:36 RUL: EVENT#TEMP>85 performs "VAR1 more85"
18:00:36 RSL: RESULT = {"Var1":"more85"}

18:01:05 CMD: event temp=83
18:01:05 RSL: RESULT = {"Event":"Done"}
18:01:05 RUL: EVENT#TEMP>81 performs "VAR1 more81"
18:01:05 RSL: RESULT = {"Var1":"more81"}
```

