### PR TITLE
Fix Force Elliptic Curve for Letsencrypt TLS #6042

### DIFF
--- a/sonoff/StackThunk_light.cpp
+++ b/sonoff/StackThunk_light.cpp
@@ -40,7 +40,7 @@ uint32_t *stack_thunk_light_save = NULL;  /* Saved A1 while in BearSSL */
 uint32_t stack_thunk_light_refcnt = 0;
 
 //#define _stackSize (5600/4)
-#ifdef USE_MQTT_AWS_IOT
+#if defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_TLS_FORCE_EC_CIPHER)
   #define _stackSize (5300/4)   // using a light version of bearssl we can save 300 bytes
 #else
   #define _stackSize (3600/4)   // using a light version of bearssl we can save 2k

--- a/sonoff/WiFiClientSecureLightBearSSL.cpp
+++ b/sonoff/WiFiClientSecureLightBearSSL.cpp
@@ -758,7 +758,7 @@ extern "C" {
 	// We limit to a single cipher to reduce footprint
   // we reference it, don't put in PROGMEM
   static const uint16_t suites[] = {
-#ifdef USE_MQTT_AWS_IOT
+#if defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_TLS_FORCE_EC_CIPHER)
 		BR_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 #else
 		BR_TLS_RSA_WITH_AES_128_GCM_SHA256
@@ -785,8 +785,8 @@ extern "C" {
 		br_ssl_engine_set_aes_ctr(&cc->eng, &br_aes_small_ctr_vtable);
 		br_ssl_engine_set_ghash(&cc->eng, &br_ghash_ctmul32);
 
-#ifdef USE_MQTT_AWS_IOT
-		// we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt
+#if defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_TLS_FORCE_EC_CIPHER)
+		// we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
 		br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);
 #endif
   }

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -8,6 +8,7 @@
  * Add command Time to disable NTP and set UTC time as Epoch value if above 1451602800 (=20160101). Time 0 re-enables NTP (#5279)
  * Add AZ7798 automatic setting of clock display (#6034)
  * Add Epoch and UptimeSec to JSON messages (#6068)
+ * Fix Force Elliptic Curve for Letsencrypt TLS #6042
  *
  * 6.6.0 20190707
  * Remove support of TLS on core 2.3.0 and extent support on core 2.4.2 and up

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -266,6 +266,7 @@
 // Using TLS starting with version v6.5.0.16 compilation will only work using Core 2.4.2 and 2.5.2. No longer supported: 2.3.0
 //#define USE_MQTT_TLS                             // Use TLS for MQTT connection (+34.5k code, +7.0k mem and +4.8k additional during connection handshake)
 //  #define USE_MQTT_TLS_CA_CERT                   // Force full CA validation instead of fingerprints, slower, but simpler to use (+2.2k code, +1.9k mem during connection handshake)
+//  #define USE_MQTT_TLS_FORCE_EC_CIPHER           // Force Elliptic Curve cipher (higher security) required by some servers (automatically enabled with USE_MQTT_AWS_IOT) (+11.4k code, +0.4k mem)
 //  #define USE_MQTT_AWS_IOT                       // Enable MQTT for AWS IoT - requires a private key (+11.4k code, +0.4k mem)
                                                  //   Note: you need to generate a private key + certificate per device and update 'sonoff/sonoff_aws_iot.cpp'
                                                  //   Full documentation here: https://github.com/arendst/Sonoff-Tasmota/wiki/AWS-IoT


### PR DESCRIPTION
## Description:

Add a compilation option to use EC ciphers with Letsencrypt.
No code change, just different #ifdef combinations. Adding `#define USE_MQTT_TLS_FORCE_EC_CIPHER`

I'm not sure it really fixes #6042, but anyways this might be useful in the future when MQTT brokers raise the requirements for TLS ciphers.

**Related issue (if applicable):** fixes #6042 (supposedly)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2 - 2.4.2 and 2.5.2 only
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
