### PR TITLE
added tuya touch wall switch support

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -316,10 +316,11 @@ enum SupportedModules {
   SP10,
   WAGA,
   SYF05,
-  MAXMODULE,
   TUYA_TOUCH_T1,
   TUYA_TOUCH_T2,
-  TUYA_TOUCH_T3, };
+  TUYA_TOUCH_T3,
+  MAXMODULE
+ };
 
 #define USER_MODULE        255
 
@@ -1643,7 +1644,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_KEY2,        // GPIO03
      0,                // GPIO04
      0,                // GPIO05
-     0, 0, 0, 0, 0, 0,
+     0, 0,
      GPIO_KEY1,        // GPIO12
      GPIO_REL1,        // GPIO13
      0,
@@ -1656,7 +1657,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_KEY2,        // GPIO03
      GPIO_REL2,        // GPIO04
      0,                // GPIO05
-     0, 0, 0, 0, 0, 0,
+     0, 0,
      GPIO_KEY1,        // GPIO12
      GPIO_REL1,        // GPIO13
      0,
@@ -1669,7 +1670,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_KEY2,        // GPIO03
      GPIO_REL2,        // GPIO04
      GPIO_KEY3,        // GPIO05
-     0, 0, 0, 0, 0, 0,
+     0, 0,
      GPIO_KEY1,        // GPIO12
      GPIO_REL1,        // GPIO13
      0,

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -316,7 +316,10 @@ enum SupportedModules {
   SP10,
   WAGA,
   SYF05,
-  MAXMODULE };
+  MAXMODULE,
+  TUYA_TOUCH_T1,
+  TUYA_TOUCH_T2,
+  TUYA_TOUCH_T3, };
 
 #define USER_MODULE        255
 
@@ -643,6 +646,9 @@ const uint8_t kModuleNiceList[MAXMODULE] PROGMEM = {
   ARMTRONIX_DIMMERS,
   PS_16_DZ,
   H801,                // Light Devices
+  TUYA_TOUCH_T1,       // Tuya Wifi Touch Wall-Switch 1 Gang (different brandings, EU: Jinvoo Smart)
+  TUYA_TOUCH_T2,       // Tuya Wifi Touch Wall-Switch 2 Gang
+  TUYA_TOUCH_T3,       // Tuya Wifi Touch Wall-Switch 3 Gang
   MAGICHOME,
   ARILUX_LC01,
   ARILUX_LC06,
@@ -1630,6 +1636,45 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_USER,
      GPIO_USER,
      0
+  },
+  { "Tuya T1",         // Tuya Wifi Touch Wall-Switch 1 Gang (ESP8266)
+     GPIO_LED1,        // GPIO00
+     0, 0,
+     GPIO_KEY2,        // GPIO03
+     0,                // GPIO04
+     0,                // GPIO05
+     0, 0, 0, 0, 0, 0,
+     GPIO_KEY1,        // GPIO12
+     GPIO_REL1,        // GPIO13
+     0,
+     0,                // GPIO15
+     0, 0
+  },
+  { "Tuya T2",         // Tuya Wifi Touch Wall-Switch 2 Gang (ESP8266)
+     GPIO_LED1,        // GPIO00
+     0, 0,
+     GPIO_KEY2,        // GPIO03
+     GPIO_REL2,        // GPIO04
+     0,                // GPIO05
+     0, 0, 0, 0, 0, 0,
+     GPIO_KEY1,        // GPIO12
+     GPIO_REL1,        // GPIO13
+     0,
+     0,                // GPIO15
+     0, 0
+  },
+  { "Tuya T3",         // Tuya Wifi Touch Wall-Switch 3 Gang (ESP8266)
+     GPIO_LED1,        // GPIO00
+     0, 0,
+     GPIO_KEY2,        // GPIO03
+     GPIO_REL2,        // GPIO04
+     GPIO_KEY3,        // GPIO05
+     0, 0, 0, 0, 0, 0,
+     GPIO_KEY1,        // GPIO12
+     GPIO_REL1,        // GPIO13
+     0,
+     GPIO_REL3,        // GPIO15
+     0, 0
   },
   { "Gosund SP1 v23",  // https://www.amazon.de/gp/product/B0777BWS1P
      0,


### PR DESCRIPTION
## Description:
Adds support for Tuya Touch devices which are available under different brandings. Tested on several devices from Jinvoo (https://www.amazon.de/Jinvoo-Lichtschalter-Fernbedienung-Sprachsteuerung-Timing-Funktion), 1-3 Gang, normal switches, curtain switches. 

These devices are relatively cheap and can be flashed over wifi using https://github.com/ct-Open-Source/tuya-convert.

Also works for Curtain Switches (https://www.amazon.de/Jinvoo-Controller-Compatibile-Neutralleiter-Unterstützung/)


## Checklist:
  - [x] The pull request is done against the dev branch
  - [x] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
