### PR TITLE
Add uptime metric to prometheus exporter

### DIFF
--- a/tasmota/xsns_91_prometheus.ino
+++ b/tasmota/xsns_91_prometheus.ino
@@ -37,6 +37,8 @@ void HandleMetrics(void)
 
   char parameter[FLOATSZ];
 
+  WSContentSend_P(PSTR("# TYPE tasmota_uptime_seconds gauge\ntasmota_uptime_seconds %d\n"), uptime);
+
   if (!isnan(global_temperature)) {
     dtostrfd(global_temperature, Settings.flag2.temperature_resolution, parameter);
     WSContentSend_P(PSTR("# TYPE global_temperature gauge\nglobal_temperature %s\n"), parameter);


### PR DESCRIPTION
I'm following the naming practices:
https://prometheus.io/docs/practices/naming/
- an application prefix (tasmota_)
- a unit suffix in plural form

Tested building and flashing: looks like

```
tasmota_uptime_seconds 78
```

## Description:

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

I've tested this on a [Kogan Smart Plug](https://www.kogan.com/au/buy/kogan-smarterhome-smart-plug-energy-meter-5v-24a-usb-ports-4-pack/), but I don't really know what "core ESP8266 V.2.7.1" and "core ESP32 V.1.12.2" mean.