### PR TITLE
Add SetOption73 for PWM White Temperature mode, default on PHILIPS bulbs (#6534)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -5,6 +5,7 @@
  * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495)
  * Add command SetOption72 0/1 to switch between software (0) or hardware (1) energy total counter (#6561)
  * Add Zigbee tracking of connected devices and auto-probing of Manuf/Model Ids
+ * Add SetOption73 for PWM White Temperature mode, default on PHILIPS bilbs (#6534)
  *
  * 6.6.0.14 20190925
  * Change command Tariffx to allow time entries like 23 (hours), 1320 (minutes) or 23:00. NOTE: As this is development branch previous tariffs are lost! (#6488)

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -86,7 +86,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t energy_weekend : 1;           // bit 20 (v6.6.0.8)  - CMND_TARIFF
     uint32_t dds2382_model : 1;            // bit 21 (v6.6.0.14) - SetOption71 - Select different Modbus registers for Active Energy (#6531)
     uint32_t hardware_energy_total : 1;    // bit 22 (v6.6.0.15) - SetOption72 - Enable / Disable hardware energy total counter as reference (#6561)
-    uint32_t spare23 : 1;
+    uint32_t white_temp_as_pwm : 1;        // bit 23 (v6.6.0.15) - SetOption73 - Enable Color Temp as a PWM channel, instead of seperate CW/W channels (#6534)
     uint32_t spare24 : 1;
     uint32_t spare25 : 1;
     uint32_t spare26 : 1;

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1413,6 +1413,9 @@ void GpioInit(void)
     devices_present = 0;
     baudrate = 19200;
   }
+  else if (PHILIPS == my_module_type) {
+    Settings.flag3.white_temp_as_pwm = true;    // force SetOption73 for Module 48
+  }
 
   if (!light_type) {
     devices_present = 0;


### PR DESCRIPTION
## Description:

Added SetOption73 for bulbs with cold/warm controlled as PWM.
Classical bulb have separate channels for WarmWhite and ColdWhite. These new bulbs (like Xiaomi Philips) use 1 PWM for Brightness and 1 PWM for ColorTemp.

Note: Module 48 (Xiaomi Philips) automatically forces SetOption73.

**Related issue (if applicable):** fixes #6534 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
