### PR TITLE
AP MODE: Add Restore Config Button

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1695,7 +1695,7 @@ void HandleWifiConfiguration(void)
   if (WifiIsInManagerMode()) {
 #ifndef FIRMWARE_MINIMAL
     WSContentSpaceButton(BUTTON_RESTORE);
-    WSContentSpaceButton(BUTTON_RESET_CONFIGURATION);
+    WSContentButton(BUTTON_RESET_CONFIGURATION);
 #endif  // FIRMWARE_MINIMAL
     WSContentSpaceButton(BUTTON_RESTART);
   } else {

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1693,10 +1693,11 @@ void HandleWifiConfiguration(void)
   }
 
   if (WifiIsInManagerMode()) {
-    WSContentSpaceButton(BUTTON_RESTART);
 #ifndef FIRMWARE_MINIMAL
+    WSContentSpaceButton(BUTTON_RESTORE);
     WSContentSpaceButton(BUTTON_RESET_CONFIGURATION);
 #endif  // FIRMWARE_MINIMAL
+    WSContentSpaceButton(BUTTON_RESTART);
   } else {
     WSContentSpaceButton(BUTTON_CONFIGURATION);
   }
@@ -1970,7 +1971,11 @@ void HandleRestoreConfiguration(void)
   WSContentSendStyle();
   WSContentSend_P(HTTP_FORM_RST);
   WSContentSend_P(HTTP_FORM_RST_UPG, D_RESTORE);
-  WSContentSpaceButton(BUTTON_CONFIGURATION);
+  if (WifiIsInManagerMode()) {
+    WSContentSpaceButton(BUTTON_MAIN);
+  } else {
+    WSContentSpaceButton(BUTTON_CONFIGURATION);
+  }
   WSContentStop();
 
   Web.upload_error = 0;


### PR DESCRIPTION
## Description:

Added a **Restore Configuration Button** when Tasmota is on AP (Access Point) Mode for easy restore of a previously saved configuration, making the initial setup faster for a reseted device.

**Related issue (if applicable):** fixes #7306

BEFORE and AFTER this PR:

![image](https://user-images.githubusercontent.com/35405447/71455036-0dd46600-2772-11ea-9364-4227794a89bd.png)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
