### PR TITLE
Fixes functionality of command Sensor20 for NovaSDS

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -348,7 +348,7 @@ struct SYSCFG {
   uint8_t       rgbwwTable[5];             // 71A
   uint8_t       user_template_base;        // 71F
   mytmplt       user_template;             // 720  29 bytes
-  uint8_t       novasds_period;            // 73D
+  uint8_t       novasds_startingoffset;    // 73D
   uint8_t       web_color[18][3];          // 73E
   uint16_t      display_width;             // 774
   uint16_t      display_height;            // 776

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -849,7 +849,7 @@ void SettingsDefaultSet2(void)
     Settings.rgbwwTable[j] = 255;
   }
 
-  Settings.novasds_period = WORKING_PERIOD;
+  Settings.novasds_startingoffset = STARTING_OFFSET;
 
   SettingsDefaultWebColor();
 
@@ -1102,7 +1102,7 @@ void SettingsDelta(void)
       Settings.param[P_RGB_REMAP] = RGB_REMAP_RGBW;
     }
     if (Settings.version < 0x06050003) {
-      Settings.novasds_period = WORKING_PERIOD;
+      Settings.novasds_startingoffset = STARTING_OFFSET;
     }
     if (Settings.version < 0x06050006) {
       SettingsDefaultWebColor();

--- a/sonoff/xsns_20_novasds.ino
+++ b/sonoff/xsns_20_novasds.ino
@@ -151,7 +151,7 @@ void NovaSdsSecond(void)                 // Every second
     NovaSdsSetWorkPeriod();
     novasds_valid=1;
   }
-  if((Settings.tele_period - STARTING_OFFSET <= 0))
+  if((Settings.tele_period - Settings.novasds_startingoffset <= 0))
   {
     if(!cont_mode)
     { //switched to continuous mode
@@ -162,7 +162,7 @@ void NovaSdsSecond(void)                 // Every second
   else
     cont_mode = 0;
 
-  if(tele_period == Settings.tele_period - STARTING_OFFSET && !cont_mode)
+  if(tele_period == Settings.tele_period -  Settings.novasds_startingoffset && !cont_mode)
   { //lets start fan and laser
     NovaSdsCommand(NOVA_SDS_SLEEP_AND_WORK, NOVA_SDS_SET_MODE, NOVA_SDS_WORK, NOVA_SDS_DEVICE_ID, nullptr);  
   }
@@ -191,10 +191,10 @@ void NovaSdsSecond(void)                 // Every second
 bool NovaSdsCommandSensor(void)
 {
   if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload < 256)) {
-    Settings.novasds_period = XdrvMailbox.payload;
-    NovaSdsSetWorkPeriod();
+    if( XdrvMailbox.payload < 10 ) Settings.novasds_startingoffset = 10;
+    else Settings.novasds_startingoffset = XdrvMailbox.payload;
   }
-  Response_P(S_JSON_SENSOR_INDEX_NVALUE, XSNS_20, Settings.novasds_period);
+  Response_P(S_JSON_SENSOR_INDEX_NVALUE, XSNS_20, Settings.novasds_startingoffset);
 
   return true;
 }


### PR DESCRIPTION
Fixes the functionality of command "Sensor20" which was missing after merge #6673.

With command "Sensor20" you can now set the starting offset at runtime. The polling interval still depends on the tele_period.

## Description:

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
