### PR TITLE
KNX: Fix compilation issue when using KNX on Tasmota-IR firmware type

### DIFF
--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -499,6 +499,7 @@ void KNX_INIT(void)
   if (GetUsedInModule(GPIO_DHT22, my_module.io)) { device_param[KNX_HUMIDITY-1].show = true; }
   if (GetUsedInModule(GPIO_SI7021, my_module.io)) { device_param[KNX_HUMIDITY-1].show = true; }
 
+#if defined(USE_ENERGY_SENSOR)
   // Any device with a Power Monitoring
   if ( energy_flg != ENERGY_NONE ) {
     device_param[KNX_ENERGY_POWER-1].show = true;
@@ -509,6 +510,7 @@ void KNX_INIT(void)
     device_param[KNX_ENERGY_CURRENT-1].show = true;
     device_param[KNX_ENERGY_POWERFACTOR-1].show = true;
   }
+#endif
 
 #ifdef USE_RULES
   device_param[KNX_SLOT1-1].show = true;


### PR DESCRIPTION
## Description:

KNX: Fix compilation issue when using KNX on Tasmota-IR firmware type

**Related issue (if applicable):** fixes @effelle report on Discord

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
