### PR TITLE
Add INPUT_PULLUP option for single DS18B20

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -283,6 +283,7 @@
 //#define USE_DS18x20_LEGACY                       // Optional for more than one DS18x20 sensors with dynamic scan using library OneWire (+1k5 code)
 #define USE_DS18x20                              // Optional for more than one DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
 //  #define W1_PARASITE_POWER                      // If using USE_DS18x20 then optimize for parasite powered sensors
+//  #define DS18B20_INTERNAL_PULLUP	               // Use INPUT_PULLUP internal pullup resistors for single DS18B20
 
 // -- I2C sensors ---------------------------------
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)

--- a/sonoff/xsns_05_ds18b20.ino
+++ b/sonoff/xsns_05_ds18b20.ino
@@ -42,7 +42,11 @@ uint8_t OneWireReset(void)
   uint8_t retries = 125;
 
   //noInterrupts();
+#ifdef DS18B20_INTERNAL_PULLUP
+  pinMode(ds18x20_pin, INPUT_PULLUP);
+#else
   pinMode(ds18x20_pin, INPUT);
+#endif
   do {
     if (--retries == 0) {
       return 0;
@@ -52,7 +56,11 @@ uint8_t OneWireReset(void)
   pinMode(ds18x20_pin, OUTPUT);
   digitalWrite(ds18x20_pin, LOW);
   delayMicroseconds(480);
+#ifdef DS18B20_INTERNAL_PULLUP
+  pinMode(ds18x20_pin, INPUT_PULLUP);
+#else
   pinMode(ds18x20_pin, INPUT);
+#endif
   delayMicroseconds(70);
   uint8_t r = !digitalRead(ds18x20_pin);
   //interrupts();
@@ -81,7 +89,11 @@ uint8_t OneWireReadBit(void)
   pinMode(ds18x20_pin, OUTPUT);
   digitalWrite(ds18x20_pin, LOW);
   delayMicroseconds(3);
+#ifdef DS18B20_INTERNAL_PULLUP
+  pinMode(ds18x20_pin, INPUT_PULLUP);
+#else
   pinMode(ds18x20_pin, INPUT);
+#endif
   delayMicroseconds(10);
   uint8_t r = digitalRead(ds18x20_pin);
   //interrupts();


### PR DESCRIPTION
This feature allows users to connect a single DS18B20 directly to a GPIO pin without an external pull-up resistor.  (The internal pullups on the ESP8266 are strong enough for a single directly connected DS18B20.)

Reference:  https://wp.josh.com/2014/06/23/no-external-pull-up-needed-for-ds18b20-temp-sensor/