### PR TITLE
suppress Gcc10.1 warning...

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -126,6 +126,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 platform                  = https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/platform-espressif8266-2.9.0.tar.gz
 platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 build_unflags             = ${esp_defaults.build_unflags}
+                            -Wswitch-unreachable
 build_flags               = ${esp82xx_defaults.build_flags}
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -128,6 +128,7 @@ platform_packages         = ;framework-arduinoespressif8266 @ https://github.com
 build_unflags             = ${esp_defaults.build_unflags}
                             -Wswitch-unreachable
 build_flags               = ${esp82xx_defaults.build_flags}
+                            -Wno-switch-unreachable
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221


### PR DESCRIPTION
in lib IRremoteESP8266-2.7.8

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
