### PR TITLE
PN532: Segregate UID and DATA usage

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -325,8 +325,9 @@
 //  #define USE_DS3231                             // Enable DS3231 external RTC in case no Wifi is avaliable. See docs in the source file (+1k2 code)
 //    #define USE_RTC_ADDR  0x68                   // Default I2C address 0x68
 //  #define USE_MGC3130                            // Enable MGC3130 Electric Field Effect Sensor (I2C address 0x42) (+2k7 code, 0k3 mem)
-//  #define USE_PN532_I2C                          // Enable PN532 - Near Field Communication (NFC) controller (+3k3 code, 508 bytes of mem)
-//    #define USE_PN532_CAUSE_EVENTS               // Enable PN532 driver to cause event's on card read in addition to immediate telemetry
+//  #define USE_PN532_I2C                          // Enable PN532 - Near Field Communication (NFC) controller (+1k7 code, 164 bytes of mem)
+//    #define USE_PN532_DATA_FUNCTION              // Enable PN532 DATA Usage using Sensor15 command (+1k6 code, 316 bytes of mem)
+//    #define USE_PN532_CAUSE_EVENTS               // Enable PN532 driver to cause event's on card read in addition to immediate telemetry (+64 bytes code, 48 bytes mem)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/sonoff/xsns_40_pn532_i2c.ino
+++ b/sonoff/xsns_40_pn532_i2c.ino
@@ -61,9 +61,13 @@ uint8_t pn532_i2c_detected = 0;
 uint8_t pn532_i2c_packetbuffer[64];
 uint8_t pn532_i2c_scan_defer_report = 0;         // If a valid card was found we will not scan for one again in the same two seconds so we set this to 19 if a card was found
 uint8_t pn532_i2c_command = 0;
+
 uint8_t pn532_i2c_disable = 0;
+
+#ifdef USE_PN532_DATA_FUNCTION
 uint8_t pn532_i2c_function = 0;
 uint8_t pn532_i2c_newdata[16];
+#endif // USE_PN532_DATA_FUNCTION
 
 const uint8_t PROGMEM pn532_global_timeout = 10;
 
@@ -285,6 +289,8 @@ boolean PN532_readPassiveTargetID(uint8_t cardbaudrate, uint8_t *uid, uint8_t *u
   return true;
 }
 
+#ifdef USE_PN532_DATA_FUNCTION
+
 uint8_t mifareclassic_AuthenticateBlock (uint8_t *uid, uint8_t uidLen, uint32_t blockNumber, uint8_t keyNumber, uint8_t *keyData)
 {
     uint8_t i;
@@ -370,6 +376,7 @@ uint8_t mifareclassic_WriteDataBlock (uint8_t blockNumber, uint8_t *data)
     return (0 < PN532_readResponse(pn532_i2c_packetbuffer, sizeof(pn532_i2c_packetbuffer)));
 }
 
+#endif // USE_PN532_DATA_FUNCTION
 
 void PN532_ScanForTag(void)
 {
@@ -384,11 +391,17 @@ void PN532_ScanForTag(void)
       pn532_i2c_scan_defer_report--;
     } else {
       char uids[15];
+      
+#ifdef USE_PN532_DATA_FUNCTION      
       char card_datas[34];
+#endif // USE_PN532_DATA_FUNCTION      
+
       sprintf(uids,"");
       for (uint8_t i = 0;i < uid_len;i++) {
         sprintf(uids,"%s%02X",uids,uid[i]);
       }
+      
+#ifdef USE_PN532_DATA_FUNCTION      
       if (uid_len == 4) { // Lets try to read block 0 of the mifare classic card for more information
         uint8_t keyuniversal[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
         if (mifareclassic_AuthenticateBlock (uid, uid_len, 1, 1, keyuniversal)) {
@@ -435,17 +448,28 @@ void PN532_ScanForTag(void)
           break;
       }
       pn532_i2c_function = 0;
+#endif // USE_PN532_DATA_FUNCTION      
+      
       snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"" D_JSON_TIME "\":\"%s\""), GetDateAndTime(DT_LOCAL).c_str());
+
+#ifdef USE_PN532_DATA_FUNCTION
       snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"PN532\":{\"UID\":\"%s\", \"DATA\":\"%s\"}}"), mqtt_data, uids, card_datas);
+#else
+      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"PN532\":{\"UID\":\"%s\"}}"), mqtt_data, uids);
+#endif // USE_PN532_DATA_FUNCTION      
+
       MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
 
-#ifdef USE_PN532_CAUSE_EVENTS      
+#ifdef USE_PN532_CAUSE_EVENTS
 
       char command[71];
+#ifdef USE_PN532_DATA_FUNCTION
       sprintf(command,"backlog event PN532_UID=%s;event PN532_DATA=%s",uids,card_datas);
+#else
+      sprintf(command,"event PN532_UID=%s",uids);
+#endif // USE_PN532_DATA_FUNCTION      
       ExecuteCommand(command, SRC_RULE);
-      
-#endif
+#endif // USE_PN532_CAUSE_EVENTS
       
       pn532_i2c_scan_defer_report = 7; // Ignore tags found for two seconds
     }
@@ -453,6 +477,8 @@ void PN532_ScanForTag(void)
     if (pn532_i2c_scan_defer_report > 0) { pn532_i2c_scan_defer_report--; }
   }
 }
+
+#ifdef USE_PN532_DATA_FUNCTION
 
 boolean PN532_Command(void)
 {
@@ -500,6 +526,8 @@ boolean PN532_Command(void)
   }
 }
 
+#endif // USE_PN532_DATA_FUNCTION
+
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/
@@ -518,11 +546,15 @@ boolean Xsns40(byte function)
       case FUNC_EVERY_SECOND:
         PN532_Detect();
         break;
+
+#ifdef USE_PN532_DATA_FUNCTION        
       case FUNC_COMMAND:
         if (XSNS_40 == XdrvMailbox.index) {
           result = PN532_Command();
         }
         break;
+#endif // USE_PN532_DATA_FUNCTION        
+
       case FUNC_SAVE_BEFORE_RESTART:
         if (!pn532_i2c_disable) {
           pn532_i2c_disable = 1;


### PR DESCRIPTION
It seems further debugging will be necessary for full DATA usage functionality as there appear to be some different cards and their responses are not yet incorporated because I do not have any such cards.

So for now we enable only UID use and allow DATA usage to be included by a new USE_PN532_DATA_FUNCTION directive in my_user_config.h

Issue https://github.com/arendst/Sonoff-Tasmota/issues/4941 bears reference.