### PR TITLE
sml bus decoder syntax update

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -499,7 +499,10 @@ const uint8_t meter[]=
 #define USE_SML_MEDIAN_FILTER
 
 // max number of vars , may be adjusted
+#ifndef MAX_VARS
 #define MAX_VARS 20
+#endif
+
 // max number of meters , may be adjusted
 #define MAX_METERS 5
 double meter_vars[MAX_VARS];
@@ -1427,14 +1430,25 @@ void SML_Decode(uint8_t index) {
               //ignore
               mp+=2;
               cp++;
-            } else if (!strncmp(mp,"uuuuuuuu",8)) {
+            } else if (!strncmp(mp,"UUuuUUuu",8)) {
               uint32_t val= (cp[0]<<24)|(cp[1]<<16)|(cp[2]<<8)|(cp[3]<<0);
               ebus_dval=val;
               mbus_dval=val;
               mp+=8;
               cp+=4;
-            }
-            else if (*mp=='u' && *(mp+1)=='u' && *(mp+2)=='u' && *(mp+3)=='u'){
+            } else if (*mp=='U' && *(mp+1)=='U' && *(mp+2)=='u' && *(mp+3)=='u'){
+              uint16_t val = cp[1]|(cp[0]<<8);
+              mbus_dval=val;
+              ebus_dval=val;
+              mp+=4;
+              cp+=2;
+            } else if (!strncmp(mp,"SSssSSss",8)) {
+              int32_t val= (cp[0]<<24)|(cp[1]<<16)|(cp[2]<<8)|(cp[3]<<0);
+              ebus_dval=val;
+              mbus_dval=val;
+              mp+=8;
+              cp+=4;
+            } else if (*mp=='u' && *(mp+1)=='u' && *(mp+2)=='U' && *(mp+3)=='U'){
               uint16_t val = cp[0]|(cp[1]<<8);
               mbus_dval=val;
               ebus_dval=val;
@@ -1442,17 +1456,25 @@ void SML_Decode(uint8_t index) {
               cp+=2;
             } else if (*mp=='u' && *(mp+1)=='u') {
               uint8_t val = *cp++;
+              mbus_dval=val;
               ebus_dval=val;
               mp+=2;
-            }
-            else if (*mp=='s' && *(mp+1)=='s' && *(mp+2)=='s' && *(mp+3)=='s') {
+            } else if (*mp=='s' && *(mp+1)=='s' && *(mp+2)=='S' && *(mp+3)=='S') {
               int16_t val = *cp|(*(cp+1)<<8);
+              mbus_dval=val;
+              ebus_dval=val;
+              mp+=4;
+              cp+=2;
+            } else if (*mp=='S' && *(mp+1)=='S' && *(mp+2)=='s' && *(mp+3)=='s') {
+              int16_t val = cp[1]|(cp[0]<<8);
+              mbus_dval=val;
               ebus_dval=val;
               mp+=4;
               cp+=2;
             }
             else if (*mp=='s' && *(mp+1)=='s') {
               int8_t val = *cp++;
+              mbus_dval=val;
               ebus_dval=val;
               mp+=2;
             }


### PR DESCRIPTION
support for byte order

## Description:

bus decoder syntax support for byte oder

upper case means high order byte

unsigned 16,32 bit
UUuu or uuUU
UUuuUUuu
signed 16,32 bit
SSss or  ssSS
SSssSSss



## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).