### PR TITLE
Use pre 2.6 as default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -173,12 +173,12 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;build_flags               = ${core_2_3_0.build_flags}
 ;platform                  = ${core_2_4_2.platform}
 ;build_flags               = ${core_2_4_2.build_flags}
-platform                  = ${core_2_5_2.platform}
-build_flags               = ${core_2_5_2.build_flags}
+;platform                  = ${core_2_5_2.platform}
+;build_flags               = ${core_2_5_2.build_flags}
 ;platform                  = ${core_stage.platform}
 ;build_flags               = ${core_stage.build_flags}
-;platform                  = ${core_pre.platform}
-;build_flags               = ${core_pre.build_flags}
+platform                  = ${core_pre.platform}
+build_flags               = ${core_pre.build_flags}
 
 [common]
 framework                 = arduino


### PR DESCRIPTION
After some weeks of testing (and fixing the mqtt lag issue BIG THX @ascillato ) it is stated, pre 2.6 core is better than core 2.5.2.
The pre core 2.6 differs from main Arduino repo. Two additional PRs added (PR which frees >600 bytes iram and PR which fixes mqtt lag)  
Main benefit core pre 2.6. fixes mqtt reconnects of cores 2.4.x. and 2.5.x

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
