### PR TITLE
Add support for Lohas bulbs with multiple CW LED channels

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,7 +2,7 @@
  * 6.6.0.15 20191003
  * Change command PulseTime JSON message format and allow display of all pulsetimer information (#6519)
  * Add support for Chint DDSU666 Modbus energy meter by Pablo Zerón
- * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495)
+ * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495) 
  *
  * 6.6.0.14 20190925
  * Change command Tariffx to allow time entries like 23 (hours), 1320 (minutes) or 23:00. NOTE: As this is development branch previous tariffs are lost! (#6488)

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,7 +2,8 @@
  * 6.6.0.15 20191003
  * Change command PulseTime JSON message format and allow display of all pulsetimer information (#6519)
  * Add support for Chint DDSU666 Modbus energy meter by Pablo Zerón
- * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495) 
+ * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495)
+ * Add support for Lohas bulbs with mutliple channels of CW LEDs
  *
  * 6.6.0.14 20190925
  * Change command Tariffx to allow time entries like 23 (hours), 1320 (minutes) or 23:00. NOTE: As this is development branch previous tariffs are lost! (#6488)

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1430,6 +1430,9 @@ void GpioInit(void)
   else if (AILIGHT == my_module_type) {     // RGBW led
     light_type = LT_RGBW;
   }
+  else if (LOHAS_RGBW == my_module_type) {     // RGBW led with 2 or more CW led channels
+    light_type = LT_RGBW;
+  }
   else if (SONOFF_B1 == my_module_type) {   // RGBWC led
     light_type = LT_RGBWC;
   }

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -386,6 +386,7 @@ enum SupportedModules {
   SYF05,
   SONOFF_L1,
   SONOFF_IFAN03,
+  LOHAS_RGBW,
   MAXMODULE};
 
 #define USER_MODULE        255
@@ -815,6 +816,7 @@ const uint8_t kModuleNiceList[] PROGMEM = {
   AILIGHT,             // Light Bulbs
   PHILIPS,
   SYF05,
+  LOHAS_RGBW,
   YTF_IR_BRIDGE,
   WITTY,               // Development Devices
   WEMOS
@@ -2115,7 +2117,25 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL2,        // GPIO14 WIFI_O1 Relay 2 (0 = Off, 1 = On) controlling the fan
      GPIO_REL4,        // GPIO15 WIFI_O3 Relay 4 (0 = Off, 1 = On) controlling the fan
      0, 0
-  }
+  },
+  { "Lohas RGBW",      // LOHAS RBGW - (ESP8266 - 2 my9291 chips) - dual and triple channels of cool white 
+     GPIO_KEY1,        // GPIO00 Pad
+     GPIO_USER,        // GPIO01 Serial RXD and Optional sensor pad
+     GPIO_USER,        // GPIO02 Optional sensor SDA pad
+     GPIO_USER,        // GPIO03 Serial TXD and Optional sensor pad
+     0, 0,
+                       // GPIO06 (SD_CLK   Flash)
+                       // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
+                       // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
+     0,                // GPIO09 (SD_DATA2 Flash QIO or ESP8285)
+     0,                // GPIO10 (SD_DATA3 Flash QIO or ESP8285)
+                       // GPIO11 (SD_CMD   Flash)
+     0,
+     GPIO_DI,          // GPIO13 my9291 DI
+     0,
+     GPIO_DCKI,        // GPIO15 my9291 DCKI
+     0, 0
+  }  
 };
 
 #endif  // _SONOFF_TEMPLATE_H_

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -36,7 +36,7 @@ enum UserSelectablePins {
   GPIO_SWT1,           // User connected external switches
   GPIO_SWT2,
   GPIO_SWT3,
-  GPIO_SWT
+  GPIO_SWT4,
   GPIO_SWT5,
   GPIO_SWT6,
   GPIO_SWT7,

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -36,7 +36,7 @@ enum UserSelectablePins {
   GPIO_SWT1,           // User connected external switches
   GPIO_SWT2,
   GPIO_SWT3,
-  GPIO_SWT4,
+  GPIO_SWT
   GPIO_SWT5,
   GPIO_SWT6,
   GPIO_SWT7,
@@ -2118,7 +2118,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      GPIO_REL4,        // GPIO15 WIFI_O3 Relay 4 (0 = Off, 1 = On) controlling the fan
      0, 0
   },
-  { "Lohas RGBW",      // LOHAS RBGW - (ESP8266 - 2 my9291 chips) - dual and triple channels of cool white 
+  { "Lohas RGBW",      // LOHAS RBGW - (ESP8266 - 2 my9231 chips) - dual and triple channels of cool white 
      GPIO_KEY1,        // GPIO00 Pad
      GPIO_USER,        // GPIO01 Serial RXD and Optional sensor pad
      GPIO_USER,        // GPIO02 Optional sensor SDA pad

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1228,7 +1228,7 @@ void LightMy92x1Write(uint8_t data)
 void LightMy92x1Init(void)
 {
   uint8_t chips = 1;                    // 1 (AiLight)
-  if (LT_RGBWC == light_type) {
+  if ((LT_RGBWC == light_type) || (LOHAS_RGBW == my_module_type)) {
     chips = 2;                          // 2 (Sonoff B1)
   }
 
@@ -1250,15 +1250,18 @@ void LightMy92x1Init(void)
 
 void LightMy92x1Duty(uint8_t duty_r, uint8_t duty_g, uint8_t duty_b, uint8_t duty_w, uint8_t duty_c)
 {
-  uint8_t channels[2] = { 4, 6 };
+  uint8_t channels[3] = { 4, 6, 6 };
 
   uint8_t didx = 0;                     // 0 (AiLight)
   if (LT_RGBWC == light_type) {
     didx = 1;                           // 1 (Sonoff B1)
   }
-
-  uint8_t duty[2][6] = {{ duty_r, duty_g, duty_b, duty_w, 0, 0 },        // Definition for RGBW channels
-                        { duty_w, duty_c, 0, duty_g, duty_r, duty_b }};  // Definition for RGBWC channels
+  if (LOHAS_RGBW == my_module_type) {
+    didx = 2;                          // 2 (Lohas RGBW)
+  }
+  uint8_t duty[3][6] = {{ duty_r, duty_g, duty_b, duty_w, 0, 0 },        // Definition for RGBW channels
+                        { duty_w, duty_c, 0, duty_g, duty_r, duty_b },   // Definition for RGBWC channels
+                        { duty_r, duty_g, duty_b, duty_w, duty_w, duty_w }};  // Lohas RGBW uses up to 3 CW channels 
 
   os_delay_us(12);                      // TStop > 12us.
   for (uint32_t channel = 0; channel < channels[didx]; channel++) {


### PR DESCRIPTION
## Description:
Add support for Lohas bulbs with multiple CW LED channels.  Utilizes two my2921 chips, one model has 2 CW channels and another has 3 CW channels.  This PR covers both models.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
