### PR TITLE
Fix crash when uneven string size

### DIFF
--- a/sonoff/support.ino
+++ b/sonoff/support.ino
@@ -835,7 +835,7 @@ void SerialSendRaw(char *codes)
 
   int size = strlen(codes);
 
-  while (size > 0) {
+  while (size > 1) {
     strlcpy(stemp, codes, sizeof(stemp));
     code = strtol(stemp, &p, 16);
     Serial.write(code);

--- a/sonoff/xdrv_08_serial_bridge.ino
+++ b/sonoff/xdrv_08_serial_bridge.ino
@@ -126,7 +126,7 @@ void CmndSSerialSend(void)
         char *codes = RemoveSpace(XdrvMailbox.data);
         int size = strlen(XdrvMailbox.data);
 
-        while (size > 0) {
+        while (size > 1) {
           strlcpy(stemp, codes, sizeof(stemp));
           code = strtol(stemp, &p, 16);
           SerialBridgeSerial->write(code);                                  // "AA004566" as hex values

--- a/sonoff/xdrv_23_zigbee_9_impl.ino
+++ b/sonoff/xdrv_23_zigbee_9_impl.ino
@@ -291,7 +291,7 @@ void CmndZigbeeZNPSend(void)
 
 		SBuffer buf((size+1)/2);
 
-    while (size > 0) {
+    while (size > 1) {
       char stemp[3];
       strlcpy(stemp, codes, sizeof(stemp));
       code = strtol(stemp, nullptr, 16);


### PR DESCRIPTION
## Description:

Fix a crash that would happen when a Hex string is composed of an uneven number of hex digits; in such case the last digit is ignored. No change for well formed hex strings.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
