### PR TITLE
KNX: Revert FastPrecisePowf due to lost of precision

### DIFF
--- a/lib/esp-knx-ip-0.5.2/esp-knx-ip.h
+++ b/lib/esp-knx-ip-0.5.2/esp-knx-ip.h
@@ -398,7 +398,7 @@ typedef struct __callback_assignment
 } callback_assignment_t;
 
 // FastPrecisePowf from tasmota/support_float.ino
-extern float FastPrecisePowf(const float x, const float y);
+//extern float FastPrecisePowf(const float x, const float y);
 
 class ESPKNXIP {
   public:
@@ -567,7 +567,7 @@ class ESPKNXIP {
     callback_assignment_id_t __callback_register_assignment(address_t address, callback_id_t id);
     void __callback_delete_assignment(callback_assignment_id_t id);
 
-    static inline float pow(float a, float b) { return FastPrecisePowf(a, b); }
+    //static inline float pow(float a, float b) { return FastPrecisePowf(a, b); }
 
     ESP8266WebServer *server;
     address_t physaddr;


### PR DESCRIPTION
## Description:

The `FastPrecisePowf` function reduces the flash usage on 5Kb but it don't provide enough precision for KNX telegram encoding producing an incorrect value to be sent or receive.

See the following example:

![image](https://user-images.githubusercontent.com/35405447/84814038-42b9cb00-afe7-11ea-852b-c9b7a5aaedc6.png)

With this PR:

![image](https://user-images.githubusercontent.com/35405447/84812647-169d4a80-afe5-11ea-9b9a-bcf0624a4d9d.png)

I'm looking for another way of encoding the KNX telegram for float values. In the meantime, it is better to use those extra 5Kb for the KNX firmware in favour of a correct KNX telegram encoding.
I'm working also on refactoring the KNX driver to reduce RAM and flash usage and also adding new functionalities.

**Related issue (if applicable):** fixes NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
