### PR TITLE
Sml script dynamic baudrate and serial transmit support

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1715,6 +1715,30 @@ chknext:
           goto exit;
         }
 #endif
+#ifdef USE_SML_SCRIPT_CMD
+        if (!strncmp(vname,"sml(",4)) {
+          lp+=4;
+          float fvar1;
+          lp=GetNumericResult(lp,OPER_EQU,&fvar1,0);
+          SCRIPT_SKIP_SPACES
+          float fvar2;
+          lp=GetNumericResult(lp,OPER_EQU,&fvar2,0);
+          SCRIPT_SKIP_SPACES
+          if (fvar2==0) {
+            float fvar3;
+            lp=GetNumericResult(lp,OPER_EQU,&fvar3,0);
+            fvar=SML_SetBaud(fvar1,fvar3);
+          } else {
+            char str[SCRIPT_MAXSSIZE];
+            lp=GetStringResult(lp,OPER_EQU,str,0);
+            fvar=SML_Write(fvar1,str);
+          }
+          lp++;
+          fvar=0;
+          len=0;
+          goto exit;
+        }
+#endif
         break;
       case 't':
         if (!strncmp(vname,"time",4)) {

--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -2109,6 +2109,50 @@ init10:
 }
 
 
+#ifdef USE_SML_SCRIPT_CMD
+uint32_t SML_SetBaud(uint32_t meter, uint32_t br) {
+  if (meter<1 || meter>meters_used) return 0;
+  meter--;
+  if (!meter_ss[meter]) return 0;
+  if (meter_ss[meter]->begin(br)) {
+    meter_ss[meter]->flush();
+  }
+  if (meter_ss[meter]->hardwareSerial()) {
+    if (meter_desc_p[meter].type=='M') {
+      Serial.begin(br, SERIAL_8E1);
+    }
+  }
+  return 1;
+}
+
+uint32_t SML_Write(uint32_t meter,char *hstr) {
+  if (meter<1 || meter>meters_used) return 0;
+  meter--;
+  if (!meter_ss[meter]) return 0;
+
+  SML_Send_Seq(meter,hstr);
+
+  /*
+
+  uint8_t sbuff[32];
+  uint8_t *ucp=sbuff,slen=0;
+  char *cp=hstr;
+  while (*cp) {
+    if (!*cp || !*(cp+1)) break;
+    uint8_t iob=(sml_hexnibble(*cp) << 4) | sml_hexnibble(*(cp+1));
+    cp+=2;
+    *ucp++=iob;
+    slen++;
+    if (slen>=sizeof(sbuff)) break;
+  }
+  meter_ss[meter]->write(sbuff,slen);
+  return slen;
+  */
+  return 1;
+}
+#endif
+
+
 void SetDBGLed(uint8_t srcpin, uint8_t ledpin) {
     pinMode(ledpin, OUTPUT);
     if (digitalRead(srcpin)) {

--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -2129,25 +2129,7 @@ uint32_t SML_Write(uint32_t meter,char *hstr) {
   if (meter<1 || meter>meters_used) return 0;
   meter--;
   if (!meter_ss[meter]) return 0;
-
   SML_Send_Seq(meter,hstr);
-
-  /*
-
-  uint8_t sbuff[32];
-  uint8_t *ucp=sbuff,slen=0;
-  char *cp=hstr;
-  while (*cp) {
-    if (!*cp || !*(cp+1)) break;
-    uint8_t iob=(sml_hexnibble(*cp) << 4) | sml_hexnibble(*(cp+1));
-    cp+=2;
-    *ucp++=iob;
-    slen++;
-    if (slen>=sizeof(sbuff)) break;
-  }
-  meter_ss[meter]->write(sbuff,slen);
-  return slen;
-  */
   return 1;
 }
 #endif


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #7592

script support for dynamic baud rates and serial transmit in sml meter driver
required for some special meters

enabled by 
#define USE_SML_SCRIPT_CMD

adds 2 script cmds

res=sml(meter 0 baud)
sets baud rate of meter (1..N) to serial baud rate
res=sml(meter 1 "hexstr")
send binary code of hexadecimal byte string to meter (1..N)



## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).