### PR TITLE
Support for core 2.6.0....

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -102,8 +102,10 @@ extra_scripts             = pio/strip-floats.py
 ;build_flags               = ${core_2_3_0.build_flags}
 ;platform                  = ${core_2_4_2.platform}
 ;build_flags               = ${core_2_4_2.build_flags}
-platform                  = ${core_pre.platform}
-build_flags               = ${core_pre.build_flags}
+platform                  = ${core_2_6_0.platform}
+build_flags               = ${core_2_6_0.build_flags}
+;platform                  = ${core_pre.platform}
+;build_flags               = ${core_pre.build_flags}
 ;platform                  = ${core_pre_ipv6.platform}
 ;build_flags               = ${core_pre_ipv6.build_flags}
 ;platform                  = ${core_stage.platform}
@@ -137,6 +139,50 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; lwIP 2 - Higher Bandwidth (Tasmota default)
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
                             -DVTABLES_IN_FLASH
+
+[core_2_6_0]
+; *** Esp8266 core for Arduino version 2.6.0 (only for Windows and most Linux variants, sorry no Mac)
+; *** custom setup until the core 2.6.0 version is official released from PlatformIO crew
+platform                  = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_0
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+                            -O2
+                            -DBEARSSL_SSL_BASIC
+; NONOSDK221
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
+; NONOSDK22x_190313
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
+; NONOSDK22x_190703 (Tasmota default)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+; NONOSDK22x_191024
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK22x_191105
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
+; NONOSDK3V0 (known issues)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; VTABLES in Flash (Tasmota default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++-exc
 
 [core_pre]
 ; *** Arduino Esp8266 core pre 2.6.x for Tasmota (recommended version, no known issues)


### PR DESCRIPTION
not for all platforms, since core 2.6.0 is not official released from PlatformIO crew.
Support for Windows and most Linux variants and gitpod. Mac is NOT supported.

Thanks @blakadder  for doing the Linux part

Core is selected as default

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.0
  - [] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
