### PR TITLE
Change to Tasmota freeze stage for development...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -101,16 +101,15 @@ build_flags               = -DUSE_IR_REMOTE_FULL
                             -DDECODE_PRONTO=false -DSEND_PRONTO=false
 
 [core_active]
-platform                  = ${core_2_6_1.platform}
-platform_packages         = ${core_2_6_1.platform_packages}
-build_flags               = ${core_2_6_1.build_flags}
+platform                  = ${tasmota_core_stage.platform}
+platform_packages         = ${tasmota_core_stage.platform_packages}
+build_flags               = ${tasmota_core_stage.build_flags}
 
-[core_2_6_1]
-; *** Esp8266 core for Arduino version 2.6.1
-platform                  = espressif8266@2.3.0
-platform_packages         =
+[tasmota_core_stage]
+; *** Esp8266 core for Arduino version stable beta
+platform                  = espressif8266@2.3.3
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#372a3ec297dfe8501bed1ec4552244695b5e8ced
 build_flags               = ${esp82xx_defaults.build_flags}
-                            -Wl,-Teagle.flash.1m.ld
                             -DBEARSSL_SSL_BASIC
 ; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
                             -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703


### PR DESCRIPTION
solving issue https://github.com/arendst/Tasmota/issues/7879 
Tests of the freezed stage core shows (so far) no issues. 
With regard to the new release version 8.2. with gzip support a good test in advance to verify the stability of the upcoming core 2.7.
The core 2.7. will no longer change significantly to the one used here.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on feature stage 372a3ec2
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
