### PR TITLE
Keep non-handled `0012/0055` Aqara events

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1342,6 +1342,7 @@ int32_t Z_AqaraCubeFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObjec
         json[aqara_cube_side] = val - 512;
         break;
     }
+    return 1;
   }
 
   //     Source: https://github.com/kirovilya/ioBroker.zigbee
@@ -1363,7 +1364,7 @@ int32_t Z_AqaraCubeFunc(const class ZCLFrame *zcl, uint16_t shortaddr, JsonObjec
   //     presentValue = x + 256 = push/slide cube while side x is on top
   //     presentValue = x + 512 = double tap while side x is on top
 
-  return 1;
+  return 0;
 }
 
 // Aqara Vibration Sensor - special proprietary attributes


### PR DESCRIPTION
## Description:

Surface Aqara attribute: cluster 0x0012, attribute 0x0055 to ZbReceived in case it was not transformed into human readable attributes.

Aqara Cube has a specific decoder for this attribute. Unfortunately Aqara switch attributes were dropped because they share the same attribute id. Now the attribute is correctly displayed as `"0012/0055":<value>`

Example:
```
zbznpreceive 44810000120003700101008D00D2AF07000008181D0A550021000003701D

SENSOR = {"ZbReceived":{"0x7003":{"Device":"0x7003","0012/0055":0,"Endpoint":1,"LinkQuality":141}}}
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
