### PR TITLE
Tuya serial dimmer and switch fixes

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -78,7 +78,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t no_hold_retain : 1;           // bit 12 (v6.4.1.19) - SetOption62 - Don't use retain flag on HOLD messages
     uint32_t no_power_feedback : 1;        // bit 13 (v6.5.0.9)  - SetOption63 - Don't scan relay power state at restart
     uint32_t use_underscore : 1;           // bit 14 (v6.5.0.12) - SetOption64 - Enable "_" instead of "-" as sensor index separator
-    uint32_t tuya_show_dimmer : 1;		     // bit 15 (v6.5.0.15) - SetOption65 - Enable or Disable Dimmer slider control
+    uint32_t tuya_disable_dimmer : 1;      // bit 15 (v6.5.0.15) - SetOption65 - Enable or Disable Tuya Serial Dimmer control
     uint32_t tuya_dimmer_range_255 : 1;    // bit 16 (v6.6.0.1)  - SetOption66 - Enable or Disable Dimmer range 255 slider control
     uint32_t buzzer_enable : 1;            // bit 17 (v6.6.0.1)  - SetOption67 - Enable buzzer when available
     uint32_t pwm_multi_channels : 1;       // bit 18 (v6.6.0.3)  - SetOption68 - Enable multi-channels PWM instead of Color PWM

--- a/sonoff/support_command.ino
+++ b/sonoff/support_command.ino
@@ -621,6 +621,9 @@ void CmndSetoption(void)
           if (18 == pindex) { // SetOption68 for multi-channel PWM, requires a reboot
             restart_flag = 2;
           }
+          if (15 == pindex) { // SetOption65 for tuya_disable_dimmer requires a reboot
+            restart_flag = 2;
+          }
         }
       }
       else {                   // SetOption32 .. 49

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -942,7 +942,7 @@ void HandleRoot(void)
       if ((LST_COLDWARM == (light_type &7)) || (LST_RGBWC == (light_type &7))) {
         WSContentSend_P(HTTP_MSG_SLIDER1, LightGetColorTemp());
       }
-      if (!Settings.flag3.tuya_show_dimmer) {
+      if (!Settings.flag3.tuya_disable_dimmer) {
         WSContentSend_P(HTTP_MSG_SLIDER2, Settings.light_dimmer);
       }
     }

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -942,9 +942,7 @@ void HandleRoot(void)
       if ((LST_COLDWARM == (light_type &7)) || (LST_RGBWC == (light_type &7))) {
         WSContentSend_P(HTTP_MSG_SLIDER1, LightGetColorTemp());
       }
-      if (!Settings.flag3.tuya_disable_dimmer) {
-        WSContentSend_P(HTTP_MSG_SLIDER2, Settings.light_dimmer);
-      }
+      WSContentSend_P(HTTP_MSG_SLIDER2, Settings.light_dimmer);
     }
 #endif
     WSContentSend_P(HTTP_TABLE100);

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -291,7 +291,12 @@ bool TuyaModuleSelected(void)
     Settings.my_gp.io[3] = GPIO_TUYA_RX;
     restart_flag = 2;
   }
-  light_type = LT_SERIAL1;
+  if (Settings.flag3.tuya_disable_dimmer == 0) {
+    light_type = LT_SERIAL1;
+  } else {
+    light_type = LT_BASIC;
+  }
+
   return true;
 }
 

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -149,7 +149,7 @@ void LightSerialDuty(uint8_t duty)
       if (duty < 25) { duty = 25; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
     }
 
-    if (Settings.flag3.tuya_show_dimmer == 0) {
+    if (Settings.flag3.tuya_disable_dimmer == 0) {
       if(Settings.flag3.tuya_dimmer_range_255 == 0) {
         duty = changeUIntScale(duty, 0, 255, 0, 100);
       }
@@ -160,7 +160,7 @@ void LightSerialDuty(uint8_t duty)
     }
   } else {
     Tuya.ignore_dim = false;  // reset flag
-    if (Settings.flag3.tuya_show_dimmer == 0) {
+    if (Settings.flag3.tuya_disable_dimmer == 0) {
       if(Settings.flag3.tuya_dimmer_range_255 == 0) {
         duty = changeUIntScale(duty, 0, 255, 0, 100);
       }
@@ -216,7 +216,7 @@ void TuyaPacketProcess(void)
       else if (Tuya.buffer[5] == 8) {  // dim packet
 
         AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Dim State=%d"), Tuya.buffer[13]);
-        if (Settings.flag3.tuya_show_dimmer == 0) {
+        if (Settings.flag3.tuya_disable_dimmer == 0) {
           if (!Settings.param[P_TUYA_DIMMER_ID]) {
             AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Autoconfiguring Dimmer ID %d"), Tuya.buffer[6]);
             Settings.param[P_TUYA_DIMMER_ID] = Tuya.buffer[6];

--- a/sonoff/xdrv_16_tuyadimmer.ino
+++ b/sonoff/xdrv_16_tuyadimmer.ino
@@ -139,6 +139,7 @@ bool TuyaSetPower(void)
 bool TuyaSetChannels(void)
 {
   LightSerialDuty(((uint8_t*)XdrvMailbox.data)[0]);
+  delay(20); // Hack when power is off and dimmer is set then both commands go too soon to Serial out.
   return true;
 }
 


### PR DESCRIPTION
## Description:

This PR fixes current issues with Tuya Serial Dimmers and Switches. All the commits messages have explanation in detail about each change. The changes are

- Rename `tuya_show_dimmer` to `tuya_disable_dimmer` to make name same as the option functionality
- Fix Tuya serial switches are detected as dimmers even with `SetOption65 1`
- Fix Tuya dimmer doesn't switch on from HASS.

These changes are tested by myself on 

[MakeGood Tuya AC Dimmer](https://www.aliexpress.com/item/32663017309.html?spm=a2g0o.productlist.0.0.73f23c95NEMetl&algo_pvid=d31135d7-1791-4468-94d0-f0c75737a327&algo_expid=d31135d7-1791-4468-94d0-f0c75737a327-0&btsid=59a8e7b1-b52b-49d1-97c9-777d96025bbb&ws_ab_test=searchweb0_0,searchweb201602_6,searchweb201603_55)

[MakeGood Tuya 3 Gang Switch](https://www.aliexpress.com/item/32810617250.html?spm=a2g0o.productlist.0.0.73f23c95NEMetl&algo_pvid=d31135d7-1791-4468-94d0-f0c75737a327&algo_expid=d31135d7-1791-4468-94d0-f0c75737a327-3&btsid=59a8e7b1-b52b-49d1-97c9-777d96025bbb&ws_ab_test=searchweb0_0,searchweb201602_6,searchweb201603_55)

After these changes go in Wiki pages for `SetOption65` needs to be corrected and new details need to be added to Tuya Dimmer pages


**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
