### PR TITLE
Support IRSend long press ('repeat' feature from IRRemoteESP8266)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -3,6 +3,7 @@
  * Add support for Sonoff iFan03 as module 71 (#5988)
  * Add support for a buzzer
  * Add command SetOption67 0/1 to disable or enable a buzzer as used in iFan03
+ * Add support IRSend long press ('repeat' feature from IRRemoteESP8266) (#6074)
  *
  * 6.6.0.1 20190708
  * Fix Domoticz battery level set to 100 if define USE_ADC_VCC is not used (#6033)

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -374,6 +374,7 @@
   #define D_JSON_IR_BITS "Bits"
   #define D_JSON_IR_DATA "Data"
   #define D_JSON_IR_RAWDATA "RawData"
+  #define D_JSON_IR_REPEAT "Repeat"
 #define D_CMND_IRHVAC "IRHVAC"
   #define D_JSON_IRHVAC_VENDOR "VENDOR"
   #define D_JSON_IRHVAC_POWER "POWER"


### PR DESCRIPTION
Some IR devices need a longer signal to be sent, equivalent to a long press on the remote controller.

IRRemoteESP8266 already supports the 'repeat' parameter, I added it to the JSON.

Now you can either send:

`IRsend { "protocol": "SAMSUNG", "bits": 32, "data": 551502015 }`

or

`IRsend { "protocol": "NEC", "bits": 32, "data":"0x02FDFE80", "repeat": 2 }`

By default `repeat` is 0 which means 'sent once', except when the protocol expects a minimal repeat (ex: SONY minimum repeat is 2).

No change to previous versions if you don't specific 'repeat' parameter.

**Related issue (if applicable):** fixes #6074

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
