### PR TITLE
Fix wrong gamma correction for Module 48 lights (PWM5 for CT)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix LCD line and column positioning (#7387)
 - Fix Display handling of hexadecimal escape characters (#7387)
 - Fix Improved fade linearity with gamma correction
+- Fix wrong gamma correction for Module 48 lights (PWM5 for CT)
 
 ### 8.1.0.1 20191225
 


### PR DESCRIPTION
## Description:

When using Module 48, i.e. PWM5 is used for CT, the value for PWM4 was wrong: gamma correction was applied twice.

Bonus: this fix reduces code size by 44 bytes.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
