### PR TITLE
Fix BatteryPercentage calculation

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -703,7 +703,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { Zuint16,  Cx0001, 0x0000,  Z(MainsVoltage),         &Z_Copy },
   { Zuint8,   Cx0001, 0x0001,  Z(MainsFrequency),       &Z_Copy },
   { Zuint8,   Cx0001, 0x0020,  Z(BatteryVoltage),       &Z_FloatDiv10 },
-  { Zuint8,   Cx0001, 0x0021,  Z(BatteryPercentage),    &Z_Copy },
+  { Zuint8,   Cx0001, 0x0021,  Z(BatteryPercentage),    &Z_FloatDiv2 },
 
   // Device Temperature Configuration cluster
   { Zint16,   Cx0002, 0x0000,  Z(CurrentTemperature),   &Z_Copy },


### PR DESCRIPTION
## Description:

The ZigBee attribute `"BatteryPercentage"` should be divided by 2 to get the actual percentage.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
