### PR TITLE
Windmeter: make ISR variables volatile

### DIFF
--- a/tasmota/xsns_68_windmeter.ino
+++ b/tasmota/xsns_68_windmeter.ino
@@ -58,8 +58,8 @@ float const windmeter_pi = 3.1415926535897932384626433;  // Pi
 float const windmeter_2pi = windmeter_pi * 2;
 
 struct WINDMETER {
-  uint32_t counter_time;
-  unsigned long counter = 0;
+  volatile uint32_t counter_time;
+  volatile unsigned long counter = 0;
   //uint32_t speed_time;
   float speed = 0;
   float last_tele_speed = 0;


### PR DESCRIPTION
## Description:
As suggested by @device111 in issue below, variables used in ISR should be marked as volatile.

**Related issue (if applicable):** #8614

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
