### PR TITLE
Remove cstage from platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -103,8 +103,6 @@ platform                  = ${core_2_6_1.platform}
 build_flags               = ${core_2_6_1.build_flags}
 ;platform                  = ${core_stage.platform}
 ;build_flags               = ${core_stage.build_flags}
-;platform                  = ${core_cstage.platform}
-;build_flags               = ${core_cstage.build_flags}
 
 ; *********************************************************************
 
@@ -162,8 +160,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
-; Code optimization see https://github.com/esp8266/Arduino/issues/5790#issuecomment-475672473
-                            -O2
                             -DBEARSSL_SSL_BASIC
 ; NONOSDK221
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
@@ -188,49 +184,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
 ; VTABLES in Flash (Tasmota default)
-                            -DVTABLES_IN_FLASH
-; VTABLES in Heap
-;                            -DVTABLES_IN_DRAM
-; VTABLES in IRAM
-;                            -DVTABLES_IN_IRAM
-; enable one option set -> No exception recommended
-; No exception code in firmware
-                            -fno-exceptions
-                            -lstdc++
-; Exception code in firmware /needs much space! 90k
-;                           -fexceptions
-;                           -lstdc++-exc
-
-[core_cstage]
-; *** Arduino Esp8266 -> Stage with Xtensa build chain 2.5.0.4 and Esptoolpy 2.8
-platform                  = https://github.com/Jason2866/platform-espressif8266.git#feature/stage
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Tesp8266.flash.1m.ld
-                            -O2
-                            -DBEARSSL_SSL_BASIC
-; NONOSDK221
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
-; NONOSDK22x_190313
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
-; NONOSDK3V0 (known issues)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; VTABLES in Flash (default)
                             -DVTABLES_IN_FLASH
 ; VTABLES in Heap
 ;                            -DVTABLES_IN_DRAM


### PR DESCRIPTION
because it is not needed anymore. 
New build chain is used in Platformio feature/stage since the release of 2.6.1

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
