### PR TITLE
Make a previously undocumented switch debouncing feature clean and official

### DIFF
--- a/tasmota/support_switch.ino
+++ b/tasmota/support_switch.ino
@@ -82,8 +82,8 @@ void SwitchProbe(void)
   if (uptime < 4) { return; }                           // Block GPIO for 4 seconds after poweron to workaround Wemos D1 / Obi RTS circuit
 
   uint8_t state_filter = Settings.switch_debounce / SWITCH_PROBE_INTERVAL;   // 5, 10, 15
-  uint8_t force_high = (Settings.switch_debounce % 50) &1;                   // 51, 101, 151 etc
-  uint8_t force_low = (Settings.switch_debounce % 50) &2;                    // 52, 102, 152 etc
+  uint8_t force_high = (Settings.switch_debounce % 10) &1;                   // 51, 101, 151 etc
+  uint8_t force_low = (Settings.switch_debounce % 10) &2;                    // 52, 102, 152 etc
 
   for (uint32_t i = 0; i < MAX_SWITCHES; i++) {
     if (PinUsed(GPIO_SWT1, i)) {


### PR DESCRIPTION


## Description:

The switch debouncing code has two undocumented features: force_high and force_low. These features help sticking to the current state when the switch GPIO line is noisy. These features can be activated by the low bits of the SwitchDebounce command.

The module 50 has no real meaning in the calculations. The switch debouncing timer runs every 10 msec, the minimum value of the SwitchDebounce parameter is 40, its granularity is 1, only the default value is 50. Using only the last digit as debouncing flags keeps compatibility and makes place for future improvements.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
