### PR TITLE
fix scripter USE_SCRIPT_GLOBVARS without USE_DEVICE_GROUPS

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -383,6 +383,14 @@ struct SCRIPT_MEM {
 #ifdef USE_SCRIPT_GLOBVARS
 IPAddress last_udp_ip;
 WiFiUDP Script_PortUdp;
+
+#ifndef USE_DEVICE_GROUPS
+char * IPAddressToString(const IPAddress& ip_address) {
+  static char buffer[16];
+  sprintf_P(buffer, PSTR("%u.%u.%u.%u"), ip_address[0], ip_address[1], ip_address[2], ip_address[3]);
+  return buffer;
+}
+#endif
 #endif
 
 int16_t last_findex;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #8817 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
