### PR TITLE
Add hide Alexa objects with friendlyname starting with '$'

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -5,6 +5,7 @@
  * Add command SetOption73 0/1 to re-enable HTTP Cross-Origin Resource Sharing (CORS) now default disabled (#6767)
  * Add frequency to ADE7953 energy monitor as used in Shelly 2.5 by ljakob (#6778)
  * Add command SetOption74 0/1 to enable DS18x20 internal pull-up and remove define DS18B20_INTERNAL_PULLUP (#6795)
+ * Add hide Alexa objects with friendlyname starting with '$' (#6722, #6762)
  *
  * 6.7.1.1 20191026
  * Change ArduinoSlave to TasmotaSlave (Experimental)


### PR DESCRIPTION
## Description:

After second thoughts, it was actually easy to hide specific objects from Alexa.
Objects with friendly-names starting with dollar sign '$' will not be discovered by Alexa. If they were already discovered previously, they will still continue to work.

As there are only 4 friendly names, if friendlyname-4 starts with '$', all devices after device number 4 (included) will not be discovered by Alexa.

**Related issue (if applicable):** fixes #6722 #6762 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
