### PR TITLE
Control which relay activity turns on the LED

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -266,6 +266,7 @@
 #define D_CMND_ALTITUDE "Altitude"
 #define D_CMND_LEDPOWER "LedPower"
 #define D_CMND_LEDSTATE "LedState"
+#define D_CMND_LEDRELAYMASK "LedRelayMask"
 #define D_CMND_I2CSCAN "I2CScan"
 #define D_CMND_SERIALSEND "SerialSend"
 #define D_CMND_SERIALDELIMITER "SerialDelimiter"

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -332,7 +332,8 @@ struct SYSCFG {
   mytmplt       user_template;             // 720  29 bytes
   uint8_t       novasds_period;            // 73D
 
-  uint8_t       free_73D[86];              // 73E
+  uint8_t       ledrelaymask;              // 73E
+  uint8_t       free_73D[85];              // 73F
 
   uint32_t      drivers[3];                // 794
   uint32_t      monitors;                  // 7A0

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -625,6 +625,7 @@ void SettingsDefaultSet2(void)
   Settings.blinktime = APP_BLINKTIME;
   Settings.blinkcount = APP_BLINKCOUNT;
   Settings.ledstate = APP_LEDSTATE;
+  Settings.ledrelaymask = 0xff;
   Settings.pulse_timer[0] = APP_PULSETIME;
 //  for (uint8_t i = 1; i < MAX_PULSETIMERS; i++) { Settings.pulse_timer[i] = 0; }
 


### PR DESCRIPTION
For a device with multiple relays and only one LED, this update add the command LedRelayMask that indicates which relay when turned on will also turn on the LED. LSB is relay one and so one.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
