### PR TITLE
Fix use of SerialDelimiter value 128

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,7 @@
-/* 6.5.0.7 20190410
+/* 6.5.0.8 20190412
+ * Fix use of SerialDelimiter value 128
+ * 
+ * 6.5.0.7 20190410
  * Add command LedMask to assign which relay has access to power LED (#5602, #5612)
  *
  * 6.5.0.6 20190409

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2274,7 +2274,7 @@ void SerialInput(void)
       if (serial_in_byte || Settings.flag.mqtt_serial_raw) {                     // Any char between 1 and 127 or any char (0 - 255)
         if ((serial_in_byte_counter < INPUT_BUFFER_SIZE -1) &&                   // Add char to string if it still fits and ...
             ((isprint(serial_in_byte) && (128 == Settings.serial_delimiter)) ||  // Any char between 32 and 127
-             (serial_in_byte != Settings.serial_delimiter) ||                    // Any char between 1 and 127 and not being delimiter
+             (serial_in_byte != Settings.serial_delimiter && (128 != Settings.serial_delimiter)) ||                    // Any char between 1 and 127 and not being delimiter
               Settings.flag.mqtt_serial_raw)) {                                  // Any char between 0 and 255
           serial_in_buffer[serial_in_byte_counter++] = serial_in_byte;
           serial_polling_window = millis();

--- a/sonoff/sonoff_version.h
+++ b/sonoff/sonoff_version.h
@@ -20,6 +20,6 @@
 #ifndef _SONOFF_VERSION_H_
 #define _SONOFF_VERSION_H_
 
-const uint32_t VERSION = 0x06050007;
+const uint32_t VERSION = 0x06050008;
 
 #endif  // _SONOFF_VERSION_H_


### PR DESCRIPTION
## Description:

Fix use of SerialDelimiter value 128
It was allowing printable characters when set to 128 but also all characters that are not 128

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).