### PR TITLE
Move constants in PMEM

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -407,9 +407,9 @@ bool SettingsUpdateText(uint32_t index, const char* replace_me)
   }
 
   // Make a copy first in case we use source from Settings.text
-  uint32_t replace_len = strlen(replace_me);
+  uint32_t replace_len = strlen_P(replace_me);
   char replace[replace_len +1];
-  memcpy(replace, replace_me, sizeof(replace));
+  memcpy_P(replace, replace_me, sizeof(replace));
 
   uint32_t start_pos = 0;
   uint32_t end_pos = 0;
@@ -744,11 +744,11 @@ void SettingsDefaultSet2(void)
   Settings.module = MODULE;
   ModuleDefault(WEMOS);
 //  for (uint32_t i = 0; i < ARRAY_SIZE(Settings.my_gp.io); i++) { Settings.my_gp.io[i] = GPIO_NONE; }
-  SettingsUpdateText(SET_FRIENDLYNAME1, FRIENDLY_NAME);
-  SettingsUpdateText(SET_FRIENDLYNAME2, FRIENDLY_NAME"2");
-  SettingsUpdateText(SET_FRIENDLYNAME3, FRIENDLY_NAME"3");
-  SettingsUpdateText(SET_FRIENDLYNAME4, FRIENDLY_NAME"4");
-  SettingsUpdateText(SET_OTAURL, OTA_URL);
+  SettingsUpdateText(SET_FRIENDLYNAME1, PSTR(FRIENDLY_NAME));
+  SettingsUpdateText(SET_FRIENDLYNAME2, PSTR(FRIENDLY_NAME"2"));
+  SettingsUpdateText(SET_FRIENDLYNAME3, PSTR(FRIENDLY_NAME"3"));
+  SettingsUpdateText(SET_FRIENDLYNAME4, PSTR(FRIENDLY_NAME"4"));
+  SettingsUpdateText(SET_OTAURL, PSTR(OTA_URL));
 
   // Power
   Settings.flag.save_state = SAVE_STATE;
@@ -779,14 +779,14 @@ void SettingsDefaultSet2(void)
   ParseIp(&Settings.ip_address[3], WIFI_DNS);
   Settings.sta_config = WIFI_CONFIG_TOOL;
 //  Settings.sta_active = 0;
-  SettingsUpdateText(SET_STASSID1, STA_SSID1);
-  SettingsUpdateText(SET_STASSID2, STA_SSID2);
-  SettingsUpdateText(SET_STAPWD1, STA_PASS1);
-  SettingsUpdateText(SET_STAPWD2, STA_PASS2);
+  SettingsUpdateText(SET_STASSID1, PSTR(STA_SSID1));
+  SettingsUpdateText(SET_STASSID2, PSTR(STA_SSID2));
+  SettingsUpdateText(SET_STAPWD1, PSTR(STA_PASS1));
+  SettingsUpdateText(SET_STAPWD2, PSTR(STA_PASS2));
   SettingsUpdateText(SET_HOSTNAME, WIFI_HOSTNAME);
 
   // Syslog
-  SettingsUpdateText(SET_SYSLOG_HOST, SYS_LOG_HOST);
+  SettingsUpdateText(SET_SYSLOG_HOST, PSTR(SYS_LOG_HOST));
   Settings.syslog_port = SYS_LOG_PORT;
   Settings.syslog_level = SYS_LOG_LEVEL;
 
@@ -796,8 +796,8 @@ void SettingsDefaultSet2(void)
   Settings.flag3.mdns_enabled = MDNS_ENABLED;
   Settings.webserver = WEB_SERVER;
   Settings.weblog_level = WEB_LOG_LEVEL;
-  SettingsUpdateText(SET_WEBPWD, WEB_PASSWORD);
-  SettingsUpdateText(SET_CORS, CORS_DOMAIN);
+  SettingsUpdateText(SET_WEBPWD, PSTR(WEB_PASSWORD));
+  SettingsUpdateText(SET_CORS, PSTR(CORS_DOMAIN));
 
   // Button
   Settings.flag.button_restrict = KEY_DISABLE_MULTIPRESS;
@@ -841,13 +841,13 @@ void SettingsDefaultSet2(void)
   SettingsUpdateText(SET_STATE_TXT2, MQTT_STATUS_ON);
   SettingsUpdateText(SET_STATE_TXT3, MQTT_CMND_TOGGLE);
   SettingsUpdateText(SET_STATE_TXT4, MQTT_CMND_HOLD);
