### PR TITLE
MCP230xx - Add Interrupt Retain

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,6 +1,7 @@
 /* 6.3.0.16 20181201
  * Add support for iFan02 Fanspeed in Domoticz using a selector (#4517)
  * Add Announce Switches to MQTT Discovery (#4531)
+ * Update MCP230xx driver to support interrupt retention over teleperiod (#4547)
  *
  * 6.3.0.15 20181201
  * Removed command SetOption36 (#4497)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -156,7 +156,7 @@ typedef union {
     uint16_t int_report_mode : 2;           // Interrupt reporting mode 0 = immediate telemetry & event, 1 = immediate event only, 2 = immediate telemetry only
     uint16_t int_report_defer : 4;          // Number of interrupts to ignore until reporting (default 0, max 15)
     uint16_t int_count_en : 1;              // Enable interrupt counter for this pin
-    uint16_t spare12 : 1;
+    uint16_t int_retain_flag : 1;           // Report if interrupt occured for pin in next teleperiod
     uint16_t spare13 : 1;
     uint16_t spare14 : 1;
     uint16_t spare15 : 1;

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -47,11 +47,14 @@ uint8_t mcp230xx_pincount = 0;
 uint8_t mcp230xx_int_en = 0;
 uint8_t mcp230xx_int_prio_counter = 0;
 uint8_t mcp230xx_int_counter_en = 0;
+uint8_t mcp230xx_int_retainer_en = 0;
 uint8_t mcp230xx_int_sec_counter = 0;
 
 uint8_t mcp230xx_int_report_defer_counter[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
 
 uint16_t mcp230xx_int_counter[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+
+uint8_t mcp230xx_int_retainer[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}; // Used to store if an interrupt occured that needs to be retained until teleperiod
 
 unsigned long int_millis[16]; // To keep track of millis() since last interrupt
 
@@ -79,6 +82,20 @@ void MCP230xx_CheckForIntCounter(void) {
   }
 }
   
+void MCP230xx_CheckForIntRetainer(void) {
+  uint8_t en = 0;
+  for (uint8_t ca=0;ca<16;ca++) {
+    if (Settings.mcp230xx_config[ca].int_retain_flag) {
+      en=1;
+    }
+  }
+  mcp230xx_int_retainer_en=en;
+  if (!mcp230xx_int_retainer_en) { // Interrupt counters are disabled, so we clear all the counters
+    for (uint8_t ca=0;ca<16;ca++) {
+      mcp230xx_int_retainer[ca] = 0;
+    }
+  }
+}
 
 const char* ConvertNumTxt(uint8_t statu, uint8_t pinmod=0) {
 #ifdef USE_MCP230xx_OUTPUT
@@ -177,7 +194,8 @@ void MCP230xx_ApplySettings(void) {
     int_millis[idx]=millis();
   }
   mcp230xx_int_en = int_en;
-  MCP230xx_CheckForIntCounter(); // update register on whether or not we should be counting interrupts
+  MCP230xx_CheckForIntCounter();  // update register on whether or not we should be counting interrupts
+  MCP230xx_CheckForIntRetainer(); // update register on whether or not we should be retaining interrupt events for teleperiod
 }
 
 void MCP230xx_Detect(void)
@@ -256,6 +274,13 @@ void MCP230xx_CheckForInterrupt(void) {
                     } else {
                       report_int = 0; // defer int report for now
                     }
+                  }
+                }
+                // check if interrupt retain is used, if it is for this pin then we do not report immediately as it will be reported in teleperiod
+                if (report_int) {
+                  if (Settings.mcp230xx_config[intp+(mcp230xx_port*8)].int_retain_flag) {
+                    mcp230xx_int_retainer[intp+(mcp230xx_port*8)] = 1;
+                    report_int = 0; // do not report for now
                   }
                 }
                 if (Settings.mcp230xx_config[intp+(mcp230xx_port*8)].int_count_en) { // We do not want to report via tele or event if counting is enabled
@@ -382,8 +407,8 @@ void MCP230xx_Reset(uint8_t pinmode) {
       Settings.mcp230xx_config[pinx].int_report_mode=3; // Disabled for pinmode 1, 5 and 6 (No interrupts there)
     }
     Settings.mcp230xx_config[pinx].int_report_defer=0; // Disabled
-    Settings.mcp230xx_config[pinx].int_count_en=0;  // Disabled
-    Settings.mcp230xx_config[pinx].spare12=0;
+    Settings.mcp230xx_config[pinx].int_count_en=0;     // Disabled by default
+    Settings.mcp230xx_config[pinx].int_retain_flag=0;  // Disabled by default
     Settings.mcp230xx_config[pinx].spare13=0;
     Settings.mcp230xx_config[pinx].spare14=0;
     Settings.mcp230xx_config[pinx].spare15=0;
@@ -533,6 +558,41 @@ bool MCP230xx_Command(void) {
           }
         } else {
           snprintf_P(mqtt_data, sizeof(mqtt_data), MCP230XX_INTCFG_RESPONSE,"CNT",pin,Settings.mcp230xx_config[pin].int_count_en);  // "{\"MCP230xx_INT%s\":{\"D_%i\":%i}}";
+          return serviced;
+        }
+      }
+      serviced = false;
+      return serviced;
+    } else {
+      serviced = false;
+      return serviced;
+    }
+  }
+
+  if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 1),"INTRETAIN")) {
+    if (paramcount > 1) {
+      uint8_t pin = atoi(subStr(sub_string, XdrvMailbox.data, ",", 2));
+      if (pin < mcp230xx_pincount) {
+        if (pin == 0) {
+          if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "0")) validpin=true;
+        } else {
+          validpin = true;
+        }
+      }
+      if (validpin) {
+        if (paramcount > 2) {
+          uint8_t int_retain = atoi(subStr(sub_string, XdrvMailbox.data, ",", 3));
+          if ((int_retain >= 0) && (int_retain <= 1)) {
+            Settings.mcp230xx_config[pin].int_retain_flag=int_retain;
+            snprintf_P(mqtt_data, sizeof(mqtt_data), MCP230XX_INTCFG_RESPONSE,"INT_RETAIN",pin,Settings.mcp230xx_config[pin].int_retain_flag);
+            MCP230xx_CheckForIntRetainer();
+            return serviced;
+          } else {
+            serviced=false;
+            return serviced;
+          }
+        } else {
+          snprintf_P(mqtt_data, sizeof(mqtt_data), MCP230XX_INTCFG_RESPONSE,"INT_RETAIN",pin,Settings.mcp230xx_config[pin].int_retain_flag);
           return serviced;
         }
       }
@@ -703,6 +763,19 @@ void MCP230xx_Interrupt_Counter_Report(void) {
   mcp230xx_int_sec_counter = 0;
 }
 
+void MCP230xx_Interrupt_Retain_Report(void) {
+  uint16_t retainresult = 0;
+  snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_TIME "\":\"%s\",\"MCP_INTRETAIN\": {"), GetDateAndTime(DT_LOCAL).c_str());
+  for (uint8_t pinx = 0;pinx < mcp230xx_pincount;pinx++) {
+    if (Settings.mcp230xx_config[pinx].int_retain_flag) { 
+      snprintf_P(mqtt_data,sizeof(mqtt_data), PSTR("%s\"D%i\":%i,"),mqtt_data,pinx,mcp230xx_int_retainer[pinx]);
+      retainresult |= (((mcp230xx_int_retainer[pinx])&1) << pinx);
+      mcp230xx_int_retainer[pinx]=0;
+    }
+  }
+  snprintf_P(mqtt_data,sizeof(mqtt_data),PSTR("%s\"Value\":%u}}"),mqtt_data,retainresult);
+  MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
+}
 
 /*********************************************************************************************\
    Interface
@@ -722,6 +795,11 @@ boolean Xsns29(byte function)
           mcp230xx_int_sec_counter++;
           if (mcp230xx_int_sec_counter >= Settings.mcp230xx_int_timer) { // Interrupt counter interval reached, lets report
             MCP230xx_Interrupt_Counter_Report();
+          }
+        }
+        if (tele_period == 0) {
+          if (mcp230xx_int_retainer_en) { // We have pins configured for interrupt retain reporting
+            MCP230xx_Interrupt_Retain_Report();
           }
         }
 #ifdef USE_MCP230xx_OUTPUT


### PR DESCRIPTION
Add new setting for retaining interrupt until next teleperiod = 0

New command:
sensor29 intretain,pin,0 // Disable interrupt retain for pin
sensor29 intretain,pin,1 // Enable interrupt retain for pin

Enabling interrupt retain will disable immediate telemetry and event reporting but will retain the fact that an interrupt has occurred for a particular pin.

This data is then reported when teleperiod reaches 0 as follows:

`{"Time":"2018-12-06T23:59:26","MCP_INTRETAIN": {"D0":1,"D1":0,"D2":1,"D3":1,"D4":0,"Value":13}}`

The pins on which interrupts occurred are reported as 1 and the combined bitset is represented as a decimal representation in Value.

For the functionality to work the relevant pins also need to be configured as INPUT with Interrupt (mode of choice) enabled.

All other interrupt-related responses are suppressed when interrupt retain is enabled for a particular pin but will still report as normal for pins not enabled for interrupt retain.

Once telemetry has been done the state of each retention is reset to 0.

This PR is related to user use case initially proposed by PR https://github.com/arendst/Sonoff-Tasmota/pull/4536 and then reworked after discussion on Discord Chat as to what the actual requirements need to be.