### PR TITLE
Add a define for controlling the default MDNS state.

### DIFF
--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -622,6 +622,9 @@ void SettingsDefaultSet2(void)
   Settings.weblog_level = WEB_LOG_LEVEL;
   strlcpy(Settings.web_password, WEB_PASSWORD, sizeof(Settings.web_password));
 
+  // MDNS host discovery
+  Settings.flag3.mdns_enabled = DISCOVERY_ENABLED;
+
   // Button
 //  Settings.flag.button_restrict = 0;
 //  Settings.flag.button_swap = 0;
@@ -1018,7 +1021,7 @@ void SettingsDelta(void)
       }
     }
     if (Settings.version < 0x06040105) {
-      Settings.flag3.mdns_enabled = 0;
+      Settings.flag3.mdns_enabled = DISCOVERY_ENABLED;
       Settings.param[P_MDNS_DELAYED_START] = 0;
     }
 

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -83,6 +83,8 @@ typedef unsigned long power_t;              // Power (Relay) type
 
 #define WIFI_HOSTNAME          "%s-%04d"    // Expands to <MQTT_TOPIC>-<last 4 decimal chars of MAC address>
 
+#define DISCOVERY_ENABLED      0            // If set, MDNS will be enabled. Otherwise, it needs to be enable via SetOption55.
+
 #define CONFIG_FILE_SIGN       0xA5         // Configuration file signature
 #define CONFIG_FILE_XOR        0x5A         // Configuration file xor (0 = No Xor)
 

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -83,8 +83,6 @@ typedef unsigned long power_t;              // Power (Relay) type
 
 #define WIFI_HOSTNAME          "%s-%04d"    // Expands to <MQTT_TOPIC>-<last 4 decimal chars of MAC address>
 
-#define DISCOVERY_ENABLED      0            // If set, MDNS will be enabled. Otherwise, it needs to be enable via SetOption55.
-
 #define CONFIG_FILE_SIGN       0xA5         // Configuration file signature
 #define CONFIG_FILE_XOR        0x5A         // Configuration file xor (0 = No Xor)
 


### PR DESCRIPTION
This only affects the first boot when flash is empty or invalid. After
flash been written once, MDNS is controlled bia SetOption55.