### PR TITLE
Add DGR light sequence support

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -398,6 +398,7 @@
 #define D_CMND_RGBWWTABLE "RGBWWTable"
 #define D_CMND_ROTATION "Rotation"
 #define D_CMND_SCHEME "Scheme"
+#define D_CMND_SEQUENCE_OFFSET "SequenceOffset"
 #define D_CMND_SPEED "Speed"
 #define D_CMND_WAKEUP "Wakeup"
 #define D_CMND_WAKEUPDURATION "WakeUpDuration"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -426,7 +426,7 @@
   #define DEVICE_GROUPS_PORT 4447                // Device groups multicast port
   #define USE_DEVICE_GROUPS_SEND                 // Add support for the DevGroupSend command (+0k6 code)
 #define USE_PWM_DIMMER                           // Add support for MJ-SD01/acenx/NTONPOWER PWM dimmers (+2k2 code, DGR=0k4)
-  #define USE_PWM_DIMMER_REMOTE                  // Add support for remote switches to PWM Dimmer, also adds device groups support (+0k9 code plus device groups size)
+  #define USE_PWM_DIMMER_REMOTE                  // Add support for remote switches to PWM Dimmer (requires USE_DEVICE_GROUPS) (+0k9 code)
 //#define USE_KEELOQ                               // Add support for Jarolift rollers by Keeloq algorithm (+4k5 code)
 #define USE_SONOFF_D1                            // Add support for Sonoff D1 Dimmer (+0k7 code)
 
@@ -441,6 +441,7 @@
 #define USE_SONOFF_L1                            // Add support for Sonoff L1 led control
 #define USE_ELECTRIQ_MOODL                       // Add support for ElectriQ iQ-wifiMOODL RGBW LED controller (+0k3 code)
 #define USE_LIGHT_PALETTE                        // Add support for color palette (+0k7 code)
+#define USE_DGR_LIGHT_SEQUENCE                   // Add support for device group light sequencing (requires USE_DEVICE_GROUPS) (+0k2 code)
 
 // -- Counter input -------------------------------
 #define USE_COUNTER                              // Enable inputs as counter (+0k8 code)

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -350,7 +350,7 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
       else {
         switch (item) {
           case DGR_ITEM_LIGHT_CHANNELS:
-            log_length = snprintf(log_ptr, log_remaining, PSTR("%u,%u,%u,%u,%u"), *message_ptr, *(message_ptr + 1), *(message_ptr + 2), *(message_ptr + 3), *(message_ptr + 4));
+            log_length = snprintf(log_ptr, log_remaining, PSTR("%u,%u,%u,%u,%u,%u"), *message_ptr, *(message_ptr + 1), *(message_ptr + 2), *(message_ptr + 3), *(message_ptr + 4), *(message_ptr + 5));
             break;
         }
       }
@@ -549,7 +549,7 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
           else {
             switch (item) {
               case DGR_ITEM_LIGHT_CHANNELS:
-                for (int i = 0; i < 5; i++) {
+                for (int i = 0; i < 6; i++) {
                   *out_ptr++ = strtoul((char *)value_ptr, (char **)&value_ptr, 0);
                   if (*value_ptr == ',') value_ptr++;
                 }
@@ -665,7 +665,7 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
           else {
             switch (item) {
               case DGR_ITEM_LIGHT_CHANNELS:
-                value = 5;
+                value = 6;
                 break;
             }
           }

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -114,15 +114,10 @@ extern "C" void resetPins();
 #define MESSZ                       (MQTT_MAX_PACKET_SIZE -TOPSZ -7)  // Max number of characters in JSON message string
 #endif
 
-#ifdef USE_PWM_DIMMER_REMOTE
-#ifdef USE_PWM_DIMMER
 #ifndef USE_DEVICE_GROUPS
-#define USE_DEVICE_GROUPS
-#endif  // USE_DEVICE_GROUPS
-#else   // USE_PWM_DIMMER
 #undef USE_PWM_DIMMER_REMOTE
-#endif  // USE_PWM_DIMMER
-#endif  // USE_PWM_DIMMER_REMOTE
+#undef USE_DGR_LIGHT_SEQUENCE
+#endif  // USE_DEVICE_GROUPS
 
 #ifndef DOMOTICZ_UPDATE_TIMER
 #define DOMOTICZ_UPDATE_TIMER       0          // [DomoticzUpdateTimer] Send relay status (0 = disable, 1 - 3600 seconds) (Optional)


### PR DESCRIPTION
## Description:

Add support for light sequencing using device groups. Using the SequenceOffset command, the position in a sequence of lights can be specified. If a SequenceOffset is specified, updates to the light channels received from the device group are added to a FIFO buffer of SequenceOffset entries. In this way, each color change is delayed by SequenceOffset updates. 

For example, given a string of Tasmota lights, the first light would be set as the master with a SequenceOffset of 0 and a palette of colors specified with the Palette command. The second light would have a SequenceOffset of 1, the third light a SequenceOffset of 2, and so on. When scheme 2 is started on the first light, the lights display a light sequence similar to a light strip.

Command|Parameters
:---|:---
SequenceOffset|0..255 = Set the position of the light in a sequence of lights to use the device groups light sequence feature.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
