### PR TITLE
Fix SeaPressure unit for HASS autodiscovery

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -449,7 +449,7 @@ void HAssAnnounceSensor(const char* sensorname, const char* subsensortype)
     } else if (!strcmp_P(subsensortype, PSTR(D_JSON_HUMIDITY))) {
       TryResponseAppend_P(HASS_DISCOVER_SENSOR_HUM, sensorname);
     } else if (!strcmp_P(subsensortype, PSTR(D_JSON_PRESSURE)) 
-               || !strcmp_P(subsensortype, PSTR(D_JSON_PRESSUREATSEALEVEL))) {
+               || !strcmp_P(subsensortype, PSTR(D_JSON_PRESSUREATSEALEVEL))){
       TryResponseAppend_P(HASS_DISCOVER_SENSOR_PRESS, PressureUnit().c_str(), sensorname, subsensortype);
     } else if (!strcmp_P(subsensortype, PSTR(D_JSON_TOTAL))
                || !strcmp_P(subsensortype, PSTR(D_JSON_TODAY))

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -96,7 +96,7 @@ const char HASS_DISCOVER_SENSOR_HUM[] PROGMEM =
 
 const char HASS_DISCOVER_SENSOR_PRESS[] PROGMEM =
   ",\"unit_of_meas\":\"%s\","                         // PressureUnit() setting
-  "\"val_tpl\":\"{{value_json['%s'].Pressure}}\","    // "BME280":{"Temperature":19.7,"Humidity":27.8,"Pressure":990.1} -> {{ value_json['BME280'].Pressure }}
+  "\"val_tpl\":\"{{value_json['%s'].%s}}\","          // "BME280":{"Temperature":19.7,"Humidity":27.8,"Pressure":990.1} -> {{ value_json['BME280'].Pressure }}
   "\"dev_cla\":\"pressure\"";                         // pressure
 
 //ENERGY
@@ -448,8 +448,9 @@ void HAssAnnounceSensor(const char* sensorname, const char* subsensortype)
       TryResponseAppend_P(HASS_DISCOVER_SENSOR_TEMP, TempUnit(), sensorname);
     } else if (!strcmp_P(subsensortype, PSTR(D_JSON_HUMIDITY))) {
       TryResponseAppend_P(HASS_DISCOVER_SENSOR_HUM, sensorname);
-    } else if (!strcmp_P(subsensortype, PSTR(D_JSON_PRESSURE))) {
-      TryResponseAppend_P(HASS_DISCOVER_SENSOR_PRESS, PressureUnit().c_str(), sensorname);
+    } else if (!strcmp_P(subsensortype, PSTR(D_JSON_PRESSURE)) 
+               || !strcmp_P(subsensortype, PSTR(D_JSON_PRESSUREATSEALEVEL))) {
+      TryResponseAppend_P(HASS_DISCOVER_SENSOR_PRESS, PressureUnit().c_str(), sensorname, subsensortype);
     } else if (!strcmp_P(subsensortype, PSTR(D_JSON_TOTAL))
                || !strcmp_P(subsensortype, PSTR(D_JSON_TODAY))
                || !strcmp_P(subsensortype, PSTR(D_JSON_YESTERDAY))){


### PR DESCRIPTION
## Description:

fixed missing SeaPressure unit (hPa) in Home Assistant autodiscovery message

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
