### PR TITLE
TasmotaSlave: Bugfix

### DIFF
--- a/tasmota/xdrv_31_tasmota_slave.ino
+++ b/tasmota/xdrv_31_tasmota_slave.ino
@@ -580,9 +580,12 @@ bool Xdrv31(uint8_t function)
 
   switch (function) {
     case FUNC_EVERY_100_MSECOND:
-      if ((TSlave.type) && (TSlaveSettings.features.func_every_100_msecond)) {
+      if (TSlave.type) {
         if (TasmotaSlave_Serial->available()) {
           TasmotaSlave_ProcessIn();
+        }
+        if (TSlaveSettings.features.func_every_100_msecond) {
+          TasmotaSlave_sendCmnd(CMND_FUNC_EVERY_100_MSECOND, 0);
         }
       }
       break;


### PR DESCRIPTION
## Description:

Bugfix - telemetry did not work unless the 100ms callback was enabled on the slave

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
