### PR TITLE
Add SetOption59 capability to MCP230XX

### DIFF
--- a/tasmota/xsns_29_mcp230xx.ino
+++ b/tasmota/xsns_29_mcp230xx.ino
@@ -306,6 +306,9 @@ void MCP230xx_CheckForInterrupt(void) {
                     ResponseTime_P(PSTR(",\"MCP230XX_INT\":{\"D%i\":%i,\"MS\":%lu}}"),
                       intp+(mcp230xx_port*8), ((mcp230xx_intcap >> intp) & 0x01),millis_since_last_int);
                     MqttPublishPrefixTopic_P(RESULT_OR_STAT, PSTR("MCP230XX_INT"));
+                    if (Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/SENSOR in addition to stat/%topic%/RESULT
+                        MqttPublishSensor();
+                    }
                   }
                   if (int_event) {
                     char command[19]; // Theoretical max = 'event MCPINT_D16=1' so 18 + 1 (for the \n)


### PR DESCRIPTION
## Description:

Adds SetOption59 capability to MCP230XX driver.
The original purpose of SetOption59 is justifiable not only with usual switches and relays, but also with expanders like MCP230XX

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
