### PR TITLE
Increased Web command size

### DIFF
--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -2165,7 +2165,7 @@ void HandleHttpCommand(void)
   if (valid) {
     uint32_t curridx = web_log_index;
     String svalue = WebServer->arg("cmnd");
-    if (svalue.length() && (svalue.length() < INPUT_BUFFER_SIZE)) {
+    if (svalue.length() && (svalue.length() < MQTT_MAX_PACKET_SIZE)) {
       ExecuteWebCommand((char*)svalue.c_str(), SRC_WEBCOMMAND);
       if (web_log_index != curridx) {
         uint32_t counter = curridx;
@@ -2231,7 +2231,7 @@ void HandleConsoleRefresh(void)
   uint32_t counter = 0;                // Initial start, should never be 0 again
 
   String svalue = WebServer->arg("c1");
-  if (svalue.length() && (svalue.length() < INPUT_BUFFER_SIZE)) {
+  if (svalue.length() && (svalue.length() < MQTT_MAX_PACKET_SIZE)) {
     AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_COMMAND "%s"), svalue.c_str());
     ExecuteWebCommand((char*)svalue.c_str(), SRC_WEBCONSOLE);
   }


### PR DESCRIPTION
## Description:

The max Web Console command size was limited to INPUT_BUFFER_SIZE (520 - Serial input size). However the Serial buffer is not used, and command size buffer is allocated by Arduino core in a variable length String.

This PR increases the max Web command to the same size as MQTT command.

This solves the issue of some long IRSend raw would not fit in console but would fit in MQTT. I also will need larger Console commands to store AWS IoT certificate in Flash.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
