### PR TITLE
Fix postpone saving settings to flash until Fade is complete

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change new Fade system much smoother, Speed now up to 40 (#6942, #3714)
 - Fix Arduino IDE function prototyping compile error (#6982)
 - Change update lib IRremoteESP8266 updated to v2.7.1, -2.7k flash and -1.5k RAM for Tasmota-IR
+- Fix postpone saving settings to flash until Fade is complete, avoids pause in Fade
 
 ### 7.0.0.5 20191118
 

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1795,6 +1795,12 @@ void LightApplyFade(void) {
       // Note: Settings.light_speed is the number of half-seconds for a 100% fade,
       // i.e. light_speed=1 means 1024 steps in 10 ticks (500ms)
       Light.fade_duration = (distance * Settings.light_speed * 10) / 1024;
+      // Also postpone the save_data for the duration of the Fade (in seconds)
+      uint32_t delay_seconds = 1 + (Light.fade_duration + 19) / 20;   // add one more second
+      // AddLog_P2(LOG_LEVEL_INFO, PSTR("delay_seconds %d, save_data_counter %d"), delay_seconds, save_data_counter);
+      if (save_data_counter < delay_seconds) {
+        save_data_counter = delay_seconds;      // pospone
+      }
     } else {
       // no fade needed, we keep the duration at zero, it will fallback directly to end of fade
     }


### PR DESCRIPTION
## Description:

This PR avoids having micro-pauses during Fade in / Fade Out due to saving Settings to Flash.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
