### PR TITLE
Error in PIO dev version is fixed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
-  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.3.2
+  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
   - [ ] The code change is tested and works on core ESP32 V.1.12.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -85,7 +85,9 @@ extra_scripts             = pio/strip-floats.py
 [esp_defaults]
 ; *** remove undesired all warnings
 build_unflags             = -Wall
-build_flags               = -D_IR_ENABLE_DEFAULT_=false
+                            -Wdeprecated-declarations
+build_flags               = -Wno-deprecated-declarations
+                            -D_IR_ENABLE_DEFAULT_=false
                             -DDECODE_HASH=true -DDECODE_NEC=true -DSEND_NEC=true
                             -DDECODE_RC5=true -DSEND_RC5=true -DDECODE_RC6=true -DSEND_RC6=true
 ; new mechanism to set the IRremoteESP8266 supported protocols: none except HASH, NEC, RC5, RC6
@@ -98,6 +100,7 @@ build_flags               = -D_IR_ENABLE_DEFAULT_=false
 [esp82xx_defaults]
 build_flags               = ${esp_defaults.build_flags}
                             -Wl,-Map,firmware.map
+                            -D CORE_DEBUG_LEVEL=0
                             -D NDEBUG
                             -mtarget-align
                             -DFP_IN_IROM
@@ -120,8 +123,8 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 
 
 [core]
-; *** Esp8266 Arduino core core 2.7.4
+; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
 platform                  = espressif8266@2.6.2
-platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.3.2/esp8266-2.7.3.2.zip
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -88,7 +88,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-platform                  = espressif8266@2.6.1
+platform                  = espressif8266@2.6.2
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -124,7 +124,7 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core version. Tasmota stage or Arduino stage version. Built with GCC 10.1 toolchain
-platform                  = espressif8266@2.6.1
+platform                  = espressif8266@2.6.2
 platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/framework-arduinoespressif8266-3.20900.0.tar.gz
                             ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
                             toolchain-xtensa @ ~2.100100.0


### PR DESCRIPTION
with commit https://github.com/platformio/platformio-core/commit/2459e85c1dc9a1ecfe632c611594c6c302c8af6b

and switch off deprecated warning for SPIFFS

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
