### PR TITLE
Nimble no warnig, optimise CommandHandler()

### DIFF
--- a/libesp32/NimBLE-Arduino/src/NimBLEDevice.cpp
+++ b/libesp32/NimBLE-Arduino/src/NimBLEDevice.cpp
@@ -39,7 +39,7 @@ static const char* LOG_TAG = "NimBLEDevice";
 /**
  * Singletons for the NimBLEDevice.
  */
-bool            initialized = false;
+bool            NimBLEDevice_initialized = false;
 NimBLEScan*     NimBLEDevice::m_pScan = nullptr;
 NimBLEServer*   NimBLEDevice::m_pServer = nullptr;
 uint32_t        NimBLEDevice::m_passkey = 123456;
@@ -409,8 +409,8 @@ void NimBLEDevice::stopAdvertising() {
  * @param deviceName The device name of the device.
  */
 /* STATIC */ void NimBLEDevice::init(std::string deviceName) {
-    if(!initialized){
-        initialized = true; // Set the initialization flag to ensure we are only initialized once.
+    if(!NimBLEDevice_initialized){
+        NimBLEDevice_initialized = true; // Set the initialization flag to ensure we are only initialized once.
         
         int rc=0;
         esp_err_t errRc = ESP_OK;
@@ -476,7 +476,7 @@ void NimBLEDevice::stopAdvertising() {
             NIMBLE_LOGE(LOG_TAG, "esp_nimble_hci_and_controller_deinit() failed with error: %d", ret);
         }
         
-        initialized = false;
+        NimBLEDevice_initialized = false;
     }
 } // deinit
 
@@ -485,7 +485,7 @@ void NimBLEDevice::stopAdvertising() {
  * @brief Check if the initialization is complete.
  */
 bool NimBLEDevice::getInitialized() {
-    return initialized;
+    return NimBLEDevice_initialized;
 } // getInitialized
 
 

--- a/libesp32/NimBLE-Arduino/src/mesh/glue.h
+++ b/libesp32/NimBLE-Arduino/src/mesh/glue.h
@@ -330,8 +330,11 @@ static inline void net_buf_simple_restore(struct os_mbuf *buf,
       buf->om_len = state->len;
 }
 
-static inline void sys_memcpy_swap(void *dst, const void *src, size_t length)
+static inline void sys_memcpy_swap(void *destination, const void *source, size_t length)
 {
+    u8_t *dst = destination;
+    const u8_t *src = source;
+    
     __ASSERT(((src < dst && (src + length) <= dst) ||
           (src > dst && (dst + length) <= src)),
          "Source and destination buffers must not overlap");
@@ -339,7 +342,7 @@ static inline void sys_memcpy_swap(void *dst, const void *src, size_t length)
     src += length - 1;
 
     for (; length > 0; length--) {
-        *((u8_t *)dst++) = *((u8_t *)src--);
+        *dst++ = *src--;
     }
 }
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -204,14 +204,19 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len)
   if (type != nullptr) {
     type++;
     uint32_t i;
-    for (i = 0; i < strlen(type); i++) {
-      type[i] = toupper(type[i]);
+    int nLen; // strlen(type)
+    char *s = type;
+    for (nLen = 0; *s; s++, nLen++) {
+      *s=toupper(*s);
     }
-    while (isdigit(type[i-1])) {
-      i--;
+    i = nLen;
+    if (i > 0) { // may be 0
+      while (isdigit(type[i-1])) {
+        i--;
+      }
     }
-    if (i < strlen(type)) {
-      index = atoi(type +i);
+    if (i < nLen) {
+      index = atoi(type + i);
       user_index = true;
     }
     type[i] = '\0';


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [x] The code change is tested and works on core ESP32
  - [ ] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
I had an error with two vars named "installed", so it`s better to change it in NimBle, but i could not find the other var in Tasmota code.
I see your last changes, please think about ARRAY_SIZE macro, in MSVC it's _countof() i use it since many years.
```
#ifndef ARRAY_SIZE
#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
#endi
```
73 Jörg