### PR TITLE
Hiding User Configurable Pins for SHELLY 1

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1472,10 +1472,10 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      0, 0
   },
   { "Shelly 1",        // Shelly1 Open Source (ESP8266 - 2MB) - https://shelly.cloud/shelly1-open-source/
-     GPIO_USER,        // GPIO00 - Only to be used when Shelly is connected to 12V DC
-     GPIO_USER,        // GPIO01 Serial RXD - Only to be used when Shelly is connected to 12V DC
+     0,                // GPIO00 - Can be changed to GPIO_USER, only if Shelly is powered with 12V DC
+     0,                // GPIO01 Serial RXD - Can be changed to GPIO_USER, only if Shelly is powered with 12V DC
      0,
-     GPIO_USER,        // GPIO03 Serial TXD - Only to be used when Shelly is connected to 12V DC
+     0,                // GPIO03 Serial TXD - Can be changed to GPIO_USER, only if Shelly is powered with 12V DC
      GPIO_REL1,        // GPIO04 Relay (0 = Off, 1 = On)
      GPIO_SWT1_NP,     // GPIO05 SW pin
                        // GPIO06 (SD_CLK   Flash)


### PR DESCRIPTION
Some users had tried to connect sensors to shelly 1, being it powered by mains AC. So, as it is a very dangerous condition and a safety concern, those extra GPIO are being taken from the template. Comments about this, were left on the code for people who really know what they are doing.

## Description:

**Related issue (if applicable):** fixes #5487

## Checklist:
  - [x] The pull request is done against the dev branch
  - [x] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
