### PR TITLE
Optimized function 'mp'

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1512,7 +1512,7 @@ chknext:
                 (*opp=='>' && fvar1>fvar2) || 
                 (*opp=='=' && fvar1==fvar2)) 
             {
-              if (*lp!='<' && *lp!='>' && *lp!='=') {
+              if (*lp!='<' && *lp!='>' && *lp!='=' && *lp!=')' && *lp!=SCRIPT_EOL) {
                 float fvar3;
                 lp=GetNumericResult(lp,OPER_EQU,&fvar3,0);
                 SCRIPT_SKIP_SPACES

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1502,30 +1502,27 @@ chknext:
           lp=GetNumericResult(lp,OPER_EQU,&fvar1,0);
           SCRIPT_SKIP_SPACES
           while (*lp!=')') {
-            char str[SCRIPT_MAXSSIZE];
-            lp=GetStringResult(lp,OPER_EQU,str,0);
-            SCRIPT_SKIP_SPACES
-            char *pstr=str;
-            pstr++;
+            char *opp=lp;
+            lp++;
             float fvar2;
-            pstr=GetNumericResult(pstr,OPER_EQU,&fvar2,0);
-            while (*pstr==' ') pstr++;
+            lp=GetNumericResult(lp,OPER_EQU,&fvar2,0);
+            SCRIPT_SKIP_SPACES
             fvar=fvar1;
-            if ((str[0]=='<' && fvar1<fvar2) || 
-                (str[0]=='>' && fvar1>fvar2) || 
-                (str[0]=='=' && fvar1==fvar2)) 
+            if ((*opp=='<' && fvar1<fvar2) || 
+                (*opp=='>' && fvar1>fvar2) || 
+                (*opp=='=' && fvar1==fvar2)) 
             {
-              if (*pstr==':') {
-                pstr++;
-                while (*pstr==' ') pstr++;
+              if (*lp!='<' && *lp!='>' && *lp!='=') {
                 float fvar3;
-                pstr=GetNumericResult(pstr,OPER_EQU,&fvar3,0);
+                lp=GetNumericResult(lp,OPER_EQU,&fvar3,0);
+                SCRIPT_SKIP_SPACES
                 fvar=fvar3;
               } else {
                 fvar=fvar2;
               }
               break;
             }
+            while (*lp!='<' && *lp!='>' && *lp!='=' && *lp!=')' && *lp!=SCRIPT_EOL) lp++;
           }
           len=0;
           goto exit;


### PR DESCRIPTION
Leaner syntax of function `mp` and simplified implementation.
New documentation:

Mapping function `mp`

It addresses a standard task with less code and much flexibility: Mapping of an arbitrary incoming numeric value into a defined schema of allowed/reasonable ranges.

The numeric value `x` passed as the first parameter is compared to the mprules in the order they are provided as subsequent parameters. If the value matches the criteria, the defined value is returned. Subsequent mprules are skipped. If `x` matches none of the mprules, `x` is returned unchanged. 
```
mp(x mprule1 mprule2 ... mprule<n>)
```

An mprule starts with one of the comparison operators `<`, `>` or `=`, followed by a numeric value `v1`, optionally followed by a second numeric value `v2`:
```
<|>|=v1[ v2]
```

Each of the numeric values `x`, `v1` and `v2` can be a literal, an expression or a variable.

Example 1: `<8 0` - this mprule reads: If x is less than 8, return 0.
Example 2: `>100` - this mprule reads: If x is greater than 100, return 100. 

Example 3:
```
y=mp(x <8 0 >100)
```
Assigns 0 to y if x is less than 8.
Assigns 100 to y if x is greater than 100.
Assigns x to y for all values of x that do not meet the above criteria (8 to 100).

The above example 3 does the same as the following code - with just one line insead of 7 and 20 characters less:
```
y=x
if x<8 {
y=0
}
if x>100 {
y=100
}
```

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
