### PR TITLE
Fix line used for tagging during custom builds

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -543,6 +543,8 @@
 //#define USE_HRE                                  // Add support for Badger HR-E Water Meter (+1k4 code)
 //#define USE_A4988_Stepper                        // Add support for A4988 stepper-motor-driver-circuit (+10k5 code)
 
+// -- End of general directives -------------------
+
 /*********************************************************************************************\
  * Debug features
 \*********************************************************************************************/

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -524,7 +524,7 @@
   #define USE_ZIGBEE_PRECFGKEY_H 0x0D0C0A0806040200L  // note: changing requires to re-pair all devices
   #define USE_ZIGBEE_PERMIT_JOIN false           // don't allow joining by default
 
-// ------------------------------------------------
+// -- Other sensors/drivers -----------------------
 
 #define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
 

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -440,7 +440,7 @@
 //#define USE_RDM6300                              // Add support for RDM6300 125kHz RFID Reader (+0k8)
 //#define USE_IBEACON                              // Add support for bluetooth LE passive scan of ibeacon devices (uses HM17 module)
 
-// Power monitoring sensors -----------------------
+// -- Power monitoring sensors --------------------
 #define USE_ENERGY_MARGIN_DETECTION              // Add support for Energy Margin detection (+1k6 code)
   #define USE_ENERGY_POWER_LIMIT                 // Add additional support for Energy Power Limit detection (+1k2 code)
 #define USE_PZEM004T                             // Add support for PZEM004T Energy monitor (+2k code)


### PR DESCRIPTION
I'm starting to use lines with `--` in them to identify different portions of the my_user_config.h to determine which directives are mandatory to make a build possible and those that may be commented out without impacting on a compile.

This is useful for automation of custom builds wherein the my_user_config.h file is loaded, edited according to requirements, and rewritten by means of a program or script.

I'm guessing this particular line is an exception by mistake so this PR just brings this particular line in check with the others that look the same or follow the same convention of

`-- FUNCTIONAL DESCRIPTION ---------------`

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
