### PR TITLE
Install only one and latest Esptool.py

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -227,7 +227,7 @@ build_type = debug
 
 [common32]
 platform                = espressif32@1.12.0
-platform_packages       =
+platform_packages       = tool-esptoolpy@1.20800.0
 board                   = wemos_d1_mini32
 board_build.ldscript    = esp32_out.ld
 board_build.partitions  = esp32_partition_app1984k_spiffs64k.csv


### PR DESCRIPTION
ESP32 still uses as default the outdated esptool 2.6. 
Since esptool 2.8 is already used for ESP8266 use it for ESP32 too and prevent install of version 2.6

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
