### PR TITLE
Add Zigbee use distinct MQTT topics per device for SENSOR, allowing retained messages (#7835)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add Zigbee features and improvements and remove support for Zigbee commands starting with ``Zigbee...``
 - Add support for MaxBotix HRXL-MaxSonar ultrasonic range finders by Jon Little (#7814)
 - Add support for Romanian language translations by Augustin Marti
+- Add Zigbee use distinct MQTT topics per device for SENSOR, allowing retained messages (#7835)
 
 ### 8.1.0.9 20200220
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -108,7 +108,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t led_timeout : 1;              // bit 4 (v8.1.0.9)   - SetOption86 - PWM Dimmer Turn brightness LED's off 5 seconds after last change
     uint32_t powered_off_led : 1;          // bit 5 (v8.1.0.9)   - SetOption87 - PWM Dimmer Turn red LED on when powered off
     uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - PWM Dimmer Buttons control remote devices
-    uint32_t spare07 : 1;
+    uint32_t zigbee_distinct_topics : 1;   // bit 7 (v8.1.0.10)  - SetOption89 - Distinct MQTT topics per device for Zigbee (#7835)
     uint32_t spare08 : 1;
     uint32_t spare09 : 1;
     uint32_t spare10 : 1;

--- a/tasmota/xdrv_23_zigbee_3_devices.ino
+++ b/tasmota/xdrv_23_zigbee_3_devices.ino
@@ -758,13 +758,17 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
 
   if (use_fname) {
     Response_P(PSTR("{\"" D_JSON_ZIGBEE_RECEIVED "\":{\"%s\":%s}}"), fname->c_str(), msg.c_str());
-    MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR));
-    XdrvRulesProcess();
   } else {
     Response_P(PSTR("{\"" D_JSON_ZIGBEE_RECEIVED "\":{\"0x%04X\":%s}}"), shortaddr, msg.c_str());
-    MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR));
-    XdrvRulesProcess();
   }
+  if (Settings.flag4.zigbee_distinct_topics) {
+    char subtopic[16];
+    snprintf_P(subtopic, sizeof(subtopic), PSTR("%04X/" D_RSLT_SENSOR), shortaddr);
+    MqttPublishPrefixTopic_P(TELE, subtopic, Settings.flag.mqtt_sensor_retain);
+  } else {
+    MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
+  }
+  XdrvRulesProcess();
 }
 
 void Z_Devices::jsonPublishNow(uint16_t shortaddr, JsonObject & values) {


### PR DESCRIPTION
## Description:

Add `SetOption89` to have distinct MQTT topics Zigbee SENSOR messages. This allows to persist the last known state of a zigbee device via retained messages.

When `SetOption81 1`, the 4 hex digit id of the device is added.

Exemple:

```
SetOption89 0
tele/tasmota/Zigbee_home/SENSOR = {"ZbReceived":{"Bulb":{"Device":"0x5ADF","Dimmer":254,"Endpoint":1,"LinkQuality":72}}}
```

```
SetOption89 1
tele/tasmota/Zigbee_home/5ADF/SENSOR = {"ZbReceived":{"Bulb":{"Device":"0x5ADF","Dimmer":254,"Endpoint":1,"LinkQuality":70}}}
```

**Related issue (if applicable):** fixes #7835 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
