### PR TITLE
Autoupdate Energy.total with the value reported by hardware (sdm120, …

### DIFF
--- a/sonoff/xdrv_03_energy.ino
+++ b/sonoff/xdrv_03_energy.ino
@@ -190,6 +190,13 @@ void EnergyUpdateTotal(float value, bool kwh)
   else if (value != Energy.start_energy) {
     Energy.kWhtoday = (unsigned long)((value - Energy.start_energy) * multiplier);
   }
+
+  if (Energy.total < value){
+    RtcSettings.energy_kWhtotal = (unsigned long)((value * multiplier) - Energy.kWhtoday_offset - Energy.kWhtoday);
+    Settings.energy_kWhtotal = RtcSettings.energy_kWhtotal;
+    Energy.total = (float)(RtcSettings.energy_kWhtotal + Energy.kWhtoday_offset + Energy.kWhtoday) / 100000;
+    Settings.energy_kWhtotal_time = (!Energy.kWhtoday_offset) ? LocalTime() : Midnight();
+  }
   EnergyUpdateToday();
 }
 


### PR DESCRIPTION
…etc).

After five day with continuous grid failures, by a DANA in the south of Spain, and loosing the loosing the sincro with the hardware counter (SDM120), instead of calc it by hand, I add the autoupdate function to always be in sincro with the hardware counter.