### PR TITLE
Initial IPv6 support (SLAAC). Builds against 2.5.2 and 2.6.0 staging.…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,32 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -fno-exceptions
                             -lstdc++
 
+[core_2_5_2_ipv6]
+; *** Esp8266 core for Arduino version 2.5.2
+platform                  = espressif8266@~2.2.2
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
+                            -O2
+                            -DBEARSSL_SSL_BASIC
+; nonos-sdk 22x
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
+; nonos-sdk-pre-v3
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth IPv6
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
+                            -DVTABLES_IN_FLASH
+                            -fno-exceptions
+                            -lstdc++
+
 [core_stage]
 ; *** Esp8266 core for Arduino version latest beta
 platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
@@ -117,8 +143,46 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
 ; lwIP 2 - Higher Bandwitdh Low Memory no Features
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwitdh no Features
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; VTABLES in Flash (default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++-exc
+
+[core_stage_ipv6]
+; *** Esp8266 core for Arduino version latest beta
+platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
+                            -O2
+                            -DBEARSSL_SSL_BASIC
+; nonos-sdk 22y
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
+; nonos-sdk 22x
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
+; nonos-sdk-pre-v3
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwitdh Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth IPv6
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
 ; VTABLES in Flash (default)
                             -DVTABLES_IN_FLASH
 ; VTABLES in Heap
@@ -178,10 +242,14 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;build_flags               = ${core_2_4_2.build_flags}
 ;platform                  = ${core_2_5_2.platform}
 ;build_flags               = ${core_2_5_2.build_flags}
+;platform                  = ${core_2_5_2_ipv6.platform}
+;build_flags               = ${core_2_5_2_ipv6.build_flags}
 ;platform                  = ${core_stage.platform}
 ;build_flags               = ${core_stage.build_flags}
-platform                  = ${core_pre.platform}
-build_flags               = ${core_pre.build_flags}
+platform                  = ${core_stage_ipv6.platform}
+build_flags               = ${core_stage_ipv6.build_flags}
+;platform                  = ${core_pre.platform}
+;build_flags               = ${core_pre.build_flags}
 
 [common]
 framework                 = arduino

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT услуга е намерена на"
 #define D_FOUND_AT "намерена в"
 #define D_SYSLOG_HOST_NOT_FOUND "Хостът на системния лог не е намерен"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Запазено във флаш паметта на"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Služba MQTT byla nalezena"
 #define D_FOUND_AT "znalezeno v"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host nebyl nalezen"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Uloženo do paměti flash v"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT-Service gefunden bei"
 #define D_FOUND_AT "gefunden bei"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog-Host nicht gefunden"
+#define D_CONNECT_V6_ADDR_INFO "IPv6 globale Adresse"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "in Flash gespeichert am"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Βρέθηκε υπηρεσία MQTT στο"
 #define D_FOUND_AT "βρέθηκε στο"
 #define D_SYSLOG_HOST_NOT_FOUND "Δε βρέθηκε Syslog Host"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Αποθηκεύτηκε από τη Flash στο"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT service found on"
 #define D_FOUND_AT "found at"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host not found"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Saved to flash at"

--- a/sonoff/language/es-ES.h
+++ b/sonoff/language/es-ES.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Servicio MQTT encontrado en"
 #define D_FOUND_AT "encontrado en"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host no encontrado"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Grabado a la flash en"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Service MQTT trouvé sur"
 #define D_FOUND_AT "trouvé à"
 #define D_SYSLOG_HOST_NOT_FOUND "Hôte SysLog introuvable"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Enregistré en flash à"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT נמצאו שירותי"
 #define D_FOUND_AT "נמצא ב"
 #define D_SYSLOG_HOST_NOT_FOUND "לא נמצא Syslog מארח"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "נשמר לפלאש ב"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "élő MQTT szolgáltatás a(z)"
 #define D_FOUND_AT "a(z)"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog hoszt nem található"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Flash-re mentve a(z)"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Servizio MQTT trovato su"
 #define D_FOUND_AT "trovato a"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host non trovato"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Salvato nella flash in"

--- a/sonoff/language/ko-KO.h
+++ b/sonoff/language/ko-KO.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT 서비스 발견"
 #define D_FOUND_AT "다음에서 발견"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog 호스트가 발견되지 않았습니다"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "플래시에 저장"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT dienst gevonden op"
 #define D_FOUND_AT "gevonden op"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host niet gevonden"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Opgeslagen in flash op"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Usługa MQTT została znaleziona"
 #define D_FOUND_AT "znalezione w"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host nie znaleziony"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Zapisane do pamięci flash w"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Serviço MQTT encontrado em"
 #define D_FOUND_AT "encontrado em"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog anfitrião não encontrado"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Guardado na flash em"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Serviço MQTT encontrado em"
 #define D_FOUND_AT "encontrado em"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog anfitrião não encontrado"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Guardado na flash em"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT сервис service найдено"
 #define D_FOUND_AT "найдено в"
 #define D_SYSLOG_HOST_NOT_FOUND "System лог хост не найден"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Сохранено во флэш-память"

--- a/sonoff/language/sk-SK.h
+++ b/sonoff/language/sk-SK.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Služba MQTT bola nájdená"
 #define D_FOUND_AT "nájdené v"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog Host nebol nájdený"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Uložené do flash pamäte v"

--- a/sonoff/language/sv-SE.h
+++ b/sonoff/language/sv-SE.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT-tjänst hittades på"
 #define D_FOUND_AT "hittades vid"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog-värd hittades inte"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Sparade till flash vid"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "Üzerinden MQTT serivisi tespit edildi"
 #define D_FOUND_AT "(bulundu)"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog hostu bulunamadı"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Bellekten (Flash) kaydedidi:"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "MQTT сервер знайдено"
 #define D_FOUND_AT "знайдено в"
 #define D_SYSLOG_HOST_NOT_FOUND "Сервер журналу не знайдено"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "Збережено в флэш-пам'ять"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "发现 MQTT 服务:"
 #define D_FOUND_AT "发现:"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog 主机未找到"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "保存到 flash:"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -213,6 +213,7 @@
 #define D_MQTT_SERVICE_FOUND "發現MQTT服務:"
 #define D_FOUND_AT "found at"
 #define D_SYSLOG_HOST_NOT_FOUND "Syslog主機未找到"
+#define D_CONNECT_V6_ADDR_INFO "Got IPv6 global address"
 
 // settings.ino
 #define D_SAVED_TO_FLASH_AT "保存到 flash:"

--- a/sonoff/support_wifi.ino
+++ b/sonoff/support_wifi.ino
@@ -33,6 +33,9 @@ const uint8_t WIFI_CHECK_SEC = 20;         // seconds
 const uint8_t WIFI_RETRY_OFFSET_SEC = 20;  // seconds
 
 #include <ESP8266WiFi.h>                   // Wifi, MQTT, Ota, WifiManager
+#if LWIP_IPV6
+#include <AddrList.h>                      // IPv6 DualStack
+#endif
 
 struct WIFI {
   uint32_t last_event = 0;                 // Last wifi connection event
@@ -235,6 +238,24 @@ void WifiBegin(uint8_t flag, uint8_t channel)
   }
   AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CONNECTING_TO_AP "%d %s " D_IN_MODE " 11%c " D_AS " %s..."),
     Settings.sta_active +1, Settings.sta_ssid[Settings.sta_active], kWifiPhyMode[WiFi.getPhyMode() & 0x3], my_hostname);
+
+#if LWIP_IPV6
+  for (bool configured = false; !configured;) {
+    uint16_t cfgcnt=0;
+    for (auto addr : addrList)
+    {
+      if ((configured = !addr.isLocal() && addr.isV6()) || cfgcnt==30) break; // IPv6 is mandatory but stop after 15 seconds
+      delay(500);  // Loop until real IPv6 address is aquired or too many tries failed
+      cfgcnt++;
+    }
+  }
+  for (auto a : addrList) {
+    if(!a.isLocal() && !a.isLegacy())
+    {
+      AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CONNECT_V6_ADDR_INFO " %s"),a.toString().c_str());
+    }
+  }
+#endif
 }
 
 void WifiBeginAfterScan()


### PR DESCRIPTION
## Description:
Initial IPv6 support for SLAAC (automatic address configuration). Webfrontend and MQTT works using IPv6. Problems with `.text1' will not fit in region `iram1_0_seg' for all builds besides sonoff-minimal, sonoff-basic, sonoff-classic, sonoff-ir. IPv6 support seems to use some iram what causes the larger environments to fail. 

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
Only 2.5.2 and pre-2.6 support IPv6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

Greetings,

      Heiko.