### PR TITLE
Improve Shutter operation for HASS, MQTT and Internationalization

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -500,6 +500,8 @@
 #define D_PRFX_SHUTTER "Shutter"
 #define D_CMND_SHUTTER_OPEN "Open"
 #define D_CMND_SHUTTER_CLOSE "Close"
+#define D_CMND_SHUTTER_UP "Up"
+#define D_CMND_SHUTTER_DOWN "Down"
 #define D_CMND_SHUTTER_STOP "Stop"
 #define D_CMND_SHUTTER_POSITION "Position"
 #define D_CMND_SHUTTER_OPENTIME "OpenDuration"


### PR DESCRIPTION
## Description:
1) Update ShutterPosition(X) command so that UP/OPEN DOWN/CLOSE and STOP can be used (as well as percentage).  This negates need for using Backlog command for Home-Assistant or other controllers.

This also uses the Internationalization so they can be updates for other languages.

2) Update MQTT Reporting so that ALL Shutters are reported every time (regardless of current movement)
This removes parsing errors in Home-Assistant when updating status of MQTT Covers and controller supports more than 1 Shutter.

**Related issue (if applicable):

## Checklist:
  - [X ] The pull request is done against the latest dev branch
  - [ X] Only relevant files were touched
  - [2*] Only one feature/fix was added per PR.
  - [ X] The code change is tested and works on core 2.6.1
  - [ X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
