### PR TITLE
Analog scaling for ADC analog input A0

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -538,7 +538,7 @@ const char HTTP_SNS_TEMP[] PROGMEM = "%s{s}%s " D_TEMPERATURE "{m}%s&deg;%c{e}";
 const char HTTP_SNS_HUM[] PROGMEM = "%s{s}%s " D_HUMIDITY "{m}%s%%{e}";                                      // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 const char HTTP_SNS_PRESSURE[] PROGMEM = "%s{s}%s " D_PRESSURE "{m}%s %s{e}";                                // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 const char HTTP_SNS_SEAPRESSURE[] PROGMEM = "%s{s}%s " D_PRESSUREATSEALEVEL "{m}%s %s{e}";                   // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
-const char HTTP_SNS_ANALOG[] PROGMEM = "%s{s}%s " D_ANALOG_INPUT "%d{m}%d{e}";                               // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+const char HTTP_SNS_ANALOG[] PROGMEM = "%s{s}%s " D_ANALOG_INPUT "%d{m}%s{e}";                               // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 
 #if defined(USE_MHZ19) || defined(USE_SENSEAIR)
 const char HTTP_SNS_CO2[] PROGMEM = "%s{s}%s " D_CO2 "{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";                // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -182,6 +182,10 @@
 #define PRESSURE_RESOLUTION    1                 // [PressRes] Maximum number of decimals (0 - 3) showing sensor Pressure
 #define ENERGY_RESOLUTION      3                 // [EnergyRes] Maximum number of decimals (0 - 5) showing energy usage in kWh
 
