### PR TITLE
Add inter-message gap for IRSend raw

### DIFF
--- a/sonoff/xdrv_05_irremote.ino
+++ b/sonoff/xdrv_05_irremote.ino
@@ -803,6 +803,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       irsend_active = true;
       for (uint32_t r = 0; r <= repeat; r++) {
         irsend->sendRaw(raw_array, i, parm[0]);
+        if (r < repeat) {         // if it's not the last message
+          irsend->space(40000);   // since we don't know the inter-message gap, place an arbitrary 40ms gap
+        }
       }
     }
     else if (6 == count) {                          // NEC Protocol
@@ -810,6 +813,8 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       uint16_t raw_array[strlen(p)*2+3];            // Header + bits + end
       raw_array[i++] = parm[1];                     // Header mark
       raw_array[i++] = parm[2];                     // Header space
+      uint32_t inter_message_32 = (parm[1] + parm[2]) * 3;  // compute an inter-message gap (32 bits)
+      uint16_t inter_message = (inter_message_32 > 65000) ? 65000 : inter_message_32;  // avoid 16 bits overflow
       for (; *p; *p++) {
         if (*p == '0') {
           raw_array[i++] = parm[3];                 // Bit mark
@@ -824,6 +829,9 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       irsend_active = true;
       for (uint32_t r = 0; r <= repeat; r++) {
         irsend->sendRaw(raw_array, i, parm[0]);
+        if (r < repeat) {         // if it's not the last message
+          irsend->space(inter_message);   // since we don't know the inter-message gap, place an arbitrary 40ms gap
+        }
       }
     }
     else {


### PR DESCRIPTION
## Description:

Complement to PR #6176 

This PR inserts inter-message gaps for `IRSend raw,...`.

If `header_mark` and `header_space` are specified, the gap will be computed as `(header_mark + header_space) * 3` with a high limit of 65ms to avoid 16 bits overflow.

If `header_mark` and `header_space` are not specified, the gap will be 40ms.

**Related issue (if applicable):** fixes #6074

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
