### PR TITLE
Moving more strings to PROGMEM

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -77,6 +77,14 @@ void ResponseCmndIdxNumber(int value)
   Response_P(S_JSON_COMMAND_INDEX_NVALUE, XdrvMailbox.command, XdrvMailbox.index, value);
 }
 
+void ResponseCmndChar_P(const char* value)
+{
+  size_t buf_size = strlen_P(value);
+  char buf[buf_size + 1];
+  strcpy_P(buf, value);
+  Response_P(S_JSON_COMMAND_SVALUE, XdrvMailbox.command, buf);
+}
+
 void ResponseCmndChar(const char* value)
 {
   Response_P(S_JSON_COMMAND_SVALUE, XdrvMailbox.command, value);
@@ -602,7 +610,7 @@ void CmndRestart(void)
     EspRestart();
     break;
   default:
-    ResponseCmndChar(D_JSON_ONE_TO_RESTART);
+    ResponseCmndChar_P(PSTR(D_JSON_ONE_TO_RESTART));
   }
 }
 
@@ -1059,7 +1067,7 @@ void CmndTemplate(void)
     if (JsonTemplate(XdrvMailbox.data)) {    // Free 336 bytes StaticJsonBuffer stack space by moving code to function
       if (USER_MODULE == Settings.module) { restart_flag = 2; }
     } else {
-      ResponseCmndChar(D_JSON_INVALID_JSON);
+      ResponseCmndChar_P(PSTR(D_JSON_INVALID_JSON));
       error = true;
     }
   }

--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -258,10 +258,10 @@ void IrRemoteCmndResponse(uint32_t error)
 {
   switch (error) {
     case IE_INVALID_RAWDATA:
-      ResponseCmndChar(D_JSON_INVALID_RAWDATA);
+      ResponseCmndChar_P(PSTR(D_JSON_INVALID_RAWDATA));
       break;
     case IE_INVALID_JSON:
-      ResponseCmndChar(D_JSON_INVALID_JSON);
+      ResponseCmndChar_P(PSTR(D_JSON_INVALID_JSON));
       break;
     case IE_SYNTAX_IRSEND:
       Response_P(PSTR("{\"" D_CMND_IRSEND "\":\"" D_JSON_NO " " D_JSON_IR_PROTOCOL ", " D_JSON_IR_BITS " " D_JSON_OR " " D_JSON_IR_DATA "\"}"));

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -605,10 +605,10 @@ void IrRemoteCmndResponse(uint32_t error)
 {
   switch (error) {
     case IE_INVALID_RAWDATA:
-      ResponseCmndChar(D_JSON_INVALID_RAWDATA);
+      ResponseCmndChar_P(PSTR(D_JSON_INVALID_RAWDATA));
       break;
     case IE_INVALID_JSON:
-      ResponseCmndChar(D_JSON_INVALID_JSON);
+      ResponseCmndChar_P(PSTR(D_JSON_INVALID_JSON));
       break;
     case IE_SYNTAX_IRSEND:
       Response_P(PSTR("{\"" D_CMND_IRSEND "\":\"" D_JSON_NO " " D_JSON_IR_BITS " " D_JSON_OR " " D_JSON_IR_DATA "\"}"));

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -461,7 +461,7 @@ uint32_t findEchoGeneration(void) {
     gen = 1;        // if no user-agent, also revert to gen v1
   }
 
-  AddLog_P2(LOG_LEVEL_DEBUG_MORE, D_LOG_HTTP D_HUE " User-Agent: %s, gen=%d", user_agent.c_str(), gen);  // Header collection is set in xdrv_01_webserver.ino, in StartWebserver()
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_HTTP D_HUE " User-Agent: %s, gen=%d"), user_agent.c_str(), gen);  // Header collection is set in xdrv_01_webserver.ino, in StartWebserver()
 
   return gen;
 }
@@ -705,8 +705,8 @@ void HueLights(String *path)
   uint32_t device_id;   // the raw device_id used by Hue emulation
   uint8_t maxhue = (devices_present > MAX_HUE_DEVICES) ? MAX_HUE_DEVICES : devices_present;
 
-  path->remove(0,path->indexOf("/lights"));          // Remove until /lights
-  if (path->endsWith("/lights")) {                   // Got /lights
+  path->remove(0,path->indexOf(F("/lights")));          // Remove until /lights
+  if (path->endsWith(F("/lights"))) {                   // Got /lights
     response = "{";
     bool appending = false;
     CheckHue(&response, appending);
@@ -718,9 +718,9 @@ void HueLights(String *path)
 #endif
     response += "}";
   }
-  else if (path->endsWith("/state")) {               // Got ID/state
+  else if (path->endsWith(F("/state"))) {               // Got ID/state
     path->remove(0,8);                               // Remove /lights/
-    path->remove(path->indexOf("/state"));           // Remove /state
+    path->remove(path->indexOf(F("/state")));           // Remove /state
     device_id = atoi(path->c_str());
     device = DecodeLightId(device_id);
 #ifdef USE_ZIGBEE
@@ -741,8 +741,8 @@ void HueLights(String *path)
     }
 
   }
-  else if(path->indexOf("/lights/") >= 0) {          // Got /lights/ID
-    AddLog_P2(LOG_LEVEL_DEBUG_MORE, "/lights path=%s", path->c_str());
+  else if(path->indexOf(F("/lights/")) >= 0) {          // Got /lights/ID
+    AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("/lights path=%s"), path->c_str());
     path->remove(0,8);                               // Remove /lights/
     device_id = atoi(path->c_str());
     device = DecodeLightId(device_id);

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -94,9 +94,9 @@ int32_t Z_Reboot(int32_t res, class SBuffer &buf) {
   GetTextIndexed(reason_str, sizeof(reason_str), reason, Z_RebootReason);
 
   Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
-                  "\"Status\":%d,\"Message\":\"%s\",\"RestartReason\":\"%s\""
+                  "\"Status\":%d,\"Message\":\"CC2530 booted\",\"RestartReason\":\"%s\""
                   ",\"MajorRel\":%d,\"MinorRel\":%d}}"),
-                  ZIGBEE_STATUS_BOOT, "CC2530 booted", reason_str,
+                  ZIGBEE_STATUS_BOOT, reason_str,
                   major_rel, minor_rel);
 
   MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEE_STATE));


### PR DESCRIPTION
## Description:

I'm pushing more strings to PROGMEM to save on precious RAM, consuming a little more less-precious flash. I have introduced `ResponseCmndChar_P` in addition to `ResponseCmndChar`

Changes were only applied to IR, Hue and Zigbee.

Impact on resources (when Zigbee, IR and Hue emulation are enabled):
RAM:  **-532 bytes**
Flash:  +320 bytes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
