### PR TITLE
sendmail with bearsssl-light

### DIFF
--- a/sonoff/WiFiClientSecureLightBearSSL.cpp
+++ b/sonoff/WiFiClientSecureLightBearSSL.cpp
@@ -21,7 +21,8 @@
 */
 
 #include "my_user_config.h"
-#ifdef USE_MQTT_TLS
+//#ifdef USE_MQTT_TLS
+#if defined(USE_MQTT_TLS) || defined (USE_SENDMAIL)
 
 //#define DEBUG_TLS
 

--- a/sonoff/sendemail.h
+++ b/sonoff/sendemail.h
@@ -3,10 +3,12 @@
 
 //#define DEBUG_EMAIL_PORT
 
-#include <WiFiClient.h>
-#include <WiFiClientSecure.h>
+//#include <WiFiClient.h>
+//#include <WiFiClientSecure.h>
 #include <base64.h>
-#include <core_version.h>
+//#include <core_version.h>
+
+#include "WiFiClientSecureLightBearSSL.h"
 
 class SendEmail
 {
@@ -22,10 +24,7 @@ class SendEmail
     WiFiClient* client;
 #else
     // use bear ssl
-  //  #include "WiFiClientSecureLightBearSSL.h"
-  //  BearSSL::WiFiClientSecure_light *client;
-    BearSSL::WiFiClientSecure* client;
-    //WiFiClientSecure* client;
+    BearSSL::WiFiClientSecure_light *client;
 #endif
     String readClient();
     void a3_to_a4(unsigned char * a4, unsigned char * a3);

--- a/sonoff/sendemail.ino
+++ b/sonoff/sendemail.ino
@@ -1,10 +1,12 @@
+#ifdef USE_SENDMAIL
+
 #include "sendemail.h"
 
 // enable serial debugging
 //#define DEBUG_EMAIL_PORT Serial
 
 SendEmail::SendEmail(const String& host, const int port, const String& user, const String& passwd, const int timeout, const int auth_used) :
-    host(host), port(port), user(user), passwd(passwd), timeout(timeout), ssl(ssl), auth_used(auth_used), client(new WiFiClientSecure())
+    host(host), port(port), user(user), passwd(passwd), timeout(timeout), ssl(ssl), auth_used(auth_used), client(new BearSSL::WiFiClientSecure_light(1024,1024))
 {
 
 }
@@ -22,7 +24,7 @@ String SendEmail::readClient()
   return r;
 }
 
-void SetSerialBaudrate(int baudrate);
+//void SetSerialBaudrate(int baudrate);
 
 bool SendEmail::send(const String& from, const String& to, const String& subject, const String& msg)
 {
@@ -42,21 +44,23 @@ bool SendEmail::send(const String& from, const String& to, const String& subject
 
 #if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_2)
 #else
-  client->setInsecure();
+  //client->setInsecure();
+  /*
   bool mfln = client->probeMaxFragmentLength(host.c_str(), port, 512);
 #ifdef DEBUG_EMAIL_PORT
   DEBUG_EMAIL_PORT.printf("MFLN supported: %s\n", mfln ? "yes" : "no");
 #endif
   if (mfln) {
       client->setBufferSizes(512, 512);
-  }
+  }*/
 #endif
 
 
   if (!client->connect(host.c_str(), port))
   {
 #ifdef DEBUG_EMAIL_PORT
-      DEBUG_EMAIL_PORT.println("Connection failed");
+      DEBUG_EMAIL_PORT.println("Connection failed: ");
+      //DEBUG_EMAIL_PORT.println (client->getLastSSLError());
 #endif
     return false;
   }
@@ -302,3 +306,5 @@ int SendEmail::base64_encode(char *output, const char *input, int inputLen) {
 	return encLen;
 }
 #endif
+
+#endif // USE_SENDMAIL

--- a/sonoff/xdrv_01_webserver.ino
+++ b/sonoff/xdrv_01_webserver.ino
@@ -2461,7 +2461,8 @@ String UrlEncode(const String& text)
 // sendmail [*:*:*:*:*:to:subject] data uses defines from user_config
 // sendmail currently only works with core 2.4.2
 
-#define SEND_MAIL_MINRAM 19*1024
+
+#define SEND_MAIL_MINRAM 12*1024
 
 uint16_t SendMail(char *buffer) {
   uint16_t count;


### PR DESCRIPTION
## Description:

thanks to @s-hadingers bear ssl light sendmail now works with only 12k of ram!


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
