### PR TITLE
Fix Tasmota compilation with USE_SCRIPT and USE_SCRIPT_FATFS, USE_SCRIPT_GLOBVARS, USE_DEVICE_GROUPS

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -2018,10 +2018,12 @@ chknext:
           goto strexit;
         }
 #ifdef USE_SCRIPT_GLOBVARS
+#ifdef USE_DEVICE_GROUPS
         if (!strncmp(vname,"luip",4)) {
           if (sp) strlcpy(sp,IPAddressToString(last_udp_ip),glob_script_mem.max_ssize);
           goto strexit;
         }
+#endif
 #endif
         if (!strncmp(vname,"loglvl",6)) {
           fvar=glob_script_mem.script_loglevel;

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -5496,7 +5496,6 @@ void ScriptGetSDCard(void) {
   }
   HandleNotFound();
 }
-#endif // USE_SCRIPT_FATFS
 
 void SendFile(char *fname) {
 char buff[512];
@@ -5530,6 +5529,7 @@ char buff[512];
 
   Webserver->client().stop();
 }
+#endif // USE_SCRIPT_FATFS
 
 void ScriptFullWebpage(void) {
   uint32_t fullpage_refresh=10000;


### PR DESCRIPTION
## Description: This little ptach fixes Tasmota compilation with USE_SCRIPT defined combined with USE_SCRIPT_FATFS undefined, USE_SCRIPT_GLOBVARS defined and USE_DEVICE_GROUPS undefined

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
