### PR TITLE
Moved LQI to Zigbee devices

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -72,7 +72,7 @@ typedef struct Z_Device {
   uint16_t              hue;            // last Hue: 0..359
   uint16_t              x, y;           // last color [x,y]
   uint8_t               linkquality;    // lqi from last message, 0xFF means unknown
-  uint8_t               batterypercentx2;// battery percentage x 2 (0..200), 0xFF means unknwon
+  uint8_t               batterypercent; // battery percentage (0..100), 0xFF means unknwon
 } Z_Device;
 
 /*********************************************************************************************\
@@ -151,8 +151,8 @@ public:
   void setReachable(uint16_t shortaddr, bool reachable);
   void setLQI(uint16_t shortaddr, uint8_t lqi);
   uint8_t getLQI(uint16_t shortaddr) const;
-  void setBatteryPercentx2(uint16_t shortaddr, uint8_t bpx2);
-  uint8_t getBatteryPercentx2(uint16_t shortaddr) const;
+  void setBatteryPercent(uint16_t shortaddr, uint8_t bp);
+  uint8_t getBatteryPercent(uint16_t shortaddr) const;
 
   // get next sequence number for (increment at each all)
   uint8_t getNextSeqNumber(uint16_t shortaddr);
@@ -642,17 +642,17 @@ uint8_t Z_Devices::getLQI(uint16_t shortaddr) const {
   return 0xFF;
 }
 
-void Z_Devices::setBatteryPercentx2(uint16_t shortaddr, uint8_t bpx2) {
+void Z_Devices::setBatteryPercent(uint16_t shortaddr, uint8_t bp) {
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
-  device.batterypercentx2 = bpx2;
+  device.batterypercent = bp;
 }
 
-uint8_t Z_Devices::getBatteryPercentx2(uint16_t shortaddr) const {
+uint8_t Z_Devices::getBatteryPercent(uint16_t shortaddr) const {
   int32_t found = findShortAddr(shortaddr);
   if (found >= 0) {
     const Z_Device & device = devicesAt(found);
-    return device.batterypercentx2;
+    return device.batterypercent;
   }
   return 0xFF;
 }

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -71,6 +71,8 @@ typedef struct Z_Device {
   uint16_t              ct;             // last CT: 153-500
   uint16_t              hue;            // last Hue: 0..359
   uint16_t              x, y;           // last color [x,y]
+  uint8_t               linkquality;    // lqi from last message, 0xFF means unknown
+  uint8_t               batterypercentx2;// battery percentage x 2 (0..200), 0xFF means unknwon
 } Z_Device;
 
 /*********************************************************************************************\
@@ -147,6 +149,10 @@ public:
   const char * getModelId(uint16_t shortaddr) const;
   const char * getManufacturerId(uint16_t shortaddr) const;
   void setReachable(uint16_t shortaddr, bool reachable);
+  void setLQI(uint16_t shortaddr, uint8_t lqi);
+  uint8_t getLQI(uint16_t shortaddr) const;
+  void setBatteryPercentx2(uint16_t shortaddr, uint8_t bpx2);
+  uint8_t getBatteryPercentx2(uint16_t shortaddr) const;
 
   // get next sequence number for (increment at each all)
   uint8_t getNextSeqNumber(uint16_t shortaddr);
@@ -294,6 +300,8 @@ Z_Device & Z_Devices::createDeviceEntry(uint16_t shortaddr, uint64_t longaddr) {
                       200,        // ct
                       0,          // hue
                       0, 0,       // x, y
+                      0xFF,       // lqi, 0xFF = unknown
+                      0xFF        // battery percentage x 2, 0xFF means unknown
                     };
 
   device_alloc->json_buffer = new DynamicJsonBuffer(16);
@@ -617,6 +625,36 @@ void Z_Devices::setReachable(uint16_t shortaddr, bool reachable) {
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   bitWrite(device.power, 7, reachable);
+}
+
+void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (&device == nullptr) { return; }                 // don't crash if not found
+  device.linkquality = lqi;
+}
+
+uint8_t Z_Devices::getLQI(uint16_t shortaddr) const {
+  int32_t found = findShortAddr(shortaddr);
+  if (found >= 0) {
+    const Z_Device & device = devicesAt(found);
+    return device.linkquality;
+  }
+  return 0xFF;
+}
+
+void Z_Devices::setBatteryPercentx2(uint16_t shortaddr, uint8_t bpx2) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (&device == nullptr) { return; }                 // don't crash if not found
+  device.batterypercentx2 = bpx2;
+}
+
+uint8_t Z_Devices::getBatteryPercentx2(uint16_t shortaddr) const {
+  int32_t found = findShortAddr(shortaddr);
+  if (found >= 0) {
+    const Z_Device & device = devicesAt(found);
+    return device.batterypercentx2;
+  }
+  return 0xFF;
 }
 
 // get the next sequance number for the device, or use the global seq number if device is unknown

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1187,7 +1187,7 @@ int32_t Z_ModelKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObjec
 }
 // Record BatteryPercentage
 int32_t Z_BatteryPercentageKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  zigbee_devices.setBatteryPercentx2(shortaddr, value.as<uint8_t>());
+  zigbee_devices.setBatteryPercent(shortaddr, json[new_name]);
   return 1;
 }
 
@@ -1343,7 +1343,7 @@ int32_t Z_AqaraSensorFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObj
       json[F("BatteryVoltage")] = batteryvoltage;
       uint8_t batterypercentage = toPercentageCR2032(val);
       json[F("BatteryPercentage")] = batterypercentage;
-      zigbee_devices.setBatteryPercentx2(shortaddr, batterypercentage * 2);
+      zigbee_devices.setBatteryPercent(shortaddr, batterypercentage);
       // deprecated
       json[F(D_JSON_VOLTAGE)] = batteryvoltage;
       json[F("Battery")] = toPercentageCR2032(val);

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1210,7 +1210,7 @@ int32_t Z_AqaraCubeFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObjec
   const char * modelId_c = zigbee_devices.getModelId(shortaddr);  // null if unknown
   String modelId((char*) modelId_c);
 
-  if (modelId.startsWith(F("lumi.sensor_cube."))) {   // only for Aqara cube
+  if (modelId.startsWith(F("lumi.sensor_cube"))) {   // only for Aqara cube
     int32_t val = value;
     const __FlashStringHelper *aqara_cube = F("AqaraCube");
     const __FlashStringHelper *aqara_cube_side = F("AqaraCubeSide");

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -128,6 +128,7 @@ enum Z_ConvOperators {
   Z_AqaraSensor,        // decode prioprietary Aqara Sensor message
   Z_AqaraVibration,     // decode Aqara vibration modes
   Z_AqaraCube,          // decode Aqara cube
+  Z_BatteryPercentage,  // memorize Battery Percentage in RAM
 };
 
 ZF(ZCLVersion) ZF(AppVersion) ZF(StackVersion) ZF(HWVersion) ZF(Manufacturer) ZF(ModelId)
@@ -238,7 +239,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { Zuint16,  Cx0001, 0x0000,  Z(MainsVoltage),         1,  Z_Nop },
   { Zuint8,   Cx0001, 0x0001,  Z(MainsFrequency),       1,  Z_Nop },
   { Zuint8,   Cx0001, 0x0020,  Z(BatteryVoltage),       -10,Z_Nop },   // divide by 10
-  { Zuint8,   Cx0001, 0x0021,  Z(BatteryPercentage),    -2, Z_Nop },   // divide by 2
+  { Zuint8,   Cx0001, 0x0021,  Z(BatteryPercentage),    -2, Z_BatteryPercentage },   // divide by 2
 
   // Device Temperature Configuration cluster
   { Zint16,   Cx0002, 0x0000,  Z(CurrentTemperature),   1,  Z_Nop },
@@ -1176,14 +1177,17 @@ void ZCLFrame::parseClusterSpecificCommand(JsonObject& json, uint8_t offset) {
 // ======================================================================
 // Record Manuf
 int32_t Z_ManufKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = value;
   zigbee_devices.setManufId(shortaddr, value.as<const char*>());
   return 1;
 }
-//
+// Record ModelId
 int32_t Z_ModelKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = value;
   zigbee_devices.setModelId(shortaddr, value.as<const char*>());
+  return 1;
+}
+// Record BatteryPercentage
+int32_t Z_BatteryPercentageKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
+  zigbee_devices.setBatteryPercentx2(shortaddr, value.as<uint8_t>());
   return 1;
 }
 
@@ -1191,22 +1195,6 @@ int32_t Z_ModelKeepFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObjec
 int32_t Z_AddPressureUnitFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
   json[new_name] = F(D_UNIT_PRESSURE);
   return 0;   // keep original key
-}
-
-// Convert int to float and divide by 100
-int32_t Z_FloatDiv100Func(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = ((float)value) / 100.0f;
-  return 1;   // remove original key
-}
-// Convert int to float and divide by 10
-int32_t Z_FloatDiv10Func(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = ((float)value) / 10.0f;
-  return 1;   // remove original key
-}
-// Convert int to float and divide by 10
-int32_t Z_FloatDiv2Func(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = ((float)value) / 2.0f;
-  return 1;   // remove original key
 }
 
 // Publish a message for `"Occupancy":0` when the timer expired
@@ -1219,8 +1207,6 @@ int32_t Z_OccupancyCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t clu
 
 // Aqara Cube
 int32_t Z_AqaraCubeFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObject& json, const char *name, JsonVariant& value, const String &new_name, uint16_t cluster, uint16_t attr) {
-  json[new_name] = value;   // copy the original value
-
   const char * modelId_c = zigbee_devices.getModelId(shortaddr);  // null if unknown
   String modelId((char*) modelId_c);
 
@@ -1353,7 +1339,13 @@ int32_t Z_AqaraSensorFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObj
     json.remove(tmp);
     bool translated = false;    // were we able to translate to a known format?
     if (0x01 == attrid) {
-      json[F(D_JSON_VOLTAGE)] = val / 1000.0f;
+      float batteryvoltage = val / 1000.0f;
+      json[F("BatteryVoltage")] = batteryvoltage;
+      uint8_t batterypercentage = toPercentageCR2032(val);
+      json[F("BatteryPercentage")] = batterypercentage;
+      zigbee_devices.setBatteryPercentx2(shortaddr, batterypercentage * 2);
+      // deprecated
+      json[F(D_JSON_VOLTAGE)] = batteryvoltage;
       json[F("Battery")] = toPercentageCR2032(val);
     } else if ((nullptr != modelId) && (0 == zcl->getManufCode())) {
       translated = true;
@@ -1430,6 +1422,9 @@ int32_t Z_ApplyConverter(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObje
       break;
     case Z_AqaraCube:
       func = &Z_AqaraCubeFunc;
+      break;
+    case Z_BatteryPercentage:
+      func = &Z_BatteryPercentageKeepFunc;
       break;
   };
 

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -758,7 +758,7 @@ int32_t Z_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
                               timestamp);
   zcl_received.log();
 
-  ZdSetLinkQuality(srcaddr, linkquality);
+  zigbee_devices.setLQI(srcaddr, linkquality);
 
   char shortaddr[8];
   snprintf_P(shortaddr, sizeof(shortaddr), PSTR("0x%04X"), srcaddr);

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1069,44 +1069,6 @@ void CmndZbConfig(void) {
 }
 
 /*********************************************************************************************\
- * Database of linkqualities - there must be a better way to implement this ...
-\*********************************************************************************************/
-
-const uint8_t MAX_ZBRECORDS = 16;
-
-typedef struct Z_DevRecord_t {
-  uint16_t shortaddr;
-  uint8_t  linkquality;
-} Z_DevRecord_t;
-
-Z_DevRecord_t Z_DevRecord[MAX_ZBRECORDS];
-uint8_t Z_DevIndex = 0;
-
-void ZdSetLinkQuality(uint16_t shortaddr, uint8_t linkquality) {
-  if (Z_DevIndex < MAX_ZBRECORDS -1) {
-    uint32_t i;
-    for (i = 0; i < Z_DevIndex; i++) {
-      if (shortaddr == Z_DevRecord[i].shortaddr) {
-        Z_DevRecord[i].linkquality = linkquality;
-        return;
-      }
-    }
-    Z_DevRecord[i].shortaddr = shortaddr;
-    Z_DevRecord[i].linkquality = linkquality;
-    Z_DevIndex++;
-  }
-}
-
-uint8_t ZdGetLinkQuality(uint16_t shortaddr) {
-  for (uint32_t i = 0; i < Z_DevIndex; i++) {
-    if (shortaddr == Z_DevRecord[i].shortaddr) {
-      return Z_DevRecord[i].linkquality;
-    }
-  }
-  return 0;
-}
-
-/*********************************************************************************************\
  * Presentation
 \*********************************************************************************************/
 
