### PR TITLE
Add light palette support

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -389,6 +389,7 @@
 #define D_CMND_LED "Led"
 #define D_CMND_LEDTABLE "LedTable"
 #define D_CMND_FADE "Fade"
+#define D_CMND_PALETTE "Palette"
 #define D_CMND_PIXELS "Pixels"
 #define D_CMND_RGBWWTABLE "RGBWWTable"
 #define D_CMND_ROTATION "Rotation"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -436,6 +436,7 @@
 #define USE_SM2135                               // Add support for SM2135 RGBCW led control as used in Action LSC (+0k6 code)
 #define USE_SONOFF_L1                            // Add support for Sonoff L1 led control
 #define USE_ELECTRIQ_MOODL                       // Add support for ElectriQ iQ-wifiMOODL RGBW LED controller (+0k3 code)
+#define USE_LIGHT_PALETTE                       // Add support for color palette (+0k9 code)
 
 // -- Counter input -------------------------------
 #define USE_COUNTER                              // Enable inputs as counter (+0k8 code)

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -400,18 +400,10 @@ void PWMDimmerHandleButton(void)
                 else
 #endif  // USE_PWM_DIMMER_REMOTE
                   uint8_value = Light.fixed_color_index;
-                if (is_down_button) {
-                  if (uint8_value)
-                    uint8_value--;
-                  else
-                    uint8_value = MAX_FIXED_COLOR;
-                }
-                else {
-                  if (uint8_value < MAX_FIXED_COLOR)
-                    uint8_value++;
-                  else
-                    uint8_value = 0;
-                }
+                if (is_down_button)
+                  uint8_value--;
+                else
+                  uint8_value++;
 #ifdef USE_PWM_DIMMER_REMOTE
                 if (!active_device_is_local)
                   active_remote_pwm_dimmer->fixed_color_index = uint8_value;


### PR DESCRIPTION
## Description:

Light palette support adds the ability to specify a palette of colors to use instead of the standard color wheel and fixed colors. The Palette command specifies the list of colors to use. The list is allocated dynamically and is not stored in the settings so it is not preserved across restarts. Once a palette is specified, the Color<1,2> and Scheme<2,3,4> commands use the colors in the palette. The palette is cleared using the Palette 0 command.

### Commands

Command|Parameters
:---|:---
|Palette| 0 = Clear the color palette<br><color\>[ ...] = Set the list of colors to be used by the Color<1,2> and Scheme<2,3,4> commands with each color separated by a space

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
