### PR TITLE
MQTT latency improvement

### DIFF
--- a/lib/PubSubClient-EspEasy-2.6.09/src/PubSubClient.cpp
+++ b/lib/PubSubClient-EspEasy-2.6.09/src/PubSubClient.cpp
@@ -303,7 +303,7 @@ boolean PubSubClient::loop() {
                 pingOutstanding = true;
             }
         }
-        if (_client->available()) {
+        while (_client->available()) {
             uint8_t llen;
             uint16_t len = readPacket(&llen);
             uint16_t msgId = 0;

--- a/lib/PubSubClient-EspEasy-2.6.09/src/PubSubClient.cpp
+++ b/lib/PubSubClient-EspEasy-2.6.09/src/PubSubClient.cpp
@@ -346,6 +346,7 @@ boolean PubSubClient::loop() {
                 // readPacket has closed the connection
                 return false;
             }
+            optimistic_yield(1000);
         }
         return true;
     }

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,7 @@
-/* 6.5.0.10 20190513
+/* 6.5.0.11 20190517
+ * Reduced latency of Tasmota for incominig MQTT commands
+ *
+ * 6.5.0.10 20190513
  * Enable ADC0 by default in my_user_config.h (#5671)
  * Add user configurable ADC0 to Module and Template configuration compatible with current FLAG options (#5671)
  * Add support for Shelly 1PM Template {"NAME":"Shelly 1PM","GPIO":[56,0,0,0,82,134,0,0,0,0,0,21,0],"FLAG":2,"BASE":18} (#5716)


### PR DESCRIPTION
## Description:

The current implementation of MQTT PubSubClient process only one incoming MQTT message per one loop() call (e.g. it could be just MQTT ping response). In combination with default Dynamic 50 ms sleep of the main Tasmota loop this increase latency of execution of incoming MQTT messages especially if there are several cumming within 50ms interval. The latency is dependent on the number of messages.

This PR proposes simple change removing this negative effect by small change in PubSubClient implmentation.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works.
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
