### PR TITLE
PN532: Prevent non AlphaNumberic on DATA

### DIFF
--- a/sonoff/xsns_40_pn532_i2c.ino
+++ b/sonoff/xsns_40_pn532_i2c.ino
@@ -406,7 +406,13 @@ void PN532_ScanForTag(void)
         uint8_t keyuniversal[6] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
         if (mifareclassic_AuthenticateBlock (uid, uid_len, 1, 1, keyuniversal)) {
           if (mifareclassic_ReadDataBlock(1, card_data)) {
-            memcpy(&card_datas,&card_data,sizeof(card_data)); // Cast block 1 to a string
+            for (uint8_t i = 0;i < sizeof(card_data);i++) {
+              if ((isalpha(card_data[i])) || ((isdigit(card_data[i])))) {
+                card_datas[i] = char(card_data[i]);
+              } else {
+                card_datas[i] = '\0';
+              }
+            }
           }
           if (pn532_i2c_function == 1) { // erase block 1 of card
             for (uint8_t i = 0;i<16;i++) {


### PR DESCRIPTION
Block 1 (Used for text DATA) on a blank or newly formatted card may contain character values other than alpha-numeric which is the only characters we really want to use so I added a small loop to just ignore those cases so that we don't get garbage on the DATA JSON when such a card/tag is scanned.

Issue https://github.com/arendst/Sonoff-Tasmota/issues/4941 bears reference.