### PR TITLE
Fixed issue with displaying Bulgarian translation strings

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * Change webserver HTML input, button, textarea, and select name based on id
  * Fix webserver multiple Javascript window.onload functionality
  * Fix PZem startup issue (#5875)
+ * Fixed issue with incorrect displaying some of the translated strings to Bulgarian language.
  *
  * 6.5.0.13 20190527
  * Add command SetOption38 6..255 to set IRReceive protocol detection sensitivity mimizing UNKNOWN protocols (#5853)

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -787,8 +787,14 @@ void WSContentSendStyle(void)
 
 void WSContentButton(uint8_t title_index)
 {
+  #if MY_LANGUAGE == bg-BG
+    #define _TITLE_SIZE 64
+  #else
+    #define _TITLE_SIZE 32
+  #endif
+
   char action[4];
-  char title[32];
+  char title[_TITLE_SIZE];
 
   if (title_index <= BUTTON_RESET_CONFIGURATION) {
     char confirm[64];
@@ -1489,7 +1495,14 @@ void HandleLoggingConfiguration(void)
   WSContentStart_P(S_CONFIGURE_LOGGING);
   WSContentSendStyle();
   WSContentSend_P(HTTP_FORM_LOG1);
-  char stemp1[32];
+
+  #if MY_LANGUAGE == bg-BG
+    #define _STEMP1_SIZE 45
+  #else
+    #define _STEMP1_SIZE 32
+  #endif
+
+  char stemp1[_STEMP1_SIZE];
   char stemp2[32];
   uint8_t dlevel[3] = { LOG_LEVEL_INFO, LOG_LEVEL_INFO, LOG_LEVEL_NONE };
   for (uint8_t idx = 0; idx < 3; idx++) {

--- a/sonoff/xdrv_07_domoticz.ino
+++ b/sonoff/xdrv_07_domoticz.ino
@@ -455,7 +455,13 @@ void HandleDomoticzConfiguration(void)
     return;
   }
 
-  char stemp[32];
+  #if MY_LANGUAGE == bg-BG
+    #define _STEMP_SIZE 40
+  #else
+    #define _STEMP_SIZE 32
+  #endif
+
+  char stemp[_STEMP_SIZE];
 
   WSContentStart_P(S_CONFIGURE_DOMOTICZ);
   WSContentSendStyle();


### PR DESCRIPTION
## Description:
Several strings from Bulgarian translations are displayed incorrectly because of small buffers used. The fix contain buffer resizing only when Bulgarian language is selected.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