-  char fingerprint[60];
-  strlcpy(fingerprint, MQTT_FINGERPRINT1, sizeof(fingerprint));
+  char fingerprint[64];
+  strncpy_P(fingerprint, PSTR(MQTT_FINGERPRINT1), sizeof(fingerprint));
   char *p = fingerprint;
   for (uint32_t i = 0; i < 20; i++) {
     Settings.mqtt_fingerprint[0][i] = strtol(p, &p, 16);
   }
-  strlcpy(fingerprint, MQTT_FINGERPRINT2, sizeof(fingerprint));
+  strncpy_P(fingerprint, PSTR(MQTT_FINGERPRINT2), sizeof(fingerprint));
   p = fingerprint;
   for (uint32_t i = 0; i < 20; i++) {
     Settings.mqtt_fingerprint[1][i] = strtol(p, &p, 16);
@@ -1010,9 +1010,9 @@ void SettingsDefaultSet2(void)
     Settings.timezone = APP_TIMEZONE / 60;
     Settings.timezone_minutes = abs(APP_TIMEZONE % 60);
   }
-  SettingsUpdateText(SET_NTPSERVER1, NTP_SERVER1);
-  SettingsUpdateText(SET_NTPSERVER2, NTP_SERVER2);
-  SettingsUpdateText(SET_NTPSERVER3, NTP_SERVER3);
+  SettingsUpdateText(SET_NTPSERVER1, PSTR(NTP_SERVER1));
+  SettingsUpdateText(SET_NTPSERVER2, PSTR(NTP_SERVER2));
+  SettingsUpdateText(SET_NTPSERVER3, PSTR(NTP_SERVER3));
   for (uint32_t i = 0; i < MAX_NTP_SERVERS; i++) {
     SettingsUpdateText(SET_NTPSERVER1 +i, ReplaceCommaWithDot(SettingsText(SET_NTPSERVER1 +i)));
   }

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -659,7 +659,7 @@ void CmndUpgrade(void)
 void CmndOtaUrl(void)
 {
   if (XdrvMailbox.data_len > 0) {
-    SettingsUpdateText(SET_OTAURL, (SC_DEFAULT == Shortcut()) ? OTA_URL : XdrvMailbox.data);
+    SettingsUpdateText(SET_OTAURL, (SC_DEFAULT == Shortcut()) ? PSTR(OTA_URL) : XdrvMailbox.data);
   }
   ResponseCmndChar(SettingsText(SET_OTAURL));
 }
@@ -1394,7 +1394,7 @@ void CmndNtpServer(void)
       uint32_t ntp_server = SET_NTPSERVER1 + XdrvMailbox.index -1;
       if (XdrvMailbox.data_len > 0) {
         SettingsUpdateText(ntp_server,
-          (SC_CLEAR == Shortcut()) ? "" : (SC_DEFAULT == Shortcut()) ? (1 == XdrvMailbox.index) ? NTP_SERVER1 : (2 == XdrvMailbox.index) ? NTP_SERVER2 : NTP_SERVER3 : XdrvMailbox.data);
+          (SC_CLEAR == Shortcut()) ? "" : (SC_DEFAULT == Shortcut()) ? (1 == XdrvMailbox.index) ? PSTR(NTP_SERVER1) : (2 == XdrvMailbox.index) ? PSTR(NTP_SERVER2) : PSTR(NTP_SERVER3) : XdrvMailbox.data);
         SettingsUpdateText(ntp_server, ReplaceCommaWithDot(SettingsText(ntp_server)));
   //        restart_flag = 2;  // Issue #3890
         ntp_force_sync = true;
