### PR TITLE
TasmotaSerial: Force wait for Stop Bit

### DIFF
--- a/lib/TasmotaSerial-2.3.5/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-2.3.5/src/TasmotaSerial.cpp
@@ -276,6 +276,8 @@ void TasmotaSerial::rxRead()
         m_in_pos = next;
       }
 
+      TM_SERIAL_WAIT_RCV_LOOP;    // wait for stop bit
+      wait += m_bit_time / 4;
       if (loop <= 0) { break; }   // exit now if not very high speed or buffer full
 
       bool start_of_next_byte = false;


### PR DESCRIPTION
## Description:

Theo, can you please try this change with PZEM. This was the main change from the previous version: forcing to wait for the first stop bit. It could indeed fail if the last bit glitched or if there was a parity bit (which I doubt on PZEM).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
