### PR TITLE
Fix regression from latest Platformio optimization

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -36,10 +36,10 @@ default_envs =
 
 
 [common]
-platform                  = ${core_active.platform}
-platform_packages         = ${core_active.platform_packages}
-build_unflags             = ${core_active.build_unflags}
-build_flags               = ${core_active.build_flags}
+platform                  = ${core.platform}
+platform_packages         = ${core.platform_packages}
+build_unflags             = ${core.build_unflags}
+build_flags               = ${core.build_flags}
 ; *** Optional Debug messages
 ;                            -DDEBUG_TASMOTA_CORE
 ;                            -DDEBUG_TASMOTA_DRIVER
@@ -71,7 +71,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 ;                            pio/strip-floats.py
 ;                            pio/http-uploader.py
 
-[core_active]
+[core]
 ; Activate only (one set) if you want to override the standard core defined in platformio.ini !!!
 
 ;platform                  = ${tasmota_stage.platform}
@@ -87,7 +87,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-extends                   = core
+platform                  = espressif8266@2.5.3
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git#52b3e5b7b3ccedcede665682f7896b637b64dbf5
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -123,7 +123,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core for Arduino version latest development version
-extends                   = core
+platform                  = espressif8266@2.5.3
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -160,7 +160,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]
-extends                   = core
 build_type                = debug
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
when Platformio_override.ini is activated and no other core is choosen as the selected in platformio.ini

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
