### PR TITLE
Initial DALI bus support

### DIFF
--- a/lib/DALI/Dali.cpp
+++ b/lib/DALI/Dali.cpp
@@ -1,0 +1,517 @@
+
+#include "Dali.h"
+
+
+
+Dali::Dali() //constructor
+{
+  applyWorkAround1Mhz = 0;
+}
+
+
+void Dali::setTxPin(uint8_t pin)
+{
+  TxPin = pin; // user sets the digital pin as output
+  pinMode(TxPin, OUTPUT); 
+  digitalWrite(TxPin, HIGH);
+}
+
+void Dali::setRxAnalogPin(uint8_t pin)
+{
+	RxAnalogPin = pin; // user sets the digital pin as output
+}
+
+void Dali::workAround1MhzTinyCore(uint8_t a)
+{
+  applyWorkAround1Mhz = a;
+}
+
+void Dali::setupAnalogReceive(uint8_t pin) 
+{
+	setRxAnalogPin(pin); // user sets the analog pin as input
+}
+
+
+void Dali::setupTransmit(uint8_t pin)
+{
+  setTxPin(pin);
+  speedFactor = 2;
+  //we don't use exact calculation of passed time spent outside of transmitter
+  //because of high ovehead associated with it, instead we use this 
+  //emprirically determined values to compensate for the time loss
+  
+  #if F_CPU == 1000000UL
+    uint16_t compensationFactor = 88; //must be divisible by 8 for workaround
+  #elif F_CPU == 8000000UL
+    uint16_t compensationFactor = 12; 
+  #else //16000000Mhz
+    uint16_t compensationFactor = 4; 
+  #endif  
+
+#if (F_CPU == 80000000UL) || (F_CPU == 160000000)   // ESP8266 80MHz or 160 MHz
+  delay1 = delay2 = (HALF_BIT_INTERVAL >> speedFactor) - 2;
+#else
+  delay1 = (HALF_BIT_INTERVAL >> speedFactor) - compensationFactor;
+  delay2 = (HALF_BIT_INTERVAL >> speedFactor) - 2;
+  period = delay1 + delay2;
+  
+  #if F_CPU == 1000000UL
+    delay2 -= 22; //22+2 = 24 is divisible by 8
+    if (applyWorkAround1Mhz) { //definition of micro delay is broken for 1MHz speed in tiny cores as of now (May 2013)
+      //this is a workaround that will allow us to transmit on 1Mhz
+      //divide the wait time by 8
+      delay1 >>= 3;
+      delay2 >>= 3;
+    }
+  #endif
+#endif
+
+	}
+
+
+void Dali::transmit(uint8_t cmd1, uint8_t cmd2) // transmit commands to DALI bus (address byte, command byte)
+{
+	sendBit(1);
+	sendByte(cmd1);
+	sendByte(cmd2);
+	digitalWrite(TxPin, HIGH);
+}
+
+
+void Dali::sendByte(uint8_t b) 
+{
+	for (int i = 7; i >= 0; i--) 
+	{
+		sendBit((b >> i) & 1);
+	}
+}
+
+
+void Dali::sendBit(int b) 
+{		
+ if (b) {
+		sendOne();
+	}
+	else {
+		sendZero();
+	} 
+}
+
+
+void Dali::sendZero(void)
+{
+  digitalWrite(TxPin, HIGH);
+  delayMicroseconds(delay2);
+  digitalWrite(TxPin, LOW);
+  delayMicroseconds(delay1);
+
+}
+
+
+void Dali::sendOne(void)
+{
+  digitalWrite(TxPin, LOW);
+  delayMicroseconds(delay2);
+  digitalWrite(TxPin, HIGH);
+  delayMicroseconds(delay1);
+}
+
+
+void Dali::busTest() //DALI bus test
+{
+	int maxLevel;
+	int minLevel;
+	
+	//Luminaries must turn on and turn off. If not, check connection.
+	delay(100);
+	dali.transmit(BROADCAST_C, OFF_C); //Broadcast ON
+	delay(500);
+	dali.transmit(BROADCAST_C, ON_C); //Broadcast OFF
+	delay(100);
+	while (!Serial);
+	
+	//Receive response from luminaries: max and min level
+	dali.transmit(BROADCAST_C, QUERY_STATUS);
+	maxLevel = dali.maxResponseLevel();
+	dali.transmit(BROADCAST_C, QUERY_STATUS);
+	minLevel = dali.minResponseLevel();
+
+	if (dali.msgMode) {
+		Serial.print("Min Level: ");
+		Serial.print(minLevel);
+		Serial.println();
+		Serial.print("Max Level: ");
+		Serial.print(maxLevel);
+		Serial.println();
+	}
+
+	dali.analogLevel = (int)(maxLevel + minLevel) / 2;
+	
+}
+
+
+void Dali::splitAdd(long input, uint8_t &highbyte, uint8_t &middlebyte, uint8_t &lowbyte) 
+{
+	highbyte = input >> 16;
+	middlebyte = input >> 8;
+	lowbyte = input;
+}
+
+
+
+// define min response level
+int Dali::minResponseLevel() 
+{
+
+	const uint8_t dalistep = 40; //us
+	uint16_t rxmin = 1024;
+	uint16_t dalidata;
+	long idalistep;
+
+	
+	
+	for (idalistep = 0; idalistep < dali.daliTimeout; idalistep = idalistep + dalistep) {
+		dalidata = analogRead(RxAnalogPin);
+		if (dalidata < rxmin) {
+			rxmin = dalidata;
+		};
+		delayMicroseconds(dalistep);
+	}
+	return rxmin; 
+}
+
+// define max response level
+int Dali::maxResponseLevel() 
+{
+
+	const uint8_t dalistep = 40; //us
+	uint16_t rxmax = 0;
+	uint16_t dalidata;
+	long idalistep;
+
+	
+	for (idalistep = 0; idalistep < dali.daliTimeout; idalistep = idalistep + dalistep) {
+		dalidata = analogRead(dali.RxAnalogPin);
+		if (dalidata > rxmax) {
+			rxmax = dalidata;
+		};
+		delayMicroseconds(dalistep);
+	}
+	return rxmax;
+}
+
+
+//scan for individual short address
+void Dali::scanShortAdd()
+{
+
+	const int delayTime = 10;
+	const uint8_t start_ind_adress = 0;
+	const uint8_t finish_ind_adress = 127;
+	uint8_t add_byte;
+	uint8_t device_short_add;
+	uint8_t response;
+		
+	dali.transmit(BROADCAST_C, OFF_C); // Broadcast Off
+	delay(delayTime);
+	
+	if (dali.msgMode) {
+		Serial.println("Short addresses:");
+	}
+
+	for (device_short_add = start_ind_adress; device_short_add <= 63; device_short_add++) {
+
+		add_byte = 1 + (device_short_add << 1); // convert short address to address byte
+		
+		
+		dali.transmit(add_byte, 0xA1);
+		
+		response = dali.receive();
+
+		// makes it better?
+		delay(100);
+		
+		if (dali.getResponse) {
+			
+			dali.transmit(add_byte, ON_C); // switch on
+			delay(1000);
+			dali.transmit(add_byte, OFF_C); // switch off
+			delay(1000);
+
+		}
+		else {
+			response = 0;
+		}
+
+		
+		
+		if (dali.msgMode) {
+			Serial.print("BIN: ");
+			Serial.print(device_short_add, BIN);
+			Serial.print(" ");
+			Serial.print("DEC: ");
+			Serial.print(device_short_add, DEC);
+			Serial.print(" ");
+			Serial.print("HEX: ");
+			Serial.print(device_short_add, HEX);
+			Serial.print(" ");
+			if (dali.getResponse) {
+				Serial.print("Get response");
+			}
+			else {
+				Serial.print("No response");
+			}
+			Serial.println();
+		}
+		else {
+			if (dali.getResponse) {
+				Serial.println(255, BIN);
+			}
+			else {
+				Serial.println(0, BIN);
+			}
+			
+		}
+
+	}
+
+	dali.transmit(BROADCAST_C, ON_C); // Broadcast On
+	Serial.println();
+	delay(delayTime);
+
+}
+
+
+int Dali::readBinaryString(const char *s) 
+{
+	int result = 0;
+	while (*s) {
+		result <<= 1;
+		if (*s++ == '1') result |= 1;
+	}
+	return result;
+}
+
+
+bool Dali::cmdCheck(String & input, int & cmd1, int & cmd2) 
+{
+	bool test = true;
+
+	input.replace(" ", "");   // Delete spaces
+
+	if (input.length() != 16) {
+		test = false; //check if command contain 16bit
+	}
+	else {
+		for (int i = 0; i <= input.length() - 1; i++) {
+			if ((int)input.charAt(i) == 49 or (int)input.charAt(i) == 48) {}
+			else {
+				test = false;
+			};
+		};
+	};
+
+	if (test) {
+		cmd1 = readBinaryString(input.substring(0, 8).c_str());
+		cmd2 = readBinaryString(input.substring(8, 16).c_str());
+	}
+
+	return test;
+}
+
+void Dali::initialisation() {
+
+	const int delaytime = 10; //ms
+
+	long low_longadd = 0x000000;
+	long high_longadd = 0xFFFFFF;
+	long longadd = (long)(low_longadd + high_longadd) / 2;
+	uint8_t highbyte;
+	uint8_t middlebyte;
+	uint8_t lowbyte;
+	uint8_t short_add = 0;
+	uint8_t cmd2;
+
+	delay(delaytime);
+	dali.transmit(BROADCAST_C, RESET);
+	delay(delaytime);
+	dali.transmit(BROADCAST_C, RESET);
+	delay(delaytime);
+	dali.transmit(BROADCAST_C, OFF_C);
+	delay(delaytime);
+	dali.transmit(0b10100101, 0b00000000); //initialise
+	delay(delaytime);
+	dali.transmit(0b10100101, 0b00000000); //initialise
+	delay(delaytime);
+	dali.transmit(0b10100111, 0b00000000); //randomise
+	delay(delaytime);
+	dali.transmit(0b10100111, 0b00000000); //randomise
+
+	if (dali.msgMode) {
+		Serial.println("Searching fo long addresses:");
+	}
+
+	while (longadd <= 0xFFFFFF - 2 and short_add <= 64) {
+		while ((high_longadd - low_longadd) > 1) {
+
+			dali.splitAdd(longadd, highbyte, middlebyte, lowbyte); //divide 24bit adress into three 8bit adresses
+			delay(delaytime);
+			dali.transmit(0b10110001, highbyte); //search HB
+			delay(delaytime);
+			dali.transmit(0b10110011, middlebyte); //search MB
+			delay(delaytime);
+			dali.transmit(0b10110101, lowbyte); //search LB
+			delay(delaytime);
+			dali.transmit(0b10101001, 0b00000000); //compare
+			
+			if (minResponseLevel() > dali.analogLevel) 
+			{
+				low_longadd = longadd;
+			}
+			else 
+			{
+				high_longadd = longadd;
+			}
+			
+			longadd = (low_longadd + high_longadd) / 2; //center
+
+			if (dali.msgMode) {
+				Serial.print("BIN: ");
+				Serial.print(longadd + 1, BIN);
+				Serial.print(" ");
+				Serial.print("DEC: ");
+				Serial.print(longadd + 1, DEC);
+				Serial.print(" ");
+				Serial.print("HEX: ");
+				Serial.print(longadd + 1, HEX);
+				Serial.println();
+			}
+			else {
+				Serial.println(longadd + 1);
+			}
+		} // second while
+
+
+		if (high_longadd != 0xFFFFFF) 
+		{
+			splitAdd(longadd + 1, highbyte, middlebyte, lowbyte);
+			dali.transmit(0b10110001, highbyte); //search HB
+			delay(delaytime);
+			dali.transmit(0b10110011, middlebyte); //search MB
+			delay(delaytime);
+			dali.transmit(0b10110101, lowbyte); //search LB
+			delay(delaytime);
+			dali.transmit(0b10110111, 1 + (short_add << 1)); //program short adress
+			delay(delaytime);
+			dali.transmit(0b10101011, 0b00000000); //withdraw
+			delay(delaytime);
+			dali.transmit(1 + (short_add << 1), ON_C);
+			delay(1000);
+			dali.transmit(1 + (short_add << 1), OFF_C);
+			delay(delaytime);
+			short_add++;
+
+			if (dali.msgMode) {	
+			Serial.println("Assigning a short address");
+			}
+
+			high_longadd = 0xFFFFFF;
+			longadd = (low_longadd + high_longadd) / 2;
+
+		}
+		else {
+			if (dali.msgMode) { 
+				Serial.println("End"); 
+			}
+		}
+	} // first while
+
+
+	dali.transmit(0b10100001, 0b00000000);  //terminate
+	dali.transmit(BROADCAST_C, ON_C);  //broadcast on
+}
+
+
+uint8_t Dali::receive() {
+
+
+	
+	unsigned long startFuncTime = 0;
+	bool previousLogicLevel = 1;
+	bool currentLogicLevel = 1;
+	uint8_t arrLength = 20;
+	int  timeArray[arrLength];
+	int i = 0;
+	int k = 0;
+	bool logicLevelArray[arrLength];
+	int response = 0;
+
+	dali.getResponse = false;
+	startFuncTime = micros();
+	
+	// add check for micros overlap here!!!
+
+	while (micros() - startFuncTime < dali.daliTimeout and i < arrLength)
+	{
+		// geting response
+		if (analogRead(dali.RxAnalogPin) > dali.analogLevel) {
+			currentLogicLevel = 1;
+		}
+		else {
+			currentLogicLevel = 0;
+		}
+
+		if (previousLogicLevel != currentLogicLevel) {
+			timeArray[i] = micros() - startFuncTime;
+			logicLevelArray[i] = currentLogicLevel;
+			previousLogicLevel = currentLogicLevel;
+			dali.getResponse = true;
+			i++;
+
+		}
+	}
+
+		
+	
+	arrLength = i;
+
+	//decoding to manchester
+	for (i = 0; i < arrLength - 1; i++) {
+		if ((timeArray[i + 1] - timeArray[i]) > 0.75 * dali.period) {
+			for (k = arrLength; k > i; k--) {
+				timeArray[k] = timeArray[k - 1];
+				logicLevelArray[k] = logicLevelArray[k - 1];
+			}
+			arrLength++;
+			timeArray[i + 1] = (timeArray[i] + timeArray[i + 2]) / 2;
+			logicLevelArray[i + 1] = logicLevelArray[i];
+		}
+	}
+
+
+
+
+
+	k = 8;
+
+	for (i = 1; i < arrLength; i++) {
+		if (logicLevelArray[i] == 1) {
+			if ((int)round((timeArray[i] - timeArray[0]) / (0.5 * dali.period)) & 1) {
+				response = response + (1 << k);
+			}
+			k--;
+		}
+	}
+
+	
+	//remove start bit
+	response = (uint8_t)response;
+	
+	return response;
+
+}
+
+
+
+
+	Dali dali;

