### PR TITLE
Change ToHex to ToHex_P PROGMEM compatible

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1177,7 +1177,7 @@ void SerialInput(void)
     serial_in_buffer[serial_in_byte_counter] = 0;                                // Serial data completed
     char hex_char[(serial_in_byte_counter * 2) + 2];
     Response_P(PSTR("{\"" D_JSON_SERIALRECEIVED "\":\"%s\"}"),
-      (Settings.flag.mqtt_serial_raw) ? ToHex((unsigned char*)serial_in_buffer, serial_in_byte_counter, hex_char, sizeof(hex_char)) : serial_in_buffer);
+      (Settings.flag.mqtt_serial_raw) ? ToHex_P((unsigned char*)serial_in_buffer, serial_in_byte_counter, hex_char, sizeof(hex_char)) : serial_in_buffer);
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_SERIALRECEIVED));
     XdrvRulesProcess();
     serial_in_byte_counter = 0;

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -42,7 +42,7 @@ void WifiWpsStatusCallback(wps_cb_status status);
 void KNX_CB_Action(message_t const &msg, void *arg);
 //#endif  // USE_KNX
 
-char* ToHex(unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween = '\0');
+char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween = '\0');
 
 /*********************************************************************************************\
  * Default global defines

--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -293,19 +293,19 @@ char* ulltoa(unsigned long long value, char *str, int radix)
 }
 
 // see https://stackoverflow.com/questions/6357031/how-do-you-convert-a-byte-array-to-a-hexadecimal-string-in-c
-// char* ToHex(unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween = '\0'); in sonoff_post.h
-char* ToHex(unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween)
+// char* ToHex_P(unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween = '\0'); in sonoff_post.h
+char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, char inbetween)
 {
-  // ToHex(in, insz, out, outz)      -> "12345667"
-  // ToHex(in, insz, out, outz, ' ') -> "12 34 56 67"
-  // ToHex(in, insz, out, outz, ':') -> "12:34:56:67"
+  // ToHex_P(in, insz, out, outz)      -> "12345667"
+  // ToHex_P(in, insz, out, outz, ' ') -> "12 34 56 67"
+  // ToHex_P(in, insz, out, outz, ':') -> "12:34:56:67"
   static const char * hex = "0123456789ABCDEF";
   int between = (inbetween) ? 3 : 2;
-  unsigned char * pin = in;
+  const unsigned char * pin = in;
   char * pout = out;
   for (; pin < in+insz; pout += between, pin++) {
-    pout[0] = hex[(*pin>>4) & 0xF];
-    pout[1] = hex[ *pin     & 0xF];
+    pout[0] = hex[(pgm_read_byte(pin)>>4) & 0xF];
+    pout[1] = hex[ pgm_read_byte(pin)     & 0xF];
     if (inbetween) { pout[2] = inbetween; }
     if (pout + 3 - out > outsz) { break; }  // Better to truncate output string than overflow buffer
   }
@@ -1554,11 +1554,11 @@ void AddLogBuffer(uint32_t loglevel, uint8_t *buffer, uint32_t count)
 */
 /*
   strcpy_P(log_data, PSTR("DMP: "));
-  ToHex(buffer, count, log_data + strlen(log_data), sizeof(log_data) - strlen(log_data), ' ');
+  ToHex_P(buffer, count, log_data + strlen(log_data), sizeof(log_data) - strlen(log_data), ' ');
   AddLog(loglevel);
 */
   char hex_char[count * 3];
-  AddLog_P2(loglevel, PSTR("DMP: %s"), ToHex(buffer, count, hex_char, sizeof(hex_char), ' '));
+  AddLog_P2(loglevel, PSTR("DMP: %s"), ToHex_P(buffer, count, hex_char, sizeof(hex_char), ' '));
 }
 
 void AddLogSerial(uint32_t loglevel)

--- a/sonoff/support_command.ino
+++ b/sonoff/support_command.ino
@@ -326,7 +326,7 @@ void CmndStatus(void)
                           D_JSON_RESOLUTION "\":\"%08X\",\"" D_CMND_SETOPTION "\":[\"%08X\",\"%s\",\"%08X\"]}}"),
                           Settings.seriallog_level, Settings.weblog_level, Settings.syslog_level,
                           Settings.syslog_host, Settings.syslog_port, Settings.sta_ssid[0], Settings.sta_ssid[1], Settings.tele_period,
-                          Settings.flag2.data, Settings.flag.data, ToHex((unsigned char*)Settings.param, PARAM8_SIZE, stemp2, sizeof(stemp2)), Settings.flag3.data);
+                          Settings.flag2.data, Settings.flag.data, ToHex_P((unsigned char*)Settings.param, PARAM8_SIZE, stemp2, sizeof(stemp2)), Settings.flag3.data);
     MqttPublishPrefixTopic_P(option, PSTR(D_CMND_STATUS "3"));
   }
 

--- a/sonoff/support_wifi.ino
+++ b/sonoff/support_wifi.ino
@@ -329,7 +329,7 @@ void WifiBeginAfterScan()
           (known) ? (j) ? '2' : '1' : '-',
           ssid_scan.c_str(),
           chan_scan,
