### PR TITLE
Analog Moisture Sensor

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -99,6 +99,7 @@
 #define D_JSON_MEMORY_ERROR "Memory error"
 #define D_JSON_MINIMAL "minimal"
 #define D_JSON_MODEL "Model"
+#define D_JSON_MOISTURE "Moisture"
 #define D_JSON_MQTT_COUNT "MqttCount"
 #define D_JSON_NO "No"
 #define D_JSON_NOISE "Noise"
@@ -589,6 +590,7 @@ const char JSON_SNS_TEMP[] PROGMEM = ",\"%s\":{\"" D_JSON_TEMPERATURE "\":%s}";
 const char JSON_SNS_TEMPHUM[] PROGMEM = ",\"%s\":{\"" D_JSON_TEMPERATURE "\":%s,\"" D_JSON_HUMIDITY "\":%s}";
 
 const char JSON_SNS_ILLUMINANCE[] PROGMEM = ",\"%s\":{\"" D_JSON_ILLUMINANCE "\":%d}";
+const char JSON_SNS_MOISTURE[] PROGMEM = ",\"%s\":{\"" D_JSON_MOISTURE "\":%d}";
 
 const char JSON_SNS_GNGPM[] PROGMEM = ",\"%s\":{\"" D_JSON_TOTAL_USAGE "\":%s,\"" D_JSON_FLOWRATE "\":%s}";
 
@@ -618,6 +620,8 @@ const char HTTP_SNS_CO2[] PROGMEM = "{s}%s " D_CO2 "{m}%d " D_UNIT_PARTS_PER_MIL
 const char HTTP_SNS_CO2EAVG[] PROGMEM = "{s}%s " D_ECO2 "{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";  // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 const char HTTP_SNS_GALLONS[] PROGMEM = "{s}%s " D_TOTAL_USAGE "{m}%s " D_UNIT_GALLONS " {e}";    // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 const char HTTP_SNS_GPM[] PROGMEM = "{s}%s " D_FLOW_RATE "{m}%s " D_UNIT_GALLONS_PER_MIN" {e}";   // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+const char HTTP_SNS_MOISTURE[] PROGMEM = "{s}%s " D_MOISTURE "{m}%d %%{e}";                        // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+
 
 const char S_MAIN_MENU[] PROGMEM = D_MAIN_MENU;
 const char S_CONFIGURATION[] PROGMEM = D_CONFIGURATION;

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Светлина"
 #define D_LWT "LWT"
 #define D_MODULE "Модул"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "неколкократно натискане"
 #define D_NOISE "Шум"

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Světlo"
 #define D_LWT "LWT"
 #define D_MODULE "Modul"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "několikeré-stisknutí"
 #define D_NOISE "Hluk"

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Licht"
 #define D_LWT "LWT"
 #define D_MODULE "Modul"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "Mehrfachdruck"
 #define D_NOISE "Lautstärke"

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Φως"
 #define D_LWT "LWT"
 #define D_MODULE "Μονάδα"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "ανίχνευση για πολλαπλά πατήματα"
 #define D_NOISE "Θόρυβος"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Light"
 #define D_LWT "LWT"
 #define D_MODULE "Module"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-press"
 #define D_NOISE "Noise"

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Luz"
 #define D_LWT "LWT"
 #define D_MODULE "Módulo"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-press"
 #define D_NOISE "Ruido"

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Lumière"
 #define D_LWT "LWT"
 #define D_MODULE "Module"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-pression"
 #define D_NOISE "Bruit"

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "אור"
 #define D_LWT "LWT"
 #define D_MODULE "מודול"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "לחיצה מרובה"
 #define D_NOISE "רעש"

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Fény"
 #define D_LWT "LWT"
 #define D_MODULE "Modul"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "több lenyomás"
 #define D_NOISE "Zaj"

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Luce"
 #define D_LWT "LWT"
 #define D_MODULE "Modulo"
+#define D_MOISTURE "Umidità"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-pressione"
 #define D_NOISE "Rumore"

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "밝게"
 #define D_LWT "LWT"
 #define D_MODULE "모듈"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-press"
 #define D_NOISE "소음"

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Licht"
 #define D_LWT "LWT"
 #define D_MODULE "Module"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "meervoudig"
 #define D_NOISE "Lawaai"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Światło"
 #define D_LWT "LWT"
 #define D_MODULE "Moduł"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "Wielokrotne naciśnięcie"
 #define D_NOISE "Szum"

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Luz"
 #define D_LWT "LWT"
 #define D_MODULE "Módulo"
