### PR TITLE
Update to ESP32 framework 1.12.4

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -170,7 +170,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; ***  expect the unexpected. Many features not working!!!    ***
 
 [common32]
-platform                = espressif32@1.12.2
+platform                = espressif32@1.12.4
 platform_packages       = tool-esptoolpy@1.20800.0
 board                   = esp32dev
 board_build.ldscript    = esp32_out.ld
@@ -198,12 +198,9 @@ build_flags             = ${esp_defaults.build_flags}
     -D sint16_t=int16_t
     -D memcpy_P=memcpy
 	  -D memcmp_P=memcmp
-    -D USE_CONFIG_OVERRIDE
 
 lib_extra_dirs =
     libesp32
 
 lib_ignore =
-  ;  ILI9488
-  ;  SSD3115
     cc1101


### PR DESCRIPTION
and remove obsolete and redundant entry
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
