### PR TITLE
Fix SO88 incoming relay state check

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -387,7 +387,7 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
         case DGR_ITEM_POWER:
           if (Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
             bool on = (value & 1);
-            if (on != (power & 1)) ExecuteCommandPower(device_group_index + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
+            if (on != (power & (1 << device_group_index))) ExecuteCommandPower(device_group_index + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
           }
           else if (device_group->local) {
             uint8_t mask_devices = value >> 24;
@@ -396,7 +396,6 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
               uint32_t mask = 1 << i;
               bool on = (value & mask);
               if (on != (power & mask)) ExecuteCommandPower(i + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
-              if (Settings.flag4.remote_device_mode) break; // SetOption88 - Enable relays in separate device groups
             }
           }
           break;

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -573,7 +573,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
 #ifdef USE_DEVICE_GROUPS
     if (SRC_REMOTE != source && SRC_RETRY != source) {
       if (Settings.flag4.remote_device_mode)  // SetOption88 - Enable relays in separate device groups
-        SendDeviceGroupMessage(device - 1, DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, (power >> device - 1) & 1 | 0x01000000);  // Explicitly set number of relays to one
+        SendDeviceGroupMessage(device - 1, DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, (power >> (device - 1)) & 1 | 0x01000000);  // Explicitly set number of relays to one
       else
         SendLocalDeviceGroupMessage(DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, power);
     }


### PR DESCRIPTION
## Description:

Fix checking the current relay state on incoming messages when SetOption88 is enabled.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
