### PR TITLE
Fixed reboot on zero cross dimmer

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -118,7 +118,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t network_ethernet : 1;         // bit 14 (v8.3.1.3)  - CMND_ETHERNET
     uint32_t tuyamcu_baudrate : 1;         // bit 15 (v8.3.1.6)  - SetOption97 - Set Baud rate for TuyaMCU serial communication (0 = 9600 or 1 = 115200)
     uint32_t rotary_uses_rules : 1;        // bit 16 (v8.3.1.6)  - SetOption98 - Use rules instead of light control
-    uint32_t spare17 : 1;
+    uint32_t zerocross_dimmer : 1;         // bit 17 (v8.3.1.4)  = SetOption99 - Enable zerocross dimmer on PWM DIMMER
     uint32_t spare18 : 1;
     uint32_t spare19 : 1;
     uint32_t spare20 : 1;

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2185,7 +2185,9 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         if (!isChannelCT(i)) {   // if CT don't use pwm_min and pwm_max
           cur_col = cur_col > 0 ? changeUIntScale(cur_col, 0, Settings.pwm_range, Light.pwm_min, Light.pwm_max) : 0;   // shrink to the range of pwm_min..pwm_max
         }
-        analogWrite(Pin(GPIO_PWM1, i), bitRead(pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col);
+        if (!Settings.flag4.zerocross_dimmer) {
+          analogWrite(Pin(GPIO_PWM1, i), bitRead(pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col);
+        }
       }
     }
   }

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -81,9 +81,8 @@ void CounterUpdate(uint8_t index)
     if bitRead(Counter.pin_state, index) {
       // PWMfrequency 100
       // restart PWM each second (german 50Hz has to up to 0.01% deviation)
-      // set COUNTERDEBOUNCELOW 1 to catch the raising edge
       // Zero-HIGH is typical 2ms
-      if (bitRead(Counter.pin_state, index) && Settings.flag4.zerocross_dimmer) {
+      if (RtcSettings.pulse_counter[index]%100 == 0 && PinUsed(GPIO_PWM1, index) && Settings.flag4.zerocross_dimmer) {
         const uint32_t current_cycle = ESP.getCycleCount();
         // stop pwm on PIN to start in Sync with rising edge
         // calculate timeoffset to fire PWM

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -166,7 +166,7 @@ void CounterInit(void)
     if (PinUsed(GPIO_CNTR1, i)) {
       Counter.any_counter = true;
       pinMode(Pin(GPIO_CNTR1, i), bitRead(Counter.no_pullup, i) ? INPUT : INPUT_PULLUP);
-      if ((0 == Settings.pulse_counter_debounce_low) && (0 == Settings.pulse_counter_debounce_high)) {
+      if ((0 == Settings.pulse_counter_debounce_low) && (0 == Settings.pulse_counter_debounce_high) && !Settings.flag4.zerocross_dimmer) {
         Counter.pin_state = 0;
         attachInterrupt(Pin(GPIO_CNTR1, i), counter_callbacks[i], FALLING);
       } else {

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -83,11 +83,12 @@ void CounterUpdate(uint8_t index)
       // restart PWM each second (german 50Hz has to up to 0.01% deviation)
       // set COUNTERDEBOUNCELOW 1 to catch the raising edge
       // Zero-HIGH is typical 2ms
-      if (RtcSettings.pulse_counter[index]%100 == 0 && PinUsed(GPIO_PWM1, index)) {
+      if (bitRead(Counter.pin_state, index) && Settings.flag4.zerocross_dimmer) {
         const uint32_t current_cycle = ESP.getCycleCount();
         // stop pwm on PIN to start in Sync with rising edge
         // calculate timeoffset to fire PWM
-        uint16_t dimm_time= 10000 * (100 - light_state.getDimmer(index)) / Settings.pwm_frequency;
+        uint16_t cur_col = Light.fade_start_10[0 + Light.pwm_offset];
+        uint32_t dimm_time= 1000000 / Settings.pwm_frequency * (1024 - cur_col) / 1024;
         digitalWrite(Pin(GPIO_PWM1, index), LOW);
         // 1000µs to ensure not to fire on the next sinus wave
         if (dimm_time < (1000000 / Settings.pwm_frequency)-1000) {


### PR DESCRIPTION
## Description:
Added Setoption99 to avoid that dimmer changes PWM when zero cross is enabled. Counter is responsible for dimming. Removed requirement for COUNTERDEBOUNCELOW. Avoid interference with other configurations.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [ x] The code change is tested and works on core ESP8266 V.2.7.1
  - [x ] The code change is tested and works on core ESP32 V.1.12.2
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
