### PR TITLE
Change Domoticz P1 smart meter sensor total usage logic, issue #6444

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -178,11 +178,11 @@ typedef union {
 
 typedef struct {
   uint32_t usage1_kWhtotal;
-  uint32_t usage1_kWhtoday;
+  uint32_t usage2_kWhtotal;
   uint32_t return1_kWhtotal;
   uint32_t return2_kWhtotal;
   uint32_t last_return_kWhtotal;
-  uint32_t free;
+  uint32_t last_usage_kWhtotal;
 } EnergyUsage;
 
 

--- a/sonoff/xdrv_03_energy.ino
+++ b/sonoff/xdrv_03_energy.ino
@@ -167,12 +167,14 @@ void EnergyUpdateToday(void)
   Energy.daily = (float)(RtcSettings.energy_kWhtoday) / 100000;
   Energy.total = (float)(RtcSettings.energy_kWhtotal + RtcSettings.energy_kWhtoday) / 100000;
 
-  if (EnergyTariff1Active()) {  // Tarrif1 = Off-Peak
-    RtcSettings.energy_usage.usage1_kWhtotal += energy_diff;
-    RtcSettings.energy_usage.return1_kWhtotal += return_diff;
-  } else {
-    RtcSettings.energy_usage.usage2_kWhtotal += energy_diff;
-    RtcSettings.energy_usage.return2_kWhtotal += return_diff;
+  if (RtcTime.valid){
+    if (EnergyTariff1Active()) {  // Tarrif1 = Off-Peak
+      RtcSettings.energy_usage.usage1_kWhtotal += energy_diff;
+      RtcSettings.energy_usage.return1_kWhtotal += return_diff;
+    } else {
+      RtcSettings.energy_usage.usage2_kWhtotal += energy_diff;
+      RtcSettings.energy_usage.return2_kWhtotal += return_diff;
+    }
   }
 }
 


### PR DESCRIPTION
I changed the calc method of the total usage to use the same calc method as the export control, after that not more wrong data is reported by the P1 smart meter sensor to Domoticz.

![p1 new code](https://user-images.githubusercontent.com/9143666/65322643-b093ac00-dba7-11e9-9cf7-efe303bc49c7.png)

@arendst are you agree with that.