### PR TITLE
Small fixes in platformio

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_2_5_2]
 ; *** Esp8266 core for Arduino version 2.5.2
-platform                  = espressif8266@~2.2.0
+platform                  = espressif8266@~2.2.1
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473 


### PR DESCRIPTION
Fixes in platformio update to 2.2.1
Fixed broken example "esp8266-nonos-sdk-blink"
Use 115200 upload speed by default (issue https://github.com/platformio/platform-espressif8266/issues/153)

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
