### PR TITLE
New 2.5.0-2 toolchain does not like uncast bitwise

### DIFF
--- a/lib/esp-knx-ip-0.5.1/esp-knx-ip-send.cpp
+++ b/lib/esp-knx-ip-0.5.1/esp-knx-ip-send.cpp
@@ -133,7 +133,7 @@ void ESPKNXIP::send_2byte_float(address_t const &receiver, knx_command_type_t ct
 	++e;
 	for (; v > 2047.0f; v /= 2)
 	++e;
-	long m = round(v) & 0x7FF;
+	long m = (long)round(v) & 0x7FF;
 	short msb = (short) (e << 3 | m >> 8);
 	if (val < 0.0f)
 	msb |= 0x80;


### PR DESCRIPTION
The new toolchain (2.5.0-2) used from core 2.5.0 does not want bitwise operations to be performed on non-integer variables so we cast the double used in send_2byte_float() to a (long) as it should be.