### PR TITLE
update CT slider to more accurate color allocation

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1263,7 +1263,7 @@ void WebSliderColdWarm(void)
 {
   WSContentSend_P(HTTP_MSG_SLIDER_GRADIENT,  // Cold Warm
     "a",             // a - Unique HTML id
-    "#fff", "#ff0",  // White to Yellow
+    "#eff", "#f81",  // 6500k in RGB (White) to 2500k in RGB (Warm Yellow)
     1,               // sl1
     153, 500,        // Range color temperature
     LightGetColorTemp(),


### PR DESCRIPTION
tweaked slider colors to more realistic portrayal (but still not accurate! and will never be!)
from
![image](https://user-images.githubusercontent.com/5904370/89931250-38453780-dc0c-11ea-8c86-b6bf1b77653f.png)

to
![image](https://user-images.githubusercontent.com/5904370/89931195-2e233900-dc0c-11ea-998c-fa5593cfe695.png)


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
