### PR TITLE
Zigbee EZSP milestone 4

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -679,6 +679,7 @@
                                                   // if PANID == 0xFFFE, then the device will act as a Zigbee end-device (non-router), the parameters below are ignored
   #define USE_ZIGBEE_EXTPANID 0xCCCCCCCCCCCCCCCCL // arbitrary extended PAN ID
   #define USE_ZIGBEE_CHANNEL  11                  // Zigbee Channel (11-26)
+  #define USE_ZIGBEE_TXRADIO_DBM  20                  // Tx Radio power in dBm (only for EZSP, EFR32 can go up to 20 dBm)
   #define USE_ZIGBEE_PRECFGKEY_L 0x0F0D0B0907050301L  // note: changing requires to re-pair all devices
   #define USE_ZIGBEE_PRECFGKEY_H 0x0D0C0A0806040200L  // note: changing requires to re-pair all devices
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -559,7 +559,7 @@ struct {
   uint64_t      zb_precfgkey_h;            // F28
   uint16_t      zb_pan_id;                 // F30
   uint8_t       zb_channel;                // F32
-  uint8_t       zb_free_byte;              // F33
+  uint8_t       zb_txradio_dbm;            // F33
   uint16_t      pms_wake_interval;         // F34
   uint8_t       config_version;            // F36
   uint8_t       windmeter_pulses_x_rot;    // F37

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -106,6 +106,7 @@ enum Zigbee_StateMachine_Instruction_Set {
 #define ZI_WAIT_RECV_FUNC(x, m, f)  { .i = { ZGB_INSTR_WAIT_RECV_CALL, sizeof(m), (x)} },  { .p = (const void*)(m) }, { .p = (const void*)(f) },
 
 // Labels used in the State Machine -- internal only
+const uint8_t  ZIGBEE_LABEL_RESTART = 1;     // Restart the state_machine in a different mode
 const uint8_t  ZIGBEE_LABEL_INIT_COORD = 10;     // Start ZNP as coordinator
 const uint8_t  ZIGBEE_LABEL_START_COORD = 11;     // Start ZNP as coordinator
 const uint8_t  ZIGBEE_LABEL_INIT_ROUTER = 12;    // Init ZNP as router
@@ -118,13 +119,16 @@ const uint8_t  ZIGBEE_LABEL_BOOT_TIME_OUT = 18;    // MCU has not rebooted
 const uint8_t  ZIGBEE_LABEL_FACT_RESET_ROUTER_DEVICE_POST = 19;   // common post configuration for router and device
 const uint8_t  ZIGBEE_LABEL_READY = 20;   // goto label 20 for main loop
 const uint8_t  ZIGBEE_LABEL_MAIN_LOOP = 21;   // main loop
+const uint8_t  ZIGBEE_LABEL_NETWORK_CONFIGURED = 22;   // main loop
+const uint8_t  ZIGBEE_LABEL_BAD_CONFIG = 23;          // EZSP configuration is not the right one
 const uint8_t  ZIGBEE_LABEL_PERMIT_JOIN_CLOSE = 30;   // disable permit join
 const uint8_t  ZIGBEE_LABEL_PERMIT_JOIN_OPEN_60 = 31;    // enable permit join for 60 seconds
 const uint8_t  ZIGBEE_LABEL_PERMIT_JOIN_OPEN_XX = 32;    // enable permit join for 60 seconds
-// factory reset
+// factory reset or reconfiguration
 const uint8_t  ZIGBEE_LABEL_FACT_RESET_COORD = 50;   // main loop
 const uint8_t  ZIGBEE_LABEL_FACT_RESET_ROUTER = 51;   // main loop
 const uint8_t  ZIGBEE_LABEL_FACT_RESET_DEVICE = 52;   // main loop
+const uint8_t  ZIGBEE_LABEL_CONFIGURE_EZSP = 53;   // main loop
 // errors
 const uint8_t  ZIGBEE_LABEL_ABORT = 99;   // goto label 99 in case of fatal error
 const uint8_t  ZIGBEE_LABEL_UNSUPPORTED_VERSION = 98;  // Unsupported ZNP version
@@ -371,7 +375,7 @@ ZBM(ZBR_PERMITJOINREQ, Z_SRSP | Z_ZDO, ZDO_MGMT_PERMIT_JOIN_REQ, Z_SUCCESS)    /
 ZBM(ZBR_PERMITJOIN_AREQ_RSP,  Z_AREQ | Z_ZDO, ZDO_MGMT_PERMIT_JOIN_RSP, 0x00, 0x00 /* srcAddr*/, Z_SUCCESS )   // 45B6000000
 
 // Update the relevant commands with Settings
-void Z_UpdateConfig(uint8_t zb_channel, uint16_t zb_pan_id, uint64_t zb_ext_panid, uint64_t zb_precfgkey_l, uint64_t zb_precfgkey_h) {
+void ZNP_UpdateConfig(uint8_t zb_channel, uint16_t zb_pan_id, uint64_t zb_ext_panid, uint64_t zb_precfgkey_l, uint64_t zb_precfgkey_h) {
   uint32_t zb_channel_mask = (1 << zb_channel);
 
   ZBW(ZBR_PAN, Z_SRSP | Z_SAPI, SAPI_READ_CONFIGURATION, Z_SUCCESS, CONF_PANID, 0x02 /* len */,
@@ -422,26 +426,26 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_NOOP()
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
-    ZI_ON_RECV_UNEXPECTED(&Z_Recv_Default)
+    ZI_ON_RECV_UNEXPECTED(&ZNP_Recv_Default)
     ZI_WAIT(10500)                             // wait for 10 seconds for Tasmota to stabilize
 
     //ZI_MQTT_STATE(ZIGBEE_STATUS_BOOT, "Booting")
     //ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "rebooting device")
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_BOOT_TIME_OUT)    // give a second chance
     ZI_SEND(ZBS_RESET)                        // reboot cc2530 just in case we rebooted ESP8266 but not cc2530
-    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &Z_Reboot)             // timeout 5s
+    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
     ZI_GOTO(ZIGBEE_LABEL_BOOT_OK)
 
   ZI_LABEL(ZIGBEE_LABEL_BOOT_TIME_OUT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_SEND(ZBS_RESET)                        // reboot cc2530 just in case we rebooted ESP8266 but not cc2530
-    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &Z_Reboot)             // timeout 5s
+    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
 
   ZI_LABEL(ZIGBEE_LABEL_BOOT_OK)
     ZI_WAIT(100)
     ZI_LOG(LOG_LEVEL_DEBUG, kCheckingDeviceConfiguration)     // Log Debug: checking device configuration
     ZI_SEND(ZBS_VERSION)                      // check ZNP software version
-    ZI_WAIT_RECV_FUNC(2000, ZBR_VERSION, &Z_ReceiveCheckVersion)  // Check if version is valid
+    ZI_WAIT_RECV_FUNC(2000, ZBR_VERSION, &ZNP_ReceiveCheckVersion)  // Check if version is valid
 
     // Dispatching whether coordinator, router or end-device
     ZI_CALL(&Z_SwitchDeviceType, 0)           // goto ZIGBEE_LABEL_INIT_ROUTER, ZIGBEE_LABEL_INIT_DEVICE or continue if coordinator
@@ -476,9 +480,9 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     //ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "starting zigbee coordinator")
     ZI_SEND(ZBS_STARTUPFROMAPP)                       // start coordinator
     ZI_WAIT_RECV(2000, ZBR_STARTUPFROMAPP)        // wait for sync ack of command
-    ZI_WAIT_UNTIL_FUNC(10000, AREQ_STARTUPFROMAPP, &Z_ReceiveStateChange)      // wait for async message that coordinator started
+    ZI_WAIT_UNTIL_FUNC(10000, AREQ_STARTUPFROMAPP, &ZNP_ReceiveStateChange)      // wait for async message that coordinator started
     ZI_SEND(ZBS_GETDEVICEINFO)                    // GetDeviceInfo
-    ZI_WAIT_RECV_FUNC(2000, ZBR_GETDEVICEINFO, &Z_ReceiveDeviceInfo)
+    ZI_WAIT_RECV_FUNC(2000, ZBR_GETDEVICEINFO, &ZNP_ReceiveDeviceInfo)
     //ZI_WAIT_RECV(2000, ZBR_GETDEVICEINFO)         // memorize info
     ZI_SEND(ZBS_ZDO_NODEDESCREQ)                  // Z_ZDO:nodeDescReq
     ZI_WAIT_RECV(1000, ZBR_ZDO_NODEDESCREQ)
@@ -537,7 +541,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_WAIT_RECV(1000, ZBR_W_OK)
     // Now mark the device as ready, writing 0x55 in memory slot 0x0F00
     ZI_SEND(ZBS_WNV_INITZNPHC)                    // Init NV ZNP Has Configured
-    ZI_WAIT_RECV_FUNC(1000, ZBR_WNV_INIT_OK, &Z_CheckNVWrite)
+    ZI_WAIT_RECV_FUNC(1000, ZBR_WNV_INIT_OK, &ZNP_CheckNVWrite)
     ZI_SEND(ZBS_WNV_ZNPHC)                        // Write NV ZNP Has Configured
     ZI_WAIT_RECV(1000, ZBR_WNV_OK)
 
@@ -563,9 +567,9 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_WAIT_RECV(1000, ZBR_AF_REGISTER)
     ZI_SEND(ZBS_STARTUPFROMAPP)                   // start router
     ZI_WAIT_RECV(2000, ZBR_STARTUPFROMAPP)        // wait for sync ack of command
-    ZI_WAIT_UNTIL_FUNC(0xFFFF, AREQ_STARTUPFROMAPP, &Z_ReceiveStateChange)      // wait for async message that coordinator started
+    ZI_WAIT_UNTIL_FUNC(0xFFFF, AREQ_STARTUPFROMAPP, &ZNP_ReceiveStateChange)      // wait for async message that coordinator started
     ZI_SEND(ZBS_GETDEVICEINFO)                    // GetDeviceInfo
-    ZI_WAIT_RECV_FUNC(2000, ZBR_GETDEVICEINFO, &Z_ReceiveDeviceInfo)
+    ZI_WAIT_RECV_FUNC(2000, ZBR_GETDEVICEINFO, &ZNP_ReceiveDeviceInfo)
     ZI_GOTO(ZIGBEE_LABEL_READY)
 
   ZI_LABEL(ZIGBEE_LABEL_FACT_RESET_ROUTER)        // Factory reset for router
@@ -585,7 +589,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
 
     // Now mark the device as ready, writing 0x55 in memory slot 0x0F00
     ZI_SEND(ZBS_WNV_INITZNPHC)                    // Init NV ZNP Has Configured
-    ZI_WAIT_RECV_FUNC(1000, ZBR_WNV_INIT_OK, &Z_CheckNVWrite)
+    ZI_WAIT_RECV_FUNC(1000, ZBR_WNV_INIT_OK, &ZNP_CheckNVWrite)
     ZI_SEND(ZBS_WNV_ZNPHC)                        // Write NV ZNP Has Configured
     ZI_WAIT_RECV(1000, ZBR_WNV_OK)
 
@@ -632,11 +636,6 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
 
 #ifdef USE_ZIGBEE_EZSP
 
-// Update the relevant commands with Settings
-void Z_UpdateConfig(uint8_t zb_channel, uint16_t zb_pan_id, uint64_t zb_ext_panid, uint64_t zb_precfgkey_l, uint64_t zb_precfgkey_h) {
-}
-
-
 // patterns for EZSP
 
 // wait for RSTACK, meaning the device booted
@@ -666,8 +665,8 @@ ZBM(ZBR_SET_OK,  EZSP_setConfigurationValue, 0x00 /*high*/, 0x00 /*ok*/)   // 53
 ZBM(ZBR_SET_OK2, 0x00, 0x00 /*high*/, 0x00 /*ok*/)   // 000000  - TODO why does setting EZSP_CONFIG_PACKET_BUFFER_COUNT has a different response?
 
 // Read some configuration values
-ZBM(ZBS_GET_APS_UNI,      EZSP_getConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_APS_UNICAST_MESSAGE_COUNT)                   // 520003
-ZBM(ZBR_GET_OK,           EZSP_getConfigurationValue, 0x00 /*high*/, 0x00 /*ok*/)   // 5200 - followed by the value
+// ZBM(ZBS_GET_APS_UNI,      EZSP_getConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_APS_UNICAST_MESSAGE_COUNT)                   // 520003
+// ZBM(ZBR_GET_OK,           EZSP_getConfigurationValue, 0x00 /*high*/, 0x00 /*ok*/)   // 5200 - followed by the value
 
 // Add Endpoints
 ZBM(ZBS_ADD_ENDPOINT1,    EZSP_addEndpoint, 0x00 /*high*/, 0x01 /*ep*/, Z_B0(Z_PROF_HA), Z_B1(Z_PROF_HA),
@@ -697,7 +696,7 @@ ZBM(ZBR_SET_CONCENTRATOR, EZSP_setConcentrator, 0x00 /*high*/, 0x00 /*ok*/)     
 
 // setInitialSecurityState
 #define EZ_SECURITY_MODE  EMBER_TRUST_CENTER_GLOBAL_LINK_KEY | EMBER_PRECONFIGURED_NETWORK_KEY_MODE | EMBER_HAVE_NETWORK_KEY | EMBER_HAVE_PRECONFIGURED_KEY
-ZBM(ZBS_SET_SECURITY,     EZSP_setInitialSecurityState, 0x00 /*high*/,
+ZBR(ZBS_SET_SECURITY,     EZSP_setInitialSecurityState, 0x00 /*high*/,
                           Z_B0(EZ_SECURITY_MODE), Z_B1(EZ_SECURITY_MODE),
                           // preConfiguredKey
                           0x5A, 0x69, 0x67, 0x42, 0x65, 0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39,   // well known key "ZigBeeAlliance09"
@@ -715,7 +714,7 @@ ZBM(ZBR_SET_SECURITY,     EZSP_setInitialSecurityState, 0x00 /*high*/, 0x00 /*st
 ZBM(ZBS_SET_POLICY_00,    EZSP_setPolicy, 0x00 /*high*/, EZSP_TRUST_CENTER_POLICY,
                           EZSP_DECISION_ALLOW_JOINS | EZSP_DECISION_ALLOW_UNSECURED_REJOINS)    // 55000003
 ZBM(ZBS_SET_POLICY_02,    EZSP_setPolicy, 0x00 /*high*/, EZSP_UNICAST_REPLIES_POLICY,
-                          EZSP_HOST_WILL_NOT_SUPPLY_REPLY)    // 550002210
+                          EZSP_HOST_WILL_NOT_SUPPLY_REPLY)    // 55000220
 ZBM(ZBS_SET_POLICY_03,    EZSP_setPolicy, 0x00 /*high*/, EZSP_POLL_HANDLER_POLICY,
                           EZSP_POLL_HANDLER_IGNORE)    // 55000330
 ZBM(ZBS_SET_POLICY_05,    EZSP_setPolicy, 0x00 /*high*/, EZSP_TC_KEY_REQUEST_POLICY,
@@ -724,12 +723,16 @@ ZBM(ZBS_SET_POLICY_06,    EZSP_setPolicy, 0x00 /*high*/, EZSP_APP_KEY_REQUEST_PO
                           EZSP_DENY_APP_KEY_REQUESTS)    // 55000660
 ZBM(ZBR_SET_POLICY_XX,    EZSP_setPolicy, 0x00 /*high*/, 0x00 /*status*/)
 
+// networkInit - restart the network from previous settings
+ZBM(ZBS_NETWORK_INIT,     EZSP_networkInit, 0x00 /*high*/, 0x00, 0x00)        // 17000000
+ZBM(ZBR_NETWORK_INIT,     EZSP_networkInit, 0x00 /*high*/, 0x00 /*status*/)   // 170000
+
 // formNetwork - i.e. start zigbee network as coordinator
-ZBM(ZBS_FORM_NETWORK,     EZSP_formNetwork, 0x00 /*high*/,
+ZBR(ZBS_FORM_NETWORK,     EZSP_formNetwork, 0x00 /*high*/,
                           Z_B0(USE_ZIGBEE_EXTPANID), Z_B1(USE_ZIGBEE_EXTPANID), Z_B2(USE_ZIGBEE_EXTPANID), Z_B3(USE_ZIGBEE_EXTPANID),
                           Z_B4(USE_ZIGBEE_EXTPANID), Z_B5(USE_ZIGBEE_EXTPANID), Z_B6(USE_ZIGBEE_EXTPANID), Z_B7(USE_ZIGBEE_EXTPANID),
                           Z_B0(USE_ZIGBEE_PANID), Z_B1(USE_ZIGBEE_PANID),
-                          20 /*radioTxPower*/,
+                          USE_ZIGBEE_TXRADIO_DBM /*radioTxPower*/,
                           USE_ZIGBEE_CHANNEL /*channel*/,
                           EMBER_USE_MAC_ASSOCIATION,
                           0xFF,0xFF, /*nwkManagerId, unused*/
@@ -739,34 +742,103 @@ ZBM(ZBS_FORM_NETWORK,     EZSP_formNetwork, 0x00 /*high*/,
 ZBM(ZBR_FORM_NETWORK,     EZSP_formNetwork, 0x00 /*high*/, 0x00 /*status*/)   // 1E0000
 ZBM(ZBR_NETWORK_UP,       EZSP_stackStatusHandler, 0x00 /*high*/, EMBER_NETWORK_UP)   // 190090
 
+// leaveNetwork
+ZBR(ZBS_LEAVE_NETWORK,    EZSP_leaveNetwork, 0x00 /*high*/)   // 2000
+ZBM(ZBR_LEAVE_NETWORK,    EZSP_leaveNetwork, 0x00 /*high*/)   // 2000, we don't care whether it succeeeded or the network was not up
+
 // read configuration details
 ZBM(ZBS_GET_NETW_PARM,    EZSP_getNetworkParameters, 0x00 /*high*/)   // 2800
 ZBM(ZBR_GET_NETW_PARM,    EZSP_getNetworkParameters, 0x00 /*high*/, 0x00 /*ok*/)   // 2800
+ZBR(ZBR_CHECK_NETW_PARM,  EZSP_getNetworkParameters, 0x00 /*high*/,
+                          0x00 /*status*/,
+                          EMBER_COORDINATOR /*0x01*/,
+                          Z_B0(USE_ZIGBEE_EXTPANID), Z_B1(USE_ZIGBEE_EXTPANID), Z_B2(USE_ZIGBEE_EXTPANID), Z_B3(USE_ZIGBEE_EXTPANID),
+                          Z_B4(USE_ZIGBEE_EXTPANID), Z_B5(USE_ZIGBEE_EXTPANID), Z_B6(USE_ZIGBEE_EXTPANID), Z_B7(USE_ZIGBEE_EXTPANID),
+                          Z_B0(USE_ZIGBEE_PANID), Z_B1(USE_ZIGBEE_PANID),
+                          USE_ZIGBEE_TXRADIO_DBM /*radioTxPower*/,
+                          USE_ZIGBEE_CHANNEL /*channel*/,
+                          )   // 2800...
+
 ZBM(ZBS_GET_EUI64,        EZSP_getEui64, 0x00 /*high*/)   // 2600
 ZBM(ZBR_GET_EUI64,        EZSP_getEui64, 0x00 /*high*/)   // 2600
 ZBM(ZBS_GET_NODEID,       EZSP_getNodeId, 0x00 /*high*/)   // 2700
 ZBM(ZBR_GET_NODEID,       EZSP_getNodeId, 0x00 /*high*/)   // 2700
 
+// getCurrentSecurityState
+// TODO double check the security bitmask
+ZBM(ZBS_GET_CURR_SEC,     EZSP_getCurrentSecurityState, 0x00 /*high*/)   // 6900
+ZBR(ZBR_GET_CURR_SEC,     EZSP_getCurrentSecurityState, 0x00 /*high*/,
+                          0x00 /*status*/,
+                          0x7C, 0x00 /*Current Security Bitmask*/,
+                          )   // 6900...
+
+/*********************************************************************************************\
+ * Update the relevant commands with Settings
+\*********************************************************************************************/
+//
+void EZ_UpdateConfig(uint8_t zb_channel, uint16_t zb_pan_id, uint64_t zb_ext_panid, uint64_t zb_precfgkey_l, uint64_t zb_precfgkey_h, uint8_t zb_txradio_dbm) {
+  uint8_t txradio = zb_txradio_dbm;
+  // restrict txradio to acceptable range, and use default otherwise
+  if (txradio == 0) { txradio = USE_ZIGBEE_TXRADIO_DBM; }
+  if (txradio > 20) { txradio = USE_ZIGBEE_TXRADIO_DBM; }
+
+  ZBW(ZBS_SET_SECURITY,     EZSP_setInitialSecurityState, 0x00 /*high*/,
+                            Z_B0(EZ_SECURITY_MODE), Z_B1(EZ_SECURITY_MODE),
+                            // preConfiguredKey
+                            0x5A, 0x69, 0x67, 0x42, 0x65, 0x65, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65, 0x30, 0x39,   // well known key "ZigBeeAlliance09"
+                            // networkKey
+                            Z_B0(zb_precfgkey_l), Z_B1(zb_precfgkey_l), Z_B2(zb_precfgkey_l), Z_B3(zb_precfgkey_l),
+                            Z_B4(zb_precfgkey_l), Z_B5(zb_precfgkey_l), Z_B6(zb_precfgkey_l), Z_B7(zb_precfgkey_l),
+                            Z_B0(zb_precfgkey_h), Z_B1(zb_precfgkey_h), Z_B2(zb_precfgkey_h), Z_B3(zb_precfgkey_h),
+                            Z_B4(zb_precfgkey_h), Z_B5(zb_precfgkey_h), Z_B6(zb_precfgkey_h), Z_B7(zb_precfgkey_h),
+                            0x00 /*sequence*/,
+                            0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00, /*trustcenter*/
+                            )
+
+  ZBW(ZBS_FORM_NETWORK,     EZSP_formNetwork, 0x00 /*high*/,
+                            Z_B0(zb_ext_panid), Z_B1(zb_ext_panid), Z_B2(zb_ext_panid), Z_B3(zb_ext_panid),
+                            Z_B4(zb_ext_panid), Z_B5(zb_ext_panid), Z_B6(zb_ext_panid), Z_B7(zb_ext_panid),
+                            Z_B0(zb_pan_id), Z_B1(zb_pan_id),
+                            txradio /*radioTxPower*/,
+                            zb_channel /*channel*/,
+                            EMBER_USE_MAC_ASSOCIATION,
+                            0xFF,0xFF, /*nwkManagerId, unused*/
+                            0x00, /*nwkUpdateId, unused*/
+                            0x00,0x00,0x00,0x00, /*NWK channel mask, unused*/
+                            )  // 1E00...
+
+ZBW(ZBR_CHECK_NETW_PARM,      EZSP_getNetworkParameters, 0x00 /*high*/,
+                          0x00 /*status*/,
+                          EMBER_COORDINATOR /*0x01*/,
+                          Z_B0(zb_ext_panid), Z_B1(zb_ext_panid), Z_B2(zb_ext_panid), Z_B3(zb_ext_panid),
+                          Z_B4(zb_ext_panid), Z_B5(zb_ext_panid), Z_B6(zb_ext_panid), Z_B7(zb_ext_panid),
+                          Z_B0(zb_pan_id), Z_B1(zb_pan_id),
+                          txradio /*radioTxPower*/,
+                          zb_channel /*channel*/,
+                          )   // 2800...
+}
 
 static const Zigbee_Instruction zb_prog[] PROGMEM = {
   ZI_LABEL(0)
     ZI_NOOP()
+    ZI_CALL(EZ_Set_ResetConfig, 0)           // for the firt pass, don't do a reset_config
+  ZI_LABEL(ZIGBEE_LABEL_RESTART)
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
-    ZI_ON_RECV_UNEXPECTED(&Z_Recv_Default)
+    ZI_ON_RECV_UNEXPECTED(&EZ_Recv_Default)
     ZI_WAIT(10500)                             // wait for 10 seconds for Tasmota to stabilize
 
     // Hardware reset
     ZI_LOG(LOG_LEVEL_INFO, kResettingDevice)     // Log Debug: resetting EZSP device
-    ZI_CALL(&Z_Reset_Device, 0)         // LOW = reset
+    ZI_CALL(&EZ_Reset_Device, 0)         // LOW = reset
     ZI_WAIT(100)                        // wait for .1 second
-    ZI_CALL(&Z_Reset_Device, 1)         // HIGH = release reset
+    ZI_CALL(&EZ_Reset_Device, 1)         // HIGH = release reset
 
     // wait for device to start
     ZI_WAIT_UNTIL(5000, ZBR_RSTACK)     // wait for RSTACK message
  
     // Init device and probe version
-    ZI_SEND(ZBS_VERSION)                ZI_WAIT_RECV_FUNC(1000, ZBR_VERSION, &Z_ReceiveCheckVersion)       // check EXT PAN ID
+    ZI_SEND(ZBS_VERSION)                ZI_WAIT_RECV_FUNC(1000, ZBR_VERSION, &EZ_ReceiveCheckVersion)       // check EXT PAN ID
 
     // configure EFR32
     ZI_MQTT_STATE(ZIGBEE_STATUS_STARTING, kConfiguredCoord)
@@ -786,7 +858,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
 
     // read configuration
     // TODO - not sure it's useful
-    //ZI_SEND(ZBS_GET_APS_UNI)            ZI_WAIT_RECV_FUNC(500, ZBR_GET_OK, &Z_ReadAPSUnicastMessage)
+    //ZI_SEND(ZBS_GET_APS_UNI)            ZI_WAIT_RECV_FUNC(500, ZBR_GET_OK, &EZ_ReadAPSUnicastMessage)
 
     // add endpoint 0x01 and 0x0B
     ZI_SEND(ZBS_ADD_ENDPOINT1)          ZI_WAIT_RECV(500, ZBR_ADD_ENDPOINT)
@@ -796,21 +868,52 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_SEND(ZBS_SET_CONCENTRATOR)       ZI_WAIT_RECV(500, ZBR_SET_CONCENTRATOR)
 
     // setInitialSecurityState
-    ZI_SEND(ZBS_SET_SECURITY)           ZI_WAIT_RECV(500, ZBR_SET_SECURITY)
     ZI_SEND(ZBS_SET_POLICY_00)          ZI_WAIT_RECV(500, ZBR_SET_POLICY_XX)
     ZI_SEND(ZBS_SET_POLICY_02)          ZI_WAIT_RECV(500, ZBR_SET_POLICY_XX)
     ZI_SEND(ZBS_SET_POLICY_03)          ZI_WAIT_RECV(500, ZBR_SET_POLICY_XX)
     ZI_SEND(ZBS_SET_POLICY_05)          ZI_WAIT_RECV(500, ZBR_SET_POLICY_XX)
     ZI_SEND(ZBS_SET_POLICY_06)          ZI_WAIT_RECV(500, ZBR_SET_POLICY_XX)
 
+    // set encryption keys
+    ZI_SEND(ZBS_SET_SECURITY)           ZI_WAIT_RECV(500, ZBR_SET_SECURITY)
+
+    // Decide whether we try 'networkInit()' to restore configuration, or create a new network
+    ZI_CALL(&EZ_GotoIfResetConfig, ZIGBEE_LABEL_CONFIGURE_EZSP)    // goto ZIGBEE_LABEL_CONFIGURE_EZSP if reset_config is set
+
+    // ZI_GOTO(ZIGBEE_LABEL_CONFIGURE_EZSP)
+
+    // // Try networkInit to restore settings, and check if network comes up
+    ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_BAD_CONFIG)    // 
+    ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_BAD_CONFIG)
+    ZI_SEND(ZBS_NETWORK_INIT)           ZI_WAIT_RECV(500, ZBR_NETWORK_INIT)
+    ZI_WAIT_RECV(1500, ZBR_NETWORK_UP)    // wait for network to start
+    // check if configuration is ok
+    ZI_SEND(ZBS_GET_CURR_SEC)           ZI_WAIT_RECV(500, ZBR_GET_CURR_SEC)
+    ZI_SEND(ZBS_GET_NETW_PARM)          ZI_WAIT_RECV(500, ZBR_CHECK_NETW_PARM)
+    // all ok, proceed to next step
+    ZI_GOTO(ZIGBEE_LABEL_NETWORK_CONFIGURED)
+
+  ZI_LABEL(ZIGBEE_LABEL_BAD_CONFIG)
+    ZI_MQTT_STATE(ZIGBEE_STATUS_RESET_CONF, kResetting)
+    ZI_CALL(EZ_Set_ResetConfig, 1)           // change mode to reset_config
+    ZI_GOTO(ZIGBEE_LABEL_RESTART)       // restart state_machine
+
+  ZI_LABEL(ZIGBEE_LABEL_CONFIGURE_EZSP)
+    // Set back normal error handlers
+    ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
+    ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     // formNetwork
     ZI_SEND(ZBS_FORM_NETWORK)           ZI_WAIT_RECV(500, ZBR_FORM_NETWORK)
     ZI_WAIT_RECV(5000, ZBR_NETWORK_UP)    // wait for network to start
 
+  ZI_LABEL(ZIGBEE_LABEL_NETWORK_CONFIGURED)
+    // Set back normal error handlers
+    ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
+    ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     // Query device information
-    ZI_SEND(ZBS_GET_EUI64)              ZI_WAIT_RECV_FUNC(500, ZBR_GET_EUI64, &Z_EZSPGetEUI64)
-    ZI_SEND(ZBS_GET_NODEID)             ZI_WAIT_RECV_FUNC(500, ZBR_GET_NODEID, &Z_EZSPGetNodeId)
-    ZI_SEND(ZBS_GET_NETW_PARM)          ZI_WAIT_RECV_FUNC(500, ZBR_GET_NETW_PARM, &Z_EZSPNetworkParameters)
+    ZI_SEND(ZBS_GET_EUI64)              ZI_WAIT_RECV_FUNC(500, ZBR_GET_EUI64, &EZ_GetEUI64)
+    ZI_SEND(ZBS_GET_NODEID)             ZI_WAIT_RECV_FUNC(500, ZBR_GET_NODEID, &EZ_GetNodeId)
+    ZI_SEND(ZBS_GET_NETW_PARM)          ZI_WAIT_RECV_FUNC(500, ZBR_GET_NETW_PARM, &EZ_NetworkParameters)
 
   ZI_LABEL(ZIGBEE_LABEL_READY)
     ZI_MQTT_STATE(ZIGBEE_STATUS_OK, kStarted)

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -542,7 +542,7 @@ int32_t ZigbeeProcessInputRaw(class SBuffer &buf) {
       
       // RSTACK
       // received just after boot, either because of Power up, hardware reset or RST
-      Z_EZSP_RSTACK(buf.get8(2));
+      EZ_RSTACK(buf.get8(2));
       EZSP_Serial.from_ack = 0;
       EZSP_Serial.to_ack = 0;
 
@@ -555,7 +555,7 @@ int32_t ZigbeeProcessInputRaw(class SBuffer &buf) {
     } else if (control_byte == 0xC2) {
       
       // ERROR
-      Z_EZSP_ERROR(buf.get8(2));
+      EZ_ERROR(buf.get8(2));
       zigbee.active = false;           // stop all zigbee activities
     } else {
 
@@ -691,6 +691,38 @@ void ZigbeeZCLSend_Raw(uint16_t shortaddr, uint16_t groupaddr, uint16_t clusterI
 
   ZigbeeZNPSend(buf.getBuffer(), buf.len());
 #endif // USE_ZIGBEE_ZNP
+
+#ifdef USE_ZIGBEE_EZSP
+  SBuffer buf(32+len);
+
+  buf.add16(EZSP_sendUnicast);          // 3400
+  buf.add8(EMBER_OUTGOING_DIRECT);    // 00
+  buf.add16(shortaddr);               // dest addr
+  // ApsFrame
+  buf.add16(Z_PROF_HA);               // Home Automation profile
+  buf.add16(clusterId);               // cluster
+  buf.add8(0x01);                     // srcEp
+  buf.add8(endpoint);                 // dstEp
+  buf.add16(EMBER_APS_OPTION_ENABLE_ROUTE_DISCOVERY | EMBER_APS_OPTION_RETRY);      // APS frame
+  buf.add16(groupaddr);               // groupId
+  buf.add8(transacId);
+  // end of ApsFrame
+  buf.add8(0x01);                     // tag TODO
+
+  buf.add8(3 + len + (manuf ? 2 : 0));
+  buf.add8((needResponse ? 0x00 : 0x10) | (clusterSpecific ? 0x01 : 0x00) | (manuf ? 0x04 : 0x00));                 // Frame Control Field
+  if (manuf) {
+    buf.add16(manuf);               // add Manuf Id if not null
+  }
+  buf.add8(transacId);              // Transaction Sequance Number
+  buf.add8(cmdId);
+  if (len > 0) {
+    buf.addBuffer(msg, len);        // add the payload
+  }
+
+  ZigbeeEZSPSendCmd(buf.buf(), buf.len(), true);
+  
+#endif // USE_ZIGBEE_EZSP
 }
 
 #endif // USE_ZIGBEE


### PR DESCRIPTION
## Description:

This version in now stable for EZSP, restores configuration after reboot, sends and receives commands.

It will need a little better management of the Reset GPIO, better handling of ASH Serial ACK/NAK.
All features are working except Zigbee Binding.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
