### PR TITLE
Bugfix local temperature sensor in fahrenheit for Thermostat driver

### DIFF
--- a/tasmota/xdrv_39_thermostat.ino
+++ b/tasmota/xdrv_39_thermostat.ino
@@ -1333,7 +1333,13 @@ void ThermostatGetLocalSensor(uint8_t ctr_output) {
   if (root.success()) {
     const char* value_c = root[THERMOSTAT_SENSOR_NAME]["Temperature"];
     if (value_c != NULL && strlen(value_c) > 0 && (isdigit(value_c[0]) || (value_c[0] == '-' && isdigit(value_c[1])) ) ) {
-      int16_t value = (int16_t)(CharToFloat(value_c) * 10);
+      int16_t value;
+      if (Thermostat[ctr_output].status.temp_format == TEMP_FAHRENHEIT) {
+        value = (int16_t)ThermostatFahrenheitToCelsius((int32_t)(CharToFloat(value_c) * 10), TEMP_CONV_ABSOLUTE);
+      }
+      else {
+        value = (int16_t)(CharToFloat(value_c) * 10);
+      }
       if ( (value >= -1000) 
         && (value <= 1000)
         && (Thermostat[ctr_output].status.sensor_type == SENSOR_LOCAL)) {


### PR DESCRIPTION
## Description:

Bugfix for local temperature sensor reading in Fahrenheit degrees. If the local temperature readings are in Fahrenheit, even if the thermostat is configured for Fahrenheit the internal conversion to celsius will not happen and therefore the controller will not work properly.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
