### PR TITLE
Enable user_config_override.h for ESP32 by default

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -188,7 +188,7 @@ build_flags             = ${esp_defaults.build_flags}
     -D sint16_t=int16_t
     -D memcpy_P=memcpy
 	  -D memcmp_P=memcmp
-;    -D USE_CONFIG_OVERRIDE
+    -D USE_CONFIG_OVERRIDE
 
 lib_extra_dirs =
     libesp32


### PR DESCRIPTION
since we have always a user_config_override.h generated with override_copy.py if there is none.
So the behaviour for the ESP32 is the same as for the ESP82xx

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
