### PR TITLE
Temperature offset directive for BME680

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -293,6 +293,7 @@
   #define USE_HTU                                // Enable HTU21/SI7013/SI7020/SI7021 sensor (I2C address 0x40) (+1k5 code)
   #define USE_BMP                                // Enable BMP085/BMP180/BMP280/BME280 sensors (I2C addresses 0x76 and 0x77) (+4k4 code)
 //    #define USE_BME680                           // Enable support for BME680 sensor using Bosch BME680 library (+4k code)
+      #define BME680_OFFSET	-4.0                 // Temperature offset for BME680 (-4 seems to be average)
   #define USE_BH1750                             // Enable BH1750 sensor (I2C address 0x23 or 0x5C) (+0k5 code)
 //  #define USE_VEML6070                           // Enable VEML6070 sensor (I2C addresses 0x38 and 0x39) (+1k5 code)
     #define USE_VEML6070_RSET    270000          // VEML6070, Rset in Ohm used on PCB board, default 270K = 270000ohm, range for this sensor: 220K ... 1Meg

--- a/sonoff/xsns_09_bmp.ino
+++ b/sonoff/xsns_09_bmp.ino
@@ -426,7 +426,11 @@ void Bme680Read(uint8_t bmp_idx)
       rslt = bme680_get_sensor_data(&data, &gas_sensor[bmp_idx]);
       if (rslt != BME680_OK) { return; }
 
+#ifdef BME680_OFFSET
+      bmp_sensors[bmp_idx].bmp_temperature = data.temperature / 100.0 + BME680_OFFSET;
+#else
       bmp_sensors[bmp_idx].bmp_temperature = data.temperature / 100.0;
+#endif
       bmp_sensors[bmp_idx].bmp_humidity = data.humidity / 1000.0;
       bmp_sensors[bmp_idx].bmp_pressure = data.pressure / 100.0;
       /* Avoid using measurements from an unstable heating setup */


### PR DESCRIPTION
The BME680 is known to return a temperature reading that is 3 - 4 C too high due to it's internal heater for gas measurement.  This directive allows compensation for that issue inside Tasmota instead of dealing with it after the fact.

I'm running with this mod on three different units (two indoors, one outdoor) and have found -4.0 C. to be fairly consistently accurate across all three.

Context: https://github.com/pimoroni/bme680-python/issues/11