### PR TITLE
Fix bad snprintf in format()

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -200,12 +200,13 @@ char* Format(char* output, const char* input, int size)
     if (token != NULL) {
       digits = atoi(token);
       if (digits) {
+        char tmp[size];
         if (strchr(token, 'd')) {
-          snprintf_P(output, size, PSTR("%s%c0%dd"), output, '%', digits);
-          snprintf_P(output, size, output, ESP.getChipId() & 0x1fff);       // %04d - short chip ID in dec, like in hostname
+          snprintf_P(tmp, size, PSTR("%s%c0%dd"), output, '%', digits);
+          snprintf(output, size, tmp, ESP.getChipId() & 0x1fff);            // %04d - short chip ID in dec, like in hostname
         } else {
-          snprintf_P(output, size, PSTR("%s%c0%dX"), output, '%', digits);
-          snprintf_P(output, size, output, ESP.getChipId());                // %06X - full chip ID in hex
+          snprintf_P(tmp, size, PSTR("%s%c0%dX"), output, '%', digits);
+          snprintf_P(output, size, tmp, ESP.getChipId());                   // %06X - full chip ID in hex
         }
       } else {
         if (strchr(token, 'd')) {
@@ -624,9 +625,9 @@ void MqttDataHandler(char* topic, uint8_t* data, unsigned int data_len)
       //   We also need at least 3 chars to make a valid version number string.
       if (((1 == data_len) && (1 == payload)) || ((data_len >= 3) && NewerVersion(dataBuf))) {
         ota_state_flag = 3;
-        snprintf_P(mqtt_data, sizeof(mqtt_data), "{\"%s\":\"" D_JSON_VERSION " %s " D_JSON_FROM " %s\"}", command, my_version, GetOtaUrl(stemp1, sizeof(stemp1)));
+        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"%s\":\"" D_JSON_VERSION " %s " D_JSON_FROM " %s\"}"), command, my_version, GetOtaUrl(stemp1, sizeof(stemp1)));
       } else {
-        snprintf_P(mqtt_data, sizeof(mqtt_data), "{\"%s\":\"" D_JSON_ONE_OR_GT "\"}", command, my_version);
+        snprintf_P(mqtt_data, sizeof(mqtt_data), PSTR("{\"%s\":\"" D_JSON_ONE_OR_GT "\"}"), command, my_version);
       }
     }
     else if (CMND_OTAURL == command_code) {


### PR DESCRIPTION
## Description:
Fix illegal calls to snprintf_P where output string is same as format string in format() which causes ChipID to be incorrectly formatted with core 2.5.0.

Core 2.5.0:
![image](https://user-images.githubusercontent.com/14281572/54038114-0da5b280-41c0-11e9-8a0f-6ef2b0febe75.png)

Core 2.3.0 / 2.4.2:
![image](https://user-images.githubusercontent.com/14281572/54038125-14342a00-41c0-11e9-9864-979b0d9599aa.png)


I tried to find this pattern elsewhere in the code with this regex, but it seems to be the only case:
https://regex101.com/r/lZa25j/1

Background:
snprintf_P has previously copied the format string to a temporary buffer:
``` C++
int vsnprintf_P(char* str, size_t strSize, PGM_P formatP, va_list ap) {
    int ret;

    size_t fmtLen = strlen_P(formatP);
    char* format = new char[fmtLen + 1];
    strcpy_P(format, formatP);

    ret = vsnprintf(str, strSize, format, ap);

    delete[] format;

    return ret;
}
```

This is no longer the case in core 2.5.0:
https://github.com/esp8266/Arduino/commit/6280e98b0360f85fdac2b8f10707fffb4f6e6e31
https://github.com/igrr/newlib-xtensa/commit/61f08d03e875a64629deaaa0b975e179bcfa4ea0#diff-41d58351e2a3ed465ccfa03961a37263

## Checklist:
  - [x] The pull request is done against the dev branch
  - [x] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
