### PR TITLE
Fix wrong sign of attributes

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1397,7 +1397,7 @@ int32_t Z_ApplyConverter(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObje
       if (multiplier > 0) {
         json[new_name] = ((float)value) * multiplier;
       } else {
-        json[new_name] = ((float)value) / multiplier;
+        json[new_name] = ((float)value) / (-multiplier);
       }
   }
 

--- a/tasmota/xdrv_23_zigbee_9_impl.ino
+++ b/tasmota/xdrv_23_zigbee_9_impl.ino
@@ -483,7 +483,7 @@ void ZbSendReportWrite(const JsonObject &val_pubwrite, uint16_t device, uint16_t
       if (multiplier > 0) {         // inverse of decoding
         val_f = val_f / multiplier;
       } else {
-        val_f = val_f * multiplier;
+        val_f = val_f * (-multiplier);
       }
       use_val = false;
     }


### PR DESCRIPTION
## Description:

Fix wrong sign when converting some Zigbee attributes (bug introduced in the last Zigbee commit).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
