### PR TITLE
fix serial buffer issues

### DIFF
--- a/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
@@ -174,6 +174,7 @@ bool TasmotaSerial::begin(long speed, int stop_bits) {
       m_uart = tasmota_serial_index;
       tasmota_serial_index--;
       TSerial = new HardwareSerial(m_uart);
+      if (TM_SERIAL_BUFFER_SIZE != serial_buffer_size) TSerial->setRxBufferSize(serial_buffer_size);
       if (2 == m_stop_bits) {
         TSerial->begin(speed, SERIAL_8N2, m_rx_pin, m_tx_pin);
       } else {

--- a/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
@@ -174,7 +174,9 @@ bool TasmotaSerial::begin(long speed, int stop_bits) {
       m_uart = tasmota_serial_index;
       tasmota_serial_index--;
       TSerial = new HardwareSerial(m_uart);
-      if (TM_SERIAL_BUFFER_SIZE != serial_buffer_size) TSerial->setRxBufferSize(serial_buffer_size);
+      if (serial_buffer_size > 256) {
+        TSerial->setRxBufferSize(serial_buffer_size);
+      }
       if (2 == m_stop_bits) {
         TSerial->begin(speed, SERIAL_8N2, m_rx_pin, m_tx_pin);
       } else {

--- a/tasmota/xsns_52_ibeacon.ino
+++ b/tasmota/xsns_52_ibeacon.ino
@@ -25,6 +25,8 @@
 
 #include <TasmotaSerial.h>
 
+#define TMSBSIZ 256
+
 #define HM17_BAUDRATE 9600
 
 #define IBEACON_DEBUG
@@ -96,7 +98,7 @@ void IBEACON_Init() {
 
 // actually doesnt work reliably with software serial
   if (PinUsed(GPIO_IBEACON_RX) && PinUsed(GPIO_IBEACON_TX)) {
-    IBEACON_Serial = new TasmotaSerial(Pin(GPIO_IBEACON_RX), Pin(GPIO_IBEACON_TX),1);
+    IBEACON_Serial = new TasmotaSerial(Pin(GPIO_IBEACON_RX), Pin(GPIO_IBEACON_TX),1,0,TMSBSIZ);
     if (IBEACON_Serial->begin(HM17_BAUDRATE)) {
       if (IBEACON_Serial->hardwareSerial()) {
         ClaimSerial();
@@ -144,7 +146,7 @@ void hm17_every_second(void) {
 void hm17_sbclr(void) {
   memset(hm17_sbuffer,0,HM17_BSIZ);
   hm17_sindex=0;
-  IBEACON_Serial->flush();
+  //IBEACON_Serial->flush();
 }
 
 void hm17_sendcmd(uint8_t cmd) {
@@ -405,7 +407,7 @@ hm17_v110:
           }
         } else {
 #ifdef IBEACON_DEBUG
-          if (hm17_debug) AddLog_P2(LOG_LEVEL_INFO, PSTR(">>%s"),&hm17_sbuffer[8]);
+          if (hm17_debug) AddLog_P2(LOG_LEVEL_INFO, PSTR(">->%s"),&hm17_sbuffer[8]);
 #endif
         }
         break;
@@ -517,7 +519,7 @@ bool xsns52_cmd(void) {
 #ifdef IBEACON_DEBUG
       else if (*cp=='d') {
         cp++;
-        if (*cp) hm17_debug=atoi(cp);
+        hm17_debug=atoi(cp);
         Response_P(S_JSON_IBEACON, XSNS_52,"debug",hm17_debug);
       }
 #endif


### PR DESCRIPTION
## Description:

fixes serial receive buffer to small in sml and ibeacon driver (ESP8266 and ESP32)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_