### PR TITLE
Virtual one-button Zigbee switch support for switchmodes 11 and 12

### DIFF
--- a/tasmota/support_switch.ino
+++ b/tasmota/support_switch.ino
@@ -154,6 +154,12 @@ void SwitchHandler(uint8_t mode)
 
       if (Switch.hold_timer[i]) {
         Switch.hold_timer[i]--;
+        if(Switch.hold_timer[i] == loops_per_second * Settings.param[P_HOLD_TIME] / 25) {
+          if((Settings.switchmode[i]==PUSHHOLDMULTI)&(NOT_PRESSED == Switch.last_state[i]))
+            SendKey(KEY_SWITCH, i +1, POWER_INCREMENT);  // Execute command via MQTT
+          if((Settings.switchmode[i]==PUSHHOLDMULTI_INV)&(PRESSED == Switch.last_state[i]))
+            SendKey(KEY_SWITCH, i +1, POWER_INCREMENT);  // Execute command via MQTT
+        }
         if (0 == Switch.hold_timer[i]) {
 
           switch (Settings.switchmode[i]) {
@@ -270,6 +276,9 @@ void SwitchHandler(uint8_t mode)
             if (Switch.hold_timer[i] > loops_per_second * Settings.param[P_HOLD_TIME] / 25) {
               switchflag = POWER_TOGGLE;   // Toggle with pushbutton
             }
+            else {
+                SendKey(KEY_SWITCH, i +1, POWER_RELEASE);  // Execute command via MQTT  
+            } 
             Switch.hold_timer[i] = loops_per_second * Settings.param[P_HOLD_TIME] / 10;
           }
           break;
@@ -285,7 +294,10 @@ void SwitchHandler(uint8_t mode)
           if (NOT_PRESSED == button) {
             if (Switch.hold_timer[i] > loops_per_second * Settings.param[P_HOLD_TIME] / 25) {
               switchflag = POWER_TOGGLE;   // Toggle with pushbutton
-            }
+            }            
+            else {
+                SendKey(KEY_SWITCH, i +1, POWER_RELEASE);  // Execute command via MQTT  
+            } 
             Switch.hold_timer[i] = loops_per_second * Settings.param[P_HOLD_TIME] / 10;
           }
           break;

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -232,7 +232,7 @@ enum TopicOptions { CMND, STAT, TELE, nu1, RESULT_OR_CMND, RESULT_OR_STAT, RESUL
 enum ExecuteCommandPowerOptions { POWER_OFF, POWER_ON, POWER_TOGGLE, POWER_BLINK, POWER_BLINK_STOP,
                                   POWER_OFF_NO_STATE = 8, POWER_ON_NO_STATE, POWER_TOGGLE_NO_STATE,
                                   POWER_SHOW_STATE = 16 };
-enum SendKeyPowerOptions { POWER_HOLD = 3, POWER_INCREMENT = 4, POWER_INV = 5, POWER_CLEAR = 6, CLEAR_RETAIN = 9 };
+enum SendKeyPowerOptions { POWER_HOLD = 3, POWER_INCREMENT = 4, POWER_INV = 5, POWER_CLEAR = 6, POWER_RELEASE = 7, CLEAR_RETAIN = 9 };
 enum SendKeyOptions { KEY_BUTTON, KEY_SWITCH };
 enum SendKeyMultiClick { SINGLE = 10, DOUBLE = 11, TRIPLE = 12, QUAD = 13, PENTA = 14};
 


### PR DESCRIPTION
## Description:
with small changes switchmode 11 and switchmode 12 supports Zigbee switches.
Requested on https://github.com/arendst/Tasmota/issues/8386
When the button is released the tasmota device will immediatly send a POWER_RELEASE=7 state

For discussion: The device could instead of a 7 send a 0

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
