### PR TITLE
Official Platformio release of core 2.5.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,30 +65,9 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
                             -DVTABLES_IN_FLASH
 
-[core_2_5_0]
-; *** Esp8266 core for Arduino version 2.5.0
-platform                  = espressif8266@~2.0.4
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
-                            -O2
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-                            -DVTABLES_IN_FLASH
-                            -fno-exceptions
-                            -lstdc++
-
 [core_2_5_1]
-; *** Esp8266 core for Arduino version 2.5.1 (release is still not availible via Platformio)
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
+; *** Esp8266 core for Arduino version 2.5.1
+platform                  = espressif8266@~2.1.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
@@ -154,8 +133,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;build_flags               = ${core_2_3_0.build_flags}
 ;platform                  = ${core_2_4_2.platform}
 ;build_flags               = ${core_2_4_2.build_flags}
-;platform                  = ${core_2_5_0.platform}
-;build_flags               = ${core_2_5_0.build_flags}
 platform                  = ${core_2_5_1.platform}
 build_flags               = ${core_2_5_1.build_flags}
 ;platform                  = ${core_stage.platform}


### PR DESCRIPTION
Use official resource of Platformio for core 2.5.1 and delete support for core 2.5.0.
Core 2.5.1 is a bug fix release for core 2.5.0

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
