### PR TITLE
Timers: Use visibility instead of disabled

### DIFF
--- a/tasmota/xdrv_09_timers.ino
+++ b/tasmota/xdrv_09_timers.ino
@@ -554,10 +554,10 @@ const char HTTP_TIMER_SCRIPT2[] PROGMEM =
     "o=qs('#ho');"
     "e=o.childElementCount;"
     "if(b==1){"
-      "qs('#dr').disabled='';"
+      "qs('#dr').style.visibility='';"
       "if(e>12){for(i=12;i<=23;i++){o.removeChild(o.lastElementChild);}}"  // Create offset hours select options
     "}else{"
-      "qs('#dr').disabled='disabled';"
+      "qs('#dr').style.visibility='hidden';"
       "if(e<23){for(i=12;i<=23;i++){ce(i,o);}}"                   // Create hours select options
     "}"
   "}";


### PR DESCRIPTION
## Description:

The "+/-" chooser is only needed for sunrise/sunset.
Otherwise it's disabled currently.
This works.

But it's a little confusing. Especially, if you first had
"-" there (for sunset) and then switched to normal "time",
then the "-" is still there, but you can't change it,
because it's disabled.

It looks better, if one uses .style.visibility to hide the
element. It doesn't change the layout, just the element
isn't shown.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
