### PR TITLE
Don't align PSTR on 4 bytes boundaries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -99,7 +99,8 @@ build_flags               = ${esp_defaults.build_flags}
                             -D NDEBUG
                             -mtarget-align
                             -DFP_IN_IROM
-
+                            ; the following removes the 4-bytes alignment for PSTR(), waiting for a cleaner flag from Arduino Core
+                            -DPSTR\(s\)=\(__extension__\(\{static\ const\ char\ __c\[\]\ __attribute__\(\(__aligned__\(1\)\)\)\ __attribute__\(\(section\(\ \"\\\\\".irom0.pstr.\"\ __FILE__\ \".\"\ __STRINGIZE\(__LINE__\)\ \".\"\ \ __STRINGIZE\(__COUNTER__\)\ \"\\\\\"\,\ \\\\\"aSM\\\\\"\,\ \@progbits\,\ 1\ \#\"\)\)\)\ =\ \(s\)\;\ \&__c\[0\]\;\}\)\)
 
 [irremoteesp_full]
 build_flags               = -DUSE_IR_REMOTE_FULL


### PR DESCRIPTION
## Description:

Arduino Core aligns `PSTR()` Flash strings on 4-bytes boundaries which makes `memmove_P` and `memcpy_P` faster, but wastes Flash space. Standard RAM strings are not 4-bytes aligned.

This compile option redefines `PSTR()` macro to remove the alignement constraints.

Flash size reduction: **1784 bytes** on Tasmota, probably more on bigger builds.

Note: the macro is completely redefined, I will submit a PR to Arduino Core to have a simpler flag.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.0
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
