### PR TITLE
Tuya mcu support

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -444,6 +444,10 @@
 #define D_CMND_LATITUDE "Latitude"
 #define D_CMND_LONGITUDE "Longitude"
 
+// Commands xdrv_16_tuyadimmer.ino
+
+#define D_CMND_TUYA_MCU "TuyaMCU"
+
 // Commands xdrv_23_zigbee.ino
 #define D_CMND_ZIGBEEZNPSEND "ZigbeeZNPSend"
   #define D_JSON_ZIGBEEZNPRECEIVED "ZigbeeZNPReceived"

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -307,7 +307,7 @@
 // -- Optional modules ----------------------------
 #define USE_BUZZER                               // Add support for a buzzer (+0k6 code)
 #define USE_SONOFF_IFAN                          // Add support for Sonoff iFan02 and iFan03 (+2k code)
-#define USE_TUYA_DIMMER                          // Add support for Tuya Serial Dimmer
+#define USE_TUYA_MCU                             // Add support for Tuya Serial MCU
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
 #define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
 #define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -372,11 +372,9 @@ struct SYSCFG {
   uint16_t      web_refresh;               // 7CC
   char          mems[MAX_RULE_MEMS][10];   // 7CE
   char          rules[MAX_RULE_SETS][MAX_RULE_SIZE]; // 800 uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
-  uint8_t       data8[32];                 // E00
-  uint16_t      data16[16];                // E20
-  TuyaFnidDpidMap tuya_fnid_map[MAX_TUYA_FUNCTIONS];     // E40    32 bytes
+  TuyaFnidDpidMap tuya_fnid_map[MAX_TUYA_FUNCTIONS];  // E00    32 bytes
 
-  uint8_t       free_e20[416];             // E60
+  uint8_t       free_e20[480];             // E20
 
                                            // FFF last location
 } Settings;

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -185,6 +185,14 @@ typedef struct {
   uint32_t last_return_kWhtotal;
 } EnergyUsage;
 
