### PR TITLE
touch button update, fix display settings font and size

### DIFF
--- a/sonoff/xdrv_13_display.ino
+++ b/sonoff/xdrv_13_display.ino
@@ -1247,6 +1247,12 @@ void DisplayInitDriver(void)
 {
   XdspCall(FUNC_DISPLAY_INIT_DRIVER);
 
+  if (renderer) {
+    renderer->setTextFont(Settings.display_font);
+    renderer->setTextSize(Settings.display_size);
+  }
+
+
 //  AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "Display model %d"), Settings.display_model);
 
   if (Settings.display_model) {
@@ -1376,14 +1382,18 @@ void CmndDisplaySize(void)
 {
   if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= 4)) {
     Settings.display_size = XdrvMailbox.payload;
+    if (renderer) renderer->setTextSize(Settings.display_size);
+    else DisplaySetSize(Settings.display_size);
   }
   ResponseCmndNumber(Settings.display_size);
 }
 
 void CmndDisplayFont(void)
 {
-  if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= 4)) {
+  if ((XdrvMailbox.payload >=0) && (XdrvMailbox.payload <= 4)) {
     Settings.display_font = XdrvMailbox.payload;
+    if (renderer) renderer->setTextFont(Settings.display_font);
+    else DisplaySetFont(Settings.display_font);
   }
   ResponseCmndNumber(Settings.display_font);
 }
