### PR TITLE
Fix WeMo emulation for 1G echo and 2G echo dot (#6086)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -11,6 +11,7 @@
  * Add AZ7798 automatic setting of clock display (#6034)
  * Add Epoch and UptimeSec to JSON messages (#6068)
  * Add support for up to 4 INA219 sensors (#6046)
+ * Fix WeMo emulation for 1G echo and 2G echo dot (#6086)
  *
  * 6.6.0 20190707
  * Remove support of TLS on core 2.3.0 and extent support on core 2.4.2 and up

--- a/sonoff/support_udp.ino
+++ b/sonoff/support_udp.ino
@@ -36,6 +36,7 @@ bool udp_response_mutex = false;         // M-Search response mutex to control r
 \*********************************************************************************************/
 
 const char URN_BELKIN_DEVICE[] PROGMEM = "urn:belkin:device:**";
+const char URN_BELKIN_DEVICE_CAP[] PROGMEM = "urn:Belkin:device:**";
 const char UPNP_ROOTDEVICE[] PROGMEM = "upnp:rootdevice";
 const char SSDPSEARCH_ALL[] PROGMEM = "ssdpsearch:all";
 const char SSDP_ALL[] PROGMEM = "ssdp:all";

--- a/sonoff/xdrv_21_wemo.ino
+++ b/sonoff/xdrv_21_wemo.ino
@@ -62,7 +62,7 @@ void WemoRespondToMSearch(int echo_type)
   if (PortUdp.beginPacket(udp_remote_ip, udp_remote_port)) {
     char type[24];
     if (1 == echo_type) {              // type1 echo 1g & dot 2g
-      strcpy_P(type, URN_BELKIN_DEVICE);
+      strcpy_P(type, URN_BELKIN_DEVICE_CAP);
     } else {                           // type2 echo 2g (echo, plus, show)
       strcpy_P(type, UPNP_ROOTDEVICE);
     }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #6086
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
