### PR TITLE
unify USE_*_COMPRESSION to USE_UNISHOX_COMPRESSION

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -394,12 +394,14 @@
 // -- Ping ----------------------------------------
 //  #define USE_PING                                 // Enable Ping command (+2k code)
 
+#define USE_UNISHOX_COMPRESSION                  // add support for string compression for RULES or SCRIPT
+
 // -- Rules or Script  ----------------------------
 // Select none or only one of the below defines USE_RULES or USE_SCRIPT
 #define USE_RULES                                // Add support for rules (+8k code)
-  #define USE_RULES_COMPRESSION                  // Compresses rules in Flash at about ~50% (+3.3k code)
+  // with USE_UNISHOX_COMPRESSION                // Compresses rules in Flash at about ~50% (+3.3k code)
 //#define USE_SCRIPT                               // Add support for script (+17k code)
-  #define USE_SCRIPT_COMPRESSION
+                                                 // supports USE_UNISHOX_COMPRESSION
   //#define USE_SCRIPT_FATFS 4                     // Script: Add FAT FileSystem Support
 
 //  #define USE_EXPRESSION                         // Add support for expression evaluation in rules (+3k2 code, +64 bytes mem)

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1882,7 +1882,7 @@ void AddLogBufferSize(uint32_t loglevel, uint8_t *buffer, uint32_t count, uint32
  * Uncompress static PROGMEM strings
 \*********************************************************************************************/
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
 
 #include <unishox.h>
 
@@ -1908,4 +1908,4 @@ String Decompress(const char * compressed, size_t uncompressed_size) {
   return content;
 }
 
-#endif // defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#endif // USE_UNISHOX_COMPRESSION

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -73,7 +73,7 @@ uint32_t DecodeLightId(uint32_t hue_id);
 #ifdef USE_SCRIPT_FATFS
 #undef LITTLEFS_SCRIPT_SIZE
 #undef EEP_SCRIPT_SIZE
-#undef USE_SCRIPT_COMPRESSION
+#undef USE_UNISHOX_COMPRESSION
 #if USE_SCRIPT_FATFS==-1
 #ifdef ESP32
 #error "script fat file option -1 currently not supported for ESP32"
@@ -88,13 +88,13 @@ uint32_t DecodeLightId(uint32_t hue_id);
 // lfs on esp8266 spiffs on esp32
 #ifdef LITTLEFS_SCRIPT_SIZE
 #undef EEP_SCRIPT_SIZE
-#undef USE_SCRIPT_COMPRESSION
+#undef USE_UNISHOX_COMPRESSION
 #pragma message "script little file system option used"
 #endif // LITTLEFS_SCRIPT_SIZE
 
 // eeprom script
 #ifdef EEP_SCRIPT_SIZE
-#undef USE_SCRIPT_COMPRESSION
+#undef USE_UNISHOX_COMPRESSION
 #ifdef USE_24C256
 #pragma message "script 24c256 file option used"
 #else
@@ -104,12 +104,12 @@ uint32_t DecodeLightId(uint32_t hue_id);
 #endif // EEP_SCRIPT_SIZE
 
 // compression last option before default
-#ifdef USE_SCRIPT_COMPRESSION
+#ifdef USE_UNISHOX_COMPRESSION
 #pragma message "script compression option used"
-#endif // USE_SCRIPT_COMPRESSION
+#endif // USE_UNISHOX_COMPRESSION
 
 
-#ifdef USE_SCRIPT_COMPRESSION
+#ifdef USE_UNISHOX_COMPRESSION
 #include <unishox.h>
 
 #define SCRIPT_COMPRESS compressor.unishox_compress
@@ -117,7 +117,7 @@ uint32_t DecodeLightId(uint32_t hue_id);
 #ifndef UNISHOXRSIZE
 #define UNISHOXRSIZE 2560
 #endif
-#endif // USE_SCRIPT_COMPRESSION
+#endif // USE_UNISHOX_COMPRESSION
 
 
 #if defined(LITTLEFS_SCRIPT_SIZE) || (USE_SCRIPT_FATFS==-1)
@@ -4178,7 +4178,7 @@ void ScriptSaveSettings(void) {
     glob_script_mem.script_mem_size=0;
   }
 
-#ifdef USE_SCRIPT_COMPRESSION
+#ifdef USE_UNISHOX_COMPRESSION
   //AddLog_P2(LOG_LEVEL_INFO,PSTR("in string: %s len = %d"),glob_script_mem.script_ram,strlen(glob_script_mem.script_ram));
   uint32_t len_compressed = SCRIPT_COMPRESS(glob_script_mem.script_ram, strlen(glob_script_mem.script_ram), Settings.rules[0], MAX_SCRIPT_SIZE-1);
   if (len_compressed > 0) {
@@ -4187,7 +4187,7 @@ void ScriptSaveSettings(void) {
   } else {
     AddLog_P2(LOG_LEVEL_INFO, PSTR("script compress error: %d"), len_compressed);
   }
-#endif // USE_SCRIPT_COMPRESSION
+#endif // USE_UNISHOX_COMPRESSION
 
   if (bitRead(Settings.rule_enabled, 0)) {
     int16_t res=Init_Scripter();
@@ -5830,7 +5830,7 @@ bool Xdrv10(uint8_t function)
       glob_script_mem.script_pram=(uint8_t*)Settings.script_pram[0];
       glob_script_mem.script_pram_size=PMEM_SIZE;
 
-#ifdef USE_SCRIPT_COMPRESSION
+#ifdef USE_UNISHOX_COMPRESSION
       int32_t len_decompressed;
       sprt=(char*)calloc(UNISHOXRSIZE+8,1);
       if (!sprt) { break; }
@@ -5839,7 +5839,7 @@ bool Xdrv10(uint8_t function)
       len_decompressed = SCRIPT_DECOMPRESS(Settings.rules[0], strlen(Settings.rules[0]), glob_script_mem.script_ram, glob_script_mem.script_size);
       if (len_decompressed>0) glob_script_mem.script_ram[len_decompressed]=0;
       //AddLog_P2(LOG_LEVEL_INFO, PSTR("decompressed script len %d"),len_decompressed);
-#endif // USE_SCRIPT_COMPRESSION
+#endif // USE_UNISHOX_COMPRESSION
 
 #ifdef USE_BUTTON_EVENT
       for (uint32_t cnt=0;cnt<MAX_KEYS;cnt++) {

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -85,7 +85,7 @@ void WemoRespondToMSearch(int echo_type)
  * Wemo web server additions
 \*********************************************************************************************/
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
 
 //<scpd xmlns="urn:Belkin:service-1-0"><actionList><action><name>SetBinaryState</name><argumentList><argument><retval/><name>BinaryState</name><relatedStateVariable>BinaryState</relatedStateVariable><direction>in</direction></argument></argumentList></action><action><name>GetBinaryState</name><argumentList><argument><retval/><name>BinaryState</name><relatedStateVariable>BinaryState</relatedStateVariable><direction>out</direction></argument></argumentList></action></actionList><serviceStateTable><stateVariable sendEvents="yes"><name>BinaryState</name><dataType>bool</dataType><defaultValue>0</defaultValue></stateVariable><stateVariable sendEvents="yes"><name>level</name><dataType>string</dataType><defaultValue>0</defaultValue></stateVariable></serviceStateTable></scpd>\r\n\r\n
 //Successfully compressed from 779 to 249 bytes (-68%)
@@ -293,7 +293,7 @@ void HandleUpnpEvent(void)
     }
   }
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
   snprintf_P(event, sizeof(event), Decompress(WEMO_RESPONSE_STATE_SOAP, WEMO_RESPONSE_STATE_SOAP_SIZE).c_str(), state, bitRead(power, devices_present -1), state);
 #else
   snprintf_P(event, sizeof(event), WEMO_RESPONSE_STATE_SOAP, state, bitRead(power, devices_present -1), state);
@@ -305,7 +305,7 @@ void HandleUpnpService(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_EVENT_SERVICE));
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
   WSSend(200, CT_PLAIN, Decompress(WEMO_EVENTSERVICE_XML, WEMO_EVENTSERVICE_XML_SIZE));
 #else
   WSSend(200, CT_PLAIN, FPSTR(WEMO_EVENTSERVICE_XML));
@@ -316,7 +316,7 @@ void HandleUpnpMetaService(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_META_SERVICE));
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
   WSSend(200, CT_PLAIN, Decompress(WEMO_METASERVICE_XML, WEMO_METASERVICE_XML_SIZE));
 #else
   WSSend(200, CT_PLAIN, FPSTR(WEMO_METASERVICE_XML));
@@ -327,7 +327,7 @@ void HandleUpnpSetupWemo(void)
 {
   AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_SETUP));
 
-#if defined(USE_RULES_COMPRESSION) || defined(USE_SCRIPT_COMPRESSION)
+#ifdef USE_UNISHOX_COMPRESSION
   String setup_xml = Decompress(WEMO_SETUP_XML, WEMO_SETUP_XML_SIZE);
 #else
   String setup_xml = FPSTR(WEMO_SETUP_XML);


### PR DESCRIPTION
## Description:

Pure cosmetical refactoring, which hopefully will improve readability in the future a tiny bit.
Using compression in RULES or SCRIPTS creates overhead and internal testing indicates, that we can win some memory back by compressing strings at other places as shown in the we wemo-driver.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
