### PR TITLE
add psram to info page ESP32

### DIFF
--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -98,6 +98,8 @@
 #define D_FILE "Файл"
 #define D_FLOW_RATE "Дебит"
 #define D_FREE_MEMORY "Свободна памет"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Честота"
 #define D_GAS "Газ"
 #define D_GATEWAY "Шлюз"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -98,6 +98,8 @@
 #define D_FILE "Soubor"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Volná paměť"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Kmitočet"
 #define D_GAS "Plyn"
 #define D_GATEWAY "Výchozí brána"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -98,6 +98,8 @@
 #define D_FILE "Datei"
 #define D_FLOW_RATE "Durchflussmenge"
 #define D_FREE_MEMORY "Freier Arbeitsspeicher"
+#define D_PSR_MAX_MEMORY "PS-RAM Speicher"
+#define D_PSR_FREE_MEMORY "PS-RAM freier Speicher"
 #define D_FREQUENCY "Frequenz"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -98,6 +98,8 @@
 #define D_FILE "Αρχείο"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Ελεύθερη μνήμη"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Συχνότητα"
 #define D_GAS "Αέριο"
 #define D_GATEWAY "Πύλη"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -98,6 +98,8 @@
 #define D_FILE "File"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Free Memory"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequency"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -98,6 +98,8 @@
 #define D_FILE "Archivo"
 #define D_FLOW_RATE "Caudal"
 #define D_FREE_MEMORY "Memoria Libre"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frecuencia"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -98,6 +98,8 @@
 #define D_FILE "Fichier"
 #define D_FLOW_RATE "Débit"
 #define D_FREE_MEMORY "Mémoire libre"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Fréquence"
 #define D_GAS "Gaz"
 #define D_GATEWAY "Passerelle"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -98,6 +98,8 @@
 #define D_FILE "קובץ"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "זכרון פנוי"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "תדר"
 #define D_GAS "גז"
 #define D_GATEWAY "שער"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -98,6 +98,8 @@
 #define D_FILE "Fájl"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Szabad memória"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frekvencia"
 #define D_GAS "Gáz"
 #define D_GATEWAY "Átjáró"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -98,6 +98,8 @@
 #define D_FILE "File"
 #define D_FLOW_RATE "Flusso dati"
 #define D_FREE_MEMORY "Memoria Libera"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequenza"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -98,6 +98,8 @@
 #define D_FILE "파일"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "남은 메모리"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequency"
 #define D_GAS "가스"
 #define D_GATEWAY "게이트웨이"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -98,6 +98,8 @@
 #define D_FILE "Bestand"
 #define D_FLOW_RATE "Debiet"
 #define D_FREE_MEMORY "Vrij geheugen"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequentie"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -98,6 +98,8 @@
 #define D_FILE "Plik"
 #define D_FLOW_RATE "Przepływ"
 #define D_FREE_MEMORY "Wolna pamięć"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Częstotliwość"
 #define D_GAS "Gas"
 #define D_GATEWAY "Brama"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -98,6 +98,8 @@
 #define D_FILE "Arquivo"
 #define D_FLOW_RATE "Quociente de vazão"
 #define D_FREE_MEMORY "Memória livre"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequência"
 #define D_GAS "Gás"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -98,6 +98,8 @@
 #define D_FILE "Ficheiro"
 #define D_FLOW_RATE "Taxa de Fluxo"
 #define D_FREE_MEMORY "Memoria Livre"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequência"
 #define D_GAS "Gás"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -98,6 +98,8 @@
 #define D_FILE "Fișier"
 #define D_FLOW_RATE "Debit"
 #define D_FREE_MEMORY "Memorie Liberă"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frecvență"
 #define D_GAS "Gaz"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -98,6 +98,8 @@
 #define D_FILE "Файл"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Свободная память"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequency"
 #define D_GAS "Газ"
 #define D_GATEWAY "Шлюз"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -98,6 +98,8 @@
 #define D_FALSE "Nepravda"
 #define D_FILE "Súbor"
 #define D_FREE_MEMORY "Voľná pamäť"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frekvencia"
 #define D_GAS "Plyn"
 #define D_GATEWAY "Predvolená brána"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -98,6 +98,8 @@
 #define D_FILE "Fil"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Ledigt minne"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frekvens"
 #define D_GAS "Gas"
 #define D_GATEWAY "Gateway"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -98,6 +98,8 @@
 #define D_FILE "Dosya"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "Boş Hafıza"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frekans"
 #define D_GAS "Gas"
 #define D_GATEWAY "Geçit"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -98,6 +98,8 @@
 #define D_FILE "Файл"
 #define D_FLOW_RATE "Потік"
 #define D_FREE_MEMORY "Вільна память"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Частота"
 #define D_GAS "Газ"
 #define D_GATEWAY "Шлюз"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -98,6 +98,8 @@
 #define D_FILE "文件:"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "空闲内存"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "频率"
 #define D_GAS "气体"
 #define D_GATEWAY "网关"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -98,6 +98,8 @@
 #define D_FILE "文件:"
 #define D_FLOW_RATE "Flow rate"
 #define D_FREE_MEMORY "可用記憶體"
+#define D_PSR_MAX_MEMORY "PS-RAM Memory"
+#define D_PSR_FREE_MEMORY "PS-RAM free Memory"
 #define D_FREQUENCY "Frequency"
 #define D_GAS "氣體"
 #define D_GATEWAY "網關"

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2284,6 +2284,12 @@ void HandleInformation(void)
   WSContentSend_P(PSTR("}1" D_PROGRAM_SIZE "}2%dkB"), ESP_getSketchSize() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_PROGRAM_SPACE "}2%dkB"), ESP.getFreeSketchSpace() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_MEMORY "}2%dkB"), freeMem / 1024);
+#ifdef ESP32
+  if (psramFound()) {
+    WSContentSend_P(PSTR("}1" D_PSR_MAX_MEMORY "}2%dkB"), ESP.getPsramSize() / 1024);
+    WSContentSend_P(PSTR("}1" D_PSR_FREE_MEMORY "}2%dkB"), ESP.getFreePsram() / 1024);
+  }
+#endif
   WSContentSend_P(PSTR("</td></tr></table>"));
 
   WSContentSend_P(HTTP_SCRIPT_INFO_END);


### PR DESCRIPTION
## Description:

ADD PSRAM info to info page on ESP32

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
