### PR TITLE
Dooya RF Protocol for Blind and Shutters 

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -424,6 +424,14 @@
 #define D_CMND_LATITUDE "Latitude"
 #define D_CMND_LONGITUDE "Longitude"
 
+// Commands xdrv_91_dooyaRF.ino
+#define D_JSON_DOOYARF_GROUP "Group"
+#define D_JSON_DOOYARF_BLIND "Blind"
+#define D_JSON_DOOYARF_ACTION "Action"
+#define D_JSON_DOOYARF_ACTION_UP "Up"
+#define D_JSON_DOOYARF_ACTION_DOWN "Down"
+#define D_JSON_DOOYARF_ACTION_STOP "Stop"
+#define D_JSON_DOOYARF_ACTION_PROG "Prog"
 /********************************************************************************************/
 
 #define D_ASTERIX "********"

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -586,6 +586,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/es-ES.h
+++ b/sonoff/language/es-ES.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ko-KO.h
+++ b/sonoff/language/ko-KO.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/sk-SK.h
+++ b/sonoff/language/sk-SK.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/sv-SE.h
+++ b/sonoff/language/sv-SE.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -585,6 +585,7 @@
 #define D_SENSOR_HRE_CLOCK     "HRE Clock"
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
+#define D_SENSOR_DOOYARF_TX      "DOOYA Tx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -439,6 +439,7 @@
 
 //#define USE_HRE                                  // Add support for Badger HR-E Water Meter (+1k4 code)
 
