### PR TITLE
revert serial related ESP32-changes of the GPS-driver, not needed anymore

### DIFF
--- a/tasmota/xsns_60_GPS.ino
+++ b/tasmota/xsns_60_GPS.ino
@@ -119,10 +119,6 @@ rule3 on tele-FLOG#sec do DisplayText  [f0c1l4]SAV:%value%  endon on tele-FLOG#r
 #include "NTPServer.h"
 #include "NTPPacket.h"
 
-#ifdef ESP32
-#include <HardwareSerial.h>
-#endif
-
 /*********************************************************************************************\
  * constants
 \*********************************************************************************************/
@@ -299,11 +295,7 @@ enum UBXMsgType {
 #ifdef USE_FLOG
 FLOG *Flog = nullptr;
 #endif //USE_FLOG
-#ifdef ESP8266
 TasmotaSerial *UBXSerial;
-#else
-HardwareSerial *UBXSerial;
-#endif
 
 NtpServer timeServer(PortUdp);
 
@@ -363,21 +355,13 @@ void UBXDetect(void)
 {
   UBX.mode.init = 0;
   if ((pin[GPIO_GPS_RX] < 99) && (pin[GPIO_GPS_TX] < 99)) {
-#ifdef ESP8266
     UBXSerial = new TasmotaSerial(pin[GPIO_GPS_RX], pin[GPIO_GPS_TX], 1, 0, UBX_SERIAL_BUFFER_SIZE); // 64 byte buffer is NOT enough
     if (UBXSerial->begin(9600)) {
-#else
-    UBXSerial = new HardwareSerial(2);
-    UBXSerial->begin(9600,SERIAL_8N1,pin[GPIO_GPS_RX], pin[GPIO_GPS_TX]);
-    {
-#endif
       DEBUG_SENSOR_LOG(PSTR("UBX: started serial"));
-#ifdef ESP8266
       if (UBXSerial->hardwareSerial()) {
         ClaimSerial();
         DEBUG_SENSOR_LOG(PSTR("UBX: claim HW"));
       }
-#endif
     }
   }
   else {


### PR DESCRIPTION
## Description:

Tested with the new version of TasmotaSerial.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
