### PR TITLE
Add wildcard patter for JSON marching in rules using ``?`` pattern

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Change Energy JSON ExportActive field from ``"ExportActive":[33.736,11.717,16.978]`` to ``"ExportActive":33.736,"ExportTariff":[11.717,16.978]``
 - Add Three Phase Export Active Energy to SDM630 driver
 - Add commands ``LedPwmOn 0..255``, ``LedPwmOff 0..255`` and ``LedPwmMode1 0/1`` to control led brightness by George (#8491)
+- Add wildcard patter for JSON marching in rules using ``?`` pattern
 
 ### 8.3.1.1 20200518
 

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1875,65 +1875,6 @@ void AddLogBufferSize(uint32_t loglevel, uint8_t *buffer, uint32_t count, uint32
 }
 
 /*********************************************************************************************\
- * JSON parsing
-\*********************************************************************************************/
-
-// does the character needs to be escaped, and if so with which character
-char escapeJSONChar(char c) {
-  if ((c == '\"') || (c == '\\')) {
-    return c;
-  }
-  if (c == '\n') { return 'n'; }
-  if (c == '\t') { return 't'; }
-  if (c == '\r') { return 'r'; }
-  if (c == '\f') { return 'f'; }
-  if (c == '\b') { return 'b'; }
-  return 0;
-}
-
-String escapeJSONString(const char *str) {
-  String r("");
-  if (nullptr == str) { return r; }
-
-  bool needs_escape = false;
-  size_t len_out = 1;
-  const char * c = str;
-
-  while (*c) {
-    if (escapeJSONChar(*c)) {
-      len_out++;
-      needs_escape = true;
-    }
-    c++;
-    len_out++;
-  }
-
-  if (needs_escape) {
-    // we need to escape some chars
-    // allocate target buffer
-    r.reserve(len_out);
-    c = str;
-    char *d = r.begin();
-    while (*c) {
-      char c2 = escapeJSONChar(*c);
-      if (c2) {
-        c++;
-        *d++ = '\\';
-        *d++ = c2;
-      } else {
-        *d++ = *c++;
-      }
-    }
-    *d = 0;   // add NULL terminator
-    r = (char*) r.begin();      // assign the buffer to the string
-  } else {
-    r = str;
-  }
-
-  return r;
-}
-
-/*********************************************************************************************\
  * Uncompress static PROGMEM strings
 \*********************************************************************************************/
 

--- a/tasmota/support_json.ino
+++ b/tasmota/support_json.ino
@@ -1,0 +1,106 @@
+/*
+  support_json.ino - Static binary buffer for Zigbee on Tasmota
+
+  Copyright (C) 2020  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*********************************************************************************************\
+ * JSON parsing
+\*********************************************************************************************/
+
+// does the character needs to be escaped, and if so with which character
+char EscapeJSONChar(char c) {
+  if ((c == '\"') || (c == '\\')) {
+    return c;
+  }
+  if (c == '\n') { return 'n'; }
+  if (c == '\t') { return 't'; }
+  if (c == '\r') { return 'r'; }
+  if (c == '\f') { return 'f'; }
+  if (c == '\b') { return 'b'; }
+  return 0;
+}
+
+String EscapeJSONString(const char *str) {
+  String r("");
+  if (nullptr == str) { return r; }
+
+  bool needs_escape = false;
+  size_t len_out = 1;
+  const char * c = str;
+
+  while (*c) {
+    if (EscapeJSONChar(*c)) {
+      len_out++;
+      needs_escape = true;
+    }
+    c++;
+    len_out++;
+  }
+
+  if (needs_escape) {
+    // we need to escape some chars
+    // allocate target buffer
+    r.reserve(len_out);
+    c = str;
+    char *d = r.begin();
+    while (*c) {
+      char c2 = EscapeJSONChar(*c);
+      if (c2) {
+        c++;
+        *d++ = '\\';
+        *d++ = c2;
+      } else {
+        *d++ = *c++;
+      }
+    }
+    *d = 0;   // add NULL terminator
+    r = (char*) r.begin();      // assign the buffer to the string
+  } else {
+    r = str;
+  }
+
+  return r;
+}
+
+/*********************************************************************************************\
+ * Find key - case insensitive
+\*********************************************************************************************/
+
+// Given a JsonObject, finds the value as JsonVariant for the key needle.
+// The search is case-insensitive, and will find the first match in the order of keys in JSON
+//
+// If the key is not found, returns a nullptr
+// Input: needle cannot be NULL but may be PROGMEM
+const JsonVariant &GetCaseInsensitive(const JsonObject &json, const char *needle) {
+  // key can be in PROGMEM
+  // if needle == "?" then we return the first valid key
+  bool wildcard = strcmp_P("?", needle) == 0;
+  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
+    return *(JsonVariant*)nullptr;
+  }
+
+  for (JsonObject::const_iterator it=json.begin(); it!=json.end(); ++it) {
+    const char *key = it->key;
+    const JsonVariant &value = it->value;
+
+    if (wildcard || (0 == strcasecmp_P(key, needle))) {
+      return value;
+    }
+  }
+  // if not found
+  return *(JsonVariant*)nullptr;
+}

