### PR TITLE
Fix wrong set of IR protocols with 'sonoff-ircustom'

### DIFF
--- a/lib/IRremoteESP8266-2.6.5/src/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266-2.6.5/src/IRremoteESP8266.h
@@ -58,7 +58,7 @@
 // The Air Conditioner protocols are the most expensive memory-wise.
 //
 
-#if defined(FIRMWARE_IR) || defined(FIRMWARE_IR_CUSTOM)   // full IR protocols
+#ifdef USE_IR_REMOTE_FULL   // full IR protocols
 #define DECODE_HASH            true  // Semi-unique code for unknown messages
 
 #define SEND_RAW               true


### PR DESCRIPTION
## Description:

#ifdefs were mixed up and 'sonoff-ircustom' was compiling with the incomplete set of protocols. Now fixed.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
