### PR TITLE
extend Honeywell HPMA library for compact devices

### DIFF
--- a/lib/HPMA115S0/example/example.ino
+++ b/lib/HPMA115S0/example/example.ino
@@ -6,7 +6,7 @@
  * @license MIT
  */
 
-#include <HPMA115S0.h>
+#include <hpma115S0.h>
 #include <SoftwareSerial.h>
 
 //Create an instance of software serial

--- a/lib/HPMA115S0/src/hpma115S0.cpp
+++ b/lib/HPMA115S0/src/hpma115S0.cpp
@@ -45,7 +45,7 @@ void HPMA115S0::Init() {
  * @param size of buffer
  * @return  void
  */
-void HPMA115S0::SendCmd(unsigned char * cmdBuf, unsigned int cmdSize) {
+void HPMA115S0::SendCmd(const char * cmdBuf, unsigned int cmdSize) {
   //Clear RX
   while (_serial.available())
     _serial.read();
@@ -114,18 +114,28 @@ int HPMA115S0::ReadCmdResp(unsigned char * dataBuf, unsigned int dataBufSize, un
  * @return  returns true if valid measurements were read from sensor
  */
 boolean HPMA115S0::ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10) {
-  unsigned char cmdBuf[] = {0x68, 0x01, 0x04, 0x93};
-  static unsigned char dataBuf[HPM_READ_PARTICLE_MEASURMENT_LEN - 1];
+  const char cmdBuf[] = {0x68, 0x01, 0x04, 0x93};
+  static unsigned char dataBuf[HPM_READ_PARTICLE_MEASURMENT_LEN_C - 1];
+  int len;
 
-  //Serial.println("PS- Reading Particle Measurements..." );
+  // Serial.println("PS- Reading Particle Measurements..." );
 
   //Send command
   SendCmd(cmdBuf, 4);
 
   //Read response
-  if (ReadCmdResp(dataBuf, sizeof(dataBuf), READ_PARTICLE_MEASURMENT) == (HPM_READ_PARTICLE_MEASURMENT_LEN - 1)) {
-    _pm2_5 = dataBuf[0] * 256 + dataBuf[1];
-    _pm10 = dataBuf[2] * 256 + dataBuf[3];
+  len = ReadCmdResp(dataBuf, sizeof(dataBuf), READ_PARTICLE_MEASURMENT);
+  if ((len == (HPM_READ_PARTICLE_MEASURMENT_LEN - 1)) || (len == (HPM_READ_PARTICLE_MEASURMENT_LEN_C - 1))) {
+
+    if (len == (HPM_READ_PARTICLE_MEASURMENT_LEN - 1)) {
+      // HPMA115S0 Standard devices
+      _pm2_5 = dataBuf[0] * 256 + dataBuf[1];
+      _pm10 = dataBuf[2] * 256 + dataBuf[3];
+    } else {
+      // HPMA115C0 Compact devices
+      _pm2_5 = dataBuf[2] * 256 + dataBuf[3];
+      _pm10 = dataBuf[6] * 256 + dataBuf[7];
+    } 
     *pm2_5 = _pm2_5;
     *pm10 = _pm10;
     // Serial.println("PS- PM 2.5: " + String(_pm2_5) + " ug/m3" );
@@ -140,7 +150,7 @@ boolean HPMA115S0::ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * 
  * @return  void
  */
 void HPMA115S0::StartParticleMeasurement() {
-  unsigned char cmd[] = {0x68, 0x01, 0x01, 0x96};
+  const char cmd[] = {0x68, 0x01, 0x01, 0x96};
   SendCmd(cmd, 4);
 }
 
@@ -149,7 +159,7 @@ void HPMA115S0::StartParticleMeasurement() {
  * @return  void
  */
 void HPMA115S0::StopParticleMeasurement() {
-  unsigned char cmd[] = {0x68, 0x01, 0x02, 0x95};
+  const char cmd[] = {0x68, 0x01, 0x02, 0x95};
   SendCmd(cmd, 4);
 }
 
@@ -158,7 +168,7 @@ void HPMA115S0::StopParticleMeasurement() {
  * @return  void
  */
 void HPMA115S0::EnableAutoSend() {
-  unsigned char cmd[] = {0x68, 0x01, 0x40, 0x57};
+  const char cmd[] = {0x68, 0x01, 0x40, 0x57};
   SendCmd(cmd, 4);
 }
 
@@ -167,7 +177,7 @@ void HPMA115S0::EnableAutoSend() {
  * @return  void
  */
 void HPMA115S0::DisableAutoSend() {
-  unsigned char cmd[] = {0x68, 0x01, 0x20, 0x77};
+  const char cmd[] = {0x68, 0x01, 0x20, 0x77};
   SendCmd(cmd, 4);
 }
 

--- a/lib/HPMA115S0/src/hpma115S0.h
+++ b/lib/HPMA115S0/src/hpma115S0.h
@@ -13,8 +13,9 @@
 #include "Arduino.h"
 
 #define HPM_CMD_RESP_HEAD 0x40
-#define HPM_MAX_RESP_SIZE 8 // max command response size is 8 bytes
+#define HPM_MAX_RESP_SIZE 16 // max command response size is 16 bytes
 #define HPM_READ_PARTICLE_MEASURMENT_LEN 5
+#define HPM_READ_PARTICLE_MEASURMENT_LEN_C 13
 
 enum CMD_TYPE_T {
     READ_PARTICLE_MEASURMENT = 0x04,
@@ -53,8 +54,8 @@ public:
     /**
      * @brief Function that sends a read command to sensor
      * @return  returns true if valid measurements were read from sensor
-     */boolean ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10)
-    ;
+     */
+    boolean ReadParticleMeasurement(unsigned int * pm2_5, unsigned int * pm10);
 
     /**
      * @brief Function that starts sensor measurement
@@ -108,7 +109,7 @@ private:
      * @param size of buffer
      * @return  void
      */
-    void SendCmd(unsigned char * command, unsigned int size);
+    void SendCmd(const char * command, unsigned int size);
 
     /**
     * @brief Function that reads command response from sensor


### PR DESCRIPTION
The HPMA115C0-xxx is a new series of devices than has a
slightly different (longer) response than the HPMA115S0-xxx

This patch keeps the same API as the original library and
picks out the PM2.5 and PM10 reading from the new response
format.

The patch also changes a const change to be more in line with
the upstream library for future rebases.

This change has also been merge-requested into the upstream
library.

Signed-off-by: David Hunt <dave@davidhunt.ie>

## Description:

**Related issue (if applicable): None (extension of existing HPMA driver)

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