@@ -1602,7 +1602,7 @@ void CmndReset(void)
   switch (XdrvMailbox.payload) {
   case 1:
     restart_flag = 211;
-    ResponseCmndChar(D_JSON_RESET_AND_RESTARTING);
+    ResponseCmndChar(PSTR(D_JSON_RESET_AND_RESTARTING));
     break;
   case 2 ... 6:
     restart_flag = 210 + XdrvMailbox.payload;
@@ -1614,7 +1614,7 @@ void CmndReset(void)
     ResponseCmndDone();
     break;
   default:
-    ResponseCmndChar(D_JSON_ONE_TO_RESET);
+    ResponseCmndChar(PSTR(D_JSON_ONE_TO_RESET));
   }
 }
 

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1087,7 +1087,7 @@ void HandleRoot(void)
 
           WSContentSend_P(HTTP_MSG_SLIDER_GRADIENT,  // Hue
             "b",             // b - Unique HTML id
-            "#800", "#f00 5%,#ff0 20%,#0f0 35%,#0ff 50%,#00f 65%,#f0f 80%,#f00 95%,#800",  // Hue colors
+            "#800", PSTR("#f00 5%,#ff0 20%,#0f0 35%,#0ff 50%,#00f 65%,#f0f 80%,#f00 95%,#800"),  // Hue colors
             2,               // sl2 - Unique range HTML id - Used as source for Saturation end color
             1, 359,          // Range valid Hue
             hue,

--- a/tasmota/xdrv_06_snfbridge.ino
+++ b/tasmota/xdrv_06_snfbridge.ino
@@ -481,11 +481,11 @@ void CmndRfKey(void)
       SnfBridge.learn_active = 0;
       if (2 == XdrvMailbox.payload) {              // Learn RF data
         SonoffBridgeLearn(XdrvMailbox.index);
-        ResponseCmndIdxChar(D_JSON_START_LEARNING);
+        ResponseCmndIdxChar(PSTR(D_JSON_START_LEARNING));
       }
       else if (3 == XdrvMailbox.payload) {         // Unlearn RF data
         Settings.rf_code[XdrvMailbox.index][0] = 0;  // Reset sync_time MSB
-        ResponseCmndIdxChar(D_JSON_SET_TO_DEFAULT);
+        ResponseCmndIdxChar(PSTR(D_JSON_SET_TO_DEFAULT));
       }
       else if (4 == XdrvMailbox.payload) {         // Save RF data provided by RFSync, RfLow, RfHigh and last RfCode
         for (uint32_t i = 0; i < 6; i++) {
@@ -494,7 +494,7 @@ void CmndRfKey(void)
         Settings.rf_code[XdrvMailbox.index][6] = (SnfBridge.last_send_code >> 16) & 0xff;
         Settings.rf_code[XdrvMailbox.index][7] = (SnfBridge.last_send_code >> 8) & 0xff;
         Settings.rf_code[XdrvMailbox.index][8] = SnfBridge.last_send_code & 0xff;
-        ResponseCmndIdxChar(D_JSON_SAVED);
+        ResponseCmndIdxChar(PSTR(D_JSON_SAVED));
       } else if (5 == XdrvMailbox.payload) {      // Show default or learned RF data
         uint8_t key = XdrvMailbox.index;
         uint8_t index = (0 == Settings.rf_code[key][0]) ? 0 : key;  // Use default if sync_time MSB = 0
@@ -513,10 +513,10 @@ void CmndRfKey(void)
       } else {
         if ((1 == XdrvMailbox.payload) || (0 == Settings.rf_code[XdrvMailbox.index][0])) {  // Test sync_time MSB
           SonoffBridgeSend(0, XdrvMailbox.index);  // Send default RF data
-          ResponseCmndIdxChar(D_JSON_DEFAULT_SENT);
+          ResponseCmndIdxChar(PSTR(D_JSON_DEFAULT_SENT));
         } else {
           SonoffBridgeSend(XdrvMailbox.index, 0);  // Send learned RF data
-          ResponseCmndIdxChar(D_JSON_LEARNED_SENT);
+          ResponseCmndIdxChar(PSTR(D_JSON_LEARNED_SENT));
         }
       }
     } else {

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -259,10 +259,10 @@ bool Xdrv21(uint8_t function)
   if (devices_present && (EMUL_WEMO == Settings.flag2.emulation)) {
     switch (function) {
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/upnp/control/basicevent1", HTTP_POST, HandleUpnpEvent);
-        Webserver->on("/eventservice.xml", HandleUpnpService);
-        Webserver->on("/metainfoservice.xml", HandleUpnpMetaService);
-        Webserver->on("/setup.xml", HandleUpnpSetupWemo);
+        Webserver->on(F("/upnp/control/basicevent1"), HTTP_POST, HandleUpnpEvent);
+        Webserver->on(F("/eventservice.xml"), HandleUpnpService);
+        Webserver->on(F("/metainfoservice.xml"), HandleUpnpMetaService);
+        Webserver->on(F("/setup.xml"), HandleUpnpSetupWemo);
         break;
     }
   }


### PR DESCRIPTION
## Description:

Moving multiple constants into PMEM instead of RAM.
`vsnprintf()` from Arduino now accepts all string parameters in Flash, not only the template.

Saves **420 bytes of RAM**.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.0
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
