### PR TITLE
Add tasmota_flash_writes_total to Prometheus

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -40,6 +40,7 @@ void HandleMetrics(void)
                   my_version, my_image, GetBuildDateAndTime().c_str());
   WSContentSend_P(PSTR("# TYPE tasmota_uptime_seconds gauge\ntasmota_uptime_seconds %d\n"), uptime);
   WSContentSend_P(PSTR("# TYPE tasmota_boot_count counter\ntasmota_boot_count %d\n"), Settings.bootcount);
+  WSContentSend_P(PSTR("# TYPE tasmota_flash_writes_total counter\ntasmota_flash_writes_total %d\n"), Settings.save_flag);
 
 
   // Pseudo-metric providing metadata about the WiFi station.


### PR DESCRIPTION
Follows prometheus naming best practices for unitless accumulating counts:
https://prometheus.io/docs/practices/naming/#metric-names

(cf http_requests_total).

In practice this looks like:

```
# TYPE tasmota_flash_writes_total counter
tasmota_flash_writes_total 65
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).