### PR TITLE
Remove all non standard entrys from platformio.ini...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,6 +45,11 @@ default_envs =
 ;                tasmota-TR
 ;                tasmota-TW
 ;                tasmota-UK
+;
+; *** alternatively can be done in file: platformio_override.ini
+; *** See example: platformio_override_sample.ini
+; *********************************************************************
+
 
 [common]
 framework                 = arduino
@@ -57,62 +62,34 @@ build_flags               = ${core_active.build_flags}
 ; *********************************************************************
 ; *** Uncomment, by deleting ";" in line below, to use custom settings from file user_config_override.h 
 ;                            -DUSE_CONFIG_OVERRIDE
+;
+; *** alternatively can be done in: platformio_override.ini
+; *** See example: platformio_override_sample.ini
 ; *********************************************************************
-
-; *** Optional Debug messages
-;                            -DDEBUG_TASMOTA_CORE
-;                            -DDEBUG_TASMOTA_DRIVER
-;                            -DDEBUG_TASMOTA_SENSOR
-
-; *** Optional Firmware configurations
-;                            -DFIRMWARE_MINIMAL
-;                            -DFIRMWARE_SENSORS
-;                            -DFIRMWARE_BASIC
-;                            -DFIRMWARE_KNX_NO_EMULATION
-;                            -DFIRMWARE_DISPLAYS
-;                            -DFIRMWARE_IR
-;                            -DFIRMWARE_IR_CUSTOM
 
 ; *** Fix espressif8266@1.7.0 induced undesired all warnings
 build_unflags             = -Wall
 
-; set CPU frequency to 80MHz (default) or 160MHz
 board_build.f_cpu         = 80000000L
-;board_build.f_cpu         = 160000000L
-
 monitor_speed             = 115200
 upload_speed              = 115200
-upload_resetmethod        = nodemcu
-
 ; *** Upload Serial reset method for Wemos and NodeMCU
+upload_resetmethod        = nodemcu
 upload_port               = COM5
+extra_scripts             = ${scripts_defaults.extra_scripts}
+
+[scripts_defaults]
 extra_scripts             = pio/strip-floats.py
                             pio/name-firmware.py
-;                            pio/obj-dump.py
-
-; *** Upload file to OTA server using SCP
-;upload_port               = user@host:/path
-;extra_scripts             = pio/strip-floats.py, pio/sftp-uploader.py
-
-; *** Upload file to OTA server in folder api/arduino using HTTP
-;upload_port               = domus1:80/api/upload-arduino.php
-;extra_scripts             = pio/strip-floats.py, pio/http-uploader.py
-
-[core_active]
-; Select one core set for platform and build_flags
-platform                  = ${core_2_6_1.platform}
-build_flags               = ${core_2_6_1.build_flags}
-;platform                  = ${core_2_6_2.platform}
-;build_flags               = ${core_2_6_2.build_flags}
-;platform                  = ${core_stage.platform}
-;build_flags               = ${core_stage.build_flags}
-
-; *********************************************************************
 
 [esp82xx_defaults]
 build_flags               = -D NDEBUG
                             -mtarget-align
                             -Wl,-Map,firmware.map
+
+[core_active]
+platform                  = ${core_2_6_1.platform}
+build_flags               = ${core_2_6_1.build_flags}
 
 [core_2_6_1]
 ; *** Esp8266 core for Arduino version 2.6.1
@@ -120,129 +97,16 @@ platform                  = espressif8266@2.3.0
 build_flags               = ${esp82xx_defaults.build_flags}
                             -Wl,-Teagle.flash.1m.ld
                             -DBEARSSL_SSL_BASIC
-; NONOSDK221
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
-; NONOSDK22x_190313
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
+; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
-; NONOSDK3V0 (known issues)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+; lwIP 2 - Higher Bandwidth no Features
                             -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; lwIP 2 - Higher Bandwidth IPv6 (use ONLY if you need IPv6, experimental!)
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
-; VTABLES in Flash (Tasmota default)
+; VTABLES in Flash
                             -DVTABLES_IN_FLASH
-; VTABLES in Heap
-;                            -DVTABLES_IN_DRAM
-; VTABLES in IRAM
-;                            -DVTABLES_IN_IRAM
-; enable one option set -> No exception recommended
 ; No exception code in firmware
                             -fno-exceptions
                             -lstdc++
-; Exception code in firmware /needs much space! 90k
-;                           -fexceptions
-;                           -lstdc++-exc
 
