### PR TITLE
added "build_dir"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,6 +9,7 @@
 
 [platformio]
 src_dir = sonoff
+build_dir = .pioenvs
 
 ; *** Uncomment one of the lines below to build/upload only one environment
 ;env_default = sonoff


### PR DESCRIPTION
to make Core 2.3.0 compile with PlatformIO V.4.0.
Change has no impact to older versions of PlatformIO

## Description:

**Related issue (if applicable):** fixes #6084
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on all cores
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
