### PR TITLE
fix default power state logic invoked even if already serviced by a d…

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -222,8 +222,8 @@ void SetDevicePower(power_t rpower, uint32_t source)
   else if (EXS_RELAY == my_module_type) {
     SetLatchingRelay(rpower, 1);
   }
-  else
 #endif  // ESP8266
+  else
   {
     for (uint32_t i = 0; i < devices_present; i++) {
       power_t state = rpower &1;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** issue found while developing a new driver, not sure if there's already a bug for this.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.0 (I don't have a ESP32 to test)
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
