### PR TITLE
Interlock mode can be set upon compilation

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -280,6 +280,12 @@
 #define APP_DISABLE_POWERCYCLE false             // [SetOption65] Disable fast power cycle detection for device reset
 #define DEEPSLEEP_BOOTCOUNT    false             // [SetOption76] Enable incrementing bootcount when deepsleep is enabled
 
+#define APP_INTERLOCK_MODE     false             // [Interlock] Relay interlock mode
+#define APP_INTERLOCK_GROUP_1  0xFF              // [Interlock] Relay bitmask for interlock group 1 (0x00 if undef)
+//#define APP_INTERLOCK_GROUP_2  0x00              // [Interlock] Relay bitmask for interlock group 2 (0x00 if undef)
+//#define APP_INTERLOCK_GROUP_3  0x00              // [Interlock] Relay bitmask for interlock group 3 (0x00 if undef)
+//#define APP_INTERLOCK_GROUP_4  0x00              // [Interlock] Relay bitmask for interlock group 4 (0x00 if undef)
+
 // -- Lights --------------------------------------
 #define WS2812_LEDS            30                // [Pixels] Number of WS2812 LEDs to start with (max is 512)
 #define LIGHT_MODE             true              // [SetOption15] Switch between commands PWM or COLOR/DIMMER/CT/CHANNEL

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -765,8 +765,20 @@ void SettingsDefaultSet2(void)
   }
 
   // Module
-//  flag.interlock |= 0;
-  Settings.interlock[0] = 0xFF;         // Legacy support using all relays in one interlock group
+  flag.interlock |= APP_INTERLOCK_MODE;
+  for (uint32_t i = 0; i < MAX_INTERLOCKS; i++) { Settings.interlock[i] = 0; }
+#ifdef APP_INTERLOCK_GROUP_1
+  Settings.interlock[0] = APP_INTERLOCK_GROUP_1;         // Legacy support using all relays in one interlock group
+#endif
+#ifdef APP_INTERLOCK_GROUP_2
+  Settings.interlock[1] = APP_INTERLOCK_GROUP_2;
+#endif
+#ifdef APP_INTERLOCK_GROUP_3
+  Settings.interlock[2] = APP_INTERLOCK_GROUP_3;
+#endif
+#ifdef APP_INTERLOCK_GROUP_4
+  Settings.interlock[3] = APP_INTERLOCK_GROUP_4;
+#endif
   Settings.module = MODULE;
   Settings.fallback_module = FALLBACK_MODULE;
   ModuleDefault(WEMOS);
@@ -1188,8 +1200,19 @@ void SettingsDelta(void)
       Settings.param[P_MDNS_DELAYED_START] = 0;
     }
     if (Settings.version < 0x0604010B) {
-      Settings.interlock[0] = 0xFF;         // Legacy support using all relays in one interlock group
-      for (uint32_t i = 1; i < MAX_INTERLOCKS; i++) { Settings.interlock[i] = 0; }
+      for (uint32_t i = 0; i < MAX_INTERLOCKS; i++) { Settings.interlock[i] = 0; }
+#ifdef APP_INTERLOCK_GROUP_1
+      Settings.interlock[0] = APP_INTERLOCK_GROUP_1;         // Legacy support using all relays in one interlock group
+#endif
+#ifdef APP_INTERLOCK_GROUP_2
+      Settings.interlock[1] = APP_INTERLOCK_GROUP_2;
+#endif
+#ifdef APP_INTERLOCK_GROUP_3
+      Settings.interlock[2] = APP_INTERLOCK_GROUP_3;
+#endif
+#ifdef APP_INTERLOCK_GROUP_4
+      Settings.interlock[3] = APP_INTERLOCK_GROUP_4;
+#endif
     }
     if (Settings.version < 0x0604010D) {
       Settings.param[P_BOOT_LOOP_OFFSET] = BOOT_LOOP_OFFSET;  // SetOption36

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1627,7 +1627,8 @@ void CmndInterlock(void)
     }
     ResponseAppend_P(PSTR("\"}"));
   } else {
-    Settings.flag.interlock = 0;                                // CMND_INTERLOCK - Enable/disable interlock
+    // never ever reset interlock mode inadvertently if we forced it upon compilation
+    Settings.flag.interlock = APP_INTERLOCK_MODE;               // CMND_INTERLOCK - Enable/disable interlock
     ResponseCmndStateText(Settings.flag.interlock);
   }
 }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):**
Interlock functionality is crucial for shutters and blinds using the ShutterMode 0 model. This functionality lets us create a custom build when the interlock settings could survive even resetting the eeprom content to its factory default.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
