### PR TITLE
Reset 0 to clear down stats

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -272,6 +272,7 @@
   #define D_JSON_ONE_TO_RESTART "1 to restart"
 #define D_CMND_RESET "Reset"
   #define D_JSON_RESET_AND_RESTARTING "Reset and Restarting"
+  #define D_JSON_RESET_DOWN_STATS "Counts reset"
   #define D_JSON_ONE_TO_RESET "1 to reset"
 #define D_CMND_TIME "Time"
 #define D_CMND_TIMEZONE "Timezone"

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Брой"
 #define D_COUNTER "Брояч"
 #define D_CURRENT "Ток"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Данни"
 #define D_DARKLIGHT "Тъмна"
 #define D_DEBUG "Дебъгване"
@@ -119,6 +120,7 @@
 #define D_NONE "Няма"
 #define D_OFF "Изкл."
 #define D_OFFLINE "Офлайн"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ок"
 #define D_ON "Вкл."
 #define D_ONLINE "Онлайн"

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Počítej"
 #define D_COUNTER "Počítadlo"
 #define D_CURRENT "Proud"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Tmavý"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Žádný"
 #define D_OFF "Vyp."
 #define D_OFFLINE "Neaktivní"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "OK"
 #define D_ON "Zap."
 #define D_ONLINE "Aktivní"

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -75,6 +75,7 @@
 #define D_COUNT "zählen"
 #define D_COUNTER "Zähler"
 #define D_CURRENT "Strom"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Daten"
 #define D_DARKLIGHT "dunkel"
 #define D_DEBUG "debug"
@@ -119,6 +120,7 @@
 #define D_NONE "keine"
 #define D_OFF "aus"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "OK"
 #define D_ON "an"
 #define D_ONLINE "Online"

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -75,6 +75,7 @@
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Μετρητής"
 #define D_CURRENT "Ένταση"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Δεδομένα"
 #define D_DARKLIGHT "Σκοτεινό"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Κανένα"
 #define D_OFF "Off"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "On"
 #define D_ONLINE "Online"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Count"
 #define D_COUNTER "Counter"
 #define D_CURRENT "Current"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Dark"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "None"
 #define D_OFF "Off"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "On"
 #define D_ONLINE "Online"

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Conteo"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corriente"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Datos"
 #define D_DARKLIGHT "Oscuro"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Ninguno"
 #define D_OFF "Apagado"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "Encendido"
 #define D_ONLINE "Online"

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.6.0.15
+ * Updated until v7.1.2.4
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -71,10 +71,11 @@
 #define D_COLDLIGHT "Froid"
 #define D_COMMAND "Commande"
 #define D_CONNECTED "Connecté"
-#define D_CORS_DOMAIN "CORS Domain"
+#define D_CORS_DOMAIN "Domaine CORS"
 #define D_COUNT "Compte"
 #define D_COUNTER "Compteur"
 #define D_CURRENT "Courant"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Donnée"
 #define D_DARKLIGHT "Sombre"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Aucun"
 #define D_OFF "Arrêt"
 #define D_OFFLINE "Déconnecté"
+#define D_OFFLINE_COUNT "Durée hors-ligne"
 #define D_OK "Ok"
 #define D_ON "Marche"
 #define D_ONLINE "Connecté"
@@ -281,7 +283,7 @@
 
 #define D_MQTT_PARAMETERS "Paramètres MQTT"
 #define D_CLIENT "Client"
-#define D_FULL_TOPIC "topic complet"
+#define D_FULL_TOPIC "Topic complet"
 
 #define D_LOGGING_PARAMETERS "Paramètres du journal"
 #define D_SERIAL_LOG_LEVEL "Niveau de journalisation série"
@@ -688,7 +690,7 @@
 #define D_CHECKING        "En test"
 #define D_WORKING         "En marche"
 #define D_FAILURE         "Défault"
-#define D_SOLAX_ERROR_0   "Aucun Code d'erreur"
+#define D_SOLAX_ERROR_0   "Aucun code d'erreur"
 #define D_SOLAX_ERROR_1   "Défaut Perte de réseau"
 #define D_SOLAX_ERROR_2   "Défaut Tension réseau"
 #define D_SOLAX_ERROR_3   "Défaut Fréquence réseau"

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -75,6 +75,8 @@
 #define D_COUNT "סופר"
 #define D_COUNTER "מונה"
 #define D_CURRENT "נוכחי"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "נתונים"
 #define D_DARKLIGHT "חושך"
 #define D_DEBUG "באגים"
