### PR TITLE
Reserve 28 bytes in Settings for Zigbee configuration

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -499,9 +499,14 @@ struct PACKED SYSCFG {
   uint8_t       as3935_sensor_cfg[5];      // F10
   As3935IntCfg  as3935_functions;          // F15
   As3935Param   as3935_parameter;          // F16
+  uint64_t      zb_ext_panid;              // F18
+  uint64_t      zb_precfgkey_l;            // F20
+  uint64_t      zb_precfgkey_h;            // F28
+  uint16_t      zb_pan_id;                 // F30
+  uint8_t       zb_channel;                // F32
+  uint8_t       zb_free_byte;              // F33
 
-  uint8_t       free_f18[160];             // F18
-
+  uint8_t       free_f18[132];             // F34
 
   uint16_t      pulse_counter_debounce_low;  // FB8
   uint16_t      pulse_counter_debounce_high; // FBA


### PR DESCRIPTION
## Description:

Reserve 28 bytes in Settings to implement user configurable Zigbee parameters, instead of compile time. I'm fixing the locations now, since I need 4 bytes alignment for some settings.

I reserved 28 bytes instead of 27 to ensure good 4 bytes alignment.

Implementation of settings will follow shortly.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
