### PR TITLE
Add support for 64x48 SSD1306 OLED (#6740)

### DIFF
--- a/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
+++ b/lib/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
@@ -916,15 +916,22 @@ uint8_t *Adafruit_SSD1306::getBuffer(void) {
             of graphics commands, as best needed by one's own application.
 */
 void Adafruit_SSD1306::display(void) {
+  int16_t col_start = 0;
+  int16_t col_end = WIDTH - 1;
+  if ((64 == WIDTH) && (48 == HEIGHT)) {    // for 64x48, we need to shift by 32 in both directions
+    col_start += 32;
+    col_end += 32;
+  }
+
   TRANSACTION_START
   static const uint8_t PROGMEM dlist1[] = {
     SSD1306_PAGEADDR,
     0,                         // Page start address
     0xFF,                      // Page end (not really, but works here)
-    SSD1306_COLUMNADDR,
-    0 };                       // Column start address
+    SSD1306_COLUMNADDR };
   ssd1306_commandList(dlist1, sizeof(dlist1));
-  ssd1306_command1(WIDTH - 1); // Column end address
+  ssd1306_command1(col_start); // Column start address
+  ssd1306_command1(col_end); // Column end address
 
 #if defined(ESP8266)
   // ESP8266 needs a periodic yield() call to avoid watchdog reset.

--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add command ``ZbRestore`` to restore device configuration dumped with ``ZbStatus 2``
 - Add support for unreachable (unplugged) Zigbee devices in Philips Hue emulation and Alexa
 - Add Zigbee ``ZbUnbind``command
+- Add support for 64x48 SSD1306 OLED (#6740)
 
 ## Released
 


### PR DESCRIPTION
## Description:

Final change to support 64x48 SSD1306 OLED displays. The code was already by @krijnenr but never merged into development. I confirm it works with 64x48 OLED display (Wemos D1 shield from Aliex)

**Related issue (if applicable):** fixes #6740 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
