### PR TITLE
Add manufactureURL to the hue description.xml endpoint

### DIFF
--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -124,6 +124,7 @@ const char HUE_DESCRIPTION_XML[] PROGMEM =
     "<friendlyName>Amazon-Echo-HA-Bridge ({x1)</friendlyName>"
 //    "<friendlyName>Philips hue ({x1)</friendlyName>"
     "<manufacturer>Royal Philips Electronics</manufacturer>"
+    "<manufacturerURL>http://www.philips.com</manufacturerURL>"
     "<modelDescription>Philips hue Personal Wireless Lighting</modelDescription>"
     "<modelName>Philips hue bridge 2012</modelName>"
     "<modelNumber>929000226503</modelNumber>"


### PR DESCRIPTION
## Description:

The netdisco library by HA looks for manufacture, modelNumber and manufactureURL for its auto discovery mechanism. https://github.com/home-assistant/netdisco/blob/master/netdisco/discoverables/philips_hue.py

Currently, tasmota doesn't return this, and as a result home assistant doesn't discover the emulator.

this commit adds a manufactureURL so discovery works
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
