### PR TITLE
Plain ARROW symbols on buttons that command shutters

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1106,7 +1106,19 @@ void HandleRoot(void)
       }
     } else {
 #endif  // USE_SONOFF_IFAN
-      for (uint32_t idx = 1; idx <= devices_present; idx++) {
+
+
+  	//  display shutter dedicated buttons first...													//// fork lh61
+      uint32 btn = 1;
+#ifdef USE_SHUTTER
+      if (Settings.flag3.shutter_mode) {  // SetOption80 - Enable shutter support
+        for (btn=1; btn <= 2*shutters_present; btn++) {
+          WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / devices_present, btn,(btn%2) ?"▲":"▼","");		// Up arrow: ?,? Dn arrow ?, ?
+        }
+      }
+#endif  // USE_SHUTTER
+	  //  ... then remaining buttons
+    for (uint32_t idx = btn; idx <= devices_present; idx++) {
         snprintf_P(stemp, sizeof(stemp), PSTR(" %d"), idx);
         WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / devices_present, idx, (devices_present < 5) ? D_BUTTON_TOGGLE : "", (devices_present > 1) ? stemp : "");
       }


### PR DESCRIPTION
## Description:
 It's a change I wanted for myself for a long time and the recent arise of the **shutter driver** gives me that opportunity to do it. 

This code change makes a difference between Up and Down buttons in the case of a shutter. Labels of buttons of other relays are not affected.

Here is the result:
First screenshot shows a Dual R2 defined as shutter, second picture shows what happens on a Sonoff CH4 when only 2 first relays form a shutter and last one the same device with 2 shutters.

<img src="https://user-images.githubusercontent.com/33861984/70478849-5c300680-1adc-11ea-9e13-e17592189a22.png" width="200">  <img src="https://user-images.githubusercontent.com/33861984/70479178-1889cc80-1add-11ea-9de5-2a122f8b8f91.png" width="200">  <img src="https://user-images.githubusercontent.com/33861984/70479196-22abcb00-1add-11ea-887f-a87298db0d86.png" width="200">   

- The code change is reduiced thanks to the fact that UP relay is hard-coded as the First one in the  xdrv_27_Shutter.ino driver, and DOWN relay as the second.
- The arrow symbols have the advantage to require no i18n (no code increase) and fit in even tiny buttons. As a UTF8 character it should be readable on every modern browser. Isn't it?
- The code size cost is +16 bytes compared to previous commit v7.1.2.4 (3d2e77f) compiled with `-DUSE_SHUTTER` (585,328 bytes).
- The change doesn't apply to tasmota.bin because the Shutter driver is not supported by default.

I join the tasmota binary here for the one who want to test because one need to uncomment `#define USE_SHUTTER` in `my_user_config.h` to allow shutter support.
-> [PR_v7124.zip](https://github.com/arendst/Tasmota/files/3942064/PR_v7124.zip)
## Checklist:
  - [✓] The pull request is done against the latest dev branch
  - [✓] Only relevant files were touched
  - [✓] Only one feature/fix was added per PR.
  - [✓] The code change is tested and works on core 2.6.1
  - [✓] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [✓] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).