--- a/lib/DALI/Dali.h
+++ b/lib/DALI/Dali.h
@@ -1,0 +1,119 @@
+
+
+#ifndef dali_h
+#define dali_h
+
+//timer scaling factors for different transmission speeds
+#define MAN_300 0
+#define MAN_600 1
+#define MAN_1200 2
+#define MAN_2400 3
+#define MAN_4800 4
+#define MAN_9600 5
+#define MAN_19200 6
+#define MAN_38400 7
+
+/*
+Timer 2 in the ATMega328 and Timer 1 in a ATtiny85 is used to find the time between
+each transition coming from the demodulation circuit.
+Their setup is for sampling the input in regular intervals.
+For practical reasons we use power of 2 timer prescaller for sampling, 
+for best timing we use pulse lenght as integer multiple of sampling speed.
+We chose to sample every 8 ticks, and pulse lenght of 48 ticks 
+thats 6 samples per pulse, lower sampling rate (3) will not work well for 
+innacurate clocks (like internal oscilator) higher sampling rate (12) will
+cause too much overhead and will not work at higher transmission speeds.
+This gives us 16000000Hz/48/256 = 1302 pulses per second (so it's not really 1200) 
+At different transmission speeds or on different microcontroller frequencies, clock prescaller is adjusted 
+to be compatible with those values. We allow about 50% clock speed difference both ways
+allowing us to transmit even with up to 100% in clock speed difference
+*/
+
+// DALI coomands
+#define BROADCAST_DP 0b11111110
+#define BROADCAST_C 0b11111111
+#define ON_DP 0b11111110
+#define OFF_DP 0b00000000
+#define ON_C 0b00000101
+#define OFF_C 0b00000000
+# define QUERY_STATUS 0b10010000
+# define RESET 0b00100000
+
+
+//setup timing for transmitter
+#define HALF_BIT_INTERVAL 1666 
+
+
+
+
+
+#if defined(ARDUINO) && ARDUINO >= 100
+  #include "Arduino.h"
+#else
+  #include "WProgram.h"
+  #include <pins_arduino.h>
+#endif
+
+class Dali
+{
+  public:
+	Dali(); //the constructor
+    void setTxPin(uint8_t pin); //set the arduino digital pin for transmit. 
+    void setRxAnalogPin(uint8_t pin); //set the arduino digital pin for receive.
+    void workAround1MhzTinyCore(uint8_t a = 1); //apply workaround for defect in tiny Core library for 1Mhz
+    void setupTransmit(uint8_t pin); //set up transmission
+	void setupAnalogReceive(uint8_t pin);
+    void transmit(uint8_t cmd1, uint8_t cmd2); //transmit 16 bits of data
+	void scanShortAdd(); //scan for short address
+	void busTest(); // bus test
+	void initialisation(); //initialization of new luminaries
+	bool cmdCheck(String & input, int & cmd1, int & cmd2);
+	uint8_t receive(); //get response
+
+	int minResponseLevel(); 
+	int maxResponseLevel();
+    
+    uint8_t speedFactor;
+    uint16_t delay1;
+    uint16_t delay2;
+	uint16_t period;
+	String errorMsg; //error message of last operation
+	bool msgMode; //0 - get only response from dali bus to COM; 1 - response with text (comments)
+	bool getResponse;
+	uint8_t RxAnalogPin;
+
+	long daliTimeout = 20000; //us, DALI response timeout
+	int analogLevel = 870; //analog border level (less - "0"; more - "1")
+	
+
+
+    
+  private:
+	
+	void sendByte(uint8_t b); //transmit 8 bits of data
+	void sendBit(int b); //transmit 1 bit of data
+	void sendZero(void); //transmit "0"
+    void sendOne(void); //transmit "1"
+   	void splitAdd(long input, uint8_t &highbyte, uint8_t &middlebyte, uint8_t &lowbyte); //split random address 
+	
+	
+	int readBinaryString(const char *s);
+
+	uint8_t TxPin;
+	
+    uint8_t applyWorkAround1Mhz;
+	uint8_t rxAnalogPin = 0;
+
+};//end of class Dali
+
+// Cant really do this as a real C++ class, since we need to have
+// an ISR
+extern "C"
+{
+    
+    
+   }
+
+extern Dali dali;
+
+#endif

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -586,6 +586,7 @@
 #define D_SENSOR_HRE_DATA      "HRE Data"
 #define D_SENSOR_ADE7953_IRQ   "ADE7953 IRQ"
 #define D_SENSOR_BUZZER        "Buzzer"
