### PR TITLE
TasmotaSlave: Bugfix for slave sent Tele & Add support for sending commands to Tasmota

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased (development)
 
+- TasmotaSlave bugfix for buffer overrun on Tele
+- TasmotaSlave add support for executing commands on Tasmota
 
 ## Released
 


### PR DESCRIPTION
## Description:

- Fix buffer overrun created when TasmotaSlave sends immediate telemetry
- Add support for sending commands to Tasmota from the TasmotaSlave

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
