### PR TITLE
ZBBridge make green LED brighter

### DIFF
--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -52,6 +52,25 @@ EZSP_Serial_t EZSP_Serial;
 #include <TasmotaSerial.h>
 TasmotaSerial *ZigbeeSerial = nullptr;
 
+//
+// Blink Led Status
+//
+const uint32_t Z_LED_STATUS_ON_MILLIS = 50;   // keep led on at least 50 ms
+bool Z_LedStatusSet(bool onoff) {
+  static bool led_status_on = false;
+  static uint32_t led_on_time = 0;
+
+  if (onoff) {
+    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 1);
+    led_status_on = true;
+    led_on_time = millis();
+  } else if ((led_status_on) && (TimePassedSince(led_on_time) >= Z_LED_STATUS_ON_MILLIS)) {
+    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 0);
+    led_status_on = false;
+  }
+  return led_status_on;
+}
+
 /********************************************************************************************/
 //
 // Called at event loop, checks for incoming data from the CC2530
@@ -150,16 +169,15 @@ void ZigbeeInputLoop(void) {
 	static uint32_t zigbee_polling_window = 0;    // number of milliseconds since first byte
   static bool escape = false;                          // was the previous byte an escape?
   bool frame_complete = false;                  // frame is ready and complete
-  bool led_status_on = false;                   // did we turn on the led receive led
   // Receive only valid EZSP frames:
   // 1A - Cancel - cancel all previous bytes
   // 7D - Escape byte - following byte is escaped
   // 7E - end of frame
 
+  Z_LedStatusSet(false);
+
   while (ZigbeeSerial->available()) {
-    // turn on receive LED<1>
-    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 1);
-    led_status_on = true;     // don't forget to switch it off
+    Z_LedStatusSet(true); // turn on receive LED<1>
 
     yield();
     uint8_t zigbee_in_byte = ZigbeeSerial->read();
@@ -205,10 +223,6 @@ void ZigbeeInputLoop(void) {
       zigbee_polling_window = millis();                               // Wait for more data
     }   // adding bytes
   }     // while (ZigbeeSerial->available())
-  // turn receive led off
-  if (led_status_on) {
-    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 0);
-  }
 
   uint32_t frame_len = zigbee_buffer->len();
   if (frame_complete || (frame_len && (millis() > (zigbee_polling_window + ZIGBEE_POLLING)))) {
@@ -427,8 +441,6 @@ void ZigbeeEZSPSend_Out(uint8_t out_byte) {
 // - send frame
 // send_cancel: should we first send a EZSP_CANCEL (0x1A) before the message to clear any leftover
 void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
-  bool led_status_on = false;
-
 	if ((len < 1) || (len > 252)) {
 		// abort, message cannot be less than 2 bytes for CMD1 and CMD2
 		AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_JSON_ZIGBEE_EZSP_SENT ": bad message len %d"), len);
@@ -437,8 +449,7 @@ void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
 	uint8_t data_len = len - 2;		// removing CMD1 and CMD2
 
   // turn send led on
-  SetLedPowerIdx(ZIGBEE_LED_SEND, 1);
-  led_status_on = true;
+  Z_LedStatusSet(true);
 
   if (ZigbeeSerial) {
     if (send_cancel) {
@@ -478,10 +489,6 @@ void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
 
     // finally send End of Frame
     ZigbeeSerial->write(ZIGBEE_EZSP_EOF);		// 0x1A
-  }
-  // turn send led off
-  if (led_status_on) {
-    SetLedPowerIdx(ZIGBEE_LED_SEND, 0);
   }
 
   // Now send a MQTT message to report the sent message

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -47,11 +47,6 @@ public:
 
 EZSP_Serial_t EZSP_Serial;
 
-#endif // USE_ZIGBEE_EZSP
-
-#include <TasmotaSerial.h>
-TasmotaSerial *ZigbeeSerial = nullptr;
-
 //
 // Blink Led Status
 //
@@ -70,6 +65,11 @@ bool Z_LedStatusSet(bool onoff) {
   }
   return led_status_on;
 }
+
+#endif // USE_ZIGBEE_EZSP
+
+#include <TasmotaSerial.h>
+TasmotaSerial *ZigbeeSerial = nullptr;
 
 /********************************************************************************************/
 //


### PR DESCRIPTION
## Description:

Ensure the green LED remains at least 50ms to indicate communication between ESP8266 and EFR32 (Zigbee MCU)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
