### PR TITLE
Add tasmota_info prometheus psuedo-metric.

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -35,6 +35,9 @@ void HandleMetrics(void)
 
   char parameter[FLOATSZ];
 
+  // Pseudo-metric providing metadata about the running firmware version.
+  WSContentSend_P(PSTR("# TYPE tasmota_info gauge\ntasmota_info{version=\"%s\",image=\"%s\",build_timestamp=\"%s\"} 1\n"),
+                  my_version, my_image, GetBuildDateAndTime().c_str());
   WSContentSend_P(PSTR("# TYPE tasmota_uptime_seconds gauge\ntasmota_uptime_seconds %d\n"), uptime);
   WSContentSend_P(PSTR("# TYPE tasmota_boot_count counter\ntasmota_boot_count %d\n"), Settings.bootcount);
 


### PR DESCRIPTION
Exports version, image type, and build timestamp.

It's common to export something like this to show version numbers across the fleet.

Outputs:
```
# TYPE tasmota_info gauge
tasmota_info{version="8.3.1.6",image="(tasmota)",build_timestamp="2020-06-27T15:02:34"} 1
```

For example, the Go language exporter exposes version:
```
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.14.4"} 1
```

And prometheus exposes:
```
# HELP prometheus_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which prometheus was built.
# TYPE prometheus_build_info gauge
prometheus_build_info{branch="HEAD",goversion="go1.14.4",revision="eba3fdcbf0d378b66600281903e3aab515732b39",version="2.19.1"} 1
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

Tested on a Kogan Smart Plug.