### PR TITLE
decode-config.py: adapt settings

### DIFF
--- a/tools/decode-config.html
+++ b/tools/decode-config.html
@@ -211,109 +211,109 @@ If you do not want using auto extensions use the <code>--no-extension</code> par
 <p>For better reading each short written arg (minus sign <code>-</code>) has a corresponding long version (two minus signs <code>--</code>), eg. <code>--device</code> for <code>-d</code> or <code>--file</code> for <code>-f</code> (note: not even all <code>--</code> arg has a corresponding <code>-</code> one).</p>
 <p>A short list of possible program args is displayed using <code>-h</code> or <code>--help</code>.</p>
 <p>For advanced help use <code>-H</code> or <code>--full-help</code>:</p>
-<pre><code><span class="hljs-title">usage</span>: decode-config.py [-f &lt;filename&gt;] [-d &lt;host&gt;] [-<span class="hljs-type">P</span> &lt;port&gt;]
-                        [-u &lt;username&gt;] [-p &lt;password&gt;] [-i &lt;filename&gt;]
-                        [-o &lt;filename&gt;] [-t json|bin|dmp] [-<span class="hljs-type">E</span>] [-e] [-<span class="hljs-type">F</span>]
-                        [<span class="hljs-comment">--json-indent &lt;indent&gt;] [--json-compact]</span>
-                        [<span class="hljs-comment">--json-hide-pw] [--json-show-pw]</span>
-                        [<span class="hljs-comment">--cmnd-indent &lt;indent&gt;] [--cmnd-groups]</span>
-                        [<span class="hljs-comment">--cmnd-nogroups] [--cmnd-sort] [--cmnd-unsort]</span>
-                        [-c &lt;filename&gt;] [-<span class="hljs-type">S</span>] [-<span class="hljs-type">T</span> json|cmnd|command]
-                        [-g {<span class="hljs-type">Display</span>,<span class="hljs-type">Domoticz</span>,<span class="hljs-type">Internal</span>,<span class="hljs-type">KNX</span>,<span class="hljs-type">Led</span>,<span class="hljs-type">Logging</span>,<span class="hljs-type">MCP230xx</span>,<span class="hljs-type">MQTT</span>,<span class="hljs-type">Main</span>,<span class="hljs-type">Management</span>,<span class="hljs-type">Pow</span>,<span class="hljs-type">Sensor</span>,<span class="hljs-type">Serial</span>,<span class="hljs-type">SetOption</span>,<span class="hljs-type">SonoffRF</span>,<span class="hljs-type">System</span>,<span class="hljs-type">Timers</span>,<span class="hljs-type">Wifi</span>} [{<span class="hljs-type">Display</span>,<span class="hljs-type">Domoticz</span>,<span class="hljs-type">Internal</span>,<span class="hljs-type">KNX</span>,<span class="hljs-type">Led</span>,<span class="hljs-type">Logging</span>,<span class="hljs-type">MCP230xx</span>,<span class="hljs-type">MQTT</span>,<span class="hljs-type">Main</span>,<span class="hljs-type">Management</span>,<span class="hljs-type">Pow</span>,<span class="hljs-type">Sensor</span>,<span class="hljs-type">Serial</span>,<span class="hljs-type">SetOption</span>,<span class="hljs-type">SonoffRF</span>,<span class="hljs-type">System</span>,<span class="hljs-type">Timers</span>,<span class="hljs-type">Wifi</span>} ...]]
-                        [<span class="hljs-comment">--ignore-warnings] [-h] [-H] [-v] [-V]</span>
+<pre><code>usage: <span class="hljs-keyword">decode</span>-config.py [-f &lt;filename&gt;] [-<span class="hljs-keyword">d</span> &lt;host&gt;] [-P &lt;port&gt;]
+                        [-<span class="hljs-keyword">u</span> &lt;username&gt;] [-p &lt;password&gt;] [-i &lt;filename&gt;]
+                        [-o &lt;filename&gt;] [-t json|bin|dmp] [-<span class="hljs-keyword">E</span>] [-<span class="hljs-keyword">e</span>] [-F]
+                        [--json-indent &lt;indent&gt;] [--json-compact]
+                        [--json-hide-pw] [--json-show-pw]
+                        [--cmnd-indent &lt;indent&gt;] [--cmnd-groups]
+                        [--cmnd-nogroups] [--cmnd-<span class="hljs-keyword">sort</span>] [--cmnd-unsort]
+                        [-c &lt;filename&gt;] [-S] [-T json|cmnd|command]
+                        [-<span class="hljs-keyword">g</span> {Control,Devices,<span class="hljs-keyword">Display</span>,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,<span class="hljs-keyword">Timer</span>,Wifi} [{Control,Devices,<span class="hljs-keyword">Display</span>,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,<span class="hljs-keyword">Timer</span>,Wifi} ...]]
+                        [--ignore-warnings] [-<span class="hljs-keyword">h</span>] [-<span class="hljs-keyword">H</span>] [-v] [-V]
 
