### PR TITLE
Add command ``SetOption91 1`` to enable fading at startup / power on

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add command ``SetOption90 1`` to disable non-json MQTT messages (#8044)
 - Add command ``Sensor10 0/1/2`` to control BH1750 resolution - 0 = High (default), 1 = High2, 2 = Low (#8016)
 - Add command ``Sensor10 31..254`` to control BH1750 measurement time which defaults to 69 (#8016)
+- Add command ``SetOption91 1`` to enable fading at startup / power on
 
 ### 8.2.0.2 20200328
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -110,7 +110,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - PWM Dimmer Buttons control remote devices
     uint32_t zigbee_distinct_topics : 1;   // bit 7 (v8.1.0.10)  - SetOption89 - Distinct MQTT topics per device for Zigbee (#7835)
     uint32_t only_json_message : 1;        // bit 8 (v8.2.0.3)   - SetOption90 - Disable non-json MQTT response
-    uint32_t spare09 : 1;
+    uint32_t fade_at_startup : 1;          // bit 9 (v8.2.0.3)   - SetOption91 - Enable light fading at start/power on
     uint32_t spare10 : 1;
     uint32_t spare11 : 1;
     uint32_t spare12 : 1;

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1310,6 +1310,9 @@ void LightInit(void)
   Light.power = 0;
   Light.update = true;
   Light.wakeup_active = 0;
+  if (Settings.flag4.fade_at_startup) {
+    Light.fade_initialized = true;      // consider fade intialized starting from black
+  }
 
   LightUpdateColorMapping();
 }


### PR DESCRIPTION
## Description:

Fading at startup (power on or reboot) is disabled by default because it cannot be rendered smoothly (short freeze maybe due to wiffi scan). Option91 allows to force fade at start-up.

**Related issue (if applicable):** fixes #8073

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
