### PR TITLE
Nova SDS polling enhancement 

### DIFF
--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -429,8 +429,8 @@
   #define CO2_HIGH             1200              // Above this CO2 value show red light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
-#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
-  #define WORKING_PERIOD       5                 // Working period of the SDS Sensor, Takes a reading every X Minutes
+#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+1k5 code)
+  #define STARTING_OFFSET      30                // Turn on NovaSDS XX-seconds before tele_period is reached
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge (+0k8 code)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10                // Set the startup volume on init, the range can be 0..30(max)


### PR DESCRIPTION
## Description:  

Changed the type for getting sensor values to polling. Before we used the "working period" method (the sensor starts/stops periodically on it's own and reports the data if Tasmota asks for values). Because of that I've detected a drift after some time which means that you don't get current values if "tele_period" is reached. Another point was that the "working period" method only allows a frequency above 1 minute. The new code starts the sensor directly (with commands sleep and work) if we reached a time we set in define "STARTING_OFFSET". 5 seconds before tele_period, we are doing 4 measurements, calculate the average and current values are present if tele_period is reached. The new method allows us also to get a polling frequency below 1 minute (usable for early fire detection). For precise measurements values of STARTING_OFFSET above 30 seconds are recommended. If using STARTING_OFFSET of 30 seconds and tele_period of 30 seconds the sensor now runs permanent.

Fixed also wrong values at defines NOVA_SDS_SLEEP and NOVA_SDS_WORK.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
