### PR TITLE
Dooya RF Protocol for Blind and Shutters

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -424,6 +424,14 @@
 #define D_CMND_LATITUDE "Latitude"
 #define D_CMND_LONGITUDE "Longitude"
 
+// Commands xdrv_91_timers.ino
+#define D_JSON_RF433_GROUP "Group"
+#define D_JSON_RF433_BLIND "Blind"
+#define D_JSON_RF433_ACTION "Action"
+#define D_JSON_RF433_ACTION_UP "Up"
+#define D_JSON_RF433_ACTION_DOWN "Down"
+#define D_JSON_RF433_ACTION_STOP "Stop"
+#define D_JSON_RF433_ACTION_PROG "Prog"
 /********************************************************************************************/
 
 #define D_ASTERIX "********"

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   bg-BG.h - localization for Bulgaria - Bulgarian for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends
@@ -586,6 +586,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   cs-CZ.h - localization for Czech with diacritics - Czech for Sonoff-Tasmota
 
   Copyright (C) 2019  Vladimír Synek
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   de-DE.h - localization for German - Germany for Sonoff-Tasmota
 
   Copyright (C) 2019  VinceMasuka
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   el-GR.h - localization for Greek - Greece for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends (translated by Nick Galfas)
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   en-GB.h - localization for English - United Kingdom for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/es-ES.h
+++ b/sonoff/language/es-ES.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   es-ES.h - localization for Spanish - Spain for Sonoff-Tasmota
 
   Copyright (C) 2019  Adrian Scillato
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   fr-FR.h - localization for French - France for Sonoff-Tasmota
 
   Copyright (C) 2019  Olivier Francais
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   he-HE.h - localization for Hebrew - Israel for Sonoff-Tasmota
 
   Copyright (C) 2019  Yuval Mejahez
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   hu-HU.h - localization for Hungarian in Hungary for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   it-IT.h - localization for Italian - Italy for Sonoff-Tasmota
 
   Copyright (C) 2019 Gennaro Tortone - some mods by Antonio Fragola
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ko-KO.h
+++ b/sonoff/language/ko-KO.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   ko-KO.h - localization for Korean - Korean for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends (translated by NyaamZ)
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   nl-NL.h - localization for Dutch - Nederland for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   pl-PL-d.h - localization for Polish with diacritics - Poland for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends (translated by roblad - Robert L., upgraded by R. Turala)
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   pt-BR.h - localization for Portuguese - Brazil for Sonoff-Tasmota
 
   Copyright (C) 2019  Fabiano Bovo
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   pt-PT.h - localization for Portuguese - Portugal for Sonoff-Tasmota
 
   Copyright (C) 2019  Paulo Paiva
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   ru-RU.h - localization for Russian - Rissia for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends / roman-vn
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/sk-SK.h
+++ b/sonoff/language/sk-SK.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   sk-SK.h - localization for Slovak with diacritics - Slovak for Sonoff-Tasmota
 
   Copyright (C) 2019  Vladimír Jendroľ
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/sv-SE.h
+++ b/sonoff/language/sv-SE.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   sv-SE.h - localization for Swedish - Svenska for Sonoff-Tasmota
 
   Copyright (C) 2019  Gunnar Norin
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   tr-TR.h - localization for Turkish - Turkey for Sonoff-Tasmota
 
   Copyright (C) 2019  Ali Sait Teke and Theo Arends
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   uk-UK.h - localization for Ukrainian - Ukrain for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends / vadym-adik
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   zh-CN.h - localization for Chinese (Simplified) - China for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends (translated by killadm)
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   zh-TW.h - localization for Chinese (Traditional) - Taiwan for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends (translated by dannydu)
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_RF433_TX      "RF433 Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   sonoff_template.h - template settings for Sonoff-Tasmota
 
   Copyright (C) 2019  Theo Arends