@@ -1128,9 +1090,9 @@ void ZigbeeShow(bool json)
         name = spart1;
       }
       snprintf_P(spart2, sizeof(spart2), PSTR("-"));
-      uint8_t lq = ZdGetLinkQuality(shortaddr);
-      if (lq) {
-        snprintf_P(spart2, sizeof(spart2), PSTR("%d"), lq);
+      uint8_t lqi = zigbee_devices.getLQI(shortaddr);
+      if (0xFF != lqi) {
+        snprintf_P(spart2, sizeof(spart2), PSTR("%d"), lqi);
       }
 
       WSContentSend_PD(PSTR("{s}%s{m}LQI %s{e}"), name, spart2);

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1094,6 +1094,11 @@ void ZigbeeShow(bool json)
       if (0xFF != lqi) {
         snprintf_P(spart2, sizeof(spart2), PSTR("%d"), lqi);
       }
+      // uint8_t bp = zigbee_devices.getBatteryPercentx2(shortaddr);
+      // Be aware that bp
+      // if (0xFF != bp) {
+      //   snprintf_P(spart2, sizeof(spart2), PSTR("%d"), bp);
+      // }
 
       WSContentSend_PD(PSTR("{s}%s{m}LQI %s{e}"), name, spart2);
     }


### PR DESCRIPTION
## Description:

LQI from last message is now kept in the same memory structure as the rest of Zigbee devices. Note: LQI is not stored in Flash, and LQI update does not trigger a Flash write.

I also added BatteryPercentage, if this is something you want to add on the web console. Code example is commented in `ZigbeeShow()`.

Last change, I added `BatteryVoltage` and `BatteryPercentage` attributes to Aqara devices, to be consistent with other devices. `Battery` and `Voltage` are kept but please consider them as deprecated.

Edit: also relaxed detection of Aqara Cube, as per discussion on Discord.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
