### PR TITLE
Add DevGroupName command

### DIFF
--- a/Device_Groups.md
+++ b/Device_Groups.md
@@ -11,7 +11,7 @@ To enable device groups, execute the command SetOption85 1.
 
 ## Device Groups Operation
 
-The device group name is the MQTT group topic set with the GroupTopic command. All devices in the same IP network with the same group topic are in the same group. Some modules may define additional device groups. For example, if Remote Device Mode is enabled, the PWM Dimmer module defines three devices groups.
+The device group name is set with the DevGroupName command. If the device group name is not set for a group, the MQTT group topic is used (with the device group number appended for device group numbers > 1). All devices in the same IP network with the same device group name are in the same group. Some modules may define additional device groups. For example, if Remote Device Mode is enabled, the PWM Dimmer module defines three devices groups.
 
 The items that are sent to the group and the items that are received from the group are selected with the DevGroupShare command. By default all items are sent and received from the group. An example of when the DevGroupShare command would be used is when you have a group of lights that you control with a dimmer switch and home automation software. You want the dimmer switch to be able to control all items. The home automation software controls each light individually. When it controls the whole group, it actually sends command to each light in the group. If you use the home automation software to turn an individual light on or off or change it’s brightness, color or scheme, you do not want the change to be replicated to the other lights. In this case, you would set the incoming and outgoing item masks to 0xffffffff (all items) on the dimmer switch (DevGroupShare 0xffffffff,0xffffffff) and set the incoming item mask to 0xffffffff and outgoing item mask to 0 on all the lights (DevGroupShare 0xffffffff,0).
 
@@ -34,10 +34,10 @@ The items that are sent to the group and the items that are received from the gr
    </td>
   </tr>
   <tr>
-   <td>GroupTopic&lt;x>
+   <td>DevGroupName&lt;x>
    </td>
-   <td>1 = reset device group &lt;x> MQTT group topic to firmware default (MQTT_GRPTOPIC) and restart<br>
-&lt;value> = set device group &lt;x> MQTT group topic (32 chars max) and restart
+   <td>0 = clear device group &lt;x> name and restart<br>
+&lt;value> = set device group &lt;x>name and restart
    </td>
   </tr>
 </table>

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -293,6 +293,7 @@
 #define D_CMND_SPEEDUNIT "SpeedUnit"
 #define D_CMND_I2CSCAN "I2CScan"
 #define D_CMND_I2CDRIVER "I2CDriver"
+#define D_CMND_DEVGROUP_NAME "DevGroupName"
 #define D_CMND_DEVGROUP_SHARE "DevGroupShare"
 #define D_CMND_SERIALSEND "SerialSend"
 #define D_CMND_SERIALDELIMITER "SerialDelimiter"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -32,7 +32,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
 #ifdef USE_DEVICE_GROUPS
-  D_CMND_DEVGROUP_SHARE "|"
+  D_CMND_DEVGROUP_NAME "|" D_CMND_DEVGROUP_SHARE "|"
 #endif  // USE_DEVICE_GROUPS
   D_CMND_SENSOR "|" D_CMND_DRIVER;
 
@@ -51,7 +51,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndI2cScan, CmndI2cDriver,
 #endif
 #ifdef USE_DEVICE_GROUPS
-  &CmndDevGroupShare,
+  &CmndDevGroupName, &CmndDevGroupShare,
 #endif  // USE_DEVICE_GROUPS
   &CmndSensor, &CmndDriver };
 
@@ -1707,6 +1707,21 @@ void CmndI2cDriver(void)
 #endif  // USE_I2C
 
 #ifdef USE_DEVICE_GROUPS
