### PR TITLE
MCP230xx: Prevent inadvertent pinmode change

### DIFF
--- a/sonoff/xsns_29_mcp230xx.ino
+++ b/sonoff/xsns_29_mcp230xx.ino
@@ -655,9 +655,9 @@ bool MCP230xx_Command(void) {
       intmode = atoi(subStr(sub_string, XdrvMailbox.data, ",", 4));
     }
 #ifdef USE_MCP230xx_OUTPUT
-    if ((pin < mcp230xx_pincount) && (pinmode > 0) && (pinmode < 7) && (pullup < 2)) {
+    if ((pin < mcp230xx_pincount) && (pinmode > 0) && (pinmode < 7) && (pullup < 2) && (paramcount > 2)) {
 #else // not use OUTPUT
-    if ((pin < mcp230xx_pincount) && (pinmode > 0) && (pinmode < 5) && (pullup < 2)) {
+    if ((pin < mcp230xx_pincount) && (pinmode > 0) && (pinmode < 5) && (pullup < 2) && (paramcount > 2)) {
 #endif // USE_MCP230xx_OUTPUT
       Settings.mcp230xx_config[pin].pinmode=pinmode;
       Settings.mcp230xx_config[pin].pullup=pullup;


### PR DESCRIPTION
## Description:

We've added support for `sensor29 pin,0/1` for `OFF/ON` with PR #6524 but the current code would allow the pinmode to be changed without specifying a default state e.g. `sensor29 pin,3` would cause the pinmode to be changed to input even if it was previously configured for output (pinmode 5/6)

This change prevents instances of unexpected behaviour by enforcing the configuration rules as outlined in the wiki e.g.

`sensor29 pin,pinmode,pullup/default state (if used for output)`

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
