### PR TITLE
Add LightPowerIRAM() for rotary interrupt handler

### DIFF
--- a/tasmota/support_rotary.ino
+++ b/tasmota/support_rotary.ino
@@ -43,7 +43,7 @@ void update_rotary(void) ICACHE_RAM_ATTR;
 void update_rotary(void)
 {
   if (MI_DESK_LAMP == my_module_type) {
-    if (LightPower()) {
+    if (LightPowerIRAM()) {
       /*
       * https://github.com/PaulStoffregen/Encoder/blob/master/Encoder.h
       */

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -277,6 +277,16 @@ power_t LightPower(void)
   return Light.power;                     // Make external
 }
 
+// IRAM variant for rotary
+#ifndef ARDUINO_ESP8266_RELEASE_2_3_0      // Fix core 2.5.x ISR not in IRAM Exception
+power_t LightPowerIRAM(void) ICACHE_RAM_ATTR;
+#endif  // ARDUINO_ESP8266_RELEASE_2_3_0
+
+power_t LightPowerIRAM(void)
+{
+  return Light.power;                     // Make external
+}
+
 uint8_t LightDevice(void)
 {
   return Light.device;                    // Make external


### PR DESCRIPTION
## Description:

Commit b82d1fdcc3fdf53d33becb38ed2b93ad4a022152, the interrupt handler still called `LightPower()` which is not in IRAM. I added `LightPowerIRAM()` variant in IRAM. Only rotary uses it, the linker will evict this function from IRAM if not used elsewhare.

**Related issue (if applicable):** fixes #7410 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
