### PR TITLE
Add save call stack in RTC memory in case of crash

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.1.2.2 20191206
 
 - Add command ``SerialConfig 0..23`` or ``SerialConfig 8N1`` to select Serial Config (#7108)
+- Add save call stack in RTC memory in case of crash, command ``Status 12`` to dump the stack
 
 ### 7.1.2.1 20191206
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -293,8 +293,6 @@
   #define D_JSON_FLAG "FLAG"
   #define D_JSON_BASE "BASE"
 #define D_CMND_TEMPOFFSET "TempOffset"
-#define D_CMND_CRASH "Crash"
-  #define D_JSON_ONE_TO_CRASH "1 to crash"
 
 // Commands xdrv_01_mqtt.ino
 #define D_CMND_MQTTLOG "MqttLog"

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -208,6 +208,7 @@
   #define D_STATUS9_MARGIN "PTH"
   #define D_STATUS10_SENSOR "SNS"
   #define D_STATUS11_STATUS "STS"
+  #define D_STATUS12_STATUS "STK"
 #define D_CMND_STATE "State"
 #define D_CMND_POWER "Power"
 #define D_CMND_FANSPEED "FanSpeed"
@@ -292,6 +293,8 @@
   #define D_JSON_FLAG "FLAG"
   #define D_JSON_BASE "BASE"
 #define D_CMND_TEMPOFFSET "TempOffset"
+#define D_CMND_CRASH "Crash"
+  #define D_JSON_ONE_TO_CRASH "1 to crash"
 
 // Commands xdrv_01_mqtt.ino
 #define D_CMND_MQTTLOG "MqttLog"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -268,9 +268,6 @@
 //#define MY_LANGUAGE            zh-CN           // Chinese (Simplified) in China
 //#define MY_LANGUAGE            zh-TW           // Chinese (Traditional) in Taiwan
 
-// -- Crash generator ---------------------------
-//#define USE_CRASH                                // add a `Crash` command to test the crash recorder (+48 bytes)
-
 // -- Wifi Config tools ---------------------------
 #define WIFI_SOFT_AP_CHANNEL   1                 // Soft Access Point Channel number between 1 and 13 as used by Wifi Manager web GUI
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -268,6 +268,9 @@
 //#define MY_LANGUAGE            zh-CN           // Chinese (Simplified) in China
 //#define MY_LANGUAGE            zh-TW           // Chinese (Traditional) in Taiwan
 
+// -- Crash generator ---------------------------
+//#define USE_CRASH                                // add a `Crash` command to test the crash recorder (+48 bytes)
+
 // -- Wifi Config tools ---------------------------
 #define WIFI_SOFT_AP_CHANNEL   1                 // Soft Access Point Channel number between 1 and 13 as used by Wifi Manager web GUI
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -30,9 +30,6 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
-#ifdef USE_CRASH
-  D_CMND_CRASH "|"
-#endif
   D_CMND_SENSOR "|" D_CMND_DRIVER ;
 
 void (* const TasmotaCommand[])(void) PROGMEM = {
@@ -47,9 +44,6 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower, &CmndTempOffset,
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
-#endif
-#ifdef USE_CRASH
-  &CmndCrash,
 #endif
   &CmndSensor, &CmndDriver };
 
@@ -576,6 +570,9 @@ void CmndRestart(void)
   case 1:
     restart_flag = 2;
     ResponseCmndChar(D_JSON_RESTARTING);
+    break;
+  case -1:
+    CmndCrash();    // force a crash
     break;
   case 99:
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_APPLICATION D_RESTARTING));

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -30,7 +30,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
-  D_CMND_SENSOR "|" D_CMND_DRIVER ;
+  D_CMND_SENSOR "|" D_CMND_DRIVER;
 
 void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
@@ -45,7 +45,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
 #endif
-  &CmndSensor, &CmndDriver};
+  &CmndSensor, &CmndDriver };
 
 const char kWifiConfig[] PROGMEM =
   D_WCFG_0_RESTART "||" D_WCFG_2_WIFIMANAGER "||" D_WCFG_4_RETRY "|" D_WCFG_5_WAIT "|" D_WCFG_6_SERIAL "|" D_WCFG_7_WIFIMANAGER_RESET_ONLY;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -45,7 +45,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
 #endif
-  &CmndSensor, &CmndDriver };
+  &CmndSensor, &CmndDriver};
 
 const char kWifiConfig[] PROGMEM =
   D_WCFG_0_RESTART "||" D_WCFG_2_WIFIMANAGER "||" D_WCFG_4_RETRY "|" D_WCFG_5_WAIT "|" D_WCFG_6_SERIAL "|" D_WCFG_7_WIFIMANAGER_RESET_ONLY;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -30,7 +30,10 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
-  D_CMND_SENSOR "|" D_CMND_DRIVER;
+#ifdef USE_CRASH
+  D_CMND_CRASH "|"
+#endif
+  D_CMND_SENSOR "|" D_CMND_DRIVER ;
 
 void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
