### PR TITLE
Add new SDK option to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -230,6 +230,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
 ; NONOSDK22x_191024
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK22x_191105
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105                            
 ; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 ; lwIP 1.4


### PR DESCRIPTION
## Description:

Arduino ESP8266 Core have added a new option to select latest commit of SDK2.2 from 2019-11-05
So far, this SDK22x_191105 works very fast and reliable on my devices.

**Related issue (if applicable):** fixes NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
