### PR TITLE
Work-around for Philips Hue emulation issue (#5849)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * Add command SetOption38 6..255 to set IRReceive protocol detection sensitivity mimizing UNKNOWN protocols (#5853)
  * Fix missing white channel for WS2812 (#5869)
  * Add reset of Energy values when connection to sensor is lost for over 4 seconds (#5874, #5881)
+ * Work-around for Philips Hue emulation issue (#5849)
  *
  * 6.5.0.12 20190521
  * Add AriLux RF control GPIO option "ALux IrSel" (159) replacing "Led4i" (59) for full LED control (#5709)

--- a/sonoff/xdrv_20_hue.ino
+++ b/sonoff/xdrv_20_hue.ino
@@ -342,6 +342,13 @@ void HueLightStatus2(uint8_t device, String *response)
   response->replace("{j2", GetHueDeviceId(device));
 }
 
+// generate a unique lightId mixing local IP address and deice number
+// it is limited to 16 devices.
+uint32_t lightId(uint32_t idx) {
+    uint32_t ip_local = WiFi.localIP();
+    return ((ip_local & 0xFF000000) >> 20) + idx % 16; // >> 24 * 16 is equivalent to >> 20
+}
+
 void HueGlobalConfig(String *path)
 {
   String response;
@@ -350,7 +357,7 @@ void HueGlobalConfig(String *path)
   path->remove(0,1);                                 // cut leading / to get <id>
   response = F("{\"lights\":{\"");
   for (uint8_t i = 1; i <= maxhue; i++) {
-    response += i;
+    response += lightId(i);
     response += F("\":{\"state\":");
     HueLightStatus1(i, &response);
     HueLightStatus2(i, &response);
@@ -394,7 +401,7 @@ void HueLights(String *path)
   if (path->endsWith("/lights")) {                   // Got /lights
     response = "{\"";
     for (uint8_t i = 1; i <= maxhue; i++) {
-      response += i;
+      response += lightId(i);
       response += F("\":{\"state\":");
       HueLightStatus1(i, &response);
       HueLightStatus2(i, &response);
@@ -562,7 +569,7 @@ void HueLights(String *path)
   }
   else if(path->indexOf("/lights/") >= 0) {          // Got /lights/ID
     path->remove(0,8);                               // Remove /lights/
-    device = atoi(path->c_str());
+    device = atoi(path->c_str()) % 16;
     if ((device < 1) || (device > maxhue)) {
       device = 1;
     }
@@ -591,7 +598,7 @@ void HueGroups(String *path)
     String lights = F("\"1\"");
     for (uint8_t i = 2; i <= maxhue; i++) {
       lights += ",\"";
-      lights += String(i);
+      lights += lightId(i);
       lights += "\"";
     }
     response.replace("{l1", lights);


### PR DESCRIPTION
## Description:

This is a work-around for #5849. Normally lights have ids "1", "2"... on each bridge. Enforcing unique lightIds ensures that Alexa does not get confused.

The new lightId is computed as follows: (last byte of IP address * 16) + light number.

Ex: for 192.168.1.100 - light 1, it would be (100*16+1 = 1601)

This works fine if Tasmota devices don't change IP address, you may have issues if the devices change IP addresses.

**Related issue (if applicable):** fixes #5849

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
