### PR TITLE
Add Zigbee add options to ``ZbSend`` ``Config`` and ``ReadCondig``

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix ESP32 PWM range
 - Add Zigbee better support for IKEA Motion Sensor
 - Add ESP32 Analog input support for GPIO32 to GPIO39
+- Add Zigbee add options to ``ZbSend`` ``Config`` and ``ReadCondig``
 
 ### 8.4.0 20200730
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -541,6 +541,8 @@
 #define D_CMND_ZIGBEE_SEND "Send"
 #define D_CMND_ZIGBEE_WRITE "Write"
 #define D_CMND_ZIGBEE_REPORT "Report"
+#define D_CMND_ZIGBEE_READ_CONFIG "ReadConfig"
+#define D_CMND_ZIGBEE_CONFIG "Config"
 #define D_CMND_ZIGBEE_RESPONSE "Response"
   #define D_JSON_ZIGBEE_ZCL_SENT "ZbZCLSent"
 #define D_JSON_ZIGBEE_RECEIVED "ZbReceived"

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -426,8 +426,12 @@ void convertClusterSpecific(JsonObject& json, uint16_t cluster, uint8_t cmd, boo
       if ((cluster == 0x0500) && (cmd == 0x00)) {
         // "ZoneStatusChange"
         json[command_name] = xyz.x;
-        json[command_name2 + F("Ext")] = xyz.y;
-        json[command_name2 + F("Zone")] = xyz.z;
+        if (0 != xyz.y) {
+          json[command_name2 + F("Ext")] = xyz.y;
+        }
+        if ((0 != xyz.z) && (0xFF != xyz.z)) {
+          json[command_name2 + F("Zone")] = xyz.z;
+        }
       } else if ((cluster == 0x0004) && ((cmd == 0x00) || (cmd == 0x01) || (cmd == 0x03))) {
         // AddGroupResp or ViewGroupResp (group name ignored) or RemoveGroup
         json[command_name] = xyz.y;
@@ -525,6 +529,7 @@ void convertClusterSpecific(JsonObject& json, uint16_t cluster, uint8_t cmd, boo
 // If not found:
 //  - returns nullptr
 const __FlashStringHelper* zigbeeFindCommand(const char *command, uint16_t *cluster, uint16_t *cmd) {
+  if (nullptr == command) { return nullptr; }
   for (uint32_t i = 0; i < sizeof(Z_Commands) / sizeof(Z_Commands[0]); i++) {
     const Z_CommandConverter *conv = &Z_Commands[i];
     uint8_t conv_direction = pgm_read_byte(&conv->direction);

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1028,6 +1028,10 @@ void Z_IncomingMessage(ZCLFrame &zcl_received) {
     } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_READ_ATTRIBUTES == zcl_received.getCmdId())) {
       zcl_received.parseReadAttributes(json);
       // never defer read_attributes, so the auto-responder can send response back on a per cluster basis
+    } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_READ_REPORTING_CONFIGURATION_RESPONSE == zcl_received.getCmdId())) {
+      zcl_received.parseReadConfigAttributes(json);
+    } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_CONFIGURE_REPORTING_RESPONSE == zcl_received.getCmdId())) {
+      zcl_received.parseConfigAttributes(json);
     } else if (zcl_received.isClusterSpecificCommand()) {
       zcl_received.parseClusterSpecificCommand(json);
     }


### PR DESCRIPTION
## Description:


**New commands for `ZbSend`: `Config` to configure attribute reporting, and `ReadConfig` to read attribute reporting configuration.**

Zigbee device can be configure to periodically report their state, whether they are sensors (temperature...), plug (on/off) or bulbs (dimmer...). Some vendors like Xiaomi pre-configure their device with attribute reporting, other requires to explicitly set attribute reporting.

Note: some device also require **binding** to specify to which device the attribute should be reported. Xiaomi sets auto-reporting to the coordinator on endpoint 1 or 11. Others like Philips, OSRAM require an explicit binding.

For this example we will consider an OSRAM Plug, for which I have set the name `OSRAM` with `ZbName 0x<device>,OSRAM`

### 1. Bind to the coordinator:

