### PR TITLE
Light controller code update for dual dimmers.

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,6 @@
 /*
+ * Fixed the light controller when used with LT_serial2 dimmer devices.
+ *
  * 6.5.0.15 20190606
  * Change pubsubclient MQTT_KEEPALIVE from 10 to 30 seconds in preparation of AWS IoT support
  * Add support for AWS IoT with TLS 1.2 on core 2.5.2. Full doc here: https://github.com/arendst/Sonoff-Tasmota/wiki/AWS-IoT

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -121,7 +121,7 @@
 \*********************************************************************************************/
 
 #define XDRV_04              4
-#define DEBUG_LIGHT
+//#define DEBUG_LIGHT
 
 const uint8_t WS2812_SCHEMES = 7;    // Number of additional WS2812 schemes supported by xdrv_ws2812.ino
 
@@ -1461,7 +1461,7 @@ void LightUpdateColorMapping(void)
   light_controller.setCTRGBLinked(ct_rgb_linked);
 
   light_update = 1;
-  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("%d colors: %d %d %d %d %d") ,Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
+  //AddLog_P2(LOG_LEVEL_DEBUG, PSTR("%d colors: %d %d %d %d %d") ,Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
 }
 
 void LightSetDimmer(uint8_t dimmer) {

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -121,7 +121,7 @@
 \*********************************************************************************************/
 
 #define XDRV_04              4
-//#define DEBUG_LIGHT
+#define DEBUG_LIGHT
 
 const uint8_t WS2812_SCHEMES = 7;    // Number of additional WS2812 schemes supported by xdrv_ws2812.ino
 
@@ -359,7 +359,11 @@ class LightStateClass {
 
       switch (_subtype) {
         case LST_COLDWARM:
-          _color_mode = LCM_CT;
+          if(LT_SERIAL2 == light_type){
+            _color_mode = LCM_RGB;
+          }else{
+            _color_mode = LCM_CT;
+          }
           break;
 
         case LST_NONE:
@@ -893,8 +897,13 @@ public:
         light_current_color[0] = briRGB;
         break;
       case LST_COLDWARM:
-        light_current_color[0] = c;
-        light_current_color[1] = w;
+        if (light_type == LT_SERIAL2){
+          light_current_color[0] = r;
+          light_current_color[1] = g;
+        }else{
+          light_current_color[0] = c;
+          light_current_color[1] = w;
+        }
         break;
       case LST_RGBW:
       case LST_RGBWC:
@@ -1335,7 +1344,7 @@ void LightInit(void)
   light_controller.setSubType(light_subtype);
   light_controller.loadSettings();
 
-  if (LST_SINGLE == light_subtype) {
+  if ((LST_SINGLE == light_subtype) || ((light_type == LT_SERIAL2) && (light_subtype == LST_COLDWARM))) {
     Settings.light_color[0] = 255;      // One channel only supports Dimmer but needs max color
   }
   if (light_type < LT_PWM6) {           // PWM
@@ -1452,7 +1461,7 @@ void LightUpdateColorMapping(void)
   light_controller.setCTRGBLinked(ct_rgb_linked);
 
   light_update = 1;
-  //AddLog_P2(LOG_LEVEL_DEBUG, PSTR("%d colors: %d %d %d %d %d") ,Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
+  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("%d colors: %d %d %d %d %d") ,Settings.param[P_RGB_REMAP], light_color_remap[0],light_color_remap[1],light_color_remap[2],light_color_remap[3],light_color_remap[4]);
 }
 
 void LightSetDimmer(uint8_t dimmer) {


### PR DESCRIPTION
## Description:
The updated light controller from PR #5702 breaks the ability to use light_type LT_SERIAL2. With two dimmers you cannot set the channels individually anymore. So command `channel1 50`  or `channel2 50` does not work anymore.

This is because it it's light_subtype becomes LST_COLDWARM. And the cold/warm light bulb type has some protections against the total brightness being more than 255, as well as not using channels 1 and 2 for the 

This PR addresses these issues. 

I doubt it is the right way in the current light controller designers vision. Maybe @s-hadinger can have a look at this code. 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).