### PR TITLE
Fix Rules were not triggered with IR unknown protocol or in sonoff-ir

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -2,6 +2,7 @@
  * 6.6.0.18 20191010
  * Add command DimmerRange in Light module to support 2 byte dimming ranges from Tuya
  * Add Zigbee additional commands and sending messages to control devices (#6095)
+ * Fix Rules were not triggered with IR unknown protocol or in sonoff-it (#6629)
  *
  * 6.6.0.17 20191009
  * Add command SetOption34 0..255 to set backlog delay. Default value is 200 (mSeconds) (#6562)

--- a/sonoff/xdrv_05_irremote.ino
+++ b/sonoff/xdrv_05_irremote.ino
@@ -174,13 +174,13 @@ void IrReceiveCheck(void)
       ResponseJsonEndEnd();
       MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_IRRECEIVED));
 
-      if (iridx) {
-        XdrvRulesProcess();
+      XdrvRulesProcess();
 #ifdef USE_DOMOTICZ
+      if (iridx) {
         unsigned long value = results.value | (iridx << 28);  // [Protocol:4, Data:28]
         DomoticzSensor(DZ_COUNT, value);                      // Send data as Domoticz Counter value
-#endif  // USE_DOMOTICZ
       }
+#endif  // USE_DOMOTICZ
     }
 
     irrecv->resume();

--- a/sonoff/xdrv_05_irremote_full.ino
+++ b/sonoff/xdrv_05_irremote_full.ino
@@ -198,14 +198,10 @@ String sendIRJsonState(const struct decode_results &results) {
 
 void IrReceiveCheck(void)
 {
-  char sirtype[14];  // Max is AIWA_RC_T501
-  int8_t iridx = 0;
-
   decode_results results;
 
   if (irrecv->decode(&results)) {
     uint32_t now = millis();
-
 
 //    if ((now - ir_lasttime > IR_TIME_AVOID_DUPLICATE) && (UNKNOWN != results.decode_type) && (results.bits > 0)) {
     if (!irsend_active && (now - ir_lasttime > IR_TIME_AVOID_DUPLICATE)) {
@@ -236,13 +232,7 @@ void IrReceiveCheck(void)
       ResponseJsonEndEnd();
       MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_IRRECEIVED));
 
-      if (iridx) {
-        XdrvRulesProcess();
-#ifdef USE_DOMOTICZ
-        unsigned long value = results.value | (iridx << 28);  // [Protocol:4, Data:28]
-        DomoticzSensor(DZ_COUNT, value);                      // Send data as Domoticz Counter value
-#endif  // USE_DOMOTICZ
-      }
+      XdrvRulesProcess();
     }
 
     irrecv->resume();


### PR DESCRIPTION
## Description:

Rules are now correctly triggered when IR unknown protocol is received.
Rules are now correctly triggered with "sonoff-ir" and "sonoff-ircustom"

**Related issue (if applicable):** fixes #6629 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
