### PR TITLE
Prep for Buttons V2

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -86,8 +86,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t energy_weekend : 1;           // bit 20 (v6.6.0.8)  - CMND_TARIFF
     uint32_t dds2382_model : 1;            // bit 21 (v6.6.0.14) - SetOption71 - Select different Modbus registers for Active Energy (#6531)
     uint32_t hardware_energy_total : 1;    // bit 22 (v6.6.0.15) - SetOption72 - Enable hardware energy total counter as reference (#6561)
-    uint32_t ex_cors_enabled : 1;          // bit 23 (v7.0.0.1)  - SetOption73 - Enable HTTP CORS
-    uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
+    uint32_t mqtt_buttons : 1;             // bit 23 (v8.2.0.3)  - SetOption73 - Detach buttons from relays and enable MQTT action state for multipress    uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
     uint32_t grouptopic_mode : 1;          // bit 25 (v7.0.0.1)  - SetOption75 - GroupTopic replaces %topic% (0) or fixed topic cmnd/grouptopic (1)
     uint32_t bootcount_update : 1;         // bit 26 (v7.0.0.4)  - SetOption76 - Enable incrementing bootcount when deepsleep is enabled
     uint32_t slider_dimmer_stay_on : 1;    // bit 27 (v7.0.0.6)  - SetOption77 - Do not power off if slider moved to far left

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -86,7 +86,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t energy_weekend : 1;           // bit 20 (v6.6.0.8)  - CMND_TARIFF
     uint32_t dds2382_model : 1;            // bit 21 (v6.6.0.14) - SetOption71 - Select different Modbus registers for Active Energy (#6531)
     uint32_t hardware_energy_total : 1;    // bit 22 (v6.6.0.15) - SetOption72 - Enable hardware energy total counter as reference (#6561)
