### PR TITLE
Add HASS_STATE to command STATE

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -615,6 +615,11 @@ void MqttDataHandler(char* topic, uint8_t* data, unsigned int data_len)
       if (Settings.flag3.hass_tele_on_power) {
         MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
       }
+#ifdef USE_HOME_ASSISTANT
+      if (Settings.flag.hass_discovery) {
+        HAssPublishStatus();
+      }
+#endif  // USE_HOME_ASSISTANT	    
     }
     else if (CMND_SLEEP == command_code) {
       if ((payload >= 0) && (payload < 251)) {


### PR DESCRIPTION
O## Description:

**Related issue (if applicable):** none (issue reported in discord chat by @DavidFW1960)

The command `STATE` has a secondary mqtt message in the case that `SETOPTION59` is `1`
This PR adds another mqtt message (`HASS_STATE`) if HomeAssistant discovery is enabled.

In the actual codebase of Tasmota, `HASS_STATE` is only sent right after the teleperiod is sent. This PR adds a command to ask for `HASS_STATE` manually.

This is useful for syncing Home Assistant with all the states of Tasmota devices when HA is restarted.
The [actual automation for Sync on HA restart](https://github.com/arendst/Sonoff-Tasmota/wiki/Home-Assistant#tip-sync-power-state) explained in the wiki, will also make use of this new message.

## Checklist:
  - [x] The pull request is done against the dev branch
  - [x] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
