### PR TITLE
Minor size optimizations

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -87,10 +87,7 @@ void ResponseCmndIdxNumber(int value)
 
 void ResponseCmndChar_P(const char* value)
 {
-  size_t buf_size = strlen_P(value);
-  char buf[buf_size + 1];
-  strcpy_P(buf, value);
-  Response_P(S_JSON_COMMAND_SVALUE, XdrvMailbox.command, buf);
+  Response_P(S_JSON_COMMAND_SVALUE, XdrvMailbox.command, value);
 }
 
 void ResponseCmndChar(const char* value)

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -844,9 +844,7 @@ void WSContentStart_P(const char* title, bool auth)
   WSContentBegin(200, CT_HTML);
 
   if (title != nullptr) {
-    char ctitle[strlen_P(title) +1];
-    strcpy_P(ctitle, title);                       // Get title from flash to RAM
-    WSContentSend_P(HTTP_HEADER1, SettingsText(SET_FRIENDLYNAME1), ctitle);
+    WSContentSend_P(HTTP_HEADER1, SettingsText(SET_FRIENDLYNAME1), title);
   }
 }
 

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -626,10 +626,8 @@ void ZigbeeStateMachine_Run(void) {
       case ZGB_INSTR_MQTT_STATE:
         {
         const char *f_msg = (const char*) cur_ptr1;
-        char buf[strlen_P(f_msg) + 1];
-        strcpy_P(buf, f_msg);
         Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{\"Status\":%d,\"Message\":\"%s\"}}"),
-                          cur_d8, buf);
+                          cur_d8, f_msg);
       	MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEE_STATE));
       	XdrvRulesProcess();
         }


### PR DESCRIPTION
## Description:

Now that `vsnprintf()` supports PROGMEM strings, there are copies in RAM we don't need to do anymore.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.0
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
