### PR TITLE
Add support for Arduno Uno/Mini/Nano on Serial

### DIFF
--- a/lib/ArduinoHexParse/README.md
+++ b/lib/ArduinoHexParse/README.md
@@ -1,0 +1,3 @@
+# ArduinoHexParse
+
+Parse hex files created by Arduino for Uno/Mini/Nano

--- a/lib/ArduinoHexParse/keywords.txt
+++ b/lib/ArduinoHexParse/keywords.txt
@@ -1,0 +1,25 @@
+#######################################
+# Syntax Coloring Map for ArduinoHexParse
+# (esp8266)
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+ArduinoHexParse	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+ArduinoHexParse  KEYWORD2
+ParseLine        KEYWORD2
+GetFlashPage     KEYWORD2
+GetLoadAddress   KEYWORD2
+IsFlashPageReady KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+

--- a/lib/ArduinoHexParse/library.json
+++ b/lib/ArduinoHexParse/library.json
@@ -1,0 +1,12 @@
+{
+    "name": "ArduinoHexParse",
+    "version": "0.0.1",
+    "description": "Parse hex files created by Arduino for Uno/Mini/Nano",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/arendst/Sonoff-Tasmota/lib/ArduinoHexParse"
+    },
+    "frameworks": "arduino",
+    "platforms": "espressif8266"
+}

--- a/lib/ArduinoHexParse/library.properties
+++ b/lib/ArduinoHexParse/library.properties
@@ -1,0 +1,9 @@
+name=ArduinoHexParse
+version=0.0.1
+author=Andre Thomas
+maintainer=Andre Thomas <andre1024@gmail.com>
+sentence=Parse hex files created by Arduino for Uno/Mini/Nano
+paragraph=
+category=Signal Input/Output
+url=
+architectures=esp8266

