### PR TITLE
Use defined mcast addr for device groups instead of sharing emuation

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -421,10 +421,12 @@
 #define USE_EXS_DIMMER                           // Add support for ES-Store WiFi Dimmer (+1k5 code)
 //  #define EXS_MCU_CMNDS                          // Add command to send MCU commands (+0k8 code)
 //#define USE_HOTPLUG                              // Add support for sensor HotPlug
-#define USE_DEVICE_GROUPS                        // Add support for device groups (+5k6 code)
-  #define USE_DEVICE_GROUPS_SEND                 // Add support for the DevGroupSend command (+0k5 code)
-#define USE_PWM_DIMMER                           // Add support for MJ-SD01/acenx/NTONPOWER PWM dimmers (+2k5 code)
-  #define USE_PWM_DIMMER_REMOTE                  // Add support for remote switches to PWM Dimmer, also adds device groups support (+1k code plus device groups size)
+#define USE_DEVICE_GROUPS                        // Add support for device groups (+5k5 code)
+  #define DEVICE_GROUPS_ADDRESS 239,255,250,250  // Device groups multicast address
+  #define DEVICE_GROUPS_PORT 4447                // Device groups multicast port
+  #define USE_DEVICE_GROUPS_SEND                 // Add support for the DevGroupSend command (+0k6 code)
+#define USE_PWM_DIMMER                           // Add support for MJ-SD01/acenx/NTONPOWER PWM dimmers (+2k2 code, DGR=0k4)
+  #define USE_PWM_DIMMER_REMOTE                  // Add support for remote switches to PWM Dimmer, also adds device groups support (+0k9 code plus device groups size)
 //#define USE_KEELOQ                               // Add support for Jarolift rollers by Keeloq algorithm (+4k5 code)
 #define USE_SONOFF_D1                            // Add support for Sonoff D1 Dimmer (+0k7 code)
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -876,6 +876,7 @@ void CmndSetoption(void)
           else if (4 == ptype) {           // SetOption82 .. 113
             bitWrite(Settings.flag4.data, pindex, XdrvMailbox.payload);
             switch (pindex) {
+              case 3:                      // SetOption85 - Enable Device Groups
               case 6:                      // SetOption88 - PWM Dimmer Buttons control remote devices
                 restart_flag = 2;
                 break;
@@ -1798,8 +1799,9 @@ void CmndDevGroupSend(void)
 {
   uint8_t device_group_index = (XdrvMailbox.usridx ? XdrvMailbox.index - 1 : 0);
   if (device_group_index < device_group_count) {
-    _SendDeviceGroupMessage(device_group_index, DGR_MSGTYPE_UPDATE_COMMAND);
-    ResponseCmndChar(XdrvMailbox.data);
+    if (!_SendDeviceGroupMessage(device_group_index, DGR_MSGTYPE_UPDATE_COMMAND)) {
+      ResponseCmndChar(XdrvMailbox.data);
+    }
   }
 }
 #endif  // USE_DEVICE_GROUPS_SEND

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -440,9 +440,9 @@ cleanup:
 bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType message_type, ...)
 {
   // If device groups is not up, ignore this request.
-  // If we're currently processing a remote device message, ignore this request.
   if (!device_groups_up) return 1;
 
+  // If we're currently processing a remote device message, ignore this request.
   if (ignore_dgr_sends && message_type != DGR_MSGTYPE_UPDATE_COMMAND) return 0;
 
   // Get a pointer to the device information for this device.
@@ -632,7 +632,7 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
 
       // If this item is shared with the group add it to the message.
       shared = true;
-      if (!device_group_index) shared = DeviceGroupItemShared(false, item);
+      if (!device_group_index && message_type != DGR_MSGTYPE_UPDATE_COMMAND) shared = DeviceGroupItemShared(false, item);
       if (shared) {
         *message_ptr++ = item;
 
@@ -698,8 +698,8 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
   SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, device_group->message_length, false);
 
 #ifdef USE_DEVICE_GROUPS_SEND
-  // If the device group is local, handle the message locally.
-  if (message_type == DGR_MSGTYPE_UPDATE_COMMAND && device_group->local) {
+  // If this is the DevGroupSend command, also handle the update locally.
+  if (message_type == DGR_MSGTYPE_UPDATE_COMMAND) {
     struct XDRVMAILBOX save_XdrvMailbox = XdrvMailbox;
     SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, device_group->message_length, true);
     XdrvMailbox = save_XdrvMailbox;

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -26,8 +26,9 @@
 //#define DEVICE_GROUPS_DEBUG
 #define DGR_MEMBER_TIMEOUT        45000
 #define DGR_ANNOUNCEMENT_INTERVAL 60000
+#define DEVICE_GROUP_MESSAGE      "TASMOTA_DGR"
 
-extern bool udp_connected;
+const char kDeviceGroupMessage[] PROGMEM = DEVICE_GROUP_MESSAGE;
 
 struct device_group_member {
   struct device_group_member * flink;
@@ -49,7 +50,7 @@ struct device_group {
   uint8_t initial_status_requests_remaining;
   bool local;
   char group_name[TOPSZ];
-  char message[128];
+  uint8_t message[128];
   struct device_group_member * device_group_members;
 #ifdef USE_DEVICE_GROUPS_SEND
   uint8_t values_8bit[DGR_ITEM_LAST_8BIT];
@@ -58,15 +59,54 @@ struct device_group {
 #endif  // USE_DEVICE_GROUPS_SEND
 };
 
+WiFiUDP device_groups_udp;
 struct device_group * device_groups;
-char * log_ptr;
-int log_remaining;
-uint32_t next_check_time = 0;
+uint32_t next_check_time;
 bool device_groups_initialized = false;
-bool device_groups_initialization_failed = false;
+bool device_groups_up = false;
 bool building_status_message = false;
 bool ignore_dgr_sends = false;
-bool udp_was_connected = false;
+
+char * IPAddressToString(const IPAddress& ip_address)
+{
+  static char buffer[16];
+  sprintf_P(buffer, PSTR("%u.%u.%u.%u"), ip_address[0], ip_address[1], ip_address[2], ip_address[3]);
+  return buffer;
+}
+
+uint8_t * BeginDeviceGroupMessage(struct device_group * device_group, uint16_t flags, bool hold_sequence = false)
+{
+  uint8_t * message_ptr = &device_group->message[device_group->message_header_length];
+  if (!hold_sequence && !++device_group->outgoing_sequence) device_group->outgoing_sequence = 1;
+  *message_ptr++ = device_group->outgoing_sequence & 0xff;
+  *message_ptr++ = device_group->outgoing_sequence >> 8;
+  *message_ptr++ = flags & 0xff;
+  *message_ptr++ = flags >> 8;
+  return message_ptr;
+}
+
+// Return true if we're configured to share the specified item.
+bool DeviceGroupItemShared(bool incoming, uint8_t item)
+{
+  uint32_t mask;
+  if (item == DGR_ITEM_LIGHT_BRI || item == DGR_ITEM_BRI_POWER_ON)
+    mask = DGR_SHARE_LIGHT_BRI;
+  else if (item == DGR_ITEM_POWER)
+    mask = DGR_SHARE_POWER;
+  else if (item == DGR_ITEM_LIGHT_SCHEME)
+    mask = DGR_SHARE_LIGHT_SCHEME;
+  else if (item == DGR_ITEM_LIGHT_FIXED_COLOR || DGR_ITEM_LIGHT_CHANNELS)
+    mask = DGR_SHARE_LIGHT_COLOR;
+  else if (item == DGR_ITEM_LIGHT_FADE || item == DGR_ITEM_LIGHT_SPEED)
+    mask = DGR_SHARE_LIGHT_FADE;
+  else  if (item == DGR_ITEM_BRI_PRESET_LOW || item == DGR_ITEM_BRI_PRESET_HIGH)
+    mask = DGR_SHARE_DIMMER_SETTINGS;
+  else if (item == DGR_ITEM_EVENT)
+    mask = DGR_SHARE_EVENT;
+  else
+    return true;
+  return mask & (incoming ? Settings.device_group_share_in : Settings.device_group_share_out);
+}
 
 void DeviceGroupsInit(void)
 {
@@ -78,14 +118,13 @@ void DeviceGroupsInit(void)
 
   // Initialize the device information for each device group.
   device_groups = (struct device_group *)calloc(device_group_count, sizeof(struct device_group));
-  if (device_groups == nullptr) {
-    AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error allocating %u-element device group array"), device_group_count);
-    device_groups_initialization_failed = true;
+  if (!device_groups) {
+    AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error allocating %u-element array"), device_group_count);
     return;
   }
 
-  for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++) {
-    struct device_group * device_group = &device_groups[device_group_index];
+  struct device_group * device_group = device_groups;
+  for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++, device_group++) {
     strcpy(device_group->group_name, SettingsText(SET_DEV_GROUP_NAME1 + device_group_index));
 
     // If the device group name is not set, use the MQTT group topic (with the device group index +
@@ -93,12 +132,10 @@ void DeviceGroupsInit(void)
     if (!device_group->group_name[0]) {
       strcpy(device_group->group_name, SettingsText(SET_MQTT_GRP_TOPIC));
       if (device_group_index) {
-        char str[10];
-        sprintf_P(str, PSTR("%u"), device_group_index + 1);
-        strcat(device_group->group_name, str);
+        snprintf_P(device_group->group_name, sizeof(device_group->group_name), PSTR("%s%u"), device_group->group_name, device_group_index + 1);
       }
     }
-    device_group->message_header_length = sprintf_P(device_group->message, PSTR("%s%s HTTP/1.1\n\n"), kDeviceGroupMessage, device_group->group_name);
+    device_group->message_header_length = sprintf_P((char *)device_group->message, PSTR("%s%s"), kDeviceGroupMessage, device_group->group_name) + 1;
     device_group->last_full_status_sequence = -1;
   }
 
@@ -112,85 +149,58 @@ void DeviceGroupsInit(void)
   device_groups_initialized = true;
 }
 
-char * IPAddressToString(const IPAddress& ip_address)
+void DeviceGroupsStart()
 {
-  static char buffer[16];
-  sprintf_P(buffer, PSTR("%u.%u.%u.%u"), ip_address[0], ip_address[1], ip_address[2], ip_address[3]);
-  return buffer;
-}
+  if (Settings.flag4.device_groups_enabled && !device_groups_up && !restart_flag) {
 
-void AddDeviceGroupLog(const char * format, ...) {
-  va_list ap;
-  va_start(ap, format);
-  int log_length = vsnprintf_P(log_ptr, log_remaining, format, ap);
-  va_end(ap);
-  log_ptr += log_length;
-  log_remaining -= log_length;
-}
+    // If we haven't successfuly initialized device groups yet, attempt to do it now.
+    if (!device_groups_initialized) {
+      DeviceGroupsInit();
+      if (!device_groups_initialized) return;
+    }
 
-char * BeginDeviceGroupMessage(struct device_group * device_group, uint16_t flags, bool hold_sequence = false)
-{
-  char * message_ptr = &device_group->message[device_group->message_header_length];
-  if (!hold_sequence && !++device_group->outgoing_sequence) device_group->outgoing_sequence = 1;
-  *message_ptr++ = device_group->outgoing_sequence & 0xff;
-  *message_ptr++ = device_group->outgoing_sequence >> 8;
-  *message_ptr++ = flags & 0xff;
-  *message_ptr++ = flags >> 8;
-  return message_ptr;
-}
+    // Subscribe to device groups multicasts.
+    if (!device_groups_udp.beginMulticast(WiFi.localIP(), IPAddress(DEVICE_GROUPS_ADDRESS), DEVICE_GROUPS_PORT)) {
+      AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error subscribing"));
+      return;
+    }
+    device_groups_up = true;
 
-// Return true if we're configured to share the specified item.
-bool DeviceGroupItemShared(bool incoming, uint8_t item)
-{
-  uint8_t mask = 0;
-  switch (item) {
-    case DGR_ITEM_LIGHT_BRI:
-    case DGR_ITEM_BRI_POWER_ON:
-      mask = DGR_SHARE_LIGHT_BRI;
-      break;
-    case DGR_ITEM_POWER:
-      mask = DGR_SHARE_POWER;
-      break;
-    case DGR_ITEM_LIGHT_SCHEME:
-      mask = DGR_SHARE_LIGHT_SCHEME;
-      break;
-    case DGR_ITEM_LIGHT_FIXED_COLOR:
-    case DGR_ITEM_LIGHT_CHANNELS:
-      mask = DGR_SHARE_LIGHT_COLOR;
-      break;
-    case DGR_ITEM_LIGHT_FADE:
-    case DGR_ITEM_LIGHT_SPEED:
-      mask = DGR_SHARE_LIGHT_FADE;
-      break;
-    case DGR_ITEM_BRI_PRESET_LOW:
-    case DGR_ITEM_BRI_PRESET_HIGH:
-      mask = DGR_SHARE_DIMMER_SETTINGS;
-      break;
-    case DGR_ITEM_EVENT:
-      mask = DGR_SHARE_EVENT;
-      break;
+    // The WiFi was down but now it's up and device groups is initialized. (Re-)discover devices in
+    // our device group(s). Load the status request message for all device groups. This message will
+    // be multicast 10 times at 200ms intervals.
+    next_check_time = millis() + 2000;
+    struct device_group * device_group = device_groups;
+    for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++, device_group++) {
+      device_group->next_announcement_time = -1;
+      device_group->message_length = BeginDeviceGroupMessage(device_group, DGR_FLAG_RESET | DGR_FLAG_STATUS_REQUEST) - device_group->message;
+      device_group->initial_status_requests_remaining = 10;
+      device_group->next_ack_check_time = next_check_time;
+    }
+    AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: (Re)discovering members"));
   }
-  return (!mask || ((incoming ? Settings.device_group_share_in : Settings.device_group_share_out) & mask));
 }
 
-void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct device_group_member * device_group_member, char * message, int message_length, bool received)
+void DeviceGroupsStop()
 {
-  char log_buffer[LOGSZ];
+  device_groups_udp.flush();
+  device_groups_up = false;
+}
+
+void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct device_group_member * device_group_member, uint8_t * message, int message_length, bool received)
+{
+  char log_buffer[512];
   bool item_processed = false;
   uint16_t message_sequence;
   uint16_t flags;
   int device_group_index = device_group - device_groups;
+  int log_length;
+  int log_remaining;
+  char * log_ptr;
 
-  log_ptr = log_buffer;
-  log_remaining = sizeof(log_buffer);
-  AddDeviceGroupLog(PSTR("DGR: %s %s message"), (received ? PSTR("Received") : PSTR("Sending")), device_group->group_name);
-  if (received || device_group_member) AddDeviceGroupLog(PSTR(" %s %s"), (received ? PSTR("from") : PSTR("to")), (device_group_member ? IPAddressToString(device_group_member->ip_address) : PSTR("local")));
-
-  // Find the start of the actual message (after the http header).
-  char * message_end_ptr = message + message_length;
-  char * message_ptr = strstr_P(message, PSTR("\n\n"));
-  if (message_ptr == nullptr) return;
-  message_ptr += 2;
+  // Find the end and start of the actual message (after the header).
+  uint8_t * message_end_ptr = message + message_length;
+  uint8_t * message_ptr = message + strlen((char *)message) + 1;
 
   // Get the message sequence and flags.
   if (message_ptr + 4 > message_end_ptr) goto badmsg;  // Malformed message - must be at least 16-bit sequence, 16-bit flags left
@@ -198,13 +208,17 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
   message_sequence |= *message_ptr++ << 8;
   flags = *message_ptr++;
   flags |= *message_ptr++ << 8;
-  AddDeviceGroupLog(PSTR(": seq=%u, flags=%u"), message_sequence, flags);
+
+  // Initialize the log buffer.
+  log_length = sprintf(log_buffer, PSTR("DGR: %s %s message %s %s: seq=%u, flags=%u"), (received ? PSTR("Received") : PSTR("Sending")), device_group->group_name, (received ? PSTR("from") : PSTR("to")), (device_group_member ? IPAddressToString(device_group_member->ip_address) : received ? PSTR("local") : PSTR("network")), message_sequence, flags);
+  log_ptr = log_buffer + log_length;
+  log_remaining = sizeof(log_buffer) - log_length;
 
   // If this is an announcement, just log it.
   if (flags == DGR_FLAG_ANNOUNCEMENT) goto write_log;
 
-  // If this is a received ack message, save the message sequence if it's newwer than the last ack
-  // we received from this member.
+  // If this is a received ack message, save the message sequence if it's newer than the last ack we
+  // received from this member.
   if (flags == DGR_FLAG_ACK) {
     if (received && device_group_member && (message_sequence > device_group_member->acked_sequence || device_group_member->acked_sequence - message_sequence < 64536)) {
       device_group_member->acked_sequence = message_sequence;
@@ -218,13 +232,15 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
       if (!(flags & DGR_FLAG_MORE_TO_COME)) {
         *(message_ptr - 2) = DGR_FLAG_ACK;
         *(message_ptr - 1) = 0;
-        SendReceiveDeviceGroupPacket(device_group, device_group_member, message, message_ptr - message, false);
+        SendReceiveDeviceGroupMessage(device_group, device_group_member, message, message_ptr - message, false);
       }
     }
 
-    // If we're sending this message directly to a member, it's a resend of the lst message.
+    // If we're sending this message directly to a member, it's a resend.
     else {
-      AddDeviceGroupLog(PSTR(", last ack=%u"), device_group_member->acked_sequence);
+      log_length = snprintf(log_ptr, log_remaining, PSTR(", last ack=%u"), device_group_member->acked_sequence);
+      log_ptr += log_length;
+      log_remaining -= log_length;
       goto write_log;
     }
   }
@@ -239,7 +255,9 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
     if (device_group_member) {
       if (message_sequence <= device_group_member->received_sequence) {
         if (message_sequence == device_group_member->received_sequence || device_group_member->received_sequence - message_sequence > 64536) {
-          AddDeviceGroupLog(PSTR(" (old)"));
+          log_length = snprintf(log_ptr, log_remaining, PSTR(" (old)"));
+          log_ptr += log_length;
+          log_remaining -= log_length;
           goto write_log;
         }
       }
@@ -294,8 +312,10 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
     }
 #endif  // DEVICE_GROUPS_DEBUG
 
-    AddDeviceGroupLog(PSTR(", %u="), item);
-    if (received) XdrvMailbox.data = message_ptr;
+    log_length = snprintf(log_ptr, log_remaining, PSTR(", %u="), item);
+    log_ptr += log_length;
+    log_remaining -= log_length;
+    log_length = 0;
     if (item <= DGR_ITEM_LAST_32BIT) {
       value = *message_ptr++;
       if (item > DGR_ITEM_MAX_8BIT) {
@@ -318,29 +338,34 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
         device_group->values_8bit[item] = value;
       }
 #endif  // USE_DEVICE_GROUPS_SEND
-      AddDeviceGroupLog(PSTR("%u"), value);
-    }
-    else if (item <= DGR_ITEM_MAX_STRING) {
-      value = strlen(message_ptr);
-      if (message_ptr + value >= message_end_ptr) goto badmsg;  // Malformed message
-      AddDeviceGroupLog(PSTR("'%s'"), message_ptr);
-      message_ptr += value + 1;
+      log_length = snprintf(log_ptr, log_remaining, PSTR("%u"), value);
     }
     else {
-      switch (item) {
-        case DGR_ITEM_LIGHT_CHANNELS:
-          AddDeviceGroupLog(PSTR("%08X%02X"), *(uint32_t *)message_ptr, *(message_ptr + 4));
-          message_ptr += 5;
-          break;
+      value = *message_ptr++;
+      if (received) XdrvMailbox.data = (char *)message_ptr;
+      if (message_ptr + value >= message_end_ptr) goto badmsg;  // Malformed message
+      if (item <= DGR_ITEM_MAX_STRING) {
+        log_length = snprintf(log_ptr, log_remaining, PSTR("'%s'"), message_ptr);
       }
+      else {
+        switch (item) {
+          case DGR_ITEM_LIGHT_CHANNELS:
+            log_length = snprintf(log_ptr, log_remaining, PSTR("%u,%u,%u,%u,%u"), *message_ptr, *(message_ptr + 1), *(message_ptr + 2), *(message_ptr + 3), *(message_ptr + 4));
+            break;
+        }
+      }
+      message_ptr += value;
     }
+    log_ptr += log_length;
+    log_remaining -= log_length;
 
     if (received && DeviceGroupItemShared(true, item)) {
       item_processed = true;
       XdrvMailbox.command_code = item;
       XdrvMailbox.payload = value;
       XdrvMailbox.data_len = value;
-      AddDeviceGroupLog(PSTR("*"));
+      *log_ptr++ = '*';
+      log_remaining--;
       switch (item) {
         case DGR_ITEM_POWER:
           if (device_group->local) {
@@ -371,12 +396,10 @@ void SendReceiveDeviceGroupPacket(struct device_group * device_group, struct dev
       XdrvMailbox.command_code = DGR_ITEM_EOL;
       XdrvCall(FUNC_DEVICE_GROUP_ITEM);
     }
-
-    skip_light_fade = false;
-    ignore_dgr_sends = false;
   }
 
 write_log:
+  *log_ptr++ = 0;
   AddLog_P(LOG_LEVEL_DEBUG_MORE, log_buffer);
 
   // If this is a received status request message, then if the requestor didn't just ack our
@@ -391,14 +414,16 @@ write_log:
 
   // If this is a message being sent, send it.
   else {
-    for (int attempt = 1; attempt <= 5; attempt++) {
-      if (PortUdp.beginPacket((device_group_member ? device_group_member->ip_address : IPAddress(239,255,255,250)), 1900)) {
-        PortUdp_write(message, message_length);
-        if (PortUdp.endPacket()) return;
+    int attempt;
+    IPAddress ip_address = (device_group_member ? device_group_member->ip_address : IPAddress(DEVICE_GROUPS_ADDRESS));
+    for (attempt = 1; attempt <= 5; attempt++) {
+      if (device_groups_udp.beginPacket(ip_address, DEVICE_GROUPS_PORT)) {
+        device_groups_udp.write(message, message_length);
+        if (device_groups_udp.endPacket()) break;
       }
       delay(10);
     }
-    AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error sending message"));
+    if (attempt > 5) AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error sending message"));
   }
   goto cleanup;
 
@@ -412,36 +437,31 @@ cleanup:
   }
 }
 
-void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType message_type, ...)
+bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType message_type, ...)
 {
-  // If device groups are not enabled, ignore this request.
-  if (!Settings.flag4.device_groups_enabled) return;
-
-  // If UDP is not set up, ignore this request.
-  if (!udp_connected) return;
-
+  // If device groups is not up, ignore this request.
   // If we're currently processing a remote device message, ignore this request.
-  if (ignore_dgr_sends && message_type != DGR_MSGTYPE_UPDATE_COMMAND) return;
+  if (!device_groups_up) return 1;
+
+  if (ignore_dgr_sends && message_type != DGR_MSGTYPE_UPDATE_COMMAND) return 0;
 
   // Get a pointer to the device information for this device.
   struct device_group * device_group = &device_groups[device_group_index];
 
   // If we're still sending initial status requests, ignore this request.
-  if (device_group->initial_status_requests_remaining) return;
+  if (device_group->initial_status_requests_remaining) return 1;
 
   // Load the message header, sequence and flags.
 #ifdef DEVICE_GROUPS_DEBUG
     AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Building %s %spacket"), device_group->group_name, (message_type == DGR_MSGTYP_FULL_STATUS ? PSTR("full status ") : PSTR("")));
 #endif  // DEVICE_GROUPS_DEBUG
-#ifdef USE_DEVICE_GROUPS_SEND
-#endif  // USE_DEVICE_GROUPS_SEND
   uint16_t original_sequence = device_group->outgoing_sequence;
   uint16_t flags = 0;
   if (message_type == DGR_MSGTYP_UPDATE_MORE_TO_COME)
     flags = DGR_FLAG_MORE_TO_COME;
   else if (message_type == DGR_MSGTYP_UPDATE_DIRECT)
     flags = DGR_FLAG_DIRECT;
-  char * message_ptr = BeginDeviceGroupMessage(device_group, flags, building_status_message || message_type == DGR_MSGTYP_PARTIAL_UPDATE);
+  uint8_t * message_ptr = BeginDeviceGroupMessage(device_group, flags, building_status_message || message_type == DGR_MSGTYP_PARTIAL_UPDATE);
 
   // A full status request is a request from a remote device for the status of every item we
   // control. As long as we're building it, we may as well multicast the status update to all
@@ -462,62 +482,63 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
     XdrvCall(FUNC_DEVICE_GROUP_ITEM);
     building_status_message = false;
 
+    // Set the status update flag in the outgoing message.
+    *(message_ptr - 2) |= DGR_FLAG_FULL_STATUS;
+
     // If we have nothing to share with the other members, just send the EOL item.
     if (!device_group->message_length) {
       *message_ptr++ = 0;
       device_group->message_length = message_ptr - device_group->message;
     }
-
-    // Set the status update flag in the outgoing message.
-    *(message_ptr + 2) |= DGR_FLAG_FULL_STATUS;
   }
 
   else {
 #ifdef USE_DEVICE_GROUPS_SEND
+    uint8_t out_buffer[128];
     bool escaped;
     char chr;
     char oper;
     uint32_t old_value;
-    char * out_ptr;
+    uint8_t * out_ptr = out_buffer;
 #endif  // USE_DEVICE_GROUPS_SEND
     struct item {
       uint8_t item;
       uint32_t value;
       void * value_ptr;
     } item_array[32];
-//    bool items_added = false;
     bool shared;
     uint8_t item;
     uint32_t value;
-    char * value_ptr;
+    uint8_t * value_ptr;
+    uint8_t * first_item_ptr = message_ptr;
     struct item * item_ptr;
     va_list ap;
 
     // Build an array of all the items and values in this update.
-    memset(item_array, 0, sizeof(item_array));
     item_ptr = item_array;
 #ifdef USE_DEVICE_GROUPS_SEND
     if (message_type == DGR_MSGTYPE_UPDATE_COMMAND) {
-      value_ptr = XdrvMailbox.data;
-      while ((item = strtoul(value_ptr, &value_ptr, 0))) {
+      value_ptr = (uint8_t *)XdrvMailbox.data;
+      while ((item = strtoul((char *)value_ptr, (char **)&value_ptr, 0))) {
         item_ptr->item = item;
-        if (*value_ptr == '=') {
-          value_ptr++;
-          if (item <= DGR_ITEM_MAX_32BIT) {
-            oper = 0;
-            if (*value_ptr == '@') {
-              oper = value_ptr[1];
-              value_ptr += 2;
-            }
-            value = strtoul(value_ptr, &value_ptr, 0);
-            if (oper) {
-              old_value = (item <= DGR_ITEM_MAX_8BIT ? device_group->values_8bit[item] : (item <= DGR_ITEM_MAX_16BIT ? device_group->values_16bit[item - DGR_ITEM_MAX_8BIT - 1] : device_group->values_32bit[item - DGR_ITEM_MAX_16BIT - 1]));
-              value = (oper == '+' ? old_value + value : (oper == '-' ? old_value - value : (oper == '^' ? old_value ^ (value ? value : 0xffffffff) : old_value)));
-            }
-            item_ptr->value = value;
+        if (*value_ptr != '=') return 1;
+        value_ptr++;
+        if (item <= DGR_ITEM_MAX_32BIT) {
+          oper = 0;
+          if (*value_ptr == '@') {
+            oper = value_ptr[1];
+            value_ptr += 2;
           }
-          else if (item <= DGR_ITEM_MAX_STRING) {
-            item_ptr->value_ptr = out_ptr = value_ptr;
+          value = (isdigit(*value_ptr) ? strtoul((char *)value_ptr, (char **)&value_ptr, 0) : 1);
+          if (oper) {
+            old_value = (item <= DGR_ITEM_MAX_8BIT ? device_group->values_8bit[item] : (item <= DGR_ITEM_MAX_16BIT ? device_group->values_16bit[item - DGR_ITEM_MAX_8BIT - 1] : device_group->values_32bit[item - DGR_ITEM_MAX_16BIT - 1]));
+            value = (oper == '+' ? old_value + value : (oper == '-' ? old_value - value : (oper == '^' ? old_value ^ (value ? value : 0xffffffff) : old_value)));
+          }
+          item_ptr->value = value;
+        }
+        else {
+          item_ptr->value_ptr = out_ptr;
+          if (item <= DGR_ITEM_MAX_STRING) {
             escaped = false;
             while ((chr = *value_ptr++)) {
               if (chr == ' ' && !escaped) break;
@@ -528,9 +549,8 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
           else {
             switch (item) {
               case DGR_ITEM_LIGHT_CHANNELS:
-                item_ptr->value_ptr = out_ptr = value_ptr;
                 for (int i = 0; i < 5; i++) {
-                  *out_ptr = strtoul(value_ptr, &value_ptr, 0);
+                  *out_ptr++ = strtoul((char *)value_ptr, (char **)&value_ptr, 0);
                   if (*value_ptr == ',') value_ptr++;
                 }
                 break;
@@ -550,11 +570,7 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
         else if (item <= DGR_ITEM_MAX_STRING)
           item_ptr->value_ptr = va_arg(ap, char *);
         else {
-          switch (item) {
-            case DGR_ITEM_LIGHT_CHANNELS:
-              item_ptr->value_ptr = va_arg(ap, uint8_t *);
-              break;
-          }
+          item_ptr->value_ptr = va_arg(ap, uint8_t *);
         }
         item_ptr++;
       }
@@ -562,6 +578,7 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
 #ifdef USE_DEVICE_GROUPS_SEND
     }
 #endif  // USE_DEVICE_GROUPS_SEND
+    item_ptr->item = 0;
 
     // If we're still building this update or all group members haven't acknowledged the previous
     // update yet, update the message to include these new updates. First we need to rebuild the
@@ -572,68 +589,38 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
 
       // Rebuild the previous update message, removing any items whose values are included in this
       // new update.
-      char * previous_message_ptr = message_ptr;
+      uint8_t * previous_message_ptr = message_ptr;
       while (item = *previous_message_ptr++) {
+
+        // Determine the length of this item's value.
+        if (item <= DGR_ITEM_MAX_32BIT) {
+          value = 1;
+          if (item > DGR_ITEM_MAX_8BIT) {
+            value = 2;
+            if (item > DGR_ITEM_MAX_16BIT) {
+              value = 4;
+            }
+          }
+        }
+        else {
+          value = *previous_message_ptr + 1;
+        }
 
         // Search for this item in the new update.
         for (item_ptr = item_array; item_ptr->item; item_ptr++) {
           if (item_ptr->item == item) break;
         }
 
-        // If this item was found in the new update skip over it and it's value.
-        if (item_ptr->item) {
-          if (item <= DGR_ITEM_MAX_32BIT) {
-            previous_message_ptr++;
-            if (item > DGR_ITEM_MAX_8BIT) {
-              previous_message_ptr++;
-              if (item > DGR_ITEM_MAX_16BIT) {
-                previous_message_ptr++;
-                previous_message_ptr++;
-              }
-            }
-          }
-          else if (item <= DGR_ITEM_MAX_STRING) {
-            previous_message_ptr += strlen(previous_message_ptr) + 1;
-          }
-          else {
-            switch (item) {
-              case DGR_ITEM_LIGHT_CHANNELS:
-                previous_message_ptr += 5;
-                break;
-            }
-          }
+        // If this item was not found in the new update, copy it to the new update message.
+        if (!item_ptr->item) {
+          kept_item_count++;
+          *message_ptr++ = item;
+          memmove(message_ptr, previous_message_ptr, value);
+          message_ptr += value;
         }
 
-        // If this item was not found in the new udpate, copy it to the new update message.
-        else {
-          *message_ptr++ = item;
-          if (item <= DGR_ITEM_MAX_32BIT) {
-            *message_ptr++ = *previous_message_ptr++;
-            if (item > DGR_ITEM_MAX_8BIT) {
-              *message_ptr++ = *previous_message_ptr++;
-              if (item > DGR_ITEM_MAX_16BIT) {
-                *message_ptr++ = *previous_message_ptr++;
-                *message_ptr++ = *previous_message_ptr++;
-              }
-            }
-          }
-          else if (item <= DGR_ITEM_MAX_STRING) {
-            value = strlen(previous_message_ptr) + 1;
-            memmove(message_ptr, previous_message_ptr, value);
-            previous_message_ptr += value;
-            message_ptr += value;
-          }
-          else {
-            switch (item) {
-              case DGR_ITEM_LIGHT_CHANNELS:
-                memmove(message_ptr, previous_message_ptr, 5);
-                previous_message_ptr += 5;
-                message_ptr += 5;
-                break;
-            }
-          }
-          kept_item_count++;
-        }
+        // Advance past the item value.
+        previous_message_ptr += value;
       }
 #ifdef DEVICE_GROUPS_DEBUG
       AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: %u items carried over"), kept_item_count);
@@ -647,7 +634,6 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
       shared = true;
       if (!device_group_index) shared = DeviceGroupItemShared(false, item);
       if (shared) {
-//        items_added = true;
         *message_ptr++ = item;
 
         // For integer items, add the value to the message.
@@ -671,54 +657,51 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
           }
         }
 
-        // For string items, add the null-terminated string to the message.
-        else if (item <= DGR_ITEM_MAX_STRING) {
-          if (item_ptr->value_ptr) {
-            value = strlen((const char *)item_ptr->value_ptr);
-            memcpy(message_ptr, item_ptr->value_ptr, value);
-            message_ptr += value;
-          }
-          *message_ptr++ = 0;
-        }
-
-        // For special items, handle them individually.
+        // For string items and special items, get the value length.
         else {
-          switch (item) {
-            case DGR_ITEM_LIGHT_CHANNELS:
-              value_ptr = (char *)item_ptr->value_ptr;
-              for (int i = 0; i < 5; i++) {
-                *message_ptr++ = (value_ptr ? *value_ptr++ : 0);
-              }
-              break;
+          if (item <= DGR_ITEM_MAX_STRING) {
+            value = strlen((const char *)item_ptr->value_ptr) + 1;
           }
+          else {
+            switch (item) {
+              case DGR_ITEM_LIGHT_CHANNELS:
+                value = 5;
+                break;
+            }
+          }
+
+          // Load the length and copy the value.
+          *message_ptr++ = value;
+          memcpy(message_ptr, item_ptr->value_ptr, value);
+          message_ptr += value;
         }
       }
     }
 
     // If we added any items, add the EOL item code and calculate the message length.
-//    if (items_added) {
+    if (message_ptr != first_item_ptr) {
       *message_ptr++ = 0;
       device_group->message_length = message_ptr - device_group->message;
-//    }
+    }
 
     // If there's going to be more items added to this message, return.
-    if (building_status_message || message_type == DGR_MSGTYP_PARTIAL_UPDATE) return;
+    if (building_status_message || message_type == DGR_MSGTYP_PARTIAL_UPDATE) return 0;
   }
 
   // If there is no message, restore the sequence number and return.
   if (!device_group->message_length) {
     device_group->outgoing_sequence = original_sequence;
-    return;
+    return 0;
   }
 
   // Multicast the packet.
-  SendReceiveDeviceGroupPacket(device_group, nullptr, device_group->message, device_group->message_length, false);
+  SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, device_group->message_length, false);
 
 #ifdef USE_DEVICE_GROUPS_SEND
   // If the device group is local, handle the message locally.
   if (message_type == DGR_MSGTYPE_UPDATE_COMMAND && device_group->local) {
     struct XDRVMAILBOX save_XdrvMailbox = XdrvMailbox;
-    SendReceiveDeviceGroupPacket(device_group, nullptr, device_group->message, device_group->message_length, true);
+    SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, device_group->message_length, true);
     XdrvMailbox = save_XdrvMailbox;
   }
 #endif  // USE_DEVICE_GROUPS_SEND
@@ -737,29 +720,24 @@ void _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
 
   device_group->next_announcement_time = now + DGR_ANNOUNCEMENT_INTERVAL;
   if (device_group->next_announcement_time < next_check_time) next_check_time = device_group->next_announcement_time;
+  return 0;
 }
 
-void ProcessDeviceGroupMessage(char * message, int message_length)
+void ProcessDeviceGroupMessage(uint8_t * message, int message_length)
 {
-  // Make the group name a null-terminated string.
-  char * message_group_name = message + sizeof(DEVICE_GROUP_MESSAGE) - 1;
-  char * message_ptr = strchr(message_group_name, ' ');
-  if (message_ptr == nullptr) return;
-  *message_ptr = 0;
-
   // Search for a device group with the target group name. If one isn't found, return.
-  struct device_group * device_group;
   uint8_t device_group_index = 0;
+  struct device_group * device_group = device_groups;
+  char * message_group_name = (char *)message + sizeof(DEVICE_GROUP_MESSAGE) - 1;
   for (;;) {
-    device_group = &device_groups[device_group_index];
     if (!strcmp(message_group_name, device_group->group_name)) break;
     if (++device_group_index >= device_group_count) return;
+    device_group++;
   }
-  *message_ptr++ = ' ';
 
   // Find the group member. If this is a new group member, add it.
   struct device_group_member * device_group_member;
-  IPAddress remote_ip = PortUdp.remoteIP();
+  IPAddress remote_ip = device_groups_udp.remoteIP();
   struct device_group_member * * flink = &device_group->device_group_members;
   for (;;) {
     device_group_member = *flink;
@@ -769,9 +747,9 @@ void ProcessDeviceGroupMessage(char * message, int message_length)
         AddLog_P2(LOG_LEVEL_ERROR, PSTR("DGR: Error allocating member block"));
         return;
       }
-      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Adding member %s"), IPAddressToString(remote_ip));
       device_group_member->ip_address = remote_ip;
       *flink = device_group_member;
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Member %s added"), IPAddressToString(remote_ip));
       break;
     }
     else if (device_group_member->ip_address == remote_ip) {
@@ -780,7 +758,7 @@ void ProcessDeviceGroupMessage(char * message, int message_length)
     flink = &device_group_member->flink;
   }
 
-  SendReceiveDeviceGroupPacket(device_group, device_group_member, message, message_length, true);
+  SendReceiveDeviceGroupMessage(device_group, device_group_member, message, message_length, true);
 }
 
 void DeviceGroupStatus(uint8_t device_group_index)
@@ -800,141 +778,120 @@ void DeviceGroupStatus(uint8_t device_group_index)
 
 void DeviceGroupsLoop(void)
 {
-  if (!Settings.flag4.device_groups_enabled) return;
-  if (udp_connected) {
-    uint32_t now = millis();
+  if (!device_groups_up || restart_flag) return;
 
-    // If UDP was not connected before, (re)initialize.
-    if (!udp_was_connected) {
-      udp_was_connected = true;
-
-      if (!device_groups_initialized) DeviceGroupsInit();
-      if (device_groups_initialization_failed) return;
-
-      // Load the status request message for all device groups. This message will be multicast 10
-      // times at 200ms intervals.
-      next_check_time = now + 3000;
-      for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++) {
-        device_group * device_group = &device_groups[device_group_index];
-        device_group->next_announcement_time = -1;
-        device_group->message_length = BeginDeviceGroupMessage(device_group, DGR_FLAG_RESET | DGR_FLAG_STATUS_REQUEST) - device_group->message;
-        device_group->initial_status_requests_remaining = 10;
-        device_group->next_ack_check_time = next_check_time;
-      }
-      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: (Re)discovering members"));
-    }
-
-    if (device_groups_initialization_failed) return;
-
-    // If it's time to check on things, iterate through the device groups.
-    if (next_check_time <= now) {
-#ifdef DEVICE_GROUPS_DEBUG
-AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Ckecking next_check_time=%u, now=%u"), next_check_time, now);
-#endif  // DEVICE_GROUPS_DEBUG
-      next_check_time = now + DGR_ANNOUNCEMENT_INTERVAL * 2;
-
-      for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++) {
-        device_group * device_group = &device_groups[device_group_index];
-
-        // If we're still waiting for acks to the last update from this device group, ...
-        if (device_group->next_ack_check_time) {
-
-          // If it's time to check for acks, ...
-          if (device_group->next_ack_check_time <= now) {
-
-            // If we're still sending the initial status request message, send it.
-            if (device_group->initial_status_requests_remaining) {
-              if (--device_group->initial_status_requests_remaining) {
-#ifdef DEVICE_GROUPS_DEBUG
-              AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Sending initial status request for group %s"), device_group->group_name);
-#endif  // DEVICE_GROUPS_DEBUG
-                SendReceiveDeviceGroupPacket(device_group, nullptr, device_group->message, device_group->message_length, false);
-
-                device_group->message[device_group->message_header_length + 2] = DGR_FLAG_STATUS_REQUEST; // The reset flag is on only for the first packet - turn it off now
-                device_group->next_ack_check_time = now + 200;
-              }
-
-              // If we've sent the initial status request message the set number of times, send our
-              // status to all the members.
-              else {
-                device_group->next_ack_check_time = 0;
-                _SendDeviceGroupMessage(device_group_index, DGR_MSGTYP_FULL_STATUS);
-              }
-            }
-
-            // If we're done initializing, iterate through the group memebers, ...
-            else {
-#ifdef DEVICE_GROUPS_DEBUG
-              AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Checking for ack's"));
-#endif  // DEVICE_GROUPS_DEBUG
-              bool acked = true;
-              struct device_group_member ** flink = &device_group->device_group_members;
-              struct device_group_member * device_group_member;
-              while ((device_group_member = *flink)) {
-
-                // If we have not received an ack to our last message from this member, ...
-                if (device_group_member->acked_sequence != device_group->outgoing_sequence) {
-
-                  // If we haven't receive an ack from this member in DGR_MEMBER_TIMEOUT ms, assume
-                  // they're offline and remove them from the group.
-                  if (device_group->member_timeout_time < now) {
-                    AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Removing member %s"), IPAddressToString(device_group_member->ip_address));
-                    *flink = device_group_member->flink;
-                    free(device_group_member);
-                  }
-
-                  // Otherwise, unicast the last message directly to this member.
-                  else {
-                    SendReceiveDeviceGroupPacket(device_group, device_group_member, device_group->message, device_group->message_length, false);
-                    device_group_member->unicast_count++;
-                    acked = false;
-                    flink = &device_group_member->flink;
-                  }
-                }
-                else {
-                  flink = &device_group_member->flink;
-                }
-              }
-
-              // If we've received an ack to the last message from all members, clear the ack check
-              // time and zero-out the message length.
-              if (acked) {
-                device_group->next_ack_check_time = 0;
-                device_group->message_length = 0; // Let _SendDeviceGroupMessage know we're done with this update
-              }
-
-              // If there are still members we haven't received an ack from, set the next ack check
-              // time. We start at 200ms and double the interval each pass with a maximum interval of
-              // 5 seconds.
-              else {
-                device_group->ack_check_interval *= 2;
-                if (device_group->ack_check_interval > 5000) device_group->ack_check_interval = 5000;
-                device_group->next_ack_check_time = now + device_group->ack_check_interval;
-              }
-            }
-          }
-
-          if (device_group->next_ack_check_time < next_check_time) next_check_time = device_group->next_ack_check_time;
-        }
-
-        // If it's time to send a multicast announcement for this group, send it. This is to
-        // announcement ourself to any members that have somehow not heard about us. We send it at
-        // the announcement interval plus a random number of milliseconds so that even if all the
-        // devices booted at the same time, they don't all multicast their announcements at the same
-        // time.
-#ifdef DEVICE_GROUPS_DEBUG
-        AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: next_announcement_time=%u, now=%u"), device_group->next_announcement_time, now);
-#endif  // DEVICE_GROUPS_DEBUG
-        if (device_group->next_announcement_time <= now) {
-          SendReceiveDeviceGroupPacket(device_group, nullptr, device_group->message, BeginDeviceGroupMessage(device_group, DGR_FLAG_ANNOUNCEMENT, true) - device_group->message, false);
-          device_group->next_announcement_time = now + DGR_ANNOUNCEMENT_INTERVAL + random(10000);
-        }
-        if (device_group->next_announcement_time < next_check_time) next_check_time = device_group->next_announcement_time;
+  while (device_groups_udp.parsePacket()) {
+    uint8_t packet_buffer[512];
+    int length = device_groups_udp.read(packet_buffer, sizeof(packet_buffer) - 1);
+    if (length > 0) {
+      packet_buffer[length] = 0;
+      if (!strncmp_P((char *)packet_buffer, kDeviceGroupMessage, sizeof(DEVICE_GROUP_MESSAGE) - 1)) {
+        ProcessDeviceGroupMessage(packet_buffer, length);
       }
     }
   }
-  else {
-    udp_was_connected = false;
+
+  uint32_t now = millis();
+
+  // If it's time to check on things, iterate through the device groups.
+  if ((long)(now - next_check_time) >= 0) {
+#ifdef DEVICE_GROUPS_DEBUG
+AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Checking next_check_time=%u, now=%u"), next_check_time, now);
+#endif  // DEVICE_GROUPS_DEBUG
+    next_check_time = now + DGR_ANNOUNCEMENT_INTERVAL * 2;
+
+    struct device_group * device_group = device_groups;
+    for (uint32_t device_group_index = 0; device_group_index < device_group_count; device_group_index++, device_group++) {
+
+      // If we're still waiting for acks to the last update from this device group, ...
+      if (device_group->next_ack_check_time) {
+
+        // If it's time to check for acks, ...
+        if ((long)(now - device_group->next_ack_check_time) >= 0) {
+
+          // If we're still sending the initial status request message, send it.
+          if (device_group->initial_status_requests_remaining) {
+            if (--device_group->initial_status_requests_remaining) {
+#ifdef DEVICE_GROUPS_DEBUG
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Sending initial status request for group %s"), device_group->group_name);
+#endif  // DEVICE_GROUPS_DEBUG
+              SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, device_group->message_length, false);
+              device_group->message[device_group->message_header_length + 2] = DGR_FLAG_STATUS_REQUEST; // The reset flag is on only for the first packet - turn it off now
+              next_check_time = device_group->next_ack_check_time = now + 200;
+              continue;
+            }
+
+            // If we've sent the initial status request message the set number of times, send our
+            // status to all the members.
+            else {
+              _SendDeviceGroupMessage(device_group_index, DGR_MSGTYP_FULL_STATUS);
+            }
+          }
+
+          // If we're done initializing, iterate through the group memebers, ...
+          else {
+#ifdef DEVICE_GROUPS_DEBUG
+            AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Checking for ack's"));
+#endif  // DEVICE_GROUPS_DEBUG
+            bool acked = true;
+            struct device_group_member ** flink = &device_group->device_group_members;
+            struct device_group_member * device_group_member;
+            while ((device_group_member = *flink)) {
+
+              // If we have not received an ack to our last message from this member, ...
+              if (device_group_member->acked_sequence != device_group->outgoing_sequence) {
+
+                // If we haven't receive an ack from this member in DGR_MEMBER_TIMEOUT ms, assume
+                // they're offline and remove them from the group.
+                if ((long)(now - device_group->member_timeout_time) >= 0) {
+                  *flink = device_group_member->flink;
+                  free(device_group_member);
+                  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: Member %s removed"), IPAddressToString(device_group_member->ip_address));
+                  continue;
+                }
+
+                // Otherwise, unicast the last message directly to this member.
+                SendReceiveDeviceGroupMessage(device_group, device_group_member, device_group->message, device_group->message_length, false);
+                device_group_member->unicast_count++;
+                acked = false;
+              }
+              flink = &device_group_member->flink;
+            }
+
+            // If we've received an ack to the last message from all members, clear the ack check
+            // time and zero-out the message length.
+            if (acked) {
+              device_group->next_ack_check_time = 0;
+              device_group->message_length = 0; // Let _SendDeviceGroupMessage know we're done with this update
+            }
+
+            // If there are still members we haven't received an ack from, set the next ack check
+            // time. We start at 200ms and double the interval each pass with a maximum interval of
+            // 5 seconds.
+            else {
+              device_group->ack_check_interval *= 2;
+              if (device_group->ack_check_interval > 5000) device_group->ack_check_interval = 5000;
+              device_group->next_ack_check_time = now + device_group->ack_check_interval;
+            }
+          }
+        }
+
+        if (device_group->next_ack_check_time < next_check_time) next_check_time = device_group->next_ack_check_time;
+      }
+
+      // If it's time to send a multicast announcement for this group, send it. This is to
+      // announcement ourself to any members that have somehow not heard about us. We send it at the
+      // announcement interval plus a random number of milliseconds so that even if all the devices
+      // booted at the same time, they don't all multicast their announcements at the same time.
+#ifdef DEVICE_GROUPS_DEBUG
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DGR: next_announcement_time=%u, now=%u"), device_group->next_announcement_time, now);
+#endif  // DEVICE_GROUPS_DEBUG
+      if ((long)(now - device_group->next_announcement_time) >= 0) {
+        SendReceiveDeviceGroupMessage(device_group, nullptr, device_group->message, BeginDeviceGroupMessage(device_group, DGR_FLAG_ANNOUNCEMENT, true) - device_group->message, false);
+        device_group->next_announcement_time = now + DGR_ANNOUNCEMENT_INTERVAL + random(10000);
+      }
+      if (device_group->next_announcement_time < next_check_time) next_check_time = device_group->next_announcement_time;
+    }
   }
 }
 

--- a/tasmota/support_udp.ino
+++ b/tasmota/support_udp.ino
@@ -49,7 +49,11 @@ bool UdpDisconnect(void)
 {
   if (udp_connected) {
     PortUdp.flush();
+#ifdef USE_DEVICE_GROUPS
+    PortUdp.stop();
+#else // USE_DEVICE_GROUPS
     WiFiUDP::stopAll();
+#endif  // !USE_DEVICE_GROUPS
     AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPNP D_MULTICAST_DISABLED));
     udp_connected = false;
   }
@@ -135,12 +139,6 @@ void PollUdp(void)
           continue;
         }
       }
-
-#ifdef USE_DEVICE_GROUPS
-      if (Settings.flag4.device_groups_enabled && !strncmp_P(packet_buffer, kDeviceGroupMessage, sizeof(DEVICE_GROUP_MESSAGE) - 1)) {
-        ProcessDeviceGroupMessage(packet_buffer, len);
-      }
-#endif  // USE_DEVICE_GROUPS
     }
     optimistic_yield(100);
   }

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -573,14 +573,12 @@ void WifiCheck(uint8_t param)
           StopWebserver();
         }
 #ifdef USE_EMULATION
-#ifdef USE_DEVICE_GROUPS
-        if (Settings.flag2.emulation || Settings.flag4.device_groups_enabled) { UdpConnect(); }
-#else // USE_DEVICE_GROUPS
       if (Settings.flag2.emulation) { UdpConnect(); }
-#endif // USE_DEVICE_GROUPS
 #endif  // USE_EMULATION
 #endif  // USE_WEBSERVER
-
+#ifdef USE_DEVICE_GROUPS
+        DeviceGroupsStart();
+#endif  // USE_DEVICE_GROUPS
 #ifdef USE_KNX
         if (!knx_started && Settings.flag.knx_enabled) {  // CMND_KNX_ENABLED
           KNXStart();
@@ -593,6 +591,9 @@ void WifiCheck(uint8_t param)
 #ifdef USE_EMULATION
         UdpDisconnect();
 #endif  // USE_EMULATION
+#ifdef USE_DEVICE_GROUPS_SSDP
+        DeviceGroupsStop();
+#endif  // USE_DEVICE_GROUPS_SSDP
         Wifi.mdns_begun = 0;
 #ifdef USE_KNX
         knx_started = false;

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -591,9 +591,9 @@ void WifiCheck(uint8_t param)
 #ifdef USE_EMULATION
         UdpDisconnect();
 #endif  // USE_EMULATION
-#ifdef USE_DEVICE_GROUPS_SSDP
+#ifdef USE_DEVICE_GROUPS
         DeviceGroupsStop();
-#endif  // USE_DEVICE_GROUPS_SSDP
+#endif  // USE_DEVICE_GROUPS
         Wifi.mdns_begun = 0;
 #ifdef USE_KNX
         knx_started = false;

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -304,7 +304,7 @@ enum DevGroupMessageType { DGR_MSGTYP_FULL_STATUS, DGR_MSGTYP_PARTIAL_UPDATE, DG
 
 enum DevGroupMessageFlag { DGR_FLAG_RESET = 1, DGR_FLAG_STATUS_REQUEST = 2, DGR_FLAG_FULL_STATUS = 4, DGR_FLAG_ACK = 8, DGR_FLAG_MORE_TO_COME = 16, DGR_FLAG_DIRECT = 32, DGR_FLAG_ANNOUNCEMENT = 64 };
 
-enum DevGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS,
+enum DevGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS, DGR_ITEM_FLAGS,
                     DGR_ITEM_LIGHT_FADE, DGR_ITEM_LIGHT_SPEED, DGR_ITEM_LIGHT_BRI, DGR_ITEM_LIGHT_SCHEME, DGR_ITEM_LIGHT_FIXED_COLOR,
                     DGR_ITEM_BRI_PRESET_LOW, DGR_ITEM_BRI_PRESET_HIGH, DGR_ITEM_BRI_POWER_ON,
                     // Add new 8-bit items before this line
@@ -312,7 +312,7 @@ enum DevGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS,
                     //DGR_ITEM_ANALOG1, DGR_ITEM_ANALOG2, DGR_ITEM_ANALOG3, DGR_ITEM_ANALOG4, DGR_ITEM_ANALOG5,
                     // Add new 16-bit items before this line
                     DGR_ITEM_LAST_16BIT, DGR_ITEM_MAX_16BIT = 127,
-                    DGR_ITEM_POWER, DGR_ITEM_DIMMER_RANGE,
+                    DGR_ITEM_POWER,
                     // Add new 32-bit items before this line
                     DGR_ITEM_LAST_32BIT, DGR_ITEM_MAX_32BIT = 191,
                     DGR_ITEM_EVENT, DGR_ITEM_COMMAND,

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -63,9 +63,6 @@ extern "C" void resetPins();
 #ifdef USE_EMULATION_WEMO
 #define USE_EMULATION
 #endif
-#ifdef USE_DEVICE_GROUPS
-#define USE_EMULATION
-#endif
                                                // See https://github.com/esp8266/Arduino/pull/4889
 #undef NO_EXTRA_4K_HEAP                        // Allocate 4k heap for WPS in ESP8166/Arduino core v2.4.2 (was always allocated in previous versions)
 
@@ -329,8 +326,6 @@ const char kWebColors[] PROGMEM =
 #ifdef USE_DEVICE_GROUPS
 #define SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, ...) _SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, __VA_ARGS__, 0)
 #define SendLocalDeviceGroupMessage(REQUEST_TYPE, ...) _SendDeviceGroupMessage(0, REQUEST_TYPE, __VA_ARGS__, 0)
-#define DEVICE_GROUP_MESSAGE "M-TASMOTA_DGR/"
-const char kDeviceGroupMessage[] PROGMEM = DEVICE_GROUP_MESSAGE;
 uint8_t device_group_count = 1;
 #endif  // USE_DEVICE_GROUPS
 

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3058,11 +3058,7 @@ bool Xdrv01(uint8_t function)
     case FUNC_LOOP:
       PollDnsWebserver();
 #ifdef USE_EMULATION
-#ifdef USE_DEVICE_GROUPS
-      if (Settings.flag2.emulation || Settings.flag4.device_groups_enabled) { PollUdp(); }
-#else // USE_DEVICE_GROUPS
       if (Settings.flag2.emulation) { PollUdp(); }
-#endif // USE_DEVICE_GROUPS
 #endif  // USE_EMULATION
       break;
     case FUNC_COMMAND:

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -276,7 +276,7 @@ void PWMDimmerHandleButton(void)
   }
 
   bool state_updated = false;
-  int8_t bri_offset = 0;
+  int32_t bri_offset = 0;
   uint8_t power_on_bri = 0;
   uint8_t dgr_item = 0;
   uint8_t dgr_value;
@@ -550,7 +550,7 @@ void PWMDimmerHandleButton(void)
             // If the button was not held, adjust the brightness. Set the direction based on which
             // button is pressed. The new brightness will be calculated below.
             if (button_hold_time[button_index] >= now) {
-              bri_offset = (is_down_button ? -10 : 10);
+              bri_offset = (is_down_button ? -1 : 1);
               dgr_item = 255;
             }
 
@@ -591,9 +591,8 @@ void PWMDimmerHandleButton(void)
     else
 #endif  // USE_PWM_DIMMER_REMOTE
       bri = light_state.getBri();
-    int32_t new_bri;
-    bri_offset *= (Settings.light_correction ? 4 : bri / 16 + 1);
-    new_bri = bri + bri_offset;
+    int32_t new_bri = bri + bri_offset * ((dgr_item ? 16 : Settings.light_correction ? 4 : bri / 16 + 1));
+
     if (bri_offset > 0) {
       if (new_bri > 255) new_bri = 255;
     }
@@ -602,7 +601,7 @@ void PWMDimmerHandleButton(void)
     }
     if (new_bri != bri) {
 #ifdef USE_DEVICE_GROUPS
-      SendDeviceGroupMessage(power_button_index, (dgr_item ? DGR_MSGTYP_PARTIAL_UPDATE : DGR_MSGTYP_UPDATE_MORE_TO_COME), DGR_ITEM_LIGHT_BRI, new_bri);
+      SendDeviceGroupMessage(power_button_index, (dgr_item ? DGR_MSGTYP_UPDATE : DGR_MSGTYP_UPDATE_MORE_TO_COME), DGR_ITEM_LIGHT_BRI, new_bri);
 #endif  // USE_DEVICE_GROUPS
 #ifdef USE_PWM_DIMMER_REMOTE
       if (!active_device_is_local)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes [#8258](https://github.com/arendst/Tasmota/issues/8258)

<b>**** NOTE: This is a breaking change. This update changes the multicast address and port used by device groups. All devices using the device groups feature must be upgraded. ****</b>

Use compile-time defined multicast address for device groups instead of sharing the emulation (SSDP) socket.

For DevGroupSend, ignore out share mask and always process locally.

Code size reductions.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
