### PR TITLE
Add Zigbee commands ``ZbBindState`` and ``manuf``attribute

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 8.2.0.3 20200329
 
 - Add support for longer template names
+- Add Zigbee commands ``ZbBindState`` and ``manuf``attribute
 
 ### 8.2.0.2 20200328
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -507,6 +507,8 @@
   #define D_JSON_ZIGBEE_BIND "ZbBind"
 #define D_CMND_ZIGBEE_UNBIND "Unbind"
   #define D_JSON_ZIGBEE_UNBIND "ZbUnbind"
+#define D_CMND_ZIGBEE_BIND_STATE "BindState"
+  #define D_JSON_ZIGBEE_BIND_STATE "ZbBindState"
 #define D_CMND_ZIGBEE_PING "Ping"
   #define D_JSON_ZIGBEE_PING "ZbPing"
   #define D_JSON_ZIGBEE_IEEE "IEEEAddr"

--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -399,14 +399,14 @@ String getZigbeeStatusMessage(uint8_t status) {
                                              "|UNSUP_MANUF_CLUSTER_COMMAND|UNSUP_MANUF_GENERAL_COMMAND|INVALID_FIELD|UNSUPPORTED_ATTRIBUTE|INVALID_VALE|READ_ONLY"
                                              "|INSUFFICIENT_SPACE|DUPLICATE_EXISTS|NOT_FOUND|UNREPORTABLE_ATTRIBUTE|INVALID_DATA_TYPE|INVALID_SELECTOR|WRITE_ONLY"
                                              "|INCONSISTENT_STARTUP_STATE|DEFINED_OUT_OF_BAND|INCONSISTENT|ACTION_DENIED|TIMEOUT|ABORT|INVALID_IMAGE|WAIT_FOR_DATA"
-                                             "|NO_IMAGE_AVAILABLE|REQUIRE_MORE_IMAGE|NOTIFICATION_PENDING|HARDWARE_FAILURE|SOFTWARE_FAILURE|CALIBRATION_ERROR|UNSUPPORTED_CLUSTER"
+                                             "|NO_IMAGE_AVAILABLE|REQUIRE_MORE_IMAGE|NOTIFICATION_PENDING|HARDWARE_FAILURE|SOFTWARE_FAILURE|CALIBRATION_ERROR|UNSUPPORTED_CLUSTER|NO_ROUTE"
                                              "|CHANNEL_ACCESS_FAILURE|NO_ACK|NO_APP_ACK|NO_ROUTE"
                                              ;
   static const uint8_t StatusIdx[] PROGMEM = { 0x00, 0x01, 0x7E, 0x7F, 0x80, 0x81, 0x82,
                                                0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
                                                0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
                                                0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97,
-                                               0x98, 0x99, 0x9A, 0xC0, 0xC1, 0xC2, 0xC3,
+                                               0x98, 0x99, 0x9A, 0xC0, 0xC1, 0xC2, 0xC3, 0xCD,
                                                0xE1, 0xE9, 0xA7, 0xD0};
 
   char msg[32];

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -130,7 +130,7 @@ void ZigbeeHueGroups(String * lights) {
 // Send commands
 // Power On/Off
 void ZigbeeHuePower(uint16_t shortaddr, bool power) {
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0006, power ? 1 : 0, "");
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0006, power ? 1 : 0, "");
   zigbee_devices.updateHueState(shortaddr, &power, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
@@ -139,7 +139,7 @@ void ZigbeeHueDimmer(uint16_t shortaddr, uint8_t dimmer) {
   if (dimmer > 0xFE) { dimmer = 0xFE; }
   char param[8];
   snprintf_P(param, sizeof(param), PSTR("%02X0A00"), dimmer);
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0008, 0x04, param);
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0008, 0x04, param);
   zigbee_devices.updateHueState(shortaddr, nullptr, nullptr, &dimmer, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
@@ -150,7 +150,7 @@ void ZigbeeHueCT(uint16_t shortaddr, uint16_t ct) {
   char param[12];
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0A00"), ct & 0xFF, ct >> 8);
   uint8_t colormode = 2;      // "ct"
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x0A, param);
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x0A, param);
   zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, &ct, nullptr, nullptr, nullptr, nullptr);
 }
 
@@ -161,7 +161,7 @@ void ZigbeeHueXY(uint16_t shortaddr, uint16_t x, uint16_t y) {
   if (y > 0xFEFF) { y = 0xFEFF; }
   snprintf_P(param, sizeof(param), PSTR("%02X%02X%02X%02X0A00"), x & 0xFF, x >> 8, y & 0xFF, y >> 8);
   uint8_t colormode = 1;      // "xy"
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x07, param);
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x07, param);
   zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, nullptr, nullptr, nullptr, &x, &y, nullptr);
 }
 
@@ -172,7 +172,7 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
   if (sat > 0xFE) { sat = 0xFE; }
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0000"), hue8, sat);
   uint8_t colormode = 0;      // "hs"
