### PR TITLE
Add Tuya Dimmer 10 second heartbeat

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,5 @@
 /* 6.5.0.8 20190413
+ * Add Tuya Dimmer 10 second heartbeat serial packet required by some Tuya dimmer secondary MCUs
  * Fix use of SerialDelimiter value 128 (#5634)
  * Fix lost syslog connection regression from 6.5.0.4
  * Add Shelly 2.5 Energy Monitoring (#5592)

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -52,6 +52,7 @@ uint8_t tuya_cmd_status = 0;                // Current status of serial-read
 uint8_t tuya_cmd_checksum = 0;              // Checksum of tuya command
 uint8_t tuya_data_len = 0;                  // Data lenght of command
 int8_t tuya_wifi_state = -2;                // Keep MCU wifi-status in sync with WifiState()
+uint8_t tuya_heartbeat_timer = 0;           // 10 second heartbeat timer for tuya module
 
 char *tuya_buffer = nullptr;                // Serial receive buffer
 int tuya_byte_counter = 0;                  // Index in serial receive buffer
@@ -294,6 +295,7 @@ void TuyaInit(void)
       TuyaSendCmd(TUYA_CMD_MCU_CONF);
     }
   }
+  tuya_heartbeat_timer = 0; // init heartbeat timer when dimmer init is done
 }
 
 void TuyaSerialInput(void)
@@ -410,6 +412,11 @@ bool Xdrv16(uint8_t function)
         break;
       case FUNC_EVERY_SECOND:
         if(TuyaSerial && tuya_wifi_state!=WifiState()) { TuyaSetWifiLed(); }
+        tuya_heartbeat_timer++;
+        if (tuya_heartbeat_timer > 10) {
+           tuya_heartbeat_timer = 0;
+           TuyaSendCmd(TUYA_CMD_HEARTBEAT);
+        } 
         break;
       case FUNC_SET_CHANNELS:
         result = TuyaSetChannels();


### PR DESCRIPTION
Some newer dimmer modules require the stock firmware method of sending a heartbeat packet every 10-11 seconds to the secondary MCU.  This was tested on 2 other Tuya based dimmers that did not require this heartbeat packet and no adverse impacts have been found.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
