### PR TITLE
Container to build all or custom builds with one run.

### DIFF
--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:2
+
+LABEL author="Eduard Angold"
+
+# Install platformio. To be able to build tasmota <=v6.6.0 (and later)
+# we have to use version 3.6.7 of platformio.
+RUN pip install --upgrade pip &&\ 
+    pip install -U platformio==3.6.7
+
+# Init project
+COPY init_pio_tasmota /init_pio_tasmota
+
+# Install project dependencies using a init project.
+RUN cd /init_pio_tasmota &&\ 
+    pio run &&\
+    cd ../ &&\ 
+    rm -fr init_pio_tasmota &&\ 
+    cp -r /root/.platformio / &&\ 
+    chmod -R 777 /.platformio
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
+

--- a/build-container/README.md
+++ b/build-container/README.md
@@ -1,0 +1,26 @@
+# Docker container for tasmota builds
+This Container will setup a proper build environment for [Sonoff-Tasmota](https://github.com/arendst/Sonoff-Tasmota)
+
+## Create container
+`docker build -t mytasmota:latest .`
+
+## Use a ready container from docker hub
+Use instead of the container `mytasmota:latest` the published container `eddyhub/docker-tasmota:latest` from docker hub.
+
+## Build all development binaries
+`git clone https://github.com/arendst/Sonoff-Tasmota.git`
+`docker run -ti --rm -v $(pwd)/Sonoff-Tasmota:/tasmota -u $UID:$GID mytasmota:latest`
+
+## Build a specific binary with custom options
+Checkout Sonoff-Tasmota: `git clone https://github.com/arendst/Sonoff-Tasmota.git`
+Mount the source as volume in `/tasmota`. **Prefix** any parameter available in `Sonoff-Tasmota/sonoff/my_user_config.h` with `TASMOTA_` as a environment variable for the container. **Also don't forget to escape what needs to be escaped in your shell.** **Strings** should be in **double quotes**. My config example:
+`docker run -ti --rm -v $(pwd)/Sonoff-Tasmota:/tasmota -e TASMOTA_STA_SSID1='"my-wifi"' -e TASMOTA_STA_PASS1='"my-wifi-password"' -e TASMOTA_MQTT_HOST='my-mqtt-host' -e TASMOTA_MQTT_USER='"my-mqtt-user"' -e TASMOTA_MQTT_PASS='"my-mqtt-password"' -e TASMOTA_WEB_PASSWORD='"my-web-password"' -u $UID:$GID mytasmota:latest --environment sonoff-DE
+
+Now you should have the file Sonoff-Tasmota/.pioenvs/sonoff-DE/firmware.bin which can be flashed on your device.
+
+## Build a specific version of tasmota
+Checkout out the needed version before using the build instructions above:
+- `git clone https://github.com/arendst/Sonoff-Tasmota.git`
+- `git -C Sonoff-Tasmota checkout v6.6.0`
+Build it:
+- `docker run -ti --rm -v $(pwd)/Sonoff-Tasmota:/tasmota -u $UID:$GID mytasmota:latest`

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -1,0 +1,35 @@
+# configure build via environment
+#!/bin/bash
+
+TASMOTA_VOLUME='/tasmota'
+USER_CONFIG_OVERRIDE="${TASMOTA_VOLUME}/sonoff/user_config_override.h"
+
+if [ -d $TASMOTA_VOLUME ]; then
+	cd $TASMOTA_VOLUME
+	if [ -n "$(env | grep ^TASMOTA_)" ]; then
+		echo "Removing $USER_CONFIG_OVERRIDE and creating a new one."
+		rm "$USER_CONFIG_OVERRIDE"
+		#export PLATFORMIO_BUILD_FLAGS='-DUSE_CONFIG_OVERRIDE'
+		sed -i 's/^; *-DUSE_CONFIG_OVERRIDE/                            -DUSE_CONFIG_OVERRIDE/' platformio.ini
+		echo '#ifndef _USER_CONFIG_OVERRIDE_H_' >> $USER_CONFIG_OVERRIDE
+		echo '#define _USER_CONFIG_OVERRIDE_H_' >> $USER_CONFIG_OVERRIDE
+		echo '#warning **** user_config_override.h: Using Settings from this File ****' >> $USER_CONFIG_OVERRIDE	
+		echo '#undef CFG_HOLDER' >> $USER_CONFIG_OVERRIDE
+		echo '#define CFG_HOLDER	1' >> $USER_CONFIG_OVERRIDE
+		for i in $(env | grep ^TASMOTA_); do
+			config=${i#TASMOTA_}
+			key=$(echo $config | cut -d '=' -f 1)
+			value=$(echo $config | cut -d '=' -f 2)
+			echo "#undef ${key}" >> $USER_CONFIG_OVERRIDE
+			echo "#define ${key}	${value}" >> $USER_CONFIG_OVERRIDE
+		done
+		echo '#endif' >> $USER_CONFIG_OVERRIDE
+	fi
+	echo "Compiling..."
+	#pio run -t clean
+	pio run $@
+	echo "Everything done you find your builds in .pioenvs/<build-flavour>/firmware.bin"
+else
+	echo ">>> NO TASMOTA VOLUME MOUNTED --> EXITING"
+	exit 0;
+fi

--- a/build-container/init_pio_tasmota/platformio.ini
+++ b/build-container/init_pio_tasmota/platformio.ini
@@ -1,0 +1,30 @@
+[env:core_2_3_0]
+; *** Esp8266 core for Arduino version 2.3.0
+platform                  = espressif8266@1.5.0
+framework                 = arduino
+board                     = esp01_1m
+
+[env:core_2_4_2]
+; *** Esp8266 core for Arduino version 2.4.2
+platform                  = espressif8266@1.8.0
+framework                 = arduino
+board                     = esp01_1m
+
+[env:core_2_5_2]
+; *** Esp8266 core for Arduino version 2.5.2
+platform                  = espressif8266@~2.2.2
+framework                 = arduino
+board                     = esp01_1m
+
+[env:core_stage]
+; *** Esp8266 core for Arduino version latest beta
+platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
+framework                 = arduino
+board                     = esp01_1m
+
+[env:core_pre]
+; *** Arduino Esp8266 core pre 2.6.x for Tasmota (mqtt reconnects fixed)
+platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
+framework                 = arduino
+board                     = esp01_1m
+

--- a/build-container/init_pio_tasmota/src/main.cpp
+++ b/build-container/init_pio_tasmota/src/main.cpp
@@ -1,0 +1,3 @@
+#include <Arduino.h>
+void setup() {}
+void loop() {}


### PR DESCRIPTION
## Description:
Container to build all or custom builds with one run. No IDE, no python or platformio needed. Install docker, build the container on your machine or use the one already published on docker hub and start building customized firmware. See README.md for more information.

I just needed a simple solution to build some binaries without setting up python or platformio on my build machine. Maybe you find this addition useful. It is also possible to add esptool to flash the generated firmware to the device, but I would add this feature later.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