+void CmndDevGroupName(void)
+{
+  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_DEV_GROUP_NAMES)) {
+    if (XdrvMailbox.data_len > 0) {
+      if (XdrvMailbox.data_len > TOPSZ)
+        XdrvMailbox.data[TOPSZ - 1] = 0;
+      else if (1 == XdrvMailbox.data_len && ('"' == XdrvMailbox.data[0] || '0' == XdrvMailbox.data[0]))
+        XdrvMailbox.data[0] = 0;
+      SettingsUpdateText(SET_DEV_GROUP_NAME1 + XdrvMailbox.index - 1, XdrvMailbox.data);
+      restart_flag = 2;
+    }
+    ResponseCmndAll(SET_DEV_GROUP_NAME1, MAX_DEV_GROUP_NAMES);
+  }
+}
+
 void CmndDevGroupShare(void)
 {
   uint32_t parm[2] = { Settings.device_group_share_in, Settings.device_group_share_out };

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -82,6 +82,7 @@ const uint8_t MAX_RULE_MEMS = 16;           // Max number of saved vars
 const uint8_t MAX_FRIENDLYNAMES = 8;        // Max number of Friendly names
 const uint8_t MAX_BUTTON_TEXT = 16;         // Max number of GUI button labels
 const uint8_t MAX_GROUP_TOPICS = 4;         // Max number of Group Topics
+const uint8_t MAX_DEV_GROUP_NAMES = 4;      // Max number of Device Group names
 
 const uint8_t MAX_HUE_DEVICES = 15;         // Max number of Philips Hue device per emulation
 
@@ -302,30 +303,30 @@ enum SettingsTextIndex { SET_OTAURL,
                          SET_BUTTON1, SET_BUTTON2, SET_BUTTON3, SET_BUTTON4, SET_BUTTON5, SET_BUTTON6, SET_BUTTON7, SET_BUTTON8,
                          SET_BUTTON9, SET_BUTTON10, SET_BUTTON11, SET_BUTTON12, SET_BUTTON13, SET_BUTTON14, SET_BUTTON15, SET_BUTTON16,
                          SET_MQTT_GRP_TOPIC2, SET_MQTT_GRP_TOPIC3, SET_MQTT_GRP_TOPIC4,
-                         SET_TEMPLATE_NAME,
+                         SET_TEMPLATE_NAME, SET_DEV_GROUP_NAME1, SET_DEV_GROUP_NAME2, SET_DEV_GROUP_NAME3, SET_DEV_GROUP_NAME4,
                          SET_MAX };
 
-enum DeviceGroupMessageType { DGR_MSGTYP_FULL_STATUS, DGR_MSGTYP_PARTIAL_UPDATE, DGR_MSGTYP_UPDATE, DGR_MSGTYP_UPDATE_MORE_TO_COME, DGR_MSGTYP_UPDATE_DIRECT, DGR_MSGTYP_REUPDATE };
+enum DevGroupMessageType { DGR_MSGTYP_FULL_STATUS, DGR_MSGTYP_PARTIAL_UPDATE, DGR_MSGTYP_UPDATE, DGR_MSGTYP_UPDATE_MORE_TO_COME, DGR_MSGTYP_UPDATE_DIRECT, DGR_MSGTYP_REUPDATE };
 
-enum DeviceGroupMessageFlag { DGR_FLAG_RESET = 1, DGR_FLAG_STATUS_REQUEST = 2, DGR_FLAG_FULL_STATUS = 4, DGR_FLAG_ACK = 8, DGR_FLAG_MORE_TO_COME = 16, DGR_FLAG_DIRECT = 32, DGR_FLAG_ANNOUNCEMENT = 64 };
+enum DevGroupMessageFlag { DGR_FLAG_RESET = 1, DGR_FLAG_STATUS_REQUEST = 2, DGR_FLAG_FULL_STATUS = 4, DGR_FLAG_ACK = 8, DGR_FLAG_MORE_TO_COME = 16, DGR_FLAG_DIRECT = 32, DGR_FLAG_ANNOUNCEMENT = 64 };
 
-enum DeviceGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS,
-                       DGR_ITEM_LIGHT_FADE, DGR_ITEM_LIGHT_SPEED, DGR_ITEM_LIGHT_BRI, DGR_ITEM_LIGHT_SCHEME, DGR_ITEM_LIGHT_FIXED_COLOR,
-                       DGR_ITEM_BRI_PRESET_LOW, DGR_ITEM_BRI_PRESET_HIGH, DGR_ITEM_BRI_POWER_ON,
-                       // Add new 8-bit items before this line
-                       DGR_ITEM_LAST_8BIT, DGR_ITEM_MAX_8BIT = 63,
-                       DGR_ITEM_ANALOG1, DGR_ITEM_ANALOG2, DGR_ITEM_ANALOG3, DGR_ITEM_ANALOG4, DGR_ITEM_ANALOG5,
-                       // Add new 16-bit items before this line
-                       DGR_ITEM_LAST_16BIT, DGR_ITEM_MAX_16BIT = 127,
-                       DGR_ITEM_POWER, DGR_ITEM_DIMMER_RANGE,
-                       // Add new 32-bit items before this line
-                       DGR_ITEM_LAST_32BIT, DGR_ITEM_MAX_32BIT = 191,
-                       // Add new string items before this line
-                       DGR_ITEM_LAST_STRING, DGR_ITEM_MAX_STRING = 223,
-                       DGR_ITEM_LIGHT_CHANNELS };
+enum DevGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS,
+                    DGR_ITEM_LIGHT_FADE, DGR_ITEM_LIGHT_SPEED, DGR_ITEM_LIGHT_BRI, DGR_ITEM_LIGHT_SCHEME, DGR_ITEM_LIGHT_FIXED_COLOR,
+                    DGR_ITEM_BRI_PRESET_LOW, DGR_ITEM_BRI_PRESET_HIGH, DGR_ITEM_BRI_POWER_ON,
+                    // Add new 8-bit items before this line
+                    DGR_ITEM_LAST_8BIT, DGR_ITEM_MAX_8BIT = 63,
+                    DGR_ITEM_ANALOG1, DGR_ITEM_ANALOG2, DGR_ITEM_ANALOG3, DGR_ITEM_ANALOG4, DGR_ITEM_ANALOG5,
+                    // Add new 16-bit items before this line
+                    DGR_ITEM_LAST_16BIT, DGR_ITEM_MAX_16BIT = 127,
+                    DGR_ITEM_POWER, DGR_ITEM_DIMMER_RANGE,
+                    // Add new 32-bit items before this line
+                    DGR_ITEM_LAST_32BIT, DGR_ITEM_MAX_32BIT = 191,
+                    // Add new string items before this line
+                    DGR_ITEM_LAST_STRING, DGR_ITEM_MAX_STRING = 223,
+                    DGR_ITEM_LIGHT_CHANNELS };
 
