### PR TITLE
Fix no import and export data with dds238-2 meter issue #6531

### DIFF
--- a/sonoff/xnrg_09_dds2382.ino
+++ b/sonoff/xnrg_09_dds2382.ino
@@ -55,7 +55,7 @@ void Dds2382EverySecond(void)
       Energy.data_valid[0] = 0;
 
       //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40
-      // SA FC BC EnergyTotal             ExportActiv ImportActiv                         Volta Curre APowe RPowe PFact Frequ Crc--
+      // SA FC BC EnergyTotal                                     ExportActiv ImportActiv Volta Curre APowe RPowe PFact Frequ Crc--
 
       Energy.voltage[0] = (float)((buffer[27] << 8) + buffer[28]) / 10.0;
       Energy.current[0] = (float)((buffer[29] << 8) + buffer[30]) / 100.0;
@@ -63,9 +63,9 @@ void Dds2382EverySecond(void)
       Energy.reactive_power[0] = (float)((buffer[33] << 8) + buffer[34]);
       Energy.power_factor[0] = (float)((buffer[35] << 8) + buffer[36]) / 1000.0;                                          // 1.00
       Energy.frequency[0] = (float)((buffer[37] << 8) + buffer[38]) / 100.0;                                              // 50.0 Hz
-      Energy.export_active = (float)((buffer[11] << 24) + (buffer[12] << 16) + (buffer[13] << 8) + buffer[14]) / 100.0;  // 429496729.0 W
+      Energy.export_active = (float)((buffer[19] << 24) + (buffer[20] << 16) + (buffer[21] << 8) + buffer[22]) / 100.0;  // 429496729.0 W
 //      float energy_total = (float)((buffer[3] << 24) + (buffer[4] << 16) + (buffer[5] << 8) + buffer[6]) / 100.0;  // 429496729.0 W
-      float import_active = (float)((buffer[15] << 24) + (buffer[16] << 16) + (buffer[17] << 8) + buffer[18]) / 100.0;  // 429496729.0 W
+      float import_active = (float)((buffer[23] << 24) + (buffer[24] << 16) + (buffer[25] << 8) + buffer[26]) / 100.0;  // 429496729.0 W
 
       EnergyUpdateTotal(import_active, false);  // 484.708 kWh
     }


### PR DESCRIPTION
As you can see in the issue #6531 no import and export data is show using the dds2382 meter.

After a search in google, all references to the dds2382 I found show a mismatch in the import and export bytes in the actual implementation.

````
Register(s) | Meaning | Scale Unit | Data format | R/W
-- | -- | -- | -- | --
0000h-0001h | total energy | 1/100 kWh | unsigned dword | R¹
0002h-0003h | reserved |   | unsigned dword |  
0004h-0005h | reserved |   | unsigned dword |  
0006h-0007h | reserved |   | unsigned dword |  
0008h-0009h | export energy | 1/100 kWh | unsigned dword | R¹
000Ah-000Bh | import energy | 1/100 kWh | unsigned dword | R¹
000Ch | voltage | 1/10 V | unsigned word | R
000Dh | current | 1/100 A | unsigned word | R
000Eh | active power | 1 W | signed word | R
000Fh | reactive power | 1 VAr | unsigned word | R
0010h | power factor | 1/1000 | unsigned word | R
0011h | frequency | 1/100 Hz | unsigned word | R
0012h | reserved |   | unsigned word |  
0013h | reserved |   | unsigned word |  
0014h | reserved |   | unsigned word |  
0015h:high | station address | 1-247 | unsigned char | R/W
0015h:low | baud rate | 1-4² | unsigned char
````

Changing these values, the meter start to show the missing data, @arendst where did you find the register data? maybe can exist two versions of the same model with different register struct? 