### PR TITLE
Initial hack to get IPv6 up and running. Ping -6 and webinterface works.

### DIFF
--- a/lib/TasmotaMqtt-1.1.1/src/mqtt/mqtt.c
+++ b/lib/TasmotaMqtt-1.1.1/src/mqtt/mqtt.c
@@ -85,9 +85,9 @@ mqtt_dns_found(const char *name, ip_addr_t *ipaddr, void *arg)
             *((uint8 *) &ipaddr->addr + 2),
             *((uint8 *) &ipaddr->addr + 3));
 
-  if (client->ip.addr == 0 && ipaddr->addr != 0)
+  if (client->ip.u_addr.ip4.addr == 0 && ipaddr->u_addr.ip4.addr != 0)
   {
-    os_memcpy(client->pCon->proto.tcp->remote_ip, &ipaddr->addr, 4);
+    os_memcpy(client->pCon->proto.tcp->remote_ip, &ipaddr->u_addr.ip4.addr, 4);
     if (client->security) {
 #ifdef MQTT_SSL_ENABLE
       espconn_secure_set_size(ESPCONN_CLIENT, MQTT_SSL_SIZE);

--- a/platformio.ini
+++ b/platformio.ini
@@ -97,7 +97,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; lwIP 2 - Higher Bandwitdh Low Memory no Features
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
 ; lwIP 2 - Higher Bandwitdh no Features
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
 ; VTABLES in Flash (default)
                             -DVTABLES_IN_FLASH
 ; VTABLES in Heap
@@ -116,12 +116,12 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Select one core set for platform and build_flags
 ;platform                  = ${core_2_3_0.platform}
 ;build_flags               = ${core_2_3_0.build_flags}
-platform                  = ${core_2_4_2.platform}
-build_flags               = ${core_2_4_2.build_flags}
+;platform                  = ${core_2_4_2.platform}
+;build_flags               = ${core_2_4_2.build_flags}
 ;platform                  = ${core_2_5_0.platform}
 ;build_flags               = ${core_2_5_0.build_flags}
-;platform                  = ${core_stage.platform}
-;build_flags               = ${core_stage.build_flags}
+platform                  = ${core_stage.platform}
+build_flags               = ${core_stage.build_flags}
 
 [common]
 framework                 = arduino

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -295,7 +295,7 @@ struct SYSCFG {
   byte          ina219_mode;               // 531
   uint16_t      pulse_timer[MAX_PULSETIMERS]; // 532
   uint16_t      button_debounce;           // 542
-  uint32_t      ip_address[4];             // 544
+  IPAddress     ip_address[4];             // 544 // Breaking hack for testing only
   unsigned long energy_kWhtotal;           // 554
   char          mqtt_fulltopic[100];       // 558
   SysBitfield2  flag2;                     // 5BC

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -470,7 +470,7 @@ void MqttDataHandler(char* topic, byte* data, unsigned int data_len)
 //  uint8_t user_append_index = 0;
   uint16_t i = 0;
   uint16_t index;
-  uint32_t address;
+  IPAddress address;
 
   ShowFreeMem(PSTR("MqttDataHandler"));
 

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -361,9 +361,9 @@ uint8_t Shortcut(const char* str)
   return result;
 }
 
-boolean ParseIp(uint32_t* addr, const char* str)
+boolean ParseIp(IPAddress* addr, const char* str)
 {
-  uint8_t *part = (uint8_t*)addr;
+/*  uint8_t *part = (uint8_t*)addr;
   byte i;
 
   *addr = 0;
@@ -375,7 +375,7 @@ boolean ParseIp(uint32_t* addr, const char* str)
     }
     str++;                                   // Point to next character after separator
   }
-  return (3 == i);
+  return (3 == i); */
 }
 
 void MakeValidMqtt(byte option, char* str)


### PR DESCRIPTION
Hi,

startet a trial to get IPv6 running using core_stage. Had to do some minor changes in support_wifi.ino and TasmotaMqtt-1.1.1 mostly regarding the handling of IPv4 Adresses. With v6 enabled we have DualStack and addr isn't an u_int32 anymore but a struct.

00:00:00 Project sonoff Sonoff Version 6.4.1.9(sonoff)-STAGE
IPV6 is enabled
.........IF='ap' IPv6=1 local=1 hostname='' addr= fe80::xxx:7fff:fe88:e805
IF='st' IPv6=0 local=0 hostname='sonoff-2053' addr= 192.168.100.229 / mask:255.255.255.0 / gw:192.168.100.254
IF='st' IPv6=1 local=1 hostname='sonoff-2053' addr= fe80::xxx:7fff:fe88:e805
IF='st' IPv6=1 local=0 hostname='sonoff-2053' addr= 2a01:xxx:5:150:5ecf:7fff:fe88:e805
00:00:05 WIF: Connecting to AP1 krupp.net in mode 11N as sonoff-2053...
00:00:05 HTP: Web server active on sonoff-2053 with IP address 192.168.100.229
19:12:34 WIF: Connected

Webserver-Access is working. ping -6 works.

Code size for sonoff.bin is
DATA: [====== ] 61.7% (used 50532 bytes from 81920 bytes)
PROGRAM: [====== ] 57.4% (used 587520 bytes from 1023984 bytes)

This PR is not considered to be merged but as reference on what would be necessarry to be checked/changed (especially handling of IPv4 as u_int32) for a working IPv6 implementation.

Greetings,
Altelch.