### PR TITLE
Rename "Data" to "Hash" and limit to 32 bits when receiving UNKNOWN IR protocol

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * 6.6.0.12 20190910
  * Redesign command Tariff to now default to 0 (=disabled) and allowing to set both Standard Time (ST) and Daylight Savings Time (DST) start hour
  *  Commands Tariff1 22,23 = Tariff1 (Off-Peak) ST,DST   Tariff2 (Standard) 6,7 = Tariff2 ST,DST   Tariff9 0/1 = Weekend toggle (1 = Off-Peak during weekend)
+ * Change rename "Data" to "Hash" and limit to 32 bits when receiving UNKNOWN IR protocol (see DECODE_HASH from IRremoteESP8266)
  *
  * 6.6.0.11 20190907
  * Change Settings crc calculation allowing short term backward compatibility

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -385,6 +385,7 @@
   #define D_JSON_IR_BITS "Bits"
   #define D_JSON_IR_DATA "Data"
   #define D_JSON_IR_DATALSB "DataLSB"
+  #define D_JSON_IR_HASH "Hash"
   #define D_JSON_IR_RAWDATA "RawData"
   #define D_JSON_IR_REPEAT "Repeat"
 #define D_CMND_IRHVAC "IRHVAC"

--- a/sonoff/xdrv_05_irremote_full.ino
+++ b/sonoff/xdrv_05_irremote_full.ino
@@ -177,20 +177,31 @@ String sendIRJsonState(const struct decode_results &results) {
     json += resultToHexidecimal(&results);
     json += "\"";
   } else {
-    json += ",\"" D_JSON_IR_DATA "\":";
+    if (UNKNOWN != results.decode_type) {
+      json += ",\"" D_JSON_IR_DATA "\":";
+    } else {
+      json += ",\"" D_JSON_IR_HASH "\":";
+    }
     if (Settings.flag.ir_receive_decimal) {
       char svalue[32];
       ulltoa(results.value, svalue, 10);
       json += svalue;
     } else {
       char hvalue[64];
-      IrUint64toHex(results.value, hvalue, results.bits);  // Get 64bit value as hex 0x00123456
-      json += "\"";
-      json += hvalue;
-      json += "\",\"" D_JSON_IR_DATALSB "\":\"";
-      IrUint64toHex(reverseBitsInBytes64(results.value), hvalue, results.bits);  // Get 64bit value as hex 0x00123456, LSB
-      json += hvalue;
-      json += "\"";
+      if (UNKNOWN != results.decode_type) {
+        IrUint64toHex(results.value, hvalue, results.bits);  // Get 64bit value as hex 0x00123456
+        json += "\"";
+        json += hvalue;
+        json += "\",\"" D_JSON_IR_DATALSB "\":\"";
+        IrUint64toHex(reverseBitsInBytes64(results.value), hvalue, results.bits);  // Get 64bit value as hex 0x00123456, LSB
+        json += hvalue;
+        json += "\"";
+      } else {    // UNKNOWN
+        IrUint64toHex(results.value, hvalue, 32);  // Unknown is always 32 bits
+        json += "\"";
+        json += hvalue;
+        json += "\"";
+      }
     }
   }
   json += ",\"" D_JSON_IR_REPEAT "\":";


### PR DESCRIPTION
## Description:

When receiving `UNKNOWN` IR protocol, the data field is actually a 32 bits hash that allows to recognize the same message, but cannot be used to send anything (see `DECODE_HASH` from IRremoteESP8266). This created confusion with users.

With this PR, uses a new `Hash` field instead of `Data` when protocol is `UNKNOWN` and the field is always 32 bits regardless of the number of bits of the message.

The change is made for both `sonoff` and `sonoff-ir`

Example:

`19:44:49 MQT: tele/sonoff/IR1/RESULT = {"Time":"2019-09-10T19:44:49","IrReceived":{"Protocol":"UNKNOWN","Bits":47,"Hash":"0x22E3A2B2","Repeat":0}}`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
