### PR TITLE
Use Tasmota_stage core 2.7.3.1 from Tasmota Github

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -88,13 +88,9 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.5.1
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino/releases/download/2.7.3.1/esp8266-2.7.3.1.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.3.1/esp8266-2.7.3.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
-                            -std=c17
-                            -std=gnu++17
 build_flags               = ${esp82xx_defaults.build_flags}
-                            -std=gnu99
-                            -std=c++11
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221


### PR DESCRIPTION
and delete unneeded compiler flags

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
