### PR TITLE
Set gamma correction as default behavior, ie "Ledtable 1"

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * Add command SetOption63 0/1 to disable relay state feedback scan at restart (#5594, #5663)
  * Fix TasmotaSerial at 9600 bps solving DFPlayer comms (#5528)
  * Fix Shelly 2.5 overtemp
+ * Set gamma correction as default behavior, ie "Ledtable 1"
  *
  * 6.5.0.8 20190413
  * Add Tuya Dimmer 10 second heartbeat serial packet required by some Tuya dimmer secondary MCUs

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -860,7 +860,7 @@ void SettingsDefaultSet2(void)
     Settings.light_color[i] = 255;
 //    Settings.pwm_value[i] = 0;
   }
-//  Settings.light_correction = 0;
+  Settings.light_correction = 1;
   Settings.light_dimmer = 10;
 //  Settings.light_fade = 0;
   Settings.light_speed = 1;
@@ -1002,7 +1002,7 @@ void SettingsDelta(void)
       Settings.light_color[1] = 0;
       Settings.light_color[2] = 0;
       Settings.light_dimmer = 10;
-      Settings.light_correction = 0;
+      Settings.light_correction = 1;
       Settings.light_fade = 0;
       Settings.light_speed = 1;
       Settings.light_scheme = 0;


### PR DESCRIPTION
## Description:

Set LED Gamma correction as the default behavior. Gamma correction makes the Dimmer and colors feel more natural.

Currently off by default, it requires to explicitly set "Ledtable 1". I feel it should be the opposite: Gamma by default and explicitly disable if not needed.

**Related issue (if applicable): 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).