### PR TITLE
Add DS18x20 support in Tasmota-IR

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -3,6 +3,7 @@
  * Add command WebColor19 to control color of Module and Name (#6811)
  * Add support for Honeywell I2C HIH series Humidity and Temperetaure sensor (#6808)
  * Fix wrong Dimmer behavior introduced with #6799 when SetOption37 < 128
+ * Change add DS18x20 support in Tasmota-IR
  *
  * 7.0.0.1 20191027
  * Remove references to versions before 6.0

--- a/tasmota/tasmota_post.h
+++ b/tasmota/tasmota_post.h
@@ -356,7 +356,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
   #undef USE_DDSU666                             // Disable support for Chint DDSU666 Modbus energy monitor (+0k6 code)
   #undef USE_SOLAX_X1                            // Disable support for Solax X1 series Modbus log info (+3k1 code)
 
-#undef USE_DS18x20                               // Disable support for DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
+//#undef USE_DS18x20                               // Disable support for DS18x20 sensors with id sort, single scan and read retry (+1k3 code)
 
 #undef USE_I2C                                   // Disable all I2C sensors
 #undef USE_SPI                                   // Disable all SPI devices


### PR DESCRIPTION
## Description:

As requested on Google Groups, users are adding DS18x20 to ir-blasters.

Increase flash size: 2.6k, Tasmota-IR is now 563k.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
