### PR TITLE
Fix ``WakeUp <x>`` ignores provided value (#7473)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for gzipped binaries
 - Update IRremoteESP8266 lib updated to v2.7.2
+- Fix ``WakeUp <x>`` ignores provided value (#7473)
 
 ### 8.1.0.2 20191230
 

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2325,7 +2325,7 @@ void CmndScheme(void)
 void CmndWakeup(void)
 {
   if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 100)) {
-    Settings.light_dimmer = XdrvMailbox.payload;
+    light_controller.changeDimmer(XdrvMailbox.payload);
   }
   Light.wakeup_active = 3;
   Settings.light_scheme = LS_WAKEUP;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #7473 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
