### PR TITLE
Initial support for shutter button control

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -514,6 +514,7 @@
 
 // Commands xdrv_32_hotplug.ino
 #define D_CMND_HOTPLUG "HotPlug"
+#define D_CMND_SHUTTER_BUTTON "Button"
 
 // Commands xsns_02_analog.ino
 #define D_CMND_ADCPARAM "AdcParam"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -465,8 +465,9 @@ struct SYSCFG {
   uint8_t       mqttlog_level;             // F01
   uint8_t       sps30_inuse_hours;         // F02
   uint8_t       hotplug_scan;              // F03 -- scan for hotplug every 'hoplugscan' time
+  uint32_t      shutter_button[MAX_KEYS];  // F04
 
-  uint8_t       free_f04[232];             // F04
+  uint8_t       free_f03[216];             // F13
 
   uint32_t      i2c_drivers[3];            // FEC I2cDriver
   uint32_t      cfg_timestamp;             // FF8

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -465,10 +465,11 @@ struct SYSCFG {
   uint8_t       mqttlog_level;             // F01
   uint8_t       sps30_inuse_hours;         // F02
   uint8_t       hotplug_scan;              // F03 -- scan for hotplug every 'hoplugscan' time
-  uint32_t      shutter_button[MAX_KEYS];  // F04
+  uint8_t       reserved1;                 // F04
 
-  uint8_t       free_f03[216];             // F13
-
+  uint8_t       free_f05[215];             // F05
+  
+  uint32_t      shutter_button[MAX_KEYS];  // FDC
   uint32_t      i2c_drivers[3];            // FEC I2cDriver
   uint32_t      cfg_timestamp;             // FF8
   uint32_t      cfg_crc32;                 // FFC


### PR DESCRIPTION
New command "ShutterButton<x> <a> <b> <c> <d> <e> <f> <g> <h> <i> <j>" added that allows to assign a tasmota button <x> to control shutter <a>.

Single press button shutter is set to position <b>.  Double press button shutter is set to position <c>. Tripple press button shutter is set to position <d>. Hold button shutter is set to position <e>. Disabling any button action is given by <b> ... <e> equal to "-". Any press of the button while the shutter is moving will immediately stop that shutter.

Global steering of all your shutters at home is supported by MQTT. By any button action an MQTT command can be initiated to the <grouptopic> of the device. For single press button this can be enabled by <f> equal to "1". Disabling is indicated by <f> equal to "0". Double to hold actions are given by <g> ... <i>, correspondingly. When <j> is equal to "0" only "cmnd/<grouptopic>/Shutterposition<y> ..." with <y>=<x> is fired. When <j> is equal to "1" <y>=1...4 is used to control any shutter number of a tasmota device having same <grouptopic>.

Easy setup for an "up" button:
ShutterButton<x> <a> up (same as ShutterButton<x> <a> 100 50 74 100 0 0 0 1 1)
Single press will move shutter up to 100%, double press to 50% and tripple press to 74%. Holding the button for more than the hold time (SetOption32) moves all shutters with same <grouptopic> up to 100%.

Easy setup for an "down" button:
ShutterButton<x> <a> down (same as ShutterButton<x> <a> 0 50 24 0 0 0 0 1 1)
Single press will move shutter down to 0%, double press to 50% and tripple press to 24%. Holding the button for more than the hold time (SetOption32) moves all shutters with same <grouptopic> down to 0%.

Easy setup for an "updown" button:
ShutterButton<x> <a> updown (same as ShutterButton<x> <a> 100 0 50 - 0 0 0 0 0)
Single press will move shutter up to 100%, double press down to 0% and tripple press to 50%. No hold action and no other shutter control by MQTT.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
