### PR TITLE
Fix #6247 and bug introduced in #6243

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -631,7 +631,7 @@ void MqttShowState(void)
 
   for (uint32_t i = 1; i <= devices_present; i++) {
 #ifdef USE_LIGHT
-    if (i >= light_device) {
+    if ((light_device) && (i >= light_device)) {
       if (i == light_device)  { LightState(1); }    // call it only once
     } else {
 #endif

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1643,10 +1643,10 @@ void LightState(uint8_t append)
       GetPowerDevice(scommand, light_device + i, sizeof(scommand), 1);
       uint32_t light_power_masked = light_power & (1 << i);    // the light_power value for this device
       light_power_masked = light_power_masked ? 1 : 0;                    // convert to on/off
-      ResponseAppend_P(PSTR("\"%s\":\"%s\",\"" D_CMND_CHANNEL "%d\":%d"), scommand, GetStateText(light_power_masked), light_device + i,
+      ResponseAppend_P(PSTR("\"%s\":\"%s\",\"" D_CMND_CHANNEL "%d\":%d,"), scommand, GetStateText(light_power_masked), light_device + i,
         changeUIntScale(light_current_color[i], 0, 255, 0, 100));
     }
-    ResponseAppend_P(PSTR(",\"" D_CMND_COLOR "\":\"%s\""), LightGetColor(scolor));
+    ResponseAppend_P(PSTR("\"" D_CMND_COLOR "\":\"%s\""), LightGetColor(scolor));
   }   // light_pwm_multi_channels
 
   if (!append) {


### PR DESCRIPTION
## Description:

Two bugs introduced by #6243

- Comma missing in JSON output between channel outputs
- Power would not be reported in telemetry if no PWM is present

**Related issue (if applicable):** fixes #6247 and #6191 via #6243

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
