### PR TITLE
#enhancement: Adding option to compensate on a global level temperature

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -290,6 +290,7 @@
   #define D_JSON_GPIO "GPIO"
   #define D_JSON_FLAG "FLAG"
   #define D_JSON_BASE "BASE"
+#define D_CMND_TEMPOFFSET "TempOffset"
 
 // Commands xdrv_01_mqtt.ino
 #define D_CMND_MQTTLOG "MqttLog"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -434,8 +434,8 @@ struct SYSCFG {
   uint32_t      deepsleep;                 // E94
   uint16_t      energy_power_delta;        // E98
   uint8_t       shutter_motordelay[MAX_SHUTTERS];    // E9A
-
-  uint8_t       free_e9e[2];               // E9E
+  int8_t        temp_comp;
+  uint8_t       free_e9e[1];               // E9E
 
   uint8_t       web_color2[2][3];          // EA0 - Needs to be on integer / 3 distance from web_color
 

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -520,6 +520,7 @@ float ConvertTemp(float c)
   if (!isnan(c) && Settings.flag.temperature_conversion) {    // SetOption8 - Switch between Celsius or Fahrenheit
     result = c * 1.8 + 32;                                    // Fahrenheit
   }
+  result = result + (0.1 * Settings.temp_comp);
   return result;
 }
 
@@ -530,6 +531,7 @@ float ConvertTempToCelsius(float c)
   if (!isnan(c) && Settings.flag.temperature_conversion) {    // SetOption8 - Switch between Celsius or Fahrenheit
     result = (c - 32) / 1.8;                                  // Celsius
   }
+  result = result + (0.1 * Settings.temp_comp);
   return result;
 }
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -26,7 +26,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_BUTTONDEBOUNCE "|" D_CMND_SWITCHDEBOUNCE "|" D_CMND_SYSLOG "|" D_CMND_LOGHOST "|" D_CMND_LOGPORT "|" D_CMND_SERIALSEND "|" D_CMND_BAUDRATE "|"
   D_CMND_SERIALDELIMITER "|" D_CMND_IPADDRESS "|" D_CMND_NTPSERVER "|" D_CMND_AP "|" D_CMND_SSID "|" D_CMND_PASSWORD "|" D_CMND_HOSTNAME "|" D_CMND_WIFICONFIG "|"
   D_CMND_FRIENDLYNAME "|" D_CMND_SWITCHMODE "|" D_CMND_INTERLOCK "|" D_CMND_TELEPERIOD "|" D_CMND_RESET "|" D_CMND_TIME "|" D_CMND_TIMEZONE "|" D_CMND_TIMESTD "|"
-  D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_WIFIPOWER "|"
+  D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|"
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
@@ -41,7 +41,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndButtonDebounce, &CmndSwitchDebounce, &CmndSyslog, &CmndLoghost, &CmndLogport, &CmndSerialSend, &CmndBaudrate,
   &CmndSerialDelimiter, &CmndIpAddress, &CmndNtpServer, &CmndAp, &CmndSsid, &CmndPassword, &CmndHostname, &CmndWifiConfig,
   &CmndFriendlyname, &CmndSwitchMode, &CmndInterlock, &CmndTeleperiod, &CmndReset, &CmndTime, &CmndTimezone, &CmndTimeStd,
-  &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower,
+  &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower, &CmndTempOffset,
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
 #endif
@@ -495,6 +495,15 @@ void CmndState(void)
   }
 #endif  // USE_HOME_ASSISTANT
 }
+
+void CmndTempOffset(void)
+{
+  if ((XdrvMailbox.payload > -127) && (XdrvMailbox.payload < 127) && (XdrvMailbox.data_len > 0)) {
+    Settings.temp_comp = XdrvMailbox.payload;
+  }
+  ResponseCmndNumber(Settings.temp_comp);
+}
+
 
 void CmndSleep(void)
 {


### PR DESCRIPTION
## Description:
nearly all sensors have some deviation on temperature based on different reasons. To compensate for all different kinds o temperature sensors would result in a heavy add of code. Therefore I use the "small edition" with only ONE compensation factor. If there are more sensors this compensation will work for all temp-sensors. Comp can be between -12.6 °C/F and +12.6°C/F. It should suitable for most cases. Just digital +- independent if it is C or F. If changing the UNIT, the compensation will be wrong.


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [ x] The code change is tested and works on core 2.6
  - [ x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
