### PR TITLE
PR Template. Move the CI Pass request to a Note

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,6 @@
   - [ ] Only one feature/fix was added per PR.
   - [ ] The code change is tested and works on core ESP8266 V.2.7.0
   - [ ] The code change is tested and works on core ESP32 V.1.12.0
-  - [ ] The code change pass CI tests. **Your PR cannot be merged unless tests pass**
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
+
+_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_


### PR DESCRIPTION
## Description:

PR Template. Move the CI Pass request checkbox to a Note like in here.

As the CI Test is done after the PR is submitted, a checkbox for "The code change must pass CI tests" is always left unchecked. It should be better to just add a note that the proposed PR is going to be tested and that the CI Tests must be passed in order to merge the PR. Any CI Test error should be addressed by the author of the PR, before merging.

**Related issue (if applicable):** fixes NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.0
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_