@@ -44,6 +47,9 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower, &CmndTempOffset,
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
+#endif
+#ifdef USE_CRASH
+  &CmndCrash,
 #endif
   &CmndSensor, &CmndDriver };
 
@@ -481,6 +487,13 @@ void CmndStatus(void)
     MqttShowState();
     ResponseJsonEnd();
     MqttPublishPrefixTopic_P(option, PSTR(D_CMND_STATUS "11"));
+  }
+
+  if ((0 == payload) || (12 == payload)) {
+    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS12_STATUS "\":"));
+    CrashDump();
+    ResponseJsonEnd();
+    MqttPublishPrefixTopic_P(option, PSTR(D_CMND_STATUS "12"));
   }
 
 #ifdef USE_SCRIPT_STATUS

--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -46,12 +46,8 @@ extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack
 // Generate a crash to test the crash recorder
 void CmndCrash(void)
 {
-  if (1 == XdrvMailbox.payload) {
-    volatile uint32_t dummy;
-    dummy = *((uint32_t*) 0x00000000);                // invalid address
-  } else {
-    ResponseCmndChar(D_JSON_ONE_TO_CRASH);
-  }
+  volatile uint32_t dummy;
+  dummy = *((uint32_t*) 0x00000000);
 }
 
 // Clear the RTC dump area when we do a normal reboot, this avoids garbage data to stay in RTC

--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -1,0 +1,80 @@
+/*
+  support_crash_recorder.ino - record the call stack in RTC in cas of crash
+
+  Copyright (C) 2019  Stephan Hadinger, Theo Arends, 
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const uint32_t dump_max_len = 64;                   // dump only 64 call addresses
+
+/**
+ * Save crash information in RTC memory
+ * This function is called automatically if ESP8266 suffers an exception
+ * It should be kept quick / consise to be able to execute before hardware wdt may kick in
+ */
+extern "C" void custom_crash_callback(struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) {
+  uint32_t addr_written = 0;      // how many addresses have we already written in RTC
+  uint32_t value;                 // 4 bytes buffer to write to RTC
+
+  for (uint32_t i = stack; i < stack_end; i += 4) {
+    value = *((uint32_t*) i);     // load value from stack
+    if ((value >= 0x40000000) && (value < 0x40300000)) {  // keep only addresses in code area
+      ESP.rtcUserMemoryWrite(addr_written, (uint32_t*)&value, sizeof(value));
+      addr_written++;
+      if (addr_written >= dump_max_len) { break; }        // we store only 64 addresses
+    }
+  }
+  // fill the rest of RTC with zeros
+  value = 0;
+  while (addr_written < dump_max_len) {
+    ESP.rtcUserMemoryWrite(addr_written++, (uint32_t*)&value, sizeof(value));
+  }
+}
+
+// Generate a crash to test the crash recorder
+void CmndCrash(void)
+{
+  if (1 == XdrvMailbox.payload) {
+    volatile uint32_t dummy;
+    dummy = *((uint32_t*) 0x00000000);                // invalid address
+  } else {
+    ResponseCmndChar(D_JSON_ONE_TO_CRASH);
+  }
+}
+
+// Clear the RTC dump area when we do a normal reboot, this avoids garbage data to stay in RTC
+void CrashDumpClear(void) {
+  uint32_t value = 0;
+  for (uint32_t i = 0; i < dump_max_len; i++) {
+    ESP.rtcUserMemoryWrite(i, (uint32_t*)&value, sizeof(value));
+  }
+}
+
+/*********************************************************************************************\
+ * CmndCrashDump - dump the crash history - called by `Status 12`
+\*********************************************************************************************/
+void CrashDump(void)
+{
+  ResponseAppend_P(PSTR("{\"call_chain\":["));
+  for (uint32_t i = 0; i < dump_max_len; i++) {
+    uint32_t value;
+    ESP.rtcUserMemoryRead(i, (uint32_t*)&value, sizeof(value));
+    if ((value >= 0x40000000) && (value < 0x40300000)) {
+      if (i > 0) { ResponseAppend_P(PSTR(",")); }
+      ResponseAppend_P(PSTR("\"%08x\""), value);
+    }
+  }
+  ResponseAppend_P(PSTR("]}"));
+}

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -617,6 +617,7 @@ void WifiShutdown(void)
 void EspRestart(void)
 {
   WifiShutdown();
+  CrashDumpClear();           // Clear the stack dump in RTC
 //  ESP.restart();            // This results in exception 3 on restarts on core 2.3.0
   ESP.reset();
 }

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -131,7 +131,7 @@ const uint32_t SOFT_BAUDRATE = 9600;        // Default software serial baudrate
 const uint32_t APP_BAUDRATE = 115200;       // Default serial baudrate
 const uint32_t SERIAL_POLLING = 100;        // Serial receive polling in ms
 const uint32_t ZIGBEE_POLLING = 100;        // Serial receive polling in ms
