### PR TITLE
Added /stat/RESULT for Button and Switches

### DIFF
--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -508,6 +508,9 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
   char scommand[CMDSZ];
   char key_topic[sizeof(Settings.button_topic)];
   bool result = false;
+  char sb_topic[TOPSZ];
+  char stemp1[TOPSZ];
+  char *state_topic = stemp1;
 
   char *tmp = (key) ? Settings.switch_topic : Settings.button_topic;
   Format(key_topic, tmp, sizeof(key_topic));
@@ -540,6 +543,11 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
 #ifdef USE_KNX
   KnxSendButtonPower(key, device, state);
 #endif  // USE_KNX
+  // publish a stat/RESULT for switches and buttons state for home automation //
+  snprintf_P(sb_topic, sizeof(sb_topic), GetTopic_P(state_topic, STAT, mqtt_topic, PSTR(D_RSLT_RESULT))); 
+  Response_P(PSTR("{\"%s%d\":%d}"), (key) ? "SWITCH" : "BUTTON", device, state);
+  MqttPublish(sb_topic, false);	
+	
   return result;
 }
 

--- a/sonoff/sonoff.ino
+++ b/sonoff/sonoff.ino
@@ -544,9 +544,11 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
   KnxSendButtonPower(key, device, state);
 #endif  // USE_KNX
   // publish a stat/RESULT for switches and buttons state for home automation //
-  snprintf_P(sb_topic, sizeof(sb_topic), GetTopic_P(state_topic, STAT, mqtt_topic, PSTR(D_RSLT_RESULT))); 
-  Response_P(PSTR("{\"%s%d\":%d}"), (key) ? "SWITCH" : "BUTTON", device, state);
-  MqttPublish(sb_topic, false);	
+  if (Settings.flag.hass_discovery) {
+    snprintf_P(sb_topic, sizeof(sb_topic), GetTopic_P(state_topic, STAT, mqtt_topic, PSTR(D_RSLT_RESULT))); 
+    Response_P(PSTR("{\"%s%d\":%d}"), (key) ? "SWITCH" : "BUTTON", device, state);
+    MqttPublish(sb_topic, false);
+  }
 	
   return result;
 }


### PR DESCRIPTION
## Description:
This PR introduce new MQTT `/stat/RESULT`, useful for a more granular control over buttons and switches under Home Assistant/OpenHab using HA integration as some users had requested.  
```
16:49:06 MQT: stat/sonoff/RESULT = {"BUTTON2":2}
16:49:06 MQT: stat/sonoff/RESULT = {"POWER":"ON"}
16:49:06 MQT: stat/sonoff/POWER = ON
16:49:08 MQT: stat/sonoff/RESULT = {"BUTTON2":2}
16:49:08 MQT: stat/sonoff/RESULT = {"POWER":"OFF"}
16:49:08 MQT: stat/sonoff/POWER = OFF
16:49:12 MQT: stat/sonoff/RESULT = {"SWITCH1":1}
16:49:12 MQT: stat/sonoff/RESULT = {"POWER":"ON"}
16:49:12 MQT: stat/sonoff/POWER = ON
16:49:15 MQT: stat/sonoff/RESULT = {"SWITCH1":0}
16:49:15 MQT: stat/sonoff/RESULT = {"POWER":"OFF"}
16:49:15 MQT: stat/sonoff/POWER = OFF
```
Can be bind to Setoption19 if needed to avoid eccessive MQTT traffic. 

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core pre-2.6
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
