### PR TITLE
Disable USE_DISCOVERY and USE_EMULATION in sonoff-ir, reducing code size by 30k

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -328,7 +328,8 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #define CODE_IMAGE 7
 
 #undef USE_EMULATION_HUE                      // disable Hue emulation - only for lights and relays
-//#undef USE_EMULATION_WEMO                     // disable Wemo emulation - only for relays
+#undef USE_EMULATION_WEMO                     // disable Wemo emulation - only for relays
+#undef USE_EMULATION
 
 //#undef USE_DOMOTICZ                           // Disable Domoticz
 //#undef USE_HOME_ASSISTANT                     // Disable Home Assistant
@@ -338,7 +339,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 //#undef USE_TIMERS_WEB                         // Disable support for timer webpage
 //#undef USE_SUNRISE                            // Disable support for Sunrise and sunset tools
 //#undef USE_RULES                              // Disable support for rules
-//#undef USE_DISCOVERY                            // Disable mDNS for the following services (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
+#undef USE_DISCOVERY                            // Disable mDNS for the following services (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
 
 // -- Optional modules -------------------------
 #undef USE_BUZZER                             // Disable support for a buzzer (+0k6 code)


### PR DESCRIPTION
## Description:

Disable `USE_DISCOVERY` and `USE_EMULATION` in `sonoff-ir`, reducing code size by 30k

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
