### PR TITLE
Create an objdump from firmware.elf automatically

### DIFF
--- a/pio/obj-dump.py
+++ b/pio/obj-dump.py
@@ -1,0 +1,9 @@
+# Little convenience script to get an object dump
+
+Import('env')
+
+def obj_dump_after_elf(source, target, env):
+    print("Create firmware.asm")
+    env.Execute("xtensa-lx106-elf-objdump "+ "-D " + str(target[0]) + " > "+ "${PROGNAME}.asm")
+    
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", [obj_dump_after_elf])

--- a/platformio.ini
+++ b/platformio.ini
@@ -220,6 +220,7 @@ upload_resetmethod        = nodemcu
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port               = COM5
 extra_scripts             = pio/strip-floats.py
+                            pio/obj_dump.py
 
 ; *** Upload file to OTA server using SCP
 ;upload_port               = user@host:/path

--- a/platformio.ini
+++ b/platformio.ini
@@ -220,7 +220,7 @@ upload_resetmethod        = nodemcu
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port               = COM5
 extra_scripts             = pio/strip-floats.py
-                            pio/obj_dump.py
+                            pio/obj-dump.py
 
 ; *** Upload file to OTA server using SCP
 ;upload_port               = user@host:/path


### PR DESCRIPTION
## Description:

Simple convenience script to create firmware.asm from firmware.elf in the build process as a light weight debugging tool.
Will create a file of roughly 20 MByte and should probably be deactivated by default.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2 and 2.5.2
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
