### PR TITLE
Add Bugfix Arduino Core 2.5.1 and use as default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -71,7 +71,8 @@ platform                  = espressif8266@~2.0.4
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
-                            -O2                            
+                            -O2
+                            -DBEARSSL_SSL_BASIC
 ; lwIP 1.4
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,7 +72,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
                             -O2
-                            -DBEARSSL_SSL_BASIC
 ; lwIP 1.4
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
@@ -94,6 +93,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
                             -O2
+                            -DBEARSSL_SSL_BASIC
 ; nonos-sdk 22x
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 ; nonos-sdk-pre-v3
@@ -118,7 +118,8 @@ platform                  = https://github.com/platformio/platform-espressif8266
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
-                            -O2                            
+                            -O2
+                            -DBEARSSL_SSL_BASIC
 ; nonos-sdk 22x
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 ; nonos-sdk-pre-v3

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,7 @@ platform                  = espressif8266@1.8.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m0.ld
                             -lstdc++ -lsupc++
-; lwIP 1.4 (Default)
+; lwIP 1.4
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
@@ -72,7 +72,32 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
                             -O2                            
-; lwIP 1.4 (Default)
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+                            -DVTABLES_IN_FLASH
+                            -fno-exceptions
+                            -lstdc++
+
+[core_2_5_1]
+; *** Esp8266 core for Arduino version 2.5.1 (release is still not availible via Platformio)
+platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
+                            -O2
+; nonos-sdk 22x
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
+; nonos-sdk-pre-v3
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4 
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
@@ -97,7 +122,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 ; nonos-sdk-pre-v3
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3                            
-; lwIP 1.4 (Default)
+; lwIP 1.4
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
@@ -125,10 +150,12 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Select one core set for platform and build_flags
 ;platform                  = ${core_2_3_0.platform}
 ;build_flags               = ${core_2_3_0.build_flags}
-platform                  = ${core_2_4_2.platform}
-build_flags               = ${core_2_4_2.build_flags}
+;platform                  = ${core_2_4_2.platform}
+;build_flags               = ${core_2_4_2.build_flags}
 ;platform                  = ${core_2_5_0.platform}
 ;build_flags               = ${core_2_5_0.build_flags}
+platform                  = ${core_2_5_1.platform}
+build_flags               = ${core_2_5_1.build_flags}
 ;platform                  = ${core_stage.platform}
 ;build_flags               = ${core_stage.build_flags}
 


### PR DESCRIPTION
Since bugfix release is still not availible via orig. Platformio Github it is donwloaded via forked source from https://github.com/Jason2866/platform-espressif8266.git#Tasmota

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
