### PR TITLE
setting pinMode for the pin used by RFRecv to INPUT

### DIFF
--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -85,6 +85,7 @@ void RfInit(void)
     mySwitch.enableTransmit(pin[GPIO_RFSEND]);
   }
   if (pin[GPIO_RFRECV] < 99) {
+    pinMode( pin[GPIO_RFRECV], INPUT);
     mySwitch.enableReceive(pin[GPIO_RFRECV]);
   }
 }


### PR DESCRIPTION
## Description:
After a certain version receiving RF stopped working, what looks like is a problm due to not set pin to INPUT.
**RFrecv stopped working:** fixes  #6776

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
