### PR TITLE
Use latest SDK22y for core_stage

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -99,8 +99,10 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
                             -O2
                             -DBEARSSL_SSL_BASIC
+; nonos-sdk 22y
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
 ; nonos-sdk 22x
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
 ; nonos-sdk-pre-v3
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 ; lwIP 1.4


### PR DESCRIPTION
Switch default FW to "2.2.2-dev(38a443e)" (menu:2.2.1+100) 

* enable by default latest 2.2.x firmware, including fixed espnow
* LittleFS: avoid crash when FS size is 0
* flash size defaults: 1M for generic board, not empty FS for all

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
