### PR TITLE
Added N0DY_RELAY module

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1705,9 +1705,16 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_USER,        // GPIO03 Serial TXD or Optional sensor on J2 TXD (if not using serial io)
      GPIO_REL2_INV,    // GPIO04 Relay 2 (active low)
      GPIO_REL1_INV,    // GPIO05 Relay 1 (active low)
-     0, 0, 0, 0, 0, 0, // Flash connection
-     0, 0, 0, 0, 0,    // Unused GPIO 12-16
-     0                 // ADC0 Analog input
+                       // GPIO06 (SD_CLK   Flash)
+                       // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
+                       // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
+     0,                // GPIO09 (SD_DATA2 Flash QIO or ESP8285)
+     0,                // GPIO10 (SD_DATA3 Flash QIO or ESP8285)
+                       // GPIO11 (SD_CMD   Flash)
+     0,                // GPIO12
+     0,                // GPIO13 Button
+     0,                // GPIO14 IR Transmitter
+     0, 0, 0
   }
 };
 

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -275,6 +275,7 @@ enum SupportedModules {
   MANZOKU_EU_4,
   OBI2,
   YTF_IR_BRIDGE,
+  N0DY_RELAY,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -538,6 +539,7 @@ const uint8_t kModuleNiceList[MAXMODULE] PROGMEM = {
   WION,
   SHELLY1,
   SHELLY2,
+  N0DY_RELAY,
   BLITZWOLF_BWSHP,    // Socket Relay Devices with Energy Monitoring
   TECKIN,
   TECKIN_US,
@@ -1693,6 +1695,19 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_KEY1,        // GPIO13 Button
      GPIO_IRSEND,      // GPIO14 IR Transmitter
      0, 0, 0
+  },  
+  { "N0DY Relay",      // N0DY Wifi Dual Relay (ESP-07)
+                       // https://www.n0dy.com/product/web-controlled-dual-relay/
+                       // https://www.amazon.com/dp/B072MKV8ZM
+     GPIO_KEY1,        // GPIO00 PROG Button
+     GPIO_USER,        // GPIO01 Serial RXD or Optional sensor on J2 RXD (if not using serial io)
+     0,                // GPIO02 
+     GPIO_USER,        // GPIO03 Serial TXD or Optional sensor on J2 TXD (if not using serial io)
+     GPIO_REL2_INV,    // GPIO04 Relay 2 (active low)
+     GPIO_REL1_INV,    // GPIO05 Relay 1 (active low)
+     0, 0, 0, 0, 0, 0, // Flash connection
+     0, 0, 0, 0, 0,    // Unused GPIO 12-16
+     0                 // ADC0 Analog input
   }
 };
 


### PR DESCRIPTION
Create new module to support "N0DY Wifi Relay" device, with two relays.

Device can be found at:
https://www.n0dy.com/product/web-controlled-dual-relay/
https://www.amazon.com/dp/B072MKV8ZM

Hardware is open-source on github: n0dyjeff/WiFiRelay