### PR TITLE
Change default PWM Frequency to 223 Hz instead of 880 Hz

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add command ``SetOption73 1`` for button decoupling and send multi-press and hold MQTT messages by Federico Leoni (#8235)
 - Add command ``SO`` as shortcut for command ``SetOption``
 - Change PWM implementation to Arduino #7231
+- Change default PWM Frequency to 223 Hz instead of 880 Hz for less interrupt pressure
 
 ### 8.2.0.3 20200329
 

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -110,7 +110,7 @@ const uint16_t WS2812_MAX_LEDS = 512;       // Max number of LEDs
 const uint32_t PWM_RANGE = 1023;            // 255..1023 needs to be devisible by 256
 //const uint16_t PWM_FREQ = 1000;             // 100..1000 Hz led refresh
 //const uint16_t PWM_FREQ = 910;              // 100..1000 Hz led refresh (iTead value)
-const uint16_t PWM_FREQ = 880;              // 100..1000 Hz led refresh (BN-SZ01 value)
+const uint16_t PWM_FREQ = 223;              // 100..4000 Hz led refresh
 const uint16_t PWM_MAX = 4000;              // [PWM_MAX] Maximum frequency - Default: 4000
 const uint16_t PWM_MIN = 100;               // [PWM_MIN] Minimum frequency - Default: 100
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)


### PR DESCRIPTION
##  Description:

Change the default PWM Frequency to 223 Hz. The previous was 880 Hz.

For LEDs, any frequency above 100 Hz should not create any visible flickering. 223 Hz is high enough to look smooth, while not too close to a multiple of 50 Hz or 60 Hz. And it's a prime number (which is mostly irrelevant but cool).

Lowering frequency makes the interrupt load lower, and less flickering at reboot when wifi connects.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core_stage
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
