### PR TITLE
New command: Humidity Offset 

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -304,6 +304,7 @@
   #define D_JSON_FLAG "FLAG"
   #define D_JSON_BASE "BASE"
 #define D_CMND_TEMPOFFSET "TempOffset"
+#define D_CMND_HUMOFFSET "HumOffset"
 
 // Commands xdrv_01_mqtt.ino
 #define D_CMND_MQTTLOG "MqttLog"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -467,8 +467,9 @@ struct SYSCFG {
   uint8_t       bri_min;                   // F05
   uint8_t       bri_preset_low;            // F06
   uint8_t       bri_preset_high;           // F07
+  int8_t        hum_comp;                  // F08
 
-  uint8_t       free_f08[180];             // F08
+  uint8_t       free_f09[179];             // F09
 
   uint32_t      keeloq_master_msb;         // FBC
   uint32_t      keeloq_master_lsb;         // FC0

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -617,10 +617,14 @@ char TempUnit(void)
 
 float ConvertHumidity(float h)
 {
+  float result = h;
+
   global_update = uptime;
   global_humidity = h;
+  
+  result = result + (0.1 * Settings.hum_comp);
 
-  return h;
+  return result;
 }
 
 float CalcTempHumToDew(float t, float h)

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -26,7 +26,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_BUTTONDEBOUNCE "|" D_CMND_SWITCHDEBOUNCE "|" D_CMND_SYSLOG "|" D_CMND_LOGHOST "|" D_CMND_LOGPORT "|" D_CMND_SERIALSEND "|" D_CMND_BAUDRATE "|" D_CMND_SERIALCONFIG "|"
   D_CMND_SERIALDELIMITER "|" D_CMND_IPADDRESS "|" D_CMND_NTPSERVER "|" D_CMND_AP "|" D_CMND_SSID "|" D_CMND_PASSWORD "|" D_CMND_HOSTNAME "|" D_CMND_WIFICONFIG "|"
   D_CMND_FRIENDLYNAME "|" D_CMND_SWITCHMODE "|" D_CMND_INTERLOCK "|" D_CMND_TELEPERIOD "|" D_CMND_RESET "|" D_CMND_TIME "|" D_CMND_TIMEZONE "|" D_CMND_TIMESTD "|"
-  D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|"
+  D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|" D_CMND_HUMOFFSET "|"
   D_CMND_SPEEDUNIT "|"
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
@@ -45,7 +45,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndButtonDebounce, &CmndSwitchDebounce, &CmndSyslog, &CmndLoghost, &CmndLogport, &CmndSerialSend, &CmndBaudrate, &CmndSerialConfig,
   &CmndSerialDelimiter, &CmndIpAddress, &CmndNtpServer, &CmndAp, &CmndSsid, &CmndPassword, &CmndHostname, &CmndWifiConfig,
   &CmndFriendlyname, &CmndSwitchMode, &CmndInterlock, &CmndTeleperiod, &CmndReset, &CmndTime, &CmndTimezone, &CmndTimeStd,
-  &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower, &CmndTempOffset,
+  &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndWifiPower, &CmndTempOffset, &CmndHumOffset,
   &CmndSpeedUnit,
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
@@ -536,6 +536,17 @@ void CmndTempOffset(void)
     }
   }
   ResponseCmndFloat((float)(Settings.temp_comp) / 10, 1);
+}
+
+void CmndHumOffset(void)
+{
+  if (XdrvMailbox.data_len > 0) {
+    int value = (int)(CharToFloat(XdrvMailbox.data) * 10);
+    if ((value > -101) && (value < 101)) {
+      Settings.hum_comp = value;
+    }
+  }
+  ResponseCmndFloat((float)(Settings.hum_comp) / 10, 1);
 }
 
 void CmndSleep(void)


### PR DESCRIPTION
## Description:
New command `HumOffset` to compensate natural deviations of humidity sensors. Similar to `TempOffset`introduced by @stefanbode . 
The range goes from `-10.0` to `+ 10.0` units (not %) and will affect ALL the humidity sensor connected to the device. 

Usage:
To query:
```
00:08:56 CMD: HumOffset
00:08:56 MQT: stat/tasmota_2350B0/RESULT = {"HumOffset":0.0}
```
Add a value:
```
00:09:04 CMD: HumOffset 1.2
00:09:04 MQT: stat/tasmota_2350B0/RESULT = {"HumOffset":1.2}
```
Subtract a value:
```
00:09:23 CMD: HumOffset -2.8
00:09:23 MQT: stat/tasmota_2350B0/RESULT = {"HumOffset":-2.8}
```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here> None

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core Tasmota_core_stage
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
