### PR TITLE
Zigbee EZSP minor improvements

### DIFF
--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -27,6 +27,7 @@
 #endif
 
 #define OCCUPANCY "Occupancy"             // global define for Aqara
+#define ZIGBEE_EZSP_RESET_LED     4       // Led<x> number to drive the EZSP Reset pin
 
 typedef uint64_t Z_IEEEAddress;
 typedef uint16_t Z_ShortAddress;

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -647,11 +647,11 @@ ZBM(ZBR_VERSION, EZSP_version, 0x00, 0x08, 0x02)      // 00000802 - expect v8, p
 
 // general configuration
 // inspired from bellows: https://github.com/zigpy/bellows/blob/dev/bellows/config/ezsp.py
-ZBM(ZBS_SET_ADDR_TABLE,   EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_KEY_TABLE_SIZE, 0x04, 0x00)                  // 53001E0400
+ZBM(ZBS_SET_ADDR_TABLE,   EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_KEY_TABLE_SIZE, 0x02, 0x00)                  // 53001E0400
 ZBM(ZBS_SET_MCAST_TABLE,  EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_MULTICAST_TABLE_SIZE, 0x10, 0x00)            // 5300061000
 ZBM(ZBS_SET_STK_PROF,     EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_STACK_PROFILE, 0x02, 0x00)                   // 53000C0200
 ZBM(ZBS_SET_SEC_LEVEL,    EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_SECURITY_LEVEL, 0x05, 0x00)                  // 53000D0500
-ZBM(ZBS_SET_MAX_DEVICES,  EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_MAX_END_DEVICE_CHILDREN, 0x18, 0x00)         // 5300111800
+ZBM(ZBS_SET_MAX_DEVICES,  EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_MAX_END_DEVICE_CHILDREN, 0x20, 0x00)         // 5300111800
 ZBM(ZBS_SET_INDIRECT_TMO, EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_INDIRECT_TRANSMISSION_TIMEOUT, 0x00, 0x1E)   // 530012001E
 ZBM(ZBS_SET_TC_CACHE,     EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_TRUST_CENTER_ADDRESS_CACHE_SIZE, 0x02, 0x00) // 5300190200
 ZBM(ZBS_SET_ROUTE_TBL,    EZSP_setConfigurationValue, 0x00 /*high*/, EZSP_CONFIG_SOURCE_ROUTE_TABLE_SIZE, 0x10, 0x00)         // 53001A1000
@@ -671,21 +671,21 @@ ZBM(ZBR_SET_OK2, 0x00, 0x00 /*high*/, 0x00 /*ok*/)   // 000000  - TODO why does 
 // Add Endpoints
 ZBM(ZBS_ADD_ENDPOINT1,    EZSP_addEndpoint, 0x00 /*high*/, 0x01 /*ep*/, Z_B0(Z_PROF_HA), Z_B1(Z_PROF_HA),
                           0x05, 0x00 /* AppDeviceId */, 0x00 /* AppDevVer */,
-                          0x0E /* inputClusterCount */,                         // actually all clusters will be received
+                          0x00 /* inputClusterCount */,                         // actually all clusters will be received
                           0X00 /* outputClusterCount */,                        // 02000104010500000000
-                          0x00,0x00,  0x04,0x00,  0x05,0x00,  0x06,0x00,      // 0x0000, 0x0004, 0x0005, 0x0006
-                          0x07,0x00,  0x08,0x00,  0x0A,0x00,  0x02,0x01,      // 0x0007, 0x0008, 0x000A, 0X0102
-                          0x00,0x03,  0x00,0x04,  0x02,0x04,  0x03,0x04,      // 0x0300, 0x0400, 0x0402, 0x0403
-                          0x05,0x04,  0x06,0x04,                              // 0x0405, 0x0406
+                          // 0x00,0x00,  0x04,0x00,  0x05,0x00,  0x06,0x00,      // 0x0000, 0x0004, 0x0005, 0x0006
+                          // 0x07,0x00,  0x08,0x00,  0x0A,0x00,  0x02,0x01,      // 0x0007, 0x0008, 0x000A, 0X0102
+                          // 0x00,0x03,  0x00,0x04,  0x02,0x04,  0x03,0x04,      // 0x0300, 0x0400, 0x0402, 0x0403
+                          // 0x05,0x04,  0x06,0x04,                              // 0x0405, 0x0406
                           )
 ZBM(ZBS_ADD_ENDPOINTB,    EZSP_addEndpoint, 0x00 /*high*/, 0x0B /*ep*/, Z_B0(Z_PROF_HA), Z_B1(Z_PROF_HA),
                           0x05, 0x00 /* AppDeviceId */, 0x00 /* AppDevVer */,
-                          0x0E /* inputClusterCount */,                         // actually all clusters will be received
+                          0x00 /* inputClusterCount */,                         // actually all clusters will be received
                           0X00 /* outputClusterCount */,                        // 02000B04010500000000
-                          0x00,0x00,  0x04,0x00,  0x05,0x00,  0x06,0x00,      // 0x0000, 0x0004, 0x0005, 0x0006
-                          0x07,0x00,  0x08,0x00,  0x0A,0x00,  0x02,0x01,      // 0x0007, 0x0008, 0x000A, 0X0102
-                          0x00,0x03,  0x00,0x04,  0x02,0x04,  0x03,0x04,      // 0x0300, 0x0400, 0x0402, 0x0403
-                          0x05,0x04,  0x06,0x04,                              // 0x0405, 0x0406
+                          // 0x00,0x00,  0x04,0x00,  0x05,0x00,  0x06,0x00,      // 0x0000, 0x0004, 0x0005, 0x0006
+                          // 0x07,0x00,  0x08,0x00,  0x0A,0x00,  0x02,0x01,      // 0x0007, 0x0008, 0x000A, 0X0102
+                          // 0x00,0x03,  0x00,0x04,  0x02,0x04,  0x03,0x04,      // 0x0300, 0x0400, 0x0402, 0x0403
+                          // 0x05,0x04,  0x06,0x04,                              // 0x0405, 0x0406
                           )
 ZBM(ZBR_ADD_ENDPOINT,     EZSP_addEndpoint, 0x00 /*high*/, 0x00 /*ok*/)           // 020000
 

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -31,6 +31,9 @@ const uint8_t  ZIGBEE_EZSP_CANCEL = 0x1A;  // cancel byte
 const uint8_t  ZIGBEE_EZSP_EOF = 0x7E;          // end of frame
 const uint8_t  ZIGBEE_EZSP_ESCAPE = 0x7D;       // escape byte
 
