### PR TITLE
Only set power for devices included in updates

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -333,7 +333,7 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DeviceGroupMessageType 
           if (item > DGR_ITEM_MAX_16BIT) {
             value >>= 8;
             *message_ptr++ = value & 0xff;
-            *message_ptr++ = value >> 8;
+            *message_ptr++ = (item == DGR_ITEM_POWER ? devices_present : value >> 8);
           }
         }
       }
@@ -590,6 +590,8 @@ void ProcessDeviceGroupMessage(char * packet, int packet_length)
 
     if (DeviceGroupItemShared(true, item)) {
       if (item == DGR_ITEM_POWER) {
+        uint8_t mask_devices = value >> 24;
+        if (mask_devices > devices_present) mask_devices = devices_present;
         for (uint32_t i = 0; i < devices_present; i++) {
           uint32_t mask = 1 << i;
           bool on = (value & mask);


### PR DESCRIPTION
## Description:

Previous all bits in the power bitmask were processed by all devies that had the power bit set in the device_group_share_in mask. This caused problems, for example, with devices that had two relays in a group with devices that only had one relay. The one-relay devices would send updates with the second relay bit always off.

With this update, the device groups logic includes the number of relays (devices_present) on the sending device in the update. Receiver only process the minimum of the number of relays on the local device and the number of relays on the sending device. In this way, devices with fewer relays will not overwrite the power setting of higher numbered relays on remote devices.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
