### PR TITLE
scripter esp32 flash file ffat support

### DIFF
--- a/esp32_partition_app1572k_ffat983k.csv
+++ b/esp32_partition_app1572k_ffat983k.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x180000,
+app1,     app,  ota_1,   0x190000, 0x180000,
+ffat,   data, fat,  0x310000,0x0F0000,

--- a/esp32_partition_app1984k_ffat12M.csv
+++ b/esp32_partition_app1984k_ffat12M.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1F0000,
+app1,     app,  ota_1,   0x200000, 0x1F0000,
+ffat,   data, fat,  0x3F0000,0xC10000,


### PR DESCRIPTION
## Description:

adds flash file FFAT support for ESP32
added 2 linker files

for 4mb flash
esp32_partition_app1572k_ffat983k.csv
for 16mb flash  (e.g.TTGo watch)
esp32_partition_app1984k_ffat12M.csv

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_