### PR TITLE
Fix restore all 5 channels at boot

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -134,6 +134,12 @@
 #ifndef DEFAULT_DIMMER_MIN
 #define DEFAULT_DIMMER_MIN          0
 #endif
+#ifndef DEFAULT_LIGHT_DIMMER
+#define DEFAULT_LIGHT_DIMMER        10
+#endif
+#ifndef DEFAULT_LIGHT_COMPONENT
+#define DEFAULT_LIGHT_COMPONENT     255
+#endif
 
 enum WebColors {
   COL_TEXT, COL_BACKGROUND, COL_FORM,
@@ -814,11 +820,11 @@ void SettingsDefaultSet2(void)
   Settings.pwm_frequency = PWM_FREQ;
   Settings.pwm_range = PWM_RANGE;
   for (uint32_t i = 0; i < MAX_PWMS; i++) {
-    Settings.light_color[i] = 255;
+    Settings.light_color[i] = DEFAULT_LIGHT_COMPONENT;
 //    Settings.pwm_value[i] = 0;
   }
   Settings.light_correction = 1;
-  Settings.light_dimmer = 10;
+  Settings.light_dimmer = DEFAULT_LIGHT_DIMMER;
 //  Settings.light_fade = 0;
   Settings.light_speed = 1;
 //  Settings.light_scheme = 0;

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -879,7 +879,16 @@ public:
       // We apply dimmer in priority to RGB
       uint8_t bri = _state->DimmerToBri(Settings.light_dimmer);
       if (Settings.light_color[0] + Settings.light_color[1] + Settings.light_color[2] > 0) {
-        _state->setColorMode(LCM_RGB);
+        // The default values are #FFFFFFFFFF, in this case we avoid setting all channels
+        // at the same time, see #6534
+        if ( (DEFAULT_LIGHT_COMPONENT == Settings.light_color[0]) &&
+             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[1]) &&
+             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[2]) &&
+             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[3]) &&
+             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[4]) &&
+             (DEFAULT_LIGHT_DIMMER    == Settings.light_dimmer) ) {
+          _state->setColorMode(LCM_RGB);
+        }
         _state->setBriRGB(bri);
       } else {
         _state->setBriCT(bri);


### PR DESCRIPTION
## Description:

Restores all 5 channels at reboot, reversing partially the behavior introduced in #6612 
The only case where White is disabled is when `Color 1A1A1AFFFF` which is transformed to `Color 1A1A1A0000` at reboot. This is to avoid overloading a freshly tasmotized device, as reported in #6534

**Related issue (if applicable):** fixes #6863 #6764 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
