### PR TITLE
Remove IR protocols from build Tasmota....

### DIFF
--- a/lib/IRremoteESP8266-2.7.0/src/IRremoteESP8266.h
+++ b/lib/IRremoteESP8266-2.7.0/src/IRremoteESP8266.h
@@ -282,7 +282,7 @@
 #define SEND_NEC               true
 
 #define DECODE_SHERWOOD        false  // Doesn't exist. Actually is DECODE_NEC
-#define SEND_SHERWOOD          true
+#define SEND_SHERWOOD          false
 
 #define DECODE_RC5             true
 #define SEND_RC5               true
@@ -291,187 +291,187 @@
 #define SEND_RC6               true
 
 #define DECODE_RCMM            false
-#define SEND_RCMM              true
+#define SEND_RCMM              false
 
-#define DECODE_SONY            true
-#define SEND_SONY              true
+#define DECODE_SONY            false
+#define SEND_SONY              false
 
-#define DECODE_PANASONIC       true
-#define SEND_PANASONIC         true
+#define DECODE_PANASONIC       false
+#define SEND_PANASONIC         false
 
-#define DECODE_JVC             true
-#define SEND_JVC               true
+#define DECODE_JVC             false
+#define SEND_JVC               false
 
-#define DECODE_SAMSUNG         true
-#define SEND_SAMSUNG           true
+#define DECODE_SAMSUNG         false
+#define SEND_SAMSUNG           false
 
 #define DECODE_SAMSUNG36       false
-#define SEND_SAMSUNG36         true
+#define SEND_SAMSUNG36         false
 
 #define DECODE_SAMSUNG_AC      false
-#define SEND_SAMSUNG_AC        true
+#define SEND_SAMSUNG_AC        false
 
 #define DECODE_WHYNTER         false
-#define SEND_WHYNTER           true
+#define SEND_WHYNTER           false
 
 #define DECODE_AIWA_RC_T501    false
-#define SEND_AIWA_RC_T501      true
+#define SEND_AIWA_RC_T501      false
 
-#define DECODE_LG              true
-#define SEND_LG                true
+#define DECODE_LG              false
+#define SEND_LG                false
 
 #define DECODE_SANYO           false
-#define SEND_SANYO             true
+#define SEND_SANYO             false
 
 #define DECODE_MITSUBISHI      false
-#define SEND_MITSUBISHI        true
+#define SEND_MITSUBISHI        false
 
 #define DECODE_MITSUBISHI2     false
-#define SEND_MITSUBISHI2       true
+#define SEND_MITSUBISHI2       false
 
 #define DECODE_DISH            false
-#define SEND_DISH              true
+#define SEND_DISH              false
 
 #define DECODE_SHARP           false
-#define SEND_SHARP             true
+#define SEND_SHARP             false
 
 #define DECODE_SHARP_AC        false
-#define SEND_SHARP_AC          true
+#define SEND_SHARP_AC          false
 
 #define DECODE_DENON           false
-#define SEND_DENON             true
+#define SEND_DENON             false
 
 #define DECODE_KELVINATOR      false
-#define SEND_KELVINATOR        true
+#define SEND_KELVINATOR        false
 
 #define DECODE_MITSUBISHI_AC   false  // Beta.
-#define SEND_MITSUBISHI_AC     true
+#define SEND_MITSUBISHI_AC     false
 
 #define DECODE_FUJITSU_AC      false
-#define SEND_FUJITSU_AC        true
+#define SEND_FUJITSU_AC        false
 
 #define DECODE_INAX            false
-#define SEND_INAX              true
+#define SEND_INAX              false
 
 #define DECODE_DAIKIN          false
-#define SEND_DAIKIN            true
+#define SEND_DAIKIN            false
 
 #define DECODE_COOLIX          false
-#define SEND_COOLIX            true
+#define SEND_COOLIX            false
 
 #define DECODE_GLOBALCACHE     false  // Not written.
-#define SEND_GLOBALCACHE       true
+#define SEND_GLOBALCACHE       false
 
 #define DECODE_GOODWEATHER     false
-#define SEND_GOODWEATHER       true
+#define SEND_GOODWEATHER       false
 
 #define DECODE_GREE            false
