### PR TITLE
Implement capability for setting CORS to a specific website instead o…

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -335,6 +335,7 @@
 #define D_CMND_WEBSENSOR "WebSensor"
 #define D_CMND_EMULATION "Emulation"
 #define D_CMND_SENDMAIL "Sendmail"
+#define D_CMND_CORS "CORS"
 
 // Commands xdrv_03_energy.ino
 #define D_CMND_POWERLOW "PowerLow"

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Хладна"
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Свързан"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Брой"
 #define D_COUNTER "Брояч"
 #define D_CURRENT "Ток"          // As in Voltage and Current

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Studené světlo"
 #define D_COMMAND "Příkaz"
 #define D_CONNECTED "...připojeno"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Počítej"
 #define D_COUNTER "Počítadlo"
 #define D_CURRENT "Proud"          // As in Voltage and Current

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "kalt"
 #define D_COMMAND "Befehl"
 #define D_CONNECTED "verbunden"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "zählen"
 #define D_COUNTER "Zähler"
 #define D_CURRENT "Strom"          // As in Voltage and Current

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -72,6 +72,7 @@
 #define D_COMMAND "Εντολή"
 #define D_CONNECTED "Συνδεδεμένο"
 #define D_COUNT "Μέτρηση"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Μετρητής"
 #define D_CURRENT "Ένταση"          // As in Voltage and Current
 #define D_DATA "Δεδομένα"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Cold"
 #define D_COMMAND "Command"
 #define D_CONNECTED "Connected"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Count"
 #define D_COUNTER "Counter"
 #define D_CURRENT "Current"          // As in Voltage and Current

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Fría"
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Conectado"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Conteo"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corriente"          // As in Voltage and Current

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Froid"
 #define D_COMMAND "Commande"
 #define D_CONNECTED "Connecté"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Compte"
 #define D_COUNTER "Compteur"
 #define D_CURRENT "Courant"          // As in Voltage and Current

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "אור קר"
 #define D_COMMAND "פקודה"
 #define D_CONNECTED "מחובר"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "סופר"
 #define D_COUNTER "מונה"
 #define D_CURRENT "נוכחי"          // As in Voltage and Current

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Hideg fény"
 #define D_COMMAND "Parancs"
 #define D_CONNECTED "Csatlakoztatva"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Szám"
 #define D_COUNTER "Számláló"
 #define D_CURRENT "Áramerősség"          // As in Voltage and Current

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Fredda"
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Connesso"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Conteggio"
 #define D_COUNTER "Contatore"
 #define D_CURRENT "Corrente"          // As in Voltage and Current

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -72,6 +72,7 @@
 #define D_COMMAND "커맨드"
 #define D_CONNECTED "연결됨"
 #define D_COUNT "횟수"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Counter"
 #define D_CURRENT "전류"          // As in Voltage and Current
 #define D_DATA "Data"

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -72,6 +72,7 @@
 #define D_COMMAND "Opdracht"
 #define D_CONNECTED "Verbonden"
 #define D_COUNT "Aantal"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Teller"
 #define D_CURRENT "Stroom"          // As in Voltage and Current
 #define D_DATA "Data"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Zimny"
 #define D_COMMAND "Komenda"
 #define D_CONNECTED "Połączony"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Licz"
 #define D_COUNTER "Licznik"
 #define D_CURRENT "Prąd"          // As in Voltage and Current

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Luz fria"
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Ligado"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corrente"          // As in Voltage and Current

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Luz Fria"
 #define D_COMMAND "Comando"
 #define D_CONNECTED "Ligado"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corrente"          // As in Voltage and Current

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Холодный"
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Соединен"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Подсчет"
 #define D_COUNTER "Счетчик"
 #define D_CURRENT "Ток"          // As in Voltage and Current

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Studené svetlo"
 #define D_COMMAND "Príkaz"
 #define D_CONNECTED "...pripojené"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Počítaj"
 #define D_COUNTER "Počítadlo"
 #define D_CURRENT "Prúd"          // As in Voltage and Current

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Kallt"
 #define D_COMMAND "Kommando"
 #define D_CONNECTED "Ansluten"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Räkna"
 #define D_COUNTER "Räknare"
 #define D_CURRENT "Ström"          // As in Voltage and Current

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Soğuk"
 #define D_COMMAND "Komut"
 #define D_CONNECTED "Bağlandı"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Sayı"
 #define D_COUNTER "Sayaç"
 #define D_CURRENT "Current"          // As in Voltage and Current

