### PR TITLE
AP MODE: Added Button to Configuration

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1693,10 +1693,11 @@ void HandleWifiConfiguration(void)
   }
 
   if (WifiIsInManagerMode()) {
-    WSContentSpaceButton(BUTTON_RESTART);
 #ifndef FIRMWARE_MINIMAL
-    WSContentSpaceButton(BUTTON_RESET_CONFIGURATION);
+    WSContentSpaceButton(BUTTON_CONFIGURATION);
+    WSContentButton(BUTTON_CONSOLE);
 #endif  // FIRMWARE_MINIMAL
+    WSContentSpaceButton(BUTTON_RESTART);
   } else {
     WSContentSpaceButton(BUTTON_CONFIGURATION);
   }


### PR DESCRIPTION
## Description:

Added easy access to all configurations while on AP mode. This helps when the user wants to restore a previously saved configuration, config MQTT, set fixed IP by commands, etc, etc, making the initial setup faster.

**Related issue (if applicable):** fixes #7306, #2219 and #2333

BEFORE and AFTER this PR:

![image](https://user-images.githubusercontent.com/35405447/71426033-bf946980-2682-11ea-9ed1-58c68d0923a9.png)

The configuration button goes to the standard configuration MENU of Tasmota, where the user can reset the actual configuration, restore a previously saved configuration, config MQTT, etc. On the Configuration MENU, if you click in MAIN MENU, it returns to the main AP menu showed in the picture above. The same goes to the console. Fixed IP and other settings can be defined by commands in the console.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
