### PR TITLE
Add WiFi metrics to prometheus exporter

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -41,6 +41,13 @@ void HandleMetrics(void)
   WSContentSend_P(PSTR("# TYPE tasmota_uptime_seconds gauge\ntasmota_uptime_seconds %d\n"), uptime);
   WSContentSend_P(PSTR("# TYPE tasmota_boot_count counter\ntasmota_boot_count %d\n"), Settings.bootcount);
 
+
+  // Pseudo-metric providing metadata about the WiFi station.
+  WSContentSend_P(PSTR("# TYPE tasmota_wifi_station_info gauge\ntasmota_wifi_station_info{bssid=\"%s\",ssid=\"%s\"} 1\n"), WiFi.BSSIDstr().c_str(), WiFi.SSID().c_str());
+
+  // Wi-Fi Signal strength
+  WSContentSend_P(PSTR("# TYPE tasmota_wifi_station_signal_dbm gauge\ntasmota_wifi_station_signal_dbm{mac_address=\"%s\"} %d\n"), WiFi.BSSIDstr().c_str(), WiFi.RSSI());
+
   if (!isnan(global_temperature)) {
     dtostrfd(global_temperature, Settings.flag2.temperature_resolution, parameter);
     WSContentSend_P(PSTR("# TYPE global_temperature gauge\nglobal_temperature %s\n"), parameter);


### PR DESCRIPTION
Adds `tasmota_wifi_station_info` and `tasmota_wifi_station_signal_dbm` metrics to Prometheus exporter.

They look like this:

```
# TYPE tasmota_wifi_station_info gauge
tasmota_wifi_station_info{bssid="AA:BB:CC:DD:EE:FF", ssid="Marriott_Guest"} 1
```
```
# TYPE tasmota_wifi_station_signal_dbm gauge
tasmota_wifi_station_signal_dbm{mac_address="AA:BB:CC:DD:EE:FF"} -75
```

To avoid reinventing my own schema, I've tried to follow the lead of the [Prometheus Node Exporter](https://github.com/prometheus/node_exporter/) here, which outputs metrics like:

```
# HELP node_wifi_station_info Labeled WiFi interface station information as provided by the operating system.
# TYPE node_wifi_station_info gauge
node_wifi_station_info{bssid="aa:bb:cc:dd:ee:ff",device="wlan0",mode="client",ssid="Marriott_Guest"} 1
```
```
# HELP node_wifi_station_signal_dbm The current WiFi signal strength, in decibel-milliwatts (dBm).
# TYPE node_wifi_station_signal_dbm gauge
node_wifi_station_signal_dbm{device="wlan0",mac_address="aa:bb:cc:dd:ee:ff"} -59
```
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

Tested this on a Kogan Smart Plug.