### PR TITLE
Read response on WebSend instead of just fulshing it

### DIFF
--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -1981,7 +1981,16 @@ int WebSend(char *buffer)
 //AddLog(LOG_LEVEL_DEBUG);
 
         client.print(url.c_str());
-        client.flush();
+//        String rsp = "";
+        while (client.connected())
+        {
+          if (client.available()) {
+            char c = client.read();
+//            rsp += c;
+          }
+        }
+//        snprintf_P(log_data, sizeof(log_data), PSTR("DBG: Resp |%s|"), rsp.c_str());
+//        AddLog(LOG_LEVEL_DEBUG);
         client.stop();
         status = 0;                           // No error - Done
       } else {


### PR DESCRIPTION
This makes the communication between two tasmota devices reliable.

Exemple to remote control a S26 from a T1:
rule1 on Power2#State do WebSend [sonoff-2] Power %value% endon