### PR TITLE
Change Philips Hue emulation now exposes modelId and manufacturerId

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Change default PWM Frequency to 977 Hz from 223 Hz
 - Change minimum PWM Frequency from 100 Hz to 40 Hz
 - Change PWM updated to the latest version of Arduino PR #7231
+- Change Philips Hue emulation now exposes modelId and manufacturerId
 
 ### 8.2.0.5 20200425
 

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -144,9 +144,9 @@ const char HUE_LIGHTS_STATUS_JSON1_SUFFIX[] PROGMEM =
 const char HUE_LIGHTS_STATUS_JSON2[] PROGMEM =
   ",\"type\":\"Extended color light\","
   "\"name\":\"%s\","
-  "\"modelid\":\"LCT007\","
-  "\"uniqueid\":\"%s\","
-  "\"swversion\":\"5.50.1.19085\"}";
+  "\"modelid\":\"%s\","
+  "\"manufacturername\":\"%s\","
+  "\"uniqueid\":\"%s\"}";
 const char HUE_GROUP0_STATUS_JSON[] PROGMEM =
   "{\"name\":\"Group 0\","
    "\"lights\":[{l1],"
@@ -358,7 +358,7 @@ bool HueActive(uint8_t device) {
 
 void HueLightStatus2(uint8_t device, String *response)
 {
-  const size_t buf_size = 192;
+  const size_t buf_size = 300;
   char * buf = (char*) malloc(buf_size);
   const size_t max_name_len = 32;
   char fname[max_name_len + 1];
@@ -376,7 +376,11 @@ void HueLightStatus2(uint8_t device, String *response)
     }
     fname[fname_len] = 0x00;
   }
-  snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON2, fname, GetHueDeviceId(device).c_str());
+  snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON2,
+            escapeJSONString(fname).c_str(),
+            escapeJSONString(Settings.user_template_name).c_str(),
+            PSTR("Tasmota"),
+            GetHueDeviceId(device).c_str());
   *response += buf;
   free(buf);
 }

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -127,6 +127,7 @@ public:
   void setFriendlyName(uint16_t shortaddr, const char * str);
   const char * getFriendlyName(uint16_t shortaddr) const;
   const char * getModelId(uint16_t shortaddr) const;
+  const char * getManufacturerId(uint16_t shortaddr) const;
   void setReachable(uint16_t shortaddr, bool reachable);
 
   // get next sequence number for (increment at each all)
@@ -585,6 +586,15 @@ const char * Z_Devices::getModelId(uint16_t shortaddr) const {
   if (found >= 0) {
     const Z_Device & device = devicesAt(found);
     return device.modelId;
+  }
+  return nullptr;
+}
+
+const char * Z_Devices::getManufacturerId(uint16_t shortaddr) const {
+  int32_t found = findShortAddr(shortaddr);
+  if (found >= 0) {
+    const Z_Device & device = devicesAt(found);
+    return device.manufacturerId;
   }
   return nullptr;
 }

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -75,16 +75,21 @@ void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, Stri
 
 void HueLightStatus2Zigbee(uint16_t shortaddr, String *response)
 {
-  const size_t buf_size = 192;
+  const size_t buf_size = 300;
   char * buf = (char*) malloc(buf_size);
 
   const char * friendlyName = zigbee_devices.getFriendlyName(shortaddr);
+  const char * modelId = zigbee_devices.getModelId(shortaddr);
+  const char * manufacturerId = zigbee_devices.getManufacturerId(shortaddr);
   char shortaddrname[8];
   snprintf_P(shortaddrname, sizeof(shortaddrname), PSTR("0x%04X"), shortaddr);
 
   snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON2,
-              (friendlyName) ? friendlyName : shortaddrname,
+              (friendlyName) ? escapeJSONString(friendlyName).c_str() : shortaddrname,
+              (modelId) ? escapeJSONString(modelId).c_str() : PSTR("Unknown"),
+              (manufacturerId) ? escapeJSONString(manufacturerId).c_str() : PSTR("Tasmota"),
               GetHueDeviceId(shortaddr).c_str());
+              
   *response += buf;
   free(buf);
 }


### PR DESCRIPTION
## Description:

Philips Hue emulation now exposes modelId and manufacturerId.

For lights, modelId is the Template name, manufacturerId is "Tasmota".

For Zigbee, it is the modelId and manufacturerId of the device.

**Related issue (if applicable):** fixes https://github.com/ebaauw/homebridge-hue/issues/693

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
