### PR TITLE
Added new var %topic% for rules

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -452,6 +452,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%TIME%"), String(MinutesPastMidnight()));
       RulesVarReplace(commands, F("%UPTIME%"), String(MinutesUptime()));
       RulesVarReplace(commands, F("%TIMESTAMP%"), GetDateAndTime(DT_LOCAL));
+      RulesVarReplace(commands, F("%TOPIC%"), Settings.mqtt_topic);
 #if defined(USE_TIMERS) && defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));
       RulesVarReplace(commands, F("%SUNSET%"), String(SunMinutes(1)));


### PR DESCRIPTION
## Description:

Added new variable `%topic%` for rules as this has been requested several times before.

Example:
```yaml
17:07:51 CMD: topic
17:07:51 MQT: stat/living/RESULT = {"Topic":"living"}
17:07:53 CMD: rule
17:07:53 MQT: stat/living/RESULT = {"Rule1":"ON","Once":"OFF","StopOnError":"OFF","Free":460,"Rules":"on event#test do publish cmnd/%topic%/power 2 endon"}
17:07:57 CMD: event test
17:07:57 MQT: stat/living/RESULT = {"Event":"Done"}
17:07:57 RUL: EVENT#TEST performs "publish cmnd/living/power 2"
17:07:57 MQT: cmnd/living/power = 2
17:07:57 MQT: stat/living/RESULT = {"POWER1":"ON"}
17:07:57 MQT: stat/living/POWER1 = ON
```

**Related issue (if applicable):** fixes #5522
 
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
