### PR TITLE
Remove Alexa message "this value is outside the range of the device"

### DIFF
--- a/sonoff/xplg_wemohue.ino
+++ b/sonoff/xplg_wemohue.ino
@@ -568,7 +568,7 @@ void HueLightStatus1(byte device, String *response)
 {
   float hue = 0;
   float sat = 0;
-  float bri = 0;
+  float bri = 254;
   uint16_t ct = 500;
 
   if (light_type) {


### PR DESCRIPTION
This workaround for issue #3159 is removing the message "this value is outside the range of the device" allowing me to use hue emulation with Alexa on an Amazon echo dot 3rd generation .