### PR TITLE
fixed color/dimmer/channel inconsistencies

### DIFF
--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -627,7 +627,7 @@ void LightSetDimmer(uint8_t myDimmer)
   }
 
   //determine highest color to premultiply dimmer with
-  uint8_t highest = 0;
+  uint8_t highest = 1;
   for (uint8_t i = 0; i < light_subtype; i++) {
     if (highest < Settings.light_color[i]) {
       highest = Settings.light_color[i];


### PR DESCRIPTION
PR related to #5151 

I think I was able to fix everything.
Steps taken:
- Not touching user-supplied color value, storing in Settings as is
- calculate new dimmer value from highest color channel
- dimmer is now 255 resolution internally instead of a percentage (commands still work the same)
- when the dimmer value changes, "normalized" to 255 color is calculated and dimmer applied to that.
- replaced some floats by uint16_t to save memory and performance while offering precise and predictable calculations
- made sure forward/backward mapping of 100 and 255 range for the user interface is consistent (related to the result always being one less issue)

The only remaining inconsistency is that if you set a color and at a later point set the dimmer value to the same dimmer value that was calculated from that color, it can still be a little bit off. That's just inherently caused by the percentage resolution of the dimmer.

I tested it with an RGBW stripe and couldn't find any problems using the commands color, dimmer, channelX and the fading settings. Shouldn't have affected any of the animations, since the way light_current_color works hasn't changed at all. I tried setting up a dummy device with only 2 channels, simulating Warm/Cold white devices, but I can't really verify it everything's working properly with that, so maybe someone should check.

From a performance and memory standpoint, I think, if anything, I probably improved the situation by getting rid of some floats. The only increase is that when changing the dimmer, the highest channel value has to be determined, which shouldn't be much of an impact.