### PR TITLE
Core Stage added NONOSDK22x_191024...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -154,11 +154,15 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
                             -O2
                             -DBEARSSL_SSL_BASIC
-; nonos-sdk 22y
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22y
-; nonos-sdk 22x
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x
-; nonos-sdk-pre-v3
+; NONOSDK221
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
+; NONOSDK22x_190313
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
+; NONOSDK22x_190703 (Tasmota default)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+; NONOSDK22x_191024
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 ; lwIP 1.4
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
@@ -170,7 +174,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
 ; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; VTABLES in Flash (default)
+; VTABLES in Flash (Tasmota default)
                             -DVTABLES_IN_FLASH
 ; VTABLES in Heap
 ;                            -DVTABLES_IN_DRAM


### PR DESCRIPTION
and enabled by default for core stage. Updated NONO SDK22x from191024. See https://github.com/esp8266/Arduino/commit/ba50bd57b81cf4106fe44ab831d5a061facd4be9

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on **feature/stage**
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
