### PR TITLE
platformio: fix build with core 2.4.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; *** Esp8266 core for Arduino version 2.4.2
 platform                  = espressif8266@1.8.0
 build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Tesp8266.flash.1m0.ld
                             -lstdc++ -lsupc++
 ; lwIP 1.4 (Default)
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH


### PR DESCRIPTION
`pio run` fails with the following message when building against core 2.4.2:

```
/home/chaosmaster/.platformio/packages/toolchain-xtensa/bin/../lib/gcc/xtensa-lx106-elf/4.8.2/../../../../xtensa-lx106-elf/bin/ld: cannot open linker script file eagle.flash.common.ld: No such file or directory
collect2: error: ld returned 1 exit status
*** [.pioenvs/sonoff/firmware.elf] Error 1
```

Removing the explicit linker-file _esp8266.flash.1m0.ld_ fixes this.