### PR TITLE
Ported DeepSleep to ESP32

### DIFF
--- a/tasmota/tasmota_template_ESP32.h
+++ b/tasmota/tasmota_template_ESP32.h
@@ -36,7 +36,6 @@
 
 // Not ported (yet)
 #undef USE_DISCOVERY
-#undef USE_DEEPSLEEP
 #undef USE_MY92X1
 #undef USE_TUYA_MCU
 #undef USE_PS_16_DZ

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -71,13 +71,12 @@ void DeepSleepReInit(void)
       AddLog_P2(LOG_LEVEL_ERROR, PSTR("DSL: Remain DeepSleep %d"), RtcSettings.ultradeepsleep);
       RtcSettingsSave();
       RtcRebootReset();
-      #ifdef ESP8266
-        ESP.deepSleep(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep), WAKE_RF_DEFAULT);
-      #endif
-      #ifdef ESP32
-        esp_sleep_enable_timer_wakeup(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep));
-        esp_deep_sleep_start();
-      #endif
+#ifdef ESP8266
+      ESP.deepSleep(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep), WAKE_RF_DEFAULT);
+#else  // ESP32
+      esp_sleep_enable_timer_wakeup(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep));
+      esp_deep_sleep_start();
+#endif  // ESP8266 or ESP32
       yield();
       // Sleeping
     }
@@ -144,11 +143,10 @@ void DeepSleepStart(void)
   RtcSettingsSave();
 #ifdef ESP8266
   ESP.deepSleep(100 * RtcSettings.deepsleep_slip * deepsleep_sleeptime);
-#endif
-#ifdef ESP32
+#else  // ESP32
   esp_sleep_enable_timer_wakeup(100 * RtcSettings.deepsleep_slip * deepsleep_sleeptime);
   esp_deep_sleep_start();
-#endif
+#endif  // ESP8266 or ESP32
   yield();
 }
 

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -71,7 +71,13 @@ void DeepSleepReInit(void)
       AddLog_P2(LOG_LEVEL_ERROR, PSTR("DSL: Remain DeepSleep %d"), RtcSettings.ultradeepsleep);
       RtcSettingsSave();
       RtcRebootReset();
-      ESP.deepSleep(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep), WAKE_RF_DEFAULT);
+      #ifdef ESP8266
+        ESP.deepSleep(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep), WAKE_RF_DEFAULT);
+      #endif
+      #ifdef ESP32
+        esp_sleep_enable_timer_wakeup(100 * RtcSettings.deepsleep_slip * (DEEPSLEEP_MAX_CYCLE < RtcSettings.ultradeepsleep ? DEEPSLEEP_MAX_CYCLE : RtcSettings.ultradeepsleep));
+        esp_deep_sleep_start();
+      #endif
       yield();
       // Sleeping
     }
@@ -136,8 +142,13 @@ void DeepSleepStart(void)
   WifiShutdown();
   RtcSettings.ultradeepsleep = RtcSettings.nextwakeup - UtcTime();
   RtcSettingsSave();
-
+#ifdef ESP8266
   ESP.deepSleep(100 * RtcSettings.deepsleep_slip * deepsleep_sleeptime);
+#endif
+#ifdef ESP32
+  esp_sleep_enable_timer_wakeup(100 * RtcSettings.deepsleep_slip * deepsleep_sleeptime);
+  esp_deep_sleep_start();
+#endif
   yield();
 }
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
Added Deepsleep to ESP32 #9020. Additional special ESP32 deepsleep feature will be added. Currently ONLY TIME supported.

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR.
  - [ x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [ x] The code change is tested and works on core ESP32 V.1.12.2
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
