### PR TITLE
SerialDelimiter call 128 fix

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2274,7 +2274,7 @@ void SerialInput(void)
       if (serial_in_byte || Settings.flag.mqtt_serial_raw) {                     // Any char between 1 and 127 or any char (0 - 255)
         if ((serial_in_byte_counter < INPUT_BUFFER_SIZE -1) &&                   // Add char to string if it still fits and ...
             ((isprint(serial_in_byte) && (128 == Settings.serial_delimiter)) ||  // Any char between 32 and 127
-             (serial_in_byte != Settings.serial_delimiter) ||                    // Any char between 1 and 127 and not being delimiter
+             (serial_in_byte != Settings.serial_delimiter && (128 != Settings.serial_delimiter)) ||                    // Any char between 1 and 127 and not being delimiter
               Settings.flag.mqtt_serial_raw)) {                                  // Any char between 0 and 255
           serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
           serial_polling_window = millis();


### PR DESCRIPTION
When set to 128, printable characters were allowed, good, but also any character that is not 128 was also allowed.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
