### PR TITLE
Better error message when domain does not exist

### DIFF
--- a/tasmota/xdrv_38_ping.ino
+++ b/tasmota/xdrv_38_ping.ino
@@ -333,6 +333,14 @@ void CmndPing(void) {
   } else if (-1 == res) {
     ResponseCmndChar_P(PSTR("Ping already ongoing for this IP"));
   } else {
+    Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
+                    "\"Reachable\":false"
+                    ",\"IP\":\"\""
+                    ",\"Success\":false"
+                    "}}}"),
+                    XdrvMailbox.data
+                    );
+    MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_PING));
     ResponseCmndChar_P(PSTR("Unable to resolve IP address"));
   }
 }


### PR DESCRIPTION
## Description:

`Ping` command, add additional error message when DNS domain is unknown, for easier parsing.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
