### PR TITLE
RULES: Fix duplicated BACKLOG when using EVENT inside a BACKLOG

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -438,7 +438,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       String ucommand = commands;
       ucommand.toUpperCase();
 //      if (!ucommand.startsWith("BACKLOG")) { commands = "backlog " + commands; }  // Always use Backlog to prevent power race exception
-      if (ucommand.indexOf("EVENT ") != -1) { commands = "backlog " + commands; }  // Always use Backlog with event to prevent rule event loop exception
+      if ((ucommand.indexOf("EVENT ") != -1) && (ucommand.indexOf("BACKLOG ") == -1)) { commands = "backlog " + commands; }  // Always use Backlog with event to prevent rule event loop exception
 
       RulesVarReplace(commands, F("%VALUE%"), Rules.event_value);
       for (uint32_t i = 0; i < MAX_RULE_VARS; i++) {


### PR DESCRIPTION
## Description:

Rules: Fix duplicated `backlog` when using `event` inside a `backlog`

**Related issue (if applicable):** fixes #7147

Before applying this PR:

```
22:23:09 CMD: rule3 ON event#test do backlog var2 %value%;event PublishStatus ENDON
22:23:09 MQT: stat/luzescalera/RESULT = {"Rule3":"ON","Once":"OFF","StopOnError":"OFF","Free":448,"Rules":"ON event#test do backlog var2 %value%;event PublishStatus ENDON"}
22:23:17 CMD: event test=5
22:23:17 SRC: WebConsole from 192.168.1.123
22:23:17 CMD: Grupo 0, Índice 1, Comando "EVENT", Datos "test=5"
22:23:17 MQT: stat/luzescalera/RESULT = {"Event":"Done"}

22:23:17 RUL: EVENT#TEST performs "backlog backlog var2 5;event PublishStatus"

22:23:17 SRC: Rule
22:23:17 CMD: Grupo 0, Índice 1, Comando "BACKLOG", Datos "backlog var2 5;event PublishStatus"
22:23:17 SRC: Backlog
22:23:17 CMD: Grupo 0, Índice 2, Comando "VAR", Datos "5"
22:23:17 MQT: stat/luzescalera/RESULT = {"Var2":"5"}
22:23:17 SRC: Backlog
22:23:17 CMD: Grupo 0, Índice 1, Comando "EVENT", Datos "PublishStatus"
22:23:17 MQT: stat/luzescalera/RESULT = {"Event":"Done"}
```

After applying this PR:

```
22:21:47 CMD: rule1 ON event#test do backlog var2 %value%;event PublishStatus ENDON
22:21:47 MQT: stat/living/RESULT = {"Rule1":"ON","Once":"OFF","StopOnError":"OFF","Free":448,"Rules":"ON event#test do backlog var2 %value%;event PublishStatus ENDON"}
22:27:22 CMD: event test=5
22:27:22 SRC: WebConsole from 192.168.1.123
22:27:22 CMD: Grupo 0, Índice 1, Comando "EVENT", Datos "test=5"
22:27:22 MQT: stat/living/RESULT = {"Event":"Done"}

22:27:23 RUL: EVENT#TEST performs "backlog var2 5;event PublishStatus"

22:27:23 SRC: Rule
22:27:23 CMD: Grupo 0, Índice 1, Comando "BACKLOG", Datos "var2 5;event PublishStatus"
22:27:23 SRC: Backlog
22:27:23 CMD: Grupo 0, Índice 2, Comando "VAR", Datos "5"
22:27:23 MQT: stat/living/RESULT = {"Var2":"5"}
22:27:23 SRC: Backlog
22:27:23 CMD: Grupo 0, Índice 1, Comando "EVENT", Datos "PublishStatus"
22:27:23 MQT: stat/living/RESULT = {"Event":"Done"}
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
