### PR TITLE
Announce RGBW light, add 'White' helper command

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -330,6 +330,7 @@
 #define D_CMND_SPEED "Speed"
 #define D_CMND_WAKEUP "Wakeup"
 #define D_CMND_WAKEUPDURATION "WakeUpDuration"
+#define D_CMND_WHITE "White"
 #define D_CMND_WIDTH "Width"
 
 // Commands xdrv_05_irremote.ino

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -58,11 +58,11 @@
 enum LightCommands {
   CMND_COLOR, CMND_COLORTEMPERATURE, CMND_DIMMER, CMND_LED, CMND_LEDTABLE, CMND_FADE,
   CMND_PIXELS, CMND_RGBWWTABLE, CMND_ROTATION, CMND_SCHEME, CMND_SPEED, CMND_WAKEUP, CMND_WAKEUPDURATION,
-  CMND_WIDTH, CMND_CHANNEL, CMND_HSBCOLOR, CMND_UNDOCA };
+  CMND_WHITE, CMND_WIDTH, CMND_CHANNEL, CMND_HSBCOLOR, CMND_UNDOCA };
 const char kLightCommands[] PROGMEM =
   D_CMND_COLOR "|" D_CMND_COLORTEMPERATURE "|" D_CMND_DIMMER "|" D_CMND_LED "|" D_CMND_LEDTABLE "|" D_CMND_FADE "|"
   D_CMND_PIXELS "|" D_CMND_RGBWWTABLE "|" D_CMND_ROTATION "|" D_CMND_SCHEME "|" D_CMND_SPEED "|" D_CMND_WAKEUP "|" D_CMND_WAKEUPDURATION "|"
-  D_CMND_WIDTH "|" D_CMND_CHANNEL "|" D_CMND_HSBCOLOR "|UNDOCA" ;
+  D_CMND_WHITE "|" D_CMND_WIDTH "|" D_CMND_CHANNEL "|" D_CMND_HSBCOLOR "|UNDOCA" ;
 
 struct LRgbColor {
   uint8_t R, G, B;
@@ -1098,7 +1098,13 @@ boolean LightCommand(void)
   if (-1 == command_code) {
     serviced = false;  // Unknown command
   }
-  else if ((CMND_COLOR == command_code) && (light_subtype > LST_SINGLE) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= 6)) {
+  else if ((CMND_WHITE == command_code) && (light_subtype == LST_RGBW) && (XdrvMailbox.index == 1)) {
+    command_code = CMND_COLOR;
+    uint8_t value = atoi(XdrvMailbox.data);
+    snprintf_P(scolor, sizeof(scolor), PSTR("0,0,0,%d"), value*255/100);
+    XdrvMailbox.data = scolor;
+  }
+  if ((CMND_COLOR == command_code) && (light_subtype > LST_SINGLE) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= 6)) {
     if (XdrvMailbox.data_len > 0) {
       valid_entry = LightColorEntry(XdrvMailbox.data, XdrvMailbox.data_len);
       if (valid_entry) {

--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -61,6 +61,12 @@ const char HASS_DISCOVER_LIGHT_COLOR[] PROGMEM =
   "\"rgb_state_topic\":\"%s\","                    // stat/led2/RESULT
   "\"rgb_value_template\":\"{{value_json." D_CMND_COLOR ".split(',')[0:3]|join(',')}}\"";
 
+const char HASS_DISCOVER_LIGHT_WHITE[] PROGMEM =
+  "%s,\"white_value_command_topic\":\"%s\","       // cmnd/led2/White
+  "\"white_value_state_topic\":\"%s\","            // stat/led2/RESULT
+  "\"white_value_scale\":100,"
+  "\"white_value_template\":\"{{ value_json.Channel[3] }}\"";
+
 const char HASS_DISCOVER_LIGHT_CT[] PROGMEM =
   "%s,\"color_temp_command_topic\":\"%s\","        // cmnd/led2/CT
   "\"color_temp_state_topic\":\"%s\","             // stat/led2/RESULT
@@ -125,6 +131,12 @@ const char HASS_DISCOVER_LIGHT_COLOR_SHORT[] PROGMEM =
   "%s,\"rgb_cmd_t\":\"%s2\","                      // cmnd/led2/Color2
   "\"rgb_stat_t\":\"%s\","                         // stat/led2/RESULT
   "\"rgb_val_tpl\":\"{{value_json." D_CMND_COLOR ".split(',')[0:3]|join(',')}}\"";
+
+const char HASS_DISCOVER_LIGHT_WHITE_SHORT[] PROGMEM =
+  "%s,\"whit_val_cmd_t\":\"%s\","                  // cmnd/led2/White
+  "\"whit_val_stat_t\":\"%s\","                    // stat/led2/RESULT
+  "\"white_value_scale\":100,"                     // (No abbreviation defined)
+  "\"whit_val_tpl\":\"{{ value_json.Channel[3] }}\"";
 
 const char HASS_DISCOVER_LIGHT_CT_SHORT[] PROGMEM =
   "%s,\"clr_temp_cmd_t\":\"%s\","                  // cmnd/led2/CT
@@ -257,6 +269,16 @@ void HAssAnnounceRelayLight(void)
             snprintf_P(mqtt_data, sizeof(mqtt_data), HASS_DISCOVER_LIGHT_SCHEME_SHORT, mqtt_data, effect_command_topic, state_topic);
           }
 
+        }
+        if (LST_RGBW == light_subtype) {
+          char _white_temp_command_topic[TOPSZ];
+          char *white_temp_command_topic = _white_temp_command_topic;
+
+          GetTopic_P(white_temp_command_topic, CMND, mqtt_topic, D_CMND_WHITE);
+          if (Settings.flag3.hass_short_discovery_msg)
+            Shorten(&white_temp_command_topic, prefix);
+          snprintf_P(mqtt_data, sizeof(mqtt_data), Settings.flag3.hass_short_discovery_msg?HASS_DISCOVER_LIGHT_WHITE_SHORT:HASS_DISCOVER_LIGHT_WHITE,
+                     mqtt_data, white_temp_command_topic, state_topic);
         }
         if ((LST_COLDWARM == light_subtype) || (LST_RGBWC == light_subtype)) {
           char _color_temp_command_topic[TOPSZ];


### PR DESCRIPTION
Add support for Hass MQTT discovery for RGBW light

Also add new helper command 'White', only supported for RGBW-light, which will turn off RGB channels and set white channel to the specified level.

The purpose of this command is to align with Hass mqtt.light (https://www.home-assistant.io/components/light.mqtt/) which expects the light's white value to be sent as an integer to a specified topic, and which can't be templated. Otherwise "Color 0,0,0,<white_level>" would have worked just as well.