@@ -181,6 +181,7 @@ enum UserSelectablePins {
   GPIO_HRE_CLOCK,      // Clock/Power line for HR-E Water Meter
   GPIO_HRE_DATA,       // Data line for HR-E Water Meter
   GPIO_ADE7953_IRQ,    // ADE7953 IRQ
+  GPIO_RF433_TX,       // RF433 transmitter module  
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -246,6 +247,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_ROTARY "1a|" D_SENSOR_ROTARY "1b|" D_SENSOR_ROTARY "2a|" D_SENSOR_ROTARY "2b|"
   D_SENSOR_HRE_CLOCK "|" D_SENSOR_HRE_DATA "|"
   D_SENSOR_ADE7953_IRQ "|"
+  D_SENSOR_RF433_TX "|"
   ;
 
 /********************************************************************************************/
@@ -601,8 +603,9 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_HRE
   GPIO_HRE_CLOCK,
-  GPIO_HRE_DATA
+  GPIO_HRE_DATA,
 #endif
+  GPIO_RF433_TX	
 };
 
 const uint8_t kModuleNiceList[] PROGMEM = {

--- a/sonoff/xdrv_91_rf433.ino
+++ b/sonoff/xdrv_91_rf433.ino
@@ -1,0 +1,178 @@
+/*
+  xdrv_91_rf443.ino - Dooya Blind and Shutter RF Protocol support for Sonoff-Tasmota
+
+  Copyright (C) 2019  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  
+*/
+
+//#ifdef USE_RF433_TRANS
+
+#define XDRV_91             91
+/*********************************************************************************************\
+ * constants
+\*********************************************************************************************/
+#define D_CMND_RF433 "rf433"
+
+//The key to timing success is each bit regardless of True or False must be 1080 microsecond long in real time.
+
+#define PREP_LONG 8550 //8550
+#define START_HIGH 4725 //4725
+#define START_LOW 1525 //1525
+#define SHORT_BIT 350 //330 
+#define LONG_BIT 730 //715
+
+int last_delay =0;
+
+void init_msg(){
+  digitalWrite(pin[GPIO_RF433_TX], LOW); //LOW
+  delayMicroseconds(PREP_LONG - last_delay); 
+  digitalWrite(pin[GPIO_RF433_TX], HIGH);
+  delayMicroseconds(START_HIGH);
+  digitalWrite(pin[GPIO_RF433_TX], LOW); //LOW
+  delayMicroseconds(START_LOW);
+}
+
+void send_bit(int state){
+  int high_time, low_time;
+ 
+  if(state){ //True State
+    high_time = LONG_BIT;
+    low_time=SHORT_BIT;
+  }else{ //False State
+    high_time = SHORT_BIT;
+    low_time=LONG_BIT;
+  }
+  //output to the transmiter 
+  digitalWrite(pin[GPIO_RF433_TX], HIGH); //HIGH
+  delayMicroseconds(high_time);
+  digitalWrite(pin[GPIO_RF433_TX], LOW); //LOW
+  delayMicroseconds(low_time);
+  last_delay = low_time;
+}
+
+void hex_to_int(char chr){
+    int revbin[4];
+    int n = chr - 48; 
+    int j;
+    
+    if(n > 9){n-=7;} 
+    for(j=0;j<4;j++){
+       revbin[j]=(n % 2);
+       n = n / 2; 
+    }
+    for (int k = j - 1; k >= 0; k--){ 
+      send_bit(revbin[k]);
+      //Serial.print(revbin[k],DEC);
+    }
+    //Serial.println();
+    return;
+}
+
+void rf433Init(void) {
+  pinMode(pin[GPIO_RF433_TX],OUTPUT);
+  return;
+}
+
+//rf433 {"group":"0x9F340E","blind":1,"action":up}
+//rf433 {"group":"0x9F340E","blind":1,"action":down}
+//rf433 {"group":"0x9F340E","blind":1,"action":stop}
+//rf433 {"group":"0x9F340E","blind":1,"action":prog}
+
+bool rf433Command(){
+    char command [CMDSZ];
+    bool serviced = false;
+    char parm_uc[10];
+    
+    //copy from DRV05_irremote    
+    char dataBufUc[XdrvMailbox.data_len]; 
+    UpperCase(dataBufUc, XdrvMailbox.data);
+    StaticJsonBuffer<128> jsonBuf;
+    JsonObject &root = jsonBuf.parseObject(dataBufUc);
+
+    if (!root.success()) {
+        Response_P(S_JSON_COMMAND_SVALUE, command, D_JSON_INVALID_JSON);
+    }else{
+        char parm_uc[10];
+        char responce[12];
+              
+        //Construct the RF Message.
+        strcpy(responce,root[UpperCase_P(parm_uc, PSTR(D_JSON_RF433_GROUP))]);
+        strcat(responce,"B");
+        strcat(responce,root[UpperCase_P(parm_uc, PSTR(D_JSON_RF433_BLIND))]);
+        const char *action = root[UpperCase_P(parm_uc, PSTR(D_JSON_RF433_ACTION))];        
+
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_RF433_ACTION_UP)))){
+          strcat(responce,"11");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_RF433_ACTION_DOWN)))){
+          strcat(responce,"33");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_RF433_ACTION_STOP)))){
+          strcat(responce,"55");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_RF433_ACTION_PROG)))){
+          strcat(responce,"CC");
+          serviced = true;
+        }
+
+        if(serviced){
+          for(int h=0;h<10;h++){
+            last_delay =0;
+            init_msg();
+            for(int i=2;i<12;i++){hex_to_int(responce[i]);}
+          }
+          Response_P(responce);
+            
+        }else{
+          Serial.println(pin[GPIO_RF433_TX]);
+          serviced = true;
+        }
+    }
+    return(serviced);
+}
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv91(uint8_t function)
+{ 
+  bool result = false;
+
+  if (pin[GPIO_RF433_TX] < 99) {
+    switch (function) {
+      case FUNC_PRE_INIT:
+        rf433Init();                             // init and start communication
+        break;
+      case FUNC_EVERY_50_MSECOND:
+        break;
+      case FUNC_EVERY_SECOND:
+        break;
+      case FUNC_JSON_APPEND:
+        break;
+      case FUNC_SAVE_BEFORE_RESTART:
+        break;
+      case FUNC_COMMAND:
+        result = rf433Command();  // Return true on success
+        break;
+    }
+  }
+  return result; 
+}
+
+//#endif  // USE_RF433


### PR DESCRIPTION
Hi Guys have never contributed code to Tasmota before but this is my second attempt so I'm hoping this meets spec.
The protocol is for Dooya devices which is used on just about all blinds and shutter from China.
The hardware requirement is a single RF433 tx module requiring 1 output pin.
I will enable a blind or shutter using a DC1602 or similar RF remote of which there are several to control up to 15 blinds or shutters with a single command or individually. I have added this to DRV91 but this will likely need to be moved I suspect. The command is given is JSON and there is examples in the Driver code .

Jason
