### PR TITLE
Fix crashdump bad JSON

### DIFF
--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -69,10 +69,8 @@ void CrashDump(void)
 
   for (uint32_t i = 0; i < count; i++) {
     ESP.rtcUserMemoryRead(i, (uint32_t*)&value, sizeof(value));
-    if ((value >= 0x40000000) && (value < 0x40300000)) {
-      if (i > 0) { ResponseAppend_P(PSTR(",")); }
-      ResponseAppend_P(PSTR("\"%08x\""), value);
-    }
+    if (i > 0) { ResponseAppend_P(PSTR(",")); }
+    ResponseAppend_P(PSTR("\"%08x\""), value);
   }
   ResponseAppend_P(PSTR("]}"));
 }


### PR DESCRIPTION
## Description:

Fix to avoid generating a bad JSON from crash recorder. The test for valid value is not needed anymore in CrashDump(), it never dumps more than 63 values.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
