### PR TITLE
Fix Zigbee sending wrong Sat value with Hue emulation

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change HM-10 sensor type detection and add features (#7962)
 - Change GPIO initialization solving possible Relay toggle on (OTA) restart
 - Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``
+- Fix Zigbee sending wrong Sat value with Hue emulation
 
 ## Released
 

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -1007,7 +1007,7 @@ String Z_Devices::dump(uint32_t dump_mode, uint16_t status_shortaddr) const {
       if (device.modelId) {
         dev[F(D_JSON_MODEL D_JSON_ID)] = device.modelId;
       }
-      if (-1 != device.bulbtype) {
+      if (device.bulbtype >= 0) {
         dev[F(D_JSON_ZIGBEE_LIGHT)] = device.bulbtype;   // sign extend, 0xFF changed as -1
       }
       if (device.manufacturerId) {

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -130,6 +130,7 @@ void ZigbeeHuePower(uint16_t shortaddr, uint8_t power) {
 
 // Dimmer
 void ZigbeeHueDimmer(uint16_t shortaddr, uint8_t dimmer) {
+  if (dimmer > 0xFE) { dimmer = 0xFE; }
   char param[8];
   snprintf_P(param, sizeof(param), PSTR("%02X0A00"), dimmer);
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0008, 0x04, param);
@@ -138,6 +139,7 @@ void ZigbeeHueDimmer(uint16_t shortaddr, uint8_t dimmer) {
 
 // CT
 void ZigbeeHueCT(uint16_t shortaddr, uint16_t ct) {
+  if (ct > 0xFEFF) { ct = 0xFEFF; }
   AddLog_P2(LOG_LEVEL_INFO, PSTR("ZigbeeHueCT 0x%04X - %d"), shortaddr, ct);
   char param[12];
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0A00"), ct & 0xFF, ct >> 8);
@@ -149,6 +151,8 @@ void ZigbeeHueCT(uint16_t shortaddr, uint16_t ct) {
 // XY
 void ZigbeeHueXY(uint16_t shortaddr, uint16_t x, uint16_t y) {
   char param[16];
+  if (x > 0xFEFF) { x = 0xFEFF; }
+  if (y > 0xFEFF) { y = 0xFEFF; }
   snprintf_P(param, sizeof(param), PSTR("%02X%02X%02X%02X0A00"), x & 0xFF, x >> 8, y & 0xFF, y >> 8);
   uint8_t colormode = 1;      // "xy"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x07, param);
@@ -159,6 +163,7 @@ void ZigbeeHueXY(uint16_t shortaddr, uint16_t x, uint16_t y) {
 void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
   char param[16];
   uint8_t hue8 = changeUIntScale(hue, 0, 360, 0, 254);
+  if (sat > 0xFE) { sat = 0xFE; }
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0A00"), hue8, sat);
   uint8_t colormode = 0;      // "hs"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x06, param);

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -756,7 +756,8 @@ void CmndZbLight(void) {
 
   if (p) {
     int8_t bulbtype = strtol(p, nullptr, 10);
-    if (bulbtype > 5) { bulbtype = 5; }
+    if (bulbtype > 5)  { bulbtype = 5; }
+    if (bulbtype < -1) { bulbtype = -1; }
     zigbee_devices.setHueBulbtype(shortaddr, bulbtype);
   }
   String dump = zigbee_devices.dumpLightState(shortaddr);

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -756,6 +756,7 @@ void CmndZbLight(void) {
 
   if (p) {
     int8_t bulbtype = strtol(p, nullptr, 10);
+    if (bulbtype > 5) { bulbtype = 5; }
     zigbee_devices.setHueBulbtype(shortaddr, bulbtype);
   }
   String dump = zigbee_devices.dumpLightState(shortaddr);


### PR DESCRIPTION
## Description:

Fixes issues in changing color on RGB lights via Alexa.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