-#define SEND_GREE              true
+#define SEND_GREE              false
 
 #define DECODE_PRONTO          false  // Not written.
-#define SEND_PRONTO            true
+#define SEND_PRONTO            false
 
 #define DECODE_ARGO            false  // Experimental
-#define SEND_ARGO              true
+#define SEND_ARGO              false
 
 #define DECODE_TROTEC          false
-#define SEND_TROTEC            true
+#define SEND_TROTEC            false
 
 #define DECODE_NIKAI           false
-#define SEND_NIKAI             true
+#define SEND_NIKAI             false
 
 #define DECODE_TOSHIBA_AC      false
-#define SEND_TOSHIBA_AC        true
+#define SEND_TOSHIBA_AC        false
 
 #define DECODE_MAGIQUEST       false
-#define SEND_MAGIQUEST         true
+#define SEND_MAGIQUEST         false
 
 #define DECODE_MIDEA           false
-#define SEND_MIDEA             true
+#define SEND_MIDEA             false
 
 #define DECODE_LASERTAG        false
-#define SEND_LASERTAG          true
+#define SEND_LASERTAG          false
 
 #define DECODE_CARRIER_AC      false
-#define SEND_CARRIER_AC        true
+#define SEND_CARRIER_AC        false
 
 #define DECODE_HAIER_AC        false
-#define SEND_HAIER_AC          true
+#define SEND_HAIER_AC          false
 
 #define DECODE_HITACHI_AC      false
-#define SEND_HITACHI_AC        true
+#define SEND_HITACHI_AC        false
 
 #define DECODE_HITACHI_AC1     false
-#define SEND_HITACHI_AC1       true
+#define SEND_HITACHI_AC1       false
 
 #define DECODE_HITACHI_AC2     false
-#define SEND_HITACHI_AC2       true
+#define SEND_HITACHI_AC2       false
 
 #define DECODE_GICABLE         false
-#define SEND_GICABLE           true
+#define SEND_GICABLE           false
 
 #define DECODE_HAIER_AC_YRW02  false
-#define SEND_HAIER_AC_YRW02    true
+#define SEND_HAIER_AC_YRW02    false
 
 #define DECODE_WHIRLPOOL_AC    false
-#define SEND_WHIRLPOOL_AC      true
+#define SEND_WHIRLPOOL_AC      false
 
 #define DECODE_LUTRON          false
-#define SEND_LUTRON            true
+#define SEND_LUTRON            false
 
 #define DECODE_ELECTRA_AC      false
-#define SEND_ELECTRA_AC        true
+#define SEND_ELECTRA_AC        false
 
 #define DECODE_PANASONIC_AC    false
-#define SEND_PANASONIC_AC      true
+#define SEND_PANASONIC_AC      false
 
 #define DECODE_MWM             false
-#define SEND_MWM               true
+#define SEND_MWM               false
 
 #define DECODE_PIONEER         false
-#define SEND_PIONEER           true
+#define SEND_PIONEER           false
 
 #define DECODE_DAIKIN2         false
-#define SEND_DAIKIN2           true
+#define SEND_DAIKIN2           false
 
 #define DECODE_VESTEL_AC       false
-#define SEND_VESTEL_AC         true
+#define SEND_VESTEL_AC         false
 
 #define DECODE_TECO            false
-#define SEND_TECO              true
+#define SEND_TECO              false
 
 #define DECODE_TCL112AC        false
-#define SEND_TCL112AC          true
+#define SEND_TCL112AC          false
 
 #define DECODE_LEGOPF          false
-#define SEND_LEGOPF            true
+#define SEND_LEGOPF            false
 
 #define DECODE_MITSUBISHIHEAVY false
-#define SEND_MITSUBISHIHEAVY   true
+#define SEND_MITSUBISHIHEAVY   false
 
 #define DECODE_DAIKIN216       false
-#define SEND_DAIKIN216         true
+#define SEND_DAIKIN216         false
 
 #define DECODE_DAIKIN160       false
-#define SEND_DAIKIN160         true
+#define SEND_DAIKIN160         false
 
 #define DECODE_NEOCLIMA        false
-#define SEND_NEOCLIMA          true
+#define SEND_NEOCLIMA          false
 
 #define DECODE_DAIKIN176       false