@@ -1804,7 +1814,7 @@ void Restore_graph(uint8_t num, char *path) {
   if (!fp) return;
   char vbuff[32];
   char *cp=vbuff;
-  char buf[2];
+  uint8_t buf[2];
   uint8_t findex=0;
 
   for (uint32_t count=0;count<=gp->xs+4;count++) {

--- a/sonoff/xdsp_07_sh1106.ino
+++ b/sonoff/xdsp_07_sh1106.ino
@@ -145,13 +145,13 @@ void SH1106Refresh(void)  // Every second
   if (Settings.display_mode) {  // Mode 0 is User text
     switch (Settings.display_mode) {
       case 1:  // Time
-        Ssd1306Time();
+        SH1106Time();
         break;
       case 2:  // Local
       case 3:  // Local
       case 4:  // Mqtt
       case 5:  // Mqtt
-        Ssd1306PrintLog();
+        SH1106PrintLog();
         break;
     }
   }

--- a/sonoff/xdsp_08_ILI9488.ino
+++ b/sonoff/xdsp_08_ILI9488.ino
@@ -127,9 +127,16 @@ void ILI9488_MQTT(uint8_t count,const char *cp) {
   ResponseTime_P(PSTR(",\"RA8876\":{\"%s%d\":\"%d\"}}"), cp,count+1,(buttons[count]->vpower&0x80)>>7);
   MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
 }
+
+void ILI9488_RDW_BUTT(uint32_t count,uint32_t pwr) {
+  buttons[count]->xdrawButton(pwr);
+  if (pwr) buttons[count]->vpower|=0x80;
+  else buttons[count]->vpower&=0x7f;
+}
 // check digitizer hit
 void FT6236Check() {
 uint16_t temp;
+uint8_t rbutt=0,vbutt=0;
 ili9488_ctouch_counter++;
 if (2 == ili9488_ctouch_counter) {
   // every 100 ms should be enough
@@ -157,17 +164,17 @@ if (2 == ili9488_ctouch_counter) {
       // now must compare with defined buttons
       for (uint8_t count=0; count<MAXBUTTONS; count++) {
         if (buttons[count]) {
+            uint8_t bflags=buttons[count]->vpower&0x7f;
             if (buttons[count]->contains(ili9488_pLoc.x,ili9488_pLoc.y)) {
                 // did hit
                 buttons[count]->press(true);
                 if (buttons[count]->justPressed()) {
-                  uint8_t bflags=buttons[count]->vpower&0x7f;
                   if (!bflags) {
-                    // real button
-                    if (!SendKey(KEY_BUTTON, count+1, POWER_TOGGLE)) {
-                      ExecuteCommandPower(count+1, POWER_TOGGLE, SRC_BUTTON);
+                    uint8_t pwr=bitRead(power,rbutt);
+                    if (!SendKey(KEY_BUTTON, rbutt+1, POWER_TOGGLE)) {
+                      ExecuteCommandPower(rbutt+1, POWER_TOGGLE, SRC_BUTTON);
+                      ILI9488_RDW_BUTT(count,!pwr);
                     }
-                    buttons[count]->xdrawButton(bitRead(power,count));
                   } else {
                     // virtual button
                     const char *cp;
@@ -185,6 +192,11 @@ if (2 == ili9488_ctouch_counter) {
                   }
                 }
             }
+            if (!bflags) {
+              rbutt++;
+            } else {
+              vbutt++;
+            }
         }
       }
     }
@@ -192,15 +204,27 @@ if (2 == ili9488_ctouch_counter) {
     // no hit
     for (uint8_t count=0; count<MAXBUTTONS; count++) {
       if (buttons[count]) {
+        uint8_t bflags=buttons[count]->vpower&0x7f;
         buttons[count]->press(false);
         if (buttons[count]->justReleased()) {
           uint8_t bflags=buttons[count]->vpower&0x7f;
-          if (bflags>1) {
-            // push button
-            buttons[count]->vpower&=0x7f;
-            ILI9488_MQTT(count,"PBT");
+          if (bflags>0) {
+            if (bflags>1) {
+              // push button
+              buttons[count]->vpower&=0x7f;
+              ILI9488_MQTT(count,"PBT");
+            }
+            buttons[count]->xdrawButton(buttons[count]->vpower&0x80);
           }
-          buttons[count]->xdrawButton(buttons[count]->vpower&0x80);
+        }
+        if (!bflags) {
+          // check if power button stage changed
+          uint8_t pwr=bitRead(power,rbutt);
+          uint8_t vpwr=(buttons[count]->vpower&0x80)>>7;
+          if (pwr!=vpwr) {
+            ILI9488_RDW_BUTT(count,pwr);
+          }
+          rbutt++;
         }
       }
     }

--- a/sonoff/xdsp_10_RA8876.ino
+++ b/sonoff/xdsp_10_RA8876.ino
@@ -113,9 +113,16 @@ void RA8876_MQTT(uint8_t count,const char *cp) {
   MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
 }
 
+void RA8876_RDW_BUTT(uint32_t count,uint32_t pwr) {
+  buttons[count]->xdrawButton(pwr);
+  if (pwr) buttons[count]->vpower|=0x80;
+  else buttons[count]->vpower&=0x7f;
+}
+
 // check digitizer hit
 void FT5316Check() {
 uint16_t temp;
+uint8_t rbutt=0,vbutt=0;
 ra8876_ctouch_counter++;
 if (2 == ra8876_ctouch_counter) {
   // every 100 ms should be enough
@@ -152,23 +159,26 @@ if (2 == ra8876_ctouch_counter) {
           break;
       }
       */
+      //AddLog_P2(LOG_LEVEL_INFO, PSTR(">> %d,%d"),ra8876_pLoc.x,ra8876_pLoc.y);
+
 
       //Serial.printf("loc x: %d , loc y: %d\n",pLoc.x,pLoc.y);
 
       // now must compare with defined buttons
       for (uint8_t count=0; count<MAXBUTTONS; count++) {
         if (buttons[count]) {
+            uint8_t bflags=buttons[count]->vpower&0x7f;
             if (buttons[count]->contains(ra8876_pLoc.x,ra8876_pLoc.y)) {
                 // did hit
                 buttons[count]->press(true);
                 if (buttons[count]->justPressed()) {
-                  uint8_t bflags=buttons[count]->vpower&0x7f;
                   if (!bflags) {
                     // real button
-                    if (!SendKey(KEY_BUTTON, count+1, POWER_TOGGLE)) {
-                      ExecuteCommandPower(count+1, POWER_TOGGLE, SRC_BUTTON);
+                    uint8_t pwr=bitRead(power,rbutt);
+                    if (!SendKey(KEY_BUTTON, rbutt+1, POWER_TOGGLE)) {
+                      ExecuteCommandPower(rbutt+1, POWER_TOGGLE, SRC_BUTTON);
+                      RA8876_RDW_BUTT(count,!pwr);
                     }
-                    buttons[count]->xdrawButton(bitRead(power,count));
                   } else {
                     // virtual button
                     const char *cp;
@@ -186,6 +196,11 @@ if (2 == ra8876_ctouch_counter) {
                   }
                 }
             }
+            if (!bflags) {
+              rbutt++;
+            } else {
+              vbutt++;
+            }
         }
       }
     }
@@ -193,15 +208,26 @@ if (2 == ra8876_ctouch_counter) {
     // no hit
     for (uint8_t count=0; count<MAXBUTTONS; count++) {
       if (buttons[count]) {
+        uint8_t bflags=buttons[count]->vpower&0x7f;
         buttons[count]->press(false);
         if (buttons[count]->justReleased()) {
-          uint8_t bflags=buttons[count]->vpower&0x7f;
-          if (bflags>1) {
-            // push button
-            buttons[count]->vpower&=0x7f;
-            RA8876_MQTT(count,"PBT");
+          if (bflags>0) {
+            if (bflags>1) {
+              // push button
+              buttons[count]->vpower&=0x7f;
+              RA8876_MQTT(count,"PBT");
+            }
+            buttons[count]->xdrawButton(buttons[count]->vpower&0x80);
           }
-          buttons[count]->xdrawButton(buttons[count]->vpower&0x80);
+        }
+        if (!bflags) {
+          // check if power button stage changed
+          uint8_t pwr=bitRead(power,rbutt);
+          uint8_t vpwr=(buttons[count]->vpower&0x80)>>7;
+          if (pwr!=vpwr) {
+            RA8876_RDW_BUTT(count,pwr);
+          }
+          rbutt++;
         }
       }
     }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<#6357>

displayfont, displaysize now immediately set font and size
touch button interface rework.

remark:
on pre core 2.6 the touch i2c driver is unreliable. until now i could not figure out what is wrong
obviously there must be changes in the i2c driver.



## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).