### PR TITLE
Add new SDK version available only for STAGE core

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -85,11 +85,11 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
 ; NONOSDK22x_190313
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
+; NONOSDK22x_190703 = 2.2.1+100-dev(38a443e) (Tasmota default) (Firmware 2K smaller than NONOSDK22x_191105)
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
+; NONOSDK22x_191024 = 2.2.1+111-dev(5ab15d1)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
+; NONOSDK22x_191105 = 2.2.1+113-dev(bb83b9b)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
 ; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
@@ -129,11 +129,11 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
 ; NONOSDK22x_190313
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 = 2.2.2-dev(38a443e) (Tasmota default)
+; NONOSDK22x_190703 = 2.2.1+100-dev(38a443e) (Tasmota default) (Firmware 2K smaller than NONOSDK22x_191105)
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024 = 2.2.2-dev(5ab15d1)
+; NONOSDK22x_191024 = 2.2.1+111-dev(5ab15d1)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105 = 2.2.2-dev(bb83b9b)
+; NONOSDK22x_191105 = 2.2.1+113-dev(bb83b9b)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
 ; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
@@ -173,12 +173,14 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
 ; NONOSDK22x_190313
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190313
-; NONOSDK22x_190703 (Tasmota default)
+; NONOSDK22x_190703 = 2.2.1+100-dev(38a443e) (Tasmota default) (Firmware 2K smaller than NONOSDK22x_191105)
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; NONOSDK22x_191024
+; NONOSDK22x_191024 = 2.2.1+111-dev(5ab15d1)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191024
-; NONOSDK22x_191105
+; NONOSDK22x_191105 = 2.2.1+113-dev(bb83b9b)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191105
+; NONOSDK22x_191122 = 2.2.1+119-dev(a58da79)
+;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191122
 ; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
 ; lwIP 1.4


### PR DESCRIPTION
## Description:

This new SDK is added as an option but only for STAGE version of the arduino core.
Also some comments about older SDK are fixed

**Related issue (if applicable):** https://github.com/esp8266/Arduino/pull/6879

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
