### PR TITLE
Allow DS18x20 sensor in lite version

### DIFF
--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -459,7 +459,7 @@
 
 #undef USE_COUNTER                               // Disable counters
 #define USE_ADC_VCC                              // Display Vcc in Power status. Disable for use as Analog input on selected devices
-#undef USE_DS18x20                               // Disable DS18x20 sensor
+//#undef USE_DS18x20                               // Disable DS18x20 sensor
 #undef USE_I2C                                   // Disable all I2C sensors and devices
 #undef USE_SPI                                   // Disable all SPI devices
 #undef USE_DISPLAY                               // Disable Display support


### PR DESCRIPTION
## Description:

Allow DS18x20 sensor in lite version. It's so small. On many devices it's enough to use the lite version, with DS18x20 enabled it's more universal.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
