### PR TITLE
Core stage is now built with GCC10.1 toolchain

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -122,9 +122,9 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                           -lstdc++-exc
 
 [core_stage]
-; *** Esp8266 core for Arduino version latest development version
-platform                  = espressif8266@2.6.0
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+; *** Esp8266 core version. Tasmota stage or Arduino stage version. Built with GCC 10.1 toolchain
+platform                  = https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/platform-espressif8266-2.9.0.tar.gz
+platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 
@@ -203,3 +203,4 @@ lib_extra_dirs =
 
 lib_ignore =
     cc1101
+   


### PR DESCRIPTION
## Description:

since a few days.

The platformio entry: 
```
platform                  = https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/platform-espressif8266-2.9.0.tar.gz 
```
installs the toolchain GCC10.1 from here https://github.com/earlephilhower/esp-quick-toolchain/releases/tag/3.0.0-gnu12
and uses Arduino Core with commit https://github.com/esp8266/Arduino/commit/252cb1d968657e44a3f66e2729c9d308d8265c44

uncommenting line:

```
platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
```
switches to actual Arduino Core stage (compile of Tasmota fails. Tasmota needs changes)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
