### PR TITLE
Zigbee fix skipped attributes

### DIFF
--- a/tasmota/xdrv_23_zigbee_3_devices.ino
+++ b/tasmota/xdrv_23_zigbee_3_devices.ino
@@ -659,7 +659,12 @@ bool Z_Devices::jsonIsConflict(uint16_t shortaddr, const JsonObject &values) {
   for (auto kv : values) {
     String key_string = kv.key;
 
-    if (strcasecmp_P(kv.key, PSTR(D_CMND_ZIGBEE_LINKQUALITY))) {  // exception = ignore duplicates for LinkQuality
+    if (0 == strcasecmp_P(kv.key, PSTR(D_CMND_ZIGBEE_ENDPOINT))) {
+      // attribute "Endpoint"
+      if (kv.value.as<unsigned int>() != device.json->get<unsigned int>(kv.key)) {
+        return true;
+      }
+    } else if (strcasecmp_P(kv.key, PSTR(D_CMND_ZIGBEE_LINKQUALITY))) {  // exception = ignore duplicates for LinkQuality
       if (device.json->containsKey(kv.key)) {
         return true;          // conflict!
       }

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -504,10 +504,9 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
     if (zigbee_devices.jsonIsConflict(srcaddr, json)) {
       // there is conflicting values, force a publish of the previous message now and don't coalesce
       zigbee_devices.jsonPublishFlush(srcaddr);
-    } else {
-      zigbee_devices.jsonAppend(srcaddr, json);
-      zigbee_devices.setTimer(srcaddr, USE_ZIGBEE_COALESCE_ATTR_TIMER, clusterid, srcendpoint, 0, &Z_PublishAttributes);
     }
+    zigbee_devices.jsonAppend(srcaddr, json);
+    zigbee_devices.setTimer(srcaddr, USE_ZIGBEE_COALESCE_ATTR_TIMER, clusterid, srcendpoint, 0, &Z_PublishAttributes);
   } else {
     // Publish immediately
     zigbee_devices.jsonPublishNow(srcaddr, json);


### PR DESCRIPTION
## Description:

Fix a regression that would hide some attributes instead of coalescing them. Bug was reported on Discord by (a)cheney.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
