### PR TITLE
Disarm Zigbee timer for Occupancy:0

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -65,7 +65,7 @@ typedef int32_t (*Z_DeviceTimer)(uint16_t shortaddr, uint16_t groupaddr, uint16_
 typedef enum Z_Def_Category {
   Z_CAT_NONE = 0,             // no category, it will happen anyways
   Z_CAT_READ_ATTR,            // Attribute reporting, either READ_ATTRIBUTE or REPORT_ATTRIBUTE, we coalesce all attributes reported if we can
-  Z_CAT_VIRTUAL_ATTR,         // Creation of a virtual attribute, typically after a time-out. Ex: Aqara presence sensor
+  Z_CAT_VIRTUAL_OCCUPANCY,    // Creation of a virtual attribute, typically after a time-out. Ex: Aqara presence sensor
   Z_CAT_REACHABILITY,         // timer set to measure reachability of device, i.e. if we don't get an answer after 1s, it is marked as unreachable (for Alexa)
   Z_CAT_READ_0006,            // Read 0x0006 cluster
   Z_CAT_READ_0008,            // Read 0x0008 cluster

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -534,7 +534,9 @@ void Z_AqaraOccupancy(uint16_t shortaddr, uint16_t cluster, uint8_t endpoint, co
     uint32_t occupancy = strToUInt(val_endpoint);
 
     if (occupancy) {
-      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, OCCUPANCY_TIMEOUT, cluster, endpoint, Z_CAT_VIRTUAL_ATTR, 0, &Z_OccupancyCallback);
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, OCCUPANCY_TIMEOUT, cluster, endpoint, Z_CAT_VIRTUAL_OCCUPANCY, 0, &Z_OccupancyCallback);
+    } else {
+      zigbee_devices.resetTimersForDevice(shortaddr, 0 /* groupaddr */, Z_CAT_VIRTUAL_OCCUPANCY);
     }
   }
 }


### PR DESCRIPTION
## Description:

By default Z2T arms a timer of 90 seconds after receiving `"Occupancy":1` and generates a synthetic event `"Occupancy":0`. This is required for Aqara presence sensor.

Philips Hue Motion Sensor does send `"Occupancy":0`. This PR disarms the timer when `"Occupancy":0` is received within 90 seconds.

**Related issue (if applicable):** fixes #8192 

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core Tasmota_core_stage
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