-<span class="hljs-type">Backup</span>/<span class="hljs-type">Restore</span> <span class="hljs-type">Sonoff</span>-<span class="hljs-type">Tasmota</span> configuration <span class="hljs-class"><span class="hljs-keyword">data</span>. <span class="hljs-type">Args</span> that start with '<span class="hljs-comment">--'</span></span>
-(eg. -f) can also be set <span class="hljs-keyword">in</span> a config file (specified via -c). <span class="hljs-type">Config</span> file
-<span class="hljs-title">syntax</span> allows: key=value, flag=true, stuff=[a,b,c] (for details, see syntax at
-<span class="hljs-title">https</span>://goo.gl/<span class="hljs-type">R74nmi</span>). <span class="hljs-type">If</span> an arg is specified <span class="hljs-keyword">in</span> more than one place, <span class="hljs-keyword">then</span>
-<span class="hljs-title">commandline</span> values override config file values which override defaults.
+Backup/<span class="hljs-keyword">Restore</span> Sonoff-Tasmota configuration data. <span class="hljs-keyword">Args</span> that start with '--'
+(eg. -f) can also be <span class="hljs-keyword">set</span> <span class="hljs-keyword">in</span> a config <span class="hljs-keyword">file</span> (specified via -c). Config <span class="hljs-keyword">file</span>
+<span class="hljs-keyword">syntax</span> allows: key=value, flag=true, stuff=[a,b,c] (<span class="hljs-keyword">for</span> details, see <span class="hljs-keyword">syntax</span> at
+https:<span class="hljs-comment">//goo.gl/R74nmi). If an arg is specified in more than one place, then</span>
+commandline values override config <span class="hljs-keyword">file</span> values <span class="hljs-keyword">which</span> override defaults.
 
-<span class="hljs-type">Source</span>:
-  <span class="hljs-type">Read</span>/<span class="hljs-type">Write</span> <span class="hljs-type">Tasmota</span> configuration from/to
+Source:
+  <span class="hljs-keyword">Read</span>/Write Tasmota configuration from/to
 
-  -f, <span class="hljs-comment">--file, --tasmota-file &lt;filename&gt;</span>
-                        file to retrieve/write <span class="hljs-type">Tasmota</span> configuration from/to
-                        (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>)'
-  -d, <span class="hljs-comment">--device, --host &lt;host&gt;</span>
-                        hostname or <span class="hljs-type">IP</span> address to retrieve/send <span class="hljs-type">Tasmota</span>
-                        configuration from/to (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>)
-  -<span class="hljs-type">P</span>, <span class="hljs-comment">--port &lt;port&gt;     TCP/IP port number to use for the host connection</span>
-                        (<span class="hljs-keyword">default</span>: 80)
-  -u, <span class="hljs-comment">--username &lt;username&gt;</span>
-                        host <span class="hljs-type">HTTP</span> access username (<span class="hljs-keyword">default</span>: admin)
-  -p, <span class="hljs-comment">--password &lt;password&gt;</span>
-                        host <span class="hljs-type">HTTP</span> access password (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>)
+  -f, --<span class="hljs-keyword">file</span>, --tasmota-<span class="hljs-keyword">file</span> &lt;filename&gt;
+                        <span class="hljs-keyword">file</span> to retrieve/write Tasmota configuration from/to
+                        (default: None)'
+  -<span class="hljs-keyword">d</span>, --device, --host &lt;host&gt;
+                        hostname or IP address to retrieve/send Tasmota
+                        configuration from/to (default: None)
+  -P, --port &lt;port&gt;     TCP/IP port number to <span class="hljs-keyword">use</span> <span class="hljs-keyword">for</span> the host connection
+                        (default: 80)
+  -<span class="hljs-keyword">u</span>, --username &lt;username&gt;
+                        host HTTP access username (default: admin)
+  -p, --password &lt;password&gt;
+                        host HTTP access password (default: None)
 
-<span class="hljs-type">Backup</span>/<span class="hljs-type">Restore</span>:
-  <span class="hljs-type">Backup</span> &amp; restore specification
+Backup/<span class="hljs-keyword">Restore</span>:
+  Backup &amp; <span class="hljs-keyword">restore</span> specification
 
-  -i, <span class="hljs-comment">--restore-file &lt;filename&gt;</span>
-                        file to restore configuration from (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>).
-                        <span class="hljs-type">Replacements</span>: @v=firmware version from config,
-                        @f=device friendly name from config, @h=device
-                        hostname from config, @<span class="hljs-type">H</span>=device hostname from device
-                        (-d arg only)
-  -o, <span class="hljs-comment">--backup-file &lt;filename&gt;</span>
-                        file to backup configuration to (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>).
-                        <span class="hljs-type">Replacements</span>: @v=firmware version from config,
-                        @f=device friendly name from config, @h=device
-                        hostname from config, @<span class="hljs-type">H</span>=device hostname from device
-                        (-d arg only)
-  -t, <span class="hljs-comment">--backup-type json|bin|dmp</span>
-                        backup filetype (<span class="hljs-keyword">default</span>: 'json')
-  -<span class="hljs-type">E</span>, <span class="hljs-comment">--extension       append filetype extension for -i and -o filename</span>
-                        (<span class="hljs-keyword">default</span>)
-  -e, <span class="hljs-comment">--no-extension    do not append filetype extension, use -i and -o</span>
+  -i, --<span class="hljs-keyword">restore</span>-<span class="hljs-keyword">file</span> &lt;filename&gt;
+                        <span class="hljs-keyword">file</span> to <span class="hljs-keyword">restore</span> configuration from (default: None).
+                        Replacements: @v=firmware <span class="hljs-keyword">version</span> from config,
+                        @f=device friendly name from config, @<span class="hljs-keyword">h</span>=device
+                        hostname from config, @<span class="hljs-keyword">H</span>=device hostname from device
+                        (-<span class="hljs-keyword">d</span> arg only)
+  -o, --backup-<span class="hljs-keyword">file</span> &lt;filename&gt;
+                        <span class="hljs-keyword">file</span> to backup configuration to (default: None).
+                        Replacements: @v=firmware <span class="hljs-keyword">version</span> from config,
+                        @f=device friendly name from config, @<span class="hljs-keyword">h</span>=device
+                        hostname from config, @<span class="hljs-keyword">H</span>=device hostname from device
+                        (-<span class="hljs-keyword">d</span> arg only)
+  -t, --backup-<span class="hljs-keyword">type</span> json|bin|dmp
+                        backup filetype (default: 'json')
+  -<span class="hljs-keyword">E</span>, --extension       <span class="hljs-keyword">append</span> filetype extension <span class="hljs-keyword">for</span> -i and -o filename
+                        (default)
+  -<span class="hljs-keyword">e</span>, --<span class="hljs-keyword">no</span>-extension    <span class="hljs-keyword">do</span> not <span class="hljs-keyword">append</span> filetype extension, <span class="hljs-keyword">use</span> -i and -o
                         filename <span class="hljs-keyword">as</span> passed
-  -<span class="hljs-type">F</span>, <span class="hljs-comment">--force-restore   force restore even configuration is identical</span>
+  -F, --force-<span class="hljs-keyword">restore</span>   force <span class="hljs-keyword">restore</span> even configuration is identical
 
-<span class="hljs-type">JSON</span> output:
-  <span class="hljs-type">JSON</span> format specification
+JSON output:
+  JSON <span class="hljs-keyword">format</span> specification
 
-  <span class="hljs-comment">--json-indent &lt;indent&gt;</span>
-                        pretty-printed <span class="hljs-type">JSON</span> output using indent level
-                        (<span class="hljs-keyword">default</span>: '<span class="hljs-type">None'</span>). -1 disables indent.
-  <span class="hljs-comment">--json-compact        compact JSON output by eliminate whitespace</span>
-  <span class="hljs-comment">--json-hide-pw        hide passwords</span>
-  <span class="hljs-comment">--json-show-pw, --json-unhide-pw</span>
-                        unhide passwords (<span class="hljs-keyword">default</span>)
+  --json-indent &lt;indent&gt;
+                        pretty-printed JSON output using indent level
+                        (default: 'None'). -1 disables indent.
+  --json-compact        compact JSON output <span class="hljs-keyword">by</span> eliminate whitespace
+  --json-hide-pw        hide passwords
+  --json-show-pw, --json-unhide-pw
+                        unhide passwords (default)
 
-<span class="hljs-type">Tasmota</span> command output:
-  <span class="hljs-type">Tasmota</span> command output format specification
+Tasmota command output:
+  Tasmota command output <span class="hljs-keyword">format</span> specification
 
-  <span class="hljs-comment">--cmnd-indent &lt;indent&gt;</span>
-                        <span class="hljs-type">Tasmota</span> command grouping indent level (<span class="hljs-keyword">default</span>: '2').
-                        <span class="hljs-number">0</span> disables indent
-  <span class="hljs-comment">--cmnd-groups         group Tasmota commands (default)</span>
-  <span class="hljs-comment">--cmnd-nogroups       leave Tasmota commands ungrouped</span>
-  <span class="hljs-comment">--cmnd-sort           sort Tasmota commands (default)</span>
-  <span class="hljs-comment">--cmnd-unsort         leave Tasmota commands unsorted</span>
+  --cmnd-indent &lt;indent&gt;
+                        Tasmota command grouping indent level (default: '2').
+                        0 disables indent
+  --cmnd-groups         group Tasmota commands (default)
+  --cmnd-nogroups       leave Tasmota commands ungrouped
+  --cmnd-<span class="hljs-keyword">sort</span>           <span class="hljs-keyword">sort</span> Tasmota commands (default)
+  --cmnd-unsort         leave Tasmota commands unsorted
 
-<span class="hljs-type">Common</span>:
-  <span class="hljs-type">Optional</span> arguments
+Common:
+  Optional arguments
 
-  -c, <span class="hljs-comment">--config &lt;filename&gt;</span>
-                        program config file - can be used to set <span class="hljs-keyword">default</span>
-                        command args (<span class="hljs-keyword">default</span>: <span class="hljs-type">None</span>)
-  -<span class="hljs-type">S</span>, <span class="hljs-comment">--output          display output regardsless of backup/restore usage</span>
-                        (<span class="hljs-keyword">default</span> do not output on backup or restore usage)
-  -<span class="hljs-type">T</span>, <span class="hljs-comment">--output-format json|cmnd|command</span>
-                        display output format (<span class="hljs-keyword">default</span>: 'json')
-  -g, <span class="hljs-comment">--group {Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi}</span>
-                        limit <span class="hljs-class"><span class="hljs-keyword">data</span> processing to command groups (<span class="hljs-title">default</span> <span class="hljs-title">no</span>
-                        <span class="hljs-title">filter</span>)</span>
-  <span class="hljs-comment">--ignore-warnings     do not exit on warnings. Not recommended, used by your</span>
+  -c, --config &lt;filename&gt;
+                        <span class="hljs-keyword">program</span> config <span class="hljs-keyword">file</span> - can be used to <span class="hljs-keyword">set</span> default
+                        command <span class="hljs-keyword">args</span> (default: None)
+  -S, --output          <span class="hljs-keyword">display</span> output regardsless of backup/<span class="hljs-keyword">restore</span> usage
+                        (default <span class="hljs-keyword">do</span> not output <span class="hljs-keyword">on</span> backup or <span class="hljs-keyword">restore</span> usage)
+  -T, --output-<span class="hljs-keyword">format</span> json|cmnd|command
+                        <span class="hljs-keyword">display</span> output <span class="hljs-keyword">format</span> (default: 'json')
+  -<span class="hljs-keyword">g</span>, --group {Control,Devices,<span class="hljs-keyword">Display</span>,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,<span class="hljs-keyword">Timer</span>,Wifi}
+                        limit data processing to command groups (default <span class="hljs-keyword">no</span>
+                        filter)
+  --ignore-warnings     <span class="hljs-keyword">do</span> not <span class="hljs-keyword">exit</span> <span class="hljs-keyword">on</span> warnings. Not recommended, used <span class="hljs-keyword">by</span> your
                         own responsibility!
 
-<span class="hljs-type">Info</span>:
-  <span class="hljs-type">Extra</span> information
+Info:
+  Extra information
 
-  -h, <span class="hljs-comment">--help            show usage help message and exit</span>
-  -<span class="hljs-type">H</span>, <span class="hljs-comment">--full-help       show full help message and exit</span>
-  -v, <span class="hljs-comment">--verbose         produce more output about what the program does</span>
-  -<span class="hljs-type">V</span>, <span class="hljs-comment">--version         show program's version number and exit</span>
+  -<span class="hljs-keyword">h</span>, --<span class="hljs-keyword">help</span>            show usage <span class="hljs-keyword">help</span> message and <span class="hljs-keyword">exit</span>
+  -<span class="hljs-keyword">H</span>, --full-<span class="hljs-keyword">help</span>       show full <span class="hljs-keyword">help</span> message and <span class="hljs-keyword">exit</span>
+  -v, --verbose         produce <span class="hljs-keyword">more</span> output <span class="hljs-keyword">about</span> what the <span class="hljs-keyword">program</span> does
+  -V, --<span class="hljs-keyword">version</span>         show <span class="hljs-keyword">program</span>'s <span class="hljs-keyword">version</span> number and <span class="hljs-keyword">exit</span>
 
-<span class="hljs-type">Either</span> argument -d &lt;host&gt; or -f &lt;filename&gt; must be given.
+Either argument -<span class="hljs-keyword">d</span> &lt;host&gt; or -f &lt;filename&gt; must be given.
 </code></pre><h3 id="program-parameter-notes">Program parameter notes</h3>
 <p><em>decode-config.py</em></p>
 <h3 id="examples">Examples</h3>

--- a/tools/decode-config.md
+++ b/tools/decode-config.md
@@ -237,7 +237,7 @@ For advanced help use `-H` or `--full-help`:
                             [--cmnd-indent <indent>] [--cmnd-groups]
                             [--cmnd-nogroups] [--cmnd-sort] [--cmnd-unsort]
                             [-c <filename>] [-S] [-T json|cmnd|command]
-                            [-g {Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi} [{Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi} ...]]
+                            [-g {Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi} [{Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi} ...]]
                             [--ignore-warnings] [-h] [-H] [-v] [-V]
 
     Backup/Restore Sonoff-Tasmota configuration data. Args that start with '--'
@@ -317,7 +317,7 @@ For advanced help use `-H` or `--full-help`:
                             (default do not output on backup or restore usage)
       -T, --output-format json|cmnd|command
                             display output format (default: 'json')
-      -g, --group {Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi}
+      -g, --group {Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi}
                             limit data processing to command groups (default no
                             filter)
       --ignore-warnings     do not exit on warnings. Not recommended, used by your

--- a/tools/decode-config.py
+++ b/tools/decode-config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-VER = '2.1.0024'
+VER = '2.2.0025'
 
 """
     decode-config.py - Backup/Restore Sonoff-Tasmota configuration data
@@ -43,7 +43,7 @@ Usage: decode-config.py [-f <filename>] [-d <host>] [-P <port>]
                         [--cmnd-indent <indent>] [--cmnd-groups]
                         [--cmnd-nogroups] [--cmnd-sort] [--cmnd-unsort]
                         [-c <filename>] [-S] [-T json|cmnd|command]
-                        [-g {Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi} [{Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi} ...]]
+                        [-g {Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi} [{Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi} ...]]
                         [--ignore-warnings] [-h] [-H] [-v] [-V]
 
     Backup/Restore Sonoff-Tasmota configuration data. Args that start with '--'
@@ -123,7 +123,7 @@ Usage: decode-config.py [-f <filename>] [-d <host>] [-P <port>]
                             (default do not output on backup or restore usage)
       -T, --output-format json|cmnd|command
                             display output format (default: 'json')
-      -g, --group {Display,Domoticz,Internal,KNX,Led,Logging,MCP230xx,MQTT,Main,Management,Pow,Sensor,Serial,SetOption,SonoffRF,System,Timers,Wifi}
+      -g, --group {Control,Devices,Display,Domoticz,Internal,KNX,Light,MQTT,Management,Power,Rules,Sensor,Serial,SetOption,SonoffRF,System,Timer,Wifi}
                             limit data processing to command groups (default no
                             filter)
       --ignore-warnings     do not exit on warnings. Not recommended, used by your
@@ -308,7 +308,7 @@ Settings dictionary describes the config file fields definition:
                     Tasmota command definition
                     <group>:        <string>
                         command group string
-                    <tasmotacmnd>:   <function>
+                    <tasmotacmnd>:   <function> | (<function>,...)
                         convert data into Tasmota command function
 
             <converter>:    <readconverter> | (<readconverter>, <writeconverter>)
@@ -407,7 +407,6 @@ def MqttFingerprint(value, idx=None):
 # ----------------------------------------------------------------------
 # Tasmota configuration data definition
 # ----------------------------------------------------------------------
-Groups = ('Main','Sensor','Timers','Management','Wifi','MQTT','Serial','SetOption','Logging','Pow','Led','KNX','Domoticz','Display','MCP230xx')
 Setting_5_10_0 = {
                               # <format>, <addrdef>, <datadef> [,<converter>]
     'cfg_holder':                   ('<L',  0x000,       (None, None,                           (INTERNAL,      None)), '"0x{:08x}".format($)' ),
@@ -415,40 +414,40 @@ Setting_5_10_0 = {
     'version':                      ('<L',  0x008,       (None, None,                           (INTERNAL,      None)), ('hex($)',  False) ),
     'bootcount':                    ('<L',  0x00C,       (None, None,                           ('System',      None)), (None,      False) ),
     'flag':                         ({
-        'save_state':               ('<L', (0x010,1, 0), (None, None,                           ('Management',  '"SetOption0 {}".format($)')) ),
-        'button_restrict':          ('<L', (0x010,1, 1), (None, None,                           ('Management',  '"SetOption1 {}".format($)')) ),
-        'value_units':              ('<L', (0x010,1, 2), (None, None,                           ('MQTT',        '"SetOption2 {}".format($)')) ),
-        'mqtt_enabled':             ('<L', (0x010,1, 3), (None, None,                           ('MQTT',        '"SetOption3 {}".format($)')) ),
-        'mqtt_response':            ('<L', (0x010,1, 4), (None, None,                           ('MQTT',        '"SetOption4 {}".format($)')) ),
-        'mqtt_power_retain':        ('<L', (0x010,1, 5), (None, None,                           ('Main',        '"PowerRetain {}".format($)')) ),
+        'save_state':               ('<L', (0x010,1, 0), (None, None,                           ('SetOption',   '"SetOption0 {}".format($)')) ),
+        'button_restrict':          ('<L', (0x010,1, 1), (None, None,                           ('SetOption',   '"SetOption1 {}".format($)')) ),
+        'value_units':              ('<L', (0x010,1, 2), (None, None,                           ('SetOption',   '"SetOption2 {}".format($)')) ),
+        'mqtt_enabled':             ('<L', (0x010,1, 3), (None, None,                           ('SetOption',   '"SetOption3 {}".format($)')) ),
+        'mqtt_response':            ('<L', (0x010,1, 4), (None, None,                           ('SetOption',   '"SetOption4 {}".format($)')) ),
+        'mqtt_power_retain':        ('<L', (0x010,1, 5), (None, None,                           ('MQTT',        '"PowerRetain {}".format($)')) ),
         'mqtt_button_retain':       ('<L', (0x010,1, 6), (None, None,                           ('MQTT',        '"ButtonRetain {}".format($)')) ),
         'mqtt_switch_retain':       ('<L', (0x010,1, 7), (None, None,                           ('MQTT',        '"SwitchRetain {}".format($)')) ),
-        'temperature_conversion':   ('<L', (0x010,1, 8), (None, None,                           ('Sensor',      '"SetOption8 {}".format($)')) ),
+        'temperature_conversion':   ('<L', (0x010,1, 8), (None, None,                           ('SetOption',   '"SetOption8 {}".format($)')) ),
         'mqtt_sensor_retain':       ('<L', (0x010,1, 9), (None, None,                           ('MQTT',        '"SensorRetain {}".format($)')) ),
-        'mqtt_offline':             ('<L', (0x010,1,10), (None, None,                           ('MQTT',        '"SetOption10 {}".format($)')) ),
-        'button_swap':              ('<L', (0x010,1,11), (None, None,                           ('Main',        '"SetOption11 {}".format($)')) ),
+        'mqtt_offline':             ('<L', (0x010,1,10), (None, None,                           ('SetOption',   '"SetOption10 {}".format($)')) ),
+        'button_swap':              ('<L', (0x010,1,11), (None, None,                           ('SetOption',   '"SetOption11 {}".format($)')) ),
         'stop_flash_rotate':        ('<L', (0x010,1,12), (None, None,                           ('Management',  '"SetOption12 {}".format($)')) ),
-        'button_single':            ('<L', (0x010,1,13), (None, None,                           ('Main',        '"SetOption13 {}".format($)')) ),
-        'interlock':                ('<L', (0x010,1,14), (None, None,                           ('Main',        '"SetOption14 {}".format($)')) ),
-        'pwm_control':              ('<L', (0x010,1,15), (None, None,                           ('Main',        '"SetOption15 {}".format($)')) ),
+        'button_single':            ('<L', (0x010,1,13), (None, None,                           ('SetOption',   '"SetOption13 {}".format($)')) ),
+        'interlock':                ('<L', (0x010,1,14), (None, None,                           ('SetOption',   '"SetOption14 {}".format($)')) ),
+        'pwm_control':              ('<L', (0x010,1,15), (None, None,                           ('SetOption',   '"SetOption15 {}".format($)')) ),
         'ws_clock_reverse':         ('<L', (0x010,1,16), (None, None,                           ('SetOption',   '"SetOption16 {}".format($)')) ),
         'decimal_text':             ('<L', (0x010,1,17), (None, None,                           ('SetOption',   '"SetOption17 {}".format($)')) ),
                                     },      0x010,       (None, None,                           ('*',           None)), (None,      None) ),
     'save_data':                    ('<h',  0x014,       (None, '0 <= $ <= 3600',               ('Management',  '"SaveData {}".format($)')) ),
     'timezone':                     ('b',   0x016,       (None, '-13 <= $ <= 13 or $==99',      ('Management',  '"Timezone {}".format($)')) ),
-    'ota_url':                      ('101s',0x017,       (None, None,                           ('Main',        '"OtaUrl {}".format($)')) ),
+    'ota_url':                      ('101s',0x017,       (None, None,                           ('Management',  '"OtaUrl {}".format($)')) ),
     'mqtt_prefix':                  ('11s', 0x07C,       ([3],  None,                           ('MQTT',        '"Prefix{} {}".format(#,$)')) ),
-    'seriallog_level':              ('B',   0x09E,       (None, '0 <= $ <= 5',                  ('Logging',     '"SerialLog {}".format($)')) ),
+    'seriallog_level':              ('B',   0x09E,       (None, '0 <= $ <= 5',                  ('Management',  '"SerialLog {}".format($)')) ),
     'sta_config':                   ('B',   0x09F,       (None, '0 <= $ <= 5',                  ('Wifi',        '"WifiConfig {}".format($)')) ),
     'sta_active':                   ('B',   0x0A0,       (None, '0 <= $ <= 1',                  ('Wifi',        '"AP {}".format($)')) ),
     'sta_ssid':                     ('33s', 0x0A1,       ([2],  None,                           ('Wifi',        '"SSId{} {}".format(#,$)')) ),
     'sta_pwd':                      ('65s', 0x0E3,       ([2],  None,                           ('Wifi',        '"Password{} {}".format(#,$)')), (passwordread,passwordwrite) ),
     'hostname':                     ('33s', 0x165,       (None, None,                           ('Wifi',        '"Hostname {}".format($)')) ),
-    'syslog_host':                  ('33s', 0x186,       (None, None,                           ('Logging',     '"LogHost {}".format($)')) ),
-    'syslog_port':                  ('<H',  0x1A8,       (None, '1 <= $ <= 32766',              ('Logging',     '"LogPort {}".format($)')) ),
-    'syslog_level':                 ('B',   0x1AA,       (None, '0 <= $ <= 4',                  ('Logging',     '"SysLog {}".format($)')) ),
+    'syslog_host':                  ('33s', 0x186,       (None, None,                           ('Management',  '"LogHost {}".format($)')) ),
+    'syslog_port':                  ('<H',  0x1A8,       (None, '1 <= $ <= 32766',              ('Management',  '"LogPort {}".format($)')) ),
+    'syslog_level':                 ('B',   0x1AA,       (None, '0 <= $ <= 4',                  ('Management',  '"SysLog {}".format($)')) ),
     'webserver':                    ('B',   0x1AB,       (None, '0 <= $ <= 2',                  ('Wifi',        '"WebServer {}".format($)')) ),
-    'weblog_level':                 ('B',   0x1AC,       (None, '0 <= $ <= 4',                  ('Logging',     '"WebLog {}".format($)')) ),
+    'weblog_level':                 ('B',   0x1AC,       (None, '0 <= $ <= 4',                  ('Management',  '"WebLog {}".format($)')) ),
     'mqtt_fingerprint':             ('60s', 0x1AD,       (None, None,                           ('MQTT',        None)) ),
     'mqtt_host':                    ('33s', 0x1E9,       (None, None,                           ('MQTT',        '"MqttHost {}".format($)')) ),
     'mqtt_port':                    ('<H',  0x20A,       (None, None,                           ('MQTT',        '"MqttPort {}".format($)')) ),
@@ -461,84 +460,84 @@ Setting_5_10_0 = {
     'mqtt_fingerprinth':            ('B',   0x2D2,       ([20], None,                           ('MQTT',        None)) ),
     'pwm_frequency':                ('<H',  0x2E6,       (None, '$==1 or 100 <= $ <= 4000',     ('Management',  '"PwmFrequency {}".format($)')) ),
     'power':                        ({
-        'power1':                   ('<L', (0x2E8,1,0),  (None, None,                           ('Main',        '"Power1 {}".format($)')) ),
-        'power2':                   ('<L', (0x2E8,1,1),  (None, None,                           ('Main',        '"Power2 {}".format($)')) ),
-        'power3':                   ('<L', (0x2E8,1,2),  (None, None,                           ('Main',        '"Power3 {}".format($)')) ),
-        'power4':                   ('<L', (0x2E8,1,3),  (None, None,                           ('Main',        '"Power4 {}".format($)')) ),
-        'power5':                   ('<L', (0x2E8,1,4),  (None, None,                           ('Main',        '"Power5 {}".format($)')) ),
-        'power6':                   ('<L', (0x2E8,1,5),  (None, None,                           ('Main',        '"Power6 {}".format($)')) ),
-        'power7':                   ('<L', (0x2E8,1,6),  (None, None,                           ('Main',        '"Power7 {}".format($)')) ),
-        'power8':                   ('<L', (0x2E8,1,7),  (None, None,                           ('Main',        '"Power8 {}".format($)')) ),
-                                    },      0x2E8,       (None, None,                           ('Main',        None)), (None,      None) ),
+        'power1':                   ('<L', (0x2E8,1,0),  (None, None,                           ('Control',     '"Power1 {}".format($)')) ),
+        'power2':                   ('<L', (0x2E8,1,1),  (None, None,                           ('Control',     '"Power2 {}".format($)')) ),
+        'power3':                   ('<L', (0x2E8,1,2),  (None, None,                           ('Control',     '"Power3 {}".format($)')) ),
+        'power4':                   ('<L', (0x2E8,1,3),  (None, None,                           ('Control',     '"Power4 {}".format($)')) ),
+        'power5':                   ('<L', (0x2E8,1,4),  (None, None,                           ('Control',     '"Power5 {}".format($)')) ),
+        'power6':                   ('<L', (0x2E8,1,5),  (None, None,                           ('Control',     '"Power6 {}".format($)')) ),
+        'power7':                   ('<L', (0x2E8,1,6),  (None, None,                           ('Control',     '"Power7 {}".format($)')) ),
+        'power8':                   ('<L', (0x2E8,1,7),  (None, None,                           ('Control',     '"Power8 {}".format($)')) ),
+                                    },      0x2E8,       (None, None,                           ('Control',     None)), (None,      None) ),
     'pwm_value':                    ('<H',  0x2EC,       ([5],  '0 <= $ <= 1023',               ('Management',  '"Pwm{} {}".format(#,$)')) ),
     'altitude':                     ('<h',  0x2F6,       (None, '-30000 <= $ <= 30000',         ('Sensor',      '"Altitude {}".format($)')) ),
     'tele_period':                  ('<H',  0x2F8,       (None, '0 <= $ <= 1 or 10 <= $ <= 3600',('MQTT',       '"TelePeriod {}".format($)')) ),
-    'ledstate':                     ('B',   0x2FB,       (None, '0 <= ($ & 0x7) <= 7',          ('Main',        '"LedState {}".format($)')) ),
+    'ledstate':                     ('B',   0x2FB,       (None, '0 <= ($ & 0x7) <= 7',          ('Control',     '"LedState {}".format(($ & 0x7))')) ),
     'param':                        ('B',   0x2FC,       ([23], None,                           ('SetOption',   '"SetOption{} {}".format(#+31,$)')) ),
     'state_text':                   ('11s', 0x313,       ([4],  None,                           ('MQTT',        '"StateText{} {}".format(#,$)')) ),
     'domoticz_update_timer':        ('<H',  0x340,       (None, '0 <= $ <= 3600',               ('Domoticz',    '"DomoticzUpdateTimer {}".format($)')) ),
     'pwm_range':                    ('<H',  0x342,       (None, '$==1 or 255 <= $ <= 1023',     ('Management',  '"PwmRange {}".format($)')) ),
     'domoticz_relay_idx':           ('<L',  0x344,       ([4],  None,                           ('Domoticz',    '"DomoticzIdx{} {}".format(#,$)')) ),
     'domoticz_key_idx':             ('<L',  0x354,       ([4],  None,                           ('Domoticz',    '"DomoticzKeyIdx{} {}".format(#,$)')) ),
-    'energy_power_calibration':     ('<L',  0x364,       (None, None,                           ('Pow',         '"PowerSet {}".format($)')) ),
-    'energy_voltage_calibration':   ('<L',  0x368,       (None, None,                           ('Pow',         '"VoltageSet {}".format($)')) ),
-    'energy_current_calibration':   ('<L',  0x36C,       (None, None,                           ('Pow',         '"CurrentSet {}".format($)')) ),
-    'energy_kWhtoday':              ('<L',  0x370,       (None, '0 <= $ <= 4250000',            ('Pow',         '"EnergyReset1 {}".format(int(round(float($)/100)))')) ),
-    'energy_kWhyesterday':          ('<L',  0x374,       (None, '0 <= $ <= 4250000',            ('Pow',         '"EnergyReset2 {}".format(int(round(float($)/100)))')) ),
-    'energy_kWhdoy':                ('<H',  0x378,       (None, None,                           ('Pow',         None)) ),
-    'energy_min_power':             ('<H',  0x37A,       (None, None,                           ('Pow',         '"PowerLow {}".format($)')) ),
-    'energy_max_power':             ('<H',  0x37C,       (None, None,                           ('Pow',         '"PowerHigh {}".format($)')) ),
-    'energy_min_voltage':           ('<H',  0x37E,       (None, None,                           ('Pow',         '"VoltageLow {}".format($)')) ),
-    'energy_max_voltage':           ('<H',  0x380,       (None, None,                           ('Pow',         '"VoltageHigh {}".format($)')) ),
-    'energy_min_current':           ('<H',  0x382,       (None, None,                           ('Pow',         '"CurrentLow {}".format($)')) ),
-    'energy_max_current':           ('<H',  0x384,       (None, None,                           ('Pow',         '"CurrentHigh {}".format($)')) ),
-    'energy_max_power_limit':       ('<H',  0x386,       (None, None,                           ('Pow',         '"MaxPower {}".format($)')) ),
-    'energy_max_power_limit_hold':  ('<H',  0x388,       (None, None,                           ('Pow',         '"MaxPowerHold {}".format($)')) ),
-    'energy_max_power_limit_window':('<H',  0x38A,       (None, None,                           ('Pow',         '"MaxPowerWindow {}".format($)')) ),
-    'energy_max_power_safe_limit':  ('<H',  0x38C,       (None, None,                           ('Pow',         '"SavePower {}".format($)')) ),
+    'energy_power_calibration':     ('<L',  0x364,       (None, None,                           ('Power',       '"PowerSet {}".format($)')) ),
+    'energy_voltage_calibration':   ('<L',  0x368,       (None, None,                           ('Power',       '"VoltageSet {}".format($)')) ),
+    'energy_current_calibration':   ('<L',  0x36C,       (None, None,                           ('Power',       '"CurrentSet {}".format($)')) ),
+    'energy_kWhtoday':              ('<L',  0x370,       (None, '0 <= $ <= 4250000',            ('Power',       '"EnergyReset1 {}".format(int(round(float($)/100)))')) ),
+    'energy_kWhyesterday':          ('<L',  0x374,       (None, '0 <= $ <= 4250000',            ('Power',       '"EnergyReset2 {}".format(int(round(float($)/100)))')) ),
+    'energy_kWhdoy':                ('<H',  0x378,       (None, None,                           ('Power',       None)) ),
+    'energy_min_power':             ('<H',  0x37A,       (None, None,                           ('Power',       '"PowerLow {}".format($)')) ),
+    'energy_max_power':             ('<H',  0x37C,       (None, None,                           ('Power',       '"PowerHigh {}".format($)')) ),
+    'energy_min_voltage':           ('<H',  0x37E,       (None, None,                           ('Power',       '"VoltageLow {}".format($)')) ),
+    'energy_max_voltage':           ('<H',  0x380,       (None, None,                           ('Power',       '"VoltageHigh {}".format($)')) ),
+    'energy_min_current':           ('<H',  0x382,       (None, None,                           ('Power',       '"CurrentLow {}".format($)')) ),
+    'energy_max_current':           ('<H',  0x384,       (None, None,                           ('Power',       '"CurrentHigh {}".format($)')) ),
+    'energy_max_power_limit':       ('<H',  0x386,       (None, None,                           ('Power',       '"MaxPower {}".format($)')) ),
+    'energy_max_power_limit_hold':  ('<H',  0x388,       (None, None,                           ('Power',       '"MaxPowerHold {}".format($)')) ),
+    'energy_max_power_limit_window':('<H',  0x38A,       (None, None,                           ('Power',       '"MaxPowerWindow {}".format($)')) ),
+    'energy_max_power_safe_limit':  ('<H',  0x38C,       (None, None,                           ('Power',       '"SavePower {}".format($)')) ),
     'energy_max_power_safe_limit_hold':
-                                    ('<H',  0x38E,       (None, None,                           ('Pow',         '"SavePowerHold {}".format($)')) ),
+                                    ('<H',  0x38E,       (None, None,                           ('Power',       '"SavePowerHold {}".format($)')) ),
     'energy_max_power_safe_limit_window':
-                                    ('<H',  0x390,       (None, None,                           ('Pow',         '"SavePowerWindow {}".format($)')) ),
-    'energy_max_energy':            ('<H',  0x392,       (None, None,                           ('Pow',         '"MaxEnergy {}".format($)')) ),
-    'energy_max_energy_start':      ('<H',  0x394,       (None, None,                           ('Pow',         '"MaxEnergyStart {}".format($)')) ),
+                                    ('<H',  0x390,       (None, None,                           ('Power',       '"SavePowerWindow {}".format($)')) ),
+    'energy_max_energy':            ('<H',  0x392,       (None, None,                           ('Power',       '"MaxEnergy {}".format($)')) ),
+    'energy_max_energy_start':      ('<H',  0x394,       (None, None,                           ('Power',       '"MaxEnergyStart {}".format($)')) ),
     'mqtt_retry':                   ('<H',  0x396,       (None, '10 <= $ <= 32000',             ('MQTT',        '"MqttRetry {}".format($)')) ),
-    'poweronstate':                 ('B',   0x398,       (None, '0 <= $ <= 5',                  ('Main',        '"PowerOnState {}".format($)')) ),
+    'poweronstate':                 ('B',   0x398,       (None, '0 <= $ <= 5',                  ('Control',     '"PowerOnState {}".format($)')) ),
     'last_module':                  ('B',   0x399,       (None, None,                           ('System',      None)) ),
-    'blinktime':                    ('<H',  0x39A,       (None, '2 <= $ <= 3600',               ('Main',        '"BlinkTime {}".format($)')) ),
-    'blinkcount':                   ('<H',  0x39C,       (None, '0 <= $ <= 32000',              ('Main',        '"BlinkCount {}".format($)')) ),
+    'blinktime':                    ('<H',  0x39A,       (None, '2 <= $ <= 3600',               ('Control',     '"BlinkTime {}".format($)')) ),
+    'blinkcount':                   ('<H',  0x39C,       (None, '0 <= $ <= 32000',              ('Control',     '"BlinkCount {}".format($)')) ),
     'friendlyname':                 ('33s', 0x3AC,       ([4],  None,                           ('Management',  '"FriendlyName{} {}".format(#,$)')) ),
     'switch_topic':                 ('33s', 0x430,       (None, None,                           ('MQTT',        '"SwitchTopic {}".format($)')) ),
     'sleep':                        ('B',   0x453,       (None, '0 <= $ <= 250',                ('Management',  '"Sleep {}".format($)')) ),
     'domoticz_switch_idx':          ('<H',  0x454,       ([4],  None,                           ('Domoticz',    '"DomoticzSwitchIdx{} {}".format(#,$)')) ),
     'domoticz_sensor_idx':          ('<H',  0x45C,       ([12], None,                           ('Domoticz',    '"DomoticzSensorIdx{} {}".format(#,$)')) ),
     'module':                       ('B',   0x474,       (None, None,                           ('Management',  '"Module {}".format($)')) ),
-    'ws_color':                     ('B',   0x475,       ([4,3],None,                           ('Led',         None)) ),
-    'ws_width':                     ('B',   0x481,       ([3],  None,                           ('Led',         None)) ),
+    'ws_color':                     ('B',   0x475,       ([4,3],None,                           ('Light',       None)) ),
+    'ws_width':                     ('B',   0x481,       ([3],  None,                           ('Light',       None)) ),
     'my_gp':                        ('B',   0x484,       ([18], None,                           ('Management',  '"Gpio{} {}".format(#,$)')) ),
-    'light_pixels':                 ('<H',  0x496,       (None, '1 <= $ <= 512',                ('Led',         '"Pxels {}".format($)')) ),
-    'light_color':                  ('B',   0x498,       ([5],  None,                           ('Led',         None)) ),
-    'light_correction':             ('B',   0x49D     ,  (None, '0 <= $ <= 1',                  ('Led',         '"LedTable {}".format($)')) ),
-    'light_dimmer':                 ('B',   0x49E,       (None, '0 <= $ <= 100',                ('Led',         '"Wakeup {}".format($)')) ),
-    'light_fade':                   ('B',   0x4A1,       (None, '0 <= $ <= 1',                  ('Led',         '"Fade {}".format($)')) ),
-    'light_speed':                  ('B',   0x4A2,       (None, '1 <= $ <= 20',                 ('Led',         '"Speed {}".format($)')) ),
-    'light_scheme':                 ('B',   0x4A3,       (None, None,                           ('Led',         '"Scheme {}".format($)')) ),
-    'light_width':                  ('B',   0x4A4,       (None, '0 <= $ <= 4',                  ('Led',         '"Width {}".format($)')) ),
-    'light_wakeup':                 ('<H',  0x4A6,       (None, '0 <= $ <= 3100',               ('Led',         '"WakeUpDuration {}".format($)')) ),
+    'light_pixels':                 ('<H',  0x496,       (None, '1 <= $ <= 512',                ('Light',       '"Pxels {}".format($)')) ),
+    'light_color':                  ('B',   0x498,       ([5],  None,                           ('Light',       None)) ),
+    'light_correction':             ('B',   0x49D     ,  (None, '0 <= $ <= 1',                  ('Light',       '"LedTable {}".format($)')) ),
+    'light_dimmer':                 ('B',   0x49E,       (None, '0 <= $ <= 100',                ('Light',       '"Wakeup {}".format($)')) ),
+    'light_fade':                   ('B',   0x4A1,       (None, '0 <= $ <= 1',                  ('Light',       '"Fade {}".format($)')) ),
+    'light_speed':                  ('B',   0x4A2,       (None, '1 <= $ <= 20',                 ('Light',       '"Speed {}".format($)')) ),
+    'light_scheme':                 ('B',   0x4A3,       (None, None,                           ('Light',       '"Scheme {}".format($)')) ),
+    'light_width':                  ('B',   0x4A4,       (None, '0 <= $ <= 4',                  ('Light',       '"Width {}".format($)')) ),
+    'light_wakeup':                 ('<H',  0x4A6,       (None, '0 <= $ <= 3100',               ('Light',       '"WakeUpDuration {}".format($)')) ),
     'web_password':                 ('33s', 0x4A9,       (None, None,                           ('Wifi',        '"WebPassword {}".format($)')), (passwordread,passwordwrite) ),
-    'switchmode':                   ('B',   0x4CA,       ([4],  '0 <= $ <= 7',                  ('Main',        '"SwitchMode{} {}".format(#,$)')) ),
+    'switchmode':                   ('B',   0x4CA,       ([4],  '0 <= $ <= 7',                  ('Control',     '"SwitchMode{} {}".format(#,$)')) ),
     'ntp_server':                   ('33s', 0x4CE,       ([3],  None,                           ('Wifi',        '"NtpServer{} {}".format(#,$)')) ),
     'ina219_mode':                  ('B',   0x531,       (None, '0 <= $ <= 7',                  ('Sensor',      '"Sensor13 {}".format($)')) ),
-    'pulse_timer':                  ('<H',  0x532,       ([8],  '0 <= $ <= 64900',              ('Main',        '"PulseTime{} {}".format(#,$)')) ),
+    'pulse_timer':                  ('<H',  0x532,       ([8],  '0 <= $ <= 64900',              ('Control',     '"PulseTime{} {}".format(#,$)')) ),
     'ip_address':                   ('<L',  0x544,       ([4],  None,                           ('Wifi',        '"IPAddress{} {}".format(#,$)')), ("socket.inet_ntoa(struct.pack('<L', $))", "struct.unpack('<L', socket.inet_aton($))[0]")),
-    'energy_kWhtotal':              ('<L',  0x554,       (None, '0 <= $ <= 4250000000',         ('Pow',         '"EnergyReset3 {}".format(int(round(float($)/100)))')) ),
+    'energy_kWhtotal':              ('<L',  0x554,       (None, '0 <= $ <= 4250000000',         ('Power',       '"EnergyReset3 {}".format(int(round(float($)/100)))')) ),
     'mqtt_fulltopic':               ('100s',0x558,       (None, None,                           ('MQTT',        '"FullTopic {}".format($)')) ),
     'flag2':                        ({
-        'current_resolution':       ('<L', (0x5BC,2,15), (None, '0 <= $ <= 3',                  ('Pow',         '"AmpRes {}".format($)')) ),
-        'voltage_resolution':       ('<L', (0x5BC,2,17), (None, '0 <= $ <= 3',                  ('Pow',         '"VoltRes {}".format($)')) ),
-        'wattage_resolution':       ('<L', (0x5BC,2,19), (None, '0 <= $ <= 3',                  ('Pow',         '"WattRes {}".format($)')) ),
+        'current_resolution':       ('<L', (0x5BC,2,15), (None, '0 <= $ <= 3',                  ('Power',       '"AmpRes {}".format($)')) ),
+        'voltage_resolution':       ('<L', (0x5BC,2,17), (None, '0 <= $ <= 3',                  ('Power',       '"VoltRes {}".format($)')) ),
+        'wattage_resolution':       ('<L', (0x5BC,2,19), (None, '0 <= $ <= 3',                  ('Power',       '"WattRes {}".format($)')) ),
         'emulation':                ('<L', (0x5BC,2,21), (None, '0 <= $ <= 2',                  ('Management',  '"Emulation {}".format($)')) ),
-        'energy_resolution':        ('<L', (0x5BC,3,23), (None, '0 <= $ <= 5',                  ('Pow',         '"EnergyRes {}".format($)')) ),
+        'energy_resolution':        ('<L', (0x5BC,3,23), (None, '0 <= $ <= 5',                  ('Power',       '"EnergyRes {}".format($)')) ),
         'pressure_resolution':      ('<L', (0x5BC,2,26), (None, '0 <= $ <= 3',                  ('Sensor',      '"PressRes {}".format($)')) ),
         'humidity_resolution':      ('<L', (0x5BC,2,28), (None, '0 <= $ <= 3',                  ('Sensor',      '"HumRes {}".format($)')) ),
         'temperature_resolution':   ('<L', (0x5BC,2,30), (None, '0 <= $ <= 3',                  ('Sensor',      '"TempRes {}".format($)')) ),
@@ -567,15 +566,15 @@ Setting_5_11_0.update               ({
     'display_size':                 ('B',   0x2E1,       (None, '1 <= $ <= 4',                  ('Display',     '"Size {}".format($)')) ),
                                     })
 Setting_5_11_0['flag'][0].update    ({
-        'light_signal':             ('<L', (0x010,1,18), (None, None,                           ('Sensor',      '"SetOption18 {}".format($)')) ),
+        'light_signal':             ('<L', (0x010,1,18), (None, None,                           ('SetOption',   '"SetOption18 {}".format($)')) ),
                                     })
 Setting_5_11_0.pop('mqtt_fingerprinth',None)
 # ======================================================================
 Setting_5_12_0 = copy.deepcopy(Setting_5_11_0)
 Setting_5_12_0['flag'][0].update    ({
         'hass_discovery':           ('<L', (0x010,1,19), (None, None,                           ('SetOption',   '"SetOption19 {}".format($)')) ),
-        'not_power_linked':         ('<L', (0x010,1,20), (None, None,                           ('Led',         '"SetOption20 {}".format($)')) ),
-        'no_power_on_check':        ('<L', (0x010,1,21), (None, None,                           ('Pow',         '"SetOption21 {}".format($)')) ),
+        'not_power_linked':         ('<L', (0x010,1,20), (None, None,                           ('SetOption',   '"SetOption20 {}".format($)')) ),
+        'no_power_on_check':        ('<L', (0x010,1,21), (None, None,                           ('SetOption',   '"SetOption21 {}".format($)')) ),
                                     })
 # ======================================================================
 Setting_5_13_1 = copy.deepcopy(Setting_5_12_0)
@@ -588,36 +587,36 @@ Setting_5_13_1['flag'][0].update    ({
 Setting_5_13_1.update               ({
     'baudrate':                     ('B',   0x09D,       (None, None,                           ('Serial',      '"Baudrate {}".format($)')), ('$ * 1200','$ / 1200') ),
     'mqtt_fingerprint':             ('20s', 0x1AD,       ([2],  None,                           ('MQTT',        MqttFingerprint)) ),
-    'energy_power_delta':           ('B',   0x33F,       (None, None,                           ('Pow',         '"PowerDelta {}".format($)')) ),
-    'light_rotation':               ('<H',  0x39E,       (None, None,                           ('Led',         '"Rotation {}".format($)')) ),
+    'energy_power_delta':           ('B',   0x33F,       (None, None,                           ('Power',       '"PowerDelta {}".format($)')) ),
+    'light_rotation':               ('<H',  0x39E,       (None, None,                           ('Light',       '"Rotation {}".format($)')) ),
     'serial_delimiter':             ('B',   0x451,       (None, None,                           ('Serial',      '"SerialDelimiter {}".format($)')) ),
     'sbaudrate':                    ('B',   0x452,       (None, None,                           ('Serial',      '"SBaudrate {}".format($)')), ('$ * 1200','$ / 1200') ),
     'knx_GA_registered':            ('B',   0x4A5,       (None, None,                           ('KNX',         None)) ),
     'knx_CB_registered':            ('B',   0x4A8,       (None, None,                           ('KNX',         None)) ),
     'timer':                        ({
-        '_':                        ('<L',  0x670,       (None, None,                           ('Timers',      '"Timer{} {{\\\"Arm\\\":{arm},\\\"Mode\\\":{mode},\\\"Time\\\":\\\"{tsign}{time}\\\",\\\"Window\\\":{window},\\\"Days\\\":\\\"{days}\\\",\\\"Repeat\\\":{repeat},\\\"Output\\\":{device},\\\"Action\\\":{power}}}".format(#, arm=bitsRead($,31),mode=bitsRead($,29,2),tsign="-" if bitsRead($,29,2)>0 and bitsRead($,0,11)>(12*60) else "",time=time.strftime("%H:%M",time.gmtime((bitsRead($,0,11) if bitsRead($,29,2)==0 else bitsRead($,0,11) if bitsRead($,0,11)<=(12*60) else bitsRead($,0,11)-(12*60))*60)),window=bitsRead($,11,4),repeat=bitsRead($,15),days="{:07b}".format(bitsRead($,16,7))[::-1],device=bitsRead($,23,4)+1,power=bitsRead($,27,2) )')), ('"0x{:08x}".format($)', False) ),
-        'time':                     ('<L', (0x670,11, 0),(None, '0 <= $ < 1440',                ('Timers',      None)) ),
-        'window':                   ('<L', (0x670, 4,11),(None, None,                           ('Timers',      None)) ),
-        'repeat':                   ('<L', (0x670, 1,15),(None, None,                           ('Timers',      None)) ),
-        'days':                     ('<L', (0x670, 7,16),(None, None,                           ('Timers',      None)), '"0b{:07b}".format($)' ),
-        'device':                   ('<L', (0x670, 4,23),(None, None,                           ('Timers',      None)) ),
-        'power':                    ('<L', (0x670, 2,27),(None, None,                           ('Timers',      None)) ),
-        'mode':                     ('<L', (0x670, 2,29),(None, '0 <= $ <= 3',                  ('Timers',      None)) ),
-        'arm':                      ('<L', (0x670, 1,31),(None, None,                           ('Timers',      None)) ),
-                                    },      0x670,       ([16], None,                           ('Timers',      None)) ),
-    'latitude':                     ('i',   0x6B0,       (None, None,                           ('Timers',      '"Latitude {}".format($)')),  ('float($) / 1000000', 'int($ * 1000000)')),
-    'longitude':                    ('i',   0x6B4,       (None, None,                           ('Timers',      '"Longitude {}".format($)')), ('float($) / 1000000', 'int($ * 1000000)')),
+        '_':                        ('<L',  0x670,       (None, None,                           ('Timer',       '"Timer{} {{\\\"Arm\\\":{arm},\\\"Mode\\\":{mode},\\\"Time\\\":\\\"{tsign}{time}\\\",\\\"Window\\\":{window},\\\"Days\\\":\\\"{days}\\\",\\\"Repeat\\\":{repeat},\\\"Output\\\":{device},\\\"Action\\\":{power}}}".format(#, arm=bitsRead($,31),mode=bitsRead($,29,2),tsign="-" if bitsRead($,29,2)>0 and bitsRead($,0,11)>(12*60) else "",time=time.strftime("%H:%M",time.gmtime((bitsRead($,0,11) if bitsRead($,29,2)==0 else bitsRead($,0,11) if bitsRead($,0,11)<=(12*60) else bitsRead($,0,11)-(12*60))*60)),window=bitsRead($,11,4),repeat=bitsRead($,15),days="{:07b}".format(bitsRead($,16,7))[::-1],device=bitsRead($,23,4)+1,power=bitsRead($,27,2) )')), ('"0x{:08x}".format($)', False) ),
+        'time':                     ('<L', (0x670,11, 0),(None, '0 <= $ < 1440',                ('Timer',       None)) ),
+        'window':                   ('<L', (0x670, 4,11),(None, None,                           ('Timer',       None)) ),
+        'repeat':                   ('<L', (0x670, 1,15),(None, None,                           ('Timer',       None)) ),
+        'days':                     ('<L', (0x670, 7,16),(None, None,                           ('Timer',       None)), '"0b{:07b}".format($)' ),
+        'device':                   ('<L', (0x670, 4,23),(None, None,                           ('Timer',       None)) ),
+        'power':                    ('<L', (0x670, 2,27),(None, None,                           ('Timer',       None)) ),
+        'mode':                     ('<L', (0x670, 2,29),(None, '0 <= $ <= 3',                  ('Timer',       None)) ),
+        'arm':                      ('<L', (0x670, 1,31),(None, None,                           ('Timer',       None)) ),
+                                    },      0x670,       ([16], None,                           ('Timer',       None)) ),
+    'latitude':                     ('i',   0x6B0,       (None, None,                           ('Timer',       '"Latitude {}".format($)')),  ('float($) / 1000000', 'int($ * 1000000)')),
+    'longitude':                    ('i',   0x6B4,       (None, None,                           ('Timer',       '"Longitude {}".format($)')), ('float($) / 1000000', 'int($ * 1000000)')),
     'knx_physsical_addr':           ('<H',  0x6B8,       (None, None,                           ('KNX',         None)) ),
     'knx_GA_addr':                  ('<H',  0x6BA,       ([10], None,                           ('KNX',         None)) ),
     'knx_CB_addr':                  ('<H',  0x6CE,       ([10], None,                           ('KNX',         None)) ),
     'knx_GA_param':                 ('B',   0x6E2,       ([10], None,                           ('KNX',         None)) ),
     'knx_CB_param':                 ('B',   0x6EC,       ([10], None,                           ('KNX',         None)) ),
-    'rules':                        ('512s',0x800,       (None, None,                           ('Management',  '"Rule {}".format("\\"" if len($)==0 else $)')) ),
+    'rules':                        ('512s',0x800,       (None, None,                           ('Rules',       '"Rule {}".format("\\"" if len($)==0 else $)')) ),
                                     })
 # ======================================================================
 Setting_5_14_0 = copy.deepcopy(Setting_5_13_1)
 Setting_5_14_0['flag'][0].update    ({
-        'device_index_enable':      ('<L', (0x010,1,26), (None, None,                           ('Main',        '"SetOption26 {}".format($)')) ),
+        'device_index_enable':      ('<L', (0x010,1,26), (None, None,                           ('SetOption',   '"SetOption26 {}".format($)')) ),
                                     })
 Setting_5_14_0['flag'][0].pop('rules_once',None)
 Setting_5_14_0.update               ({
@@ -639,17 +638,17 @@ Setting_6_0_0.update({
     'bootcount':                    ('<H',  0x00C,       (None, None,                           ('System',      None)), (None, False)),
     'cfg_crc':                      ('<H',  0x00E,       (None, None,                           (INTERNAL,      None)), '"0x{:04x}".format($)'),
     'rule_enabled':                 ({
-        'rule1':                    ('B',  (0x49F,1,0),  (None, None,                           ('Management',  '"Rule1 {}".format($)')) ),
-        'rule2':                    ('B',  (0x49F,1,1),  (None, None,                           ('Management',  '"Rule2 {}".format($)')) ),
-        'rule3':                    ('B',  (0x49F,1,2),  (None, None,                           ('Management',  '"Rule3 {}".format($)')) ),
-                                    },      0x49F,       (None, None,                           ('Management',  None)), (None,      None) ),
+        'rule1':                    ('B',  (0x49F,1,0),  (None, None,                           ('Rules',       '"Rule1 {}".format($)')) ),
+        'rule2':                    ('B',  (0x49F,1,1),  (None, None,                           ('Rules',       '"Rule2 {}".format($)')) ),
+        'rule3':                    ('B',  (0x49F,1,2),  (None, None,                           ('Rules',       '"Rule3 {}".format($)')) ),
+                                    },      0x49F,       (None, None,                           ('Rules',       None)), (None,      None) ),
     'rule_once':                    ({
-        'rule1':                    ('B',  (0x4A0,1,0),  (None, None,                           ('Management',  '"Rule1 {}".format($+4)')) ),
-        'rule2':                    ('B',  (0x4A0,1,1),  (None, None,                           ('Management',  '"Rule2 {}".format($+4)')) ),
-        'rule3':                    ('B',  (0x4A0,1,2),  (None, None,                           ('Management',  '"Rule3 {}".format($+4)')) ),
-                                    },      0x4A0,       (None, None,                           ('Management',  None)), (None,      None) ),
-    'mems':                         ('10s', 0x7CE,       ([5],  None,                           ('Management',  '"Mem{} {}".format(#,"\\"" if len($)==0 else $)')) ),
-    'rules':                        ('512s',0x800,       ([3],  None,                           ('Management',  '"Rule{} {}".format(#,"\\"" if len($)==0 else $)')) ),
+        'rule1':                    ('B',  (0x4A0,1,0),  (None, None,                           ('Rules',       '"Rule1 {}".format($+4)')) ),
+        'rule2':                    ('B',  (0x4A0,1,1),  (None, None,                           ('Rules',       '"Rule2 {}".format($+4)')) ),
+        'rule3':                    ('B',  (0x4A0,1,2),  (None, None,                           ('Rules',       '"Rule3 {}".format($+4)')) ),
+                                    },      0x4A0,       (None, None,                           ('Rules',       None)), (None,      None) ),
+    'mems':                         ('10s', 0x7CE,       ([5],  None,                           ('Rules',       '"Mem{} {}".format(#,"\\"" if len($)==0 else $)')) ),
+    'rules':                        ('512s',0x800,       ([3],  None,                           ('Rules',       '"Rule{} {}".format(#,"\\"" if len($)==0 else $)')) ),
 })
 Setting_6_0_0['flag'][0].update     ({
         'knx_enable_enhancement':   ('<L', (0x010,1,27), (None, None,                           ('KNX',         '"KNX_ENHANCED {}".format($)')) ),
@@ -658,16 +657,16 @@ Setting_6_0_0['flag'][0].update     ({
 Setting_6_1_1 = copy.deepcopy(Setting_6_0_0)
 Setting_6_1_1.update                ({
     'flag3':                        ('<L',  0x3A0,       (None, None,                           ('System',      None)), '"0x{:08x}".format($)' ),
-    'switchmode':                   ('B',   0x3A4,       ([8],  '0 <= $ <= 7',                  ('Main',        '"SwitchMode{} {}".format(#,$)')) ),
+    'switchmode':                   ('B',   0x3A4,       ([8],  '0 <= $ <= 7',                  ('Control',     '"SwitchMode{} {}".format(#,$)')) ),
     'mcp230xx_config':              ({
-        '_':                        ('<L',  0x6F6,       (None, None,                           ('MCP230xx',    '"Sensor29 {pin},{pinmode},{pullup},{intmode}".format(pin=#-1, pinmode=@["mcp230xx_config"][#-1]["pinmode"], pullup=@["mcp230xx_config"][#-1]["pullup"], intmode=@["mcp230xx_config"][#-1]["int_report_mode"])')), ('"0x{:08x}".format($)', False) ),
-        'pinmode':                  ('<L', (0x6F6,3, 0), (None, '0 <= $ <= 5',                  ('MCP230xx',    None)) ),
-        'pullup':                   ('<L', (0x6F6,1, 3), (None, None,                           ('MCP230xx',    None)) ),
-        'saved_state':              ('<L', (0x6F6,1, 4), (None, None,                           ('MCP230xx',    None)) ),
-        'int_report_mode':          ('<L', (0x6F6,2, 5), (None, None,                           ('MCP230xx',    None)) ),
-        'int_report_defer':         ('<L', (0x6F6,4, 7), (None, None,                           ('MCP230xx',    None)) ),
-        'int_count_en':             ('<L', (0x6F6,1,11), (None, None,                           ('MCP230xx',    None)) ),
-                                     },     0x6F6,       ([16], None,                           ('MCP230xx',    None)), (None,      None) ),
+        '_':                        ('<L',  0x6F6,       (None, None,                           ('Devices',     '"Sensor29 {pin},{pinmode},{pullup},{intmode}".format(pin=#-1, pinmode=@["mcp230xx_config"][#-1]["pinmode"], pullup=@["mcp230xx_config"][#-1]["pullup"], intmode=@["mcp230xx_config"][#-1]["int_report_mode"])')), ('"0x{:08x}".format($)', False) ),
+        'pinmode':                  ('<L', (0x6F6,3, 0), (None, None,                           ('Devices',     None)) ),
+        'pullup':                   ('<L', (0x6F6,1, 3), (None, None,                           ('Devices',     None)) ),
+        'saved_state':              ('<L', (0x6F6,1, 4), (None, None,                           ('Devices',     None)) ),
+        'int_report_mode':          ('<L', (0x6F6,2, 5), (None, None,                           ('Devices',     None)) ),
+        'int_report_defer':         ('<L', (0x6F6,4, 7), (None, None,                           ('Devices',     None)) ),
+        'int_count_en':             ('<L', (0x6F6,1,11), (None, None,                           ('Devices',     None)) ),
+                                     },     0x6F6,       ([16], None,                           ('Devices',     None)), (None,      None) ),
                                     })
 Setting_6_1_1['flag'][0].update     ({
         'rf_receive_decimal':       ('<L', (0x010,1,28), (None, None,                           ('SetOption' ,  '"SetOption28 {}".format($)')) ),
@@ -678,20 +677,20 @@ Setting_6_1_1['flag'][0].update     ({
 Setting_6_2_1 = copy.deepcopy(Setting_6_1_1)
 Setting_6_2_1.update                ({
     'rule_stop':                    ({
-        'rule1':                    ('B',  (0x1A7,1,0),  (None, None,                           ('Management',  '"Rule1 {}".format($+8)')) ),
-        'rule2':                    ('B',  (0x1A7,1,1),  (None, None,                           ('Management',  '"Rule2 {}".format($+8)')) ),
-        'rule3':                    ('B',  (0x1A7,1,2),  (None, None,                           ('Management',  '"Rule3 {}".format($+8)')) ),
+        'rule1':                    ('B',  (0x1A7,1,0),  (None, None,                           ('Rules',       '"Rule1 {}".format($+8)')) ),
+        'rule2':                    ('B',  (0x1A7,1,1),  (None, None,                           ('Rules',       '"Rule2 {}".format($+8)')) ),
+        'rule3':                    ('B',  (0x1A7,1,2),  (None, None,                           ('Rules',       '"Rule3 {}".format($+8)')) ),
                                      },     0x1A7,        None),
     'display_rotate':               ('B',   0x2FA,       (None, '0 <= $ <= 3',                  ('Display',     '"Rotate {}".format($)')) ),
     'display_font':                 ('B',   0x312,       (None, '1 <= $ <= 4',                  ('Display',     '"Font {}".format($)')) ),
     'flag3':                        ({
-         'timers_enable':           ('<L', (0x3A0,1, 0), (None, None,                           ('Timers',      '"Timers {}".format($)')) ),
+         'timers_enable':           ('<L', (0x3A0,1, 0), (None, None,                           ('Timer',       '"Timers {}".format($)')) ),
          'user_esp8285_enable':     ('<L', (0x3A0,1,31), (None, None,                           ('System',      None)) ),
                                     },      0x3A0,       (None, None,                           ('*',           None)), (None,      None) ),
-    'button_debounce':              ('<H',  0x542,       (None, '40 <= $ <= 1000',              ('Main',        '"ButtonDebounce {}".format($)')) ),
-    'switch_debounce':              ('<H',  0x66E,       (None, '40 <= $ <= 1000',              ('Main',        '"SwitchDebounce {}".format($)')) ),
-    'mcp230xx_int_prio':            ('B',   0x716,       (None, None,                           ('MCP230xx',    None)) ),
-    'mcp230xx_int_timer':           ('<H',  0x718,       (None, None,                           ('MCP230xx',    None)) ),
+    'button_debounce':              ('<H',  0x542,       (None, '40 <= $ <= 1000',              ('Control',     '"ButtonDebounce {}".format($)')) ),
+    'switch_debounce':              ('<H',  0x66E,       (None, '40 <= $ <= 1000',              ('Control',     '"SwitchDebounce {}".format($)')) ),
+    'mcp230xx_int_prio':            ('B',   0x716,       (None, None,                           ('Devices',     None)) ),
+    'mcp230xx_int_timer':           ('<H',  0x718,       (None, None,                           ('Devices',     None)) ),
                                     })
 Setting_6_2_1['flag'][0].pop('rules_enabled',None)
 Setting_6_2_1['flag'][0].update     ({
@@ -710,7 +709,7 @@ Setting_6_2_1_2['flag3'][0].update  ({
 # ======================================================================
 Setting_6_2_1_3 = copy.deepcopy(Setting_6_2_1_2)
 Setting_6_2_1_3['flag2'][0].update  ({
-        'frequency_resolution':     ('<L', (0x5BC,2,11), (None, '0 <= $ <= 3',                  ('Pow',         '"FreqRes {}".format($)')) ),
+        'frequency_resolution':     ('<L', (0x5BC,2,11), (None, '0 <= $ <= 3',                  ('Power',       '"FreqRes {}".format($)')) ),
                                     })
 Setting_6_2_1_3['flag3'][0].update  ({
         'time_append_timezone':     ('<L', (0x3A0,1, 2), (None, None,                           ('SetOption',   '"SetOption52 {}".format($)')) ),
@@ -718,7 +717,10 @@ Setting_6_2_1_3['flag3'][0].update  ({
 # ======================================================================
 Setting_6_2_1_6 = copy.deepcopy(Setting_6_2_1_3)
 Setting_6_2_1_6.update({
-    'energy_frequency_calibration': ('<L',  0x7C8,       (None, '45000 < $ < 65000',            ('Pow',         '"FrequencySet {}".format($)')) ),
+    'energy_power_calibration':     ('<L',  0x364,       (None, None,                           ('Power',       None)) ),
+    'energy_voltage_calibration':   ('<L',  0x368,       (None, None,                           ('Power',       None)) ),
+    'energy_current_calibration':   ('<L',  0x36C,       (None, None,                           ('Power',       None)) ),
+    'energy_frequency_calibration': ('<L',  0x7C8,       (None, '45000 < $ < 65000',            ('Power',       '"FrequencySet {}".format($)')) ),
 })
 # ======================================================================
 Setting_6_2_1_10 = copy.deepcopy(Setting_6_2_1_6)
@@ -732,7 +734,7 @@ Setting_6_2_1_14.update({
     'weight_max':                   ('<H',  0x7BE,       (None, None,                           ('Management',  '"Sensor34 5 {}".format($)')), ('float($) / 1000', 'int($ * 1000)') ),        # undocumented
     'weight_reference':             ('<L',  0x7C0,       (None, None,                           ('Management',  '"Sensor34 3 {}".format($)')) ),     # undocumented
     'weight_calibration':           ('<L',  0x7C4,       (None, None,                           ('Management',  '"Sensor34 4 {}".format($)')) ),     # undocumented
-    'web_refresh':                  ('<H',  0x7CC,       (None, '1000 <= $ <= 10000',           ('Management',  '"WebRefresh {}".format($)')) ),     # undocumented
+    'web_refresh':                  ('<H',  0x7CC,       (None, '1000 <= $ <= 10000',           ('Wifi',        '"WebRefresh {}".format($)')) ),     # undocumented
 })
 Setting_6_2_1_14['flag2'][0].update ({
         'weight_resolution':        ('<L', (0x5BC,2, 9), (None, '0 <= $ <= 3',                  ('Management',  '"WeightRes {}".format($)')) ),      # undocumented
@@ -749,12 +751,12 @@ Setting_6_2_1_20['flag3'][0].update ({
 # ======================================================================
 Setting_6_3_0 = copy.deepcopy(Setting_6_2_1_20)
 Setting_6_3_0.update({
-    'energy_kWhtotal_time':         ('<L',  0x7B4,       (None, None,                           ('System',           None)) ),
+    'energy_kWhtotal_time':         ('<L',  0x7B4,       (None, None,                           ('System',       None)) ),
 })
 # ======================================================================
 Setting_6_3_0_2 = copy.deepcopy(Setting_6_3_0)
 Setting_6_3_0_2.update({
-    'timezone_minutes':             ('B',   0x66D,       (None, None,                           ('System',           None)) ),
+    'timezone_minutes':             ('B',   0x66D,       (None, None,                           ('System',       None)) ),
 })
 Setting_6_3_0_2['flag'][0].pop('rules_once',None)
 Setting_6_3_0_2['flag'][0].update   ({
@@ -763,10 +765,10 @@ Setting_6_3_0_2['flag'][0].update   ({
 # ======================================================================
 Setting_6_3_0_4 = copy.deepcopy(Setting_6_3_0_2)
 Setting_6_3_0_4.update({
-    'drivers':                      ('<L',  0x794,       ([3],  None,                           ('System',           None)), '"0x{:08x}".format($)' ),
-    'monitors':                     ('<L',  0x7A0,       (None, None,                           ('System',           None)), '"0x{:08x}".format($)' ),
-    'sensors':                      ('<L',  0x7A4,       ([3],  None,                           ('System',           None)), '"0x{:08x}".format($)' ),
-    'displays':                     ('<L',  0x7B0,       (None, None,                           ('System',           None)), '"0x{:08x}".format($)' ),
+    'drivers':                      ('<L',  0x794,       ([3],  None,                           ('System',       None)), '"0x{:08x}".format($)' ),
+    'monitors':                     ('<L',  0x7A0,       (None, None,                           ('System',       None)), '"0x{:08x}".format($)' ),
+    'sensors':                      ('<L',  0x7A4,       ([3],  None,                           ('System',       None)), '"0x{:08x}".format($)' ),
+    'displays':                     ('<L',  0x7B0,       (None, None,                           ('System',       None)), '"0x{:08x}".format($)' ),
 })
 Setting_6_3_0_4['flag3'][0].update ({
         'tuya_apply_o20':           ('<L', (0x3A0,1, 4), (None, None,                           ('SetOption',   '"SetOption54 {}".format($)')) ),
@@ -795,7 +797,7 @@ Setting_6_3_0_13['flag3'][0].update ({
 # ======================================================================
 Setting_6_3_0_14 = copy.deepcopy(Setting_6_3_0_13)
 Setting_6_3_0_14['flag2'][0].update ({
-        'calc_resolution':          ('<L', (0x5BC,3, 6), (None, '0 <= $ <= 7',                  ('Management',  '"CalcRes {}".format($)')) ),
+        'calc_resolution':          ('<L', (0x5BC,3, 6), (None, '0 <= $ <= 7',                  ('Rules',       '"CalcRes {}".format($)')) ),
                                     })
 # ======================================================================
 Setting_6_3_0_15 = copy.deepcopy(Setting_6_3_0_14)
@@ -805,7 +807,7 @@ Setting_6_3_0_15['flag3'][0].update ({
 # ======================================================================
 Setting_6_3_0_16 = copy.deepcopy(Setting_6_3_0_15)
 Setting_6_3_0_16['mcp230xx_config'][0].update ({
-        'int_retain_flag':          ('<L', (0x6F6,1,12), (None, None,                           ('MCP230xx',    None)) ),
+        'int_retain_flag':          ('<L', (0x6F6,1,12), (None, None,                           ('Devices',     None)) ),
                                     })
 Setting_6_3_0_16['flag3'][0].update ({
         'button_switch_force_local':('<L', (0x3A0,1,11), (None, None,                           ('SetOption',   '"SetOption61 {}".format($)')) ),
@@ -832,10 +834,10 @@ Setting_6_4_1_8['flag3'][0].update ({
 Setting_6_4_1_11 = copy.deepcopy(Setting_6_4_1_8)
 Setting_6_4_1_11['flag3'][0].pop('split_interlock',None)
 Setting_6_4_1_11.update            ({
-    'interlock':                    ('B',   0x4CA,       ([4],  None,                           ('Main',        None)), '"0x{:02x}".format($)' ),
+    'interlock':                    ('B',   0x4CA,       ([4],  None,                           ('Control',     None)), '"0x{:02x}".format($)' ),
                                     })
 Setting_6_4_1_11['flag'][0].update ({
-        'interlock':                ('<L', (0x010,1,14), (None, None,                           ('Main',        '"Interlock {}".format($)')) ),
+        'interlock':                ('<L', (0x010,1,14), (None, None,                           ('Control',     '"Interlock {}".format($)')) ),
                                     })
 # ======================================================================
 Setting_6_4_1_13 = copy.deepcopy(Setting_6_4_1_11)
@@ -888,15 +890,21 @@ Setting_6_5_0_3.update({
 # ======================================================================
 Setting_6_5_0_6 = copy.deepcopy(Setting_6_5_0_3)
 Setting_6_5_0_6.update({
-    'web_color':                    ('3B',   0x73E,       ([18], None,                          ('Wifi',          '"WebColor{} {}{:06x}".format(#,chr(35),int($,0))')), '"0x{:06x}".format($)' ),
+    'web_color':                    ('3B',   0x73E,       ([18], None,                          ('Wifi',        '"WebColor{} {}{:06x}".format(#,chr(35),int($,0))')), '"0x{:06x}".format($)' ),
                                     })
 # ======================================================================
 Setting_6_5_0_7 = copy.deepcopy(Setting_6_5_0_6)
 Setting_6_5_0_7.update({
-    'ledmask':                      ('<H',   0x7BC,       (None, None,                          ('Main',          '"LedMask {}".format($)')), '"0x{:04x}".format($)' ),
+    'ledmask':                      ('<H',   0x7BC,       (None, None,                          ('Control',     '"LedMask {}".format($)')), '"0x{:04x}".format($)' ),
+                                    })
+# ======================================================================
+Setting_6_5_0_9 = copy.deepcopy(Setting_6_5_0_7)
+Setting_6_5_0_9['flag3'][0].update ({
+        'no_power_feedback':             ('<L', (0x3A0,1,13), (None, None,                      ('SetOption',   '"SetOption63 {}".format($)')) ),
                                     })
 # ======================================================================
 Settings = [
+            (0x6050009, 0xe00, Setting_6_5_0_9),
             (0x6050007, 0xe00, Setting_6_5_0_7),
             (0x6050006, 0xe00, Setting_6_5_0_6),
             (0x6050003, 0xe00, Setting_6_5_0_3),
@@ -1259,10 +1267,10 @@ def MakeFilename(filename, filetype, configmapping):
     if 'version' in configmapping:
         config_version = GetVersionStr( int(str(configmapping['version']), 0) )
     if 'friendlyname' in configmapping:
-        config_friendlyname = configmapping['friendlyname'][0]
+        config_friendlyname = re.sub('[^0-9a-zA-Z]','_', configmapping['friendlyname'][0])
     if 'hostname' in configmapping:
         if configmapping['hostname'].find('%') < 0:
-            config_hostname = configmapping['hostname']
+            config_hostname = re.sub('[^0-9a-zA-Z]','_', configmapping['hostname'])
     if filename.find('@H') >= 0 and args.device is not None:
         device_hostname = GetTasmotaHostname(args.device, args.port, username=args.username, password=args.password)
         if device_hostname is None:
@@ -1493,7 +1501,6 @@ def PushTasmotaConfig(encode_cfg, host, port, username=DEFAULTS['source']['usern
     # post data
     c = pycurl.Curl()
     header = HTTPHeader()
-    from StringIO import StringIO
     buffer_ = io.BytesIO()
     c.setopt(c.HEADERFUNCTION, header.store)
     c.setopt(c.WRITEFUNCTION, lambda x: None)
@@ -1665,9 +1672,16 @@ def GetFieldDef(fielddef, fields="format_, addrdef, baseaddr, bits, bitshift, da
                 if group is not None and not isinstance(group, (str, unicode)):
                     print >> sys.stderr, 'wrong <group> {} in <fielddef> {}'.format(group, fielddef)
                     raise SyntaxError('<fielddef> error')
-                if tasmotacmnd is not None and not callable(tasmotacmnd) and not isinstance(tasmotacmnd, (str, unicode)):
-                    print >> sys.stderr, 'wrong <tasmotacmnd> {} in <fielddef> {}'.format(tasmotacmnd, fielddef)
-                    raise SyntaxError('<fielddef> error')
+                if tasmotacmnd is isinstance(tasmotacmnd, tuple):
+                    tasmotacmnds = tasmotacmnd
+                    for tasmotacmnd in tasmotacmnds:
+                        if tasmotacmnd is not None and not callable(tasmotacmnd) and not isinstance(tasmotacmnd, (str, unicode)):
+                            print >> sys.stderr, 'wrong <tasmotacmnd> {} in <fielddef> {}'.format(tasmotacmnd, fielddef)
+                            raise SyntaxError('<fielddef> error')
+                else:
+                    if tasmotacmnd is not None and not callable(tasmotacmnd) and not isinstance(tasmotacmnd, (str, unicode)):
+                        print >> sys.stderr, 'wrong <tasmotacmnd> {} in <fielddef> {}'.format(tasmotacmnd, fielddef)
+                        raise SyntaxError('<fielddef> error')
             else:
                 print >> sys.stderr, 'wrong <cmd> {} length ({}) in <fielddef> {}'.format(cmd, len(cmd), fielddef)
                 raise SyntaxError('<fielddef> error')
@@ -1991,10 +2005,13 @@ def IsFilterGroup(group):
     @return:
         True if group is in filter, otherwise False
     """
+
     if args.filter is not None:
         if group is None:
             return False
-        if group != INTERNAL and group != '*' and group not in args.filter:
+        if group == '*':
+            return False
+        if group.title() != INTERNAL.title() and group.title() not in (groupname.title() for groupname in args.filter):
             return False
     return True
 
@@ -2373,12 +2390,20 @@ def SetCmnd(cmnds, fieldname, fielddef, valuemapping, mappedvalue, addroffset=0,
 
     # a simple value
     elif isinstance(format_, (str, bool, int, float, long)):
-        cmnd = CmndConverter(valuemapping, mappedvalue, idx, fielddef)
-
-        if group is not None and cmnd is not None:
-            if group not in cmnds:
-                cmnds[group] = []
-            cmnds[group].append(cmnd)
+        if isinstance(tasmotacmnd, tuple):
+            tasmotacmnds = tasmotacmnd
+            for tasmotacmnd in tasmotacmnds:
+                cmnd = CmndConverter(valuemapping, mappedvalue, idx, fielddef)
+                if group is not None and cmnd is not None:
+                    if group not in cmnds:
+                        cmnds[group] = []
+                    cmnds[group].append(cmnd)
+        else:
+            cmnd = CmndConverter(valuemapping, mappedvalue, idx, fielddef)
+            if group is not None and cmnd is not None:
+                if group not in cmnds:
+                    cmnds[group] = []
+                cmnds[group].append(cmnd)
 
     return cmnds
 
@@ -2401,7 +2426,7 @@ def Bin2Mapping(decode_cfg):
 
     # if we did not found a mathching setting
     if setting is None:
-        exit(ExitCode.UNSUPPORTED_VERSION, "Tasmota configuration version 0x{:x} not supported".format(version),line=inspect.getlineno(inspect.currentframe()))
+        exit(ExitCode.UNSUPPORTED_VERSION, "Tasmota configuration version {} not supported".format(version),line=inspect.getlineno(inspect.currentframe()))
 
     if 'version' in setting:
         cfg_version = GetField(decode_cfg, 'version', setting['version'], raw=True)
@@ -2655,7 +2680,7 @@ def Restore(restorefile, backupfileformat, encode_cfg, decode_cfg, configmapping
 
     elif filetype == FileType.BIN:
         if args.verbose:
-            message("Reading restore file '{}' (binary format)".format(restorefilename), typ=LogType.INFO)
+            message("Reading restore file '{}' (Binary format)".format(restorefilename), typ=LogType.INFO)
         try:
             with open(restorefilename, "rb") as restorefp:
                 restorebin = restorefp.read()
@@ -2688,6 +2713,13 @@ def Restore(restorefile, backupfileformat, encode_cfg, decode_cfg, configmapping
         exit(ExitCode.FILE_READ_ERROR, "File '{}' unknown error".format(restorefilename),line=inspect.getlineno(inspect.currentframe()))
 
     if new_encode_cfg is not None:
+        if args.verbose:
+            new_decode_cfg = DecryptEncrypt(new_encode_cfg)
+            # get binary header and template to use
+            version, size, setting = GetTemplateSetting(new_decode_cfg)
+            # get config file version
+            cfg_version = GetField(new_decode_cfg, 'version', setting['version'], raw=True)
+            message("Config file contains data of Sonoff-Tasmota {}".format(GetVersionStr(cfg_version)), typ=LogType.INFO)
         if args.forcerestore or new_encode_cfg != encode_cfg:
             # write config direct to device via http
             if args.device is not None:
@@ -2734,9 +2766,11 @@ def OutputTasmotaCmnds(tasmotacmnds):
             for cmnd in cmnds:
                 print "{}{}".format(" "*args.cmndindent, cmnd)
 
+    groups = GetGroupList(Settings[0][2])
+
     if args.cmndgroup:
-        for group in Groups:
-            if group in tasmotacmnds:
+        for group in groups:
+            if group.title() in (groupname.title() for groupname in tasmotacmnds):
                 cmnds = tasmotacmnds[group]
                 print
                 print "# {}:".format(group)
@@ -2744,8 +2778,8 @@ def OutputTasmotaCmnds(tasmotacmnds):
                     
     else:
         cmnds = []
-        for group in Groups:
-            if group in tasmotacmnds:
+        for group in groups:
+            if group.title() in (groupname.title() for groupname in tasmotacmnds):
                 cmnds.extend(tasmotacmnds[group])
         OutputTasmotaSubCmnds(cmnds)
 
@@ -2913,6 +2947,7 @@ def ParseArgs():
                             dest='filter',
                             choices=groups,
                             nargs='+',
+                            type=lambda s : s.title(),
                             default=DEFAULTS['common']['filter'],
                             help="limit data processing to command groups (default {})".format("no filter" if DEFAULTS['common']['filter'] == None else DEFAULTS['common']['filter']) )
     common.add_argument('--ignore-warnings',
@@ -2993,7 +3028,7 @@ if __name__ == "__main__":
     # decode into mappings dictionary
     configmapping = Bin2Mapping(decode_cfg)
     if args.verbose and 'version' in configmapping:
-        message("{} '{}' is using version {}".format('File' if args.tasmotafile is not None else 'Device',
+        message("{} '{}' is using Sonoff-Tasmota {}".format('File' if args.tasmotafile is not None else 'Device',
                                                      args.tasmotafile if args.tasmotafile is not None else args.device,
                                                      GetVersionStr(configmapping['version'])),
                                                      typ=LogType.INFO)


### PR DESCRIPTION
- fix suppress of empty values for output format "Tasmota cmnd"
- add SetOption63 (no_power_feedback)
- add config file verbose info
- change `@f`/`@h` macro char replacement (alphanumeric chars only, same as Tasmota does)
- remove mcp230xx pinmode validation
- revert PowerSet, VoltageSet, CurrentSet for >= v6.2.1.6 from -T cmnd
- allow mix case for -g parameter
- adjust command groups -g to Tasmota Wiki

## Description:

adjust tool to current Tasmota version changes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
