### PR TITLE
Reduce flash size after change to IRremoteESP8266 v2.7.0

### DIFF
--- a/lib/IRremoteESP8266-2.7.0/src/IRtext.cpp
+++ b/lib/IRremoteESP8266-2.7.0/src/IRtext.cpp
@@ -8,6 +8,8 @@
 
 // Common
 
+#ifdef USE_IR_REMOTE_FULL   // full IR protocols
+
 String kUnknownStr = D_STR_UNKNOWN;
 String kProtocolStr = D_STR_PROTOCOL;
 String kPowerStr = D_STR_POWER;
@@ -147,3 +149,5 @@ String kFalseStr = D_STR_FALSE;
 String kRepeatStr = D_STR_REPEAT;
 String kCodeStr = D_STR_CODE;
 String kBitsStr = D_STR_BITS;
+
+#endif // USE_IR_REMOTE_FULL   // full IR protocols

--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -5,6 +5,7 @@
  * Fix wrong Dimmer behavior introduced with #6799 when SetOption37 < 128
  * Change add DS18x20 support in Tasmota-IR
  * Add Zigbee command support, considered as v1.0 for full Zigbee support
+ * Fix Reduce flash size after change to IRremoteESP8266 v2.7.0
  *
  * 7.0.0.1 20191027
  * Remove references to versions before 6.0


### PR DESCRIPTION
## Description:

The Flash increased is due to `String` static allocators. This is a first patch. I will push an issue to the author.

Flash size is down again by 3.7KB.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
