### PR TITLE
SO59 support for Power0

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -369,6 +369,9 @@ void CmndPower(void)
       XdrvMailbox.payload = POWER_SHOW_STATE;
     }
     SetAllPower(XdrvMailbox.payload, SRC_IGNORE);
+    if (Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
+      MqttPublishTeleState();
+    }
     mqtt_data[0] = '\0';
   }
 }


### PR DESCRIPTION
## Description:

When `SetOption59` is enabled `Power0` will publish a `/STATE` topic as normal `Power<x>` do.

**Related issue (if applicable):** fixes #8863 

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
