### PR TITLE
Support 'relay' outputs triggered by 'low' values where the relay circuit is triggered by driven 3.3v being 'low'

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -550,6 +550,9 @@
   #define USE_TASMOTA_SLAVE_FLASH_SPEED 57600      // Usually 57600 for 3.3V variants and 115200 for 5V variants
   #define USE_TASMOTA_SLAVE_SERIAL_SPEED 57600     // Depends on the sketch that is running on the Uno/Pro Mini
 
+//#define USE_RELAYS_OC                            // Allow RelayNoc and RelayNoci in gui selection
+
+
 // -- End of general directives -------------------
 
 /*********************************************************************************************\

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1092,6 +1092,12 @@ bool GetUsedInModule(uint32_t val, uint8_t *arr)
   if ((val >= GPIO_REL1_INV) && (val < GPIO_REL1_INV + MAX_RELAYS)) {
     offset = -(GPIO_REL1_INV - GPIO_REL1);
   }
+  if ((val >= GPIO_REL1_OC) && (val < GPIO_REL1_OC + MAX_RELAYS)) {
+    offset = -(GPIO_REL1_OC - GPIO_REL1);
+  }
+  if ((val >= GPIO_REL1_OC_INV) && (val < GPIO_REL1_OC_INV + MAX_RELAYS)) {
+    offset = -(GPIO_REL1_OC_INV - GPIO_REL1);
+  }
 
   if ((val >= GPIO_LED1) && (val < GPIO_LED1 + MAX_LEDS)) {
     offset = (GPIO_LED1_INV - GPIO_LED1);

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1092,13 +1092,14 @@ bool GetUsedInModule(uint32_t val, uint8_t *arr)
   if ((val >= GPIO_REL1_INV) && (val < GPIO_REL1_INV + MAX_RELAYS)) {
     offset = -(GPIO_REL1_INV - GPIO_REL1);
   }
+#ifdef USE_RELAYS_OC
   if ((val >= GPIO_REL1_OC) && (val < GPIO_REL1_OC + MAX_RELAYS)) {
     offset = -(GPIO_REL1_OC - GPIO_REL1);
   }
   if ((val >= GPIO_REL1_OC_INV) && (val < GPIO_REL1_OC_INV + MAX_RELAYS)) {
     offset = -(GPIO_REL1_OC_INV - GPIO_REL1);
   }
-
+#endif
   if ((val >= GPIO_LED1) && (val < GPIO_LED1 + MAX_LEDS)) {
     offset = (GPIO_LED1_INV - GPIO_LED1);
   }

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -214,6 +214,22 @@ enum UserSelectablePins {
   GPIO_TASMOTASLAVE_RST_INV, // Slave Reset Inverted
   GPIO_HPMA_RX,        // Honeywell HPMA115S0 Serial interface
   GPIO_HPMA_TX,        // Honeywell HPMA115S0 Serial interface
+  GPIO_REL1_OC,           // Relays
+  GPIO_REL2_OC,
+  GPIO_REL3_OC,
+  GPIO_REL4_OC,
+  GPIO_REL5_OC,
+  GPIO_REL6_OC,
+  GPIO_REL7_OC,
+  GPIO_REL8_OC,
+  GPIO_REL1_OC_INV,
+  GPIO_REL2_OC_INV,
+  GPIO_REL3_OC_INV,
+  GPIO_REL4_OC_INV,
+  GPIO_REL5_OC_INV,
+  GPIO_REL6_OC_INV,
+  GPIO_REL7_OC_INV,
+  GPIO_REL8_OC_INV,
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -294,6 +310,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_DEEPSLEEP "|" D_SENSOR_EXS_ENABLE "|"
   D_SENSOR_SLAVE_TX "|" D_SENSOR_SLAVE_RX "|" D_SENSOR_SLAVE_RESET "|" D_SENSOR_SLAVE_RESET "i|"
   D_SENSOR_HPMA_RX "|" D_SENSOR_HPMA_TX "|"
+  D_SENSOR_RELAY "1oc|" D_SENSOR_RELAY "2oc|" D_SENSOR_RELAY "3oc|" D_SENSOR_RELAY "4oc|" D_SENSOR_RELAY "5oc|" D_SENSOR_RELAY "6oc|" D_SENSOR_RELAY "7oc|" D_SENSOR_RELAY "8oc|"
+  D_SENSOR_RELAY "1oci|" D_SENSOR_RELAY "2oci|" D_SENSOR_RELAY "3oci|" D_SENSOR_RELAY "4oci|" D_SENSOR_RELAY "5oci|" D_SENSOR_RELAY "6oci|" D_SENSOR_RELAY "7oci|" D_SENSOR_RELAY "8oci|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -481,20 +499,36 @@ const uint8_t kGpioNiceList[] PROGMEM = {
   GPIO_SWT8_NP,
   GPIO_REL1,           // Relays
   GPIO_REL1_INV,
+  GPIO_REL1_OC,           // Relays
+  GPIO_REL1_OC_INV,
   GPIO_REL2,
   GPIO_REL2_INV,
+  GPIO_REL2_OC,           // Relays
+  GPIO_REL2_OC_INV,
   GPIO_REL3,
   GPIO_REL3_INV,
+  GPIO_REL3_OC,           // Relays
+  GPIO_REL3_OC_INV,
   GPIO_REL4,
   GPIO_REL4_INV,
+  GPIO_REL4_OC,           // Relays
+  GPIO_REL4_OC_INV,
   GPIO_REL5,
   GPIO_REL5_INV,
+  GPIO_REL5_OC,           // Relays
+  GPIO_REL5_OC_INV,
   GPIO_REL6,
   GPIO_REL6_INV,
+  GPIO_REL6_OC,           // Relays
+  GPIO_REL6_OC_INV,
   GPIO_REL7,
   GPIO_REL7_INV,
+  GPIO_REL7_OC,           // Relays
+  GPIO_REL7_OC_INV,
   GPIO_REL8,
   GPIO_REL8_INV,
+  GPIO_REL8_OC,           // Relays
+  GPIO_REL8_OC_INV,
   GPIO_LED1,           // Leds
   GPIO_LED1_INV,
   GPIO_LED2,

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -214,6 +214,7 @@ enum UserSelectablePins {
   GPIO_TASMOTASLAVE_RST_INV, // Slave Reset Inverted
   GPIO_HPMA_RX,        // Honeywell HPMA115S0 Serial interface
   GPIO_HPMA_TX,        // Honeywell HPMA115S0 Serial interface
+#ifdef USE_RELAYS_OC
   GPIO_REL1_OC,           // Relays
   GPIO_REL2_OC,
   GPIO_REL3_OC,
@@ -230,6 +231,7 @@ enum UserSelectablePins {
   GPIO_REL6_OC_INV,
   GPIO_REL7_OC_INV,
   GPIO_REL8_OC_INV,
+#endif  
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -310,8 +312,10 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_DEEPSLEEP "|" D_SENSOR_EXS_ENABLE "|"
   D_SENSOR_SLAVE_TX "|" D_SENSOR_SLAVE_RX "|" D_SENSOR_SLAVE_RESET "|" D_SENSOR_SLAVE_RESET "i|"
   D_SENSOR_HPMA_RX "|" D_SENSOR_HPMA_TX "|"
+#ifdef USE_RELAYS_OC
   D_SENSOR_RELAY "1oc|" D_SENSOR_RELAY "2oc|" D_SENSOR_RELAY "3oc|" D_SENSOR_RELAY "4oc|" D_SENSOR_RELAY "5oc|" D_SENSOR_RELAY "6oc|" D_SENSOR_RELAY "7oc|" D_SENSOR_RELAY "8oc|"
   D_SENSOR_RELAY "1oci|" D_SENSOR_RELAY "2oci|" D_SENSOR_RELAY "3oci|" D_SENSOR_RELAY "4oci|" D_SENSOR_RELAY "5oci|" D_SENSOR_RELAY "6oci|" D_SENSOR_RELAY "7oci|" D_SENSOR_RELAY "8oci|"
+#endif  
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -499,36 +503,38 @@ const uint8_t kGpioNiceList[] PROGMEM = {
   GPIO_SWT8_NP,
   GPIO_REL1,           // Relays
   GPIO_REL1_INV,
-  GPIO_REL1_OC,           // Relays
-  GPIO_REL1_OC_INV,
   GPIO_REL2,
   GPIO_REL2_INV,
-  GPIO_REL2_OC,           // Relays
-  GPIO_REL2_OC_INV,
   GPIO_REL3,
   GPIO_REL3_INV,
-  GPIO_REL3_OC,           // Relays
-  GPIO_REL3_OC_INV,
   GPIO_REL4,
   GPIO_REL4_INV,
-  GPIO_REL4_OC,           // Relays
-  GPIO_REL4_OC_INV,
   GPIO_REL5,
   GPIO_REL5_INV,
-  GPIO_REL5_OC,           // Relays
-  GPIO_REL5_OC_INV,
   GPIO_REL6,
   GPIO_REL6_INV,
-  GPIO_REL6_OC,           // Relays
-  GPIO_REL6_OC_INV,
   GPIO_REL7,
   GPIO_REL7_INV,
-  GPIO_REL7_OC,           // Relays
-  GPIO_REL7_OC_INV,
   GPIO_REL8,
   GPIO_REL8_INV,
-  GPIO_REL8_OC,           // Relays
+#ifdef USE_RELAYS_OC
+  GPIO_REL1_OC,           // Relays which only drive to 0v on gpio
+  GPIO_REL1_OC_INV,
+  GPIO_REL2_OC,           
+  GPIO_REL2_OC_INV,
+  GPIO_REL3_OC,           
+  GPIO_REL3_OC_INV,
+  GPIO_REL4_OC,           
+  GPIO_REL4_OC_INV,
+  GPIO_REL5_OC,           
+  GPIO_REL5_OC_INV,
+  GPIO_REL6_OC,           
+  GPIO_REL6_OC_INV,
+  GPIO_REL7_OC,           
+  GPIO_REL7_OC_INV,
+  GPIO_REL8_OC,           
   GPIO_REL8_OC_INV,
+#endif  
   GPIO_LED1,           // Leds
   GPIO_LED1_INV,
   GPIO_LED2,


### PR DESCRIPTION
## Description:
if Relay<N>oc or Relay<N>oci are selected, then when the port value is 1, set the port to INPUT (basically, high impedance).

This is to allow relays to be attached which have 5v pullup, and are triggered by low.  If the pin is left at OUTPUT, then the 3.3v driven 'high' value sinks enough current to trigger the relay.

So; this basically allows you to use '5v' relays triggered by grounding an input.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x ] The pull request is done against the latest dev branch
  - [ x ] Only relevant files were touched
  - [ x ] Only one feature/fix was added per PR.
  - [ x ] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
We await the test....?
  - [ x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
