### PR TITLE
visual tweaks of Dark UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ firmware.asm
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 *.bak
-
-platformio.ini
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ firmware.asm
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 *.bak
+
+platformio.ini
+.gitignore

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -147,28 +147,28 @@
 #define COLOR_CONSOLE               "#fff"       // [WebColor7] Console background color - White
 */
 // Dark theme
-// webcolor {"webcolor":["#eee","#181818","#4f4f4f","#000","#ddd","#6a9955","#1e1e1e"]}
-#define COLOR_TEXT                  "#eee"       // [WebColor1] Global text color - Whiteish
-#define COLOR_BACKGROUND            "#181818"    // [WebColor2] Global background color - Blackish
-#define COLOR_FORM                  "#4f4f4f"    // [WebColor3] Form background color - Greyish
+// webcolor {"webcolor":["#eaeaea","#252525","#4f4f4f","#000","#ddd","#65c115","#1f1f1f"]}
+#define COLOR_TEXT                  "#eaeaea"       // [WebColor1] Global text color - Very light gray
+#define COLOR_BACKGROUND            "#252525"    // [WebColor2] Global background color - Very dark gray (mostly black)
+#define COLOR_FORM                  "#4f4f4f"    // [WebColor3] Form background color - Very dark gray
 #define COLOR_INPUT_TEXT            "#000"       // [WebColor4] Input text color - Black
-#define COLOR_INPUT                 "#ddd"       // [WebColor5] Input background color - Darker white
-#define COLOR_CONSOLE_TEXT          "#6a9955"    // [WebColor6] Console text color - Greenish
-#define COLOR_CONSOLE               "#1e1e1e"    // [WebColor7] Console background color - Blackish
+#define COLOR_INPUT                 "#ddd"       // [WebColor5] Input background color - Very light gray
+#define COLOR_CONSOLE_TEXT          "#65c115"    // [WebColor6] Console text color - Strong Green
+#define COLOR_CONSOLE               "#1f1f1f"    // [WebColor7] Console background color - Very dark gray (mostly black)
 
 // Other colors
-#define COLOR_TEXT_WARNING          "#f00"       // [WebColor8] Warning text color - Red
-#define COLOR_TEXT_SUCCESS          "#008000"    // [WebColor9] Success text color - Green
-#define COLOR_BUTTON_TEXT           "#fff"       // [WebColor10] Button text color - White
-#define COLOR_BUTTON                "#1fa3ec"    // [WebColor11] Button color - Blueish
-#define COLOR_BUTTON_HOVER          "#0e70a4"    // [WebColor12] Button color when hovered over - Darker blueish
-#define COLOR_BUTTON_RESET          "#d43535"    // [WebColor13] Restart/Reset/Delete button color - Redish
-#define COLOR_BUTTON_RESET_HOVER    "#931f1f"    // [WebColor14] Restart/Reset/Delete button color when hovered over - Darker redish
-#define COLOR_BUTTON_SAVE           "#47c266"    // [WebColor15] Save button color - Greenish
-#define COLOR_BUTTON_SAVE_HOVER     "#5aaf6f"    // [WebColor16] Save button color when hovered over - Darker greenish
-#define COLOR_TIMER_TAB_TEXT        "#fff"       // [WebColor17] Config timer tab text color - White
-#define COLOR_TIMER_TAB_BACKGROUND  "#999"       // [WebColor18] Config timer tab background color - Light grey
-#define COLOR_TITLE_TEXT            COLOR_TEXT   // [WebColor19] Title text color - Whiteish
+#define COLOR_TEXT_WARNING          "#ff5661"    // [WebColor8] Warning text color - Brick Red
+#define COLOR_TEXT_SUCCESS          "#008000"    // [WebColor9] Success text color - Dark lime green
+#define COLOR_BUTTON_TEXT           "#faffff"    // [WebColor10] Button text color - Very pale (mostly white) cyan
+#define COLOR_BUTTON                "#1fa3ec"    // [WebColor11] Button color - Vivid blue
+#define COLOR_BUTTON_HOVER          "#0e70a4"    // [WebColor12] Button color when hovered over - Dark blue
+#define COLOR_BUTTON_RESET          "#d43535"    // [WebColor13] Restart/Reset/Delete button color - Strong red
+#define COLOR_BUTTON_RESET_HOVER    "#931f1f"    // [WebColor14] Restart/Reset/Delete button color when hovered over - Dark red
+#define COLOR_BUTTON_SAVE           "#47c266"    // [WebColor15] Save button color - Moderate lime green
+#define COLOR_BUTTON_SAVE_HOVER     "#5aaf6f"    // [WebColor16] Save button color when hovered over - Dark moderate lime green
+#define COLOR_TIMER_TAB_TEXT        "#faffff"    // [WebColor17] Config timer tab text color - Very pale (mostly white) cyan.
+#define COLOR_TIMER_TAB_BACKGROUND  "#999"       // [WebColor18] Config timer tab background color - Dark gray
+#define COLOR_TITLE_TEXT            COLOR_TEXT   // [WebColor19] Title text color - Very light gray
 
 // -- mDNS ----------------------------------------
 #define MDNS_ENABLED           0                 // [SetOption55] Use mDNS (0 = Disable, 1 = Enable)

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -352,7 +352,7 @@ const char HTTP_HEAD_STYLE2[] PROGMEM =
   ".bred:hover{background:#%06x;}"  // COLOR_BUTTON_RESET_HOVER
   ".bgrn{background:#%06x;}"  // COLOR_BUTTON_SAVE
   ".bgrn:hover{background:#%06x;}"  // COLOR_BUTTON_SAVE_HOVER
