### PR TITLE
Fix german wifi connect message

### DIFF
--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -54,7 +54,7 @@
 #define D_ADMIN "Admin"
 #define D_AIR_QUALITY "Luftqualität"
 #define D_AP "AP"                    // Access Point
-#define D_AS "wie"
+#define D_AS "als"
 #define D_AUTO "AUTO"
 #define D_BLINK "Blinken"
 #define D_BLINKOFF "BlinkenAus"


### PR DESCRIPTION
Fix german wifi connect message:
Use correct translation "als" when reporting a wifi connect as host.

Signed-off-by: Soeren Moch <smoch@web.de>

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
