### PR TITLE
sync platformio_override.ini with platformio.ini

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
-  - [ ] The code change is tested and works on core ESP8266 V.2.7.2
+  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.8.0
   - [ ] The code change is tested and works on core ESP32 V.1.12.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
-  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.8.0
+  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
   - [ ] The code change is tested and works on core ESP32 V.1.12.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -124,6 +124,6 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.2
 platform                  = espressif8266@2.5.1
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.8.0-tasmota/esp8266-2.8.0.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.2.1/esp8266-2.7.2.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -87,7 +87,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-platform                  = espressif8266@2.6.0
+platform                  = espressif8266@2.5.1
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.8.0-tasmota/esp8266-2.8.0.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -143,8 +143,6 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK22x_191122
 ; NONOSDK3V0 (known issues)
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK3
-; lwIP 1.4
-;                            -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 ; lwIP 2 - Low Memory
 ;                            -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
 ; lwIP 2 - Higher Bandwidth

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -88,7 +88,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.5.1
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.8.0-tasmota/esp8266-2.8.0.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.2.1/esp8266-2.7.2.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 


### PR DESCRIPTION
Platform is `platform  = espressif8266@2.5.1` no need to install `platform  = espressif8266@2.6.0` too. It is overwritten anyway with Tasmota core
`platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.8.0-tasmota/esp8266-2.8.0.zip`

Delete lwIP 1.4 from core_stage because it is not anymore in core > 2.7.2

Change PR Template to Tasmota Core 2.8.0

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.8.0
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
