### PR TITLE
Change new Fade system much smoother, Speed now up to 40

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.0.0.6 20191122
 
 - Add colorpicker to WebUI by Christian Staars (#6984)
+- Change new Fade system much smoother, Speed now up to 40 (#6942, #3714)
 
 ### 7.0.0.5 20191118
 


### PR DESCRIPTION
## Description:

Major rewrite of the `Fade` system for a much smoother rendering.

Now `Speed` is deterministic and represents the time in half-seconds to move from 0% to 100%.

Example: `Speed 4` means it takes 2 seconds from 0% to 100%, and by consequence 0.5s from 0% to 25%.

Other changes:

- Fixed bug that prevented RGB values to go above 25% of brightness (after Gamma correction) if White Blend mode was activated
- `changeUIntScale()` can now accepts `to_min > to_max` and compute accurately. This reduces overall code size.

Flash increase: 350 bytes.

**Related issue (if applicable):** fixes #6942 #3714 
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
