### PR TITLE
Fix labeling of web buttons for shutters

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -502,6 +502,8 @@
 #define D_CMND_SHUTTER_CLOSE "Close"
 #define D_CMND_SHUTTER_UP "Up"
 #define D_CMND_SHUTTER_DOWN "Down"
+#define D_CMND_SHUTTER_TOGGLEUP "ToggleUp"
+#define D_CMND_SHUTTER_TOGGLEDOWN "ToggleDown"
 #define D_CMND_SHUTTER_STOP "Stop"
 #define D_CMND_SHUTTER_POSITION "Position"
 #define D_CMND_SHUTTER_OPENTIME "OpenDuration"

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -667,15 +667,15 @@ void CmndShutterPosition(void)
     // value 0 with data_len > 0 can mean Open
     if ((XdrvMailbox.data_len > 1) && (XdrvMailbox.payload <= 0)) {
       //UpperCase(XdrvMailbox.data, XdrvMailbox.data);
-      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_UP) || !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_OPEN)) {
+      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_UP) || !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_OPEN) || ((Shutter.direction[index]==0) && !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_TOGGLEUP))) {
         CmndShutterOpen();
         return;
       }
-      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_DOWN) || !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_CLOSE)) {
+      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_DOWN) || !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_CLOSE) || ((Shutter.direction[index]==0) && !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_TOGGLEDOWN))) {
         CmndShutterClose();
         return;
       }
-      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_STOP)) {
+      if (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_STOP) || ((Shutter.direction[index]) && (!strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_TOGGLEUP) || !strcasecmp(XdrvMailbox.data,D_CMND_SHUTTER_TOGGLEDOWN)))) {
         XdrvMailbox.payload = -99;
         CmndShutterStop();
         return;


### PR DESCRIPTION
Instead of switching power of the shutter relais web buttons will issue shutter commands to work right when in shuttermode 1. Up down labels arrow up/down fixed for more than one shutter.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
