### PR TITLE
Make gzip Python2.7 compatible

### DIFF
--- a/pio/gzip-firmware.py
+++ b/pio/gzip-firmware.py
@@ -13,17 +13,11 @@ def bin_gzip(source, target, env):
     gzip_file = "{}firmware{}{}.bin.gz".format(OUTPUT_DIR, os.path.sep, variant)
 
     # check if new target files exist and remove if necessary
-    for f in [gzip_file]:
-        if os.path.isfile(f):
-            os.remove(f)
+    if os.path.isfile(gzip_file): os.remove(gzip_file)
 
     # write gzip firmware file
-    fp = open(bin_file,"rb")
-    data = fp.read()
-    bindata = bytearray(data)
-    with gzip.open(gzip_file, "wb") as f:
-        f.write(bindata)
-    fp.close()
-    f.close()
+    with open(bin_file,"rb") as fp:
+        with gzip.open(gzip_file, "wb") as f:
+            shutil.copyfileobj(fp, f)
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])


### PR DESCRIPTION
## Description:

Simplify and make `gzip-firmware.py` compatible with both Python 3 and Python 2.7.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
