### PR TITLE
DHT sensors protocol refactoring

### DIFF
--- a/tasmota/xsns_06_dht.ino
+++ b/tasmota/xsns_06_dht.ino
@@ -1,7 +1,7 @@
 /*
   xsns_06_dht.ino - DHTxx, AM23xx and SI7021 temperature and humidity sensor support for Tasmota
 
-  Copyright (C) 2019  Theo Arends
+  Copyright (C) 2020  Theo Arends
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #5619

Created one switch to embrace start reading protocols for all sensors in one place that helps for better readability. Only DHT22 protocol has been changed according to the issue #5619. Tested on AM2302.

DHT21, DHT22, AM2301, AM2302
Specs:
https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf

Protocol:
	1. MCU PULLS LOW data bus for 1 to 10ms to activate sensor
	2. MCU PULLS UP data bus for 20-40us to ask sensor for response
	3. SENSOR PULLS LOW data bus for 80us as a response
	4. SENSOR PULLS UP data bus for 80us for data sending preparation
	5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70us for "1")

DHT11
Specs:
https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf

Protocol:
	1. MCU PULLS LOW data bus for at least 18ms to activate sensor
	2. MCU PULLS UP data bus for 20-40us to ask sensor for response
	3. SENSOR PULLS LOW data bus for 80us as a response
	4. SENSOR PULLS UP data bus for 80us for data sending preparation
	5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70 us for "1")

SI7021
Specs:
https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf

Protocol:
Reverse-engineered on arendst#735 (comment):
	1. MCU PULLS LOW data bus for at 500us to activate sensor
	2. MCU PULLS UP data bus for ~40us to ask sensor for response
	3. SENSOR starts sending data (LOW 40us then HIGH ~25us for "0" or ~75us for "1")
	4. SENSOR sends "1" start bit as a response
	5. SENSOR sends 16 bits (2 bytes) of a humidity with one decimal (i.e. 35.6% is sent as 356)
	6. SENSOR sends 16 bits (2 bytes) of a temperature with one decimal (i.e. 23.4C is sent as 234)
	7. SENSOR sends 8 bits (1 byte) checksum of 4 data bytes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).