### PR TITLE
Add the possibility to add Custom env in a extra file

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -12,6 +12,7 @@
 
 [platformio]
 extra_configs = platformio_tasmota_env32.ini
+                platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
 default_envs =


### PR DESCRIPTION
to build special Tasmota versions with Compiler switches defined in [env:tasmota-xyz] in platformio_tasmota_cenv.ini to control user_config_override.h
Example:
`"[env:tasmota-zigbee]
build_flags = ${common.build_flags} -DHANS_CONFIG_ZIGBEE=true"`
which referrs to in user_config_override.h

```
#ifdef HANS_CONFIG_ZIGBEE 

#undef CODE_IMAGE_STR
#define CODE_IMAGE_STR "ZIGBEE"

#define USE_WEBSERVER                            // Enable web server and Wifi Manager (+66k code, +8k mem)
  #define USE_JAVASCRIPT_ES6                     // Enable ECMAScript6 syntax using less JavaScript code bytes (fails on IE11)
//  #define USE_WEBSEND_RESPONSE                   // Enable command WebSend response message (+1k code)

//#define USE_RULES                                // Add support for rules (+4k4 code)
//  #define USE_EXPRESSION                         // Add support for expression evaluation in rules (+3k2 code, +64 bytes mem)
//    #define SUPPORT_IF_STATEMENT                 // Add support for IF statement in rules (+4k2 code, -332 bytes mem)
//  #define SUPPORT_MQTT_EVENT                     // Support trigger event with MQTT subscriptions (+3k5 code)

//#define USE_SCRIPT                               // Add support for script
//  #define USE_SCRIPT_FATFS 4                     // Add support for script storage on SD card (+12k code, +4k mem)
//  #define USE_SCRIPT_WEB_DISPLAY


#define USE_ADC_VCC                              // Display Vcc in Power status. Disable for use as Analog input on selected devices


// -- Zigbee interface ----------------------------
#define USE_ZIGBEE                               // Enable serial communication with Zigbee CC2530 flashed with ZNP (+35k code, +3.2k mem)
  #define USE_ZIGBEE_PANID  0x1A63                // arbitrary PAN ID for Zigbee network, must be unique in the home
  #define USE_ZIGBEE_EXTPANID 0xCCCCCCCCCCCCCCCCL // arbitrary extended PAN ID
  #define USE_ZIGBEE_CHANNEL  11                  // Zigbee Channel (11-26)
  #define USE_ZIGBEE_PRECFGKEY_L 0x0F0D0B0907050301L  // note: changing requires to re-pair all devices
  #define USE_ZIGBEE_PRECFGKEY_H 0x0D0C0A0806040200L  // note: changing requires to re-pair all devices
  #define USE_ZIGBEE_PERMIT_JOIN false           // don't allow joining by default
  #define USE_ZIGBEE_COALESCE_ATTR_TIMER 350     // timer to coalesce attribute values (in ms)


#endif 
```

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core Tasmota_core_stage
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
