### PR TITLE
Update to platformio v.2.1.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_2_5_1]
 ; *** Esp8266 core for Arduino version 2.5.1
-platform                  = espressif8266@~2.1.0
+platform                  = espressif8266@~2.1.1
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 


### PR DESCRIPTION
For some platforms esptool flash fails. https://github.com/platformio/platform-espressif8266/issues/149
Fixed in v.2.1.1

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