--- a/lib/ArduinoHexParse/src/ArduinoHexParse.cpp
+++ b/lib/ArduinoHexParse/src/ArduinoHexParse.cpp
@@ -1,0 +1,134 @@
+/*
+  Copyright (C) 2019  Andre Thomas and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#include "ArduinoHexParse.h"
+
+ArduinoHexParse::ArduinoHexParse(void)
+{
+  loadAddress[0] = 0;
+  loadAddress[1] = 0;
+}
+
+void ArduinoHexParse::ParseLine(byte* hexline)
+{
+  recordType = GetRecordType(hexline);
+  if (0 == recordType) {
+    address = GetAddress(hexline);
+    len = GetLength(hexline);
+    GetData(hexline, len);
+    if (128 == PageMemIdx) {
+      if (!firstRun) {
+        loadAddress[1] += 0x40;
+        if (0 == loadAddress[1]) {
+          loadAddress[0] += 1;
+        }
+      }
+      firstRun = false;
+      FlashPageReady = true;
+      PageMemIdx = 0;
+    }
+    nextAddress = address + len;
+  }
+  if (1 == recordType) {
+    EndOfFile();
+    FlashPageReady = true;
+  }
+}
+
+bool ArduinoHexParse::IsFlashPageReady(void)
+{
+  return FlashPageReady;
+}
+
+byte* ArduinoHexParse::GetFlashPage(void)
+{
+  FlashPageReady = false;
+  return FlashPage;
+}
+
+byte* ArduinoHexParse::GetLoadAddress(void)
+{
+  return loadAddress;
+}
+
+void ArduinoHexParse::GetLoadAddress(byte* hexline)
+{
+  char buff[3];
+  buff[2] = '\0';
+  buff[0] = hexline[3];
+  buff[1] = hexline[4];
+  loadAddress[0] = strtol(buff, 0, 16); 
+  buff[0] = hexline[5];
+  buff[1] = hexline[6];
+  loadAddress[1] = strtol(buff, 0, 16); 
+}
+
+byte* ArduinoHexParse::GetData(byte* hexline, uint32_t len)
+{
+  uint32_t start = 9;
+  uint32_t end = (len * 2) + start;
+  char buff[3];
+  buff[2] = '\0';
+  for (uint32_t x = start; x < end; x = x+2) {
+    buff[0] = hexline[x];
+    buff[1] = hexline[x+1];
+    FlashPage[PageMemIdx] = strtol(buff, 0, 16);
+    PageMemIdx++;
+  }
+}
+
+void ArduinoHexParse::EndOfFile(void)
+{
+  loadAddress[1] += 0x40;
+  if (0 == loadAddress[1]) {
+    loadAddress[0] += 1;
+  }
+  while (128 > PageMemIdx) {          // Fill the remaing space in the memory page with 0xFF
+    FlashPage[PageMemIdx] = 0xFF;
+    PageMemIdx++;
+  }
+}
+
+uint32_t ArduinoHexParse::GetAddress(byte* hexline)
+{
+  char buff[5];
+  buff[0] = hexline[3];
+  buff[1] = hexline[4];
+  buff[2] = hexline[5];
+  buff[3] = hexline[6];
+  buff[4] = '\0';
+  return strtol(buff, 0, 16); 
+}
+
+uint16_t ArduinoHexParse::GetLength(byte* hexline)
+{
+  char buff[3];
+  buff[0] = hexline[1];
+  buff[1] = hexline[2];
+  buff[2] = '\0';
+  return strtol(buff, 0, 16); 
+}
+
+uint16_t ArduinoHexParse::GetRecordType(byte* hexline)
+{
+  char buff[3];
+  buff[0] = hexline[7];
+  buff[1] = hexline[8];
+  buff[2] = '\0';
+  return strtol(buff, 0, 16); 
+}

--- a/lib/ArduinoHexParse/src/ArduinoHexParse.h
+++ b/lib/ArduinoHexParse/src/ArduinoHexParse.h
@@ -1,0 +1,47 @@
+/*
+  Copyright (C) 2019  Andre Thomas and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __ARDUINOHEXPARSE_H__
+
+#include <Arduino.h>
+
+class ArduinoHexParse {
+  public:
+    ArduinoHexParse(void);
+    void ParseLine(byte* data);
+    byte* GetFlashPage(void);
+    byte* GetLoadAddress(void);
+    bool IsFlashPageReady(void);
+  private:
+    uint32_t address = 0;
+    uint32_t len = 0;
+    uint32_t nextAddress = 0;
+    uint32_t PageMemIdx = 0;
+    uint32_t recordType = 0;
+    byte FlashPage[128];
+    byte loadAddress[2];
+    bool FlashPageReady = false;
+    bool firstRun = true;
+    uint32_t GetAddress(byte* hexline);
+    uint16_t GetLength(byte* hexline);
+    uint16_t GetRecordType(byte* hexline);
+    byte* GetData(byte* hexline, uint32_t len);
+    void GetLoadAddress(byte* hexline);
+    void EndOfFile(void);
+};
+
+#endif // __ARDUINOHEXPARSE_H__

--- a/sonoff/_changelog.ino
+++ b/sonoff/_changelog.ino
@@ -4,6 +4,7 @@
  * Add absolute PowerDelta using command PowerDelta 101..32000 where 101 = 101-100 = 1W, 202 = 202-100 = 102W (#5901)
  * Add support for EX-Store WiFi Dimmer V4 (#5856)
  * Add ZigbeeRead command and many improvements (#6095)
+ * Add ArduinoSlave driver (EXPERIMENTAL)
  *
  * 6.6.0.19 20191018
  * Replace obsolete xsns_23_sdm120 with xnrg_08_sdm120 and consolidate define USE_SDM120

--- a/sonoff/language/bg-BG.h
+++ b/sonoff/language/bg-BG.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/cs-CZ.h
+++ b/sonoff/language/cs-CZ.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/de-DE.h
+++ b/sonoff/language/de-DE.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/el-GR.h
+++ b/sonoff/language/el-GR.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/en-GB.h
+++ b/sonoff/language/en-GB.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/es-ES.h
+++ b/sonoff/language/es-ES.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/fr-FR.h
+++ b/sonoff/language/fr-FR.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/he-HE.h
+++ b/sonoff/language/he-HE.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/hu-HU.h
+++ b/sonoff/language/hu-HU.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/it-IT.h
+++ b/sonoff/language/it-IT.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ko-KO.h
+++ b/sonoff/language/ko-KO.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/nl-NL.h
+++ b/sonoff/language/nl-NL.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pl-PL.h
+++ b/sonoff/language/pl-PL.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-BR.h
+++ b/sonoff/language/pt-BR.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/pt-PT.h
+++ b/sonoff/language/pt-PT.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/ru-RU.h
+++ b/sonoff/language/ru-RU.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/sk-SK.h
+++ b/sonoff/language/sk-SK.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/sv-SE.h
+++ b/sonoff/language/sv-SE.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/tr-TR.h
+++ b/sonoff/language/tr-TR.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/sonoff/language/uk-UK.h
+++ b/sonoff/language/uk-UK.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/sonoff/language/zh-CN.h
+++ b/sonoff/language/zh-CN.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/language/zh-TW.h
+++ b/sonoff/language/zh-TW.h
@@ -627,6 +627,9 @@
 #define D_SENSOR_SM2135_DAT    "SM2135 Dat"
 #define D_SENSOR_DEEPSLEEP     "DeepSleep"
 #define D_SENSOR_EXS_ENABLE    "EXS Enable"
+#define D_SENSOR_ARDUINO_TX    "Arduino TX"
+#define D_SENSOR_ARDUINO_RX    "Arduino RX"
+#define D_SENSOR_ARDUINO_RESET "Arduino RST"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/sonoff/my_user_config.h
+++ b/sonoff/my_user_config.h
@@ -541,6 +541,11 @@
 //#define USE_HRE                                  // Add support for Badger HR-E Water Meter (+1k4 code)
 //#define USE_A4988_STEPPER                        // Add support for A4988/DRV8825 stepper-motor-driver-circuit (+10k5 code)
 
+//#define USE_ARDUINO_SLAVE                        // Add support for Arduino Uno/Pro Mini via serial interface including flashing (+2k3 code, 44 mem)
+//  #define USE_ARDUINO_FLASH_SPEED 57600          // Usually 57600 for 3.3V variants and 115200 for 5V variants
+//  #define USE_ARDUINO_SERIAL_SPEED 57600         // Depends on the sketch that is running on the Uno/Pro Mini
+//  #define USE_ARDUINO_INVERT_RESET
+
 // -- End of general directives -------------------
 
 /*********************************************************************************************\

--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -208,6 +208,9 @@ enum UserSelectablePins {
   GPIO_SM2135_DAT,     // SM2135 Dat
   GPIO_DEEPSLEEP,      // Kill switch for deepsleep
   GPIO_EXS_ENABLE,     // EXS MCU Enable
+  GPIO_ARDUINO_TXD,    // Arduino Slave TX
+  GPIO_ARDUINO_RXD,    // Arduino Slave RX
+  GPIO_ARDUINO_RESET,  // Arduino Reset Pin
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -286,6 +289,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_DDSU666_TX "|" D_SENSOR_DDSU666_RX "|"
   D_SENSOR_SM2135_CLK "|" D_SENSOR_SM2135_DAT "|"
   D_SENSOR_DEEPSLEEP "|" D_SENSOR_EXS_ENABLE "|"
+  D_SENSOR_ARDUINO_TX "|" D_SENSOR_ARDUINO_RX "|" D_SENSOR_ARDUINO_RESET "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -697,6 +701,11 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_PN532_HSU
   GPIO_PN532_TXD,      // PN532 HSU Tx
   GPIO_PN532_RXD,      // PN532 HSU Rx
+#endif
+#ifdef USE_ARDUINO_SLAVE
+  GPIO_ARDUINO_TXD,    // Arduino Slave TX
+  GPIO_ARDUINO_RXD,    // Arduino Slave RX
+  GPIO_ARDUINO_RESET,  // Arduino Reset Pin
 #endif
 #ifdef USE_RDM6300
   GPIO_RDM6300_RX,

--- a/sonoff/xdrv_31_arduino_slave.ino
+++ b/sonoff/xdrv_31_arduino_slave.ino
@@ -1,0 +1,277 @@
+/*
+  xdrv_31_arduino_slave.ino - Support for Arduino Slave on Serial
+
+  Copyright (C) 2019  Andre Thomas and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ARDUINO_SLAVE
+
+#include <TasmotaSerial.h>
+#include <ArduinoHexParse.h>
+
+#define CONST_STK_CRC_EOP          0x20
+
+#define CMND_STK_GET_SYNC          0x30
+#define CMND_STK_SET_DEVICE        0x42
+#define CMND_STK_SET_DEVICE_EXT    0x45
+#define CMND_STK_ENTER_PROGMODE    0x50
+#define CMND_STK_LEAVE_PROGMODE    0x51
+#define CMND_STK_LOAD_ADDRESS      0x55
+#define CMND_STK_PROG_PAGE         0x64
+
+uint32_t as_spi_hex_size = 0;
+uint8_t as_spi_sector_start = 0x96;
+uint8_t as_spi_sector_counter = 0x96;
+uint8_t as_spi_sector_cursor = 0;
+bool as_flashing = false;
+
+uint8_t as_type = 0;
+
+TasmotaSerial *ArduinoSlave_Serial;
+
+#define XDRV_31                    31
+
+uint8_t ArduinoSlave_UpdateInit(void)
+{
+  as_spi_hex_size = 0;
+  as_spi_sector_counter = as_spi_sector_start; // Reset the pre-defined write address where firmware will temporarily be stored
+  as_spi_sector_cursor = 0;
+  return 0;
+}
+
+void ArduinoSlave_Reset(void)
+{
+  if (as_type) {
+#ifdef USE_ARDUINO_INVERT_RESET    
+    digitalWrite(pin[GPIO_ARDUINO_RESET], LOW);
+    delay(1);
+    digitalWrite(pin[GPIO_ARDUINO_RESET], HIGH);
+    delay(1);
+    digitalWrite(pin[GPIO_ARDUINO_RESET], LOW);
+    delay(5);
+#else
+    digitalWrite(pin[GPIO_ARDUINO_RESET], HIGH);
+    delay(1);
+    digitalWrite(pin[GPIO_ARDUINO_RESET], LOW);
+    delay(1);
+    digitalWrite(pin[GPIO_ARDUINO_RESET], HIGH);
+    delay(5);
+#endif
+  }
+}
+
+uint8_t ArduinoSlave_waitForSerialData(int dataCount, int timeout) {
+  int timer = 0;
+  while (timer < timeout) {
+    if (ArduinoSlave_Serial->available() >= dataCount) {
+      return 1;
+    }
+    delay(1);
+    timer++;
+  }
+  return 0;
+}
+
+byte ArduinoSlave_sendBytes(byte* bytes, int count) {
+  ArduinoSlave_Serial->write(bytes, count);
+  ArduinoSlave_waitForSerialData(2, 1000);
+  byte sync = ArduinoSlave_Serial->read();
+  byte ok = ArduinoSlave_Serial->read();
+  if (sync == 0x14 && ok == 0x10) {
+    return 1;
+  }
+  return 0;
+}
+
+byte ArduinoSlave_execCmd(byte cmd) {
+  byte bytes[] = { cmd, CONST_STK_CRC_EOP };
+  return ArduinoSlave_sendBytes(bytes, 2);
+}
+
+byte ArduinoSlave_execParam(byte cmd, byte* params, int count) {
+  byte bytes[32];
+  bytes[0] = cmd;
+  int i = 0;
+  while (i < count) {
+    bytes[i + 1] = params[i];
+    i++;
+  }
+  bytes[i + 1] = CONST_STK_CRC_EOP;
+  return ArduinoSlave_sendBytes(bytes, i + 2);
+}
+
+uint8_t ArduinoSlave_exitProgMode(void)
+{
+  return ArduinoSlave_execCmd(CMND_STK_LEAVE_PROGMODE); // Exit programming mode
+}
+
+void ArduinoSlave_SetupFlash(void)
+{
+  byte ProgParams[] = {0x86,0x00,0x00,0x01,0x01,0x01,0x01,0x03,0xff,0xff,0xff,0xff,0x00,0x80,0x04,0x00,0x00,0x00,0x80,0x00};
+  byte ExtProgParams[] = {0x05,0x04,0xd7,0xc2,0x00};
+  ArduinoSlave_Serial->begin(USE_ARDUINO_FLASH_SPEED);
+  if (ArduinoSlave_Serial->hardwareSerial()) { 
+    ClaimSerial();
+  }
+  ArduinoSlave_Reset();
+  ArduinoSlave_execCmd(CMND_STK_GET_SYNC);
+  ArduinoSlave_execParam(CMND_STK_SET_DEVICE, ProgParams, sizeof(ProgParams));            // Set programming parameters
+  ArduinoSlave_execParam(CMND_STK_SET_DEVICE_EXT, ExtProgParams, sizeof(ExtProgParams));  // Set extended programming parameters
+  ArduinoSlave_execCmd(CMND_STK_ENTER_PROGMODE);                                          // Enter programming mode
+}
+
+uint8_t ArduinoSlave_loadAddress(byte adrHi, byte adrLo) {
+  byte params[] = { adrHi, adrLo };
+  return ArduinoSlave_execParam(CMND_STK_LOAD_ADDRESS, params, sizeof(params));
+}
+
+void ArduinoSlave_FlashPage(byte* address, byte* data)
+{
+  byte Header[] = {CMND_STK_PROG_PAGE, 0x00, 0x80, 0x46};
+  ArduinoSlave_loadAddress(address[1], address[0]);
+  ArduinoSlave_Serial->write(Header, 4);
+  for (int i = 0; i < 128; i++) {
+    ArduinoSlave_Serial->write(data[i]);
+  }
+  ArduinoSlave_Serial->write(CONST_STK_CRC_EOP);
+  ArduinoSlave_waitForSerialData(2, 1000);
+  ArduinoSlave_Serial->read();
+  ArduinoSlave_Serial->read();
+}
+
+void ArduinoSlave_Flash(void)
+{
+  bool reading = true;
+  uint32_t read = 0;
+  uint32_t processed = 0;
+  char thishexline[50];
+  uint8_t position = 0;
+  char* flash_buffer;
+  ArduinoHexParse hexParse = ArduinoHexParse();
+
+  ArduinoSlave_SetupFlash();
+
+  flash_buffer = new char[SPI_FLASH_SEC_SIZE];
+  while (reading) {
+    ESP.flashRead(0x96000 + read, (uint32_t*)flash_buffer, FLASH_SECTOR_SIZE);
+    read = read + FLASH_SECTOR_SIZE;
+    if (read >= as_spi_hex_size) { 
+      reading = false;
+    }
+    for (uint16_t ca=0; ca<FLASH_SECTOR_SIZE; ca++) {
+      processed++;
+      if (processed <= as_spi_hex_size) {
+        if (':' == flash_buffer[ca]) {
+          position = 0;
+        }
+        if (0x0D == flash_buffer[ca]) {
+          thishexline[position] = 0;
+          hexParse.ParseLine((byte*)thishexline);
+          if (hexParse.IsFlashPageReady()) {
+            byte* page = hexParse.GetFlashPage();
+            byte* address = hexParse.GetLoadAddress();
+            ArduinoSlave_FlashPage(address, page);
+          }
+        } else {
+          if (0x0A != flash_buffer[ca]) {
+            thishexline[position] = flash_buffer[ca];
+            position++;
+          }
+        }
+      }
+    }
+  }
+  as_flashing = false;
+  ArduinoSlave_exitProgMode();
+  restart_flag = 2;
+}
+
+void ArduinoSlave_SetFlagFlashing(bool value)
+{
+  as_flashing = value;
+}
+
+bool ArduinoSlave_GetFlagFlashing(void)
+{
+  return as_flashing;
+}
+
+void ArduinoSlave_WriteBuffer(uint8_t *buf, size_t size)
+{
+  if (0 == as_spi_sector_cursor) { // Starting a new sector write so we need to erase it first
+    ESP.flashEraseSector(as_spi_sector_counter);
+  }
+  as_spi_sector_cursor++;
+  ESP.flashWrite((as_spi_sector_counter * 0x1000)+((as_spi_sector_cursor-1)*2048), (uint32_t*)buf, size);
+  as_spi_hex_size = as_spi_hex_size + size;
+  if (2 == as_spi_sector_cursor) {  // The web upload sends 2048 bytes at a time so keep track of the cursor position to reset it for the next flash sector erase
+    as_spi_sector_cursor = 0;
+    as_spi_sector_counter++;
+  }
+}
+
+void ArduinoSlave_Init(void)
+{
+  if (as_type) {
+    return;
+  }
+  if ((pin[GPIO_ARDUINO_RXD] < 99) && (pin[GPIO_ARDUINO_TXD] < 99) && (pin[GPIO_ARDUINO_RESET] < 99)) {
+    ArduinoSlave_Serial = new TasmotaSerial(pin[GPIO_ARDUINO_RXD], pin[GPIO_ARDUINO_TXD], 1, 0, 200);
+    if (ArduinoSlave_Serial->begin(USE_ARDUINO_SERIAL_SPEED)) {
+      if (ArduinoSlave_Serial->hardwareSerial()) { 
+        ClaimSerial();
+      }
+      pinMode(pin[GPIO_ARDUINO_RESET], OUTPUT);
+      as_type = 1;
+      ArduinoSlave_Reset();
+      AddLog_P2(LOG_LEVEL_INFO, PSTR("Arduino Slave Enabled"));
+    }
+  }
+}
+
+void ArduinoSlave_Show(bool json)
+{
+  if (as_type) {
+    char buffer[100];
+    ArduinoSlave_Serial->flush();
+    ArduinoSlave_Serial->print("JSON");
+    ArduinoSlave_Serial->find(char(0xFE));
+    uint16_t haveread = ArduinoSlave_Serial->readBytesUntil(char(0xFF), buffer, sizeof(buffer)-1);
+    buffer[haveread] = '\0';
+    if (json) {
+      ResponseAppend_P(PSTR(",\"ArduinoSlave\":%s"), buffer);
+    }
+  }
+}
+
+bool Xdrv31(uint8_t function)
+{
+  bool result = false;
+  switch (function) {
+    case FUNC_EVERY_SECOND:
+      ArduinoSlave_Init();
+      break;
+    case FUNC_JSON_APPEND:
+      ArduinoSlave_Show(1);
+      break;
+    case FUNC_COMMAND_DRIVER:
+      break;
+    default:
+      break;
+  }
+}
+
+#endif // USE_ARDUINO_SLAVE


### PR DESCRIPTION
## Description:

This PR adds initial support to OTA flash and use a serial connected Arduino Uno/Mini/Nano.

Uploading a hex file which was compiled for an Uno/Mini/Nano is done through the same OTA menu page as would be done for an RF Bridge.

Support is added for both normal reset and inverted reset.

A normal reset is for when the reset pin would be connected directly to the reset pin of the atmega328 chip of the arduino board and inverted reset operation allows using the Green/RTS pin on the edge of the pro mini boards.

I have not extended the communication protocol so currently, only JSON support is possible in a sensor like implementation but after getting some feedback from how users want to use this functionality as an extension of their Tasmota wemos/nodemcu boards I will extend that functionality to include bidirectional control where possible (i.e. act as a sensor or a driver)

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
