### PR TITLE
Parallelize Travis build and remove cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,40 @@ language: python
 python:
   - '2.7'
 sudo: false
-cache:
-  directories:
-    - "~/.platformio"
 install:
   - pip install -U platformio
 
+env:
+  - ENV=sonoff
+  - ENV=sonoff-minimal
+  - ENV=sonoff-basic
+  - ENV=sonoff-classic
+  - ENV=sonoff-knx
+  - ENV=sonoff-sensors
+  - ENV=sonoff-display
+  - ENV=sonoff-BG
+  - ENV=sonoff-BR
+  - ENV=sonoff-CN
+  - ENV=sonoff-CZ
+  - ENV=sonoff-DE
+  - ENV=sonoff-ES
+  - ENV=sonoff-FR
+  - ENV=sonoff-GR
+  - ENV=sonoff-HE
+  - ENV=sonoff-HU
+  - ENV=sonoff-IT
+  - ENV=sonoff-KO
+  - ENV=sonoff-NL
+  - ENV=sonoff-PL
+  - ENV=sonoff-PT
+  - ENV=sonoff-RU
+  - ENV=sonoff-SE
+  - ENV=sonoff-SK
+  - ENV=sonoff-TR
+  - ENV=sonoff-TW
+  - ENV=sonoff-UK
+
 script:
-  - platformio run
+  - platformio run -e $ENV
 before_deploy:
   - for file in .pioenvs/*/firmware.bin; do cp $file ${file%/*}.bin; done


### PR DESCRIPTION
## Description:

Parallelize Travis builds to speed up building on Travis CI when it has more free resources. This also makes build display better and easier to find out which environments failed.
Example : https://travis-ci.org/shantur/Sonoff-Tasmota/builds/577355846

Cons for this change is that new environment needs to be added .travis.yml file as well.

Also remove caching in Travis CI to reduce issues related to caches.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
