### PR TITLE
Add Zigbee send automatic ZigbeeRead after sending a command

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.1.2.6 20191214
 
 - Change some more Settings locations freeing up space for future single char allowing variable length text
+- Add Zigbee send automatic ZigbeeRead after sending a command
 
 ### 7.1.2.5 20191213
 

--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -19,8 +19,6 @@
 
 #ifdef USE_ZIGBEE
 
-#define ZIGBEE_VERBOSE      // output versbose MQTT Zigbee logs. Will remain active for now
-
 typedef uint64_t Z_IEEEAddress;
 typedef uint16_t Z_ShortAddress;
 

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -1,0 +1,26 @@
+/*
+  xdrv_23_zigbee_1_headers.ino - zigbee support for Tasmota
+
+  Copyright (C) 2019  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+// contains some definitions for functions used before their declarations
+
+void ZigbeeZCLSend(uint16_t dtsAddr, uint16_t clusterId, uint8_t endpoint, uint8_t cmdId, bool clusterSpecific, const uint8_t *msg, size_t len, bool disableDefResp = true, uint8_t transacId = 1);
+
+#endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -53,7 +53,6 @@ public:
                            uint8_t srcendpoint, uint8_t dstendpoint, uint8_t wasbroadcast,
                            uint8_t linkquality, uint8_t securityuse, uint8_t seqnumber,
                            uint32_t timestamp) {
-#ifdef ZIGBEE_VERBOSE
     char hex_char[_payload.len()*2+2];
 		ToHex_P((unsigned char*)_payload.getBuffer(), _payload.len(), hex_char, sizeof(hex_char));
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR("{\"" D_JSON_ZIGBEEZCL_RECEIVED "\":{"
@@ -69,7 +68,6 @@ public:
                     timestamp,
                     _frame_control, _manuf_code, _transact_seq, _cmd_id,
                     hex_char);
-#endif
   }
 
   static ZCLFrame parseRawFrame(const SBuffer &buf, uint8_t offset, uint8_t len, uint16_t clusterid, uint16_t groupid) { // parse a raw frame and build the ZCL frame object
@@ -497,7 +495,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { 0x0007, 0x0000,  "SwitchType",           &Z_Copy },
 
   // Level Control cluster
-  { 0x0008, 0x0000,  "CurrentLevel",         &Z_Copy },
+  { 0x0008, 0x0000,  "Dimmer",               &Z_Copy },
   // { 0x0008, 0x0001,  "RemainingTime",        &Z_Copy },
   // { 0x0008, 0x0010,  "OnOffTransitionTime",  &Z_Copy },
   // { 0x0008, 0x0011,  "OnLevel",              &Z_Copy },
@@ -652,14 +650,14 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { 0x0102, 0x0019,  "IntermediateSetpointsTilt",&Z_Copy },
 
   // Color Control cluster
-  { 0x0300, 0x0000,  "CurrentHue",           &Z_Copy },
-  { 0x0300, 0x0001,  "CurrentSaturation",    &Z_Copy },
+  { 0x0300, 0x0000,  "Hue",                  &Z_Copy },
+  { 0x0300, 0x0001,  "Sat",                  &Z_Copy },
   { 0x0300, 0x0002,  "RemainingTime",        &Z_Copy },
-  { 0x0300, 0x0003,  "CurrentX",             &Z_Copy },
-  { 0x0300, 0x0004,  "CurrentY",             &Z_Copy },
+  { 0x0300, 0x0003,  "X",                    &Z_Copy },
+  { 0x0300, 0x0004,  "Y",                    &Z_Copy },
   { 0x0300, 0x0005,  "DriftCompensation",    &Z_Copy },
   { 0x0300, 0x0006,  "CompensationText",     &Z_Copy },
-  { 0x0300, 0x0007,  "ColorTemperatureMireds",&Z_Copy },
+  { 0x0300, 0x0007,  "CT",                   &Z_Copy },
   { 0x0300, 0x0008,  "ColorMode",            &Z_Copy },
   { 0x0300, 0x0010,  "NumberOfPrimaries",    &Z_Copy },
   { 0x0300, 0x0011,  "Primary1X",            &Z_Copy },

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -372,12 +372,10 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
   zigbee_devices.updateLastSeen(srcaddr);
   ZCLFrame zcl_received = ZCLFrame::parseRawFrame(buf, 19, buf.get8(18), clusterid, groupid);
 
-#ifdef ZIGBEE_VERBOSE
   zcl_received.publishMQTTReceived(groupid, clusterid, srcaddr,
                                   srcendpoint, dstendpoint, wasbroadcast,
                                   linkquality, securityuse, seqnumber,
                                   timestamp);
-#endif
 
   char shortaddr[8];
   snprintf_P(shortaddr, sizeof(shortaddr), PSTR("0x%04X"), srcaddr);


### PR DESCRIPTION
## Description:

As requested in #7187, Z2T now automatically sends a `ZigbeeRead` after a command to read back the actual value. The delay before sending the `ZigbeeRead` will depend on the command:

- On/Off: waits 0.2s
- Lights: waits 1.05 s (as fading is default to 1s)
- Shutters: waits 10.0 s

Example: (Philips Hue Zigbee bulb)
```
ZigbeeSend { "device":"0x3D82", "endpoint":"0x0B", "send":{"Power":"Toggle"} }
16:05:23 CMD: ZigbeeSend { "device":"0x3D82", "endpoint":"0x0B", "send":{"Power":"Toggle"} }
16:05:23 MQT: stat/tasmota/Zigbee_home/RESULT = {"ZigbeeSend":"Done"}
16:05:24 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x3D82":{"Power":false,"LinkQuality":23}}}

ZigbeeSend { "device":"0x3D82", "endpoint":"0x0B", "send":{"Dimmer":128} }
16:05:49 CMD: ZigbeeSend { "device":"0x3D82", "endpoint":"0x0B", "send":{"Dimmer":128} }
16:05:49 MQT: stat/tasmota/Zigbee_home/RESULT = {"ZigbeeSend":"Done"}
16:05:51 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x3D82":{"Dimmer":128,"LinkQuality":26}}}
```

**Related issue (if applicable):** fixes #7187 
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
