### PR TITLE
TuyaMCU: SetOption97 to set higher baud rate

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -116,7 +116,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t max6675 : 1;                  // bit 12 (v8.3.1.2)  - SetOption94 - Implement simpler MAX6675 protocol instead of MAX31855
     uint32_t network_wifi : 1;             // bit 13 (v8.3.1.3)  - CMND_WIFI
     uint32_t network_ethernet : 1;         // bit 14 (v8.3.1.3)  = CMND_ETHERNET
-    uint32_t spare15 : 1;
+    uint32_t tuyamcu_baudrate : 1;         // bit 15 (v8.3.1.6)  - SetOption97 - Set Baud rate for TuyaMCU serial communication (0 = 9600 or 1 = 115200)
     uint32_t spare16 : 1;
     uint32_t spare17 : 1;
     uint32_t spare18 : 1;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -899,6 +899,7 @@ void CmndSetoption(void)
             switch (pindex) {
               case 3:                      // SetOption85 - Enable Device Groups
               case 6:                      // SetOption88 - PWM Dimmer Buttons control remote devices
+              case 15:                     // SetOption97 - Set Baud rate for TuyaMCU serial communication (0 = 9600 or 1 = 115200)
                 restart_flag = 2;
                 break;
             }

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -641,13 +641,16 @@ bool TuyaModuleSelected(void)
 
 void TuyaInit(void)
 {
+  int baudrate = 9600;
+  if (Settings.flag4.tuyamcu_baudrate) { baudrate = 115200; }  // SetOption97 - Set Baud rate for TuyaMCU serial communication (0 = 9600 or 1 = 115200)
+
   Tuya.buffer = (char*)(malloc(TUYA_BUFFER_SIZE));
   if (Tuya.buffer != nullptr) {
     TuyaSerial = new TasmotaSerial(Pin(GPIO_TUYA_RX), Pin(GPIO_TUYA_TX), 2);
-    if (TuyaSerial->begin(9600)) {
+    if (TuyaSerial->begin(baudrate)) {
       if (TuyaSerial->hardwareSerial()) { ClaimSerial(); }
       // Get MCU Configuration
-      AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Request MCU configuration"));
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: Request MCU configuration at %d baud rate"));
 
       TuyaSendCmd(TUYA_CMD_QUERY_PRODUCT);
     }


### PR DESCRIPTION
## Description:
Working with @digiblur we found a new TuyaMCU that needs to initialize the serial communication at 115200 instead of 9600 like the Treatlife Fan/Light Controller. 
More information [here](https://docs.tuya.com/en/iot/device-development/access-mode-mcu/wifi-general-solution/software-reference-wifi/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb).

This PR add `SetOpion97` to enable the higher speed when needed:
```
SetOption97 - Set Baud rate for TuyaMCU serial communication (0 = 9600 or 1 = 115200)
```
Default is set to `0` and will automatically restart the device to apply the new change and re-initialize the MCU again.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here> None

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
