### PR TITLE
Quick fix since PIO dev has issue...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -120,8 +120,8 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 
 
 [core]
-; *** Esp8266 Tasmota modified Arduino core based on core 2.7.3
-platform                  = espressif8266@2.6.1
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.3.2/esp8266-2.7.3.2.zip
+; *** Esp8266 Arduino core core 2.7.4
+platform                  = espressif8266@2.6.2
+;platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.3.2/esp8266-2.7.3.2.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
Use unmodified Arduino Core 2.7.4 since latest PlatformIO dev has a issue with function `platform_packages`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on core ESP8266 V.2.7.4
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
