### PR TITLE
Home Assistant integration BTN/SW

### DIFF
--- a/sonoff/xdrv_12_home_assistant.ino
+++ b/sonoff/xdrv_12_home_assistant.ino
@@ -347,7 +347,7 @@ void HAssAnnounceSwitches(void)
   // Send info about buttons
   char *tmp = Settings.switch_topic;
   Format(sw_topic, tmp, sizeof(sw_topic));
-  if ((strlen(sw_topic) != 0) && strcmp(sw_topic, "0")) {
+  if (strlen(sw_topic) != 0) {
     for (uint32_t switch_index = 0; switch_index < MAX_SWITCHES; switch_index++) {
       uint8_t switch_present = 0;
       uint8_t toggle = 1;
@@ -376,7 +376,7 @@ void HAssAnnounceButtons(void)
   // Send info about buttons
   char *tmp = Settings.button_topic;
   Format(key_topic, tmp, sizeof(key_topic));
-  if ((strlen(key_topic) != 0) && strcmp(key_topic, "0")) {
+  if (strlen(key_topic) != 0) {
     for (uint32_t button_index = 0; button_index < MAX_KEYS; button_index++) {
       uint8_t button_present = 0;
       uint8_t toggle = 1;


### PR DESCRIPTION
## Description:
Removed a `strcmp` for `buttontopic` and `switchtopic` name. HA integration must enable buttons and switches independently from the name.

**Related issue (if applicable):** fixes #6530

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