+#define ADC_SCALE              1                 // Scale value for analog scaling (used if USE_ADC_VCC is disabled)
+#define ADC_OFFSET             0                 // Offset value for analog scaling (used if USE_ADC_VCC is disabled)
+#define ADC_DECIMALS           3                 // Number of decimals of scaled analog value (used if USE_ADC_VCC is disabled)
+
 /*********************************************************************************************\
  * END OF SECTION 1
  *

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -165,6 +165,14 @@ typedef union {
   };
 } Mcp230xxCfg;
 
+typedef union {
+  struct {
+    int scale;                              // Scale value for analog scaling
+    int offset;                             // Offset value for analog scaling
+    uint8_t resolution;                     // Number of decimals of scaled analog value
+  };
+} AdcCfg;
+
 /*
 struct SYSCFG {
   unsigned long cfg_holder;                // 000 Pre v6 header
@@ -338,7 +346,8 @@ struct SYSCFG {
   uint16_t      web_refresh;               // 7CC
   char          mems[MAX_RULE_MEMS][10];   // 7CE
   char          rules[MAX_RULE_SETS][MAX_RULE_SIZE]; // 800 uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
-                                           // E00 - FFF free locations
+  AdcCfg        adc_config;                // E00 Uses 9 bytes
+                                           // E0A - FFF free locations
 } Settings;
 
 struct RTCRBT {

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -632,6 +632,13 @@ void SettingsDefaultSet2(void)
   Settings.longitude = (int)((double)LONGITUDE * 1000000);
   SettingsDefaultSet_5_13_1c();  // Time STD/DST settings
 
+  // Analog
+  #ifndef USE_ADC_VCC
+  Settings.adc_config.scale = (int)((double)ADC_SCALE * 10000);
+  Settings.adc_config.offset = (int)((double)ADC_OFFSET * 10000);
+  Settings.adc_config.resolution = ADC_DECIMALS;
+  #endif // USE_ADC_VCC
+
   Settings.button_debounce = KEY_DEBOUNCE_TIME;
   Settings.switch_debounce = SWITCH_DEBOUNCE_TIME;
 

--- a/sonoff/xsns_02_analog.ino
+++ b/sonoff/xsns_02_analog.ino
@@ -25,16 +25,23 @@
 #define XSNS_02             2
 
 uint16_t adc_last_value = 0;
+double scale = 1;
+double offset = 0;
+uint8_t resolution = 3;
 
-uint16_t AdcRead(void)
+const char ADC_SENSOR_RESPONSE[] PROGMEM = "{\"Sensor02_A%i\":{\"SCALE\":%s,\"OFFSET\":%s,\"DECIMALS\":%i}}";
+
+double AdcRead(void)
 {
-  uint16_t analog = 0;
+  uint16_t analogRaw = 0;   // Raw analog value read from analog input
+  double analogEU;          // Scaled analog value in engineering units
   for (byte i = 0; i < 32; i++) {
-    analog += analogRead(A0);
+    analogRaw += analogRead(A0);
     delay(1);
   }
-  analog >>= 5;
-  return analog;
+  analogRaw >>= 5;
+  analogEU = scale * analogRaw + offset;
+  return analogEU;
 }
 
 #ifdef USE_RULES
@@ -52,15 +59,93 @@ void AdcEvery250ms(void)
 
 void AdcShow(boolean json)
 {
-  uint16_t analog = AdcRead();
+  char analog[10];
+  double analogEU = AdcRead();
+  dtostrfd(analogEU, resolution, analog);
 
   if (json) {
-    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"ANALOG\":{\"A0\":%d}"), mqtt_data, analog);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"ANALOG\":{\"A0\":%s}"), mqtt_data, analog);
 #ifdef USE_WEBSERVER
   } else {
     snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_ANALOG, mqtt_data, "", 0, analog);
 #endif  // USE_WEBSERVER
   }
+}
+
+/***********************************************************************************\
+ * Command Sensor02
+ *
+ * Analog scaling formula: 
+ *    analogEU = SCALE * analogRaw + OFFSET
+ * 
+ * Command  | Payload       | Description
+ * ---------|---------------|---------------------------------------------
+ * Sensor02 |               | Show current parameter values
+ * Sensor02 | SCALE,a       | Set scale to value a. Scale is double 
+ * Sensor02 | OFFSET,b      | Set offset to value b. Offset is double
+ * Sensor02 | DECIMALS,d    | Set resolution to d decimal digits.
+ ***********************************************************************************/
+
+bool AdcCommandSensor(void)
+{
+  boolean serviced = true;
+  uint8_t paramcount = 0;
+  char scale_str[10];
+  char offset_str[10];
+
+  if (XdrvMailbox.data_len > 0) {
+    paramcount=1;
+  }
+  else {
+    dtostrfd(scale, 4, scale_str);
+    dtostrfd(offset, 4, offset_str);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), ADC_SENSOR_RESPONSE,0,scale_str,offset_str,resolution);
+    return serviced;
+  }
+
+  char sub_string[XdrvMailbox.data_len];
+  for (uint8_t ca=0;ca<XdrvMailbox.data_len;ca++) { // Replace <space> and <=> with <,> and count parameters
+    if ((' ' == XdrvMailbox.data[ca]) || ('=' == XdrvMailbox.data[ca])) { XdrvMailbox.data[ca] = ','; }
+    if (',' == XdrvMailbox.data[ca]) { paramcount++; }
+  }
+  UpperCase(XdrvMailbox.data,XdrvMailbox.data); // All upper case
+
+  if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 1),"SCALE")) {  // SCALE Command parameter
+    if (paramcount > 1) {
+      scale = CharToDouble(subStr(sub_string, XdrvMailbox.data, ",", 2));
+      AdcShow(1);
+      return serviced;
+    }
+    else {
+      serviced = false;
+      return serviced;
+    }
+  }
+
+  if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 1),"OFFSET")) { // OFFSET Command parameter
+    if (paramcount > 1) {
+      offset = CharToDouble(subStr(sub_string, XdrvMailbox.data, ",", 2));
+      AdcShow(1);
+      return serviced;
+    }
+    else {
+      serviced = false;
+      return serviced;
+    }
+  }
+
+  if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 1),"DECIMALS")) { // DECIMALS Command parameter
+    if (paramcount > 1) {
+      resolution = CharToDouble(subStr(sub_string, XdrvMailbox.data, ",", 2));
+      AdcShow(1);
+      return serviced;
+    }
+    else {
+      serviced = false;
+      return serviced;
+    }
+  }
+
 }
 
 /*********************************************************************************************\
@@ -73,6 +158,15 @@ boolean Xsns02(byte function)
 
   if (pin[GPIO_ADC0] < 99) {
     switch (function) {
+      case FUNC_COMMAND:
+        if (XSNS_02 == XdrvMailbox.index) {
+          result = AdcCommandSensor();
+      
+ //         snprintf_P(log_data, sizeof(log_data), PSTR("ANALOG: Cmd Result %s"), result ? "true" : "false");
+ //         AddLog(LOG_LEVEL_DEBUG);
+      
+        }
+        break;
 #ifdef USE_RULES
       case FUNC_EVERY_250_MSECOND:
         AdcEvery250ms();


### PR DESCRIPTION
Hi,

The current implementation of analog input (sensor02) uses only raw values (0-1024)
This update adds the new feature of scaling the raw analog value to engineering units.

The scaling is based on the linear formula:
**analogEU = Scale * analogRaw + Offset**
where:
- analogEU: The scaled analog value in engineering units. The type is double.
- Scale: The scale factor. The type is double
- analogRaw: The analog raw value read by the ADC. The type is uint16_t
- Offset: The offset value. The type is double.

The scale and offset values are set by using the new command "sensor02".
See the comments in xsns_02_analog.ino for details about its format.

Also, the number of decimals for the scaled analog value can be set by using the "sensor02" command.

The scaling parameters are stored in flash memory and can be initialized in my_user_config.h

If this update is accepted I will create a new Wiki page on how to use the analog input with the new feature.

Thanks,
evzone