### PR TITLE
Add more Prometheus energy metrics and make changes to existing ones

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -924,6 +924,7 @@ void EnergyShow(bool json)
         float apparent_power = Energy.apparent_power[i];
         if (isnan(apparent_power)) {
           apparent_power = Energy.voltage[i] * Energy.current[i];
+          Energy.apparent_power[i] = apparent_power;
         }
         if (apparent_power < Energy.active_power[i]) {  // Should be impossible
           Energy.active_power[i] = apparent_power;
@@ -935,6 +936,7 @@ void EnergyShow(bool json)
           if (power_factor > 1) {
             power_factor = 1;
           }
+          Energy.power_factor[i] = power_factor;
         }
         if (0 == i) { power_factor_knx = power_factor; }
 
@@ -947,6 +949,7 @@ void EnergyShow(bool json)
             // difference between active and apparent power is greater than 1.5W or 1%
             reactive_power = (float)(RoundSqrtInt((uint32_t)(apparent_power * apparent_power * 100) - (uint32_t)(Energy.active_power[i] * Energy.active_power[i] * 100))) / 10;
           }
+          Energy.reactive_power[i] = reactive_power;
         }
 
         dtostrfd(apparent_power, Settings.flag2.wattage_resolution, apparent_power_chr[i]);
@@ -956,8 +959,9 @@ void EnergyShow(bool json)
     }
     for (uint32_t i = 0; i < Energy.phase_count; i++) {
       float frequency = Energy.frequency[i];
-      if (isnan(Energy.frequency[i])) {
+      if (isnan(frequency)) {
         frequency = 0;
+        Energy.frequency[i] = frequency;
       }
       dtostrfd(frequency, Settings.flag2.frequency_resolution, frequency_chr[i]);
     }

--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -64,15 +64,23 @@ void HandleMetrics(void)
 
 #ifdef USE_ENERGY_SENSOR
   dtostrfd(Energy.voltage[0], Settings.flag2.voltage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE voltage gauge\nvoltage %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_voltage_volts gauge\nenergy_voltage_volts %s\n"), parameter);
   dtostrfd(Energy.current[0], Settings.flag2.current_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE current gauge\ncurrent %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_current_amperes gauge\nenergy_current_amperes %s\n"), parameter);
   dtostrfd(Energy.active_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE active_power gauge\nactive_power %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_active_watts gauge\nenergy_power_active_watts %s\n"), parameter);
+  dtostrfd(Energy.apparent_power[0], Settings.flag2.wattage_resolution, parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_apparent_voltamperes gauge\nenergy_power_apparent_voltamperes %s\n"), parameter);
+  dtostrfd(Energy.reactive_power[0], Settings.flag2.wattage_resolution, parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_reactive_voltamperes gauge\nenergy_power_reactive_voltamperes  %s\n"), parameter);
+  dtostrfd(Energy.frequency[0], Settings.flag2.frequency_resolution, parameter);
+  WSContentSend_P(PSTR("# TYPE energy_frequency_hertz gauge\nenergy_frequency_hertz %s\n"), parameter);
+  dtostrfd(Energy.power_factor[0], 2, parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_factor gauge\nenergy_power_factor %s\n"), parameter);
   dtostrfd(Energy.daily, Settings.flag2.energy_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_daily gauge\nenergy_daily %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_daily counter\nenergy_power_kilowatts_daily %s\n"), parameter);
   dtostrfd(Energy.total, Settings.flag2.energy_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_total counter\nenergy_total %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_total counter\nenergy_power_kilowatts_total %s\n"), parameter);
 #endif
 
 /*

--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -63,20 +63,22 @@ void HandleMetrics(void)
   }
 
 #ifdef USE_ENERGY_SENSOR
-  dtostrfd(Energy.voltage[0], Settings.flag2.voltage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_voltage_volts gauge\nenergy_voltage_volts %s\n"), parameter);
-  dtostrfd(Energy.current[0], Settings.flag2.current_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_current_amperes gauge\nenergy_current_amperes %s\n"), parameter);
-  dtostrfd(Energy.active_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_power_active_watts gauge\nenergy_power_active_watts %s\n"), parameter);
-  dtostrfd(Energy.apparent_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_power_apparent_voltamperes gauge\nenergy_power_apparent_voltamperes %s\n"), parameter);
-  dtostrfd(Energy.reactive_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_power_reactive_voltamperes gauge\nenergy_power_reactive_voltamperes  %s\n"), parameter);
-  dtostrfd(Energy.frequency[0], Settings.flag2.frequency_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_frequency_hertz gauge\nenergy_frequency_hertz %s\n"), parameter);
-  dtostrfd(Energy.power_factor[0], 2, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_power_factor gauge\nenergy_power_factor %s\n"), parameter);
+  for (uint32_t i = 0; i < Energy.phase_count; i++) {
+    dtostrfd(Energy.voltage[i], Settings.flag2.voltage_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_voltage_volts gauge\nenergy_phase_%d_voltage_volts %s\n"), i, i, parameter);
+    dtostrfd(Energy.current[i], Settings.flag2.current_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_current_amperes gauge\nenergy_phase_%d_current_amperes %s\n"), i, i, parameter);
+    dtostrfd(Energy.active_power[i], Settings.flag2.wattage_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_power_active_watts gauge\nenergy_phase_%d_power_active_watts %s\n"), i, i, parameter);
+    dtostrfd(Energy.apparent_power[i], Settings.flag2.wattage_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_power_apparent_voltamperes gauge\nenergy_phase_%d_power_apparent_voltamperes %s\n"), i, i, parameter);
+    dtostrfd(Energy.reactive_power[i], Settings.flag2.wattage_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_power_reactive_voltamperes gauge\nenergy_phase_%d_power_reactive_voltamperes  %s\n"), i, i, parameter);
+    dtostrfd(Energy.power_factor[i], 2, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_power_factor gauge\nenergy_phase_%d_power_factor %s\n"), i, i, parameter);
+    dtostrfd(Energy.frequency[i], Settings.flag2.frequency_resolution, parameter);
+    WSContentSend_P(PSTR("# TYPE energy_phase_%d_frequency_hertz gauge\nenergy_phase_%d_frequency_hertz %s\n"), i, i, parameter);
+  }
   dtostrfd(Energy.daily, Settings.flag2.energy_resolution, parameter);
   WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_daily counter\nenergy_power_kilowatts_daily %s\n"), parameter);
   dtostrfd(Energy.total, Settings.flag2.energy_resolution, parameter);


### PR DESCRIPTION
## Description:
Hi, I'm not very experienced with embedded development - I hope my code is not too bad.

First I've renamed the existing metrics to more closely match the Prometheus best practice from https://prometheus.io/docs/practices/naming/ - I was mostly best-guessing the names/units, so I'd be very happy about suggestions for improvements.

Second, I've added more metrics from the Energy struct, using the variables and resolution settings as done so in other parts of the code. To do this I needed to write some values back into the Energy struct from the code where they are calculated.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