+
+typedef struct {
+  uint8_t fnid = 0;
+  uint8_t dpid = 0;
+} TuyaFnidDpidMap;
+
+const uint8_t MAX_TUYA_FUNCTIONS = 16;
+
 /*
 struct SYSCFG {
   unsigned long cfg_holder;                // 000 Pre v6 header
@@ -366,8 +374,9 @@ struct SYSCFG {
   char          rules[MAX_RULE_SETS][MAX_RULE_SIZE]; // 800 uses 512 bytes in v5.12.0m, 3 x 512 bytes in v5.14.0b
   uint8_t       data8[32];                 // E00
   uint16_t      data16[16];                // E20
+  TuyaFnidDpidMap tuya_fnid_map[MAX_TUYA_FUNCTIONS];     // E40    32 bytes
 
-  uint8_t       free_e20[448];             // E40
+  uint8_t       free_e20[416];             // E60
 
                                            // FFF last location
 } Settings;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -1096,6 +1096,41 @@ void SettingsDelta(void)
       Settings.sbaudrate = Settings.ex_sbaudrate * 4;
     }
 
+    if (Settings.version < 0x0606000A) {
+      uint8_t tuyaindex = 0;
+      if (Settings.param[P_TUYA_DIMMER_ID] > 0) {
+        Settings.tuya_fnid_map[tuyaindex].fnid = 21; //TUYA_MCU_FUNC_DIMMER; // Move Tuya Dimmer Id to Map
+        Settings.tuya_fnid_map[tuyaindex].dpid = Settings.param[P_TUYA_DIMMER_ID];
+        tuyaindex++;
+      } else if (Settings.flag3.tuya_disable_dimmer == 1) {
+        Settings.tuya_fnid_map[tuyaindex].fnid = 11; //TUYA_MCU_FUNC_REL1; // Create FnID for Switches
+        Settings.tuya_fnid_map[tuyaindex].dpid = 1;
+        tuyaindex++;
+      }
+      if (Settings.param[P_TUYA_RELAYS] > 0) {
+        for (uint8_t i = 0 ; i < Settings.param[P_TUYA_RELAYS]; i++) {
+          Settings.tuya_fnid_map[tuyaindex].fnid = 12 + i; //TUYA_MCU_FUNC_REL2+; // Create FnID for Switches
+          Settings.tuya_fnid_map[tuyaindex].dpid = i + 2;
+          tuyaindex++;
+        }
+      }
+      if (Settings.param[P_TUYA_POWER_ID] > 0) {
+        Settings.tuya_fnid_map[tuyaindex].fnid = 31; //TUYA_MCU_FUNC_POWER; // Move Tuya Power Id to Map
+        Settings.tuya_fnid_map[tuyaindex].dpid = Settings.param[P_TUYA_POWER_ID];
+        tuyaindex++;
+      }
+      if (Settings.param[P_TUYA_VOLTAGE_ID] > 0) {
+        Settings.tuya_fnid_map[tuyaindex].fnid = 33; //TUYA_MCU_FUNC_VOLTAGE; // Move Tuya Voltage Id to Map
+        Settings.tuya_fnid_map[tuyaindex].dpid = Settings.param[P_TUYA_VOLTAGE_ID];
+        tuyaindex++;
+      }
+      if (Settings.param[P_TUYA_CURRENT_ID] > 0) {
+        Settings.tuya_fnid_map[tuyaindex].fnid = 32; //TUYA_MCU_FUNC_CURRENT; // Move Tuya Current Id to Map
+        Settings.tuya_fnid_map[tuyaindex].dpid = Settings.param[P_TUYA_CURRENT_ID];
+        tuyaindex++;
+      }
+
+    }
     Settings.version = VERSION;
     SettingsSave(1);
   }

--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -85,7 +85,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 
 // -- Optional modules -------------------------
 #define USE_SONOFF_IFAN                       // Add support for Sonoff iFan02 and iFan03 (+2k code)
-#define USE_TUYA_DIMMER                       // Add support for Tuya Serial Dimmer
+#define USE_TUYA_MCU                          // Add support for Tuya Serial MCU
 #ifndef TUYA_DIMMER_ID
   #define TUYA_DIMMER_ID       0              // Default dimmer Id
 #endif
@@ -217,7 +217,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 //#ifndef USE_SONOFF_IFAN
 #define USE_SONOFF_IFAN                       // Add support for Sonoff iFan02 and iFan03 (+2k code)
 //#endif
-#undef USE_TUYA_DIMMER                        // Disable support for Tuya Serial Dimmer
+#undef USE_TUYA_MCU                           // Disable support for Tuya Serial MCU
 #undef USE_ARMTRONIX_DIMMERS                  // Disable support for Armtronix Dimmers (+1k4 code)
 #undef USE_PS_16_DZ                           // Disable support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)
 #undef ROTARY_V1                              // Disable support for MI Desk Lamp
@@ -345,7 +345,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 // -- Optional modules -------------------------
 #undef USE_BUZZER                             // Disable support for a buzzer (+0k6 code)
 #undef USE_SONOFF_IFAN                        // Disable support for Sonoff iFan02 and iFan03 (+2k code)
-#undef USE_TUYA_DIMMER                        // Disable support for Tuya Serial Dimmer
+#undef USE_TUYA_MCU                           // Disable support for Tuya Serial MCU
 #undef USE_ARMTRONIX_DIMMERS                  // Disable support for Armtronix Dimmers (+1k4 code)
 #undef USE_PS_16_DZ                           // Disable support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)
 #undef USE_DS18x20                            // Disable Optional for more than one DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
@@ -436,7 +436,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 
 // -- Optional modules -------------------------
 #define USE_SONOFF_IFAN                       // Add support for Sonoff iFan02 and iFan03 (+2k code)
-//#undef USE_TUYA_DIMMER                        // Disable support for Tuya Serial Dimmer
+//#undef USE_TUYA_MCU                         // Disable support for Tuya Serial MCU
 #undef USE_ARMTRONIX_DIMMERS                  // Disable support for Armtronix Dimmers (+1k4 code)
 #undef USE_PS_16_DZ                           // Disable support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)
 #undef ROTARY_V1                              // Disable support for MI Desk Lamp
@@ -517,7 +517,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 
 // -- Optional modules -------------------------
 #undef USE_SONOFF_IFAN                        // Disable support for Sonoff iFan02 and iFan03 (+2k code)
-#undef USE_TUYA_DIMMER                        // Disable support for Tuya Serial Dimmer
+#undef USE_TUYA_MCU                           // Disable support for Tuya Serial MCU
 #undef USE_ARMTRONIX_DIMMERS                  // Disable support for Armtronix Dimmers (+1k4 code)
 #undef USE_PS_16_DZ                           // Disable support for PS-16-DZ Dimmer and Sonoff L1 (+2k code)
 #undef ROTARY_V1                              // Disable support for MI Desk Lamp

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -541,7 +541,7 @@ const uint8_t kGpioNiceList[] PROGMEM = {
   GPIO_SM16716_DAT,    // SM16716 DATA
   GPIO_SM16716_SEL,    // SM16716 SELECT
 #endif  // USE_SM16716
-#ifdef USE_TUYA_DIMMER
+#ifdef USE_TUYA_MCU
   GPIO_TUYA_TX,        // Tuya Serial interface
   GPIO_TUYA_RX,        // Tuya Serial interface
 #endif
@@ -749,7 +749,7 @@ const uint8_t kModuleNiceList[] PROGMEM = {
   OBI2,
   MANZOKU_EU_4,
   ESP_SWITCH,          // Switch Devices
-#ifdef USE_TUYA_DIMMER
+#ifdef USE_TUYA_MCU
   TUYA_DIMMER,         // Dimmer Devices
 #endif
 #ifdef USE_ARMTRONIX_DIMMERS
@@ -1728,7 +1728,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL1,        // GPIO14 Relay SRU 5VDC SDA (0 = Off, 1 = On )
      0, 0, 0
   },
-  { "Tuya Dimmer",     // Tuya Dimmer (ESP8266 w/ separate MCU dimmer)
+  { "Tuya MCU",     // Tuya MCU device (ESP8266 w/ separate MCU)
                        // https://www.amazon.com/gp/product/B07CTNSZZ8/ref=oh_aui_detailpage_o00_s00?ie=UTF8&psc=1
      GPIO_USER,        // Virtual Button (controlled by MCU)
      GPIO_USER,        // GPIO01 MCU serial control

--- a/sonoff/sonoff_version.h
+++ b/sonoff/sonoff_version.h
@@ -20,6 +20,6 @@
 #ifndef _SONOFF_VERSION_H_
 #define _SONOFF_VERSION_H_
 
-const uint32_t VERSION = 0x06060009;
+const uint32_t VERSION = 0x0606000A;
 
 #endif  // _SONOFF_VERSION_H_

--- a/sonoff/support_command.ino
+++ b/sonoff/support_command.ino
@@ -661,7 +661,7 @@ void CmndSetoption(void)
               IrReceiveUpdateThreshold();
               break;
 #endif
-#ifdef USE_TUYA_DIMMER
+#ifdef USE_TUYA_MCU
             case P_TUYA_RELAYS:
             case P_TUYA_POWER_ID:
             case P_TUYA_CURRENT_ID:

--- a/sonoff/support_features.ino
+++ b/sonoff/support_features.ino
@@ -171,7 +171,7 @@ void GetFeatures(void)
 #ifdef USE_PCA9685
   feature_drv2 |= 0x00004000;  // xdrv_15_pca9685.ino
 #endif
-#if defined(USE_LIGHT) && defined(USE_TUYA_DIMMER)
+#if defined(USE_LIGHT) && defined(USE_TUYA_MCU)
   feature_drv2 |= 0x00008000;  // xdrv_16_tuyadimmer.ino
 #endif
 #ifdef USE_RC_SWITCH

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -1,5 +1,5 @@
 /*
-  xdrv_16_tuyadimmer.ino - Tuya dimmer support for Sonoff-Tasmota
+  xdrv_16_tuyamcu.ino - Tuya MCU support for Sonoff-Tasmota
 
   Copyright (C) 2019  digiblur, Joel Stein and Theo Arends
 
@@ -18,7 +18,7 @@
 */
 
 #ifdef USE_LIGHT
