### PR TITLE
Fix PMW sleep restored

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -218,7 +218,8 @@
                                                  //   (POWER_ALL_OFF, POWER_ALL_ON, POWER_ALL_SAVED_TOGGLE, POWER_ALL_SAVED, POWER_ALL_ALWAYS_ON, POWER_ALL_OFF_PULSETIME_ON)
 #define APP_BLINKTIME          10                // [BlinkTime] Time in 0.1 Sec to blink/toggle power for relay 1
 #define APP_BLINKCOUNT         10                // [BlinkCount] Number of blinks (0 = 32000)
-#define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec)
+#define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec),
+#define PWM_MIN_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering   
 
 #define KEY_DEBOUNCE_TIME      50                // [ButtonDebounce] Number of mSeconds button press debounce time
 #define KEY_HOLD_TIME          40                // [SetOption32] Number of 0.1 seconds to hold Button or external Pushbutton before sending HOLD message

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -219,7 +219,7 @@
 #define APP_BLINKTIME          10                // [BlinkTime] Time in 0.1 Sec to blink/toggle power for relay 1
 #define APP_BLINKCOUNT         10                // [BlinkCount] Number of blinks (0 = 32000)
 #define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec),
-#define PWM_MIN_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering   
+#define PWM_MAX_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering   
 
 #define KEY_DEBOUNCE_TIME      50                // [ButtonDebounce] Number of mSeconds button press debounce time
 #define KEY_HOLD_TIME          40                // [SetOption32] Number of 0.1 seconds to hold Button or external Pushbutton before sending HOLD message

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1593,12 +1593,12 @@ void LightAnimate(void)
     if (!Light.fade_running) {
       sleep = Settings.sleep;
     }
-  } else {
-#ifdef PWM_LIGHTSCHEME0_IGNORE_SLEEP
-    sleep = (LS_POWER == Settings.light_scheme) && (!Light.fade_running) ? Settings.sleep : 0;  // If no animation then use sleep as is
-#else
-    sleep = 0;
-#endif // PWM_LIGHTSCHEME0_IGNORE_SLEEP
+  } else {	
+    if (Settings.sleep > PWM_MIN_SLEEP) {	
+      sleep = PWM_MIN_SLEEP;      // set a minimal value of 50 milliseconds to ensure that animations are smooth	
+    } else {	
+      sleep = Settings.sleep;     // or keep the current sleep if it's lower than 50
+    }
     switch (Settings.light_scheme) {
       case LS_POWER:
         light_controller.calcLevels(Light.new_color);

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1594,8 +1594,8 @@ void LightAnimate(void)
       sleep = Settings.sleep;
     }
   } else {	
-    if (Settings.sleep > PWM_MIN_SLEEP) {	
-      sleep = PWM_MIN_SLEEP;      // set a minimal value of 50 milliseconds to ensure that animations are smooth	
+    if (Settings.sleep > PWM_MAX_SLEEP) {	
+      sleep = PWM_MAX_SLEEP;      // set a maxumum value of 50 milliseconds to ensure that animations are smooth	
     } else {	
       sleep = Settings.sleep;     // or keep the current sleep if it's lower than 50
     }


### PR DESCRIPTION
## Description:

I mistakenly reverted #6980 with #7007. This PR restores the sleep behavior of #6980 and introduces `#define PWM_MIN_SLEEP` to change the default value.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