-  "a{text-decoration:none;}"
+  "a{color: #00BFFF;text-decoration:none;}"
   ".p{float:left;text-align:left;}"
   ".q{float:right;text-align:right;}";
 const char HTTP_HEAD_STYLE3[] PROGMEM =
@@ -2578,10 +2578,10 @@ extern uint8_t tasm_cmd_activ;
 
 bool JsonWebColor(const char* dataBuf)
 {
-  // Default (light)
+  // Default (Dark theme)
+  // {"WebColor":["#eaeaea","#252525","#4f4f4f","#000000","#dddddd","#65c115","#1f1f1f","#ff5661","#008000","#faffff","#1fa3ec","#0e70a4","#d43535","#931f1f","#47c266","#5aaf6f","#faffff","#999999","#eaeaea"]}
+  // Default pre v7 (Light theme)
   // {"WebColor":["#000000","#ffffff","#f2f2f2","#000000","#ffffff","#000000","#ffffff","#ff0000","#008000","#ffffff","#1fa3ec","#0e70a4","#d43535","#931f1f","#47c266","#5aaf6f","#ffffff","#999999","#000000"]}
-  // Alternative (Dark)
-  // {"Webcolor":["#eeeeee","#181818","#4f4f4f","#000000","#dddddd","#6a9955","#1e1e1e","#ff0000","#008000","#ffffff","#1fa3ec","#0e70a4","#d43535","#931f1f","#47c266","#5aaf6f","#ffffff","#999999","#eeeeee"]}
 
   char dataBufLc[strlen(dataBuf) +1];
   LowerCase(dataBufLc, dataBuf);


### PR DESCRIPTION
## Description:
Color tweaks to the dark theme to make it slightly softer on the eyes and fixing some issues (super bright red, almost invisible scan for wifi, too dark console font). 
Updated color names in comments according to colorhexa.com

![image](https://user-images.githubusercontent.com/5904370/68242469-e209ef00-0010-11ea-8b74-3aa2bbb29930.png)
![image](https://user-images.githubusercontent.com/5904370/68242452-d7e7f080-0010-11ea-80a9-26c8550241e7.png)
![image](https://user-images.githubusercontent.com/5904370/68242514-f817af80-0010-11ea-928e-8271aef42136.png)
![image](https://user-images.githubusercontent.com/5904370/68242493-ed5d1a80-0010-11ea-9bdb-3d9d9217dfbd.png)

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on core pre-2.6
  - [x ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
