### PR TITLE
Tuya Dimmer: Make dimmer lower limit optional.

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -82,7 +82,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t tuya_dimmer_range_255 : 1;    // bit 16 (v6.6.0.1)  - SetOption66 - Enable or Disable Dimmer range 255 slider control
     uint32_t buzzer_enable : 1;            // bit 17 (v6.6.0.1)  - SetOption67 - Enable buzzer when available
     uint32_t pwm_multi_channels : 1;       // bit 18 (v6.6.0.3)  - SetOption68 - Enable multi-channels PWM instead of Color PWM
-    uint32_t spare19 : 1;
+    uint32_t tuya_dimmer_min_limit : 1;    // bit 19 (v6.6.0.5)  - SetOption69 - Limits Tuya dimmers to minimum of 10% (25) when enabled.
     uint32_t spare20 : 1;
     uint32_t spare21 : 1;
     uint32_t spare22 : 1;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -890,7 +890,6 @@ void SettingsDefaultSet2(void)
   Settings.light_pixels = WS2812_LEDS;
 //  Settings.light_rotation = 0;
   SettingsDefaultSet_5_8_1();    // Clock color
-  Settings.flag3.tuya_dimmer_min_limit = 1;
 
   // Display
   SettingsDefaultSet_5_10_1();   // Display settings

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -890,6 +890,7 @@ void SettingsDefaultSet2(void)
   Settings.light_pixels = WS2812_LEDS;
 //  Settings.light_rotation = 0;
   SettingsDefaultSet_5_8_1();    // Clock color
+  Settings.flag3.tuya_dimmer_min_limit = 1;
 
   // Display
   SettingsDefaultSet_5_10_1();   // Display settings

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -143,7 +143,9 @@ bool TuyaSetChannels(void)
 void LightSerialDuty(uint8_t duty)
 {
   if (duty > 0 && !tuya_ignore_dim && TuyaSerial) {
-    if (duty < 25) { duty = 25; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
+    if (Settings.flag3.tuya_dimmer_min_limit) { // Enable dimming limit SetOption69: Enabled by default
+      if (duty < 25) { duty = 25; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
+    }
 
     if (Settings.flag3.tuya_show_dimmer == 0) {
       if(Settings.flag3.tuya_dimmer_range_255 == 0) {


### PR DESCRIPTION
Not all Tuya dimmers have a lower limit of 10% (25)

## Description:

Not all Tuya dimmers have a lower limit of 10% (25). So making it configurable.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
