### PR TITLE
Fix Setption13 on Buttons V2

### DIFF
--- a/tasmota/support_button_v2.ino
+++ b/tasmota/support_button_v2.ino
@@ -304,7 +304,7 @@ void ButtonHandler(void)
   }
 }
 
-void MqttButtonTopic(uint8_t index, uint8_t action, uint8_t hold)
+void MqttButtonTopic(uint8_t button_id, uint8_t action, uint8_t hold)
 {
   char scommand[CMDSZ];
   char stopic[TOPSZ];
@@ -312,8 +312,8 @@ void MqttButtonTopic(uint8_t index, uint8_t action, uint8_t hold)
 
   GetTextIndexed(mqttstate, sizeof(mqttstate), action, kMultiPress);  
 
-  SendKey(KEY_BUTTON, index, (hold) ? 3 : action +9);
-  snprintf_P(scommand, sizeof(scommand), PSTR("BUTTON%d"), index);
+  SendKey(KEY_BUTTON, button_id, (hold) ? 3 : action +9);
+  snprintf_P(scommand, sizeof(scommand), PSTR("BUTTON%d"), button_id);
   GetTopic_P(stopic, STAT, mqtt_topic, scommand);
   Response_P(S_JSON_COMMAND_SVALUE, "ACTION", (hold) ? SettingsText(SET_STATE_TXT4) : mqttstate);
   MqttPublish(stopic);


### PR DESCRIPTION
## Description:
Removed a bug when SetOption13 is enabled at the same time of SetOption73 (no output at all).
Now when both enabled Tasmota will publish just an mqtt message for the first press, ignoring all the others.
Also moved the MQTT topics generation on an external void to reduce code pollution.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core Tasmota_core_stage
  - [X] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
