### PR TITLE
Added feature to set all possible mode for Parity, Stop, and Data bits

### DIFF
--- a/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
@@ -163,7 +163,6 @@ bool TasmotaSerial::begin(long speed, int stop_bits, int serial_config) {
     Serial.flush();
     if (serial_config >=0) {
       Serial.begin(speed, (SerialConfig) serial_config);
-
     // Keep old call begin compatibility
     } else {
       if (2 == m_stop_bits) {
@@ -186,7 +185,6 @@ bool TasmotaSerial::begin(long speed, int stop_bits, int serial_config) {
       }
       if (serial_config >=0) {
         TSerial->begin(speed, serial_config, m_rx_pin, m_tx_pin);
-
       // Keep old call begin compatibility
       } else {
         if (2 == m_stop_bits) {

--- a/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
+++ b/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.cpp
@@ -163,6 +163,7 @@ bool TasmotaSerial::begin(long speed, int stop_bits, int serial_config) {
     Serial.flush();
     if (serial_config >=0) {
       Serial.begin(speed, (SerialConfig) serial_config);
+      
     // Keep old call begin compatibility
     } else {
       if (2 == m_stop_bits) {
@@ -185,6 +186,7 @@ bool TasmotaSerial::begin(long speed, int stop_bits, int serial_config) {
       }
       if (serial_config >=0) {
         TSerial->begin(speed, serial_config, m_rx_pin, m_tx_pin);
+
       // Keep old call begin compatibility
       } else {
         if (2 == m_stop_bits) {

--- a/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.h
+++ b/lib/TasmotaSerial-3.0.0/src/TasmotaSerial.h
@@ -45,7 +45,7 @@ class TasmotaSerial : public Stream {
     TasmotaSerial(int receive_pin, int transmit_pin, int hardware_fallback = 0, int nwmode = 0, int buffer_size = TM_SERIAL_BUFFER_SIZE);
     virtual ~TasmotaSerial();
 
-    bool begin(long speed, int stop_bits = 1);
+    bool begin(long speed, int stop_bits = 1, int serial_config = -1);
     bool begin();
     bool hardwareSerial();
     int peek();


### PR DESCRIPTION
## Description:

This PR add new parameter `serial_config` to 
`bool TasmotaSerial::begin(long speed, int stop_bits, int serial_config)`

Leaving parameter `stop_bits` will not break the existing and leaving `serial_config` parameter empty will work as today.
`myTasmoSerial->begin(1200, SERIAL_8E1);`

Today calling with `myTasmoSerial->begin(1200, SERIAL_7E1);` leave to 8N1 so we needed to add another parameter to avoid breaking current implementation, so to do specific configuration for example we can now use  
`myTasmoSerial->begin(1200, 0, SERIAL_7E1);`

**Related issues** fixes #3837 and #5494

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