--- a/tasmota/language/uk-UK.h
+++ b/tasmota/language/uk-UK.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "Холодний"
 #define D_COMMAND "Команда"
 #define D_CONNECTED "Під'єднано"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "Розмір"
 #define D_COUNTER "Лічильник"
 #define D_CURRENT "Струм"           // As in Voltage and Current

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "冷"
 #define D_COMMAND "命令:"
 #define D_CONNECTED "已连接"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "数量:"
 #define D_COUNTER "计数器"
 #define D_CURRENT "电流"          // As in Voltage and Current

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -71,6 +71,7 @@
 #define D_COLDLIGHT "冷"
 #define D_COMMAND "命令:"
 #define D_CONNECTED "已連接"
+#define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNT "數量:"
 #define D_COUNTER "Counter"
 #define D_CURRENT "電流"          // As in Voltage and Current

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -132,7 +132,7 @@
 #define WEB_PASSWORD           ""                // [WebPassword] Web server Admin mode Password for WEB_USERNAME (empty string = Disable)
 #define FRIENDLY_NAME          "Tasmota"         // [FriendlyName] Friendlyname up to 32 characters used by webpages and Alexa
 #define EMULATION              EMUL_NONE         // [Emulation] Select Belkin WeMo (single relay/light) or Hue Bridge emulation (multi relay/light) (EMUL_NONE, EMUL_WEMO or EMUL_HUE)
-
+#define CORS_DOMAIN            ""                // [CorsDomain] CORS Domain for preflight requests
 // -- HTTP GUI Colors -----------------------------
 // HTML hex color codes. Only 3 and 6 digit hex string values are supported!! See https://www.w3schools.com/colors/colors_hex.asp
 // Light theme - pre v7
@@ -219,7 +219,7 @@
 #define APP_BLINKTIME          10                // [BlinkTime] Time in 0.1 Sec to blink/toggle power for relay 1
 #define APP_BLINKCOUNT         10                // [BlinkCount] Number of blinks (0 = 32000)
 #define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec),
-#define PWM_MAX_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering   
+#define PWM_MAX_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering
 
 #define KEY_DEBOUNCE_TIME      50                // [ButtonDebounce] Number of mSeconds button press debounce time
 #define KEY_HOLD_TIME          40                // [SetOption32] Number of 0.1 seconds to hold Button or external Pushbutton before sending HOLD message
@@ -291,7 +291,7 @@
 // Using TLS starting with version v6.5.0.16 compilation will only work using Core 2.4.2 and 2.5.2. No longer supported: 2.3.0
 //#define USE_MQTT_TLS                             // Use TLS for MQTT connection (+34.5k code, +7.0k mem and +4.8k additional during connection handshake)
 //  #define USE_MQTT_TLS_CA_CERT                   // Force full CA validation instead of fingerprints, slower, but simpler to use.  (+2.2k code, +1.9k mem during connection handshake)
