### PR TITLE
fix pwm multichannel

### DIFF
--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -8,6 +8,7 @@
  * Add incremental beeps to Ifan03 remote control fan speed buttons (#6636)
  * Add rule support after every command execution like Fanspeed#Data=2 (#6636)
  * Fix handling of ligth channels when pwm_multichannel (Option68) is enabled
+ * Add WebUI for multiple, independent PWM channels
  *
  * 6.6.0.17 20191009
  * Add command SetOption34 0..255 to set backlog delay. Default value is 200 (mSeconds) (#6562)

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -7,6 +7,7 @@
  * Add define USE_SONOFF_RF to enable/disable Sonoff Rf support (#6648)
  * Add incremental beeps to Ifan03 remote control fan speed buttons (#6636)
  * Add rule support after every command execution like Fanspeed#Data=2 (#6636)
+ * Fix handling of ligth channels when pwm_multichannel (Option68) is enabled
  *
  * 6.6.0.17 20191009
  * Add command SetOption34 0..255 to set backlog delay. Default value is 200 (mSeconds) (#6562)


### PR DESCRIPTION
## Description:

With Option68 enabled, the pwm channels are independent. The channel
setting code was indirectly using setRGB and setCW. Those methods
recalculate the channel values to adjust for brightness, thereby
modifying the channel values.
    
This change add raw channel set/get methods that do not modify the
channels values and uses those when pwm_multichannel is in effect.

Add WebIf support for setting the channels.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
