### PR TITLE
PubSubClient: Allow clean disconnection as optional.

### DIFF
--- a/lib/PubSubClient-EspEasy-2.7.12/src/PubSubClient.cpp
+++ b/lib/PubSubClient-EspEasy-2.7.12/src/PubSubClient.cpp
@@ -610,11 +610,13 @@ boolean PubSubClient::unsubscribe(const char* topic) {
     return false;
 }
 
-void PubSubClient::disconnect() {
+void PubSubClient::disconnect(bool disconnect_package) {
     buffer[0] = MQTTDISCONNECT;
     buffer[1] = 0;
     if (_client != nullptr) {
-      _client->write(buffer,2);
+      if (disconnect_package) {
+        _client->write(buffer,2);
+      }
       _client->flush();
       _client->stop();
     }

--- a/lib/PubSubClient-EspEasy-2.7.12/src/PubSubClient.h
+++ b/lib/PubSubClient-EspEasy-2.7.12/src/PubSubClient.h
@@ -141,7 +141,7 @@ public:
    boolean connect(const char* id, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage);
    boolean connect(const char* id, const char* user, const char* pass, const char* willTopic, uint8_t willQos, boolean willRetain, const char* willMessage, boolean cleanSession);
-   void disconnect();
+   void disconnect(bool disconnect_package = false);
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);
    boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);


### PR DESCRIPTION
## Description:

**PubSubClient Library**: Allow clean disconnection as optional.

This avoid the automatic deletion of the LWT message in the MQTT broker for clean disconnections in order to let LWT to work on all disconnections cases (Wifi disconnection, wifi bad comms, Normal Restart, Config Changes, unintended or intentional crash, OTA updates, ArduinoOTA, etc) and showing the Tasmota device as OFF-LINE in the home automation software until it reconnects and the LWT with ONLINE is sent again.

**Related issue (if applicable):** fixes #7189

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
