### PR TITLE
Fix send IRSend for Pioneer devices (#6100)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -5,6 +5,7 @@
  * Add command SetOption67 0/1 to disable or enable a buzzer as used in iFan03
  * Add support IRSend long press ('repeat' feature from IRRemoteESP8266) (#6074)
  * Add support for optional IRHVAC Midea/Komeco protocol (#3227)
+ * Fix IRSend for Pioneer devices (#6100)
  *
  * 6.6.0.1 20190708
  * Fix Domoticz battery level set to 100 if define USE_ADC_VCC is not used (#6033)

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -443,6 +443,7 @@
 //  #define USE_IR_SEND_SHARP                      // Support IRsend Sharp protocol
   #define USE_IR_SEND_SONY                       // Support IRsend Sony protocol
 //  #define USE_IR_SEND_WHYNTER                    // Support IRsend Whynter protocol
+  #define USE_IR_SEND_PIONEER                    // Support IRsend Pioneer protocol
 
 //  #define USE_IR_HVAC                            // Support for HVAC systems using IR (+3k5 code)
     #define USE_IR_HVAC_TOSHIBA                  // Support IRhvac Toshiba protocol


### PR DESCRIPTION
## Description:

After spending the ween-end to remote debug the issue from #6100 and with the help of @oprtyo

It appears that Pioneer timings are 5% shorter than NEC. If you're lucky, some devices will tolerate the difference, but some will not. This fixes aligns timing to actual Pioneer IR. For example, the NEC preamble is 9ms + 4.5ms, whereas the Pioneer timing is 8.5ms and 4.25ms. Frequency is also 40KHz instead of 38KHz.

I also introduced an easier way to add IR codes above SHARP (14). Pioneer code is 50 in IRRemoteESP8266, which would require very long strings.

The feature depends on the `#define USE_IR_SEND_PIONEER` toggle that I enabled by default. @arendst you decide whether you accept to keep it enabled (there are lots of Pioneer devices out there) or if it requires custom compile.

Note: I will make a PR for IRRemoteESP8266 to make it hopefully official.

Code increase: 240 bytes.

**Related issue (if applicable):** fixes #6100

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
