### PR TITLE
Change Zigbee log verbosity reduction

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -9,6 +9,7 @@
  * Change Kept only NEC/RC5/RC6/HASH IR protocols in standard Tasmota, all other protocols require Tasmota-IR, saving 4K
  * Add command SetOption76 0/1 to enable incrementing bootcount when deepsleep is enabled (#6930)
  * Change Reset erase end address from as seen by SDK (getFlashChipSize) to full flash size (getFlashChipRealSize)
+ * Change Zigbee log verbosity reduction
  *
  * 7.0.0.3 20191103
  * Add command I2cDriver for I2C driver runtime control using document I2CDEVICES.md

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Фазов ъгъл"

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phasenwinkel"

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Ángulo de Fase"

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Angle de phase"

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Fázisszög"

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Angolo Fase"

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Fase hoek"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Ângulo de Fase"

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Ângulo de fase"

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Угол фазы"

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Fasvinkel"

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/language/uk-UK.h
+++ b/tasmota/language/uk-UK.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Кут фази"

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "相位角"

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -691,6 +691,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 
 //SDM220
 #define D_PHASE_ANGLE     "Phase Angle"

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -388,7 +388,7 @@ uint32_t parseSingleAttribute(JsonObject& json, char *attrid_str, class SBuffer 
   // String pp;    // pretty print
   // json[attrid_str].prettyPrintTo(pp);
   // // now store the attribute
-  // AddLog_P2(LOG_LEVEL_INFO, PSTR("ZIG: ZCL attribute decoded, id %s, type 0x%02X, val=%s"),
+  // AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "ZCL attribute decoded, id %s, type 0x%02X, val=%s"),
   //                                attrid_str, attrtype, pp.c_str());
   return i - offset;    // how much have we increased the index
 }

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -435,7 +435,6 @@ const Z_Dispatcher Z_DispatchTable[] PROGMEM = {
 
 int32_t Z_Recv_Default(int32_t res, const class SBuffer &buf) {
   // Default message handler for new messages
-  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZIG: Z_Recv_Default"));
   if (zigbee.init_phase) {
     // if still during initialization phase, ignore any unexpected message
   	return -1;	// ignore message

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -66,7 +66,7 @@ int32_t ZigbeeProcessInput(class SBuffer &buf) {
       }
     }
 
-    AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZIG: ZigbeeProcessInput: recv_prefix_match = %d, recv_filter_match = %d"), recv_prefix_match, recv_filter_match);
+    AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ZIGBEE "ZigbeeProcessInput: recv_prefix_match = %d, recv_filter_match = %d"), recv_prefix_match, recv_filter_match);
   }
 
   // if there is a recv_callback, call it now
@@ -105,7 +105,7 @@ int32_t ZigbeeProcessInput(class SBuffer &buf) {
       res = (*zigbee.recv_unexpected)(res, buf);
     }
   }
-  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZIG: ZigbeeProcessInput: res = %d"), res);
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ZIGBEE "ZigbeeProcessInput: res = %d"), res);
 
   // change state accordingly
   if (0 == res) {
@@ -184,7 +184,7 @@ void ZigbeeInput(void)
 		ToHex_P((unsigned char*)zigbee_buffer->getBuffer(), zigbee_buffer->len(), hex_char, sizeof(hex_char));
 
 #ifndef Z_USE_SOFTWARE_SERIAL
-    AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZIG: Bytes follor_read_metric = %0d"), ZigbeeSerial->getLoopReadMetric());
+    AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ZIGBEE "Bytes follow_read_metric = %0d"), ZigbeeSerial->getLoopReadMetric());
 #endif
 		// buffer received, now check integrity
 		if (zigbee_buffer->len() != zigbee_frame_len) {
@@ -195,15 +195,17 @@ void ZigbeeInput(void)
       AddLog_P2(LOG_LEVEL_INFO, PSTR(D_JSON_ZIGBEEZNPRECEIVED ": received bad FCS frame %s, %d"), hex_char, fcs);
 		} else {
 			// frame is correct
-			AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_JSON_ZIGBEEZNPRECEIVED ": received correct frame %s"), hex_char);
+			//AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_JSON_ZIGBEEZNPRECEIVED ": received correct frame %s"), hex_char);
 
 			SBuffer znp_buffer = zigbee_buffer->subBuffer(2, zigbee_frame_len - 3);	// remove SOF, LEN and FCS
 
 #ifdef ZIGBEE_VERBOSE
 			ToHex_P((unsigned char*)znp_buffer.getBuffer(), znp_buffer.len(), hex_char, sizeof(hex_char));
-	    Response_P(PSTR("{\"" D_JSON_ZIGBEEZNPRECEIVED "\":\"%s\"}"), hex_char);
-	    MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZNPRECEIVED));
-	    XdrvRulesProcess();
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZNPRECEIVED " %s"),
+                                 hex_char);
+	    // Response_P(PSTR("{\"" D_JSON_ZIGBEEZNPRECEIVED "\":\"%s\"}"), hex_char);
+	    // MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZNPRECEIVED));
+	    // XdrvRulesProcess();
 #endif
 
 			// now process the message
@@ -333,10 +335,8 @@ void ZigbeeZNPSend(const uint8_t *msg, size_t len) {
 #ifdef ZIGBEE_VERBOSE
 	// Now send a MQTT message to report the sent message
 	char hex_char[(len * 2) + 2];
-	Response_P(PSTR("{\"" D_JSON_ZIGBEEZNPSENT "\":\"%s\"}"),
-			ToHex_P(msg, len, hex_char, sizeof(hex_char)));
-	MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZNPSENT));
-	XdrvRulesProcess();
+  AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZNPSENT " %s"),
+                               		ToHex_P(msg, len, hex_char, sizeof(hex_char)));
 #endif
 }
 


### PR DESCRIPTION
## Description:

Now ZigbeeZNPSent and ZigbeeZNPReceived are produced only at DEBUG log level (3).

`ZigbeeState` are still output at INFO level and publish to MQTT.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
