### PR TITLE
Touch pin as button for ESP32

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1472,6 +1472,12 @@ void GpioInit(void)
         ButtonInvertFlag(mpin - AGPIO(GPIO_KEY1_INV_NP));  //  0 .. 3
         mpin -= (AGPIO(GPIO_KEY1_INV_NP) - AGPIO(GPIO_KEY1));
       }
+#ifdef ESP32
+      else if ((mpin >= AGPIO(GPIO_KEY1_TC)) && (mpin < (AGPIO(GPIO_KEY1_TC) + MAX_KEYS))) {
+        ButtonTouchFlag(mpin - AGPIO(GPIO_KEY1_TC));  //  0 .. 3
+        mpin -= (AGPIO(GPIO_KEY1_TC) - AGPIO(GPIO_KEY1));
+      }
+#endif //ESP32
       else if ((mpin >= AGPIO(GPIO_REL1_INV)) && (mpin < (AGPIO(GPIO_REL1_INV) + MAX_RELAYS))) {
         bitSet(rel_inverted, mpin - AGPIO(GPIO_REL1_INV));
         mpin -= (AGPIO(GPIO_REL1_INV) - AGPIO(GPIO_REL1));

--- a/tasmota/tasmota_template_ESP32.h
+++ b/tasmota/tasmota_template_ESP32.h
@@ -44,7 +44,7 @@
 
 enum UserSelectablePins {
   GPIO_NONE,                           // Not used
-  GPIO_KEY1, GPIO_KEY1_NP, GPIO_KEY1_INV, GPIO_KEY1_INV_NP, GPIO_KEY1_TC, // 4 x Button + Touch
+  GPIO_KEY1, GPIO_KEY1_NP, GPIO_KEY1_INV, GPIO_KEY1_INV_NP, // 4 x Button
   GPIO_SWT1, GPIO_SWT1_NP,             // 8 x User connected external switches
   GPIO_REL1, GPIO_REL1_INV,            // 8 x Relays
   GPIO_LED1, GPIO_LED1_INV,            // 4 x Leds
@@ -127,6 +127,7 @@ enum UserSelectablePins {
   GPIO_WEBCAM_PSRCS,
   GPIO_BOILER_OT_RX, GPIO_BOILER_OT_TX,  // OpenTherm Boiler TX pin
   GPIO_WINDMETER_SPEED,                // WindMeter speed counter pin
+  GPIO_KEY1_TC,                       // Touch pin as button
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -138,7 +139,7 @@ enum ProgramSelectablePins {
 // Text in webpage Module Parameters and commands GPIOS and GPIO
 const char kSensorNames[] PROGMEM =
   D_SENSOR_NONE "|"
-  D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "_n|" D_SENSOR_BUTTON "_i|" D_SENSOR_BUTTON "_in|" D_SENSOR_BUTTON "_tc|"
+  D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "_n|" D_SENSOR_BUTTON "_i|" D_SENSOR_BUTTON "_in|"
   D_SENSOR_SWITCH "|" D_SENSOR_SWITCH "_n|"
   D_SENSOR_RELAY "|" D_SENSOR_RELAY "_i|"
   D_SENSOR_LED "|" D_SENSOR_LED "_i|"
@@ -215,7 +216,7 @@ const char kSensorNames[] PROGMEM =
   D_GPIO_WEBCAM_HSD "|"
   D_GPIO_WEBCAM_PSRCS "|"
   D_SENSOR_BOILER_OT_RX "|" D_SENSOR_BOILER_OT_TX "|"
-  D_SENSOR_WINDMETER_SPEED
+  D_SENSOR_WINDMETER_SPEED "|" D_SENSOR_BUTTON "_tc"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -230,7 +231,6 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_KEY1_NP) + MAX_KEYS,
   AGPIO(GPIO_KEY1_INV) + MAX_KEYS,
   AGPIO(GPIO_KEY1_INV_NP) + MAX_KEYS,
-  AGPIO(GPIO_KEY1_TC) + MAX_KEYS,
   AGPIO(GPIO_SWT1) + MAX_SWITCHES,      // User connected external switches
   AGPIO(GPIO_SWT1_NP) + MAX_SWITCHES,
   AGPIO(GPIO_REL1) + MAX_RELAYS,        // Relays
@@ -543,6 +543,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_WEBCAM_HSD) + MAX_WEBCAM_HSD,
   AGPIO(GPIO_WEBCAM_PSRCS),
 #endif
+  AGPIO(GPIO_KEY1_TC) + MAX_KEYS
 };
 
 //********************************************************************************************
@@ -550,7 +551,6 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #define MAX_GPIO_PIN       40   // Number of supported GPIO
 #define MIN_FLASH_PINS     4    // Number of flash chip pins unusable for configuration (GPIO6, 7, 8 and 11)
 #define MAX_USER_PINS      36   // MAX_GPIO_PIN - MIN_FLASH_PINS
-// #define MAX_TOUCH_PINS     10   // Number of supported TOUCH PINS
 #define WEMOS_MODULE       0    // Wemos module
 
 //                                  0 1 2 3 4 5 6 7 8 9101112131415161718192021222324252627282930313233343536373839

--- a/tasmota/tasmota_template_ESP32.h
+++ b/tasmota/tasmota_template_ESP32.h
@@ -44,7 +44,7 @@
 
 enum UserSelectablePins {
   GPIO_NONE,                           // Not used
-  GPIO_KEY1, GPIO_KEY1_NP, GPIO_KEY1_INV, GPIO_KEY1_INV_NP,  // 4 x Button
+  GPIO_KEY1, GPIO_KEY1_NP, GPIO_KEY1_INV, GPIO_KEY1_INV_NP, GPIO_KEY1_TC, // 4 x Button + Touch
   GPIO_SWT1, GPIO_SWT1_NP,             // 8 x User connected external switches
   GPIO_REL1, GPIO_REL1_INV,            // 8 x Relays
   GPIO_LED1, GPIO_LED1_INV,            // 4 x Leds
@@ -138,7 +138,7 @@ enum ProgramSelectablePins {
 // Text in webpage Module Parameters and commands GPIOS and GPIO
 const char kSensorNames[] PROGMEM =
   D_SENSOR_NONE "|"
-  D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "_n|" D_SENSOR_BUTTON "_i|" D_SENSOR_BUTTON "_in|"
+  D_SENSOR_BUTTON "|" D_SENSOR_BUTTON "_n|" D_SENSOR_BUTTON "_i|" D_SENSOR_BUTTON "_in|" D_SENSOR_BUTTON "_tc|"
   D_SENSOR_SWITCH "|" D_SENSOR_SWITCH "_n|"
   D_SENSOR_RELAY "|" D_SENSOR_RELAY "_i|"
   D_SENSOR_LED "|" D_SENSOR_LED "_i|"
@@ -230,6 +230,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_KEY1_NP) + MAX_KEYS,
   AGPIO(GPIO_KEY1_INV) + MAX_KEYS,
   AGPIO(GPIO_KEY1_INV_NP) + MAX_KEYS,
+  AGPIO(GPIO_KEY1_TC) + MAX_KEYS,
   AGPIO(GPIO_SWT1) + MAX_SWITCHES,      // User connected external switches
   AGPIO(GPIO_SWT1_NP) + MAX_SWITCHES,
   AGPIO(GPIO_REL1) + MAX_RELAYS,        // Relays
@@ -549,6 +550,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #define MAX_GPIO_PIN       40   // Number of supported GPIO
 #define MIN_FLASH_PINS     4    // Number of flash chip pins unusable for configuration (GPIO6, 7, 8 and 11)
 #define MAX_USER_PINS      36   // MAX_GPIO_PIN - MIN_FLASH_PINS
+// #define MAX_TOUCH_PINS     10   // Number of supported TOUCH PINS
 #define WEMOS_MODULE       0    // Wemos module
 
 //                                  0 1 2 3 4 5 6 7 8 9101112131415161718192021222324252627282930313233343536373839


### PR DESCRIPTION
## Description:

Configure a touch pin of the ESP32 as a touch button.

Simple denoising and for the moment fixed threshold values, which should probably be changeable at runtime for different environments.

No error checking for the configuration -> the user must chose usable touch pins.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
