### PR TITLE
Allow 4 DHT sensors

### DIFF
--- a/tasmota/xsns_06_dht.ino
+++ b/tasmota/xsns_06_dht.ino
@@ -28,7 +28,7 @@
 
 #define XSNS_06          6
 
-#define DHT_MAX_SENSORS  3
+#define DHT_MAX_SENSORS  4
 #define DHT_MAX_RETRY    8
 
 uint32_t dht_max_cycles;


### PR DESCRIPTION
## Description:
*** The smallest PR ever ;-) ***

Why limit DHT driver to 3 sensors only when a Wemos D1 can easily handle 4 of them?
I know one can't go further due to MQTT message size limit (I already reached this limit when trying to read 10x DS18B20).

Currently it works for more than a week (precisely since the 29th as the chart says ;-) ) at a `Teleperiod 60` with `Heap~27` but with a reduced Tasmota footprint. Now I replaced that firmware with the full size tasmota of this commit.  

![chart_4x AM231_Monthly](https://user-images.githubusercontent.com/33861984/70484357-e59b0500-1aeb-11ea-8db8-66a2218fb4b6.png)


For me the purpose is to check new and old DHT devices and calibrate, I already have one AM2301 that stick to 100% RH that I have to replace and here an other old one that shows a 10% RH deviation, so now I have some spare devices.

<img src="https://user-images.githubusercontent.com/33861984/70483442-af0fbb00-1ae8-11ea-9b26-c743e8f01570.png" size=200>

## Checklist:
  - [✓] The pull request is done against the latest dev branch
  - [✓] Only relevant files were touched
  - [✓] Only one feature/fix was added per PR.
  - [✓] The code change is tested and works on core 2.6.1
  - [✓] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [✓] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
