### PR TITLE
Make DNS resolution order switchable by define (only IPv6 related)

### DIFF
--- a/patches/1-framework-arduinoespressif8266-change_dns_gethostbyname.patch
+++ b/patches/1-framework-arduinoespressif8266-change_dns_gethostbyname.patch
@@ -1,0 +1,6 @@
+619a620,622
+> #ifdef LWIP_IPV6
+>     err_t err = dns_gethostbyname_addrtype(aHostname, &addr, &wifi_dns_found_callback, &aResult,LWIP_DNS_ADDRTYPE_DEFAULT);
+> #else
+620a624
+> #endif

--- a/pio/ipv6-patch.py
+++ b/pio/ipv6-patch.py
@@ -1,0 +1,25 @@
+from os.path import join, isfile
+
+Import("env")
+
+if "-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH" in env['BUILD_FLAGS']:
+
+  FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-arduinoespressif8266")
+  patchflag_path = join(FRAMEWORK_DIR, ".patching-done")
+
+  # patch file only if we didn't do it before
+  if not isfile(join(FRAMEWORK_DIR, ".patching-done")):
+    original_file = join(FRAMEWORK_DIR, "libraries", "ESP8266WiFi", "src", "ESP8266WiFiGeneric.cpp")
+    patched_file = join("patches", "1-framework-arduinoespressif8266-change_dns_gethostbyname.patch")
+
+    print("Patching " + original_file)
+
+    assert isfile(original_file) and isfile(patched_file)
+
+    env.Execute("patch %s %s" % (original_file, patched_file))
+
+    def _touch(path):
+        with open(path, "w") as fp:
+            fp.write("")
+
+    env.Execute(lambda *args, **kwargs: _touch(patchflag_path))

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,6 +87,7 @@ upload_resetmethod        = nodemcu
 upload_port               = COM5
 extra_scripts             = pio/strip-floats.py
                             pio/name-firmware.py
+			    pre:pio/ipv6-patch.py
 ;                            pio/obj-dump.py
 
 ; *** Upload file to OTA server using SCP
@@ -141,6 +142,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
 ; lwIP 2 - Higher Bandwidth IPv6 (use ONLY if you need IPv6, experimental!)
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
+;			     -DLWIP_DNS_ADDRTYPE_DEFAULT=LWIP_DNS_ADDRTYPE_IPV6_IPV4
 ; VTABLES in Flash (Tasmota default)
                             -DVTABLES_IN_FLASH
 ; VTABLES in Heap


### PR DESCRIPTION
## Description:
PIO uses prebuilt liblwip6-1460-feat.a which is built with DNS resolution order IPV4 before IPv6. This causes problems in IPv6 only environments if there is a DNS record with A and AAAA. lwip then tries to connect to the resolved v4 even if there is no global IPv4 address. Didn't find a way to get pio rebuild the complete library. That's why I patched ESP8266WifiGeneric.cpp to use dns_gethostbyname_addrtype instead of dns_gethostbyname (which is only a wrapper of _addrtype and the define to prefer v4). With this patch it's possible to select resolution beaviour during compile time. The patch-script checks for IPv6 and does nothing if not enabled.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
