### PR TITLE
Add ``SetOption84 1`` sends AWS IoT device shadow updates (alternative to retained)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.1.0.5 20200126
 
 - Change wifi connectivity stability (#7602)
+- Add ``SetOption84 1`` sends AWS IoT device shadow updates (alternative to retained)
 
 ### 8.1.0.4 20200116
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -102,8 +102,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption82 .. SetOption113
     uint32_t alexa_ct_range : 1;           // bit 0 (v8.1.0.2)   - SetOption82 - Reduced CT range for Alexa
-    uint32_t zigbee_use_names : 1;         // bit 1 (V8.1.0.4)   - SetOption83 - Use FriendlyNames instead of ShortAddresses when possible
-    uint32_t spare02 : 1;
+    uint32_t zigbee_use_names : 1;         // bit 1 (v8.1.0.4)   - SetOption83 - Use FriendlyNames instead of ShortAddresses when possible
+    uint32_t awsiot_shadow : 1;            // bit 2 (v8.1.0.5)   - SetOption84 - (AWS IoT) publish MQTT state to a device shadow
     uint32_t spare03 : 1;
     uint32_t spare04 : 1;
     uint32_t spare05 : 1;


### PR DESCRIPTION
## Description:

(experimental) When using AWS IoT, added `SetOption84 1` to send device shadows updates after all MQTT messages. This is an alternative to retained messages not supported by AWS IoT.

Example:

```
xx:xx:xx MQT: tele/tasmota/Test/INFO1 = {"Module":"Generic","Version":"8.1.0.5(tasmota)","FallbackTopic":"cmnd/DVES_xxxxxx_fb/","GroupTopic":"cmnd/tasmotas/"}
xx:xx:xx MQT: Updated shadow: $aws/things/tasmota_Test/shadow/update
```

To read the value of the shadow, send an empty message to `$aws/things/<device>/shadow/update`

Note: if `Topic` contains a `'/'` character, they are replaced with `'_'`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
