### PR TITLE
Update Core 2.5.0 to build chain 2.0.4

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,9 +67,11 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_2_5_0]
 ; *** Esp8266 core for Arduino version 2.5.0
-platform                  = espressif8266@2.0.1
+platform                  = espressif8266@~2.0.4
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
+; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
+                            -O2                            
 ; lwIP 1.4 (Default)
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
@@ -89,6 +91,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
+; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
+                            -O2                            
 ; nonos-sdk 22x
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 ; nonos-sdk-pre-v3


### PR DESCRIPTION
Update Core 2.5.0 to build chain 2.0.4
Set Compiler Option -O2 for Core 2.5.0 and Core Stage (Faster code) See https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the dev branch
  - [ ] Only relevant files were touched (Also beware if your editor has auto-formatting feature enabled)
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
