### PR TITLE
PCF8574 - skip detection if i2c address is defined in USE_MCP230xx_ADDR

### DIFF
--- a/tasmota/xdrv_28_pcf8574.ino
+++ b/tasmota/xdrv_28_pcf8574.ino
@@ -93,6 +93,12 @@ void Pcf8574Init(void)
     }
 
     pcf8574_address++;
+#ifdef USE_MCP230xx_ADDR
+    if (USE_MCP230xx_ADDR == pcf8574_address) {
+      AddLog_P2(LOG_LEVEL_INFO, PSTR("PCF: Addr: 0x%x reserved for MCP320xx, skipping PCF8574 probe"), pcf8574_address);
+      pcf8574_address++;
+    }
+#endif
     if ((PCF8574_ADDR1 +7) == pcf8574_address) {  // Support I2C addresses 0x20 to 0x26 and 0x39 to 0x3F
       pcf8574_address = PCF8574_ADDR2 +1;
     }


### PR DESCRIPTION
Currently the PCF8574 address selection detects the MCP230xx which is using an address in the range 0x20 - 0x26.
This fix skips the address defined in #define USE_MCP230xx_ADDR

## Description:

MCP230xx could not detected and used if PCF8574 is enabled. The PCF8574 auto detection finds the MC230xx since the addresses are inside the PCF  address range. 
With this fix PCF8574 could be used as output and MCP230xx as input at the same  time.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