+#define D_SENSOR_DALI          "DALI"
 #define D_SENSOR_OLED_RESET    "OLED Reset"
 #define D_SENSOR_ZIGBEE_TXD    "Zigbee Tx"
 #define D_SENSOR_ZIGBEE_RXD    "Zigbee Rx"

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -311,6 +311,7 @@
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
 #define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
 #define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)
+#define USE_DALI                                 // Add DALI support
 //#define ROTARY_V1                                // Add support for MI Desk Lamp
 
 // -- Counter input -------------------------------

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -186,6 +186,8 @@ enum UserSelectablePins {
   GPIO_ARIRFSEL,       // Arilux RF Receive input selected
   GPIO_BUZZER,         // Buzzer
   GPIO_BUZZER_INV,     // Inverted buzzer
+  GPIO_DALI,           // DALI
+  GPIO_DALI_INV,       // Inverted DALI
   GPIO_OLED_RESET,     // OLED Display Reset
   GPIO_SOLAXX1_TX,     // Solax Inverter tx pin
   GPIO_SOLAXX1_RX,     // Solax Inverter rx pin
@@ -260,6 +262,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_LED_LINK "|" D_SENSOR_LED_LINK "i|"
   D_SENSOR_ARIRFSEL "|"
   D_SENSOR_BUZZER "|" D_SENSOR_BUZZER "i|"
+  D_SENSOR_DALI "|" D_SENSOR_DALI "i|"
   D_SENSOR_OLED_RESET "|"
   D_SENSOR_SOLAXX1_TX "|" D_SENSOR_SOLAXX1_RX "|"
   D_SENSOR_ZIGBEE_TXD "|" D_SENSOR_ZIGBEE_RXD "|"
@@ -493,6 +496,10 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_BUZZER
   GPIO_BUZZER,         // Buzzer
   GPIO_BUZZER_INV,     // Inverted buzzer
+#endif
+#ifdef USE_DALI
+  GPIO_DALI,           // DALI
+  GPIO_DALI_INV,       // Inverted DALI
 #endif
   GPIO_TXD,            // Serial interface
   GPIO_RXD,            // Serial interface

--- a/sonoff/xdrv_25_dali.ino
+++ b/sonoff/xdrv_25_dali.ino
@@ -1,0 +1,124 @@
+/*
+  xdrv_25_dali.ino - DALI support for Sonoff-Tasmota
+
+  Copyright (C) 2019  Stefan Agner
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_DALI
+/*********************************************************************************************\
+ * DALI (Digital Addressable Lighting Interface) support
+\*********************************************************************************************/
+
+#include <Dali.h>
+
+#define XDRV_25                    25
+
+enum ExecuteCommandDaliOptions { DALI_OFF, DALI_ON, DALI_BUS_TEST = 9 };
+
+struct DALI {
+  bool active = true;
+} Dali;
+
+/*********************************************************************************************/
+
+/*********************************************************************************************/
+
+void DaliInit(void)
+{
+  if (pin[GPIO_DALI] < 99) {
+    dali.setupTransmit(pin[GPIO_DALI]); //setup digital pin to transmit commands
+    AddLog_P2(LOG_LEVEL_INFO, PSTR("DALI: active on pin %d"), pin[GPIO_DALI]);
+    dali.msgMode = true;
+    //dali.busTest();
+    devices_present++;
+  } else {
+    Dali.active = false;
+  }
+}
+
+/*********************************************************************************************\
+ * Commands
+\*********************************************************************************************/
+
+const char kDaliCommands[] PROGMEM = "|"  // No prefix
+  "DALI" "|" "DALIDimmer" ;
+
+void (* const DaliCommand[])(void) PROGMEM = {
+  &CmndDali, &CmndDaliDimmer };
+
+void CmndDali(void)
+{
+
+  // DALI commands
+  //
+  // DALI off or 0    = DALI broadcast all off
+  // DALI on or 1     = DALI broadcast all on
+  // DALI 9           = Bus Test
+  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= devices_present)) {
+    AddLog_P2(LOG_LEVEL_INFO, PSTR("DALI: idx %d, payload %d"), XdrvMailbox.index, XdrvMailbox.payload);
+    switch (XdrvMailbox.payload) {
+    case DALI_OFF:
+      dali.transmit(BROADCAST_C, OFF_C);
+      break;
+    case DALI_ON:
+      dali.transmit(BROADCAST_C, ON_C);
+      break;
+    case DALI_BUS_TEST:
+      dali.transmit(BROADCAST_C, ON_C);
+      break;
+    }
+  }
+
+  ResponseCmndDone();
+}
+
+void CmndDaliDimmer(void)
+{
+
+  // DALI commands
+  //
+  // DALI 0..254     = DALI brightness control
+  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= devices_present)) {
+    if (XdrvMailbox.payload > 254) { XdrvMailbox.payload = 254; }
+    AddLog_P2(LOG_LEVEL_INFO, PSTR("DALI: idx %d, brightness %d"), XdrvMailbox.index, XdrvMailbox.payload);
+    dali.transmit(BROADCAST_DP, XdrvMailbox.payload);
+  }
+
+  ResponseCmndDone();
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv25(uint8_t function)
+{
+  bool result = false;
+
+  if (Dali.active) {
+    switch (function) {
+      case FUNC_COMMAND:
+        result = DecodeCommand(kDaliCommands, DaliCommand);
+        break;
+      case FUNC_PRE_INIT:
+        DaliInit();
+        break;
+    }
+  }
+  return result;
+}
+
+#endif  // USE_DALI


### PR DESCRIPTION
Initial support for DALI (Digital Addressable Lighting Interface) bus
support. Currently only two commands are implemented which send out
commands using bus broadcasts. This is sufficient to control a single
DALI capable device.

The DALI library has been borrowed from the Simple DALI Controller
project:
https://create.arduino.cc/projecthub/NabiyevTR/simple-dali-controller-506e44

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
