### PR TITLE
Display WiFi channel on web information page

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,6 +1,5 @@
 /* 6.4.0.1 20181217
  * Add support for AZ-Instrument 7798 CO2 meter/datalogger (#4672)
- * Display WiFi channel number on Web UI Information page (#4667)
  *
  * 6.4.0 20181217
  * Change GUI Configure Module by using AJAX for data fetch to cut page size (and memory use) by 40%

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,5 +1,5 @@
 /* 6.4.0.1 20181217
- * New release
+ * Display WiFi channel number on Web UI Information page (#4667)
  *
  * 6.4.0 20181217
  * Change GUI Configure Module by using AJAX for data fetch to cut page size (and memory use) by 40%

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -1295,7 +1295,7 @@ void HandleInformation(void)
 
   func += F("}1}2&nbsp;");  // Empty line
   func += F("}1" D_AP); func += String(Settings.sta_active +1);
-    func += F(" " D_SSID " (" D_RSSI ")}2"); func += Settings.sta_ssid[Settings.sta_active]; func += F(" ("); func += WifiGetRssiAsQuality(WiFi.RSSI()); func += F("%)");
+    func += F(" " D_SSID " (" D_RSSI ")}2"); func += Settings.sta_ssid[Settings.sta_active]; func += F(" ch"); func+= WiFi.channel(); func += F(" ("); func += WifiGetRssiAsQuality(WiFi.RSSI()); func += F("%)");
   func += F("}1" D_HOSTNAME "}2"); func += my_hostname;
   if (mdns_begun) { func += F(".local"); }
   if (static_cast<uint32_t>(WiFi.localIP()) != 0) {


### PR DESCRIPTION
Update Information web page to display channel current channel number.

![image](https://user-images.githubusercontent.com/470015/50137495-fd0e2c00-02a3-11e9-9125-b026aceb5622.png)

Request eminates from https://github.com/arendst/Sonoff-Tasmota/issues/3664#issuecomment-448061327