### PR TITLE
Limit power after reinit

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -950,17 +950,21 @@ public:
       // only if non-multi channel
       // We apply dimmer in priority to RGB
       uint8_t bri = _state->DimmerToBri(Settings.light_dimmer);
+
+      // The default values are #FFFFFFFFFF, in this case we avoid setting all channels
+      // at the same time, see #6534 and #8120
+      if ((DEFAULT_LIGHT_COMPONENT == Settings.light_color[0]) &&
+          (DEFAULT_LIGHT_COMPONENT == Settings.light_color[1]) &&
+          (DEFAULT_LIGHT_COMPONENT == Settings.light_color[2]) &&
+          (DEFAULT_LIGHT_COMPONENT == Settings.light_color[3]) &&
+          (DEFAULT_LIGHT_COMPONENT == Settings.light_color[4]) &&
+          (DEFAULT_LIGHT_DIMMER    == Settings.light_dimmer) ) {
+        _state->setBriCT(bri);
+        _state->setBriRGB(bri);
+        _state->setColorMode(LCM_RGB);
+      }
+
       if (Settings.light_color[0] + Settings.light_color[1] + Settings.light_color[2] > 0) {
-        // The default values are #FFFFFFFFFF, in this case we avoid setting all channels
-        // at the same time, see #6534
-        if ( (DEFAULT_LIGHT_COMPONENT == Settings.light_color[0]) &&
-             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[1]) &&
-             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[2]) &&
-             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[3]) &&
-             (DEFAULT_LIGHT_COMPONENT == Settings.light_color[4]) &&
-             (DEFAULT_LIGHT_DIMMER    == Settings.light_dimmer) ) {
-          _state->setColorMode(LCM_RGB);
-        }
         _state->setBriRGB(bri);
       } else {
         _state->setBriCT(bri);


### PR DESCRIPTION
## Description:

Avoid setting PWM to maximum level after initial flash or reinit (ex: Reset 5).
It was already done for RGB but not for 2-channels bulbs.

**Related issue (if applicable):** fixes #8120 (partial solution, don't close the issue yet)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