@@ -119,6 +121,7 @@
 #define D_NONE "כלום"
 #define D_OFF "כבוי"
 #define D_OFFLINE "מנותק"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "אוקיי"
 #define D_ON "פועל"
 #define D_ONLINE "מחובר"

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Szám"
 #define D_COUNTER "Számláló"
 #define D_CURRENT "Áramerősség"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Adat"
 #define D_DARKLIGHT "Min. fényerő"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "nincs"
 #define D_OFF "Ki"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "OK"
 #define D_ON "Be"
 #define D_ONLINE "Online"

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Conteggio"
 #define D_COUNTER "Contatore"
 #define D_CURRENT "Corrente"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Dati"
 #define D_DARKLIGHT "Scuro"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Nessuno"
 #define D_OFF "Off"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "On"
 #define D_ONLINE "Online"

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -75,6 +75,7 @@
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Counter"
 #define D_CURRENT "전류"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "어둡게"
 #define D_DEBUG "디버그"
@@ -119,6 +120,7 @@
 #define D_NONE "없음"
 #define D_OFF "꺼짐"
 #define D_OFFLINE "오프라인"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "켜짐"
 #define D_ONLINE "온라인"

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -75,6 +75,7 @@
 #define D_CORS_DOMAIN "CORS Domain"
 #define D_COUNTER "Teller"
 #define D_CURRENT "Stroom"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Donker"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Geen"
 #define D_OFF "Uit"
 #define D_OFFLINE "Offline"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "Aan"
 #define D_ONLINE "Online"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Licz"
 #define D_COUNTER "Licznik"
 #define D_CURRENT "Prąd"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Ciemny"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Brak"
 #define D_OFF "Wyłączony"
 #define D_OFFLINE "Nieaktywny"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "Załączony"
 #define D_ONLINE "Aktywny"

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corrente"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Dados"
 #define D_DARKLIGHT "Luz escura"
 #define D_DEBUG "Depurar"
@@ -119,6 +120,7 @@
 #define D_NONE "Nenhum"
 #define D_OFF "Desligado"
 #define D_OFFLINE "Desconectado"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "Ligado"
 #define D_ONLINE "Conectado"

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Contagem"
 #define D_COUNTER "Contador"
 #define D_CURRENT "Corrente"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Dados"
 #define D_DARKLIGHT "Luz Escura"
 #define D_DEBUG "Depurar"
@@ -119,6 +120,7 @@
 #define D_NONE "Nenhum"
 #define D_OFF "Off"
 #define D_OFFLINE "Desconetado"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "On"
 #define D_ONLINE "Conetado"

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Подсчет"
 #define D_COUNTER "Счетчик"
 #define D_CURRENT "Ток"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Данные"
 #define D_DARKLIGHT "Темный"
 #define D_DEBUG "Отладка"
@@ -119,6 +120,7 @@
 #define D_NONE "Нет"
 #define D_OFF "Выкл"
 #define D_OFFLINE "Офф-лайн"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ок"
 #define D_ON "Вкл"
 #define D_ONLINE "Он-лайн"

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Počítaj"
 #define D_COUNTER "Počítadlo"
 #define D_CURRENT "Prúd"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Dáta"
 #define D_FLOW_RATE "Flow rate"
 #define D_DARKLIGHT "Tmavý"
@@ -119,6 +120,7 @@
 #define D_NONE "Žiadny"
 #define D_OFF "Vyp."
 #define D_OFFLINE "Neaktívny"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "OK"
 #define D_ON "Zap."
 #define D_ONLINE "Aktívny"

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Räkna"
 #define D_COUNTER "Räknare"
 #define D_CURRENT "Ström"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Mörkt"
 #define D_DEBUG "Debug"
@@ -119,6 +120,7 @@
 #define D_NONE "Ingen"
 #define D_OFF "Av"
 #define D_OFFLINE "Off-line"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ok"
 #define D_ON "På"
 #define D_ONLINE "Ansluten"

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Sayı"
 #define D_COUNTER "Sayaç"
 #define D_CURRENT "Current"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Data"
 #define D_DARKLIGHT "Karanlık"
 #define D_DEBUG "Hata Ayıklama"
@@ -119,6 +120,7 @@
 #define D_NONE "None"
 #define D_OFF "Off"
 #define D_OFFLINE "Çevirimdışı"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Tamam"
 #define D_ON "On"
 #define D_ONLINE "Çevirimiçi"

--- a/tasmota/language/uk-UK.h
+++ b/tasmota/language/uk-UK.h
@@ -75,6 +75,7 @@
 #define D_COUNT "Розмір"
 #define D_COUNTER "Лічильник"
 #define D_CURRENT "Струм"           // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "Дані"
 #define D_DARKLIGHT "Темний"
 #define D_DEBUG "Налагодження"
@@ -119,6 +120,7 @@
 #define D_NONE "Нічого"
 #define D_OFF "Вимк."
 #define D_OFFLINE "Офф-лайн"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "Ок"
 #define D_ON "Увімк."
 #define D_ONLINE "Он-лайн"

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -75,6 +75,7 @@
 #define D_COUNT "数量:"
 #define D_COUNTER "计数器"
 #define D_CURRENT "电流"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "数据:"
 #define D_DARKLIGHT "暗"
 #define D_DEBUG "调试"
