### PR TITLE
MCP9808 label sensors with hex address

### DIFF
--- a/tasmota/xsns_72_mcp9808.ino
+++ b/tasmota/xsns_72_mcp9808.ino
@@ -78,10 +78,10 @@ void MCP9808Show(bool json) {
     char temperature[33];
     dtostrfd(mcp9808_sensors[i].temperature, Settings.flag2.temperature_resolution, temperature);
 
-    char sensor_name[10];
+    char sensor_name[11];
     strlcpy(sensor_name, mcp9808_cfg.types, sizeof(sensor_name));
     if (mcp9808_cfg.count > 1) {
-      snprintf_P(sensor_name, sizeof(sensor_name), PSTR("%s%c%d"), sensor_name, IndexSeparator(), i +1); // MCP9808-1
+      snprintf_P(sensor_name, sizeof(sensor_name), PSTR("%s%c%02X"), sensor_name, IndexSeparator(), mcp9808_sensors[i].address); // MCP9808-18, MCP9808-1A  etc.
     }
 
     if (json) {


### PR DESCRIPTION
## Description:
Consider 3 MCP9808s 0x18, 0x19 and 0x1A i.e. MCP9808-1, MCP9808-2 and MCP9808-3
with the current setup if 0x18 was to become disconnected from the system then the mapping would be as such 0x19 and 0x1A become MCP9808-1 and MCP9808-2
In certain control situations this could be a real issue.
Would it not be better to use the naming convention i've seen with BME280's? i.e. use the address as a tag MCP9808-18, MCP9808-19 and MCP9808-1A

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [*] The pull request is done against the latest dev branch
  - [*] Only relevant files were touched
  - [*] Only one feature/fix was added per PR.
  - [*] The code change is tested and works on core ESP8266 V.2.7.1
  - [*] The code change is tested and works on core ESP32 V.1.12.2
  - [*] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
