### PR TITLE
Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.2.0.1 20200321
 
 - Change HM-10 sensor type detection and add features (#7962)
+- Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``
 
 ## Released
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -514,6 +514,7 @@
   #define D_JSON_ZIGBEE_STATUS_MSG "StatusMessage"
 #define D_CMND_ZIGBEE_LIGHT "Light"
   #define D_JSON_ZIGBEE_LIGHT "Light"
+#define D_CMND_ZIGBEE_RESTORE "Restore"
 
 // Commands xdrv_25_A4988_Stepper.ino
 #define D_CMND_MOTOR "MOTOR"

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -43,6 +43,42 @@ JsonVariant &getCaseInsensitive(const JsonObject &json, const char *needle) {
   return *(JsonVariant*)nullptr;
 }
 
+// get the result as a string (const char*) and nullptr if there is no field or the string is empty
+const char * getCaseInsensitiveConstCharNull(const JsonObject &json, const char *needle) {
+  const JsonVariant &val = getCaseInsensitive(json, needle);
+  if (&val) {
+    const char *val_cs = val.as<const char*>();
+    if (strlen(val_cs)) {
+      return val_cs;
+    }
+  }
+  return nullptr;
+}
+
+// Get an JSON attribute, with case insensitive key search starting with *needle
+JsonVariant &startsWithCaseInsensitive(const JsonObject &json, const char *needle) {
+  // key can be in PROGMEM
+  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
+    return *(JsonVariant*)nullptr;
+  }
+
+  String needle_s(needle);
+  needle_s.toLowerCase();
+
+  for (auto kv : json) {
+    String key_s(kv.key);
+    key_s.toLowerCase();
+    JsonVariant &value = kv.value;
+
+    if (key_s.startsWith(needle_s)) {
+      return value;
+    }
+  }
+  // if not found
+  return *(JsonVariant*)nullptr;
+}
+
+
 uint32_t parseHex(const char **data, size_t max_len = 8) {
   uint32_t ret = 0;
   for (uint32_t i = 0; i < max_len; i++) {


### PR DESCRIPTION
## Description:

When you erase the Z2T configuration, devices remain paired but you lose internal device configuration like `manufacturer`, `IEEEAddress` or `modelId`. I got tired of having to re-pair some devices just to load back this information.

The new command `ZbRestore` lets you import any device configuration you alread exported with `ZbStatus2`.

Syntax: `ZbRestore <json>` where `<json>` can be:

- Complete `ZbStatus2` output:
```ZbRestore {"ZbStatus2":[{"Device":"0xA406","Name":"Temp","IEEEAddr":"0x00158D00036B50AE","ModelId":"lumi.weather","Manufacturer":"LUMI","Endpoints":["0x01"]}]}```

- An array of devices configuration:
```ZbRestore [{"Device":"0xA406","Name":"Temp","IEEEAddr":"0x00158D00036B50AE","ModelId":"lumi.weather","Manufacturer":"LUMI","Endpoints":["0x01"]}]```

- A single device json:
```ZbRestore {"Device":"0xA406","Name":"Temp","IEEEAddr":"0x00158D00036B50AE","ModelId":"lumi.weather","Manufacturer":"LUMI","Endpoints":["0x01"]}```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
