### PR TITLE
support for AS3935, initial commit

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -69,3 +69,4 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   45  | USE_HDC1080         | xsns_65 | HDC1080  | 0x40        | Temperature and Humidity sensor
   46  | USE_IAQ             | xsns_66 | IAQ      | 0x5a        | Air quality sensor
   47  | USE_DISPLAY_SEVENSEG| xdsp_11 | HT16K33  | 0x70 - 0x77 | Seven segment LED
+  48  | USE_AS3935          | xsns_67 | AS3935   | 0x03        | Franklin Lightning Sensor 

--- a/tasmota/language/bg-BG.h
+++ b/tasmota/language/bg-BG.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -674,6 +675,7 @@
 #define D_UNIT_GALLONS_PER_MIN "gal/min"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"
 #define D_UNIT_KILOOHM "kΩ"
 #define D_UNIT_KILOWATTHOUR "kWh"

--- a/tasmota/language/cs-CZ.h
+++ b/tasmota/language/cs-CZ.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -674,6 +675,7 @@
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"
 #define D_UNIT_KILOWATTHOUR "kWh"

--- a/tasmota/language/de-DE.h
+++ b/tasmota/language/de-DE.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/el-GR.h
+++ b/tasmota/language/el-GR.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/en-GB.h
+++ b/tasmota/language/en-GB.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/es-ES.h
+++ b/tasmota/language/es-ES.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/fr-FR.h
+++ b/tasmota/language/fr-FR.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "gal/mn"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/he-HE.h
+++ b/tasmota/language/he-HE.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/hu-HU.h
+++ b/tasmota/language/hu-HU.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/it-IT.h
+++ b/tasmota/language/it-IT.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 - GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL - RX"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL - TX"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/ko-KO.h
+++ b/tasmota/language/ko-KO.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/nl-NL.h
+++ b/tasmota/language/nl-NL.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/pl-PL.h
+++ b/tasmota/language/pl-PL.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/pt-BR.h
+++ b/tasmota/language/pt-BR.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/pt-PT.h
+++ b/tasmota/language/pt-PT.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/ro-RO.h
+++ b/tasmota/language/ro-RO.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/ru-RU.h
+++ b/tasmota/language/ru-RU.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "А"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "кОм"

--- a/tasmota/language/sk-SK.h
+++ b/tasmota/language/sk-SK.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -674,6 +675,7 @@
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"
 #define D_UNIT_KILOWATTHOUR "kWh"

--- a/tasmota/language/sv-SE.h
+++ b/tasmota/language/sv-SE.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "ink"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/tr-TR.h
+++ b/tasmota/language/tr-TR.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "A"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "kΩ"

--- a/tasmota/language/uk-UA.h
+++ b/tasmota/language/uk-UA.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE                    "А"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS                   "гал"
 #define D_UNIT_GALLONS_PER_MIN           "гал/хв"
 #define D_UNIT_INCREMENTS                "інк"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM                  "кг"
 #define D_UNIT_KILOMETER_PER_HOUR        "км/г" // or "km/h"
 #define D_UNIT_KILOOHM                   "㏀"

--- a/tasmota/language/zh-CN.h
+++ b/tasmota/language/zh-CN.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "安"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "千克"
 #define D_UNIT_KILOMETER_PER_HOUR "公里/时"  // or "km/h"
 #define D_UNIT_KILOOHM "千欧"

--- a/tasmota/language/zh-TW.h
+++ b/tasmota/language/zh-TW.h
@@ -664,6 +664,7 @@
 #define D_SENSOR_CC1101_GDO2   "CC1101 GDO2"
 #define D_SENSOR_HRXL_RX       "HRXL Rx"
 #define D_SENSOR_ELECTRIQ_MOODL "MOODL Tx"
+#define D_SENSOR_AS3935         "AS3935"
 
 // Units
 #define D_UNIT_AMPERE "安"
@@ -673,6 +674,7 @@
 #define D_UNIT_GALLONS "gal"
 #define D_UNIT_GALLONS_PER_MIN "g/m"
 #define D_UNIT_INCREMENTS "inc"
+#define D_UNIT_KILOMETER "km"
 #define D_UNIT_KILOGRAM "kg"
 #define D_UNIT_KILOMETER_PER_HOUR "km/h"  // or "km/h"
 #define D_UNIT_KILOOHM "千歐"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -503,7 +503,7 @@
 //    #define WEMOS_MOTOR_V1_FREQ  1000            // Default frequency
 //  #define USE_HDC1080                            // [I2cDriver45] Enable HDC1080 temperature/humidity sensor (I2C address 0x40) (+1k5 code)
 //  #define USE_IAQ                                // [I2cDriver46] Enable iAQ-core air quality sensor (I2C address 0x5a) (+0k6 code)
-   #define USE_AS3935                              // [I2cDriver48] Enable AS3935 Franklin Lightning Sensor (I2C address 0x03) (+5k3 code)
+//   #define USE_AS3935                              // [I2cDriver48] Enable AS3935 Franklin Lightning Sensor (I2C address 0x03) (+5k4 code)
    
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -503,7 +503,8 @@
 //    #define WEMOS_MOTOR_V1_FREQ  1000            // Default frequency
 //  #define USE_HDC1080                            // [I2cDriver45] Enable HDC1080 temperature/humidity sensor (I2C address 0x40) (+1k5 code)
 //  #define USE_IAQ                                // [I2cDriver46] Enable iAQ-core air quality sensor (I2C address 0x5a) (+0k6 code)
-
+   #define USE_AS3935                              // [I2cDriver48] Enable AS3935 Franklin Lightning Sensor (I2C address 0x03) (+5k3 code)
+   
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0
     #define USE_DISPLAY_LCD                      // [DisplayModel 1] [I2cDriver3] Enable Lcd display (I2C addresses 0x27 and 0x3F) (+6k code)

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -211,6 +211,30 @@ typedef union {
   };
 } SensorCfg1;
 