-[core_2_6_2]
-; *** Esp8266 core for Arduino version 2.6.2
-platform                  = espressif8266@2.3.1
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-                            -DBEARSSL_SSL_BASIC
-; NONOSDK221
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
-; NONOSDK22x_190313
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
-; NONOSDK3V0 (known issues)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; lwIP 2 - Higher Bandwidth IPv6 (use ONLY if you need IPv6, experimental!)
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
-; VTABLES in Flash (Tasmota default)
-                            -DVTABLES_IN_FLASH
-; VTABLES in Heap
-;                            -DVTABLES_IN_DRAM
-; VTABLES in IRAM
-;                            -DVTABLES_IN_IRAM
-; enable one option set -> No exception recommended
-; No exception code in firmware
-                            -fno-exceptions
-                            -lstdc++
-; Exception code in firmware /needs much space! 90k
-;                           -fexceptions
-;                           -lstdc++-exc
-
-[core_stage]
-; *** Esp8266 core for Arduino version latest beta
-platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
-build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
-                            -DBEARSSL_SSL_BASIC
-; NONOSDK221
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
-; NONOSDK22x_190313
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105                            
-; NONOSDK3V0 (known issues)
-;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
-; lwIP 2 - Low Memory
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
-; lwIP 2 - Higher Bandwidth
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-; lwIP 2 - Higher Bandwidth Low Memory no Features
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
-; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; VTABLES in Flash (Tasmota default)
-                            -DVTABLES_IN_FLASH
-; VTABLES in Heap
-;                            -DVTABLES_IN_DRAM
-; VTABLES in IRAM
-;                            -DVTABLES_IN_IRAM
-; enable one option set -> No exception recommended
-; No exception code in firmware
-                            -fno-exceptions
-                            -lstdc++
-; Exception code in firmware /needs much space! 90k
-;                           -fexceptions
-;                           -lstdc++-exc
 
 [env:tasmota]
 platform = ${common.platform}
@@ -250,22 +114,6 @@ framework = ${common.framework}
 board = ${common.board}
 board_build.flash_mode = ${common.board_build.flash_mode}
 board_build.f_cpu = ${common.board_build.f_cpu}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags}
-monitor_speed = ${common.monitor_speed}
-upload_port = ${common.upload_port}
-upload_resetmethod = ${common.upload_resetmethod}
-upload_speed = ${common.upload_speed}
-extra_scripts = ${common.extra_scripts}
-
-; *** Debug version used for PlatformIO Home Project Inspection
-[env:tasmota-debug]
-platform = ${common.platform}
-framework = ${common.framework}
-board = ${common.board}
-board_build.flash_mode = ${common.board_build.flash_mode}
-board_build.f_cpu = ${common.board_build.f_cpu}
-build_type = debug
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}
 monitor_speed = ${common.monitor_speed}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -1,11 +1,14 @@
-; PlatformIO Project Configuration Override File
+; ***  Example PlatformIO Project Configuration Override File  ***
+; ***  Changes done here overrides settings in platformio.ini  ***
+; 
+; ****************************************************************
+; ***  to activate rename this fie to platformio_override.ini  ***
+; **************************************************************** 
 ;
-;   Build options: build flags, source filter, extra scripting
-;   Upload options: custom port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;
-; Please visit documentation for the other options and examples
+; Please visit documentation for the options and examples
 ; http://docs.platformio.org/en/stable/projectconf.html
+;
+
 
 [platformio]
 
@@ -24,14 +27,197 @@ default_envs =
 
 
 [common]
-; *** Use settings from file user_config_override.h 
+platform                  = ${core_active.platform}
 build_flags               = ${core_active.build_flags}
+; *** Use settings from file user_config_override.h 
                           -DUSE_CONFIG_OVERRIDE
+
+; *** Optional Firmware configurations
+;                            -DFIRMWARE_MINIMAL
+;                            -DFIRMWARE_SENSORS
+;                            -DFIRMWARE_BASIC
+;                            -DFIRMWARE_KNX_NO_EMULATION
+;                            -DFIRMWARE_DISPLAYS
+;                            -DFIRMWARE_IR
+;                            -DFIRMWARE_IR_CUSTOM
+
+; *** Optional Debug messages
+;                            -DDEBUG_TASMOTA_CORE
+;                            -DDEBUG_TASMOTA_DRIVER
+;                            -DDEBUG_TASMOTA_SENSOR
+
+; set CPU frequency to 80MHz (default) or 160MHz
+;board_build.f_cpu         = 160000000L
 
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port               = COM5
 
