### PR TITLE
Update TasmotaSerial.cpp - Change speed >= 50000 for 57600bps

### DIFF
--- a/lib/TasmotaSerial-2.4.1/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-2.4.1/src/TasmotaSerial.cpp
@@ -158,7 +158,7 @@ bool TasmotaSerial::begin(long speed, int stop_bits) {
     m_bit_time = ESP.getCpuFreqMHz() * 1000000 / speed;
     m_bit_start_time = m_bit_time + m_bit_time/3 - (ESP.getCpuFreqMHz() > 120 ? 700 : 500); // pre-compute first wait
     m_high_speed = (speed >= 9600);
-    m_very_high_speed = (speed >= 100000);
+    m_very_high_speed = (speed >= 50000);
   }
   return m_valid;
 }


### PR DESCRIPTION
## Description:

Change recommended by @s-hadinger makes software serial work better @ 57600bps which makes it possible to use software serial to flash Arduino Uno/Mini/Nano boards using software serial.

Without this change, stray characters are sometimes encountered.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
