### PR TITLE
Add multiple GroupTopic<x> (x=1-4) (default disabled)

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -344,6 +344,7 @@
 // -- MQTT ----------------------------------------
 #define MQTT_TELE_RETAIN     0                   // Tele messages may send retain flag (0 = off, 1 = on)
 #define MQTT_CLEAN_SESSION   1                   // Mqtt clean session connection (0 = No clean session, 1 = Clean session (default))
+//#define USE_GROUPTOPIC_SET                       // Enable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 
 // -- MQTT - Domoticz -----------------------------
 #define USE_DOMOTICZ                             // Enable Domoticz (+6k code, +0.3k mem)

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -130,11 +130,11 @@ char* GetTopic_P(char *stopic, uint32_t prefix, char *topic, const char* subtopi
   return stopic;
 }
 
-char* GetGroupTopic_P(char *stopic, const char* subtopic)
+char* GetGroupTopic_P(char *stopic, const char* subtopic, int itopic)
 {
   // SetOption75 0: %prefix%/nothing/%topic% = cmnd/nothing/<grouptopic>/#
   // SetOption75 1: cmnd/<grouptopic>
-  return GetTopic_P(stopic, (Settings.flag3.grouptopic_mode) ? CMND +8 : CMND, SettingsText(SET_MQTT_GRP_TOPIC), subtopic);  // SetOption75 - GroupTopic replaces %topic% (0) or fixed topic cmnd/grouptopic (1)
+  return GetTopic_P(stopic, (Settings.flag3.grouptopic_mode) ? CMND +8 : CMND, SettingsText(itopic), subtopic);  // SetOption75 - GroupTopic replaces %topic% (0) or fixed topic cmnd/grouptopic (1)
 }
 
 char* GetFallbackTopic_P(char *stopic, const char* subtopic)

--- a/tasmota/tasmota_post.h
+++ b/tasmota/tasmota_post.h
@@ -98,6 +98,7 @@ extern "C" void resetPins();
 #define CODE_IMAGE_STR "sensors"
 
 #undef USE_DISCOVERY                             // Disable mDNS (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 
 // -- Optional modules ----------------------------
 //#define ROTARY_V1                                // Add support for MI Desk Lamp
@@ -273,6 +274,7 @@ extern "C" void resetPins();
 #undef USE_PWM_DIMMER_REMOTE                     // Disbale support for remote switches to PWM Dimmer
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 #endif  // FIRMWARE_KNX_NO_EMULATION
 
 /*********************************************************************************************\
@@ -292,6 +294,7 @@ extern "C" void resetPins();
 #undef USE_EMULATION_WEMO                        // Disable Belkin WeMo emulation for Alexa (+6k code, +2k mem common)
 #undef USE_DOMOTICZ                              // Disable Domoticz
 #undef USE_HOME_ASSISTANT                        // Disable Home Assistant
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 
 // -- Optional modules ----------------------------
 #undef ROTARY_V1                                 // Disable support for MI Desk Lamp
@@ -373,6 +376,7 @@ extern "C" void resetPins();
 //#undef USE_SUNRISE                               // Disable support for Sunrise and sunset tools
 //#undef USE_RULES                                 // Disable support for rules
 #undef USE_DISCOVERY                             // Disable mDNS for the following services (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 
 // -- Optional modules ----------------------------
 #undef ROTARY_V1                                 // Disable support for MI Desk Lamp
@@ -474,6 +478,7 @@ extern "C" void resetPins();
 #undef USE_DOMOTICZ                              // Disable Domoticz
 #undef USE_HOME_ASSISTANT                        // Disable Home Assistant
 #undef USE_MQTT_TLS                              // Disable TLS support won't work as the MQTTHost is not set
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 #undef USE_KNX                                   // Disable KNX IP Protocol Support
 //#undef USE_WEBSERVER                             // Disable Webserver
 #undef USE_WEBSEND_RESPONSE                      // Disable command WebSend response message (+1k code)
@@ -595,6 +600,7 @@ extern "C" void resetPins();
 #undef USE_DOMOTICZ                              // Disable Domoticz
 #undef USE_HOME_ASSISTANT                        // Disable Home Assistant
 //#undef USE_MQTT_TLS                              // Disable TLS support won't work as the MQTTHost is not set
+#undef USE_GROUPTOPIC_SET                        // Disable multiple GROUPTOPIC<x>, x=1-4 (+0k1 code)
 #undef USE_KNX                                   // Disable KNX IP Protocol Support
 //#undef USE_WEBSERVER                             // Disable Webserver
 #undef USE_WEBSEND_RESPONSE                      // Disable command WebSend response message (+1k code)

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2127,7 +2127,16 @@ void HandleInformation(void)
     WSContentSend_P(PSTR("}1" D_MQTT_CLIENT "}2%s"), mqtt_client);
     WSContentSend_P(PSTR("}1" D_MQTT_TOPIC "}2%s"), SettingsText(SET_MQTT_TOPIC));
 //    WSContentSend_P(PSTR("}1" D_MQTT_GROUP_TOPIC "}2%s"), SettingsText(SET_MQTT_GRP_TOPIC));
-    WSContentSend_P(PSTR("}1" D_MQTT_GROUP_TOPIC "}2%s"), GetGroupTopic_P(stopic, ""));
+#ifdef USE_GROUPTOPIC_SET
+    WSContentSend_P(PSTR("}1" D_MQTT_GROUP_TOPIC " 1}2%s"), GetGroupTopic_P(stopic, "", SET_MQTT_GRP_TOPIC));
+    for(uint32_t i=0; i < 3; i++) {
+      if (strlen(SettingsText(SET_MQTT_GRP_TOPIC2+i))) {
+        WSContentSend_P(PSTR("}1" D_MQTT_GROUP_TOPIC " %d}2%s"), 2+i, GetGroupTopic_P(stopic, "", SET_MQTT_GRP_TOPIC2+i));
+      }
+    }
+#else  // USE_GROUPTOPIC_SET
+    WSContentSend_P(PSTR("}1" D_MQTT_GROUP_TOPIC "}2%s"), GetGroupTopic_P(stopic, "", SET_MQTT_GRP_TOPIC));
+#endif  // USE_GROUPTOPIC_SET
     WSContentSend_P(PSTR("}1" D_MQTT_FULL_TOPIC "}2%s"), GetTopic_P(stopic, CMND, mqtt_topic, ""));
     WSContentSend_P(PSTR("}1" D_MQTT " " D_FALLBACK_TOPIC "}2%s"), GetFallbackTopic_P(stopic, ""));
   } else {

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -685,7 +685,7 @@ void ShutterButtonHandler(void)
                 for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
                   if ((i==shutter_index) || (Settings.shutter_button[button_index] & (0x01<<30))) {
                     snprintf_P(scommand, sizeof(scommand),PSTR("ShutterPosition%d"), i+1);
-                    GetGroupTopic_P(stopic, scommand);
+                    GetGroupTopic_P(stopic, scommand, SET_MQTT_GRP_TOPIC);
                     Response_P("%d", position);
                     MqttPublish(stopic, false);
                   }


### PR DESCRIPTION
## Description:

`#define USE_GROUPTOPIC_SET` enables multiple grouptopics (1-4) subscription even when USE_DEVICE_GROUPS is not used.

Usefull for controlling devices in overlapping groups having [Device Group](https://github.com/arendst/Tasmota/blob/development/Device_Groups.md) feature disabled (e.g. using this MQTT based only for commands not implemented in device group feature).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