+#define D_MOISTURE "Umidade"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-pressão"
 #define D_NOISE "Ruído"

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Luz"
 #define D_LWT "LWT"
 #define D_MODULE "Módulo"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-pressão"
 #define D_NOISE "Ruído"

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Свет"
 #define D_LWT "LWT"
 #define D_MODULE "Модуль"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "многократное нажатие"
 #define D_NOISE "Шум"

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Svetlo"
 #define D_LWT "LWT"
 #define D_MODULE "Modul"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-stlačenie"
 #define D_NOISE "Hluk"

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Ljus"
 #define D_LWT "LWT"
 #define D_MODULE "Modul"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "fler tryck"
 #define D_NOISE "Oväsen"

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Işık"
 #define D_LWT "LWT"
 #define D_MODULE "Modül"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "multi-press"
 #define D_NOISE "Noise"

--- a/tasmota/language/uk-UK.h
+++ b/tasmota/language/uk-UK.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "Світло"
 #define D_LWT "LWT"
 #define D_MODULE "Модуль"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "Багаторазове натискання"
 #define D_NOISE "Шум"

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "灯"
 #define D_LWT "LWT"
 #define D_MODULE "模块"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "多次按键"
 #define D_NOISE "嘈杂"

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -113,6 +113,7 @@
 #define D_LIGHT "燈"
 #define D_LWT "LWT"
 #define D_MODULE "模組"
+#define D_MOISTURE "Moisture"
 #define D_MQTT "MQTT"
 #define D_MULTI_PRESS "多次按鍵"
 #define D_NOISE "雜訊"

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -313,6 +313,7 @@ enum UserSelectableAdc0 {
   ADC0_BUTTON_INV,
 //  ADC0_SWITCH,         // Switch
 //  ADC0_SWITCH_INV,
+  ADC0_MOIST,          // Moisture
   ADC0_END };
 
 // Programmer selectable ADC0 functionality
@@ -326,6 +327,7 @@ const char kAdc0Names[] PROGMEM =
   D_SENSOR_NONE "|" D_ANALOG_INPUT "|"
   D_TEMPERATURE "|" D_LIGHT "|"
   D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "i|"
+  D_MOISTURE "|"
 //  D_SENSOR_SWITCH "|" D_SENSOR_SWITCH "i|"
   ;
 

--- a/tasmota/xsns_02_analog.ino
+++ b/tasmota/xsns_02_analog.ino
@@ -66,6 +66,12 @@ void AdcInit(void)
       Settings.adc_param2 = ANALOG_LDR_LUX_CALC_SCALAR;
       Settings.adc_param3 = ANALOG_LDR_LUX_CALC_EXPONENT * 10000;
     }
+    else if (ADC0_MOIST == my_adc0) {
+      Settings.adc_param_type = ADC0_MOIST;
+      Settings.adc_param1 = 0;
+      Settings.adc_param2 = 1023;
+      Settings.adc_param3 = 0;
+    }
   }
 }
 
@@ -113,6 +119,20 @@ uint16_t AdcGetLux(void)
   return (uint16_t)ldrLux;
 }
 
