### PR TITLE
Better support for LCD 2004A 20x4 #8062

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,5 @@ script:
   - platformio run -e $ENV
 before_deploy:
   - for file in .pioenvs/*/firmware.bin; do cp $file ${file%/*}.bin; done
+
+  

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -502,6 +502,8 @@
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0
     #define USE_DISPLAY_LCD                      // [DisplayModel 1] [I2cDriver3] Enable Lcd display (I2C addresses 0x27 and 0x3F) (+6k code)
+    #define USE_DISPLAY_LCD_ROWS 4               // Rows of display
+    #define USE_DISPLAY_LCD_COLS 20              // Columns of display
     #define USE_DISPLAY_SSD1306                  // [DisplayModel 2] [I2cDriver4] Enable SSD1306 Oled 128x64 display (I2C addresses 0x3C and 0x3D) (+16k code)
     #define USE_DISPLAY_MATRIX                   // [DisplayModel 3] [I2cDriver5] Enable 8x8 Matrix display (I2C adresseses see below) (+11k code)
       #define MTX_ADDRESS1     0x71              // [DisplayAddress1] I2C address of first 8x8 matrix module

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1087,9 +1087,18 @@ void SettingsDefaultSet2(void)
 //  Settings.display_model = 0;
   Settings.display_mode = 1;
   Settings.display_refresh = 2;
+  #ifdef USE_DISPLAY_LCD_ROWS
+  Settings.display_rows = USE_DISPLAY_LCD_ROWS;
+  #else
   Settings.display_rows = 2;
+  #endif
+  #ifdef USE_DISPLAY_LCD_COLS
+  Settings.display_cols[0] = USE_DISPLAY_LCD_COLS;
+  Settings.display_cols[1] = USE_DISPLAY_LCD_COLS/2;
+  #else
   Settings.display_cols[0] = 16;
   Settings.display_cols[1] = 8;
+  #endif
   Settings.display_dimmer = 1;
   Settings.display_size = 1;
   Settings.display_font = 1;


### PR DESCRIPTION
## Description:
Allow #define settings for LCD rows and columns to better support 2004A LCD I2C device.
Positioning the cursor via DisplayText [lpcp] acts strange where top left is [l1c1] as opposed
to [l0c0] as expected, but I don't think this change caused that.

**Related issue (if applicable):** fixes #8062

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
