### PR TITLE
Remove trailing comments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -94,8 +94,8 @@ build_flags               = -D NDEBUG
 
 [irremoteesp8266_full]
 build_flags               = -DUSE_IR_REMOTE_FULL
-                            -U_IR_ENABLE_DEFAULT_                       ; use default, i.e. enable all protocols
-                            -DDECODE_PRONTO=false -DSEND_PRONTO=false   ; except PRONTO
+                            -U_IR_ENABLE_DEFAULT_
+                            -DDECODE_PRONTO=false -DSEND_PRONTO=false
 
 [core_active]
 platform                  = ${core_2_6_1.platform}


### PR DESCRIPTION
## Description:

Issue: `Tasmota-IR` takes 664KB instead of 564KB. It looks like `-DFIRMWARE_IR` directive is ignored.

It seems that trailing comments causes issues with the hackbox script.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
