### PR TITLE
Fix Sensor15 command crash due to the wrong memory specifier

### DIFF
--- a/sonoff/xsns_15_mhz19.ino
+++ b/sonoff/xsns_15_mhz19.ino
@@ -71,8 +71,8 @@ TasmotaSerial *MhzSerial;
 
 const char kMhzModels[] PROGMEM = "|B";
 
-const char ABC_ENABLED[] PROGMEM = "ABC is Enabled";
-const char ABC_DISABLED[] PROGMEM = "ABC is Enabled";
+const char ABC_ENABLED[] = "ABC is Enabled";
+const char ABC_DISABLED[] = "ABC is Disabled";
 
 enum MhzCommands { MHZ_CMND_READPPM, MHZ_CMND_ABCENABLE, MHZ_CMND_ABCDISABLE, MHZ_CMND_ZEROPOINT, MHZ_CMND_RESET, MHZ_CMND_RANGE_1000, MHZ_CMND_RANGE_2000, MHZ_CMND_RANGE_3000, MHZ_CMND_RANGE_5000 };
 const uint8_t kMhzCommands[][4] PROGMEM = {


### PR DESCRIPTION
## Description:
Sensor15 command restarts MCU due to the wrong memory specification

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
