### PR TITLE
Tasmota: Execute poweronstate after all modules are initialized.

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -276,6 +276,22 @@ void setup(void)
 
   WifiConnect();
 
+  AddLog_P2(LOG_LEVEL_INFO, PSTR(D_PROJECT " %s %s " D_VERSION " %s%s-" ARDUINO_ESP8266_RELEASE), PROJECT, SettingsText(SET_FRIENDLYNAME1), my_version, my_image);
+#ifdef FIRMWARE_MINIMAL
+  AddLog_P2(LOG_LEVEL_INFO, PSTR(D_WARNING_MINIMAL_VERSION));
+#endif  // FIRMWARE_MINIMAL
+
+  memcpy_P(log_data, VERSION_MARKER, 1);  // Dummy for compiler saving VERSION_MARKER
+
+  RtcInit();
+
+#ifdef USE_ARDUINO_OTA
+  ArduinoOTAInit();
+#endif  // USE_ARDUINO_OTA
+
+  XdrvCall(FUNC_INIT);
+  XsnsCall(FUNC_INIT);
+
   if (MOTOR == my_module_type) { Settings.poweronstate = POWER_ALL_ON; }  // Needs always on else in limbo!
   if (POWER_ALL_ALWAYS_ON == Settings.poweronstate) {
     SetDevicePower(1, SRC_RESTART);
@@ -325,21 +341,6 @@ void setup(void)
   }
   blink_powersave = power;
 
-  AddLog_P2(LOG_LEVEL_INFO, PSTR(D_PROJECT " %s %s " D_VERSION " %s%s-" ARDUINO_ESP8266_RELEASE), PROJECT, SettingsText(SET_FRIENDLYNAME1), my_version, my_image);
-#ifdef FIRMWARE_MINIMAL
-  AddLog_P2(LOG_LEVEL_INFO, PSTR(D_WARNING_MINIMAL_VERSION));
-#endif  // FIRMWARE_MINIMAL
-
-  memcpy_P(log_data, VERSION_MARKER, 1);  // Dummy for compiler saving VERSION_MARKER
-
-  RtcInit();
-
-#ifdef USE_ARDUINO_OTA
-  ArduinoOTAInit();
-#endif  // USE_ARDUINO_OTA
-
-  XdrvCall(FUNC_INIT);
-  XsnsCall(FUNC_INIT);
 }
 
 void BacklogLoop(void)


### PR DESCRIPTION
Fixes #7412

## Description:

Execute poweronstate after all modules are initialized.
TuyaMCU module isn't setup before poweronstate is executed in boot process. 

**Related issue (if applicable):** fixes #7412 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
