### PR TITLE
Zigbee aqara switch, support for double/triple clicks

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -511,6 +511,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
 
   // On/off cluster
   { 0x0006, 0x0000,  "Power",                &Z_Copy },
+  { 0x0006, 0x8000,  "Power",                &Z_Copy },   // See 7280
 
   // On/Off Switch Configuration cluster
   { 0x0007, 0x0000,  "SwitchType",           &Z_Copy },


### PR DESCRIPTION
## Description:

Report `00006/8000` Aqara Switch proprietary attribute as `Power` attribute.

Possible values are: `false`/`true` (1 click), `2` (double click), `3` (triple click)

**Related issue (if applicable):** fixes #7280 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
