### PR TITLE
Zigbee CC2530 more robust reset

### DIFF
--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -114,8 +114,6 @@ const uint8_t  ZIGBEE_LABEL_START_ROUTER = 13;    // Start ZNP as router
 const uint8_t  ZIGBEE_LABEL_INIT_DEVICE = 14;    // Init ZNP as end-device
 const uint8_t  ZIGBEE_LABEL_START_DEVICE = 15;    // Start ZNP as end-device
 const uint8_t  ZIGBEE_LABEL_START_ROUTER_DEVICE = 16;    // Start common to router and device
-const uint8_t  ZIGBEE_LABEL_BOOT_OK = 17;    // MCU has rebooted
-const uint8_t  ZIGBEE_LABEL_BOOT_TIME_OUT = 18;    // MCU has not rebooted
 const uint8_t  ZIGBEE_LABEL_FACT_RESET_ROUTER_DEVICE_POST = 19;   // common post configuration for router and device
 const uint8_t  ZIGBEE_LABEL_READY = 20;   // goto label 20 for main loop
 const uint8_t  ZIGBEE_LABEL_MAIN_LOOP = 21;   // main loop
@@ -430,18 +428,12 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_WAIT(10500)                             // wait for 10 seconds for Tasmota to stabilize
 
     //ZI_MQTT_STATE(ZIGBEE_STATUS_BOOT, "Booting")
-    //ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "rebooting device")
-    ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_BOOT_TIME_OUT)    // give a second chance
-    ZI_SEND(ZBS_RESET)                        // reboot cc2530 just in case we rebooted ESP8266 but not cc2530
-    ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
-    ZI_GOTO(ZIGBEE_LABEL_BOOT_OK)
+    ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "rebooting device")
 
-  ZI_LABEL(ZIGBEE_LABEL_BOOT_TIME_OUT)
-    ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
-    ZI_SEND(ZBS_RESET)                        // reboot cc2530 just in case we rebooted ESP8266 but not cc2530
+    ZI_CALL(&ZNP_Reset_Device, 0)         // LOW = reset
+    ZI_WAIT(100)                          // wait for .1 second
+    ZI_CALL(&ZNP_Reset_Device, 1)         // HIGH = release reset
     ZI_WAIT_RECV_FUNC(5000, ZBR_RESET, &ZNP_Reboot)             // timeout 5s
-
-  ZI_LABEL(ZIGBEE_LABEL_BOOT_OK)
     ZI_WAIT(100)
     ZI_LOG(LOG_LEVEL_DEBUG, kCheckingDeviceConfiguration)     // Log Debug: checking device configuration
     ZI_SEND(ZBS_VERSION)                      // check ZNP software version

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1065,7 +1065,7 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
 }
 
 //
-// Callback for loading Zigbee configuration from Flash, called by the state machine
+// Callback for resetting the NCP, called by the state machine
 //
 // value = 0 : drive reset pin and halt MCU
 // value = 1 : release the reset pin, restart
@@ -1146,6 +1146,26 @@ int32_t Z_PublishAttributes(uint16_t shortaddr, uint16_t groupaddr, uint16_t clu
 \*********************************************************************************************/
 
 #ifdef USE_ZIGBEE_ZNP
+
+//
+// Callback for resetting the NCP, called by the state machine
+//
+// value = 0 : drive reset pin and halt MCU
+// value = 1 : release the reset pin, restart
+int32_t ZNP_Reset_Device(uint8_t value) {
+  // we use Led4i to drive the reset pin. Since it is reverted we need to pass 1 to start reset, and 0 to release reset
+  if (PinUsed(GPIO_LED1, ZIGBEE_EZSP_RESET_LED - 1)) {
+    SetLedPowerIdx(ZIGBEE_EZSP_RESET_LED - 1, value ? 0 : 1);
+  } else {
+    // no GPIO so we use software Reset instead
+    if (value) {  // send reset only when we are supposed to release reset
+      // flush the serial buffer, sending 0xFF 256 times.
+      ZigbeeZNPFlush();
+      ZigbeeZNPSend(ZBS_RESET, sizeof(ZBS_RESET));
+    }
+  }
+  return 0;                              // continue
+}
 
 int32_t ZNP_ReceiveAfIncomingMessage(int32_t res, const class SBuffer &buf) {
   uint16_t        groupid = buf.get16(2);

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -302,6 +302,16 @@ void ZigbeeInitSerial(void)
 
 #ifdef USE_ZIGBEE_ZNP
 
+// flush any ongoing frame, sending 256 times 0xFF
+void ZigbeeZNPFlush(void) {
+  if (ZigbeeSerial) {
+		for (uint32_t i = 0; i < 256; i++) {
+			ZigbeeSerial->write(0xFF);
+    }
+    AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZNPSENT " 0xFF x 255"));
+  }
+}
+
 void ZigbeeZNPSend(const uint8_t *msg, size_t len) {
 	if ((len < 2) || (len > 252)) {
 		// abort, message cannot be less than 2 bytes for CMD1 and CMD2


### PR DESCRIPTION
## Description:

More robust CC2530 reset:
- added a hardware reset GPIO if connected to `CC_RST` pin on CC2530. That's `GPIO5` on Superhouse.tv board. You need to configure the GPIO as `Led4i` (identical to EZSP reset pin).
- if no hardware reset, Tasmota first sends 256 times 0xFF before sending a software reset to flush any ongoing frame

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
