### PR TITLE
make tsl2561 compatible with SHT3x

### DIFF
--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -48,7 +48,6 @@ bool Tsl2561Read(void)
   uint16_t scaledFull, scaledIr;
   uint32_t full, ir;
 
-  if (Tsl.available()) {
     if (Tsl.on()) {
       if (Tsl.id(id)
         && Tsl2561Util::autoGain(Tsl, gain, exposure, scaledFull, scaledIr)
@@ -58,7 +57,6 @@ bool Tsl2561Read(void)
         tsl2561_milliLux = 0;
       }
     }
-  }
   tsl2561_valid = SENSOR_MAX_MISS;
   return true;
 }
@@ -67,9 +65,9 @@ void Tsl2561Detect(void)
 {
   if (tsl2561_type) { return; }
 
-  if (!Tsl.available()) {
+  if (I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49)) {
     Tsl.begin();
-    if (Tsl.available()) {
+    if (Tsl.on()) {
       tsl2561_type = 1;
       snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, tsl2561_types, Tsl.address());
       AddLog(LOG_LEVEL_DEBUG);
@@ -88,7 +86,7 @@ void Tsl2561EverySecond(void)
     if (tsl2561_type) {
       if (!Tsl2561Read()) {
         AddLogMissed(tsl2561_types, tsl2561_valid);
-//        if (!tsl2561_valid) { tsl2561_type = 0; }
+               if (!tsl2561_valid) { tsl2561_type = 0; }
       }
     }
   }


### PR DESCRIPTION
For unknown reasons the co-installation of a SHT3x leads to a malfunction of the available-function of the TSL-library. This function returns always true in this case.
As the Tasmota-driver relies on it, the tsl2561-sensor was never initialized („thinking, that all is well“).

This slightly modified version circumvents this.

I did as few code changes as possible and maybe, we will revisit the code later. For now it should work.