### PR TITLE
Added %utctime% as rules variable

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -476,6 +476,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
         RulesVarReplace(commands, stemp, SettingsText(SET_MEM1 +i));
       }
       RulesVarReplace(commands, F("%TIME%"), String(MinutesPastMidnight()));
+      RulesVarReplace(commands, F("%UTCTIME%"), String(UtcTime()));
       RulesVarReplace(commands, F("%UPTIME%"), String(MinutesUptime()));
       RulesVarReplace(commands, F("%TIMESTAMP%"), GetDateAndTime(DT_LOCAL));
       RulesVarReplace(commands, F("%TOPIC%"), SettingsText(SET_MQTT_TOPIC));


### PR DESCRIPTION
## Description:

The docs in section "Rules Variables" lists some valid %*variablename*% including `%utctime%` but this one was not implemented.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core Tasmota_core_stage
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
