### PR TITLE
Add support for AZ-Instrument 7798 CO2 meter/datalogger

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -182,7 +182,6 @@ The following binary downloads have been compiled with ESP8266/Arduino library c
 | USE_RC_SWITCH                  | - | - | - | x | x | x |
 | USE_RF_SENSOR                  | - | - | - | - | - | x | AlectoV2 only
 | USE_DISPLAY                    | - | - | - | - | - | - |
-| USE_AZ7798                     | - | - | - | - | - | - |
 
 ## Changelog
 Version 6.4.0 20181217
@@ -245,4 +244,3 @@ Version 6.4.0 20181217
  * Add support for GPIO02 for newer Sonoff Basic (#4518)
  * Add Announce Switches to MQTT Discovery (#4531)
  * Add support for Manzoku Power Strip (#4590)
- * Add support for AZ-Instrument 7798 CO2 meter/datalogger

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -182,6 +182,7 @@ The following binary downloads have been compiled with ESP8266/Arduino library c
 | USE_RC_SWITCH                  | - | - | - | x | x | x |
 | USE_RF_SENSOR                  | - | - | - | - | - | x | AlectoV2 only
 | USE_DISPLAY                    | - | - | - | - | - | - |
+| USE_AZ7798                     | - | - | - | x | x | x |
 
 ## Changelog
 Version 6.4.0 20181217
@@ -244,3 +245,4 @@ Version 6.4.0 20181217
  * Add support for GPIO02 for newer Sonoff Basic (#4518)
  * Add Announce Switches to MQTT Discovery (#4531)
  * Add support for Manzoku Power Strip (#4590)
+ * Add support for AZ-Instrument 7798 CO2 meter/datalogger

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -182,7 +182,7 @@ The following binary downloads have been compiled with ESP8266/Arduino library c
 | USE_RC_SWITCH                  | - | - | - | x | x | x |
 | USE_RF_SENSOR                  | - | - | - | - | - | x | AlectoV2 only
 | USE_DISPLAY                    | - | - | - | - | - | - |
-| USE_AZ7798                     | - | - | - | x | x | x |
+| USE_AZ7798                     | - | - | - | - | - | - |
 
 ## Changelog
 Version 6.4.0 20181217

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,67 +34,132 @@ src_dir = sonoff
 ;env_default = sonoff-PT
 ;env_default = sonoff-RU
 ;env_default = sonoff-SE
+;env_default = sonoff-SK
 ;env_default = sonoff-TR
 ;env_default = sonoff-TW
 ;env_default = sonoff-UK
 
-[common] ; ************************************************************
+[esp82xx_defaults]
+build_flags               = -D NDEBUG
+                            -mtarget-align
+                            -Wl,-Map,firmware.map
+
+[core_2_3_0]
 ; *** Esp8266 core for Arduino version 2.3.0
-;platform = espressif8266@1.5.0
+platform                  = espressif8266@1.5.0
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Tesp8266.flash.1m0.ld
+
+[core_2_4_2]
 ; *** Esp8266 core for Arduino version 2.4.2
-platform = espressif8266@1.8.0
+platform                  = espressif8266@1.8.0
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m0.ld
+                            -lstdc++ -lsupc++
+; lwIP 1.4 (Default)
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                            -DVTABLES_IN_FLASH
+
+[core_2_5_0]
+; *** Esp8266 core for Arduino version Core 2.5.0 beta tested for Tasmota
+platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+; lwIP 1.4 (Default)
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+                            -DVTABLES_IN_FLASH
+                            -fno-exceptions
+                            -lstdc++-nox
+
+[core_stage]
 ; *** Esp8266 core for Arduino version latest beta
-;platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
-; *** Esp8266 core for Arduino current version (located in %USERPROFILE%\.platformio\platforms\espressif8266)
-;platform = espressif8266
+platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+; lwIP 1.4 (Default)
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwitdh Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwitdh no Features
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; VTABLES in Flash (default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++-nox
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++
 
-framework = arduino
-board = esp01_1m
-board_build.flash_mode = dout
+[core_active]
+; Select one core set for platform and build_flags
+;platform                  = ${core_2_3_0.platform}
+;build_flags               = ${core_2_3_0.build_flags}
+platform                  = ${core_2_4_2.platform}
+build_flags               = ${core_2_4_2.build_flags}
+;platform                  = ${core_2_5_0.platform}
+;build_flags               = ${core_2_5_0.build_flags}
+;platform                  = ${core_stage.platform}
+;build_flags               = ${core_stage.build_flags}
 
-; set CPU frequency to 80MHz (default) or 160MHz
-board_build.f_cpu = 80000000L
-;board_build.f_cpu = 160000000L
+[common]
+framework                 = arduino
+board                     = esp01_1m
+board_build.flash_mode    = dout
+
+platform                  = ${core_active.platform}
+build_flags               = ${core_active.build_flags}
+;                            -DUSE_CLASSIC
+;                            -DBE_MINIMAL
+;                            -DUSE_SENSORS
+;                            -DUSE_BASIC
+;                            -DUSE_KNX_NO_EMULATION
+;                            -DUSE_DISPLAYS
+;                            -DUSE_CONFIG_OVERRIDE
 
 ; *** Fix espressif8266@1.7.0 induced undesired all warnings
-build_unflags = -Wall
+build_unflags             = -Wall
 
-build_flags =
-; if using esp8266 core 2.5.0 (stage) or up
-;  -Wl,-Tesp8266.flash.1m.ld -Wl,-Map,firmware.map
-; if using esp8266 core < 2.5.0
-  -Wl,-Tesp8266.flash.1m0.ld -Wl,-Map,firmware.map
-  -mtarget-align
-;  -DUSE_CONFIG_OVERRIDE
-; lwIP 2 - Higher Bandwitdh (core 2.4.2)
-  -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwitdh no Features (core 2.5.0)
-;  -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-  -DVTABLES_IN_FLASH
+; set CPU frequency to 80MHz (default) or 160MHz
+board_build.f_cpu         = 80000000L
+;board_build.f_cpu         = 160000000L
 
-; if using esp8266 core 2.5.0 (stage) or up
-; No exception code in firmware
-;  -fno-exceptions
-;  -lstdc++-nox
-
-; *** Serial Monitor options
-monitor_speed = 115200
+monitor_speed             = 115200
+upload_speed              = 115200
+upload_resetmethod        = nodemcu
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
-upload_speed = 115200
-upload_resetmethod = nodemcu
-upload_port = COM5
-
-; *** Fix Esp/Arduino core 2.4.x induced Tasmota unused floating point includes
-extra_scripts = pio/strip-floats.py
+upload_port               = COM5
+extra_scripts             = pio/strip-floats.py
 
 ; *** Upload file to OTA server using SCP
-;upload_port = user@host:/path
-;extra_scripts = pio/strip-floats.py, pio/sftp-uploader.py
+;upload_port               = user@host:/path
+;extra_scripts             = pio/strip-floats.py, pio/sftp-uploader.py
 
-; *** Upload file to OTA server using HTTP
-;upload_port = domus1:80/api/upload-arduino.php
-;extra_scripts = pio/strip-floats.py, pio/http-uploader.py
+; *** Upload file to OTA server in folder api/arduino using HTTP
+;upload_port               = domus1:80/api/upload-arduino.php
+;extra_scripts             = pio/strip-floats.py, pio/http-uploader.py
 
 ; *********************************************************************
 
@@ -414,6 +479,20 @@ board_build.flash_mode = ${common.board_build.flash_mode}
 board_build.f_cpu = ${common.board_build.f_cpu}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} -DMY_LANGUAGE=sv-SE
+monitor_speed = ${common.monitor_speed}
+upload_port = ${common.upload_port}
+upload_resetmethod = ${common.upload_resetmethod}
+upload_speed = ${common.upload_speed}
+extra_scripts = ${common.extra_scripts}
+
+[env:sonoff-SK]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board}
+board_build.flash_mode = ${common.board_build.flash_mode}
+board_build.f_cpu = ${common.board_build.f_cpu}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} -DMY_LANGUAGE=sk-SK
 monitor_speed = ${common.monitor_speed}
 upload_port = ${common.upload_port}
 upload_resetmethod = ${common.upload_resetmethod}

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,132 +34,67 @@ src_dir = sonoff
 ;env_default = sonoff-PT
 ;env_default = sonoff-RU
 ;env_default = sonoff-SE
-;env_default = sonoff-SK
 ;env_default = sonoff-TR
 ;env_default = sonoff-TW
 ;env_default = sonoff-UK
 
-[esp82xx_defaults]
-build_flags               = -D NDEBUG
-                            -mtarget-align
-                            -Wl,-Map,firmware.map
-
-[core_2_3_0]
+[common] ; ************************************************************
 ; *** Esp8266 core for Arduino version 2.3.0
-platform                  = espressif8266@1.5.0
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Tesp8266.flash.1m0.ld
-
-[core_2_4_2]
+;platform = espressif8266@1.5.0
 ; *** Esp8266 core for Arduino version 2.4.2
-platform                  = espressif8266@1.8.0
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m0.ld
-                            -lstdc++ -lsupc++
-; lwIP 1.4 (Default)
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-                            -DVTABLES_IN_FLASH
-
-[core_2_5_0]
-; *** Esp8266 core for Arduino version Core 2.5.0 beta tested for Tasmota
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-; lwIP 1.4 (Default)
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-                            -DVTABLES_IN_FLASH
-                            -fno-exceptions
-                            -lstdc++-nox
-
-[core_stage]
+platform = espressif8266@1.8.0
 ; *** Esp8266 core for Arduino version latest beta
-platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-; lwIP 1.4 (Default)
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwitdh Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwitdh no Features
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; VTABLES in Flash (default)
-                            -DVTABLES_IN_FLASH
-; VTABLES in Heap
-;                            -DVTABLES_IN_DRAM
-; VTABLES in IRAM
-;                            -DVTABLES_IN_IRAM
-; enable one option set -> No exception recommended
-; No exception code in firmware
-                            -fno-exceptions
-                            -lstdc++-nox
-; Exception code in firmware /needs much space! 90k
-;                           -fexceptions
-;                           -lstdc++
+;platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
+; *** Esp8266 core for Arduino current version (located in %USERPROFILE%\.platformio\platforms\espressif8266)
+;platform = espressif8266
 
-[core_active]
-; Select one core set for platform and build_flags
-;platform                  = ${core_2_3_0.platform}
-;build_flags               = ${core_2_3_0.build_flags}
-platform                  = ${core_2_4_2.platform}
-build_flags               = ${core_2_4_2.build_flags}
-;platform                  = ${core_2_5_0.platform}
-;build_flags               = ${core_2_5_0.build_flags}
-;platform                  = ${core_stage.platform}
-;build_flags               = ${core_stage.build_flags}
-
-[common]
-framework                 = arduino
-board                     = esp01_1m
-board_build.flash_mode    = dout
-
-platform                  = ${core_active.platform}
-build_flags               = ${core_active.build_flags}
-;                            -DUSE_CLASSIC
-;                            -DBE_MINIMAL
-;                            -DUSE_SENSORS
-;                            -DUSE_BASIC
-;                            -DUSE_KNX_NO_EMULATION
-;                            -DUSE_DISPLAYS
-;                            -DUSE_CONFIG_OVERRIDE
-
-; *** Fix espressif8266@1.7.0 induced undesired all warnings
-build_unflags             = -Wall
+framework = arduino
+board = esp01_1m
+board_build.flash_mode = dout
 
 ; set CPU frequency to 80MHz (default) or 160MHz
-board_build.f_cpu         = 80000000L
-;board_build.f_cpu         = 160000000L
+board_build.f_cpu = 80000000L
+;board_build.f_cpu = 160000000L
 
-monitor_speed             = 115200
-upload_speed              = 115200
-upload_resetmethod        = nodemcu
+; *** Fix espressif8266@1.7.0 induced undesired all warnings
+build_unflags = -Wall
+
+build_flags =
+; if using esp8266 core 2.5.0 (stage) or up
+;  -Wl,-Tesp8266.flash.1m.ld -Wl,-Map,firmware.map
+; if using esp8266 core < 2.5.0
+  -Wl,-Tesp8266.flash.1m0.ld -Wl,-Map,firmware.map
+  -mtarget-align
+;  -DUSE_CONFIG_OVERRIDE
+; lwIP 2 - Higher Bandwitdh (core 2.4.2)
+  -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwitdh no Features (core 2.5.0)
+;  -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+  -DVTABLES_IN_FLASH
+
+; if using esp8266 core 2.5.0 (stage) or up
+; No exception code in firmware
+;  -fno-exceptions
+;  -lstdc++-nox
+
+; *** Serial Monitor options
+monitor_speed = 115200
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
-upload_port               = /dev/ttyUSB1
-extra_scripts             = pio/strip-floats.py
+upload_speed = 115200
+upload_resetmethod = nodemcu
+upload_port = COM5
+
+; *** Fix Esp/Arduino core 2.4.x induced Tasmota unused floating point includes
+extra_scripts = pio/strip-floats.py
 
 ; *** Upload file to OTA server using SCP
-;upload_port               = user@host:/path
-;extra_scripts             = pio/strip-floats.py, pio/sftp-uploader.py
+;upload_port = user@host:/path
+;extra_scripts = pio/strip-floats.py, pio/sftp-uploader.py
 
-; *** Upload file to OTA server in folder api/arduino using HTTP
-;upload_port               = domus1:80/api/upload-arduino.php
-;extra_scripts             = pio/strip-floats.py, pio/http-uploader.py
+; *** Upload file to OTA server using HTTP
+;upload_port = domus1:80/api/upload-arduino.php
+;extra_scripts = pio/strip-floats.py, pio/http-uploader.py
 
 ; *********************************************************************
 
@@ -485,20 +420,6 @@ upload_resetmethod = ${common.upload_resetmethod}
 upload_speed = ${common.upload_speed}
 extra_scripts = ${common.extra_scripts}
 
-[env:sonoff-SK]
-platform = ${common.platform}
-framework = ${common.framework}
-board = ${common.board}
-board_build.flash_mode = ${common.board_build.flash_mode}
-board_build.f_cpu = ${common.board_build.f_cpu}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} -DMY_LANGUAGE=sk-SK
-monitor_speed = ${common.monitor_speed}
-upload_port = ${common.upload_port}
-upload_resetmethod = ${common.upload_resetmethod}
-upload_speed = ${common.upload_speed}
-extra_scripts = ${common.extra_scripts}
-
 [env:sonoff-TR]
 platform = ${common.platform}
 framework = ${common.framework}
@@ -540,28 +461,3 @@ upload_port = ${common.upload_port}
 upload_resetmethod = ${common.upload_resetmethod}
 upload_speed = ${common.upload_speed}
 extra_scripts = ${common.extra_scripts}
-
-[env:wemos-d1-mini]
-platform = espressif8266
-framework = arduino
-board = esp01_1m
-board_build.flash_mode = dout
-build_flags = -Wl,-Tesp8266.flash.1m0.ld -DMQTT_MAX_PACKET_SIZE=1000
-lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
-extra_scripts = pio/strip-floats.py
-
-; *** Serial Monitor options
-monitor_speed = 115200
-
-; *** Upload Serial reset method for Wemos and NodeMCU
-upload_resetmethod = nodemcu
-upload_speed = 115200
-upload_port = /dev/ttyUSB1
-
-; *** Upload file to OTA server using SCP
-;upload_port = user@host:/path
-;extra_scripts = pio/strip-floats.py, pio/sftp-uploader.py
-
-; *** Upload file to OTA server using HTTP
-;upload_port = domus1:80/api/upload-arduino.php
-;extra_scripts = pio/strip-floats.py, pio/http-uploader.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -150,7 +150,7 @@ upload_speed              = 115200
 upload_resetmethod        = nodemcu
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
-upload_port               = COM5
+upload_port               = /dev/ttyUSB1
 extra_scripts             = pio/strip-floats.py
 
 ; *** Upload file to OTA server using SCP
@@ -540,3 +540,28 @@ upload_port = ${common.upload_port}
 upload_resetmethod = ${common.upload_resetmethod}
 upload_speed = ${common.upload_speed}
 extra_scripts = ${common.extra_scripts}
+
+[env:wemos-d1-mini]
+platform = espressif8266
+framework = arduino
+board = esp01_1m
+board_build.flash_mode = dout
+build_flags = -Wl,-Tesp8266.flash.1m0.ld -DMQTT_MAX_PACKET_SIZE=1000
+lib_deps = PubSubClient, NeoPixelBus, IRremoteESP8266, ArduinoJSON
+extra_scripts = pio/strip-floats.py
+
+; *** Serial Monitor options
+monitor_speed = 115200
+
+; *** Upload Serial reset method for Wemos and NodeMCU
+upload_resetmethod = nodemcu
+upload_speed = 115200
+upload_port = /dev/ttyUSB1
+
+; *** Upload file to OTA server using SCP
+;upload_port = user@host:/path
+;extra_scripts = pio/strip-floats.py, pio/sftp-uploader.py
+
+; *** Upload file to OTA server using HTTP
+;upload_port = domus1:80/api/upload-arduino.php
+;extra_scripts = pio/strip-floats.py, pio/http-uploader.py

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -548,7 +548,7 @@ const char HTTP_SNS_SEAPRESSURE[] PROGMEM = "%s{s}%s " D_PRESSUREATSEALEVEL "{m}
 const char HTTP_SNS_ANALOG[] PROGMEM = "%s{s}%s " D_ANALOG_INPUT "%d{m}%d{e}";                               // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 const char HTTP_SNS_ILLUMINANCE[] PROGMEM = "%s{s}%s " D_ILLUMINANCE "{m}%d " D_UNIT_LUX "{e}";              // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 
-#if defined(USE_MHZ19) || defined(USE_SENSEAIR)
+#if defined(USE_MHZ19) || defined(USE_SENSEAIR) || defined(USE_AZ7798)
 const char HTTP_SNS_CO2[] PROGMEM = "%s{s}%s " D_CO2 "{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";                // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 #endif  // USE_WEBSERVER
 

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.2.1.20
+ * Updated until v6.4.0.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -77,14 +77,14 @@
 #define D_DATA "Данни"
 #define D_DARKLIGHT "Тъмна"
 #define D_DEBUG "Дебъгване"
-#define D_DISABLED "Деактивиран"
+#define D_DISABLED "Забранен"
 #define D_DISTANCE "Разстояние"
 #define D_DNS_SERVER "DNS Сървър"
 #define D_DONE "Изпълнено"
-#define D_DST_TIME "DST"
+#define D_DST_TIME "Лятно време"
 #define D_ECO2 "eCO₂"
 #define D_EMULATION "Емулация"
-#define D_ENABLED "Активиран"
+#define D_ENABLED "Разрешен"
 #define D_ERASE "Изтриване"
 #define D_ERROR "Грешка"
 #define D_FAHRENHEIT "Фаренхайт"
@@ -128,11 +128,11 @@
 #define D_POWERUSAGE_APPARENT "Пълна мощност"
 #define D_POWERUSAGE_REACTIVE "Реактивна мощност"
 #define D_PRESSURE "Налягане"
-#define D_PRESSUREATSEALEVEL "Налягане на морското ниво"
+#define D_PRESSUREATSEALEVEL "Налягане при морското ниво"
 #define D_PROGRAM_FLASH_SIZE "Размер на флаш паметта за програми"
 #define D_PROGRAM_SIZE "Размер на програмата"
 #define D_PROJECT "Проект"
-#define D_RAIN "Rain"
+#define D_RAIN "Дъжд"
 #define D_RECEIVED "Получено"
 #define D_RESTART "Рестарт"
 #define D_RESTARTING "Рестартиране"
@@ -393,7 +393,7 @@
 #define D_CONFIGURE_TIMER "Конфигуриране на таймер"
 #define D_TIMER_PARAMETERS "Параметри на таймера"
 #define D_TIMER_ENABLE "Активиране на таймера"
-#define D_TIMER_ARM "Arm"
+#define D_TIMER_ARM "Активиран"
 #define D_TIMER_TIME "Време"
 #define D_TIMER_DAYS "Дни"
 #define D_TIMER_REPEAT "Повтори"
@@ -537,7 +537,7 @@
 #define D_SENSOR_SSPI_SCLK "SSPI SCLK"
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
-#define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_RF_SENSOR "RF датчик"
 #define D_SENSOR_AZ_RX   "AZ Rx"
 #define D_SENSOR_AZ_TX   "AZ Tx"
 
@@ -599,13 +599,13 @@
 #define D_LOG_WIFI "WIF: "         // Wifi
 
 //SDM220
-#define D_PHASE_ANGLE     "Phase Angle"
-#define D_IMPORT_ACTIVE   "Import Active"
-#define D_EXPORT_ACTIVE   "Export Active"
-#define D_IMPORT_REACTIVE "Import Reactive"
-#define D_EXPORT_REACTIVE "Export Reactive"
-#define D_TOTAL_REACTIVE  "Total Reactive"
+#define D_PHASE_ANGLE     "Фазов ъгъл"
+#define D_IMPORT_ACTIVE   "Входна активна мощност"
+#define D_EXPORT_ACTIVE   "Изходна активна мощност"
+#define D_IMPORT_REACTIVE "Входна реактивна мощност"
+#define D_EXPORT_REACTIVE "Изходна реактивна мощност"
+#define D_TOTAL_REACTIVE  "Общо реактивна мощност"
 #define D_UNIT_KWARH      "kVArh"
-#define D_UNIT_ANGLE      "Deg"
+#define D_UNIT_ANGLE      "°"
 
 #endif  // _LANGUAGE_BG_BG_H_

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/es-AR.h
+++ b/sonoff/language/es-AR.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/sk-SK.h
+++ b/sonoff/language/sk-SK.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Senzor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/sv-SE.h
+++ b/sonoff/language/sv-SE.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -538,6 +538,8 @@
 #define D_SENSOR_SSPI_CS   "SSPI CS"
 #define D_SENSOR_SSPI_DC   "SSPI DC"
 #define D_SENSOR_RF_SENSOR "RF Sensor"
+#define D_SENSOR_AZ_RX   "AZ Rx"
+#define D_SENSOR_AZ_TX   "AZ Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -283,7 +283,7 @@
 //  #define W1_PARASITE_POWER                      // If using USE_DS18x20 then optimize for parasite powered sensors
 
 // -- I2C sensors ---------------------------------
-#define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
+//#define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
 
 #ifdef USE_I2C
   #define USE_SHT                                // Enable SHT1X sensor (+1k4 code)
@@ -348,12 +348,12 @@
 #endif  // USE_SPI
 
 // -- Serial sensors ------------------------------
-#define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
-#define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)
+//#define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
+//#define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)
   #define CO2_LOW              800               // Below this CO2 value show green light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
   #define CO2_HIGH             1200              // Above this CO2 value show red light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
-#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
-#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
+//#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
+//#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
   #define WORKING_PERIOD       5                 // Working period of the SDS Sensor, Takes a reading every X Minutes
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge (+0k8 code)
 //#define USE_SDM120                               // Add support for Eastron SDM120-Modbus energy meter (+1k7 code)
@@ -363,35 +363,35 @@
   #define SDM630_SPEED         9600              // SDM630-Modbus RS485 serial speed (default: 9600 baud)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10                // Set the startup volume on init, the range can be 0..30(max)
-#define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
+//#define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
-#define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
-#define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer
-
+//#define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
+//#define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer
+#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger (+1k6 code)
 // Power monitoring sensors -----------------------
-#define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
-#define USE_PZEM_AC                              // Add support for PZEM014,016 Energy monitor (+1k1 code)
-#define USE_PZEM_DC                              // Add support for PZEM003,017 Energy monitor (+1k1 code)
-#define USE_MCP39F501                            // Add support for MCP39F501 Energy monitor as used in Shelly 2 (+3k1 code)
+//#define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
+//#define USE_PZEM_AC                              // Add support for PZEM014,016 Energy monitor (+1k1 code)
+//#define USE_PZEM_DC                              // Add support for PZEM003,017 Energy monitor (+1k1 code)
+//#define USE_MCP39F501                            // Add support for MCP39F501 Energy monitor as used in Shelly 2 (+3k1 code)
 
 // -- Low level interface devices -----------------
-#define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k3 code, 0k3 mem, 48 iram)
+//#define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k3 code, 0k3 mem, 48 iram)
 //  #define USE_IR_HVAC                            // Support for HVAC (Toshiba, Mitsubishi and LG) system using IR (+3k5 code)
-  #define USE_IR_RECEIVE                         // Support for IR receiver (+7k2 code, 264 iram)
+//  #define USE_IR_RECEIVE                         // Support for IR receiver (+7k2 code, 264 iram)
     #define IR_RCV_BUFFER_SIZE      100          // Max number of packets allowed in capture buffer (default 100 (*2 bytes ram))
     #define IR_RCV_TIMEOUT          15           // Number of milli-Seconds of no-more-data before we consider a message ended (default 15)
     #define IR_RCV_MIN_UNKNOWN_SIZE 6            // Set the smallest sized "UNKNOWN" message packets we actually care about (default 6)
 
-#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
-  #define USE_WS2812_CTYPE     NEO_GRB           // WS2812 Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
+//#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
+//  #define USE_WS2812_CTYPE     NEO_GRB           // WS2812 Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial RXD) (+1k mem). When USE_WS2812_DMA is enabled expect Exceptions on Pow
 
-#define USE_ARILUX_RF                            // Add support for Arilux RF remote controller (+0k8 code, 252 iram (non 2.3.0))
+//#define USE_ARILUX_RF                            // Add support for Arilux RF remote controller (+0k8 code, 252 iram (non 2.3.0))
 
-#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
+//#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
 
 //#define USE_TM1638                               // Add support for TM1638 switches copying Switch1 .. Switch8 (+1k code)
-#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
+//#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
 //  #define USE_HX711_GUI                          // Add optional web GUI to HX711 as scale (+1k8 code)
 
 #define USE_RF_FLASH                             // Add support for flashing the EFM8BB1 chip on the Sonoff RF Bridge. C2CK must be connected to GPIO4, C2D to GPIO5 on the PCB (+3k code)

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -209,6 +209,7 @@
 //#define MY_LANGUAGE            pt-BR           // Portuguese in Brazil
 //#define MY_LANGUAGE            pt-PT           // Portuguese in Portugal
 //#define MY_LANGUAGE            ru-RU           // Russian in Russia
+//#define MY_LANGUAGE            sk-SK           // Slovak in Slovakia
 //#define MY_LANGUAGE            sv-SE           // Swedish in Sweden
 //#define MY_LANGUAGE            tr-TR           // Turkish in Turkey
 //#define MY_LANGUAGE            uk-UK           // Ukrainian in Ukrain

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -209,7 +209,6 @@
 //#define MY_LANGUAGE            pt-BR           // Portuguese in Brazil
 //#define MY_LANGUAGE            pt-PT           // Portuguese in Portugal
 //#define MY_LANGUAGE            ru-RU           // Russian in Russia
-//#define MY_LANGUAGE            sk-SK           // Slovak in Slovakia
 //#define MY_LANGUAGE            sv-SE           // Swedish in Sweden
 //#define MY_LANGUAGE            tr-TR           // Turkish in Turkey
 //#define MY_LANGUAGE            uk-UK           // Ukrainian in Ukrain
@@ -283,7 +282,7 @@
 //  #define W1_PARASITE_POWER                      // If using USE_DS18x20 then optimize for parasite powered sensors
 
 // -- I2C sensors ---------------------------------
-//#define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
+#define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
 
 #ifdef USE_I2C
   #define USE_SHT                                // Enable SHT1X sensor (+1k4 code)
@@ -348,12 +347,12 @@
 #endif  // USE_SPI
 
 // -- Serial sensors ------------------------------
-//#define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
-//#define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)
+#define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
+#define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)
   #define CO2_LOW              800               // Below this CO2 value show green light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
   #define CO2_HIGH             1200              // Above this CO2 value show red light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
-//#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
-//#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
+#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
+#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
   #define WORKING_PERIOD       5                 // Working period of the SDS Sensor, Takes a reading every X Minutes
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge (+0k8 code)
 //#define USE_SDM120                               // Add support for Eastron SDM120-Modbus energy meter (+1k7 code)
@@ -363,35 +362,36 @@
   #define SDM630_SPEED         9600              // SDM630-Modbus RS485 serial speed (default: 9600 baud)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10                // Set the startup volume on init, the range can be 0..30(max)
-//#define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
+#define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
-//#define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
-//#define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer
-#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger (+1k6 code)
+#define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
+#define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer
+//#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger (+1k6 code)
+
 // Power monitoring sensors -----------------------
-//#define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
-//#define USE_PZEM_AC                              // Add support for PZEM014,016 Energy monitor (+1k1 code)
-//#define USE_PZEM_DC                              // Add support for PZEM003,017 Energy monitor (+1k1 code)
-//#define USE_MCP39F501                            // Add support for MCP39F501 Energy monitor as used in Shelly 2 (+3k1 code)
+#define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)
+#define USE_PZEM_AC                              // Add support for PZEM014,016 Energy monitor (+1k1 code)
+#define USE_PZEM_DC                              // Add support for PZEM003,017 Energy monitor (+1k1 code)
+#define USE_MCP39F501                            // Add support for MCP39F501 Energy monitor as used in Shelly 2 (+3k1 code)
 
 // -- Low level interface devices -----------------
-//#define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k3 code, 0k3 mem, 48 iram)
+#define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k3 code, 0k3 mem, 48 iram)
 //  #define USE_IR_HVAC                            // Support for HVAC (Toshiba, Mitsubishi and LG) system using IR (+3k5 code)
-//  #define USE_IR_RECEIVE                         // Support for IR receiver (+7k2 code, 264 iram)
+  #define USE_IR_RECEIVE                         // Support for IR receiver (+7k2 code, 264 iram)
     #define IR_RCV_BUFFER_SIZE      100          // Max number of packets allowed in capture buffer (default 100 (*2 bytes ram))
     #define IR_RCV_TIMEOUT          15           // Number of milli-Seconds of no-more-data before we consider a message ended (default 15)
     #define IR_RCV_MIN_UNKNOWN_SIZE 6            // Set the smallest sized "UNKNOWN" message packets we actually care about (default 6)
 
-//#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
-//  #define USE_WS2812_CTYPE     NEO_GRB           // WS2812 Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
+#define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
+  #define USE_WS2812_CTYPE     NEO_GRB           // WS2812 Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial RXD) (+1k mem). When USE_WS2812_DMA is enabled expect Exceptions on Pow
 
-//#define USE_ARILUX_RF                            // Add support for Arilux RF remote controller (+0k8 code, 252 iram (non 2.3.0))
+#define USE_ARILUX_RF                            // Add support for Arilux RF remote controller (+0k8 code, 252 iram (non 2.3.0))
 
-//#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
+#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
 
 //#define USE_TM1638                               // Add support for TM1638 switches copying Switch1 .. Switch8 (+1k code)
-//#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
+#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
 //  #define USE_HX711_GUI                          // Add optional web GUI to HX711 as scale (+1k8 code)
 
 #define USE_RF_FLASH                             // Add support for flashing the EFM8BB1 chip on the Sonoff RF Bridge. C2CK must be connected to GPIO4, C2D to GPIO5 on the PCB (+3k code)

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -135,7 +135,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #define USE_RF_SENSOR                         // Add support for RF sensor receiver (434MHz or 868MHz) (+0k8 code)
 //  #define USE_THEO_V2                         // Add support for decoding Theo V2 sensors as documented on https://sidweb.nl using 434MHz RF sensor receiver (+1k4 code)
   #define USE_ALECTO_V2                       // Add support for decoding Alecto V2 sensors like ACH2010, WS3000 and DKW2012 using 868MHz RF sensor receiver (+1k7 code)
-#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger
+//#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger
 #endif  // USE_SENSORS
 
 /*********************************************************************************************\

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -135,6 +135,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #define USE_RF_SENSOR                         // Add support for RF sensor receiver (434MHz or 868MHz) (+0k8 code)
 //  #define USE_THEO_V2                         // Add support for decoding Theo V2 sensors as documented on https://sidweb.nl using 434MHz RF sensor receiver (+1k4 code)
   #define USE_ALECTO_V2                       // Add support for decoding Alecto V2 sensors like ACH2010, WS3000 and DKW2012 using 868MHz RF sensor receiver (+1k7 code)
+#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger
 #endif  // USE_SENSORS
 
 /*********************************************************************************************\
@@ -193,6 +194,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #undef USE_RF_SENSOR                          // Disable support for RF sensor receiver (434MHz or 868MHz) (+0k8 code)
 #undef DEBUG_THEO                             // Disable debug code
 #undef USE_DEBUG_DRIVER                       // Disable debug code
+#undef USE_AZ7798                             // Disable support for AZ-Instrument 7798 CO2 datalogger
 #endif  // USE_CLASSIC
 
 /*********************************************************************************************\
@@ -313,6 +315,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #undef USE_RF_SENSOR                          // Disable support for RF sensor receiver (434MHz or 868MHz) (+0k8 code)
 #undef DEBUG_THEO                             // Disable debug code
 #undef USE_DEBUG_DRIVER                       // Disable debug code
+#undef USE_AZ7798                             // Disable support for AZ-Instrument 7798 CO2 datalogger
 #endif  // USE_BASIC
 
 /*********************************************************************************************\
@@ -375,6 +378,7 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #undef USE_RF_SENSOR                          // Disable support for RF sensor receiver (434MHz or 868MHz) (+0k8 code)
 #undef DEBUG_THEO                             // Disable debug code
 #undef USE_DEBUG_DRIVER                       // Disable debug code
+#undef USE_AZ7798                             // Disable support for AZ-Instrument 7798 CO2 datalogger
 #endif  // BE_MINIMAL
 
 /*********************************************************************************************\

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -141,6 +141,8 @@ enum UserSelectablePins {
   GPIO_SSPI_CS,        // Software SPI Chip Select
   GPIO_SSPI_DC,        // Software SPI Data or Command
   GPIO_RF_SENSOR,      // Rf receiver with sensor decoding
+  GPIO_AZ_TXD,         // AZ-Instrument 7798 Serial interface
+  GPIO_AZ_RXD,         // AZ-Instrument 7798 Serial interface
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality offset by user selectable GPIOs
@@ -201,7 +203,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_TUYA_TX "|" D_SENSOR_TUYA_RX "|"
   D_SENSOR_MGC3130_XFER "|" D_SENSOR_MGC3130_RESET "|"
   D_SENSOR_SSPI_MISO "|" D_SENSOR_SSPI_MOSI "|" D_SENSOR_SSPI_SCLK "|" D_SENSOR_SSPI_CS "|" D_SENSOR_SSPI_DC "|"
-  D_SENSOR_RF_SENSOR;
+  D_SENSOR_RF_SENSOR "|"
+  D_SENSOR_AZ_TX "|" D_SENSOR_AZ_RX;
 
 /********************************************************************************************/
 
@@ -453,6 +456,10 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_MGC3130
   GPIO_MGC3130_XFER,
   GPIO_MGC3130_RESET
+#endif
+#ifdef USE_AZ7798
+  GPIO_AZ_TXD,         // AZ-Instrument 7798 CO2 datalogger Serial interface
+  GPIO_AZ_RXD          // AZ-Instrument 7798 CO2 datalogger Serial interface
 #endif
 };
 

--- a/sonoff/support_features.ino
+++ b/sonoff/support_features.ino
@@ -370,7 +370,9 @@ void GetFeatures(void)
 #ifdef USE_ALECTO_V2
   feature_sns2 |= 0x00020000;
 #endif
-//  feature_sns2 |= 0x00040000;
+#ifdef USE_AZ7798
+  feature_sns2 |= 0x00040000;
+#endif
 //  feature_sns2 |= 0x00080000;
 //  feature_sns2 |= 0x00100000;
 //  feature_sns2 |= 0x00200000;

--- a/sonoff/xsns_38_az7798.ino
+++ b/sonoff/xsns_38_az7798.ino
@@ -188,9 +188,7 @@ void AzEverySecond(void)
     if(az_response[i] == 'C') {             // meter transmits in degC
       az_temperature = ConvertTemp((float)az_temperature); // convert to degF, depending on settings
     } else {                                // meter transmits in degF
-      if(!Settings.flag.temperature_conversion) {
-        az_temperature = (az_temperature - 32) / 1.8; // convert to degC
-      }
+      az_temperature = ConvertTemp((az_temperature - 32) / 1.8); // convert to degC and then C or F depending on setting
     }
     i++;                                    // advance to first delimiter
     if(az_response[i] != ':') {

--- a/sonoff/xsns_38_az7798.ino
+++ b/sonoff/xsns_38_az7798.ino
@@ -1,0 +1,306 @@
+/*
+  xsns_38_az7798.ino - AZ_Instrument 7798 CO2/temperature/humidity meter support for Sonoff-Tasmota
+
+  Copyright (C) 2018  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_AZ7798
+
+#define XSNS_38 38
+
+/*********************************************************************************************\
+ * CO2, temperature and humidity meter and data logger
+ * Known by different names (brief survey 2018-12-16):
+ *  - AZ-Instrument 7798 (http://www.az-instrument.com.tw)
+ *  - co2meter.com AZ-0004
+ *  - Extech CO200
+ *  - BES CO7788 (https://www.aliexpress.com)
+ *  - AZ CO87 (https://www.aliexpress.com)
+ *  - no doubt there are more ...
+ *
+ * Hardware Serial will be selected if GPIO1 = [AZ Tx] and GPIO3 = [AZ Rx]
+ *
+ * Inside the meter, the serial comms wire with the red stripe goes to GPIO1.
+ * The other one therefore to GPIO3.
+ * WeMos D1 Mini is powered from the incoming 5V.
+ *
+ * This implementation was derived from xsns_15_mhz19.ino from
+ * Sonoff-Tasmota-6.3.0 by Arthur de Beun.
+ *
+ * The serial comms protocol is not publicly documented, that I could find.
+ * The info below was obtained by reverse-engineering.
+ * Port settings: 9600 8N1
+ * The suppied USB interface has a CP20x USB-serial bridge.
+ * The 3-way, 2.5mm jack has tip=RxD, middle=TxD and base=0V
+ * The TxD output swing is 3V3.
+ *
+ * There is never a space before the 0x0d, but the other spaces are there.
+ *
+ * serial number / ID
+ *   request:  I 0x0d
+ *   response: i 12345678 7798V3.4 0x0d
+ *
+ * log info
+ *   request:  M 0x0d
+ *   response: m 45 1 C 1af4 0cf4 0x0d
+ *
+ *             45 = number of records, but there are only 15 lines of 3 values each)
+ *              1 = sample rate in seconds
+ *              C = celcius, F
+ *      1af4 0cf4 = seconds since 2000-01-01 00:00:00
+ *
+ *          start time 2014-04-30 19:35:16
+ *          end time   2014-04-30 19:35:30
+ *
+ * download log data
+ *   request:  D 0x0d
+ *   response: m 45 1 C 1af4 0cf4 0x0d
+ *             d 174 955 698 0x0d
+ *               174 = temp in [C * 10]
+ *               955 = CO2 [ppm]
+ *               698 = RH in [% * 10]
+ *             d 174 990 694 0x0d
+ *       ...
+ *             d 173 929 654 0x0d
+ *
+ *            15 lines in total, 1 second apart
+ *
+ * Sync datalogger time with PC
+ *   request:  C 452295746 0x0d
+ *   response: > 0x0d
+ *
+ *              452295746 = seconds since 2000-01-01 00:00:00
+ *
+ * Identifier:
+ *   request:  J -------- 1 0x0d
+ *
+ *             the characters (dashes) in the above become the first part of the response to the I command (12345678 above)
+ *
+ * Set sample rate
+ *   request:  S 10 0x0d
+ *   response: m 12 10 C 1af5 7be1 0x0d
+ *
+ * Other characters that seem to give a response:
+ * A  responds with >
+ *    so is similar to the response to C, so other characters may be required
+ *    A is the beep alarm perhaps?
+ *    parameters would be CO2 level and on/off, as per front panel P1.3 setting?
+ *
+ * L  responds with >
+ *    L perhaps sets the limits for the good and normal levels (P1.1 and P1.2)?
+ *
+ * Q  responds with >
+ *    Q is reset maybe (P4.1)?
+ *
+ * :  responds with : T19.9C:C2167ppm:H57.4%
+ *    This one gives the current readings.
+ **********************************************************************************************
+
+/*********************************************************************************************/
+
+#include <TasmotaSerial.h>
+
+#ifndef CO2_LOW
+#define CO2_LOW                      800     // Below this CO2 value show green light
+#endif
+#ifndef CO2_HIGH
+#define CO2_HIGH                     1200    // Above this CO2 value show red light
+#endif
+
+#define AZ_READ_TIMEOUT              400     // Must be way less than 1000 but enough to read 9 bytes at 9600 bps
+
+TasmotaSerial *AzSerial;
+
+const char ktype[] = "AZ7798";
+uint8_t az_type = 1;
+uint16_t az_co2 = 0;
+double az_temperature = 0;
+double az_humidity = 0;
+uint8_t az_received = 0;
+uint8_t az_state = 0;
+
+/*********************************************************************************************/
+
+void AzEverySecond()
+{
+  az_state++;
+  if (5 == az_state) {                      // every 5 seconds
+    az_state = 0;
+
+    AzSerial->flush();                      // sync reception
+    AzSerial->write(":\r", 2);
+    az_received = 0;
+
+    uint8_t az_response[32];
+    unsigned long start = millis();
+    uint8_t counter = 0;
+    uint8_t i, j;
+    uint8_t response_substr[16];
+
+    do {
+      if (AzSerial->available() > 0) {
+        az_response[counter] = AzSerial->read();
+        if(az_response[counter] == 0x0d) { az_received = 1; }
+        counter++;
+      } else {
+        delay(5);
+      }
+    } while(((millis() - start) < AZ_READ_TIMEOUT) && (counter < sizeof(az_response)) && !az_received);
+
+    AddLogSerial(LOG_LEVEL_DEBUG_MORE, az_response, counter);
+
+    if (!az_received) {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 comms timeout"));
+      return;
+    }
+
+    i = 0;
+    while((az_response[i] != 'T') && (i < counter)) {i++;} // find the start of response
+    if(az_response[i] != 'T') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 failed to find start of response"));
+      return;
+    }
+    i++;                                    // advance to start of temperature value
+    j = 0;
+    // find the end of temperature
+    while((az_response[i] != 'C') && (az_response[i] != 'F') && (i < counter)) {
+      response_substr[j++] = az_response[i++];
+    }
+    if((az_response[i] != 'C') && (az_response[i] != 'F')){
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 failed to find end of temperature"));
+      return;
+    }
+    response_substr[j] = 0;                 // add null terminator
+    az_temperature = CharToDouble((char*)response_substr); // units (C or F) depends on meter setting
+    if(az_response[i] == 'C') {             // meter transmits in degC
+      az_temperature = ConvertTemp((float)az_temperature); // convert to degF, depending on settings
+    } else {                                // meter transmits in degF
+      if(!Settings.flag.temperature_conversion) {
+        az_temperature = (az_temperature - 32) / 1.8; // convert to degC
+      }
+    }
+    i++;                                    // advance to first delimiter
+    if(az_response[i] != ':') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 error first delimiter"));
+      return;
+    }
+    i++;                                    // advance to start of CO2
+    if(az_response[i] != 'C') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 error start of CO2"));
+      return;
+    }
+    i++;                                    // advance to start of CO2 value
+    j = 0;
+    // find the end of CO2
+    while((az_response[i] != 'p') && (i < counter)) {
+      response_substr[j++] = az_response[i++];
+    }
+    if(az_response[i] != 'p') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 failed to find end of CO2"));
+      return;
+    }
+    response_substr[j] = 0;                 // add null terminator
+    az_co2 = atoi((char*)response_substr);
+    LightSetSignal(CO2_LOW, CO2_HIGH, az_co2);
+    i += 3;                                 // advance to second delimiter
+    if(az_response[i] != ':') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 error second delimiter"));
+      return;
+    }
+    i++;                                    // advance to start of humidity
+    if(az_response[i] != 'H') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 error start of humidity"));
+      return;
+    }
+    i++;                                    // advance to start of humidity value
+    j = 0;
+    // find the end of humidity
+    while((az_response[i] != '%') && (i < counter)) {
+      response_substr[j++] = az_response[i++];
+    }
+    if(az_response[i] != '%') {
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 failed to find end of humidity"));
+      return;
+    }
+    response_substr[j] = 0;                 // add null terminator
+    az_humidity = CharToDouble((char*)response_substr);
+  }
+}
+
+/*********************************************************************************************/
+
+void AzInit()
+{
+  az_type = 0;
+  if ((pin[GPIO_AZ_RXD] < 99) && (pin[GPIO_AZ_TXD] < 99)) {
+    AzSerial = new TasmotaSerial(pin[GPIO_AZ_RXD], pin[GPIO_AZ_TXD], 1);
+    if (AzSerial->begin(9600)) {
+      if (AzSerial->hardwareSerial()) { ClaimSerial(); }
+      az_type = 1;
+    }
+  }
+}
+
+void AzShow(boolean json)
+{
+  char temperature[10], humidity[10];
+  dtostrfd(az_temperature, Settings.flag2.temperature_resolution, temperature);
+  dtostrfd(az_humidity, Settings.flag2.humidity_resolution, humidity);
+
+  if (json) {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"%s\":{\"" D_JSON_CO2 "\":%d,\"" D_JSON_TEMPERATURE "\":%s,\"" D_JSON_HUMIDITY "\":%s}"), mqtt_data, ktype, az_co2, temperature, humidity);
+#ifdef USE_DOMOTICZ
+    if (0 == tele_period) DomoticzSensor(DZ_AIRQUALITY, az_co2);
+#endif  // USE_DOMOTICZ
+#ifdef USE_WEBSERVER
+  } else {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_CO2, mqtt_data, ktype, az_co2);
+    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_TEMP, mqtt_data, ktype, temperature, TempUnit());
+    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_HUM, mqtt_data, ktype, humidity);
+#endif  // USE_WEBSERVER
+  }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+boolean Xsns36(byte function)
+{
+  boolean result = false;
+
+  if(az_type){
+    switch (function) {
+      case FUNC_INIT:
+        AzInit();
+        break;
+      case FUNC_EVERY_SECOND:
+        AzEverySecond();
+        break;
+      case FUNC_JSON_APPEND:
+        AzShow(1);
+        break;
+#ifdef USE_WEBSERVER
+      case FUNC_WEB_APPEND:
+        AzShow(0);
+        break;
+#endif  // USE_WEBSERVER
+    }
+  }
+  return result;
+}
+
+#endif  // USE_AZ7798

