### PR TITLE
Add HASS status sensor + improve HASS discovery

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -160,6 +160,7 @@
 #define D_JSON_ZERO_POINT_CALIBRATION "Zero Point Calibration"
 
 #define D_RSLT_ENERGY "ENERGY"
+#define D_RSLT_HASS_STATE "HASS_STATE"
 #define D_RSLT_INFO "INFO"
 #define D_RSLT_MARGINS "MARGINS"
 #define D_RSLT_POWER "POWER"


### PR DESCRIPTION
Announce a status sensor for each device as in the below screenshot.

Also improve Hass discovery:
- Only announce the device in the status sensor, to avoid overflowing the MQTT message buffer
  With this change, full topic and friendly name (32 characters) is supported without any issue for all device types (worst case is RGBW light).
- In case there is again issue with overflow in the future, add helper `try_snprintf_P` which:
  - Detects and prints an error message in the log in case the buffer is too small
  - Makes sure invalid JSON is never generated

![image](https://user-images.githubusercontent.com/14281572/52366926-26993780-2a4b-11e9-8cfb-ebf2d29df3fe.png)

