### PR TITLE
Add Light skip_light_fade flag and Dimmer3 command, Ignore MCU dimmer…

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -511,9 +511,7 @@ void ProcessDeviceGroupMessage(char * packet, int packet_length)
   */
   XdrvMailbox.command = nullptr;  // Indicates the source is a device group update
   XdrvMailbox.index = flags | device_group_index << 16;
-
-  light_fade = Settings.light_fade;
-  if (flags & (DGR_FLAG_MORE_TO_COME | DGR_FLAG_DIRECT)) Settings.light_fade = false;
+  if (flags & (DGR_FLAG_MORE_TO_COME | DGR_FLAG_DIRECT)) skip_light_fade = true;
 
   for (;;) {
     if (packet_length - (message_ptr - packet) < 1) goto badmsg;  // Malformed message
@@ -548,9 +546,6 @@ void ProcessDeviceGroupMessage(char * packet, int packet_length)
           value |= *message_ptr++ << 16;
           value |= *message_ptr++ << 24;
         }
-      }
-      else if (item == DGR_ITEM_LIGHT_FADE) {
-        light_fade = value;
       }
 #ifdef DEVICE_GROUPS_DEBUG
       AddLog_P2(LOG_LEVEL_DEBUG, PSTR("<item=%u, value=%u"), item, value);
@@ -595,7 +590,7 @@ void ProcessDeviceGroupMessage(char * packet, int packet_length)
 
   XdrvMailbox.command_code = DGR_ITEM_EOL;
   XdrvCall(FUNC_DEVICE_GROUP_REQUEST);
-  Settings.light_fade = light_fade;
+  skip_light_fade = false;
 
   processing_remote_device_message = false;
 #ifdef DEVICE_GROUPS_DEBUG

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -159,6 +159,7 @@ bool spi_flg = false;                       // SPI configured
 bool soft_spi_flg = false;                  // Software SPI configured
 bool ntp_force_sync = false;                // Force NTP sync
 bool is_8285 = false;                       // Hardware device ESP8266EX (0) or ESP8285 (1)
+bool skip_light_fade;                       // Temporarily skip light fading
 myio my_module;                             // Active copy of Module GPIOs (17 x 8 bits)
 gpio_flag my_module_flag;                   // Active copy of Template GPIO flags
 StateBitfield global_state;                 // Global states (currently Wifi and Mqtt) (8 bits)


### PR DESCRIPTION
## Description:

Add Light skip_light_fade flag as a way to temporarily disable light fading. This is used by the TuyaMCU module and is probably needed by other dimmer modules to prevent the light from fading to the newly received dimmer level.

Add index 3 to Dimmer command to disable light fading when changing the dimmer level. The Dimmer3 command is used by the TuyaMCU module to set the brightness when a dimmer change is received from the MCU.

In xdrv_16_tuyamcu.ino, ignore dimmer changes received from the MCU for 250ms after we send a dimmer change command to the MCU. When the dimmer level is changed multiple times quickly (by pressing the dimmer buttons on a remote dimmer switch for example), we send the command to the MCU and several ms later, we receive the confirmation from the MCU. By that time, we have already sent a new dimmer command with a different dimmer level to the MCU. If we don't ignore the confirmation from the MCU, we wind of setting the dimmer level back to an old value. The remote dimmer switch and MCU wind up fighting each other. Ignoring the MCU dimmer commands for 250ms solves this problem.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
