### PR TITLE
Disable mDNS for sonoff-sensors freeing IRAM

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -83,6 +83,8 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #undef CODE_IMAGE
 #define CODE_IMAGE 3
 
+#undef USE_DISCOVERY                          // Disable mDNS (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
+
 // -- Optional modules -------------------------
 #define USE_SONOFF_IFAN                       // Add support for Sonoff iFan02 and iFan03 (+2k code)
 #define USE_TUYA_MCU                          // Add support for Tuya Serial MCU


### PR DESCRIPTION
Compile fails for sonoff-sensors (IRAM)
mDNS is not a sensor and switched off by default.

## Description:

Sonoff-sensors is not compiling with core pre 2.6

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
