### PR TITLE
fix chartofloat digit overflow

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -167,6 +167,8 @@ float CharToFloat(const char *str)
   float right = 0;
   if (*pt == '.') {
     pt++;
+    // limit decimals to float max
+    pt[7]=0;
     right = atoi(pt);                              // Decimal part
     while (isdigit(*pt)) {
       pt++;


### PR DESCRIPTION
## Description:

fixes CharToFloat decimal overflow

without limit
49.95012283325195 => 49.00002289
with limit
49.95012283325195 = 49.95012283

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_