### PR TITLE
Fix Rules Evaluation when using break and several triggers are true

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -425,16 +425,15 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
     if (plen == -1) { plen = 9999; }
     if (plen2 == -1) { plen2 = 9999; }
     plen = tmin(plen, plen2);
-    if (plen == plen2) { stop_all_rules = true; }         // If BREAK was used, Stop execution of this rule set
 
     String commands = rules.substring(pevt +4, plen);     // "Backlog Dimmer 10;Color 100000"
-    plen += 6;
     Rules.event_value = "";
     String event = event_saved;
 
 //AddLog_P2(LOG_LEVEL_DEBUG, PSTR("RUL: Event |%s|, Rule |%s|, Command(s) |%s|"), event.c_str(), event_trigger.c_str(), commands.c_str());
 
     if (RulesRuleMatch(rule_set, event, event_trigger)) {
+      if (plen == plen2) { stop_all_rules = true; }         // If BREAK was used on a triggered rule, Stop execution of this rule set
       commands.trim();
       String ucommand = commands;
       ucommand.toUpperCase();
@@ -473,6 +472,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       serviced = true;
       if (stop_all_rules) { return serviced; }            // If BREAK was used, Stop execution of this rule set
     }
+    plen += 6;
     Rules.trigger_count[rule_set]++;
   }
   return serviced;


### PR DESCRIPTION
## Description:
When checking several triggers that were true at the same time and BREAK was being used, some rules were not executed.

The rule: 
```
rule3 on system#boot do var4 0 break on tele-SI7021#temperature do var4 %value% endon on tele-SI7021#humidity do var5 %value% endon
```
was not triggering the third statement.

Thanks to @TheMan04 in Discord for pointing this issue.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

-------------------------

## Comment:

Before this Fix, the rule tested on github conversations:
```
rule1 on System#boot do var1 1 break on wifi#Connected do var2 %value% endon on mqtt#Connected do var3 %value% endon
```
was working as expected but because all those triggers never happens on the same evaluation cycle.

-------------------------

## Tests:

Tests showing the new correct behaviour:

```
15:30:50 CMD: rule3
15:30:50 MQT: stat/riego/RESULT = {"Rule3":"ON","Once":"OFF","StopOnError":"OFF","Free":386,"Rules":"on system#boot do var4 0 break on tele-SI7021#temperature do var4 %value% break on tele-SI7021#humidity do var5 %value% endon"}
15:31:17 MQT: tele/riego/STATE = {"Time":"2019-11-12T15:31:17","Uptime":"0T00:02:16","UptimeSec":136,"Heap":26,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":37,"MqttCount":1,"POWER1":"OFF","POWER2":"OFF","POWER3":"OFF","POWER4":"OFF","POWER5":"OFF","POWER6":"OFF","POWER7":"OFF","Wifi":{"AP":2,"SSId":"NetWireless","BSSId":"18:D6:C7:80:38:2C","Channel":11,"RSSI":36,"LinkCount":1,"Downtime":"0T00:00:06"}}
15:31:17 MQT: tele/riego/SENSOR = {"Time":"2019-11-12T15:31:17","COUNTER":{"C1":0},"ANALOG":{"A0":1},"SI7021":{"Temperature":36.4,"Humidity":22.7},"TempUnit":"C"}
15:31:17 RUL: TELE-SI7021#TEMPERATURE performs "var4 36.4"
15:31:17 MQT: stat/riego/RESULT = {"Var4":"36.4"}

15:31:25 CMD: rule3 on system#boot do var4 0 break on tele-SI7021#temperature do var4 %value% endon on tele-SI7021#humidity do var5 %value% endon
15:31:25 MQT: stat/riego/RESULT = {"Rule3":"ON","Once":"OFF","StopOnError":"OFF","Free":386,"Rules":"on system#boot do var4 0 break on tele-SI7021#temperature do var4 %value% endon on tele-SI7021#humidity do var5 %value% endon"}
15:32:17 MQT: tele/riego/STATE = {"Time":"2019-11-12T15:32:17","Uptime":"0T00:03:16","UptimeSec":196,"Heap":26,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":59,"MqttCount":1,"POWER1":"OFF","POWER2":"OFF","POWER3":"OFF","POWER4":"OFF","POWER5":"OFF","POWER6":"OFF","POWER7":"OFF","Wifi":{"AP":2,"SSId":"NetWireless","BSSId":"18:D6:C7:80:38:2C","Channel":11,"RSSI":38,"LinkCount":1,"Downtime":"0T00:00:06"}}
15:32:17 MQT: tele/riego/SENSOR = {"Time":"2019-11-12T15:32:17","COUNTER":{"C1":0},"ANALOG":{"A0":1},"SI7021":{"Temperature":36.4,"Humidity":23.4},"TempUnit":"C"}
15:32:17 RUL: TELE-SI7021#TEMPERATURE performs "var4 36.4"
15:32:17 MQT: stat/riego/RESULT = {"Var4":"36.4"}
15:32:17 RUL: TELE-SI7021#HUMIDITY performs "var5 23.4"
15:32:17 MQT: stat/riego/RESULT = {"Var5":"23.4"}

15:32:42 CMD: rule3 on system#boot do var4 0 endon on tele-SI7021#temperature do var4 %value% endon on tele-SI7021#humidity do var5 %value% endon
15:32:42 MQT: stat/riego/RESULT = {"Rule3":"ON","Once":"OFF","StopOnError":"OFF","Free":386,"Rules":"on system#boot do var4 0 endon on tele-SI7021#temperature do var4 %value% endon on tele-SI7021#humidity do var5 %value% endon"}
15:33:17 MQT: tele/riego/SENSOR = {"Time":"2019-11-12T15:33:17","COUNTER":{"C1":0},"ANALOG":{"A0":1},"SI7021":{"Temperature":36.4,"Humidity":24.2},"TempUnit":"C"}
15:33:17 RUL: TELE-SI7021#TEMPERATURE performs "var4 36.4"
15:33:17 MQT: stat/riego/RESULT = {"Var4":"36.4"}
15:33:17 RUL: TELE-SI7021#HUMIDITY performs "var5 24.2"
15:33:17 MQT: stat/riego/RESULT = {"Var5":"24.2"}
```

