### PR TITLE
Add ``WIFI_PERSISTENT`` compile option

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for HDC1080 Temperature and Humidity sensor by Luis Teixeira (#7888)
 - Add commands ``SwitchMode 13`` PushOn and ``SwitchMode 14`` PushOnInverted (#7912)
 - Add Zigbee support for Hue emulation by Stefan Hadinger
+- Add ``WIFI_PERSISTENT`` compile option, helps wifi reconnects for Ubiquiti nano-HD
 
 ### 8.1.0.10 20200227
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -72,6 +72,7 @@
                                                  // The configuration can be changed after first setup using WifiConfig 0, 2, 4, 5, 6 and 7.
 #define WIFI_SCAN_AT_RESTART   false             // [SetOption56] Scan wifi network at restart for configured AP's
 #define WIFI_SCAN_REGULARLY    false             // [SetOption57] Scan wifi network every 44 minutes for configured AP's
+// #define WIFI_PERSISTENT                          // forces persistent wifi settings in Espressif SDK, might help for some Wifi reconnects after hardware resets
 
 // -- Syslog --------------------------------------
 #define SYS_LOG_HOST           ""                // [LogHost] (Linux) syslog host

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -179,7 +179,11 @@ void WifiBegin(uint8_t flag, uint8_t channel)
   WifiSetMode(WIFI_OFF);
 #endif
 
+#ifdef WIFI_PERSISTENT
+  WiFi.persistent(true);    // Might help for some Wifi reconnect after hardware reset
+#else
   WiFi.persistent(false);   // Solve possible wifi init errors (re-add at 6.2.1.16 #4044, #4083)
+#endif
   WiFi.disconnect(true);    // Delete SDK wifi config
   delay(200);
 //  WiFi.mode(WIFI_STA);      // Disable AP mode


### PR DESCRIPTION
## Description:

Add `WIFI_PERSISTENT` compile option, helps wifi reconnects for Ubiquiti nano-HD.

I'm not sure setting wifi persistence to false actually helped #4044, #4083. Now it's possible to compile a specific option with persistence set to true.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
