### PR TITLE
Add support for unreachable (unplugged) Zigbee devices in Philips Hue emulation and Alexa

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix Zigbee sending wrong Sat value with Hue emulation
 - Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``
 - Add support for unreachable (unplugged) Zigbee devices in Philips Hue emulation and Alexa
+- Add Zigbee ``ZbUnbind``command
 
 ## Released
 

--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change GPIO initialization solving possible Relay toggle on (OTA) restart
 - Fix Zigbee sending wrong Sat value with Hue emulation
 - Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``
+- Add support for unreachable (unplugged) Zigbee devices in Philips Hue emulation and Alexa
 
 ## Released
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -505,6 +505,8 @@
 #define D_JSON_ZIGBEE_RECEIVED "ZbReceived"
 #define D_CMND_ZIGBEE_BIND "Bind"
   #define D_JSON_ZIGBEE_BIND "ZbBind"
+#define D_CMND_ZIGBEE_UNBIND "Unbind"
+  #define D_JSON_ZIGBEE_UNBIND "ZbUnbind"
 #define D_CMND_ZIGBEE_PING "Ping"
   #define D_JSON_ZIGBEE_PING "ZbPing"
   #define D_JSON_ZIGBEE_IEEE "IEEEAddr"

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -24,13 +24,19 @@
 
 // idx: index in the list of zigbee_devices
 void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, String *response) {
-  uint8_t  power, colormode, bri, sat;
+  static const char HUE_LIGHTS_STATUS_JSON1_SUFFIX_ZIGBEE[] PROGMEM =
+    "%s\"alert\":\"none\","
+    "\"effect\":\"none\","
+    "\"reachable\":%s}";
+
+  bool     power, reachable;
+  uint8_t  colormode, bri, sat;
   uint16_t ct, hue;
   uint16_t x, y;
   String light_status = "";
   uint32_t echo_gen = findEchoGeneration();   // 1 for 1st gen =+ Echo Dot 2nd gen, 2 for 2nd gen and above
 
-  zigbee_devices.getHueState(shortaddr, &power, &colormode, &bri, &sat, &ct, &hue, &x, &y);
+  zigbee_devices.getHueState(shortaddr, &power, &colormode, &bri, &sat, &ct, &hue, &x, &y, &reachable);
 
   if (bri > 254)   bri = 254;    // Philips Hue bri is between 1 and 254
   if (bri < 1)     bri = 1;
@@ -40,7 +46,7 @@ void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, Stri
   const size_t buf_size = 256;
   char * buf = (char*) malloc(buf_size);     // temp buffer for strings, avoid stack
 
-  snprintf_P(buf, buf_size, PSTR("{\"on\":%s,"), (power & 1) ? "true" : "false");
+  snprintf_P(buf, buf_size, PSTR("{\"on\":%s,"), power ? "true" : "false");
   // Brightness for all devices with PWM
   if ((1 == echo_gen) || (LST_SINGLE <= local_light_subtype)) { // force dimmer for 1st gen Echo
     snprintf_P(buf, buf_size, PSTR("%s\"bri\":%d,"), buf, bri);
@@ -61,7 +67,7 @@ void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, Stri
   if (LST_COLDWARM == local_light_subtype || LST_RGBW <= local_light_subtype) {  // white temp
     snprintf_P(buf, buf_size, PSTR("%s\"ct\":%d,"), buf, ct > 0 ? ct : 284);
   }
-  snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON1_SUFFIX, buf);
+  snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON1_SUFFIX_ZIGBEE, buf, reachable ? "true" : "false");
 
   *response += buf;
   free(buf);
@@ -123,9 +129,9 @@ void ZigbeeHueGroups(String * lights) {
 
 // Send commands
 // Power On/Off
-void ZigbeeHuePower(uint16_t shortaddr, uint8_t power) {
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0006, power, "");
-  zigbee_devices.updateHueState(shortaddr, &power, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+void ZigbeeHuePower(uint16_t shortaddr, bool power) {
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0006, power ? 1 : 0, "");
+  zigbee_devices.updateHueState(shortaddr, &power, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 // Dimmer
@@ -134,7 +140,7 @@ void ZigbeeHueDimmer(uint16_t shortaddr, uint8_t dimmer) {
   char param[8];
   snprintf_P(param, sizeof(param), PSTR("%02X0A00"), dimmer);
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0008, 0x04, param);
-  zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, &dimmer, nullptr, nullptr, nullptr, nullptr, nullptr);
+  zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, &dimmer, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 // CT
@@ -145,7 +151,7 @@ void ZigbeeHueCT(uint16_t shortaddr, uint16_t ct) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0A00"), ct & 0xFF, ct >> 8);
   uint8_t colormode = 2;      // "ct"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x0A, param);
-  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, &ct, nullptr, nullptr, nullptr);
+  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, &ct, nullptr, nullptr, nullptr, nullptr);
 }
 
 // XY