-#define SEND_DAIKIN176         true
+#define SEND_DAIKIN176         false
 
 #define DECODE_DAIKIN128       false
-#define SEND_DAIKIN128         true
+#define SEND_DAIKIN128         false
 
 #define DECODE_AMCOR           false
-#define SEND_AMCOR             true
+#define SEND_AMCOR             false
 
 #define DECODE_DAIKIN152       false
-#define SEND_DAIKIN152         true
+#define SEND_DAIKIN152         false
 
 #define DECODE_HITACHI_AC424   false
-#define SEND_HITACHI_AC424     true
+#define SEND_HITACHI_AC424     false
 
 #endif  // defined(FIRMWARE_IR) || defined(FIRMWARE_IR_CUSTOM)   // full IR protocols
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -510,19 +510,19 @@
 // -- IR Remote features - subset of IR protocols --------------------------
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k3 code, 0k3 mem, 48 iram)
 //  #define USE_IR_SEND_AIWA                       // Support IRsend Aiwa protocol
-  #define USE_IR_SEND_DISH                       // Support IRsend Dish protocol
-  #define USE_IR_SEND_JVC                        // Support IRsend JVC protocol
+//  #define USE_IR_SEND_DISH                       // Support IRsend Dish protocol
+//  #define USE_IR_SEND_JVC                        // Support IRsend JVC protocol
 //  #define USE_IR_SEND_LG                         // Support IRsend LG protocol
 //  #define USE_IR_SEND_MITSUBISHI                 // Support IRsend Mitsubishi protocol
   #define USE_IR_SEND_NEC                        // Support IRsend NEC protocol
-  #define USE_IR_SEND_PANASONIC                  // Support IRsend Panasonic protocol
-  #define USE_IR_SEND_PIONEER                    // Support IRsend Pioneer protocol
+//  #define USE_IR_SEND_PANASONIC                  // Support IRsend Panasonic protocol
+//  #define USE_IR_SEND_PIONEER                    // Support IRsend Pioneer protocol
   #define USE_IR_SEND_RC5                        // Support IRsend Philips RC5 protocol
   #define USE_IR_SEND_RC6                        // Support IRsend Philips RC6 protocol
-  #define USE_IR_SEND_SAMSUNG                    // Support IRsend Samsung protocol
+//  #define USE_IR_SEND_SAMSUNG                    // Support IRsend Samsung protocol
 //  #define USE_IR_SEND_SANYO                      // Support IRsend Sanyo protocol
 //  #define USE_IR_SEND_SHARP                      // Support IRsend Sharp protocol
-  #define USE_IR_SEND_SONY                       // Support IRsend Sony protocol
+//  #define USE_IR_SEND_SONY                       // Support IRsend Sony protocol
 //  #define USE_IR_SEND_WHYNTER                    // Support IRsend Whynter protocol
 
 //  #define USE_IR_HVAC                            // Support for HVAC systems using IR (+3k5 code)

--- a/tasmota/tasmota_post.h
+++ b/tasmota/tasmota_post.h
@@ -194,7 +194,7 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #define USE_MAX31855                             // Add support for MAX31855 K-Type thermocouple sensor using softSPI
 //#define USE_MAX31865                             // Add support for MAX31865 RTD sensors using softSPI
 #define USE_IR_REMOTE                            // Send IR remote commands using library IRremoteESP8266 and ArduinoJson (+4k code, 0k3 mem, 48 iram)
-  #define USE_IR_HVAC                            // Support for HVAC system using IR (+2k code)
+//  #define USE_IR_HVAC                            // Support for HVAC system using IR (+2k code)
   #define USE_IR_RECEIVE                         // Support for IR receiver (+5k5 code, 264 iram)
 
 //#define USE_ZIGBEE                               // Enable serial communication with Zigbee CC2530 flashed with ZNP


### PR DESCRIPTION
to reduce flash size usage. Very seldom needed IR protocols are removed from main tasmota build.
NEC, RC5, RC6 and send RAW and Hash decode are still there.
This protocols are used by most consumer remotes and LED devices with IR remotes

For full IR protocols support there is IR-Tasmota. 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
