### PR TITLE
Fix Zigbee auto-increment transaction number (#7757)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Revert most wifi connectivity changes introduced in 8.1.0.5 (#7746, #7602, #7621)
 - Add initial support for Sensors AHT10 and AHT15 by Martin Wagner (#7596)
 - Add support for Wemos Motor Shield V1 by Denis Sborets (#7764)
+- Fix Zigbee auto-increment transaction number (#7757)
 
 ### 8.1.0.8 20200212
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -489,6 +489,7 @@
 #define D_CMND_ZIGBEE_FORGET "Forget"
 #define D_CMND_ZIGBEE_SAVE "Save"
   #define D_CMND_ZIGBEE_LINKQUALITY "LinkQuality"
+  #define D_CMND_ZIGBEE_ENDPOINT "Endpoint"
 #define D_CMND_ZIGBEE_READ "Read"
 #define D_CMND_ZIGBEE_SEND "Send"
   #define D_JSON_ZIGBEE_ZCL_SENT "ZbZCLSent"

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -21,7 +21,7 @@
 
 // contains some definitions for functions used before their declarations
 
-void ZigbeeZCLSend(uint16_t dtsAddr, uint16_t clusterId, uint8_t endpoint, uint8_t cmdId, bool clusterSpecific, const uint8_t *msg, size_t len, bool disableDefResp = true, uint8_t transacId = 1);
+void ZigbeeZCLSend(uint16_t dtsAddr, uint16_t clusterId, uint8_t endpoint, uint8_t cmdId, bool clusterSpecific, const uint8_t *msg, size_t len, bool needResponse, uint8_t transacId);
 
 
 // Get an JSON attribute, with case insensitive key search

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -78,7 +78,7 @@ int32_t Z_ReadAttrCallback(uint16_t shortaddr, uint16_t cluster, uint16_t endpoi
       break;
   }
   if (attrs) {
-    ZigbeeZCLSend(shortaddr, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, attrs, attrs_len, false /* we do want a response */);
+    ZigbeeZCLSend(shortaddr, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, attrs, attrs_len, true /* we do want a response */, zigbee_devices.getNextSeqNumber(shortaddr));
   }
 }
 

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -451,6 +451,8 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
   AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZCL_RAW_RECEIVED ": {\"0x%04X\":%s}"), srcaddr, msg.c_str());
 
   zcl_received.postProcessAttributes(srcaddr, json);
+  // Add Endpoint
+  json[F(D_CMND_ZIGBEE_ENDPOINT)] = srcendpoint;
   // Add linkquality
   json[F(D_CMND_ZIGBEE_LINKQUALITY)] = linkquality;
 


### PR DESCRIPTION
## Description:

Auto-increment the sequence and transaction number for each outgoing message. Sequence numbers are per-device. It seems that Aqara switches do care about seq number.

Also add `Device` attribute to `ZbReceived` message. Some multi-button switches use source endpoint to indicate which button was pressed.

Exemple:

`
MQT: tele/<topic>/SENSOR = {"ZigbeeReceived":{"Kitchen_presence":{"Device":"0xE07E", "Illuminance":37, "Endpoint":1, "LinkQuality":59}}}
`


**Related issue (if applicable):** fixes #7757 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
