### PR TITLE
Save RAM - move ledTable from RAM to FLASH

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,7 @@
-/* 6.5.0.10 20190513
+/* 6.5.0.11 20190517
+ * Offload big constant ledTable from RAM to FLASH
+ *
+ * 6.5.0.10 20190513
  * Enable ADC0 by default in my_user_config.h (#5671)
  * Add user configurable ADC0 to Module and Template configuration compatible with current FLAG options (#5671)
  * Add support for Shelly 1PM Template {"NAME":"Shelly 1PM","GPIO":[56,0,0,0,82,134,0,0,0,0,0,21,0],"FLAG":2,"BASE":18} (#5716)

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -161,7 +161,7 @@ const LCwColor kFixedColdWarm[MAX_FIXED_COLD_WARM] PROGMEM = { 0,0, 255,0, 0,255
 // from 11 bits (lower values) to 8 bits (upper values).
 // We're using the fact that lower values are small and can fit within 8 bits
 // To save flash space, the array is only 8 bits uint
-const uint8_t _ledTable[] = {
+const uint8_t _ledTable[] PROGMEM = {
   // 11 bits resolution
     0,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  2,  2,  // 11 bits, 0..2047
     2,  2,  2,  2,  3,  3,  3,  3,  4,  4,  4,  5,  5,  6,  6,  7,  // 11 bits, 0..2047
@@ -961,7 +961,7 @@ uint16_t ledGamma(uint8_t v, uint16_t bits_out = 8) {
   // bits_resolution: the resolution of _ledTable[v], between 8 and 11
   uint32_t bits_resolution = 11 - (v / 64);                     // 8..11
   int32_t  bits_correction = bits_out - bits_resolution;      // -3..3
-  uint32_t uncorrected_value = _ledTable[v];        // 0..255
+  uint32_t uncorrected_value = pgm_read_byte(&_ledTable[v]);        // 0..255
   if (0 == bits_correction) {
     // we already match the required resolution, no change
     result = uncorrected_value;


### PR DESCRIPTION
## Description:

Offloading big _ledTable in xdrv_04_light.ino from RAM to FLASH.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
