### PR TITLE
Implemented automatic setting of clock display from network time.

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,5 @@
 /*********************************************************************************************\
+ * Add automatic setting of clock display from network time for AZ7798
  * 6.6.0.1 20190707
  * Add blend RGB leds with White leds for better whites #5895 #5704
  *

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,5 +1,4 @@
 /*********************************************************************************************\
- * Add automatic setting of clock display from network time for AZ7798
  * 6.6.0.1 20190707
  * Add blend RGB leds with White leds for better whites #5895 #5704
  *

--- a/sonoff/xsns_38_az7798.ino
+++ b/sonoff/xsns_38_az7798.ino
@@ -118,7 +118,10 @@
 #define CO2_HIGH                     1200    // Above this CO2 value show red light
 #endif
 
-#define AZ_READ_TIMEOUT              400     // Must be way less than 1000 but enough to read 9 bytes at 9600 bps
+#define AZ_READ_TIMEOUT              400     // Must be way less than 1000 but enough to read 25 bytes at 9600 bps
+
+#define AZ_CLOCK_UPDATE_INTERVAL (24UL * 60 * 60) // periodically update clock display (24 hours)
+#define AZ_EPOCH (946684800UL)               // 2000-01-01 00:00:00
 
 TasmotaSerial *AzSerial;
 
@@ -129,11 +132,14 @@ double az_temperature = 0;
 double az_humidity = 0;
 uint8_t az_received = 0;
 uint8_t az_state = 0;
+unsigned long az_clock_update = 10;         // timer for periodically updating clock display
 
 /*********************************************************************************************/
 
 void AzEverySecond(void)
 {
+  unsigned long start = millis();
+
   az_state++;
   if (5 == az_state) {                      // every 5 seconds
     az_state = 0;
@@ -143,7 +149,6 @@ void AzEverySecond(void)
     az_received = 0;
 
     uint8_t az_response[32];
-    unsigned long start = millis();
     uint8_t counter = 0;
     uint8_t i, j;
     uint8_t response_substr[16];
@@ -233,6 +238,25 @@ void AzEverySecond(void)
     }
     response_substr[j] = 0;                 // add null terminator
     az_humidity = ConvertHumidity(CharToFloat((char*)response_substr));
+  }
+
+  // update the clock from network time
+  if ((az_clock_update == 0) && (local_time > AZ_EPOCH)) {
+    char tmpString[16];
+    sprintf(tmpString, "C %d\r", (int)(local_time - AZ_EPOCH));
+    AzSerial->write(tmpString);
+    // discard the response
+    do {
+      if (AzSerial->available() > 0) {
+        if(AzSerial->read() == 0x0d) { break; }
+      } else {
+        delay(5);
+      }
+    } while(((millis() - start) < AZ_READ_TIMEOUT));
+    az_clock_update = AZ_CLOCK_UPDATE_INTERVAL;
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "AZ7798 clock updated"));
+  } else {
+    az_clock_update--;
   }
 }
 


### PR DESCRIPTION
## Description:
The display of the AZ7798 CO2 meter includes a clock showing date and time.This is normally set manually but slowly drifts or is reset when the power is off for too long. This enhancement automatically sets the clock time from the network time, shortly after power on and then every 24 hours thereafter.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched (Also remember to add to _changelog.ino_ file without updating version)
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works.
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
