### PR TITLE
Add platformio_tasmota_cenv.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tasmota*.bin
 tasmota*.bin.gz
 tasmota*.map
 platformio_override.ini
+platformio_tasmota_cenv.ini
 
 ## Visual Studio Code specific ######
 .vscode


### PR DESCRIPTION
Existing `platformio_tasmota_cenv.ini` needs to be ignored from git

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
