### PR TITLE
Added exposure of MCP Out Pins as Relays

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -207,6 +207,7 @@ void SetDevicePower(power_t rpower, uint32_t source)
 
   XdrvMailbox.index = rpower;
   XdrvCall(FUNC_SET_POWER);               // Signal power state
+  XsnsCall(FUNC_SET_POWER);               // Signal power state
 
   XdrvMailbox.index = rpower;
   XdrvMailbox.payload = source;
@@ -1746,4 +1747,5 @@ void GpioInit(void)
   SetLedLink(Settings.ledstate &8);
 
   XdrvCall(FUNC_PRE_INIT);
+  XsnsCall(FUNC_PRE_INIT);
 }


### PR DESCRIPTION
## Description:
MCP can define GPIO and output pin. Currently, these are only accessible through sensor29 command. The new functionality will add the OUT PINS as additional RELAYS after the already defined one. The MCP is defined as a sensor but is is also a driver, therefore a bit xsns and xdv. Need to add the hook for FUNC_PRE_INIT and SET_POWER to interact with relay state and ensure the last state of the relay is retained after reboot. FUNC_INIT does not allow to come up with the correct RELAY state after reboot.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
