### PR TITLE
Fix better control of RGB/White when SetOption37 >128, added Dimmer1 and Dimmer2 commands

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -5,6 +5,7 @@
  * Add command SetOption73 0/1 to re-enable HTTP Cross-Origin Resource Sharing (CORS) now default disabled (#6767)
  * Add frequency to ADE7953 energy monitor as used in Shelly 2.5 by ljakob (#6778)
  * Add command SetOption74 0/1 to enable DS18x20 internal pull-up and remove define DS18B20_INTERNAL_PULLUP (#6795)
+ * Fix better control of RGB/White when SetOption37 >128, added Dimmer1 and Dimmer2 commands (#6714)
  *
  * 6.7.1.1 20191026
  * Change ArduinoSlave to TasmotaSlave (Experimental)

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -699,6 +699,9 @@ void CmndSetoption(void)
             param_low = 1;
             param_high = 250;
             break;
+          case P_RGB_REMAP:
+            restart_flag = 2;    // SetOption37 needs a reboot in most cases
+            break;
         }
         if ((XdrvMailbox.payload >= param_low) && (XdrvMailbox.payload <= param_high)) {
           Settings.param[pindex] = XdrvMailbox.payload;


### PR DESCRIPTION
## Description:

- Better control of RGB/White when SetOption37 >128. Now you see two disctinct devices that you can power on/off with `Power1` and `Power2`.
- I added `Dimmer2` command to change only dimmer of white channels. `Dimmer` or `Dimmer1` will only change RGB brightness.
- Changes to `SetOption37` will trigger a reboot, it is required in most cases.
- Also added `Channel<x> +` and `Channel<x> -` to add/substract 10 to brightness channel (range is still 0..100). This is an old request from @jziolkowski 

I didn't add sliders for the two separate dimmers. @RoadRunnr would you be kind enough to look at it?

**Related issue (if applicable):** fixes #6714 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
