### PR TITLE
Add ``DimmerRange`` for PWM lights (#8120)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Add support for AS3935 Lightning Sensor by device111 (#8130)
 - Fix prevent multiple pings to run concurrently
 - Fix Scheme 2-4 brightness when SetOption68 1 (#8058)
+- Add ``DimmerRange`` for PWM lights (#8120)
 
 ### 8.2.0.2 20200328
 


### PR DESCRIPTION
## Description:

`DimmerRange` is now applied to PWM lights. This allows to set a minimum PMW value for non-zero levels. This is required for PMW_DIMMER and Mi Desk Lamp.

`DimmerRange` levels are 0..100 and gamma correction is applied if required.

To set the minimum value, set one channel to max value, ex: `Color FF0000` then use `Dimmer <x>` to reduce brightness until the light turns off, and set `DimmerRange` to this value + 1. With `LedTable 1`, the minimum value is usually 35-40.

**Related issue (if applicable):** fixes #8120 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
