### PR TITLE
Change Gamma correction for smoother changes at low brightness

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.1.0.1 20191225
 
 - Fix commands ``Display`` and ``Counter`` from overruling command processing (#7322)
+- Change Gamma correction for smoother changes at low brightness
 
 ## Released
 


### PR DESCRIPTION
## Description:

Change the Gamma correction from a table to a simpler multi-linear approximation. This allows smoother changes at low brightness, and reduces code by 144 bytes.

See below the graphs, orange is the ideal curve, blue is the approximation.

![Gamma](https://user-images.githubusercontent.com/49731213/71492128-3c674500-2835-11ea-8aaf-7e5e59e37a91.png)


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