--- a/tasmota/support_json.ino
+++ b/tasmota/support_json.ino
@@ -1,5 +1,5 @@
 /*
-  support_json.ino - Static binary buffer for Zigbee on Tasmota
+  support_json.ino - JSON support functions
 
   Copyright (C) 2020  Theo Arends and Stephan Hadinger
 

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -437,8 +437,8 @@ void HueLightStatus2(uint8_t device, String *response)
     fname[fname_len] = 0x00;
   }
   snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON2,
-            escapeJSONString(fname).c_str(),
-            escapeJSONString(Settings.user_template_name).c_str(),
+            EscapeJSONString(fname).c_str(),
+            EscapeJSONString(Settings.user_template_name).c_str(),
             PSTR("Tasmota"),
             GetHueDeviceId(device).c_str());
   *response += buf;

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -23,29 +23,9 @@
 
 void ZigbeeZCLSend_Raw(uint16_t dtsAddr, uint16_t groupaddr, uint16_t clusterId, uint8_t endpoint, uint8_t cmdId, bool clusterSpecific, const uint8_t *msg, size_t len, bool needResponse, uint8_t transacId);
 
-
-// Get an JSON attribute, with case insensitive key search
-const JsonVariant &getCaseInsensitive(const JsonObject &json, const char *needle) {
-  // key can be in PROGMEM
-  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
-    return *(JsonVariant*)nullptr;
-  }
-
-  for (JsonObject::const_iterator it=json.begin(); it!=json.end(); ++it) {
-    const char *key = it->key;
-    const JsonVariant &value = it->value;
-
-    if (0 == strcasecmp_P(key, needle)) {
-      return value;
-    }
-  }
-  // if not found
-  return *(JsonVariant*)nullptr;
-}
-
 // get the result as a string (const char*) and nullptr if there is no field or the string is empty
 const char * getCaseInsensitiveConstCharNull(const JsonObject &json, const char *needle) {
-  const JsonVariant &val = getCaseInsensitive(json, needle);
+  const JsonVariant &val = GetCaseInsensitive(json, needle);
   if (&val) {
     const char *val_cs = val.as<const char*>();
     if (strlen(val_cs)) {

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -1075,7 +1075,7 @@ int32_t Z_Devices::deviceRestore(const JsonObject &json) {
   size_t   endpoints_len = 0;
 
   // read mandatory "Device"
-  const JsonVariant &val_device = getCaseInsensitive(json, PSTR("Device"));
+  const JsonVariant &val_device = GetCaseInsensitive(json, PSTR("Device"));
   if (nullptr != &val_device) {
     device = strToUInt(val_device);
   } else {
@@ -1083,7 +1083,7 @@ int32_t Z_Devices::deviceRestore(const JsonObject &json) {
   }
 
   // read "IEEEAddr" 64 bits in format "0x0000000000000000"
-  const JsonVariant &val_ieeeaddr = getCaseInsensitive(json, PSTR("IEEEAddr"));
+  const JsonVariant &val_ieeeaddr = GetCaseInsensitive(json, PSTR("IEEEAddr"));
   if (nullptr != &val_ieeeaddr) {
     ieeeaddr = strtoull(val_ieeeaddr.as<const char*>(), nullptr, 0);
   }
@@ -1098,7 +1098,7 @@ int32_t Z_Devices::deviceRestore(const JsonObject &json) {
   manufid = getCaseInsensitiveConstCharNull(json, PSTR("Manufacturer"));
 
   // read "Light"
-  const JsonVariant &val_bulbtype = getCaseInsensitive(json, PSTR(D_JSON_ZIGBEE_LIGHT));
+  const JsonVariant &val_bulbtype = GetCaseInsensitive(json, PSTR(D_JSON_ZIGBEE_LIGHT));
   if (nullptr != &val_bulbtype) { bulbtype = strToUInt(val_bulbtype);; }
 
   // update internal device information
@@ -1109,7 +1109,7 @@ int32_t Z_Devices::deviceRestore(const JsonObject &json) {
   if (&val_bulbtype) { setHueBulbtype(device, bulbtype); }
 
   // read "Endpoints"
-  const JsonVariant &val_endpoints = getCaseInsensitive(json, PSTR("Endpoints"));
+  const JsonVariant &val_endpoints = GetCaseInsensitive(json, PSTR("Endpoints"));
   if ((nullptr != &val_endpoints) && (val_endpoints.is<JsonArray>())) {
     const JsonArray &arr_ep = val_endpoints.as<const JsonArray&>();
     endpoints_len = arr_ep.size();

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -85,9 +85,9 @@ void HueLightStatus2Zigbee(uint16_t shortaddr, String *response)
   snprintf_P(shortaddrname, sizeof(shortaddrname), PSTR("0x%04X"), shortaddr);
 
   snprintf_P(buf, buf_size, HUE_LIGHTS_STATUS_JSON2,
-              (friendlyName) ? escapeJSONString(friendlyName).c_str() : shortaddrname,
-              (modelId) ? escapeJSONString(modelId).c_str() : PSTR("Unknown"),
-              (manufacturerId) ? escapeJSONString(manufacturerId).c_str() : PSTR("Tasmota"),
+              (friendlyName) ? EscapeJSONString(friendlyName).c_str() : shortaddrname,
+              (modelId) ? EscapeJSONString(modelId).c_str() : PSTR("Unknown"),
+              (manufacturerId) ? EscapeJSONString(manufacturerId).c_str() : PSTR("Tasmota"),
               GetHueDeviceId(shortaddr).c_str());
               
   *response += buf;

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -600,7 +600,7 @@ void Z_SendAFInfoRequest(uint16_t shortaddr) {
 void Z_AqaraOccupancy(uint16_t shortaddr, uint16_t cluster, uint8_t endpoint, const JsonObject &json) {
   static const uint32_t OCCUPANCY_TIMEOUT = 90 * 1000;  // 90 s
   // Read OCCUPANCY value if any
-  const JsonVariant &val_endpoint = getCaseInsensitive(json, PSTR(OCCUPANCY));
+  const JsonVariant &val_endpoint = GetCaseInsensitive(json, PSTR(OCCUPANCY));
   if (nullptr != &val_endpoint) {
     uint32_t occupancy = strToUInt(val_endpoint);
 

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -427,13 +427,13 @@ void CmndZbSend(void) {
   bool     clusterSpecific = true;
 
   // parse JSON
-  const JsonVariant &val_device = getCaseInsensitive(json, PSTR("Device"));
+  const JsonVariant &val_device = GetCaseInsensitive(json, PSTR("Device"));
   if (nullptr != &val_device) {
     device = zigbee_devices.parseDeviceParam(val_device.as<char*>());
     if (BAD_SHORTADDR == device) { ResponseCmndChar_P(PSTR("Invalid parameter")); return; }
   }
   if (BAD_SHORTADDR == device) {     // if not found, check if we have a group
-    const JsonVariant &val_group = getCaseInsensitive(json, PSTR("Group"));
+    const JsonVariant &val_group = GetCaseInsensitive(json, PSTR("Group"));
     if (nullptr != &val_group) {
       groupaddr = strToUInt(val_group);
     } else {                  // no device nor group
@@ -442,11 +442,11 @@ void CmndZbSend(void) {
     }
   }
 
-  const JsonVariant &val_endpoint = getCaseInsensitive(json, PSTR("Endpoint"));
+  const JsonVariant &val_endpoint = GetCaseInsensitive(json, PSTR("Endpoint"));
   if (nullptr != &val_endpoint) { endpoint = strToUInt(val_endpoint); }
-  const JsonVariant &val_manuf = getCaseInsensitive(json, PSTR("Manuf"));
+  const JsonVariant &val_manuf = GetCaseInsensitive(json, PSTR("Manuf"));
   if (nullptr != &val_manuf) { manuf = strToUInt(val_manuf); }
-  const JsonVariant &val_cmd = getCaseInsensitive(json, PSTR("Send"));
+  const JsonVariant &val_cmd = GetCaseInsensitive(json, PSTR("Send"));
   if (nullptr != &val_cmd) {
     // probe the type of the argument
     // If JSON object, it's high level commands
@@ -582,7 +582,7 @@ void ZbBindUnbind(bool unbind) {    // false = bind, true = unbind
 
   // Information about source device: "Device", "Endpoint", "Cluster"
   //  - the source endpoint must have a known IEEE address
-  const JsonVariant &val_device = getCaseInsensitive(json, PSTR("Device"));
+  const JsonVariant &val_device = GetCaseInsensitive(json, PSTR("Device"));
   if (nullptr != &val_device) {
     srcDevice = zigbee_devices.parseDeviceParam(val_device.as<char*>());
   }
@@ -591,17 +591,17 @@ void ZbBindUnbind(bool unbind) {    // false = bind, true = unbind
   uint64_t srcLongAddr = zigbee_devices.getDeviceLongAddr(srcDevice);
   if (0 == srcLongAddr) { ResponseCmndChar_P(PSTR("Unknown source IEEE address")); return; }
   // look for source endpoint
-  const JsonVariant &val_endpoint = getCaseInsensitive(json, PSTR("Endpoint"));
+  const JsonVariant &val_endpoint = GetCaseInsensitive(json, PSTR("Endpoint"));
   if (nullptr != &val_endpoint) { endpoint = strToUInt(val_endpoint); }
   // look for source cluster
-  const JsonVariant &val_cluster = getCaseInsensitive(json, PSTR("Cluster"));
+  const JsonVariant &val_cluster = GetCaseInsensitive(json, PSTR("Cluster"));
   if (nullptr != &val_cluster) { cluster = strToUInt(val_cluster); }
 
   // Either Device address
   // In this case the following parameters are mandatory
   //  - "ToDevice" and the device must have a known IEEE address
   //  - "ToEndpoint"
-  const JsonVariant &dst_device = getCaseInsensitive(json, PSTR("ToDevice"));
+  const JsonVariant &dst_device = GetCaseInsensitive(json, PSTR("ToDevice"));
   if (nullptr != &dst_device) {
     dstDevice = zigbee_devices.parseDeviceParam(dst_device.as<char*>());
     if (BAD_SHORTADDR == dstDevice) { ResponseCmndChar_P(PSTR("Invalid parameter")); return; }
@@ -612,12 +612,12 @@ void ZbBindUnbind(bool unbind) {    // false = bind, true = unbind
     }
     if (0 == dstLongAddr) { ResponseCmndChar_P(PSTR("Unknown dest IEEE address")); return; }
 
-    const JsonVariant &val_toendpoint = getCaseInsensitive(json, PSTR("ToEndpoint"));
+    const JsonVariant &val_toendpoint = GetCaseInsensitive(json, PSTR("ToEndpoint"));
     if (nullptr != &val_toendpoint) { toendpoint = strToUInt(val_endpoint); } else { toendpoint = endpoint; }
   }
 
   // Or Group Address - we don't need a dstEndpoint in this case
-  const JsonVariant &to_group = getCaseInsensitive(json, PSTR("ToGroup"));
+  const JsonVariant &to_group = GetCaseInsensitive(json, PSTR("ToGroup"));
   if (nullptr != &to_group) { toGroup = strToUInt(to_group); }
 
   // make sure we don't have conflicting parameters
@@ -907,13 +907,13 @@ void CmndZbRead(void) {
   size_t   attrs_len = 0;
   uint8_t* attrs = nullptr;       // empty string is valid
 
-  const JsonVariant &val_device = getCaseInsensitive(json, PSTR("Device"));
+  const JsonVariant &val_device = GetCaseInsensitive(json, PSTR("Device"));
   if (nullptr != &val_device) {
     device = zigbee_devices.parseDeviceParam(val_device.as<char*>());
     if (BAD_SHORTADDR == device) { ResponseCmndChar_P(PSTR("Invalid parameter")); return; }
   }
   if (BAD_SHORTADDR == device) {     // if not found, check if we have a group
-    const JsonVariant &val_group = getCaseInsensitive(json, PSTR("Group"));
+    const JsonVariant &val_group = GetCaseInsensitive(json, PSTR("Group"));
     if (nullptr != &val_group) {
       groupaddr = strToUInt(val_group);
     } else {                  // no device nor group
@@ -922,14 +922,14 @@ void CmndZbRead(void) {
     }
   }
 
-  const JsonVariant &val_cluster = getCaseInsensitive(json, PSTR("Cluster"));
+  const JsonVariant &val_cluster = GetCaseInsensitive(json, PSTR("Cluster"));
   if (nullptr != &val_cluster) { cluster = strToUInt(val_cluster); }
-  const JsonVariant &val_endpoint = getCaseInsensitive(json, PSTR("Endpoint"));
+  const JsonVariant &val_endpoint = GetCaseInsensitive(json, PSTR("Endpoint"));
   if (nullptr != &val_endpoint) { endpoint = strToUInt(val_endpoint); }
-  const JsonVariant &val_manuf = getCaseInsensitive(json, PSTR("Manuf"));
+  const JsonVariant &val_manuf = GetCaseInsensitive(json, PSTR("Manuf"));
   if (nullptr != &val_manuf) { manuf = strToUInt(val_manuf); }
 
-  const JsonVariant &val_attr = getCaseInsensitive(json, PSTR("Read"));
+  const JsonVariant &val_attr = GetCaseInsensitive(json, PSTR("Read"));
   if (nullptr != &val_attr) {
     uint16_t val = strToUInt(val_attr);
     if (val_attr.is<JsonArray>()) {
@@ -1034,21 +1034,21 @@ void CmndZbConfig(void) {
     if (!json.success()) { ResponseCmndChar_P(PSTR(D_JSON_INVALID_JSON)); return; }
 
     // Channel
-    const JsonVariant &val_channel = getCaseInsensitive(json, PSTR("Channel"));
+    const JsonVariant &val_channel = GetCaseInsensitive(json, PSTR("Channel"));
     if (nullptr != &val_channel) { zb_channel = strToUInt(val_channel); }
     if (zb_channel < 11) { zb_channel = 11; }
     if (zb_channel > 26) { zb_channel = 26; }
     // PanID
-    const JsonVariant &val_pan_id = getCaseInsensitive(json, PSTR("PanID"));
+    const JsonVariant &val_pan_id = GetCaseInsensitive(json, PSTR("PanID"));
     if (nullptr != &val_pan_id) { zb_pan_id = strToUInt(val_pan_id); }
     // ExtPanID
-    const JsonVariant &val_ext_pan_id = getCaseInsensitive(json, PSTR("ExtPanID"));
+    const JsonVariant &val_ext_pan_id = GetCaseInsensitive(json, PSTR("ExtPanID"));
     if (nullptr != &val_ext_pan_id) { zb_ext_panid = strtoull(val_ext_pan_id.as<const char*>(), nullptr, 0); }
     // KeyL
-    const JsonVariant &val_key_l = getCaseInsensitive(json, PSTR("KeyL"));
+    const JsonVariant &val_key_l = GetCaseInsensitive(json, PSTR("KeyL"));
     if (nullptr != &val_key_l) { zb_precfgkey_l = strtoull(val_key_l.as<const char*>(), nullptr, 0); }
     // KeyH
-    const JsonVariant &val_key_h = getCaseInsensitive(json, PSTR("KeyH"));
+    const JsonVariant &val_key_h = GetCaseInsensitive(json, PSTR("KeyH"));
     if (nullptr != &val_key_h) { zb_precfgkey_h = strtoull(val_key_h.as<const char*>(), nullptr, 0); }
 
     // Check if a parameter was changed after all


### PR DESCRIPTION
## Description:

Added `?` JSON pattern to Rules. You can now use patterns like `on zbreceived#?#Device do VAR1 %value% endon` to skip a level. Note: pattern will match the first key of the sub-level, use it preferably when there is only 1 sub-key.

Theo, I also added `support_json.ino` to put in one place the JSON support functions.

I also did a small code size optimization to keep Flash size constant.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
