### PR TITLE
Fix nova sds json

### DIFF
--- a/tasmota/xsns_20_novasds.ino
+++ b/tasmota/xsns_20_novasds.ino
@@ -230,7 +230,7 @@ void NovaSdsShow(bool json)
     char pm2_5[33];
     dtostrfd(pm2_5f, 1, pm2_5);
     if (json) {
-      ResponseAppend_P(PSTR(",\"SDS0X1\":{\"PM2.5\":%s,\"PM10\":%s}"), pm2_5, pm10);
+      ResponseAppend_P(PSTR(",\"SDS0X1\":{\"PM2_5\":%s,\"PM10\":%s}"), pm2_5, pm10);
 #ifdef USE_DOMOTICZ
       if (0 == tele_period) {
         DomoticzSensor(DZ_VOLTAGE, pm2_5);  // PM2.5


### PR DESCRIPTION
## Description:

The nova sds json had a dot inside its namings and that affects parsing for some home automation softwares. Changed dot by underscore. 

**Related issue (if applicable):** fixes #7548 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
