### PR TITLE
Move '#include user_config_override.h' in 'my_user_config.h'.

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -549,6 +549,10 @@
  * No user configurable items below
 \*********************************************************************************************/
 
+#ifdef USE_CONFIG_OVERRIDE
+  #include "user_config_override.h"         // Configuration overrides for my_user_config.h
+#endif
+
 #if defined(USE_DISCOVERY) && defined(USE_MQTT_AWS_IOT)
   #error "Select either USE_DISCOVERY or USE_MQTT_AWS_IOT, mDNS takes too much code space and is not needed for AWS IoT"
 #endif

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -30,9 +30,6 @@
 #include "sonoff_version.h"                 // Sonoff-Tasmota version information
 #include "sonoff.h"                         // Enumeration used in my_user_config.h
 #include "my_user_config.h"                 // Fixed user configurable options
-#ifdef USE_CONFIG_OVERRIDE
-  #include "user_config_override.h"         // Configuration overrides for my_user_config.h
-#endif
 #ifdef USE_MQTT_TLS
   #include <t_bearssl.h>                    // we need to include before "sonoff_post.h" to take precedence over the BearSSL version in Arduino
 #endif  // USE_MQTT_TLS


### PR DESCRIPTION
## Description:

Moved `#include user_config_override.h` at the end of `my_user_config.h` instead of inside `sonoff.ino`.
Benefit: allows user_config_override.h to change parameters like USE_MQTT_TLS.
Downside: generates 3 warnings instead of 1 when 

Theo, I don't see any wrong side effect for this, but I would like your advice on this one.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
