### PR TITLE
Fix fixed color bug introduced by palette code

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2384,9 +2384,6 @@ bool LightColorEntry(char *buffer, uint32_t buffer_length)
       }
     } else {
       value = atoi(buffer);
-#ifdef USE_LIGHT_PALETTE
-      value--;
-#endif  // USE_LIGHT_PALETTE
     }
 #ifdef USE_LIGHT_PALETTE
     if (Light.palette_count) value = value % Light.palette_count;
@@ -2417,6 +2414,7 @@ bool LightColorEntry(char *buffer, uint32_t buffer_length)
   }
 #ifdef USE_LIGHT_PALETTE
   else if (Light.palette_count) {
+    value--;
     Light.wheel = value;
     memcpy_P(&Light.entry_color, &Light.palette[value * LST_MAX], LST_MAX);
     entry_type = 1;                                 // Hexadecimal


### PR DESCRIPTION
## Description:

The palette code decremented the fixed color value in all cases instead of only when a palette is active. This resulted in all fixed colors being shifted by one. This PR fixes that.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
