### PR TITLE
Allow to disable SNTP when using TIME <epoch>

### DIFF
--- a/tasmota/support_rtc.ino
+++ b/tasmota/support_rtc.ino
@@ -460,7 +460,9 @@ void RtcSetTime(uint32_t epoch)
   if (epoch < START_VALID_TIME) {  // 2016-01-01
     Rtc.user_time_entry = false;
     ntp_force_sync = true;
+    sntp_init();
   } else {
+    sntp_stop();
     Rtc.user_time_entry = true;
     Rtc.utc_time = epoch -1;    // Will be corrected by RtcSecond
   }


### PR DESCRIPTION
## Description:

When Tasmota is on a network without access to NTP, and, as an option, is used the command `TIME <epoch>` in order to disable NTP Sync and to use just internal RTC (in order to be able to use timers and rules) the NTP requests continue to being performed but not used internally. This PR aims to disable also the SNTP library when using this offline method, and to reenable SNTP when executing `TIME 0` command.

This also serves as a workaround for now, if there is no NTP and there are restarts with exception 29. The user can set the time in Tasmota until he/she fixes its NTP network issue. Those exceptions come from _sntp.c_ from the arduino core. More investigation is required to find the issue and report it properly.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
