### PR TITLE
rc-switch fix and support for Conrad_RS-200 protocol

### DIFF
--- a/lib/rc-switch-2.6.2.13/RCSwitch.cpp
+++ b/lib/rc-switch-2.6.2.13/RCSwitch.cpp
@@ -78,8 +78,10 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 100, { 30, 71 }, {  4, 11 }, {  9,  6 }, false },    // protocol 3
   { 380, {  1,  6 }, {  1,  3 }, {  3,  1 }, false },    // protocol 4
   { 500, {  6, 14 }, {  1,  2 }, {  2,  1 }, false },    // protocol 5
-  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },      // protocol 6 (HT6P20B)
-  { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false }     // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+  { 450, { 23,  1 }, {  1,  2 }, {  2,  1 }, true },     // protocol 6 (HT6P20B)
+  { 150, {  2, 62 }, {  1,  6 }, {  6,  1 }, false },    // protocol 7 (HS2303-PT, i. e. used in AUKEY Remote)
+  { 200, {  3, 130}, {  7, 16 }, {  3,  16}, false},     // protocol 8 Conrad RS-200 RX
+  { 200, { 130, 7 }, {  16, 7 }, { 16,  3 }, true}       // protocol 9 Conrad RS-200 TX
 };
 
 enum {
@@ -669,7 +671,7 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
   if (duration > RCSwitch::nSeparationLimit) {
     // A long stretch without signal level change occurred. This could
     // be the gap between two transmission.
-    if (diff(duration, RCSwitch::timings[0]) < 200) {
+    if ((repeatCount==0) || (diff(duration, RCSwitch::timings[0]) < 200)) {
       // This long signal is close in length to the long signal which
       // started the previously recorded timings; this suggests that
       // it may indeed by a a gap between two transmissions (we assume


### PR DESCRIPTION
There is a tiny bug hat prevents the usage for "Conrad RS-200" based devices. The RS-200 protocol does not repeat packets that often. One need already to detect the end of the first packet. The gap between two transmission are not handled right when RF packet is received first time.

a) 1st gap detection fixed
b) Furthermore the "Conrad RS-200" protocol is added.

Same fix is submitted as PR towards sui77/rc-switch.
 
## Description:

**Related issue (if applicable):** fixes #7404 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
