### PR TITLE
Scripter tasks

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,10 +17,10 @@ extra_configs = platformio_tasmota_env.ini
                 platformio_override.ini
 
 ; *** Build/upload environment
-default_envs = 
+default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
 ;                tasmota
-;                tasmota-ircustom     
+;                tasmota-ircustom
 ;                tasmota-minimal
 ;                tasmota-lite
 ;                tasmota-knx
@@ -66,8 +66,8 @@ platform_packages         = ${core_active.platform_packages}
 build_flags               = ${core_active.build_flags}
 
 ; *********************************************************************
-; *** Use custom settings from file user_config_override.h 
-                            -DUSE_CONFIG_OVERRIDE
+; *** Use custom settings from file user_config_override.h
+;                            -DUSE_CONFIG_OVERRIDE
 ; *********************************************************************
 
 ; *** Fix espressif8266@1.7.0 induced undesired all warnings


### PR DESCRIPTION
## Description:

ESP32 task initial  support

#define USE_SCRIPT_TASK

res=ct(num timer core)
creates a task num (1 or 2) 
which is executed every timer (ms) time
on core  0 or 1

the sections are named
\>t1 for task 1
\>t2 for task 2

\>D
\>B
; create task 1 every 1000 ms on core 0
ct(1 1000 0)
; create task 2 every 3000 ms on core 1
ct(2 3000 1)

\>t1
print task1 on core %core%

\>t2
print task2 on core %core%


remark:
user_config_overwite in platform.ini default on causes file not found on CI
how to handle this?

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.0
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_