### PR TITLE
Add command Sensor35 (Tx2x sensor)

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -630,6 +630,7 @@
 // Select none or only one of the below defines
 //#define USE_TX20_WIND_SENSOR                     // Add support for La Crosse TX20 anemometer (+2k6/0k8 code)
 //#define USE_TX23_WIND_SENSOR                     // Add support for La Crosse TX23 anemometer (+2k7/1k code)
+  //#define USE_TX2x_WIND_SPEED_UNIT 0             // TX2x default speed unit (0 = km/h, 1 = m/s, 2 = kn, 3 = mph, 4 = ft/s, 5 = yd/s)
 
 //#define USE_RC_SWITCH                            // Add support for RF transceiver using library RcSwitch (+2k7 code, 460 iram)
 

--- a/tasmota/xsns_35_tx20.ino
+++ b/tasmota/xsns_35_tx20.ino
@@ -79,6 +79,7 @@ extern "C" {
 #ifdef USE_WEBSERVER
 #define D_TX20_WIND_AVG "&empty;"
 #define D_TX20_WIND_ANGLE "&ang;"
+#define D_TX20_WIND_DEGREE "&deg;"
 const char HTTP_SNS_TX2X[] PROGMEM =
    "{s}" D_TX2x_NAME " " D_TX20_WIND_SPEED "{m}%s " D_UNIT_KILOMETER_PER_HOUR "{e}"
 #ifndef USE_TX2X_WIND_SENSOR_NOSTATISTICS
@@ -86,10 +87,10 @@ const char HTTP_SNS_TX2X[] PROGMEM =
    "{s}" D_TX2x_NAME " " D_TX20_WIND_SPEED_MIN "{m}%s " D_UNIT_KILOMETER_PER_HOUR "{e}"
    "{s}" D_TX2x_NAME " " D_TX20_WIND_SPEED_MAX "{m}%s " D_UNIT_KILOMETER_PER_HOUR "{e}"
 #endif  // USE_TX2X_WIND_SENSOR_NOSTATISTICS
-   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION "{m}%s %s&deg;{e}"
+   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION "{m}%s %s" D_TX20_WIND_DEGREE "{e}"
 #ifndef USE_TX2X_WIND_SENSOR_NOSTATISTICS
-   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION " " D_TX20_WIND_AVG "{m}%s %s&deg;{e}"
-   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION " " D_TX20_WIND_ANGLE "{m}%s&deg; (%s&deg;,%s&deg;)";
+   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION " " D_TX20_WIND_AVG "{m}%s %s" D_TX20_WIND_DEGREE "{e}"
+   "{s}" D_TX2x_NAME " " D_TX20_WIND_DIRECTION " " D_TX20_WIND_ANGLE "{m}%s" D_TX20_WIND_DEGREE " (%s,%s)" D_TX20_WIND_DEGREE;
 #endif  // USE_TX2X_WIND_SENSOR_NOSTATISTICS
    ;
 #endif  // USE_WEBSERVER
@@ -514,7 +515,7 @@ void Tx2xShow(bool json)
       wind_direction_string
     );
 #else  // USE_TX2x_LEGACY_JSON
-    ResponseAppend_P(Tx2xAvailable()?PSTR(",\"" D_TX2x_NAME "\":{\"Speed\":{\"Act\":%s,\"Avg\":%s,\"Min\":%s,\"Max\":%s},\"Dir\":{\"Card\":\"%s\",\"Deg\":%s,\"Avg\":%s,\"AvgCard\":\"%s\",\"Min\":%s,\"Max\":%s,\"Range\":%s}}"):PSTR(""),
+    ResponseAppend_P(Tx2xAvailable()?PSTR(",\"" D_TX2x_NAME "\":{\"Speed\":{\"Act\":%s,\"Avg\":%s,\"Min\":%s,\"Max\":%s},\"Dir\":{\"Card\":\"%s\",\"Deg\":%s,\"Avg\":%s,\"AvgCard\":\"%s\",\"Min\":%s,\"Max\":%s,\"Range\":%s}},\"SpeedUnit\":\"km/h\""):PSTR(""),
       wind_speed_string,
       wind_speed_avg_string,
       wind_speed_min_string,
@@ -533,7 +534,7 @@ void Tx2xShow(bool json)
     ResponseAppend_P(Tx2xAvailable()?PSTR(",\"" D_TX2x_NAME "\":{\"Speed\":%s,\"Direction\":\"%s\",\"Degree\":%s}"):PSTR(""),
       wind_speed_string, wind_direction_cardinal_string, wind_direction_string);
 #else  // USE_TX2x_LEGACY_JSON
-    ResponseAppend_P(Tx2xAvailable()?PSTR(",\"" D_TX2x_NAME "\":{\"Speed\":{\"Act\":%s},\"Dir\":{\"Card\":\"%s\",\"Deg\":%s}}"):PSTR(""),
+    ResponseAppend_P(Tx2xAvailable()?PSTR(",\"" D_TX2x_NAME "\":{\"Speed\":{\"Act\":%s},\"Dir\":{\"Card\":\"%s\",\"Deg\":%s}},\"SpeedUnit\":\"km/h\""):PSTR(""),
       wind_speed_string, wind_direction_cardinal_string, wind_direction_string);
 #endif  // USE_TX2x_LEGACY_JSON
 #endif  // USE_TX2X_WIND_SENSOR_NOSTATISTICS


### PR DESCRIPTION
## Description:
- Sensor Tx2X - set/get windspeed unit
0 = km/h (kilometer per hour)
1 = m/s (meter per second)
2 = kn (knot)
3 = mph (miles per hour)
4 = ft/s (foot per second)
5 = yd/h (yard per second)
for permanent storage compile own binary or use rules, e.g. `ON System#Boot DO Sensor35 1 ENDON`
- TX2x standardize units
- TX2x localized global names

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
