### PR TITLE
Add SetOption68 to enable multi-channel PWM instead of a single light (#6134)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -9,6 +9,7 @@
  * Add define USE_ENERGY_POWER_LIMIT to disable Energy Power Limit detection while Energy Margin detection is active
  * Add allow repeat/longpress for IRSend raw, introduced IRSend<r> option (#6074)
  * Change Store AWS IoT Private Key and Certificate in SPI Flash avoiding device-specific compilations
+ * Add SetOption68 to enable multi-channel PWM instead of a single light (#6134)
  *
  * 6.6.0.2 20190714
  * Change commands Var and Mem to show all parameters when no index is given (#6107)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -81,7 +81,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t tuya_show_dimmer : 1;		     // bit 15 (v6.5.0.15) - SetOption65 - Enable or Disable Dimmer slider control
     uint32_t tuya_dimmer_range_255 : 1;    // bit 16 (v6.6.0.1)  - SetOption66 - Enable or Disable Dimmer range 255 slider control
     uint32_t buzzer_enable : 1;            // bit 17 (v6.6.0.1)  - SetOption67 - Enable buzzer when available
-    uint32_t spare18 : 1;
+    uint32_t pmw_multi_channels : 1;       // bit 18 (v6.6.0.3)  - SetOption68 - Enable multi-channels PWM insteas of Color PWM
     uint32_t spare19 : 1;
     uint32_t spare20 : 1;
     uint32_t spare21 : 1;

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -59,6 +59,7 @@ const uint8_t MAX_COUNTERS = 4;             // Max number of counter sensors
 const uint8_t MAX_TIMERS = 16;              // Max number of Timers
 const uint8_t MAX_PULSETIMERS = 8;          // Max number of supported pulse timers
 const uint8_t MAX_FRIENDLYNAMES = 4;        // Max number of Friendly names
+const uint8_t MAX_HUE_DEVICES = 15;         // Max number of Philips Hue device per emulation
 const uint8_t MAX_DOMOTICZ_IDX = 4;         // Max number of Domoticz device, key and switch indices
 const uint8_t MAX_DOMOTICZ_SNS_IDX = 12;    // Max number of Domoticz sensors indices
 const uint8_t MAX_KNX_GA = 10;              // Max number of KNX Group Addresses to read that can be set
@@ -264,7 +265,7 @@ const uint8_t kDefaultRfCode[9] PROGMEM = { 0x21, 0x16, 0x01, 0x0E, 0x03, 0x48, 
 \*********************************************************************************************/
 
 extern uint8_t light_device;  // Light device number
-extern uint8_t light_power;  // Light power
+extern power_t light_power;  // Light power
 extern uint8_t rotary_changed; // Rotary switch changed
 
 #endif  // _SONOFF_H_

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1451,6 +1451,13 @@ void GpioInit(void)
     light_type |= LT_SM16716;
   }
 #endif  // USE_SM16716
+
+  // post-process for lights
+  if (Settings.flag3.pmw_multi_channels) {
+    uint32_t pwm_channels = (light_type & 7) > LST_MAX ? LST_MAX : (light_type & 7);
+    if (0 == pwm_channels)  pwm_channels = 1;
+    devices_present += pwm_channels - 1;  // add the pwm channels controls at the end
+  }
 #endif  // USE_LIGHT
   if (!light_type) {
     for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only

--- a/sonoff/support_command.ino
+++ b/sonoff/support_command.ino
@@ -585,6 +585,9 @@ void CmndSetoption(void)
           if (10 == pindex) {  // SetOption60 enable or disable traditional sleep
             WiFiSetSleepMode();  // Update WiFi sleep mode accordingly
           }
+          if (18 == pindex) { // SetOption68 for multi-channel PWM, requires a reboot
+            restart_flag = 2;
+          }
         }
       }
       else {                   // SetOption32 .. 49

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -46,6 +46,8 @@ uint8_t *efm8bb1_update = nullptr;
 
 enum UploadTypes { UPL_TASMOTA, UPL_SETTINGS, UPL_EFM8BB1 };
 
+static const char * HEADER_KEYS[] = { "User-Agent", };
+
 const char HTTP_HEAD[] PROGMEM =
   "<!DOCTYPE html><html lang=\"" D_HTML_LANGUAGE "\" class=\"\">"
   "<head>"
@@ -543,6 +545,11 @@ void StartWebserver(int type, IPAddress ipweb)
 #endif  // Not FIRMWARE_MINIMAL
     }
     reset_web_log_flag = false;
+
+    // Collect User-Agent for Alexa Hue Emulation
+    // This is used in xdrv_20_hue.ino in function findEchoGeneration()
+    WebServer->collectHeaders(HEADER_KEYS, sizeof(HEADER_KEYS)/sizeof(char*));
+
     WebServer->begin(); // Web server start
   }
   if (webserver_state != type) {

--- a/sonoff/xdrv_20_hue.ino
+++ b/sonoff/xdrv_20_hue.ino
@@ -243,6 +243,22 @@ uint16_t prev_ct  = 254;
 char     prev_x_str[24] = "\0"; // store previously set xy by Alexa app
 char     prev_y_str[24] = "\0";
 
+uint8_t getLocalLightSubtype(uint8_t device) {
+  if (light_type) {
+    if (device >= light_device) {
+      if (Settings.flag3.pmw_multi_channels) {
+        return LST_SINGLE;     // If SetOption68, each channel acts like a dimmer
+      } else {
+        return light_subtype;  // the actual light
+      }
+    } else {
+      return LST_NONE;       // relays
+    }
+  } else {
+    return LST_NONE;
+  }
+}
+
 void HueLightStatus1(uint8_t device, String *response)
 {
   uint16_t ct = 0;
@@ -251,14 +267,18 @@ void HueLightStatus1(uint8_t device, String *response)
   uint16_t hue = 0;
   uint8_t  sat = 0;
   uint8_t  bri = 254;
+  uint32_t echo_gen = findEchoGeneration();   // 1 for 1st gen =+ Echo Dot 2nd gen, 2 for 2nd gen and above
+  // local_light_subtype simulates the light_subtype for 'device'
+  // For relays LST_NONE, for dimmers LST_SINGLE
+  uint8_t local_light_subtype = getLocalLightSubtype(device);
 
+  bri = LightGetBri(device);   // get Dimmer corrected with SetOption68
+  if (bri > 254)  bri = 254;    // Philips Hue bri is between 1 and 254
+  if (bri < 1)    bri = 1;
 
   if (light_type) {
     light_state.getHSB(&hue, &sat, nullptr);
-    bri = light_state.getBri();
 
-    if (bri > 254)  bri = 254;    // Philips Hue bri is between 1 and 254
-    if (bri < 1)    bri = 1;
     if ((bri > prev_bri ? bri - prev_bri : prev_bri - bri) < 1)
       bri = prev_bri;
 
@@ -293,17 +313,17 @@ void HueLightStatus1(uint8_t device, String *response)
   *response += FPSTR(HUE_LIGHTS_STATUS_JSON1);
   response->replace("{state}", (power & (1 << (device-1))) ? "true" : "false");
   // Brightness for all devices with PWM
-  //if (LST_SINGLE <= light_subtype) {
-  light_status += "\"bri\":";
-  light_status += String(bri);
-  light_status += ",";
-  //}
-  if (LST_COLDWARM <= light_subtype) {
+  if ((1 == echo_gen) || (LST_SINGLE <= local_light_subtype)) { // force dimmer for 1st gen Echo
+    light_status += "\"bri\":";
+    light_status += String(bri);
+    light_status += ",";
+  }
+  if (LST_COLDWARM <= local_light_subtype) {
     light_status += F("\"colormode\":\"");
     light_status += (g_gotct ? "ct" : "hs");
     light_status += "\",";
   }
-  if (LST_RGB <= light_subtype) {  // colors
+  if (LST_RGB <= local_light_subtype) {  // colors
     if (prev_x_str[0] && prev_y_str[0]) {
       light_status += "\"xy\":[";
       light_status += prev_x_str;
@@ -327,10 +347,10 @@ void HueLightStatus1(uint8_t device, String *response)
     light_status += String(sat);
     light_status += ",";
   }
-  if (LST_COLDWARM == light_subtype || LST_RGBW <= light_subtype) {  // white temp
+  if (LST_COLDWARM == local_light_subtype || LST_RGBW <= local_light_subtype) {  // white temp
     light_status += "\"ct\":";
-    light_status += String(ct > 0 ? ct : 284);
-    light_status += ",";  // if no ct, default to medium white
+    light_status += String(ct > 0 ? ct : 284);  // if no ct, default to medium white
+    light_status += ",";
   }
   response->replace("{light_status}", light_status);
 }
@@ -338,7 +358,20 @@ void HueLightStatus1(uint8_t device, String *response)
 void HueLightStatus2(uint8_t device, String *response)
 {
   *response += FPSTR(HUE_LIGHTS_STATUS_JSON2);
-  response->replace("{j1", Settings.friendlyname[device-1]);
+  if (device <= MAX_FRIENDLYNAMES) {
+    response->replace("{j1", Settings.friendlyname[device-1]);
+  } else {
+    char fname[33];
+    strcpy(fname, Settings.friendlyname[MAX_FRIENDLYNAMES-1]);
+    uint32_t fname_len = strlen(fname);
+    if (fname_len >= 33-3) {
+      fname[33-3] = 0x00;
+      fname_len = 33-3;
+    }
+    fname[fname_len++] = '-';
+    fname[fname_len++] = '0' + device - MAX_FRIENDLYNAMES;
+    response->replace("{j1", fname);
+  }
   response->replace("{j2", GetHueDeviceId(device));
 }
 
@@ -357,10 +390,32 @@ uint32_t DecodeLightId(uint32_t id) {
   return id & 0xF;
 }
 
+static const char * FIRST_GEN_UA[] = {  // list of User-Agents signature
+  "AEOBC",                              // Echo Dot 2ng Generation
+};
+
+// Check if the Echo device is of 1st generation, which triggers different results
+uint32_t findEchoGeneration(void) {
+  // result is 1 for 1st gen, 2 for 2nd gen and further
+  String user_agent = WebServer->header("User-Agent");
+  uint32_t gen = 2;
+
+  for (uint32_t i = 0; i < sizeof(FIRST_GEN_UA)/sizeof(char*); i++) {
+    if (user_agent.indexOf(FIRST_GEN_UA[i]) >= 0) {  // found
+      gen = 1;
+      break;
+    }
+  }
+
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, D_LOG_HTTP D_HUE " User-Agent: %s, gen=%d", user_agent.c_str(), gen);  // Header collection is set in xdrv_01_webserver.ino, in StartWebserver()
+
+  return gen;
+}
+
 void HueGlobalConfig(String *path)
 {
   String response;
-  uint8_t maxhue = (devices_present > MAX_FRIENDLYNAMES) ? MAX_FRIENDLYNAMES : devices_present;
+  uint8_t maxhue = (devices_present > MAX_HUE_DEVICES) ? MAX_HUE_DEVICES : devices_present;
 
   path->remove(0,1);                                 // cut leading / to get <id>
   response = F("{\"lights\":{\"");
@@ -403,7 +458,8 @@ void HueLights(String *path)
   bool on = false;
   bool change = false;  // need to change a parameter to the light
   uint8_t device = 1;
-  uint8_t maxhue = (devices_present > MAX_FRIENDLYNAMES) ? MAX_FRIENDLYNAMES : devices_present;
+  uint8_t local_light_subtype = light_subtype;
+  uint8_t maxhue = (devices_present > MAX_HUE_DEVICES) ? MAX_HUE_DEVICES : devices_present;
 
   path->remove(0,path->indexOf("/lights"));          // Remove until /lights
   if (path->endsWith("/lights")) {                   // Got /lights
@@ -426,6 +482,8 @@ void HueLights(String *path)
     if ((device < 1) || (device > maxhue)) {
       device = 1;
     }
+    local_light_subtype = getLocalLightSubtype(device); // get the subtype for this device
+
     if (WebServer->args()) {
       response = "[";
 
@@ -452,14 +510,18 @@ void HueLights(String *path)
         resp = true;
       }
 
-      if (light_type) {
-        light_state.getHSB(&hue, &sat, nullptr);
-        bri = light_state.getBri();   // get the combined bri for CT and RGB, not only the RGB one
-        ct = light_state.getCT();
-        uint8_t color_mode = light_state.getColorMode();
-        if (LCM_RGB == color_mode) { g_gotct = false; }
-        if (LCM_CT  == color_mode) { g_gotct = true; }
-        // If LCM_BOTH == color_mode, leave g_gotct unchanged
+      if (light_type && (local_light_subtype >= LST_SINGLE)) {
+        if (!Settings.flag3.pmw_multi_channels) {
+          light_state.getHSB(&hue, &sat, nullptr);
+          bri = light_state.getBri();   // get the combined bri for CT and RGB, not only the RGB one
+          ct = light_state.getCT();
+          uint8_t color_mode = light_state.getColorMode();
+          if (LCM_RGB == color_mode) { g_gotct = false; }
+          if (LCM_CT  == color_mode) { g_gotct = true; }
+          // If LCM_BOTH == color_mode, leave g_gotct unchanged
+        } else {    // treat each channel as simple dimmer
+          bri = LightGetBri(device);
+        }
       }
       prev_x_str[0] = prev_y_str[0] = 0;  // reset xy string
 
@@ -551,14 +613,18 @@ void HueLights(String *path)
         resp = true;
       }
       if (change) {
-        if (light_type) {
-          if (g_gotct) {
-            light_controller.changeCTB(ct, bri);
-          } else {
-            light_controller.changeHSB(hue, sat, bri);
+        if (light_type && (local_light_subtype > LST_NONE)) {   // not relay
+          if (!Settings.flag3.pmw_multi_channels) {
+            if (g_gotct) {
+              light_controller.changeCTB(ct, bri);
+            } else {
+              light_controller.changeHSB(hue, sat, bri);
+            }
+            LightPreparePower();
+          } else {  // SetOption68 On, each channel is a dimmer
+            LightSetBri(device, bri);
           }
-          LightPreparePower();
-          if (LST_COLDWARM <= light_subtype) {
+          if (LST_COLDWARM <= local_light_subtype) {
             MqttPublishPrefixTopic_P(RESULT_OR_STAT, PSTR(D_CMND_COLOR));
           } else {
             MqttPublishPrefixTopic_P(RESULT_OR_STAT, PSTR(D_CMND_DIMMER));
@@ -577,6 +643,7 @@ void HueLights(String *path)
     }
   }
   else if(path->indexOf("/lights/") >= 0) {          // Got /lights/ID
+    AddLog_P2(LOG_LEVEL_DEBUG_MORE, "/lights path=%s", path->c_str());
     path->remove(0,8);                               // Remove /lights/
     device = DecodeLightId(atoi(path->c_str()));
     if ((device < 1) || (device > maxhue)) {
@@ -600,7 +667,7 @@ void HueGroups(String *path)
  * http://sonoff/api/username/groups?1={"name":"Woonkamer","lights":[],"type":"Room","class":"Living room"})
  */
   String response = "{}";
-  uint8_t maxhue = (devices_present > MAX_FRIENDLYNAMES) ? MAX_FRIENDLYNAMES : devices_present;
+  uint8_t maxhue = (devices_present > MAX_HUE_DEVICES) ? MAX_HUE_DEVICES : devices_present;
 
   if (path->endsWith("/0")) {
     response = FPSTR(HUE_GROUP0_STATUS_JSON);


### PR DESCRIPTION
## Description:

Introduced `SetOption68 1` to treat PWM as separate channels instead of a single light. In this mode use `Power<x>` to turn on/off lights, and `Channel<x>` (0..100) to change the value of each channel. `Color <hhhhhh>` still works to set all channels at once.

Numbering of devices is: 1/ First Relays, 2/ then PWMs. `Channel<x>` is aligned to `Power<x>` numbering. For example. Let's say you have 2 Relays and 3 PWMs.

Relay1: `Power1`
Relay2: `Power2`
PWM1: `Power3` and `Channel3`
PWM2: `Power4` and `Channel4`
PWM3: `Power5` and `Channel5`

Note: change of `SetOption68` will trigger a reboot.

More than 4 Hue devices are now allowed, the first 4 use the Friendly Names from the settings, following devices get the FriendlyName4 name with `-<n>` appended.

Also, corrected a bug in Hue Emulation when enabling Relays with a Light, dimmer would get mixed up.

Improved Relays management, for Echo above Echo Dot 2nd Gen, simple relays now appear without a dimmer bar. The Dimmer is however necessary for Echo Dot 2nd Gen to detect the Relay. If relays get undetected, we need to add User-Agent signatures.

Code increase: 1.2k (sadly, but I have hints to reduce Hue code size)

**Related issue (if applicable):** fixes #6134

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
