### PR TITLE
Encode json string from serial to mqtt

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1349,7 +1349,11 @@ void SerialInput(void)
     bool assume_json = (!Settings.flag.mqtt_serial_raw && (serial_in_buffer[0] == '{'));
     Response_P(PSTR("{\"" D_JSON_SERIALRECEIVED "\":%s%s%s}"),
       (assume_json) ? "" : "\"",
-      (Settings.flag.mqtt_serial_raw) ? ToHex_P((unsigned char*)serial_in_buffer, serial_in_byte_counter, hex_char, sizeof(hex_char)) : serial_in_buffer,
+      (Settings.flag.mqtt_serial_raw) 
+        ? ToHex_P((unsigned char*)serial_in_buffer, serial_in_byte_counter, hex_char, sizeof(hex_char)) 
+        : (assume_json) 
+            ? serial_in_buffer 
+            : EscapeJSONString(serial_in_buffer).c_str(),
       (assume_json) ? "" : "\"");
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_SERIALRECEIVED));
     XdrvRulesProcess();

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -124,12 +124,12 @@ const uint16_t SYSLOG_TIMER = 600;          // Seconds to restore syslog_level
 const uint16_t SERIALLOG_TIMER = 600;       // Seconds to disable SerialLog
 const uint8_t OTA_ATTEMPTS = 5;             // Number of times to try fetching the new firmware
 
-const uint16_t INPUT_BUFFER_SIZE = 520;     // Max number of characters in serial command buffer
+const uint16_t INPUT_BUFFER_SIZE = 510;     // Max number of characters in serial command buffer: floor((MIN_MESSZ - len({"SerialReceived":""})) / 2) + 1
 const uint16_t FLOATSZ = 16;                // Max number of characters in float result from dtostrfd (max 32)
 const uint16_t CMDSZ = 24;                  // Max number of characters in command
 const uint16_t TOPSZ = 151;                 // Max number of characters in topic string
 const uint16_t LOGSZ = 700;                 // Max number of characters in log
-const uint16_t MIN_MESSZ = 1040;            // Min number of characters in MQTT message (1000 - TOPSZ - 9 header bytes)
+const uint16_t MIN_MESSZ = 1040;            // Min number of characters in MQTT message (1200 - TOPSZ - 9 header bytes)
 
 const uint8_t SENSOR_MAX_MISS = 5;          // Max number of missed sensor reads before deciding it's offline
 

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -124,7 +124,7 @@ const uint16_t SYSLOG_TIMER = 600;          // Seconds to restore syslog_level
 const uint16_t SERIALLOG_TIMER = 600;       // Seconds to disable SerialLog
 const uint8_t OTA_ATTEMPTS = 5;             // Number of times to try fetching the new firmware
 
-const uint16_t INPUT_BUFFER_SIZE = 510;     // Max number of characters in serial command buffer: floor((MIN_MESSZ - len({"SerialReceived":""})) / 2) + 1
+const uint16_t INPUT_BUFFER_SIZE = 520;     // Max number of characters in serial command buffer
 const uint16_t FLOATSZ = 16;                // Max number of characters in float result from dtostrfd (max 32)
 const uint16_t CMDSZ = 24;                  // Max number of characters in command
 const uint16_t TOPSZ = 151;                 // Max number of characters in topic string

--- a/tasmota/xdrv_08_serial_bridge.ino
+++ b/tasmota/xdrv_08_serial_bridge.ino
@@ -80,7 +80,11 @@ void SerialBridgeInput(void)
     bool assume_json = (!serial_bridge_raw && (serial_bridge_buffer[0] == '{'));
     Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":%s%s%s}"),
       (assume_json) ? "" : "\"",
-      (serial_bridge_raw) ? ToHex_P((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)) : serial_bridge_buffer,
+      (serial_bridge_raw) 
+        ? ToHex_P((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)) 
+        : (assume_json) 
+            ? serial_bridge_buffer 
+            : EscapeJSONString(serial_bridge_buffer).c_str(),
       (assume_json) ? "" : "\"");
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
     XdrvRulesProcess();

--- a/tasmota/xdrv_08_serial_bridge.ino
+++ b/tasmota/xdrv_08_serial_bridge.ino
@@ -76,16 +76,23 @@ void SerialBridgeInput(void)
 
   if (serial_bridge_in_byte_counter && (millis() > (serial_bridge_polling_window + SERIAL_POLLING))) {
     serial_bridge_buffer[serial_bridge_in_byte_counter] = 0;                   // Serial data completed
-    char hex_char[(serial_bridge_in_byte_counter * 2) + 2];
     bool assume_json = (!serial_bridge_raw && (serial_bridge_buffer[0] == '{'));
-    Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":%s%s%s}"),
-      (assume_json) ? "" : "\"",
-      (serial_bridge_raw) 
-        ? ToHex_P((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)) 
-        : (assume_json) 
-            ? serial_bridge_buffer 
-            : EscapeJSONString(serial_bridge_buffer).c_str(),
-      (assume_json) ? "" : "\"");
+
+    Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":"));
+    if (assume_json) {
+      ResponseAppend_P(serial_bridge_buffer);
+    } else {
+      ResponseAppend_P(PSTR("\""));
+      if (serial_bridge_raw) {
+        char hex_char[(serial_bridge_in_byte_counter * 2) + 2];
+        ResponseAppend_P(ToHex_P((unsigned char*)serial_bridge_buffer, serial_bridge_in_byte_counter, hex_char, sizeof(hex_char)));
+      } else {
+        ResponseAppend_P(EscapeJSONString(serial_bridge_buffer).c_str());
+      }
+      ResponseAppend_P(PSTR("\""));
+    }
+    ResponseAppend_P(PSTR("}"));
+
     MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
     XdrvRulesProcess();
     serial_bridge_in_byte_counter = 0;


### PR DESCRIPTION
## Description:

When serial data is send over mqtt as json string, it is not encoded, making it hard to consume the message in json-aware clients if it contains special chars (`"`, `\`, new line, tab, etc).

This fix uses the new `EscapeJSONString` function when the content is not raw or assumed json. 

Also reduced the serial input buffer size a little bit, so it compensates for the json wrapper characters and can always contain a completely encoded hex or json message.

Could be a breaking change for everyone with workarounds in place.

**Related issue (if applicable):** fixes #8329

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
