### PR TITLE
Fix issue if STARTING_OFFSET is undefined

### DIFF
--- a/sonoff/sonoff_post.h
+++ b/sonoff/sonoff_post.h
@@ -708,6 +708,10 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #define SWITCH_MODE            TOGGLE            // TOGGLE, FOLLOW or FOLLOW_INV (the wall switch state)
 #endif
 
+#ifndef STARTING_OFFSET                          // NOVA SDS parameter used in settings
+#define STARTING_OFFSET      30
+#endif
+
 #ifndef MQTT_FINGERPRINT1
 // Set an all-zeros default fingerprint to activate auto-learning on first connection (AWS IoT)
 #define MQTT_FINGERPRINT1      "00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00"


### PR DESCRIPTION
## Description:

If STARTING_OFFSET is undefined in _my_user_config.h_ file, the compilation fails due to this parameter is used in the defaults of _settings.ino_

**Related issue (if applicable):** Reported in Discord by @davidFW1960

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
