### PR TITLE
Adding build environment with shutter functionality enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - ENV=tasmota-lite
   - ENV=tasmota-knx
   - ENV=tasmota-sensors
+  - ENV=tasmota-shutter
   - ENV=tasmota-display
   - ENV=tasmota-ir
   - ENV=tasmota-BG

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -22,6 +22,7 @@ default_envs =
 ;                tasmota-lite
 ;                tasmota-knx
 ;                tasmota-sensors
+;                tasmota-shutter
 ;                tasmota-display
 ;                tasmota-ir
 
@@ -36,6 +37,7 @@ build_flags               = ${core_active.build_flags}
 ; *** Optional Firmware configurations
 ;                            -DFIRMWARE_MINIMAL
 ;                            -DFIRMWARE_SENSORS
+;                            -DFIRMWARE_SHUTTER
 ;                            -DFIRMWARE_LITE
 ;                            -DFIRMWARE_KNX_NO_EMULATION
 ;                            -DFIRMWARE_DISPLAYS

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -27,6 +27,9 @@ build_flags = ${common.build_flags} -DFIRMWARE_KNX_NO_EMULATION
 [env:tasmota-sensors]
 build_flags = ${common.build_flags} -DFIRMWARE_SENSORS
 
+[env:tasmota-shutter]
+build_flags = ${common.build_flags} -DFIRMWARE_SHUTTER
+
 [env:tasmota-display]
 build_flags = ${common.build_flags} -DFIRMWARE_DISPLAYS
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -572,6 +572,7 @@
 
 //#define FIRMWARE_LITE                            // Create tasmota-lite with no sensors
 //#define FIRMWARE_SENSORS                         // Create tasmota-sensors with useful sensors enabled
+//#define FIRMWARE_SHUTTER                         // Create tasmota-shutter with shutter function enabled
 //#define FIRMWARE_KNX_NO_EMULATION                // Create tasmota-knx with KNX but without Emulation
 //#define FIRMWARE_DISPLAYS                        // Create tasmota-display with display drivers enabled
 //#define FIRMWARE_IR                              // Create tasmota-ir with IR full protocols activated, and many sensors disabled

--- a/tasmota/tasmota_post.h
+++ b/tasmota/tasmota_post.h
@@ -215,6 +215,17 @@ char* ToHex_P(const unsigned char * in, size_t insz, char * out, size_t outsz, c
 #endif  // FIRMWARE_SENSORS
 
 /*********************************************************************************************\
+ * [tasmota-shutter.bin]
+ * Provide an image with shutter function enabled
+\*********************************************************************************************/
+
+#ifdef FIRMWARE_SHUTTER
+
+#define USE_SHUTTER                               // Enable Shutter support for up to 4 shutter with different motortypes (+6k code)
+
+#endif  // FIRMWARE_SHUTTER
+
+/*********************************************************************************************\
  * [tasmota-knx.bin]
  * Provide a dedicated KNX image allowing enough code and memory space
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:

Since the stefanbode's Shutter functionality is integrated in Tasmota, I really missed the option of using a precompiled binary for quickly updating my shutter switches. I therefore made this pull request adding a new build template using the standard 'tasmota' build with the added Shutter option enabled.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