```
ZbBind {"Device":"OSRAM","Cluster":"Power"}

RSL: RESULT = {"ZbBind":{"Device":"0x1677","Name":"OSRAM","Status":0,"StatusMessage":"SUCCESS"}}
```

Actually the full command is `ZbBind {"Device":"OSRAM","ToDevice":"0x0000","Endpoint":3,"ToEndpoint":1,"Cluster":6}` but `ToDevice` is default to `0x0000` and `ToEndpoint` defaults to 1. `Cluster` is inferred from `Power` attribute so you don't need to know the actual cluster number. `Endpoint` is set to the first endpoint of the device, which is `3` for OSRAM plug.

### 2. Set attribute reporting for `Power` attribute

```
ZbSend {"Device":"OSRAM","Config":{"Power":{"MinInterval":1,"MaxInterval":600}}}

RSL: SENSOR = {"OSRAM":{"Device":"0x1677","Name":"OSRAM","ConfigResponse":{"Status":0,"StatusMsg":"SUCCESS"},"Endpoint":3,"LinkQuality":60}}
```

### 3. Optional, check both binding and attribute reporting configuration.

Check the binding:
```
ZbBindState OSRAM

RSL: RESULT = {"ZbBindState":{"Device":"0x1677","Name":"OSRAM","Status":0,"StatusMessage":"SUCCESS","BindingsTotal":1,"BindingsStart":1,"Bindings":[{"Cluster":"0x0006","Endpoint":3,"ToDevice":"0x680AE2FFFE6E103B","ToEndpoint":1}]}}
```

The interesting part is `{"Cluster":"0x0006","Endpoint":3,"ToDevice":"0x680AE2FFFE6E103B","ToEndpoint":1}`. The binding is made on cluster 6 from the endpoint 3 of the OSRAM plug, to the endpoint 1 of `0x680AE2FFFE6E103B` which is the address of the coordinator.

Check the attribute reporting:
```
ZbSend {"Device":"OSRAM","ReadConfig":{"Power":true}}

RSL: SENSOR = {"OSRAM":{"Device":"0x1677","Name":"OSRAM","ReadConfig":{"0006/0000":{"Power":true,"MinInterval":1,"MaxInterval":600}},"Endpoint":3,"LinkQuality":37}}
```

The interesting part is: `"0006/0000":{"Power":true,"MinInterval":1,"MaxInterval":600}`. `0006/0000` shows the attribute is from cluster 0x0006 and id 0x0000. `"Power":true` indicates the name of the attribute if it is known.

### How attribute reporting works

For each attribute you can set:
- `MinInterval` (in seconds) the minimum time to report the attribute value. The device will never send a new attribute update until the `MinInterval` is over. If multiple changes happen during this interval, only the last value is reported.
- `MaxInterval` (in seconds) the maximum time to report the attribute value. If no value has been reported, the device will at least report its every `MaxInterval`. Don't set this value too low or your network will be swamped in traffic, and you will drain the battery of devices.
- `ReportableChange` (in the unit of the attribute). For non-discrete attributes, i.e. analog readings (temp, humidity...), this defines the threshold for a change of value to report the attribute change. This prevents creating too much traffic if an attribute has very small changes.

### Advanced: `DirectionReceived`

Although it is rarely used, you can also set a time-out for a device that is supposed to receive periodic attribute reporting from other devices.

To read, set the attribute value to `false`:

```
ZbSend {"Device":"OSRAM","ReadConfig":{"Power":false}}

10:08:07 RSL: SENSOR = {"OSRAM":{"Device":"0x1677","Name":"OSRAM","ReadConfig":{"0006_0000":{"DirectionReceived":true,"Power":true,"TimeoutPeriod":0}},"Endpoint":3,"LinkQuality":39}}
```

To change it, add `"DirectionReceived":true`:
```
ZbSend {"Device":"OSRAM","Config":{"Power":{"DirectionReceived":true,"TimeoutPeriod":0}}}

RSL: SENSOR = {"OSRAM":{"Device":"0x1677","Name":"OSRAM","ConfigResponse":{"Status":0,"StatusMsg":"SUCCESS"},"Endpoint":3,"LinkQuality":58}}
```

### Minor changes

Added attributes for cluster `0x0500` aka IAS (Intruder Alarm System): `ZoneState`, `ZoneType`, `ZoneStatus`


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