-enum DeviceGroupShareItem { DGR_SHARE_POWER = 1, DGR_SHARE_LIGHT_BRI = 2, DGR_SHARE_LIGHT_FADE = 4, DGR_SHARE_LIGHT_SCHEME = 8,
-                            DGR_SHARE_LIGHT_COLOR = 16, DGR_SHARE_DIMMER_SETTINGS = 32 };
+enum DevGroupShareItem { DGR_SHARE_POWER = 1, DGR_SHARE_LIGHT_BRI = 2, DGR_SHARE_LIGHT_FADE = 4, DGR_SHARE_LIGHT_SCHEME = 8,
+                         DGR_SHARE_LIGHT_COLOR = 16, DGR_SHARE_DIMMER_SETTINGS = 32 };
 
 enum CommandSource { SRC_IGNORE, SRC_MQTT, SRC_RESTART, SRC_BUTTON, SRC_SWITCH, SRC_BACKLOG, SRC_SERIAL, SRC_WEBGUI, SRC_WEBCOMMAND, SRC_WEBCONSOLE, SRC_PULSETIMER,
                      SRC_TIMER, SRC_RULE, SRC_MAXPOWER, SRC_MAXENERGY, SRC_OVERTEMP, SRC_LIGHT, SRC_KNX, SRC_DISPLAY, SRC_WEMO, SRC_HUE, SRC_RETRY, SRC_REMOTE, SRC_SHUTTER,

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2131,14 +2131,14 @@ void LightSendDeviceGroupStatus(bool force)
   }
 }
 
-void LightHandleDeviceGroupItem(void)
+void LightHandleDevGroupItem(void)
 {
   static bool send_state = false;
   static bool restore_power = false;
   bool more_to_come;
   uint32_t value = XdrvMailbox.payload;
 #ifdef USE_PWM_DIMMER_REMOTE
-  if (XdrvMailbox.index & 0xff0000) return; // Ignore updates from other device groups
+  if (*XdrvMailbox.topic) return; // Ignore updates from other device groups
 #endif  // USE_PWM_DIMMER_REMOTE
   switch (XdrvMailbox.command_code) {
     case DGR_ITEM_EOL:
@@ -2774,7 +2774,7 @@ bool Xdrv04(uint8_t function)
         break;
 #ifdef USE_DEVICE_GROUPS
       case FUNC_DEVICE_GROUP_ITEM:
-        LightHandleDeviceGroupItem();
+        LightHandleDevGroupItem();
         break;
 #endif  // USE_DEVICE_GROUPS
       case FUNC_SET_POWER:

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -101,6 +101,7 @@ void PWMModulePreInit(void)
   if (Settings.flag4.remote_device_mode) {
     Settings.flag4.device_groups_enabled = true;
 
+    device_group_count = 0;
     for (uint32_t button_index = 0; button_index < MAX_KEYS; button_index++) {
       if (pin[GPIO_KEY1 + button_index] < 99) device_group_count++;
     }
@@ -169,11 +170,11 @@ void PWMDimmerSetPower(void)
 }
 
 #ifdef USE_DEVICE_GROUPS
-void PWMDimmerHandleDeviceGroupItem(void)
+void PWMDimmerHandleDevGroupItem(void)
 {
   uint32_t value = XdrvMailbox.payload;
 #ifdef USE_PWM_DIMMER_REMOTE
-  uint8_t device_group_index = XdrvMailbox.index >> 16 & 0xff;
+  uint8_t device_group_index = *(uint8_t *)XdrvMailbox.topic;
   bool device_is_local = device_groups[device_group_index].local;
   struct remote_pwm_dimmer * remote_pwm_dimmer = &remote_pwm_dimmers[device_group_index];
 #endif  // USE_PWM_DIMMER_REMOTE
@@ -763,7 +764,7 @@ bool Xdrv35(uint8_t function)
 
 #ifdef USE_DEVICE_GROUPS
     case FUNC_DEVICE_GROUP_ITEM:
-      PWMDimmerHandleDeviceGroupItem();
+      PWMDimmerHandleDevGroupItem();
       break;
 #endif  // USE_DEVICE_GROUPS
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<8082>

Add DevGroupName command and use the settings for the device group names instead of MQTT group topics. If a device group name is not set, fallback to MQTT Group Topic 1 (with the device group number appended for device group numbers > 1). This maintains compatibility with previous releases for all devices using device groups except those using the PWM DImmer module with remote device mode enabled.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
