### PR TITLE
Fix Zigbee crash with Occupancy sensor (#8089)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add command ``SetOption41 <x>`` to force sending gratuitous ARP every <x> seconds
 - Add quick wifi reconnect using saved AP parameters when ``SetOption56 0`` (#3189)
 - Fix PWM flickering during wifi connection (#8046)
+- Fix Zigbee crash with Occupancy sensor (#8089)
 
 ### 8.2.0.2 20200328
 

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -706,6 +706,7 @@ void Z_Devices::setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_m
 }
 
 // Run timer at each tick
+// WARNING: don't set a new timer within a running timer, this causes memory corruption
 void Z_Devices::runTimer(void) {
   // visit all timers
   for (auto it = _deferred.begin(); it != _deferred.end(); it++) {


### PR DESCRIPTION
## Description:

Setting a timer within a timer caused a memory corruption due to the implementation of `std::vector<>`

**Related issue (if applicable):** fixes #8089 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
