### PR TITLE
Improved INA219 driver supports custom defined shunt resistor

### DIFF
--- a/tasmota/xsns_13_ina219.ino
+++ b/tasmota/xsns_13_ina219.ino
@@ -51,23 +51,30 @@
 #define INA219_CONFIG_GAIN_8_320MV              (0x1800)  // Gain 8, 320mV Range
 
 #define INA219_CONFIG_BADCRES_MASK              (0x0780)  // Bus ADC Resolution Mask
-#define INA219_CONFIG_BADCRES_9BIT              (0x0080)  // 9-bit bus res = 0..511
-#define INA219_CONFIG_BADCRES_10BIT             (0x0100)  // 10-bit bus res = 0..1023
-#define INA219_CONFIG_BADCRES_11BIT             (0x0200)  // 11-bit bus res = 0..2047
-#define INA219_CONFIG_BADCRES_12BIT             (0x0400)  // 12-bit bus res = 0..4097
+#define INA219_CONFIG_BADCRES_9BIT_1S_84US      (0x0<<7)  // 9-bit bus res = 0..511
+#define INA219_CONFIG_BADCRES_10BIT_1S_148US    (0x1<<7)  // 10-bit bus res = 0..1023
+#define INA219_CONFIG_BADCRES_11BIT_1S_276US    (0x2<<7)  // 11-bit bus res = 0..2047
+#define INA219_CONFIG_BADCRES_12BIT_1S_532US    (0x3<<7)  // 12-bit bus res = 0..4097
+#define INA219_CONFIG_BADCRES_12BIT_2S_1060US   (0x9<<7)  // 2 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_4S_2130US   (0xA<<7)  // 4 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_8S_4260US   (0xB<<7)  // 8 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_16S_8510US  (0xC<<7)  // 16 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_32S_17MS    (0xD<<7)  // 32 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_64S_34MS    (0xE<<7)  // 64 x 12-bit bus samples averaged together
+#define INA219_CONFIG_BADCRES_12BIT_128S_69MS   (0xF<<7)  // 128 x 12-bit bus samples averaged together
 
 #define INA219_CONFIG_SADCRES_MASK              (0x0078)  // Shunt ADC Resolution and Averaging Mask
-#define INA219_CONFIG_SADCRES_9BIT_1S_84US      (0x0000)  // 1 x 9-bit shunt sample
-#define INA219_CONFIG_SADCRES_10BIT_1S_148US    (0x0008)  // 1 x 10-bit shunt sample
-#define INA219_CONFIG_SADCRES_11BIT_1S_276US    (0x0010)  // 1 x 11-bit shunt sample
-#define INA219_CONFIG_SADCRES_12BIT_1S_532US    (0x0018)  // 1 x 12-bit shunt sample
-#define INA219_CONFIG_SADCRES_12BIT_2S_1060US   (0x0048)  // 2 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_4S_2130US   (0x0050)  // 4 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_8S_4260US   (0x0058)  // 8 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_16S_8510US  (0x0060)  // 16 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_32S_17MS    (0x0068)  // 32 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_64S_34MS    (0x0070)  // 64 x 12-bit shunt samples averaged together
-#define INA219_CONFIG_SADCRES_12BIT_128S_69MS   (0x0078)  // 128 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_9BIT_1S_84US      (0x0<<3)  // 1 x 9-bit shunt sample
+#define INA219_CONFIG_SADCRES_10BIT_1S_148US    (0x1<<3)  // 1 x 10-bit shunt sample
+#define INA219_CONFIG_SADCRES_11BIT_1S_276US    (0x2<<3)  // 1 x 11-bit shunt sample
+#define INA219_CONFIG_SADCRES_12BIT_1S_532US    (0x3<<3)  // 1 x 12-bit shunt sample
+#define INA219_CONFIG_SADCRES_12BIT_2S_1060US   (0x9<<3)  // 2 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_4S_2130US   (0xA<<3)  // 4 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_8S_4260US   (0xB<<3)  // 8 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_16S_8510US  (0xC<<3)  // 16 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_32S_17MS    (0xD<<3)  // 32 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_64S_34MS    (0xE<<3)  // 64 x 12-bit shunt samples averaged together
+#define INA219_CONFIG_SADCRES_12BIT_128S_69MS   (0xF<<3)  // 128 x 12-bit shunt samples averaged together
 
 #define INA219_CONFIG_MODE_MASK                 (0x0007)  // Operating Mode Mask
 #define INA219_CONFIG_MODE_POWERDOWN            (0x0000)
@@ -85,12 +92,20 @@
 #define INA219_REG_CURRENT                      (0x04)
 #define INA219_REG_CALIBRATION                  (0x05)
 
