### PR TITLE
Add support for sending GlobalCache codes via irsend

### DIFF
--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -470,9 +470,8 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       return IE_INVALID_RAWDATA;
     }   // Parameters must be at least 3
 
-
 #ifdef IR_GC
-   if (strcmp(str, "gc") == 0 ||strcmp(str, "GC") == 0) {  //if first parameter is gc then we process global cache data else it is raw
+   if (strcmp(str, "gc") == 0 || strcmp(str, "GC") == 0) {  //if first parameter is gc then we process global cache data else it is raw
 	uint16_t GC[count+1];
 	for (uint32_t i = 0; i <= count; i++) {
 	  GC[i] = strtol(strtok_r(nullptr, ", ", &p), nullptr, 0);
@@ -480,14 +479,13 @@ uint32_t IrRemoteCmndIrSendRaw(void)
         return IE_INVALID_RAWDATA;                
       }
     }
+	irsend_active = true;
 	for (uint32_t r = 0; r <= repeat; r++) {
       irsend->sendGC(GC, count+1);
     }
 	return IE_NO_ERROR;
   }
 #endif
-
-
 
     uint16_t parm[count];
     for (uint32_t i = 0; i < count; i++) {

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -470,6 +470,29 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       return IE_INVALID_RAWDATA;
     }   // Parameters must be at least 3
 
+
+#ifdef IR_GC
+//ir_gc
+
+  if (strcmp(str, "gc") == 0) {  //if first parameter is gc then we process global cache data else it is raw
+       
+	uint16_t GC[count+1];
+	for (uint32_t i = 0; i <= count; i++) {
+	  GC[i] = strtol(strtok_r(nullptr, ", ", &p), nullptr, 0);
+      if (!GC[i]) {
+         return IE_INVALID_RAWDATA;                
+      }
+      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: GC value %d"), GC[i]);
+    }
+    irsend->sendGC(GC, count+1);
+		AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: GC sent count %d"), count);
+    return IE_NO_ERROR;
+  }
+//end ir_gc
+#endif
+
+
+
     uint16_t parm[count];
     for (uint32_t i = 0; i < count; i++) {
       parm[i] = strtol(strtok_r(nullptr, ", ", &p), nullptr, 0);

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -472,23 +472,19 @@ uint32_t IrRemoteCmndIrSendRaw(void)
 
 
 #ifdef IR_GC
-//ir_gc
-
-  if (strcmp(str, "gc") == 0) {  //if first parameter is gc then we process global cache data else it is raw
-       
+   if (strcmp(str, "gc") == 0 ||strcmp(str, "GC") == 0) {  //if first parameter is gc then we process global cache data else it is raw
 	uint16_t GC[count+1];
 	for (uint32_t i = 0; i <= count; i++) {
 	  GC[i] = strtol(strtok_r(nullptr, ", ", &p), nullptr, 0);
       if (!GC[i]) {
-         return IE_INVALID_RAWDATA;                
+        return IE_INVALID_RAWDATA;                
       }
-      AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: GC value %d"), GC[i]);
     }
-    irsend->sendGC(GC, count+1);
-		AddLog_P2(LOG_LEVEL_DEBUG, PSTR("DBG: GC sent count %d"), count);
-    return IE_NO_ERROR;
+	for (uint32_t r = 0; r <= repeat; r++) {
+      irsend->sendGC(GC, count+1);
+    }
+	return IE_NO_ERROR;
   }
-//end ir_gc
 #endif
 
 

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -470,8 +470,7 @@ uint32_t IrRemoteCmndIrSendRaw(void)
       return IE_INVALID_RAWDATA;
     }   // Parameters must be at least 3
 
-#ifdef IR_GC
-   if (strcmp(str, "gc") == 0 || strcmp(str, "GC") == 0) {  //if first parameter is gc then we process global cache data else it is raw
+   if (strcasecmp(str, "gc") == 0) {  //if first parameter is gc then we process global cache data else it is raw
 	uint16_t GC[count+1];
 	for (uint32_t i = 0; i <= count; i++) {
 	  GC[i] = strtol(strtok_r(nullptr, ", ", &p), nullptr, 0);
@@ -485,7 +484,6 @@ uint32_t IrRemoteCmndIrSendRaw(void)
     }
 	return IE_NO_ERROR;
   }
-#endif
 
     uint16_t parm[count];
     for (uint32_t i = 0; i < count; i++) {


### PR DESCRIPTION
Small function to add support for GlobalCache formated ir commands.  Uses the same format as irsend<x> raw,xxx.
use irsend<x> gc,xxx,xxx 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
