### PR TITLE
Change Lights: simplified gamma correction and 10 bits internal computation

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix commands ``Display`` and ``Counter`` from overruling command processing (#7322)
 - Add SerialConfig to ``Status 1``
 - Add WifiPower to ``Status 5``
+- Change Lights: simplified gamma correction and 10 bits internal computation
 
 ## Released
 


### PR DESCRIPTION
## Description:

End of year cleaning: code size reduction of 636 bytes:

- Change of Gamma correction from a table to a simpler multi-linear approximation. This allows smoother changes at low brightness.
- All internal lights computation is made with 10 bits resolution only, instead of 8+10, this saves even more code.

See below the multi-linear approximation of Gamma (orange is ideal, blue is approximation):

<img src="https://user-images.githubusercontent.com/49731213/71531106-798f0e00-28ed-11ea-8916-9ce2e9b98e27.png" width="360">

PR has been thoroughly tested with various bulbs, at 8 bits (My92x2) and 10 bits (PWM).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