-                                                   // This includes the LetsEncrypt CA in tasmota_ca.ino for verifying server certificates 
+                                                   // This includes the LetsEncrypt CA in tasmota_ca.ino for verifying server certificates
 //  #define USE_MQTT_TLS_FORCE_EC_CIPHER           // Force Elliptic Curve cipher (higher security) required by some servers (automatically enabled with USE_MQTT_AWS_IOT) (+11.4k code, +0.4k mem)
 //  #define USE_MQTT_AWS_IOT                       // Enable MQTT for AWS IoT - requires a private key (+11.9k code, +0.4k mem)
                                                  //   Note: you need to generate a private key + certificate per device and update 'tasmota/tasmota_aws_iot.cpp'

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -86,7 +86,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t energy_weekend : 1;           // bit 20 (v6.6.0.8)  - CMND_TARIFF
     uint32_t dds2382_model : 1;            // bit 21 (v6.6.0.14) - SetOption71 - Select different Modbus registers for Active Energy (#6531)
     uint32_t hardware_energy_total : 1;    // bit 22 (v6.6.0.15) - SetOption72 - Enable hardware energy total counter as reference (#6561)
-    uint32_t cors_enabled : 1;             // bit 23 (v7.0.0.1)  - SetOption73 - Enable HTTP CORS
+    uint32_t ex_cors_enabled : 1;             // bit 23 (v7.0.0.1)  - SetOption73 - Enable HTTP CORS
     uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
     uint32_t grouptopic_mode : 1;          // bit 25 (v7.0.0.1)  - SetOption75 - GroupTopic replaces %topic% (0) or fixed topic cmnd/grouptopic (1)
     uint32_t bootcount_update : 1;         // bit 26 (v7.0.0.4)  - SetOption76 - Enable incrementing bootcount when deepsleep is enabled
@@ -438,7 +438,8 @@ struct SYSCFG {
 
   uint8_t       web_color2[2][3];          // EA0 - Needs to be on integer / 3 distance from web_color
 
-  uint8_t       free_ea4[326];             // EA6
+  char          cors_domain[33];           // EC1
+  uint8_t       free_ea4[293];             // EA6
 
   uint32_t      i2c_drivers[3];            // FEC I2cDriver
   uint32_t      cfg_timestamp;             // FF8

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -140,6 +140,10 @@
 #ifndef DEFAULT_LIGHT_COMPONENT
 #define DEFAULT_LIGHT_COMPONENT     255
 #endif
+#ifndef CORS_ENABLED_ALL
+#define CORS_ENABLED_ALL            "*"
+#endif
+
 
 enum WebColors {
   COL_TEXT, COL_BACKGROUND, COL_FORM,
@@ -718,6 +722,7 @@ void SettingsDefaultSet2(void)
   Settings.weblog_level = WEB_LOG_LEVEL;
   strlcpy(Settings.web_password, WEB_PASSWORD, sizeof(Settings.web_password));
   Settings.flag3.mdns_enabled = MDNS_ENABLED;
+  strlcpy(Settings.cors_domain, CORS_DOMAIN, sizeof(Settings.cors_domain));
 
   // Button
 //  Settings.flag.button_restrict = 0;
@@ -1175,6 +1180,14 @@ void SettingsDelta(void)
     }
     if (Settings.version < 0x07010202) {
       Settings.serial_config = TS_SERIAL_8N1;
+    }
+
+    if (Settings.version < 0x07010204) {
+      if (Settings.flag3.ex_cors_enabled == 1) {
+        strlcpy(Settings.cors_domain, CORS_ENABLED_ALL, sizeof(Settings.cors_domain));
+      } else {
+        Settings.cors_domain[0] = 0;
+      }
     }
 
     Settings.version = VERSION;

--- a/tasmota/tasmota_version.h
+++ b/tasmota/tasmota_version.h
@@ -20,6 +20,6 @@
 #ifndef _TASMOTA_VERSION_H_
 #define _TASMOTA_VERSION_H_
 
-const uint32_t VERSION = 0x07010203;
+const uint32_t VERSION = 0x07010204;
 
 #endif  // _TASMOTA_VERSION_H_


### PR DESCRIPTION
Implement capability for setting CORS to a specific website instead of just enable for all websites

## Description:

This feature makes user keep device secure by just enabling CORS for a specific website / url.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
