### PR TITLE
Support up to 32 devices for Hue emulation

### DIFF
--- a/sonoff/xdrv_20_hue.ino
+++ b/sonoff/xdrv_20_hue.ino
@@ -376,18 +376,36 @@ void HueLightStatus2(uint8_t device, String *response)
 }
 
 // generate a unique lightId mixing local IP address and device number
-// it is limited to 16 devices.
-// last 24 bits of Mac address + 4 bits of local light
-uint32_t EncodeLightId(uint8_t idx)
+// it is limited to 32 devices.
+// last 24 bits of Mac address + 4 bits of local light + high bit for relays 16-31, relay 32 is mapped to 0
+uint32_t EncodeLightId(uint8_t relay_id)
 {
   uint8_t mac[6];
   WiFi.macAddress(mac);
-  uint32_t id = (mac[3] << 20) | (mac[4] << 12) | (mac[5] << 4) | (idx & 0xF);
+  uint32_t id = 0;
+
+  if (relay_id >= 32) {   // for Relay #32, we encode as 0
+    relay_id = 0;
+  }
+  if (relay_id > 15) {
+    id = (1 << 28);
+  }
+
+  id |= (mac[3] << 20) | (mac[4] << 12) | (mac[5] << 4) | (relay_id & 0xF);
   return id;
 }
 
-uint32_t DecodeLightId(uint32_t id) {
-  return id & 0xF;
+// get hue_id and decode the relay_id
+// 4 LSB decode to 1-15, if bit 28 is set, it encodes 16-31, if 0 then 32
+uint32_t DecodeLightId(uint32_t hue_id) {
+  uint8_t relay_id = hue_id & 0xF;
+  if (hue_id & (1 << 28)) {   // check if bit 25 is set, if so we have
+    relay_id += 16;
+  }
+  if (0 == relay_id) {        // special value 0 is actually relay #32
+    relay_id = 32;
+  }
+  return relay_id;
 }
 
 static const char * FIRST_GEN_UA[] = {  // list of User-Agents signature


### PR DESCRIPTION
## Description:

Raise the limit from 15 to 32 devices adressable via Hue emulation. This allows to use the full range of `power_t` devices (32 bits).

**Related issue (if applicable):** fixes #6456

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
