### PR TITLE
Added rule-based mapping function for scripting

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1496,6 +1496,40 @@ chknext:
           fvar=!global_state.mqtt_down;
           goto exit;
         }
+        if (!strncmp(vname,"mp(",3)) {
+          lp+=3;
+          float fvar1;
+          lp=GetNumericResult(lp,OPER_EQU,&fvar1,0);
+          SCRIPT_SKIP_SPACES
+          while (*lp!=')') {
+            char str[SCRIPT_MAXSSIZE];
+            lp=GetStringResult(lp,OPER_EQU,str,0);
+            SCRIPT_SKIP_SPACES
+            char *pstr=str;
+            pstr++;
+            float fvar2;
+            pstr=GetNumericResult(pstr,OPER_EQU,&fvar2,0);
+            while (*pstr==' ') pstr++;
+            fvar=fvar1;
+            if ((str[0]=='<' && fvar1<fvar2) || 
+                (str[0]=='>' && fvar1>fvar2) || 
+                (str[0]=='=' && fvar1==fvar2)) 
+            {
+              if (*pstr==':') {
+                pstr++;
+                while (*pstr==' ') pstr++;
+                float fvar3;
+                pstr=GetNumericResult(pstr,OPER_EQU,&fvar3,0);
+                fvar=fvar3;
+              } else {
+                fvar=fvar2;
+              }
+              break;
+            }
+          }
+          len=0;
+          goto exit;
+        }
         break;
       case 'p':
         if (!strncmp(vname,"pin[",4)) {


### PR DESCRIPTION
Added mapping function `mp`
```
mp(x str1 str2 ... str<n>)
```
It addresses a standard task with less code and much flexibility: mapping an arbitrary incoming numeric value into the allowed range.
The numeric value `x` passed as the first parameter is compared to the rules in the order they are provided as subsequent sting parameters. If the value matches the criteria, the defined value is returned. Subsequent rules are skipped. If `x` matches none of the rules, `x` is returned unchanged. 

Rules consist of one of the comparison operators `< > =` followed by a numeric value `v1`, optionally followed by a colon and another numeric value `v2`.
```
<|>|=v1[:v2] 
```
Example 1: `"<8:0"` - this rule reads: If x is less than 8, return 0.
Example 2: `">100"` - this rule reads: If x is greater than 100, return 100. 

Example 3:
```
y=mp(x "<8:0" ">100")
```
Assigns 0 to y if x is less than 8.
Assigns 100 to y if x is greater than 100.
Assigns x to y for all values of x that do not meet the above criteria (8 to 100).

The above code of example 3 does the same as the following code - with just one line of code and 15 characters less:
```
y=x
if x<8 {
y=0
}
if x>100 {
y=100
}
```

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
