### PR TITLE
rename prometheus metric names to match best practice

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -64,15 +64,15 @@ void HandleMetrics(void)
 
 #ifdef USE_ENERGY_SENSOR
   dtostrfd(Energy.voltage[0], Settings.flag2.voltage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE voltage gauge\nvoltage %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_voltage_volts gauge\nenergy_voltage_volts %s\n"), parameter);
   dtostrfd(Energy.current[0], Settings.flag2.current_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE current gauge\ncurrent %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_current_amperes gauge\nenergy_current_amperes %s\n"), parameter);
   dtostrfd(Energy.active_power[0], Settings.flag2.wattage_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE active_power gauge\nactive_power %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_active_watts gauge\nenergy_power_active_watts %s\n"), parameter);
   dtostrfd(Energy.daily, Settings.flag2.energy_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_daily gauge\nenergy_daily %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_daily counter\nenergy_power_kilowatts_daily %s\n"), parameter);
   dtostrfd(Energy.total, Settings.flag2.energy_resolution, parameter);
-  WSContentSend_P(PSTR("# TYPE energy_total counter\nenergy_total %s\n"), parameter);
+  WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_total counter\nenergy_power_kilowatts_total %s\n"), parameter);
 #endif
 
 /*


### PR DESCRIPTION
## Description:

I've renamed the existing metrics to more closely match the Prometheus best practice from https://prometheus.io/docs/practices/naming/

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
