### PR TITLE
Add new tele- rule triggers

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -565,7 +565,7 @@ void MqttShowState(void)
       if (i == LightDevice())  { LightState(1); }    // call it only once
     } else {
 #endif
-      ResponseAppend_P(PSTR(",\"%s\":\"%s\""), GetPowerDevice(stemp1, i, sizeof(stemp1), Settings.flag.device_index_enable),  // SetOption26 - Switch between POWER or POWER1
+      ResponseAppend_P(PSTR(",\"%s\":{\"STATE\":\"%s\"}"), GetPowerDevice(stemp1, i, sizeof(stemp1), Settings.flag.device_index_enable),  // SetOption26 - Switch between POWER or POWER1
                                                GetStateText(bitRead(power, i-1)));
 #ifdef USE_SONOFF_IFAN
       if (IsModuleIfan()) {
@@ -592,7 +592,7 @@ void MqttPublishTeleState(void)
   mqtt_data[0] = '\0';
   MqttShowState();
   MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_STATE), MQTT_TELE_RETAIN);
-#ifdef USE_SCRIPT
+#if defined(USE_RULES) || defined(USE_SCRIPT)
   RulesTeleperiod();  // Allow rule based HA messages
 #endif  // USE_SCRIPT
 }


### PR DESCRIPTION
## Description:

By adding the rule trigger `tele-power1#state` for relays (as done in PR #7088 for switches), this PR also unlocks several other triggers for rules, that were accessible before only by the scripting feature.

New set of rule triggers:

* `tele-power1#state`
* `tele-wifi1#ap`
* `tele-wifi1#ssid`
* `tele-wifi1#bssid`
* `tele-wifi1#channel`
* `tele-wifi1#RSSI`
* `tele-wifi1#LinkCount`
* `tele-wifi1#Downtime`

**Related issue (if applicable):** fixes some custom periodics updates for power status as done in PR #7088 for switches. If a Home Automation Software can't use the information of **teleperiod** and/or **status 11** as Tasmota's default, now the user can use a rule, to be triggered at teleperiod time, so as to periodically inform relay's status or wifi status like for example:

```
rule1 1
rule1 on tele-relay1#state do publish stat/mydevice/relay1 %value% endon
```

This PR is backwards compatible due there was no trigger for relays or wifi at teleperiod time and it also don't affect the instantaneous trigger `power1#state`.

At this moment, the Tele message is like:

```
15:04:57 MQT: tele/living/STATE = {"Time":"2019-12-02T15:04:57","Uptime":"0T00:06:13","UptimeSec":373,"Heap":20,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":19,"MqttCount":1,"POWER1":"OFF","Wifi":{"AP":2,"SSId":"NetWirelessB","BSSId":"D8:5D:4C:C6:84:56","Channel":11,"RSSI":52,"LinkCount":1,"Downtime":"0T00:00:06"}}

```

and with this PR, it changes to:

```
15:04:57 MQT: tele/living/STATE = {"Time":"2019-12-02T15:04:57","Uptime":"0T00:06:13","UptimeSec":373,"Heap":20,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":19,"MqttCount":1,"POWER1":{"STATE":"OFF"},"Wifi":{"AP":2,"SSId":"NetWirelessB","BSSId":"D8:5D:4C:C6:84:56","Channel":11,"RSSI":52,"LinkCount":1,"Downtime":"0T00:00:06"}}

```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
