### PR TITLE
Missed one character previous of closure bracket

### DIFF
--- a/sonoff/xdrv_10_rules.ino
+++ b/sonoff/xdrv_10_rules.ino
@@ -1027,7 +1027,7 @@ bool findNextObjectValue(char * &pointer, float &value)
     } else if (*pointer == '(') {     //It is a sub expression bracketed with ()
       char * closureBracket = findClosureBracket(pointer);        //Get the position of closure bracket ")"
       if (closureBracket != nullptr) {
-        value = evaluateExpression(pointer+1, closureBracket - pointer - 2);
+        value = evaluateExpression(pointer+1, closureBracket - pointer - 1);
         pointer = closureBracket + 1;
         bSucceed = true;
       }
@@ -1323,7 +1323,7 @@ bool findNextLogicObjectValue(char * &pointer, bool &value)
     } else if (*pointer == '(') {     //It is a sub expression bracketed with ()
       char * closureBracket = findClosureBracket(pointer);        //Get the position of closure bracket ")"
       if (closureBracket != nullptr) {
-        value = evaluateLogicalExpression(pointer+1, closureBracket - pointer - 2);
+        value = evaluateLogicalExpression(pointer+1, closureBracket - pointer - 1);
         pointer = closureBracket + 1;
         bSucceed = true;
       }


### PR DESCRIPTION
## Description:
For example:
Var1 = (1+2)
will be treat as:
Var1 = 1+

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