-#ifdef USE_TUYA_DIMMER
+#ifdef USE_TUYA_MCU
 
 #define XDRV_16                16
 #define XNRG_08                8
@@ -640,5 +640,5 @@ bool Xdrv16(uint8_t function)
   return result;
 }
 
-#endif  // USE_TUYA_DIMMER
+#endif  // USE_TUYA_MCU
 #endif  // USE_LIGHT

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -336,10 +336,10 @@ void TuyaPacketProcess(void)
               ExecuteCommandPower(fnId - TUYA_MCU_FUNC_REL1 + 1, Tuya.buffer[10], SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
             }
           } else if (fnId >= TUYA_MCU_FUNC_SWT1 && fnId <= TUYA_MCU_FUNC_SWT4) {
-            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Switch-%d --> MCU State: %d Current State:%d"),fnId - TUYA_MCU_FUNC_SWT1 + 1,Tuya.buffer[10], SwitchGetVirtual(fnId - TUYA_MCU_FUNC_SWT1 + 1));
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Switch-%d --> MCU State: %d Current State:%d"),fnId - TUYA_MCU_FUNC_SWT1 + 1,Tuya.buffer[10], SwitchGetVirtual(fnId - TUYA_MCU_FUNC_SWT1));
 
-            if (SwitchGetVirtual(fnId - TUYA_MCU_FUNC_SWT1 + 1) != Tuya.buffer[10]) {
-              SwitchSetVirtual(fnId - TUYA_MCU_FUNC_SWT1 + 1, Tuya.buffer[10]);
+            if (SwitchGetVirtual(fnId - TUYA_MCU_FUNC_SWT1) != Tuya.buffer[10]) {
+              SwitchSetVirtual(fnId - TUYA_MCU_FUNC_SWT1, Tuya.buffer[10]);
               SwitchHandler(1);
             }
           }

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -80,6 +80,14 @@ enum TuyaSupportedFunctions {
   TUYA_MCU_FUNC_POWER = 31,
   TUYA_MCU_FUNC_CURRENT,
   TUYA_MCU_FUNC_VOLTAGE,
+  TUYA_MCU_FUNC_REL1_INV = 41,           // Inverted Relays
+  TUYA_MCU_FUNC_REL2_INV,
+  TUYA_MCU_FUNC_REL3_INV,
+  TUYA_MCU_FUNC_REL4_INV,
+  TUYA_MCU_FUNC_REL5_INV,
+  TUYA_MCU_FUNC_REL6_INV,
+  TUYA_MCU_FUNC_REL7_INV,
+  TUYA_MCU_FUNC_REL8_INV,
   TUYA_MCU_FUNC_LAST = 255
 };
 
@@ -93,7 +101,7 @@ void (* const TuyaCommand[])(void) PROGMEM = {
 
 /*
 
-TuyaMap fnid,dpid
+TuyaMcu fnid,dpid
 
 */
 
@@ -159,13 +167,30 @@ void TuyaAddMcuFunc(uint8_t fnId, uint8_t dpId) {
       }
     }
   }
