### PR TITLE
Fix #5869, missing white channnel for WS2812

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,5 +1,6 @@
 /* 6.5.0.13 20190527
  * Add command SetOption38 6..255 to set IRReceive protocol detection sensitivity mimizing UNKNOWN protocols (#5853)
+ * Fix missing white channel for SW2812 (#5869)
  *
  * 6.5.0.12 20190521
  * Add AriLux RF control GPIO option "ALux IrSel" (159) replacing "Led4i" (59) for full LED control (#5709)

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,6 +1,6 @@
 /* 6.5.0.13 20190527
  * Add command SetOption38 6..255 to set IRReceive protocol detection sensitivity mimizing UNKNOWN protocols (#5853)
- * Fix missing white channel for SW2812 (#5869)
+ * Fix missing white channel for WS2812 (#5869)
  *
  * 6.5.0.12 20190521
  * Add AriLux RF control GPIO option "ALux IrSel" (159) replacing "Led4i" (59) for full LED control (#5709)

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1326,6 +1326,12 @@ void LightInit(void)
   light_device = devices_present;
   light_subtype = (light_type & 7) > LST_MAX ? LST_MAX : (light_type & 7); // Always 0 - LST_MAX (5)
 
+#if defined(USE_WS2812) && (USE_WS2812_CTYPE > NEO_3LED)
+  if (LT_WS2812 == light_type) {
+    light_subtype++;  // from RGB to RGBW
+  }
+#endif
+
   light_controller.setSubType(light_subtype);
   light_controller.loadSettings();
 
@@ -1362,9 +1368,6 @@ void LightInit(void)
   }
 #ifdef USE_WS2812  // ************************************************************************
   else if (LT_WS2812 == light_type) {
-#if (USE_WS2812_CTYPE > NEO_3LED)
-    light_subtype++;  // from RGB to RGBW
-#endif
     Ws2812Init();
     max_scheme = LS_MAX + WS2812_SCHEMES;
   }


### PR DESCRIPTION
## Description:

The light_subtype was updated after initializing the Light engine, missing the white channel.

**Related issue (if applicable): #5869

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).