### PR TITLE
Fixed: Coldwhite/Warmwhite channels were inverted, back to RGBCW

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -6,6 +6,7 @@
  * Refactored management of lights, using classes and integers instead of floats.
  * Extend PWM resolution from 8 to 10 bits for low brightness lights
  * Allow all 5 PWM channels individually adressable with LEDs. (#5741)
+ * Fixed inversion of WC/WW channels, back to RGBCW
  *
  * 6.5.0.8 20190413
  * Add Tuya Dimmer 10 second heartbeat serial packet required by some Tuya dimmer secondary MCUs


### PR DESCRIPTION
## Description:

Since #5702 Coldwhite and Warmwhite channels were inverted. Now channels are back to RBBCW (and not RGBWC)

**Related issue (if applicable): #5761

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

