### PR TITLE
Add blend RGB leds with White leds for better whites #5895 #5704

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,7 @@
 /*********************************************************************************************\
+ * 6.6.0.1 20190707
+ * Add blend RGB leds with White leds for better whites #5895 #5704
+ *
  * 6.6.0 20190707
  * Remove support of TLS on core 2.3.0 and extent support on core 2.4.2 and up
  * Remove MQTT uptime message every hour


### PR DESCRIPTION
## Description:

When setting last argument of `rgbwwtable`to zero, like this `rgbwwtable 255,255,255,255,0`, color will be automatically blended between RGB and White. Any White component will be taken off RGB and used on White leds.

Changing the 4th argument can be used to calibrate White vs RGB: often white leds are more bright than RGB. For example, Sonoff B1 would require `rgbwwtable 255,255,255,35,0`.

Works only with lights with 4 (RGBW) or 5 (RGBCW) channels.

@arendst I bumped to version to 6.6.0.1.

**Related issue (if applicable):** fixes #5895 #5704

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to add to _changelog.ino_ file without updating version)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
