### PR TITLE
Serialsend6 - comma-separated decimal send as binary

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -906,6 +906,17 @@ void SerialSendRaw(char *codes)
   }
 }
 
+// values is a comma-delimited string: e.g. "72,101,108,108,111,32,87,111,114,108,100,33,10"
+void SerialSendDecimal(char *values)
+{
+  char* &p;
+  uint8_t code;
+  for (str = strtok_r(values, ",", &p); str; str = strtok_r(nullptr, ",", &p)) {
+    code = (uint8_t)atoi(str);
+    Serial.write(code);
+  }
+}
+
 uint32_t GetHash(const char *buffer, size_t size)
 {
   uint32_t hash = 0;

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -909,9 +909,9 @@ void SerialSendRaw(char *codes)
 // values is a comma-delimited string: e.g. "72,101,108,108,111,32,87,111,114,108,100,33,10"
 void SerialSendDecimal(char *values)
 {
-  char* &p;
+  char *p;
   uint8_t code;
-  for (str = strtok_r(values, ",", &p); str; str = strtok_r(nullptr, ",", &p)) {
+  for (char* str = strtok_r(values, ",", &p); str; str = strtok_r(nullptr, ",", &p)) {
     code = (uint8_t)atoi(str);
     Serial.write(code);
   }

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1334,7 +1334,7 @@ void CmndSerialConfig(void)
 
 void CmndSerialSend(void)
 {
-  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= 5)) {
+  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= 6)) {
     SetSeriallog(LOG_LEVEL_NONE);
     Settings.flag.mqtt_serial = 1;                                  // CMND_SERIALSEND and CMND_SERIALLOG
     Settings.flag.mqtt_serial_raw = (XdrvMailbox.index > 3) ? 1 : 0;  // CMND_SERIALSEND3

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1354,6 +1354,9 @@ void CmndSerialSend(void)
       else if (5 == XdrvMailbox.index) {
         SerialSendRaw(RemoveSpace(XdrvMailbox.data));               // "AA004566" as hex values
       }
+      else if (6 == XdrvMailbox.index) {
+        SerialSendDecimal(XdrvMailbox.data);
+      }
       ResponseCmndDone();
     }
   }


### PR DESCRIPTION
## Description:

Alternative to #8920 (i.e. one or the other). Same use case - allowing sending of parameters using rules to binary serial devices e.g.  #5737. I've noted that the mqtt response formats in HEX when serial is received after a binary message is sent - I don't think this should change so it's treated the same.

example: `serialsend6 255,85,5,5,220,10`

An example rule that (should) allow the above device to work with vanilla tasmota + this PR:
`rule1`
`on dimmer#state=0 do event setdimmer=5 endon`
`on dimmer#state>0 do backlog scale1 %value%,1,100,16,255; event udimmer endon`
`on dimmer#boot do backlog baudrate 9600; scale1 %value%,1,100,16,255; event udimmer endon`
`on event#udimmer do event setdimmer=%var1% endon`
`on event#setdimmer do serialsend6 255,85,%value%,5,220,10 endon`
`on power1#state=0 do event setdimmer=5 endon`
`on power1#state=1 do event setdimmer=%var1% endon`

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
> no device to test sorry
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
