### PR TITLE
Reserve SetOptions for Virtual CT

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -124,9 +124,9 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t teleinfo_baudrate : 1;        // bit 20 (v8.4.0.1)  - SetOption102 - Set Baud rate for Teleinfo communication (0 = 1200 or 1 = 9600)
     uint32_t mqtt_tls : 1;                 // bit 21 (v8.4.0.1)  - SetOption103 - Enable TLS mode (requires TLS version)
     uint32_t mqtt_no_retain : 1;           // bit 22 (v8.4.0.1)  - SetOption104 - No Retain - disable all MQTT retained messages, some brokers don't support it: AWS IoT, Losant
-    uint32_t spare23 : 1;
-    uint32_t spare24 : 1;
-    uint32_t spare25 : 1;
+    uint32_t white_blend_mode : 1;         // bit 23 (v8.4.0.1)  - SetOption105 - White Blend Mode - used to be `RGBWWTable` last value `0`, now deprecated in favor of this option
+    uint32_t virtual_ct : 1;               // bit 24 (v8.4.0.1)  - SetOption106 - Virtual CT - Creates a virtual White ColorTemp for RGBW lights
+    uint32_t virtual_ct_cw : 1;            // bit 25 (v8.4.0.1)  - SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
     uint32_t spare26 : 1;
     uint32_t spare27 : 1;
     uint32_t spare28 : 1;


### PR DESCRIPTION
## Description:

Reserve the 3x `SetOption` for future Virtual CT feature.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
