### PR TITLE
HAss force [is_topic_light] for PWM_Dimmer module

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -218,7 +218,7 @@ void HAssAnnounceRelayLight(void)
   for (uint32_t i = 1; i <= MAX_RELAYS; i++)
   {
     bool RelayX = PinUsed(GPIO_REL1 +i-1);
-    is_topic_light = Settings.flag.hass_light && RelayX || light_type && !RelayX; // SetOption30 - Enforce HAss autodiscovery as light
+    is_topic_light = Settings.flag.hass_light && RelayX || light_type && !RelayX || PwmMod; // SetOption30 - Enforce HAss autodiscovery as light
 
     mqtt_data[0] = '\0'; // Clear retained message
 
@@ -237,7 +237,7 @@ void HAssAnnounceRelayLight(void)
       AddLog_P2(LOG_LEVEL_ERROR, PSTR("%s"), kHAssError2);
     } else {
       if (Settings.flag.hass_discovery && (RelayX || (Light.device > 0) && (max_lights > 0)) && !err_flag )
-      {                    // SetOption19 - Control Home Assistantautomatic discovery (See SetOption59)
+      {                    // SetOption19 - Control Home Assistant automatic discovery (See SetOption59)
           char name[TOPSZ]; // friendlyname(33) + " " + index
           char value_template[33];
           char prefix[TOPSZ];
@@ -260,7 +260,7 @@ void HAssAnnounceRelayLight(void)
           TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO_SHORT, unique_id, ESP_getChipId());
 
   #ifdef USE_LIGHT
-        if ((i >= Light.device)) {
+        if (i >= Light.device) {
           if (!RelayX || PwmMod) {
             char *brightness_command_topic = stemp1;
             strncpy_P(stemp3, Settings.flag.not_power_linked ? PSTR("last") : PSTR("brightness"), sizeof(stemp3)); // SetOption20 - Control power in relation to Dimmer/Color/Ct changes


### PR DESCRIPTION
## Description:
Fix to avoid warning/error logs under latest Home Assistant (>=109.0). 

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
