### PR TITLE
Fix wrong Dimmer behavior introduced with #6799 when SetOption37 < 128

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -2,6 +2,7 @@
  * 7.0.0.2 20191102
  * Add command WebColor19 to control color of Module and Name (#6811)
  * Add support for Honeywell I2C HIH series Humidity and Temperetaure sensor (#6808)
+ * Fix wrong Dimmer behavior introduced with #6799 when SetOption37 < 128
  *
  * 7.0.0.1 20191027
  * Remove references to versions before 6.0


### PR DESCRIPTION
## Description:

Bug reported by @blakadder on Discord.

Now `Dimmer` has the following behavior:

* If `SetOption37` < 128 (default behavior), RGB and White are linked, i.e. only one of both can be On at the same time. `Dimmer` has the same behavior as before, it will change the dimmer value for the current mode, either RGB or White.
* If `SetOption37` >= 128 (also called unlinked), RGB and White/CWWW are treated as two independant channels. `Dimmer` or `Dimmer1` will change the Dimmer for RGB. `Dimmer2` will change the Dimmer for white(s). `Dimmer0` will change both Dimmers at once.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
