### PR TITLE
Update STALE Bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,9 +1,9 @@
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 45
+daysUntilStale: 25
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 15
+daysUntilClose: 5
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
@@ -37,4 +37,4 @@ closeComment: >
 limitPerRun: 30
 
 # Limit to only `issues` or `pulls`
-only: issues
+#only: issues


### PR DESCRIPTION
As the amount of users in the community has grown, the rate of issues that are opened every month have grown too. This led to an increase of issues that are left behind (not closed by its author no matter if it is answered or solved) making collaborators to spend more time on searching for those between the opened issues. The actual rate of the Bot is 60 days to close an issue that has been left behind (45 days to raise attention to that issue and then other more 15 days to close it if no one comment on that issue), and as the amount of opened issues are around 250-300 each month and only 1/3 is being closed by their authors, in 60 days the amount of issues can raise to about 400 opened issues if no action is taken by collaborators.

With this update to the BOT, the new rate will be 25 days to raise the attention to the issue, and if there is no one comment on that issue, the Bot will close it after 5 more days. This 30 days are more suited to the actual speed of the project.

As always the Bot will not close any issue labeled as 
  - pinned
  - security
  - enhancement
  - bug

And also, if the issue is closed by the Bot, it can be reopened again by collaborators if needed.

Also this update expands the Bot activity to PRs, so PRs should be labeled as well as issues.