### PR TITLE
Display 6 digits hex for RFCode #6846

### DIFF
--- a/tasmota/xdrv_06_snfbridge.ino
+++ b/tasmota/xdrv_06_snfbridge.ino
@@ -468,7 +468,7 @@ void CmndRfBridge(void)  // RfSync, RfLow, RfHigh, RfHost and RfCode
   if (10 == radix) {
     snprintf_P(stemp, sizeof(stemp), PSTR("%d"), code);
   } else {
-    snprintf_P(stemp, sizeof(stemp), PSTR("\"#%X\""), code);
+    snprintf_P(stemp, sizeof(stemp), PSTR("\"#%06X\""), code);
   }
   Response_P(S_JSON_COMMAND_XVALUE, XdrvMailbox.command, stemp);
 }


### PR DESCRIPTION
## Description:

Display all 24 bits (6 hex digits) code with `RFCode`

**Related issue (if applicable):** fixes #6846 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
