### PR TITLE
Add Zigbee auto-responder for common attributes

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add ``CpuFrequency`` to ``status 2``
 - Add ``FlashFrequency`` to ``status 4``
 - Add support for up to two BH1750 sensors controlled by commands ``BH1750Resolution`` and ``BH1750MTime`` (#8139)
+- Add Zigbee auto-responder for common attributes
 
 ### 8.3.1.1 20200518
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -528,6 +528,7 @@
 #define D_CMND_ZIGBEE_SEND "Send"
 #define D_CMND_ZIGBEE_WRITE "Write"
 #define D_CMND_ZIGBEE_REPORT "Report"
+#define D_CMND_ZIGBEE_RESPONSE "Response"
   #define D_JSON_ZIGBEE_ZCL_SENT "ZbZCLSent"
 #define D_JSON_ZIGBEE_RECEIVED "ZbReceived"
 #define D_CMND_ZIGBEE_BIND "Bind"

--- a/tasmota/support_json.ino
+++ b/tasmota/support_json.ino
@@ -89,7 +89,7 @@ const JsonVariant &GetCaseInsensitive(const JsonObject &json, const char *needle
   // key can be in PROGMEM
   // if needle == "?" then we return the first valid key
   bool wildcard = strcmp_P("?", needle) == 0;
-  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle))) {
+  if ((nullptr == &json) || (nullptr == needle) || (0 == pgm_read_byte(needle)) || (!json.success())) {
     return *(JsonVariant*)nullptr;
   }
 
@@ -103,4 +103,10 @@ const JsonVariant &GetCaseInsensitive(const JsonObject &json, const char *needle
   }
   // if not found
   return *(JsonVariant*)nullptr;
+}
+
+// This function returns true if the JsonObject contains the specified key
+// It's just a wrapper to the previous function but it can be tricky to test nullptr on an object ref
+bool HasKeyCaseInsensitive(const JsonObject &json, const char *needle) {
+  return &GetCaseInsensitive(json, needle) != nullptr;
 }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1429,6 +1429,10 @@ void LightGetHSB(uint16_t *hue, uint8_t *sat, uint8_t *bri) {
   light_state.getHSB(hue, sat, bri);
 }
 
+void LightGetXY(float *X, float *Y) {
+  light_state.getXY(X, Y);
+}
+
 void LightHsToRgb(uint16_t hue, uint8_t sat, uint8_t *r_r, uint8_t *r_g, uint8_t *r_b) {
   light_state.HsToRgb(hue, sat, r_r, r_g, r_b);
 }

--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -384,7 +384,6 @@ enum ZCL_Global_Commands {
   ZCL_DEFAULT_RESPONSE = 0x0b,
   ZCL_DISCOVER_ATTRIBUTES = 0x0c,
   ZCL_DISCOVER_ATTRIBUTES_RESPONSE = 0x0d
-
 };
 
 #define ZF(s) static const char ZS_ ## s[] PROGMEM = #s;

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -526,6 +526,8 @@ void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
 
 // Find the first endpoint of the device
 uint8_t Z_Devices::findFirstEndpoint(uint16_t shortaddr) const {
+  // When in router of end-device mode, the coordinator was not probed, in this case always talk to endpoint 1
+  if (0x0000 == shortaddr) { return 1; }
   int32_t found = findShortAddr(shortaddr);
   if (found < 0)  return 0;     // avoid creating an entry if the device was never seen
   const Z_Device &device = devicesAt(found);

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -657,21 +657,24 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
   } else {  
     // Build the ZbReceive json
     if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_REPORT_ATTRIBUTES == zcl_received.getCmdId())) {
-      zcl_received.parseRawAttributes(json);    // Zigbee report attributes from sensors
+      zcl_received.parseReportAttributes(json);    // Zigbee report attributes from sensors
       if (clusterid) { defer_attributes = true; }  // don't defer system Cluster=0 messages
     } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_READ_ATTRIBUTES_RESPONSE == zcl_received.getCmdId())) {
       zcl_received.parseReadAttributesResponse(json);
       if (clusterid) { defer_attributes = true; }  // don't defer system Cluster=0 messages
     } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_READ_ATTRIBUTES == zcl_received.getCmdId())) {
       zcl_received.parseReadAttributes(json);
-      if (clusterid) { defer_attributes = true; }  // don't defer system Cluster=0 messages
+      // never defer read_attributes, so the auto-responder can send response back on a per cluster basis
     } else if (zcl_received.isClusterSpecificCommand()) {
       zcl_received.parseClusterSpecificCommand(json);
     }
-    String msg("");
-    msg.reserve(100);
-    json.printTo(msg);
-    AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZCL_RAW_RECEIVED ": {\"0x%04X\":%s}"), srcaddr, msg.c_str());
+
+    {   // fence to force early de-allocation of msg
+      String msg("");
+      msg.reserve(100);
+      json.printTo(msg);
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZCL_RAW_RECEIVED ": {\"0x%04X\":%s}"), srcaddr, msg.c_str());
+    }
 
     zcl_received.postProcessAttributes(srcaddr, json);
     // Add Endpoint
