### PR TITLE
decode-config.py: adapt settings

### DIFF
--- a/tools/decode-config.py
+++ b/tools/decode-config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-VER = '2.3.0032'
+VER = '2.3.0033'
 
 """
     decode-config.py - Backup/Restore Sonoff-Tasmota configuration data
@@ -984,7 +984,22 @@ Setting_6_6_0_9.update              ({
     'sbaudrate':                    ('<H',  0x77A,       (None, None,                           ('Serial',      '"SBaudrate {}".format($)')), ('$ * 1200','$ / 1200') ),
                                     })
 # ======================================================================
+Setting_6_6_0_10 = copy.deepcopy(Setting_6_6_0_9)
+Setting_6_6_0_10.update             ({
+    'cfg_timestamp':                ('<L',  0xFF8,       (None, None,                           (INTERNAL,      None)) ),
+    'cfg_crc32':                    ('<L',  0xFFC,       (None, None,                           (INTERNAL,      None)), '"0x{:08x}".format($)' ),
+    'tuya_fnid_map':                ({
+        'fnid':                     ('B',   0xE00,       (None, None,                           ('Management',  '"TuyaMCU {},{}".format($,@["tuya_fnid_map"][#-1]["dpid"]) if ($!=0 or @["tuya_fnid_map"][#-1]["dpid"]!=0) else None')) ),
+        'dpid':                     ('B',   0xE01,       (None, None,                           ('Management',  None)) ),
+                                    },      0xE00,       ([16], None,                           ('Management',  None)), (None,      None) ),
+                                    })
+Setting_6_6_0_10['flag2'][0].update ({
+        'time_format':              ('<L', (0x5BC,2, 4), (None, None,                           ('Management', '"Time {}".format($+1)')) ),
+                                    })
+Setting_6_6_0_10['flag3'][0].pop('tuya_show_dimmer',None)
+# ======================================================================
 Settings = [
+            (0x606000A,0x1000, Setting_6_6_0_10),
             (0x6060009,0x1000, Setting_6_6_0_9),
             (0x6060008,0x1000, Setting_6_6_0_8),
             (0x6060007,0x1000, Setting_6_6_0_7),


### PR DESCRIPTION
- add Time (time_format)
- add TuyaMCU (tuya_fnid_map)
- add cfg_timestamp/cfg_crc32
- remove SetOption65 (tuya_disable_dimmer)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
