### PR TITLE
Fix AWS IoT won't compile

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1355,7 +1355,7 @@ void SettingsDelta(void)
       } else {
         char aws_mqtt_host[66];
         snprintf_P(aws_mqtt_host, sizeof(aws_mqtt_host), PSTR("%s%s"), temp9, temp7);
-        SettingsUpdateText(SET_MQTT_HOST, mqtt_host);
+        SettingsUpdateText(SET_MQTT_HOST, aws_mqtt_host);
         SettingsUpdateText(SET_MQTT_USER, "");
       }
 #else


### PR DESCRIPTION
## Description:

Fixing an issue that prevents AWS IoT to compile on v8.0.0.1

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
