### PR TITLE
fix 12hr early Sunset/Sunrise (xdrv_09_timers.ino )

### DIFF
--- a/tasmota/xdrv_09_timers.ino
+++ b/tasmota/xdrv_09_timers.ino
@@ -583,7 +583,7 @@ const char HTTP_TIMER_SCRIPT3[] PROGMEM =
     "if(m==0){s|=l;}"                                             // Get time
 #ifdef USE_SUNRISE
     "if((m==1)||(m==2)){"
-      "if(qs('#dr').selectedIndex>0){l+=720;}"                    // If negative offset, add 12h to given offset time
+      "if(qs('#dr').selectedIndex>0){if(l>0){l+=720;}}"           // If negative offset and delta-time > 0, add 12h to given offset time
       "s|=l&0x7FF;"                                               // Save offset instead of time
     "}"
 #endif


### PR DESCRIPTION
## Description:
Fix a small web/configuration issue causing the Sunset/Sunrise timer activates 12 hours early when  accidentally using an negative zero offset  (-00:00 time).  In case the user enters "-" (minus)  00:00. The web-script sees this as an delta,  subtracts 720 minutes (12 hours) before adding the delta time. This causes that  the subset/sunrise will go off , 12 hours early.

If and in case users really want 12 hours before, it is more logical they enter a real time-offset as intended.

The fix is small, but prevent a problem that the SunSet (or SunRise)  timer (at timer mode 2 or 1), will otherwise trigger 12 hours early or later then intended.  
Without the change: the configuration will read:  ... "mode": 2, "power": 1, "repeat": 1, "time": 720, "window": 0},
After the proposed correction (and of course a configuration save), the configuration will result into: "mode": 2, "power": 1, "repeat": 1, "time": 0, "window": 0 ...

Note: this is my first active contribution in the steeple chase what is required. It is quite an experience to have things sorted out and I'm open to improvements. TIA for your considerations.
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).