### PR TITLE
[WIP] Make break behaviour in rules match documentation. 

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -404,8 +404,8 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
   Rules.trigger_count[rule_set] = 0;
   int plen = 0;
   int plen2 = 0;
-  bool stop_all_rules = false;
   while (true) {
+    bool stop_all_rules = false;
     rules = rules.substring(plen);                        // Select relative to last rule
     rules.trim();
     if (!rules.length()) { return serviced; }             // No more rules


### PR DESCRIPTION
If the trigger matches in a clause which ends in a break, stop processing the rule.
If the trigger doesn't match, presence or not of a break has no effect.

Open questions:
* Is this the designers intended behaviour?
* Will this break existing rules that depend on existing behaviour.

** fixes #6888

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core pre-2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
