### PR TITLE
Added save MCU state and dump to MQTT for Tuya devices

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -456,6 +456,7 @@
 #define D_CMND_TUYA_MCU "TuyaMCU"
 #define D_CMND_TUYA_MCU_SEND_STATE "TuyaSend"
 #define D_JSON_TUYA_MCU_RECEIVED "TuyaReceived"
+#define D_JSON_TUYA_MCU_STATUS "TuyaStatus"
 
 // Commands xdrv_23_zigbee.ino
 #define D_ZIGBEE_NOT_STARTED "Zigbee not started (yet)"


### PR DESCRIPTION
## Description:

Added save/dump capability to TuyaMCU driver: this means that every dpId is saved in a memory structure and dumped to MQTT every minute.
This option is quite useful because on devices with many dpId it is of interest to monitor and record them (for example: a humidifier might report its parameters each with own dpId and also temperature/humidity with other dpIds).
Since doing the same with rules is quite complicated due to the fact that each dpId sends a specific TuyaCmd string, with this changes the status is report without doing anything.

It might also be useful to add and option to enable/disable this but I'm not sure if something is already reserved here: it might be a twin option of Option66, where instead of enabling all MQTT messages it enables only the retained one sent with TuyaDumpState. I can add this with no effort if only I know which Option it should be associated with.

## Checklist:
  - [ X] The pull request is done against the latest dev branch
  - [ X] Only relevant files were touched
  - [ X] Only one feature/fix was added per PR.
  - [ X] The code change is tested and works on core 2.6
  - [ X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
