### PR TITLE
Minor Zigbee improvements

### DIFF
--- a/tasmota/xdrv_23_zigbee_3_devices.ino
+++ b/tasmota/xdrv_23_zigbee_3_devices.ino
@@ -123,6 +123,7 @@ public:
 
   // Mark data as 'dirty' and requiring to save in Flash
   void dirty(void);
+  void clean(void);   // avoid writing to flash the last changes
 
   // Find device by name, can be short_addr, long_addr, number_in_array or name
   uint16_t parseDeviceParam(const char * param, bool short_must_be_known = false) const;
@@ -469,22 +470,28 @@ void Z_Devices::setManufId(uint16_t shortaddr, const char * str) {
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   _updateLastSeen(device);
+  if (!device.manufacturerId.equals(str)) {
+    dirty();
+  }
   device.manufacturerId = str;
-  dirty();
 }
 void Z_Devices::setModelId(uint16_t shortaddr, const char * str) {
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   _updateLastSeen(device);
+  if (!device.modelId.equals(str)) {
+    dirty();
+  }
   device.modelId = str;
-  dirty();
 }
 void Z_Devices::setFriendlyName(uint16_t shortaddr, const char * str) {
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   _updateLastSeen(device);
+  if (!device.friendlyName.equals(str)) {
+    dirty();
+  }
   device.friendlyName = str;
-  dirty();
 }
 
 const String * Z_Devices::getFriendlyName(uint16_t shortaddr) const {
@@ -690,6 +697,9 @@ void Z_Devices::jsonPublishNow(uint16_t shortaddr, JsonObject & values) {
 
 void Z_Devices::dirty(void) {
   _saveTimer = kZigbeeSaveDelaySeconds * 1000 + millis();
+}
+void Z_Devices::clean(void) {
+  _saveTimer = 0;
 }
 
 // Parse the command parameters for either:

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -268,6 +268,7 @@ void loadZigbeeDevices(void) {
     buf.addBuffer(z_dev_start + sizeof(z_flashdata_t), buf_len);
     AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee devices data in Flash (%d bytes)"), buf_len);
     hidrateDevices(buf);
+    zigbee_devices.clean();   // don't write back to Flash what we just loaded
   } else {
     AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "No zigbee devices data in Flash"));
   }
@@ -308,6 +309,7 @@ void saveZigbeeDevices(void) {
 
 // Erase the flash area containing the ZigbeeData
 void eraseZigbeeDevices(void) {
+  zigbee_devices.clean();     // avoid writing data to flash after erase
   // first copy SPI buffer into ram
   uint8_t *spi_buffer = (uint8_t*) malloc(z_spi_len);
   if (!spi_buffer) {

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -40,11 +40,11 @@ const Z_CommandConverter Z_Commands[] = {
   { "Color",        "0300!07/xxxxyyyy0A00" }, // x, y (uint16)
   { "CT",           "0300!0A/xxxx0A00" },     // Color Temperature Mireds (uint16)
   { "Shutter",      "0102!xx" },
-  { "ShutterOpen",  "0102!00"},
-  { "ShutterClose", "0102!01"},
-  { "ShutterStop",  "0102!02"},
-  { "ShutterLift",  "0102!05xx"},           // Lift percentage, 0%=open, 100%=closed
-  { "ShutterTilt",  "0102!08xx"},           // Tilt percentage
+  { "ShutterOpen",  "0102!00" },
+  { "ShutterClose", "0102!01" },
+  { "ShutterStop",  "0102!02" },
+  { "ShutterLift",  "0102!05xx" },            // Lift percentage, 0%=open, 100%=closed
+  { "ShutterTilt",  "0102!08xx" },            // Tilt percentage
 };
 
 #define ZLE(x) ((x) & 0xFF), ((x) >> 8)     // Little Endian

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -463,7 +463,7 @@ void CmndZigbeeSend(void) {
   if (nullptr != &val_device) { device = strToUInt(val_device); }
   const JsonVariant &val_endpoint = getCaseInsensitive(json, PSTR("endpoint"));
   if (nullptr != &val_endpoint) { endpoint = strToUInt(val_endpoint); }
-  const JsonVariant val_cmd = getCaseInsensitive(json, PSTR("Send"));
+  const JsonVariant &val_cmd = getCaseInsensitive(json, PSTR("Send"));
   if (nullptr != &val_cmd) {
     // probe the type of the argument
     // If JSON object, it's high level commands


### PR DESCRIPTION
## Description:

Fixed a crash in `ZigbeeSend` if `Send` attribute is missing.
Avoid storing Zigbee data to Flash when not needed: after initial load and if Model/Manuf/Name is set to the same value.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
