### PR TITLE
Align slider behaviour with mqtt...

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1056,7 +1056,7 @@ void HandleRoot(void)
             "s",             // s - Unique HTML id related to eb('s').style.background='linear-gradient(to right,rgb('+sl+'%%,'+sl+'%%,'+sl+'%%),hsl('+eb('sl2').value+',100%%,50%%))';
             scolor, stemp,   // Brightness to max current color
             3,               // sl3 - Unique range HTML id - Not used
-            1, 100,          // Range 1 to 100%
+            0, 100,          // Range 0 to 100%
             changeUIntScale(sat, 0, 255, 0, 100),
             'n', 0);         // n0 - Value id
         }
@@ -1065,7 +1065,7 @@ void HandleRoot(void)
           "c",               // c - Unique HTML id
           "#000", "#fff",    // Black to White
           4,                 // sl4 - Unique range HTML id - Used as source for Saturation begin color
-          1, 100,            // Range 1 to 100%
+          0, 100,            // Range 0 to 100%
           Settings.light_dimmer,
           'd', 0);           // d0 - Value id is related to lc("d0", value) and WebGetArg("d0", tmp, sizeof(tmp));
       } else {  // Settings.flag3.pwm_multi_channels - SetOption68 1 - Enable multi-channels PWM instead of Color PWM


### PR DESCRIPTION
commands. Via slider it was NOT possible to set ```{"POWER1":"OFF","Dimmer1":0,"POWER2":"OFF","Dimmer2":100,"Color":"000000FF","HSBColor":"0,0,0","Channel":[0,0,0,100]}```
min value was before the change
```{"POWER1":"ON","Dimmer1":1,"POWER2":"OFF","Dimmer2":100,"Color":"030303FF","HSBColor":"1,1,1","Channel":[1,1,1,100]}```

Thx @Staars  for looking into

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
