### PR TITLE
read firmware verion for FLORA devices

### DIFF
--- a/tasmota/xsns_62_MI_ESP32.ino
+++ b/tasmota/xsns_62_MI_ESP32.ino
@@ -1210,7 +1210,6 @@ bool MI32Cmd(void) {
 const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 {m}%u%s / %u{e}";
 const char HTTP_MI32_SERIAL[] PROGMEM = "{s}%s %s{m}%02x:%02x:%02x:%02x:%02x:%02x%{e}";
 const char HTTP_BATTERY[] PROGMEM = "{s}%s" " Battery" "{m}%u %%{e}";
-const char HTTP_FIRMWARE[] PROGMEM = "{s}%s" " Firmware" "{m}%s{e}";
 const char HTTP_VOLTAGE[] PROGMEM = "{s}%s " D_VOLTAGE "{m}%s V{e}";
 const char HTTP_MI32_FLORA_DATA[] PROGMEM = "{s}%s" " Fertility" "{m}%u us/cm{e}";
 const char HTTP_MI32_HL[] PROGMEM = "{s}<hr>{m}<hr>{e}";
@@ -1315,9 +1314,6 @@ void MI32Show(bool json)
             char voltage[FLOATSZ];
             dtostrfd((MIBLEsensors[i].volt)/1000.0f, Settings.flag2.voltage_resolution, voltage);
             WSContentSend_PD(HTTP_VOLTAGE, kMI32SlaveType[MIBLEsensors[i].type-1], voltage);
-          }
-          if (MIBLEsensors[i].type == FLORA) {
-            WSContentSend_PD(HTTP_FIRMWARE, kMI32SlaveType[MIBLEsensors[i].type-1], MIBLEsensors[i].firmware);
           }
         }
       }

--- a/tasmota/xsns_62_MI_ESP32.ino
+++ b/tasmota/xsns_62_MI_ESP32.ino
@@ -141,6 +141,7 @@ struct mi_sensor_t{
     uint8_t bat; // many values seem to be hard-coded garbage (LYWSD0x, GCD1)
     uint16_t volt; // LYWSD03MMC
   };
+  char firmware[6]; // actually only for FLORA but hopefully we can add for more devices
 };
 
 std::vector<mi_sensor_t> MIBLEsensors;
@@ -773,6 +774,8 @@ void MI32batteryFLORA(){
     if(pChr->canRead()) {
       const char *buf = pChr->readValue().c_str();
       MI32readBat((char*)buf);
+      //we also can read the firmware from response no extra request needed
+      MI32readFirmwareFLORA((char*)buf);
     }
   }
   MI32.mode.readingDone = 1;
@@ -1012,6 +1015,23 @@ bool MI32readBat(char *_buf){
   return false;
 }
 
+bool MI32readFirmwareFLORA(char *_buf){
+  DEBUG_SENSOR_LOG(PSTR("%s: raw data: %x%x%x%x%x%x%x"),D_CMND_MI32,_buf[0],_buf[1],_buf[2],_buf[3],_buf[4],_buf[5],_buf[6]);
+  if(_buf[0] != 0){
+    char _firmware[5]; // FLORA send 5 byte for firmware version
+    strncpy(_firmware, _buf+2, 5);
+    AddLog_P2(LOG_LEVEL_DEBUG,PSTR("%s: Firmware: %s"),D_CMND_MI32,_firmware);
+
+    uint32_t _slot = MI32.state.sensor;
+    DEBUG_SENSOR_LOG(PSTR("MIBLE: Sensor slot: %u"), _slot);
+
+    memcpy(MIBLEsensors[_slot].firmware, _firmware, 5);
+    MIBLEsensors[_slot].firmware[5] = '\0';
+    return true;
+  }
+  return false;
+}
+
 /**
  * @brief Main loop of the driver, "high level"-loop
  *
@@ -1190,6 +1210,7 @@ bool MI32Cmd(void) {
 const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 {m}%u%s / %u{e}";
 const char HTTP_MI32_SERIAL[] PROGMEM = "{s}%s %s{m}%02x:%02x:%02x:%02x:%02x:%02x%{e}";
 const char HTTP_BATTERY[] PROGMEM = "{s}%s" " Battery" "{m}%u %%{e}";
+const char HTTP_FIRMWARE[] PROGMEM = "{s}%s" " Firmware" "{m}%s{e}";
 const char HTTP_VOLTAGE[] PROGMEM = "{s}%s " D_VOLTAGE "{m}%s V{e}";
 const char HTTP_MI32_FLORA_DATA[] PROGMEM = "{s}%s" " Fertility" "{m}%u us/cm{e}";
 const char HTTP_MI32_HL[] PROGMEM = "{s}<hr>{m}<hr>{e}";
@@ -1241,6 +1262,9 @@ void MI32Show(bool json)
           dtostrfd((MIBLEsensors[i].volt)/1000.0f, Settings.flag2.voltage_resolution, voltage);
           ResponseAppend_P(PSTR(",\"" D_VOLTAGE "\":%s"), voltage);
         }
+        if (MIBLEsensors[i].type == FLORA) { //actually we can only read FLORA
+          ResponseAppend_P(PSTR(",\"Firmware\":\"%s\""), MIBLEsensors[i].firmware);
+        }
       }
       ResponseAppend_P(PSTR("}"));
     }
@@ -1291,6 +1315,9 @@ void MI32Show(bool json)
             char voltage[FLOATSZ];
             dtostrfd((MIBLEsensors[i].volt)/1000.0f, Settings.flag2.voltage_resolution, voltage);
             WSContentSend_PD(HTTP_VOLTAGE, kMI32SlaveType[MIBLEsensors[i].type-1], voltage);
+          }
+          if (MIBLEsensors[i].type == FLORA) {
+            WSContentSend_PD(HTTP_FIRMWARE, kMI32SlaveType[MIBLEsensors[i].type-1], MIBLEsensors[i].firmware);
           }
         }
       }


### PR DESCRIPTION

## Description:

the FLORA sensors send the firmware version number while they send the
battery info so we parse it and send it via mqtt (json) and also
present it in the webinterface

only in files for ESP32

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
