### PR TITLE
Fix crash in unishox decompress #8486

### DIFF
--- a/lib/Unishox-1.0-shadinger/src/unishox.cpp
+++ b/lib/Unishox-1.0-shadinger/src/unishox.cpp
@@ -433,8 +433,8 @@ int32_t Unishox::getNumFromBits(uint32_t count) {
 // Code size optimized, recalculate adder[] like in encodeCount
 uint32_t Unishox::readCount(void) {
   int32_t idx = getCodeIdx(us_hcode);
+  if ((1 == idx) || (idx >= sizeof(bit_len)) || (idx < 0)) return 0;  // unsupported or end of stream
   if (idx >= 1) idx--;    // we skip v = 1 (code '0') since we no more accept 2 bits encoding
-  if ((idx >= sizeof(bit_len)) || (idx < 0)) return 0;  // unsupported or end of stream
 
   int base;
   int till = 0;
@@ -470,7 +470,7 @@ int32_t Unishox::unishox_decompress(const char *p_in, size_t p_len, char *p_out,
 
   len <<= 3;    // *8, len in bits
   out[ol] = 0;
-  while (bit_no < len) {
+  while ((byte_no << 3) + bit_no - 8 < len) {
     int32_t h, v;
     char c = 0;
     byte is_upper = is_all_upper;


### PR DESCRIPTION
## Description:

Fix crash of unishox decompress (since Class optimized version).

**Related issue (if applicable):** fixes #8486

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