+const uint32_t ZIGBEE_LED_RECEIVE = 0;     // LED<1> blinks when receiving
+const uint32_t ZIGBEE_LED_SEND = 0;        // LED<2> blinks when receiving
+
 class EZSP_Serial_t {
 public:
   uint8_t  to_ack = 0;      // 0..7, frame number of next id to send
@@ -144,12 +147,17 @@ void ZigbeeInputLoop(void) {
 	static uint32_t zigbee_polling_window = 0;    // number of milliseconds since first byte
   static bool escape = false;                          // was the previous byte an escape?
   bool frame_complete = false;                  // frame is ready and complete
+  bool led_status_on = false;                   // did we turn on the led receive led
   // Receive only valid EZSP frames:
   // 1A - Cancel - cancel all previous bytes
   // 7D - Escape byte - following byte is escaped
   // 7E - end of frame
 
   while (ZigbeeSerial->available()) {
+    // turn on receive LED<1>
+    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 1);
+    led_status_on = true;     // don't forget to switch it off
+
     yield();
     uint8_t zigbee_in_byte = ZigbeeSerial->read();
 		AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("ZIG: ZbInput byte=0x%02X len=%d"), zigbee_in_byte, zigbee_buffer->len());
@@ -194,6 +202,10 @@ void ZigbeeInputLoop(void) {
       zigbee_polling_window = millis();                               // Wait for more data
     }   // adding bytes
   }     // while (ZigbeeSerial->available())
+  // turn receive led off
+  if (led_status_on) {
+    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 0);
+  }
 
   uint32_t frame_len = zigbee_buffer->len();
   if (frame_complete || (frame_len && (millis() > (zigbee_polling_window + ZIGBEE_POLLING)))) {
@@ -402,12 +414,18 @@ void ZigbeeEZSPSend_Out(uint8_t out_byte) {
 // - send frame
 // send_cancel: should we first send a EZSP_CANCEL (0x1A) before the message to clear any leftover
 void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
+  bool led_status_on = false;
+
 	if ((len < 1) || (len > 252)) {
 		// abort, message cannot be less than 2 bytes for CMD1 and CMD2
 		AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_JSON_ZIGBEE_EZSP_SENT ": bad message len %d"), len);
 		return;
 	}
 	uint8_t data_len = len - 2;		// removing CMD1 and CMD2
+
+  // turn send led on
+  SetLedPowerIdx(ZIGBEE_LED_SEND, 1);
+  led_status_on = true;
 
   if (ZigbeeSerial) {
     if (send_cancel) {
@@ -448,6 +466,11 @@ void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
     // finally send End of Frame
     ZigbeeSerial->write(ZIGBEE_EZSP_EOF);		// 0x1A
   }
+  // turn send led off
+  if (led_status_on) {
+    SetLedPowerIdx(ZIGBEE_LED_SEND, 0);
+  }
+
   // Now send a MQTT message to report the sent message
   char hex_char[(len * 2) + 2];
   AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEE_EZSP_SENT_RAW " %s"),


### PR DESCRIPTION
## Description:

Use of `Led1i` to show incoming/outgoing traffic.
Better handling of software or hardware reset.
Final template to be used: `{"NAME":"Sonoff Zigbee","GPIO":[56,165,0,166,59,58,0,0,0,158,0,0,17],"FLAG":0,"BASE":18}`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
