### PR TITLE
KNX: Add Scene Support

### DIFF
--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Подобрена комуникация"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Използвана енергия днес"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Spotřeba Dnes"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Erweiterte Kommunikation"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energie heute"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Βελτίωση επικοινωνίας"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Ενέργεια σήμερα"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energy Today"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Mejora de Comunicación"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX ESCENA TX"
+#define D_KNX_RX_SCENE "KNX ESCENA RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energía Hoy"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Amélioration de la communication"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX Scène TX"
+#define D_KNX_RX_SCENE "KNX Scène RX"
 
 // xsns_03_energy.ino
 #define D_ENERGY_TODAY "Énergie aujourd'hui"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "שיפור התקשורת"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "צריכה יומית"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Mai energia"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Miglioramento comunicazione"
 #define D_KNX_TX_SLOT "KNX - TX"
 #define D_KNX_RX_SLOT "KNX - RX"
+#define D_KNX_TX_SCENE "Scena - TX"
+#define D_KNX_RX_SCENE "Scena - RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energia - oggi"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "커뮤니케이션 강화"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "금일 전력 사용량"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Verbeter verbinding"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Verbruik vandaag"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Rozszerzenia"
 #define D_KNX_TX_SLOT "Gniazdo TX"
 #define D_KNX_RX_SLOT "Gniazdo RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energia dzisiaj"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Melhoria da comunicação"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Consumo energético de hoje"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Melhoria de Comunicação"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Consumo energético de hoje"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Îmbunătățire Communicație"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energia de Azi"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Энергия Сегодня"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Spotreba dnes"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Kommuniceringsförbättring"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energi idag"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Energy Today"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Підвищення зв'язку"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "Енергія Сьогодні"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "通讯增强"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "今日用电量"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -445,6 +445,8 @@
 #define D_KNX_ENHANCEMENT "Communication Enhancement"
 #define D_KNX_TX_SLOT "KNX TX"
 #define D_KNX_RX_SLOT "KNX RX"
+#define D_KNX_TX_SCENE "KNX SCENE TX"
+#define D_KNX_RX_SCENE "KNX SCENE RX"
 
 // xdrv_03_energy.ino
 #define D_ENERGY_TODAY "今日用電量"

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -203,7 +203,8 @@ const uint32_t LOOP_SLEEP_DELAY = 50;       // Lowest number of milliseconds to 
 #define KNX_SLOT3              28
 #define KNX_SLOT4              29
 #define KNX_SLOT5              30
-#define KNX_MAX_device_param   30
+#define KNX_SCENE              31
+#define KNX_MAX_device_param   31
 #define MAX_KNXTX_CMNDS        5
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Add KNX Scene Support.

If rules are enabled, now the user can define a KNX address for a new KNX SLOT called Scene. This new slot is available for receiving a scene number and also for transmitting a scene number, using KNX DPT 17.001 (1 byte - integer). The Scene number can be any number from 0 to 63 as defined in the KNX standard.

When Tasmota receives a scene number, it will trigger the rule event `KNX_SCENE` with the number of scene received. Example:

```lua
Rule1 1
Rule1 on EVENT#KNX_SCENE=1 do dimmer 50 endon
```

If the user wants to send a scene number to the KNX Bus, it can be used the command `KNXTx_Scene <number>`. Example:

```lua
Rule2 1
Rule2 on Switch#State do KNXTx_Scene 1 endon
```

**Note:** If using Home Assistant with KNX scenes, HA defines the KNX scenes from 1 to 64 but it sends to the KNX bus as 0 to 63. So, if your HA scene is 5, your Tasmota will receive 4.

**Related issue (if applicable):** fixes #6711 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
