### PR TITLE
Xiaomi Philips brightness (#6091)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -12,6 +12,7 @@
  * Add Epoch and UptimeSec to JSON messages (#6068)
  * Add support for up to 4 INA219 sensors (#6046)
  * Fix WeMo emulation for 1G echo and 2G echo dot (#6086)
+ * Fix Xiaomi Philips brightness (#6091)
  *
  * 6.6.0 20190707
  * Remove support of TLS on core 2.3.0 and extent support on core 2.4.2 and up

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1807,14 +1807,18 @@ void LightAnimate(void)
 
       if (PHILIPS == my_module_type) {
         // Xiaomi Philips bulbs follow a different scheme:
-        // channel 0=intensity, channel2=temperature
-        uint16_t pxBri = cur_col[0] + cur_col[1];
-        if (pxBri > 255) { pxBri = 255; }
-        //cur_col[1] = cur_col[0]; // get 8 bits CT from WC -- not really used
-        cur_col_10bits[1] = changeUIntScale(cur_col[0], 0, pxBri, 0, 1023);  // get 10 bits CT from WC / (WC+WW)
+        uint8_t cold;   // channel 1 is the color tone, mapped to cold channel (0..255)
+        light_state.getCW(&cold, nullptr);
+        cur_col[1] = cold;
+        cur_col_10bits[1] = changeUIntScale(cur_col[1], 0, 255, 0, 1023);
+        // now set channel 0 to overall brightness
+        uint8_t pxBri = light_state.getBriCT();
+        // channel 0=intensity, channel1=temperature
         if (Settings.light_correction) { // gamma correction
+          cur_col[0] = ledGamma(pxBri);
           cur_col_10bits[0] = ledGamma(pxBri, 10);    // 10 bits gamma correction
         } else {
+          cur_col[0] = pxBri;
           cur_col_10bits[0] = changeUIntScale(pxBri, 0, 255, 0, 1023);  // no gamma, extend to 10 bits
         }
       } else {  // PHILIPS != my_module_type


### PR DESCRIPTION
## Description:

I don't own a Philips Xiaomi bulb, but simulated on a led device. This should be back to 6.5.0 behavior.

**Related issue (if applicable):** fixes #6091 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
