### PR TITLE
Device waga

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1819,7 +1819,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
   },
   { "WAGA CHCZ02MB",   // WAGA life CHCZ02MB (HJL-01 Energy Monitoring)
                        // https://www.ebay.com/itm/332595697006
-     GPIO_LED1,        // GPIO00 Red LED
+     GPIO_LED2,        // GPIO00 Red LED
      0,                // GPIO01 Serial TX
      0,                // GPIO02
      GPIO_NRG_SEL_INV, // GPIO03 HJL-01 Sel output (1 = Voltage)
@@ -1834,7 +1834,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL1,        // GPIO12 Relay
      GPIO_KEY1,        // GPIO13 Button
      GPIO_NRG_CF1,     // GPIO14 HJL-01 CF1 voltage / current
-     GPIO_LED2,        // GPIO15 Blue LED - Link status
+     GPIO_LED1,        // GPIO15 Blue LED - Link status
      0, 0
   }
 };

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1798,7 +1798,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_ROT_B,       // GPIO13 Rotary switch B pin
      0, 0, 0, 0
   },
-  { "SP10",            // Tuya SP10 (ESP8285 - BL0937 Energy Monitoring)
+  { "SP10",            // Tuya SP10 (BL0937 Energy Monitoring)
                        // https://www.aliexpress.com/item/Smart-Mini-WiFi-Plug-Outlet-Switch-Work-With-ForEcho-Alexa-Google-Home-Remote-EU-Smart-Socket/32963670423.html
      0,                // GPIO00
      GPIO_PWM1,        // GPIO01 Nightlight
@@ -1814,7 +1814,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
                        // GPIO11 (SD_CMD   Flash)
      GPIO_NRG_SEL_INV, // GPIO12 BL0937 Sel output (1 = Voltage)
      GPIO_LED1,        // GPIO13 Blue LED - Link status
-     GPIO_REL1,        // GPIO14 Relay 1 and red LED
+     GPIO_REL1,        // GPIO14 Relay and red LED
      0, 0, 0
   },
   { "WAGA CHCZ02MB",   // WAGA life CHCZ02MB (HJL-01 Energy Monitoring)

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -293,6 +293,7 @@ enum SupportedModules {
   ZX2820,
   MI_DESK_LAMP,
   SP10,
+  WAGA,
   MAXMODULE };
 
 /********************************************************************************************/
@@ -574,6 +575,7 @@ const uint8_t kModuleNiceList[MAXMODULE] PROGMEM = {
   DIGOO,
   KA10,
   SP10,
+  WAGA,
   NEO_COOLCAM,         // Socket Relay Devices
   OBI,
   OBI2,
@@ -1814,6 +1816,26 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_LED1,        // GPIO13 Blue LED - Link status
      GPIO_REL1,        // GPIO14 Relay 1 and red LED
      0, 0, 0
+  },
+  { "WAGA CHCZ02MB",   // WAGA life CHCZ02MB (HJL-01 Energy Monitoring)
+                       // https://www.ebay.com/itm/332595697006
+     GPIO_LED1,        // GPIO00 Red LED
+     0,                // GPIO01 Serial TX
+     0,                // GPIO02
+     GPIO_NRG_SEL_INV, // GPIO03 HJL-01 Sel output (1 = Voltage)
+     0,                // GPIO04 
+     GPIO_HJL_CF,      // GPIO05 HJL-01 CF power
+                       // GPIO06 (SD_CLK   Flash)
+                       // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
+                       // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
+     0,                // GPIO09 (SD_DATA2 Flash QIO or ESP8285)
+     0,                // GPIO10 (SD_DATA3 Flash QIO or ESP8285)
+                       // GPIO11 (SD_CMD   Flash)
+     GPIO_REL1,        // GPIO12 Relay
+     GPIO_KEY1,        // GPIO13 Button
+     GPIO_NRG_CF1,     // GPIO14 HJL-01 CF1 voltage / current
+     GPIO_LED2,        // GPIO15 Blue LED - Link status
+     0, 0
   }
 };
 

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1819,7 +1819,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
   },
   { "WAGA CHCZ02MB",   // WAGA life CHCZ02MB (HJL-01 Energy Monitoring)
                        // https://www.ebay.com/itm/332595697006
-     GPIO_LED2,        // GPIO00 Red LED
+     GPIO_LED2_INV,    // GPIO00 Red LED
      0,                // GPIO01 Serial TX
      0,                // GPIO02
      GPIO_NRG_SEL_INV, // GPIO03 HJL-01 Sel output (1 = Voltage)
@@ -1834,7 +1834,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL1,        // GPIO12 Relay
      GPIO_KEY1,        // GPIO13 Button
      GPIO_NRG_CF1,     // GPIO14 HJL-01 CF1 voltage / current
-     GPIO_LED1,        // GPIO15 Blue LED - Link status
+     GPIO_LED1_INV,    // GPIO15 Blue LED - Link status
      0, 0
   }
 };


### PR DESCRIPTION
This merge request adds support for WAGA life CHCZ02MB smart socket and also fixes the comments of SP10 smart socket. The disassembly of device is probably impossible without leaving significant marks on it, but it should work with TuyOTA (not tested).