### PR TITLE
Zigbee optimized state machine and support for better ZCL Step commands

### DIFF
--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -49,13 +49,14 @@ ZF(ResetAlarm) ZF(ResetAllAlarms)
 ZF(HueSat) ZF(Color)
 ZF(ShutterOpen) ZF(ShutterClose) ZF(ShutterStop) ZF(ShutterLift) ZF(ShutterTilt) ZF(Shutter)
 //ZF(Occupancy)
-ZF(DimmerMove) ZF(DimmerStep)
-ZF(HueMove) ZF(HueStep) ZF(SatMove) ZF(SatStep) ZF(ColorMove) ZF(ColorStep)
+ZF(DimmerMove) ZF(DimmerStep) ZF(DimmerStepUp) ZF(DimmerStepDown)
+ZF(HueMove) ZF(HueStep) ZF(HueStepUp) ZF(HueStepDown) ZF(SatMove) ZF(SatStep) ZF(ColorMove) ZF(ColorStep) ZF(ColorTempStep) ZF(ColorTempStepUp) ZF(ColorTempStepDown) 
 ZF(ArrowClick) ZF(ArrowHold) ZF(ArrowRelease) ZF(ZoneStatusChange)
 
-ZF(xxxx00) ZF(xxxx) ZF(01xxxx) ZF(00) ZF(01) ZF() ZF(xxxxyy) ZF(00190200) ZF(01190200) ZF(xxyyyy) ZF(xx)
+ZF(xxxx00) ZF(xxxx) ZF(01xxxx) ZF(03xxxx) ZF(00) ZF(01) ZF() ZF(xxxxyy) ZF(00190200) ZF(01190200) ZF(xxyyyy) ZF(xx)
 ZF(xx000A00) ZF(xx0A00) ZF(xxyy0A00) ZF(xxxxyyyy0A00) ZF(xxxx0A00) ZF(xx0A)
 ZF(xx190A00) ZF(xx19) ZF(xx190A) ZF(xxxxyyyy) ZF(xxxxyyzz) ZF(xxyyzzzz) ZF(xxyyyyzz)
+ZF(00xx0A00) ZF(01xx0A00) ZF(03xx0A00) ZF(01xxxx0A0000000000) ZF(03xxxx0A0000000000) ZF(xxyyyy0A0000000000)
 
 // Cluster specific commands
 // Note: the table is both for sending commands, but also displaying received commands
@@ -103,17 +104,24 @@ const Z_CommandConverter Z_Commands[] PROGMEM = {
   // Decoders only - normally not used to send, and names may be masked by previous definitions
   { Z(Dimmer),         0x0008, 0x00, 0x01,   Z(xx) },
   { Z(DimmerMove),     0x0008, 0x01, 0x01,   Z(xx0A) },
+  { Z(DimmerStepUp),   0x0008, 0x02, 0x01,   Z(00xx0A00) },
+  { Z(DimmerStepDown), 0x0008, 0x02, 0x01,   Z(01xx0A00) },
   { Z(DimmerStep),     0x0008, 0x02, 0x01,   Z(xx190A00) },
   { Z(DimmerMove),     0x0008, 0x05, 0x01,   Z(xx0A) },
   { Z(DimmerUp),       0x0008, 0x06, 0x01,   Z(00) },
   { Z(DimmerDown),     0x0008, 0x06, 0x01,   Z(01) },
   { Z(DimmerStop),     0x0008, 0x07, 0x01,   Z() },
   { Z(HueMove),        0x0300, 0x01, 0x01,   Z(xx19) },
+  { Z(HueStepUp),      0x0300, 0x02, 0x01,   Z(01xx0A00) },
+  { Z(HueStepDown),    0x0300, 0x02, 0x01,   Z(03xx0A00) },
   { Z(HueStep),        0x0300, 0x02, 0x01,   Z(xx190A00) },
   { Z(SatMove),        0x0300, 0x04, 0x01,   Z(xx19) },
   { Z(SatStep),        0x0300, 0x05, 0x01,   Z(xx190A) },
   { Z(ColorMove),      0x0300, 0x08, 0x01,   Z(xxxxyyyy) },
   { Z(ColorStep),      0x0300, 0x09, 0x01,   Z(xxxxyyyy0A00) },
+  { Z(ColorTempStepUp),  0x0300, 0x4C, 0x01,   Z(01xxxx0A0000000000) },     //xxxx = step
+  { Z(ColorTempStepDown),0x0300, 0x4C, 0x01,   Z(03xxxx0A0000000000) },     //xxxx = step
+  { Z(ColorTempStep),  0x0300, 0x4C, 0x01,   Z(xxyyyy0A0000000000) },     //xx = 0x01 up, 0x03 down, yyyy = step
   // Tradfri
   { Z(ArrowClick),     0x0005, 0x07, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right
   { Z(ArrowHold),      0x0005, 0x08, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right


### PR DESCRIPTION
## Description:

Optimized Zigbee state machine for Routers and End Devices.

Better support for `DimmerStep`, `ColorStep` and `ColorTempStep`.

Potentially breaking change, now reports `"DimmerStepDown":43` for IKEA Remote instead of `"DimmerStep":1`, which gives more information about the size of the step.

**Related issue (if applicable):** fixes #8419

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