@@ -701,6 +704,9 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
     } else {
       // Publish immediately
       zigbee_devices.jsonPublishNow(srcaddr, json);
+
+      // Add auto-responder here
+      Z_AutoResponder(srcaddr, clusterid, srcendpoint, json[F("ReadNames")]);
     }
   }
   return -1;
@@ -815,6 +821,76 @@ int32_t Z_Query_Bulbs(uint8_t value) {
 int32_t Z_State_Ready(uint8_t value) {
   zigbee.init_phase = false;             // initialization phase complete
   return 0;                              // continue
+}
+
+//
+// Auto-responder for Read request from extenal devices.
+//
+// Mostly used for routers/end-devices
+// json: holds the attributes in JSON format
+void Z_AutoResponder(uint16_t srcaddr, uint16_t cluster, uint8_t endpoint, const JsonObject &json) {
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& json_out = jsonBuffer.createObject();
+
+  // responder
+  switch (cluster) {
+    case 0x0000:
+      if (HasKeyCaseInsensitive(json, PSTR("ModelId")))           { json_out[F("ModelId")] = F("Tasmota Z2T"); }
+      if (HasKeyCaseInsensitive(json, PSTR("Manufacturer")))      { json_out[F("Manufacturer")] = F("Tasmota"); }
+      break;
+#ifdef USE_LIGHT
+    case 0x0006:
+      if (HasKeyCaseInsensitive(json, PSTR("Power")))             { json_out[F("Power")] = Light.power ? 1 : 0; }
+      break;
+    case 0x0008:
+      if (HasKeyCaseInsensitive(json, PSTR("Dimmer")))            { json_out[F("Dimmer")] = LightGetDimmer(0); }
+      break;
+    case 0x0300:
+      {
+      uint16_t hue;
+      uint8_t  sat;
+      float XY[2];
+      LightGetHSB(&hue, &sat, nullptr);
+      LightGetXY(&XY[0], &XY[1]);
+      uint16_t uxy[2];
+      for (uint32_t i = 0; i < ARRAY_SIZE(XY); i++) {
+        uxy[i] = XY[i] * 65536.0f;
+        uxy[i] = (uxy[i] > 0xFEFF) ? uxy[i] : 0xFEFF;
+      }
+      if (HasKeyCaseInsensitive(json, PSTR("Hue")))               { json_out[F("Hue")] = changeUIntScale(hue, 0, 360, 0, 254); }
+      if (HasKeyCaseInsensitive(json, PSTR("Sat")))               { json_out[F("Sat")] = changeUIntScale(sat, 0, 255, 0, 254); }
+      if (HasKeyCaseInsensitive(json, PSTR("CT")))                { json_out[F("CT")] = LightGetColorTemp(); }
+      if (HasKeyCaseInsensitive(json, PSTR("X")))                 { json_out[F("X")] = uxy[0]; }
+      if (HasKeyCaseInsensitive(json, PSTR("Y")))                 { json_out[F("Y")] = uxy[1]; }
+      }
+      break;
+#endif
+    case 0x000A:    // Time
+      if (HasKeyCaseInsensitive(json, PSTR("Time")))              { json_out[F("Time")] = Rtc.utc_time; }
+      if (HasKeyCaseInsensitive(json, PSTR("TimeStatus")))        { json_out[F("TimeStatus")] = (Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? 0x02 : 0x00; }  // if time is beyond 2010 then we are synchronized
+      if (HasKeyCaseInsensitive(json, PSTR("TimeZone")))          { json_out[F("TimeZone")] = Settings.toffset[0] * 60; }   // seconds
+      break;
+  }
+
+  if (json_out.size() > 0) {
+    // we have a non-empty output
+
+    // log first
+    String msg("");
+    msg.reserve(100);
+    json_out.printTo(msg);
+    AddLog_P2(LOG_LEVEL_INFO, PSTR("ZIG: Auto-responder: ZbSend {\"Device\":\"0x%04X\""
+                                          ",\"Cluster\":\"0x%04X\""
+                                          ",\"Endpoint\":%d"
+                                          ",\"Response\":%s}"
+                                          ),
+                                          srcaddr, cluster, endpoint,
+                                          msg.c_str());
+
+    // send
+    const JsonVariant &json_out_v = json_out;
+    ZbSendReportWrite(json_out_v, srcaddr, 0 /* group */,cluster, endpoint, 0 /* manuf */, ZCL_READ_ATTRIBUTES_RESPONSE);
+  }
 }
 
 #endif // USE_ZIGBEE


### PR DESCRIPTION
## Description:

Several minor fixes to `ZbSend` wrt to endpoints and cluster selection.

`ZbSend` with commands `Write` or `Report` automatically adjust values according to encoding. For example when you send `"Temperature":24.5`, it converts to an int value of 245.

Added auto-responder to common attributes: `ModelId`, `Manufacturer`, `Time`, `TimeStatus`, `TimeZone` and several Light attributes: `Power`, `Dimmer`, `Sat`, `Hue`, `CT`, `X`, `Y`.

**Related issue (if applicable):** fixes #8399

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
