### PR TITLE
Remove any whitespace in TlsKey base64

### DIFF
--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -1071,6 +1071,19 @@ void CmndTlsKey(void) {
       }
       memcpy_P(spi_buffer, tls_spi_start, tls_spi_len);
 
+      // remove any white space from the base64
+      char *cursor = XdrvMailbox.data;
+      uint32_t offset = 0;
+      while (1) {
+        *cursor = *(cursor + offset);
+        if ((' ' == *cursor) || ('\t' == *cursor) || ('\n' == *cursor)) {   // if space found, remove this char until end of string
+          offset++;
+        } else {
+          if (0 == *cursor) { break; }
+          cursor++;
+        }
+      }
+
       // allocate buffer for decoded base64
       uint32_t bin_len = decode_base64_length((unsigned char*)XdrvMailbox.data);
       uint8_t  *bin_buf = nullptr;


### PR DESCRIPTION
## Description:

Removes any whitespace in the `TlsKey1` or `TlsKey2` base64 input to avoid any corrupt certificate. I'm working on simplifying the provisioning of certificates, unfortunately the tool I'm using adds spaces in the base64 stream.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
