### PR TITLE
Add a new rule trigger: tele-switch1#state

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -609,7 +609,7 @@ bool MqttShowSensor(void)
     if (pin[GPIO_SWT1 +i] < 99) {
 #endif  // USE_TM1638
       bool swm = ((FOLLOW_INV == Settings.switchmode[i]) || (PUSHBUTTON_INV == Settings.switchmode[i]) || (PUSHBUTTONHOLD_INV == Settings.switchmode[i]));
-      ResponseAppend_P(PSTR(",\"" D_JSON_SWITCH "%d\":\"%s\""), i +1, GetStateText(swm ^ SwitchLastState(i)));
+      ResponseAppend_P(PSTR(",\"" D_JSON_SWITCH "%d\":{\"STATE\":\"%s\"}"), i +1, GetStateText(swm ^ SwitchLastState(i)));
     }
   }
   XsnsCall(FUNC_JSON_APPEND);


### PR DESCRIPTION
## Description:

Add a new rule trigger: `tele-switch1#state`.

**Related issue (if applicable):** fixes some custom periodics updates for switches. If a Home Automation Software can't use the information of **teleperiod** and/or **status 10** as Tasmota's default, now the user can use a rule, to be triggered at teleperiod time, so as to periodically inform switches' status like for example:

```
rule1 1
rule1 on tele-switch1#state do publish stat/mydevice/switch1 %value% endon
```

This PR is backwards compatible due there was no trigger for switches at teleperiod time and it also don't affect the instantaneous trigger `switch1#state`.

At this moment, the Tele message is like:

```
12:27:11 MQT: tele/riego/STATE = {"Time":"2019-12-02T12:27:11","Uptime":"0T01:22:15","UptimeSec":4935,"Heap":27,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":52,"MqttCount":1,"POWER1":"OFF","POWER2":"OFF","POWER3":"OFF","POWER4":"OFF","POWER5":"OFF","POWER6":"OFF","POWER7":"OFF","Wifi":{"AP":2,"SSId":"NetWirelessB","BSSId":"D8:5D:4C:C6:84:56","Channel":11,"RSSI":58,"LinkCount":1,"Downtime":"0T00:00:09"}}
12:27:11 MQT: tele/riego/SENSOR = {"Time":"2019-12-02T12:27:11","Switch1":"ON","COUNTER":{"C1":0},"ANALOG":{"A0":2},"SI7021":{"Temperature":32.0,"Humidity":14.2},"TempUnit":"C"}
```

and with this PR, it changes to:

```
12:27:11 MQT: tele/riego/STATE = {"Time":"2019-12-02T12:27:11","Uptime":"0T01:22:15","UptimeSec":4935,"Heap":27,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":52,"MqttCount":1,"POWER1":"OFF","POWER2":"OFF","POWER3":"OFF","POWER4":"OFF","POWER5":"OFF","POWER6":"OFF","POWER7":"OFF","Wifi":{"AP":2,"SSId":"NetWirelessB","BSSId":"D8:5D:4C:C6:84:56","Channel":11,"RSSI":58,"LinkCount":1,"Downtime":"0T00:00:09"}}
12:27:11 MQT: tele/riego/SENSOR = {"Time":"2019-12-02T12:27:11","Switch1":{"STATE":"ON"},"COUNTER":{"C1":0},"ANALOG":{"A0":2},"SI7021":{"Temperature":32.0,"Humidity":14.2},"TempUnit":"C"}
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
