### PR TITLE
No Map file is generated for ESP32

### DIFF
--- a/pio/name-firmware.py
+++ b/pio/name-firmware.py
@@ -28,6 +28,7 @@ def bin_map_copy(source, target, env):
     shutil.copy(str(target[0]), bin_file)
 
     # copy firmware.map to map/<variant>.map
-    shutil.copy("firmware.map", map_file)
+    if os.path.isfile("firmware.map"):
+        shutil.move("firmware.map", map_file)
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_map_copy])


### PR DESCRIPTION
Fix error for ESP32. Scripts checks if exists and generates only in target folder if there

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage and ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
