### PR TITLE
Make DS18x20 sensor parasite power mode run time configurable

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -300,6 +300,7 @@
 #define SHUTTER_SUPPORT        false             // [SetOption80] Enable shutter support
 #define PCF8574_INVERT_PORTS   false             // [SetOption81] Invert all ports on PCF8574 devices
 #define ZIGBEE_FRIENDLY_NAMES  false             // [SetOption83] Enable Zigbee FriendlyNames instead of ShortAddresses when possible
+#define DS18X20_PARASITE_POWER false             // [SetOption90] Enable parasite power for DS18x20 sensor
 
 /*********************************************************************************************\
  * END OF SECTION 1
@@ -441,7 +442,6 @@
 
 // -- One wire sensors ----------------------------
 #define USE_DS18x20                              // Add support for DS18x20 sensors with id sort, single scan and read retry (+2k6 code)
-//  #define W1_PARASITE_POWER                      // Optimize for parasite powered sensors
 
 // -- I2C sensors ---------------------------------
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -109,7 +109,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t powered_off_led : 1;          // bit 5 (v8.1.0.9)   - SetOption87 - PWM Dimmer Turn red LED on when powered off
     uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - PWM Dimmer Buttons control remote devices
     uint32_t zigbee_distinct_topics : 1;   // bit 7 (v8.1.0.10)  - SetOption89 - Distinct MQTT topics per device for Zigbee (#7835)
-    uint32_t spare08 : 1;
+    uint32_t ds18x20_parasite_power : 1;   // bit 8 (v8.1.0.12)  - SetOption90 - Enable parasite power for DS18x20 sensor
     uint32_t spare09 : 1;
     uint32_t spare10 : 1;
     uint32_t spare11 : 1;

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1022,6 +1022,7 @@ void SettingsDefaultSet2(void)
   Settings.flag2.temperature_resolution = TEMP_RESOLUTION;
   Settings.flag3.ds18x20_internal_pullup = DS18X20_PULL_UP;
   Settings.flag3.counter_reset_on_tele = COUNTER_RESET;
+  Settings.flag4.ds18x20_parasite_power = DS18X20_PARASITE_POWER;
 //  Settings.altitude = 0;
 
   // Rules


### PR DESCRIPTION
## Description:

This PR implement use of SetOption90 to change driver to use
different timing for parasite powered sensors at runtime

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core 2.6.1
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
