### PR TITLE
ESP32 remove not used or

### DIFF
--- a/platformio_override_esp32.ini
+++ b/platformio_override_esp32.ini
@@ -99,9 +99,8 @@ lib_extra_dirs =
     libesp32
 
 lib_ignore =
-    ESP MQTT
     ILI9488
     SSD3115
     cc1101
-	FrogmoreScd30
+    FrogmoreScd30
     ArduinoNTPd

--- a/platformio_override_esp32.ini
+++ b/platformio_override_esp32.ini
@@ -100,9 +100,7 @@ lib_extra_dirs =
 
 lib_ignore =
     ESP MQTT
-    TasmotaMqtt
     ILI9488
-    RA8876
     SSD3115
     cc1101
 	FrogmoreScd30

--- a/platformio_override_esp32.ini
+++ b/platformio_override_esp32.ini
@@ -102,5 +102,4 @@ lib_ignore =
     ILI9488
     SSD3115
     cc1101
-    FrogmoreScd30
     ArduinoNTPd


### PR DESCRIPTION
now supported from ignore libs

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
