### PR TITLE
remove deprecated function

### DIFF
--- a/tasmota/xsns_27_apds9960.ino
+++ b/tasmota/xsns_27_apds9960.ino
@@ -39,18 +39,18 @@
 #define XSNS_27             27
 #define XI2C_21             21  // See I2CDEVICES.md
 
-#if defined(USE_SHT) || defined(USE_VEML6070) || defined(USE_TSL2561)
-  #warning **** Turned off conflicting drivers SHT and VEML6070 ****
-  #ifdef USE_SHT
-  #undef USE_SHT          // SHT-Driver blocks gesture sensor
-  #endif
-  #ifdef USE_VEML6070
-  #undef USE_VEML6070     // address conflict on the I2C-bus
-  #endif
-  #ifdef USE_TSL2561
-  #undef USE_TSL2561     // possible address conflict on the I2C-bus
-  #endif
-#endif
+// #if defined(USE_SHT) || defined(USE_VEML6070) || defined(USE_TSL2561)
+//   #warning **** Turned off conflicting drivers SHT and VEML6070 ****
+//   #ifdef USE_SHT
+//   #undef USE_SHT          // SHT-Driver blocks gesture sensor
+//   #endif
+//   #ifdef USE_VEML6070
+//   #undef USE_VEML6070     // address conflict on the I2C-bus
+//   #endif
+//   #ifdef USE_TSL2561
+//   #undef USE_TSL2561     // possible address conflict on the I2C-bus
+//   #endif
+// #endif
 
 #define APDS9960_I2C_ADDR         0x39
 


### PR DESCRIPTION
## Description:
Remove deprecated driver disable function, now covered with I2CDriver. Only commented out just in case

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on core Tasmota_core_stage
  - [x ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