-    uint32_t mqtt_buttons : 1;             // bit 23 (v8.2.0.3)  - SetOption73 - Detach buttons from relays and enable MQTT action state for multipress    uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
+    uint32_t mqtt_buttons : 1;             // bit 23 (v8.2.0.3)  - SetOption73 - Detach buttons from relays and enable MQTT action state for multipress    
+    uint32_t ds18x20_internal_pullup : 1;  // bit 24 (v7.0.0.1)  - SetOption74 - Enable internal pullup for single DS18x20 sensor
     uint32_t grouptopic_mode : 1;          // bit 25 (v7.0.0.1)  - SetOption75 - GroupTopic replaces %topic% (0) or fixed topic cmnd/grouptopic (1)
     uint32_t bootcount_update : 1;         // bit 26 (v7.0.0.4)  - SetOption76 - Enable incrementing bootcount when deepsleep is enabled
     uint32_t slider_dimmer_stay_on : 1;    // bit 27 (v7.0.0.6)  - SetOption77 - Do not power off if slider moved to far left

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1243,11 +1243,11 @@ void SettingsDelta(void)
       Settings.ex_serial_config = TS_SERIAL_8N1;
     }
     if (Settings.version < 0x07010204) {
-      if (Settings.flag3.ex_cors_enabled == 1) {
-        strlcpy(Settings.ex_cors_domain, CORS_ENABLED_ALL, sizeof(Settings.ex_cors_domain));
-      } else {
-        Settings.ex_cors_domain[0] = 0;
-      }
+    //   if (Settings.flag3.ex_cors_enabled == 1) {
+    //     strlcpy(Settings.ex_cors_domain, CORS_ENABLED_ALL, sizeof(Settings.ex_cors_domain));
+    //   } else {
+    //     Settings.ex_cors_domain[0] = 0;
+    //   }
     }
     if (Settings.version < 0x07010205) {
       Settings.seriallog_level = Settings.ex_seriallog_level;  // 09E -> 452

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1243,11 +1243,11 @@ void SettingsDelta(void)
       Settings.ex_serial_config = TS_SERIAL_8N1;
     }
     if (Settings.version < 0x07010204) {
-    //   if (Settings.flag3.ex_cors_enabled == 1) {
-    //     strlcpy(Settings.ex_cors_domain, CORS_ENABLED_ALL, sizeof(Settings.ex_cors_domain));
-    //   } else {
-    //     Settings.ex_cors_domain[0] = 0;
-    //   }
+       if (Settings.flag3.mqtt_buttons == 1) {
+         strlcpy(Settings.ex_cors_domain, CORS_ENABLED_ALL, sizeof(Settings.ex_cors_domain));
+       } else {
+         Settings.ex_cors_domain[0] = 0;
+       }
     }
     if (Settings.version < 0x07010205) {
       Settings.seriallog_level = Settings.ex_seriallog_level;  // 09E -> 452

--- a/tasmota/support_button_V2
+++ b/tasmota/support_button_V2
@@ -1,0 +1,316 @@
+/*
+  support_button.ino - button support for Tasmota
+
+  Copyright (C) 2020  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BUTTON_V2
+#ifdef BUTTON_V2
+/*********************************************************************************************\
+ * Button support
+\*********************************************************************************************/
+
+#define MAX_BUTTON_COMMANDS  3  // Max number of button commands supported
+#define MAX_RELAY_BUTTON1 4     // Max number of relay controlled by button1
+
+const char kCommands[] PROGMEM =
+  D_CMND_WIFICONFIG " 2|" D_CMND_RESTART " 1|" D_CMND_UPGRADE " 1";
+  //D_CMND_WIFICONFIG " 2|" D_CMND_WIFICONFIG " 2|" D_CMND_WIFICONFIG " 2|" D_CMND_RESTART " 1|" D_CMND_UPGRADE " 1";
+const char kMultiPress[] PROGMEM =
+  "|SINGLE|DOUBLE|TRIPLE|QUAD|PENTA|";
+
+struct BUTTON {
+  unsigned long debounce = 0;                // Button debounce timer
+  uint16_t hold_timer[MAX_KEYS] = { 0 };     // Timer for button hold
+  uint16_t dual_code = 0;                    // Sonoff dual received code
+
+  uint8_t last_state[MAX_KEYS] = { NOT_PRESSED, NOT_PRESSED, NOT_PRESSED, NOT_PRESSED };  // Last button states
+  uint8_t window_timer[MAX_KEYS] = { 0 };    // Max time between button presses to record press count
+  uint8_t press_counter[MAX_KEYS] = { 0 };   // Number of button presses within Button.window_timer
+
+  uint8_t dual_receive_count = 0;            // Sonoff dual input flag
+  uint8_t no_pullup_mask = 0;                // key no pullup flag (1 = no pullup)
+  uint8_t inverted_mask = 0;                 // Key inverted flag (1 = inverted)
+  uint8_t present = 0;                       // Number of buttons found flag
+  uint8_t adc = 99;                          // ADC0 button number
+} Button;
+
+/********************************************************************************************/
+
+void ButtonPullupFlag(uint8 button_bit)
+{
+  bitSet(Button.no_pullup_mask, button_bit);
+}
+
+void ButtonInvertFlag(uint8 button_bit)
+{
+  bitSet(Button.inverted_mask, button_bit);
+}
+
+void ButtonInit(void)
+{
+  Button.present = 0;
+  for (uint32_t i = 0; i < MAX_KEYS; i++) {
+    if (pin[GPIO_KEY1 +i] < 99) {
+      Button.present++;
+      pinMode(pin[GPIO_KEY1 +i], bitRead(Button.no_pullup_mask, i) ? INPUT : ((16 == pin[GPIO_KEY1 +i]) ? INPUT_PULLDOWN_16 : INPUT_PULLUP));
+    }
+#ifndef USE_ADC_VCC
+    else if ((99 == Button.adc) && ((ADC0_BUTTON == my_adc0) || (ADC0_BUTTON_INV == my_adc0))) {
+      Button.present++;
+      Button.adc = i;
+    }
+#endif  // USE_ADC_VCC
+  }
+}
+
+uint8_t ButtonSerial(uint8_t serial_in_byte)
+{
+  if (Button.dual_receive_count) {
+    Button.dual_receive_count--;
+    if (Button.dual_receive_count) {
+      Button.dual_code = (Button.dual_code << 8) | serial_in_byte;
+      serial_in_byte = 0;
+    } else {
+      if (serial_in_byte != 0xA1) {
+        Button.dual_code = 0;                // 0xA1 - End of Sonoff dual button code
+      }
+    }
+  }
+  if (0xA0 == serial_in_byte) {              // 0xA0 - Start of Sonoff dual button code
+    serial_in_byte = 0;
+    Button.dual_code = 0;
+    Button.dual_receive_count = 3;
+  }
+
+  return serial_in_byte;
+}
+
+/*********************************************************************************************\
+ * Button handler with single press only or multi-press and hold on all buttons
+ *
+ * ButtonDebounce (50) - Debounce time in mSec
+ * SetOption1 (0)      - If set do not execute config commands
+ * SetOption11 (0)     - If set perform single press action on double press and reverse
+ * SetOption13 (0)     - If set act on single press only
+ * SetOption32 (40)    - Max button hold time in Seconds
+ * SetOption40 (0)     - Number of 0.1 seconds until hold is discarded if SetOption1 1 and SetOption13 0
+ * SetOption73 (0)     - Decouple button from relay and send just mqtt topic
+\*********************************************************************************************/
+
+void ButtonHandler(void)
+{
+  if (uptime < 4) { return; }                                   // Block GPIO for 4 seconds after poweron to workaround Wemos D1 / Obi RTS circuit
+
+  uint8_t hold_time_extent = IMMINENT_RESET_FACTOR;             // Extent hold time factor in case of iminnent Reset command
+  uint16_t loops_per_second = 1000 / Settings.button_debounce;  // ButtonDebounce (50)
+  char scmnd[20];
+  char scommand[CMDSZ];
+  char stopic[TOPSZ];
+
+//  uint8_t maxdev = (devices_present > MAX_KEYS) ? MAX_KEYS : devices_present;
+//  for (uint32_t button_index = 0; button_index < maxdev; button_index++) {
+  for (uint32_t button_index = 0; button_index < MAX_KEYS; button_index++) {
+    uint8_t button = NOT_PRESSED;
+    uint8_t button_present = 0;
+
+    if (!button_index && ((SONOFF_DUAL == my_module_type) || (CH4 == my_module_type))) {
+      button_present = 1;
+      if (Button.dual_code) {
+        AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_BUTTON " " D_CODE " %04X"), Button.dual_code);
+        button = PRESSED;
+        if (0xF500 == Button.dual_code) {                      // Button hold
+          Button.hold_timer[button_index] = (loops_per_second * Settings.param[P_HOLD_TIME] / 10) -1;  // SetOption32 (40)
+          hold_time_extent = 1;
+        }
+        Button.dual_code = 0;
+      }
+    }
+    else if (pin[GPIO_KEY1 +button_index] < 99) {
+      button_present = 1;
+      button = (digitalRead(pin[GPIO_KEY1 +button_index]) != bitRead(Button.inverted_mask, button_index));
+    }
+#ifndef USE_ADC_VCC
+    if (Button.adc == button_index) {
+      button_present = 1;
+      if (ADC0_BUTTON_INV == my_adc0) {
+        button = (AdcRead(1) < 128);
+      }
+      else if (ADC0_BUTTON == my_adc0) {
+        button = (AdcRead(1) > 128);
+      }
+    }
+#endif  // USE_ADC_VCC
+
+    if (button_present) {
+      XdrvMailbox.index = button_index;
+      XdrvMailbox.payload = button;
+      if (XdrvCall(FUNC_BUTTON_PRESSED)) {
+        // Serviced
+      }
+      else if (SONOFF_4CHPRO == my_module_type) {
+        if (Button.hold_timer[button_index]) { Button.hold_timer[button_index]--; }
+
+        bool button_pressed = false;
+        if ((PRESSED == button) && (NOT_PRESSED == Button.last_state[button_index])) {
+          AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_LEVEL_10), button_index +1);
+          Button.hold_timer[button_index] = loops_per_second;
+          button_pressed = true;
+        }
+        if ((NOT_PRESSED == button) && (PRESSED == Button.last_state[button_index])) {
+          AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_LEVEL_01), button_index +1);
+          if (!Button.hold_timer[button_index]) { button_pressed = true; }  // Do not allow within 1 second
+        }
+        if (button_pressed) {
+          if (!SendKey(KEY_BUTTON, button_index +1, POWER_TOGGLE)) {  // Execute Toggle command via MQTT if ButtonTopic is set
+            ExecuteCommandPower(button_index +1, POWER_TOGGLE, SRC_BUTTON);  // Execute Toggle command internally
+
+          }
+        }
+      } else {
+
+        if ((PRESSED == button) && (NOT_PRESSED == Button.last_state[button_index])) {
+
+          if (Settings.flag.button_single && !Settings.flag3.mqtt_buttons) {                   // SetOption13 (0) - Allow only single button press for immediate action, SetOption73 (0) - Decouple button from relay and send just mqtt topic
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_IMMEDIATE), button_index +1);
+            if (!SendKey(KEY_BUTTON, button_index +1, POWER_TOGGLE)) {  // Execute Toggle command via MQTT if ButtonTopic is set
+              ExecuteCommandPower(button_index +1, POWER_TOGGLE, SRC_BUTTON);  // Execute Toggle command internally
+            } 
+
+          } else {
+            Button.press_counter[button_index] = (Button.window_timer[button_index]) ? Button.press_counter[button_index] +1 : 1;
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_BUTTON "%d " D_MULTI_PRESS " %d"), button_index +1, Button.press_counter[button_index]);
+            Button.window_timer[button_index] = loops_per_second / 2;  // 0.5 second multi press window
+          }
+          blinks = 201;
+        }
+
+        if (NOT_PRESSED == button) {
+          Button.hold_timer[button_index] = 0;
+        } else {
+          Button.hold_timer[button_index]++;
+          if (Settings.flag.button_single) {          // SetOption13 (0) - Allow only single button press for immediate action
+            if (Button.hold_timer[button_index] == loops_per_second * hold_time_extent * Settings.param[P_HOLD_TIME] / 10) {  // SetOption32 (40) - Button held for factor times longer
+              snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_SETOPTION "13 0"));  // Disable single press only
+              ExecuteCommand(scmnd, SRC_BUTTON);
+            }
+          } else {
+            if (Button.hold_timer[button_index] == loops_per_second * Settings.param[P_HOLD_TIME] / 10) {  // SetOption32 (40) - Button hold
+              Button.press_counter[button_index] = 0;           
+              if (Settings.flag3.mqtt_buttons) {     // SetOption73 (0) - Decouple button from relay and send just mqtt topic
+                snprintf_P(scommand, sizeof(scommand), PSTR("BUTTON%d"), button_index +1);
+                GetTopic_P(stopic, STAT, mqtt_topic, scommand);
+                Response_P(S_JSON_COMMAND_SVALUE, "ACTION", GetStateText(3));
+                MqttPublish(stopic);
+              } 
+              SendKey(KEY_BUTTON, button_index +1, POWER_HOLD);  // Execute Hold command via MQTT if ButtonTopic is set             
+            } else {
+              if (Button.hold_timer[button_index] == loops_per_second * hold_time_extent * Settings.param[P_HOLD_TIME] / 10) {  // SetOption32 (40) - Button held for factor times longer
+                Button.press_counter[button_index] = 0;
+                snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_RESET " 1"));
+                ExecuteCommand(scmnd, SRC_BUTTON);
+              }
+            }
+          }
+        }
+
+        if (!Settings.flag.button_single) {                    // SetOption13 (0) - Allow multi-press
+          if (Button.window_timer[button_index]) {
+            Button.window_timer[button_index]--;
+          } else {
+            if (!restart_flag && !Button.hold_timer[button_index] && (Button.press_counter[button_index] > 0) && (Button.press_counter[button_index] < MAX_BUTTON_COMMANDS +6)) {
+              bool single_press = false;
+              if (Button.press_counter[button_index] < 3) {    // Single or Double press
+                if ((SONOFF_DUAL_R2 == my_module_type) || (SONOFF_DUAL == my_module_type) || (CH4 == my_module_type)) {
+                  single_press = true;
+                } else {
+                  single_press = (Settings.flag.button_swap +1 == Button.press_counter[button_index]);  // SetOption11 (0)
+                  if ((1 == Button.present) && (2 == devices_present)) {  // Single Button with two devices only
+                    if (Settings.flag.button_swap) {           // SetOption11 (0)
+                      Button.press_counter[button_index] = (single_press) ? 1 : 2;
+                    }                    
+                  // } else {   
+                  //   if (!Settings.flag3.mqtt_buttons && button_index != 0) {                 
+                  //     Button.press_counter[button_index] = 1;
+                  //   }
+                  }
+                }
+              }
+#if defined(USE_LIGHT) && defined(ROTARY_V1)
+              if (!((0 == button_index) && RotaryButtonPressed())) {
+#endif
+                if (!Settings.flag3.mqtt_buttons && single_press && SendKey(KEY_BUTTON, button_index + Button.press_counter[button_index], POWER_TOGGLE)) {  // Execute Toggle command via MQTT if ButtonTopic is set
+                  // Success
+                } else {
+                  if (Button.press_counter[button_index] < 6) { // Single to Penta press
+                    if (WifiState() > WIFI_RESTART) {           // Wifimanager active
+                      restart_flag = 1;
+                    } 
+                    if (!Settings.flag3.mqtt_buttons) {       
+                      if (Button.press_counter[button_index] == 1) {    // By default first press always send a TOGGLE (2) 
+                        ExecuteCommandPower(button_index + Button.press_counter[button_index], POWER_TOGGLE, SRC_BUTTON);
+                      } else {
+                        SendKey(KEY_BUTTON, button_index +1, Button.press_counter[button_index] +9);    // 2,3,4 and 5 press send just the key value (11,12,13 and 14) for rules
+                        if (0 == button_index) {    // First button can toggle up to 4 relays if present
+                          if ((Button.press_counter[button_index] > 1 && pin[GPIO_REL1 + Button.press_counter[button_index]-1] < 99) && Button.press_counter[button_index] <= MAX_RELAY_BUTTON1) { 
+                            ExecuteCommandPower(button_index + Button.press_counter[button_index], POWER_TOGGLE, SRC_BUTTON);   // Execute Toggle command internally
+                            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: Relay%d found on GPIO%d"), Button.press_counter[button_index], pin[GPIO_REL1 + Button.press_counter[button_index]-1]);
+                          }
+                        }
+                      }
+                    }
+                  } else {    // 6 - 8 press are used to send commands
+                      GetTextIndexed(scmnd, sizeof(scmnd), Button.press_counter[button_index] -6, kCommands);
+                      ExecuteCommand(scmnd, SRC_BUTTON);
+                  }                 
+                  if (Settings.flag3.mqtt_buttons) {   // SetOption73 (0) - Decouple button from relay and send just mqtt topic
+                    if (Button.press_counter[button_index] >= 1 && Button.press_counter[button_index] <= 5) { 
+                      char mqttstate[7];
+                      
+                      GetTextIndexed(mqttstate, sizeof(mqttstate), Button.press_counter[button_index], kMultiPress);
+                      SendKey(KEY_BUTTON, button_index +1, Button.press_counter[button_index] +9);      
+                      snprintf_P(scommand, sizeof(scommand), PSTR("BUTTON%d"), button_index +1);
+                      GetTopic_P(stopic, STAT, mqtt_topic, scommand);
+                      Response_P(S_JSON_COMMAND_SVALUE, "ACTION", mqttstate);
+                      MqttPublish(stopic);
+
+                    }
+                  }
+                }
+#if defined(USE_LIGHT) && defined(ROTARY_V1)
+              }
+#endif
+              Button.press_counter[button_index] = 0;
+            }
+          }
+        }
+      }
+    }
+    Button.last_state[button_index] = button;
+  }
+}
+
+void ButtonLoop(void)
+{
+  if (Button.present) {
+    if (TimeReached(Button.debounce)) {
+      SetNextTimeInterval(Button.debounce, Settings.button_debounce);  // ButtonDebounce (50)
+      ButtonHandler();
+    }
+  }
+}
+
+#endif  // BUTTON_V2

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -240,6 +240,7 @@ enum ExecuteCommandPowerOptions { POWER_OFF, POWER_ON, POWER_TOGGLE, POWER_BLINK
                                   POWER_SHOW_STATE = 16 };
 enum SendKeyPowerOptions { POWER_HOLD = 3, POWER_INCREMENT = 4, POWER_INV = 5, POWER_CLEAR = 6, CLEAR_RETAIN = 9 };
 enum SendKeyOptions { KEY_BUTTON, KEY_SWITCH };
