### PR TITLE
HAss: Fix slider for PWM_MODULE

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -195,9 +195,14 @@ void HAssAnnounceRelayLight(void)
   bool ct_light = false;                                // Controls a CT Light when SetOption37 is >= 128
   bool wt_light = false;                                // Controls a White Light when SetOption37 is >= 128
   bool err_flag = false;                                // When true it blocks the creation of entities if the order of the Relays is not correct to avoid issue with Lights
+  bool PwmMod = false;                                  // Controls PWM_DIMMER module
 
   uint8_t dimmer = 1;
   uint8_t max_lights = 1;
+
+  #ifdef ESP8266
+        if (PWM_DIMMER == my_module_type) { PwmMod = true; } 
+  #endif //ESP8266
 
   // If there is a special Light to be enabled and managed with SetOption68 or SetOption37 >= 128, Discovery calculates the maximum number of entities to be generated in advance
 
@@ -255,13 +260,8 @@ void HAssAnnounceRelayLight(void)
           TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO_SHORT, unique_id, ESP_getChipId());
 
   #ifdef USE_LIGHT
-        if ((i >= Light.device)
-  #ifdef ESP8266
-          || PWM_DIMMER == my_module_type
-  #endif
-        )
-        {
-          if (!RelayX) {
+        if ((i >= Light.device)) {
+          if (!RelayX || PwmMod) {
             char *brightness_command_topic = stemp1;
             strncpy_P(stemp3, Settings.flag.not_power_linked ? PSTR("last") : PSTR("brightness"), sizeof(stemp3)); // SetOption20 - Control power in relation to Dimmer/Color/Ct changes
             char channel_num[9];


### PR DESCRIPTION
## Description:
Fix missing brightness slider when PWM_MODULE is in use.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
