### PR TITLE
Adds new commands to use RCSwitch functionality on Sonoff Bridge with the Portisch firmware directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,42 @@
+## Sonoff-Tasmota RCSwitch Modification
+
+## Info
+Send RC codes
+Use your Sonoff RF Bridge to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets (see: https://github.com/sui77/rc-switch):<br />
+All you need is a Sonoff RF Bridge with Portisch RF-Bridge-EFM8BB1 updated firmware and one or more devices with one of the supported chipsets:
+- SC5262 / SC5272
+- HX2262 / HX2272
+- PT2262 / PT2272
+- EV1527 / RT1527 / FP1527 / HS1527
+- Intertechno outlets
+- HT6P20X
+<br />
+If yours doesn't work, you might need to adjust the pulse length.<br />
+
+## Details
+Since the Portisch firmware with RfRaw (see https://github.com/arendst/Sonoff-Tasmota/wiki/Commands) is able to directly send data directly to the RF chip, this modification uses the RfRaw command and translates the output of the RCSwitch library.
+For exmaple the new command **"RFSwitchOn 10001, 2"** will be internally translated to: **"rfraw AA B0 21 03 04 015E 041A 2A62 02010101100110011001010110010101100110011001010110 55"**<br />
+So instead of having to get or set up a remote control before having to record the code, the configurations set on the device can simply be used as parameters.<br /><br />
+For this I have added three new commands: (The last three parameters are optional!)<br />
+- **RFSwitchOn address, channel**[, protocol][, repeats][, pulse]<br />
+- **RFSwitchOff address, channel**[, protocol][, repeats][, pulse]<br />
+- **RFSwitchSend data, bits**[, protocol][, repeats][, pulse]<br />
+
+More Examples:<br />
+  - RFSwitchOn 10001, 2 <br />
+  - RFSwitchOff 10001, 2 <br />
+  - RFSwitchOn a, 2 <br />
+  - RFSwitchOff a, 2 <br />
+  - RFSwitchSend 0x501014, 24, 1, 10, 350 <br />
+  
+## Thanks
+This modification based on the great work from the Tasmota Firmware, the Portisch RF Firmware and the RCSwitch Library.<br />
+https://github.com/sui77/rc-switch<br />
+https://github.com/Portisch/RF-Bridge-EFM8BB1<br />
+https://github.com/sui77/rc-switch/<br />
+<br />
+<br />
+<br />
 ## Sonoff-Tasmota
 
 Alternative firmware for _ESP8266 based devices_ like [iTead](https://www.itead.cc/) _**Sonoff**_ with **web**, **timers**, 'Over The Air' (**OTA**) firmware updates and **sensors support**, allowing control under **Serial**, **HTTP**, **MQTT** and **KNX**, so as to be used on **Smart Home Systems**. Written for Arduino IDE and PlatformIO.

--- a/sonoff/virtual_rcswitch.cpp
+++ b/sonoff/virtual_rcswitch.cpp
@@ -1,0 +1,536 @@
+/*
+  VirtualRCSwitch Arduino libary for remote control outlet switches on snfbridge
+  based on RCSwitch - Arduino libary for remote control outlet switches
+  Copyright (c) 2011 Suat Özgür.  All right reserved.
+
+  Contributors:
+  - Andre Koehler / info(at)tomate-online(dot)de
+  - Gordeev Andrey Vladimirovich / gordeev(at)openpyro(dot)com
+  - Skineffect / http://forum.ardumote.com/viewtopic.php?f=2&t=46
+  - Dominik Fischer / dom_fischer(at)web(dot)de
+  - Frank Oltmanns / <first name>.<last name>(at)gmail(dot)com
+  - Max Horn / max(at)quendi(dot)de
+  - Robert ter Vehn / <first name>.<last name>(at)gmail(dot)com
+  
+  Project home: https://github.com/sui77/rc-switch/
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "virtual_rcswitch.h"
+
+/* Format for protocol definitions:
+* {pulselength, Sync bit, "0" bit, "1" bit}
+*
+* pulselength: pulse length in microseconds, e.g. 350
+* Sync bit: {1, 31} means 1 high pulse and 31 low pulses
+*     (perceived as a 31*pulselength long pulse, total length of sync bit is
+*     32*pulselength microseconds), i.e:
+*      _
+*     | |_______________________________ (don't count the vertical bars)
+* "0" bit: waveform for a data bit of value "0", {1, 3} means 1 high pulse
+*     and 3 low pulses, total length (1+3)*pulselength, i.e:
+*      _
+*     | |___
+* "1" bit: waveform for a data bit of value "1", e.g. {3,1}:
+*      ___
+*     |   |_
+*
+* These are combined to form Tri-State bits when sending or receiving codes.
+*/
+#if defined(ESP8266) || defined(ESP32)
+static const VirtualRCSwitch::Protocol proto[] = {
+#else
+static const VirtualRCSwitch::Protocol PROGMEM proto[] = {
+//static const VirtualRCSwitch::Protocol proto[] = {
+#endif
+    {350, {1, 31}, {1, 3}, {3, 1}, false},   // protocol 1
+    {650, {1, 10}, {1, 2}, {2, 1}, false},   // protocol 2
+    {100, {30, 71}, {4, 11}, {9, 6}, false}, // protocol 3
+    {380, {1, 6}, {1, 3}, {3, 1}, false},    // protocol 4
+    {500, {6, 14}, {1, 2}, {2, 1}, false},   // protocol 5
+    {450, {23, 1}, {1, 2}, {2, 1}, true},    // protocol 6 (HT6P20B)
+    {150, {2, 62}, {1, 6}, {6, 1}, false}    // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+};
+
+enum
+{
+    numProto = sizeof(proto) / sizeof(proto[0])
+};
+
+VirtualRCSwitch::VirtualRCSwitch()
+{
+    this->setRepeatTransmit(10);
+    this->setProtocol(1);
+    this->resetRecording();
+}
+
+/**
+* Switch a remote switch on (Type D REV)
+*
+* @param sGroup        Code of the switch group (A,B,C,D)
+* @param nDevice       Number of the switch itself (1..3)
+*/
+void VirtualRCSwitch::switchOn(char sGroup, int nDevice)
+{
+    this->sendTriState(this->getCodeWordD(sGroup, nDevice, true));
+}
+
+/**
+* Switch a remote switch off (Type D REV)
+*
+* @param sGroup        Code of the switch group (A,B,C,D)
+* @param nDevice       Number of the switch itself (1..3)
+*/
+void VirtualRCSwitch::switchOff(char sGroup, int nDevice)
+{
+    this->sendTriState(this->getCodeWordD(sGroup, nDevice, false));
+}
+
+/**
+* Switch a remote switch on (Type C Intertechno)
+*
+* @param sFamily  Familycode (a..f)
+* @param nGroup   Number of group (1..4)
+* @param nDevice  Number of device (1..4)
+*/
+void VirtualRCSwitch::switchOn(char sFamily, int nGroup, int nDevice)
+{
+    this->sendTriState(this->getCodeWordC(sFamily, nGroup, nDevice, true));
+}
+
+/**
+* Switch a remote switch off (Type C Intertechno)
+*
+* @param sFamily  Familycode (a..f)
+* @param nGroup   Number of group (1..4)
+* @param nDevice  Number of device (1..4)
+*/
+void VirtualRCSwitch::switchOff(char sFamily, int nGroup, int nDevice)
+{
+    this->sendTriState(this->getCodeWordC(sFamily, nGroup, nDevice, false));
+}
+
+/**
+* Switch a remote switch on (Type B with two rotary/sliding switches)
+*
+* @param nAddressCode  Number of the switch group (1..4)
+* @param nChannelCode  Number of the switch itself (1..4)
+*/
+void VirtualRCSwitch::switchOn(int nAddressCode, int nChannelCode)
+{
+    this->sendTriState(this->getCodeWordB(nAddressCode, nChannelCode, true));
+}
+
+/**
+* Switch a remote switch off (Type B with two rotary/sliding switches)
+*
+* @param nAddressCode  Number of the switch group (1..4)
+* @param nChannelCode  Number of the switch itself (1..4)
+*/
+void VirtualRCSwitch::switchOff(int nAddressCode, int nChannelCode)
+{
+    this->sendTriState(this->getCodeWordB(nAddressCode, nChannelCode, false));
+}
+
+/**
+* Deprecated, use switchOn(const char* sGroup, const char* sDevice) instead!
+* Switch a remote switch on (Type A with 10 pole DIP switches)
+*
+* @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+* @param nChannelCode  Number of the switch itself (1..5)
+*/
+void VirtualRCSwitch::switchOn(const char *sGroup, int nChannel)
+{
+    const char *code[6] = {"00000", "10000", "01000", "00100", "00010", "00001"};
+    this->switchOn(sGroup, code[nChannel]);
+}
+
+/**
+* Deprecated, use switchOff(const char* sGroup, const char* sDevice) instead!
+* Switch a remote switch off (Type A with 10 pole DIP switches)
+*
+* @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+* @param nChannelCode  Number of the switch itself (1..5)
+*/
+void VirtualRCSwitch::switchOff(const char *sGroup, int nChannel)
+{
+    const char *code[6] = {"00000", "10000", "01000", "00100", "00010", "00001"};
+    this->switchOff(sGroup, code[nChannel]);
+}
+
+/**
+* Switch a remote switch on (Type A with 10 pole DIP switches)
+*
+* @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+* @param sDevice       Code of the switch device (refers to DIP switches 6..10 (A..E) where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+*/
+void VirtualRCSwitch::switchOn(const char *sGroup, const char *sDevice)
+{
+    this->sendTriState(this->getCodeWordA(sGroup, sDevice, true));
+}
+
+/**
+* Switch a remote switch off (Type A with 10 pole DIP switches)
+*
+* @param sGroup        Code of the switch group (refers to DIP switches 1..5 where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+* @param sDevice       Code of the switch device (refers to DIP switches 6..10 (A..E) where "1" = on and "0" = off, if all DIP switches are on it's "11111")
+*/
+void VirtualRCSwitch::switchOff(const char *sGroup, const char *sDevice)
+{
+    this->sendTriState(this->getCodeWordA(sGroup, sDevice, false));
+}
+
+/**
+* Returns a char[13], representing the code word to be send.
+*
+*/
+char *VirtualRCSwitch::getCodeWordA(const char *sGroup, const char *sDevice, bool bStatus)
+{
+    static char sReturn[13];
+    int nReturnPos = 0;
+
+    for (int i = 0; i < 5; i++)
+    {
+        sReturn[nReturnPos++] = (sGroup[i] == '0') ? 'F' : '0';
+    }
+
+    for (int i = 0; i < 5; i++)
+    {
+        sReturn[nReturnPos++] = (sDevice[i] == '0') ? 'F' : '0';
+    }
+
+    sReturn[nReturnPos++] = bStatus ? '0' : 'F';
+    sReturn[nReturnPos++] = bStatus ? 'F' : '0';
+
+    sReturn[nReturnPos] = '\0';
+    return sReturn;
+}
+
+/**
+* Encoding for type B switches with two rotary/sliding switches.
+*
+* The code word is a tristate word and with following bit pattern:
+*
+* +-----------------------------+-----------------------------+----------+------------+
+* | 4 bits address              | 4 bits address              | 3 bits   | 1 bit      |
+* | switch group                | switch number               | not used | on / off   |
+* | 1=0FFF 2=F0FF 3=FF0F 4=FFF0 | 1=0FFF 2=F0FF 3=FF0F 4=FFF0 | FFF      | on=F off=0 |
+* +-----------------------------+-----------------------------+----------+------------+
+*
+* @param nAddressCode  Number of the switch group (1..4)
+* @param nChannelCode  Number of the switch itself (1..4)
+* @param bStatus       Whether to switch on (true) or off (false)
+*
+* @return char[13], representing a tristate code word of length 12
+*/
+char *VirtualRCSwitch::getCodeWordB(int nAddressCode, int nChannelCode, bool bStatus)
+{
+    static char sReturn[13];
+    int nReturnPos = 0;
+
+    if (nAddressCode < 1 || nAddressCode > 4 || nChannelCode < 1 || nChannelCode > 4)
+    {
+        return 0;
+    }
+
+    for (int i = 1; i <= 4; i++)
+    {
+        sReturn[nReturnPos++] = (nAddressCode == i) ? '0' : 'F';
+    }
+
+    for (int i = 1; i <= 4; i++)
+    {
+        sReturn[nReturnPos++] = (nChannelCode == i) ? '0' : 'F';
+    }
+
+    sReturn[nReturnPos++] = 'F';
+    sReturn[nReturnPos++] = 'F';
+    sReturn[nReturnPos++] = 'F';
+
+    sReturn[nReturnPos++] = bStatus ? 'F' : '0';
+
+    sReturn[nReturnPos] = '\0';
+    return sReturn;
+}
+
+/**
+* Like getCodeWord (Type C = Intertechno)
+*/
+char *VirtualRCSwitch::getCodeWordC(char sFamily, int nGroup, int nDevice, bool bStatus)
+{
+    static char sReturn[13];
+    int nReturnPos = 0;
+
+    int nFamily = (int)sFamily - 'a';
+    if (nFamily < 0 || nFamily > 15 || nGroup < 1 || nGroup > 4 || nDevice < 1 || nDevice > 4)
+    {
+        return 0;
+    }
+
+    // encode the family into four bits
+    sReturn[nReturnPos++] = (nFamily & 1) ? 'F' : '0';
+    sReturn[nReturnPos++] = (nFamily & 2) ? 'F' : '0';
+    sReturn[nReturnPos++] = (nFamily & 4) ? 'F' : '0';
+    sReturn[nReturnPos++] = (nFamily & 8) ? 'F' : '0';
+
+    // encode the device and group
+    sReturn[nReturnPos++] = ((nDevice - 1) & 1) ? 'F' : '0';
+    sReturn[nReturnPos++] = ((nDevice - 1) & 2) ? 'F' : '0';
+    sReturn[nReturnPos++] = ((nGroup - 1) & 1) ? 'F' : '0';
+    sReturn[nReturnPos++] = ((nGroup - 1) & 2) ? 'F' : '0';
+
+    // encode the status code
+    sReturn[nReturnPos++] = '0';
+    sReturn[nReturnPos++] = 'F';
+    sReturn[nReturnPos++] = 'F';
+    sReturn[nReturnPos++] = bStatus ? 'F' : '0';
+
+    sReturn[nReturnPos] = '\0';
+    return sReturn;
+}
+
+/**
+* Encoding for the REV Switch Type
+*
+* The code word is a tristate word and with following bit pattern:
+*
+* +-----------------------------+-------------------+----------+--------------+
+* | 4 bits address              | 3 bits address    | 3 bits   | 2 bits       |
+* | switch group                | device number     | not used | on / off     |
+* | A=1FFF B=F1FF C=FF1F D=FFF1 | 1=0FF 2=F0F 3=FF0 | 000      | on=10 off=01 |
+* +-----------------------------+-------------------+----------+--------------+
+*
+* Source: http://www.the-intruder.net/funksteckdosen-von-rev-uber-arduino-ansteuern/
+*
+* @param sGroup        Name of the switch group (A..D, resp. a..d)
+* @param nDevice       Number of the switch itself (1..3)
+* @param bStatus       Whether to switch on (true) or off (false)
+*
+* @return char[13], representing a tristate code word of length 12
+*/
+char *VirtualRCSwitch::getCodeWordD(char sGroup, int nDevice, bool bStatus)
+{
+    static char sReturn[13];
+    int nReturnPos = 0;
+
+    // sGroup must be one of the letters in "abcdABCD"
+    int nGroup = (sGroup >= 'a') ? (int)sGroup - 'a' : (int)sGroup - 'A';
+    if (nGroup < 0 || nGroup > 3 || nDevice < 1 || nDevice > 3)
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < 4; i++)
+    {
+        sReturn[nReturnPos++] = (nGroup == i) ? '1' : 'F';
+    }
+
+    for (int i = 1; i <= 3; i++)
+    {
+        sReturn[nReturnPos++] = (nDevice == i) ? '1' : 'F';
+    }
+
+    sReturn[nReturnPos++] = '0';
+    sReturn[nReturnPos++] = '0';
+    sReturn[nReturnPos++] = '0';
+
+    sReturn[nReturnPos++] = bStatus ? '1' : '0';
+    sReturn[nReturnPos++] = bStatus ? '0' : '1';
+
+    sReturn[nReturnPos] = '\0';
+    return sReturn;
+}
+
+/**
+* @param sCodeWord   a tristate code word consisting of the letter 0, 1, F
+*/
+void VirtualRCSwitch::sendTriState(const char *sCodeWord)
+{
+    // turn the tristate code word into the corresponding bit pattern, then send it
+    unsigned long code = 0;
+    unsigned int length = 0;
+    for (const char *p = sCodeWord; *p; p++)
+    {
+        code <<= 2L;
+        switch (*p)
+        {
+        case '0':
+            // bit pattern 00
+            break;
+        case 'F':
+            // bit pattern 01
+            code |= 1L;
+            break;
+        case '1':
+            // bit pattern 11
+            code |= 3L;
+            break;
+        }
+        length += 2;
+    }
+    this->send(code, length);
+}
+
+/**
+* @param sCodeWord   a binary code word consisting of the letter 0, 1
+*/
+void VirtualRCSwitch::send(const char *sCodeWord)
+{
+    // turn the tristate code word into the corresponding bit pattern, then send it
+    unsigned long code = 0;
+    unsigned int length = 0;
+    for (const char *p = sCodeWord; *p; p++)
+    {
+        code <<= 1L;
+        if (*p != '0')
+            code |= 1L;
+        length++;
+    }
+    this->send(code, length);
+}
+
+/**
+* Transmit the first 'length' bits of the integer 'code'. The
+* bits are sent from MSB to LSB, i.e., first the bit at position length-1,
+* then the bit at position length-2, and so on, till finally the bit at position 0.
+*/
+void VirtualRCSwitch::send(unsigned long code, unsigned int length)
+{
+
+    for (int i = length - 1; i >= 0; i--)
+    {
+        if (code & (1L << i))
+            this->transmit(protocol.one);
+        else
+            this->transmit(protocol.zero);
+    }
+    this->transmit(protocol.syncFactor);
+}
+
+/**
+* Sets the protocol to send.
+*/
+void VirtualRCSwitch::setProtocol(Protocol protocol)
+{
+    this->protocol = protocol;
+}
+
+/**
+* Sets the protocol to send, from a list of predefined protocols
+*/
+void VirtualRCSwitch::setProtocol(int nProtocol)
+{
+    if (nProtocol < 1 || nProtocol > numProto)
+    {
+        nProtocol = 1; // TODO: trigger an error, e.g. "bad protocol" ???
+    }
+#if defined(ESP8266) || defined(ESP32)
+    this->protocol = proto[nProtocol - 1];
+#else
+    memcpy_P(&this->protocol, &proto[nProtocol - 1], sizeof(Protocol));
+#endif
+}
+
+/**
+* Sets the protocol to send with pulse length in microseconds.
+*/
+void VirtualRCSwitch::setProtocol(int nProtocol, int nPulseLength)
+{
+    this->setProtocol(nProtocol);
+    this->setPulseLength(nPulseLength);
+}
+
+/**
+* Sets pulse length in microseconds
+*/
+void VirtualRCSwitch::setPulseLength(int nPulseLength)
+{
+    this->protocol.pulseLength = nPulseLength;
+}
+
+/**
+* Sets Repeat Transmits
+*/
+void VirtualRCSwitch::setRepeatTransmit(int nRepeatTransmit)
+{
+    this->nRepeatTransmit = nRepeatTransmit;
+}
+
+/**
+* Transmit a single high-low pulse.
+*/
+void VirtualRCSwitch::transmit(HighLow pulses)
+{
+
+    //uint8_t firstLogicLevel = (this->protocol.invertedSignal) ? LOW : HIGH;
+    //uint8_t secondLogicLevel = (this->protocol.invertedSignal) ? HIGH : LOW;
+
+    //digitalWrite(this->nTransmitterPin, firstLogicLevel);
+    this->recordBucket(this->protocol.pulseLength * pulses.high);
+    //digitalWrite(this->nTransmitterPin, secondLogicLevel);
+    this->recordBucket(this->protocol.pulseLength * pulses.low);
+}
+
+void VirtualRCSwitch::recordBucket(unsigned int duration)
+{
+    int bucketssize = this->buckets.size();    
+    for (size_t i = 0; i < bucketssize; i++)
+    {
+        if (this->buckets[i] == duration)
+        {            
+            rfdata+=String(i,16);
+            return;
+        }
+    }
+
+    this->rfdata+=String(bucketssize,16);
+    this->buckets.push_back(duration);
+}
+
+void VirtualRCSwitch::resetRecording()
+{
+    this->buckets.clear();
+    this->rfdata = "";  
+}
+
+String VirtualRCSwitch::toString()
+{
+    int frdatalen = this->rfdata.length();
+    int buketsize = this->buckets.size(); 
+    if (buketsize == 0 || frdatalen < 2)
+    {
+        return "";
+    }
+
+    // see BitBucketConverter.py from gerardovf
+    // fixed handling, findSyncPattern with bucketAtEnd = True
+    int dlen = 2 + buketsize * 2 + frdatalen / 2;
+
+    char tmp[10];
+
+    sprintf(tmp, "AA B0 %02X %02X %02X ", dlen, buketsize, this->nRepeatTransmit);
+
+    String result = String(tmp);
+
+    for (size_t i = 0; i < buketsize; i++)
+    {
+        sprintf(tmp, "%04X ", buckets[i]);
+        result+=tmp;
+    }
+    result+=rfdata.substring(frdatalen - 2);
+    result+=rfdata.substring(0,frdatalen - 2);
+    return result;
+}

--- a/sonoff/virtual_rcswitch.cpp
+++ b/sonoff/virtual_rcswitch.cpp
@@ -532,5 +532,7 @@ String VirtualRCSwitch::toString()
     }
     result+=rfdata.substring(frdatalen - 2);
     result+=rfdata.substring(0,frdatalen - 2);
+    result+=" 55";
+    
     return result;
 }

--- a/sonoff/virtual_rcswitch.h
+++ b/sonoff/virtual_rcswitch.h
@@ -1,0 +1,135 @@
+/*
+  VirtualRCSwitch Arduino libary for remote control outlet switches on snfbridge
+  based on RCSwitch - Arduino libary for remote control outlet switches
+  Copyright (c) 2011 Suat Özgür.  All right reserved.
+
+  Contributors:
+  - Andre Koehler / info(at)tomate-online(dot)de
+  - Gordeev Andrey Vladimirovich / gordeev(at)openpyro(dot)com
+  - Skineffect / http://forum.ardumote.com/viewtopic.php?f=2&t=46
+  - Dominik Fischer / dom_fischer(at)web(dot)de
+  - Frank Oltmanns / <first name>.<last name>(at)gmail(dot)com
+  - Max Horn / max(at)quendi(dot)de
+  - Robert ter Vehn / <first name>.<last name>(at)gmail(dot)com
+  
+  Project home: https://github.com/sui77/rc-switch/
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef _VirtualRCSwitch_h
+#define _VirtualRCSwitch_h
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include "Arduino.h"
+#else
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#define LOW 0
+#define HIGH 1
+#endif
+
+#include <stdint.h>
+
+class VirtualRCSwitch
+{
+  public:
+    VirtualRCSwitch();
+
+    void switchOn(int nGroupNumber, int nSwitchNumber);
+    void switchOff(int nGroupNumber, int nSwitchNumber);
+    void switchOn(const char *sGroup, int nSwitchNumber);
+    void switchOff(const char *sGroup, int nSwitchNumber);
+    void switchOn(char sFamily, int nGroup, int nDevice);
+    void switchOff(char sFamily, int nGroup, int nDevice);
+    void switchOn(const char *sGroup, const char *sDevice);
+    void switchOff(const char *sGroup, const char *sDevice);
+    void switchOn(char sGroup, int nDevice);
+    void switchOff(char sGroup, int nDevice);
+
+    void sendTriState(const char *sCodeWord);
+    void send(unsigned long code, unsigned int length);
+    void send(const char *sCodeWord);
+
+    void setPulseLength(int nPulseLength);
+    void setRepeatTransmit(int nRepeatTransmit);
+
+    /**
+	* Description of a single pule, which consists of a high signal
+	* whose duration is "high" times the base pulse length, followed
+	* by a low signal lasting "low" times the base pulse length.
+	* Thus, the pulse overall lasts (high+low)*pulseLength
+	*/
+    struct HighLow
+    {
+        uint8_t high;
+        uint8_t low;
+    };
+
+    /**
+	* A "protocol" describes how zero and one bits are encoded into high/low
+	* pulses.
+	*/
+    struct Protocol
+    {
+        /** base pulse length in microseconds, e.g. 350 */
+        uint16_t pulseLength;
+
+        HighLow syncFactor;
+        HighLow zero;
+        HighLow one;
+
+        /**
+		* If true, interchange high and low logic levels in all transmissions.
+		*
+		* By default, RCSwitch assumes that any signals it sends or receives
+		* can be broken down into pulses which start with a high signal level,
+		* followed by a a low signal level. This is e.g. the case for the
+		* popular PT 2260 encoder chip, and thus many switches out there.
+		*
+		* But some devices do it the other way around, and start with a low
+		* signal level, followed by a high signal level, e.g. the HT6P20B. To
+		* accommodate this, one can set invertedSignal to true, which causes
+		* RCSwitch to change how it interprets any HighLow struct FOO: It will
+		* then assume transmissions start with a low signal lasting
+		* FOO.high*pulseLength microseconds, followed by a high signal lasting
+		* FOO.low*pulseLength microseconds.
+		*/
+        bool invertedSignal;
+    };
+
+    void setProtocol(Protocol protocol);
+    void setProtocol(int nProtocol);
+    void setProtocol(int nProtocol, int nPulseLength);
+
+    String toString();
+    void resetRecording();
+
+  private:
+    char *getCodeWordA(const char *sGroup, const char *sDevice, bool bStatus);
+    char *getCodeWordB(int nGroupNumber, int nSwitchNumber, bool bStatus);
+    char *getCodeWordC(char sFamily, int nGroup, int nDevice, bool bStatus);
+    char *getCodeWordD(char group, int nDevice, bool bStatus);
+    void transmit(HighLow pulses);
+    void recordBucket(unsigned int duration);
+
+    Protocol protocol;
+    int nRepeatTransmit;
+
+    std::vector<unsigned int> buckets = std::vector<unsigned int>();
+    String rfdata = "";
+};
+
+#endif


### PR DESCRIPTION
adds new commands to use RCSwitch functionality with the Portisch firmware directly.
Examples:
  RFSwitchOn 10001, 2
  RFSwitchOff 10001, 2

  RFSwitchOn a, 2
  RFSwitchOff a, 2

  RFSwitchSend 0x501014, 24, 1, 10, 350