### PR TITLE
Add ability to change the receive buffer size in TasmotaSerial.

### DIFF
--- a/lib/TasmotaSerial-2.3.2/src/TasmotaSerial.h
+++ b/lib/TasmotaSerial-2.3.2/src/TasmotaSerial.h
@@ -38,7 +38,7 @@
 
 class TasmotaSerial : public Stream {
   public:
-    TasmotaSerial(int receive_pin, int transmit_pin, int hardware_fallback = 0,int nwmode = 0);
+    TasmotaSerial(int receive_pin, int transmit_pin, int hardware_fallback = 0,int nwmode = 0, int buffer_size = TM_SERIAL_BUFFER_SIZE);
     virtual ~TasmotaSerial();
 
     bool begin(long speed, int stop_bits = 1);
@@ -75,6 +75,7 @@ class TasmotaSerial : public Stream {
     unsigned int m_in_pos;
     unsigned int m_out_pos;
     uint8_t *m_buffer;
+    int serial_buffer_size;
 };
 
 #endif  // TasmotaSerial_h


### PR DESCRIPTION
## Description:

Zigbee needs to receive up to 256 bytes at 115200 baud, which sometimes ends up in a buffer overflow - as the event loop does not read serial buffer fast enough.

No change of the default buffer.

Theo, I understand from #1747 that there is no separate repo for TasmotaSerial. I don't know if you also want to bump the version number.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
