### PR TITLE
Fix extend PWM patch to STAGE

### DIFF
--- a/tasmota/core_esp8266_waveform.cpp
+++ b/tasmota/core_esp8266_waveform.cpp
@@ -38,7 +38,7 @@
 */
 
 #include <core_version.h>
-#if defined(ARDUINO_ESP8266_RELEASE_2_6_1) || defined(ARDUINO_ESP8266_RELEASE_2_6_2) || defined(ARDUINO_ESP8266_RELEASE_2_6_3)
+#if defined(ARDUINO_ESP8266_RELEASE_2_6_1) || defined(ARDUINO_ESP8266_RELEASE_2_6_2) || defined(ARDUINO_ESP8266_RELEASE_2_6_3) || !defined(ARDUINO_ESP8266_RELEASE)
 #warning **** Tasmota is using a patched PWM Arduino version as planned ****
 
 
@@ -261,7 +261,6 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
         // Check for toggles
         int32_t cyclesToGo = wave->nextServiceCycle - now;
         if (cyclesToGo < 0) {
-          cyclesToGo = -((-cyclesToGo) % (wave->nextTimeHighCycles + wave->nextTimeLowCycles));
           waveformState ^= mask;
           if (waveformState & mask) {
             if (i == 16) {


### PR DESCRIPTION
## Description:

PWM patch is now applied to 2.6-stage, including the frozen Tasmota Stage.
Note: the easy way to detect STAGE is when `ARDUINO_ESP8266_RELEASE` is undefined.

Also removed the modulus which should not be useful for PWM as discussed with Arduino team.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
