### PR TITLE
Add ``ZbBind`` (experimental) and bug fixes

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change wifi connectivity stability (#7602)
 - Add ``SetOption84 1`` sends AWS IoT device shadow updates (alternative to retained)
+- Add ``ZbBind`` (experimental) and bug fixes
 
 ### 8.1.0.4 20200116
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -493,6 +493,7 @@
   #define D_JSON_ZIGBEE_ZCL_SENT "ZbZCLSent"
 #define D_JSON_ZIGBEE_RECEIVED "ZbReceived"
 #define D_JSON_ZIGBEE_RECEIVED_LEGACY "ZigbeeReceived"
+#define D_CMND_ZIGBEE_BIND "Bind"
 
 // Commands xdrv_25_A4988_Stepper.ino
 #define D_CMND_MOTOR "MOTOR"

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -39,10 +39,10 @@ class ZCLFrame {
 public:
 
   ZCLFrame(uint8_t frame_control, uint16_t manuf_code, uint8_t transact_seq, uint8_t cmd_id,
-    const char *buf, size_t buf_len, uint16_t clusterid = 0, uint16_t groupid = 0,
-    uint16_t srcaddr = 0, uint8_t srcendpoint = 0, uint8_t dstendpoint = 0, uint8_t wasbroadcast = 0,
-    uint8_t linkquality = 0, uint8_t securityuse = 0, uint8_t seqnumber = 0,
-    uint32_t timestamp = 0):
+    const char *buf, size_t buf_len, uint16_t clusterid, uint16_t groupid,
+    uint16_t srcaddr, uint8_t srcendpoint, uint8_t dstendpoint, uint8_t wasbroadcast,
+    uint8_t linkquality, uint8_t securityuse, uint8_t seqnumber,
+    uint32_t timestamp):
     _cmd_id(cmd_id), _manuf_code(manuf_code), _transact_seq(transact_seq),
     _payload(buf_len ? buf_len : 250),      // allocate the data frame from source or preallocate big enough
     _cluster_id(clusterid), _group_id(groupid),
@@ -74,9 +74,9 @@ public:
   }
 
   static ZCLFrame parseRawFrame(const SBuffer &buf, uint8_t offset, uint8_t len, uint16_t clusterid, uint16_t groupid,
-                                uint16_t srcaddr = 0, uint8_t srcendpoint = 0, uint8_t dstendpoint = 0, uint8_t wasbroadcast = 0,
-                                uint8_t linkquality = 0, uint8_t securityuse = 0, uint8_t seqnumber = 0,
-                                uint32_t timestamp = 0) { // parse a raw frame and build the ZCL frame object
+                                uint16_t srcaddr, uint8_t srcendpoint, uint8_t dstendpoint, uint8_t wasbroadcast,
+                                uint8_t linkquality, uint8_t securityuse, uint8_t seqnumber,
+                                uint32_t timestamp) { // parse a raw frame and build the ZCL frame object
     uint32_t i = offset;
     ZCLHeaderFrameControl_t frame_control;
     uint16_t manuf_code = 0;
@@ -92,7 +92,10 @@ public:
     cmd_id = buf.get8(i++);
     ZCLFrame zcl_frame(frame_control.d8, manuf_code, transact_seq, cmd_id,
                        (const char *)(buf.buf() + i), len + offset - i,
-                       clusterid, groupid);
+                       clusterid, groupid,
+                       srcaddr, srcendpoint, dstendpoint, wasbroadcast,
+                       linkquality, securityuse, seqnumber,
+                       timestamp);
     return zcl_frame;
   }
 

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -33,6 +33,9 @@ int32_t Z_ReceiveDeviceInfo(int32_t res, class SBuffer &buf) {
   uint8_t device_state = buf.get8(14);
   uint8_t device_associated = buf.get8(15);
 
+  // keep track of the local IEEE address
+  localIEEEAddr = long_adr;
+
   char hex[20];
   Uint64toHex(long_adr, hex, 64);
   Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"


### PR DESCRIPTION
## Description:

Minor additions and bug fixes:

- Fixed crash for `ZbRead` and `ZbSend` when some arguments were missing
- `ZbRead` and `ZbSend` can now use friendly names
- introduced experimental `ZbBind`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
