### PR TITLE
always check for vars_events and mems_events

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -486,23 +486,25 @@ void RulesEvery50ms(void)
         event_data[0] ='\0';
       }
     }
-    else if (vars_event) {
-      for (uint8_t i = 0; i < MAX_RULE_VARS-1; i++) {
-        if (bitRead(vars_event, i)) {
-          bitClear(vars_event, i);
-          snprintf_P(json_event, sizeof(json_event), PSTR("{\"Var%d\":{\"State\":%s}}"), i+1, vars[i]);
-          RulesProcessEvent(json_event);
-          break;
+    else if (vars_event || mems_event){
+      if (vars_event) {
+        for (uint8_t i = 0; i < MAX_RULE_VARS-1; i++) {
+          if (bitRead(vars_event, i)) {
+            bitClear(vars_event, i);
+            snprintf_P(json_event, sizeof(json_event), PSTR("{\"Var%d\":{\"State\":%s}}"), i+1, vars[i]);
+            RulesProcessEvent(json_event);
+            break;
+          }
         }
       }
-    }
-    else if (mems_event) {
-      for (uint8_t i = 0; i < MAX_RULE_MEMS-1; i++) {
-        if (bitRead(mems_event, i)) {
-          bitClear(mems_event, i);
-          snprintf_P(json_event, sizeof(json_event), PSTR("{\"Mem%d\":{\"State\":%s}}"), i+1, Settings.mems[i]);
-          RulesProcessEvent(json_event);
-          break;
+      if (mems_event) {
+        for (uint8_t i = 0; i < MAX_RULE_MEMS-1; i++) {
+          if (bitRead(mems_event, i)) {
+            bitClear(mems_event, i);
+            snprintf_P(json_event, sizeof(json_event), PSTR("{\"Mem%d\":{\"State\":%s}}"), i+1, Settings.mems[i]);
+            RulesProcessEvent(json_event);
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
regarding this issue:
https://github.com/arendst/Sonoff-Tasmota/issues/5525

This should solve it, even though it might be useful, to rethink the whole flow.

BTW, to get it to work we need `#define USE_EXPRESSION` turned on and assign the vars without % (like so: on Mem2#State do backlog Var5 Mem2; Sub5 3; Mem3 Var5; endon).