### PR TITLE
Make the B or brightness part of the HSBColor command optional

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2249,31 +2249,31 @@ void CmndHsbColor(void)
     bool validHSB = (XdrvMailbox.data_len > 0);
     if (validHSB) {
       uint16_t HSB[3];
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Command with 3 comma separated parameters, Hue (0<H<360), Saturation (0<S<100) AND Brightness (0<B<100)
-        for (uint32_t i = 0; i < 3; i++) {
-          char *substr;
+      uint16_t c_hue;
+      uint8_t  c_sat;
 
-          if (0 == i) {
-            substr = strtok(XdrvMailbox.data, ",");
-          } else {
-            substr = strtok(nullptr, ",");
-          }
-          if (substr != nullptr) {
-            HSB[i] = atoi(substr);
-            if (0 < i) {
-              HSB[i] = changeUIntScale(HSB[i], 0, 100, 0, 255); // change sat and bri to 0..255
-            }
-          } else {
-            validHSB = false;
+      light_state.getHSB(&c_hue, &c_sat, nullptr);
+      HSB[0] = c_hue;
+      HSB[1] = c_sat;
+      HSB[2] = light_state.getBriRGB();
+
+      char *substr = strstr(XdrvMailbox.data, ",");
+      if (substr != nullptr) { // Command with comma separated parameters, Hue (0<H<360), Saturation (0<S<100) AND optional Brightness (0<B<100)
+        HSB[0] = atoi(XdrvMailbox.data);
+
+        for (uint32_t i = 1; i < 3; i++) {
+          substr++;
+          HSB[i] = atoi(substr);
+          HSB[i] = changeUIntScale(HSB[i], 0, 100, 0, 255); // change sat and bri to 0..255
+          substr = strstr(substr, ",");
+          if (substr == nullptr) {
+            break;
           }
         }
+        if (substr != nullptr) {
+          validHSB = false;
+        }
       } else {  // Command with only 1 parameter, Hue (0<H<360), Saturation (0<S<100) OR Brightness (0<B<100)
-        uint16_t c_hue;
-        uint8_t  c_sat;
-        light_state.getHSB(&c_hue, &c_sat, nullptr);
-        HSB[0] = c_hue;
-        HSB[1] = c_sat;
-        HSB[2] = light_state.getBri();
 
         if (1 == XdrvMailbox.index) {
           HSB[0] = XdrvMailbox.payload;


### PR DESCRIPTION
This makes it easier (possible?) to use the `HSBColor` with `hs_command_topic`
in Home-Assistant, which in turn allows completely independent control
of the color part of an RGBW or RGBWW bulb. HA setting RGB colors via the Color command means the white channel gets reset to 0, even in split mode where it is particularly annoying.

Hopefully the generated code is a bit shorter too.

I tested this on a bulb that was configured with RGB and W split. The change to using `light_state.getBriRGB()` instead of `light_state.getBri()` as the default for the brightness will probably change behaviour when the bulb isn't split.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
