### PR TITLE
Shrink tasmota-ir firmware binary

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -70,10 +70,10 @@
 | USE_LE01MR            | - | - | - | - | - | - | - |
 | USE_TELEINFO          | - | - | - | - | - | - | - |
 |                       |   |   |   |   |   |   |   |
-| USE_ADC_VCC           | x | x | - | - | - | - | - |
-| USE_COUNTER           | - | - | x | x | x | x | x |
-| USE_DS18x20           | - | - | x | x | x | x | x |
-| USE_DHT               | - | - | x | x | x | x | x |
+| USE_ADC_VCC           | x | x | - | - | - | x | - |
+| USE_COUNTER           | - | - | x | x | x | - | x |
+| USE_DS18x20           | - | - | x | x | x | - | x |
+| USE_DHT               | - | - | x | x | x | - | x |
 | USE_MAX31855          | - | - | - | - | x | - | - |
 | USE_MAX31865          | - | - | - | - | - | - | - |
 | USE_THERMOSTAT        | - | - | - | - | - | - | - |

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -347,6 +347,10 @@
 #undef USE_ELECTRIQ_MOODL                        // Disable support for ElectriQ iQ-wifiMOODL RGBW LED controller
 #undef USE_LIGHT_PALETTE                         // Disable support for color palette (+0k9 code)
 
+#undef USE_COUNTER                               // Disable counters
+#define USE_ADC_VCC                              // Display Vcc in Power status. Disable for use as Analog input on selected devices
+#undef USE_DS18x20                               // Disable DS18x20 sensor
+
 #undef USE_ENERGY_SENSOR                         // Disable energy sensors (-14k code)
   #undef USE_PZEM004T                            // Disable PZEM004T energy sensor
   #undef USE_PZEM_AC                             // Disable PZEM014,016 Energy monitor
@@ -386,7 +390,7 @@
 #undef USE_TASMOTA_CLIENT                        // Disable support for Arduino Uno/Pro Mini via serial interface including flashing (+2k3 code, 44 mem)
 #undef USE_OPENTHERM                             // Disable support for OpenTherm (+15k code)
 
-//#define USE_DHT                                  // Add support for DHT11, AM2301 (DHT21, DHT22, AM2302, AM2321) and SI7021 Temperature and Humidity sensor
+#undef USE_DHT                                   // Disable support for DHT11, AM2301 (DHT21, DHT22, AM2302, AM2321) and SI7021 Temperature and Humidity sensor
 #undef USE_MAX31855                              // Disable MAX31855 K-Type thermocouple sensor using softSPI
 #undef USE_MAX31865                              // Disable support for MAX31865 RTD sensors using softSPI
 #undef USE_SR04                                  // Disable support for for HC-SR04 ultrasonic devices


### PR DESCRIPTION
Disable Counter, DHT and DS18x20 sensors. Use ADC_VCC

reduce from 578 KB to 562 KB 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