+#define INA219_DEFAULT_SHUNT_RESISTOR_MILLIOHMS (100.0) // 0.1 Ohm
+
 uint8_t ina219_type[4] = {0,0,0,0};
 uint8_t ina219_addresses[] = { INA219_ADDRESS1, INA219_ADDRESS2, INA219_ADDRESS3, INA219_ADDRESS4 };
 
-uint32_t ina219_cal_value = 0;
-// The following multiplier is used to convert raw current values to mA, taking into account the current config settings
-uint32_t ina219_current_divider_ma = 0;
+#define __DEBUG__(a)
+
+__DEBUG__(char __dbg1[20];)
+__DEBUG__(char __dbg2[20];)
+
+// The following multiplier is used to convert shunt voltage (in mV) to current (in A)
+// Current_A = ShuntVoltage_mV / ShuntResistor_milliOhms = ShuntVoltage_mV * ina219_current_multiplier
+// ina219_current_multiplier = 1 / ShuntResistor_milliOhms
+float ina219_current_multiplier;
 
 uint8_t ina219_valid[4] = {0,0,0,0};
 float ina219_voltage[4] = {0,0,0,0};
@@ -98,54 +113,71 @@ float ina219_current[4] = {0,0,0,0};
 char ina219_types[] = "INA219";
 uint8_t ina219_count = 0;
 
