### PR TITLE
Remove build entry for core 2.4.2....

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -55,6 +55,20 @@ platform                  = espressif8266@1.5.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Tesp8266.flash.1m0.ld
 
+[core_2_4_2]
+; *** Esp8266 core for Arduino version 2.4.2
+platform                  = espressif8266@1.8.0
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m0.ld
+                            -lstdc++ -lsupc++
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                            -DVTABLES_IN_FLASH
+
 [core_pre]
 ; *** Arduino Esp8266 core pre 2.6.x for Tasmota (mqtt reconnects fixed)
 platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
@@ -173,6 +187,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Select one core set for platform and build_flags
 ;platform                  = ${core_2_3_0.platform}
 ;build_flags               = ${core_2_3_0.build_flags}
+;platform                  = ${core_2_4_2.platform}
+;build_flags               = ${core_2_4_2.build_flags}
 platform                  = ${core_pre.platform}
 build_flags               = ${core_pre.build_flags}
 ;platform                  = ${core_pre_ipv6.platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,20 +55,6 @@ platform                  = espressif8266@1.5.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Tesp8266.flash.1m0.ld
 
-[core_2_4_2]
-; *** Esp8266 core for Arduino version 2.4.2
-platform                  = espressif8266@1.8.0
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m0.ld
-                            -lstdc++ -lsupc++
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-                            -DVTABLES_IN_FLASH
-
 [core_pre]
 ; *** Arduino Esp8266 core pre 2.6.x for Tasmota (mqtt reconnects fixed)
 platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
@@ -187,8 +173,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Select one core set for platform and build_flags
 ;platform                  = ${core_2_3_0.platform}
 ;build_flags               = ${core_2_3_0.build_flags}
-;platform                  = ${core_2_4_2.platform}
-;build_flags               = ${core_2_4_2.build_flags}
 platform                  = ${core_pre.platform}
 build_flags               = ${core_pre.build_flags}
 ;platform                  = ${core_pre_ipv6.platform}

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,46 +55,6 @@ platform                  = espressif8266@1.5.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Tesp8266.flash.1m0.ld
 
-[core_2_4_2]
-; *** Esp8266 core for Arduino version 2.4.2
-platform                  = espressif8266@1.8.0
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m0.ld
-                            -lstdc++ -lsupc++
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-                            -DVTABLES_IN_FLASH
-
-[core_2_5_2]
-; *** Esp8266 core for Arduino version 2.5.2
-platform                  = espressif8266@~2.2.2
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
-                            -O2
-                            -DBEARSSL_SSL_BASIC
-; nonos-sdk 22x
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
-; nonos-sdk-pre-v3
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-                            -DVTABLES_IN_FLASH
-                            -fno-exceptions
-                            -lstdc++
-
 [core_pre]
 ; *** Arduino Esp8266 core pre 2.6.x for Tasmota (mqtt reconnects fixed)
 platform                  = https://github.com/Jason2866/platform-espressif8266.git#Tasmota
@@ -213,10 +173,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Select one core set for platform and build_flags
 ;platform                  = ${core_2_3_0.platform}
 ;build_flags               = ${core_2_3_0.build_flags}
-;platform                  = ${core_2_4_2.platform}
-;build_flags               = ${core_2_4_2.build_flags}
-;platform                  = ${core_2_5_2.platform}
-;build_flags               = ${core_2_5_2.build_flags}
 platform                  = ${core_pre.platform}
 build_flags               = ${core_pre.build_flags}
 ;platform                  = ${core_pre_ipv6.platform}


### PR DESCRIPTION
because there are many unsolved issues (bugs) in this core.
The core 2.3.0 and core pre 2.6 are better. 
Users should not use core 2.4.2 for Tasmota anymore.

Edit since 2.5.2 is already removed

## Description:
Fixes weird wifi errors

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.3.0, 2.4.2, 2.5.2, and pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
