### PR TITLE
scripter FUNC_SET_POWER into separate section >P

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1030,8 +1030,10 @@ char *isvar(char *lp, uint8_t *vtype,struct T_INDEX *tind,float *fp,char *sp,Jso
             if ((*jo).is<char*>(vn)) {
               if (!strncmp(str_value,"ON",2)) {
                 if (fp) *fp=1;
+                goto nexit;
               } else if (!strncmp(str_value,"OFF",3)) {
                 if (fp) *fp=0;
+                goto nexit;
               } else {
                 *vtype=STR_RES;
                 tind->bits.constant=1;
@@ -1039,6 +1041,7 @@ char *isvar(char *lp, uint8_t *vtype,struct T_INDEX *tind,float *fp,char *sp,Jso
                 if (sp) strlcpy(sp,str_value,SCRIPT_MAXSSIZE);
                 return lp+len;
               }
+
             } else {
               if (fp) {
                 if (!strncmp(vn.c_str(),"Epoch",5)) {
@@ -1047,6 +1050,7 @@ char *isvar(char *lp, uint8_t *vtype,struct T_INDEX *tind,float *fp,char *sp,Jso
                   *fp=CharToFloat((char*)str_value);
                 }
               }
+              nexit:
               *vtype=NUM_RES;
               tind->bits.constant=1;
               tind->bits.is_string=0;
@@ -4843,6 +4847,12 @@ bool Xdrv10(uint8_t function)
       result = ScriptCommand();
       break;
     case FUNC_SET_POWER:
+#ifdef SCRIPT_POWER_SECTION
+      if (bitRead(Settings.rule_enabled, 0)) Run_Scripter(">P",2,0);
+#else
+      if (bitRead(Settings.rule_enabled, 0)) Run_Scripter(">E",2,0);
+#endif
+      break;
     case FUNC_RULES_PROCESS:
       if (bitRead(Settings.rule_enabled, 0)) Run_Scripter(">E",2,mqtt_data);
       break;


### PR DESCRIPTION
## Description:

FUNC_SET_POWER now has optional (#define SCRIPT_POWER_SECTION) separate section >P
in stead of >E 

FUNC_SET_POWER calls >P (no JSON)
FUNC_RULES_PROCESS calls >E (with JSON)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).