### PR TITLE
prepare for other modules to use shutter. endstop fixes

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -494,6 +494,24 @@
     #define D_JSON_MOTOR_MIS "setMIS"
   #endif
 
+  // Commands xdrv_27_Shutter.ino
+  #ifdef USE_SHUTTER
+    #define D_PRFX_SHUTTER "Shutter"
+    #define D_CMND_SHUTTER_OPEN "Open"
+    #define D_CMND_SHUTTER_CLOSE "Close"
+    #define D_CMND_SHUTTER_STOP "Stop"
+    #define D_CMND_SHUTTER_POSITION "Position"
+    #define D_CMND_SHUTTER_OPENTIME "OpenDuration"
+    #define D_CMND_SHUTTER_CLOSETIME "CloseDuration"
+    #define D_CMND_SHUTTER_RELAY "Relay"
+    #define D_CMND_SHUTTER_SETHALFWAY "SetHalfway"
+    #define D_CMND_SHUTTER_SETCLOSE "SetClose"
+    #define D_CMND_SHUTTER_INVERT "Invert"
+    #define D_CMND_SHUTTER_CLIBRATION "Calibration"
+    #define D_CMND_SHUTTER_MOTORDELAY "MotorDelay"
+    #define D_CMND_SHUTTER_FREQUENCY "Frequency"
+  #endif
+
 /********************************************************************************************/
 
 // Log message prefix

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -214,7 +214,7 @@ void ShutterInit(void)
       dtostrfd((float)Shutter.open_time[i] / 10 , 1, shutter_open_chr);
       char shutter_close_chr[10];
       dtostrfd((float)Shutter.close_time[i] / 10, 1, shutter_close_chr);
-      AddLog_P2(LOG_LEVEL_INFO, PSTR("SHT: Shutter %d (Relay:%d): Init. Pos: %d [%d %%], Open Vel.: 100 Close Vel.: %d , Max Way: %d, Opentime %s [s], Closetime %s [s], CoedffCalc: c0: %d, c1 %d, c2: %d, c3: %d, c4: %d, binmask %d, is inverted %d, shuttermode %d,motordelay %d"),
+      AddLog_P2(LOG_LEVEL_INFO, PSTR("SHT: Shutter %d (Relay:%d): Init. Pos: %d [%d %%], Open Vel.: 100 Close Vel.: %d , Max Way: %d, Opentime %s [s], Closetime %s [s], CoeffCalc: c0: %d, c1 %d, c2: %d, c3: %d, c4: %d, binmask %d, is inverted %d, shuttermode %d,motordelay %d"),
         i+1, Settings.shutter_startrelay[i], Shutter.real_position[i], Settings.shutter_position[i], Shutter.close_velocity[i], Shutter.open_max[i], shutter_open_chr, shutter_close_chr,
         Settings.shuttercoeff[0][i], Settings.shuttercoeff[1][i], Settings.shuttercoeff[2][i], Settings.shuttercoeff[3][i], Settings.shuttercoeff[4][i],
         Shutter.mask, Settings.shutter_invert[i], Shutter.mode, Shutter.motordelay[i]);


### PR DESCRIPTION
## Description:
- moved definition to main (i18n) to allow other modules to use shutters.
- secure manually changing relays will not overrun end positions.
- fixed variable underflow in rare situations.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [ x] The code change is tested and works on core 2.6.1
  - [ x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
