### PR TITLE
Fix Zigbee Time and add TimeEpoch

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -136,7 +136,7 @@ ZF(MainsVoltage) ZF(MainsFrequency) ZF(BatteryVoltage) ZF(BatteryPercentage)
 ZF(CurrentTemperature) ZF(MinTempExperienced) ZF(MaxTempExperienced) ZF(OverTempTotalDwell)
 ZF(SceneCount) ZF(CurrentScene) ZF(CurrentGroup) ZF(SceneValid)
 ZF(AlarmCount) ZF(Time) ZF(TimeStatus) ZF(TimeZone) ZF(DstStart) ZF(DstEnd)
-ZF(DstShift) ZF(StandardTime) ZF(LocalTime) ZF(LastSetTime) ZF(ValidUntilTime)
+ZF(DstShift) ZF(StandardTime) ZF(LocalTime) ZF(LastSetTime) ZF(ValidUntilTime) ZF(TimeEpoch)
 
 ZF(LocationType) ZF(LocationMethod) ZF(LocationAge) ZF(QualityMeasure) ZF(NumberOfDevices)
 
@@ -283,6 +283,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { Zuint32,  Cx000A, 0x0007,  Z(LocalTime),            1,  Z_Nop },
   { ZUTC,     Cx000A, 0x0008,  Z(LastSetTime),          1,  Z_Nop },
   { ZUTC,     Cx000A, 0x0009,  Z(ValidUntilTime),       1,  Z_Nop },
+  { ZUTC,     Cx000A, 0xFF00,  Z(TimeEpoch),            1,  Z_Nop },    // Tasmota specific, epoch
 
   // RSSI Location cluster
   { Zdata8,   Cx000B, 0x0000,  Z(LocationType),         1,  Z_Nop },

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -866,7 +866,8 @@ void Z_AutoResponder(uint16_t srcaddr, uint16_t cluster, uint8_t endpoint, const
       break;
 #endif
     case 0x000A:    // Time
-      if (HasKeyCaseInsensitive(json, PSTR("Time")))              { json_out[F("Time")] = Rtc.utc_time; }
+      if (HasKeyCaseInsensitive(json, PSTR("Time")))              { json_out[F("Time")] = (Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? Rtc.utc_time - 946684800 : Rtc.utc_time; }
+      if (HasKeyCaseInsensitive(json, PSTR("TimeEpoch")))         { json_out[F("TimeEpoch")] = Rtc.utc_time; }
       if (HasKeyCaseInsensitive(json, PSTR("TimeStatus")))        { json_out[F("TimeStatus")] = (Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? 0x02 : 0x00; }  // if time is beyond 2010 then we are synchronized
       if (HasKeyCaseInsensitive(json, PSTR("TimeZone")))          { json_out[F("TimeZone")] = Settings.toffset[0] * 60; }   // seconds
       break;


### PR DESCRIPTION
## Description:

Fix Zigbee Time that was 946684800 too large (reference in 1970 instead of 2000).

Added `TimeEpoch` to simplify setting time of a Tasmota device without calculation.

**Related issue (if applicable):** fixes #8399

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