+typedef union {
+  uint8_t data;
+  struct {           
+  uint8_t nf_autotune : 1;            // Autotune the NF Noise Level
+  uint8_t dist_autotune : 1;          // Autotune Disturber on/off  
+  uint8_t nf_autotune_both : 1;        // Autotune over both Areas: INDOORS/OUDOORS
+  uint8_t mqtt_only_Light_Event : 1;  // mqtt only if lightning Irq
+  uint8_t spare4 : 1;
+  uint8_t spare5 : 1;
+  uint8_t spare6 : 1;
+  uint8_t spare7 : 1;
+  };
+} As3935IntCfg;
+
+typedef union {
+  uint16_t data;
+  struct {           
+  uint16_t nf_autotune_time : 4;            // NF Noise Autotune Time
+  uint16_t dist_autotune_time : 4;          // Disturber Autotune Time  
+  uint16_t nf_autotune_min : 4;             // Min Stages
+  uint16_t spare3 : 4;
+  };
+} As3935Param;
+
 typedef struct {
   uint32_t usage1_kWhtotal;
   uint32_t usage2_kWhtotal;
@@ -472,8 +496,12 @@ struct PACKED SYSCFG {
   int8_t        hum_comp;                  // F08
   uint8_t       wifi_channel;              // F09
   uint8_t       wifi_bssid[6];             // F0A
+  uint8_t       as3935_sensor_cfg[5];      // F10
+  As3935IntCfg  as3935_functions;          // F15
+  As3935Param   as3935_parameter;          // F16
 
-  uint8_t       free_f10[168];             // F10
+  uint8_t       free_f18[160];             // F18
+
 
   uint16_t      pulse_counter_debounce_low;  // FB8
   uint16_t      pulse_counter_debounce_high; // FBA

--- a/tasmota/support_features.ino
+++ b/tasmota/support_features.ino
@@ -548,7 +548,9 @@ void GetFeatures(void)
 #ifdef USE_DISPLAY_SEVENSEG
   feature6 |= 0x00000020;  // xdsp_11_sevenseg.ino
 #endif
-//  feature6 |= 0x00000040;
+#ifdef USE_AS3935
+  feature6 |= 0x00000040;  // xsns_67_as3935.ino
+#endif
 //  feature6 |= 0x00000080;
 
 //  feature6 |= 0x00000100;

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -226,6 +226,7 @@ enum UserSelectablePins {
   GPIO_CC1101_GDO2,    // CC1101 pin for RX
   GPIO_HRXL_RX,       // Data from MaxBotix HRXL sonar range sensor
   GPIO_ELECTRIQ_MOODL_TX, // ElectriQ iQ-wifiMOODL Serial TX
+  GPIO_AS3935,
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -312,7 +313,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_LE01MR_RX "|" D_SENSOR_LE01MR_TX "|"
   D_SENSOR_CC1101_GDO0 "|" D_SENSOR_CC1101_GDO2 "|"
   D_SENSOR_HRXL_RX "|"
-  D_SENSOR_ELECTRIQ_MOODL
+  D_SENSOR_ELECTRIQ_MOODL "|"
+  D_SENSOR_AS3935 
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -655,6 +657,9 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_HRXL
   GPIO_HRXL_RX,
+#endif
+#ifdef USE_AS3935
+  GPIO_AS3935,
 #endif
 };
 

--- a/tasmota/xsns_67_as3935.ino
+++ b/tasmota/xsns_67_as3935.ino
@@ -1,0 +1,830 @@
+/*
+  XSNS_67_AS3935.ino - AS3935 Franklin Lightning Sensor support for Tasmota
+
+  Copyright (C) 2020  Martin Wagner
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  
+*/
+
+
+#ifdef USE_I2C
+#ifdef USE_AS3935
+/*********************************************************************************************\
+ * AS3935 Lightning Sensor
+ *
+ * I2C Address: 0x03
+ *
+\*********************************************************************************************/
+
+#define XSNS_67             67
+#define XI2C_48             48  // See I2CDEVICES.md
+
+#define D_NAME_AS3935 "AS3935"
+#define AS3935_ADDR   0x03
+
+//                     Reg  mask shift
+#define IRQ_TBL       0x03, 0x0F, 0
+#define ENERGY_RAW_1  0x04, 0xFF, 0 
+#define ENERGY_RAW_2  0x05, 0xFF, 0 
+#define ENERGY_RAW_3  0x06, 0x1F, 0 
+#define LGHT_DIST     0x07, 0x3F, 0
+#define DISP_TRCO     0x08, 0x20, 5
+#define DISP_LCO      0x08, 0x80, 7
+#define TUNE_CAPS     0x08, 0x0F, 0 
+#define AFE_GB        0x00, 0x3E, 0
+#define WDTH          0x01, 0x0F, 0
+#define NF_LEVEL      0x01, 0x70, 4
+#define SPIKE_REJECT  0x02, 0x0F, 0
+#define MIN_NUM_LIGH  0x02, 0x30, 4
+#define DISTURBER     0x03, 0x20, 5
+#define LCO_FDIV      0x03, 0xC0, 6
+
+#define INDOORS       0x24
+#define OUTDOORS      0x1C
+
+// Translation
+// http
+#define D_AS3935_GAIN "gain:"
+#define D_AS3935_ENERGY "energy:"
+#define D_AS3935_DISTANCE "distance:"
+#define D_AS3935_DISTURBER "disturber:"
+#define D_AS3935_VRMS "µVrms:"
+// http Message
+#define D_AS3935_APRX "aprx.:"
+#define D_AS3935_AWAY "away"
+#define D_AS3935_LIGHT "lightning"
+#define D_AS3935_OUT "lightning out of range"
+#define D_AS3935_NOT "distance not determined"
+#define D_AS3935_ABOVE "lightning overhead"
+#define D_AS3935_NOISE "noise detected"
+#define D_AS3935_DISTDET "disturber detected"
+#define D_AS3935_INTNOEV "Interrupt with no Event!"
+#define D_AS3935_NOMESS "listening..."
+// CMD Status
+#define D_AS3935_ON "On"
+#define D_AS3935_OFF "Off"
+#define D_AS3935_INDOORS "Indoors"
+#define D_AS3935_OUTDOORS "Outdoors"
+#define D_AS3935_CAL_FAIL "calibration failed"
+#define D_AS3935_CAL_OK "calibration set to:"
+// Json
+#define D_JSON_EVENT "Event"
+#define D_JSON_DISTANCE "Distance"
+#define D_JSON_ENERGY "Energy"
+// Global
+const char HTTP_SNS_UNIT_KILOMETER[] PROGMEM = D_UNIT_KILOMETER;
+// Http
+const char HTTP_SNS_AS3935_ENERGY[] PROGMEM  = "{s}" D_NAME_AS3935 " " D_AS3935_ENERGY " {m}%d{e}";
+const char HTTP_SNS_AS3935_DISTANZ[] PROGMEM = "{s}" D_NAME_AS3935 " " D_AS3935_DISTANCE " {m}%u " D_UNIT_KILOMETER "{e}";
+const char HTTP_SNS_AS3935_VRMS[] PROGMEM = "{s}" D_NAME_AS3935 " " D_AS3935_VRMS "{m}%#4u (%d){e}";
+
+const char HTTP_SNS_AS3935_OUTDOORS[] PROGMEM = "{s}%s " D_AS3935_GAIN " {m}" D_AS3935_OUTDOORS " {e}";
+const char HTTP_SNS_AS3935_INDOORS[] PROGMEM = "{s}%s " D_AS3935_GAIN " {m}" D_AS3935_INDOORS " {e}";
+const char* const HTTP_SNS_AS3935_GAIN[] PROGMEM = {HTTP_SNS_AS3935_INDOORS, HTTP_SNS_AS3935_OUTDOORS};
+
+const char HTTP_SNS_AS3935_DIST_ON[] PROGMEM = "{s}%s " D_AS3935_DISTURBER " {m}" D_AS3935_ON " {e}";
+const char HTTP_SNS_AS3935_DIST_OFF[] PROGMEM = "{s}%s " D_AS3935_DISTURBER " {m}" D_AS3935_OFF " {e}";
+const char* const HTTP_SNS_AS3935_DISTURBER[] PROGMEM = {HTTP_SNS_AS3935_DIST_OFF, HTTP_SNS_AS3935_DIST_ON};
+// http Messages
+const char HTTP_SNS_AS3935_EMPTY[] PROGMEM = "{s}%s: " D_AS3935_NOMESS "{e}";
+const char HTTP_SNS_AS3935_OUT[] PROGMEM = "{s}%s: " D_AS3935_OUT "{e}";
+const char HTTP_SNS_AS3935_NOT[] PROGMEM = "{s}%s: " D_AS3935_NOT "{e}";
+const char HTTP_SNS_AS3935_ABOVE[] PROGMEM = "{s}%s: " D_AS3935_ABOVE "{e}";
+const char HTTP_SNS_AS3935_NOISE[] PROGMEM = "{s}%s: " D_AS3935_NOISE "{e}";
+const char HTTP_SNS_AS3935_DISTURB[] PROGMEM = "{s}%s: " D_AS3935_DISTDET "{e}";
+const char HTTP_SNS_AS3935_INTNOEV[] PROGMEM = "{s}%s: " D_AS3935_INTNOEV "{e}";
+const char HTTP_SNS_AS3935_MSG[] PROGMEM = "{s}%s: " D_AS3935_LIGHT " " D_AS3935_APRX " %d " D_UNIT_KILOMETER " " D_AS3935_AWAY "{e}";
+const char* const HTTP_SNS_AS3935_TABLE_1[] PROGMEM = { HTTP_SNS_AS3935_EMPTY, HTTP_SNS_AS3935_MSG, HTTP_SNS_AS3935_OUT, HTTP_SNS_AS3935_NOT, HTTP_SNS_AS3935_ABOVE, HTTP_SNS_AS3935_NOISE, HTTP_SNS_AS3935_DISTURB, HTTP_SNS_AS3935_INTNOEV };
+// Json 
+const char JSON_SNS_AS3935_EVENTS[] PROGMEM = ",\"%s\":{\"" D_JSON_EVENT "\":%d,\"" D_JSON_DISTANCE "\":%d,\"" D_JSON_ENERGY "\":%u}";
+// Json Command
+const char* const S_JSON_AS3935_COMMAND_ONOFF[] PROGMEM = {"\"" D_AS3935_OFF "\"","\"" D_AS3935_ON"\""};
+const char* const S_JSON_AS3935_COMMAND_GAIN[] PROGMEM = {"\"" D_AS3935_INDOORS "\"", "\"" D_AS3935_OUTDOORS "\""};
+const char* const S_JSON_AS3935_COMMAND_CAL[] PROGMEM = {"" D_AS3935_CAL_FAIL "",""  D_AS3935_CAL_OK ""};
+
+const char S_JSON_AS3935_COMMAND_STRING[] PROGMEM = "{\"" D_NAME_AS3935 "\":{\"%s\":%s}}";
+const char S_JSON_AS3935_COMMAND_NVALUE[] PROGMEM = "{\"" D_NAME_AS3935 "\":{\"%s\":%d}}";
+const char S_JSON_AS3935_COMMAND_SETTINGS[] PROGMEM = "{\"" D_NAME_AS3935 "\":{\"Gain\":%s,\"NFfloor\":%d,\"uVrms\":%d,\"Tunecaps\":%d,\"MinNumLight\":%d,\"Rejektion\":%d,\"Wdthreshold\":%d,\"MinNFstage\":%d,\"NFAutoTime\":%d,\"DisturberAutoTime\":%d,\"Disturber\":%s,\"NFauto\":%s,\"Disturberauto\":%s,\"NFautomax\":%s,\"Mqttlightevent\":%s}}";
+
+const char kAS3935_Commands[] PROGMEM  = "setnf|setminstage|setml|default|setgain|settunecaps|setrej|setwdth|disttime|nftime|disturber|autonf|autodisturber|autonfmax|mqttevent|settings|calibrate";
+
+enum AS3935_Commands {         // commands for Console
+  CMND_AS3935_SET_NF,          // Noise Floor Level, value from 0-7  (3 Bit)
+  CMND_AS3935_SET_MINNF,       // Set Min Noise Floor Level when Autotune is active Value von 0-15
+  CMND_AS3935_SET_MINLIGHT,    // Minimum number of lightning 0=1/1=5/2=9/3=16 Lightnings
+  CMND_AS3935_SET_DEF,         // set default for Sensor and Settings
+  CMND_AS3935_SET_GAIN,        // Set Inddoor/Outdoor
+  CMND_AS3935_SET_TUNE,        // Internal Tuning Capacitors (from 0 to 120pF in steps of 8pf)
+  CMND_AS3935_SET_REJ,         // Set Spike Rejection
+  CMND_AS3935_SET_WDTH,        // Watchdog threshold
+  CMND_AS3935_DISTTIME,        // Threshhold Time for Auto Disturber
+  CMND_AS3935_NFTIME,          // Threshhold Time for NF-Autotune
+  CMND_AS3935_SET_DISTURBER,   // Set Disturber on/off
+  CMND_AS3935_NF_AUTOTUNE,     // Autotune the NF Noise
+  CMND_AS3935_DIST_AUTOTUNE,   // Autotune Disturber on/off  
+  CMND_AS3935_NF_ATUNE_BOTH,   // Autotune over both Areas: INDOORS/OUDOORS
+  CMND_AS3935_MQTT_LIGHT_EVT,  // mqtt only if lightning Irq
+  CMND_AS3935_SETTINGS,        // Json output of all settings 
+  CMND_AS3935_CALIBRATE        // caps autocalibrate
+  };
+
+struct AS3935STRUCT
+{
+  bool autodist_activ = false;
+  volatile bool detected = false;
+  volatile bool dispLCO = 0;
+  uint8_t icount = 0;
+  uint8_t irq = 0;
+  uint8_t mqtt_irq = 0;
+  uint8_t http_irq = 0;
+  uint8_t http_count_start = 0;
+  int16_t http_distance = 0;
+  int16_t distance = 0;
+  uint16_t http_timer = 0;
+  uint16_t http_count = 0;
+  uint16_t nftimer = 0;
+  uint16_t disttimer = 0;
+  uint32_t intensity = 0;
+  uint32_t http_intensity = 0;
+  volatile uint32_t pulse = 0;
+} as3935_sensor;
+
+uint8_t as3935_active = 0;
+
+void ICACHE_RAM_ATTR AS3935Isr() {
+  as3935_sensor.detected = true;
+}
+
+uint8_t AS3935ReadRegister(uint8_t reg, uint8_t mask, uint8_t shift) {
+  uint8_t data = I2cRead8(AS3935_ADDR, reg);
+  if (reg == 0x08) Settings.as3935_sensor_cfg[4] = data;
+  if (reg < 0x04) Settings.as3935_sensor_cfg[reg] = data;
+  return ((data & mask) >> shift);
+}
+
+void AS3935WriteRegister(uint8_t reg, uint8_t mask, uint8_t shift, uint8_t data) {
+  uint8_t currentReg = I2cRead8(AS3935_ADDR, reg);
+  currentReg &= (~mask);
+  data <<= shift;
+  data &= mask;
+  data |= currentReg;
+  I2cWrite8(AS3935_ADDR, reg, data);
+  if (reg == 0x08) Settings.as3935_sensor_cfg[4] = I2cRead8(AS3935_ADDR, reg);
+  if (reg < 0x04) Settings.as3935_sensor_cfg[reg] = I2cRead8(AS3935_ADDR, reg);
+}
+
+/********************************************************************************************/
+// Autotune Caps
+void ICACHE_RAM_ATTR AS3935CountFreq() {
+  if (as3935_sensor.dispLCO)
+    as3935_sensor.pulse++;
+}
+
+bool AS3935AutoTuneCaps(uint8_t irqpin) {
+  int32_t maxtune = 17500; // there max 3.5 % tol
+  uint8_t besttune;
+  AS3935WriteRegister(LCO_FDIV, 0); // Fdiv 16
+  delay(2);
+  for (uint8_t tune = 0; tune < 16; tune++) {
+    AS3935WriteRegister(TUNE_CAPS, tune);
+    delay(2);
+    AS3935WriteRegister(DISP_LCO,1);
+    delay(1);
+    as3935_sensor.dispLCO = true;
+    as3935_sensor.pulse = 0;
+    attachInterrupt(digitalPinToInterrupt(irqpin), AS3935CountFreq, RISING);
+    delay(200); // 100ms callback not work accurat for fequ. measure 
+    as3935_sensor.dispLCO = false;
+    detachInterrupt(irqpin);
+    AS3935WriteRegister(DISP_LCO,0);
+    int32_t currentfreq = 500000 - ((as3935_sensor.pulse * 5) * 16);
+    if(currentfreq < 0) currentfreq = -currentfreq;
+    if(maxtune > currentfreq) {
+      maxtune = currentfreq;
+      besttune = tune;
+    }
+  }
+  if (maxtune >= 17500) // max. 3.5%
+    return false;
+  AS3935SetTuneCaps(besttune);
+  return true;
+}
+
+/********************************************************************************************/
+// functions
+void AS3935CalibrateRCO() {
+  I2cWrite8(AS3935_ADDR, 0x3D, 0x96);
+  AS3935WriteRegister(DISP_TRCO, 1);
+  delay(2);
+  AS3935WriteRegister(DISP_TRCO, 0);
+}
+
+uint8_t AS3935TransMinLights(uint8_t min_lights) {
+  if (5 > min_lights) {
+    return 0;
+  } else if (9 > min_lights) {
+    return 1;
+  } else if (16 > min_lights) {
+    return 2;
+  } else {
+    return 3;
+  }
+}
+
+uint8_t AS3935TranslMinLightsInt(uint8_t min_lights) {
+  switch (min_lights) {
+    case 0:   return 1;
+    case 1:   return 5;
+    case 2:   return 9;
+    case 3:   return 16;
+  }
+}
+
+uint8_t AS3935TranslIrq(uint8_t irq, uint8_t distance) {
+  switch(irq) {
+    case 0: return 7;  // Interrupt with no IRQ
+    case 1: return 5;  // Noise level too high
+    case 4: return 6;  // Disturber detected
+    case 8:
+    if (distance == -1) return 2;  // Lightning out of Distance
+      else if (distance == 0) return 3;  // Distance cannot be determined
+      else if (distance == 1) return 4;  // Storm is Overhead
+      else  return 1; // Lightning with Distance detected
+   }
+}
+
+void AS3935CalcVrmsLevel(uint16_t &vrms, uint8_t &stage)
+{
+  uint8_t room = AS3935GetGain();
+  uint8_t nflev = AS3935GetNoiseFloor();
+  if (room == 0x24)
+  {
+    switch (nflev){
+    case 0x00:
+      vrms = 28;
+      break;
+    case 0x01:
+      vrms = 45;
+      break;
+    case 0x02:
+      vrms = 62;
+      break;
+    case 0x03:
+      vrms = 78;
+      break;
+    case 0x04:
+      vrms = 95;
+      break;
+    case 0x05:
+      vrms = 112;
+      break;
+    case 0x06:
+      vrms = 130;
+      break;
+    case 0x07:
+      vrms = 146;
+      break;
+    }
+    stage = nflev;
+  }
+  else
+  {
+    switch (nflev)
+    {
+    case 0x00:
+      vrms = 390;
+      break;
+    case 0x01:
+      vrms = 630;
+      break;
+    case 0x02:
+      vrms = 860;
+      break;
+    case 0x03:
+      vrms = 1100;
+      break;
+    case 0x04:
+      vrms = 1140;
+      break;
+    case 0x05:
+      vrms = 1570;
+      break;
+    case 0x06:
+      vrms = 1800;
+      break;
+    case 0x07:
+      vrms = 2000;
+      break;
+    }
+    stage = nflev + 8;
+  }
+}
+
+/********************************************************************************************/
+uint8_t AS3935GetIRQ() {
+  delay(2);
+  return AS3935ReadRegister(IRQ_TBL);
+}
+
+uint8_t AS3935GetDistance() {
+  return AS3935ReadRegister(LGHT_DIST);
+}
+
+int16_t AS3935CalcDistance() {
+  uint8_t dist = AS3935GetDistance();
+  switch (dist) {
+    case 0x3F:  return -1;  // Out of Range
+    case 0x01:  return 1;   // Storm is Overhead
+    case 0x00:  return 0;   // Distance cannot be determined
+    default:    
+      if (40 < dist){ 
+        return 40;// limited because higher is not accurate
+      }  
+    return dist;
+  }
+}
+
+uint32_t  AS3935GetIntensity() {
+  uint32_t nrgy_raw = (AS3935ReadRegister(ENERGY_RAW_3) << 8);
+  nrgy_raw |= AS3935ReadRegister(ENERGY_RAW_2);
+  nrgy_raw <<= 8;
+  nrgy_raw |= AS3935ReadRegister(ENERGY_RAW_1);
+  return nrgy_raw;
+}
+
+uint8_t AS3935GetTuneCaps() {
+  return AS3935ReadRegister(TUNE_CAPS);
+}
+
+void AS3935SetTuneCaps(uint8_t tune) {
+  AS3935WriteRegister(TUNE_CAPS, tune); 
+  delay(2);
+  AS3935CalibrateRCO();
+}
+
+uint8_t AS3935GetDisturber() {
+  return AS3935ReadRegister(DISTURBER);
+}
+
+uint8_t AS3935SetDisturber(uint8_t stat) {
+  AS3935WriteRegister(DISTURBER, stat); 
+}
+
+uint8_t AS3935GetMinLights() {
+  return AS3935ReadRegister(MIN_NUM_LIGH);
+}
+
+uint8_t AS3935SetMinLights(uint8_t stat) {
+  AS3935WriteRegister(MIN_NUM_LIGH, stat);
+}
+
+uint8_t AS3935GetNoiseFloor() {
+  return AS3935ReadRegister(NF_LEVEL);
+}
+
+uint8_t AS3935SetNoiseFloor(uint8_t noise) {
+   AS3935WriteRegister(NF_LEVEL , noise);
+}
+
+uint8_t AS3935GetGain() {
+  if (AS3935ReadRegister(AFE_GB) == OUTDOORS)
+    return OUTDOORS;
+  return INDOORS;
+}
+
+uint8_t AS3935SetGain(uint8_t room) {
+  AS3935WriteRegister(AFE_GB, room);
+}
+
+uint8_t AS3935GetGainInt() { 
+  if (AS3935ReadRegister(AFE_GB) == OUTDOORS)  
+  return 1;
+return 0;
+}
+
+uint8_t AS3935GetSpikeRejection() {
+  return AS3935ReadRegister(SPIKE_REJECT);
+}
+
+void AS3935SetSpikeRejection(uint8_t rej) {
+  AS3935WriteRegister(SPIKE_REJECT, rej);
+}
+
+uint8_t AS3935GetWdth() {
+  return AS3935ReadRegister(WDTH);
+}
+
+void AS3935SetWdth(uint8_t wdth) {
+  AS3935WriteRegister(WDTH, wdth);
+}
+
+bool AS3935AutoTune(){
+  detachInterrupt(pin[GPIO_AS3935]);
+  bool result = AS3935AutoTuneCaps(pin[GPIO_AS3935]);
+  attachInterrupt(digitalPinToInterrupt(pin[GPIO_AS3935]), AS3935Isr, RISING);
+  return result;
+}
+
+/********************************************************************************************/
+// Noise Floor autofunctions
+bool AS3935LowerNoiseFloor() {
+  uint8_t noise = AS3935GetNoiseFloor();
+  uint16_t vrms;
+  uint8_t stage;
+  AS3935CalcVrmsLevel(vrms, stage);
+  if (Settings.as3935_functions.nf_autotune_both) {
+    if (stage == 8 && stage > Settings.as3935_parameter.nf_autotune_min) {
+      AS3935SetGain(INDOORS);
+      AS3935SetNoiseFloor(7);
+      return true;
+    }
+  }
+  if (0 < noise && stage > Settings.as3935_parameter.nf_autotune_min) {
+    noise--;
+    AS3935SetNoiseFloor(noise);
+    return true;
+  }
+  return false;
+}
+
+bool AS3935RaiseNoiseFloor() {
+  uint8_t noise = AS3935GetNoiseFloor();
+  uint8_t room = AS3935GetGain();
+  if (Settings.as3935_functions.nf_autotune_both) {
+    if (7 == noise && room == INDOORS) {
+      AS3935SetGain(OUTDOORS);
+      AS3935SetNoiseFloor(0);
+      return true;
+    }
+  }
+  if (7 > noise) {
+    noise++;
+    AS3935SetNoiseFloor(noise);
+    return true;
+  }
+  return false;
+}
+
+/********************************************************************************************/
+// init functions
+bool AS3935SetDefault() { 
+  I2cWrite8(AS3935_ADDR, 0x3C, 0x96); // Set default
+  delay(2);
+  Settings.as3935_sensor_cfg[0] = I2cRead8(AS3935_ADDR, 0x00);
+  Settings.as3935_sensor_cfg[1] = I2cRead8(AS3935_ADDR, 0x01);
+  Settings.as3935_sensor_cfg[2] = I2cRead8(AS3935_ADDR, 0x02);
+  Settings.as3935_sensor_cfg[3] = I2cRead8(AS3935_ADDR, 0x03);
+  Settings.as3935_sensor_cfg[4] = I2cRead8(AS3935_ADDR, 0x08);
+  Settings.as3935_parameter.nf_autotune_min = 0x00;
+  Settings.as3935_parameter.nf_autotune_time = 4;
+  Settings.as3935_parameter.dist_autotune_time = 1;
+  return true;
+}
+
+void AS3935InitSettings() {
+  if(Settings.as3935_functions.nf_autotune){
+    AS3935SetGain(INDOORS);
+    AS3935SetNoiseFloor(0);
+  }
+  I2cWrite8(AS3935_ADDR, 0x00, Settings.as3935_sensor_cfg[0]);
+  I2cWrite8(AS3935_ADDR, 0x01, Settings.as3935_sensor_cfg[1]);
+  I2cWrite8(AS3935_ADDR, 0x02, Settings.as3935_sensor_cfg[2]);
+  I2cWrite8(AS3935_ADDR, 0x03, Settings.as3935_sensor_cfg[3]);
+  I2cWrite8(AS3935_ADDR, 0x08, Settings.as3935_sensor_cfg[4]);
+  delay(2);
+}
+
+void AS3935Setup(void) {
+  if (Settings.as3935_sensor_cfg[0] == 0x00) {
+    AS3935SetDefault(); 
+  } else {
+    AS3935InitSettings();
+  }
+  AS3935CalibrateRCO();
+}
+
+bool AS3935init() {
+  uint8_t ret = I2cRead8(AS3935_ADDR, 0x00);
+  if(INDOORS == ret || OUTDOORS == ret) //  0x24
+    return true;   
+  return false;
+}
+
+void AS3935Detect(void) {
+  if (I2cActive(AS3935_ADDR)) return; 
+  if (AS3935init())
+  {
+    I2cSetActiveFound(AS3935_ADDR, D_NAME_AS3935);
+    pinMode(pin[GPIO_AS3935], INPUT);
+    attachInterrupt(digitalPinToInterrupt(pin[GPIO_AS3935]), AS3935Isr, RISING);
+    AS3935Setup();
+    as3935_active = 1;
+  }
+}
+
+void AS3935EverySecond() {
+  if (as3935_sensor.detected) {
+    as3935_sensor.irq = AS3935GetIRQ(); // 1 =Noise, 4 = Disturber, 8 = storm
+    switch (as3935_sensor.irq) {
+      case 1:
+        if (Settings.as3935_functions.nf_autotune) {
+          if (AS3935RaiseNoiseFloor()) as3935_sensor.nftimer = 0;
+        }
+        break;
+      case 4:
+        if (Settings.as3935_functions.dist_autotune) {
+          AS3935SetDisturber(1);
+          as3935_sensor.autodist_activ = true;
+        }
+        break;
+      case 8:
+        as3935_sensor.intensity = AS3935GetIntensity();
+        as3935_sensor.distance = AS3935CalcDistance();
+        as3935_sensor.http_intensity = as3935_sensor.intensity;
+        as3935_sensor.http_distance = as3935_sensor.distance;
+        break;
+    }
+    // http show
+    as3935_sensor.http_irq = AS3935TranslIrq(as3935_sensor.irq, as3935_sensor.distance);
+    // mqtt publish
+    as3935_sensor.mqtt_irq = as3935_sensor.http_irq;
+    switch (as3935_sensor.mqtt_irq) {
+      case 5:
+      case 6:
+       if (!Settings.as3935_functions.mqtt_only_Light_Event) {
+          MqttPublishSensor();
+          as3935_sensor.http_timer = 10;
+       }
+       break;
+     default:
+       as3935_sensor.http_timer = 60;
+        MqttPublishSensor();
+    }
+    // clear mqtt events for Teleperiod
+    as3935_sensor.intensity = 0;
+    as3935_sensor.distance = 0;
+    as3935_sensor.mqtt_irq = 0;
+    // start http times
+    as3935_sensor.http_count_start = 1;
+    as3935_sensor.icount++; // Int counter
+    as3935_sensor.detected = false;
+  }
+
+  if (as3935_sensor.http_count_start) as3935_sensor.http_count++;
+  // clear Http 
+  if (as3935_sensor.http_count == as3935_sensor.http_timer) {
+    as3935_sensor.http_count = 0;
+    as3935_sensor.http_count_start = 0;
+    as3935_sensor.http_intensity = 0;
+    as3935_sensor.http_distance = 0;
+    as3935_sensor.http_irq = 0;
+  }
+  // Noise Floor Autotune function
+  if (Settings.as3935_functions.nf_autotune) {
+    as3935_sensor.nftimer++;
+    if (as3935_sensor.nftimer > Settings.as3935_parameter.nf_autotune_time * 60) {
+      AS3935LowerNoiseFloor();
+      as3935_sensor.nftimer = 0;
+    }
+  }
+  // Disturber auto function
+  if (Settings.as3935_functions.dist_autotune) {
+    if (as3935_sensor.autodist_activ) as3935_sensor.disttimer++;
+    if (as3935_sensor.disttimer >= Settings.as3935_parameter.dist_autotune_time * 60) {
+      AS3935SetDisturber(0);
+      as3935_sensor.disttimer = 0;
+      as3935_sensor.autodist_activ = false;
+    }
+  }
+}
+
+bool AS3935Cmd(void) {
+  char command[CMDSZ];
+  uint8_t name_len = strlen(D_NAME_AS3935);
+  if (!strncasecmp_P(XdrvMailbox.topic, PSTR(D_NAME_AS3935), name_len)) {
+    uint32_t command_code = GetCommandCode(command, sizeof(command), XdrvMailbox.topic + name_len, kAS3935_Commands);
+    switch (command_code) {
+      case CMND_AS3935_SET_NF:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+            AS3935SetNoiseFloor(XdrvMailbox.payload);
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935GetNoiseFloor());
+        break;
+      case  CMND_AS3935_SET_MINNF:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+            Settings.as3935_parameter.nf_autotune_min = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, Settings.as3935_parameter.nf_autotune_min);
+        break;
+      case CMND_AS3935_SET_MINLIGHT:
+        if (XdrvMailbox.data_len) {
+          AS3935SetMinLights(AS3935TransMinLights(XdrvMailbox.payload));
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935TranslMinLightsInt(AS3935GetMinLights()));
+        break;
+      case CMND_AS3935_SET_DEF:
+        if (!XdrvMailbox.data_len) {
+          Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935SetDefault());
+        }
+        break;
+      case CMND_AS3935_SET_GAIN:
+        if (XdrvMailbox.data_len > 6) {
+          uint8_t data_len = strlen(D_AS3935_OUTDOORS);
+          if (!strncasecmp_P(XdrvMailbox.data, PSTR(D_AS3935_OUTDOORS), data_len)) {
+            AS3935SetGain(OUTDOORS);
+          } else {
+            AS3935SetGain(INDOORS);
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_GAIN[AS3935GetGainInt()]);
+        break;
+      case CMND_AS3935_SET_TUNE:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+            AS3935SetTuneCaps(XdrvMailbox.payload);
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935GetTuneCaps());
+        break;
+      case CMND_AS3935_SET_REJ:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+            AS3935SetSpikeRejection(XdrvMailbox.payload);
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935GetSpikeRejection());
+        break;
+      case CMND_AS3935_SET_WDTH:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+            AS3935SetWdth(XdrvMailbox.payload);
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, AS3935GetWdth());
+        break;
+      case CMND_AS3935_DISTTIME:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+           Settings.as3935_parameter.dist_autotune_time = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, Settings.as3935_parameter.dist_autotune_time);
+        break;
+      case CMND_AS3935_NFTIME:
+        if (XdrvMailbox.data_len) {
+          if (15 >= XdrvMailbox.payload) {
+           Settings.as3935_parameter.nf_autotune_time = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_NVALUE, command, Settings.as3935_parameter.nf_autotune_time);
+        break;        
+      case CMND_AS3935_SET_DISTURBER:
+        if (XdrvMailbox.data_len) {
+          if (2 > XdrvMailbox.payload) {
+            AS3935SetDisturber(XdrvMailbox.payload);
+            if (!XdrvMailbox.payload) Settings.as3935_functions.dist_autotune = 0;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_ONOFF[AS3935GetDisturber()]);
+        break;
+      case CMND_AS3935_NF_AUTOTUNE:
+        if (XdrvMailbox.data_len) {
+          if (2 > XdrvMailbox.payload) {
+            Settings.as3935_functions.nf_autotune = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_ONOFF[Settings.as3935_functions.nf_autotune]);
+        break;
+      case CMND_AS3935_DIST_AUTOTUNE:
+        if (XdrvMailbox.data_len) {
+          if (2 > XdrvMailbox.payload) {
+            Settings.as3935_functions.dist_autotune = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_ONOFF[Settings.as3935_functions.dist_autotune]);
+        break;
+      case CMND_AS3935_NF_ATUNE_BOTH:
+        if (XdrvMailbox.data_len) {
+          if (2 > XdrvMailbox.payload) {
+            Settings.as3935_functions.nf_autotune_both = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_ONOFF[Settings.as3935_functions.nf_autotune_both]);
+        break;
+      case CMND_AS3935_MQTT_LIGHT_EVT:
+        if (XdrvMailbox.data_len) {
+          if (2 > XdrvMailbox.payload) {
+            Settings.as3935_functions.mqtt_only_Light_Event = XdrvMailbox.payload;
+          }
+        }
+        Response_P(S_JSON_AS3935_COMMAND_STRING, command, S_JSON_AS3935_COMMAND_ONOFF[Settings.as3935_functions.mqtt_only_Light_Event]);
+        break;
+      case CMND_AS3935_SETTINGS: {
+        if (!XdrvMailbox.data_len) {
+          uint8_t gain = AS3935GetGainInt();
+          uint16_t vrms;
+          uint8_t stage;
+          AS3935CalcVrmsLevel(vrms, stage);
+          uint8_t nf_floor = AS3935GetNoiseFloor();
+          uint8_t min_nf = Settings.as3935_parameter.nf_autotune_min;
+          uint8_t tunecaps = AS3935GetTuneCaps();
+          uint8_t minnumlight = AS3935TranslMinLightsInt(AS3935GetMinLights());
+          uint8_t disturber = AS3935GetDisturber();
+          uint8_t reinj = AS3935GetSpikeRejection();
+          uint8_t wdth = AS3935GetWdth();
+          uint8_t nfauto = Settings.as3935_functions.nf_autotune;
+          uint8_t distauto = Settings.as3935_functions.dist_autotune;
+          uint8_t nfautomax = Settings.as3935_functions.nf_autotune_both;
+          uint8_t jsonlight = Settings.as3935_functions.mqtt_only_Light_Event;
+          uint8_t nf_time   = Settings.as3935_parameter.nf_autotune_time;
+          uint8_t dist_time   =Settings.as3935_parameter.dist_autotune_time;
+          Response_P(S_JSON_AS3935_COMMAND_SETTINGS, S_JSON_AS3935_COMMAND_GAIN[gain], nf_floor, vrms, tunecaps, minnumlight, reinj, wdth, min_nf, nf_time, dist_time, S_JSON_AS3935_COMMAND_ONOFF[disturber], S_JSON_AS3935_COMMAND_ONOFF[nfauto], S_JSON_AS3935_COMMAND_ONOFF[distauto], S_JSON_AS3935_COMMAND_ONOFF[nfautomax], S_JSON_AS3935_COMMAND_ONOFF[jsonlight]);
+        }
+      }
+      break;
+    case CMND_AS3935_CALIBRATE: {
+      bool calreslt;
+      if (!XdrvMailbox.data_len) calreslt = AS3935AutoTune();
+      Response_P(S_JSON_AS3935_COMMAND_NVALUE, S_JSON_AS3935_COMMAND_CAL[calreslt], AS3935GetTuneCaps());
+    }
+    break;
+    default:
+      return false;
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void AH3935Show(bool json) {
+    if (json) {
+      ResponseAppend_P(JSON_SNS_AS3935_EVENTS, D_SENSOR_AS3935, as3935_sensor.mqtt_irq, as3935_sensor.distance, as3935_sensor.intensity );
+
+#ifdef USE_WEBSERVER
+    } else {            
+      uint8_t gain = AS3935GetGainInt();
+      uint8_t disturber = AS3935GetDisturber();
+      uint16_t vrms;
+      uint8_t stage;  
+      AS3935CalcVrmsLevel(vrms, stage);
+
+      WSContentSend_PD(HTTP_SNS_AS3935_TABLE_1[as3935_sensor.http_irq], D_NAME_AS3935, as3935_sensor.http_distance); 
+      WSContentSend_PD(HTTP_SNS_AS3935_DISTANZ, as3935_sensor.http_distance);
+      WSContentSend_PD(HTTP_SNS_AS3935_ENERGY, as3935_sensor.http_intensity);
+      WSContentSend_PD(HTTP_SNS_AS3935_GAIN[gain], D_NAME_AS3935);
+      WSContentSend_PD(HTTP_SNS_AS3935_DISTURBER[disturber], D_NAME_AS3935);    
+      WSContentSend_PD(HTTP_SNS_AS3935_VRMS, vrms, stage);
+#endif // USE_WEBSERVER
+    }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns67(uint8_t function) {
+  if (!I2cEnabled(XI2C_48)) { return false; }
+  bool result = false;
+
+  if (FUNC_INIT == function) {
+    AS3935Detect();
+  } else if (as3935_active){    
+    switch (function) {
+      case FUNC_EVERY_SECOND:
+        AS3935EverySecond();
+        break;
+      case FUNC_COMMAND:
+       result = AS3935Cmd();
+        break;
+      case FUNC_JSON_APPEND:
+        AH3935Show(1);
+        break;
+    #ifdef USE_WEBSERVER
+      case FUNC_WEB_SENSOR:
+        AH3935Show(0);
+        break;
+    #endif  // USE_WEBSERVER
+  }
+}
+  return result;
+}
+
+#endif  // USE_AS3935
+#endif  // USE_I2C


### PR DESCRIPTION
## Description:

### **Support for AS3935 Lightning Sensor added:**

![grafik](https://user-images.githubusercontent.com/48546979/79037978-f660a200-7bd5-11ea-93d7-33444d7cfcc5.png)


-support for all AS3935 Parameters
-support of all related commands for configuration
-support of NF-Auto Function to auto Threshold the Noise Reduction
-support auf Auto Disturber
-support of calibrating the internal OSC with switchable Caps

Datasheet available at: https://www.mouser.com/datasheet/2/588/ams_AS3935_Datasheet_EN_v5-1214568.pdf 

supported commands and functions:

 Console Commands    | Description                                  | values                                        |Bitlength 
---------------------|----------------------------------------------|-----------------------------------------------|----------
 as3935setnf         | Noise Floor Level                            |                value from 0-7                 | (3 Bit)  
 as3935setml         | Minimum number of lightning                  |                1, 5, 9, 16                    | (2 bit)  
 as3935default       | load default for Sensor and Settings         |                no argument                    |          
 as3935setgain       | Set Inddoor/Outdoor                          |              Indoors/Outdoors                 | (Ascii)  
 as3935settunecaps   | Internal Tuning Cap.                         |              value from 0-15                  | (4 Bits) 
 as3935setrej        | Spike rejection                              |              value from 0-15                  | (4 Bits) 
 as3935setwdth       | Watchdog threshold                           |              value from 0-15                  | (4 Bits) 
 as3935setminstage   | min stage that could be come with NFautotune |  value from 0-15: 0-7 Indoors, 8-15 Outdoors  | (4 Bits) 
 as3935disturber     | Set Disturber                                |                   0/1                         | (1 Bit)  
 as3935autonf        | Set Auto Tune for Noise Level                |                   0/1                         | (1 Bit)  
 as3935autodisturber | Set Auto-Disturber                           |                   0/1                         | (1 Bit)  
 as3935autonfmax     | Auto Tune with INDOOR and OUTDOOR            |                   0/1                         | (1 Bit)  
 as3935mqttevent     | mqtt messages only for lightning events      |                   0/1                         | (1 Bit)  
 as3935settings      | show all settings                            |                no argument                    |          
 as3935calibrate     | auto calibrate the internal Capacitors       |                no argument                    |          
 as3935disttime      | time for reset Disturber in auto-mode        |                 0-15 min.                     | (4 Bit)  
 as3935nftime        | time for auto-Nf treshhold                   |                 0-15 min                      | (4 Bit)  





**notice for the as3935calibrate:**
normaly you don't need the calibrate function. If you buy the AS3935, the Modul has a sticker on it with the calibrated cap.
Use the "as3935settunecaps" for setting up this value.

**notice for the IRQ Pin:**
the sensor uses a software interrupt. 
Make sure, that the connections with the IRQ pin are stable to prevent flicker.


Mqtt Events:

nr.| Description                          |suppress with
---|--------------------------------------|-------------------
 0 | no event                             |                    
 1 | Lightning with Distance detected     |                   
 2 | Lightning out of Distance            |                   
 3 | Distance cannot be determined        |                    
 4 | Storm is Overhead                    |                   
 5 | Noise level too high                 |  *                 
 6 | Disturber detected                   |  *               
 7 | Irq with no Event detected           |                    


Setting table of the NF-noise sensitivity and stages:

 Stages   | NF-LEV |   AFE-GB   | uVrms |   sensitivity
-----------|--------|------------|-------|-------------------
  Stage 0  |   000  |  Indoors   |    28 | highly sensitive
  Stage 1  |   001  |  Indoors   |    45 |    
  Stage 2  |   010  |  Indoors   |    62 |        
  Stage 3  |   011  |  Indoors   |    78 |        
  Stage 4  |   100  |  Indoors   |    95 |        
  Stage 5  |   101  |  Indoors   |   112 |     
  Stage 6  |   110  |  Indoors   |   130 |      
  Stage 7  |   111  |  Indoors   |   146 |        
  Stage 8  |   000  |  Outdoors  |   390 |        
  Stage 9  |   001  |  Outdoors  |   630 |      
  Stage 10 |   010  |  Outdoors  |   860 |       
  Stage 11 |   011  |  Outdoors  |  1100 |        
  Stage 12 |   100  |  Outdoors  |  1140 |       
  Stage 13 |   101  |  Outdoors  |  1570 |        
  Stage 14 |   110  |  Outdoors  |  1800 |       
  Stage 15 |   111  |  Outdoors  |  2000 | less sensitive

the Modul need 5k4 of flash memory. By default, this module is not activated.
you must set "USE_AS3935" to compile this module.

**Tasmota settings:**

![grafik](https://user-images.githubusercontent.com/48546979/79037994-1bedab80-7bd6-11ea-88db-0d88dcb05628.png)




**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  

- [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
