### PR TITLE
Minor fixes to Hue Emulation and Light

### DIFF
--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -2281,7 +2281,7 @@ void CmndChannel(void)
       light_controller.changeChannels(Light.current_color);
       coldim = true;
     }
-    ResponseCmndIdxNumber(Light.current_color[XdrvMailbox.index -1] * 100 / 255);
+    ResponseCmndIdxNumber(changeUIntScale(Light.current_color[XdrvMailbox.index -1],0,255,0,100));
     if (coldim) {
       LightPreparePower();
     }

--- a/sonoff/xdrv_20_hue.ino
+++ b/sonoff/xdrv_20_hue.ino
@@ -364,12 +364,15 @@ void HueLightStatus2(uint8_t device, String *response)
     char fname[33];
     strcpy(fname, Settings.friendlyname[MAX_FRIENDLYNAMES-1]);
     uint32_t fname_len = strlen(fname);
-    if (fname_len >= 33-3) {
-      fname[33-3] = 0x00;
-      fname_len = 33-3;
-    }
+    if (fname_len > 30) { fname_len = 30; }
     fname[fname_len++] = '-';
-    fname[fname_len++] = '0' + device - MAX_FRIENDLYNAMES;
+    if (device - MAX_FRIENDLYNAMES < 10) {
+      fname[fname_len++] = '0' + device - MAX_FRIENDLYNAMES;
+    } else {
+      fname[fname_len++] = 'A' + device - MAX_FRIENDLYNAMES - 10;
+    }
+    fname[fname_len] = 0x00;
+
     response->replace("{j1", fname);
   }
   response->replace("{j2", GetHueDeviceId(device));


### PR DESCRIPTION
## Description:

Two minor fixes
- Fix wrong rounding when reporting `Channel` value (from Discord by @jziolkowski )
- Fix wrong friendly name with Hue Emulation above 13 devices

**Related issue (if applicable):** fixes #6456 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
