### PR TITLE
add functionality to use multiple ads1115's on one i2cbus

### DIFF
--- a/sonoff/xsns_12_ads1115.ino
+++ b/sonoff/xsns_12_ads1115.ino
@@ -161,6 +161,7 @@ int16_t Ads1115GetConversion(uint8_t channel)
 void Ads1115Detect(void)
 {
   uint16_t buffer;
+  uint16_t conf_buffer;
 
   //if (ads1115_type) {
     //return;
@@ -168,7 +169,9 @@ void Ads1115Detect(void)
 
   for (uint8_t i = 0; i < sizeof(ads1115_addresses); i++) {
     ads1115_address = ads1115_addresses[i];
-    if (I2cValidRead16(&buffer, ads1115_address, ADS1115_REG_POINTER_CONVERT)) {
+    if (I2cValidRead16(&buffer, ads1115_address, ADS1115_REG_POINTER_CONVERT) && 
+        I2cValidRead16(&conf_buffer, ads1115_address, ADS1115_REG_POINTER_CONFIG)) {
+
       Ads1115StartComparator(i, ADS1115_REG_CONFIG_MODE_CONTIN);
       ads1115_type = 1;
       ads1115_found[i] = 1;
@@ -184,8 +187,8 @@ void Ads1115GetValues(uint8_t address) {
     ads1115_address = address;
     for (uint8_t i = 0; i < 4; i++) {
         ads1115_values[i] = Ads1115GetConversion(i);
-        snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x (%i) = %i", address, i, ads1115_values[i] );
-        AddLog(LOG_LEVEL_INFO);
+        //snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x (%i) = %i", address, i, ads1115_values[i] );
+        //AddLog(LOG_LEVEL_INFO);
         }
     ads1115_address = old_address;
 }
@@ -220,8 +223,8 @@ void Ads1115Show(bool json)
   char *comma = (char*)"";
 
   for (uint8_t t = 0; t < sizeof(ads1115_addresses); t++) {
-    snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x", ads1115_addresses[t]);
-    AddLog(LOG_LEVEL_INFO);
+    //snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x", ads1115_addresses[t]);
+    //AddLog(LOG_LEVEL_INFO);
     if (ads1115_found[t]) {
       Ads1115GetValues(ads1115_addresses[t]);
       if (json) {

--- a/sonoff/xsns_12_ads1115.ino
+++ b/sonoff/xsns_12_ads1115.ino
@@ -119,7 +119,8 @@ CONFIG REGISTER
 uint8_t ads1115_type = 0;
 uint8_t ads1115_address;
 uint8_t ads1115_addresses[] = { ADS1115_ADDRESS_ADDR_GND, ADS1115_ADDRESS_ADDR_VDD, ADS1115_ADDRESS_ADDR_SDA, ADS1115_ADDRESS_ADDR_SCL };
-
+uint8_t ads1115_found[] = {false,false,false,false};
+int16_t ads1115_values[4];
 //Ads1115StartComparator(channel, ADS1115_REG_CONFIG_MODE_SINGLE);
 //Ads1115StartComparator(channel, ADS1115_REG_CONFIG_MODE_CONTIN);
 void Ads1115StartComparator(uint8_t channel, uint16_t mode)
@@ -161,51 +162,83 @@ void Ads1115Detect(void)
 {
   uint16_t buffer;
 
-  if (ads1115_type) {
-    return;
-  }
+  //if (ads1115_type) {
+    //return;
+  //}
 
   for (uint8_t i = 0; i < sizeof(ads1115_addresses); i++) {
     ads1115_address = ads1115_addresses[i];
     if (I2cValidRead16(&buffer, ads1115_address, ADS1115_REG_POINTER_CONVERT)) {
       Ads1115StartComparator(i, ADS1115_REG_CONFIG_MODE_CONTIN);
       ads1115_type = 1;
+      ads1115_found[i] = 1;
       snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, "ADS1115", ads1115_address);
       AddLog(LOG_LEVEL_DEBUG);
-      break;
+      //break;
     }
   }
 }
 
+void Ads1115GetValues(uint8_t address) {
+    uint8_t old_address = ads1115_address;
+    ads1115_address = address;
+    for (uint8_t i = 0; i < 4; i++) {
+        ads1115_values[i] = Ads1115GetConversion(i);
+        snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x (%i) = %i", address, i, ads1115_values[i] );
+        AddLog(LOG_LEVEL_INFO);
+        }
+    ads1115_address = old_address;
+}
+
+void Ads1115toJSON(char *comma_j) {
+  snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s%s{"), mqtt_data,comma_j);
+  char *comma = (char*)"";
+  for (uint8_t i = 0; i < 4; i++) {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s%s\"A%d\":%d"), mqtt_data, comma, i, ads1115_values[i]);
+    comma = (char*)",";
+    }
+  snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
+}
+
+void Ads1115toString(uint8_t address) {
+  char label[15];
+  snprintf_P(label, sizeof(label), "ADS1115(%02x)", address);
+
+  for (uint8_t i = 0; i < 4; i++) {
+    snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_ANALOG, mqtt_data, label, i, ads1115_values[i]);
+    }
+}
+
 void Ads1115Show(bool json)
 {
-  if (ads1115_type) {
-    char stemp[10];
+  if (!ads1115_type)
+    return;
 
-    uint8_t dsxflg = 0;
-    for (uint8_t i = 0; i < 4; i++) {
-      int16_t adc_value = Ads1115GetConversion(i);
+  if (json)
+    snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"ADS1115\":["), mqtt_data);
 
+  char *comma = (char*)"";
+
+  for (uint8_t t = 0; t < sizeof(ads1115_addresses); t++) {
+    snprintf_P(log_data, sizeof(log_data), "Logging ADS1115 %02x", ads1115_addresses[t]);
+    AddLog(LOG_LEVEL_INFO);
+    if (ads1115_found[t]) {
+      Ads1115GetValues(ads1115_addresses[t]);
       if (json) {
-        if (!dsxflg  ) {
-          snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s,\"ADS1115\":{"), mqtt_data);
-          stemp[0] = '\0';
+        Ads1115toJSON(comma);
+        comma = (char*)",";
         }
-        dsxflg++;
-        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s%s\"A%d\":%d"), mqtt_data, stemp, i, adc_value);
-        strlcpy(stemp, ",", sizeof(stemp));
 #ifdef USE_WEBSERVER
-      } else {
-        snprintf_P(mqtt_data, sizeof(mqtt_data), HTTP_SNS_ANALOG, mqtt_data, "ADS1115", i, adc_value);
+      else {
+        Ads1115toString(ads1115_addresses[t]);
+        }
 #endif  // USE_WEBSERVER
       }
     }
+
     if (json) {
-      if (dsxflg) {
-        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s}"), mqtt_data);
+      snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("%s]"), mqtt_data);
       }
-    }
-  }
 }
 
 /*********************************************************************************************\

--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -67,7 +67,7 @@ void Tsl2561Detect(void)
   uint8_t id;
 
   if (I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49)) {
-    if (!Tsl.id(&id)) return;
+    if (!Tsl.id(id)) return;
     Tsl.begin();
     if (Tsl.on()) {
       tsl2561_type = 1;

--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -64,11 +64,14 @@ bool Tsl2561Read(void)
 void Tsl2561Detect(void)
 {
   if (tsl2561_type) { return; }
+  uint8_t id;
 
-  if ((I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49))&&Tsl.begin()) {
+  if (I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49)) {
+    if (!Tsl.id(&id)) return;
+    Tsl.begin();
     if (Tsl.on()) {
       tsl2561_type = 1;
-      snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, tsl2561_types, Tsl.address());
+      snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, tsl2561_types, Tsl.address(), id);
       AddLog(LOG_LEVEL_DEBUG);
     }
   }

--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -65,8 +65,7 @@ void Tsl2561Detect(void)
 {
   if (tsl2561_type) { return; }
 
-  if (I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49)) {
-    Tsl.begin();
+  if ((I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49))&&Tsl.begin()) {
     if (Tsl.on()) {
       tsl2561_type = 1;
       snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, tsl2561_types, Tsl.address());


### PR DESCRIPTION
by setting up an array of flags and restructuring the output code you can now have up to 4 ads115's on one i2c bus.