### PR TITLE
Scripter fix + little fs support

### DIFF
--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -505,7 +505,7 @@ void DisplayText(void)
             cp += var;
             linebuf[fill] = 0;
             break;
-#if defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT)
+#if defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT) && USE_SCRIPT_FATFS>=0
           case 'P':
             { char *ep=strchr(cp,':');
              if (ep) {
@@ -1510,8 +1510,13 @@ void rgb888_to_565(uint8_t *in, uint16_t *out, uint32_t len);
 #endif
 #endif
 
+#if defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT) && USE_SCRIPT_FATFS>=0
 
-#if defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT)
+#ifdef ESP32
+extern FS *fsp;
+#else
+extern SDClass *fsp;
+#endif
 #define XBUFF_LEN 128
 void Draw_RGB_Bitmap(char *file,uint16_t xp, uint16_t yp) {
   if (!renderer) return;
@@ -1527,7 +1532,7 @@ void Draw_RGB_Bitmap(char *file,uint16_t xp, uint16_t yp) {
 
   if (!strcmp(estr,"rgb")) {
     // special rgb format
-    fp=SD.open(file,FILE_READ);
+    fp=fsp->open(file,FILE_READ);
     if (!fp) return;
     uint16_t xsize;
     fp.read((uint8_t*)&xsize,2);
@@ -1564,7 +1569,7 @@ void Draw_RGB_Bitmap(char *file,uint16_t xp, uint16_t yp) {
 #ifdef ESP32
 #ifdef JPEG_PICTS
     if (psramFound()) {
-      fp=SD.open(file,FILE_READ);
+      fp=fsp->open(file,FILE_READ);
       if (!fp) return;
       uint32_t size = fp.size();
       uint8_t *mem = (uint8_t *)heap_caps_malloc(size+4, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
@@ -1850,7 +1855,9 @@ void DisplayCheckGraph() {
 
 
 #if defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT)
+#ifdef ESP32
 #include <SD.h>
+#endif
 
 void Save_graph(uint8_t num, char *path) {
   if (!renderer) return;
@@ -1858,8 +1865,8 @@ void Save_graph(uint8_t num, char *path) {
   struct GRAPH *gp=graph[index];
   if (!gp) return;
   File fp;
-  SD.remove(path);
-  fp=SD.open(path,FILE_WRITE);
+  fsp->remove(path);
+  fp=fsp->open(path,FILE_WRITE);
   if (!fp) return;
   char str[32];
   sprintf_P(str,PSTR("%d\t%d\t%d\t"),gp->xcnt,gp->xs,gp->ys);
@@ -1884,7 +1891,7 @@ void Restore_graph(uint8_t num, char *path) {
   struct GRAPH *gp=graph[index];
   if (!gp) return;
   File fp;
-  fp=SD.open(path,FILE_READ);
+  fp=fsp->open(path,FILE_READ);
   if (!fp) return;
   char vbuff[32];
   char *cp=vbuff;


### PR DESCRIPTION
## Description:

fixes a bug in for next loop
some optimizations
adds iittlefs support for 4M devices with e.g. eagle.flash.4m1m.ld
#define USE_SCRIPT_FATFS -1



## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_