### PR TITLE
Adding frequency output mode for buzzer

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -129,7 +129,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t virtual_ct_cw : 1;            // bit 25 (v8.4.0.1)  - SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
     uint32_t teleinfo_rawdata : 1;         // bit 26 (v8.4.0.2)  - SetOption108 - enable Teleinfo + Tasmota Energy device (0) or Teleinfo raw data only (1)
     uint32_t alexa_gen_1 : 1;              // bit 27 (v8.4.0.3)  - SetOption109 - Alexa gen1 mode - if you only have Echo Dot 2nd gen devices
-    uint32_t spare28 : 1;                  // bit 28
+    uint32_t buzzer_freq_mode : 1;         // bit 28 (v8.4.0.3)  - SetOption110 - SetOption110 - Use frequency output for buzzer pin instead of on/off signal
     uint32_t spare29 : 1;                  // bit 29
     uint32_t spare30 : 1;                  // bit 30
     uint32_t spare31 : 1;                  // bit 31

--- a/tasmota/xdrv_24_buzzer.ino
+++ b/tasmota/xdrv_24_buzzer.ino
@@ -32,6 +32,7 @@ struct BUZZER {
   uint8_t inverted = 0;            // Buzzer inverted flag (1 = (0 = On, 1 = Off))
   uint8_t count = 0;               // Number of buzzes
   uint8_t mode = 0;                // Buzzer mode (0 = regular, 1 = infinite, 2 = follow LED)
+  uint8_t freq_mode = 0;           // Output mode (0 = regular, 1 = using frequency output)
   uint8_t set[2];
   uint8_t duration;
   uint8_t state = 0;
@@ -39,9 +40,28 @@ struct BUZZER {
 
 /*********************************************************************************************/
 
-void BuzzerOff(void)
+void BuzzerSet(uint8_t state)
 {
-  DigitalWrite(GPIO_BUZZER, 0, Buzzer.inverted);  // Buzzer Off
+  if (Buzzer.inverted) {
+    state = !state;
+  }
+
+  if (Buzzer.freq_mode == 1) {
+    static uint8_t last_state = 0;
+    if (last_state != state) {
+      if (state) {
+        analogWrite(Pin(GPIO_BUZZER, 0), Settings.pwm_range / 2);  // set 50% duty cycle for frequency output
+      }
+      else {
+        analogWrite(Pin(GPIO_BUZZER, 0), 0); // set 0% (or 100% for inverted PWM) duty cycle which turns off frequency output either way 
+      }
+      last_state = state;
+    }
+  }
+  else {
+    DigitalWrite(GPIO_BUZZER, 0, state);  // Buzzer On/Off
+  }
+  
 }
 
 //void BuzzerBeep(uint32_t count = 1, uint32_t on = 1, uint32_t off = 1, uint32_t tune = 0, uint32_t mode = 0);
@@ -69,11 +89,19 @@ void BuzzerBeep(uint32_t count, uint32_t on, uint32_t off, uint32_t tune, uint32
   }
   Buzzer.count = count * 2;  // Start buzzer
 
-  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("BUZ: %d(%d),%d,%d,0x%08X(0x%08X)"), count, Buzzer.count, on, off, tune, Buzzer.tune);
+  // We can use PWM mode for buzzer output if enabled.
+  if (Settings.flag4.buzzer_freq_mode) {     // SetOption110 - Enable frequency output mode for buzzer
+      Buzzer.freq_mode = 1;
+  }
+  else {
+    Buzzer.freq_mode = 0;
+  }
+
+  AddLog_P2(LOG_LEVEL_DEBUG, PSTR("BUZ: %d(%d),%d,%d,0x%08X(0x%08X),%d"), count, Buzzer.count, on, off, tune, Buzzer.tune, Buzzer.freq_mode);
 
   Buzzer.enable = (Buzzer.count > 0);
   if (!Buzzer.enable) {
-    BuzzerOff();
+    BuzzerSet(0);
   }
 }
 
@@ -81,7 +109,7 @@ void BuzzerSetStateToLed(uint32_t state)
 {
   if (Buzzer.enable && (2 == Buzzer.mode)) {
     Buzzer.state = (state != 0);
-    DigitalWrite(GPIO_BUZZER, 0, (Buzzer.inverted) ? !Buzzer.state : Buzzer.state);
+    BuzzerSet(Buzzer.state);
   }
 }
 
@@ -113,7 +141,7 @@ void BuzzerInit(void)
 {
   if (PinUsed(GPIO_BUZZER)) {
     pinMode(Pin(GPIO_BUZZER), OUTPUT);
-    BuzzerOff();
+    BuzzerSet(0);
   } else {
     Buzzer.active = false;
   }
@@ -140,7 +168,7 @@ void BuzzerEvery100mSec(void)
           Buzzer.duration = Buzzer.set[Buzzer.state];
         }
       }
-      DigitalWrite(GPIO_BUZZER, 0, (Buzzer.inverted) ? !Buzzer.state : Buzzer.state);
+      BuzzerSet(Buzzer.state);
     } else {
       Buzzer.enable = false;
     }


### PR DESCRIPTION
Allow to use passive buzzers (piezo) by having the buzzer module turn on/off a 50% duty cycle PWM signal on the buzzer pin. (Edited to reflect changed functionality after review)

## Description:

Right now the Buzzer command and pin configuration only allows to control active buzzers that generate the sound themselves, so it is a simple turn on/off logic. Some hardware has only passive buzzers based on piezo crystals that need a frequency input. The PWM logic has all capabilities to generate such a frequency. The proposed change causes the existing buzzer logic to turn on/off a 50% PWM frequency at its assigned pin. A new SetOptions flag turns on/off this functionality. (Edited to reflect changed functionality after review)

Code changes are minimal. While I haven't tested it against the ESP32 there is no hardware dependency that could make it fail IMO.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.2.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
