### PR TITLE
Zigbee device profile phase 1

### DIFF
--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -103,10 +103,10 @@ void ZigbeeHueStatus(String * response, uint16_t shortaddr) {
 void ZigbeeCheckHue(String * response, bool &appending) {
   uint32_t zigbee_num = zigbee_devices.devicesSize();
   for (uint32_t i = 0; i < zigbee_num; i++) {
-    int8_t bulbtype = zigbee_devices.devicesAt(i).bulbtype;
+    uint16_t shortaddr = zigbee_devices.devicesAt(i).shortaddr;
+    int8_t bulbtype = zigbee_devices.getHueBulbtype(shortaddr);
 
     if (bulbtype >= 0) {
-      uint16_t shortaddr = zigbee_devices.devicesAt(i).shortaddr;
       // this bulb is advertized
       if (appending) { *response += ","; }
       *response += "\"";
@@ -122,7 +122,8 @@ void ZigbeeCheckHue(String * response, bool &appending) {
 void ZigbeeHueGroups(String * lights) {
   uint32_t zigbee_num = zigbee_devices.devicesSize();
   for (uint32_t i = 0; i < zigbee_num; i++) {
-    int8_t bulbtype = zigbee_devices.devicesAt(i).bulbtype;
+    uint16_t shortaddr = zigbee_devices.devicesAt(i).shortaddr;
+    int8_t bulbtype = zigbee_devices.getHueBulbtype(shortaddr);
 
     if (bulbtype >= 0) {
       *lights += ",\"";

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -46,7 +46,7 @@
 // str    - FriendlyName   (null terminated C string, 32 chars max)
 // reserved for extensions
 //  -- V2 --
-// int8_t - bulbtype
+// int8_t - zigbee profile of the device
 
 // Memory footprint
 #ifdef ESP8266
@@ -126,8 +126,8 @@ class SBuffer hibernateDevice(const struct Z_Device &device) {
   }
   buf.add8(0x00);     // end of string marker
 
-  // Hue Bulbtype
-  buf.add8(device.bulbtype);
+  // Zigbee Profile
+  buf.add8(device.zb_profile);
 
   // update overall length
   buf.set8(0, buf.len());
@@ -225,7 +225,7 @@ void hydrateDevices(const SBuffer &buf) {
 
     // Hue bulbtype - if present
     if (d < dev_record_len) {
-      zigbee_devices.setHueBulbtype(shortaddr, buf_d.get8(d));
+      zigbee_devices.setZbProfile(shortaddr, buf_d.get8(d));
       d++;
     }
 

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -190,7 +190,7 @@ void zigbeeZCLSendStr(uint16_t shortaddr, uint16_t groupaddr, uint8_t endpoint, 
 // multiplier == 1: ignore
 // multiplier > 0: divide by the multiplier
 // multiplier < 0: multiply by the -multiplier (positive)
-void ZbApplyMultiplier(double &val_d, int16_t multiplier) {
+void ZbApplyMultiplier(double &val_d, int8_t multiplier) {
   if ((0 != multiplier) && (1 != multiplier)) {
     if (multiplier > 0) {         // inverse of decoding
       val_d = val_d / multiplier;
@@ -217,7 +217,7 @@ void ZbSendReportWrite(const JsonObject &val_pubwrite, uint16_t device, uint16_t
     uint16_t attr_id = 0xFFFF;
     uint16_t cluster_id = 0xFFFF;
     uint8_t  type_id = Znodata;
-    int16_t  multiplier = 1;        // multiplier to adjust the key value
+    int8_t   multiplier = 1;        // multiplier to adjust the key value
     double   val_d = 0;             // I try to avoid `double` but this type capture both float and (u)int32_t without prevision loss
     const char* val_str = "";       // variant as string
 
@@ -245,7 +245,7 @@ void ZbSendReportWrite(const JsonObject &val_pubwrite, uint16_t device, uint16_t
         uint16_t local_attr_id = pgm_read_word(&converter->attribute);
         uint16_t local_cluster_id = CxToCluster(pgm_read_byte(&converter->cluster_short));
         uint8_t  local_type_id = pgm_read_byte(&converter->type);
-        int16_t  local_multiplier = pgm_read_word(&converter->multiplier);
+        int8_t   local_multiplier = pgm_read_byte(&converter->multiplier);
         // AddLog_P2(LOG_LEVEL_DEBUG, PSTR("Try cluster = 0x%04X, attr = 0x%04X, type_id = 0x%02X"), local_cluster_id, local_attr_id, local_type_id);
 
         if (delimiter) {


### PR DESCRIPTION
## Description:

Preparing for zigbee profiles (bulb, PIR, switch...). The first profile is Light as already supported in `ZbLight`.

Minor changes:
- Added extended ZCL attributes
- internal mutliplier for attributes reduced from 16 bits to 8 bits to prepare for a table flash size reduction (not yet effective)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
