### PR TITLE
Add Crash Recorder to help investigate rare crashes

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix Zigbee uses Hardware Serial if GPIO 1/3 or GPIO 13/15 and SerialLog 0 (#7071)
 - Fix WS2812 power control (#7090)
 - Change light color schemes 2, 3 and 4 from color wheel to Hue driven
+- Add Crash Recorder to help investigate rare crashes
 
 ## Released
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -490,6 +490,17 @@
     #define D_JSON_MOTOR_MIS "setMIS"
   #endif
 
+// Commands xdrv_32_crash_recorder.ino
+#define D_CMND_CRASHRECORD "CrashRecord"
+#define D_CMND_CRASHDUMP "CrashDump"
+#define D_CMND_CRASH "Crash"
+  #define D_JSON_ONE_TO_CRASH "1 to crash"
+  #define D_JSON_CRASH_RECORD "Crashrecord"
+  #define D_JSON_CRASH_RECORD_ERASED "Crashrecord erased"
+  #define D_JSON_CRASH_RECORD_PRESENT D_CMND_CRASHDUMP " already present, use 1 to erase"
+  #define D_JSON_ERR_ERASE_SECTOR "unable to erase sector"
+  #define D_JSON_NO_DUMP "no dump found"
+
 /********************************************************************************************/
 
 // Log message prefix

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -268,6 +268,9 @@
 //#define MY_LANGUAGE            zh-CN           // Chinese (Simplified) in China
 //#define MY_LANGUAGE            zh-TW           // Chinese (Traditional) in Taiwan
 
+// -- Crash recorder ---------------------------
+#define USE_CRASH_RECORDER                       // record the crash stack trace in Flash for further investigation (+1.0k code, +0.03k mem)
+
 // -- Wifi Config tools ---------------------------
 #define WIFI_SOFT_AP_CHANNEL   1                 // Soft Access Point Channel number between 1 and 13 as used by Wifi Manager web GUI
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -74,6 +74,13 @@ void ResponseCmndChar(const char* value)
   Response_P(S_JSON_COMMAND_SVALUE, XdrvMailbox.command, value);
 }
 
+void ResponseCmndChar_P(const char* value)
+{
+  char tmp[strlen_P(value) + 1];
+  strcpy_P(tmp, value);
+  ResponseCmndChar(tmp);
+}
+
 void ResponseCmndStateText(uint32_t value)
 {
   ResponseCmndChar(GetStateText(value));

--- a/tasmota/xdrv_32_crash_recorder.ino
+++ b/tasmota/xdrv_32_crash_recorder.ino
@@ -1,0 +1,238 @@
+/*
+  xdrv_23_crash_recorder.ino - record a complete stacktrace in Flash in case of crash
+
+  Copyright (C) 2019  Stephan Hadinger, Theo Arends, 
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_CRASH_RECORDER
+
+#define XDRV_32             32
+
+const char kCrashRecorderCommands[] PROGMEM = "|" D_CMND_CRASHRECORD "|" D_CMND_CRASHDUMP "|" D_CMND_CRASH; // No prefix
+
+void (* const CrashRecorderCommand[])(void) PROGMEM = { &CmndCrashRecord, &CmndCrashDump, &CmndCrash };
+
+const uint32_t crash_bank = SETTINGS_LOCATION - CFG_ROTATES - 1;
+const uint32_t crash_addr = crash_bank * SPI_FLASH_SEC_SIZE;
+const uint64_t crash_sig   = 0xDEADBEEFCCAA5588L;     // arbitrary signature to check if crash was recorded
+const uint64_t crash_empty = 0xFFFFFFFFFFFFFFFFL;     // all ones means the flash was correctly erased
+const uint32_t dump_max_len = 1024;                   // dump only 1024 bytes of stack, i.e. 256 addresses
+
+static bool stacktrace_armed = false;        // should we record the stacktrace
+
+typedef struct CrashRecorder_t {
+  uint64_t crash_signature = crash_sig;
+  uint32_t epc1;
+  uint32_t stack_start;
+  uint32_t stack_end;
+  uint32_t stack_dump_len;
+  uint32_t stack[];
+} CrashRecorder_t;
+
+// See: https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_postmortem.cpp
+
+/**
+ * Save crash information in Flash
+ * This function is called automatically if ESP8266 suffers an exception
+ * It should be kept quick / consise to be able to execute before hardware wdt may kick in
+ */
+extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) {
+  if (!stacktrace_armed) { return; }    // exit if nothing to do
+
+  CrashRecorder_t crash_recorder;
+
+  crash_recorder.epc1             = rst_info->epc1;
+  crash_recorder.stack_start      = stack;
+  crash_recorder.stack_end        = stack_end;
+
+  uint64_t sig = 0;
+  ESP.flashRead(crash_addr, (uint32_t*) &sig, sizeof(sig));
+
+  if (crash_sig == sig) {
+    return;                 // we already have a crash recorded, we leave it untouched and quit
+  }
+  if (crash_empty != sig) {
+    // crash recorder zone is unknown content, we leave it untouched
+    return;
+  }
+  // Flash has been erased, so we're good
+
+  // now store the stack trace, limited to 3KB (which should be far enough)
+  crash_recorder.stack_dump_len = stack - stack_end;
+  if (crash_recorder.stack_dump_len > dump_max_len) { crash_recorder.stack_dump_len = dump_max_len; }
+
+  ESP.flashWrite(crash_addr, (uint32_t*) &crash_recorder, sizeof(crash_recorder));
+  ESP.flashWrite(crash_addr + sizeof(crash_recorder), (uint32_t*) stack, crash_recorder.stack_dump_len);
+}
+
+/*********************************************************************************************\
+ * CmndCrashRecord - arm the crash recorder until next reboot
+\*********************************************************************************************/
+
+// Input:
+//  0 : disable crash recorcer
+//  1 : soft enable, enable if there is not already a crash record present
+//  2 : hard enable, erase any previous crash record and enable new record
+//
+// Output:
+//  0 : Ok, disabled
+//  1 : Ok, enabled
+//  2 : Ok, enabled and previous record erased
+// -1 : Abort, crash record already present
+// -2 : Flash erase failed
+int32_t SetCrashRecorder(int32_t mode) {
+  int32_t ret = 0;
+
+  if (0 != mode) {
+    uint64_t sig = 0;
+    ESP.flashRead(crash_addr, (uint32_t*) &sig, sizeof(sig));
+
+    if ((crash_sig == sig) && (1 == mode)) {
+      ret = -1;
+    } else {
+      if (crash_empty != sig) {
+        // crash recorder zone is not clean
+        if (ESP.flashEraseSector(crash_bank)) {
+          ret = 2;
+        } else {
+          ret = -2;
+        }
+      } else {
+        ret = 1;
+      }
+    }
+  }
+
+  stacktrace_armed = (ret > 0) ? true : false;
+  return ret;
+}
+
+// Generate a crash to test the crash record
+void CmndCrash(void)
+{
+  if (1 == XdrvMailbox.payload) {
+    volatile uint32_t dummy;
+    dummy = *((uint32_t*) 0x00000000);                // invalid address
+  } else {
+    ResponseCmndChar_P(PSTR(D_JSON_ONE_TO_CRASH));
+  }
+}
+
+
+void CmndCrashRecord(void)
+{
+  int32_t mode, ret;
+
+  switch (XdrvMailbox.payload) {
+    case -99:
+      mode = 1;
+      break;
+    case 1:
+      mode = 2;
+      break;
+    default:
+      mode = 0;
+  }
+
+  ret = SetCrashRecorder(mode);
+  const char *msg;
+
+  switch (ret) {
+    case 0:
+      msg = PSTR(D_JSON_CRASH_RECORD " " D_DISABLED);
+      break;
+    case 1:
+      msg = PSTR(D_JSON_CRASH_RECORD " " D_ENABLED);
+      break;
+    case 2:
+      msg = PSTR(D_JSON_CRASH_RECORD_ERASED ", " D_ENABLED);
+      break;
+    case -1:
+      msg = PSTR(D_JSON_ABORTED ": " D_JSON_CRASH_RECORD_PRESENT);
+      break;
+    case -2:
+      msg = PSTR(D_JSON_ERROR ": " D_JSON_ERR_ERASE_SECTOR);
+      break;
+    default:
+      msg = PSTR(D_JSON_UNKNOWN);
+  }
+  ResponseCmndChar_P(msg);
+}
+
+/*********************************************************************************************\
+ * CmndCrashDump - dump the crash history
+\*********************************************************************************************/
+
+void CmndCrashDump(void)
+{
+  CrashRecorder_t dump;
+  const char *msg;
+
+  ESP.flashRead(crash_addr, (uint32_t*) &dump, sizeof(dump));
+  if (crash_sig == dump.crash_signature) {
+    // Response_P(PSTR("{\"reason\":%d,\"exccause\":%d,"
+    //                 "\"epc1\":\"0x%08x\",\"epc2\":\"0x%08x\",\"epc3\":\"0x%08x\","
+    //                 "\"excvaddr\":\"0x%08x\",\"depc\":\"0x%08x\","
+    //                 "\"stack_start\":\"0x%08x\",\"stack_end\":\"0x%08x\","
+    //                 "\"uptime\":%d"
+    //                 "}"),
+    //                 dump.info.reason, dump.info.exccause,
+    //                 dump.info.epc1, dump.info.epc2, dump.info.epc3,
+    //                 dump.info.excvaddr, dump.info.depc,
+    //                 dump.stack_start, dump.stack_end,
+    //                 dump.crash_date / 1000
+    //                 );
+    // MqttPublishPrefixTopic_P(RESULT_OR_TELE, mqtt_data);
+
+    uint32_t stack_len = dump.stack_dump_len <= dump_max_len ? dump.stack_dump_len : dump_max_len; // we will limit to 1k
+    uint32_t dump_stack[stack_len / 4];
+
+    ESP.flashRead(crash_addr + sizeof(CrashRecorder_t), dump_stack, stack_len);
+
+    uint32_t dumped = 0;
+    Response_P(PSTR("{\"epc1\":\"0x%08x\",\"call_chain\":\""), dump.epc1);
+    for (uint32_t i = 0; i < stack_len / 4; i++) {
+      uint32_t value = dump_stack[i];
+      if ((value >= 0x40000000) && (value < 0x40300000)) {
+        ResponseAppend_P(PSTR("%08x "), value);
+        dumped++;
+        if (dumped >= 64) { break; }
+      }
+    }
+    ResponseAppend_P(PSTR("\"}"));
+    MqttPublishPrefixTopic_P(RESULT_OR_TELE, mqtt_data);
+    XdrvRulesProcess();
+    msg = PSTR(D_OK);
+  } else {
+    msg = PSTR(D_JSON_NO_DUMP);
+  }
+  ResponseCmndChar_P(msg);
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv32(uint8_t function)
+{
+  if (FUNC_COMMAND == function) {
+    return DecodeCommand(kCrashRecorderCommands, CrashRecorderCommand);
+  } else {
+    return false;
+  }
+}
+
+#endif // USE_CRASH_RECORDER

--- a/tasmota/xdrv_32_crash_recorder.ino
+++ b/tasmota/xdrv_32_crash_recorder.ino
@@ -31,7 +31,7 @@ const uint64_t crash_sig   = 0xDEADBEEFCCAA5588L;     // arbitrary signature to 
 const uint64_t crash_empty = 0xFFFFFFFFFFFFFFFFL;     // all ones means the flash was correctly erased
 const uint32_t dump_max_len = 1024;                   // dump only 1024 bytes of stack, i.e. 256 addresses
 
-static bool stacktrace_armed = false;        // should we record the stacktrace
+static bool stacktrace_armed = true;        // should we record the stacktrace
 
 typedef struct CrashRecorder_t {
   uint64_t crash_signature = crash_sig;


### PR DESCRIPTION
## Description:

### CrashRecorder:

This tool is designed to help in cases of random and rare crashes. In case of a crash, the stack_trace is dumped to Serial by the Arduino Core. In case of random crashes, there is often no device recording the Serial output.

Moreover, some crashes only show `epc1:0x4000df64` as crash location. Unfortynately `0x4000df64` is actually inside the `memcpy` function is ROM, which does not tell us where this faulty calls comes from.

CrashRecorder, when enabled, stores in Flash the Stack_trace for later analysis.

Note: the Arduino Core first dumps the stack trace on Serial, then gives control to CrashRecorder. In case of crash, the state of the system is unknown so it's possible that Flash writes fail.

### How to use:

To avoid any interference with stable systems, CrashRecorder is always disabled at boot. You can enable it manually or through a rule.

Automatically enable CrashRecorder:
`Backlog Rule1 On Power1#Boot Do CrashRecord Endon; Rule1 1`

### Commands

#### `CrashRecord`: will enable the crash recorder only if no crash dump is already present.

Parameters:
`(no parameter)`: Enables CrashRecorder until next boot, except if a CrashDump is alread in memory. Use without a parameter if you use a rule to enable it. This is a protection to avoid hammering the Flash in case of a bootloop.
`1`: Erases a previous CrashDump and enables CrashRecorder until next boot.
`0`: Disables CrashRecorder.


#### `CrashDump`: outputs data from the last recorded crash.
It outputs two JSON message. The first one contains register information of the crash, and the uptime in seconds when the crash appeared. The second JSON outputs a `call_chain`: the stack is filtered to show only values that are within the code range addresses (between `0x40000000` and `0x40300000`) and that are likely actual function calls. The output is limited to 64 values to fit within the MQTT buffer size.

#### `Crash`: when used with parameter `1`, generates a crash and allows to try the crash recorder.

```
00:04:00 CMD: Crash 1

Exception (28):
epc1=0x40205283 epc2=0x00000000 epc3=0x00000000 excvaddr=0x00000000 depc=0x00000000

>>>stack>>>

ctx: cont
sp: 3ffffc50 end: 3fffffc0 offset: 01a0
3ffffdf0:  3ffffeb4 40262390 3fff1260 4025f88c  
3ffffe00:  3ffffeb4 4025f898 3fff1260 4020297c  
...
```


Full example:

```
xx:xx:xx CMD: CrashRecord
xx:xx:xx RSL: stat/tasmota/RESULT = {"CrashRecord":"Aborted: Crashrecord already present, use 1 to erase"}

xx:xx:xx CMD: CrashRecord 1
xx:xx:xx RSL: stat/tasmota/RESULT = {"CrashRecord":"Crashrecord erased, Enabled"}

xx:xx:xx CMD: Crash 1

Exception (28):
epc1=0x40205283 epc2=0x00000000 epc3=0x00000000 excvaddr=0x00000000 depc=0x00000000

>>>stack>>>

ctx: cont
sp: 3ffffc50 end: 3fffffc0 offset: 01a0
3ffffdf0:  3ffffeb4 40262390 3fff1260 4025f88c  
3ffffe00:  3ffffeb4 4025f898 3fff1260 4020297c  
...


 ets Jan  8 2013,rst cause:2, boot mode:(3,6)

load 0x4010f000, len 1384, room 16 
tail 8
chksum 0x2d
csum 0x2d
v482516e3
~ld

00:00:00 CFG: Loaded from flash at FA, Count xx

xx:xx:xx CMD: CrashDump
xx:xx:xx RSL: tele/tasmota/RESULT = {"epc1":"0x40205283","call_chain":"40262390 4025f88c 4025f898 4020297c 402029ae 4020c4dd 402169c6 40219f15 402306ec 40213a85 402147b1 40216ae0 402147ca 40216a20 402181bf 4020dbc5 4021d8b7 4022b78c 401013e9 401000c0 4010f000 4010f15c 4000044c 40000000 400000f3 4000e328 "}
xx:xx:xx RSL: stat/tasmota/RESULT = {"CrashDump":"Ok"}
```

Flash impact: +1.0KB
Ram impact: +28 bytes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
