### PR TITLE
Move standard ESP8266 core build_flags...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -99,6 +99,16 @@ build_flags               = ${esp_defaults.build_flags}
                             -D NDEBUG
                             -mtarget-align
                             -DFP_IN_IROM
+                            -DBEARSSL_SSL_BASIC
+                            ; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
+                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
+                            ; lwIP 2 - Higher Bandwidth no Features
+                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+                            ; VTABLES in Flash
+                            -DVTABLES_IN_FLASH
+                            ; No exception code in firmware
+                            -fno-exceptions
+                            -lstdc++                            
                             ; the following removes the 4-bytes alignment for PSTR(), waiting for a cleaner flag from Arduino Core
                             -DPSTR\(s\)=\(__extension__\(\{static\ const\ char\ __c\[\]\ __attribute__\(\(__aligned__\(1\)\)\)\ __attribute__\(\(section\(\ \"\\\\\".irom0.pstr.\"\ __FILE__\ \".\"\ __STRINGIZE\(__LINE__\)\ \".\"\ \ __STRINGIZE\(__COUNTER__\)\ \"\\\\\"\,\ \\\\\"aSM\\\\\"\,\ \@progbits\,\ 1\ \#\"\)\)\)\ =\ \(s\)\;\ \&__c\[0\]\;\}\)\)
 
@@ -117,13 +127,3 @@ build_flags               = ${tasmota_core.build_flags}
 platform                  = espressif8266@2.5.1
 platform_packages         = 
 build_flags               = ${esp82xx_defaults.build_flags}
-                            -DBEARSSL_SSL_BASIC
-; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
-                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_190703
-; lwIP 2 - Higher Bandwidth no Features
-                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-; VTABLES in Flash
-                            -DVTABLES_IN_FLASH
-; No exception code in firmware
-                            -fno-exceptions
-                            -lstdc++


### PR DESCRIPTION
to section `[esp82xx_defaults]`;  where it should be.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
