### PR TITLE
Add allow repeat/longpress for IRSend raw, introduced IRSend<r> option

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -7,6 +7,7 @@
  * Add MqttCount metric to STATE (#6155)
  * Add define USE_ENERGY_MARGIN_DETECTION to disable Energy Margin and Power Limit detection
  * Add define USE_ENERGY_POWER_LIMIT to disable Energy Power Limit detection while Energy Margin detection is active
+ * Add allow repeat/longpress for IRSend raw, introduced IRSend<r> option (#6074)
  *
  * 6.6.0.2 20190714
  * Change commands Var and Mem to show all parameters when no index is given (#6107)

--- a/sonoff/xdrv_05_irremote.ino
+++ b/sonoff/xdrv_05_irremote.ino
@@ -755,7 +755,7 @@ uint32_t IrRemoteCmndIrSendRaw(void)
   }
 
   // repeat
-  uint16_t repeat = XdrvMailbox.index - 1;
+  uint16_t repeat = XdrvMailbox.index > 0 ? XdrvMailbox.index - 1 : 0;
 
   uint16_t freq = atoi(str);
   if (!freq && (*str != '0')) {                     // First parameter is any string

--- a/sonoff/xdrv_05_irremote.ino
+++ b/sonoff/xdrv_05_irremote.ino
@@ -754,6 +754,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
     return IE_INVALID_RAWDATA;
   }
 
+  // repeat
+  uint16_t repeat = XdrvMailbox.index - 1;
+
   uint16_t freq = atoi(str);
   if (!freq && (*str != '0')) {                     // First parameter is any string
     uint16_t count = 0;
@@ -798,7 +801,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
         }
       }
       irsend_active = true;
-      irsend->sendRaw(raw_array, i, parm[0]);
+      for (uint32_t r = 0; r <= repeat; r++) {
+        irsend->sendRaw(raw_array, i, parm[0]);
+      }
     }
     else if (6 == count) {                          // NEC Protocol
       // IRsend raw,0,8620,4260,544,411,1496,010101101000111011001110000000001100110000000001100000000000000010001100
@@ -817,7 +822,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       }
       raw_array[i++] = parm[3];                     // Trailing mark
       irsend_active = true;
-      irsend->sendRaw(raw_array, i, parm[0]);
+      for (uint32_t r = 0; r <= repeat; r++) {
+        irsend->sendRaw(raw_array, i, parm[0]);
+      }
     }
     else {
       return IE_INVALID_RAWDATA;                    // Invalid number of parameters
@@ -842,7 +849,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
 //      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: stack count %d"), count);
 
       irsend_active = true;
-      irsend->sendRaw(raw_array, count, freq);
+      for (uint32_t r = 0; r <= repeat; r++) {
+        irsend->sendRaw(raw_array, count, freq);
+      }
     } else {
       uint16_t *raw_array = reinterpret_cast<uint16_t*>(malloc(count * sizeof(uint16_t)));
       if (raw_array == nullptr) {
@@ -856,7 +865,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
 //     AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: heap count %d"), count);
 
       irsend_active = true;
-      irsend->sendRaw(raw_array, count, freq);
+      for (uint32_t r = 0; r <= repeat; r++) {
+        irsend->sendRaw(raw_array, count, freq);
+      }
       free(raw_array);
     }
   }
@@ -890,6 +901,10 @@ uint32_t IrRemoteCmndIrSendJson(void)
   uint16_t bits = root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_BITS))];
   uint64_t data = strtoull(root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_DATA))], nullptr, 0);
   uint16_t repeat = root[UpperCase_P(parm_uc, PSTR(D_JSON_IR_REPEAT))];
+  // check if the IRSend<x> is great than repeat
+  if (XdrvMailbox.index > repeat + 1) {
+    repeat = XdrvMailbox.index - 1;
+  }
   if (!(protocol && bits)) {
     return IE_SYNTAX_IRSEND;
   }


### PR DESCRIPTION
Description:

Requested by @kobuki in #6074 
Allows to send repeats/long press with IRSend raw in addition to IRSend json.

Introduced a new parameter: `IRSend<x> ...` where `<x>` indicates the number of times the message should be sent.

Warning: `IRSend1` means the command is sent once, which is equivalent to `"repeat" = 0`. `IRSend2` is equivalent to `"repeat" = 1`. 

If both ÌRSend<x>` and `"repeat"= <r>` are specified, the greater of both is used, i.e. either `<x>` or `<r>+1`.

**Related issue (if applicable):** fixes #6074

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