+enum SendKeyMultiClick { SINGLE = 10, DOUBLE = 11, TRIPLE = 12, QUAD = 13, PENTA = 14};
 
 enum PowerOnStateOptions { POWER_ALL_OFF, POWER_ALL_ON, POWER_ALL_SAVED_TOGGLE, POWER_ALL_SAVED, POWER_ALL_ALWAYS_ON, POWER_ALL_OFF_PULSETIME_ON };
 


### PR DESCRIPTION
## Description:
**WORK IN PROGRESS - NOT ENABLED BY DEFAULT**
**Every changes made by this patch are subject to further alterations.** 
**To test the new buttons setup `support_button.ino` must be renamed to something else and `support_button_V2` must be renamed to `support_button.ino` before compiling.**


**Changelog**:

- Buttons can now perform up to 9 different actions.

- `SetOption73` will enable/disable decoupled buttons and the corresponding relays will not be triggered. When enabled, the buttons can be used in rules and a `/stat` topic will be published:
```
16:51:53 RUL: BUTTON1#STATE performs "publish button1 3"
16:51:53 MQT: button1 = 3 
16:51:53 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"HOLD"}
16:51:56 RUL: BUTTON1#STATE performs "publish button1 10"
16:51:56 MQT: button1 = 10 
16:51:56 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"SINGLE"}
16:51:59 RUL: BUTTON1#STATE performs "publish button1 11"
16:51:59 MQT: button1 = 11 
16:51:59 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"DOUBLE"}
16:52:02 RUL: BUTTON1#STATE performs "publish button1 12"
16:52:02 MQT: button1 = 12
16:52:02 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"TRIPLE"}
16:52:05 RUL: BUTTON1#STATE performs "publish button1 13"
16:52:05 MQT: button1 = 13
16:52:05 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"QUAD"}
16:52:09 RUL: BUTTON1#STATE performs "publish button1 14"
16:52:09 MQT: button1 = 14 
16:52:09 MQT: stat/tasmota_2350B0/BUTTON1 = {"ACTION":"PENTA"}
```
- Every button connected to the device can send 3 commands:
6 press: WIFICONFIG  2  
7 press: RESTART 1
8 press: UPGRADE 1

- `Button1` can control up to 4 relays with 1,2,3 or 4 press. If a relay is not present Button1 will send the corresponding value of the number of press. 

- All the other buttons will send a `TOGGLE` with the first press (when `SetOption73` is disabled) and they will also send the value for the corresponding number of press ready to use with rules: 
SINGLE press = 2 (when SetOption73 is enabled the correct value will be 10)
DOUBLE press = 11 
TRIPLE press = 12 
QUAD press = 13 
PENTA press = 14

- `SetOption1` and `SetOpion40` are not used anymore.

**WORK IN PROGRESS - NOT ENABLED BY DEFAULT**
**Every changes made by this patch are subject to further alterations.** 

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core Tasmota_core_stage
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
