### PR TITLE
Fix wrong setting of free_range after reset or restart (#8120)

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -626,6 +626,7 @@ class LightStateClass {
     void setCW(uint8_t c, uint8_t w, bool free_range = false) {
       uint16_t max = (w > c) ? w : c;   // 0..255
       uint16_t sum = c + w;
+      if (sum <= 257) { free_range = false; }    // if we don't allow free range or if sum is below 255 (with tolerance of 2)
 
       if (0 == max) {
         _briCT = 0;       // brightness set to null
@@ -721,6 +722,8 @@ class LightStateClass {
     AddLog_P2(LOG_LEVEL_DEBUG_MORE, "LightStateClass::setChannels (%d %d %d %d %d)",
       channels[0], channels[1], channels[2], channels[3], channels[4]);
     AddLog_P2(LOG_LEVEL_DEBUG_MORE, "LightStateClass::setChannels CT (%d) briRGB (%d) briCT (%d)", _ct, _briRGB, _briCT);
+    AddLog_P2(LOG_LEVEL_DEBUG_MORE, "LightStateClass::setChannels Actuals (%d %d %d %d %d)",
+      _r, _g, _b, _wc, _ww);
 #endif
   }
 
@@ -975,6 +978,9 @@ public:
           (DEFAULT_LIGHT_COMPONENT == Settings.light_color[3]) &&
           (DEFAULT_LIGHT_COMPONENT == Settings.light_color[4]) &&
           (DEFAULT_LIGHT_DIMMER    == Settings.light_dimmer) ) {
+        if ((LST_COLDWARM == Light.subtype) || (LST_RGBCW == Light.subtype)) {
+          _state->setCW(255, 0);       // avoid having both white channels at 100%, zero second channel (#see 8120)
+        }
         _state->setBriCT(bri);
         _state->setBriRGB(bri);
         _state->setColorMode(LCM_RGB);


### PR DESCRIPTION
## Description:

Internally, Cold/Warm white works in two modes.

In the standard mode, the total power for both white channels is limited to 100% to avoid overloading the power supply. Internally both channels are set so that their sum is 255, and the brightness is adjusted with Dimmer. Any `CT` command will force standard mode.

However there is a free_range mode where you can set both channel to arbitrary values and push both channels to 100% (for a total power of 200% - use at your own risk). The only way to do so is to use the `Color xxyy` value. free_range mode happens when the sum of both xx and yy exceed 255 (actually 259 to avoid rounding errors). As soos as you use the `CT` command, you go back to standard mode. `Dimmer` does not change standard/free_range mode.

The bug was that after `Reset 5`, after first flash or after Restart, the bulb was wrongly in free-range mode. This is now fixed.

After `Reset 5` the default value is CW=10%, WW=0% (i.e. CT=153, Dimmer=10).

**Related issue (if applicable):** fixes #8120 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
