### PR TITLE
PulseTime output reformat (first part)

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -177,6 +177,8 @@
 #define D_JSON_SOLAR_POWER "SolarPower"
 #define D_JSON_USAGE "Usage"
 #define D_JSON_EXPORT "Export"
+#define D_JSON_REMAINS "Remaining"
+#define D_JSON_SET "Set"
 
 #define D_RSLT_ENERGY "ENERGY"
 #define D_RSLT_HASS_STATE "HASS_STATE"
@@ -557,7 +559,7 @@ const char S_JSON_COMMAND_INDEX_LVALUE[] PROGMEM =            "{\"%s%d\":%lu}";
 const char S_JSON_COMMAND_INDEX_SVALUE[] PROGMEM =            "{\"%s%d\":\"%s\"}";
 const char S_JSON_COMMAND_INDEX_ASTERISK[] PROGMEM =          "{\"%s%d\":\"" D_ASTERISK_PWD "\"}";
 const char S_JSON_COMMAND_INDEX_SVALUE_SVALUE[] PROGMEM =     "{\"%s%d\":\"%s%s\"}";
-const char S_JSON_COMMAND_INDEX_NVALUE_ACTIVE_NVALUE[] PROGMEM = "{\"%s%d\":{\"%d\":{\"" D_JSON_ACTIVE "\":\"%d\"}}}";
+const char S_JSON_COMMAND_INDEX_NVALUE_ACTIVE_NVALUE[] PROGMEM = "{\"%s%d\":{\"" D_JSON_SET "\":\"%d\",\"" D_JSON_REMAINS "\":\"%d\"}}";
 
 const char S_JSON_SENSOR_INDEX_NVALUE[] PROGMEM =             "{\"" D_CMND_SENSOR "%d\":%d}";
 const char S_JSON_SENSOR_INDEX_SVALUE[] PROGMEM =             "{\"" D_CMND_SENSOR "%d\":\"%s\"}";


### PR DESCRIPTION
## Description:
@arendst This PR changes the json output of `pulsetimeX`, now more readable and with valid keys.
```
03:37:00 CMD: pulsetime
03:37:00 RSL: sonoff/stat/RESULT = {"PulseTime1":{"Set":"1500","Remaining":"1477"}}
```
I omitted on purpose to change `pulsetime` command, as asked by @jziolkowski. The command  is actually outputting the first element on index similar to the older version of `var` and `mem` commands. I was not happy with my solution, sorry! Then this PR solve just part of issue 6519.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
