### PR TITLE
Add support to Stage Arduino Core

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -3,6 +3,7 @@
  * Fix missing white channel for WS2812 (#5869)
  * Add reset of Energy values when connection to sensor is lost for over 4 seconds (#5874, #5881)
  * Work-around for Philips Hue emulation issue (#5849)
+ * Add support to Stage Arduino Core (next 2.6.0)
  *
  * 6.5.0.12 20190521
  * Add AriLux RF control GPIO option "ALux IrSel" (159) replacing "Led4i" (59) for full LED control (#5709)

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -235,10 +235,19 @@ extern "C" {
 }
 #include "eboot_command.h"
 
-extern "C" uint32_t _SPIFFS_end;
+#if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_1) || defined(ARDUINO_ESP8266_RELEASE_2_4_2) || defined(ARDUINO_ESP8266_RELEASE_2_5_0) || defined(ARDUINO_ESP8266_RELEASE_2_5_1) || defined(ARDUINO_ESP8266_RELEASE_2_5_2)
 
+extern "C" uint32_t _SPIFFS_end;
 // From libraries/EEPROM/EEPROM.cpp EEPROMClass
 const uint32_t SPIFFS_END = ((uint32_t)&_SPIFFS_end - 0x40200000) / SPI_FLASH_SEC_SIZE;
+
+#else  // Core > 2.5.2 and STAGE
+
+extern "C" uint32_t _FS_end;
+// From libraries/EEPROM/EEPROM.cpp EEPROMClass
+const uint32_t SPIFFS_END = ((uint32_t)&_FS_end - 0x40200000) / SPI_FLASH_SEC_SIZE;
+
+#endif
 
 // Version 4.2 config = eeprom area
 const uint32_t SETTINGS_LOCATION = SPIFFS_END;  // No need for SPIFFS as it uses EEPROM area


### PR DESCRIPTION
## Description:

The actual Stage ESP8266 Core of Arduino (next 2.6.0) had changed the SPIFFS defines of the memory to FS due to a change in the libraries (esp8266/Arduino#5511)

This PR adds a check during compiling time to use the right **_defines_** depending on the core.
* `_SPIFFS_END` for cores 2.3.0 to 2.5.2
* `_FS_END` for cores > 2.5.2 and STAGE

Tested OK.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
