### PR TITLE
Fix: Tuya Switches are detected as dimmers.

### DIFF
--- a/sonoff/support_command.ino
+++ b/sonoff/support_command.ino
@@ -621,6 +621,9 @@ void CmndSetoption(void)
           if (18 == pindex) { // SetOption68 for multi-channel PWM, requires a reboot
             restart_flag = 2;
           }
+          if (15 == pindex) { // SetOption65 for tuya_show_dimmer requires a reboot
+            restart_flag = 2;
+          }
         }
       }
       else {                   // SetOption32 .. 49

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -942,9 +942,7 @@ void HandleRoot(void)
       if ((LST_COLDWARM == (light_type &7)) || (LST_RGBWC == (light_type &7))) {
         WSContentSend_P(HTTP_MSG_SLIDER1, LightGetColorTemp());
       }
-      if (!Settings.flag3.tuya_show_dimmer) {
-        WSContentSend_P(HTTP_MSG_SLIDER2, Settings.light_dimmer);
-      }
+      WSContentSend_P(HTTP_MSG_SLIDER2, Settings.light_dimmer);
     }
 #endif
     WSContentSend_P(HTTP_TABLE100);

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -291,7 +291,12 @@ bool TuyaModuleSelected(void)
     Settings.my_gp.io[3] = GPIO_TUYA_RX;
     restart_flag = 2;
   }
-  light_type = LT_SERIAL1;
+  if (Settings.flag3.tuya_show_dimmer == 0) {
+    light_type = LT_BASIC;
+  } else {
+    light_type = LT_SERIAL1;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Tuya switches are detected as dimmers even after setting SetOption65 to 0.
Currently SetOption65 just hides the dimmer from Web UI for Tuya switches with SetOption65 to 0 but they are advertised as dimmer to HASS.
With this change we mark the switch to LT_BASIC instead of dimmable when option 65 is set. Makes sure its just an On-off switch.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
