### PR TITLE
Fix Wifi instability when light is on, due to sleep=0 (#6961, #6608)

### DIFF
--- a/tasmota/_changelog.ino
+++ b/tasmota/_changelog.ino
@@ -3,6 +3,7 @@
  * Fix boot loop regression
  * Add command TempOffset -12.6 .. 12.6 to set global temperature sensor offset (#6958)
  * Fix check deepsleep for valid values in Settings (#6961)
+ * Fix Wifi instability when light is on, due to sleep=0 (#6961, #6608)
  *
  * 7.0.0.4 20191108
  * Add command WifiPower 0 .. 20.5 to set Wifi Output Power which will be default set to 17dBm

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -100,7 +100,6 @@ const uint16_t PWM_MAX = 4000;              // [PWM_MAX] Maximum frequency - Def
 const uint16_t PWM_MIN = 100;               // [PWM_MIN] Minimum frequency - Default: 100
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
                                             //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
-//#define PWM_LIGHTSCHEME0_IGNORE_SLEEP       // Do not change sleep value for LightAnimate() scheme 0
 
 const uint16_t MAX_POWER_HOLD = 10;         // Time in SECONDS to allow max agreed power
 const uint16_t MAX_POWER_WINDOW = 30;       // Time in SECONDS to disable allow max agreed power

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1617,11 +1617,11 @@ void LightAnimate(void)
     }
   }
   else {
-#ifdef PWM_LIGHTSCHEME0_IGNORE_SLEEP
-    sleep = (LS_POWER == Settings.light_scheme) ? Settings.sleep : 0;  // If no animation then use sleep as is
-#else
-    sleep = 0;
-#endif // PWM_LIGHTSCHEME0_IGNORE_SLEEP
+    if (Settings.sleep > 50) {
+      sleep = 50;                 // set a minimal value of 50 milliseconds to ensure that animations are smooth
+    } else {
+      sleep = Settings.sleep;     // or keep the current sleep if it's lower than 50
+    }
     switch (Settings.light_scheme) {
       case LS_POWER:
         light_controller.calcLevels();

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1617,8 +1617,8 @@ void LightAnimate(void)
     }
   }
   else {
-    if (Settings.sleep > 50) {
-      sleep = 50;                 // set a minimal value of 50 milliseconds to ensure that animations are smooth
+    if (Settings.sleep > 10) {
+      sleep = 10;                 // set a minimal value of 50 milliseconds to ensure that animations are smooth
     } else {
       sleep = Settings.sleep;     // or keep the current sleep if it's lower than 50
     }


### PR DESCRIPTION
## Description:

`sleep = 0` is currently force when light is on, which creates some wifi instability. This PR forces a minimum value `sleep = 50` when lights are on to ensure smooth animations and keep wifi stability.

**Related issue (if applicable):** fixes #6961 #6608 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
