### PR TITLE
Change include of my_user_config.h

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -4,6 +4,7 @@
  * Add support for AWS IoT with TLS 1.2 on core 2.5.2. Full doc here: https://github.com/arendst/Sonoff-Tasmota/wiki/AWS-IoT
  * Add some MQTT housekeeping which might solve issue (#5755)
  * Add command SetOption65 0/1 and more Tuya Serial based device support (#5815)
+ * Fix include of my_user_config.h in sonoff_aws_iot.cpp (#5930)
  *
  * 6.5.0.14 20190602
  * Change webserver HTML input, button, textarea, and select name based on id

--- a/sonoff/sonoff_aws_iot.cpp
+++ b/sonoff/sonoff_aws_iot.cpp
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <my_user_config.h>
+#include "my_user_config.h"
 #ifdef USE_MQTT_AWS_IOT
 
 #include <bearssl/bearssl.h>


### PR DESCRIPTION
@arendst 

For some reason xtensa-lx106-elf-gcc v2.5.0-3-20ed2b9 does not find the file unless it is explicitly indicated to first look for it in the same folder the file is which is including it. I'm not sure if you did this intentionally or not - if so then leave as is and I'll do a sed command to update it prior to compiles.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
