### PR TITLE
Fix Improved fade linearity with gamma correction

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for ``AdcParam`` parameters to control ADC0 Current Transformer Apparent Power formula by Jodi Dillon (#7100)
 - Fix LCD line and column positioning (#7387)
 - Fix Display handling of hexadecimal escape characters (#7387)
+- Fix Improved fade linearity with gamma correction
 
 ### 8.1.0.1 20191225
 


### PR DESCRIPTION
## Description:

Improved fading with Gamma correction enabled.

Before: fade would go too quickly at low brightness and give the impression of slowing at full brightness. Now: overall better impression of visual linearity. The curve used is cheating a little at low brightness to avoid stuttering, while giving a weak approximation of Gamma correction.

Other change: `PowerOnState 1` will not trigger a fade at boot, to avoid stuttering due to background tasks interrupting the fade animation.

Here is the curve used (in blue), compared to the Gamma curve (orange):
<img src="https://user-images.githubusercontent.com/49731213/71642796-875bdf00-2cb1-11ea-96c8-122f9377d6d7.png" width="360">

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
