### PR TITLE
Lower minimum PWMFrequency to 40Hz

### DIFF
--- a/tasmota/core_esp8266_wiring_pwm.cpp
+++ b/tasmota/core_esp8266_wiring_pwm.cpp
@@ -45,8 +45,8 @@ extern void __analogWriteRange(uint32_t range) {
 
 
 extern void __analogWriteFreq(uint32_t freq) {
-  if (freq < 100) {
-    analogFreq = 100;
+  if (freq < 40) {              // Arduino sets a minimum of 100Hz, waiting for them to change this one.
+    analogFreq = 40;
   } else if (freq > 60000) {
     analogFreq = 60000;
   } else {

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -106,7 +106,7 @@ const uint32_t PWM_RANGE = 1023;            // 255..1023 needs to be devisible b
 //const uint16_t PWM_FREQ = 910;              // 100..1000 Hz led refresh (iTead value)
 const uint16_t PWM_FREQ = 223;              // 100..4000 Hz led refresh
 const uint16_t PWM_MAX = 4000;              // [PWM_MAX] Maximum frequency - Default: 4000
-const uint16_t PWM_MIN = 100;               // [PWM_MIN] Minimum frequency - Default: 100
+const uint16_t PWM_MIN = 40;                // [PWM_MIN] Minimum frequency - Default: 40
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
                                             //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
 


### PR DESCRIPTION
## Description:

Allow to lower PWMFrequency to 40Hz instead of 100Hz. Don't use low frequencies for LEDs, it will blink like hell.

**Related issue (if applicable):** fixes #8388

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
