### PR TITLE
Support for setting the time in the Tuya MCU

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -410,6 +410,7 @@
 #define USE_SONOFF_SC                            // Add support for Sonoff Sc (+1k1 code)
 #define USE_TUYA_MCU                             // Add support for Tuya Serial MCU
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
+  #define USE_TUYA_TIME                          // Add support for Set Time in Tuya MCU
 #define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
 #define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer (+2k code)
 #define USE_SONOFF_IFAN                          // Add support for Sonoff iFan02 and iFan03 (+2k code)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -410,7 +410,7 @@
 #define USE_SONOFF_SC                            // Add support for Sonoff Sc (+1k1 code)
 #define USE_TUYA_MCU                             // Add support for Tuya Serial MCU
   #define TUYA_DIMMER_ID       0                 // Default dimmer Id
-  #define USE_TUYA_TIME                          // Add support for Set Time in Tuya MCU
+  //#define USE_TUYA_TIME                          // Add support for Set Time in Tuya MCU
 #define USE_ARMTRONIX_DIMMERS                    // Add support for Armtronix Dimmers (+1k4 code)
 #define USE_PS_16_DZ                             // Add support for PS-16-DZ Dimmer (+2k code)
 #define USE_SONOFF_IFAN                          // Add support for Sonoff iFan02 and iFan03 (+2k code)

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -36,6 +36,7 @@
 #define TUYA_CMD_SET_DP        0x06
 #define TUYA_CMD_STATE         0x07
 #define TUYA_CMD_QUERY_STATE   0x08
+#define TUYA_CMD_SET_TIME      0x1C
 
 #define TUYA_LOW_POWER_CMD_WIFI_STATE   0x02
 #define TUYA_LOW_POWER_CMD_WIFI_RESET   0x03
@@ -539,6 +540,9 @@ void TuyaNormalPowerModePacketProcess(void)
       if (Tuya.buffer[6] == 0) {
         AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Detected MCU restart"));
         Tuya.wifi_state = -2;
+        #ifdef USE_TUYA_TIME
+        TuyaSetTime();
+        #endif
       }
       break;
 
@@ -796,6 +800,24 @@ void TuyaSetWifiLed(void)
     TuyaSendCmd(TUYA_CMD_WIFI_STATE, &Tuya.wifi_state, 1);
   }
 }
+
+#ifdef USE_TUYA_TIME
+void TuyaSetTime(void)
+{
+  uint16_t payload_len = 8;
+  uint8_t payload_buffer[8];
+  payload_buffer[0] = 0x01;
+  payload_buffer[1] = (uint8_t)RtcTime.year;
+  payload_buffer[2] = RtcTime.month;
+  payload_buffer[3] = RtcTime.day_of_month;
+  payload_buffer[4] = RtcTime.hour;
+  payload_buffer[5] = RtcTime.minute;
+  payload_buffer[6] = RtcTime.second;
+  payload_buffer[7] = RtcTime.day_of_week;
+
+  TuyaSendCmd(TUYA_CMD_SET_TIME, payload_buffer, payload_len);
+}
+#endif //USE_TUYA_TIME
 
 #ifdef USE_ENERGY_SENSOR
 /*********************************************************************************************\


### PR DESCRIPTION
Switch on with USE_TUYA_TIME

## Description:
With the new script language, much more Tuya devices can now be integrated without changing the Tasmota source code.
What is still missing is setting the time in the Tuya MCU. This change would make this possible. 
You can activate it in User_Config. Would that be an option?
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [*] The pull request is done against the latest dev branch
  - [*] Only relevant files were touched
  - [*] Only one feature/fix was added per PR.
  - [*] The code change is tested and works on core Tasmota_core_stage
  - [*] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [*] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
