### PR TITLE
Add response to ShutterCalibration command

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -731,20 +731,24 @@ void CmndShutterCalibration(void)  // ????
         // Loop through the version string, splitting on '.' seperators.
         for (char *str = strtok_r(version_dup, " ", &str_ptr); str && i < 5; str = strtok_r(nullptr, " ", &str_ptr), i++) {
           int field = atoi(str);
-          // The fields in a version string can only range from 1-255.
+          // The fields in a version string can only range from 1-30000.
           // and following value must be higher than previous one
-          if ((field <= 0) || (field > 255) ||  ( (i>0) && (field <= messwerte[i-1]) ) ) {
-            free(version_dup);
+          if ((field <= 0) || (field > 30000) ||  ( (i>0) && (field <= messwerte[i-1]) ) ) {
             break;
           }
           messwerte[i] = field;
         }
+        free(version_dup);
         for (i=0 ; i < 5 ; i++) {
-          Settings.shuttercoeff[i][XdrvMailbox.index -1] = messwerte[i] * 1000 / messwerte[4];
+          Settings.shuttercoeff[i][XdrvMailbox.index -1] = (uint32_t)messwerte[i] * 1000 / messwerte[4];
           AddLog_P2(LOG_LEVEL_INFO, PSTR("Settings.shuttercoeff: %d, i: %d, value: %d, messwert %d"), i,XdrvMailbox.index -1,Settings.shuttercoeff[i][XdrvMailbox.index -1], messwerte[i]);
         }
         ShutterInit();
         ResponseCmndIdxChar(XdrvMailbox.data);
+    } else {
+      char setting_chr[30] = "0";
+      snprintf_P(setting_chr, sizeof(setting_chr), PSTR("%d %d %d %d %d"), Settings.shuttercoeff[0][XdrvMailbox.index -1], Settings.shuttercoeff[1][XdrvMailbox.index -1], Settings.shuttercoeff[2][XdrvMailbox.index -1], Settings.shuttercoeff[3][XdrvMailbox.index -1], Settings.shuttercoeff[4][XdrvMailbox.index -1]);
+      ResponseCmndIdxChar(setting_chr);
     }
   }
 }


### PR DESCRIPTION
When ShutterCalibration<x> is called without any arguments no response was given before that allows to read out setting like for other commands. Workaround was to call ShutterRelay<x> <y>.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