-[core_active]
+extra_scripts             = ${scripts_defaults.extra_scripts}
+                            pio/obj-dump.py
 
-platform                  = ${core_2_6_2.platform}
-build_flags               = ${core_2_6_2.build_flags}
+; *** Upload file to OTA server using SCP
+;upload_port               = user@host:/path
+;extra_scripts             = ${scripts_defaults.extra_scripts} 
+;                            pio/strip-floats.py, pio/sftp-uploader.py
+
+; *** Upload file to OTA server in folder api/arduino using HTTP
+;upload_port               = domus1:80/api/upload-arduino.php
+;extra_scripts             = ${scripts_defaults.extra_scripts}
+;                            pio/strip-floats.py, pio/http-uploader.py
+
+[core_active]
+; Select one core set for platform and build_flags
+platform                  = ${core_2_6_1.platform}
+build_flags               = ${core_2_6_1.build_flags}
+;platform                  = ${core_2_6_2.platform}
+;build_flags               = ${core_2_6_2.build_flags}
+;platform                  = ${core_stage.platform}
+;build_flags               = ${core_stage.build_flags}
+
+
+[core_2_6_1]
+; *** Esp8266 core for Arduino version 2.6.1
+platform                  = espressif8266@2.3.0
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+                            -DBEARSSL_SSL_BASIC
+; NONOSDK221
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
+; NONOSDK22x_190313
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
+; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
+; NONOSDK3V0 (known issues)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; lwIP 2 - Higher Bandwidth IPv6 (use ONLY if you need IPv6, experimental!)
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
+; VTABLES in Flash (Tasmota default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++-exc
+
+[core_2_6_2]
+; *** Esp8266 core for Arduino version 2.6.2
+platform                  = espressif8266@2.3.1
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+                            -DBEARSSL_SSL_BASIC
+; NONOSDK221
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
+; NONOSDK22x_190313
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
+; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
+; NONOSDK3V0 (known issues)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; lwIP 2 - Higher Bandwidth IPv6 (use ONLY if you need IPv6, experimental!)
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_HIGHER_BANDWIDTH
+; VTABLES in Flash (Tasmota default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++-exc
+
+[core_stage]
+; *** Esp8266 core for Arduino version latest beta
+platform                  = https://github.com/platformio/platform-espressif8266.git#feature/stage
+build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wl,-Teagle.flash.1m.ld
+                            -DBEARSSL_SSL_BASIC
+; NONOSDK221
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
+; NONOSDK22x_190313
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
+; NONOSDK22x_190703 (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+; NONOSDK22x_191024
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
+; NONOSDK22x_191105
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105                            
+; NONOSDK3V0 (known issues)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
+; lwIP 1.4
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
+; lwIP 2 - Low Memory
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+; lwIP 2 - Higher Bandwidth
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+; lwIP 2 - Higher Bandwidth Low Memory no Features
+;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
+; lwIP 2 - Higher Bandwidth no Features (Tasmota default)
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+; VTABLES in Flash (Tasmota default)
+                            -DVTABLES_IN_FLASH
+; VTABLES in Heap
+;                            -DVTABLES_IN_DRAM
+; VTABLES in IRAM
+;                            -DVTABLES_IN_IRAM
+; enable one option set -> No exception recommended
+; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++
+; Exception code in firmware /needs much space! 90k
+;                           -fexceptions
+;                           -lstdc++-exc
+
+
+; *** Debug version used for PlatformIO Home Project Inspection
+[env:tasmota-debug]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board}
+board_build.flash_mode = ${common.board_build.flash_mode}
+board_build.f_cpu = ${common.board_build.f_cpu}
+build_type = debug
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags}
+monitor_speed = ${common.monitor_speed}
+upload_port = ${common.upload_port}
+upload_resetmethod = ${common.upload_resetmethod}
+upload_speed = ${common.upload_speed}
+extra_scripts = ${common.extra_scripts}


### PR DESCRIPTION
and moved to file platformio_override_sample.ini.

In platformio.ini are now only entrys to build the standard Tasmota versions.
All non standard settings are moved to `platformio_override_sample.ini`
To activate the override function the file `platformio_override_sample.ini`
needs to be renamed to `platformio_override.ini`.

By doing this, building version "Tasmota" with setting `-DUSE_CONFIG_OVERRIDE`
is activated. 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
