### PR TITLE
Add custom build environment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ src_dir = sonoff
 ;env_default = sonoff-knx
 ;env_default = sonoff-sensors
 ;env_default = sonoff-display
+;env_default = sonoff-custom
 ;env_default = sonoff-BG
 ;env_default = sonoff-BR
 ;env_default = sonoff-CN

--- a/platformio.ini
+++ b/platformio.ini
@@ -276,6 +276,20 @@ upload_resetmethod = ${common.upload_resetmethod}
 upload_speed = ${common.upload_speed}
 extra_scripts = ${common.extra_scripts}
 
+[env:sonoff-custom]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board}
+board_build.flash_mode = ${common.board_build.flash_mode}
+board_build.f_cpu = ${common.board_build.f_cpu}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} -DFIRMWARE_CUSTOM -DUSE_CONFIG_OVERRIDE
+monitor_speed = ${common.monitor_speed}
+upload_port = ${common.upload_port}
+upload_resetmethod = ${common.upload_resetmethod}
+upload_speed = ${common.upload_speed}
+extra_scripts = ${common.extra_scripts}
+
 [env:sonoff-BG]
 platform = ${common.platform}
 framework = ${common.framework}

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -556,7 +556,7 @@ const char kPrefixes[3][PRFX_MAX_STRING_LENGTH] PROGMEM = {
   D_STAT,
   D_TELE };
 
-const char kCodeImage[] PROGMEM = "sonoff|minimal|classic|sensors|knx|basic|display";
+const char kCodeImage[] PROGMEM = "sonoff|minimal|classic|sensors|knx|basic|display|custom";
 
 // support.ino
 static const char kMonthNames[] = D_MONTH3LIST;

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -438,6 +438,16 @@ void KNX_CB_Action(message_t const &msg, void *arg);
 #endif  // FIRMWARE_MINIMAL
 
 /*********************************************************************************************\
+ * [sonoff-custom.bin]
+ * Provide a custom image based on a defines in user_config_override.h
+\*********************************************************************************************/
+
+#ifdef FIRMWARE_CUSTOM
+#undef CODE_IMAGE
+#define CODE_IMAGE 7
+#endif  // FIRMWARE_CUSTOM
+
+/*********************************************************************************************\
  * Mandatory defines satisfying possible disabled defines
 \*********************************************************************************************/
 


### PR DESCRIPTION
## Description:

Currently to build a custom build the platformio.ini file needs to be edited.  This method has a few downsides,
- The edited file needs to often be stashed when doing a git pull
- The final build is still labeled according to the build env (sonoff, display etc).  Makes it difficult to establish the build is actually custom
- Custom builds are difficult to perform on an automated system because of the editing required

Some of these issues could be solved by having a copy of the repo, but then needs to be rebased regularly.

This PR attempts to solve this by adding a new env to the build `sonoff-custom`, automatically setting USE_CONFIG_OVERRIDE.

There is one current issue, the build will fail on this new environment because the file `user_config_override.h` does not exist by default.  I haven't got a solution to this as yet, but will work on this is if the general idea of this PR is acceptable.  I welcome any input on this.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to add to _changelog.ino_ file without updating version)
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works.
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
