### PR TITLE
Fix compilation with gnu++17 / c17

### DIFF
--- a/lib/bearssl-esp8266/src/pgmspace_bearssl.h
+++ b/lib/bearssl-esp8266/src/pgmspace_bearssl.h
@@ -50,7 +50,7 @@ extern "C" {
 //     w1,     w0
 
 #define pgm_read_with_offset(addr, res) \
-  asm("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
+  __asm__ ("extui    %0, %1, 0, 2\n"     /* Extract offset within word (in bytes) */ \
       "sub      %1, %1, %0\n"       /* Subtract offset from addr, yielding an aligned address */ \
       "l32i.n   %1, %1, 0x0\n"      /* Load word from aligned address */ \
       "slli     %0, %0, 3\n"        /* Mulitiply offset by 8, yielding an offset in bits */ \


### PR DESCRIPTION
## Description:

Thanks Jason and Staars for the fix.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
