### PR TITLE
Invert PCM CT for legacy Philips Xiami bulb

### DIFF
--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -1739,7 +1739,7 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
     0,                // GPIO09 (SD_DATA2 Flash QIO or ESP8285)
     0,                // GPIO10 (SD_DATA3 Flash QIO or ESP8285)
                       // GPIO11 (SD_CMD   Flash)
-    GPIO_PWM2,        // GPIO12 cold/warm light
+    GPIO_PWM2_INV,    // GPIO12i cold/warm light
     0, 0,
     GPIO_PWM1,        // GPIO15 light intensity
     0, 0


### PR DESCRIPTION
## Description:

The PWM CT way has been inverted in the past (not sure when). I don't want to change it again as many templates depend on it. Updating the legacy Module 48 temlpate.

**Related issue (if applicable):** fixes #8447

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
