### PR TITLE
Fix ZbBind crash and add Identify cluster

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -417,8 +417,8 @@ uint16_t Z_Devices::isKnownFriendlyName(const char * name) const {
 }
 
 uint64_t Z_Devices::getDeviceLongAddr(uint16_t shortaddr) const {
-  const Z_Device & device = getShortAddrConst(shortaddr);
-  return device.longaddr;
+  const Z_Device &device = getShortAddrConst(shortaddr);
+  return (&device != nullptr) ? device.longaddr : 0;
 }
 
 //

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -145,6 +145,7 @@ ZF(ZCLVersion) ZF(AppVersion) ZF(StackVersion) ZF(HWVersion) ZF(Manufacturer) ZF
 ZF(DateCode) ZF(PowerSource) ZF(SWBuildID) ZF(Power) ZF(SwitchType) ZF(Dimmer)
 ZF(MainsVoltage) ZF(MainsFrequency) ZF(BatteryVoltage) ZF(BatteryPercentage)
 ZF(CurrentTemperature) ZF(MinTempExperienced) ZF(MaxTempExperienced) ZF(OverTempTotalDwell)
+ZF(IdentifyTime)
 ZF(SceneCount) ZF(CurrentScene) ZF(CurrentGroup) ZF(SceneValid)
 ZF(AlarmCount) ZF(Time) ZF(TimeStatus) ZF(TimeZone) ZF(DstStart) ZF(DstEnd)
 ZF(DstShift) ZF(StandardTime) ZF(LocalTime) ZF(LastSetTime) ZF(ValidUntilTime) ZF(TimeEpoch)
@@ -258,6 +259,9 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { Zint16,   Cx0002, 0x0001,  Z(MinTempExperienced),   1,  Z_Nop },
   { Zint16,   Cx0002, 0x0002,  Z(MaxTempExperienced),   1,  Z_Nop },
   { Zuint16,  Cx0002, 0x0003,  Z(OverTempTotalDwell),   1,  Z_Nop },
+
+  // Identify cluster
+  { Zuint16,  Cx0003, 0x0000,  Z(IdentifyTime),         1,  Z_Nop },
 
   // Scenes cluster
   { Zuint8,   Cx0005, 0x0000,  Z(SceneCount),           1,  Z_Nop },

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -27,7 +27,7 @@ typedef struct Z_CommandConverter {
   const char * tasmota_cmd;
   uint16_t     cluster;
   uint8_t      cmd;         // normally 8 bits, 0xFF means it's a parameter
-  uint8_t      direction;   // direction of the command. 0x01 client->server, 0x02 server->client, 0x03 both
+  uint8_t      direction;   // direction of the command. 0x01 client->server, 0x02 server->client, 0x03 both, 0x80 requires custom decoding
   const char * param;
 } Z_CommandConverter;
 
@@ -40,6 +40,7 @@ typedef struct Z_XYZ_Var {    // Holds values for vairables X, Y and Z
   uint8_t     z_type = 0;
 } Z_XYZ_Var;
 
+ZF(Identify) ZF(IdentifyQuery)
 ZF(AddGroup) ZF(ViewGroup) ZF(GetGroup) ZF(GetAllGroups) ZF(RemoveGroup) ZF(RemoveAllGroups)
 ZF(AddScene) ZF(ViewScene) ZF(RemoveScene) ZF(RemoveAllScenes) ZF(RecallScene) ZF(StoreScene) ZF(GetSceneMembership)
 //ZF(Power) ZF(Dimmer)
@@ -70,6 +71,9 @@ ZF(00xx0A00) ZF(01xx0A00) ZF(03xx0A00) ZF(01xxxx0A0000000000) ZF(03xxxx0A0000000
 // - direction: the direction of the command (bit field). 0x01=from client to server (coord to device), 0x02= from server to client (response), 0x80=needs specific decoding
 // - param: the paylod template, x/y/z are substituted with arguments, little endian. For command display, payload must match until x/y/z character or until the end of the paylod. '??' means ignore.
 const Z_CommandConverter Z_Commands[] PROGMEM = {
+  // Identify cluster
+  { Z(Identify),       0x0003, 0x00, 0x01,   Z(xxxx) },         // Identify device, time in seconds
+  { Z(IdentifyQuery),  0x0003, 0x01, 0x01,   Z() },             // Identify Query (no param)
   // Group adress commands
   { Z(AddGroup),       0x0004, 0x00, 0x01,   Z(xxxx00) },       // Add group id, group name is not supported
   { Z(ViewGroup),      0x0004, 0x01, 0x01,   Z(xxxx) },         // Ask for the group name
@@ -137,6 +141,8 @@ const Z_CommandConverter Z_Commands[] PROGMEM = {
   { Z(ArrowClick),     0x0005, 0x07, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right
   { Z(ArrowHold),      0x0005, 0x08, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right
   { Z(ArrowRelease),   0x0005, 0x09, 0x01,   Z() },
+  // Response for Indetify cluster
+  { Z(IdentifyQuery),  0x0003, 0x00, 0x02,   Z(xxxx) },             // timeout in seconds
   // IAS - Intruder Alarm System + leak/fire detection
   { Z(ZoneStatusChange),0x0500, 0x00, 0x82,  Z(xxxxyyzz) },   // xxxx = zone status, yy = extended status, zz = zone id, Delay is ignored
   // responses for Group cluster commands


### PR DESCRIPTION
## Description:

Fix a crash when calling `ZbBind` for a device with IEEEAddress unknown.

Added Identify cluster. This allows to have a visual effect of a device to identify the right one when you have many of them.

Ex for OSRAM Plug, triggering Identify makes the LED flash.

**Start Identify**, parameter is the number of seconds the LED must flash.
```
ZbSend {"Device":"OSRAM","Send":{"Identify":20}}
```
Check for `SUCCESS` response.
```
RESULT = {"ZbResponse":{"Device":"0x3B49","Name":"OSRAM","Command":"0003!00","Status":0,"StatusMessage":"SUCCESS","Endpoint":3,"LinkQuality":41}}
```

**There are two ways to query the state**, either send a `IdentifyQuery` command:
```
ZbSend {"Device":"OSRAM","Send":{"IdentifyQuery":true}}
```
If Identify is still running, you will get the number of seconds left in `IdentifyQuery`:
```
SENSOR = {"ZbReceived":{"0x3B49":{"Device":"0x3B49","Name":"OSRAM","0003<00":"0A00","IdentifyQuery":10,"Endpoint":3,"LinkQuality":46}}}
```
If not, you will only get an acknowledgment of the command
```
RESULT = {"ZbResponse":{"Device":"0x3B49","Name":"OSRAM","Command":"0003!01","Status":0,"StatusMessage":"SUCCESS","Endpoint":3,"LinkQuality":41}}
```

**You can also query the `IdentifyTime` attribute**:
```
ZbSend {"Device":"OSRAM","Read":{"IdentifyTime":true}}
```
The response contains the number of seconds left in `IdentifyTime`, or `0` if no Identify is running.
```
SENSOR = {"ZbReceived":{"0x3B49":{"Device":"0x3B49","Name":"OSRAM","IdentifyTime":0,"Endpoint":3,"LinkQuality":49}}}
```


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
