### PR TITLE
Fix some errors...

### DIFF
--- a/sonoff/xdrv_28_pcf8574.ino
+++ b/sonoff/xdrv_28_pcf8574.ino
@@ -37,7 +37,7 @@ struct PCF8574 {
   uint8_t pin_mask[MAX_PCF8574] = { 0 };
   uint8_t max_connected_ports = 0;        // Max numbers of devices comming from PCF8574 modules
   uint8_t max_devices = 0;                // Max numbers of PCF8574 modules
-  char stype[8];
+  char stype[9];
   bool type = true;
 } Pcf8574;
 
@@ -95,6 +95,7 @@ void Pcf8574Init()
     pcf8574_address++;
     if ((PCF8574_ADDR1 + 8) == pcf8574_address) {
       pcf8574_address = PCF8574_ADDR2;
+      i=0;
     }
   }
   if (Pcf8574.max_devices) {
@@ -118,7 +119,7 @@ void Pcf8574Init()
         }
       }
     }
-    AddLog_P2(LOG_LEVEL_INFO, PSTR("PCF: Total devices %d, PCF8574 output ports %d"), devices_present, Pcf8574.max_connected_ports);
+    AddLog_P2(LOG_LEVEL_INFO, PSTR("PCF: Total devices %d, PCF8574 output ports %d"), Pcf8574.max_devices, Pcf8574.max_connected_ports);
   }
 }
 


### PR DESCRIPTION
1. reset loop i=1 if address switches to range PCF8574_ADDR2 (PCF8574A were NOT detected)
2. correct logoutput to show correct number of boards found 
3. String array to short for PCF8574A. Overwrite the pfc8574.type with false. Hard to find bug.....
Tested with at least 2 PCF8574 boards.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
