### PR TITLE
Update LQI on ZDO messages

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -647,12 +647,14 @@ void Z_Devices::setReachable(uint16_t shortaddr, bool reachable) {
 }
 
 void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
+  if (shortaddr == localShortAddr) { return; }
   Z_Device & device = getShortAddr(shortaddr);
   if (&device == nullptr) { return; }                 // don't crash if not found
   device.linkquality = lqi;
 }
 
 uint8_t Z_Devices::getLQI(uint16_t shortaddr) const {
+  if (shortaddr == localShortAddr) { return 0xFF; }
   int32_t found = findShortAddr(shortaddr);
   if (found >= 0) {
     const Z_Device & device = devicesAt(found);

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1152,7 +1152,6 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
   bool            securityuse = (apsoptions & EMBER_APS_OPTION_ENCRYPTION) ? true : false;
   uint16_t        groupid = buf.get16(11);
   uint8_t         seqnumber = buf.get8(13);
-  // uint8_t         linkquality = buf.get8(14);
   int8_t          linkrssi = buf.get8(15);
   uint8_t         linkquality = ZNP_RSSI2Lqi(linkrssi);   // don't take EZSP LQI but calculate our own based on ZNP 
   uint16_t        srcaddr = buf.get16(16);
@@ -1163,6 +1162,8 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
 
   if ((0x0000 == profileid) && (0x00 == srcendpoint))  {
     // ZDO request
+    // Report LQI
+    zigbee_devices.setLQI(srcaddr, linkquality);
     // Since ZDO messages start with a sequence number, we skip it
     // but we add the source address in the last 2 bytes
     SBuffer zdo_buf(buf.get8(20) - 1 + 2);


### PR DESCRIPTION
## Description:

CC2530 did not report LQI but EZSP does. This fix updates the LQI for each ZDO message received (but the LQI is not displayed in JSON messages to avoid overloading).

**Related issue (if applicable):** fixes #9009

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