-  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0x0300, 0x06, param);
+  zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x06, param);
   zigbee_devices.updateHueState(shortaddr, nullptr, &colormode, nullptr, &sat, nullptr, &hue, nullptr, nullptr, nullptr);
 }
 

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -202,13 +202,6 @@ uint32_t parseSingleAttribute(JsonObject& json, char *attrid_str, class SBuffer 
     case 0xFF:      // unk
       break;
     case 0x10:      // bool
-      {
-        uint8_t val_bool = buf.get8(i++);
-        if (0xFF != val_bool) {
-          json[attrid_str] = (bool) (val_bool ? true : false);
-        }
-      }
-      break;
     case 0x20:      // uint8
     case 0x30:      // enum8
       {

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -169,7 +169,7 @@ int32_t Z_ReadAttrCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t clus
       break;
   }
   if (attrs) {
-    ZigbeeZCLSend_Raw(shortaddr, groupaddr, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, attrs, attrs_len, true /* we do want a response */, zigbee_devices.getNextSeqNumber(shortaddr));
+    ZigbeeZCLSend_Raw(shortaddr, groupaddr, cluster, endpoint, ZCL_READ_ATTRIBUTES, false, 0, attrs, attrs_len, true /* we do want a response */, zigbee_devices.getNextSeqNumber(shortaddr));
   }
 }
 
