### PR TITLE
Add COLOR_TITLE as WebColor19

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -168,6 +168,7 @@
 #define COLOR_BUTTON_SAVE_HOVER     "#5aaf6f"    // [WebColor16] Save button color when hovered over - Darker greenish
 #define COLOR_TIMER_TAB_TEXT        "#fff"       // [WebColor17] Config timer tab text color - White
 #define COLOR_TIMER_TAB_BACKGROUND  "#999"       // [WebColor18] Config timer tab background color - Light grey
+#define COLOR_TITLE_TEXT            COLOR_TEXT   // [WebColor19] Title text color - Whiteish
 
 // -- mDNS ----------------------------------------
 #define MDNS_ENABLED           0                 // [SetOption55] Use mDNS (0 = Disable, 1 = Enable)

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -433,8 +433,9 @@ struct SYSCFG {
   uint32_t      deepsleep;                 // E94
   uint16_t      energy_power_delta;        // E98
   uint8_t       shutter_motordelay[MAX_SHUTTERS];      // E9A
-
-  uint8_t       free_e9e[346];             // E9E
+  uint8_t       free_e9e[342];             // E9E
+  uint8_t       web_color2[1][3];          // FF4
+  uint8_t       free_ff7      ;            // FF7
 
   uint32_t      cfg_timestamp;             // FF8
   uint32_t      cfg_crc32;                 // FFC

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -119,6 +119,9 @@
 #ifndef COLOR_TIMER_TAB_BACKGROUND
 #define COLOR_TIMER_TAB_BACKGROUND  "#999"     // Config timer tab background color - Light grey
 #endif
+#ifndef COLOR_TITLE_TEXT
+#define COLOR_TITLE_TEXT			      COLOR_TEXT // Title text color defaults to global text color either dark or light
+#endif
 #ifndef IR_RCV_MIN_UNKNOWN_SIZE
 #define IR_RCV_MIN_UNKNOWN_SIZE     6          // Set the smallest sized "UNKNOWN" message packets we actually care about (default 6, max 255)
 #endif
@@ -137,7 +140,7 @@ enum WebColors {
   COL_INPUT_TEXT, COL_INPUT, COL_CONSOLE_TEXT, COL_CONSOLE,
   COL_TEXT_WARNING, COL_TEXT_SUCCESS,
   COL_BUTTON_TEXT, COL_BUTTON, COL_BUTTON_HOVER, COL_BUTTON_RESET, COL_BUTTON_RESET_HOVER, COL_BUTTON_SAVE, COL_BUTTON_SAVE_HOVER,
-  COL_TIMER_TAB_TEXT, COL_TIMER_TAB_BACKGROUND,
+  COL_TIMER_TAB_TEXT, COL_TIMER_TAB_BACKGROUND, COL_TITLE,
   COL_LAST };
 
 const char kWebColors[] PROGMEM =
@@ -145,7 +148,7 @@ const char kWebColors[] PROGMEM =
   COLOR_INPUT_TEXT "|" COLOR_INPUT "|" COLOR_CONSOLE_TEXT "|" COLOR_CONSOLE "|"
   COLOR_TEXT_WARNING "|" COLOR_TEXT_SUCCESS "|"
   COLOR_BUTTON_TEXT "|" COLOR_BUTTON "|" COLOR_BUTTON_HOVER "|" COLOR_BUTTON_RESET "|" COLOR_BUTTON_RESET_HOVER "|" COLOR_BUTTON_SAVE "|" COLOR_BUTTON_SAVE_HOVER "|"
-  COLOR_TIMER_TAB_TEXT "|" COLOR_TIMER_TAB_BACKGROUND;
+  COLOR_TIMER_TAB_TEXT "|" COLOR_TIMER_TAB_BACKGROUND "|" COLOR_TITLE_TEXT;
 
 /*********************************************************************************************\
  * RTC memory

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -883,15 +883,23 @@ void WebHexCode(uint32_t i, const char* code)
     color = w | (w << 4);                                                            // 00112233
   }
 */
-
-  Settings.web_color[i][0] = (color >> 16) & 0xFF;  // Red
-  Settings.web_color[i][1] = (color >> 8) & 0xFF;   // Green
-  Settings.web_color[i][2] = color & 0xFF;          // Blue
+  uint32_t j = sizeof(Settings.web_color)/3;          // First area contains j=18 colors
+  if (i < j) { 
+    Settings.web_color[i][0] = (color >> 16) & 0xFF;  // Red
+    Settings.web_color[i][1] = (color >> 8) & 0xFF;   // Green
+    Settings.web_color[i][2] = color & 0xFF;          // Blue
+  } else {
+    Settings.web_color2[i-j][0] = (color >> 16) & 0xFF;  // Red
+    Settings.web_color2[i-j][1] = (color >> 8) & 0xFF;   // Green
+    Settings.web_color2[i-j][2] = color & 0xFF;          // Blue
+  }	  
 }
 
 uint32_t WebColor(uint32_t i)
 {
-  uint32_t tcolor = (Settings.web_color[i][0] << 16) | (Settings.web_color[i][1] << 8) | Settings.web_color[i][2];
+  uint32_t j = sizeof(Settings.web_color)/3;          // First area contains j=18 colors
+  uint32_t tcolor = (i<j)? (Settings.web_color[i][0] << 16) | (Settings.web_color[i][1] << 8) | Settings.web_color[i][2] :
+                           (Settings.web_color2[i-j][0] << 16) | (Settings.web_color2[i-j][1] << 8) | Settings.web_color2[i-j][2];
   return tcolor;
 }
 

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -364,7 +364,7 @@ const char HTTP_HEAD_STYLE3[] PROGMEM =
 #ifdef FIRMWARE_MINIMAL
   "<div style='text-align:center;color:#%06x;'><h3>" D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "</h3></div>"  // COLOR_TEXT_WARNING
 #endif
