### PR TITLE
Reset SSD1306 before initialisation when OLED reset pin is set

### DIFF
--- a/tasmota/xdsp_02_ssd1306.ino
+++ b/tasmota/xdsp_02_ssd1306.ino
@@ -83,7 +83,7 @@ void SSD1306InitDriver(void)
     // init renderer
     // oled1306 = new Adafruit_SSD1306(SSD1306_LCDWIDTH,SSD1306_LCDHEIGHT);
     oled1306 = new Adafruit_SSD1306(Settings.display_width, Settings.display_height, &Wire, reset_pin);
-    oled1306->begin(SSD1306_SWITCHCAPVCC, Settings.display_address[0], 0);
+    oled1306->begin(SSD1306_SWITCHCAPVCC, Settings.display_address[0], reset_pin >= 0);
     renderer = oled1306;
     renderer->DisplayInit(DISPLAY_INIT_MODE, Settings.display_size, Settings.display_rotate, Settings.display_font);
     renderer->setTextColor(1,0);


### PR DESCRIPTION
If an OLED Reset pin has been selected using the PIN configuration, it makes sense to also send a reset signal to this pin before initialization of the display. The current value 0 doesn't send this signal, not even when a reset pin has been selected. Hence the change of value `0` into `reset_pin >= 0`. If no reset pin was set, the value of this variable is -1. Note that the default value of the initialization method (begin), is also true, as can be read [here](https://adafruit.github.io/Adafruit_SSD1306/html/class_adafruit___s_s_d1306.html). Having the 0 value there, is overriding default behavior.

The 0 value while having the board wired up a reset-pin is actually only supposed to be used in case multiple displays are attached, and only one reset signal needs to be sent on initialization of the first display. I don't think this is the case with Tasmota though, as multiple displays aren't really supported.

This adds support for Heltec Wifi Kit 8 and probably many other boards with integrated OLED displays.

## Description:

**Related issue (if applicable):** fixes #5691

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
