### PR TITLE
Mcp230xx - Add 1 and 0 as option for ON and OFF

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -5,6 +5,7 @@
  * Add initial support for MQTT logging using command MqttLog <loglevel> (#6498)
  * Add Zigbee more support - collect endpoints and clusters, added ZigbeeDump command
  * Add initial support for shutters by Stefan Bode (#288)
+ * Add use case for sensor29 pin,1 and sensor29 pin,0 to substitute ON and OFF respectively with MCP230xx driver
  *
  * 6.6.0.13 20190922
  * Add command EnergyReset4 x,x to initialize total usage for two tarrifs

--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -628,11 +628,11 @@ bool MCP230xx_Command(void) {
 #ifdef USE_MCP230xx_OUTPUT
     if (Settings.mcp230xx_config[pin].pinmode >= 5) {
       uint8_t pincmd = Settings.mcp230xx_config[pin].pinmode - 5;
-      if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "ON")) {
+      if ((!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "ON")) || (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "1"))) {
         MCP230xx_SetOutPin(pin,abs(pincmd-1));
         return serviced;
       }
-      if (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "OFF")) {
+      if ((!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "OFF")) || (!strcmp(subStr(sub_string, XdrvMailbox.data, ",", 2), "0"))) {
         MCP230xx_SetOutPin(pin,pincmd);
         return serviced;
       }


### PR DESCRIPTION
MCP230xx - Add 1 and 0 as an option for ON and OFF

## Description:

PR #6522 bears reference.

This PR adds the ability to use `sensor29 pin,1` and `sensor29 pin,0` to substitute `sensor29 pin,ON` and `sensor29 pin,OFF` respectively.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