+/*********************************************************************************************\
+ * Calculate current multiplier depending on the selected mode
+ * For mode = 0, 1, 2 : legacy modes simplified as Vmax: 32V, Imax: 3.2A range
+ * For mode = 10..255 : specify Rshunt encoded as RRM where resistor value is RR * 10^M milliOhms
+ *                      Vmax: 32V, Imax: 0.320 / Rshunt
+ * Exemple:
+ *     10: Rshunt = 1 * 10^0 =  1 millOhms   => Max current = 320A !
+ *     11: Rshunt = 1 * 10^1 = 10 milliOhms  => Max current = 32A
+ *     21: Rshunt = 2 * 10^1 = 20 milliOhms  => Max current = 16A
+ *     12: Rshunt = 1 * 10^2 = 100 milliOhms => Max current = 3.2A == mode 0,1,2
+ *     13: Rshunt = 1 * 10^3 =   1 Ohms      => Max current = 320mA
+ * Note that some shunt values can be represented by 2 different encoded values such as
+ *     11 or 100 both present 10 milliOhms
+ * Because it is difficult to make a range check on such encoded value, none is performed
+\*********************************************************************************************/
 bool Ina219SetCalibration(uint8_t mode, uint16_t addr)
 {
   uint16_t config = 0;
 
-  switch (mode &3) {
-    case 0:  // 32V 2A
-    case 3:
-      ina219_cal_value = 4096;
-      ina219_current_divider_ma = 10;  // Current LSB = 100uA per bit (1000/100 = 10)
-      config = INA219_CONFIG_BVOLTAGERANGE_32V | INA219_CONFIG_GAIN_8_320MV | INA219_CONFIG_BADCRES_12BIT | INA219_CONFIG_SADCRES_12BIT_1S_532US | INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
-      break;
-    case 1:  // 32V 1A
-      ina219_cal_value = 10240;
-      ina219_current_divider_ma = 25;  // Current LSB = 40uA per bit (1000/40 = 25)
-      config |= INA219_CONFIG_BVOLTAGERANGE_32V | INA219_CONFIG_GAIN_8_320MV | INA219_CONFIG_BADCRES_12BIT | INA219_CONFIG_SADCRES_12BIT_1S_532US | INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
-      break;
-    case 2:  // 16V 0.4A
-      ina219_cal_value = 8192;
-      ina219_current_divider_ma = 20;  // Current LSB = 50uA per bit (1000/50 = 20)
-      config |= INA219_CONFIG_BVOLTAGERANGE_16V | INA219_CONFIG_GAIN_1_40MV | INA219_CONFIG_BADCRES_12BIT | INA219_CONFIG_SADCRES_12BIT_1S_532US | INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
-      break;
+  __DEBUG__(printf("mode = %d\n",mode);)
+  if (mode < 5)
+  {
+    // All legacy modes 0..2 are handled the same and consider default 0.1 shunt resistor
+    ina219_current_multiplier = 1.0 / INA219_DEFAULT_SHUNT_RESISTOR_MILLIOHMS;
+    __DEBUG__(dtostrfd(ina219_current_multiplier,5,__dbg1);)
+    __DEBUG__(printf("cur_mul=%s\n",__dbg1);)
   }
-  // Set Calibration register to 'Cal' calculated above
-  bool success = I2cWrite16(addr, INA219_REG_CALIBRATION, ina219_cal_value);
-  if (success) {
-    // Set Config register to take into account the settings above
-    I2cWrite16(addr, INA219_REG_CONFIG, config);
+  else if (mode >= 10)
+  {
+    int mult = mode % 10;
+    int shunt_milliOhms = mode / 10;
+    for ( ; mult > 0 ; mult-- )
+      shunt_milliOhms *= 10;
+    ina219_current_multiplier = 1.0 / shunt_milliOhms;
+    __DEBUG__(dtostrfd(ina219_current_multiplier,5,__dbg1);)
+    __DEBUG__(printf("shunt = %dmO => cur_mul=%s\n",shunt_milliOhms,__dbg1);)
   }
-  return success;
+  config = INA219_CONFIG_BVOLTAGERANGE_32V
+         | INA219_CONFIG_GAIN_8_320MV               // Use max scale
+         | INA219_CONFIG_BADCRES_12BIT_16S_8510US   // use averaging to improve accuracy
+         | INA219_CONFIG_SADCRES_12BIT_16S_8510US   // use averaging to improve accuracy
+         | INA219_CONFIG_MODE_SANDBVOLT_CONTINUOUS;
+  // Set Config register to take into account the settings above
+  return I2cWrite16(addr, INA219_REG_CONFIG, config);
 }
 
 float Ina219GetShuntVoltage_mV(uint16_t addr)
 {
   // raw shunt voltage (16-bit signed integer, so +-32767)
   int16_t value = I2cReadS16(addr, INA219_REG_SHUNTVOLTAGE);
-  // shunt voltage in mV (so +-327mV)
+  __DEBUG__(printf("ShR = 0x%04X\n",value);)
+  // convert to shunt voltage in mV (so +-327mV) (LSB=10µV=0.01mV)
   return value * 0.01;
 }
 
 float Ina219GetBusVoltage_V(uint16_t addr)
 {
-  // Shift to the right 3 to drop CNVR and OVF and multiply by LSB
-  // raw bus voltage (16-bit signed integer, so +-32767)
-  int16_t value = (int16_t)(((uint16_t)I2cReadS16(addr, INA219_REG_BUSVOLTAGE) >> 3) * 4);
-  // bus voltage in volts
-  return value * 0.001;
+  // Shift 3 to the right to drop CNVR and OVF as unsigned
+  uint16_t value = I2cRead16(addr, INA219_REG_BUSVOLTAGE) >> 3;
+  __DEBUG__(printf("BusR = 0x%04X\n",value);)
+  // and multiply by LSB raw bus voltage to return bus voltage in volts (LSB=4mV=0.004V)
+  return value * 0.004;
 }
 
+/*
 float Ina219GetCurrent_mA(uint16_t addr)
 {
   // Sometimes a sharp load will reset the INA219, which will reset the cal register,
@@ -159,14 +191,25 @@ float Ina219GetCurrent_mA(uint16_t addr)
   // current value in mA, taking into account the config settings and current LSB
   return value;
 }
+*/
 
 bool Ina219Read(void)
 {
   for (int i=0; i<sizeof(ina219_type); i++) {
     if (!ina219_type[i]) { continue; }
     uint16_t addr = ina219_addresses[i];
-    ina219_voltage[i] = Ina219GetBusVoltage_V(addr) + (Ina219GetShuntVoltage_mV(addr) / 1000);
-    ina219_current[i] = Ina219GetCurrent_mA(addr) / 1000;
+    float bus_voltage_V = Ina219GetBusVoltage_V(addr);
+    float shunt_voltage_mV = Ina219GetShuntVoltage_mV(addr);
+    __DEBUG__(dtostrfd(bus_voltage_V,5,__dbg1);)
+    __DEBUG__(dtostrfd(shunt_voltage_mV,5,__dbg2);)
+    __DEBUG__(printf("bV=%sV, sV=%smV\n",__dbg1,__dbg2);)
+    // we return the power-supply-side voltage (as bus_voltage register provides the load-side voltage)
+    ina219_voltage[i] = bus_voltage_V + (shunt_voltage_mV / 1000);
+    // current is simply calculted from shunt voltage using pre-calculated multiplier
+    ina219_current[i] = shunt_voltage_mV * ina219_current_multiplier;
+    __DEBUG__(dtostrfd(ina219_voltage[i],5,__dbg1);)
+    __DEBUG__(dtostrfd(ina219_current[i],5,__dbg2);)
+    __DEBUG__(printf("V=%sV, I=%smA\n",__dbg1,__dbg2);)
     ina219_valid[i] = SENSOR_MAX_MISS;
     //  AddLogMissed(ina219_types, ina219_valid);
   }
@@ -175,15 +218,11 @@ bool Ina219Read(void)
 
 /*********************************************************************************************\
  * Command Sensor13
- *
- * 0 - Max 32V 2A range
- * 1 - Max 32V 1A range
- * 2 - Max 16V 0.4A range
 \*********************************************************************************************/
 
 bool Ina219CommandSensor(void)
 {
-  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 2)) {
+  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 255)) {
     Settings.ina219_mode = XdrvMailbox.payload;
     restart_flag = 2;
   }
@@ -201,6 +240,7 @@ void Ina219Detect(void)
     if (I2cActive(addr)) { continue; }
     if (Ina219SetCalibration(Settings.ina219_mode, addr)) {
       I2cSetActiveFound(addr, ina219_types);
+      __DEBUG__(printf("found INA#%d @ 0x%02X\n",i,addr);)
       ina219_type[i] = 1;
       ina219_count++;
     }


### PR DESCRIPTION
## Description:

This PR adds support for custom defined shunt resistor with INA219 sensor.
It also takes the opportunity to refactor code and improve efficiency.
It was planned after deciding to help Discord user @Massivenrg who needed a shunt resistor of 20 milli-ohm for measuring currents up to 16A.

Original code was limited to support the standard 0.1 ohm shunt resistor which is mounted on the INA219 breakout module available from Adafruit or Chinese providers. This provides allows a single current measurement range up to 3.2A. However some use case needs a different current range which can only be achieved using lower of higher shunt resistor.
This PR allows specifying a custom shunt resistor value ranging from 1 milli-ohm (320A range) up more than 10 kilo-ohm (sub µA).
Compliance with legacy `Sensor13` modes 0, 1 and 2 is preserved and mode values of 10 and above are used to specify the customer shunt resistor value.
Original code was also making an unnecessary complex use of the so-called "Calibration register". This PR uses a more efficient method to calculate the current by using Ohms' law and the shunt-voltage.
Some INA219 register constants have been fixed and completed. This allows the PR to configure the INA219 to average 16 samples for both Bus Voltage and Shunt Voltage to increase accuracy of the measurement. Because this is performed in hardware and still takes much less time (<20ms) than Tasmota sensor period (1 sec) it has no impact on the performance.

**Specifying custom shunt resistor**

In order to be able to specify a large range of shunt resistor values without breaking settings compatibility (`Settings.ina219_mode` is `uint8_t`) it has been chosen to encode the resistor value as a decimal value `RRM = [10.255]` which represent:
`Shunt_Resistor_in_milliohm = RR * 10^M`
This means that the following commands define the following shunt resistors:
`Sensor13 10` define Shunt_Resistor as 1 * 10^0 = 1 milli-ohm for a maximum current of 320A
`Sensor13 11` define Shunt_Resistor as 1 * 10^1 = 10 milli-ohm for a maximum current of 32A
`Sensor13 21` define Shunt_Resistor as 2 * 10^1 = 20 milli-ohm for a maximum current of 16A
`Sensor13 12` define Shunt_Resistor as 2 * 10^2 = 100 milli-ohm for a maximum current of 3.2A (same as default)
`Sensor13 13` define Shunt_Resistor as 1 * 10^3 = 1 ohm for a maximum current of 0.32A
This may seem clunky but allows large range of values while not impacting settings storage.

**Code refactoring and removal of calibration**

Usage of calibration register seems to have been misunderstood as this code can be found in many derivative including ports to MicroPython and CircuitPython. On those platforms I already did my own driver based on the same principle.
The calibration register on INA219 is not intended to provide an effective calibration as we are expecting it (ie providing a means to finely adjust a measurement mechanism to provide accurate results).
It is intended to drive the hardware-based calculation of current and power so that a MCU with low capabilityy can avoid doing multiplications and divisions and retrieve current and power from dedicated registers. While this seems a good idea, in this case it adds complexity to the code to adjust the full-scale of the current to avoid overflow in power calculation.
As Tasmota already calculates power by performing floating point multiplication of the voltage and current, as well as some other floating points multiplication and divisions, refactoring the code in order to calculate directly the current from the shunt voltage makes the code smaller and more efficient.
While this may seems independent of the goal of this PR, the refactoring is key to implementing it efficiently.

**PR Impact on code and data**

`.irom0.text     0x8b628	=>	0x8b5d8		(-80)`
`.data           0x764	=>	  0x764		(==)`
`.bss            0xabb0	=>	 0xaba8		(-8)`

Note: As this is my 1st PR for Tasmota and I believe some changes may be requested, I left some debug code (currently disabled). I will remove it for the final submission.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core 2.6.1
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
