### PR TITLE
Fix typo in gauge metric type (#7216)

### DIFF
--- a/tasmota/xsns_91_prometheus.ino
+++ b/tasmota/xsns_91_prometheus.ino
@@ -56,7 +56,7 @@ void HandleMetrics(void)
   dtostrfd(Energy.current[0], Settings.flag2.current_resolution, parameter);
   WSContentSend_P(PSTR("# TYPE current gauge\ncurrent %s\n"), parameter);
   dtostrfd(Energy.active_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE active_power guage\nactive_power %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE active_power gauge\nactive_power %s\n"), parameter);
   dtostrfd(Energy.daily, Settings.flag2.energy_resolution, parameter);
   WSContentSend_P(PSTR("# TYPE energy_daily gauge\nenergy_daily %s\n"), parameter);
   dtostrfd(Energy.total, Settings.flag2.energy_resolution, parameter);


### PR DESCRIPTION
## Description:
Fixed typo "guage" in prometheus metrics. Prometheus can't fetch metrics with error ```invalid metric type "guage"```  without this fix

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
