### PR TITLE
Counter - SetOption79 to enable reset of counters after telemetry sent

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -92,7 +92,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t bootcount_update : 1;         // bit 26 (v7.0.0.4)  - SetOption76 - Enable incrementing bootcount when deepsleep is enabled
     uint32_t slider_dimmer_stay_on : 1;    // bit 27 (v7.0.0.6)  - SetOption77 - Do not power off if slider moved to far left
     uint32_t compatibility_check : 1;      // bit 28 (v7.1.2.6)  - SetOption78 - Disable OTA compatibility check
-    uint32_t spare29 : 1;
+    uint32_t counter_reset_on_tele : 1;    // bit 29 (v8.1.0.1)  - SetOption79 - Enable resetting of counters after telemetry was sent
     uint32_t shutter_mode : 1;             // bit 30 (v6.6.0.14) - SetOption80 - Enable shutter support
     uint32_t pcf8574_ports_inverted : 1;   // bit 31 (v6.6.0.14) - SetOption81 - Invert all ports on PCF8574 devices
   };

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -150,9 +150,6 @@ void CounterShow(bool json)
           ResponseAppend_P(PSTR(",\"COUNTER\":{"));
         }
         ResponseAppend_P(PSTR("%s\"C%d\":%s"), (header)?",":"", i +1, counter);
-        if ((0 == tele_period ) && (Settings.flag3.counter_reset_on_tele)) {
-          RtcSettings.pulse_counter[i] = 0;
-        }
         header = true;
 #ifdef USE_DOMOTICZ
         if ((0 == tele_period) && (1 == dsxflg)) {
@@ -160,6 +157,9 @@ void CounterShow(bool json)
           dsxflg++;
         }
 #endif  // USE_DOMOTICZ
+        if ((0 == tele_period ) && (Settings.flag3.counter_reset_on_tele)) {
+          RtcSettings.pulse_counter[i] = 0;
+        }
 #ifdef USE_WEBSERVER
       } else {
         WSContentSend_PD(PSTR("{s}" D_COUNTER "%d{m}%s%s{e}"),

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -150,6 +150,9 @@ void CounterShow(bool json)
           ResponseAppend_P(PSTR(",\"COUNTER\":{"));
         }
         ResponseAppend_P(PSTR("%s\"C%d\":%s"), (header)?",":"", i +1, counter);
+        if ((0 == tele_period ) && (Settings.flag3.counter_reset_on_tele)) {
+          RtcSettings.pulse_counter[i] = 0;
+        }
         header = true;
 #ifdef USE_DOMOTICZ
         if ((0 == tele_period) && (1 == dsxflg)) {


### PR DESCRIPTION
## Description:

This PR adds functionality to enable the resetting of counters after telemetry data is sent.

This is useful for counting the number of triggers from any given external signal for the entire duration of teleperiod (usually 300 seconds / 5 minutes) from for example the impulses generated by the optically isolated output of energy meters or the number of impulses received in any given telemetry period from a wind speed sensor.

It should default to SetOption79 0 which means this is not enabled by default.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
