### PR TITLE
sm16716: added config option for custom rgb order

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -421,6 +421,7 @@
 //  #define USE_ALECTO_V2                          // Add support for decoding Alecto V2 sensors like ACH2010, WS3000 and DKW2012 weather stations using 868MHz RF sensor receiver (+1k7 code)
 
 #define USE_SM16716                              // Add support for SM16716 RGB LED controller (+0k7 code)
+  #define USE_SM16716_RGB_ORDER     SM16716_RGB  // SM16716 RGB order (SM16716_RGB, SM16716_RBG, SM16716_GRB, SM16716_GBR, SM16716_BRG, SM16716_BGR) 
 
 /*********************************************************************************************\
  * Debug features are only supported in development branch

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -171,6 +171,13 @@ typedef unsigned long power_t;              // Power (Relay) type
 
 #define LT_SM16716             16           // Lights that use SM16716 will have this bit set in light_type
 
+#define SM16716_RGB            0
+#define SM16716_RBG            1
+#define SM16716_GRB            2
+#define SM16716_GBR            3
+#define SM16716_BRG            4
+#define SM16716_BGR            5
+
 #define MQTT_PUBSUBCLIENT      1            // Mqtt PubSubClient library
 #define MQTT_TASMOTAMQTT       2            // Mqtt TasmotaMqtt library based on esp-mqtt-arduino - soon obsolete
 #define MQTT_ESPMQTTARDUINO    3            // Mqtt esp-mqtt-arduino library by Ingo Randolf - obsolete but define is present for debugging purposes

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -397,6 +397,12 @@ void SM16716_SendByte(uint8_t v)
   }
 }
 
+void SM16716_SendRGB(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b) {
+  SM16716_SendByte(duty_r);
+  SM16716_SendByte(duty_g);
+  SM16716_SendByte(duty_b);
+}
+
 void SM16716_Update(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b)
 {
   if (sm16716_pin_sel < 99) {
@@ -432,17 +438,29 @@ void SM16716_Update(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b)
   // send start bit
   SM16716_SendBit(1);
   // send 24-bit rgb data
-  SM16716_SendByte(duty_r);
-  SM16716_SendByte(duty_g);
-  SM16716_SendByte(duty_b);
+#if USE_SM16716_RGB_ORDER == SM16716_RGB
+  SM16716_SendRGB(duty_r, duty_g, duty_b);
+#elif USE_SM16716_RGB_ORDER == SM16716_RBG
+  SM16716_SendRGB(duty_r, duty_b, duty_g);
+#elif USE_SM16716_RGB_ORDER == SM16716_GRB
+  SM16716_SendRGB(duty_g, duty_r, duty_b);
+#elif USE_SM16716_RGB_ORDER == SM16716_GBR
+  SM16716_SendRGB(duty_g, duty_b, duty_r);
+#elif USE_SM16716_RGB_ORDER == SM16716_BRG
+  SM16716_SendRGB(duty_b, duty_r, duty_g);
+#elif USE_SM16716_RGB_ORDER == SM16716_BGR
+  SM16716_SendRGB(duty_b, duty_g, duty_r);
+#else
+  // fall back to RGB
+  SM16716_SendRGB(duty_r, duty_g, duty_b);
+#endif
+
   // send a 'do it' pulse
   // (if multiple chips are chained, each one processes the 1st '1rgb' 25-bit block and
   // passes on the rest, right until the one starting with 0)
   //SM16716_Init();
   SM16716_SendBit(0);
-  SM16716_SendByte(0);
-  SM16716_SendByte(0);
-  SM16716_SendByte(0);
+  SM16716_SendRGB(0, 0, 0);
 }
 
 bool SM16716_ModuleSelected(void)


### PR DESCRIPTION
It seems that there is a need to make the RGB order configurable ( [Issue #5310](https://github.com/arendst/Sonoff-Tasmota/issues/5310) ), I propose a `USE_SM16716_RGB_ORDER` compile-time option and `SM16716_{RGB,RBG,...,BGR}` constants for this purpose.

The data protocol of SM16716 uses strictly RGB, but if a manufacturer wires the red leds to the 'blue' output of the controller (and vice versa), then all we can do in the firmware is to send the data in BGR order.
