### PR TITLE
Add support for #Axdiv10 to ADS1115 sensor module

### DIFF
--- a/tasmota/xsns_12_ads1115.ino
+++ b/tasmota/xsns_12_ads1115.ino
@@ -180,6 +180,17 @@ void Ads1115Detect(void)
   }
 }
 
+// Create the identifier of the the selected sensor
+void Ads1115Label(char* label, uint32_t maxsize, uint8_t address) {
+  if (1 == Ads1115.count) {
+    // "ADS1115":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
+    snprintf_P(label, maxsize, PSTR("ADS1115"));
+  } else {
+    // "ADS1115-48":{"A0":3240,"A1":3235,"A2":3269,"A3":3269},"ADS1115-49":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
+    snprintf_P(label, maxsize, PSTR("ADS1115%c%02x"), IndexSeparator(), address);
+  }
+}
+
 #ifdef USE_RULES
 // Check every 250ms if there are relevant changes in any of the analog inputs
 // and if so then trigger a message
@@ -208,13 +219,7 @@ void AdsEvery250ms(void)
       Ads1115.address = old_address;
       if (changed) {
         char label[15];
-        if (1 == Ads1115.count) {
-          // "ADS1115":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
-          snprintf_P(label, sizeof(label), PSTR("ADS1115"));
-        } else {
-          // "ADS1115-48":{"A0":3240,"A1":3235,"A2":3269,"A3":3269},"ADS1115-49":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
-          snprintf_P(label, sizeof(label), PSTR("ADS1115%c%02x"), IndexSeparator(), Ads1115.addresses[t]);
-        }
+        Ads1115Label(label, sizeof(label), Ads1115.addresses[t]);
 
         Response_P(PSTR("{\"%s\":{"), label);
 
@@ -252,13 +257,7 @@ void Ads1115Show(bool json)
       Ads1115.address = old_address;
 
       char label[15];
-      if (1 == Ads1115.count) {
-        // "ADS1115":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
-        snprintf_P(label, sizeof(label), PSTR("ADS1115"));
-      } else {
-        // "ADS1115-48":{"A0":3240,"A1":3235,"A2":3269,"A3":3269},"ADS1115-49":{"A0":3240,"A1":3235,"A2":3269,"A3":3269}
-        snprintf_P(label, sizeof(label), PSTR("ADS1115%c%02x"), IndexSeparator(), Ads1115.addresses[t]);
-      }
+      Ads1115Label(label, sizeof(label), Ads1115.addresses[t]);
 
       if (json) {
         ResponseAppend_P(PSTR(",\"%s\":{"), label);


### PR DESCRIPTION
## Description:

The default ADC sensor module has a nice feature to report analog value changes if the input changed more then 1%. This feature was missing from the ADS1115 module, wich also provides analog inputs.

To provide the same functionality as the ADC sensor module this PR adds support for the #Axdiv10 selector wich can be used in rules to trigger immediately on a relevant input change. Works exactly like in the [ADC documentation](https://tasmota.github.io/docs/ADC/#rule-triggers).

## Checklist:
  - [X ] The pull request is done against the latest dev branch
  - [ X] Only relevant files were touched
  - [ X] Only one feature/fix was added per PR.
  - [ X] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
  - [X ] The code change is tested and works on core ESP32 V.1.12.2
  - [ X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
