### PR TITLE
Scripter update

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -4854,11 +4854,13 @@ bool Xdrv10(uint8_t function)
 
   switch (function) {
     case FUNC_PRE_INIT:
+    /*
 #ifdef USE_WEBCAM
       if (Settings.module==ESP32_CAM_AITHINKER) {
         webcam_setup();
       }
 #endif
+*/
       // set defaults to rules memory
       glob_script_mem.script_ram=Settings.rules[0];
       glob_script_mem.script_size=MAX_SCRIPT_SIZE;

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -65,6 +65,35 @@ keywords if then else endif, or, and are better readable for beginners (others m
 uint32_t EncodeLightId(uint8_t relay_id);
 uint32_t DecodeLightId(uint32_t hue_id);
 
+#if defined(ESP32) && defined(ESP32_SCRIPT_SIZE) && !defined(USE_24C256) && !defined(USE_SCRIPT_FATFS)
+
+#include "FS.h"
+#include "SPIFFS.h"
+void SaveFile(const char *name,const uint8_t *buf,uint32_t len) {
+  File file = SPIFFS.open(name, FILE_WRITE);
+  if (!file) return;
+  file.write(buf, len);
+  file.close();
+}
+
+#define FORMAT_SPIFFS_IF_FAILED true
+uint8_t spiffs_mounted=0;
+
+void LoadFile(const char *name,uint8_t *buf,uint32_t len) {
+  if (!spiffs_mounted) {
+    if(!SPIFFS.begin(FORMAT_SPIFFS_IF_FAILED)){
+          //Serial.println("SPIFFS Mount Failed");
+      return;
+    }
+    spiffs_mounted=1;
+  }
+  File file = SPIFFS.open(name);
+  if (!file) return;
+  file.read(buf, len);
+  file.close();
+}
+#endif
+
 // offsets epoch readings by 1.1.2019 00:00:00 to fit into float with second resolution
 #define EPOCH_OFFSET 1546300800
 
@@ -3597,6 +3626,11 @@ void ScriptSaveSettings(void) {
     }
 #endif
 
+#if defined(ESP32) && defined(ESP32_SCRIPT_SIZE) && !defined(USE_24C256) && !defined(USE_SCRIPT_FATFS)
+    if (glob_script_mem.flags&1) {
+      SaveFile("/script.txt",(uint8_t*)glob_script_mem.script_ram,ESP32_SCRIPT_SIZE);
+    }
+#endif
   }
 
   if (glob_script_mem.script_mem) {
@@ -4820,6 +4854,11 @@ bool Xdrv10(uint8_t function)
 
   switch (function) {
     case FUNC_PRE_INIT:
+#ifdef USE_WEBCAM
+      if (Settings.module==ESP32_CAM_AITHINKER) {
+        webcam_setup();
+      }
+#endif
       // set defaults to rules memory
       glob_script_mem.script_ram=Settings.rules[0];
       glob_script_mem.script_size=MAX_SCRIPT_SIZE;
@@ -4887,6 +4926,21 @@ bool Xdrv10(uint8_t function)
       } else {
         glob_script_mem.script_sd_found=0;
       }
+#endif
+
+
+#if defined(ESP32) && defined(ESP32_SCRIPT_SIZE) && !defined(USE_24C256) && !defined(USE_SCRIPT_FATFS)
+    char *script;
+    script=(char*)calloc(ESP32_SCRIPT_SIZE+4,1);
+    if (!script) break;
+    LoadFile("/script.txt",(uint8_t*)script,ESP32_SCRIPT_SIZE);
+    glob_script_mem.script_ram=script;
+    glob_script_mem.script_size=ESP32_SCRIPT_SIZE;
+    script[ESP32_SCRIPT_SIZE-1]=0;
+    // use rules storage for permanent vars
+    glob_script_mem.script_pram=(uint8_t*)Settings.rules[0];
+    glob_script_mem.script_pram_size=MAX_SCRIPT_SIZE;
+    glob_script_mem.flags=1;
 #endif
 
       // assure permanent memory is 4 byte aligned


### PR DESCRIPTION
## Description:

expands scripter text buffer to up to 30kb on ESP32 if defined
#define ESP32_SCRIPT_SIZE

normal scripter storage:
1536 bytes for text and 50 bytes for permanent vars
with ESP32_SCRIPT_SIZE eg set to 8192:
8192 bytes for text and 1536 bytes for permanent vars

comment on SPIFFS:
spiffs is deprecated on ESP8266 but the successor is not yet ported to ESP32
since the interface api is compatible it is easy to switch when the new filesystem is ported
 
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).