### PR TITLE
Fix bug on rule variable %topic%

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -711,7 +711,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%UTCTIME%"), String(UtcTime()));
       RulesVarReplace(commands, F("%UPTIME%"), String(MinutesUptime()));
       RulesVarReplace(commands, F("%TIMESTAMP%"), GetDateAndTime(DT_LOCAL));
-      RulesVarReplace(commands, F("%TOPIC%"), SettingsText(SET_MQTT_TOPIC));
+      RulesVarReplace(commands, F("%TOPIC%"), mqtt_topic);
 #if defined(USE_TIMERS) && defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));
       RulesVarReplace(commands, F("%SUNSET%"), String(SunMinutes(1)));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #8536

As explained in the referenced issue, if having a topic as:
TOPIC: `Tasmota/%04x`

And if a rule is created like the following:
RULE1: `ON Var1#State DO Publish %topic%/Var1 %value% ENDON`

We expect to have as result a MQTT message published to the topic:
`Tasmota/3978/Var1`

But instead we were getting this:
`Tasmota/%04x/Var1`

The `%topic%` variable didn't have the replacement of the mac last digits on %04x. This bug was because the rules' driver was using an incorrect internal topic variable for this.

This PR fixes this.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
