### PR TITLE
Use dev version of PlatormIO Core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 sudo: false
 install:
   - pip install -U platformio
-  - platformio upgrade
+  - platformio upgrade --dev
   - platformio update
 
 cache: false


### PR DESCRIPTION
I would be thankful if you use the development version of PIO Core. It's very stable and you should not have any problems with it.
This should help us to be informed about any critical changes in PIO Core which can affect this project. Please report us any issues if they are related to PIO Core.
