### PR TITLE
DMY_LANGUAGE should be MY_LANGUAGE

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -51,7 +51,7 @@
 //#define DWS74_BUG
 
 // max 23 chars
-#if DMY_LANGUAGE==de-DE
+#if MY_LANGUAGE==de-DE
 // german web text
 #define D_TPWRIN "Verbrauch"
 #define D_TPWROUT "Einspeisung"


### PR DESCRIPTION
## Description:

Just a small error in the code while browsing.
DMY_LANGUAGE should be MY_LANGUAGE

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
