### PR TITLE
Change ``Ping`` now reports the hostname instead of IP address (#8948)

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add command ``SetOption100 0/1`` to remove Zigbee ``ZbReceived`` value from ``{"ZbReceived":{xxx:yyy}}`` JSON message
 - Add command ``SetOption101 0/1`` to add the Zigbee source endpoint as suffix to attributes, ex `Power3` instead of `Power` if sent from endpoint 3
 - Add command (``S``)``SerialSend6`` \<comma seperated values\> (#8937)
+- Change ``Ping`` now reports the hostname instead of IP address (#8948)
 
 ### 8.3.1.6 20200617
 


### PR DESCRIPTION
## Description:

`Ping` now reports the hostname as key and IP address in `IP` field.

Example:
```
Ping tasmota.github.io

xx:xx:xx CMD: Ping tasmota.github.io
xx:xx:xx RSL: stat/tasmota_xxxxxx/RESULT = {"Ping":"Done"}
xx:xx:xx RSL: tele/tasmota_xxxxxx/RESULT = {"Ping":{"tasmota.github.io":{"Reachable":true,"IP":"185.199.110.153","Success":1,"Timeout":0,"MinTime":9,"MaxTime":9,"AvgTime":9}}}
```

For numerical address, the result is similar:
```
Ping 192.168.1.1

xx:xx:xx CMD: Ping 192.168.1.1
xx:xx:xx RSL: stat/tasmota_xxxxxx/RESULT = {"Ping":"Done"}
xx:xx:xx RSL: stat/tasmota_xxxxxx/RESULT = {"Ping":{"192.168.1.1":{"Reachable":true,"IP":"192.168.1.1","Success":1,"Timeout":0,"MinTime":10,"MaxTime":10,"AvgTime":10}}}
```

**Related issue (if applicable):** fixes #8948 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
