### PR TITLE
%VALUEH% - hex formatting for rules + serialsend5

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -700,6 +700,14 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       }
 
       RulesVarReplace(commands, F("%VALUE%"), Rules.event_value);
+      uint32_t value_ui = TextToInt(Rules.event_value.cstr());
+      char value_hexstr[8];
+      sprintf(value_hexstr, "%08x", value_ui);
+      RulesVarReplace(commands, F("%VALUEHEX%"), String(value_hexstr));
+      for (uint32_t i = 0; i < 4; i++) {
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%VALUEHEX%d%%"), i +1);
+        RulesVarReplace(commands, stemp, String(&value_hexstr[8-(2*i)]));
+      }
       for (uint32_t i = 0; i < MAX_RULE_VARS; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%VAR%d%%"), i +1);
         RulesVarReplace(commands, stemp, rules_vars[i]);

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -702,11 +702,11 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       // %VALUEH%: format as hex (e.g. value 255 as "000000FF"), %VALUEHx%: format as hex, x bytes wide (e.g. %VALUEH1%, value 255 as "FF")
       uint32_t value_ui = Rules.event_value.toInt();
       char value_hexstr[8];
-      sprintf(value_hexstr, "%08x", value_ui);
+      sprintf(value_hexstr, "%08X", value_ui);
       RulesVarReplace(commands, F("%VALUEH%"), String(value_hexstr));
       for (uint32_t i = 0; i < 4; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%VALUEH%d%%"), i +1);
-        RulesVarReplace(commands, stemp, String(&value_hexstr[8-(2*i)]));
+        RulesVarReplace(commands, stemp, String(&value_hexstr[6-(2*i)]));
       }
       for (uint32_t i = 0; i < MAX_RULE_VARS; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%VAR%d%%"), i +1);

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -698,14 +698,14 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
           (ucommand.indexOf("BACKLOG ") == -1)) {
         commands = "backlog " + commands;
       }
-
       RulesVarReplace(commands, F("%VALUE%"), Rules.event_value);
-      uint32_t value_ui = TextToInt(Rules.event_value.cstr());
+      // %VALUEH%: format as hex (e.g. value 255 as "000000FF"), %VALUEHx%: format as hex, x bytes wide (e.g. %VALUEH1%, value 255 as "FF")
+      uint32_t value_ui = Rules.event_value.toInt();
       char value_hexstr[8];
       sprintf(value_hexstr, "%08x", value_ui);
-      RulesVarReplace(commands, F("%VALUEHEX%"), String(value_hexstr));
+      RulesVarReplace(commands, F("%VALUEH%"), String(value_hexstr));
       for (uint32_t i = 0; i < 4; i++) {
-        snprintf_P(stemp, sizeof(stemp), PSTR("%%VALUEHEX%d%%"), i +1);
+        snprintf_P(stemp, sizeof(stemp), PSTR("%%VALUEH%d%%"), i +1);
         RulesVarReplace(commands, stemp, String(&value_hexstr[8-(2*i)]));
       }
       for (uint32_t i = 0; i < MAX_RULE_VARS; i++) {


### PR DESCRIPTION
## Description:

Adds hex formatting of trigger value in rules, ideally for use with SerialSend5
%VALUEH% prints all 4 bytes: e.g. "DEADBEEF"
%VALUEH<x>% prints <x> bytes (truncated): e.g. %VALUEH2% --> "BEEF"

Allows for supporting #5737 ([template here](https://templates.blakadder.com/qs-wifi_D01_dimmer.html)) (and perhaps other devices that use binary serial MCU connections that are not currently supported by the TuyaMCU driver) without scripting (i.e. vanilla tasmota). Example rule for the referenced device, tested and working:

`rule1`
`on dimmer#state=0 do event setdimmer=5 endon`
`on dimmer#state>0 do backlog scale1 %value%,1,100,16,255; event udimmer endon`
`on dimmer#boot do backlog baudrate 9600; scale1 %value%,1,100,16,255; event udimmer endon`
`on event#udimmer do event setdimmer=%var1% endon`
`on event#setdimmer do serialsend5 FF 55 %valueh1% 05 DC 0A endon`
`on power1#state=0 do event setdimmer=5 endon`
`on power1#state=1 do event setdimmer=%var1% endon`

### Alternatives: ###
- The currently accepted workaround is via scripting. This is complicated for most users, requiring a custom build of tasmota and the script is a bit of a monster. Rules are good, because an intermediate user can copy/paste from the template page into regular tasmota and get going.
- Another workaround would be managing all this in the home automation layer - i.e. serialsend5 via MQTT. Usually results in layer upon layer of template device in home assistant, and managing state, power settings (i.e. what happens when dimmer 0 - power off?) gets pushed to the home automation also - which is again complicated for 90% of users who don't want to understand the on-board protocol inside a device, and duplicate implementation of state management that works lovely on tasmota already.
- Could add a serialsend6 to accept comma-delimited decimal values for sending as binary. Then vanilla %VALUE% could be used. Now thinking about it, this might be better. Please advise if you think it's a goer and I'll code it.
- Expanding on the idea, could add a hook in rules for formatting using sprintf: e.g. %VALUE.02X%. Would require a slight refactor to move from find-and-replace to a more markup-style processor. This felt a bit too invasive and heavy so going for the proof-of-concept first. Again, if maintainers are interested I'll code it. :)

Cheers,
grob

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on core ESP8266 V.2.7.2
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
> No device to test, sorry.
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
