### PR TITLE
Light palette

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -378,6 +378,7 @@
 #define D_CMND_LED "Led"
 #define D_CMND_LEDTABLE "LedTable"
 #define D_CMND_FADE "Fade"
+#define D_CMND_PALETTE "Palette"
 #define D_CMND_PIXELS "Pixels"
 #define D_CMND_RGBWWTABLE "RGBWWTable"
 #define D_CMND_ROTATION "Rotation"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -466,8 +466,10 @@ struct SYSCFG {
   uint8_t       sps30_inuse_hours;         // F02
   uint8_t       hotplug_scan;              // F03
   uint8_t       reserved1;                 // F04 - reserved for s-hadinger
+  uint8_t       light_palette_count;       // F05
+  uint8_t       light_palette[16][5];      // F06
 
-  uint8_t       free_f05[215];             // F05
+  uint8_t       free_f56[134];             // F56
 
   uint32_t      shutter_button[MAX_KEYS];  // FDC
   uint32_t      i2c_drivers[3];            // FEC I2cDriver

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2253,7 +2253,12 @@ void CmndSupportColor(void)
 
 void CmndColor(void)
 {
-  if ((Light.subtype > LST_SINGLE) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= 6)) {
+  if ((Light.subtype > LST_SINGLE) && (XdrvMailbox.index > 0) &&
+#ifdef USE_PALETTE
+    (XdrvMailbox.index <= 7)) {
+#else
+    (XdrvMailbox.index <= 6)) {
+#endif
     CmndSupportColor();
   }
 }


### PR DESCRIPTION
## Description:

Add support for a light Palette. The Palette command set the palette colors. Schemes 2, 3 and 4 use the palette instead of the full color spectrum. The Color7 command sets the color based on the palette index or next (+)/previous (-) palette color.

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
