### PR TITLE
Fix wrong encoding of Zigbee persistent data

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 8.1.0.7 20200210
 
 - Add new DHT driver. The old driver can still be used using define USE_DHT_OLD (#7468)
+- Fix wrong encoding of Zigbee persistent data
 
 ### 8.1.0.6 20200205
 

--- a/tasmota/xdrv_23_zigbee_3_devices.ino
+++ b/tasmota/xdrv_23_zigbee_3_devices.ino
@@ -138,7 +138,7 @@ private:
   static bool findInVector(const std::vector<T>  & vecOfElements, const T  & element);
 
   template < typename T>
-  static int32_t findEndpointInVector(const std::vector<T>  & vecOfElements, const T  & element);
+  static int32_t findEndpointInVector(const std::vector<T>  & vecOfElements, uint8_t element);
 
   // find the first endpoint match for a cluster
   static int32_t findClusterEndpoint(const std::vector<uint32_t>  & vecOfElements, uint16_t element);
@@ -180,12 +180,12 @@ bool Z_Devices::findInVector(const std::vector<T>  & vecOfElements, const T  & e
 }
 
 template < typename T>
-int32_t Z_Devices::findEndpointInVector(const std::vector<T>  & vecOfElements, const T  & element) {
+int32_t Z_Devices::findEndpointInVector(const std::vector<T>  & vecOfElements, uint8_t element) {
 	// Find given element in vector
 
   int32_t found = 0;
   for (auto &elem : vecOfElements) {
-    if ((elem >> 16) & 0xFF == element) { return found; }
+    if ( ((elem >> 16) & 0xFF) == element) { return found; }
     found++;
   }
 
@@ -427,7 +427,7 @@ void Z_Devices::addEndoint(uint16_t shortaddr, uint8_t endpoint) {
   Z_Device &device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   _updateLastSeen(device);
-  if (findEndpointInVector(device.endpoints, ep_profile) < 0) {
+  if (findEndpointInVector(device.endpoints, endpoint) < 0) {
     device.endpoints.push_back(ep_profile);
     dirty();
   }
@@ -439,7 +439,7 @@ void Z_Devices::addEndointProfile(uint16_t shortaddr, uint8_t endpoint, uint16_t
   Z_Device &device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   _updateLastSeen(device);
-  int32_t found = findEndpointInVector(device.endpoints, ep_profile);
+  int32_t found = findEndpointInVector(device.endpoints, endpoint);
   if (found < 0) {
     device.endpoints.push_back(ep_profile);
     dirty();

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -31,7 +31,7 @@
 //
 // [Array of devices]
 // [Offset = 2]
-// uint8  - length of revice record
+// uint8  - length of device record
 // uint16 - short address
 // uint64 - long IEEE address
 // uint8  - number of endpoints
@@ -43,6 +43,7 @@
 //
 // str    - ModelID (null terminated C string, 32 chars max)
 // str    - Manuf   (null terminated C string, 32 chars max)
+// str    - FriendlyName   (null terminated C string, 32 chars max)
 // reserved for extensions
 
 // Memory footprint


### PR DESCRIPTION
## Description:

Fixes corrupt encoding when persisting Zigbee device data. This may require to flush the Zigbee data with `Reset 3` and re-pair all devices.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
