### PR TITLE
Enable forced local operation when button- or switchtopic is set

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -96,6 +96,7 @@
 #define MQTT_BUTTON_RETAIN     0                 // [ButtonRetain] Button may send retain flag (0 = off, 1 = on)
 #define MQTT_POWER_RETAIN      0                 // [PowerRetain] Power status message may send retain flag (0 = off, 1 = on)
 #define MQTT_SWITCH_RETAIN     0                 // [SwitchRetain] Switch may send retain flag (0 = off, 1 = on)
+#define MQTT_BUTTON_SWITCH_FORCE_LOCAL     0     // [SetOption61] Force local operation when button/switch topic is set (0 = off, 1 = on)
 
 #define MQTT_STATUS_OFF        "OFF"             // [StateText1] Command or Status result when turned off (needs to be a string like "0" or "Off")
 #define MQTT_STATUS_ON         "ON"              // [StateText2] Command or Status result when turned on (needs to be a string like "1" or "On")

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -74,7 +74,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t receive_raw : 1;              // bit 8 (v6.3.0.11)
     uint32_t hass_tele_on_power : 1;       // bit 9 (v6.3.0.13)
     uint32_t sleep_normal : 1;             // bit 10 (v6.3.0.15) - SetOption60 - Enable normal sleep instead of dynamic sleep
-    uint32_t spare11 : 1;
+    uint32_t button_switch_force_local : 1;// bit 11
     uint32_t spare12 : 1;
     uint32_t spare13 : 1;
     uint32_t spare14 : 1;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -486,6 +486,7 @@ void SettingsDefaultSet2(void)
   Settings.flag.mqtt_power_retain = MQTT_POWER_RETAIN;
   Settings.flag.mqtt_button_retain = MQTT_BUTTON_RETAIN;
   Settings.flag.mqtt_switch_retain = MQTT_SWITCH_RETAIN;
+  Settings.flag3.button_switch_force_local = MQTT_BUTTON_SWITCH_FORCE_LOCAL;
 //  Settings.flag.mqtt_sensor_retain = 0;
 //  Settings.flag.mqtt_offline = 0;
 //  Settings.flag.mqtt_serial = 0;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1316,7 +1316,7 @@ boolean SendKey(byte key, byte device, byte state)
     if (9 == state) {
       mqtt_data[0] = '\0';
     } else {
-      if ((!strcmp(mqtt_topic, key_topic) || !strcmp(Settings.mqtt_grptopic, key_topic)) && (2 == state)) {
+      if ((Settings.flag3.button_switch_force_local || !strcmp(mqtt_topic, key_topic) || !strcmp(Settings.mqtt_grptopic, key_topic)) && (2 == state)) {
         state = ~(power >> (device -1)) &1;
       }
       snprintf_P(mqtt_data, sizeof(mqtt_data), GetStateText(state));
@@ -1328,7 +1328,7 @@ boolean SendKey(byte key, byte device, byte state)
 #else
     MqttPublishDirect(stopic, (key) ? Settings.flag.mqtt_switch_retain : Settings.flag.mqtt_button_retain);
 #endif  // USE_DOMOTICZ
-    result = true;
+    result = !Settings.flag3.button_switch_force_local;
   } else {
     snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"%s%d\":{\"State\":%d}}"), (key) ? "Switch" : "Button", device, state);
     result = XdrvRulesProcess();

--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -345,9 +345,10 @@ void HAssAnnounceSwitches(void)
 
       // Check if MQTT message will be ON/OFF or TOGGLE
       if (Settings.switchmode[switch_index] == FOLLOW || Settings.switchmode[switch_index] == FOLLOW_INV ||
+          Settings.flag3.button_switch_force_local ||
           !strcmp(mqtt_topic, sw_topic) || !strcmp(Settings.mqtt_grptopic, sw_topic))
       {
-        toggle = 0;
+        toggle = 0; // MQTT message will be ON/OFF
       }
 
       HAssAnnounceButtonSwitch(switch_index, sw_topic, switch_present, 0, toggle);
@@ -377,9 +378,10 @@ void HAssAnnounceButtons(void)
       }
 
       // Check if MQTT message will be ON/OFF or TOGGLE
-      if (!strcmp(mqtt_topic, key_topic) || !strcmp(Settings.mqtt_grptopic, key_topic))
+      if (Settings.flag3.button_switch_force_local ||
+          !strcmp(mqtt_topic, key_topic) || !strcmp(Settings.mqtt_grptopic, key_topic))
       {
-        toggle = 0;
+        toggle = 0; // MQTT message will be ON/OFF
       }
 
       HAssAnnounceButtonSwitch(button_index, key_topic, button_present, 1, toggle);


### PR DESCRIPTION
Add new option `SetOption61` which enables forced local operation when button- or switchtopic is set

The purpose is to allow non-ambiguous switch topic for automatic while still have fast local operation.
In my case, this is needed for good user experience with Sonoff T1 switches.