--- a/sonoff/xsns_38_az7798.ino
+++ b/sonoff/xsns_38_az7798.ino
@@ -134,7 +134,7 @@ uint8_t az_state = 0;
 
 /*********************************************************************************************/
 
-void AzEverySecond()
+void AzEverySecond(void)
 {
   az_state++;
   if (5 == az_state) {                      // every 5 seconds
@@ -242,7 +242,7 @@ void AzEverySecond()
 
 /*********************************************************************************************/
 
-void AzInit()
+void AzInit(void)
 {
   az_type = 0;
   if ((pin[GPIO_AZ_RXD] < 99) && (pin[GPIO_AZ_TXD] < 99)) {

--- a/sonoff/xsns_38_az7798.ino
+++ b/sonoff/xsns_38_az7798.ino
@@ -278,7 +278,7 @@ void AzShow(boolean json)
  * Interface
 \*********************************************************************************************/
 
-boolean Xsns36(byte function)
+boolean Xsns38(byte function)
 {
   boolean result = false;
 

--- a/tools/decode-status.py
+++ b/tools/decode-status.py
@@ -135,7 +135,7 @@ a_features = [[
     "USE_MCP230xx_OUTPUT","USE_MCP230xx_DISPLAYOUTPUT","USE_HLW8012","USE_CSE7766",
     "USE_MCP39F501","USE_PZEM_AC","USE_DS3231","USE_HX711",
     "USE_PZEM_DC","USE_TX20_WIND_SENSOR","USE_MGC3130","USE_RF_SENSOR",
-    "USE_THEO_V2","USE_ALECTO_V2","","",
+    "USE_THEO_V2","USE_ALECTO_V2","USE_AZ7798","",
     "","","","",
     "","","","",
     "","","",""]]


### PR DESCRIPTION
Implemented sensor interface for the AZ-Instrument 7798 CO2/temperature/humidity meter/datalogger.
See: https://www.az-instrument.com.tw/az-instrument/en/productsinfo/189.html
Tested with a Wemos D1 mini. (Can be fitted neatly inside the instrument.)
