### PR TITLE
Call XdrvCall even for power. Fix devgrp index mask in xdrv_04_light

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -601,9 +601,7 @@ void ProcessDeviceGroupMessage(char * packet, int packet_length)
           }
         }
       }
-      else {
-        XdrvCall(FUNC_DEVICE_GROUP_ITEM);
-      }
+      XdrvCall(FUNC_DEVICE_GROUP_ITEM);
     }
   }
 

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2115,7 +2115,7 @@ void LightHandleDeviceGroupItem()
   bool more_to_come;
   uint32_t value = XdrvMailbox.payload;
 #ifdef USE_PWM_DIMMER_REMOTE
-  if (XdrvMailbox.index & 0xff00) return; // Ignore updates from other device groups
+  if (XdrvMailbox.index & 0xff0000) return; // Ignore updates from other device groups
 #endif  // USE_PWM_DIMMER_REMOTE
   switch (XdrvMailbox.command_code) {
     case DGR_ITEM_EOL:


### PR DESCRIPTION
## Description:

Call XdrvCall even for power so multi-device group modules can handle power updates.

Fix device group index mask in xdrv_04_light.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
