### PR TITLE
Fix: KNX empty UDP packets sent to the network

### DIFF
--- a/lib/esp-knx-ip-0.5.2/esp-knx-ip.cpp
+++ b/lib/esp-knx-ip-0.5.2/esp-knx-ip.cpp
@@ -536,7 +536,6 @@ void ESPKNXIP::__loop_knx()
 
   uint8_t buf[read];
   udp.read(buf, read);
-  udp.flush();
 
   DEBUG_PRINT(F("Got packet:"));
 


### PR DESCRIPTION
## Description:

The flush() call after read() causes empty packets being sent as response
for all UDP packets received on the KNX UDP port. In my tests with sonoff devices, the zero length packets mentioned in #8332 vanished after removing that flush() call.

Since I do not have any ESP32 device, it would be nice if someone else could test PR.

**Related issue (if applicable):** fixes #8332

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