-  "<div style='text-align:center;'><noscript>" D_NOSCRIPT "<br></noscript>"
+  "<div style='text-align:center;color:#%06x;'><noscript>" D_NOSCRIPT "<br></noscript>" // COLOR_TITLE
 #ifdef LANGUAGE_MODULE_NAME
   "<h3>" D_MODULE " %s</h3>"
 #else
@@ -832,6 +832,7 @@ void WSContentSendStyle_P(const char* formatP, ...)
 #ifdef FIRMWARE_MINIMAL
     WebColor(COL_TEXT_WARNING),
 #endif
+    WebColor(COL_TITLE),
     ModuleName().c_str(), Settings.friendlyname[0]);
   if (Settings.flag3.gui_hostname_ip) {
     bool lip = (static_cast<uint32_t>(WiFi.localIP()) != 0);


### PR DESCRIPTION
## Description:
With this request I offer the possibility to change the title color of the WebUI too (Module type and Name). IMHO, it enhance a lot the dark theme, and it can be useful to categorize devices like Test/Production that can be differentiated at first glance on the WebUI.

WebUI theme earn a 19th color and the command may be for instance:
`WebColor {"WebColor":["#eeeeee","#000033","#4f4f4f","#000000","#dddddd","#a7f432","#1e1e1e","#ff0000","#008000","#ffffff","#1fa3ec","#0e70a4","#d43535","#931f1f","#47c266","#5aaf6f","#ffffff","#999999","#cccc88"]}
`
or just:
`webcolor19 #cc8`

<img src="https://user-images.githubusercontent.com/33861984/68066616-2c524e00-fd3b-11e9-9ef7-9f44228a5bdd.png" width="300">

Currently the settings can only store 18 WebColor, I had to find a new place for this 19th item and it defaults to the end of the settings area, a good place for a fork but not optimized if merged in the mainstream.

**Related issue (if applicable): -none-

## Checklist:
  - [✓] The pull request is done against the latest dev branch
  - [✓] Only relevant files were touched
  - [✓] Only one feature/fix was added per PR.
  - [✓] The code change is tested and works on core pre-2.6
  - [✓] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [✓] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
