### PR TITLE
Fix channel command for dual dimmers (#5940)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * Refactored TLS based on BearSSL, warning breaking change for fingerprints validation (see doc)
  * Add checkbox to GUI password field enabling visibility during password entry only (#5934)
  * Add using heap when more than 199 IRSend values need to be send. May need increase of define MQTT_MAX_PACKET_SIZE too (#5950)
+ * Fix channel command for dual dimmers (#5940)
  *
  * 6.5.0.15 20190606
  * Change pubsubclient MQTT_KEEPALIVE from 10 to 30 seconds in preparation of AWS IoT support

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -942,7 +942,13 @@ public:
   // Channels are: R G B CW WW
   // Brightness is automatically recalculated to adjust channels to the desired values
   void changeChannels(uint8_t *channels) {
-    _state->setChannels(channels);
+    if (LST_COLDWARM == light_subtype) {
+      // remap channels 0-1 to 3-4 if cold/warm
+      uint8_t remapped_channels[5] = {0,0,0,channels[0],channels[1]};
+      _state->setChannels(remapped_channels);
+    } else {
+      _state->setChannels(channels);
+    }
     saveSettings();
     calcLevels();
   }


### PR DESCRIPTION
## Description:

Fix wrong mapping of COMMAND when the light has only 2 PWM (cold/white or dual dimmers)

**Related issue:** fixes #5940 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to update _changelog.ino_ file)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
