### PR TITLE
Change default wifi config tool to wifi manager with reset only

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -66,7 +66,7 @@
 #define STA_PASS1              ""                // [Password1] Wifi password
 #define STA_SSID2              ""                // [Ssid2] Optional alternate AP Wifi SSID
 #define STA_PASS2              ""                // [Password2] Optional alternate AP Wifi password
-#define WIFI_CONFIG_TOOL       WIFI_RETRY        // [WifiConfig] Default tool if wifi fails to connect
+#define WIFI_CONFIG_TOOL       WIFI_MANAGER_RESET_ONLY  // [WifiConfig] Default tool if wifi fails to connect
                                                  //   (WIFI_RESTART, WIFI_SMARTCONFIG, WIFI_MANAGER, WIFI_WPSCONFIG, WIFI_RETRY, WIFI_WAIT, WIFI_SERIAL)
 #define WIFI_CONFIG_NO_SSID    WIFI_WPSCONFIG    // Default tool if wifi fails to connect and no SSID is configured
                                                  //   (WIFI_SMARTCONFIG, WIFI_MANAGER, WIFI_WPSCONFIG, WIFI_SERIAL)


### PR DESCRIPTION
Based on the issue #5286, #5337 and on discord conversations initial misconfiguration and loss of password is a returning problem for new users (especially with devices without physical button or devices where physical button is not connected to GPIO0), therefore I propose setting the new wificonfig 7 as  the default wifi config tool. This allows users to reset the device in case of misconfiguration, but also provides enough security to prevent leaking of credentials.

Also after merging this a notification should be placed on the [Inital config wiki page](https://github.com/arendst/Sonoff-Tasmota/wiki/Initial-Configuration), notifying the user that he should change the manager tool to the retry one after finishing and testing the configuration.