@@ -306,10 +306,10 @@ void sendHueUpdate(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uin
   }
   if (z_cat >= 0) {
     uint8_t endpoint = 0;
-    if (!groupaddr) {
+    if (shortaddr) {
       endpoint = zigbee_devices.findFirstEndpoint(shortaddr);
     }
-    if ((endpoint) || (groupaddr)) {   // send only if we know the endpoint
+    if ((!shortaddr) || (endpoint)) {   // send if group address or endpoint is known
       zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms, cluster, endpoint, z_cat, 0 /* value */, &Z_ReadAttrCallback);
       if (shortaddr) {      // reachability test is not possible for group addresses, since we don't know the list of devices in the group
         zigbee_devices.setTimer(shortaddr, groupaddr, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, cluster, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -56,7 +56,7 @@ typedef struct Zigbee_Instruction_Type {
 } Zigbee_Instruction_Type;
 
 enum Zigbee_StateMachine_Instruction_Set {
-  // 2 bytes instructions
+  // 4 bytes instructions
   ZGB_INSTR_4_BYTES = 0,
   ZGB_INSTR_NOOP = 0,                   // do nothing
   ZGB_INSTR_LABEL,                      // define a label
@@ -67,7 +67,7 @@ enum Zigbee_StateMachine_Instruction_Set {
   ZGB_INSTR_WAIT_FOREVER,               // wait forever but state machine still active
   ZGB_INSTR_STOP,                       // stop state machine with optional error code
 
-  // 6 bytes instructions
+  // 8 bytes instructions
   ZGB_INSTR_8_BYTES = 0x80,
   ZGB_INSTR_CALL = 0x80,                // call a function
   ZGB_INSTR_LOG,                        // log a message, if more detailed logging required, call a function
@@ -77,7 +77,7 @@ enum Zigbee_StateMachine_Instruction_Set {
   ZGB_INSTR_WAIT_RECV,                  // wait for a message according to the filter
   ZGB_ON_RECV_UNEXPECTED,               // function to handle unexpected messages, or nullptr
 
-  // 10 bytes instructions
+  // 12 bytes instructions
   ZGB_INSTR_12_BYTES = 0xF0,
   ZGB_INSTR_WAIT_RECV_CALL,             // wait for a filtered message and call function upon receive
 };

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -388,6 +388,7 @@ int32_t Z_BindRsp(int32_t res, const class SBuffer &buf) {
 
   return -1;
 }
+
 //
 // Handle Unbind Rsp incoming message
 //
@@ -409,6 +410,72 @@ int32_t Z_UnbindRsp(int32_t res, const class SBuffer &buf) {
                     "}}"), nwkAddr, status, getZigbeeStatusMessage(status).c_str());
   }
   MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZCL_RECEIVED));
+  XdrvRulesProcess();
+
+  return -1;
+}
+//
+// Handle MgMt Bind Rsp incoming message
+//
+int32_t Z_MgmtBindRsp(int32_t res, const class SBuffer &buf) {
+  uint16_t    shortaddr   = buf.get16(2);
+  uint8_t     status      = buf.get8(4);
+  uint8_t     bind_total  = buf.get8(5);
+  uint8_t     bind_start  = buf.get8(6);
+  uint8_t     bind_len    = buf.get8(7);
+
+  const char * friendlyName = zigbee_devices.getFriendlyName(shortaddr);
+
+  Response_P(PSTR("{\"" D_JSON_ZIGBEE_BIND_STATE "\":{\"" D_JSON_ZIGBEE_DEVICE "\":\"0x%04X\""), shortaddr);
+  if (friendlyName) {
+    ResponseAppend_P(PSTR(",\"" D_JSON_ZIGBEE_NAME "\":\"%s\""), friendlyName);
+  }
+  ResponseAppend_P(PSTR(",\"" D_JSON_ZIGBEE_STATUS "\":%d"
+                        ",\"" D_JSON_ZIGBEE_STATUS_MSG "\":\"%s\""
+                        ",\"BindingsTotal\":%d"
+                        //",\"BindingsStart\":%d"
+                        ",\"Bindings\":["
+                        ), status, getZigbeeStatusMessage(status).c_str(), bind_total);
+
+  uint32_t idx = 8;
+  for (uint32_t i = 0; i < bind_len; i++) {
+    if (idx + 14 > buf.len()) { break; }   // overflow, frame size is between 14 and 21
+
+    //uint64_t    srcaddr   = buf.get16(idx);     // unused
+    uint8_t     srcep     = buf.get8(idx + 8);
+    uint8_t     cluster   = buf.get16(idx + 9);
+    uint8_t     addrmode  = buf.get8(idx + 11);
+    uint16_t    group     = 0x0000;
+    uint64_t    dstaddr   = 0;
+    uint8_t     dstep     = 0x00;
+    if (Z_Addr_Group == addrmode) {               // Group address mode
+      group = buf.get16(idx + 12);
+      idx += 14;
+    } else if (Z_Addr_IEEEAddress == addrmode) {  // IEEE address mode
+      dstaddr = buf.get64(idx + 12);
+      dstep = buf.get8(idx + 20);
+      idx += 21;
+    } else {
+      //AddLog_P2(LOG_LEVEL_INFO, PSTR("Z_MgmtBindRsp unknwon address mode %d"), addrmode);
+      break;                                      // abort for any other value since we don't know the length of the field
+    }
+
+    if (i > 0) {
+      ResponseAppend_P(PSTR(","));
+    }
+    ResponseAppend_P(PSTR("{\"Cluster\":\"0x%04X\",\"Endpoint\":%d,"), cluster, srcep);
+    if (Z_Addr_Group == addrmode) {               // Group address mode
+      ResponseAppend_P(PSTR("\"ToGroup\":%d}"), group);
+    } else if (Z_Addr_IEEEAddress == addrmode) {  // IEEE address mode
+      char hex[20];
+      Uint64toHex(dstaddr, hex, 64);
+      ResponseAppend_P(PSTR("\"ToDevice\":\"0x%s\",\"ToEndpoint\":%d}"), hex, dstep);
+    }
+  }
+
+  ResponseAppend_P(PSTR("]}}"));
+
+  MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEE_BIND_STATE));
   XdrvRulesProcess();
 
   return -1;
@@ -579,6 +646,7 @@ ZBM(AREQ_ZDO_SIMPLEDESCRSP, Z_AREQ | Z_ZDO, ZDO_SIMPLE_DESC_RSP)            // 4
 ZBM(AREQ_ZDO_IEEE_ADDR_RSP, Z_AREQ | Z_ZDO, ZDO_IEEE_ADDR_RSP)              // 4581
 ZBM(AREQ_ZDO_BIND_RSP, Z_AREQ | Z_ZDO, ZDO_BIND_RSP)                        // 45A1
 ZBM(AREQ_ZDO_UNBIND_RSP, Z_AREQ | Z_ZDO, ZDO_UNBIND_RSP)                    // 45A2
+ZBM(AREQ_ZDO_MGMT_BIND_RSP, Z_AREQ | Z_ZDO, ZDO_MGMT_BIND_RSP)              // 45B3
 
 // Dispatcher callbacks table
 const Z_Dispatcher Z_DispatchTable[] PROGMEM = {
@@ -592,6 +660,7 @@ const Z_Dispatcher Z_DispatchTable[] PROGMEM = {
   { AREQ_ZDO_IEEE_ADDR_RSP,       &Z_ReceiveIEEEAddr },
   { AREQ_ZDO_BIND_RSP,            &Z_BindRsp },
   { AREQ_ZDO_UNBIND_RSP,          &Z_UnbindRsp },
+  { AREQ_ZDO_MGMT_BIND_RSP,       &Z_MgmtBindRsp },
 };
 
 /*********************************************************************************************\
@@ -643,6 +712,7 @@ void Z_Query_Bulb(uint16_t shortaddr, uint32_t &wait_ms) {
       zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0300, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
       wait_ms += inter_message_ms;
       zigbee_devices.setTimer(shortaddr, 0, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, 0, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
+      wait_ms += 1000;              // wait 1 second between devices
     }
   }
 }


### PR DESCRIPTION
## Description:

**BREAKING CHANGE**
Because of some liberty of Xiaomi switches, boolean data type are now reported as integer.

Before:
`{"ZbReceived":{"0xF75D":{"Power":false,"Endpoint":3,"LinkQuality":49}}}`

After:
`{"ZbReceived":{"0xF75D":{"Power":0,"Endpoint":3,"LinkQuality":49}}}`

### Other features
Add `ZbBindState` to list the current bindings of a device.
Allow to send to Group Address `0`
Add `manuf` attribute to `ZbRead` and `ZbSend` commands to send Manufacturer specific commands.
Add status code 0xCD `NO_ROUTE` meaning the coordinator doesn't know any route to the target address

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
