### PR TITLE
fix start without stop condition

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1459,6 +1459,7 @@ bool I2cValidRead(uint8_t addr, uint8_t reg, uint8_t size)
     }
     retry--;
   }
+  if (!retry) Wire.endTransmission();
   return status;
 }
 


### PR DESCRIPTION
## Description:
If a driver call the function `I2cValidRead` while in init phase and the I2C device ist not present,
the `I2cValidRead` function makes a Start without Stop condition after 3 attempts and block the bus.
this fix makes a stop condition after 3 attempts.

background:
A view driver call only `I2cActive` at init phase and afterwards reads data with the  `I2cValidRead` function but the device is unavailable.

Normaly we must check both conditions.
1. Is address aktiv?
2. Is address available?

with `I2cActive` we only check the activity of device but not the physically presents.

In the second step, i will fix the affected driver with the function `I2cSetDevice` seperate PR (xsns_65_hdc1080.ino, xsns_67_as3935.ino, xsns_70_veml6075.ino )


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
