### PR TITLE
Added support for Lyasi RGBW E27 Bulb

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -2535,7 +2535,7 @@ void GpioInit(void)
   else if (SONOFF_LED == my_module_type) {  // PWM Dual color led (White warm and cold)
     light_type = LT_PWM2;
   }
-  else if (AILIGHT == my_module_type) {     // RGBW led
+  else if (AILIGHT == my_module_type || LYASI == Settings.module) {     // RGBW led
     light_type = LT_RGBW;
   }
   else if (SONOFF_B1 == my_module_type) {   // RGBWC led

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -305,6 +305,7 @@ enum SupportedModules {
   SONOFF_BRIDGE,
   SONOFF_B1,
   AILIGHT,
+  LYASI,
   SONOFF_T11,
   SONOFF_T12,
   SONOFF_T13,
@@ -697,6 +698,7 @@ const uint8_t kModuleNiceList[] PROGMEM = {
 #endif
   KMC_70011,
   AILIGHT,             // Light Bulbs
+  LYASI,
   PHILIPS,
   SYF05,
   YTF_IR_BRIDGE,
@@ -1178,6 +1180,25 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_DCKI,        // GPIO15 my9291 DCKI
      0, 0
   },
+  { "Lyasi",         	// RGBW led (ESP8266 - my9291)
+      GPIO_KEY1,        // GPIO00 Pad
+      GPIO_USER,        // GPIO01 Serial RXD and Optional sensor pad
+      GPIO_USER,        // GPIO02 Optional sensor SDA pad
+      GPIO_USER,        // GPIO03 Serial TXD and Optional sensor pad
+      GPIO_DI, GPIO_DCKI, // DI AND DCKI ON 4 and 5
+                          // GPIO06 (SD_CLK   Flash)
+                          // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
+                          // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
+      0,                  // GPIO09
+      0,                  // GPIO10
+                          // GPIO11 (SD_CMD   Flash)
+      0,                  // GPIO12
+      0,                  // GPIO13
+      0,                  // GPIO14
+      0,                  // GPIO15
+      0,                  // GPIO16
+      0
+    },
   { "Sonoff T1 1CH",   // Sonoff T1 1CH (ESP8285)
      GPIO_KEY1,        // GPIO00 Button 1
      GPIO_USER,        // GPIO01 Serial RXD and Optional sensor


### PR DESCRIPTION
Added a new template for Lyasi bulbs
https://www.amazon.co.uk/LYASI-Multicolored-Smartphone-Controlled-Compatible/dp/B075GJGMPX

## Description:

**Related issue (if applicable):** fixes <https://github.com/arendst/Sonoff-Tasmota/issues/1822>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works.
  - [x ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
