### PR TITLE
scripter update

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -682,6 +682,11 @@ bool MqttShowSensor(void)
     }
   }
   XsnsCall(FUNC_JSON_APPEND);
+
+#ifdef USE_SCRIPT_JSON_EXPORT
+  XdrvCall(FUNC_JSON_APPEND);
+#endif
+
   bool json_data_available = (strlen(mqtt_data) - json_data_start);
   if (strstr_P(mqtt_data, PSTR(D_JSON_PRESSURE)) != nullptr) {
     ResponseAppend_P(PSTR(",\"" D_JSON_PRESSURE_UNIT "\":\"%s\""), PressureUnit().c_str());

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -1050,6 +1050,9 @@ bool HandleRootStatusRefresh(void)
   WSContentBegin(200, CT_HTML);
   WSContentSend_P(PSTR("{t}"));
   XsnsCall(FUNC_WEB_SENSOR);
+#ifdef USE_SCRIPT_WEB_DISPLAY
+  XdrvCall(FUNC_WEB_SENSOR);
+#endif
   WSContentSend_P(PSTR("</table>"));
 
   if (devices_present) {


### PR DESCRIPTION
epoch,  web show, json export

system variable epoch added
epoch does not fit in float with seconds resolution 
therefore scripter epoch offsets to 2019.1.1 00:00
#define EPOCH_OFFSET 1546300800
now we have a second resolution with float epochs (also from json imports)

#define USE_SCRIPT_WEB_DISPLAY
enables a new section >W which displays script data in web ui main page
e.g.

\>W
variable var1 = {m} %var1%
variable var2 = {m} %var2%

#define USE_SCRIPT_JSON_EXPORT
enables a new section >J which enables json exports of script data
e.g.

\>J
,"temperature":%temp%,"tstring":"%tstring%"






## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).