### PR TITLE
Bugfix Core 2.5.2 release

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,9 +65,9 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
                             -DVTABLES_IN_FLASH
 
-[core_2_5_1]
-; *** Esp8266 core for Arduino version 2.5.1
-platform                  = espressif8266@~2.1.1
+[core_2_5_2]
+; *** Esp8266 core for Arduino version 2.5.2
+platform                  = espressif8266@~2.2.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 
@@ -133,8 +133,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;build_flags               = ${core_2_3_0.build_flags}
 ;platform                  = ${core_2_4_2.platform}
 ;build_flags               = ${core_2_4_2.build_flags}
-platform                  = ${core_2_5_1.platform}
-build_flags               = ${core_2_5_1.build_flags}
+platform                  = ${core_2_5_2.platform}
+build_flags               = ${core_2_5_2.build_flags}
 ;platform                  = ${core_stage.platform}
 ;build_flags               = ${core_stage.build_flags}
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

Release 2.5.2 (#6121)

Changes since 2.5.1 (to 2.5.2)

Core
----
* Add explicit Print::write(char) (#6101)

Build system
----
* Fix typo in elf2bin for QOUT binary generation (#6116)
* Support PIO Wl-T and Arduino -T linking properly (#6095)
* Allow *.cc files to be linked into flash by default (#6100)
* Use custom "ElfToBin" builder for PIO (#6091)
* Fail if generated JSON file cannot be read (#6076)
* Moved 'Dropping' print from stdout to stderr in drop_versions.py (#6071)
* Fix PIO issue when build environment contains spaces (#6119)

Libraries
----
* Remove deadlock when server is not acking our data (#6107)
* Bugfix for stuck in write method of WiFiClient and WiFiClientSecure until the remote peer closed connection (#6104)
* Re-add original SD FAT info access methods (#6092)
* Make FILE_WRITE append in SD.h wrapper (#6106)
* Drop X509 after connection, avoid hang on TLS broken (#6065)