### PR TITLE
preserve some stack size on FUNC_EVERY_SECOND

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -838,8 +838,8 @@ void PerformEverySecond(void)
     }
   }
 
-  XdrvCall(FUNC_EVERY_SECOND);
-  XsnsCall(FUNC_EVERY_SECOND);
+  //XdrvCall(FUNC_EVERY_SECOND);
+  //XsnsCall(FUNC_EVERY_SECOND);
 }
 
 /*********************************************************************************************\
@@ -1682,6 +1682,10 @@ void loop(void)
     Every250mSeconds();
     XdrvCall(FUNC_EVERY_250_MSECOND);
     XsnsCall(FUNC_EVERY_250_MSECOND);
+    if (!state_250mS) {
+      XdrvCall(FUNC_EVERY_SECOND);
+      XsnsCall(FUNC_EVERY_SECOND);
+    }
   }
 
   if (!serial_local) { SerialInput(); }


### PR DESCRIPTION
## Description:

when comparing available stack size 
on FUNC_EVERY_100_MSECOND and FUNC_EVERY_SECOND
FUNC_EVERY_SECOND gets about 540 bytes lesser stack size.
this leads to random crashes in some cases in scripter when executed cmd in >S section needs more stack like sendmail. (TSL needs some more stack)
(this fixes the random crashes at least on sendmail)

i see no impact on the backwards compatibility or other side effects

(by the way, command ExecuteCommand also eats up some stack on longer arguments lists by copying the command to a stack buffer.)


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).