### PR TITLE
fix(platformio_override_sample): extra_scripts doesn't deal well with commas

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -59,12 +59,14 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 ; *** Upload file to OTA server using SCP
 ;upload_port               = user@host:/path
 ;extra_scripts             = ${scripts_defaults.extra_scripts}
-;                            pio/strip-floats.py, pio/sftp-uploader.py
+;                            pio/strip-floats.py
+;                            pio/sftp-uploader.py
 
 ; *** Upload file to OTA server in folder api/arduino using HTTP
 ;upload_port               = domus1:80/api/upload-arduino.php
 ;extra_scripts             = ${scripts_defaults.extra_scripts}
-;                            pio/strip-floats.py, pio/http-uploader.py
+;                            pio/strip-floats.py
+;                            pio/http-uploader.py
 
 [core_active]
 ; Select one core set for platform and build_flags


### PR DESCRIPTION
## Description:
If you put commas in the extra_scripts, it ignores the script after the comma.
Newlines work fine though.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
