### PR TITLE
Fix TuyaMcu after Light redesign.

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -1413,17 +1413,19 @@ void GpioInit(void)
     devices_present = 0;
     baudrate = 19200;
   }
-
-  if (!light_type) {
-    devices_present = 0;
-    for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only
-      if (pin[GPIO_PWM1 +i] < 99) {
-        pwm_present = true;
-        pinMode(pin[GPIO_PWM1 +i], OUTPUT);
-        analogWrite(pin[GPIO_PWM1 +i], bitRead(pwm_inverted, i) ? Settings.pwm_range - Settings.pwm_value[i] : Settings.pwm_value[i]);
+  else {
+    if (!light_type) {
+      devices_present = 0;
+      for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only
+        if (pin[GPIO_PWM1 +i] < 99) {
+          pwm_present = true;
+          pinMode(pin[GPIO_PWM1 +i], OUTPUT);
+          analogWrite(pin[GPIO_PWM1 +i], bitRead(pwm_inverted, i) ? Settings.pwm_range - Settings.pwm_value[i] : Settings.pwm_value[i]);
+        }
       }
     }
   }
+
   for (uint32_t i = 0; i < MAX_RELAYS; i++) {
     if (pin[GPIO_REL1 +i] < 99) {
       pinMode(pin[GPIO_REL1 +i], OUTPUT);

--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -1075,7 +1075,7 @@ bool LightModuleInit(void)
     devices_present += pwm_channels - 1;  // add the pwm channels controls at the end
   }
 
-  return (light_type > 0);
+  return (light_type > LT_BASIC);
 }
 
 void LightInit(void)


### PR DESCRIPTION
## Description:

TuyaMcu devices stopped showing Toggle buttons after light redesign.
I found out that it is caused because `devices_present` was being reset in here 

https://github.com/arendst/Sonoff-Tasmota/commit/019dc767403ab45f3e7fd83644ec4f9be9a14254#diff-9a0587e9aa7bed7ae2df63479960e7e0R1418

I compared it with code before redesign and seems like this code only executes when `XdrvCall(FUNC_MODULE_INIT)`. 
I am not 100% sure if this is new approach based on current light design.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