+uint16_t AdcGetMoist(void)
+// formula for calibration: value, fromLow, fromHigh, toHigh, toLow
+// Example: 632, 0, 1023, 100, 0
+// int( ( ( (<param2> - <analogue-value>) / ( <param2> - <param1> ) ) * ( <param3> - <param4> ) ) + <param4> )
+// double amoist = ((Settings.adc_param2 - (double)adc) / (Settings.adc_param2 - Settings.adc_param1) * 100;
+// int((((1023 - <analog-reading>) / ( 1023 - 0 )) * ( 100 - 0 )) + 0 )
+
+{
+   int adc = AdcRead(2);
+   double amoist = ((double)Settings.adc_param2 - (double)adc) / ((double)Settings.adc_param2 - (double)Settings.adc_param1) * 100;
+   //double amoist = ((1023 - (double)adc) / 1023) * 100;
+   return (uint16_t)amoist;
+}
+
 void AdcEverySecond(void)
 {
   if (ADC0_TEMP == my_adc0) {
@@ -126,7 +146,7 @@ void AdcEverySecond(void)
 }
 
 void AdcShow(bool json)
-{
+{ 
   if (ADC0_INPUT == my_adc0) {
     uint16_t analog = AdcRead(5);
 
@@ -173,9 +193,20 @@ void AdcShow(bool json)
 #ifdef USE_WEBSERVER
     } else {
       WSContentSend_PD(HTTP_SNS_ILLUMINANCE, "", adc_light);
+
 #endif  // USE_WEBSERVER
     }
   }
+  else if (ADC0_MOIST == my_adc0) {
+    uint16_t adc_moist = AdcGetMoist();
+    if (json) {
+      ResponseAppend_P(JSON_SNS_MOISTURE, "ANALOG", adc_moist);
+#ifdef USE_WEBSERVER
+    } else {
+      WSContentSend_PD(HTTP_SNS_MOISTURE, "", adc_moist);
+#endif  // USE_WEBSERVER
+    }
+   }
 }
 
 /*********************************************************************************************\
@@ -217,7 +248,7 @@ void CmndAdcs(void)
 void CmndAdcParam(void)
 {
   if (XdrvMailbox.data_len) {
-    if ((ADC0_TEMP == XdrvMailbox.payload) || (ADC0_LIGHT == XdrvMailbox.payload)) {
+    if ((ADC0_TEMP == XdrvMailbox.payload) || (ADC0_LIGHT == XdrvMailbox.payload) || (ADC0_MOIST == XdrvMailbox.payload)) { 
 //      if ((XdrvMailbox.payload == my_adc0) && ((ADC0_TEMP == my_adc0) || (ADC0_LIGHT == my_adc0))) {
       if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Process parameter entry
         char sub_string[XdrvMailbox.data_len +1];
@@ -227,10 +258,13 @@ void CmndAdcParam(void)
 //          Settings.adc_param_type = my_adc0;
         Settings.adc_param1 = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
         Settings.adc_param2 = strtol(subStr(sub_string, XdrvMailbox.data, ",", 3), nullptr, 10);
-        Settings.adc_param3 = (int)(CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 4)) * 10000);
+        if (!ADC0_MOIST == XdrvMailbox.payload) {
+          Settings.adc_param3 = (int)(CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 4)) * 10000);
+        }
       } else {                                         // Set default values based on current adc type
         // AdcParam 2
         // AdcParam 3
+        // AdcParam 6
         Settings.adc_param_type = 0;
         AdcInit();
       }
@@ -246,8 +280,13 @@ void CmndAdcParam(void)
   }
   char param3[33];
   dtostrfd(((double)Settings.adc_param3)/10000, precision, param3);
-  Response_P(PSTR("{\"" D_CMND_ADCPARAM "\":[%d,%d,%d,%s]}"),
-    Settings.adc_param_type, Settings.adc_param1, Settings.adc_param2, param3);
+  if ((ADC0_TEMP == my_adc0) || (ADC0_LIGHT == my_adc0)) {
+    Response_P(PSTR("{\"" D_CMND_ADCPARAM "\":[%d,%d,%d,%s]}"),
+      Settings.adc_param_type, Settings.adc_param1, Settings.adc_param2, param3);
+  } else if (ADC0_MOIST == my_adc0) {
+    Response_P(PSTR("{\"" D_CMND_ADCPARAM "\":[%d,%d,%d]}"),
+      Settings.adc_param_type, Settings.adc_param1, Settings.adc_param2);
+  } 
 }
 
 /*********************************************************************************************\
@@ -263,7 +302,7 @@ bool Xsns02(uint8_t function)
       result = DecodeCommand(kAdcCommands, AdcCommand);
       break;
     default:
-      if ((ADC0_INPUT == my_adc0) || (ADC0_TEMP == my_adc0) || (ADC0_LIGHT == my_adc0)) {
+      if ((ADC0_INPUT == my_adc0) || (ADC0_TEMP == my_adc0) || (ADC0_LIGHT == my_adc0) || (ADC0_MOIST == my_adc0)) {
         switch (function) {
 #ifdef USE_RULES
           case FUNC_EVERY_250_MSECOND:

--- a/tasmota/xsns_48_chirp.ino
+++ b/tasmota/xsns_48_chirp.ino
@@ -399,7 +399,7 @@ void ChirpEvery100MSecond(void)
 /********************************************************************************************/
 // normaly in i18n.h
 
-#define D_JSON_MOISTURE "Moisture"
+// #define D_JSON_MOISTURE "Moisture" // on i18n.h
 #define D_JSON_DARKNESS "Darkness"
 
 #ifdef USE_WEBSERVER


### PR DESCRIPTION
## Description:
This PR adds ADC0 Moisture sensor on analog selection. 
Since those sensors have a quite limited reading range when configured as pure analog  (220-550 instead of 0-1023) I've also added a calibration using `AdcParam 6, Low, High`.
Example of calibration using a glass of water: 
```
22:34:47 MQT: stat/tasmota/RESULT = {"AdcParam":[6,0,1023]}
22:34:47 MQT: stat/tasmota/STATUS8 = {"StatusSNS":{"Time":"2019-12-23T22:34:47","ANALOG":{"Moisture":76}}}
22:34:59 CMD: backlog adcparam 6,243,632; status 8 
22:34:59 MQT: stat/tasmota/RESULT = {"AdcParam":[6,243,632]}
22:34:59 MQT: stat/tasmota/STATUS8 = {"StatusSNS":{"Time":"2019-12-23T22:34:59","ANALOG":{"Moisture":100}}}
```
The calibrated value is visible on webui too:
![analog_moist](https://user-images.githubusercontent.com/7702766/71387938-f318ba80-25d4-11ea-83cc-c6eb688980fe.png)

**Related issue (if applicable):** fixes #7182

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
