### PR TITLE
webcam test whitout script

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1562,6 +1562,10 @@ chknext:
         }
         break;
       case 'l':
+        if (!strncmp(vname,"lip",3)) {
+          if (sp) strlcpy(sp,(const char*)WiFi.localIP().toString().c_str(),glob_script_mem.max_ssize);
+          goto strexit;
+        }
         if (!strncmp(vname,"loglvl",6)) {
           fvar=glob_script_mem.script_loglevel;
           tind->index=SCRIPT_LOGLEVEL;


### PR DESCRIPTION
webcam test without any script (if not defined USE_SCRIPT)

tasmota cmd 
webcam N       N=0 stop stream, N=resolution = start stream
	1 = FRAMESIZE_QQVGA2,   // 128x160
	2 = FRAMESIZE_QCIF,     // 176x144
 	3 = FRAMESIZE_HQVGA,    // 240x176
	4 = FRAMESIZE_QVGA,     // 320x240
	5 = FRAMESIZE_CIF,      // 400x296
	6 = FRAMESIZE_VGA,      // 640x480
	7 = FRAMESIZE_SVGA,     // 800x600
	8 = FRAMESIZE_XGA,      // 1024x768
	9 = FRAMESIZE_SXGA,     // 1280x1024
	10 = FRAMESIZE_UXGA,     // 1600x1200

scripter local ip as text var

tinker cam template:
{"NAME":"AITHINKER CAM","GPIO":[4992,65504,672,65504,5472,5312,65504,65504,5504,5536,736,704,5568,5440,5280,5248,0,5216,5408,5376,0,5344,5024,5056,0,0,0,0,4928,65504,5120,5088,5184,0,0,5152],"FLAG":0,"BASE":1}

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.0
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [ ] The code change pass CI tests. **Your PR cannot be merged unless tests pass**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).