### PR TITLE
ADC Range (replaces adc Moisture)

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -114,6 +114,7 @@
 #define D_JSON_ACTIVE_POWERUSAGE "ActivePower"
 #define D_JSON_APPARENT_POWERUSAGE "ApparentPower"
 #define D_JSON_REACTIVE_POWERUSAGE "ReactivePower"
+#define D_JSON_RANGE "Range"
 #define D_JSON_PRESSURE "Pressure"
 #define D_JSON_PRESSUREATSEALEVEL "SeaPressure"
 #define D_JSON_PRESSURE_UNIT "PressureUnit"
@@ -605,6 +606,7 @@ const char JSON_SNS_TEMPHUM[] PROGMEM = ",\"%s\":{\"" D_JSON_TEMPERATURE "\":%s,
 
 const char JSON_SNS_ILLUMINANCE[] PROGMEM = ",\"%s\":{\"" D_JSON_ILLUMINANCE "\":%d}";
 const char JSON_SNS_MOISTURE[] PROGMEM = ",\"%s\":{\"" D_JSON_MOISTURE "\":%d}";
+const char JSON_SNS_RANGE[] PROGMEM = ",\"%s\":{\"" D_JSON_RANGE "\":%d}";
 
 const char JSON_SNS_GNGPM[] PROGMEM = ",\"%s\":{\"" D_JSON_TOTAL_USAGE "\":%s,\"" D_JSON_FLOWRATE "\":%s}";
 
@@ -636,6 +638,8 @@ const char HTTP_SNS_CO2EAVG[] PROGMEM = "{s}%s " D_ECO2 "{m}%d " D_UNIT_PARTS_PE
 const char HTTP_SNS_GALLONS[] PROGMEM = "{s}%s " D_TOTAL_USAGE "{m}%s " D_UNIT_GALLONS " {e}";
 const char HTTP_SNS_GPM[] PROGMEM = "{s}%s " D_FLOW_RATE "{m}%s " D_UNIT_GALLONS_PER_MIN" {e}";
 const char HTTP_SNS_MOISTURE[] PROGMEM = "{s}%s " D_MOISTURE "{m}%d %%{e}";
+const char HTTP_SNS_RANGE[] PROGMEM = "{s}%s " D_RANGE "{m}%d %%{e}";
+
 
 const char HTTP_SNS_VOLTAGE[] PROGMEM = "{s}" D_VOLTAGE "{m}%s " D_UNIT_VOLT "{e}";
 const char HTTP_SNS_CURRENT[] PROGMEM = "{s}" D_CURRENT "{m}%s " D_UNIT_AMPERE "{e}";

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Размер на програмата"
 #define D_PROJECT "Проект"
 #define D_RAIN "Дъжд"
+#define D_RANGE "Range"
 #define D_RECEIVED "Получено"
 #define D_RESTART "Рестарт"
 #define D_RESTARTING "Рестартиране"

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Velikost programu"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Přijatý"
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restartování"

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Ben. Flash Speicher"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Regen"
+#define D_RANGE "Range"
 #define D_RECEIVED "erhalten"
 #define D_RESTART "Neustart"
 #define D_RESTARTING "starte neu"

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Μέγεθος προγράμματος"
 #define D_PROJECT "Έργο"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Ελήφθη"
 #define D_RESTART "Επανεκκίνηση"
 #define D_RESTARTING "Επανεκκινεί"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Program Size"
 #define D_PROJECT "Project"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Received"
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restarting"

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Tamaño Programa"
 #define D_PROJECT "Proyecto"
 #define D_RAIN "Lluvia"
+#define D_RANGE "Range"
 #define D_RECEIVED "Recibido"
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "Reiniciando"

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Taille programme"
 #define D_PROJECT "Projet"
 #define D_RAIN "Pluie"
+#define D_RANGE "Range"
 #define D_RECEIVED "Reçu"
 #define D_RESTART "Redémarrage"
 #define D_RESTARTING "Redémarre"

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "גודל תוכנית"
 #define D_PROJECT "פרויקט"
 #define D_RAIN "גשם"
+#define D_RANGE "Range"
 #define D_RECEIVED "התקבל"
 #define D_RESTART "איתחול"
 #define D_RESTARTING "הפעלה מחדש"

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Program méret"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Eső"
+#define D_RANGE "Range"
 #define D_RECEIVED "Érkezett"
 #define D_RESTART "Újraindítás"
 #define D_RESTARTING "Újraindítás"

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Dimensione Programma"
 #define D_PROJECT "Progetto"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Ricevuto"
 #define D_RESTART "Riavvio"
 #define D_RESTARTING "Riavviando"

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "프로그램 용량"
 #define D_PROJECT "프로젝트"
 #define D_RAIN "비"
