### PR TITLE
Zigbee EZSP support for bindings and groups

### DIFF
--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -461,6 +461,7 @@ enum EZSP_ZDO {
   // Network Management Server Services Requests
   ZDO_Mgmt_Lqi_req = 0x0031,
   ZDO_Mgmt_Rtg_req = 0x0032,
+  ZDO_Mgmt_Bind_req = 0x0033,
   ZDO_Mgmt_Leave_req = 0x0034,
   ZDO_Mgmt_Permit_Joining_req = 0x0036,
   ZDO_Mgmt_NWK_Update_req = 0x0038,
@@ -496,6 +497,7 @@ enum EZSP_ZDO {
   // Network Management Server Services Responses
   ZDO_Mgmt_Lqi_rsp = 0x8031,
   ZDO_Mgmt_Rtg_rsp = 0x8032,
+  ZDO_Mgmt_Bind_rsp = 0x8033,
   ZDO_Mgmt_Leave_rsp = 0x8034,
   ZDO_Mgmt_Permit_Joining_rsp = 0x8036,
   ZDO_Mgmt_NWK_Update_rsp = 0x8038,
@@ -1105,6 +1107,34 @@ typedef struct Z_StatusLine {
   uint32_t     status;          // no need to use uint8_t since it uses 32 bits anyways
   const char * status_msg;
 } Z_StatusLine;
+
+
+// ZDP Enumeration, see Zigbee spec 2.4.5
+String getZDPStatusMessage(uint8_t status) {
+  static const char    StatusMsg[] PROGMEM = "SUCCESS|INV_REQUESTTYPE|DEVICE_NOT_FOUND|INVALID_EP|NOT_ACTIVE|NOT_SUPPORTED"
+                                             "|TIMEOUT|NO_MATCH|NO_ENTRY|NO_DESCRIPTOR|INSUFFICIENT_SPACE|NOT_PERMITTED"
+                                             "|TABLE_FULL|NOT_AUTHORIZED|DEVICE_BINDING_TABLE_FULL"
+                                             ;
+  static const uint8_t StatusIdx[] PROGMEM = { 0x00, 0x80, 0x81, 0x82, 0x83, 0x84,
+                                               0x85, 0x86, 0x88, 0x89, 0x8A, 0x8B,
+                                               0x8C, 0x8D, 0x8E };
+
+  char msg[32];
+  int32_t idx = -1;
+  for (uint32_t i = 0; i < sizeof(StatusIdx); i++) {
+    if (status == pgm_read_byte(&StatusIdx[i])) {
+      idx = i;
+      break;
+    }
+  }
+  if (idx >= 0) {
+    GetTextIndexed(msg, sizeof(msg), idx, StatusMsg);
+  } else {
+    *msg = 0x00;    // empty string
+  }
+  return String(msg);
+}
+
 
 // Undocumented Zigbee ZCL code here: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Zigbee-Error-Codes-in-the-Log
 String getZigbeeStatusMessage(uint8_t status) {

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -713,6 +713,25 @@ void ZbBindUnbind(bool unbind) {    // false = bind, true = unbind
   ZigbeeZNPSend(buf.getBuffer(), buf.len());
 #endif // USE_ZIGBEE_ZNP
 
+#ifdef USE_ZIGBEE_EZSP
+  SBuffer buf(24);
+  
+  // ZDO message payload (see Zigbee spec 2.4.3.2.2)
+  buf.add64(srcLongAddr);
+  buf.add8(endpoint);
+  buf.add16(cluster);
+  if (dstLongAddr) {
+    buf.add8(Z_Addr_IEEEAddress);         // DstAddrMode - 0x03 = ADDRESS_64_BIT
+    buf.add64(dstLongAddr);
+    buf.add8(toendpoint);
+  } else {
+    buf.add8(Z_Addr_Group);               // DstAddrMode - 0x01 = GROUP_ADDRESS
+    buf.add16(toGroup);
+  }
+
+  EZ_SendZDO(srcDevice, unbind ? ZDO_UNBIND_REQ : ZDO_BIND_REQ, buf.buf(), buf.len());
+#endif // USE_ZIGBEE_EZSP
+
   ResponseCmndDone();
 }
 
@@ -747,6 +766,14 @@ void CmndZbBindState(void) {
 
   ZigbeeZNPSend(buf.getBuffer(), buf.len());
 #endif // USE_ZIGBEE_ZNP
+
+
+#ifdef USE_ZIGBEE_EZSP
+  // ZDO message payload (see Zigbee spec 2.4.3.3.4)
+  uint8_t buf[] = { 0x00 };           // index = 0
+
+  EZ_SendZDO(shortaddr, ZDO_Mgmt_Bind_req, buf, sizeof(buf));
+#endif // USE_ZIGBEE_EZSP
 
   ResponseCmndDone();
 }


### PR DESCRIPTION
## Description:

EZSP support for bindings (tested ok) and sending commands to groups (untested).

We are almost at parity with CC2530 version.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
