### PR TITLE
Aligning TuyaMCU code with Tasmota naming conventions

### DIFF
--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -453,7 +453,7 @@
 
 #define D_CMND_TUYA_MCU "TuyaMCU"
 #define D_CMND_TUYA_MCU_SEND_STATE "TuyaSend"
-#define D_JSON_TUYA_MCU_RECEIVED "TuyaMcuReceived"
+#define D_JSON_TUYA_MCU_RECEIVED "TuyaReceived"
 
 // Commands xdrv_23_zigbee.ino
 #define D_CMND_ZIGBEE_PERMITJOIN "ZigbeePermitJoin"

--- a/sonoff/i18n.h
+++ b/sonoff/i18n.h
@@ -452,6 +452,7 @@
 // Commands xdrv_16_tuyadimmer.ino
 
 #define D_CMND_TUYA_MCU "TuyaMCU"
+#define D_CMND_TUYA_MCU_SEND_STATE "TuyaSend"
 #define D_JSON_TUYA_MCU_RECEIVED "TuyaMcuReceived"
 
 // Commands xdrv_23_zigbee.ino

--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -79,7 +79,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t no_power_feedback : 1;        // bit 13 (v6.5.0.9)  - SetOption63 - Don't scan relay power state at restart
     uint32_t use_underscore : 1;           // bit 14 (v6.5.0.12) - SetOption64 - Enable "_" instead of "-" as sensor index separator
     uint32_t fast_power_cycle_disable : 1; // bit 15 (v6.6.0.20) - SetOption65 - Disable fast power cycle detection for device reset
-    uint32_t ex_tuya_dimmer_range_255 : 1;    // bit 16 (v6.6.0.1)  - SetOption66 - Enable or Disable Dimmer range 255 slider control
+    uint32_t tuya_serial_mqtt_publish : 1;    // bit 16 (v6.6.0.21)  - SetOption66 - Enable or Disable TuyaMcuReceived messages over Mqtt
     uint32_t buzzer_enable : 1;            // bit 17 (v6.6.0.1)  - SetOption67 - Enable buzzer when available
     uint32_t pwm_multi_channels : 1;       // bit 18 (v6.6.0.3)  - SetOption68 - Enable multi-channels PWM instead of Color PWM
     uint32_t ex_tuya_dimmer_min_limit : 1;    // bit 19 (v6.6.0.5)  - SetOption69 - Limits Tuya dimmers to minimum of 10% (25) when enabled.

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -1126,7 +1126,7 @@ void SettingsDelta(void)
     }
     if (Settings.version < 0x06060008) {
       // Move current tuya dimmer range to the new param.
-      if (Settings.flag3.ex_tuya_dimmer_range_255) {
+      if (Settings.flag3.tuya_serial_mqtt_publish) { // ex Settings.flag3.ex_tuya_dimmer_range_255 SetOption
         Settings.param[P_ex_DIMMER_MAX] = 100;
       } else {
         Settings.param[P_ex_DIMMER_MAX] = 255;
@@ -1200,7 +1200,7 @@ void SettingsDelta(void)
     if (Settings.version < 0x06060014) {
       // Clear unused parameters for future use
 /*
-      Settings.flag3.ex_tuya_dimmer_range_255 = 0;
+      Settings.flag3.tuya_serial_mqtt_publish = 0;  // ex Settings.flag3.ex_tuya_dimmer_range_255
       Settings.flag3.ex_tuya_dimmer_min_limit = 0;
       Settings.param[P_ex_TUYA_RELAYS] = 0;
       Settings.param[P_ex_DIMMER_MAX] = 0;

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -680,7 +680,11 @@ void TuyaSerialInput(void)
 
       ResponseAppend_P(PSTR("}}"));
 
-      MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_TUYA_MCU_RECEIVED));
+      if (Settings.flag3.tuya_serial_mqtt_publish) {
+        MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_TUYA_MCU_RECEIVED));
+      } else {
+        AddLog_P(LOG_LEVEL_DEBUG, mqtt_data);
+      }
       XdrvRulesProcess();
 
       if (!Tuya.low_power_mode) {

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -610,6 +610,7 @@ bool TuyaModuleSelected(void)
 
   if (TuyaGetDpId(TUYA_MCU_FUNC_LOWPOWER_MODE) != 0) {
     Tuya.low_power_mode = true;
+    Settings.flag3.fast_power_cycle_disable = true;
   }
 
   UpdateDevices();

--- a/sonoff/xdrv_16_tuyamcu.ino
+++ b/sonoff/xdrv_16_tuyamcu.ino
@@ -681,7 +681,7 @@ void TuyaSerialInput(void)
       ResponseAppend_P(PSTR("}}"));
 
       if (Settings.flag3.tuya_serial_mqtt_publish) {
-        MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_TUYA_MCU_RECEIVED));
+        MqttPublishPrefixTopic_P(RESULT_OR_STAT, PSTR(D_JSON_TUYA_MCU_RECEIVED));
       } else {
         AddLog_P(LOG_LEVEL_DEBUG, mqtt_data);
       }


### PR DESCRIPTION
## Description:
Building on top of shantur's PR I changed:
- TuyaMCUReceived to TuyaReceived to keep with established naming scheme (SerialSend/SerialReceived; TuyaSend/TuyaReceived)
- Changed topic of TuyaReceived from tele/%topic%/RESULT to stat/%topic%/RESULT 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Sonoff-Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
