### PR TITLE
Fix 6508

### DIFF
--- a/sonoff/xdrv_05_irremote_full.ino
+++ b/sonoff/xdrv_05_irremote_full.ino
@@ -169,15 +169,15 @@ String sendIRJsonState(const struct decode_results &results) {
       char hvalue[64];
       if (UNKNOWN != results.decode_type) {
         Uint64toHex(results.value, hvalue, results.bits);  // Get 64bit value as hex 0x00123456
-        json += "\"";
+        json += "\"0x";
         json += hvalue;
-        json += "\",\"" D_JSON_IR_DATALSB "\":\"";
+        json += "\",\"" D_JSON_IR_DATALSB "\":\"0x";
         Uint64toHex(reverseBitsInBytes64(results.value), hvalue, results.bits);  // Get 64bit value as hex 0x00123456, LSB
         json += hvalue;
         json += "\"";
       } else {    // UNKNOWN
         Uint64toHex(results.value, hvalue, 32);  // Unknown is always 32 bits
-        json += "\"";
+        json += "\"0x";
         json += hvalue;
         json += "\"";
       }
@@ -210,7 +210,7 @@ void IrReceiveCheck(void)
 //    if ((now - ir_lasttime > IR_TIME_AVOID_DUPLICATE) && (UNKNOWN != results.decode_type) && (results.bits > 0)) {
     if (!irsend_active && (now - ir_lasttime > IR_TIME_AVOID_DUPLICATE)) {
       ir_lasttime = now;
-      ResponseTime_P(PSTR(",\"" D_JSON_IRRECEIVED "\":%s"), sendIRJsonState(results).c_str());
+      Response_P(PSTR("{\"" D_JSON_IRRECEIVED "\":%s"), sendIRJsonState(results).c_str());
 
       if (Settings.flag3.receive_raw) {
         ResponseAppend_P(PSTR(",\"" D_JSON_IR_RAWDATA "\":["));
@@ -438,7 +438,7 @@ uint32_t IrRemoteCmndIrSendJson(void)
 
   char dvalue[32];
   char hvalue[32];
-  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("IRS: protocol %d, bits %d, data %s (%s), repeat %d"),
+  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("IRS: protocol %d, bits %d, data 0x%s (%s), repeat %d"),
     protocol, bits, ulltoa(data, dvalue, 10), Uint64toHex(data, hvalue, bits), repeat);
 
   irsend_active = true;     // deactivate receive


### PR DESCRIPTION
## Description:

Fix missing `0x` on Data fields.
Also removed the timestamp in IrReceived MQTT message (was there by mistake in the first place).

**Related issue (if applicable):** fixes #6508 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
