### PR TITLE
Hotfix: Use patched Core 2.7.0...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -114,7 +114,7 @@ build_flags               = ${tasmota_core.build_flags}
 [tasmota_core]
 ; *** Esp8266 Arduino core 2.7.0
 platform                  = espressif8266@2.4.0
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino/releases/download/2.7.0/esp8266-2.7.0.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.0/esp8266-2.7.0.zip
 build_flags               = ${esp82xx_defaults.build_flags}
                             -DBEARSSL_SSL_BASIC
 ; NONOSDK22x_190703 = 2.2.2-dev(38a443e)


### PR DESCRIPTION
since the new introduced XMC flash OTA handling in eboot.elf does not work. Device is a Softbrick and needs serial flashing.
Replaced eboot.elf with a older working version
Solves #8334

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.0
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
