### PR TITLE
Platformio 2.0.1 (Core 2.5.0)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,9 +65,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -DVTABLES_IN_FLASH
 
 [core_2_5_0]
-; *** Esp8266 core for Arduino version 2.5.0 (since version from platformio is faulty)
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota 
-;platform                  = espressif8266@2.0.0
+; *** Esp8266 core for Arduino version 2.5.0
+platform                  = espressif8266@2.0.1
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; lwIP 1.4 (Default)


### PR DESCRIPTION
Platformio is back to working build toolchain from core 2.4.2.