### PR TITLE
Renamed HTTP_HEAD to HTTP_HEADER

### DIFF
--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -48,7 +48,7 @@ enum UploadTypes { UPL_TASMOTA, UPL_SETTINGS, UPL_EFM8BB1 };
 
 static const char * HEADER_KEYS[] = { "User-Agent", };
 
-const char HTTP_HEAD[] PROGMEM =
+const char HTTP_HEADER[] PROGMEM =
   "<!DOCTYPE html><html lang=\"" D_HTML_LANGUAGE "\" class=\"\">"
   "<head>"
   "<meta charset='utf-8'>"
@@ -753,7 +753,7 @@ void WSContentStart_P(const char* title, bool auth)
   if (title != nullptr) {
     char ctitle[strlen_P(title) +1];
     strcpy_P(ctitle, title);                       // Get title from flash to RAM
-    WSContentSend_P(HTTP_HEAD, Settings.friendlyname[0], ctitle);
+    WSContentSend_P(HTTP_HEADER, Settings.friendlyname[0], ctitle);
   }
 }
 


### PR DESCRIPTION
## Description:

Renamed `HTTP_HEAD` to `HTTP_HEADER` to avoid a conflict with latest Arduino Core, commit https://github.com/esp8266/Arduino/commit/0dbb04e88183f5304d1ade9b60058e16e4f9a252

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
