### PR TITLE
Init delay of SM16716 increased to 1 ms

### DIFF
--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -410,7 +410,7 @@ void SM16716_Update(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b)
       digitalWrite(sm16716_pin_sel, HIGH);
       // in testing I found it takes a minimum of ~380us to wake up the chip
       // tested on a Merkury RGBW with an SM726EB
-      delayMicroseconds(400);
+      delayMicroseconds(1000);
       SM16716_Init();
     }
     else if (sm16716_enabled && !sm16716_should_enable) {


### PR DESCRIPTION
As per measurements by @damondins ([original post](https://github.com/gsimon75/Sonoff-Tasmota/pull/3#issuecomment-462059310)):

> Ok so I was able to change the code to 500ms and now the light is working as expected with color and white.
> ...
>  I initially set it to 1000ms and there wasn't any noticeable delay, so may want to play it safe to include others that may take longer.

The original post contains a typo, the delays are microseconds and not milliseconds.
