### PR TITLE
Fix missed merge of device_group_count initialization. Rename remote_…

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -107,7 +107,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t device_groups_enabled : 1;    // bit 3 (v8.1.0.9)   - SetOption85 - Enable Device Groups
     uint32_t led_timeout : 1;              // bit 4 (v8.1.0.9)   - SetOption86 - PWM Dimmer Turn brightness LED's off 5 seconds after last change
     uint32_t powered_off_led : 1;          // bit 5 (v8.1.0.9)   - SetOption87 - PWM Dimmer Turn red LED on when powered off
-    uint32_t remote_device_mode : 1;       // bit 6 (v8.1.0.9)   - SetOption88 - Enable relays in separate device groups/PWM Dimmer Buttons control remote devices
+    uint32_t multiple_device_groups : 1;   // bit 6 (v8.1.0.9)   - SetOption88 - Enable relays in separate device groups/PWM Dimmer Buttons control remote devices
     uint32_t zigbee_distinct_topics : 1;   // bit 7 (v8.1.0.10)  - SetOption89 - Distinct MQTT topics per device for Zigbee (#7835)
     uint32_t only_json_message : 1;        // bit 8 (v8.2.0.3)   - SetOption90 - Disable non-json MQTT response
     uint32_t fade_at_startup : 1;          // bit 9 (v8.2.0.3)   - SetOption91 - Enable light fading at start/power on

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -115,7 +115,7 @@ void DeviceGroupsInit(void)
 
     // If relays in sepaate device groups is enabled, set the device group count to highest numbered
     // relay.
-    if (Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+    if (Settings.flag4.multiple_device_groups) {  // SetOption88 - Enable relays in separate device groups
       for (uint32_t relay_index = 0; relay_index < MAX_RELAYS; relay_index++) {
         if (PinUsed(GPIO_REL1, relay_index)) device_group_count = relay_index + 1;
       }
@@ -385,7 +385,7 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
       log_remaining--;
       switch (item) {
         case DGR_ITEM_POWER:
-          if (Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+          if (Settings.flag4.multiple_device_groups) {  // SetOption88 - Enable relays in separate device groups
             bool on = (value & 1);
             if (on != (power & (1 << device_group_index))) ExecuteCommandPower(device_group_index + 1, (on ? POWER_ON : POWER_OFF), SRC_REMOTE);
           }
@@ -496,7 +496,7 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
     building_status_message = true;
 
     // Call the drivers to build the status update.
-    if (device_group->local || Settings.flag4.remote_device_mode) {  // SetOption88 - Enable relays in separate device groups
+    if (device_group->local || Settings.flag4.multiple_device_groups) {  // SetOption88 - Enable relays in separate device groups
       SendDeviceGroupMessage(device_group_index, DGR_MSGTYP_PARTIAL_UPDATE, DGR_ITEM_POWER, power);
     }
     XdrvMailbox.index = device_group_index << 16;

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -573,7 +573,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
     }
 #ifdef USE_DEVICE_GROUPS
     if (SRC_REMOTE != source && SRC_RETRY != source) {
-      if (Settings.flag4.remote_device_mode)  // SetOption88 - Enable relays in separate device groups
+      if (Settings.flag4.multiple_device_groups)  // SetOption88 - Enable relays in separate device groups
         SendDeviceGroupMessage(device - 1, DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, (power >> (device - 1)) & 1 | 0x01000000);  // Explicitly set number of relays to one
       else
         SendLocalDeviceGroupMessage(DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, power);

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -383,7 +383,7 @@ const char kWebColors[] PROGMEM =
 #ifdef USE_DEVICE_GROUPS
 #define SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, ...) _SendDeviceGroupMessage(DEVICE_INDEX, REQUEST_TYPE, __VA_ARGS__, 0)
 #define SendLocalDeviceGroupMessage(REQUEST_TYPE, ...) _SendDeviceGroupMessage(0, REQUEST_TYPE, __VA_ARGS__, 0)
-uint8_t device_group_count = 1;
+uint8_t device_group_count = 0;
 #endif  // USE_DEVICE_GROUPS
 
 #ifdef DEBUG_TASMOTA_CORE

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -99,7 +99,7 @@ void PWMModulePreInit(void)
 #ifdef USE_PWM_DIMMER_REMOTE
   // If remote device mode is enabled, set the device group count to the number of buttons
   // present.
-  if (Settings.flag4.remote_device_mode) {
+  if (Settings.flag4.multiple_device_groups) {
     Settings.flag4.device_groups_enabled = true;
 
     device_group_count = 0;
@@ -111,7 +111,7 @@ void PWMModulePreInit(void)
     if (remote_pwm_dimmer_count) {
       if ((remote_pwm_dimmers = (struct remote_pwm_dimmer *) calloc(remote_pwm_dimmer_count, sizeof(struct remote_pwm_dimmer))) == nullptr) {
         AddLog_P2(LOG_LEVEL_ERROR, PSTR("PWMDimmer: error allocating PWM dimmer array"));
-        Settings.flag4.remote_device_mode = false;
+        Settings.flag4.multiple_device_groups = false;
       }
       else {
         for (uint8_t i = 0; i < remote_pwm_dimmer_count; i++) {
@@ -309,7 +309,7 @@ void PWMDimmerHandleButton(void)
 #ifdef USE_PWM_DIMMER_REMOTE
       // If there are no other buttons pressed right now and remote mode is enabled, make the device
       // associated with this button the device we're going to control.
-      if (buttons_pressed == 1 && Settings.flag4.remote_device_mode) {
+      if (buttons_pressed == 1 && Settings.flag4.multiple_device_groups) {
         power_button_index = button_index;
         down_button_index = (button_index ? 0 : 1);
         active_device_is_local = device_groups[power_button_index].local;


### PR DESCRIPTION
## Description:

The change to tasmota_globals.h in [PR 8558](https://github.com/arendst/Tasmota/pull/8558) to change the initialization of device_group_count did not seem to actually get merged, This PR re-submits that change.

Also rename remote_device_mode setting to multiple_device_groups to make it more descriptive of the added functionality.

**Related issue (if applicable):** fixes #[8558](https://github.com/arendst/Tasmota/pull/8558)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
