### PR TITLE
Fix flashing H801 led at boot (#7165, #649)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add Wifi Signal Strength in dBm in addition to RSSI Wifi Experience by Andreas Schultz (#7145)
 - Add Yaw, Pitch and Roll support for MPU6050 by Philip Barclay (#7058)
 - Add reporting of raw weight to JSON from HX711 to overcome auto-tare functionality by @tobox (#7171)
+- Fix flashing H801 led at boot (#7165, #649)
 
 ### 7.1.2.3 20191208
 

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1286,15 +1286,19 @@ void GpioInit(void)
   }
 #endif  // USE_SONOFF_SC
 
-  if (!light_type) {
-    for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only
-      if (pin[GPIO_PWM1 +i] < 99) {
+  for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only
+    if (pin[GPIO_PWM1 +i] < 99) {
+      pinMode(pin[GPIO_PWM1 +i], OUTPUT);
+      if (light_type) {
+        // force PWM GPIOs to low or high mode, see #7165
+        analogWrite(pin[GPIO_PWM1 +i], bitRead(pwm_inverted, i) ? Settings.pwm_range : 0);
+      } else {
         pwm_present = true;
-        pinMode(pin[GPIO_PWM1 +i], OUTPUT);
         analogWrite(pin[GPIO_PWM1 +i], bitRead(pwm_inverted, i) ? Settings.pwm_range - Settings.pwm_value[i] : Settings.pwm_value[i]);
       }
     }
   }
+
   for (uint32_t i = 0; i < MAX_RELAYS; i++) {
     if (pin[GPIO_REL1 +i] < 99) {
       pinMode(pin[GPIO_REL1 +i], OUTPUT);


### PR DESCRIPTION
## Description:

In light mode, PWM GPIO were not initialized until `LightAnimate()` is called 50ms after the boot. It seems that leaving GPIOs in undefined state sets light on H801, but has no effect on other led controllers. Maybe a MOSFET effect (I don't know enough about MOSFETs).

Now PWM GPIOs are set to low value (Off) right at start and may change to the desired value 50ms later when `LightAnimate()` is called.

**Related issue (if applicable):** fixes #7165, #649

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
