### PR TITLE
Fix CSE7766 Sensor invalid energy load steps prevention

### DIFF
--- a/sonoff/xnrg_02_cse7766.ino
+++ b/sonoff/xnrg_02_cse7766.ino
@@ -189,6 +189,7 @@ void CseEverySecond(void)
       }
       else {
         AddLog_P(LOG_LEVEL_DEBUG, PSTR("CSE: Load overflow"));
+        cf_pulses_last_time = CSE_PULSES_NOT_INITIALIZED;
       }
       EnergyUpdateToday();
     }


### PR DESCRIPTION
## Description:
fixes PR #5793 solution which can async (load overflow) forever until device restart

**Related issue:** #5789/PR #5793 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