+  UpdateDevices();
+}
+
+void UpdateDevices() {
+  for (uint8_t i = 0; i < MAX_TUYA_FUNCTIONS; i++) {
+    uint8_t fnId = Settings.tuya_fnid_map[i].fnid;
+    if (fnId > TUYA_MCU_FUNC_NONE && Settings.tuya_fnid_map[i].dpid > 0) {
+
+      if (fnId >= TUYA_MCU_FUNC_REL1 && fnId <= TUYA_MCU_FUNC_REL8) { //Relay
+        bitClear(rel_inverted, fnId - TUYA_MCU_FUNC_REL1);
+      } else if (fnId >= TUYA_MCU_FUNC_REL1_INV && fnId <= TUYA_MCU_FUNC_REL8_INV) { // Inverted Relay
+        bitSet(rel_inverted, fnId - TUYA_MCU_FUNC_REL1_INV);
+      }
+
+    }
+  }
 }
 
 inline bool TuyaFuncIdValid(uint8_t fnId) {
   return (fnId >= TUYA_MCU_FUNC_SWT1 && fnId <= TUYA_MCU_FUNC_SWT4) ||
   (fnId >= TUYA_MCU_FUNC_REL1 && fnId <= TUYA_MCU_FUNC_REL8) ||
     fnId == TUYA_MCU_FUNC_DIMMER ||
-    (fnId >= TUYA_MCU_FUNC_POWER && fnId <= TUYA_MCU_FUNC_VOLTAGE);
+    (fnId >= TUYA_MCU_FUNC_POWER && fnId <= TUYA_MCU_FUNC_VOLTAGE) ||
+    (fnId >= TUYA_MCU_FUNC_REL1_INV && fnId <= TUYA_MCU_FUNC_REL8_INV);
 }
 
 uint8_t TuyaGetFuncId(uint8_t dpid) {
@@ -252,7 +277,7 @@ bool TuyaSetPower(void)
   int16_t source = XdrvMailbox.payload;
 
   if (source != SRC_SWITCH && TuyaSerial) {  // ignore to prevent loop from pushing state from faceplate interaction
-    TuyaSendBool(active_device, bitRead(rpower, active_device-1));
+    TuyaSendBool(active_device, bitRead(rpower, active_device-1) ^ bitRead(rel_inverted, active_device-1));
     status = true;
   }
   return status;
@@ -334,6 +359,11 @@ void TuyaPacketProcess(void)
             AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Relay-%d --> MCU State: %s Current State:%s"), fnId - TUYA_MCU_FUNC_REL1 + 1, Tuya.buffer[10]?"On":"Off",bitRead(power, fnId - TUYA_MCU_FUNC_REL1)?"On":"Off");
             if ((power || Settings.light_dimmer > 0) && (Tuya.buffer[10] != bitRead(power, fnId - TUYA_MCU_FUNC_REL1))) {
               ExecuteCommandPower(fnId - TUYA_MCU_FUNC_REL1 + 1, Tuya.buffer[10], SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
+            }
+          } else if (fnId >= TUYA_MCU_FUNC_REL1_INV && fnId <= TUYA_MCU_FUNC_REL8_INV) {
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Relay-%d-Inverted --> MCU State: %s Current State:%s"), fnId - TUYA_MCU_FUNC_REL1_INV + 1, Tuya.buffer[10]?"Off":"On",bitRead(power, fnId - TUYA_MCU_FUNC_REL1_INV) ^ 1?"Off":"On");
+            if (Tuya.buffer[10] != bitRead(power, fnId - TUYA_MCU_FUNC_REL1_INV) ^ 1) {
+              ExecuteCommandPower(fnId - TUYA_MCU_FUNC_REL1_INV + 1, Tuya.buffer[10] ^ 1, SRC_SWITCH);  // send SRC_SWITCH? to use as flag to prevent loop from inbound states from faceplate interaction
             }
           } else if (fnId >= TUYA_MCU_FUNC_SWT1 && fnId <= TUYA_MCU_FUNC_SWT4) {
             AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: RX Switch-%d --> MCU State: %d Current State:%d"),fnId - TUYA_MCU_FUNC_SWT1 + 1,Tuya.buffer[10], SwitchGetVirtual(fnId - TUYA_MCU_FUNC_SWT1));
@@ -446,8 +476,21 @@ bool TuyaModuleSelected(void)
     TuyaAddMcuFunc(TUYA_MCU_FUNC_DIMMER, TUYA_DIMMER_ID);
   }
 
-  if (TuyaGetDpId(TUYA_MCU_FUNC_REL1) == 0) {
+  bool relaySet = false;
+
+  devices_present--;
+
+  for (uint8_t i = 0 ; i < MAX_TUYA_FUNCTIONS; i++) {
+    if ((Settings.tuya_fnid_map[i].fnid >= TUYA_MCU_FUNC_REL1 && Settings.tuya_fnid_map[i].fnid <= TUYA_MCU_FUNC_REL8 ) ||
+    (Settings.tuya_fnid_map[i].fnid >= TUYA_MCU_FUNC_REL1_INV && Settings.tuya_fnid_map[i].fnid <= TUYA_MCU_FUNC_REL8_INV )) {
+      relaySet = true;
+      devices_present++;
+    }
+  }
+
+  if (!relaySet) {
     TuyaAddMcuFunc(TUYA_MCU_FUNC_REL1, 1);
+    devices_present++;
     SettingsSaveAll();
   }
 
@@ -457,17 +500,12 @@ bool TuyaModuleSelected(void)
     light_type = LT_BASIC;
   }
 
+  UpdateDevices();
   return true;
 }
 
 void TuyaInit(void)
 {
-  for(uint8_t i = TUYA_MCU_FUNC_REL2; i <= TUYA_MCU_FUNC_REL8; i++) {
-    if (TuyaGetDpId(i) != 0) {
-      devices_present++;
-    }
-  }
-
   Tuya.buffer = (char*)(malloc(TUYA_BUFFER_SIZE));
   if (Tuya.buffer != nullptr) {
     TuyaSerial = new TasmotaSerial(pin[GPIO_TUYA_RX], pin[GPIO_TUYA_TX], 2);


### PR DESCRIPTION
## Description:

More and more Tuya MCU based devices are coming in the market and people requesting to support them. This patch makes Tuya module more configurable and easier to add new functionalities. Its not just a dimmer or a switch anymore.

After this Patch Tuya MCU module has a list of supported functions and the user would need to map the functionId to dpId of their device. Once mapped correctly the Tuya module will take care for handling proper function for dpId.

Currently functions supported are

1. Switches 1 to 4 : FunctionID 1 to 4
2. Relays1 to 8 : FunctionID 11 to 18
3. Dimmer : FunctionID 21
4. Power ( Deca Watt )  : Function ID 31
5. Current ( milli Amps ) : Function ID 32
6. Voltage ( deca Volts ) : Function ID 33
7. Inverted Relays1 to 8 : Function ID 41 to 48 

The changes are

- Use a TuyaMCU command to map DPs to Functions instead of many different SetOptions. SetOption41, 44, 45, 46, 65 and many future ones won't be needed after this patch.
- Each Tuya device a maximum of 16 functions is supported
- TuyaMCU command takes argument like `11,1` which means Map Function id 11 (Relay1) to DPID 1
- Migrates old settings flags and options to new TuyaMap command
- Renames `Tuya Dimmer` module to `Tuya MCU`
 
A wiki page for new Tuya MCU implementation will be created once this PR is merged in.

As per plan each SetOption can be removed as well after this goes in.

**Related issue (if applicable):** fixes #6319 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
