### PR TITLE
Fix better handling of PWM White Temperature mode for Module 48 (#6534)

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -5,6 +5,7 @@
  * Add support for SM2135 as used in Action LSC Smart Led E14 (#6495)
  * Add command SetOption72 0/1 to switch between software (0) or hardware (1) energy total counter (#6561)
  * Add Zigbee tracking of connected devices and auto-probing of Manuf/Model Ids
+ * Fix better handling of PWM White Temperature mode for Module 48 (#6534)
  *
  * 6.6.0.14 20190925
  * Change command Tariffx to allow time entries like 23 (hours), 1320 (minutes) or 23:00. NOTE: As this is development branch previous tariffs are lost! (#6488)


### PR DESCRIPTION
## Description:

Classical bulb have separate channels for WarmWhite and ColdWhite. New bulbs (like Xiaomi Philips) use 1 PWM for Brightness and 1 PWM for ColorTemp.
This PR allows to have the same behavior with RGBCW bulbs.

**Related issue (if applicable):** fixes #6534 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
