### PR TITLE
Add Zigbee support for router and end-device mode

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Change minimum PWM Frequency from 100 Hz to 40 Hz
 - Change PWM updated to the latest version of Arduino PR #7231
 - Change Philips Hue emulation now exposes modelId and manufacturerId
+- Add Zigbee support for router and end-device mode
 
 ### 8.2.0.5 20200425
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -484,7 +484,7 @@
 
 // Commands xdrv_23_zigbee.ino
 #define D_PRFX_ZB "Zb"
-#define D_ZIGBEE_NOT_STARTED "Zigbee not started (yet)"
+#define D_ZIGBEE_NOT_STARTED "Zigbee not started"
 #define D_CMND_ZIGBEE_PERMITJOIN "PermitJoin"
 #define D_CMND_ZIGBEE_STATUS "Status"
 #define D_CMND_ZIGBEE_RESET "Reset"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -640,10 +640,13 @@
 // -- Zigbee interface ----------------------------
 //#define USE_ZIGBEE                                // Enable serial communication with Zigbee CC2530 flashed with ZNP (+49k code, +3k mem)
   #define USE_ZIGBEE_PANID  0x1A63                // arbitrary PAN ID for Zigbee network, must be unique in the home
+                                                  // if PANID == 0xFFFF, then the device will act as a Zigbee router, the parameters below are ignored
+                                                  // if PANID == 0xFFFE, then the device will act as a Zigbee end-device (non-router), the parameters below are ignored
   #define USE_ZIGBEE_EXTPANID 0xCCCCCCCCCCCCCCCCL // arbitrary extended PAN ID
   #define USE_ZIGBEE_CHANNEL  11                  // Zigbee Channel (11-26)
   #define USE_ZIGBEE_PRECFGKEY_L 0x0F0D0B0907050301L  // note: changing requires to re-pair all devices
   #define USE_ZIGBEE_PRECFGKEY_H 0x0D0C0A0806040200L  // note: changing requires to re-pair all devices
+  
   #define USE_ZIGBEE_COALESCE_ATTR_TIMER 350     // timer to coalesce attribute values (in ms)
 
 // -- Other sensors/drivers -----------------------

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -147,6 +147,18 @@ int32_t Z_ReceiveCheckVersion(int32_t res, class SBuffer &buf) {
   }
 }
 
+// checks the device type (coordinator, router, end-device)
+// If coordinator continue
+// If router goto ZIGBEE_LABEL_START_ROUTER
+// If device goto ZIGBEE_LABEL_START_DEVICE
+int32_t Z_SwitchDeviceType(int32_t res, class SBuffer &buf) {
+  switch (Settings.zb_pan_id) {
+    case 0xFFFF:    return ZIGBEE_LABEL_INIT_ROUTER;
+    case 0xFFFE:    return ZIGBEE_LABEL_INIT_DEVICE;
+    default:        return 0;   // continue
+  }
+}
+
 //
 // Helper function, checks if the incoming buffer matches the 2-bytes prefix, i.e. message type in PMEM
 //
@@ -304,6 +316,25 @@ int32_t Z_DataConfirm(int32_t res, const class SBuffer &buf) {
   }
 
   return -1;
+}
+
+//
+// Handle State Change Indication incoming message
+//
+int32_t Z_ReceiveStateChange(int32_t res, const class SBuffer &buf) {
+  uint8_t           state = buf.get8(2);
+
+  if (ZDO_DEV_NWK_DISC == state) {
+    Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
+                    "\"Status\":%d,\"Message\":\"%s\"}}"),
+                    ZIGBEE_STATUS_SCANNING, PSTR("Scanning Zigbee network")
+                    );
+
+    MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZCL_RECEIVED));
+    XdrvRulesProcess();
+  }
+
+  return res;
 }
 
 //
@@ -641,6 +672,7 @@ typedef struct Z_Dispatcher {
 // Ffilters based on ZNP frames
 ZBM(AREQ_AF_DATA_CONFIRM, Z_AREQ | Z_AF, AF_DATA_CONFIRM)                   // 4480
 ZBM(AREQ_AF_INCOMING_MESSAGE, Z_AREQ | Z_AF, AF_INCOMING_MSG)               // 4481
+// ZBM(AREQ_STATE_CHANGE_IND, Z_AREQ | Z_ZDO, ZDO_STATE_CHANGE_IND)            // 45C0
 ZBM(AREQ_END_DEVICE_ANNCE_IND, Z_AREQ | Z_ZDO, ZDO_END_DEVICE_ANNCE_IND)    // 45C1
 ZBM(AREQ_END_DEVICE_TC_DEV_IND, Z_AREQ | Z_ZDO, ZDO_TC_DEV_IND)             // 45CA
 ZBM(AREQ_PERMITJOIN_OPEN_XX, Z_AREQ | Z_ZDO, ZDO_PERMIT_JOIN_IND )          // 45CB
@@ -655,6 +687,7 @@ ZBM(AREQ_ZDO_MGMT_BIND_RSP, Z_AREQ | Z_ZDO, ZDO_MGMT_BIND_RSP)              // 4
 const Z_Dispatcher Z_DispatchTable[] PROGMEM = {
   { AREQ_AF_DATA_CONFIRM,         &Z_DataConfirm },
   { AREQ_AF_INCOMING_MESSAGE,     &Z_ReceiveAfIncomingMessage },
+  // { AREQ_STATE_CHANGE_IND,        &Z_ReceiveStateChange },
   { AREQ_END_DEVICE_ANNCE_IND,    &Z_ReceiveEndDeviceAnnonce },
   { AREQ_END_DEVICE_TC_DEV_IND,   &Z_ReceiveTCDevInd },
   { AREQ_PERMITJOIN_OPEN_XX,      &Z_ReceivePermitJoinStatus },


### PR DESCRIPTION
## Description:

Add ability to run Z2T in router or end-device mode.

To switch to router mode: `ZbConfig {"PanID":"0xFFFF"} `

To switch to end-device mode: `ZbConfig {"PanID":"0xFFFE"} `

**Related issue (if applicable):** fixes #8399 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
