### PR TITLE
Update xsns_02_analog.ino

### DIFF
--- a/tasmota/xsns_02_analog.ino
+++ b/tasmota/xsns_02_analog.ino
@@ -166,6 +166,8 @@ void AdcGetCurrentPower(uint8_t factor)
   uint16_t analog = 0;
   uint16_t analog_min = 1023;
   uint16_t analog_max = 0;
+
+  if(Settings.adc_param1==0){
   for (uint32_t i = 0; i < samples; i++) {
     analog = analogRead(A0);
     if (analog < analog_min) {
@@ -176,8 +178,19 @@ void AdcGetCurrentPower(uint8_t factor)
     }
     delay(1);
   }
-
   Adc.current = (float)(analog_max-analog_min) * ((float)(Settings.adc_param2) / 100000);
+  } 
+  else{
+
+    analog = AdcRead(5);
+    if(analog>Settings.adc_param1){
+     Adc.current = ((float)(analog) - (float)Settings.adc_param1) * ((float)(Settings.adc_param2) / 100000);
+    }
+    else{
+      Adc.current = 0;
+    }
+  }
+
   float power = Adc.current * (float)(Settings.adc_param3) / 10;
   uint32_t current_millis = millis();
   Adc.energy = Adc.energy + ((power * (current_millis - Adc.previous_millis)) / 3600000000);
@@ -357,7 +370,7 @@ void CmndAdcParam(void)
           Settings.adc_param3 = (int)(CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 4)) * 10000);
         }
         if (ADC0_CT_POWER == XdrvMailbox.payload) {
-          if ((Settings.adc_param1 & CT_FLAG_ENERGY_RESET) > 0) {
+          if ((Settings.adc_param1 == 1 & CT_FLAG_ENERGY_RESET) > 0) {
             Adc.energy = 0;
             Settings.adc_param1 ^= CT_FLAG_ENERGY_RESET;  // Cancel energy reset flag
           }


### PR DESCRIPTION
## Description:

Extension of CT_POWER to use it with as few adaptations as possible also for current measurement with OP amps in differential circuit.

Tested on a Shelly RGBW2 which obviously uses a LM321 OpAmp at the ADC input.

Adaptation of the values according to: #8011
ANALOG_CT_FLAGS (default 0) actually reserved for possible future use;
ANALOG_CT_MULTIPLIER (default 2146) multiplier*100000 to convert raw ADC peak to peak range 0..1023 to RMS current in Amps. Value of 100000 corresponds to 1
ANALOG_CT_VOLTAGE (default 2300) to convert current in Amps to apparent power in Watts using voltage in Volts*10. Value of 2200 corresponds to 220V

The first parameter is used to set the adcLOW value.
This is necessary because the OPAmp already has voltage at its output even if no current is consumed. So this sets the base.


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [ ] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
