### PR TITLE
Updated the D_TIMER_ARM variable to say "Enable"

### DIFF
--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -419,7 +419,7 @@
 #define D_CONFIGURE_TIMER "Configure Timer"
 #define D_TIMER_PARAMETERS "Timer parameters"
 #define D_TIMER_ENABLE "Enable Timers"
-#define D_TIMER_ARM "Arm"
+#define D_TIMER_ARM "Enable"
 #define D_TIMER_TIME "Time"
 #define D_TIMER_DAYS "Days"
 #define D_TIMER_REPEAT "Repeat"


### PR DESCRIPTION
Arm has been a bit of a confusing term. I think it would help new users out to rename this to "Enable". It will make the button more intuitive.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
