### PR TITLE
Add Keep last channels values when Color command end with '='

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -4,6 +4,7 @@
  * Change supported PCF8574 I2C address range to 0x20 - 0x26 allowing other I2C devices with address 0x27 to be used at the same time
  * Change supported PCF8574A I2C address range to 0x39 - 0x3F allowing other I2C devices with address 0x38 to be used at the same time
  * Change supported MCP230xx I2C address range to 0x20 - 0x26 allowing other I2C devices with address 0x27 to be used at the same time
+ * Add Keep last channels values when Color command end with '=' #6799
  *
  * 7.0.0.3 20191103
  * Initial support for I2C driver runtime control using command I2CDriver and document I2CDEVICES.md

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1901,6 +1901,11 @@ bool LightColorEntry(char *buffer, uint32_t buffer_length)
   }
 
   memset(&Light.entry_color, 0x00, sizeof(Light.entry_color));
+  // erase all channels except if the last character is '=', #6799
+  while ((buffer_length > 0) && ('=' == buffer[buffer_length - 1])) {
+    buffer_length--;  // remove all trailing '='            
+    memcpy(&Light.entry_color, &Light.current_color, sizeof(Light.entry_color));
+  }
   if (strstr(buffer, ",") != nullptr) {             // Decimal entry
     int8_t i = 0;
     for (str = strtok_r(buffer, ",", &p); str && i < 6; str = strtok_r(nullptr, ",", &p)) {


### PR DESCRIPTION
## Description:

Normally `Color` command resets unspecified channels to zero.

Ex for 5 channels light:
```
Color 1122334455       -> Color 1122334455
Color AABB             -> Color AABB000000
```

Now when you end the `Color` command with `=` it keeps the other channels unchanged.

Ex:
```
Color 1122334455       -> Color 1122334455
Color AABB=            -> Color AABB334455
```

**Related issue (if applicable):** fixes #6799 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