+#define D_RANGE "Range"
 #define D_RECEIVED "받음"
 #define D_RESTART "재시작"
 #define D_RESTARTING "재시작 중.."

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Programma Grootte"
 #define D_PROJECT "Project"
 #define D_RAIN "Regen"
+#define D_RANGE "Range"
 #define D_RECEIVED "Ontvangen"
 #define D_RESTART "Herstart"
 #define D_RESTARTING "Herstarten"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Rozmiar programu"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Deszcz"
+#define D_RANGE "Range"
 #define D_RECEIVED "Otrzymany"
 #define D_RESTART "Restart"
 #define D_RESTARTING "Restartowanie"

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Tamanho do programa"
 #define D_PROJECT "Projeto"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Recebido"
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "Reiniciando"

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Tamanho do Programa"
 #define D_PROJECT "Projeto"
 #define D_RAIN "Chuva"
+#define D_RANGE "Range"
 #define D_RECEIVED "Recebido"
 #define D_RESTART "Reiniciar"
 #define D_RESTARTING "A reiniciar"

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Размер программы "
 #define D_PROJECT "Проект"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Получено"
 #define D_RESTART "Перезапуск"
 #define D_RESTARTING "Перезапуск"

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Veľkosť programu"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Dážď"
+#define D_RANGE "Range"
 #define D_RECEIVED "Prijatý"
 #define D_RESTART "Reštart"
 #define D_RESTARTING "Reštartuje sa"

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Programstorlek"
 #define D_PROJECT "Projekt"
 #define D_RAIN "Regn"
+#define D_RANGE "Range"
 #define D_RECEIVED "Mottagen"
 #define D_RESTART "Omstart"
 #define D_RESTARTING "Startar om"

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Yazılım Boyutu"
 #define D_PROJECT "Proje"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "Alınan"
 #define D_RESTART "Yeniden Başlat"
 #define D_RESTARTING "Yeniden Başlatılıyor"

--- a/tasmota/language/uk-UA.h
+++ b/tasmota/language/uk-UA.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "Розмір програми"
 #define D_PROJECT "Проект"
 #define D_RAIN "Дощ"
+#define D_RANGE "Range"
 #define D_RECEIVED "Отримано"
 #define D_RESTART "Перезавантаження"
 #define D_RESTARTING "Перезавантаження"

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "固件大小"
 #define D_PROJECT "项目:"
 #define D_RAIN "降水量"
+#define D_RANGE "Range"
 #define D_RECEIVED "已接收"
 #define D_RESTART "重启"
 #define D_RESTARTING "正在重启"

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -137,6 +137,7 @@
 #define D_PROGRAM_SIZE "韌體大小"
 #define D_PROJECT "項目:"
 #define D_RAIN "Rain"
+#define D_RANGE "Range"
 #define D_RECEIVED "已接收"
 #define D_RESTART "重啟"
 #define D_RESTARTING "正在重啟"

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -311,7 +311,7 @@ enum UserSelectableAdc0 {
   ADC0_LIGHT,          // Light sensor
   ADC0_BUTTON,         // Button
   ADC0_BUTTON_INV,
-  ADC0_MOIST,          // Moisture
+  ADC0_RANGE,          // Range
   ADC0_CT_POWER,       // Current
 //  ADC0_SWITCH,         // Switch
 //  ADC0_SWITCH_INV,
@@ -328,7 +328,7 @@ const char kAdc0Names[] PROGMEM =
   D_SENSOR_NONE "|" D_ANALOG_INPUT "|"
   D_TEMPERATURE "|" D_LIGHT "|"
   D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "i|"
-  D_MOISTURE "|"
+  D_RANGE "|"
   D_CT_POWER "|"
 //  D_SENSOR_SWITCH "|" D_SENSOR_SWITCH "i|"
   ;


### PR DESCRIPTION
## Description:
New definitions and translations for both console and webui added to update `ADC Moisture` to a more generic `ADC Range`. 
As discussed with the team leader the new formula will returns just int values.
Usage for calibration:
```
AdcParam 6, fromLow, fromHigh, toLow, toHigh
```
reset to default configuration [6,0,1023,0,100]:
```
AdcParam 6
```

**Related issue (if applicable):** fixes #7578 and solve definitely #7402 .

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
