### PR TITLE
Copy compiled firmware(s) in folder `build_output/firmware`...

### DIFF
--- a/pio/name-firmware.py
+++ b/pio/name-firmware.py
@@ -2,11 +2,32 @@ Import('env')
 import os
 import shutil
 
-def name_firmware(source, target, env):
-    base_dir = os.path.dirname(str(target[0]))
-    new_file = "{}{}{}.bin".format(base_dir, os.path.sep, str(target[0]).split(os.path.sep)[1])
-    if os.path.isfile(new_file):
-        os.remove(new_file)
-    shutil.copyfile(str(target[0]), new_file)
+OUTPUT_DIR = "build_output{}".format(os.path.sep)
 
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [name_firmware])
+def bin_map_copy(source, target, env):
+    variant = str(target[0]).split(os.path.sep)[1]
+    
+    # check if output directories exist and create if necessary
+    if not os.path.isdir(OUTPUT_DIR):
+        os.mkdir(OUTPUT_DIR)
+
+    for d in ['firmware', 'map']:
+        if not os.path.isdir("{}{}".format(OUTPUT_DIR, d)):
+            os.mkdir("{}{}".format(OUTPUT_DIR, d))
+
+    # create string with location and file names based on variant
+    map_file = "{}map{}{}.map".format(OUTPUT_DIR, os.path.sep, variant)
+    bin_file = "{}firmware{}{}.bin".format(OUTPUT_DIR, os.path.sep, variant)
+
+    # check if new target files exist and remove if necessary
+    for f in [map_file, bin_file]:
+        if os.path.isfile(f):
+            os.remove(f)
+
+    # copy firmware.bin to firmware/<variant>.bin
+    shutil.copy(str(target[0]), bin_file)
+
+    # copy firmware.map to map/<variant>.map
+    shutil.copy("firmware.map", map_file)
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_map_copy])

--- a/platformio.ini
+++ b/platformio.ini
@@ -86,7 +86,7 @@ upload_resetmethod        = nodemcu
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port               = COM5
 extra_scripts             = pio/strip-floats.py
-;                            pio/name-firmware.py
+                            pio/name-firmware.py
 ;                            pio/obj-dump.py
 
 ; *** Upload file to OTA server using SCP


### PR DESCRIPTION
## Description:

so it is easier to find for the user. Firmware(s) is named after the `envs`. 
A second folder is generated in `build_output` -> `map` where the generated map files to the bin(s) are stored.
The original firmware.bin is left untouched on its original place.
Script is enabled by default

Thanks @jziolkowski  for the Python script.

Info @andrethomas has no effect for the build script  `thehackbox`
@ascillato as discussed in Discord

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
