### PR TITLE
Missing the end pointer reference solves #5760

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -7,6 +7,7 @@
  * Extend PWM resolution from 8 to 10 bits for low brightness lights
  * Allow all 5 PWM channels individually adressable with LEDs. (#5741)
  * Fixed inversion of WC/WW channels, back to RGBCW
+ * Fixed the Unescape() function and the SendSerial3 behaviour
  *
  * 6.5.0.8 20190413
  * Add Tuya Dimmer 10 second heartbeat serial packet required by some Tuya dimmer secondary MCUs

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -353,7 +353,7 @@ char* Unescape(char* buffer, uint16_t* size)
     }
   }
   *size = end_size;
-
+  *write++ = 0;   // add the end string pointer reference
 //  AddLogBuffer(LOG_LEVEL_DEBUG, (uint8_t*)buffer, *size);
 
   return buffer;


### PR DESCRIPTION
## Description: 
Returning from the unescape call the content in buffer still contains the ending part of the original string. The result of unescape elaboration works well, but the rest of the string is still there and in the printf in the main program infact is printed overlapped to the previous content. 
(TY MauroS for the hint.)


**Related issue (if applicable):** fixes #5760 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
