### PR TITLE
Fix Avoid full power on 5 channels after a Reset

### DIFF
--- a/sonoff/xdrv_04_light.ino
+++ b/sonoff/xdrv_04_light.ino
@@ -846,6 +846,7 @@ public:
       // We apply dimmer in priority to RGB
       uint8_t bri = _state->DimmerToBri(Settings.light_dimmer);
       if (Settings.light_color[0] + Settings.light_color[1] + Settings.light_color[2] > 0) {
+        _state->setColorMode(LCM_RGB);
         _state->setBriRGB(bri);
       } else {
         _state->setBriCT(bri);


### PR DESCRIPTION
## Description:

After initial flash or `Reset 6`, the RGBCW is set to `{"Color":"1A1A1AFFFF"}` which may stress the power supply beyond acceptable values.
This fix switches off white channels and sets `{"Color":"1A1A1A0000"}` instead.

**Related issue (if applicable):** fixes #6534 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
