### PR TITLE
i2c: I2cSetDevice wrong behavior

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1521,11 +1521,7 @@ bool I2cSetDevice(uint32_t addr)
     return false;       // If already active report as not present;
   }
   Wire.beginTransmission((uint8_t)addr);
-  bool result = (0 == Wire.endTransmission());
-  if (result) {
-    I2cSetActive(addr, 1);
-  }
-  return result;
+  return (0 == Wire.endTransmission());
 }
 #endif  // USE_I2C
 

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -4775,6 +4775,7 @@ bool Xdrv10(uint8_t function)
           glob_script_mem.script_pram_size=MAX_SCRIPT_SIZE;
 
           glob_script_mem.flags=1;
+          I2cSetActiveFound(EEPROM_ADDRESS, "EEPROM");
         }
       }
 #endif

--- a/tasmota/xdsp_08_ILI9488.ino
+++ b/tasmota/xdsp_08_ILI9488.ino
@@ -116,6 +116,7 @@ void ILI9488_InitDriver()
     if (I2cEnabled(XI2C_38) && I2cSetDevice(FT6236_address)) {
       FT6236begin(FT6236_address);
       FT6236_found=1;
+      I2cSetActiveFound(FT6236_address, "FT6236");
     } else {
       FT6236_found=0;
     }

--- a/tasmota/xdsp_10_RA8876.ino
+++ b/tasmota/xdsp_10_RA8876.ino
@@ -101,6 +101,7 @@ void RA8876_InitDriver()
     if (I2cEnabled(XI2C_39) && I2cSetDevice(FT5316_address)) {
       FT6236begin(FT5316_address);
       FT5316_found=1;
+      I2cSetActiveFound(FT5316_address, "FT5316");
     } else {
       FT5316_found=0;
     }


### PR DESCRIPTION
## Description:

Most drivers do not expect address blocking after calling i2cSetDevice.
I2cSetActive removed from I2cSetDevice. All drivers waiting for this call are fixed.

**Related issue (if applicable):** #7556

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
