### PR TITLE
Add rule length, truncates rules too long and add escape JSON

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1863,3 +1863,62 @@ void AddLogBufferSize(uint32_t loglevel, uint8_t *buffer, uint32_t count, uint32
   }
   AddLog(loglevel);
 }
+
+/*********************************************************************************************\
+ * JSON parsing
+\*********************************************************************************************/
+
+// does the character needs to be escaped, and if so with which character
+char escapeJSONChar(char c) {
+  if ((c == '\"') || (c == '\\')) {
+    return c;
+  }
+  if (c == '\n') { return 'n'; }
+  if (c == '\t') { return 't'; }
+  if (c == '\r') { return 'r'; }
+  if (c == '\f') { return 'f'; }
+  if (c == '\b') { return 'b'; }
+  return 0;
+}
+
+String escapeJSONString(const char *str) {
+  String r("");
+  if (nullptr == str) { return r; }
+
+  bool needs_escape = false;
+  size_t len_out = 1;
+  const char * c = str;
+
+  while (*c) {
+    if (escapeJSONChar(*c)) {
+      len_out++;
+      needs_escape = true;
+    }
+    c++;
+    len_out++;
+  }
+
+  if (needs_escape) {
+    // we need to escape some chars
+    // allocate target buffer
+    r.reserve(len_out);
+    c = str;
+    char *d = r.begin();
+    while (*c) {
+      char c2 = escapeJSONChar(*c);
+      if (c2) {
+        c++;
+        *d++ = '\\';
+        *d++ = c2;
+      } else {
+        *d++ = *c++;
+      }
+    }
+    *d = 0;   // add NULL terminator
+    r = (char*) r.begin();      // assign the buffer to the string
+  } else {
+    r = str;
+  }
+
+  return r;
+}

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -1992,12 +1992,21 @@ void CmndRule(void)
       }
       Rules.triggers[index -1] = 0;  // Reset once flag
     }
+    String rule = GetRule(index - 1);
+    size_t rule_len = rule.length();
+    if (rule_len >= MAX_RULE_SIZE) {
+      // we need to split the rule in chunks
+      rule = rule.substring(0, MAX_RULE_SIZE);
+      rule += F("...");
+    }
     // snprintf_P (mqtt_data, sizeof(mqtt_data), PSTR("{\"%s%d\":\"%s\",\"Once\":\"%s\",\"StopOnError\":\"%s\",\"Free\":%d,\"Rules\":\"%s\"}"),
     //   XdrvMailbox.command, index, GetStateText(bitRead(Settings.rule_enabled, index -1)), GetStateText(bitRead(Settings.rule_once, index -1)),
     //   GetStateText(bitRead(Settings.rule_stop, index -1)), sizeof(Settings.rules[index -1]) - strlen(Settings.rules[index -1]) -1, Settings.rules[index -1]);
-    snprintf_P (mqtt_data, sizeof(mqtt_data), PSTR("{\"%s%d\":\"%s\",\"Once\":\"%s\",\"StopOnError\":\"%s\",\"Free\":%d,\"Rules\":\"%s\"}"),
+    snprintf_P (mqtt_data, sizeof(mqtt_data), PSTR("{\"%s%d\":\"%s\",\"Once\":\"%s\",\"StopOnError\":\"%s\",\"Length\":%d,\"Free\":%d,\"Rules\":\"%s\"}"),
       XdrvMailbox.command, index, GetStateText(bitRead(Settings.rule_enabled, index -1)), GetStateText(bitRead(Settings.rule_once, index -1)),
-      GetStateText(bitRead(Settings.rule_stop, index -1)), sizeof(Settings.rules[0]) - GetRuleLenStorage(index - 1), GetRule(index - 1).c_str());
+      GetStateText(bitRead(Settings.rule_stop, index -1)),
+      rule_len, MAX_RULE_SIZE - GetRuleLenStorage(index - 1),
+      escapeJSONString(rule.c_str()).c_str());
   }
 }
 


### PR DESCRIPTION
## Description:

Makes sure JSON response for `Rule<x>` is correct:
- Truncate rule if longer than 512 (currently there is no way to get the rest of the rule through commands)
- Adds `Length` attribute containing the total length of the uncompressed rule
- Correctly escapes JSON characters

The general function `String escapeJSONString(const char *)` is added to correctly escape any string to JSON string.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
