### PR TITLE
NimBLE ESP32 warning suppression

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -235,6 +235,7 @@ board_build.partitions  = esp32_partition_app1984k_spiffs64k.csv
 board_build.flash_mode  = ${common.board_build.flash_mode}
 board_build.f_cpu       = ${common.board_build.f_cpu}
 build_unflags           = ${common.build_unflags}
+    -Wpointer-arith 
 monitor_speed           = ${common.monitor_speed}
 upload_port             = ${common.upload_port}
 upload_resetmethod      = ${common.upload_resetmethod}


### PR DESCRIPTION
needs to work a entry in build_unflags

## Description:

Switching off warnings `arithmetic on void- and function-pointers` when compiling ESP32 in NimBLE

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
