### PR TITLE
Revert "Fix regression build flags"

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -90,11 +90,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 platform                  = espressif8266@2.5.1
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino/releases/download/2.7.3.1/esp8266-2.7.3.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
-                            -std=c17
-                            -std=gnu++17
 build_flags               = ${esp82xx_defaults.build_flags}
-                            -std=gnu99
-                            -std=c++11
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221


### PR DESCRIPTION
Reverts arendst/Tasmota#8933

Not needed.