### PR TITLE
Fix Zigbee crash #7187

### DIFF
--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -614,9 +614,10 @@ void CmndZigbeeRead(void) {
     }
   }
 
- ZigbeeZCLSend(device, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, attrs, attrs_len, false /* we do want a response */);
+  ZigbeeZCLSend(device, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, attrs, attrs_len, false /* we do want a response */);
 
- if (attrs) { delete[] attrs; }
+  if (attrs) { delete[] attrs; }
+  ResponseCmndDone();
 }
 
 // Allow or Deny pairing of new Zigbee devices

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -235,13 +235,14 @@ void ZigbeeInit(void)
  * Commands
 \*********************************************************************************************/
 
-uint32_t strToUInt(const JsonVariant val) {
+uint32_t strToUInt(const JsonVariant &val) {
   // if the string starts with 0x, it is considered Hex, otherwise it is an int
   if (val.is<unsigned int>()) {
     return val.as<unsigned int>();
   } else {
-    if (val.is<char*>()) {
-      return strtoull(val.as<char*>(), nullptr, 0);
+    if (val.is<const char*>()) {
+      String sval = val.as<String>();
+      return strtoull(sval.c_str(), nullptr, 0);
     }
   }
   return 0;   // couldn't parse anything
@@ -593,6 +594,7 @@ void CmndZigbeeRead(void) {
 
   const JsonVariant &val_attr = getCaseInsensitive(json, PSTR("Read"));
   if (nullptr != &val_attr) {
+    uint16_t val = strToUInt(val_attr);
     if (val_attr.is<JsonArray>()) {
       JsonArray& attr_arr = val_attr;
       attrs_len = attr_arr.size() * 2;
@@ -604,11 +606,9 @@ void CmndZigbeeRead(void) {
         attrs[i++] = val & 0xFF;
         attrs[i++] = val >> 8;
       }
-
     } else {
       attrs_len = 2;
       attrs = new uint8_t[attrs_len];
-      uint16_t val = strToUInt(val_attr);
       attrs[0] = val & 0xFF;    // little endian
       attrs[1] = val >> 8;
     }


### PR DESCRIPTION
## Description:

Weird crash due to ArduinoJson having an erratic behavior. It seems that calling `val.is<JsonArray>()` then corrupts the behavior of `val.is<unsigned int>()`.

I have inverted the calls, first trying to convert the `JsonVariant` to an int, and checking if it's an array afterwards.

Also corrected added `ResponseCmndDone()` to `ZigbeeRead` to avoid falsely reporting errors.

**Related issue (if applicable):** fixes #7187 
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
