### PR TITLE
Fix compilation error when USE_DISPLAY without I2C or SPI

### DIFF
--- a/tasmota/xdsp_interface.ino
+++ b/tasmota/xdsp_interface.ino
@@ -17,6 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if defined(USE_I2C) || defined(USE_SPI)
 #ifdef USE_DISPLAY
 
 #ifdef XFUNC_PTR_IN_ROM
@@ -137,3 +138,4 @@ bool XdspCall(uint8_t Function)
 }
 
 #endif  // USE_DISPLAY
+#endif  // USE_I2C or USE_SPI


### PR DESCRIPTION
## Description:

Fixes a compilation error when `#define USE_DISPLAY` and neither `#define USE_I2C` nor `#define USE_SPI` are defined.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
