### PR TITLE
make NimBLEDevice::initialized static

### DIFF
--- a/libesp32/NimBLE-Arduino/src/NimBLEDevice.cpp
+++ b/libesp32/NimBLE-Arduino/src/NimBLEDevice.cpp
@@ -40,7 +40,7 @@ static const char* LOG_TAG = "NimBLEDevice";
 /**
  * Singletons for the NimBLEDevice.
  */
-bool            initialized = false;
+static bool            initialized = false;
 #if defined(CONFIG_BT_NIMBLE_ROLE_OBSERVER)
 NimBLEScan*     NimBLEDevice::m_pScan = nullptr;
 #endif


### PR DESCRIPTION
## Description:

Very minor issue.
Resolves naming conflict with xsns_39_max31855.ino, which BTW uses a pretty generic name for a global variable.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