@@ -156,7 +162,7 @@ void ZigbeeHueXY(uint16_t shortaddr, uint16_t x, uint16_t y) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X%02X%02X0A00"), x & 0xFF, x >> 8, y & 0xFF, y >> 8);
   uint8_t colormode = 1;      // "xy"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x07, param);
-  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, nullptr, nullptr, &x, &y);
+  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, nullptr, nullptr, &x, &y, nullptr);
 }
 
 // HueSat
@@ -167,7 +173,7 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0000"), hue8, sat);
   uint8_t colormode = 0;      // "hs"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x06, param);
-  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, &sat, nullptr, &hue, nullptr, nullptr);
+  zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, &sat, nullptr, &hue, nullptr, nullptr, nullptr);
 }
 
 void ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, String &response) {

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1215,38 +1215,38 @@ void ZCLFrame::postProcessAttributes(uint16_t shortaddr, JsonObject& json) {
 
       // see if we need to update the Hue bulb status
       if ((cluster == 0x0006) && ((attribute == 0x0000) || (attribute == 0x8000))) {
-        uint8_t power = value;
+        bool power = value;
         zigbee_devices.updateHueState(shortaddr, &power, nullptr, nullptr, nullptr,
-                                        nullptr, nullptr, nullptr, nullptr);
+                                        nullptr, nullptr, nullptr, nullptr, nullptr);
       } else if ((cluster == 0x0008) && (attribute == 0x0000)) {
         uint8_t dimmer = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, &dimmer, nullptr,
-                                        nullptr, nullptr, nullptr, nullptr);
+                                        nullptr, nullptr, nullptr, nullptr, nullptr);
       } else if ((cluster == 0x0300) && (attribute == 0x0000)) {
         uint16_t hue8 = value;
         uint16_t hue = changeUIntScale(hue8, 0, 254, 0, 360);     // change range from 0..254 to 0..360
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, nullptr, nullptr,
-                                        nullptr, &hue, nullptr, nullptr);
+                                        nullptr, &hue, nullptr, nullptr, nullptr);
       } else if ((cluster == 0x0300) && (attribute == 0x0001)) {
         uint8_t sat = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, nullptr, &sat,
-                                        nullptr, nullptr, nullptr, nullptr);
+                                        nullptr, nullptr, nullptr, nullptr, nullptr);
       } else if ((cluster == 0x0300) && (attribute == 0x0003)) {
         uint16_t x = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, nullptr, nullptr,
-                                        nullptr, nullptr, &x, nullptr);
+                                        nullptr, nullptr, &x, nullptr, nullptr);
       } else if ((cluster == 0x0300) && (attribute == 0x0004)) {
         uint16_t y = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, nullptr, nullptr,
-                                        nullptr, nullptr, nullptr, &y);
+                                        nullptr, nullptr, nullptr, &y, nullptr), nullptr;
       } else if ((cluster == 0x0300) && (attribute == 0x0007)) {
         uint16_t ct = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, nullptr, nullptr,
-                                        &ct, nullptr, nullptr, nullptr);
+                                        &ct, nullptr, nullptr, nullptr, nullptr);
       } else if ((cluster == 0x0300) && (attribute == 0x0008)) {
         uint8_t colormode = value;
         zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr,
-                                        nullptr, nullptr, nullptr, nullptr);
+                                        nullptr, nullptr, nullptr, nullptr, nullptr);
       }
 
       // Iterate on filter

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -173,6 +173,14 @@ int32_t Z_ReadAttrCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t clus
   }
 }
 
+
+// This callback is registered after a an attribute read command was made to a light, and fires if we don't get any response after 1000 ms
+int32_t Z_Unreachable(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  if (shortaddr) {
+    zigbee_devices.setReachable(shortaddr, false);     // mark device as reachable
+  }
+}
+
 // set a timer to read back the value in the future
 void zigbeeSetCommandTimer(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint) {
   uint32_t wait_ms = 0;
@@ -192,6 +200,9 @@ void zigbeeSetCommandTimer(uint16_t shortaddr, uint16_t groupaddr, uint16_t clus
   }
   if (wait_ms) {
     zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms, cluster, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+    if (shortaddr) {      // reachability test is not possible for group addresses, since we don't know the list of devices in the group
+      zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, cluster, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
+    }
   }
 }
 
