### PR TITLE
Fix v4 address check if running v6 code in v4 only environment.

### DIFF
--- a/sonoff/support_wifi.ino
+++ b/sonoff/support_wifi.ino
@@ -323,12 +323,22 @@ bool WifiCheckIPv6(void)
   }
   return ipv6_global;
 }
+
+bool WifiCheckIPAddrStatus(void)	// Return false for 169.254.x.x or fe80::/64
+{
+  bool ip_global=false;
+
+  for (auto a : addrList) {
+    if(!a.isLocal()) ip_global=true;
+  }
+  return ip_global;
+}
 #endif  // LWIP_IPV6=1
 
 void WifiCheckIp(void)
 {
 #if LWIP_IPV6
-  if(WifiCheckIPv6()) {
+  if(WifiCheckIPAddrStatus()) {
     Wifi.status = WL_CONNECTED;
 #else
   if ((WL_CONNECTED == WiFi.status()) && (static_cast<uint32_t>(WiFi.localIP()) != 0)) {
@@ -456,7 +466,7 @@ void WifiCheck(uint8_t param)
         WifiCheckIp();
       }
 #if LWIP_IPV6
-      if (WifiCheckIPv6()) {
+      if (WifiCheckIPAddrStatus()) {
 #else
       if ((WL_CONNECTED == WiFi.status()) && (static_cast<uint32_t>(WiFi.localIP()) != 0) && !Wifi.config_type) {
 #endif  // LWIP_IPV6=1


### PR DESCRIPTION
#6586  Description: Implementet v4 address check with new v6 routines. Checks if a valid v4 or v6 address was aquired. This reverts the breaking change in my last PR to get v6 only up and running. Now v6 code works in v4 only environment again.

**Related issue (if applicable):** fixes #<Sonoff-Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core pre-2.6
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
