### PR TITLE
Updated Code for Issue #6066- Dimmer Value not equal to Rx Dim State

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,4 +1,7 @@
 /*********************************************************************************************\
+ *  6.6.0.2 20190711
+ * SetOption66 - Enable or Disable Dimmer range 255 slider control
+ *
  * 6.6.0.1 20190708
  * Fix Domoticz battery level set to 100 if define USE_ADC_VCC is not used (#6033)
  * Change defines USE_TX20_WIND_SENSOR and USE_RC_SWITCH in my_user_config.h to disable to lower iram usage enabling latest core compilation (#6060, #6062)

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -1,13 +1,11 @@
 /*********************************************************************************************\
- *  6.6.0.2 20190711
- * SetOption66 - Enable or Disable Dimmer range 255 slider control
- *
  * 6.6.0.1 20190708
  * Fix Domoticz battery level set to 100 if define USE_ADC_VCC is not used (#6033)
  * Change defines USE_TX20_WIND_SENSOR and USE_RC_SWITCH in my_user_config.h to disable to lower iram usage enabling latest core compilation (#6060, #6062)
  * Add blend RGB leds with White leds for better whites (#5895, #5704)
  * Add command SetOption41 0..8 to control number of Tuya switches (#6039)
  * Add command SetOption42 0..255 to set overtemperature (Celsius only) threshold resulting in power off all on energy monitoring devices. Default setting is 90 (#6036)
+ * Add command SetOption66 0/1 to enable or disable Tuya dimmer range 255 slider control
  * Add command Time to disable NTP and set UTC time as Epoch value if above 1451602800 (=20160101). Time 0 re-enables NTP (#5279)
  * Add AZ7798 automatic setting of clock display (#6034)
  * Add Epoch and UptimeSec to JSON messages (#6068)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -78,8 +78,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t no_hold_retain : 1;           // bit 12 (v6.4.1.19) - SetOption62 - Don't use retain flag on HOLD messages
     uint32_t no_power_feedback : 1;        // bit 13 (v6.5.0.9)  - SetOption63 - Don't scan relay power state at restart
     uint32_t use_underscore : 1;           // bit 14 (v6.5.0.12) - SetOption64 - Enable "_" instead of "-" as sensor index separator
-    uint32_t tuya_show_dimmer : 1;		     // bit 15 (v6.5.0.15) - SetOption65 - Enable or Disable Dimmer slider control
-    uint32_t spare16 : 1;
+    uint32_t tuya_show_dimmer : 1;		   // bit 15 (v6.5.0.15) - SetOption65 - Enable or Disable Dimmer slider control
+    uint32_t tuya_dimmer_range_255 : 1;    // bit 16 (v6.6.0.2)  - SetOption66 - Enable or Disable Dimmer range 255 slider control
     uint32_t spare17 : 1;
     uint32_t spare18 : 1;
     uint32_t spare19 : 1;

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -146,14 +146,20 @@ void LightSerialDuty(uint8_t duty)
     if (duty < 25) { duty = 25; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
 
     if (Settings.flag3.tuya_show_dimmer == 0) {
-
-    	AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Send dim value=%d (id=%d)"), duty, Settings.param[P_TUYA_DIMMER_ID]);
-
+      if(Settings.flag3.tuya_dimmer_range_255 == 0)
+      {
+        duty = round(duty * (100. / 255.));
+      }
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Send dim value=%d (id=%d)"), duty, Settings.param[P_TUYA_DIMMER_ID]);
       TuyaSendValue(Settings.param[P_TUYA_DIMMER_ID], duty);
     }
   } else {
     tuya_ignore_dim = false;  // reset flag
     if (Settings.flag3.tuya_show_dimmer == 0) {
+      if(Settings.flag3.tuya_dimmer_range_255 == 0)
+      {
+        duty = round(duty * (100. / 255.));
+      }
       AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Send dim skipped value=%d"), duty);  // due to 0 or already set
     }
   }
@@ -211,8 +217,14 @@ void TuyaPacketProcess(void)
             AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Autoconfiguring Dimmer ID %d"), tuya_buffer[6]);
             Settings.param[P_TUYA_DIMMER_ID] = tuya_buffer[6];
           }
-
-          tuya_new_dim = round(tuya_buffer[13] * (100. / 255.));
+          if(Settings.flag3.tuya_dimmer_range_255 == 0)
+          {
+            tuya_new_dim = round(tuya_buffer[13]);
+          }
+          else
+          {
+            tuya_new_dim = round(tuya_buffer[13] * (100. / 255.));
+          }
           if ((power || Settings.flag3.tuya_apply_o20) && (tuya_new_dim > 0) && (abs(tuya_new_dim - Settings.light_dimmer) > 1)) {
             tuya_ignore_dim = true;
 

--- a/tools/decode-config.py
+++ b/tools/decode-config.py
@@ -923,7 +923,13 @@ Setting_6_5_0_15['flag3'][0].update ({
         'tuya_show_dimmer':              ('<L', (0x3A0,1,15), (None, None,                      ('SetOption',   '"SetOption65 {}".format($)')) ),
                                     })
 # ======================================================================
+Setting_6_6_0_2 = copy.deepcopy(Setting_6_5_0_15)
+Setting_6_6_0_2['flag3'][0].update ({
+        'tuya_dimmer_range_255':         ('<L', (0x3A0,1,16), (None, None,                      ('SetOption',   '"SetOption66 {}".format($)')) ),
+                                    })
+# ======================================================================
 Settings = [
+            (0x6050010, 0xe00, Setting_6_6_0_2),
             (0x605000F, 0xe00, Setting_6_5_0_15),
             (0x605000C, 0xe00, Setting_6_5_0_12),
             (0x605000B, 0xe00, Setting_6_5_0_11),

--- a/tools/decode-config.py
+++ b/tools/decode-config.py
@@ -923,13 +923,13 @@ Setting_6_5_0_15['flag3'][0].update ({
         'tuya_show_dimmer':              ('<L', (0x3A0,1,15), (None, None,                      ('SetOption',   '"SetOption65 {}".format($)')) ),
                                     })
 # ======================================================================
-Setting_6_6_0_2 = copy.deepcopy(Setting_6_5_0_15)
-Setting_6_6_0_2['flag3'][0].update ({
+Setting_6_6_0_1 = copy.deepcopy(Setting_6_5_0_15)
+Setting_6_6_0_1['flag3'][0].update ({
         'tuya_dimmer_range_255':         ('<L', (0x3A0,1,16), (None, None,                      ('SetOption',   '"SetOption66 {}".format($)')) ),
                                     })
 # ======================================================================
 Settings = [
-            (0x6050010, 0xe00, Setting_6_6_0_2),
+            (0x6050010, 0xe00, Setting_6_6_0_1),
             (0x605000F, 0xe00, Setting_6_5_0_15),
             (0x605000C, 0xe00, Setting_6_5_0_12),
             (0x605000B, 0xe00, Setting_6_5_0_11),


### PR DESCRIPTION
Change Summary

1. Added Option to select Dimmer Range (1-100 and 1-255) through SetOption66 (default is 1-100 for legacy device support

2. Updated Dimmer code to set range based on the option66 100 / 225

## Description:

**Related issue :** fixes  #6066 Tuya Dimmer Dimmer Value not equal to Rx Dim State

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