@@ -300,6 +311,10 @@ void sendHueUpdate(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uin
     }
     if ((endpoint) || (groupaddr)) {   // send only if we know the endpoint
       zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms, cluster, endpoint, z_cat, 0 /* value */, &Z_ReadAttrCallback);
+      if (shortaddr) {      // reachability test is not possible for group addresses, since we don't know the list of devices in the group
+        zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, cluster, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
+      }
+
     }
   }
 }

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -308,6 +308,7 @@ int32_t Z_DataConfirm(int32_t res, const class SBuffer &buf) {
 
 //
 // Handle Receive End Device Announce incoming message
+// This message is also received when a previously paired device is powered up
 // Send back Active Ep Req message
 //
 int32_t Z_ReceiveEndDeviceAnnonce(int32_t res, const class SBuffer &buf) {
@@ -328,6 +329,9 @@ int32_t Z_ReceiveEndDeviceAnnonce(int32_t res, const class SBuffer &buf) {
                   (capabilities & 0x08) ? "true" : "false",
                   (capabilities & 0x40) ? "true" : "false"
                   );
+  // query the state of the bulb (for Alexa)
+  uint32_t wait_ms = 2000;    // wait for 2s
+  Z_Query_Bulb(nwkAddr, wait_ms);
 
   MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZCL_RECEIVED));
   XdrvRulesProcess();
@@ -513,6 +517,10 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
     // Add linkquality
     json[F(D_CMND_ZIGBEE_LINKQUALITY)] = linkquality;
 
+    // since we just receveived data from the device, it is reachable
+    zigbee_devices.resetTimersForDevice(srcaddr, 0 /* groupaddr */, Z_CAT_REACHABILITY);    // remove any reachability timer already there
+    zigbee_devices.setReachable(srcaddr, true);     // mark device as reachable
+
     if (defer_attributes) {
       // Prepare for publish
       if (zigbee_devices.jsonIsConflict(srcaddr, json)) {
@@ -592,37 +600,35 @@ int32_t Z_Load_Devices(uint8_t value) {
 }
 
 //
+// Query the state of a bulb (light) if its type allows it
+//
+void Z_Query_Bulb(uint16_t shortaddr, uint32_t &wait_ms) {
+  const uint32_t inter_message_ms = 100;    // wait 100ms between messages
+
+  if (0 <= zigbee_devices.getHueBulbtype(shortaddr)) {
+    uint8_t endpoint = zigbee_devices.findFirstEndpoint(shortaddr);
+
+    if (endpoint) {   // send only if we know the endpoint
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0006, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      wait_ms += inter_message_ms;
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0008, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      wait_ms += inter_message_ms;
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0300, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      wait_ms += inter_message_ms;
+      zigbee_devices.setTimer(shortaddr, 0, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, 0, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
+    }
+  }
+}
+
+//
 // Send messages to query the state of each Hue emulated light
 //
 int32_t Z_Query_Bulbs(uint8_t value) {
   // Scan all devices and send deferred requests to know the state of bulbs
   uint32_t wait_ms = 1000;                  // start with 1.0 s delay
-  const uint32_t inter_message_ms = 100;    // wait 100ms between messages
   for (uint32_t i = 0; i < zigbee_devices.devicesSize(); i++) {
     const Z_Device &device = zigbee_devices.devicesAt(i);
-
-    if (0 <= device.bulbtype) {
-      uint16_t cluster;
-      uint8_t endpoint = zigbee_devices.findFirstEndpoint(device.shortaddr);
-
-      cluster = 0x0006;
-      if (endpoint) {   // send only if we know the endpoint
-        zigbee_devices.setTimer(device.shortaddr, 0 /* groupaddr */, wait_ms, cluster, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
-        wait_ms += inter_message_ms;
-      }
-
-      cluster = 0x0008;
-      if (endpoint) {   // send only if we know the endpoint
-        zigbee_devices.setTimer(device.shortaddr, 0 /* groupaddr */, wait_ms, cluster, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
-        wait_ms += inter_message_ms;
-      }
-
-      cluster = 0x0300;
-      if (endpoint) {   // send only if we know the endpoint
-        zigbee_devices.setTimer(device.shortaddr, 0 /* groupaddr */, wait_ms, cluster, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
-        wait_ms += inter_message_ms;
-      }
-    }
+    Z_Query_Bulb(device.shortaddr, wait_ms);
   }
   return 0;                              // continue
 }


### PR DESCRIPTION
## Description:

Added support for Zigbee devices not responding (time-out of 1s) meaning they are unreachable. They will be marked as unreachable in Alexa app. Devices plugged back will automatically be marked as reachable again and their status updated.

Added `ZbUnbind`command.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
