### PR TITLE
Rule did not been triggered if there's no comparation operator

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -339,6 +339,7 @@ int8_t parseCompareExpression(String &expr, String &leftExpr, String &rightExpr)
 {
   char compare_operator[3];
   int8_t compare = COMPARE_OPERATOR_NONE;
+  leftExpr = expr;
   int position;
   for (int8_t i = MAXIMUM_COMPARE_OPERATOR; i >= 0; i--) {
     snprintf_P(compare_operator, sizeof(compare_operator), kCompareOperators + (i *2));


### PR DESCRIPTION
Rule did not been triggered if there's no comparation operator provided as trigger. The issue related with the new introduced IF support.
For example:
Rule1 ON EVENT#POWERON DO ... ENDON
The rule_name should be assigned as "POWERON" by default.

## Description:

**Related issue (if applicable):** fixes #6405 

## Checklist:
  -  [ X] The pull request is done against the latest dev branch
  - [ X] Only relevant files were touched
  - [ X] Only one feature/fix was added per PR.
  - [ X] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