-const uint8_t MAX_STATUS = 11;              // Max number of status lines
+const uint8_t MAX_STATUS = 12;              // Max number of status lines
 
 const uint32_t START_VALID_TIME = 1451602800;  // Time is synced and after 2016-01-01
 


### PR DESCRIPTION
## Description:

### CrashRecorder:

This feature is designed to help in cases of random and rare crashes. In case of a crash, the stack_trace is dumped to Serial by the Arduino Core. In case of random crashes, there is often no device recording the Serial output.

Moreover, some crashes only show `epc1:0x4000df64` as crash location. Unfortynately `0x4000df64` is actually inside the `memcpy` function is ROM, which does not tell us where this faulty calls comes from.

CrashRecorder stores in RTC memory the call trace for later analysis. RTC memory survives a reboot but does not survive a power off.

Note: the Arduino Core first dumps the stack trace on Serial, then gives control to CrashRecorder. In case of crash, the state of the system is unknown so it's possible that RTC writes fail.

### How to use: `Status 12`

This feature adds `Status 12` to dump the call stack. It is best used with `Status 1` to get the crash reason.

Example - empty stack (no crash):

```
xx:xx:xx CMD: Status 1
xx:xx:xx RSL: stat/tasmota/STATUS1 = {"StatusPRM":{"Baudrate":115200,"GroupTopic":"tasmotas","OtaUrl":"http://thehackbox.org/tasmota/release/tasmota.bin","RestartReason":"Software/System restart","Uptime":"0T00:00:03","StartupUTC":"","Sleep":50,"CfgHolder":4617,"BootCount":103,"SaveCount":139,"SaveAddress":"FA000"}}

xx:xx:xx CMD: Status 12
xx:xx:xx RSL: stat/tasmota/STATUS12 = {"StatusSTK":{"call_chain":[]}}
```

Example - crash occured:
```
xx:xx:xx CMD: Status 1
xx:xx:xx RSL: stat/tasmota/STATUS1 = {"StatusPRM":{"Baudrate":115200,"GroupTopic":"tasmotas","OtaUrl":"http://thehackbox.org/tasmota/release/tasmota.bin","RestartReason":"Fatal exception:28 flag:2 (EXCEPTION) epc1:0x4020505b epc2:0x00000000 epc3:0x00000000 excvaddr:0x00000000 depc:0x00000000","Uptime":"0T00:00:06","StartupUTC":"","Sleep":50,"CfgHolder":4617,"BootCount":102,"SaveCount":138,"SaveAddress":"FB000"}}

xx:xx:xx CMD: Status 12
xx:xx:xx RSL: stat/tasmota/STATUS12 = {"StatusSTK":{"call_chain":["40264744","40264854","4020297c","40216a27","4023061c","4022b581","4023061c","402139cd","4021481d","40216b48","40214836","40216a88","40218277","40203c9f","4021d807","4022b6bc","401013e9"]}}
```

### How to force a crash (for testing): `Restart -1`

You can now use `Restart -1` to force an artifical crash, for testing purpose only.


Full example:

```
xx:xx:xx CMD: Restart -1

Exception (28):
epc1=0x4020505b epc2=0x00000000 epc3=0x00000000 excvaddr=0x00000000 depc=0x00000000

>>>stack>>>

ctx: cont
sp: 3ffffc70 end: 3fffffc0 offset: 01a0
3ffffe10:  00000000 00000000 4bc6a7f0 40264744  
3ffffe20:  3ffffeb4 40264854 3fff1308 4020297c  
3ffffe30:  00000000 3fffff11 3fffff21 00000001 
...
<<<stack<<<

 ets Jan  8 2013,rst cause:2, boot mode:(3,6)

load 0x4010f000, len 1384, room 16 
tail 8
chksum 0x2d
csum 0x2d
v482516e3
~ld

00:00:00 CFG: Loaded from flash at F9, Count xx

00:00:03 CMD: Status 1
00:00:03 RSL: stat/tasmota/STATUS1 = {"StatusPRM":{"Baudrate":115200,"GroupTopic":"tasmotas","OtaUrl":"http://thehackbox.org/tasmota/release/tasmota.bin","RestartReason":"Fatal exception:28 flag:2 (EXCEPTION) epc1:0x4020505b epc2:0x00000000 epc3:0x00000000 excvaddr:0x00000000 depc:0x00000000","Uptime":"0T00:00:05","StartupUTC":"","Sleep":50,"CfgHolder":4617,"BootCount":104,"SaveCount":140,"SaveAddress":"F9000"}}
00:00:04 CMD: Status 12
00:00:04 RSL: stat/tasmota/STATUS12 = {"StatusSTK":{"call_chain":["40264744","40264854","4020297c","40216a27","4023061c","402139cd","4021481d","40216b48","40214836","40216a88","40218277","40203c9f","4021d807","4022b6bc","401013e9"]}}

```

Flash size increase: +356 bytes
Ram impact: +0 bytes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
