### PR TITLE
Fix thermostat when using local sensor

### DIFF
--- a/tasmota/xdrv_39_thermostat.ino
+++ b/tasmota/xdrv_39_thermostat.ino
@@ -1331,7 +1331,7 @@ void ThermostatGetLocalSensor(uint8_t ctr_output) {
   DynamicJsonBuffer jsonBuffer;
   JsonObject& root = jsonBuffer.parseObject((const char*)mqtt_data);
   if (root.success()) {
-    const char* value_c = root["THERMOSTAT_SENSOR_NAME"]["Temperature"];
+    const char* value_c = root[THERMOSTAT_SENSOR_NAME]["Temperature"];
     if (value_c != NULL && strlen(value_c) > 0 && (isdigit(value_c[0]) || (value_c[0] == '-' && isdigit(value_c[1])) ) ) {
       int16_t value = (int16_t)(CharToFloat(value_c) * 10);
       if ( (value >= -1000) 


### PR DESCRIPTION
## Description:
Fixes an issue introduced in https://github.com/arendst/Tasmota/commit/e23803846fffd513475aa88ea5b8f8b45346ed1c

Macros are not expanded in string constants, so the thermostat driver
never managed to obtain the current temperature from the local sensor
(SensorInputSet 1). Fix this simply by removing the quotes. The sensor
name (THERMOSTAT_SENSOR_NAME) is defined as a quoted string in 
my_user_config.h (default "DS18B20").

The thermostat obtains the local sensor temperature by parsing the status
output (really!), e.g. tasmota/tele/spare3C3032/SENSOR {"Time":"2020-06-10T19:42:28","DS18B20":{"Id":"0000066ED9AC","Temperature":25.8},"TempUnit":"C"}
The changed code was looking for object "THERMOSTAT_SENSOR_NAME"
containing a "Temperature" value, rather than looking for an object with the
defined name (in this case "DS18B20"). The lookup never succeeded, resulting
in the current temperature to remain permanently at the default (0.0C).

The problem (and solution) can be verified using command TempMeasuredSet.
Despite the documentation saying that this applies to the MQTT sensor only (SensorInputSet 0),
calling TempMeasuredSet will actually return the appropriate measured temperature regardless of the sensor being used. It's just that any attempt to set a value will be ignored unless SensorInputSet is 0 (MQTT).
Before this change, TempMeasuredSet would always return 0.0 with SensorInputSet 1
and the thermostat controller would continue heating at maximum output.

Compiled an tested on ESP8266 (Sonoff TH16 with DS18B20).
Compiled on ESP32, but not tested due to missing hardware. However, the bug being fixed is syntax only and has no hardware dependencies.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [see above] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
