### PR TITLE
Remove code with no effect in WIFI disconnect

### DIFF
--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -683,11 +683,11 @@ void WifiShutdown(bool option = false)
     // Enable from 6.0.0a until 6.1.0a - disabled due to possible cause of bad wifi connect on core 2.3.0
     // Re-enabled from 6.3.0.7 with ESP.restart replaced by ESP.reset
     // Courtesy of EspEasy
-    WiFi.persistent(true);    // use SDK storage of SSID/WPA parameters
+    // WiFi.persistent(true);    // use SDK storage of SSID/WPA parameters
     ETS_UART_INTR_DISABLE();
     wifi_station_disconnect();  // this will store empty ssid/wpa into sdk storage
     ETS_UART_INTR_ENABLE();
-    WiFi.persistent(false);   // Do not use SDK storage of SSID/WPA parameters
+    // WiFi.persistent(false);   // Do not use SDK storage of SSID/WPA parameters
   }
   delay(100);                 // Flush anything in the network buffers.
 }


### PR DESCRIPTION
## Description:

`WiFi.persistent(true);` and `WiFi.persistent(false);` only change an attribute in Arduino Wifi object, but have no side effect. `wifi_station_disconnect();` is a function of Espressif SDK that has no knowledge of Arduino WiFi object. Hence the two lines removed had in fact no effect.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
