### PR TITLE
Fix: White added to light status (#7142)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add WifiPower to ``Status 5``
 - Add support for DS1624, DS1621 Temperature sensor by Leonid Myravjev
 - Add Zigbee attribute decoder for Xiaomi Aqara Cube
+- Fix ``White`` added to light status (#7142)
 
 ## Released
 


### PR DESCRIPTION
## Description:

Multiple fixes with `White` command and status:

- Add `White` attribute to light status
- Enable `White` command for RGBW+RGBCW bulbs, was only for RGBW
- Disable `CT` and `White` commands with `SetOption68 1`
- Fix: `White` command would wrongly switch to decimal mode `SetOption17`
- Fix: `White` command would disable RGB channel even with `SetOption37 128`
- Fix: `HSBColor` would send status twice


**Related issue (if applicable):** fixes #7142

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
