### PR TITLE
Added `SO101 1` to suffix commands with source endpoint

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -120,7 +120,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t rotary_uses_rules : 1;        // bit 16 (v8.3.1.6)  - SetOption98 - Use rules instead of light control
     uint32_t zerocross_dimmer : 1;         // bit 17 (v8.3.1.4)  - SetOption99 - Enable zerocross dimmer on PWM DIMMER
     uint32_t remove_zbreceived : 1;        // bit 18 (v8.3.1.7)  - SetOption100 - Remove ZbReceived form JSON message
-    uint32_t spare19 : 1;
+    uint32_t zb_index_ep : 1;              // bit 19 (v8.3.1.7)  - SetOption101 - Add the source endpoint as suffix to attributes, ex `Power3` instead of `Power` if sent from endpoint 3
     uint32_t spare20 : 1;
     uint32_t spare21 : 1;
     uint32_t spare22 : 1;

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -141,6 +141,7 @@ public:
   // Add an endpoint to a device
   void addEndpoint(uint16_t shortaddr, uint8_t endpoint);
   void clearEndpoints(uint16_t shortaddr);
+  uint32_t countEndpoints(uint16_t shortaddr) const;    // return the number of known endpoints (0 if unknown)
 
   void setManufId(uint16_t shortaddr, const char * str);
   void setModelId(uint16_t shortaddr, const char * str);
@@ -531,6 +532,23 @@ void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
       return;
     }
   }
+}
+
+//
+// Count the number of known endpoints
+//
+uint32_t Z_Devices::countEndpoints(uint16_t shortaddr) const {
+  uint32_t count_ep = 0;
+  int32_t found = findShortAddr(shortaddr);
+  if (found < 0)  return 0;     // avoid creating an entry if the device was never seen
+  const Z_Device &device = devicesAt(found);
+
+  for (uint32_t i = 0; i < endpoints_max; i++) {
+    if (0 != device.endpoints[i]) {
+      count_ep++;
+    }
+  }
+  return count_ep;
 }
 
 // Find the first endpoint of the device

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1157,7 +1157,7 @@ void ZCLFrame::parseResponse(void) {
 
 // Parse non-normalized attributes
 void ZCLFrame::parseClusterSpecificCommand(JsonObject& json, uint8_t offset) {
-  convertClusterSpecific(json, _cluster_id, _cmd_id, _frame_control.b.direction, _payload);
+  convertClusterSpecific(json, _cluster_id, _cmd_id, _frame_control.b.direction, _srcaddr, _srcendpoint, _payload);
   sendHueUpdate(_srcaddr, _groupaddr, _cluster_id, _cmd_id, _frame_control.b.direction);
 }
 
@@ -1423,6 +1423,8 @@ int32_t Z_ApplyConverter(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObje
 }
 
 void ZCLFrame::postProcessAttributes(uint16_t shortaddr, JsonObject& json) {
+  // source endpoint
+  uint8_t src_ep = _srcendpoint;
   // iterate on json elements
   for (auto kv : json) {
     String key_string = kv.key;
@@ -1490,6 +1492,11 @@ void ZCLFrame::postProcessAttributes(uint16_t shortaddr, JsonObject& json) {
             ((conv_attribute == attribute) || (conv_attribute == 0xFFFF)) ) {
           String new_name_str = (const __FlashStringHelper*) converter->name;
           if (suffix > 1) { new_name_str += suffix; }   // append suffix number
+          // else if (Settings.flag4.zb_index_ep) {
+          //   if (zigbee_devices.countEndpoints(shortaddr) > 0) {
+          //     new_name_str += _srcendpoint;
+          //   }
+          // }
           // apply the transformation
           int32_t drop = Z_ApplyConverter(this, shortaddr, json, key, value, new_name_str, conv_cluster, conv_attribute, conv_multiplier, conv_cb);
           if (drop) {


### PR DESCRIPTION
## Description:

Added `SetOption101 1`. For devices with more than 1 endpoint, the command received will be suffixed with the endpoint number.

This feature allows for easier Rules. If you have a switch with 3 buttons, you will receive `Power1` for endpoint 1, `Power2` for endpoint 2, `Power3` for endpoint 3. To avoid breaking compatibility, you will still receive unsuffixed commands like `Power`.

Example, With `SetOption101 0`:
```
{"OSRAM_Switch":{"Device":"0x5CD6","Name":"OSRAM_Switch","0006!01":"","Power":1,"Endpoint":1,"LinkQuality":204}}
```

With `SetOption101 1`:
```
{"OSRAM_Switch":{"Device":"0x5CD6","Name":"OSRAM_Switch","0006!01":"","Power":1,"Power1":1,"Endpoint":1,"LinkQuality":204}}
```

Also, `ZbPermitJoin 99` now throws an error for EZSP, since it is not allowed in Zigbee 3.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
