### PR TITLE
Energy: Add "EnergySaveTime" command to save the energy data every x minutes set by the command

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -373,8 +373,9 @@ struct SYSCFG {
   TuyaFnidDpidMap tuya_fnid_map[MAX_TUYA_FUNCTIONS];  // E00    32 bytes
   uint16_t      ina226_r_shunt[4];         // E20
   uint16_t      ina226_i_fs[4];            // E28
+  uint16_t      energy_save_time;          // E30
 
-  uint8_t       free_e30[456];             // E30
+  uint8_t       free_e32[454];             // E32
 
   uint32_t      cfg_timestamp;             // FF8
   uint32_t      cfg_crc32;                 // FFC

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -711,6 +711,7 @@ void SettingsDefaultSet2(void)
 //  memset((char*)&Settings.energy_usage, 0x00, sizeof(Settings.energy_usage));
   memset((char*)&RtcSettings.energy_usage, 0x00, sizeof(RtcSettings.energy_usage));
   Settings.param[P_OVER_TEMP] = ENERGY_OVERTEMP;
+  Settings.energy_save_time = 0;
 
   // IRRemote
   Settings.param[P_IR_UNKNOW_THRESHOLD] = IR_RCV_MIN_UNKNOWN_SIZE;


### PR DESCRIPTION
@arendst As you know, These days I have a lot of grid failures, so my domoticz charts are not valid, because I lose all data measured by the meters.

I added a new command to save the energy data every x minutes, the command needs a minimum of 30 minutes an a maximum of 1440 (24 hours), to avoid excessive writes to the eeprom, by default is disabled (value 0), but the user has the choice to set a value to store the data.

Thanks.