### PR TITLE
Fix NewPing-1.9.1 library.properties

### DIFF
--- a/lib/NewPing-1.9.1/library.properties
+++ b/lib/NewPing-1.9.1/library.properties
@@ -6,5 +6,5 @@ sentence=A library that makes working with ultrasonic sensors easy.
 paragraph=When I first received an ultrasonic sensor I was not happy with how poorly it performed. I soon realized the problem was not the sensor, it was the available ping and ultrasonic libraries causing the problem. The NewPing library totally fixes these problems, adds many new features, and breathes new life into these very affordable distance sensors.
 category=Sensors
 url=https://bitbucket.org/teckel12/arduino-new-ping/wiki/Home
-architectures=avr,arm
+architectures=avr,arm,esp8266
 includes=NewPing.h


### PR DESCRIPTION
Fix NewPing-1.9.1 library.properties to avoid compiler warning about possibly not supporting ESP8266 whereas we know now that it does. This causes the compiler warning (which may alarm some users unnecessarily) that NewPing claims to run on avr and stm32.