### PR TITLE
increasing in color temperature change speed

### DIFF
--- a/tasmota/support_rotary.ino
+++ b/tasmota/support_rotary.ino
@@ -117,7 +117,7 @@ void RotaryHandler(void)
         Rotary.changed = 1;
         // button1 is pressed: set color temperature
         int16_t t = LightGetColorTemp();
-        t = t + (Rotary.position - Rotary.last_position);
+        t = t + ((Rotary.position - Rotary.last_position) * 4);
         if (t < 153) {
           t = 153;
         }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

While changing the brightness of the Xiaomi Mi LED Desk Lamp works very well, the color temperature control works very slowly when adjusting with the built-in encoder. The passage of the entire brightness range requires 100 encoder pulses, the entire color temperature range is already 347 pulses. The corrected code changes the pitch of changes in color temperature from 1 to 4.