### PR TITLE
Add Setoption74 to runtime configuration of internal pullup resistor usage for single DS18x20 sensor

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -87,7 +87,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t dds2382_model : 1;            // bit 21 (v6.6.0.14) - SetOption71 - Select different Modbus registers for Active Energy (#6531)
     uint32_t hardware_energy_total : 1;    // bit 22 (v6.6.0.15) - SetOption72 - Enable / Disable hardware energy total counter as reference (#6561)
     uint32_t cors_enabled : 1;             // bit 23 (v7.0.0.1)  - SetOption73 - Enable HTTP CORS
-    uint32_t spare24 : 1;
+    uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
     uint32_t spare25 : 1;
     uint32_t spare26 : 1;
     uint32_t spare27 : 1;

--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -74,11 +74,7 @@ uint8_t OneWireReset(void)
   uint8_t retries = 125;
 
   //noInterrupts();
-#ifdef DS18B20_INTERNAL_PULLUP
-  pinMode(ds18x20_pin, INPUT_PULLUP);
-#else
-  pinMode(ds18x20_pin, INPUT);
-#endif
+  pinMode(ds18x20_pin, Settings.flag3.ds18x20_internal_pullup ? INPUT_PULLUP : INPUT);
   do {
     if (--retries == 0) {
       return 0;
@@ -88,11 +84,7 @@ uint8_t OneWireReset(void)
   pinMode(ds18x20_pin, OUTPUT);
   digitalWrite(ds18x20_pin, LOW);
   delayMicroseconds(480);
-#ifdef DS18B20_INTERNAL_PULLUP
-  pinMode(ds18x20_pin, INPUT_PULLUP);
-#else
-  pinMode(ds18x20_pin, INPUT);
-#endif
+  pinMode(ds18x20_pin, Settings.flag3.ds18x20_internal_pullup ? INPUT_PULLUP : INPUT);
   delayMicroseconds(70);
   uint8_t r = !digitalRead(ds18x20_pin);
   //interrupts();
@@ -121,11 +113,7 @@ uint8_t OneWireReadBit(void)
   pinMode(ds18x20_pin, OUTPUT);
   digitalWrite(ds18x20_pin, LOW);
   delayMicroseconds(3);
-#ifdef DS18B20_INTERNAL_PULLUP
-  pinMode(ds18x20_pin, INPUT_PULLUP);
-#else
-  pinMode(ds18x20_pin, INPUT);
-#endif
+  pinMode(ds18x20_pin, Settings.flag3.ds18x20_internal_pullup ? INPUT_PULLUP : INPUT);
   delayMicroseconds(10);
   uint8_t r = digitalRead(ds18x20_pin);
   //interrupts();


### PR DESCRIPTION


## Description:
This PR add Setoption74 to runtime configuration of internal pullup resistor usage for single DS18x20 sensor
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
