### PR TITLE
Add support for MANZUKO smart power strip (WT003-EU)

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -266,6 +266,7 @@ enum SupportedModules {
   SK03_TUYA,
   PS_16_DZ,
   TECKIN_US,
+  MANZOKU_EU_4,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -499,6 +500,7 @@ const uint8_t kModuleNiceList[MAXMODULE] PROGMEM = {
   SK03_TUYA,
   NEO_COOLCAM,        // Socket Relay Devices
   OBI,
+  MANZOKU_EU_4,
   ESP_SWITCH,         // Switch Devices
   TUYA_DIMMER,        // Dimmer Devices
   ARMTRONIX_DIMMERS,
@@ -1324,6 +1326,21 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_KEY1,        // GPIO13 Button
      GPIO_NRG_CF1,     // GPIO14 BL0937 or HJL-01 CF1 current / voltage
      0, 0, 0
+  },
+  { "Manzoku strip",      // "MANZOKU" labeled power strip, EU version
+     0,                // GPIO00
+     0,                // GPIO01 Serial RXD
+     0,
+     GPIO_KEY1,        // GPIO03 Serial TXD + Button
+     GPIO_REL2,        // GPIO04 Relay 2
+     GPIO_REL1,        // GPIO05 Relay 1
+     0, 0, 0, 0, 0, 0,
+     GPIO_REL3,        // GPIO12 Relay 3
+     GPIO_REL4,        // GPIO13 Relay 4
+     GPIO_USER,        // GPIO14
+     0,
+     GPIO_USER,        // GPIO16
+     0
   }
 };
 


### PR DESCRIPTION
## Description
Adds support for MANZUKO smart power strip.
There are various different labeled versions of this device (german version):
* https://www.amazon.de/Steckdosenleiste-AOFO-Mehrfachsteckdose-%C3%9Cberspannungsschutz-Sprachsteuerung/dp/B07GBSD11P/
* https://www.amazon.de/Steckdosenleiste-Geekbes-USB-Anschluss-Kompatibel-gesteuert/dp/B078W23BW9/

Mine is labeled "MANZUKO".
If anyone knows a common description of all of them, please comment.

Similar looking US version with different PCB, ESP8266 packaging and pin allocation:
https://github.com/arendst/Sonoff-Tasmota/wiki/SM-SO301

The ESP8266 package is "TYWE2S":
![la_wf3_08](https://user-images.githubusercontent.com/20602537/49807428-53d2ad80-fd5a-11e8-8ed4-18e65c5a281c.png)


## Flashing
Pull GPIO0 to ground.

## Pin allocation
\# GPIO | Fx
--- | ---
03 | Button 1
04 | Relay 2
05 | Relay 1
12 | Relay 3
13 | Relay 4
14 | ?