### PR TITLE
Fix PWM flickering during wifi connection (#8046)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add command ``SetOption91 1`` to enable fading at startup / power on
 - Add command ``SetOption41 <x>`` to force sending gratuitous ARP every <x> seconds
 - Add quick wifi reconnect using saved AP parameters when ``SetOption56 0`` (#3189)
+- Fix PWM flickering during wifi connection (#8046)
 
 ### 8.2.0.2 20200328
 

--- a/tasmota/core_esp8266_waveform.cpp
+++ b/tasmota/core_esp8266_waveform.cpp
@@ -274,7 +274,11 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
           // cyclesToGo = -((-cyclesToGo) % (wave->nextTimeHighCycles + wave->nextTimeLowCycles));
           //
           // Alternative version with lower CPU impact:
-          // while (-cyclesToGo > wave->nextTimeHighCycles + wave->nextTimeLowCycles) { cyclesToGo += wave->nextTimeHighCycles + wave->nextTimeLowCycles)};
+          // while (-cyclesToGo > wave->nextTimeHighCycles + wave->nextTimeLowCycles) { cyclesToGo += wave->nextTimeHighCycles + wave->nextTimeLowCycles); }
+          //
+          // detect interrupt storm, for example during wifi connection.
+          // if we overshoot the cycle by more than 25%, we forget phase and keep PWM duration
+          int32_t overshoot = (-cyclesToGo) > ((wave->nextTimeHighCycles + wave->nextTimeLowCycles) >> 2);
           waveformState ^= mask;
           if (waveformState & mask) {
             if (i == 16) {
@@ -282,16 +286,26 @@ static ICACHE_RAM_ATTR void timer1Interrupt() {
             } else {
               SetGPIO(mask);
             }
-            wave->nextServiceCycle += wave->nextTimeHighCycles;
-            nextEventCycles = min_u32(nextEventCycles, max_32(wave->nextTimeHighCycles + cyclesToGo, microsecondsToClockCycles(1)));
+            if (overshoot) {
+              wave->nextServiceCycle = now + wave->nextTimeHighCycles;
+              nextEventCycles = min_u32(nextEventCycles, wave->nextTimeHighCycles);
+            } else {
+              wave->nextServiceCycle += wave->nextTimeHighCycles;
+              nextEventCycles = min_u32(nextEventCycles, max_32(wave->nextTimeHighCycles + cyclesToGo, microsecondsToClockCycles(1)));
+            }
           } else {
             if (i == 16) {
               GP16O &= ~1; // GPIO16 write slow as it's RMW
             } else {
               ClearGPIO(mask);
             }
-            wave->nextServiceCycle += wave->nextTimeLowCycles;
-            nextEventCycles = min_u32(nextEventCycles, max_32(wave->nextTimeLowCycles + cyclesToGo, microsecondsToClockCycles(1)));
+            if (overshoot) {
+              wave->nextServiceCycle = now + wave->nextTimeLowCycles;
+              nextEventCycles = min_u32(nextEventCycles, wave->nextTimeLowCycles);
+            } else {
+              wave->nextServiceCycle += wave->nextTimeLowCycles;
+              nextEventCycles = min_u32(nextEventCycles, max_32(wave->nextTimeLowCycles + cyclesToGo, microsecondsToClockCycles(1)));
+            }
           }
         } else {
           uint32_t deltaCycles = wave->nextServiceCycle - now;


### PR DESCRIPTION
## Description:

Fix #7851 allowed the PWM interrupt handler to keep phases constant between channels and avoid flickering.

Unfortunatel, under heavy interrupt load, at wifi connection, the interrupt handler struggles to keep PWM at correct levels. In case of an overshoot of the PWM cycle by more than 25%, the interrupt handler reverts to the previous behavior and favors PWM level instead of phases.
This minimizes flickering at wifi connection.

**Related issue (if applicable):** fixes #8046 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
