### PR TITLE
separate relay and switch of a device 

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1302,12 +1302,14 @@ void GpioInit(void)
   for (uint32_t i = 0; i < MAX_RELAYS; i++) {
     if (pin[GPIO_REL1 +i] < 99) {
       pinMode(pin[GPIO_REL1 +i], OUTPUT);
-      devices_present++;
+      devices_present=i+1;   // highest relay or switch numer defines devices present
       if (EXS_RELAY == my_module_type) {
         digitalWrite(pin[GPIO_REL1 +i], bitRead(rel_inverted, i) ? 1 : 0);
         if (i &1) { devices_present--; }
       }
     }
+    if (pin[GPIO_SWT1 +i] < 99) {
+      devices_present=i+1;   // highest relay or switch numer defines devices present.    
   }
 
   for (uint32_t i = 0; i < MAX_LEDS; i++) {

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1308,7 +1308,7 @@ void GpioInit(void)
         if (i &1) { devices_present--; }
       }
     }
-    if (pin[GPIO_SWT1 +i] < 99) {
+    if (pin[GPIO_SWT1 +i] < 99) 
       devices_present=i+1;   // highest relay or switch numer defines devices present.    
   }
 

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1123,7 +1123,7 @@ void HandleRoot(void)
         }
 #endif  // USE_SHUTTER
         snprintf_P(stemp, sizeof(stemp), PSTR(" %d"), idx);
-        if(pin[GPIO_REL1 + idx-1] < 99) {   // only display relays        
+        if(pin[GPIO_REL1 + idx-1] < 99)    // only display relays        
           WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / devices_present, idx, (devices_present < 5) ? D_BUTTON_TOGGLE : "", (devices_present > 1) ? stemp : "");
       }
 #ifdef USE_SONOFF_IFAN

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1123,7 +1123,8 @@ void HandleRoot(void)
         }
 #endif  // USE_SHUTTER
         snprintf_P(stemp, sizeof(stemp), PSTR(" %d"), idx);
-        WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / devices_present, idx, (devices_present < 5) ? D_BUTTON_TOGGLE : "", (devices_present > 1) ? stemp : "");
+        if(pin[GPIO_REL1 + idx-1] < 99) {   // only display relays        
+          WSContentSend_P(HTTP_DEVICE_CONTROL, 100 / devices_present, idx, (devices_present < 5) ? D_BUTTON_TOGGLE : "", (devices_present > 1) ? stemp : "");
       }
 #ifdef USE_SONOFF_IFAN
     }


### PR DESCRIPTION
## Description:
Minor changes to  to use the switch of a device separate from the relay.
The relay can be adressed separate from the switch

To use this feature create a template where switch and relay have different index numbers.

Tested on shelly1 and shelly2.5

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
