### PR TITLE
Add support for SetOption88 to put each relay in a separate DGR

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -107,7 +107,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t device_groups_enabled : 1;    // bit 3 (v8.1.0.9)   - SetOption85 - Enable Device Groups
     uint32_t led_timeout : 1;              // bit 4 (v8.1.0.9)   - SetOption86 - PWM Dimmer Turn brightness LED's off 5 seconds after last change
     uint32_t powered_off_led : 1;          // bit 5 (v8.1.0.9)   - SetOption87 - PWM Dimmer Turn red LED on when powered off
-    uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - PWM Dimmer Buttons control remote devices
+    uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - Enable relays in separate device groups/PWM Dimmer Buttons control remote devices
     uint32_t zigbee_distinct_topics : 1;   // bit 7 (v8.1.0.10)  - SetOption89 - Distinct MQTT topics per device for Zigbee (#7835)
     uint32_t only_json_message : 1;        // bit 8 (v8.2.0.3)   - SetOption90 - Disable non-json MQTT response
     uint32_t fade_at_startup : 1;          // bit 9 (v8.2.0.3)   - SetOption91 - Enable light fading at start/power on

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -110,6 +110,23 @@ bool DeviceGroupItemShared(bool incoming, uint8_t item)
 
 void DeviceGroupsInit(void)
 {
+  // If no module set the device group count, ...
+  if (!device_group_count) {
+
+    // If relays in sepaate device groups is enabled, set the device group count to highest numbered
+    // relay.
+    if (Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+      for (uint32_t relay_index = 0; relay_index < MAX_RELAYS; relay_index++) {
+        if (PinUsed(GPIO_REL1, relay_index)) device_group_count = relay_index + 1;
+      }
+    }
+
+    // Otherwise, set the device group count to 1.
+    else {
+      device_group_count = 1;
+    }
+  }
+
   // If there are more device group names set than the number of device groups needed by the
   // mdoule, use the device group name count as the device group count.
   for (; device_group_count < MAX_DEV_GROUP_NAMES; device_group_count++) {
@@ -368,13 +385,18 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
       log_remaining--;
       switch (item) {
         case DGR_ITEM_POWER:
-          if (device_group->local) {
+          if (Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+            bool on = (value & 1);
+            if (on != (power & 1)) ExecuteCommandPower(device_group_index + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
+          }
+          else if (device_group->local) {
             uint8_t mask_devices = value >> 24;
             if (mask_devices > devices_present) mask_devices = devices_present;
-            for (uint32_t i = 0; i < devices_present; i++) {
+            for (uint32_t i = 0; i < mask_devices; i++) {
               uint32_t mask = 1 << i;
               bool on = (value & mask);
               if (on != (power & mask)) ExecuteCommandPower(i + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
+              if (Settings.flag4.remote_device_mode) break; // SetOption88 - Enable relays in separate device groups
             }
           }
           break;
@@ -475,7 +497,9 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
     building_status_message = true;
 
     // Call the drivers to build the status update.
-    if (device_group->local) SendLocalDeviceGroupMessage(DGR_MSGTYP_PARTIAL_UPDATE, DGR_ITEM_POWER, power);
+    if (device_group->local || Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+      SendDeviceGroupMessage(device_group_index, DGR_MSGTYP_PARTIAL_UPDATE, DGR_ITEM_POWER, power);
+    }
     XdrvMailbox.index = device_group_index << 16;
     XdrvMailbox.command_code = DGR_ITEM_STATUS;
     XdrvMailbox.topic = (char *)&device_group_index;
@@ -648,10 +672,7 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
               *message_ptr++ = value & 0xff;
               value >>= 8;
               // For the power item, the device count is overlayed onto the highest 8 bits.
-              if (item == DGR_ITEM_POWER) {
-                if (!value)
-                  value = (device_group_index == 0 ? devices_present : 1);
-              }
+              if (item == DGR_ITEM_POWER && !value) value = (device_group_index == 0 ? devices_present : 1);
               *message_ptr++ = value;
             }
           }

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -571,7 +571,12 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
       power ^= mask;
     }
 #ifdef USE_DEVICE_GROUPS
-    if (SRC_REMOTE != source && SRC_RETRY != source) SendLocalDeviceGroupMessage(DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, power);
+    if (SRC_REMOTE != source && SRC_RETRY != source) {
+      if (Settings.flag4.remote_device_mode)  // SetOption88 - Enable relays in separate device groups
+        SendDeviceGroupMessage(device - 1, DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, (power >> device - 1) & 1 | 0x01000000);  // Explicitly set number of relays to one
+      else
+        SendLocalDeviceGroupMessage(DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, power);
+    }
 #endif  // USE_DEVICE_GROUPS
     SetDevicePower(power, source);
 #ifdef USE_DOMOTICZ

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -335,7 +335,7 @@ const char kWebColors[] PROGMEM =
 #ifdef USE_DEVICE_GROUPS
 #define SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, ...) _SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, __VA_ARGS__, 0)
 #define SendLocalDeviceGroupMessage(REQUEST_TYPE, ...) _SendDeviceGroupMessage(0, REQUEST_TYPE, __VA_ARGS__, 0)
-uint8_t device_group_count = 1;
+uint8_t device_group_count = 0;
 #endif  // USE_DEVICE_GROUPS
 
 #ifdef DEBUG_TASMOTA_CORE


### PR DESCRIPTION
## Description:

Add support for SetOption88 to put each relay in a separate device group. This PR adds 160 bytes of code. When SetOption88 is enabled:

- Updates to the state of relay 1 are sent to device group 1, updates to the state of relay 2 are sent to device group 2, etc.
- Power updates sent to each device group send a power mask shifted so affected bit is in position 0.
- Messages received from device group 1 update the state of relay 1, messages received from device group 2 update the state of relay 2, etc.

This enables devices with multiple relays (real or virtual) to control other single relay devices (eg. a device with three buttons and three relays can be set up with three device groups to toggle the power of three single relay devices).

SetOption88 was originally only used to enable Remote Device Mode of the PWM Dimmer module. This added functionality is essentially the same concept the same SetOption88 was used which causes no conflicts with it's use in the PWM Dimmer module.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
