### PR TITLE
Use Tasmota core 2.7.4.1

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,7 +89,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.6.1
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.3.2/esp8266-2.7.3.2.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 
@@ -124,8 +124,10 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core version. Tasmota stage or Arduino stage version. Built with GCC 10.1 toolchain
-platform                  = https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/platform-espressif8266-2.9.0.tar.gz
-platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+platform                  = espressif8266@2.6.1
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/framework-arduinoespressif8266-3.20900.0.tar.gz
+                            ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+                            toolchain-xtensa @ ~2.100100.0
 build_unflags             = ${esp_defaults.build_unflags}
                             -Wswitch-unreachable
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -205,4 +207,3 @@ lib_extra_dirs =
 
 lib_ignore =
     cc1101
-   


### PR DESCRIPTION
for Tasmota stage.
- Since Platformio released the GCC10.1 build chain, use the platformio provided for Core Stage.


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1 and Arduino ESP8266 master
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
