### PR TITLE
Wrong shutter percentage reporting

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -132,7 +132,7 @@ uint8_t ShutterRealToPercentPosition(int32_t realpos, uint8_t index)
     uint16_t realpercent;
 
     for (uint8_t i=0 ; i < 5 ; i++) {
-      if (realpos > Shutter.open_max[index] * calibrate_pos[i+1] / 100) {
+      if (realpos >= Shutter.open_max[index] * calibrate_pos[i+1] / 100) {
         realpercent = Settings.shuttercoeff[i][index] /10;
         //AddLog_P2(LOG_LEVEL_INFO, PSTR("Realpercent TEMP1: %d, %% %d, coeff %d"), realpercent, realpos, Shutter_Open_Max[index] * calibrate_pos[i+1] / 100);
       } else {


### PR DESCRIPTION
With calibrated shutters and ShutterPosition<x> 100 the resulting position may not be 100. This is due to 2 issues. a) percentage is calculated wrong from position due to numerical precision. b) real_position and subsequently position after movement is slightly smaller than max_position.

a) is fixed here by avoiding calculation when position is equal to calibration point
b) open, not fixed here. Issue further depends on start_position which makes it hard to reproduce. Maybe 'stop_position_delta=20' results is real_position not reaching max_position.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
