### PR TITLE
Change Zigbee simplification of devices probing, saving Flash and memory

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add command ``HumOffset -10.0 .. 10.0`` to set global humidity sensor offset (#7934)
 - Add Zigbee support for Hue emulation by Stefan Hadinger
 - Add Dew Point to Temperature and Humidity sensors
+- Change Zigbee simplification of devices probing, saving Flash and memory
 
 ### 8.1.0.10 20200227
 

--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -388,9 +388,6 @@ enum ZCL_Global_Commands {
 #define ZF(s) static const char ZS_ ## s[] PROGMEM = #s;
 #define Z(s)  ZS_ ## s
 
-const uint16_t Z_ProfileIds[]   PROGMEM = { 0x0104, 0x0109, 0xA10E, 0xC05E };
-const char     Z_ProfileNames[] PROGMEM = "ZigBee Home Automation|ZigBee Smart Energy|ZigBee Green Power|ZigBee Light Link";
-
 typedef struct Z_StatusLine {
   uint32_t     status;          // no need to use uint8_t since it uses 32 bits anyways
   const char * status_msg;

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -108,37 +108,25 @@ class SBuffer hibernateDevice(const struct Z_Device &device) {
   buf.add8(0x00);     // overall length, will be updated later
   buf.add16(device.shortaddr);
   buf.add64(device.longaddr);
-  uint32_t endpoints = device.endpoints.size();
-  if (endpoints > 254) { endpoints = 254; }
-  buf.add8(endpoints);
+
+  uint32_t endpoints_count = 0;
+  for (endpoints_count = 0; endpoints_count < endpoints_max; endpoints_count++) {
+    if (0x00 == device.endpoints[endpoints_count]) { break; }
+  }
+
+  buf.add8(endpoints_count);
   // iterate on endpoints
-  for (std::vector<uint32_t>::const_iterator ite = device.endpoints.begin() ; ite != device.endpoints.end(); ++ite) {
-    uint32_t ep_profile = *ite;
-    uint8_t endpoint = (ep_profile >> 16) & 0xFF;
-    uint16_t profileId = ep_profile & 0xFFFF;
+  for (uint32_t i = 0; i < endpoints_max; i++) {
+    uint8_t endpoint = device.endpoints[i];
+    if (0x00 == endpoint) { break; }      // stop
 
     buf.add8(endpoint);
-    buf.add16(profileId);
-    for (std::vector<uint32_t>::const_iterator itc = device.clusters_in.begin() ; itc != device.clusters_in.end(); ++itc) {
-      uint16_t cluster = *itc & 0xFFFF;
-      uint8_t  c_endpoint = (*itc >> 16) & 0xFF;
+    buf.add16(0x0000);   // profile_id, not used anymore
 
-      if (endpoint == c_endpoint) {
-        uint8_t clusterCode = toClusterCode(cluster);
-        if (0xFF != clusterCode) { buf.add8(clusterCode); }
-      }
-    }
+    // removed clusters_in
     buf.add8(0xFF);      // end of endpoint marker
 
-    for (std::vector<uint32_t>::const_iterator itc = device.clusters_out.begin() ; itc != device.clusters_out.end(); ++itc) {
-      uint16_t cluster = *itc & 0xFFFF;
-      uint8_t  c_endpoint = (*itc >> 16) & 0xFF;
-
-      if (endpoint == c_endpoint) {
-        uint8_t clusterCode = toClusterCode(cluster);
-        if (0xFF != clusterCode) { buf.add8(clusterCode); }
-      }
-    }
+    // no more storage of clusters_out
     buf.add8(0xFF);      // end of endpoint marker
   }
 
@@ -235,22 +223,21 @@ void hydrateDevices(const SBuffer &buf) {
     for (uint32_t j = 0; j < endpoints; j++) {
       uint8_t ep = buf_d.get8(d++);
       uint16_t ep_profile = buf_d.get16(d);  d += 2;
-      zigbee_devices.addEndointProfile(shortaddr, ep, ep_profile);
+      zigbee_devices.addEndpoint(shortaddr, ep);
 
       // in clusters
       while (d < dev_record_len) {      // safe guard against overflow
         uint8_t ep_cluster = buf_d.get8(d++);
         if (0xFF == ep_cluster) { break; }   // end of block
-        zigbee_devices.addCluster(shortaddr, ep, fromClusterCode(ep_cluster), false);
+        // ignore
       }
       // out clusters
       while (d < dev_record_len) {      // safe guard against overflow
         uint8_t ep_cluster = buf_d.get8(d++);
         if (0xFF == ep_cluster) { break; }   // end of block
-        zigbee_devices.addCluster(shortaddr, ep, fromClusterCode(ep_cluster), true);
+        // ignore
       }
     }
-    zigbee_devices.shrinkToFit(shortaddr);
 //AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Device 0x%04X Memory3.shrink = %d"), shortaddr, ESP.getFreeHeap());
 
     // parse 3 strings

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -549,6 +549,7 @@ ZF(ZCLVersion) ZF(AppVersion) ZF(StackVersion) ZF(HWVersion) ZF(Manufacturer) ZF
 ZF(DateCode) ZF(PowerSource) ZF(SWBuildID) ZF(Power) ZF(SwitchType) ZF(Dimmer)
 ZF(MainsVoltage) ZF(MainsFrequency) ZF(BatteryVoltage) ZF(BatteryPercentage)
 ZF(CurrentTemperature) ZF(MinTempExperienced) ZF(MaxTempExperienced) ZF(OverTempTotalDwell)
+ZF(SceneCount) ZF(CurrentScene) ZF(CurrentGroup) ZF(SceneValid)
 ZF(AlarmCount) ZF(Time) ZF(TimeStatus) ZF(TimeZone) ZF(DstStart) ZF(DstEnd)
 ZF(DstShift) ZF(StandardTime) ZF(LocalTime) ZF(LastSetTime) ZF(ValidUntilTime)
 
@@ -659,6 +660,13 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { 0x0002, 0x0001,  Z(MinTempExperienced),   &Z_Copy },
   { 0x0002, 0x0002,  Z(MaxTempExperienced),   &Z_Copy },
   { 0x0002, 0x0003,  Z(OverTempTotalDwell),   &Z_Copy },
+
+  // Scenes cluster
+  { 0x0005, 0x0000,  Z(SceneCount),           &Z_Copy },
+  { 0x0005, 0x0001,  Z(CurrentScene),         &Z_Copy },
+  { 0x0005, 0x0002,  Z(CurrentGroup),         &Z_Copy },
+  { 0x0005, 0x0003,  Z(SceneValid),           &Z_Copy },
+  //{ 0x0005, 0x0004,  Z(NameSupport),           &Z_Copy },
 
   // On/off cluster
   { 0x0006, 0x0000,  Z(Power),                &Z_Copy },
@@ -933,7 +941,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { 0x0405, 0x0000,  Z(Humidity),             &Z_FloatDiv100 },   // Humidity
   { 0x0405, 0x0001,  Z(HumidityMinMeasuredValue),     &Z_Copy },    //
   { 0x0405, 0x0002,  Z(HumidityMaxMeasuredValue),     &Z_Copy },    //
-  { 0x0405, 0x0003,  Z(HumidityTolerance),            &Z_Copy },    //
+  { 0x0405, 0x0003,  "HumidityTolerance",            &Z_Copy },    //
   { 0x0405, 0xFFFF,  nullptr,                &Z_Remove },     // Remove all other values
 
   // Occupancy Sensing cluster

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -340,7 +340,9 @@ int32_t Z_DataConfirm(int32_t res, const class SBuffer &buf) {
   char              status_message[32];
 
   if (status) {   // only report errors
-    strncpy_P(status_message, (const char*) getZigbeeStatusMessage(status), sizeof(status_message));
+    const char * statm = (const char*) getZigbeeStatusMessage(status);
+    if (nullptr == statm) { statm = PSTR(""); }
+    strncpy_P(status_message, statm, sizeof(status_message));
     status_message[sizeof(status_message)-1] = 0;   // truncate if needed, strlcpy is safer but strlcpy_P does not exist
 
     Response_P(PSTR("{\"" D_JSON_ZIGBEE_CONFIRM "\":{\"" D_CMND_ZIGBEE_ENDPOINT "\":%d"

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -394,7 +394,7 @@ void zigbeeZCLSendStr(uint16_t shortaddr, uint16_t groupaddr, uint8_t endpoint, 
 
   if ((0 == endpoint) && (shortaddr)) {
     // endpoint is not specified, let's try to find it from shortAddr, unless it's a group address
-    endpoint = zigbee_devices.findClusterEndpointIn(shortaddr, cluster);
+    endpoint = zigbee_devices.findFirstEndpoint(shortaddr);
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZbSend: guessing endpoint 0x%02X"), endpoint);
   }
   AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZbSend: shortaddr 0x%04X, groupaddr 0x%04X, cluster 0x%04X, endpoint 0x%02X, cmd 0x%02X, data %s"),
@@ -847,7 +847,7 @@ void CmndZbRead(void) {
   }
 
   if ((0 == endpoint) && (device)) {    // try to compute the endpoint
-    endpoint = zigbee_devices.findClusterEndpointIn(device, cluster);
+    endpoint = zigbee_devices.findFirstEndpoint(device);
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR("ZbSend: guessing endpoint 0x%02X"), endpoint);
   }
   if (groupaddr) {


### PR DESCRIPTION
## Description:

Simplification of Zigbee device probing. The list of clusters per endpoint is not probed anymore, which saves Flash and memory (it wasn't really useful anyways).

As a consequence, `ZbStatus3` is removed and is now equivalent to `ZbStatus2`.

Also, added support for Zigbee scenes, they are useful when linking IKEA bulbs and remotes.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
