### PR TITLE
Fix Hue Emulation not responding on /resourcelinks, issue #6238

### DIFF
--- a/sonoff/xdrv_20_hue.ino
+++ b/sonoff/xdrv_20_hue.ino
@@ -719,6 +719,7 @@ void HandleHueApi(String *path)
   else if (path->endsWith("/sensors")) HueNotImplemented(path);
   else if (path->endsWith("/scenes")) HueNotImplemented(path);
   else if (path->endsWith("/rules")) HueNotImplemented(path);
+  else if (path->endsWith("/resourcelinks")) HueNotImplemented(path);
   else HueGlobalConfig(path);
 }
 


### PR DESCRIPTION
## Description:

Responding to `/resourcelinks` Hue API to make homebridge-hue work with Tasmota. See https://github.com/ebaauw/homebridge-hue/issues/512

**Related issue (if applicable):** fixes #6238 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
