### PR TITLE
Fix Zigbee uses Hardware Serial

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.1.1.1 20191201
 
 - Change light color schemes 2, 3 and 4 from color wheel to Hue driven
+- Fix Zigbee uses Hardware Serial if GPIO 1/3 or GPIO 13/15 and SerialLog 0 (#7071)
 
 ## Released
 


### PR DESCRIPTION
## Description:

Zigbee will now use Hardware Serial instead of Software Serial if:

- GPIO 3 (Zigbee Rx) + 1 (Zigbee Tx)
- GPIO 13 (Zigbee Rx) + 15 (Zigbee Tx) **and** `SerialLog 0`

**Related issue (if applicable):** fixes #7071 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
