### PR TITLE
DHT sensors protocol revision and refactoring

### DIFF
--- a/tasmota/xsns_06_dht.ino
+++ b/tasmota/xsns_06_dht.ino
@@ -72,28 +72,70 @@ bool DhtRead(uint8_t sensor)
 
   dht_data[0] = dht_data[1] = dht_data[2] = dht_data[3] = dht_data[4] = 0;
 
-//  digitalWrite(Dht[sensor].pin, HIGH);
-//  delay(250);
-
   if (Dht[sensor].lastresult > DHT_MAX_RETRY) {
     Dht[sensor].lastresult = 0;
     digitalWrite(Dht[sensor].pin, HIGH);  // Retry read prep
     delay(250);
   }
-  pinMode(Dht[sensor].pin, OUTPUT);
-  digitalWrite(Dht[sensor].pin, LOW);
 
-  if (GPIO_SI7021 == Dht[sensor].type) {
-    delayMicroseconds(500);
-  } else {
-    delay(20);
+  // Activate sensor using its protocol
+  noInterrupts();
+  pinMode(Dht[sensor].pin, OUTPUT);
+
+  switch (Dht[sensor].type) {
+    case GPIO_SI7021: // Start protocol for iTead SI7021
+      /*
+      Protocol:
+      Reverse-engineered on https://github.com/arendst/Tasmota/issues/735#issuecomment-348718383:
+      1. MCU PULLS LOW data bus for at 500us to activate sensor
+      2. MCU PULLS UP data bus for ~40us to ask sensor for response
+      3. SENSOR starts sending data (LOW 40us then HIGH ~25us for "0" or ~75us for "1")
+      4. SENSOR sends "1" start bit as a response
+      5. SENSOR sends 16 bits (2 bytes) of a humidity with one decimal (i.e. 35.6% is sent as 356)
+      6. SENSOR sends 16 bits (2 bytes) of a temperature with one decimal (i.e. 23.4C is sent as 234)
+      7. SENSOR sends 8 bits (1 byte) checksum of 4 data bytes
+      */
+      digitalWrite(Dht[sensor].pin, LOW);
+      delayMicroseconds(500);
+      digitalWrite(Dht[sensor].pin, HIGH);
+      delayMicroseconds(40);
+      break;
+
+    case GPIO_DHT22: // Start protocol for DHT21, DHT22, AM2301, AM2302, AM2321
+      /*
+      Protocol:
+      1. MCU PULLS LOW data bus for 1 to 10ms to activate sensor
+      2. MCU PULLS UP data bus for 20-40us to ask sensor for response
+      3. SENSOR PULLS LOW data bus for 80us as a response
+      4. SENSOR PULLS UP data bus for 80us for data sending preparation
+      5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70us for "1")
+      */
+      digitalWrite(Dht[sensor].pin, LOW);
+      delayMicroseconds(1100); // data sheet says "at least 1ms to 10ms"
+      digitalWrite(Dht[sensor].pin, HIGH);
+      delayMicroseconds(30); // data sheet says "20 to 40us"
+      break;
+
+    case GPIO_DHT11: // Start protocol for DHT11
+      /*
+        Protocol:
+        1. MCU PULLS LOW data bus for at least 18ms to activate sensor
+        2. MCU PULLS UP data bus for 20-40us to ask sensor for response
+        3. SENSOR PULLS LOW data bus for 80us as a response
+        4. SENSOR PULLS UP data bus for 80us for data sending preparation
+        5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70 us for "1")
+      */
+    default:
+      digitalWrite(Dht[sensor].pin, LOW);
+      delay(20); // data sheet says at least 18ms, 20ms just to be safe
+      digitalWrite(Dht[sensor].pin, HIGH);
+      delayMicroseconds(30); // data sheet says "20 to 40us"
+      break;
   }
 
-  noInterrupts();
-  digitalWrite(Dht[sensor].pin, HIGH);
-  delayMicroseconds(40);
+  // Listen to the sensor response
   pinMode(Dht[sensor].pin, INPUT_PULLUP);
-  delayMicroseconds(10);
+
   if (-1 == DhtExpectPulse(sensor, LOW)) {
     AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DHT D_TIMEOUT_WAITING_FOR " " D_START_SIGNAL_LOW " " D_PULSE));
     error = 1;
@@ -111,6 +153,7 @@ bool DhtRead(uint8_t sensor)
   interrupts();
   if (error) { return false; }
 
+  // Decode response
   for (uint32_t i = 0; i < 40; ++i) {
     int32_t lowCycles  = cycles[2*i];
     int32_t highCycles = cycles[2*i+1];
@@ -124,6 +167,7 @@ bool DhtRead(uint8_t sensor)
     }
   }
 
+  // Check response
   uint8_t checksum = (dht_data[0] + dht_data[1] + dht_data[2] + dht_data[3]) & 0xFF;
   if (dht_data[4] != checksum) {
     char hex_char[15];


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #5619
IMO, the root-cause of the problem were both: 1) DHT22 bad timings and 2) `noInterrupts()` that was switched on too late (should be on at the very beginning of the protocol). My AM2302 (with SONOFF Basic R2 on GPIO3 Serial In) has been working stable for 3 days now. Previously it hung (null readings) every few hours with power cycle as a remedy. I did not any hardware adjustments like better coords, connections etc. Just code changes and hanging is gone.

**Changes:**
1. Only DHT22 protocol timings have been changed regarding data sheet.
2. `noInterrupts()` command moved at the very begining of the protocol to ensure reading stability.
3. One `switch` statement created to embrace protocols for all sensors in one place for better code readability (protocols revision gathered below and placed in code comments).

**Revision based on:**

**DHT21, DHT22, AM2301, AM2302**
Specs:
https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf

Protocol:
1. MCU PULLS LOW data bus for 1 to 10ms to activate sensor
2. MCU PULLS UP data bus for 20-40us to ask sensor for response
3. SENSOR PULLS LOW data bus for 80us as a response
4. SENSOR PULLS UP data bus for 80us for data sending preparation
5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70us for "1")

**DHT11**
Specs:
https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf

Protocol:
1. MCU PULLS LOW data bus for at least 18ms to activate sensor
2. MCU PULLS UP data bus for 20-40us to ask sensor for response
3. SENSOR PULLS LOW data bus for 80us as a response
4. SENSOR PULLS UP data bus for 80us for data sending preparation
5. SENSOR starts sending data (LOW 50us then HIGH 26-28us for "0" or 70 us for "1")

**SI7021**
Specs:
https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf

Protocol:
Reverse-engineered on #735 (comment):
1. MCU PULLS LOW data bus for at 500us to activate sensor
2. MCU PULLS UP data bus for ~40us to ask sensor for response
3. SENSOR starts sending data (LOW 40us then HIGH ~25us for "0" or ~75us for "1")
4. SENSOR sends "1" start bit as a response
5. SENSOR sends 16 bits (2 bytes) of a humidity with one decimal (i.e. 35.6% is sent as 356)
6. SENSOR sends 16 bits (2 bytes) of a temperature with one decimal (i.e. 23.4C is sent as 234)
7. SENSOR sends 8 bits (1 byte) checksum of 4 data bytes


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
