### PR TITLE
Fix HA Discovery regression to use Friendly Name again.

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -644,13 +644,13 @@ void HAssAnnounceDeviceInfoAndStatusSensor(void)
     char *state_topic = stemp1;
     char *availability_topic = stemp2;
 
-    snprintf_P(name, sizeof(name), PSTR("%s status"), ModuleName().c_str());
+    snprintf_P(name, sizeof(name), PSTR("%s status"), SettingsText(SET_FRIENDLYNAME1));
     GetTopic_P(state_topic, TELE, mqtt_topic, PSTR(D_RSLT_HASS_STATE));
     GetTopic_P(availability_topic, TELE, mqtt_topic, S_LWT);
 
     Response_P(HASS_DISCOVER_BASE, name, state_topic, availability_topic);
     TryResponseAppend_P(HASS_DISCOVER_SENSOR_HASS_STATUS, state_topic);
-    TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO, unique_id, ESP_getChipId(), ModuleName().c_str(),
+    TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO, unique_id, ESP_getChipId(), SettingsText(SET_FRIENDLYNAME1),
                         ModuleName().c_str(), my_version, my_image);
     TryResponseAppend_P(PSTR("}"));
   }


### PR DESCRIPTION
## Description:
The HA Discovery commit (3e47b6fe19a512181145da211e965ee0118e2814) introduced a regression to the HomeAssistant discovery interactions, resulting in the device name = model name. Refer to issue for details.

This PR reverts back two usages of `ModuleName().c_str()` to `SettingsText(SET_FRIENDLYNAME1)`. Upgrading the firmware to a binary with this patch immediately fixes the naming in HomeAssistant.

**Related issue (if applicable):** fixes #8306 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core Tasmota_core
  - [x] The code change is tested and works on core ESP32
  - [x] The code change pass travis tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
