### PR TITLE
Add Zigbee coalesce sensor attributes into a single message

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change max number of rule ``Mem``s from 5 to 16 (#4933)
 - Change max number of rule ``Var``s from 5 to 16 (#4933)
 - Add support for max 150 characters in most command parameter strings (#3686, #4754)
+- Add Zigbee coalesce sensor attributes into a single message
 
 ## Released
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -530,6 +530,7 @@
   #define USE_ZIGBEE_PRECFGKEY_L 0x0F0D0B0907050301L  // note: changing requires to re-pair all devices
   #define USE_ZIGBEE_PRECFGKEY_H 0x0D0C0A0806040200L  // note: changing requires to re-pair all devices
   #define USE_ZIGBEE_PERMIT_JOIN false           // don't allow joining by default
+  #define USE_ZIGBEE_COALESCE_ATTR_TIMER 350     // timer to coalesce attribute values (in ms)
 
 // -- Other sensors/drivers -----------------------
 

--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -19,6 +19,8 @@
 
 #ifdef USE_ZIGBEE
 
+#define OCCUPANCY "Occupancy"             // global define for Aqara
+
 typedef uint64_t Z_IEEEAddress;
 typedef uint16_t Z_ShortAddress;
 

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -23,4 +23,24 @@
 
 void ZigbeeZCLSend(uint16_t dtsAddr, uint16_t clusterId, uint8_t endpoint, uint8_t cmdId, bool clusterSpecific, const uint8_t *msg, size_t len, bool disableDefResp = true, uint8_t transacId = 1);
 
+
+// Get an JSON attribute, with case insensitive key search
+JsonVariant &getCaseInsensitive(const JsonObject &json, const char *needle) {
+  // key can be in PROGMEM
+  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
+    return *(JsonVariant*)nullptr;
+  }
+
+  for (auto kv : json) {
+    const char *key = kv.key;
+    JsonVariant &value = kv.value;
+
+    if (0 == strcasecmp_P(key, needle)) {
+      return value;
+    }
+  }
+  // if not found
+  return *(JsonVariant*)nullptr;
+}
+
 #endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_3_devices.ino
+++ b/tasmota/xdrv_23_zigbee_3_devices.ino
@@ -42,6 +42,9 @@ typedef struct Z_Device {
   uint16_t              endpoint;       // endpoint to use for timer
   uint32_t              value;          // any raw value to use for the timer
   Z_DeviceTimer         func;           // function to call when timer occurs
+  // json buffer used for attribute reporting
+  DynamicJsonBuffer    *json_buffer;
+  JsonObject           *json;
 } Z_Device;
 
 // All devices are stored in a Vector
@@ -83,6 +86,11 @@ public:
   void resetTimer(uint32_t shortaddr);
   void setTimer(uint32_t shortaddr, uint32_t wait_ms, uint16_t cluster, uint16_t endpoint, uint32_t value, Z_DeviceTimer func);
   void runTimer(void);
+
+  // Append or clear attributes Json structure
+  void jsonClear(uint16_t shortaddr);
+  void jsonAppend(uint16_t shortaddr, JsonObject &values);
+  const JsonObject *jsonGet(uint16_t shortaddr);
 
 private:
   std::vector<Z_Device> _devices = {};
@@ -173,7 +181,9 @@ Z_Device & Z_Devices::createDeviceEntry(uint16_t shortaddr, uint64_t longaddr) {
                       std::vector<uint32_t>(),
                       std::vector<uint32_t>(),
                       0,0,0,0,
-                      nullptr };
+                      nullptr,
+                      nullptr, nullptr };
+  device.json_buffer = new DynamicJsonBuffer();
   _devices.push_back(device);
   return _devices.back();
 }
@@ -394,14 +404,55 @@ void Z_Devices::runTimer(void) {
 
     uint32_t timer = device.timer;
     if ((timer) && (timer <= now)) {
+      device.timer = 0;       // cancel the timer before calling, so the callback can set another timer
       // trigger the timer
       (*device.func)(device.shortaddr, device.cluster, device.endpoint, device.value);
-
-      device.timer = 0;       // cancel the timer
     }
   }
 }
 
+void Z_Devices::jsonClear(uint16_t shortaddr) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (&device == nullptr) { return; }                 // don't crash if not found
+
+  device.json = nullptr;
+  device.json_buffer->clear();
+}
+
+void Z_Devices::jsonAppend(uint16_t shortaddr, JsonObject &values) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (&device == nullptr) { return; }                 // don't crash if not found
+  if (&values == nullptr) { return; }
+
+  if (nullptr == device.json) {
+    device.json = &(device.json_buffer->createObject());
+  }
+  // copy all values from 'values' to 'json'
+  for (auto kv : values) {
+    String key_string = kv.key;
+    const char * key = key_string.c_str();
+    JsonVariant &val = kv.value;
+
+    device.json->remove(key_string);    // force remove to have metadata like LinkQuality at the end
+
+    if (val.is<char*>()) {
+      String sval = val.as<String>();       // force a copy of the String value
+      device.json->set(key_string, sval);
+    } else if (val.is<JsonArray>()) {
+      // todo
+    } else if (val.is<JsonObject>()) {
+      // todo
+    } else {
+      device.json->set(key_string, kv.value);
+    }
+  }
+}
+
+const JsonObject *Z_Devices::jsonGet(uint16_t shortaddr) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (&device == nullptr) { return nullptr; }                 // don't crash if not found
+  return device.json;
+}
 
 // Dump the internal memory of Zigbee devices
 // Mode = 1: simple dump of devices addresses and names

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -423,25 +423,6 @@ void zigbeeZCLSendStr(uint16_t dstAddr, uint8_t endpoint, const char *data) {
   ResponseCmndDone();
 }
 
-// Get an JSON attribute, with case insensitive key search
-JsonVariant &getCaseInsensitive(const JsonObject &json, const char *needle) {
-  // key can be in PROGMEM
-  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
-    return *(JsonVariant*)nullptr;
-  }
-
-  for (auto kv : json) {
-    const char *key = kv.key;
-    JsonVariant &value = kv.value;
-
-    if (0 == strcasecmp_P(key, needle)) {
-      return value;
-    }
-  }
-  // if not found
-  return *(JsonVariant*)nullptr;
-}
-
 void CmndZigbeeSend(void) {
   // ZigbeeSend { "device":"0x1234", "endpoint":"0x03", "send":{"Power":1} }
   // ZigbeeSend { "device":"0x1234", "endpoint":"0x03", "send":{"Power":"3"} }


### PR DESCRIPTION
## Description:

Zigbee ZCL protocol limits to only one ZCL Cluster ID per message. Hence Aqara Temp sensor needs 3 messages to transfer temperature, humidity and pressure.

This PR waits for 350ms after each sensor value received and groups all attributes into a single MQTT message.

Example (before):

```
16:27:32 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x7C71":{"Temperature":20.97,"LinkQuality":142}}}
16:27:32 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x7C71":{"Humidity":49.81,"LinkQuality":138}}}
16:27:32 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x7C71":{"PressureUnit":"hPa","Pressure":977,"Scale":-1,"ScaledValue":9777,"LinkQuality":147}}}
```

After:
```
16:27:32 MQT: tele/tasmota/Zigbee_home/SENSOR = {"ZigbeeReceived":{"0x7C71":{"Temperature":20.97,"Humidity":49.81,"PressureUnit":"hPa","Pressure":977,"Scale":-1,"ScaledValue":9777,"LinkQuality":147}}}
```

Note: the maximum delay to group message is defined in `USE_ZIGBEE_COALESCE_ATTR_TIMER `

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
