### PR TITLE
Buzzer extensions

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -347,6 +347,9 @@ void SetLedPowerIdx(uint32_t led, uint32_t state)
     }
     DigitalWrite(GPIO_LED1 + led, bitRead(led_inverted, led) ? !state : state);
   }
+  #ifdef USE_BUZZER
+  if (led == 0) { BuzzerSetStateToLed(state); }
+  #endif // USE_BUZZER
 }
 
 void SetLedPower(uint32_t state)
@@ -382,6 +385,9 @@ void SetLedLink(uint32_t state)
     if (state) { state = 1; }
     digitalWrite(led_pin, (led_inv) ? !state : state);
   }
+  #ifdef USE_BUZZER
+  BuzzerSetStateToLed(state);
+  #endif // USE_BUZZER
 }
 
 void SetPulseTimer(uint32_t index, uint32_t time)


### PR DESCRIPTION
Add infinite mode (count==-1), add follow led mode (count==-2), add count>1 for tune playback

Can we spend some memory to have more possibilities to signal persistent states via an LED?

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
