### PR TITLE
option for firmware directory added

### DIFF
--- a/tools/fw_server/fw-server.py
+++ b/tools/fw_server/fw-server.py
@@ -24,7 +24,8 @@ Requirements:
    - pip install netifaces flask
 
 Instructions:
-    Copy Sonoff-Tasmota firmware binary files in 'fw' directory.
+    Copy Sonoff-Tasmota firmware binary files in 'fw' directory or
+    specify a different directory with -f parameter.
     A set of prebuilt files can be downloaded by Sonoff-Tasmota release page:
         https://github.com/arendst/Sonoff-Tasmota/releases
 
@@ -51,7 +52,6 @@ from sys import exit
 from flask import Flask, send_file
 import netifaces as ni
 
-
 usage = "usage: fw-server {-d | -i} arg"
 
 parser = OptionParser(usage)
@@ -59,6 +59,8 @@ parser.add_option("-d", "--dev", action="store", type="string",
                   dest="netdev", default="eth0", help="network interface (default: eth0)")
 parser.add_option("-i", "--ip", action="store", type="string",
                   dest="ip", help="IP address to bind")
+parser.add_option("-f", "--fwdir", action="store", type="string",
+                  dest="fwdir", help="firmware absolute path directory (default: fw/ directory)")
 (options, args) = parser.parse_args()
 
 netip = None
@@ -72,14 +74,24 @@ if options.ip is None:
 else:
     netip = options.ip
 
+if options.fwdir is None:
+    fwdir = os.path.dirname(os.path.realpath(__file__)) + "/fw/"
+else:
+    if os.path.isdir(options.fwdir):
+        fwdir = options.fwdir
+    else:
+        print("E: directory " + options.fwdir + " not available")
+        exit(1)
+
+print(" * Directory: " + fwdir)
 
 app = Flask(__name__)
 
 
 @app.route('/<filename>')
 def fw(filename):
-    if os.path.exists("fw/" + str(filename)):
-        return send_file("fw/" + str(filename),
+    if os.path.exists(fwdir + str(filename)):
+        return send_file(fwdir + str(filename),
                          attachment_filename=filename,
                          mimetype='application/octet-stream')
 


### PR DESCRIPTION
Hi,
I added a new option for fw-server.py in order to specify a different firmware directory.
The script works also if launched from an external directory by absolute pathname...