### PR TITLE
TuyaMCU: Change dimmer scale before comparing with dimmer ranges. Fix…

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -377,8 +377,8 @@ void LightSerialDuty(uint16_t duty)
 {
   uint8_t dpid = TuyaGetDpId(TUYA_MCU_FUNC_DIMMER);
   if (duty > 0 && !Tuya.ignore_dim && TuyaSerial && dpid > 0) {
-    if (duty < Settings.dimmer_hw_min) { duty = Settings.dimmer_hw_min; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
     duty = changeUIntScale(duty, 0, 255, 0, Settings.dimmer_hw_max);
+    if (duty < Settings.dimmer_hw_min) { duty = Settings.dimmer_hw_min; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
     if (Tuya.new_dim != duty) {
       AddLog_P2(LOG_LEVEL_DEBUG, PSTR("TYA: Send dim value=%d (id=%d)"), duty, dpid);
       TuyaSendValue(dpid, duty);


### PR DESCRIPTION
Change dimmer scale before comparing with dimmer ranges Fixes #6780

## Description:

Dimmer range are hardware values not UI values.

**Related issue (if applicable):** fixes #6780 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
