### PR TITLE
Add support for 0.56" 7-Segment LED Backpack with floating point and raw segment addressing

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -563,6 +563,9 @@
                                                  // MTX_ADDRESS2 at y=1, up to MTX_ADDRESS8 at y=7
                                                  // Command: DisplayText [yn]8888
                                                  // will display 8888 at sevenseg display at I2C address MTX_ADDRESS(n-1)
+                                                 // Each segment may be address Command: DisplayText [xn]m
+                                                 //  where n is 0..4 (4 digits and middle :) and m is decimal for bitmap of which segment to turn on.
+                                                 // Reference: https://cdn-learn.adafruit.com/downloads/pdf/adafruit-led-backpack.pdf
     // #define SEVENSEG_ADDRESS1     0x70      // No longer used.  Use MTX_ADDRESS1 - MTX_ADDRESS8 instead to specify I2C address of sevenseg displays
 //    #define USE_DISPLAY_SH1106                   // [DisplayModel 7] [I2cDriver6] Enable SH1106 Oled 128x64 display (I2C addresses 0x3C and 0x3D)
 #endif  // USE_I2C

--- a/tasmota/xdsp_11_sevenseg.ino
+++ b/tasmota/xdsp_11_sevenseg.ino
@@ -106,16 +106,18 @@ void SevensegOnOff(void)
 
 void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uint8_t flag)
 {
-  uint16_t number = 0;
+  enum OutNumType {DECIMAL, HEXADECIMAL, FLOAT, SEGMENTS};
+  int16_t number = 0;
+  double numberf = 0;
   boolean hasnumber= false;
   uint8_t dots= 0;
-  boolean t=false;
-  boolean T=false;
-  boolean d=false;
-  boolean hex=false;
-  boolean done=false;
-  boolean s=false;
-  uint8_t unit=y;
+  OutNumType outnumtype= DECIMAL;
+  uint8 fds = 0; // number of fractional digits for fp number
+  boolean done= false;
+  boolean s= false;
+  uint8_t unit= y;
+  char *buf;
+
   if ((unit>=sevensegs) || (unit<0)) {
     unit=0;
   }
@@ -123,29 +125,41 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
   for (int i=0; (str[i]!='\0') && (!done); i++) {
     // [optional prefix(es) chars]digits
     // Some combinations won't make sense.
-    // Reference: https://learn.adafruit.com/adafruit-led-backpack/1-2-inch-7-segment-backpack-arduino-wiring-and-setup
+    // Reference: https://cdn-learn.adafruit.com/downloads/pdf/adafruit-led-backpack.pdf
+    // This code has been tested on 1.2" and 0.56" 7-Segment LED displays, but should mostly work for others.
     // 
     // Prefixes:
-    // x  upcoming number decimal integer displayed as hex
+    // x  upcoming decimal integer number displayed as hex
     // :  turn on middle colon
     // ^  turn on top left dot
     // v  turn on bottom left dot
     // .  turn on AM/PM/Degree dot
     // s  upcoming number is seconds, print as HH:MM or MM:SS
     // z  clear this display
+    // f  upcoming number is floating point
+    // r  raw segment based on bitmap of upcoming integer number (see reference document above)
     // 
     // Some sample valid combinations:
-    // 787    -> 787
-    // x47    -> 2F
-    // s:241  -> 04:01
-    // s241   -> 4 01
-    // s1241  -> 20:41
-    // z      ->
-    // x88    -> 58
+    //  787     -> 787
+    //  x47     -> 2F
+    //  s:241   -> 04:01
+    //  s241    -> 4 01
+    //  s1241   -> 20:41
+    //  z       ->
+    //  x88     -> 58
+    //  f8.5    -> 8.5
+    //  f-9.34  -> -9.34
+    //  f:-9.34 -> -9.34
+    //  r255    -> 8. (all 8 segments on)
 
     switch (str[i]) {
       case 'x': // print given dec value as hex
-        hex = true;
+        // hex = true;
+        outnumtype = HEXADECIMAL;
+        break;
+      case 'f': // given number is floating point number
+        // fp = true;
+        outnumtype = FLOAT;
         break;
       case ':': // print colon
         dots |= 0x02;
@@ -162,6 +176,7 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
       case 's': // duration in seconds
         s = true;
         break;
+      case '-':
       case '0':
       case '1':
       case '2':
@@ -173,7 +188,21 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
       case '8':
       case '9':
         hasnumber= true;
-        number = atoi(str+i);
+        if (outnumtype == FLOAT) {
+          // Floating point number is given
+          numberf = atof(str+i);
+          // Find number of fractional digits
+          buf= str+i;
+          char *cp= strchr(buf, '.');
+          if (cp == NULL) {
+            fds= 0;
+          } else {
+            fds= buf+strlen(buf) - 1 - cp;
+          }
+        } else {
+          // Integer is given
+          number = atoi(str+i);
+        }
         done = true;
         break;
       case 'z': // Clear this display
@@ -182,30 +211,41 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
         s=false;
         sevenseg[unit]->clear();
         break;
+      case 'r': // Raw segment
+        outnumtype= SEGMENTS;
+        break;
       default: // unknown format, ignore
         break;
     }
   }
 
-  if (s) {
-    // number is duration in seconds
-    hex = false;
-    int hour = number/60/60;
-    int minute = (number/60)%60;
-
-    if (hour) {
-      // HH:MM
-      number = hour*100 + minute;
-    } else {
-      // MM:SS
-      number = minute*100 + number%60;
-    }
-  }
 
   if (hasnumber) {
-    if (hex) {
+    if (s) {
+      // number is duration in seconds
+      int hour = number/60/60;
+      int minute = (number/60)%60;
+
+      if (hour) {
+        // HH:MM
+        number = hour*100 + minute;
+      } else {
+        // MM:SS
+        number = minute*100 + number%60;
+      }
+    }
+
+    if (outnumtype == HEXADECIMAL) {
+      // Hex
       sevenseg[unit]->print(number, HEX);
+    } else if (outnumtype == FLOAT) {
+      // Floating point
+      sevenseg[unit]->printFloat(numberf, fds, 10);
+    } else if (outnumtype == SEGMENTS) {
+      // Raw segments
+      sevenseg[unit]->writeDigitRaw(x, number);
     } else {
+      // Decimal
       sevenseg[unit]->print(number, DEC);
     }
   }

--- a/tasmota/xdsp_11_sevenseg.ino
+++ b/tasmota/xdsp_11_sevenseg.ino
@@ -149,7 +149,7 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
     //  x88     -> 58
     //  f8.5    -> 8.5
     //  f-9.34  -> -9.34
-    //  f:-9.34 -> -9.34
+    //  f:-9.34 -> -9.:34
     //  r255    -> 8. (all 8 segments on)
 
     switch (str[i]) {


### PR DESCRIPTION
## Description:
The 0.56" 7-Segment LED display from Adafruit with I2C backpack has a decimal point on each digit which may used in the display to show a floating point number.

Added support for this display, and also code to allow showing floating point number, as well as addressing every addressable segment of every digit.

This fix adds the f and r modifier prefixes to `xdsp_11_sevenseg` display driver:
From the code:
```
    // [optional prefix(es) chars]digits
    // Some combinations won't make sense.
    // Reference: https://cdn-learn.adafruit.com/downloads/pdf/adafruit-led-backpack.pdf
    // This code has been tested on 1.2" and 0.56" 7-Segment LED displays, but should mostly work for others.
    // 
    // Prefixes:
    // x  upcoming decimal integer number displayed as hex
    // :  turn on middle colon
    // ^  turn on top left dot
    // v  turn on bottom left dot
    // .  turn on AM/PM/Degree dot
    // s  upcoming number is seconds, print as HH:MM or MM:SS
    // z  clear this display
    // f  upcoming number is floating point
    // r  raw segment based on bitmap of upcoming integer number (see reference document above)
    // 
    // Some sample valid combinations:
    //  787     -> 787
    //  x47     -> 2F
    //  s:241   -> 04:01
    //  s241    -> 4 01
    //  s:1241  -> 20:41
    //  z       ->
    //  x88     -> 58
    //  f8.5    -> 8.5
    //  f-9.34  -> -9.34
    //  f:-9.34 -> -9:.34
    //  r255    -> 8. (all 8 segments on)
```
To address raw segments for digit n, use the Console command with `DisplayMode 0`:
`DisplayText [x`n`]`m
where n is in range 0..4 which specifies which digit of LED display (including : at position 2) and m is the bitmask to select individual segment.  Reference: https://cdn-learn.adafruit.com/downloads/pdf/adafruit-led-backpack.pdf.
Examples:
`DisplayText [y0x0]r255` turns all the segments of left most digit of first LED display on, giving: `8.`
`DisplayText [x0]r62[x1]r243` displays: `UP.`

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on core ESP8266 V.2.7.2
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
