### PR TITLE
Hass Discovery: fix missing trigger for toggle

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -791,7 +791,9 @@ void HAssAnyKey(void)
 
   char stopic[TOPSZ];
 
-  if (state == 3) {
+  if (state == 2) {
+    snprintf_P(trg_state, sizeof(trg_state), PSTR("SINGLE"));
+  } else if (state == 3) {
     snprintf_P(trg_state, sizeof(trg_state), GetStateText(3));
   } else {
     GetTextIndexed(trg_state, sizeof(trg_state), state -9, kHAssTriggerStringButtons);


### PR DESCRIPTION
## Description:
Fix missing trigger for `state = 2` when `SetOption73` is disabled.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.0
  - [X] The code change is tested and works on core ESP32 V.1.12.0
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
