### PR TITLE
Fix serial bridge issues

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -757,7 +757,7 @@ void MqttDataHandler(char* topic, uint8_t* data, unsigned int data_len)
               case 7:            // mqtt_switch_retain (CMND_SWITCHRETAIN)
               case 9:            // mqtt_sensor_retain (CMND_SENSORRETAIN)
               case 14:           // interlock (CMND_INTERLOCK)
-              case 22:           // mqtt_serial (SerialSend and SerialLog)
+              // case 22:           // mqtt_serial (SerialSend and SerialLog) - allow to be set for devices that just relay serial and for which no SerialSend command is done
               case 23:           // mqtt_serial_raw (SerialSend)
               case 25:           // knx_enabled (Web config)
               case 27:           // knx_enable_enhancement (Web config)
@@ -2274,7 +2274,7 @@ void SerialInput(void)
       if (serial_in_byte || Settings.flag.mqtt_serial_raw) {                     // Any char between 1 and 127 or any char (0 - 255)
         if ((serial_in_byte_counter < INPUT_BUFFER_SIZE -1) &&                   // Add char to string if it still fits and ...
             ((isprint(serial_in_byte) && (128 == Settings.serial_delimiter)) ||  // Any char between 32 and 127
-             (serial_in_byte != Settings.serial_delimiter) ||                    // Any char between 1 and 127 and not being delimiter
+             (serial_in_byte != Settings.serial_delimiter  && (128 != Settings.serial_delimiter)) ||                    // Any char between 1 and 127 and not being delimiter
               Settings.flag.mqtt_serial_raw)) {                                  // Any char between 0 and 255
           serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
           serial_polling_window = millis();


### PR DESCRIPTION
You need to be able to set MQTT Serial off (1) for a device that is there just to relay serial and for which no SerialSend will be sent.
Also SerialDelimiter 128 did not work as any character not 128 was accepted.
(use case was upgrading some weighing scales to send weights via MQTT which are received via serial)

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