+#define USE_DOOYA                               // Add Dooya BLind and Shutter Support (+1k0 code)
 /*********************************************************************************************\
  * Debug features are only supported in development branch
 \*********************************************************************************************/

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -181,6 +181,7 @@ enum UserSelectablePins {
   GPIO_HRE_CLOCK,      // Clock/Power line for HR-E Water Meter
   GPIO_HRE_DATA,       // Data line for HR-E Water Meter
   GPIO_ADE7953_IRQ,    // ADE7953 IRQ
+  GPIO_DOOYARF_TX,
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -246,6 +247,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_ROTARY "1a|" D_SENSOR_ROTARY "1b|" D_SENSOR_ROTARY "2a|" D_SENSOR_ROTARY "2b|"
   D_SENSOR_HRE_CLOCK "|" D_SENSOR_HRE_DATA "|"
   D_SENSOR_ADE7953_IRQ "|"
+  D_SENSOR_DOOYARF_TX "|"
   ;
 
 /********************************************************************************************/
@@ -603,6 +605,9 @@ const uint8_t kGpioNiceList[] PROGMEM = {
   GPIO_HRE_CLOCK,
   GPIO_HRE_DATA
 #endif
+#ifdef USE_DOOYA
+  GPIO_DOOYARF_TX,     //Dooya BLind and Shutter
+#endif //USE_DOOYA
 };
 
 const uint8_t kModuleNiceList[] PROGMEM = {

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -603,10 +603,10 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_HRE
   GPIO_HRE_CLOCK,
-  GPIO_HRE_DATA
+  GPIO_HRE_DATA,
 #endif
 #ifdef USE_DOOYA
-  GPIO_DOOYARF_TX,     //Dooya BLind and Shutter
+  GPIO_DOOYARF_TX     //Dooya BLind and Shutter
 #endif //USE_DOOYA
 };
 

--- a/sonoff/xdrv_91_dooyaRF.ino
+++ b/sonoff/xdrv_91_dooyaRF.ino
@@ -1,0 +1,183 @@
+/*
+  xdrv_91_rf443.ino - Veneta Blind RF Protocol support for Sonoff-Tasmota
+
+  Copyright (C) 2019  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  
+*/
+
+#ifdef USE_DOOYA
+
+#define XDRV_91             91
+/*********************************************************************************************\
+ * constants
+\*********************************************************************************************/
+#define D_CMND_DOOYARF "dooya"
+
+//The key to timing success is each bit regardless of True or False must be 1080 microsecond long in real time.
+
+#define PREP_LONG 8550 //8550
+#define START_HIGH 4725 //4725
+#define START_LOW 1525 //1525
+#define SHORT_BIT 350 //330 
+#define LONG_BIT 730 //715
+
+int last_delay =0;
+
+void init_msg(){
+  digitalWrite(pin[GPIO_DOOYARF_TX], LOW); //LOW
+  delayMicroseconds(PREP_LONG - last_delay); 
+  digitalWrite(pin[GPIO_DOOYARF_TX], HIGH);
+  delayMicroseconds(START_HIGH);
+  digitalWrite(pin[GPIO_DOOYARF_TX], LOW); //LOW
+  delayMicroseconds(START_LOW);
+}
+
+void send_bit(int state){
+  int high_time, low_time;
+ 
+  if(state){ //True State
+    high_time = LONG_BIT;
+    low_time=SHORT_BIT;
+  }else{ //False State
+    high_time = SHORT_BIT;
+    low_time=LONG_BIT;
+  }
+  //output to the transmiter 
+  digitalWrite(pin[GPIO_DOOYARF_TX], HIGH); //HIGH
+  delayMicroseconds(high_time);
+  digitalWrite(pin[GPIO_DOOYARF_TX], LOW); //LOW
+  delayMicroseconds(low_time);
+  last_delay = low_time;
+}
+
+void assemble_bits(char chr){
+    int revbin[4];
+    int n = chr - 48; 
+    int j;
+    //assemble bit pattern
+    if(n > 9){n-=7;} 
+    for(j=0;j<4;j++){
+       revbin[j]=(n % 2);
+       n = n / 2; 
+    }
+    //reverse bit pattern
+    for (int k = j - 1; k >= 0; k--){
+      send_bit(revbin[k]); 
+    }
+    return;
+}
+
+void dooyaInit(void) {
+  pinMode(pin[GPIO_DOOYARF_TX],OUTPUT);
+  return;
+}
+//If the Blind number is 0 then all blinds with the same group will opperate
+//together for the number is 1 or > it will only operate the individual blind
+//the blind group is a group of blinds for a room or area which could operate together using the 0 blind operation.
+  
+//dooya {"group":"0x9F340E","blind":1,"action":up}
+//dooya {"group":"0x9F340E","blind":1,"action":down}
+//dooya {"group":"0x9F340E","blind":1,"action":stop}
+//dooya {"group":"0x9F340E","blind":1,"action":prog}
+
+//dooya {"group":"0x11340E","blind":1,"action":prog}
+//dooya {"group":"0x11340E","blind":1,"action":down}
+
+bool dooyaCommand(){
+    char command [CMDSZ];
+    bool serviced = false;
+    char parm_uc[10];
+    
+    //copy from DRV05_irremote    
+    char dataBufUc[XdrvMailbox.data_len]; 
+    UpperCase(dataBufUc, XdrvMailbox.data);
+    StaticJsonBuffer<128> jsonBuf;
+    JsonObject &root = jsonBuf.parseObject(dataBufUc);
+
+    if (!root.success()) {
+        Response_P(S_JSON_COMMAND_SVALUE, command, D_JSON_INVALID_JSON);
+    }else{
+        char parm_uc[10];
+        char responce[12];
+              
+        //Construct the RF Message.
+        strcpy(responce,root[UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_GROUP))]);
+        strcat(responce,"B");
+        strcat(responce,root[UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_BLIND))]);
+        const char *action = root[UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_ACTION))];        
+
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_ACTION_UP)))){
+          strcat(responce,"11");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_ACTION_DOWN)))){
+          strcat(responce,"33");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_ACTION_STOP)))){
+          strcat(responce,"55");
+          serviced = true;
+        }
+        if(!strcmp(action,UpperCase_P(parm_uc, PSTR(D_JSON_DOOYARF_ACTION_PROG)))){
+          strcat(responce,"CC");
+          serviced = true;
+        }
+
+        if(serviced){
+          for(int h=0;h<10;h++){
+            last_delay =0;
+            init_msg();
+            for(int i=2;i<12;i++){assemble_bits(responce[i]);}
+          }
+          Response_P(responce);
+            
+        }else{
+          Serial.println(pin[GPIO_DOOYARF_TX]);
+          serviced = true;
+        }
+    }
+    return(serviced);
+}
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv91(uint8_t function)
+{ 
+  bool result = false;
+
+  if (pin[GPIO_DOOYARF_TX] < 99) {
+    switch (function) {
+      case FUNC_PRE_INIT:
+        dooyaInit();                             // init and start communication
+        break;
+      case FUNC_EVERY_50_MSECOND:
+        break;
+      case FUNC_EVERY_SECOND:
+        break;
+      case FUNC_JSON_APPEND:
+        break;
+      case FUNC_SAVE_BEFORE_RESTART:
+        break;
+      case FUNC_COMMAND:
+        result = dooyaCommand();  // Return true on success
+        break;
+    }
+  }
+  return result; 
+}
+
+#endif  // USE_DOOYA


### PR DESCRIPTION
## Description:
The protocol is for Dooya devices which is used on just about all blinds and shutter from China.
The hardware requirement is a single RF433 tx module requiring 1 output pin.
I will enable a blind or shutter using a DC1602 or similar RF remote of which there are several to control up to 15 blinds or shutters with a single command or individually. I have added this to DRV91 but this will likely need to be moved I suspect. The command is given is JSON and there is examples in the Driver code .

## Checklist:
  - [ y] The pull request is done against the latest dev branch
  - [ y] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [ y] Only one feature/fix was added per PR.
  - [ y] The code change is tested and works.
  - [ y] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ y] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
