### PR TITLE
Add serial to TCP bridge, ``TCPStart`` and ``TCPBaudRate``

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add initial support for Telegram bot (#8619)
 - Add support for HP303B Temperature and Pressure sensor by Robert Jaakke (#8638)
 - Add rule trigger ``System#Init`` to allow early rule execution without wifi and mqtt initialized yet
+- Add serial to TCP bridge, ``TCPStart`` and ``TCPBaudRate`` (needs #define USE_TCP_BRIDGE)
 
 ### 8.3.1.2 20200522
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -643,6 +643,7 @@
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
 #define D_LOG_ZIGBEE "ZIG: "       // Zigbee
+#define D_LOG_TCP "TCP: "          // TCP bridge
 
 /********************************************************************************************/
 

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE                    "А"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -691,6 +691,8 @@
 #define D_GPIO_WEBCAM_PSCLK    "CAM_PSCLK"
 #define D_GPIO_WEBCAM_HSD      "CAM_HSD"
 #define D_GPIO_WEBCAM_PSRCS    "CAM_PSRCS"
+#define D_SENSOR_TCP_TXD       "TCP Tx"
+#define D_SENSOR_TCP_RXD       "TCP Rx"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -577,6 +577,7 @@
   #define STARTING_OFFSET      30                // Turn on NovaSDS XX-seconds before tele_period is reached
 //#define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor (+1k4)
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge (+0k8 code)
+//#define USE_TCP_BRIDGE                           //  Add support for Serial to TCP bridge (+1.3k code)
 //#define USE_MP3_PLAYER                           // Use of the DFPlayer Mini MP3 Player RB-DFR-562 commands: play, volume and stop
   #define MP3_VOLUME           10                // Set the startup volume on init, the range can be 0..30(max)
 //#define USE_AZ7798                               // Add support for AZ-Instrument 7798 CO2 datalogger (+1k6 code)

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -568,8 +568,9 @@ struct {
   uint8_t       windmeter_tele_pchange;    // F3E
   uint8_t	      ledpwm_on;                 // F3F
   uint8_t	      ledpwm_off;                // F40
+  uint8_t       tcp_baudrate;              // F41
 
-  uint8_t       free_f42[119];             // F41 - Decrement if adding new Setting variables just above and below
+  uint8_t       free_f42[118];             // F42 - Decrement if adding new Setting variables just above and below
 
   // Only 32 bit boundary variables below
   uint16_t      pulse_counter_debounce_low;  // FB8

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -234,6 +234,8 @@ enum UserSelectablePins {
   GPIO_BOILER_OT_TX,   // OpenTherm Boiler TX pin
   GPIO_WINDMETER_SPEED,  // WindMeter speed counter pin
   GPIO_BL0940_RX,      // BL0940 serial interface
+  GPIO_TCP_TX,         // TCP Serial bridge
+  GPIO_TCP_RX,         // TCP Serial bridge
   GPIO_SENSOR_END };
 
 // Programmer selectable GPIO functionality
@@ -324,7 +326,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_AS3935 "|" D_SENSOR_PMS5003_TX "|"
   D_SENSOR_BOILER_OT_RX "|" D_SENSOR_BOILER_OT_TX "|"
   D_SENSOR_WINDMETER_SPEED "|"
-  D_SENSOR_BL0940_RX
+  D_SENSOR_BL0940_RX "|"
+  D_SENSOR_TCP_TXD "|" D_SENSOR_TCP_RXD
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -681,6 +684,10 @@ const uint8_t kGpioNiceList[] PROGMEM = {
 #endif
 #ifdef USE_AS3935
   GPIO_AS3935,
+#endif
+#ifdef USE_TCP_BRIDGE
+  AGPIO(GPIO_TCP_TX),      // TCP Serial bridge
+  AGPIO(GPIO_TCP_RX),      // TCP Serial bridge
 #endif
 };
 

--- a/tasmota/tasmota_template_ESP32.h
+++ b/tasmota/tasmota_template_ESP32.h
@@ -129,6 +129,7 @@ enum UserSelectablePins {
   GPIO_WINDMETER_SPEED,                // WindMeter speed counter pin
   GPIO_KEY1_TC,                        // Touch pin as button
   GPIO_BL0940_RX,                      // BL0940 serial interface
+  GPIO_TCP_TX, GPIO_TCP_RX,            // TCP to serial bridge
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -218,7 +219,8 @@ const char kSensorNames[] PROGMEM =
   D_GPIO_WEBCAM_PSRCS "|"
   D_SENSOR_BOILER_OT_RX "|" D_SENSOR_BOILER_OT_TX "|"
   D_SENSOR_WINDMETER_SPEED "|" D_SENSOR_BUTTON "_tc|"
-  D_SENSOR_BL0940_RX
+  D_SENSOR_BL0940_RX "|"
+  D_SENSOR_TCP_TXD "|" D_SENSOR_TCP_RXD
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -547,6 +549,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_WEBCAM_PSCLK),
   AGPIO(GPIO_WEBCAM_HSD) + MAX_WEBCAM_HSD,
   AGPIO(GPIO_WEBCAM_PSRCS),
+#endif
+#ifdef USE_TCP_BRIDGE
+  AGPIO(GPIO_TCP_TX),      // TCP Serial bridge
+  AGPIO(GPIO_TCP_RX),      // TCP Serial bridge
 #endif
   AGPIO(GPIO_KEY1_TC) + MAX_KEYS
 };

--- a/tasmota/xdrv_41_tcp_bridge.ino
+++ b/tasmota/xdrv_41_tcp_bridge.ino
@@ -1,0 +1,205 @@
+/*
+  xdrv_41_tcp_bridge.ino - TCP to serial bridge
+
+  Copyright (C) 2020  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_TCP_BRIDGE
+
+#define XDRV_41                    41
+
+#ifndef TCP_BRIDGE_CONNECTIONS
+#define TCP_BRIDGE_CONNECTIONS 2    // number of maximum parallel connections
+#endif
+
+#ifndef TCP_BRIDGE_BUF_SIZE
+#define TCP_BRIDGE_BUF_SIZE    255  // size of the buffer, above 132 required for efficient XMODEM
+#endif
+
+//const uint16_t tcp_port = 8880;
+WiFiServer   *server_tcp = nullptr;
+//WiFiClient   client_tcp1, client_tcp2;
+WiFiClient   client_tcp[TCP_BRIDGE_CONNECTIONS];
+uint8_t      client_next = 0;
+uint8_t     *tcp_buf = nullptr;     // data transfer buffer
+
+#include <TasmotaSerial.h>
+TasmotaSerial *TCPSerial = nullptr;
+
+const char kTCPCommands[] PROGMEM = "TCP" "|"    // prefix
+  "Start" "|" "Baudrate"
+  ;
+
+void (* const TCPCommand[])(void) PROGMEM = {
+  &CmndTCPStart, &CmndTCPBaudrate
+  };
+
+//
+// Called at event loop, checks for incoming data from the CC2530
+//
+void TCPLoop(void)
+{
+  uint8_t c;
+  bool busy;    // did we transfer some data?
+  int32_t buf_len;
+
+  if (!TCPSerial) return;
+
+  // check for a new client connection
+  if ((server_tcp) && (server_tcp->hasClient())) {
+    // find an empty slot
+    uint32_t i;
+    for (i=0; i<ARRAY_SIZE(client_tcp); i++) {
+      WiFiClient &client = client_tcp[i];
+      if (!client) {
+        client = server_tcp->available();
+        break;
+      }
+    }
+    if (i >= ARRAY_SIZE(client_tcp)) {
+      i = client_next++ % ARRAY_SIZE(client_tcp);
+      WiFiClient &client = client_tcp[i];
+      client.stop();
+      client = server_tcp->available();
+    }
+  }
+
+  do {
+    busy = false;       // exit loop if no data was transferred
+
+    // start reading the UART, this buffer can quickly overflow
+    buf_len = 0;
+    while ((buf_len < TCP_BRIDGE_BUF_SIZE) && (TCPSerial->available())) {
+      c = TCPSerial->read();
+      if (c >= 0) {
+        tcp_buf[buf_len++] = c;
+        busy = true;
+      }
+    }
+    if (buf_len > 0) {
+      char hex_char[TCP_BRIDGE_BUF_SIZE+1];
+  		ToHex_P(tcp_buf, buf_len, hex_char, 256);
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "from MCU: %s"), hex_char);
+
+      for (uint32_t i=0; i<ARRAY_SIZE(client_tcp); i++) {
+        WiFiClient &client = client_tcp[i];
+        if (client) { client.write(tcp_buf, buf_len); }
+      }
+    }
+
+    // handle data received from TCP
+    for (uint32_t i=0; i<ARRAY_SIZE(client_tcp); i++) {
+      WiFiClient &client = client_tcp[i];
+      buf_len = 0;
+      while (client && (buf_len < TCP_BRIDGE_BUF_SIZE) && (client.available())) {
+        c = client.read();
+        if (c >= 0) {
+          tcp_buf[buf_len++] = c;
+          busy = true;
+        }
+      }
+      if (buf_len > 0) {
+        char hex_char[TCP_BRIDGE_BUF_SIZE+1];
+        ToHex_P(tcp_buf, buf_len, hex_char, 256);
+        AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "to MCU/%d: %s"), i+1, hex_char);
+        TCPSerial->write(tcp_buf, buf_len);
+      }
+    }
+
+    yield();    // avoid WDT if heavy traffic
+  } while (busy);
+}
+
+/********************************************************************************************/
+void TCPInit(void) {
+  if (PinUsed(GPIO_TCP_RX) && PinUsed(GPIO_TCP_TX)) {
+    tcp_buf = (uint8_t*) malloc(TCP_BRIDGE_BUF_SIZE);
+    if (!tcp_buf) { AddLog_P2(LOG_LEVEL_ERROR, PSTR(D_LOG_TCP "could not allocate buffer")); return; }
+
+    if (!Settings.tcp_baudrate)  { Settings.tcp_baudrate = 115200 / 1200; }
+    TCPSerial = new TasmotaSerial(Pin(GPIO_TCP_RX), Pin(GPIO_TCP_TX), seriallog_level ? 1 : 2, 0, TCP_BRIDGE_BUF_SIZE);   // set a receive buffer of 256 bytes
+    TCPSerial->begin(Settings.tcp_baudrate * 1200);
+    if (TCPSerial->hardwareSerial()) {
+      ClaimSerial();
+		}
+  }
+}
+
+/*********************************************************************************************\
+ * Commands
+\*********************************************************************************************/
+
+//
+// Command `ZbConfig`
+//
+void CmndTCPStart(void) {
+
+  if (!TCPSerial) { return; }
+  int32_t tcp_port = XdrvMailbox.payload;
+
+  if (server_tcp) {
+    AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Stopping TCP server"));
+    server_tcp->stop();
+    delete server_tcp;
+    server_tcp = nullptr;
+
+    for (uint32_t i=0; i<ARRAY_SIZE(client_tcp); i++) {
+      WiFiClient &client = client_tcp[i];
+      client.stop();
+    }
+  }
+  if (tcp_port > 0) {
+    AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Starting TCP server on port %d"), tcp_port);
+    server_tcp = new WiFiServer(tcp_port);
+    server_tcp->begin(); // start TCP server
+    server_tcp->setNoDelay(true);
+  }
+
+  ResponseCmndDone();  
+}
+
+void CmndTCPBaudrate(void) {
+  if ((XdrvMailbox.payload >= 1200) && (XdrvMailbox.payload <= 115200)) {
+    XdrvMailbox.payload /= 1200;  // Make it a valid baudrate
+    Settings.tcp_baudrate = XdrvMailbox.payload;
+    TCPSerial->begin(Settings.tcp_baudrate * 1200);  // Reinitialize serial port with new baud rate
+  }
+  ResponseCmndNumber(Settings.tcp_baudrate * 1200);
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv41(uint8_t function)
+{
+  bool result = false;
+
+  switch (function) {
+    case FUNC_LOOP:
+      TCPLoop();
+      break;
+    case FUNC_PRE_INIT:
+      TCPInit();
+      break;
+    case FUNC_COMMAND:
+      result = DecodeCommand(kTCPCommands, TCPCommand);
+      break;
+  }
+  return result;
+}
+
+#endif // USE_TCP_BRIDGE


### PR DESCRIPTION
## Description:

Add a new feature: Serial to TCP bridge (similar to esp-link). This allows to remotely communicate to a MCU through ESP8266. Needs `#define USE_TCP_BRIDGE`

It adds 2 GPIO types: `TCP Tx (208)` and `TCP Rx (209)` and can work with hardware or software serial.

Commands:

- `TCPBaudRate <x>`: sets the baudrate for serial (only 8N1 mode), min `1200`, max `115200` by 1200 increments.
- `TCPStart <port>`: listens to port `<port>`. This features supports 2 parallel TCP connexions, which can be useful if you need a terminal + a specific protocol (like XMODEM). The 3rd connection will disconnect an previous connection. The number of parallel connections is a compile-time option.
- `TCPStart 0` or `TCPStart`: shuts down the TCP server and disconnects any existing connection.

For security reasons, the TCP bridge is not started at boot, and requires an explicit `TCPStart` command (can be automated with Rules).

Size impact:
- Flash: +1.3kb
- Ram: +64 bytes

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
