### PR TITLE
Use latest core 2.7.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
-  - [ ] The code change is tested and works on core ESP8266 V.2.7.1
+  - [ ] The code change is tested and works on core ESP8266 V.2.7.2
   - [ ] The code change is tested and works on core ESP32 V.1.12.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -110,8 +110,7 @@ build_flags               = ${esp_defaults.build_flags}
                             ; No exception code in firmware
                             -fno-exceptions
                             -lstdc++                            
-                            ; the following removes the 4-bytes alignment for PSTR(), waiting for a cleaner flag from Arduino Core
-                            -DPSTR\(s\)=\(__extension__\(\{static\ const\ char\ __c\[\]\ __attribute__\(\(__aligned__\(1\)\)\)\ __attribute__\(\(section\(\ \"\\\\\".irom0.pstr.\"\ __FILE__\ \".\"\ __STRINGIZE\(__LINE__\)\ \".\"\ \ __STRINGIZE\(__COUNTER__\)\ \"\\\\\"\,\ \\\\\"aSM\\\\\"\,\ \@progbits\,\ 1\ \#\"\)\)\)\ =\ \(s\)\;\ \&__c\[0\]\;\}\)\)
+                            ; the following removes the 4-bytes alignment for PSTR()
                             -DPSTR_ALIGN=1
                             ; restrict to minimal mime-types
                             -DMIMETYPE_MINIMAL
@@ -123,8 +122,8 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 
 
 [core]
-; *** Esp8266 Arduino core 2.7.1
-platform                  = espressif8266@2.5.3
+; *** Esp8266 Arduino core 2.7.2
+platform                  = espressif8266@2.6.0
 platform_packages         = 
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -87,7 +87,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-platform                  = espressif8266@2.5.3
+platform                  = espressif8266@2.6.0
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.8.0-tasmota/esp8266-2.8.0.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -123,7 +123,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core for Arduino version latest development version
-platform                  = espressif8266@2.5.3
+platform                  = espressif8266@2.6.0
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:
The ugly compiler command in platformio.ini is not needed anymore.
No other big changes...

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
