### PR TITLE
Fix check deepsleep for valid values in Settings (#6961)

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -2,6 +2,7 @@
  * 7.0.0.5 20191118
  * Fix boot loop regression
  * Add command TempOffset -12.6 .. 12.6 to set global temperature sensor offset (#6958)
+ * Fix check deepsleep for valid values in Settings (#6961)
  *
  * 7.0.0.4 20191108
  * Add command WifiPower 0 .. 20.5 to set Wifi Output Power which will be default set to 17dBm


### PR DESCRIPTION
## Description:

Value of deepsleep happen to be 0xFFFFFFFF (or -1) after some OTA scenarios. This PR resets deepsleep when the settings are out of range.

**Related issue (if applicable):** fixes #6961 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
