### PR TITLE
Disable sleep for scheme 0

### DIFF
--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -104,6 +104,7 @@ typedef unsigned long power_t;              // Power (Relay) type
 #define PWM_MIN                100          // [PWM_MIN] Minimum frequency - Default: 100
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
                                             //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
+//#define PWM_LIGHTSCHEME0_IGNORE_SLEEP       // Do not change sleep value for LightAnimate() scheme 0
 
 #define DEFAULT_POWER_DELTA    80           // Power change percentage
 #define MAX_POWER_HOLD         10           // Time in SECONDS to allow max agreed power

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -896,7 +896,11 @@ void LightAnimate(void)
     }
   }
   else {
+#ifdef PWM_LIGHTSCHEME0_IGNORE_SLEEP    
     sleep = (LS_POWER == Settings.light_scheme) ? Settings.sleep : 0;  // If no animation then use sleep as is
+#else
+    sleep = 0;
+#endif // PWM_LIGHTSCHEME0_IGNORE_SLEEP    
     switch (Settings.light_scheme) {
       case LS_POWER:
         LightSetDimmer(Settings.light_dimmer);


### PR DESCRIPTION
This PR disables sleep for light scheme 0 which was enabled with merge https://github.com/arendst/Sonoff-Tasmota/commit/f8350d65c4832077020b926556a8c5b651ccbfb3 reverting the original merge.

It still makes it possible to ignore the sleep setting for scheme 0 by conditional directive

`#define PWM_LIGHTSCHEME0_IGNORE_SLEEP` in sonoff.h

allowing for the compilation of firmware where the sleep setting would be ignored for scheme 0.

The define is commented out by default resulting in the default being that sleep is disabled as was the case before https://github.com/arendst/Sonoff-Tasmota/commit/f8350d65c4832077020b926556a8c5b651ccbfb3 was merged.