### PR TITLE
Move #define USE_PROMETHEUS to my_user_config.h

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -741,6 +741,9 @@
   #define THERMOSTAT_TEMP_BAND_NO_PEAK_DET      1         // Default temperature band in thenths of degrees celsius within no peak will be detected
   #define THERMOSTAT_TIME_STD_DEV_PEAK_DET_OK   10        // Default standard deviation in minutes of the oscillation periods within the peak detection is successful
 
+// -- Prometheus exporter ---------------------------
+//#define USE_PROMETHEUS                           // Add support for https://prometheus.io/ metrics exporting over HTTP /metrics endpoint
+
 // -- End of general directives -------------------
 
 /*********************************************************************************************\

--- a/tasmota/xsns_91_prometheus.ino
+++ b/tasmota/xsns_91_prometheus.ino
@@ -17,8 +17,6 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//#define USE_PROMETHEUS                         // Enable retrieval of metrics
-
 #ifdef USE_PROMETHEUS
 /*********************************************************************************************\
  * Prometheus support


### PR DESCRIPTION
This is where all the other #defines live.

This should make it easier to find the #define for enabling prometheus.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

The code is a no-op, as it's all commented out.