### PR TITLE
Do not include DS18B20 in every build

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -415,15 +415,6 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #endif  // FIRMWARE_IR
 
 /*********************************************************************************************\
- * Mandatory define for DS18x20 if changed by above image selections
-\*********************************************************************************************/
-
-#if defined(USE_DS18x20)
-#else
-#define USE_DS18B20                           // Default DS18B20 sensor needs no external library
-#endif
-
-/*********************************************************************************************\
  * [sonoff-basic.bin]
  * Provide an image without sensors
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:
Not every firmware has the need that the driver DS18B20 is included.
A DS18xxx driver is enabled by default in my_user_config.h 
Solves #6647

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
