### PR TITLE
fix ssd1306 rotate

### DIFF
--- a/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
+++ b/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
@@ -584,6 +584,22 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
 }
 
 
+void Adafruit_SSD1306::DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font) {
+// ignore update mode
+  //if (p==DISPLAY_INIT_MODE) {
+    setRotation(rot);
+    invertDisplay(false);
+    setTextWrap(false);         // Allow text to run off edges
+    cp437(true);
+    setTextFont(font);
+    setTextSize(size);
+    setTextColor(WHITE,BLACK);
+    setCursor(0,0);
+    fillScreen(BLACK);
+    Updateframe();
+  //}
+}
+
 #if 0
 
 // DRAWING FUNCTIONS -------------------------------------------------------

--- a/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.h
+++ b/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.h
@@ -141,6 +141,7 @@ public:
   void         invertDisplay(boolean i);
   void         dim(boolean dim);
   void         DisplayOnff(int8_t on);
+  void         DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font);
 
   #if 0
   void         clearDisplay(void);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #6687

@arendst 
this is a better fix because the whole DisplayInit was missing in ssd1306
SH1106 had this call already and rotating worked
this also sets the other params on ssd1306 like font and size 



## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).