### PR TITLE
nonos-sdk 22x as default for [core_stage]

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -89,6 +89,10 @@ build_flags               = ${esp82xx_defaults.build_flags}
 platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
+; nonos-sdk 22x
+                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
+; nonos-sdk-pre-v3
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3                            
 ; lwIP 1.4 (Default)
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory


### PR DESCRIPTION
Using for core stage latest updated nonos sdk 22x

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the dev branch
  - [ ] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
