### PR TITLE
Allow independent working of RGB and white lights

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -789,10 +789,6 @@ void MqttDataHandler(char* topic, uint8_t* data, unsigned int data_len)
               param_low = 1;
               param_high = 250;
               break;
-            case P_RGB_REMAP:
-              param_low = 0;
-              param_high = 119;
-              break;
           }
           if ((payload >= param_low) && (payload <= param_high)) {
             Settings.param[pindex] = payload;

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -622,9 +622,9 @@ void LightSetColorTemp(uint16_t ct)
   } else
   if (LST_RGBWC == light_subtype) {
     if(light_ct_rgb_linked){
-    Settings.light_color[0] = 0;
-    Settings.light_color[1] = 0;
-    Settings.light_color[2] = 0;
+      Settings.light_color[0] = 0;
+      Settings.light_color[1] = 0;
+      Settings.light_color[2] = 0;
     }
     Settings.light_color[3] = (uint8_t)icold;
     Settings.light_color[4] = (uint8_t)iwarm;
@@ -1164,9 +1164,9 @@ void LightHsbToRgb(void)
   light_current_color[1] = (uint8_t)(g * 255.0f);
   light_current_color[2] = (uint8_t)(b * 255.0f);
   if(light_ct_rgb_linked){
-  light_current_color[3] = 0;
-  light_current_color[4] = 0;
-}
+    light_current_color[3] = 0;
+    light_current_color[4] = 0;
+  }
 }
 
 /********************************************************************************************/

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -984,10 +984,8 @@ void LightAnimate(void)
   }
 
   if ((Settings.light_scheme < LS_MAX) || !light_power) {
-    for (uint8_t i = 0; i < light_subtype; i++) {
-      if (light_last_color[i] != light_new_color[i]) {
+    if (memcmp(light_last_color, light_new_color, light_subtype)) {
         light_update = 1;
-      }
     }
     if (light_update) {
       light_update = 0;

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1252,11 +1252,7 @@ bool LightColorEntry(char *buffer, uint8_t buffer_length)
     entry_type = 2;                                 // Decimal
   }
   else if (((2 * light_subtype) == buffer_length) || (buffer_length > 3)) {  // Hexadecimal entry
-    uint8_t limit = buffer_length / 2;
-    if (limit > sizeof(light_entry_color)) {        // Fix buffer overflow due to too many parameters
-      limit = sizeof(light_entry_color);
-    }
-    for (uint8_t i = 0; i < limit; i++) {
+    for (uint8_t i = 0; i < min((uint)(buffer_length / 2), sizeof(light_entry_color)); i++) {
       strlcpy(scolor, buffer + (i *2), 3);
       light_entry_color[i] = (uint8_t)strtol(scolor, &p, 16);
     }

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -111,6 +111,8 @@ uint8_t light_last_color[5];
 uint8_t light_signal_color[5];
 uint8_t light_color_remap[5];
 
+bool light_ct_rgb_linked;
+
 uint8_t light_wheel = 0;
 uint8_t light_subtype = 0;
 uint8_t light_device = 0;
@@ -570,9 +572,9 @@ void LightInit(void)
 
 void LightUpdateColorMapping(void)
 {
-  uint8_t param = Settings.param[P_RGB_REMAP];
+  uint8_t param = Settings.param[P_RGB_REMAP] & 127;
   if(param > 119){
-    param = 119;
+    param = 0;
   }
   uint8_t tmp[] = {0,1,2,3,4};
   light_color_remap[0] = tmp[param / 24];
@@ -592,6 +594,8 @@ void LightUpdateColorMapping(void)
   param = param % 2;
   light_color_remap[3] = tmp[param];
   light_color_remap[4] = tmp[1-param];
+
+  light_ct_rgb_linked = !(Settings.param[P_RGB_REMAP] & 128);
 
   light_update = 1;
   //snprintf_P(log_data, sizeof(log_data), "%d colors: %d %d %d %d %d",Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
@@ -617,9 +621,11 @@ void LightSetColorTemp(uint16_t ct)
     Settings.light_color[1] = (uint8_t)icold;
   } else
   if (LST_RGBWC == light_subtype) {
+    if(light_ct_rgb_linked){
     Settings.light_color[0] = 0;
     Settings.light_color[1] = 0;
     Settings.light_color[2] = 0;
+    }
     Settings.light_color[3] = (uint8_t)icold;
     Settings.light_color[4] = (uint8_t)iwarm;
   } else {
@@ -1157,8 +1163,10 @@ void LightHsbToRgb(void)
   light_current_color[0] = (uint8_t)(r * 255.0f);
   light_current_color[1] = (uint8_t)(g * 255.0f);
   light_current_color[2] = (uint8_t)(b * 255.0f);
+  if(light_ct_rgb_linked){
   light_current_color[3] = 0;
   light_current_color[4] = 0;
+}
 }
 
 /********************************************************************************************/

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -593,6 +593,7 @@ void LightUpdateColorMapping(void)
   light_color_remap[3] = tmp[param];
   light_color_remap[4] = tmp[1-param];
 
+  light_update = 1;
   //snprintf_P(log_data, sizeof(log_data), "%d colors: %d %d %d %d %d",Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
   //AddLog(LOG_LEVEL_DEBUG);
 }


### PR DESCRIPTION
After updating my led controllers to use latest development firmware (including #5310), I noticed setting hsbcolor clears channel4, the reason for this is pull request #3733. While this is great for that use-case it completely prevents the independent use of rgb and white channels.

This pull request adds support for unlinking the RGB and White channels via the last remaining bit of SetOption37, it also contains some smaller optimizations resulting smaller code than before the pull request.

Enabling this feature limits HsbColor to only affect RGB channels.