### PR TITLE
Ignore `bin` and `map` files after compilation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ tasmota/user_config_override.h
 build
 firmware.map
 firmware.asm
+tasmota*.bin
+tasmota*.map
 
 ## Visual Studio Code specific ######
 .vscode


### PR DESCRIPTION
## Description:

The latest scripts create a tasmota.bin and tasmota.map file that is marked as untracked by git.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