@@ -119,6 +120,7 @@
 #define D_NONE "无"
 #define D_OFF "关"
 #define D_OFFLINE "离线"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "好"
 #define D_ON "开"
 #define D_ONLINE "在线"

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -75,6 +75,7 @@
 #define D_COUNT "數量:"
 #define D_COUNTER "Counter"
 #define D_CURRENT "電流"          // As in Voltage and Current
+#define D_CYCLES "Cycles: Boot,Wifi,MQTT"
 #define D_DATA "數據:"
 #define D_DARKLIGHT "Dark"
 #define D_DEBUG "除錯"
@@ -119,6 +120,7 @@
 #define D_NONE "無"
 #define D_OFF "關"
 #define D_OFFLINE "離線"
+#define D_OFFLINE_COUNT "Offline duration"
 #define D_OK "好"
 #define D_ON "開"
 #define D_ONLINE "在線"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1423,6 +1423,13 @@ void CmndTeleperiod(void)
 void CmndReset(void)
 {
   switch (XdrvMailbox.payload) {
+  case 0:       // Only reset cycling counters (Boot, Wifi, Mqtt), Uptime and Wifi down time
+    Settings.bootcount = 0;
+    WifiResetStats();
+    MqttResetStats();
+    ClrUpTime();
+    ResponseCmndChar(D_JSON_RESET_DOWN_STATS);
+    break;
   case 1:
     restart_flag = 211;
     ResponseCmndChar(D_JSON_RESET_AND_RESTARTING);

--- a/tasmota/support_rtc.ino
+++ b/tasmota/support_rtc.ino
@@ -240,6 +240,12 @@ String GetUptime(void)
   return GetDuration(UpTime());
 }
 
+void ClrUpTime(void)
+{
+  Rtc.restart_time = Rtc.utc_time;
+  uptime = 0;               // sonoff.ino variable
+}
+
 uint32_t MinutesPastMidnight(void)
 {
   uint32_t minutes = 0;

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -326,6 +326,13 @@ String WifiDowntime(void)
   return GetDuration(Wifi.downtime);
 }
 
+void WifiResetStats(void)
+{
+  Wifi.last_event = UpTime();
+  Wifi.downtime = 0;
+  Wifi.link_count = 0;  
+}
+
 void WifiSetState(uint8_t state)
 {
   if (state == global_state.wifi_down) {

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1977,8 +1977,9 @@ void HandleInformation(void)
   WSContentSend_P(PSTR("}1" D_BUILD_DATE_AND_TIME "}2%s"), GetBuildDateAndTime().c_str());
   WSContentSend_P(PSTR("}1" D_CORE_AND_SDK_VERSION "}2" ARDUINO_ESP8266_RELEASE "/%s"), ESP.getSdkVersion());
   WSContentSend_P(PSTR("}1" D_UPTIME "}2%s"), GetUptime().c_str());
+  WSContentSend_P(PSTR("}1" D_OFFLINE_COUNT "}2%s"), WifiDowntime().c_str());
   WSContentSend_P(PSTR("}1" D_FLASH_WRITE_COUNT "}2%d at 0x%X"), Settings.save_flag, GetSettingsAddress());
-  WSContentSend_P(PSTR("}1" D_BOOT_COUNT "}2%d"), Settings.bootcount);
+  WSContentSend_P(PSTR("}1" D_CYCLES "}2(%d,%d,%d)"), Settings.bootcount, WifiLinkCount(), MqttConnectCount());
   WSContentSend_P(PSTR("}1" D_RESTART_REASON "}2%s"), GetResetReason().c_str());
   uint32_t maxfn = (devices_present > MAX_FRIENDLYNAMES) ? MAX_FRIENDLYNAMES : devices_present;
 #ifdef USE_SONOFF_IFAN

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -498,6 +498,11 @@ uint16_t MqttConnectCount(void)
   return Mqtt.connect_count;
 }
 
+void MqttResetStats(void)
+{
+  Mqtt.connect_count = 0;
+}
+
 void MqttDisconnected(int state)
 {
   Mqtt.connected = false;


### PR DESCRIPTION
## Description:
When `reset 99` feature appeared in v6.6.0.10, I smiled because I had had the same need and already implemented this locally with some extends.
Then I propose you `reset 0` to reset boot count but also Wifi disconnect and MQTT diconnect counts, it's coupled with a change in the WebUI Info page to gather in the same place those 3 counters and shows the offline duration too.
It's really handy to monitor the health of tasmota devices, issue a global MQTT `reset 0` and compare counts between devices. 
Here is the result in the WebUI info page , a reset 0 will clear those counters :  

<img src="https://user-images.githubusercontent.com/33861984/70717294-5742a100-1cee-11ea-8e91-37ce1f826174.png" size=150>   

I compiled all Tasmota flavors successfully so no language was missed.

The code size cost is 144 bytes that may be optimized if merged wit reset 99.

## Checklist:
  - [✓] The pull request is done against the latest dev branch
  - [✓] Only relevant files were touched
  - [✓] Only one feature/fix was added per PR.
  - [✓] The code change is tested and works on core 2.6.1
  - [✓] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [✓] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
