### PR TITLE
MLX90614: fix I2C-issues, refactoring and code shrink

### DIFF
--- a/tasmota/xsns_26_lm75ad.ino
+++ b/tasmota/xsns_26_lm75ad.ino
@@ -53,7 +53,11 @@ void LM75ADDetect(void)
 {
   for (uint32_t i = 0; i < sizeof(lm75ad_addresses); i++) {
     lm75ad_address = lm75ad_addresses[i];
-    if (I2cActive(lm75ad_address)) { continue; }
+    if (I2cActive(lm75ad_address)) { 
+      continue; }
+    if (!I2cSetDevice(lm75ad_address)) {
+      break; // do not make the next step without a confirmed device on the bus
+    }
     uint16_t buffer;
     if (I2cValidRead16(&buffer, lm75ad_address, LM75_THYST_REGISTER)) {
       if (buffer == 0x4B00) {


### PR DESCRIPTION
related to this: https://github.com/arendst/Tasmota/issues/6825

This sensor seems to be susceptible to conditions on the bus or in the state of the I2C-driver, which show up, after doing some read operations without an existing device. This has happened in the lm75ad-driver.
In the debugging process I tried to use the I2C-helper functions of Tasmota, which seem to work fine. This leads to a code reduction.

I did not try every driver combination, but there are a few:

07:42:12 RSL: tele/tasmota/SENSOR = {"Time":"2019-11-25T07:42:12","MLX90614":{"OBJTMP":22.2,"AMBTMP":22.4}}
07:42:17 CMD: i2cdriver
07:42:17 SRC: Serial
07:42:17 CMD: Group 0, Index 1, Command "I2CDRIVER", Data ""
07:42:17 RSL: stat/tasmota/RESULT = {"I2CDriver":"7,8,9,10,11,15,16,20,23,24,31,32,36,40"}