### PR TITLE
Only advance to next palette color when fade is done

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2234,27 +2234,21 @@ void calcGammaBulbs(uint16_t cur_col_10[5]) {
 }
 
 #ifdef USE_DEVICE_GROUPS
-void LightSendDeviceGroupStatus(bool force)
+void LightSendDeviceGroupStatus(bool status)
 {
-  static uint8_t last_channels[LST_MAX];
-  static uint8_t channels_sequence = 0;
   static uint8_t last_bri;
-
   uint8_t bri = light_state.getBri();
-  bool send_bri_update = (force || bri != last_bri);
-
+  bool send_bri_update = (status || bri != last_bri);
   if (Light.subtype > LST_SINGLE && !Light.devgrp_no_channels_out) {
-    uint8_t channels[LST_MAX + 1];
-    light_state.getChannels(channels);
-    if (force || memcmp(last_channels, channels, LST_MAX)
-#ifdef USE_LIGHT_PALETTE
-      || (Settings.light_scheme && Light.palette_count)
-#endif  // USE_LIGHT_PALETTE
-      ) {
-      memcpy(last_channels, channels, LST_MAX);
-      channels[LST_MAX] = ++channels_sequence;
-      SendLocalDeviceGroupMessage((send_bri_update ? DGR_MSGTYP_PARTIAL_UPDATE : DGR_MSGTYP_UPDATE), DGR_ITEM_LIGHT_CHANNELS, channels);
+    static uint8_t channels[LST_MAX + 1] = { 0, 0, 0, 0, 0, 0 };
+    if (status) {
+      light_state.getChannels(channels);
     }
+    else {
+      memcpy(channels, Light.new_color, LST_MAX);
+      channels[LST_MAX]++;
+    }
+    SendLocalDeviceGroupMessage((send_bri_update ? DGR_MSGTYP_PARTIAL_UPDATE : DGR_MSGTYP_UPDATE), DGR_ITEM_LIGHT_CHANNELS, channels);
   }
   if (send_bri_update) {
     last_bri = bri;

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1702,17 +1702,19 @@ void LightCycleColor(int8_t direction)
 
 #ifdef USE_LIGHT_PALETTE
   if (Light.palette_count) {
-    if (0 == direction) {
-      Light.wheel = random(Light.palette_count);
-    }
-    else {
-      Light.wheel += direction;
-      if (Light.wheel >= Light.palette_count) {
-        Light.wheel = 0;
-         if (direction < 0) Light.wheel = Light.palette_count - 1;
+    if (!Light.fade_running) {
+      if (0 == direction) {
+        Light.wheel = random(Light.palette_count);
       }
+      else {
+        Light.wheel += direction;
+        if (Light.wheel >= Light.palette_count) {
+          Light.wheel = 0;
+          if (direction < 0) Light.wheel = Light.palette_count - 1;
+        }
+      }
+      LightSetPaletteEntry();
     }
-    LightSetPaletteEntry();
     return;
   }
 #endif  // USE_LIGHT_PALETTE


### PR DESCRIPTION
## Description:

Only advance to next palette color when fade is done.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
