### PR TITLE
Possibility to set Flash frequency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -74,6 +74,7 @@ build_flags               = ${core_active.build_flags}
 build_unflags             = -Wall
 
 board_build.f_cpu         = 80000000L
+board_build.f_flash       = 40000000L
 monitor_speed             = 115200
 upload_speed              = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -170,6 +170,7 @@ board                   = esp32dev
 board_build.ldscript    = esp32_out.ld
 board_build.partitions  = esp32_partition_app1984k_spiffs64k.csv
 board_build.flash_mode  = ${common.board_build.flash_mode}
+board_build.f_flash     = ${common.board_build.f_flash}
 board_build.f_cpu       = ${common.board_build.f_cpu}
 build_unflags           = ${common.build_unflags}
                           -Wpointer-arith

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -52,6 +52,11 @@ build_flags               = ${core_active.build_flags}
 ; set CPU frequency to 80MHz (default) or 160MHz
 ;board_build.f_cpu         = 160000000L
 
+; set Flash chip frequency to 40MHz (default), 20MHz, 26Mhz, 80Mhz
+;board_build.f_flash       = 20000000L
+;board_build.f_flash       = 26000000L
+;board_build.f_flash       = 80000000L
+
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port               = COM5
 

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -5,6 +5,7 @@ framework = ${common.framework}
 board = ${common.board}
 board_build.ldscript  = ${common.board_build.ldscript}
 board_build.flash_mode = ${common.board_build.flash_mode}
+board_build.f_flash = ${common.board_build.f_flash}
 board_build.f_cpu = ${common.board_build.f_cpu}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -6,6 +6,7 @@ board                   = ${common32.board}
 board_build.ldscript    = ${common32.board_build.ldscript}
 board_build.partitions  = ${common32.board_build.partitions}
 board_build.flash_mode  = ${common32.board_build.flash_mode}
+board_build.f_flash     = ${common32.board_build.f_flash}
 board_build.f_cpu       = ${common32.board_build.f_cpu}
 monitor_speed           = ${common32.monitor_speed}
 upload_port             = ${common32.upload_port}


### PR DESCRIPTION
Some Flash chip does not work reliable with 40 Mhz. 
So it is needed to reduce the flash frequency

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