-          ToHex((unsigned char*)bssid_scan, 6, hex_char, sizeof(hex_char), ':'),
+          ToHex_P((unsigned char*)bssid_scan, 6, hex_char, sizeof(hex_char), ':'),
           rssi_scan,
           (sec_scan == ENC_TYPE_NONE) ? 0 : 1);
         delay(0);

--- a/sonoff/xdrv_02_mqtt.ino
+++ b/sonoff/xdrv_02_mqtt.ino
@@ -620,7 +620,7 @@ void MqttReconnect(void)
 #ifndef USE_MQTT_TLS_CA_CERT  // don't bother with fingerprints if using CA validation
     // create a printable version of the fingerprint received
     char buf_fingerprint[64];
-    ToHex((unsigned char *)tlsClient->getRecvPubKeyFingerprint(), 20, buf_fingerprint, sizeof(buf_fingerprint), ' ');
+    ToHex_P((unsigned char *)tlsClient->getRecvPubKeyFingerprint(), 20, buf_fingerprint, sizeof(buf_fingerprint), ' ');
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_MQTT "Server fingerprint: %s"), buf_fingerprint);
 
     if (learn_fingerprint1 || learn_fingerprint2) {
@@ -698,7 +698,7 @@ void CmndMqttFingerprint(void)
       }
       restart_flag = 2;
     }
-    ResponseCmndIdxChar(ToHex((unsigned char *)Settings.mqtt_fingerprint[XdrvMailbox.index -1], 20, fingerprint, sizeof(fingerprint), ' '));
+    ResponseCmndIdxChar(ToHex_P((unsigned char *)Settings.mqtt_fingerprint[XdrvMailbox.index -1], 20, fingerprint, sizeof(fingerprint), ' '));
   }
 }
 #endif

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -72,7 +72,7 @@ void SerialBridgeInput(void)
     serial_bridge_buffer[serial_bridge_in_byte_counter] = 0;                   // Serial data completed
     char hex_char[(serial_bridge_in_byte_counter * 2) + 2];
     Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":\"%s\"}"),
-      (serial_bridge_raw) ? ToHex((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)) : serial_bridge_buffer);
+      (serial_bridge_raw) ? ToHex_P((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)) : serial_bridge_buffer);
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
     XdrvRulesProcess();
     serial_bridge_in_byte_counter = 0;

--- a/sonoff/xdrv_23_zigbee.ino
+++ b/sonoff/xdrv_23_zigbee.ino
@@ -333,7 +333,7 @@ void ZigbeeInput(void)
   if (zigbee_in_byte_counter && (millis() > (zigbee_polling_window + ZIGBEE_POLLING))) {
     char hex_char[(zigbee_in_byte_counter * 2) + 2];
     Response_P(PSTR("{\"" D_JSON_ZIGBEEZNPRECEIVED "\":\"%s\"}"),
-      ToHex((unsigned char*)zigbee_buffer, zigbee_in_byte_counter, hex_char, sizeof(hex_char)));
+      ToHex_P((unsigned char*)zigbee_buffer, zigbee_in_byte_counter, hex_char, sizeof(hex_char)));
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZNPRECEIVED));
     XdrvRulesProcess();
     zigbee_in_byte_counter = 0;

--- a/sonoff/xsns_06_dht.ino
+++ b/sonoff/xsns_06_dht.ino
@@ -128,7 +128,7 @@ bool DhtRead(uint8_t sensor)
   if (dht_data[4] != checksum) {
     char hex_char[15];
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_DHT D_CHECKSUM_FAILURE " %s =? %02X"),
-      ToHex(dht_data, 5, hex_char, sizeof(hex_char), ' '), checksum);
+      ToHex_P(dht_data, 5, hex_char, sizeof(hex_char), ' '), checksum);
     return false;
   }
 

--- a/sonoff/xsns_20_novasds.ino
+++ b/sonoff/xsns_20_novasds.ino
@@ -82,7 +82,7 @@ bool NovaSdsCommand(uint8_t byte1, uint8_t byte2, uint8_t byte3, uint16_t sensor
   }
 
 //  char hex_char[60];
-//  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("SDS: Send %s"), ToHex((unsigned char*)novasds_cmnd, 19, hex_char, sizeof(hex_char), ' '));
+//  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("SDS: Send %s"), ToHex_P((unsigned char*)novasds_cmnd, 19, hex_char, sizeof(hex_char), ' '));
 
   // send cmnd
   NovaSdsSerial->write(novasds_cmnd, sizeof(novasds_cmnd));

--- a/sonoff/xsns_40_pn532.ino
+++ b/sonoff/xsns_40_pn532.ino
@@ -417,7 +417,7 @@ void PN532_ScanForTag(void)
       char card_datas[34];
 #endif // USE_PN532_DATA_FUNCTION
 
-      ToHex((unsigned char*)uid, uid_len, uids, sizeof(uids));
+      ToHex_P((unsigned char*)uid, uid_len, uids, sizeof(uids));
 
 #ifdef USE_PN532_DATA_FUNCTION
       if (uid_len == 4) { // Lets try to read block 1 of the mifare classic card for more information


### PR DESCRIPTION
## Description:

Theo, working on Zigbee I need ToHex to be PROGMEM compatible. Instead of duplicating code, I change all calls to ToHex_P. This change should have minimal impact on perf and code size.

I also changed input pointer to `const` type - no impact on code.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
