### PR TITLE
xsns_20_novasds working period configuration via commands

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -336,7 +336,8 @@ struct SYSCFG {
   uint16_t      web_refresh;               // 7CC
   char          mems[MAX_RULE_MEMS][10];   // 7CE
   char          rules[MAX_RULE_SETS][MAX_RULE_SIZE]; // 800 uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
-                                           // E00 - FFF free locations
+  uint8_t       novasds_period;            // E00
+                                           // E01 - FFF free locations
 } Settings;
 
 struct RTCRBT {


### PR DESCRIPTION
## Description:

Adds two commands for NOVA_SDS that allow to set working period remotely.
SENSOR20 GETPERIOD   - returns current woriking period
SENSOR20 SETPERIOD,x - sets new working period, where _x_ is number representing seconds 

## Checklist:
  - [x] The pull request is done against the dev branch
  - [x] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**