-------------------------------

## More Tests:

* If the following behaviour is required:
```
Power1 = Sensor1<17
Power2 = (Sensor1<17 OR Sensor2<45)
```

* Then, we can test the following cases in numbers:

```
A- if Sensor1 is 10, output should be POWER1 1 and POWER2 1
B- if Sensor1 is 20, output should be POWER1 0
C- if Sensor2 is 30, output should be POWER2 1
D- if Sensor2 is 50 AND Sensor1 is 20, output should be POWER2 0
```

* So, proposing the following test rules (var instead of sensor just for testing):

```
Rule1
  on var1#state<17 do backlog power1 1; power2 1 break
  on var1#state>=17 do power1 0 break
  on var2#state<45 do power2 1 endon
  on var2#state>=45 do event testsensor1=%var1% endon
  on event#testsensor1>=17 do power2 0 endon
```

* Rules all together for pasting in the console:

```
rule1 1
rule1 on var1#state<17 do backlog power1 1; power2 1 break on var1#state>=17 do power1 0 break on var2#state<45 do power2 1 endon on var2#state>=45 do event testsensor1=%var1% endon on event#testsensor1>=17 do power2 0 endon
```

* Test Cases and the output of the console:

```
18:26:06 CMD: rule1 on var1#state<17 do backlog power1 1; power2 1 break on var1#state>=17 do power1 0 break on var2#state<45 do power2 1 endon on var2#state>=45 do event testsensor1=%var1% endon on event#testsensor1>=17 do power2 0 endon
18:26:06 MQT: stat/living/RESULT = {"Rule1":"ON","Once":"OFF","StopOnError":"OFF","Free":293,"Rules":"on var1#state<17 do backlog power1 1; power2 1 break on var1#state>=17 do power1 0 break on var2#state<45 do power2 1 endon on var2#state>=45 do event testsensor1=%var1% endon on event#testsensor1>=17 do power2 0 endon"}

-CASE A-

18:28:07 CMD: var1 10
18:28:07 MQT: stat/living/RESULT = {"Var1":"10"}
18:28:07 RUL: VAR1#STATE<17 performs "backlog power1 1; power2 1"
18:28:07 MQT: stat/living/RESULT = {"POWER1":"ON"}
18:28:07 MQT: stat/living/POWER1 = ON
18:28:08 MQT: stat/living/RESULT = {"POWER2":"ON"}
18:28:08 MQT: stat/living/POWER2 = ON

-CASE B-

18:28:53 CMD: var1 20
18:28:53 MQT: stat/living/RESULT = {"Var1":"20"}
18:28:53 RUL: VAR1#STATE>=17 performs "power1 0"
18:28:53 MQT: stat/living/RESULT = {"POWER1":"OFF"}
18:28:53 MQT: stat/living/POWER1 = OFF

-CASE C-

18:29:49 CMD: var2 30
18:29:49 MQT: stat/living/RESULT = {"Var2":"30"}
18:29:49 RUL: VAR2#STATE<45 performs "power2 1"
18:29:49 MQT: stat/living/RESULT = {"POWER2":"ON"}
18:29:49 MQT: stat/living/POWER2 = ON

-CASE D-

18:31:00 CMD: var2 50
18:31:00 MQT: stat/living/RESULT = {"Var2":"50"}
18:31:00 RUL: VAR2#STATE>=45 performs "backlog event testsensor1=20"
18:31:00 MQT: stat/living/RESULT = {"Event":"Done"}
18:31:00 RUL: EVENT#TESTSENSOR1>=17 performs "power2 0"
18:31:00 MQT: stat/living/RESULT = {"POWER2":"OFF"}
18:31:00 MQT: stat/living/POWER2 = OFF
```