### PR TITLE
Further improve Hass integration

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -72,7 +72,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t use_wifi_scan : 1;            // bit 6 (v6.3.0.10)
     uint32_t use_wifi_rescan : 1;          // bit 7 (v6.3.0.10)
     uint32_t receive_raw : 1;              // bit 8 (v6.3.0.11)
-    uint32_t hass_tele_as_result : 1;      // bit 9 (v6.3.0.13)
+    uint32_t hass_tele_on_power : 1;       // bit 9 (v6.3.0.13)
     uint32_t sleep_normal : 1;             // bit 10 (v6.3.0.15) - SetOption60 - Enable normal sleep instead of dynamic sleep
     uint32_t spare11 : 1;
     uint32_t spare12 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -586,6 +586,9 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
     else if (CMND_STATE == command_code) {
       mqtt_data[0] = '\0';
       MqttShowState();
+      if (Settings.flag3.hass_tele_on_power) {
+        MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
+      }
     }
     else if (CMND_SLEEP == command_code) {
       if ((payload >= 0) && (payload < 251)) {
@@ -1393,6 +1396,11 @@ void ExecuteCommandPower(byte device, byte state, int source)
 #ifdef USE_KNX
     KnxUpdatePowerState(device, power);
 #endif  // USE_KNX
+    if (publish_power && Settings.flag3.hass_tele_on_power) {
+      mqtt_data[0] = '\0';
+      MqttShowState();
+      MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
+    }
     if (device <= MAX_PULSETIMERS) {  // Restart PulseTime if powered On
       SetPulseTimer(device -1, (((POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate) ? ~power : power) & mask) ? Settings.pulse_timer[device -1] : 0);
     }
@@ -1691,11 +1699,7 @@ void PerformEverySecond(void)
 
       mqtt_data[0] = '\0';
       MqttShowState();
-      if (Settings.flag3.hass_tele_as_result) {
-        MqttPublishPrefixTopic_P(STAT, S_RSLT_RESULT, MQTT_TELE_RETAIN);
-      } else {
-        MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
-      }
+      MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
 
       mqtt_data[0] = '\0';
       if (MqttShowSensor()) {

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -624,6 +624,11 @@ void LightPreparePower(void)
 #ifdef USE_DOMOTICZ
   DomoticzUpdatePowerState(light_device);
 #endif  // USE_DOMOTICZ
+  if (Settings.flag3.hass_tele_on_power) {
+    mqtt_data[0] = '\0';
+    MqttShowState();
+    MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
+  }
 
   LightState(0);
 }

--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -206,7 +206,8 @@ void HAssAnnounceRelayLight(void)
       }
       GetPowerDevice(value_template, i, sizeof(value_template), Settings.flag.device_index_enable);
       GetTopic_P(command_topic, CMND, mqtt_topic, value_template);
-      GetTopic_P(state_topic, STAT, mqtt_topic, S_RSLT_RESULT);
+      //GetTopic_P(state_topic, STAT, mqtt_topic, S_RSLT_RESULT);
+      GetTopic_P(state_topic, TELE, mqtt_topic, D_RSLT_STATE);
       GetTopic_P(availability_topic, TELE, mqtt_topic, S_LWT);
       FindPrefix(command_topic, state_topic, prefix);
       if (Settings.flag3.hass_short_discovery_msg) {
@@ -426,7 +427,7 @@ void HAssDiscovery(uint8_t mode)
   if (Settings.flag.hass_discovery) {
     Settings.flag.mqtt_response = 0;        // Response always as RESULT and not as uppercase command
     Settings.flag.decimal_text = 1;         // Respond with decimal color values
-    Settings.flag3.hass_tele_as_result = 1; // send tele/STATE message as stat/RESULT
+    Settings.flag3.hass_tele_on_power = 1; // send tele/STATE message as stat/RESULT
 //    Settings.light_scheme = 0;           // To just control color it needs to be Scheme 0
     if (!string_ends_with(Settings.mqtt_fulltopic, "%prefix%/")) {
       strncpy_P(Settings.mqtt_fulltopic, PSTR("%topic%/%prefix%/"), sizeof(Settings.mqtt_fulltopic));


### PR DESCRIPTION
A major remaining Home Assistant annoyance is error prints when turning off a light because dimmer and RGB keys are missing from the JSON dict:
``` json
{"POWER":"OFF"}
```

A PR on Home Assistant to remove the error prints was rejected: home-assistant/home-assistant#18723

This PR instead changes Tasmota to send tele/STATUS message when:
 - power is switched
 - light property is changed
 - `state` command is received

And also changes Hass configuration to pick light and power status from the tele/STAT JSON dict:
``` json
{
  "Time":"2018-12-02T16:51:43",
  "Uptime":"0T00:10:45",
  "Vcc":3.215,
  "SleepMode":"Dynamic",
  "Sleep":0,
  "LoadAvg":999,
  "POWER":"ON",
  "Dimmer":23,
  "Color":"58,0,0,0,0",
  "HSBColor":"0,100,23",
  "Channel":[23, 0, 0, 0, 0],
  "CT":499,
  "Scheme":0,
  "Fade":"OFF",
  "Speed":1,
  "LedTable":"OFF",
  "Wifi":{
    "AP":1,
    "SSId":"SomeWLAN",
    "BSSId":"78:8A:20:D1:0B:21",
    "Channel":11,
    "RSSI":66
  }
}
```