### PR TITLE
verify that tsl2561 works with new ads1115

### DIFF
--- a/sonoff/xsns_16_tsl2561.ino
+++ b/sonoff/xsns_16_tsl2561.ino
@@ -67,8 +67,8 @@ void Tsl2561Detect(void)
   uint8_t id;
 
   if (I2cDevice(0x29) || I2cDevice(0x39) || I2cDevice(0x49)) {
-    if (!Tsl.id(id)) return;
     Tsl.begin();
+    if (!Tsl.id(id)) return;
     if (Tsl.on()) {
       tsl2561_type = 1;
       snprintf_P(log_data, sizeof(log_data), S_LOG_I2C_FOUND_AT, tsl2561_types, Tsl.address(), id);


### PR DESCRIPTION
move Tsl.begin to above the Tsl.id check so that the tsl object is correctly initialized.