### PR TITLE
Configuration parameter to send MQTT telemetry on status change

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -122,6 +122,7 @@
 
 // -- MQTT - Telemetry ----------------------------
 #define TELE_PERIOD            300               // [TelePeriod] Telemetry (0 = disable, 10 - 3600 seconds)
+#define TELE_ON_POWER          0                 // [SetOption59] send tele/STATE together with stat/RESULT (0 = Disable, 1 = Enable)
 
 // -- MQTT - Domoticz -----------------------------
 #define DOMOTICZ_UPDATE_TIMER  0                 // [DomoticzUpdateTimer] Send relay status (0 = disable, 1 - 3600 seconds)

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -661,6 +661,7 @@ void SettingsDefaultSet2(void)
   Settings.flag.mqtt_button_retain = MQTT_BUTTON_RETAIN;
   Settings.flag.mqtt_switch_retain = MQTT_SWITCH_RETAIN;
   Settings.flag3.button_switch_force_local = MQTT_BUTTON_SWITCH_FORCE_LOCAL;
+  Settings.flag3.hass_tele_on_power = TELE_ON_POWER;
 //  Settings.flag.mqtt_sensor_retain = 0;
 //  Settings.flag.mqtt_offline = 0;
 //  Settings.flag.mqtt_serial = 0;


### PR DESCRIPTION
This adds compile time configuration parameter for `SetOption59`. At the moment `SetOption59` can be enabled at compile time only by setting `HOME_ASSISTANT_DISCOVERY_ENABLE` (AFAIK).
I added the specific parameter `TELE_ON_POWER` to independently enable `SetOption59` without enabling Home Assistant discovery.
See #4450 for background and motivation for `SetOption59`.

Any feedback on usefulness and/or naming is welcomed.