### PR TITLE
Report raw value from HX711 to overcome auto-tare functionality.

### DIFF
--- a/tasmota/xsns_34_hx711.ino
+++ b/tasmota/xsns_34_hx711.ino
@@ -57,6 +57,7 @@
 #define D_JSON_WEIGHT_MAX    "WeightMax"
 #define D_JSON_WEIGHT_ITEM   "WeightItem"
 #define D_JSON_WEIGHT_CHANGE "WeightChange"
+#define D_JSON_WEIGHT_RAW    "WeightRaw"
 
 enum HxCalibrationSteps { HX_CAL_END, HX_CAL_LIMBO, HX_CAL_FINISH, HX_CAL_FAIL, HX_CAL_DONE, HX_CAL_FIRST, HX_CAL_RESET, HX_CAL_START };
 
@@ -64,8 +65,10 @@ const char kHxCalibrationStates[] PROGMEM = D_HX_CAL_FAIL "|" D_HX_CAL_DONE "|" 
 
 struct HX {
   long weight = 0;
+  long raw = 0;
   long last_weight = 0;
   long sum_weight = 0;
+  long sum_raw = 0;
   long offset = 0;
   long scale = 1;
   long weight_diff = 0;
@@ -272,13 +275,17 @@ void HxInit(void)
 
 void HxEvery100mSecond(void)
 {
-  Hx.sum_weight += HxRead();
+  long raw = HxRead();
+  Hx.sum_raw += raw;
+  Hx.sum_weight += raw;
 
   Hx.sample_count++;
   if (HX_SAMPLES == Hx.sample_count) {
     long average = Hx.sum_weight / Hx.sample_count;  // grams
+    long raw_average = Hx.sum_raw / Hx.sample_count;  // grams
     long value = average - Hx.offset;                // grams
     Hx.weight = value / Hx.scale;                    // grams
+    Hx.raw = raw_average / Hx.scale;
     if (Hx.weight < 0) {
       if (Settings.energy_frequency_calibration) {
         long difference = Settings.energy_frequency_calibration + Hx.weight;
@@ -367,6 +374,7 @@ void HxEvery100mSecond(void)
     }
 
     Hx.sum_weight = 0;
+    Hx.sum_raw = 0;
     Hx.sample_count = 0;
   }
 }
@@ -405,7 +413,7 @@ void HxShow(bool json)
   dtostrfd(weight, Settings.flag2.weight_resolution, weight_chr);
 
   if (json) {
-    ResponseAppend_P(PSTR(",\"HX711\":{\"" D_JSON_WEIGHT "\":%s%s}"), weight_chr, scount);
+    ResponseAppend_P(PSTR(",\"HX711\":{\"" D_JSON_WEIGHT "\":%s%s, \"" D_JSON_WEIGHT_RAW "\":%d}"), weight_chr, scount, Hx.raw);
 #ifdef USE_WEBSERVER
   } else {
     WSContentSend_PD(HTTP_HX711_WEIGHT, weight_chr);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #6387 (partly)

Currently, when the device is switched off (intentionally or due to
power cut), Tasmota only supports starting with the last known weight
(Sensor34 7) or starting with 0 kg. In either case, this is sometimes
not the desired functionality. For off-site logging of weights, it is
more useful to report the raw, absolute value from the HX711 and to do
calibration/tare in upper layers.

Note: although it is called "Raw" value, the value is both averaged
and scaled! It is just the offset compensation that is missing.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
