### PR TITLE
Zigbee size optimization

### DIFF
--- a/tasmota/xdrv_23_zigbee_0_constants.ino
+++ b/tasmota/xdrv_23_zigbee_0_constants.ino
@@ -1123,6 +1123,7 @@ enum ZCL_Global_Commands {
 
 #define ZF(s) static const char ZS_ ## s[] PROGMEM = #s;
 #define Z(s)  ZS_ ## s
+#define Z_(s) Zo_ ## s
 
 // ZDP Enumeration, see Zigbee spec 2.4.5
 String getZDPStatusMessage(uint8_t status) {

--- a/tasmota/xdrv_23_zigbee_5__constants.ino
+++ b/tasmota/xdrv_23_zigbee_5__constants.ino
@@ -1,0 +1,831 @@
+/*
+  xdrv_23_zigbee_5__constants.ino - zigbee support for Tasmota
+
+  Copyright (C) 2020  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+// Below is a compilation of Strings used in Zigbee commands and converters.
+// Instead of using pointer to strings (4 bytes), we are using an offset (16 bits)
+// into an array of strings - which leads to a 1/3 more compact structure.
+
+// To generate the code below use https://tasmota.hadinger.fr/util
+// and copy/paste the entire arrays `Z_PostProcess` and `Z_Commands` concatenated
+// Note: the 'C' syntax is irrelevant, the parser only looks for `Z_(<string>)`
+
+// In addition the Python3 code used is below:
+
+/*Python code to generate code below
+
+import re
+pat = r"Z\(([^\)]+)\)"      # extract text in Z() macro
+
+def clean(s):
+    return s.strip(" \t\n\r")
+
+def strings_to_pmem(arg):
+    #strings = arg.split("\n")
+    strings = re.findall(pat, arg)
+    
+    # do some basic cleaning
+    strings_cleaned = [ clean(x) for x in strings if clean(x) != ""]
+    
+    # remove duplicates
+    strings_cleaned = list(dict.fromkeys(strings_cleaned))
+    
+    out_s = "const char Z_strings[] PROGMEM = \n"
+    out_i = "enum Z_offsets {\n"
+    
+    index = 0;
+    # add a first empty string
+    out_s += "  \"\\x00\"\n"
+    out_i +=  "  Zo_ = " + str(index) + ",\n"
+    index += 1
+    
+    for s in strings_cleaned:
+        out_s += "  \"" + s + "\" \"\\x00\"\n"
+        out_i += "  Zo_" + s + " = " + str(index) + ",\n"
+        index += len(s) + 1 # add one for null char
+    
+    out_s += "  \"\\x00\";"
+    out_i += "};"
+    
+    return ("", out_s, out_i)
+
+
+*/
+
+/*
+  DO NOT EDIT
+*/
+
+const char Z_strings[] PROGMEM = 
+  "\x00"
+  "ZCLVersion" "\x00"
+  "AppVersion" "\x00"
+  "StackVersion" "\x00"
+  "HWVersion" "\x00"
+  "Manufacturer" "\x00"
+  "ModelId" "\x00"
+  "DateCode" "\x00"
+  "PowerSource" "\x00"
+  "GenericDeviceClass" "\x00"
+  "GenericDeviceType" "\x00"
+  "ProductCode" "\x00"
+  "ProductURL" "\x00"
+  "SWBuildID" "\x00"
+  "MainsVoltage" "\x00"
+  "MainsFrequency" "\x00"
+  "BatteryVoltage" "\x00"
+  "BatteryPercentage" "\x00"
+  "CurrentTemperature" "\x00"
+  "MinTempExperienced" "\x00"
+  "MaxTempExperienced" "\x00"
+  "OverTempTotalDwell" "\x00"
+  "IdentifyTime" "\x00"
+  "GroupNameSupport" "\x00"
+  "SceneCount" "\x00"
+  "CurrentScene" "\x00"
+  "CurrentGroup" "\x00"
+  "SceneValid" "\x00"
+  "NameSupport" "\x00"
+  "Power" "\x00"
+  "StartUpOnOff" "\x00"
+  "SwitchType" "\x00"
+  "Dimmer" "\x00"
+  "DimmerOptions" "\x00"
+  "DimmerRemainingTime" "\x00"
+  "OnOffTransitionTime" "\x00"
+  "OnLevel" "\x00"
+  "OnTransitionTime" "\x00"
+  "OffTransitionTime" "\x00"
+  "DefaultMoveRate" "\x00"
+  "AlarmCount" "\x00"
+  "Time" "\x00"
+  "TimeStatus" "\x00"
+  "TimeZone" "\x00"
+  "DstStart" "\x00"
+  "DstEnd" "\x00"
+  "DstShift" "\x00"
+  "StandardTime" "\x00"
+  "LocalTime" "\x00"
+  "LastSetTime" "\x00"
+  "ValidUntilTime" "\x00"
+  "TimeEpoch" "\x00"
+  "LocationType" "\x00"
+  "LocationMethod" "\x00"
+  "LocationAge" "\x00"
+  "QualityMeasure" "\x00"
+  "NumberOfDevices" "\x00"
+  "AnalogInActiveText" "\x00"
+  "AnalogInDescription" "\x00"
+  "AnalogInInactiveText" "\x00"
+  "AnalogInMaxValue" "\x00"
+  "AnalogInMinValue" "\x00"
+  "AnalogInOutOfService" "\x00"
+  "AqaraRotate" "\x00"
+  "AnalogInPriorityArray" "\x00"
+  "AnalogInReliability" "\x00"
+  "AnalogInRelinquishDefault" "\x00"
+  "AnalogInResolution" "\x00"
+  "AnalogInStatusFlags" "\x00"
+  "AnalogInEngineeringUnits" "\x00"
+  "AnalogInApplicationType" "\x00"
+  "Aqara_FF05" "\x00"
+  "AnalogOutDescription" "\x00"
+  "AnalogOutMaxValue" "\x00"
+  "AnalogOutMinValue" "\x00"
+  "AnalogOutOutOfService" "\x00"
+  "AnalogOutValue" "\x00"
+  "AnalogOutPriorityArray" "\x00"
+  "AnalogOutReliability" "\x00"
+  "AnalogOutRelinquishDefault" "\x00"
+  "AnalogOutResolution" "\x00"
+  "AnalogOutStatusFlags" "\x00"
+  "AnalogOutEngineeringUnits" "\x00"
+  "AnalogOutApplicationType" "\x00"
+  "AnalogDescription" "\x00"
+  "AnalogOutOfService" "\x00"
+  "AnalogValue" "\x00"
+  "AnalogPriorityArray" "\x00"
+  "AnalogReliability" "\x00"
+  "AnalogRelinquishDefault" "\x00"
+  "AnalogStatusFlags" "\x00"
+  "AnalogEngineeringUnits" "\x00"
+  "AnalogApplicationType" "\x00"
+  "BinaryInActiveText" "\x00"
+  "BinaryInDescription" "\x00"
+  "BinaryInInactiveText" "\x00"
+  "BinaryInOutOfService" "\x00"
+  "BinaryInPolarity" "\x00"
+  "BinaryInValue" "\x00"
+  "BinaryInPriorityArray" "\x00"
+  "BinaryInReliability" "\x00"
+  "BinaryInStatusFlags" "\x00"
+  "BinaryInApplicationType" "\x00"
+  "BinaryOutActiveText" "\x00"
+  "BinaryOutDescription" "\x00"
+  "BinaryOutInactiveText" "\x00"
+  "BinaryOutMinimumOffTime" "\x00"
+  "BinaryOutMinimumOnTime" "\x00"
+  "BinaryOutOutOfService" "\x00"
+  "BinaryOutPolarity" "\x00"
+  "BinaryOutValue" "\x00"
+  "BinaryOutPriorityArray" "\x00"
+  "BinaryOutReliability" "\x00"
+  "BinaryOutRelinquishDefault" "\x00"
+  "BinaryOutStatusFlags" "\x00"
+  "BinaryOutApplicationType" "\x00"
+  "BinaryActiveText" "\x00"
+  "BinaryDescription" "\x00"
+  "BinaryInactiveText" "\x00"
+  "BinaryMinimumOffTime" "\x00"
+  "BinaryMinimumOnTime" "\x00"
+  "BinaryOutOfService" "\x00"
+  "BinaryValue" "\x00"
+  "BinaryPriorityArray" "\x00"
+  "BinaryReliability" "\x00"
+  "BinaryRelinquishDefault" "\x00"
+  "BinaryStatusFlags" "\x00"
+  "BinaryApplicationType" "\x00"
+  "MultiInStateText" "\x00"
+  "MultiInDescription" "\x00"
+  "MultiInNumberOfStates" "\x00"
+  "MultiInOutOfService" "\x00"
+  "MultiInValue" "\x00"
+  "MultiInReliability" "\x00"
+  "MultiInStatusFlags" "\x00"
+  "MultiInApplicationType" "\x00"
+  "MultiOutStateText" "\x00"
+  "MultiOutDescription" "\x00"
+  "MultiOutNumberOfStates" "\x00"
+  "MultiOutOutOfService" "\x00"
+  "MultiOutValue" "\x00"
+  "MultiOutPriorityArray" "\x00"
+  "MultiOutReliability" "\x00"
+  "MultiOutRelinquishDefault" "\x00"
+  "MultiOutStatusFlags" "\x00"
+  "MultiOutApplicationType" "\x00"
+  "MultiStateText" "\x00"
+  "MultiDescription" "\x00"
+  "MultiNumberOfStates" "\x00"
+  "MultiOutOfService" "\x00"
+  "MultiValue" "\x00"
+  "MultiReliability" "\x00"
+  "MultiRelinquishDefault" "\x00"
+  "MultiStatusFlags" "\x00"
+  "MultiApplicationType" "\x00"
+  "TotalProfileNum" "\x00"
+  "MultipleScheduling" "\x00"
+  "EnergyFormatting" "\x00"
+  "EnergyRemote" "\x00"
+  "ScheduleMode" "\x00"
+  "CheckinInterval" "\x00"
+  "LongPollInterval" "\x00"
+  "ShortPollInterval" "\x00"
+  "FastPollTimeout" "\x00"
+  "CheckinIntervalMin" "\x00"
+  "LongPollIntervalMin" "\x00"
+  "FastPollTimeoutMax" "\x00"
+  "PhysicalClosedLimit" "\x00"
+  "MotorStepSize" "\x00"
+  "Status" "\x00"
+  "ClosedLimit" "\x00"
+  "Mode" "\x00"
+  "LockState" "\x00"
+  "LockType" "\x00"
+  "ActuatorEnabled" "\x00"
+  "DoorState" "\x00"
+  "DoorOpenEvents" "\x00"
+  "DoorClosedEvents" "\x00"
+  "OpenPeriod" "\x00"
+  "AqaraVibrationMode" "\x00"
+  "AqaraVibrationsOrAngle" "\x00"
+  "AqaraVibration505" "\x00"
+  "AqaraAccelerometer" "\x00"
+  "WindowCoveringType" "\x00"
+  "PhysicalClosedLimitLift" "\x00"
+  "PhysicalClosedLimitTilt" "\x00"
+  "CurrentPositionLift" "\x00"
+  "CurrentPositionTilt" "\x00"
+  "NumberofActuationsLift" "\x00"
+  "NumberofActuationsTilt" "\x00"
+  "ConfigStatus" "\x00"
+  "CurrentPositionLiftPercentage" "\x00"
+  "CurrentPositionTiltPercentage" "\x00"
+  "InstalledOpenLimitLift" "\x00"
+  "InstalledClosedLimitLift" "\x00"
+  "InstalledOpenLimitTilt" "\x00"
+  "InstalledClosedLimitTilt" "\x00"
+  "VelocityLift" "\x00"
+  "AccelerationTimeLift" "\x00"
+  "DecelerationTimeLift" "\x00"
+  "IntermediateSetpointsLift" "\x00"
+  "IntermediateSetpointsTilt" "\x00"
+  "Hue" "\x00"
+  "Sat" "\x00"
+  "RemainingTime" "\x00"
+  "X" "\x00"
+  "Y" "\x00"
+  "DriftCompensation" "\x00"
+  "CompensationText" "\x00"
+  "CT" "\x00"
+  "ColorMode" "\x00"
+  "NumberOfPrimaries" "\x00"
+  "Primary1X" "\x00"
+  "Primary1Y" "\x00"
+  "Primary1Intensity" "\x00"
+  "Primary2X" "\x00"
+  "Primary2Y" "\x00"
+  "Primary2Intensity" "\x00"
+  "Primary3X" "\x00"
+  "Primary3Y" "\x00"
+  "Primary3Intensity" "\x00"
+  "WhitePointX" "\x00"
+  "WhitePointY" "\x00"
+  "ColorPointRX" "\x00"
+  "ColorPointRY" "\x00"
+  "ColorPointRIntensity" "\x00"
+  "ColorPointGX" "\x00"
+  "ColorPointGY" "\x00"
+  "ColorPointGIntensity" "\x00"
+  "ColorPointBX" "\x00"
+  "ColorPointBY" "\x00"
+  "ColorPointBIntensity" "\x00"
+  "Illuminance" "\x00"
+  "IlluminanceMinMeasuredValue" "\x00"
+  "IlluminanceMaxMeasuredValue" "\x00"
+  "IlluminanceTolerance" "\x00"
+  "IlluminanceLightSensorType" "\x00"
+  "IlluminanceLevelStatus" "\x00"
+  "IlluminanceTargetLevel" "\x00"
+  "Temperature" "\x00"
+  "TemperatureMinMeasuredValue" "\x00"
+  "TemperatureMaxMeasuredValue" "\x00"
+  "TemperatureTolerance" "\x00"
+  "PressureUnit" "\x00"
+  "Pressure" "\x00"
+  "PressureMinMeasuredValue" "\x00"
+  "PressureMaxMeasuredValue" "\x00"
+  "PressureTolerance" "\x00"
+  "PressureScaledValue" "\x00"
+  "PressureMinScaledValue" "\x00"
+  "PressureMaxScaledValue" "\x00"
+  "PressureScaledTolerance" "\x00"
+  "PressureScale" "\x00"
+  "FlowRate" "\x00"
+  "FlowMinMeasuredValue" "\x00"
+  "FlowMaxMeasuredValue" "\x00"
+  "FlowTolerance" "\x00"
+  "Humidity" "\x00"
+  "HumidityMinMeasuredValue" "\x00"
+  "HumidityMaxMeasuredValue" "\x00"
+  "HumidityTolerance" "\x00"
+  "Occupancy" "\x00"
+  "OccupancySensorType" "\x00"
+  "ZoneState" "\x00"
+  "ZoneType" "\x00"
+  "ZoneStatus" "\x00"
+  "CompanyName" "\x00"
+  "MeterTypeID" "\x00"
+  "DataQualityID" "\x00"
+  "CustomerName" "\x00"
+  "Model" "\x00"
+  "PartNumber" "\x00"
+  "ProductRevision" "\x00"
+  "SoftwareRevision" "\x00"
+  "UtilityName" "\x00"
+  "POD" "\x00"
+  "AvailablePower" "\x00"
+  "PowerThreshold" "\x00"
+  "NumberOfResets" "\x00"
+  "PersistentMemoryWrites" "\x00"
+  "LastMessageLQI" "\x00"
+  "LastMessageRSSI" "\x00"
+  "Identify" "\x00"
+  "xxxx" "\x00"
+  "IdentifyQuery" "\x00"
+  "AddGroup" "\x00"
+  "xxxx00" "\x00"
+  "ViewGroup" "\x00"
+  "GetGroup" "\x00"
+  "01xxxx" "\x00"
+  "GetAllGroups" "\x00"
+  "00" "\x00"
+  "RemoveGroup" "\x00"
+  "RemoveAllGroups" "\x00"
+  "ViewScene" "\x00"
+  "xxxxyy" "\x00"
+  "RemoveScene" "\x00"
+  "RemoveAllScenes" "\x00"
+  "RecallScene" "\x00"
+  "GetSceneMembership" "\x00"
+  "PowerOffEffect" "\x00"
+  "xxyy" "\x00"
+  "PowerOnRecall" "\x00"
+  "PowerOnTimer" "\x00"
+  "xxyyyyzzzz" "\x00"
+  "xx0A00" "\x00"
+  "DimmerUp" "\x00"
+  "00190200" "\x00"
+  "DimmerDown" "\x00"
+  "01190200" "\x00"
+  "DimmerStop" "\x00"
+  "ResetAlarm" "\x00"
+  "xxyyyy" "\x00"
+  "ResetAllAlarms" "\x00"
+  "xx000A00" "\x00"
+  "HueSat" "\x00"
+  "xxyy0A00" "\x00"
+  "Color" "\x00"
+  "xxxxyyyy0A00" "\x00"
+  "xxxx0A00" "\x00"
+  "ShutterOpen" "\x00"
+  "ShutterClose" "\x00"
+  "ShutterStop" "\x00"
+  "ShutterLift" "\x00"
+  "xx" "\x00"
+  "ShutterTilt" "\x00"
+  "Shutter" "\x00"
+  "DimmerMove" "\x00"
+  "xx0A" "\x00"
+  "DimmerStepUp" "\x00"
+  "00xx0A00" "\x00"
+  "DimmerStepDown" "\x00"
+  "01xx0A00" "\x00"
+  "DimmerStep" "\x00"
+  "xx190A00" "\x00"
+  "01" "\x00"
+  "HueMove" "\x00"
+  "xx19" "\x00"
+  "HueStepUp" "\x00"
+  "HueStepDown" "\x00"
+  "03xx0A00" "\x00"
+  "HueStep" "\x00"
+  "SatMove" "\x00"
+  "SatStep" "\x00"
+  "xx190A" "\x00"
+  "ColorMove" "\x00"
+  "xxxxyyyy" "\x00"
+  "ColorStep" "\x00"
+  "ColorTempMoveUp" "\x00"
+  "01xxxx000000000000" "\x00"
+  "ColorTempMoveDown" "\x00"
+  "03xxxx000000000000" "\x00"
+  "ColorTempMoveStop" "\x00"
+  "00xxxx000000000000" "\x00"
+  "ColorTempMove" "\x00"
+  "xxyyyy000000000000" "\x00"
+  "ColorTempStepUp" "\x00"
+  "01xxxx0A0000000000" "\x00"
+  "ColorTempStepDown" "\x00"
+  "03xxxx0A0000000000" "\x00"
+  "ColorTempStep" "\x00"
+  "xxyyyy0A0000000000" "\x00"
+  "ArrowClick" "\x00"
+  "ArrowHold" "\x00"
+  "ArrowRelease" "\x00"
+  "ZoneStatusChange" "\x00"
+  "xxxxyyzz" "\x00"
+  "xxyyzzzz" "\x00"
+  "AddScene" "\x00"
+  "xxyyyyzz" "\x00"
+  "StoreScene" "\x00"
+  "\x00";
+
+
+enum Z_offsets {
+  Zo_ = 0,
+  Zo_ZCLVersion = 1,
+  Zo_AppVersion = 12,
+  Zo_StackVersion = 23,
+  Zo_HWVersion = 36,
+  Zo_Manufacturer = 46,
+  Zo_ModelId = 59,
+  Zo_DateCode = 67,
+  Zo_PowerSource = 76,
+  Zo_GenericDeviceClass = 88,
+  Zo_GenericDeviceType = 107,
+  Zo_ProductCode = 125,
+  Zo_ProductURL = 137,
+  Zo_SWBuildID = 148,
+  Zo_MainsVoltage = 158,
+  Zo_MainsFrequency = 171,
+  Zo_BatteryVoltage = 186,
+  Zo_BatteryPercentage = 201,
+  Zo_CurrentTemperature = 219,
+  Zo_MinTempExperienced = 238,
+  Zo_MaxTempExperienced = 257,
+  Zo_OverTempTotalDwell = 276,
+  Zo_IdentifyTime = 295,
+  Zo_GroupNameSupport = 308,
+  Zo_SceneCount = 325,
+  Zo_CurrentScene = 336,
+  Zo_CurrentGroup = 349,
+  Zo_SceneValid = 362,
+  Zo_NameSupport = 373,
+  Zo_Power = 385,
+  Zo_StartUpOnOff = 391,
+  Zo_SwitchType = 404,
+  Zo_Dimmer = 415,
+  Zo_DimmerOptions = 422,
+  Zo_DimmerRemainingTime = 436,
+  Zo_OnOffTransitionTime = 456,
+  Zo_OnLevel = 476,
+  Zo_OnTransitionTime = 484,
+  Zo_OffTransitionTime = 501,
+  Zo_DefaultMoveRate = 519,
+  Zo_AlarmCount = 535,
+  Zo_Time = 546,
+  Zo_TimeStatus = 551,
+  Zo_TimeZone = 562,
+  Zo_DstStart = 571,
+  Zo_DstEnd = 580,
+  Zo_DstShift = 587,
+  Zo_StandardTime = 596,
+  Zo_LocalTime = 609,
+  Zo_LastSetTime = 619,
+  Zo_ValidUntilTime = 631,
+  Zo_TimeEpoch = 646,
+  Zo_LocationType = 656,
+  Zo_LocationMethod = 669,
+  Zo_LocationAge = 684,
+  Zo_QualityMeasure = 696,
+  Zo_NumberOfDevices = 711,
+  Zo_AnalogInActiveText = 727,
+  Zo_AnalogInDescription = 746,
+  Zo_AnalogInInactiveText = 766,
+  Zo_AnalogInMaxValue = 787,
+  Zo_AnalogInMinValue = 804,
+  Zo_AnalogInOutOfService = 821,
+  Zo_AqaraRotate = 842,
+  Zo_AnalogInPriorityArray = 854,
+  Zo_AnalogInReliability = 876,
+  Zo_AnalogInRelinquishDefault = 896,
+  Zo_AnalogInResolution = 922,
+  Zo_AnalogInStatusFlags = 941,
+  Zo_AnalogInEngineeringUnits = 961,
+  Zo_AnalogInApplicationType = 986,
+  Zo_Aqara_FF05 = 1010,
+  Zo_AnalogOutDescription = 1021,
+  Zo_AnalogOutMaxValue = 1042,
+  Zo_AnalogOutMinValue = 1060,
+  Zo_AnalogOutOutOfService = 1078,
+  Zo_AnalogOutValue = 1100,
+  Zo_AnalogOutPriorityArray = 1115,
+  Zo_AnalogOutReliability = 1138,
+  Zo_AnalogOutRelinquishDefault = 1159,
+  Zo_AnalogOutResolution = 1186,
+  Zo_AnalogOutStatusFlags = 1206,
+  Zo_AnalogOutEngineeringUnits = 1227,
+  Zo_AnalogOutApplicationType = 1253,
+  Zo_AnalogDescription = 1278,
+  Zo_AnalogOutOfService = 1296,
+  Zo_AnalogValue = 1315,
+  Zo_AnalogPriorityArray = 1327,
+  Zo_AnalogReliability = 1347,
+  Zo_AnalogRelinquishDefault = 1365,
+  Zo_AnalogStatusFlags = 1389,
+  Zo_AnalogEngineeringUnits = 1407,
+  Zo_AnalogApplicationType = 1430,
+  Zo_BinaryInActiveText = 1452,
+  Zo_BinaryInDescription = 1471,
+  Zo_BinaryInInactiveText = 1491,
+  Zo_BinaryInOutOfService = 1512,
+  Zo_BinaryInPolarity = 1533,
+  Zo_BinaryInValue = 1550,
+  Zo_BinaryInPriorityArray = 1564,
+  Zo_BinaryInReliability = 1586,
+  Zo_BinaryInStatusFlags = 1606,
+  Zo_BinaryInApplicationType = 1626,
+  Zo_BinaryOutActiveText = 1650,
+  Zo_BinaryOutDescription = 1670,
+  Zo_BinaryOutInactiveText = 1691,
+  Zo_BinaryOutMinimumOffTime = 1713,
+  Zo_BinaryOutMinimumOnTime = 1737,
+  Zo_BinaryOutOutOfService = 1760,
+  Zo_BinaryOutPolarity = 1782,
+  Zo_BinaryOutValue = 1800,
+  Zo_BinaryOutPriorityArray = 1815,
+  Zo_BinaryOutReliability = 1838,
+  Zo_BinaryOutRelinquishDefault = 1859,
+  Zo_BinaryOutStatusFlags = 1886,
+  Zo_BinaryOutApplicationType = 1907,
+  Zo_BinaryActiveText = 1932,
+  Zo_BinaryDescription = 1949,
+  Zo_BinaryInactiveText = 1967,
+  Zo_BinaryMinimumOffTime = 1986,
+  Zo_BinaryMinimumOnTime = 2007,
+  Zo_BinaryOutOfService = 2027,
+  Zo_BinaryValue = 2046,
+  Zo_BinaryPriorityArray = 2058,
+  Zo_BinaryReliability = 2078,
+  Zo_BinaryRelinquishDefault = 2096,
+  Zo_BinaryStatusFlags = 2120,
+  Zo_BinaryApplicationType = 2138,
+  Zo_MultiInStateText = 2160,
+  Zo_MultiInDescription = 2177,
+  Zo_MultiInNumberOfStates = 2196,
+  Zo_MultiInOutOfService = 2218,
+  Zo_MultiInValue = 2238,
+  Zo_MultiInReliability = 2251,
+  Zo_MultiInStatusFlags = 2270,
+  Zo_MultiInApplicationType = 2289,
+  Zo_MultiOutStateText = 2312,
+  Zo_MultiOutDescription = 2330,
+  Zo_MultiOutNumberOfStates = 2350,
+  Zo_MultiOutOutOfService = 2373,
+  Zo_MultiOutValue = 2394,
+  Zo_MultiOutPriorityArray = 2408,
+  Zo_MultiOutReliability = 2430,
+  Zo_MultiOutRelinquishDefault = 2450,
+  Zo_MultiOutStatusFlags = 2476,
+  Zo_MultiOutApplicationType = 2496,
+  Zo_MultiStateText = 2520,
+  Zo_MultiDescription = 2535,
+  Zo_MultiNumberOfStates = 2552,
+  Zo_MultiOutOfService = 2572,
+  Zo_MultiValue = 2590,
+  Zo_MultiReliability = 2601,
+  Zo_MultiRelinquishDefault = 2618,
+  Zo_MultiStatusFlags = 2641,
+  Zo_MultiApplicationType = 2658,
+  Zo_TotalProfileNum = 2679,
+  Zo_MultipleScheduling = 2695,
+  Zo_EnergyFormatting = 2714,
+  Zo_EnergyRemote = 2731,
+  Zo_ScheduleMode = 2744,
+  Zo_CheckinInterval = 2757,
+  Zo_LongPollInterval = 2773,
+  Zo_ShortPollInterval = 2790,
+  Zo_FastPollTimeout = 2808,
+  Zo_CheckinIntervalMin = 2824,
+  Zo_LongPollIntervalMin = 2843,
+  Zo_FastPollTimeoutMax = 2863,
+  Zo_PhysicalClosedLimit = 2882,
+  Zo_MotorStepSize = 2902,
+  Zo_Status = 2916,
+  Zo_ClosedLimit = 2923,
+  Zo_Mode = 2935,
+  Zo_LockState = 2940,
+  Zo_LockType = 2950,
+  Zo_ActuatorEnabled = 2959,
+  Zo_DoorState = 2975,
+  Zo_DoorOpenEvents = 2985,
+  Zo_DoorClosedEvents = 3000,
+  Zo_OpenPeriod = 3017,
+  Zo_AqaraVibrationMode = 3028,
+  Zo_AqaraVibrationsOrAngle = 3047,
+  Zo_AqaraVibration505 = 3070,
+  Zo_AqaraAccelerometer = 3088,
+  Zo_WindowCoveringType = 3107,
+  Zo_PhysicalClosedLimitLift = 3126,
+  Zo_PhysicalClosedLimitTilt = 3150,
+  Zo_CurrentPositionLift = 3174,
+  Zo_CurrentPositionTilt = 3194,
+  Zo_NumberofActuationsLift = 3214,
+  Zo_NumberofActuationsTilt = 3237,
+  Zo_ConfigStatus = 3260,
+  Zo_CurrentPositionLiftPercentage = 3273,
+  Zo_CurrentPositionTiltPercentage = 3303,
+  Zo_InstalledOpenLimitLift = 3333,
+  Zo_InstalledClosedLimitLift = 3356,
+  Zo_InstalledOpenLimitTilt = 3381,
+  Zo_InstalledClosedLimitTilt = 3404,
+  Zo_VelocityLift = 3429,
+  Zo_AccelerationTimeLift = 3442,
+  Zo_DecelerationTimeLift = 3463,
+  Zo_IntermediateSetpointsLift = 3484,
+  Zo_IntermediateSetpointsTilt = 3510,
+  Zo_Hue = 3536,
+  Zo_Sat = 3540,
+  Zo_RemainingTime = 3544,
+  Zo_X = 3558,
+  Zo_Y = 3560,
+  Zo_DriftCompensation = 3562,
+  Zo_CompensationText = 3580,
+  Zo_CT = 3597,
+  Zo_ColorMode = 3600,
+  Zo_NumberOfPrimaries = 3610,
+  Zo_Primary1X = 3628,
+  Zo_Primary1Y = 3638,
+  Zo_Primary1Intensity = 3648,
+  Zo_Primary2X = 3666,
+  Zo_Primary2Y = 3676,
+  Zo_Primary2Intensity = 3686,
+  Zo_Primary3X = 3704,
+  Zo_Primary3Y = 3714,
+  Zo_Primary3Intensity = 3724,
+  Zo_WhitePointX = 3742,
+  Zo_WhitePointY = 3754,
+  Zo_ColorPointRX = 3766,
+  Zo_ColorPointRY = 3779,
+  Zo_ColorPointRIntensity = 3792,
+  Zo_ColorPointGX = 3813,
+  Zo_ColorPointGY = 3826,
+  Zo_ColorPointGIntensity = 3839,
+  Zo_ColorPointBX = 3860,
+  Zo_ColorPointBY = 3873,
+  Zo_ColorPointBIntensity = 3886,
+  Zo_Illuminance = 3907,
+  Zo_IlluminanceMinMeasuredValue = 3919,
+  Zo_IlluminanceMaxMeasuredValue = 3947,
+  Zo_IlluminanceTolerance = 3975,
+  Zo_IlluminanceLightSensorType = 3996,
+  Zo_IlluminanceLevelStatus = 4023,
+  Zo_IlluminanceTargetLevel = 4046,
+  Zo_Temperature = 4069,
+  Zo_TemperatureMinMeasuredValue = 4081,
+  Zo_TemperatureMaxMeasuredValue = 4109,
+  Zo_TemperatureTolerance = 4137,
+  Zo_PressureUnit = 4158,
+  Zo_Pressure = 4171,
+  Zo_PressureMinMeasuredValue = 4180,
+  Zo_PressureMaxMeasuredValue = 4205,
+  Zo_PressureTolerance = 4230,
+  Zo_PressureScaledValue = 4248,
+  Zo_PressureMinScaledValue = 4268,
+  Zo_PressureMaxScaledValue = 4291,
+  Zo_PressureScaledTolerance = 4314,
+  Zo_PressureScale = 4338,
+  Zo_FlowRate = 4352,
+  Zo_FlowMinMeasuredValue = 4361,
+  Zo_FlowMaxMeasuredValue = 4382,
+  Zo_FlowTolerance = 4403,
+  Zo_Humidity = 4417,
+  Zo_HumidityMinMeasuredValue = 4426,
+  Zo_HumidityMaxMeasuredValue = 4451,
+  Zo_HumidityTolerance = 4476,
+  Zo_Occupancy = 4494,
+  Zo_OccupancySensorType = 4504,
+  Zo_ZoneState = 4524,
+  Zo_ZoneType = 4534,
+  Zo_ZoneStatus = 4543,
+  Zo_CompanyName = 4554,
+  Zo_MeterTypeID = 4566,
+  Zo_DataQualityID = 4578,
+  Zo_CustomerName = 4592,
+  Zo_Model = 4605,
+  Zo_PartNumber = 4611,
+  Zo_ProductRevision = 4622,
+  Zo_SoftwareRevision = 4638,
+  Zo_UtilityName = 4655,
+  Zo_POD = 4667,
+  Zo_AvailablePower = 4671,
+  Zo_PowerThreshold = 4686,
+  Zo_NumberOfResets = 4701,
+  Zo_PersistentMemoryWrites = 4716,
+  Zo_LastMessageLQI = 4739,
+  Zo_LastMessageRSSI = 4754,
+  Zo_Identify = 4770,
+  Zo_xxxx = 4779,
+  Zo_IdentifyQuery = 4784,
+  Zo_AddGroup = 4798,
+  Zo_xxxx00 = 4807,
+  Zo_ViewGroup = 4814,
+  Zo_GetGroup = 4824,
+  Zo_01xxxx = 4833,
+  Zo_GetAllGroups = 4840,
+  Zo_00 = 4853,
+  Zo_RemoveGroup = 4856,
+  Zo_RemoveAllGroups = 4868,
+  Zo_ViewScene = 4884,
+  Zo_xxxxyy = 4894,
+  Zo_RemoveScene = 4901,
+  Zo_RemoveAllScenes = 4913,
+  Zo_RecallScene = 4929,
+  Zo_GetSceneMembership = 4941,
+  Zo_PowerOffEffect = 4960,
+  Zo_xxyy = 4975,
+  Zo_PowerOnRecall = 4980,
+  Zo_PowerOnTimer = 4994,
+  Zo_xxyyyyzzzz = 5007,
+  Zo_xx0A00 = 5018,
+  Zo_DimmerUp = 5025,
+  Zo_00190200 = 5034,
+  Zo_DimmerDown = 5043,
+  Zo_01190200 = 5054,
+  Zo_DimmerStop = 5063,
+  Zo_ResetAlarm = 5074,
+  Zo_xxyyyy = 5085,
+  Zo_ResetAllAlarms = 5092,
+  Zo_xx000A00 = 5107,
+  Zo_HueSat = 5116,
+  Zo_xxyy0A00 = 5123,
+  Zo_Color = 5132,
+  Zo_xxxxyyyy0A00 = 5138,
+  Zo_xxxx0A00 = 5151,
+  Zo_ShutterOpen = 5160,
+  Zo_ShutterClose = 5172,
+  Zo_ShutterStop = 5185,
+  Zo_ShutterLift = 5197,
+  Zo_xx = 5209,
+  Zo_ShutterTilt = 5212,
+  Zo_Shutter = 5224,
+  Zo_DimmerMove = 5232,
+  Zo_xx0A = 5243,
+  Zo_DimmerStepUp = 5248,
+  Zo_00xx0A00 = 5261,
+  Zo_DimmerStepDown = 5270,
+  Zo_01xx0A00 = 5285,
+  Zo_DimmerStep = 5294,
+  Zo_xx190A00 = 5305,
+  Zo_01 = 5314,
+  Zo_HueMove = 5317,
+  Zo_xx19 = 5325,
+  Zo_HueStepUp = 5330,
+  Zo_HueStepDown = 5340,
+  Zo_03xx0A00 = 5352,
+  Zo_HueStep = 5361,
+  Zo_SatMove = 5369,
+  Zo_SatStep = 5377,
+  Zo_xx190A = 5385,
+  Zo_ColorMove = 5392,
+  Zo_xxxxyyyy = 5402,
+  Zo_ColorStep = 5411,
+  Zo_ColorTempMoveUp = 5421,
+  Zo_01xxxx000000000000 = 5437,
+  Zo_ColorTempMoveDown = 5456,
+  Zo_03xxxx000000000000 = 5474,
+  Zo_ColorTempMoveStop = 5493,
+  Zo_00xxxx000000000000 = 5511,
+  Zo_ColorTempMove = 5530,
+  Zo_xxyyyy000000000000 = 5544,
+  Zo_ColorTempStepUp = 5563,
+  Zo_01xxxx0A0000000000 = 5579,
+  Zo_ColorTempStepDown = 5598,
+  Zo_03xxxx0A0000000000 = 5616,
+  Zo_ColorTempStep = 5635,
+  Zo_xxyyyy0A0000000000 = 5649,
+  Zo_ArrowClick = 5668,
+  Zo_ArrowHold = 5679,
+  Zo_ArrowRelease = 5689,
+  Zo_ZoneStatusChange = 5702,
+  Zo_xxxxyyzz = 5719,
+  Zo_xxyyzzzz = 5728,
+  Zo_AddScene = 5737,
+  Zo_xxyyyyzz = 5746,
+  Zo_StoreScene = 5755,
+};
+
+
+/*
+  DO NOT EDIT
+*/
+
+
+#endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -98,7 +98,7 @@ typedef struct Z_AttributeConverter {
   uint8_t  type;
   uint8_t  cluster_short;
   uint16_t attribute;
-  const char * name;
+  uint16_t name_offset;
   int8_t   multiplier;     // multiplier for numerical value, (if > 0 multiply by x, if <0 device by x)
   uint8_t  cb;            // callback func from Z_ConvOperators
   // Z_AttrConverter func;
@@ -141,470 +141,376 @@ enum Z_ConvOperators {
   Z_BatteryPercentage,  // memorize Battery Percentage in RAM
 };
 
-ZF(ZCLVersion) ZF(AppVersion) ZF(StackVersion) ZF(HWVersion) ZF(Manufacturer) ZF(ModelId)
-ZF(GenericDeviceClass) ZF(GenericDeviceType) ZF(ProductCode) ZF(ProductURL)
-ZF(DateCode) ZF(PowerSource) ZF(SWBuildID) ZF(Power) ZF(SwitchType) ZF(Dimmer) ZF(DimmerOptions)
-ZF(DimmerRemainingTime) ZF(OnOffTransitionTime) ZF(StartUpOnOff)
-ZF(MainsVoltage) ZF(MainsFrequency) ZF(BatteryVoltage) ZF(BatteryPercentage)
-ZF(CurrentTemperature) ZF(MinTempExperienced) ZF(MaxTempExperienced) ZF(OverTempTotalDwell)
-ZF(IdentifyTime) ZF(GroupNameSupport)
-ZF(SceneCount) ZF(CurrentScene) ZF(CurrentGroup) ZF(SceneValid)
-ZF(AlarmCount) ZF(Time) ZF(TimeStatus) ZF(TimeZone) ZF(DstStart) ZF(DstEnd)
-ZF(DstShift) ZF(StandardTime) ZF(LocalTime) ZF(LastSetTime) ZF(ValidUntilTime) ZF(TimeEpoch)
-
-ZF(LocationType) ZF(LocationMethod) ZF(LocationAge) ZF(QualityMeasure) ZF(NumberOfDevices)
-
-ZF(AnalogInActiveText) ZF(AnalogInDescription) ZF(AnalogInInactiveText) ZF(AnalogInMaxValue)
-ZF(AnalogInMinValue) ZF(AnalogInOutOfService) ZF(AqaraRotate) ZF(AnalogInPriorityArray)
-ZF(AnalogInReliability) ZF(AnalogInRelinquishDefault) ZF(AnalogInResolution) ZF(AnalogInStatusFlags)
-ZF(AnalogInEngineeringUnits) ZF(AnalogInApplicationType) ZF(Aqara_FF05)
-
-ZF(AnalogOutDescription) ZF(AnalogOutMaxValue) ZF(AnalogOutMinValue) ZF(AnalogOutOutOfService)
-ZF(AnalogOutValue) ZF(AnalogOutPriorityArray) ZF(AnalogOutReliability) ZF(AnalogOutRelinquishDefault)
-ZF(AnalogOutResolution) ZF(AnalogOutStatusFlags) ZF(AnalogOutEngineeringUnits) ZF(AnalogOutApplicationType)
-
-ZF(AnalogDescription) ZF(AnalogOutOfService) ZF(AnalogValue) ZF(AnalogPriorityArray) ZF(AnalogReliability)
-ZF(AnalogRelinquishDefault) ZF(AnalogStatusFlags) ZF(AnalogEngineeringUnits) ZF(AnalogApplicationType)
-
-ZF(BinaryInActiveText) ZF(BinaryInDescription) ZF(BinaryInInactiveText) ZF(BinaryInOutOfService)
-ZF(BinaryInPolarity) ZF(BinaryInValue) ZF(BinaryInPriorityArray) ZF(BinaryInReliability)
-ZF(BinaryInStatusFlags) ZF(BinaryInApplicationType)
-
-ZF(BinaryOutActiveText) ZF(BinaryOutDescription) ZF(BinaryOutInactiveText) ZF(BinaryOutMinimumOffTime)
-ZF(BinaryOutMinimumOnTime) ZF(BinaryOutOutOfService) ZF(BinaryOutPolarity) ZF(BinaryOutValue)
-ZF(BinaryOutPriorityArray) ZF(BinaryOutReliability) ZF(BinaryOutRelinquishDefault) ZF(BinaryOutStatusFlags)
-ZF(BinaryOutApplicationType)
-
-ZF(BinaryActiveText) ZF(BinaryDescription) ZF(BinaryInactiveText) ZF(BinaryMinimumOffTime)
-ZF(BinaryMinimumOnTime) ZF(BinaryOutOfService) ZF(BinaryValue) ZF(BinaryPriorityArray) ZF(BinaryReliability)
-ZF(BinaryRelinquishDefault) ZF(BinaryStatusFlags) ZF(BinaryApplicationType)
-
-ZF(MultiInStateText) ZF(MultiInDescription) ZF(MultiInNumberOfStates) ZF(MultiInOutOfService)
-ZF(MultiInValue) ZF(MultiInReliability) ZF(MultiInStatusFlags) ZF(MultiInApplicationType)
-
-ZF(MultiOutStateText) ZF(MultiOutDescription) ZF(MultiOutNumberOfStates) ZF(MultiOutOutOfService)
-ZF(MultiOutValue) ZF(MultiOutPriorityArray) ZF(MultiOutReliability) ZF(MultiOutRelinquishDefault)
-ZF(MultiOutStatusFlags) ZF(MultiOutApplicationType)
-
-ZF(MultiStateText) ZF(MultiDescription) ZF(MultiNumberOfStates) ZF(MultiOutOfService) ZF(MultiValue)
-ZF(MultiReliability) ZF(MultiRelinquishDefault) ZF(MultiStatusFlags) ZF(MultiApplicationType)
-
-ZF(TotalProfileNum) ZF(MultipleScheduling) ZF(EnergyFormatting) ZF(EnergyRemote) ZF(ScheduleMode)
-
-ZF(CheckinInterval) ZF(LongPollInterval) ZF(ShortPollInterval) ZF(FastPollTimeout) ZF(CheckinIntervalMin)
-ZF(LongPollIntervalMin) ZF(FastPollTimeoutMax)
-
-ZF(PhysicalClosedLimit) ZF(MotorStepSize) ZF(Status) ZF(ClosedLimit) ZF(Mode)
-
-ZF(LockState) ZF(LockType) ZF(ActuatorEnabled) ZF(DoorState) ZF(DoorOpenEvents)
-ZF(DoorClosedEvents) ZF(OpenPeriod)
-
-ZF(AqaraVibrationMode) ZF(AqaraVibrationsOrAngle) ZF(AqaraVibration505) ZF(AqaraAccelerometer)
-
-ZF(WindowCoveringType) ZF(PhysicalClosedLimitLift) ZF(PhysicalClosedLimitTilt) ZF(CurrentPositionLift)
-ZF(CurrentPositionTilt) ZF(NumberofActuationsLift) ZF(NumberofActuationsTilt) ZF(ConfigStatus)
-ZF(CurrentPositionLiftPercentage) ZF(CurrentPositionTiltPercentage) ZF(InstalledOpenLimitLift)
-ZF(InstalledClosedLimitLift) ZF(InstalledOpenLimitTilt) ZF(InstalledClosedLimitTilt) ZF(VelocityLift)
-ZF(AccelerationTimeLift) ZF(DecelerationTimeLift) ZF(IntermediateSetpointsLift)
-ZF(IntermediateSetpointsTilt)
-
-ZF(Hue) ZF(Sat) ZF(RemainingTime) ZF(X) ZF(Y) ZF(DriftCompensation) ZF(CompensationText) ZF(CT)
-ZF(ColorMode) ZF(NumberOfPrimaries) ZF(Primary1X) ZF(Primary1Y) ZF(Primary1Intensity) ZF(Primary2X)
-ZF(Primary2Y) ZF(Primary2Intensity) ZF(Primary3X) ZF(Primary3Y) ZF(Primary3Intensity) ZF(WhitePointX)
-ZF(WhitePointY) ZF(ColorPointRX) ZF(ColorPointRY) ZF(ColorPointRIntensity) ZF(ColorPointGX) ZF(ColorPointGY)
-ZF(ColorPointGIntensity) ZF(ColorPointBX) ZF(ColorPointBY) ZF(ColorPointBIntensity)
-
-ZF(Illuminance) ZF(IlluminanceMinMeasuredValue) ZF(IlluminanceMaxMeasuredValue) ZF(IlluminanceTolerance)
-ZF(IlluminanceLightSensorType) ZF(IlluminanceLevelStatus) ZF(IlluminanceTargetLevel)
-
-ZF(Temperature) ZF(TemperatureMinMeasuredValue) ZF(TemperatureMaxMeasuredValue) ZF(TemperatureTolerance)
-
-ZF(PressureUnit) ZF(Pressure) ZF(PressureMinMeasuredValue) ZF(PressureMaxMeasuredValue) ZF(PressureTolerance)
-ZF(PressureScaledValue) ZF(PressureMinScaledValue) ZF(PressureMaxScaledValue) ZF(PressureScaledTolerance)
-ZF(PressureScale)
-
-ZF(FlowRate) ZF(FlowMinMeasuredValue) ZF(FlowMaxMeasuredValue) ZF(FlowTolerance)
-
-ZF(Humidity) ZF(HumidityMinMeasuredValue) ZF(HumidityMaxMeasuredValue) ZF(HumidityTolerance)
-
-ZF(Occupancy) ZF(OccupancySensorType)
-
-ZF(ZoneState) ZF(ZoneType) ZF(ZoneStatus)
-
-ZF(CompanyName) ZF(MeterTypeID) ZF(DataQualityID) ZF(CustomerName) ZF(Model) ZF(PartNumber)
-ZF(SoftwareRevision) ZF(POD) ZF(AvailablePower) ZF(PowerThreshold) ZF(ProductRevision) ZF(UtilityName)
-
-ZF(NumberOfResets) ZF(PersistentMemoryWrites) ZF(LastMessageLQI) ZF(LastMessageRSSI)
 // list of post-processing directives
 const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
-  { Zuint8,   Cx0000, 0x0000,  Z(ZCLVersion),           1,  Z_Nop },
-  { Zuint8,   Cx0000, 0x0001,  Z(AppVersion),           1,  Z_Nop },
-  { Zuint8,   Cx0000, 0x0002,  Z(StackVersion),         1,  Z_Nop },
-  { Zuint8,   Cx0000, 0x0003,  Z(HWVersion),            1,  Z_Nop },
-  { Zstring,  Cx0000, 0x0004,  Z(Manufacturer),         1,  Z_ManufKeep },    // record Manufacturer
-  { Zstring,  Cx0000, 0x0005,  Z(ModelId),              1,  Z_ModelKeep },    // record Model
-  { Zstring,  Cx0000, 0x0006,  Z(DateCode),             1,  Z_Nop },
-  { Zenum8,   Cx0000, 0x0007,  Z(PowerSource),          1,  Z_Nop },
-  { Zenum8,   Cx0000, 0x0008,  Z(GenericDeviceClass),   1,  Z_Nop },
-  { Zenum8,   Cx0000, 0x0009,  Z(GenericDeviceType),    1,  Z_Nop },
-  { Zoctstr,  Cx0000, 0x000A,  Z(ProductCode),          1,  Z_Nop },
-  { Zstring,  Cx0000, 0x000B,  Z(ProductURL),           1,  Z_Nop },
-  { Zstring,  Cx0000, 0x4000,  Z(SWBuildID),            1,  Z_Nop },
+  { Zuint8,   Cx0000, 0x0000,  Z_(ZCLVersion),           1,  Z_Nop },
+  { Zuint8,   Cx0000, 0x0001,  Z_(AppVersion),           1,  Z_Nop },
+  { Zuint8,   Cx0000, 0x0002,  Z_(StackVersion),         1,  Z_Nop },
+  { Zuint8,   Cx0000, 0x0003,  Z_(HWVersion),            1,  Z_Nop },
+  { Zstring,  Cx0000, 0x0004,  Z_(Manufacturer),         1,  Z_ManufKeep },    // record Manufacturer
+  { Zstring,  Cx0000, 0x0005,  Z_(ModelId),              1,  Z_ModelKeep },    // record Model
+  { Zstring,  Cx0000, 0x0006,  Z_(DateCode),             1,  Z_Nop },
+  { Zenum8,   Cx0000, 0x0007,  Z_(PowerSource),          1,  Z_Nop },
+  { Zenum8,   Cx0000, 0x0008,  Z_(GenericDeviceClass),   1,  Z_Nop },
+  { Zenum8,   Cx0000, 0x0009,  Z_(GenericDeviceType),    1,  Z_Nop },
+  { Zoctstr,  Cx0000, 0x000A,  Z_(ProductCode),          1,  Z_Nop },
+  { Zstring,  Cx0000, 0x000B,  Z_(ProductURL),           1,  Z_Nop },
+  { Zstring,  Cx0000, 0x4000,  Z_(SWBuildID),            1,  Z_Nop },
   // { Zunk,     Cx0000, 0xFFFF,  nullptr,                 0,  Z_Nop },    // Remove all other values
   // Cmd 0x0A - Cluster 0x0000, attribute 0xFF01 - proprietary
-  { Zmap8,    Cx0000, 0xFF01,  nullptr,                 0,  Z_AqaraSensor },    // Occupancy (map8)
+  { Zmap8,    Cx0000, 0xFF01,  Z_(),                     0,  Z_AqaraSensor },    // Occupancy (map8)
 
   // Power Configuration cluster
-  { Zuint16,  Cx0001, 0x0000,  Z(MainsVoltage),         1,  Z_Nop },
-  { Zuint8,   Cx0001, 0x0001,  Z(MainsFrequency),       1,  Z_Nop },
-  { Zuint8,   Cx0001, 0x0020,  Z(BatteryVoltage),       -10,Z_Nop },   // divide by 10
-  { Zuint8,   Cx0001, 0x0021,  Z(BatteryPercentage),    -2, Z_BatteryPercentage },   // divide by 2
+  { Zuint16,  Cx0001, 0x0000,  Z_(MainsVoltage),         1,  Z_Nop },
+  { Zuint8,   Cx0001, 0x0001,  Z_(MainsFrequency),       1,  Z_Nop },
+  { Zuint8,   Cx0001, 0x0020,  Z_(BatteryVoltage),       -10,Z_Nop },   // divide by 10
+  { Zuint8,   Cx0001, 0x0021,  Z_(BatteryPercentage),    -2, Z_BatteryPercentage },   // divide by 2
 
   // Device Temperature Configuration cluster
-  { Zint16,   Cx0002, 0x0000,  Z(CurrentTemperature),   1,  Z_Nop },
-  { Zint16,   Cx0002, 0x0001,  Z(MinTempExperienced),   1,  Z_Nop },
-  { Zint16,   Cx0002, 0x0002,  Z(MaxTempExperienced),   1,  Z_Nop },
-  { Zuint16,  Cx0002, 0x0003,  Z(OverTempTotalDwell),   1,  Z_Nop },
+  { Zint16,   Cx0002, 0x0000,  Z_(CurrentTemperature),   1,  Z_Nop },
+  { Zint16,   Cx0002, 0x0001,  Z_(MinTempExperienced),   1,  Z_Nop },
+  { Zint16,   Cx0002, 0x0002,  Z_(MaxTempExperienced),   1,  Z_Nop },
+  { Zuint16,  Cx0002, 0x0003,  Z_(OverTempTotalDwell),   1,  Z_Nop },
 
   // Identify cluster
-  { Zuint16,  Cx0003, 0x0000,  Z(IdentifyTime),         1,  Z_Nop },
+  { Zuint16,  Cx0003, 0x0000,  Z_(IdentifyTime),         1,  Z_Nop },
 
   // Groups cluster
-  { Zmap8,    Cx0004, 0x0000,  Z(GroupNameSupport),     1,  Z_Nop },
+  { Zmap8,    Cx0004, 0x0000,  Z_(GroupNameSupport),     1,  Z_Nop },
 
   // Scenes cluster
-  { Zuint8,   Cx0005, 0x0000,  Z(SceneCount),           1,  Z_Nop },
-  { Zuint8,   Cx0005, 0x0001,  Z(CurrentScene),         1,  Z_Nop },
-  { Zuint16,  Cx0005, 0x0002,  Z(CurrentGroup),         1,  Z_Nop },
-  { Zbool,    Cx0005, 0x0003,  Z(SceneValid),           1,  Z_Nop },
-  //{ Zmap8,    Cx0005, 0x0004,  Z(NameSupport),           1,  Z_Nop },
+  { Zuint8,   Cx0005, 0x0000,  Z_(SceneCount),           1,  Z_Nop },
+  { Zuint8,   Cx0005, 0x0001,  Z_(CurrentScene),         1,  Z_Nop },
+  { Zuint16,  Cx0005, 0x0002,  Z_(CurrentGroup),         1,  Z_Nop },
+  { Zbool,    Cx0005, 0x0003,  Z_(SceneValid),           1,  Z_Nop },
+  //{ Zmap8,    Cx0005, 0x0004,  Z_(NameSupport),           1,  Z_Nop },
 
   // On/off cluster
-  { Zbool,    Cx0006,    0x0000,  Z(Power),             1,  Z_Nop },
-  { Zenum8,   Cx0006,    0x4003,  Z(StartUpOnOff),      1,  Z_Nop },
-  { Zbool,    Cx0006,    0x8000,  Z(Power),             1,  Z_Nop },   // See 7280
+  { Zbool,    Cx0006,    0x0000,  Z_(Power),             1,  Z_Nop },
+  { Zenum8,   Cx0006,    0x4003,  Z_(StartUpOnOff),      1,  Z_Nop },
+  { Zbool,    Cx0006,    0x8000,  Z_(Power),             1,  Z_Nop },   // See 7280
 
   // On/Off Switch Configuration cluster
-  { Zenum8,   Cx0007, 0x0000,  Z(SwitchType),           1,  Z_Nop },
+  { Zenum8,   Cx0007, 0x0000,  Z_(SwitchType),           1,  Z_Nop },
 
   // Level Control cluster
-  { Zuint8,   Cx0008, 0x0000,  Z(Dimmer),               1,  Z_Nop },
-  { Zmap8,    Cx0008, 0x000F,  Z(DimmerOptions),        1,  Z_Nop },
-  { Zuint16,  Cx0008, 0x0001,  Z(DimmerRemainingTime),  1,  Z_Nop },
-  { Zuint16,  Cx0008, 0x0010,  Z(OnOffTransitionTime),   1,  Z_Nop },
-  // { Zuint8, Cx0008, 0x0011,  Z(OnLevel),              1,  Z_Nop },
-  // { Zuint16, Cx0008, 0x0012,  Z(OnTransitionTime),     1,  Z_Nop },
-  // { Zuint16, Cx0008, 0x0013,  Z(OffTransitionTime),    1,  Z_Nop },
-  // { Zuint16, Cx0008, 0x0014,  Z(DefaultMoveRate),      1,  Z_Nop },
+  { Zuint8,   Cx0008, 0x0000,  Z_(Dimmer),               1,  Z_Nop },
+  { Zmap8,    Cx0008, 0x000F,  Z_(DimmerOptions),        1,  Z_Nop },
+  { Zuint16,  Cx0008, 0x0001,  Z_(DimmerRemainingTime),  1,  Z_Nop },
+  { Zuint16,  Cx0008, 0x0010,  Z_(OnOffTransitionTime),   1,  Z_Nop },
+  // { Zuint8, Cx0008, 0x0011,  Z_(OnLevel),              1,  Z_Nop },
+  // { Zuint16, Cx0008, 0x0012,  Z_(OnTransitionTime),     1,  Z_Nop },
+  // { Zuint16, Cx0008, 0x0013,  Z_(OffTransitionTime),    1,  Z_Nop },
+  // { Zuint16, Cx0008, 0x0014,  Z_(DefaultMoveRate),      1,  Z_Nop },
 
   // Alarms cluster
-  { Zuint16,  Cx0009, 0x0000,  Z(AlarmCount),           1,  Z_Nop },
+  { Zuint16,  Cx0009, 0x0000,  Z_(AlarmCount),           1,  Z_Nop },
 
   // Time cluster
-  { ZUTC,     Cx000A, 0x0000,  Z(Time),                 1,  Z_Nop },
-  { Zmap8,    Cx000A, 0x0001,  Z(TimeStatus),           1,  Z_Nop },
-  { Zint32,   Cx000A, 0x0002,  Z(TimeZone),             1,  Z_Nop },
-  { Zuint32,  Cx000A, 0x0003,  Z(DstStart),             1,  Z_Nop },
-  { Zuint32,  Cx000A, 0x0004,  Z(DstEnd),               1,  Z_Nop },
-  { Zint32,   Cx000A, 0x0005,  Z(DstShift),             1,  Z_Nop },
-  { Zuint32,  Cx000A, 0x0006,  Z(StandardTime),         1,  Z_Nop },
-  { Zuint32,  Cx000A, 0x0007,  Z(LocalTime),            1,  Z_Nop },
-  { ZUTC,     Cx000A, 0x0008,  Z(LastSetTime),          1,  Z_Nop },
-  { ZUTC,     Cx000A, 0x0009,  Z(ValidUntilTime),       1,  Z_Nop },
-  { ZUTC,     Cx000A, 0xFF00,  Z(TimeEpoch),            1,  Z_Nop },    // Tasmota specific, epoch
+  { ZUTC,     Cx000A, 0x0000,  Z_(Time),                 1,  Z_Nop },
+  { Zmap8,    Cx000A, 0x0001,  Z_(TimeStatus),           1,  Z_Nop },
+  { Zint32,   Cx000A, 0x0002,  Z_(TimeZone),             1,  Z_Nop },
+  { Zuint32,  Cx000A, 0x0003,  Z_(DstStart),             1,  Z_Nop },
+  { Zuint32,  Cx000A, 0x0004,  Z_(DstEnd),               1,  Z_Nop },
+  { Zint32,   Cx000A, 0x0005,  Z_(DstShift),             1,  Z_Nop },
+  { Zuint32,  Cx000A, 0x0006,  Z_(StandardTime),         1,  Z_Nop },
+  { Zuint32,  Cx000A, 0x0007,  Z_(LocalTime),            1,  Z_Nop },
+  { ZUTC,     Cx000A, 0x0008,  Z_(LastSetTime),          1,  Z_Nop },
+  { ZUTC,     Cx000A, 0x0009,  Z_(ValidUntilTime),       1,  Z_Nop },
+  { ZUTC,     Cx000A, 0xFF00,  Z_(TimeEpoch),            1,  Z_Nop },    // Tasmota specific, epoch
 
   // RSSI Location cluster
-  { Zdata8,   Cx000B, 0x0000,  Z(LocationType),         1,  Z_Nop },
-  { Zenum8,   Cx000B, 0x0001,  Z(LocationMethod),       1,  Z_Nop },
-  { Zuint16,  Cx000B, 0x0002,  Z(LocationAge),          1,  Z_Nop },
-  { Zuint8,   Cx000B, 0x0003,  Z(QualityMeasure),       1,  Z_Nop },
-  { Zuint8,   Cx000B, 0x0004,  Z(NumberOfDevices),      1,  Z_Nop },
+  { Zdata8,   Cx000B, 0x0000,  Z_(LocationType),         1,  Z_Nop },
+  { Zenum8,   Cx000B, 0x0001,  Z_(LocationMethod),       1,  Z_Nop },
+  { Zuint16,  Cx000B, 0x0002,  Z_(LocationAge),          1,  Z_Nop },
+  { Zuint8,   Cx000B, 0x0003,  Z_(QualityMeasure),       1,  Z_Nop },
+  { Zuint8,   Cx000B, 0x0004,  Z_(NumberOfDevices),      1,  Z_Nop },
 
   // Analog Input cluster
-  // { 0xFF, Cx000C, 0x0004,  Z(AnalogInActiveText),   1,  Z_Nop },
-  { Zstring,  Cx000C, 0x001C,  Z(AnalogInDescription),  1,  Z_Nop },
-  // { 0xFF, Cx000C, 0x002E,  Z(AnalogInInactiveText), 1,  Z_Nop },
-  { Zsingle,  Cx000C, 0x0041,  Z(AnalogInMaxValue),     1,  Z_Nop },
-  { Zsingle,  Cx000C, 0x0045,  Z(AnalogInMinValue),     1,  Z_Nop },
-  { Zbool,    Cx000C, 0x0051,  Z(AnalogInOutOfService), 1,  Z_Nop },
-  { Zsingle,  Cx000C, 0x0055,  Z(AqaraRotate),          1,  Z_Nop },
-  // { 0xFF, Cx000C, 0x0057,  Z(AnalogInPriorityArray),1,  Z_Nop },
-  { Zenum8,   Cx000C, 0x0067,  Z(AnalogInReliability),  1,  Z_Nop },
-  // { 0xFF, Cx000C, 0x0068,  Z(AnalogInRelinquishDefault),1,  Z_Nop },
-  { Zsingle,  Cx000C, 0x006A,  Z(AnalogInResolution),   1,  Z_Nop },
-  { Zmap8,    Cx000C, 0x006F,  Z(AnalogInStatusFlags),  1,  Z_Nop },
-  { Zenum16,  Cx000C, 0x0075,  Z(AnalogInEngineeringUnits),1,  Z_Nop },
-  { Zuint32,  Cx000C, 0x0100,  Z(AnalogInApplicationType),1,  Z_Nop },
-  { Zuint16,  Cx000C, 0xFF05,  Z(Aqara_FF05),           1,  Z_Nop },
+  // { 0xFF, Cx000C, 0x0004,  Z_(AnalogInActiveText),   1,  Z_Nop },
+  { Zstring,  Cx000C, 0x001C,  Z_(AnalogInDescription),  1,  Z_Nop },
+  // { 0xFF, Cx000C, 0x002E,  Z_(AnalogInInactiveText), 1,  Z_Nop },
+  { Zsingle,  Cx000C, 0x0041,  Z_(AnalogInMaxValue),     1,  Z_Nop },
+  { Zsingle,  Cx000C, 0x0045,  Z_(AnalogInMinValue),     1,  Z_Nop },
+  { Zbool,    Cx000C, 0x0051,  Z_(AnalogInOutOfService), 1,  Z_Nop },
+  { Zsingle,  Cx000C, 0x0055,  Z_(AqaraRotate),          1,  Z_Nop },
+  // { 0xFF, Cx000C, 0x0057,  Z_(AnalogInPriorityArray),1,  Z_Nop },
+  { Zenum8,   Cx000C, 0x0067,  Z_(AnalogInReliability),  1,  Z_Nop },
+  // { 0xFF, Cx000C, 0x0068,  Z_(AnalogInRelinquishDefault),1,  Z_Nop },
+  { Zsingle,  Cx000C, 0x006A,  Z_(AnalogInResolution),   1,  Z_Nop },
+  { Zmap8,    Cx000C, 0x006F,  Z_(AnalogInStatusFlags),  1,  Z_Nop },
+  { Zenum16,  Cx000C, 0x0075,  Z_(AnalogInEngineeringUnits),1,  Z_Nop },
+  { Zuint32,  Cx000C, 0x0100,  Z_(AnalogInApplicationType),1,  Z_Nop },
+  { Zuint16,  Cx000C, 0xFF05,  Z_(Aqara_FF05),           1,  Z_Nop },
 
   // Analog Output cluster
-  { Zstring,  Cx000D, 0x001C,  Z(AnalogOutDescription), 1,  Z_Nop },
-  { Zsingle,  Cx000D, 0x0041,  Z(AnalogOutMaxValue),    1,  Z_Nop },
-  { Zsingle,  Cx000D, 0x0045,  Z(AnalogOutMinValue),    1,  Z_Nop },
-  { Zbool,    Cx000D, 0x0051,  Z(AnalogOutOutOfService),1,  Z_Nop },
-  { Zsingle,  Cx000D, 0x0055,  Z(AnalogOutValue),       1,  Z_Nop },
-  // { Zunk,     Cx000D, 0x0057,  Z(AnalogOutPriorityArray),1,  Z_Nop },
-  { Zenum8,   Cx000D, 0x0067,  Z(AnalogOutReliability), 1,  Z_Nop },
-  { Zsingle,  Cx000D, 0x0068,  Z(AnalogOutRelinquishDefault),1,  Z_Nop },
-  { Zsingle,  Cx000D, 0x006A,  Z(AnalogOutResolution),  1,  Z_Nop },
-  { Zmap8,    Cx000D, 0x006F,  Z(AnalogOutStatusFlags), 1,  Z_Nop },
-  { Zenum16,  Cx000D, 0x0075,  Z(AnalogOutEngineeringUnits),1,  Z_Nop },
-  { Zuint32,  Cx000D, 0x0100,  Z(AnalogOutApplicationType),1,  Z_Nop },
+  { Zstring,  Cx000D, 0x001C,  Z_(AnalogOutDescription), 1,  Z_Nop },
+  { Zsingle,  Cx000D, 0x0041,  Z_(AnalogOutMaxValue),    1,  Z_Nop },
+  { Zsingle,  Cx000D, 0x0045,  Z_(AnalogOutMinValue),    1,  Z_Nop },
+  { Zbool,    Cx000D, 0x0051,  Z_(AnalogOutOutOfService),1,  Z_Nop },
+  { Zsingle,  Cx000D, 0x0055,  Z_(AnalogOutValue),       1,  Z_Nop },
+  // { Zunk,     Cx000D, 0x0057,  Z_(AnalogOutPriorityArray),1,  Z_Nop },
+  { Zenum8,   Cx000D, 0x0067,  Z_(AnalogOutReliability), 1,  Z_Nop },
+  { Zsingle,  Cx000D, 0x0068,  Z_(AnalogOutRelinquishDefault),1,  Z_Nop },
+  { Zsingle,  Cx000D, 0x006A,  Z_(AnalogOutResolution),  1,  Z_Nop },
+  { Zmap8,    Cx000D, 0x006F,  Z_(AnalogOutStatusFlags), 1,  Z_Nop },
+  { Zenum16,  Cx000D, 0x0075,  Z_(AnalogOutEngineeringUnits),1,  Z_Nop },
+  { Zuint32,  Cx000D, 0x0100,  Z_(AnalogOutApplicationType),1,  Z_Nop },
 
   // Analog Value cluster
-  { Zstring,  Cx000E, 0x001C,  Z(AnalogDescription),    1,  Z_Nop },
-  { Zbool,    Cx000E, 0x0051,  Z(AnalogOutOfService),   1,  Z_Nop },
-  { Zsingle,  Cx000E, 0x0055,  Z(AnalogValue),          1,  Z_Nop },
-  { Zunk,     Cx000E, 0x0057,  Z(AnalogPriorityArray),  1,  Z_Nop },
-  { Zenum8,   Cx000E, 0x0067,  Z(AnalogReliability),    1,  Z_Nop },
-  { Zsingle,  Cx000E, 0x0068,  Z(AnalogRelinquishDefault),1,  Z_Nop },
-  { Zmap8,    Cx000E, 0x006F,  Z(AnalogStatusFlags),    1,  Z_Nop },
-  { Zenum16,  Cx000E, 0x0075,  Z(AnalogEngineeringUnits),1,  Z_Nop },
-  { Zuint32,  Cx000E, 0x0100,  Z(AnalogApplicationType),1,  Z_Nop },
+  { Zstring,  Cx000E, 0x001C,  Z_(AnalogDescription),    1,  Z_Nop },
+  { Zbool,    Cx000E, 0x0051,  Z_(AnalogOutOfService),   1,  Z_Nop },
+  { Zsingle,  Cx000E, 0x0055,  Z_(AnalogValue),          1,  Z_Nop },
+  { Zunk,     Cx000E, 0x0057,  Z_(AnalogPriorityArray),  1,  Z_Nop },
+  { Zenum8,   Cx000E, 0x0067,  Z_(AnalogReliability),    1,  Z_Nop },
+  { Zsingle,  Cx000E, 0x0068,  Z_(AnalogRelinquishDefault),1,  Z_Nop },
+  { Zmap8,    Cx000E, 0x006F,  Z_(AnalogStatusFlags),    1,  Z_Nop },
+  { Zenum16,  Cx000E, 0x0075,  Z_(AnalogEngineeringUnits),1,  Z_Nop },
+  { Zuint32,  Cx000E, 0x0100,  Z_(AnalogApplicationType),1,  Z_Nop },
 
   // Binary Input cluster
-  { Zstring,  Cx000F, 0x0004,  Z(BinaryInActiveText),  1,  Z_Nop },
-  { Zstring,  Cx000F, 0x001C,  Z(BinaryInDescription), 1,  Z_Nop },
-  { Zstring,  Cx000F, 0x002E,  Z(BinaryInInactiveText),1,  Z_Nop },
-  { Zbool,    Cx000F, 0x0051,  Z(BinaryInOutOfService),1,  Z_Nop },
-  { Zenum8,   Cx000F, 0x0054,  Z(BinaryInPolarity),    1,  Z_Nop },
-  { Zstring,  Cx000F, 0x0055,  Z(BinaryInValue),       1,  Z_Nop },
-  // { 0xFF, Cx000F, 0x0057,  Z(BinaryInPriorityArray),1,  Z_Nop },
-  { Zenum8,   Cx000F, 0x0067,  Z(BinaryInReliability), 1,  Z_Nop },
-  { Zmap8,    Cx000F, 0x006F,  Z(BinaryInStatusFlags), 1,  Z_Nop },
-  { Zuint32,  Cx000F, 0x0100,  Z(BinaryInApplicationType),1,  Z_Nop },
+  { Zstring,  Cx000F, 0x0004,  Z_(BinaryInActiveText),  1,  Z_Nop },
+  { Zstring,  Cx000F, 0x001C,  Z_(BinaryInDescription), 1,  Z_Nop },
+  { Zstring,  Cx000F, 0x002E,  Z_(BinaryInInactiveText),1,  Z_Nop },
+  { Zbool,    Cx000F, 0x0051,  Z_(BinaryInOutOfService),1,  Z_Nop },
+  { Zenum8,   Cx000F, 0x0054,  Z_(BinaryInPolarity),    1,  Z_Nop },
+  { Zstring,  Cx000F, 0x0055,  Z_(BinaryInValue),       1,  Z_Nop },
+  // { 0xFF, Cx000F, 0x0057,  Z_(BinaryInPriorityArray),1,  Z_Nop },
+  { Zenum8,   Cx000F, 0x0067,  Z_(BinaryInReliability), 1,  Z_Nop },
+  { Zmap8,    Cx000F, 0x006F,  Z_(BinaryInStatusFlags), 1,  Z_Nop },
+  { Zuint32,  Cx000F, 0x0100,  Z_(BinaryInApplicationType),1,  Z_Nop },
 
   // Binary Output cluster
-  { Zstring,  Cx0010, 0x0004,  Z(BinaryOutActiveText),  1,  Z_Nop },
-  { Zstring,  Cx0010, 0x001C,  Z(BinaryOutDescription), 1,  Z_Nop },
-  { Zstring,  Cx0010, 0x002E,  Z(BinaryOutInactiveText),1,  Z_Nop },
-  { Zuint32,  Cx0010, 0x0042,  Z(BinaryOutMinimumOffTime),1,  Z_Nop },
-  { Zuint32,  Cx0010, 0x0043,  Z(BinaryOutMinimumOnTime),1,  Z_Nop },
-  { Zbool,    Cx0010, 0x0051,  Z(BinaryOutOutOfService),1,  Z_Nop },
-  { Zenum8,   Cx0010, 0x0054,  Z(BinaryOutPolarity),    1,  Z_Nop },
-  { Zbool,    Cx0010, 0x0055,  Z(BinaryOutValue),       1,  Z_Nop },
-  // { Zunk,     Cx0010, 0x0057,  Z(BinaryOutPriorityArray),1,  Z_Nop },
-  { Zenum8,   Cx0010, 0x0067,  Z(BinaryOutReliability), 1,  Z_Nop },
-  { Zbool,    Cx0010, 0x0068,  Z(BinaryOutRelinquishDefault),1,  Z_Nop },
-  { Zmap8,    Cx0010, 0x006F,  Z(BinaryOutStatusFlags), 1,  Z_Nop },
-  { Zuint32,  Cx0010, 0x0100,  Z(BinaryOutApplicationType),1,  Z_Nop },
+  { Zstring,  Cx0010, 0x0004,  Z_(BinaryOutActiveText),  1,  Z_Nop },
+  { Zstring,  Cx0010, 0x001C,  Z_(BinaryOutDescription), 1,  Z_Nop },
+  { Zstring,  Cx0010, 0x002E,  Z_(BinaryOutInactiveText),1,  Z_Nop },
+  { Zuint32,  Cx0010, 0x0042,  Z_(BinaryOutMinimumOffTime),1,  Z_Nop },
+  { Zuint32,  Cx0010, 0x0043,  Z_(BinaryOutMinimumOnTime),1,  Z_Nop },
+  { Zbool,    Cx0010, 0x0051,  Z_(BinaryOutOutOfService),1,  Z_Nop },
+  { Zenum8,   Cx0010, 0x0054,  Z_(BinaryOutPolarity),    1,  Z_Nop },
+  { Zbool,    Cx0010, 0x0055,  Z_(BinaryOutValue),       1,  Z_Nop },
+  // { Zunk,     Cx0010, 0x0057,  Z_(BinaryOutPriorityArray),1,  Z_Nop },
+  { Zenum8,   Cx0010, 0x0067,  Z_(BinaryOutReliability), 1,  Z_Nop },
+  { Zbool,    Cx0010, 0x0068,  Z_(BinaryOutRelinquishDefault),1,  Z_Nop },
+  { Zmap8,    Cx0010, 0x006F,  Z_(BinaryOutStatusFlags), 1,  Z_Nop },
+  { Zuint32,  Cx0010, 0x0100,  Z_(BinaryOutApplicationType),1,  Z_Nop },
 
   // Binary Value cluster
-  { Zstring,  Cx0011, 0x0004,  Z(BinaryActiveText),     1,  Z_Nop },
-  { Zstring,  Cx0011, 0x001C,  Z(BinaryDescription),    1,  Z_Nop },
-  { Zstring,  Cx0011, 0x002E,  Z(BinaryInactiveText),   1,  Z_Nop },
-  { Zuint32,  Cx0011, 0x0042,  Z(BinaryMinimumOffTime), 1,  Z_Nop },
-  { Zuint32,  Cx0011, 0x0043,  Z(BinaryMinimumOnTime),  1,  Z_Nop },
-  { Zbool,    Cx0011, 0x0051,  Z(BinaryOutOfService),   1,  Z_Nop },
-  { Zbool,    Cx0011, 0x0055,  Z(BinaryValue),          1,  Z_Nop },
-  // { Zunk,     Cx0011, 0x0057,  Z(BinaryPriorityArray),  1,  Z_Nop },
-  { Zenum8,   Cx0011, 0x0067,  Z(BinaryReliability),    1,  Z_Nop },
-  { Zbool,    Cx0011, 0x0068,  Z(BinaryRelinquishDefault),1,  Z_Nop },
-  { Zmap8,    Cx0011, 0x006F,  Z(BinaryStatusFlags),    1,  Z_Nop },
-  { Zuint32,  Cx0011, 0x0100,  Z(BinaryApplicationType),1,  Z_Nop },
+  { Zstring,  Cx0011, 0x0004,  Z_(BinaryActiveText),     1,  Z_Nop },
+  { Zstring,  Cx0011, 0x001C,  Z_(BinaryDescription),    1,  Z_Nop },
+  { Zstring,  Cx0011, 0x002E,  Z_(BinaryInactiveText),   1,  Z_Nop },
+  { Zuint32,  Cx0011, 0x0042,  Z_(BinaryMinimumOffTime), 1,  Z_Nop },
+  { Zuint32,  Cx0011, 0x0043,  Z_(BinaryMinimumOnTime),  1,  Z_Nop },
+  { Zbool,    Cx0011, 0x0051,  Z_(BinaryOutOfService),   1,  Z_Nop },
+  { Zbool,    Cx0011, 0x0055,  Z_(BinaryValue),          1,  Z_Nop },
+  // { Zunk,     Cx0011, 0x0057,  Z_(BinaryPriorityArray),  1,  Z_Nop },
+  { Zenum8,   Cx0011, 0x0067,  Z_(BinaryReliability),    1,  Z_Nop },
+  { Zbool,    Cx0011, 0x0068,  Z_(BinaryRelinquishDefault),1,  Z_Nop },
+  { Zmap8,    Cx0011, 0x006F,  Z_(BinaryStatusFlags),    1,  Z_Nop },
+  { Zuint32,  Cx0011, 0x0100,  Z_(BinaryApplicationType),1,  Z_Nop },
 
   // Multistate Input cluster
-  // { Zunk,     Cx0012, 0x000E,  Z(MultiInStateText),     1,  Z_Nop },
-  { Zstring,  Cx0012, 0x001C,  Z(MultiInDescription),   1,  Z_Nop },
-  { Zuint16,  Cx0012, 0x004A,  Z(MultiInNumberOfStates),1,  Z_Nop },
-  { Zbool,    Cx0012, 0x0051,  Z(MultiInOutOfService),  1,  Z_Nop },
-  { Zuint16,  Cx0012, 0x0055,  Z(MultiInValue),         0,  Z_AqaraCube },
-  { Zenum8,   Cx0012, 0x0067,  Z(MultiInReliability),   1,  Z_Nop },
-  { Zmap8,    Cx0012, 0x006F,  Z(MultiInStatusFlags),   1,  Z_Nop },
-  { Zuint32,  Cx0012, 0x0100,  Z(MultiInApplicationType),1,  Z_Nop },
+  // { Zunk,     Cx0012, 0x000E,  Z_(MultiInStateText),     1,  Z_Nop },
+  { Zstring,  Cx0012, 0x001C,  Z_(MultiInDescription),   1,  Z_Nop },
+  { Zuint16,  Cx0012, 0x004A,  Z_(MultiInNumberOfStates),1,  Z_Nop },
+  { Zbool,    Cx0012, 0x0051,  Z_(MultiInOutOfService),  1,  Z_Nop },
+  { Zuint16,  Cx0012, 0x0055,  Z_(MultiInValue),         0,  Z_AqaraCube },
+  { Zenum8,   Cx0012, 0x0067,  Z_(MultiInReliability),   1,  Z_Nop },
+  { Zmap8,    Cx0012, 0x006F,  Z_(MultiInStatusFlags),   1,  Z_Nop },
+  { Zuint32,  Cx0012, 0x0100,  Z_(MultiInApplicationType),1,  Z_Nop },
 
   // Multistate output
-  // { Zunk,     Cx0013, 0x000E,  Z(MultiOutStateText),    1,  Z_Nop },
-  { Zstring,  Cx0013, 0x001C,  Z(MultiOutDescription),  1,  Z_Nop },
-  { Zuint16,  Cx0013, 0x004A,  Z(MultiOutNumberOfStates),1,  Z_Nop },
-  { Zbool,    Cx0013, 0x0051,  Z(MultiOutOutOfService), 1,  Z_Nop },
-  { Zuint16,  Cx0013, 0x0055,  Z(MultiOutValue),        1,  Z_Nop },
-  // { Zunk,     Cx0013, 0x0057,  Z(MultiOutPriorityArray),1,  Z_Nop },
-  { Zenum8,   Cx0013, 0x0067,  Z(MultiOutReliability),  1,  Z_Nop },
-  { Zuint16,  Cx0013, 0x0068,  Z(MultiOutRelinquishDefault),1,  Z_Nop },
-  { Zmap8,    Cx0013, 0x006F,  Z(MultiOutStatusFlags),  1,  Z_Nop },
-  { Zuint32,  Cx0013, 0x0100,  Z(MultiOutApplicationType),1,  Z_Nop },
+  // { Zunk,     Cx0013, 0x000E,  Z_(MultiOutStateText),    1,  Z_Nop },
+  { Zstring,  Cx0013, 0x001C,  Z_(MultiOutDescription),  1,  Z_Nop },
+  { Zuint16,  Cx0013, 0x004A,  Z_(MultiOutNumberOfStates),1,  Z_Nop },
+  { Zbool,    Cx0013, 0x0051,  Z_(MultiOutOutOfService), 1,  Z_Nop },
+  { Zuint16,  Cx0013, 0x0055,  Z_(MultiOutValue),        1,  Z_Nop },
+  // { Zunk,     Cx0013, 0x0057,  Z_(MultiOutPriorityArray),1,  Z_Nop },
+  { Zenum8,   Cx0013, 0x0067,  Z_(MultiOutReliability),  1,  Z_Nop },
+  { Zuint16,  Cx0013, 0x0068,  Z_(MultiOutRelinquishDefault),1,  Z_Nop },
+  { Zmap8,    Cx0013, 0x006F,  Z_(MultiOutStatusFlags),  1,  Z_Nop },
+  { Zuint32,  Cx0013, 0x0100,  Z_(MultiOutApplicationType),1,  Z_Nop },
 
   // Multistate Value cluster
-  // { Zunk,     Cx0014, 0x000E,  Z(MultiStateText),       1,  Z_Nop },
-  { Zstring,  Cx0014, 0x001C,  Z(MultiDescription),     1,  Z_Nop },
-  { Zuint16,  Cx0014, 0x004A,  Z(MultiNumberOfStates),  1,  Z_Nop },
-  { Zbool,    Cx0014, 0x0051,  Z(MultiOutOfService),    1,  Z_Nop },
-  { Zuint16,  Cx0014, 0x0055,  Z(MultiValue),           1,  Z_Nop },
-  { Zenum8,   Cx0014, 0x0067,  Z(MultiReliability),     1,  Z_Nop },
-  { Zuint16,  Cx0014, 0x0068,  Z(MultiRelinquishDefault),1,  Z_Nop },
-  { Zmap8,    Cx0014, 0x006F,  Z(MultiStatusFlags),     1,  Z_Nop },
-  { Zuint32,  Cx0014, 0x0100,  Z(MultiApplicationType), 1,  Z_Nop },
+  // { Zunk,     Cx0014, 0x000E,  Z_(MultiStateText),       1,  Z_Nop },
+  { Zstring,  Cx0014, 0x001C,  Z_(MultiDescription),     1,  Z_Nop },
+  { Zuint16,  Cx0014, 0x004A,  Z_(MultiNumberOfStates),  1,  Z_Nop },
+  { Zbool,    Cx0014, 0x0051,  Z_(MultiOutOfService),    1,  Z_Nop },
+  { Zuint16,  Cx0014, 0x0055,  Z_(MultiValue),           1,  Z_Nop },
+  { Zenum8,   Cx0014, 0x0067,  Z_(MultiReliability),     1,  Z_Nop },
+  { Zuint16,  Cx0014, 0x0068,  Z_(MultiRelinquishDefault),1,  Z_Nop },
+  { Zmap8,    Cx0014, 0x006F,  Z_(MultiStatusFlags),     1,  Z_Nop },
+  { Zuint32,  Cx0014, 0x0100,  Z_(MultiApplicationType), 1,  Z_Nop },
 
   // Power Profile cluster
-  { Zuint8,   Cx001A, 0x0000,  Z(TotalProfileNum),      1,  Z_Nop },
-  { Zbool,    Cx001A, 0x0001,  Z(MultipleScheduling),   1,  Z_Nop },
-  { Zmap8,    Cx001A, 0x0002,  Z(EnergyFormatting),     1,  Z_Nop },
-  { Zbool,    Cx001A, 0x0003,  Z(EnergyRemote),         1,  Z_Nop },
-  { Zmap8,    Cx001A, 0x0004,  Z(ScheduleMode),         1,  Z_Nop },
+  { Zuint8,   Cx001A, 0x0000,  Z_(TotalProfileNum),      1,  Z_Nop },
+  { Zbool,    Cx001A, 0x0001,  Z_(MultipleScheduling),   1,  Z_Nop },
+  { Zmap8,    Cx001A, 0x0002,  Z_(EnergyFormatting),     1,  Z_Nop },
+  { Zbool,    Cx001A, 0x0003,  Z_(EnergyRemote),         1,  Z_Nop },
+  { Zmap8,    Cx001A, 0x0004,  Z_(ScheduleMode),         1,  Z_Nop },
 
   // Poll Control cluster
-  { Zuint32,  Cx0020, 0x0000,  Z(CheckinInterval),      1,  Z_Nop },
-  { Zuint32,  Cx0020, 0x0001,  Z(LongPollInterval),     1,  Z_Nop },
-  { Zuint16,  Cx0020, 0x0002,  Z(ShortPollInterval),    1,  Z_Nop },
-  { Zuint16,  Cx0020, 0x0003,  Z(FastPollTimeout),      1,  Z_Nop },
-  { Zuint32,  Cx0020, 0x0004,  Z(CheckinIntervalMin),   1,  Z_Nop },
-  { Zuint32,  Cx0020, 0x0005,  Z(LongPollIntervalMin),  1,  Z_Nop },
-  { Zuint16,  Cx0020, 0x0006,  Z(FastPollTimeoutMax),   1,  Z_Nop },
+  { Zuint32,  Cx0020, 0x0000,  Z_(CheckinInterval),      1,  Z_Nop },
+  { Zuint32,  Cx0020, 0x0001,  Z_(LongPollInterval),     1,  Z_Nop },
+  { Zuint16,  Cx0020, 0x0002,  Z_(ShortPollInterval),    1,  Z_Nop },
+  { Zuint16,  Cx0020, 0x0003,  Z_(FastPollTimeout),      1,  Z_Nop },
+  { Zuint32,  Cx0020, 0x0004,  Z_(CheckinIntervalMin),   1,  Z_Nop },
+  { Zuint32,  Cx0020, 0x0005,  Z_(LongPollIntervalMin),  1,  Z_Nop },
+  { Zuint16,  Cx0020, 0x0006,  Z_(FastPollTimeoutMax),   1,  Z_Nop },
 
   // Shade Configuration cluster
-  { Zuint16,  Cx0100, 0x0000,  Z(PhysicalClosedLimit),  1,  Z_Nop },
-  { Zuint8,   Cx0100, 0x0001,  Z(MotorStepSize),        1,  Z_Nop },
-  { Zmap8,    Cx0100, 0x0002,  Z(Status),               1,  Z_Nop },
-  { Zuint16,  Cx0100, 0x0010,  Z(ClosedLimit),          1,  Z_Nop },
-  { Zenum8,   Cx0100, 0x0011,  Z(Mode),                 1,  Z_Nop },
+  { Zuint16,  Cx0100, 0x0000,  Z_(PhysicalClosedLimit),  1,  Z_Nop },
+  { Zuint8,   Cx0100, 0x0001,  Z_(MotorStepSize),        1,  Z_Nop },
+  { Zmap8,    Cx0100, 0x0002,  Z_(Status),               1,  Z_Nop },
+  { Zuint16,  Cx0100, 0x0010,  Z_(ClosedLimit),          1,  Z_Nop },
+  { Zenum8,   Cx0100, 0x0011,  Z_(Mode),                 1,  Z_Nop },
 
   // Door Lock cluster
-  { Zenum8,   Cx0101, 0x0000,  Z(LockState),            1,  Z_Nop },
-  { Zenum8,   Cx0101, 0x0001,  Z(LockType),             1,  Z_Nop },
-  { Zbool,    Cx0101, 0x0002,  Z(ActuatorEnabled),      1,  Z_Nop },
-  { Zenum8,   Cx0101, 0x0003,  Z(DoorState),            1,  Z_Nop },
-  { Zuint32,  Cx0101, 0x0004,  Z(DoorOpenEvents),       1,  Z_Nop },
-  { Zuint32,  Cx0101, 0x0005,  Z(DoorClosedEvents),     1,  Z_Nop },
-  { Zuint16,  Cx0101, 0x0006,  Z(OpenPeriod),           1,  Z_Nop },
+  { Zenum8,   Cx0101, 0x0000,  Z_(LockState),            1,  Z_Nop },
+  { Zenum8,   Cx0101, 0x0001,  Z_(LockType),             1,  Z_Nop },
+  { Zbool,    Cx0101, 0x0002,  Z_(ActuatorEnabled),      1,  Z_Nop },
+  { Zenum8,   Cx0101, 0x0003,  Z_(DoorState),            1,  Z_Nop },
+  { Zuint32,  Cx0101, 0x0004,  Z_(DoorOpenEvents),       1,  Z_Nop },
+  { Zuint32,  Cx0101, 0x0005,  Z_(DoorClosedEvents),     1,  Z_Nop },
+  { Zuint16,  Cx0101, 0x0006,  Z_(OpenPeriod),           1,  Z_Nop },
 
   // Aqara Lumi Vibration Sensor
-  { Zuint16,  Cx0101, 0x0055,  Z(AqaraVibrationMode),   0,  Z_AqaraVibration },
-  { Zuint16,  Cx0101, 0x0503,  Z(AqaraVibrationsOrAngle), 1,  Z_Nop },
-  { Zuint32,  Cx0101, 0x0505,  Z(AqaraVibration505),    1,  Z_Nop },
-  { Zuint48,  Cx0101, 0x0508,  Z(AqaraAccelerometer),   0,  Z_AqaraVibration },
+  { Zuint16,  Cx0101, 0x0055,  Z_(AqaraVibrationMode),   0,  Z_AqaraVibration },
+  { Zuint16,  Cx0101, 0x0503,  Z_(AqaraVibrationsOrAngle), 1,  Z_Nop },
+  { Zuint32,  Cx0101, 0x0505,  Z_(AqaraVibration505),    1,  Z_Nop },
+  { Zuint48,  Cx0101, 0x0508,  Z_(AqaraAccelerometer),   0,  Z_AqaraVibration },
 
   // Window Covering cluster
-  { Zenum8,   Cx0102, 0x0000,  Z(WindowCoveringType),   1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0001,  Z(PhysicalClosedLimitLift),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0002,  Z(PhysicalClosedLimitTilt),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0003,  Z(CurrentPositionLift),  1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0004,  Z(CurrentPositionTilt),  1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0005,  Z(NumberofActuationsLift),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0006,  Z(NumberofActuationsTilt),1,  Z_Nop },
-  { Zmap8,    Cx0102, 0x0007,  Z(ConfigStatus),         1,  Z_Nop },
-  { Zuint8,   Cx0102, 0x0008,  Z(CurrentPositionLiftPercentage),1,  Z_Nop },
-  { Zuint8,   Cx0102, 0x0009,  Z(CurrentPositionTiltPercentage),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0010,  Z(InstalledOpenLimitLift),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0011,  Z(InstalledClosedLimitLift),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0012,  Z(InstalledOpenLimitTilt),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0013,  Z(InstalledClosedLimitTilt),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0014,  Z(VelocityLift),         1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0015,  Z(AccelerationTimeLift),1,  Z_Nop },
-  { Zuint16,  Cx0102, 0x0016,  Z(DecelerationTimeLift), 1,  Z_Nop },
-  { Zmap8,    Cx0102, 0x0017,  Z(Mode),                 1,  Z_Nop },
-  { Zoctstr,  Cx0102, 0x0018,  Z(IntermediateSetpointsLift),1,  Z_Nop },
-  { Zoctstr,  Cx0102, 0x0019,  Z(IntermediateSetpointsTilt),1,  Z_Nop },
+  { Zenum8,   Cx0102, 0x0000,  Z_(WindowCoveringType),   1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0001,  Z_(PhysicalClosedLimitLift),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0002,  Z_(PhysicalClosedLimitTilt),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0003,  Z_(CurrentPositionLift),  1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0004,  Z_(CurrentPositionTilt),  1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0005,  Z_(NumberofActuationsLift),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0006,  Z_(NumberofActuationsTilt),1,  Z_Nop },
+  { Zmap8,    Cx0102, 0x0007,  Z_(ConfigStatus),         1,  Z_Nop },
+  { Zuint8,   Cx0102, 0x0008,  Z_(CurrentPositionLiftPercentage),1,  Z_Nop },
+  { Zuint8,   Cx0102, 0x0009,  Z_(CurrentPositionTiltPercentage),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0010,  Z_(InstalledOpenLimitLift),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0011,  Z_(InstalledClosedLimitLift),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0012,  Z_(InstalledOpenLimitTilt),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0013,  Z_(InstalledClosedLimitTilt),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0014,  Z_(VelocityLift),         1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0015,  Z_(AccelerationTimeLift),1,  Z_Nop },
+  { Zuint16,  Cx0102, 0x0016,  Z_(DecelerationTimeLift), 1,  Z_Nop },
+  { Zmap8,    Cx0102, 0x0017,  Z_(Mode),                 1,  Z_Nop },
+  { Zoctstr,  Cx0102, 0x0018,  Z_(IntermediateSetpointsLift),1,  Z_Nop },
+  { Zoctstr,  Cx0102, 0x0019,  Z_(IntermediateSetpointsTilt),1,  Z_Nop },
 
   // Color Control cluster
-  { Zuint8,   Cx0300, 0x0000,  Z(Hue),                  1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0001,  Z(Sat),                  1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0002,  Z(RemainingTime),        1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0003,  Z(X),                    1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0004,  Z(Y),                    1,  Z_Nop },
-  { Zenum8,   Cx0300, 0x0005,  Z(DriftCompensation),    1,  Z_Nop },
-  { Zstring,  Cx0300, 0x0006,  Z(CompensationText),     1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0007,  Z(CT),                   1,  Z_Nop },
-  { Zenum8,   Cx0300, 0x0008,  Z(ColorMode),            1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0010,  Z(NumberOfPrimaries),    1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0011,  Z(Primary1X),            1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0012,  Z(Primary1Y),            1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0013,  Z(Primary1Intensity),    1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0015,  Z(Primary2X),            1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0016,  Z(Primary2Y),            1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0017,  Z(Primary2Intensity),    1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0019,  Z(Primary3X),            1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x001A,  Z(Primary3Y),            1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x001B,  Z(Primary3Intensity),    1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0030,  Z(WhitePointX),          1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0031,  Z(WhitePointY),          1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0032,  Z(ColorPointRX),         1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0033,  Z(ColorPointRY),         1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0034,  Z(ColorPointRIntensity), 1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0036,  Z(ColorPointGX),         1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x0037,  Z(ColorPointGY),         1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x0038,  Z(ColorPointGIntensity), 1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x003A,  Z(ColorPointBX),         1,  Z_Nop },
-  { Zuint16,  Cx0300, 0x003B,  Z(ColorPointBY),         1,  Z_Nop },
-  { Zuint8,   Cx0300, 0x003C,  Z(ColorPointBIntensity), 1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0000,  Z_(Hue),                  1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0001,  Z_(Sat),                  1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0002,  Z_(RemainingTime),        1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0003,  Z_(X),                    1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0004,  Z_(Y),                    1,  Z_Nop },
+  { Zenum8,   Cx0300, 0x0005,  Z_(DriftCompensation),    1,  Z_Nop },
+  { Zstring,  Cx0300, 0x0006,  Z_(CompensationText),     1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0007,  Z_(CT),                   1,  Z_Nop },
+  { Zenum8,   Cx0300, 0x0008,  Z_(ColorMode),            1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0010,  Z_(NumberOfPrimaries),    1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0011,  Z_(Primary1X),            1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0012,  Z_(Primary1Y),            1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0013,  Z_(Primary1Intensity),    1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0015,  Z_(Primary2X),            1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0016,  Z_(Primary2Y),            1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0017,  Z_(Primary2Intensity),    1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0019,  Z_(Primary3X),            1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x001A,  Z_(Primary3Y),            1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x001B,  Z_(Primary3Intensity),    1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0030,  Z_(WhitePointX),          1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0031,  Z_(WhitePointY),          1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0032,  Z_(ColorPointRX),         1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0033,  Z_(ColorPointRY),         1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0034,  Z_(ColorPointRIntensity), 1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0036,  Z_(ColorPointGX),         1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x0037,  Z_(ColorPointGY),         1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x0038,  Z_(ColorPointGIntensity), 1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x003A,  Z_(ColorPointBX),         1,  Z_Nop },
+  { Zuint16,  Cx0300, 0x003B,  Z_(ColorPointBY),         1,  Z_Nop },
+  { Zuint8,   Cx0300, 0x003C,  Z_(ColorPointBIntensity), 1,  Z_Nop },
 
   // Illuminance Measurement cluster
-  { Zuint16,  Cx0400, 0x0000,  Z(Illuminance),          1,  Z_Nop },    // Illuminance (in Lux)
-  { Zuint16,  Cx0400, 0x0001,  Z(IlluminanceMinMeasuredValue),     1,  Z_Nop },    //
-  { Zuint16,  Cx0400, 0x0002,  Z(IlluminanceMaxMeasuredValue),     1,  Z_Nop },    //
-  { Zuint16,  Cx0400, 0x0003,  Z(IlluminanceTolerance),            1,  Z_Nop },    //
-  { Zenum8,   Cx0400, 0x0004,  Z(IlluminanceLightSensorType),      1,  Z_Nop },    //
-  { Zunk,     Cx0400, 0xFFFF,  nullptr,                 0,  Z_Nop },    // Remove all other values
+  { Zuint16,  Cx0400, 0x0000,  Z_(Illuminance),          1,  Z_Nop },    // Illuminance (in Lux)
+  { Zuint16,  Cx0400, 0x0001,  Z_(IlluminanceMinMeasuredValue),     1,  Z_Nop },    //
+  { Zuint16,  Cx0400, 0x0002,  Z_(IlluminanceMaxMeasuredValue),     1,  Z_Nop },    //
+  { Zuint16,  Cx0400, 0x0003,  Z_(IlluminanceTolerance),            1,  Z_Nop },    //
+  { Zenum8,   Cx0400, 0x0004,  Z_(IlluminanceLightSensorType),      1,  Z_Nop },    //
+  { Zunk,     Cx0400, 0xFFFF,  Z_(),                    0,  Z_Nop },    // Remove all other values
 
   // Illuminance Level Sensing cluster
-  { Zenum8,   Cx0401, 0x0000,  Z(IlluminanceLevelStatus),          1,  Z_Nop },    // Illuminance (in Lux)
-  { Zenum8,   Cx0401, 0x0001,  Z(IlluminanceLightSensorType),      1,  Z_Nop },    // LightSensorType
-  { Zuint16,  Cx0401, 0x0010,  Z(IlluminanceTargetLevel),          1,  Z_Nop },    //
-  { Zunk,     Cx0401, 0xFFFF,  nullptr,                0, Z_Nop },    // Remove all other values
+  { Zenum8,   Cx0401, 0x0000,  Z_(IlluminanceLevelStatus),          1,  Z_Nop },    // Illuminance (in Lux)
+  { Zenum8,   Cx0401, 0x0001,  Z_(IlluminanceLightSensorType),      1,  Z_Nop },    // LightSensorType
+  { Zuint16,  Cx0401, 0x0010,  Z_(IlluminanceTargetLevel),          1,  Z_Nop },    //
+  { Zunk,     Cx0401, 0xFFFF,  Z_(),                    0, Z_Nop },    // Remove all other values
 
   // Temperature Measurement cluster
-  { Zint16,   Cx0402, 0x0000,  Z(Temperature),          -100, Z_Nop },   // divide by 100
-  { Zint16,   Cx0402, 0x0001,  Z(TemperatureMinMeasuredValue),     -100, Z_Nop },    //
-  { Zint16,   Cx0402, 0x0002,  Z(TemperatureMaxMeasuredValue),     -100, Z_Nop },    //
-  { Zuint16,  Cx0402, 0x0003,  Z(TemperatureTolerance),            -100, Z_Nop },    //
-  { Zunk,     Cx0402, 0xFFFF,  nullptr,                0, Z_Nop },     // Remove all other values
+  { Zint16,   Cx0402, 0x0000,  Z_(Temperature),          -100, Z_Nop },   // divide by 100
+  { Zint16,   Cx0402, 0x0001,  Z_(TemperatureMinMeasuredValue),     -100, Z_Nop },    //
+  { Zint16,   Cx0402, 0x0002,  Z_(TemperatureMaxMeasuredValue),     -100, Z_Nop },    //
+  { Zuint16,  Cx0402, 0x0003,  Z_(TemperatureTolerance),            -100, Z_Nop },    //
+  { Zunk,     Cx0402, 0xFFFF,  Z_(),                    0, Z_Nop },     // Remove all other values
 
   // Pressure Measurement cluster
-  { Zunk,     Cx0403, 0x0000,  Z(PressureUnit),                 0, Z_AddPressureUnit },     // Pressure Unit
-  { Zint16,   Cx0403, 0x0000,  Z(Pressure),                     1,  Z_Nop },     // Pressure
-  { Zint16,   Cx0403, 0x0001,  Z(PressureMinMeasuredValue),     1,  Z_Nop },    //
-  { Zint16,   Cx0403, 0x0002,  Z(PressureMaxMeasuredValue),     1,  Z_Nop },    //
-  { Zuint16,  Cx0403, 0x0003,  Z(PressureTolerance),            1,  Z_Nop },    //
-  { Zint16,   Cx0403, 0x0010,  Z(PressureScaledValue),          1,  Z_Nop },    //
-  { Zint16,   Cx0403, 0x0011,  Z(PressureMinScaledValue),       1,  Z_Nop },    //
-  { Zint16,   Cx0403, 0x0012,  Z(PressureMaxScaledValue),       1,  Z_Nop },    //
-  { Zuint16,  Cx0403, 0x0013,  Z(PressureScaledTolerance),      1,  Z_Nop },    //
-  { Zint8,    Cx0403, 0x0014,  Z(PressureScale),                1,  Z_Nop },    //
-  { Zunk,     Cx0403, 0xFFFF,  nullptr,                0, Z_Nop },     // Remove all other Pressure values
+  { Zunk,     Cx0403, 0x0000,  Z_(PressureUnit),                 0, Z_AddPressureUnit },     // Pressure Unit
+  { Zint16,   Cx0403, 0x0000,  Z_(Pressure),                     1,  Z_Nop },     // Pressure
+  { Zint16,   Cx0403, 0x0001,  Z_(PressureMinMeasuredValue),     1,  Z_Nop },    //
+  { Zint16,   Cx0403, 0x0002,  Z_(PressureMaxMeasuredValue),     1,  Z_Nop },    //
+  { Zuint16,  Cx0403, 0x0003,  Z_(PressureTolerance),            1,  Z_Nop },    //
+  { Zint16,   Cx0403, 0x0010,  Z_(PressureScaledValue),          1,  Z_Nop },    //
+  { Zint16,   Cx0403, 0x0011,  Z_(PressureMinScaledValue),       1,  Z_Nop },    //
+  { Zint16,   Cx0403, 0x0012,  Z_(PressureMaxScaledValue),       1,  Z_Nop },    //
+  { Zuint16,  Cx0403, 0x0013,  Z_(PressureScaledTolerance),      1,  Z_Nop },    //
+  { Zint8,    Cx0403, 0x0014,  Z_(PressureScale),                1,  Z_Nop },    //
+  { Zunk,     Cx0403, 0xFFFF,  Z_(),                    0, Z_Nop },     // Remove all other Pressure values
 
   // Flow Measurement cluster
-  { Zuint16,  Cx0404, 0x0000,  Z(FlowRate),             -10, Z_Nop },    // Flow (in m3/h)
-  { Zuint16,  Cx0404, 0x0001,  Z(FlowMinMeasuredValue), 1,  Z_Nop },    //
-  { Zuint16,  Cx0404, 0x0002,  Z(FlowMaxMeasuredValue), 1,  Z_Nop },    //
-  { Zuint16,  Cx0404, 0x0003,  Z(FlowTolerance),        1,  Z_Nop },    //
-  { Zunk,     Cx0404, 0xFFFF,  nullptr,                 0,  Z_Nop },    // Remove all other values
+  { Zuint16,  Cx0404, 0x0000,  Z_(FlowRate),             -10, Z_Nop },    // Flow (in m3/h)
+  { Zuint16,  Cx0404, 0x0001,  Z_(FlowMinMeasuredValue), 1,  Z_Nop },    //
+  { Zuint16,  Cx0404, 0x0002,  Z_(FlowMaxMeasuredValue), 1,  Z_Nop },    //
+  { Zuint16,  Cx0404, 0x0003,  Z_(FlowTolerance),        1,  Z_Nop },    //
+  { Zunk,     Cx0404, 0xFFFF,  Z_(),                     0,  Z_Nop },    // Remove all other values
 
   // Relative Humidity Measurement cluster
-  { Zuint16,  Cx0405, 0x0000,  Z(Humidity),                     -100, Z_Nop },   // Humidity
-  { Zuint16,  Cx0405, 0x0001,  Z(HumidityMinMeasuredValue),     1,  Z_Nop },    //
-  { Zuint16,  Cx0405, 0x0002,  Z(HumidityMaxMeasuredValue),     1,  Z_Nop },    //
-  { Zuint16,  Cx0405, 0x0003,  Z(HumidityTolerance),            1,  Z_Nop },    //
-  { Zunk,     Cx0405, 0xFFFF,  nullptr,                0, Z_Nop },     // Remove all other values
+  { Zuint16,  Cx0405, 0x0000,  Z_(Humidity),                     -100, Z_Nop },   // Humidity
+  { Zuint16,  Cx0405, 0x0001,  Z_(HumidityMinMeasuredValue),     1,  Z_Nop },    //
+  { Zuint16,  Cx0405, 0x0002,  Z_(HumidityMaxMeasuredValue),     1,  Z_Nop },    //
+  { Zuint16,  Cx0405, 0x0003,  Z_(HumidityTolerance),            1,  Z_Nop },    //
+  { Zunk,     Cx0405, 0xFFFF,  Z_(),                    0, Z_Nop },     // Remove all other values
 
   // Occupancy Sensing cluster
-  { Zmap8,    Cx0406, 0x0000,  Z(Occupancy),            1,  Z_Nop },    // Occupancy (map8)
-  { Zenum8,   Cx0406, 0x0001,  Z(OccupancySensorType),  1,  Z_Nop },    // OccupancySensorType
-  { Zunk,     Cx0406, 0xFFFF,  nullptr,                0, Z_Nop },    // Remove all other values
+  { Zmap8,    Cx0406, 0x0000,  Z_(Occupancy),            1,  Z_Nop },    // Occupancy (map8)
+  { Zenum8,   Cx0406, 0x0001,  Z_(OccupancySensorType),  1,  Z_Nop },    // OccupancySensorType
+  { Zunk,     Cx0406, 0xFFFF,  Z_(),                    0, Z_Nop },    // Remove all other values
 
   // IAS Cluster (Intruder Alarm System)
-  { Zenum8,   Cx0500, 0x0000,  Z(ZoneState),            1,  Z_Nop },    // Occupancy (map8)
-  { Zenum16,  Cx0500, 0x0001,  Z(ZoneType),             1,  Z_Nop },    // Occupancy (map8)
-  { Zmap16,   Cx0500, 0x0002,  Z(ZoneStatus),           1,  Z_Nop },    // Occupancy (map8)
+  { Zenum8,   Cx0500, 0x0000,  Z_(ZoneState),            1,  Z_Nop },    // Occupancy (map8)
+  { Zenum16,  Cx0500, 0x0001,  Z_(ZoneType),             1,  Z_Nop },    // Occupancy (map8)
+  { Zmap16,   Cx0500, 0x0002,  Z_(ZoneStatus),           1,  Z_Nop },    // Occupancy (map8)
 
   // Meter Identification cluster
-  { Zstring,  Cx0B01, 0x0000,  Z(CompanyName),          1,  Z_Nop },
-  { Zuint16,  Cx0B01, 0x0001,  Z(MeterTypeID),          1,  Z_Nop },
-  { Zuint16,  Cx0B01, 0x0004,  Z(DataQualityID),        1,  Z_Nop },
-  { Zstring,  Cx0B01, 0x0005,  Z(CustomerName),         1,  Z_Nop },
-  { Zoctstr,  Cx0B01, 0x0006,  Z(Model),                1,  Z_Nop },
-  { Zoctstr,  Cx0B01, 0x0007,  Z(PartNumber),           1,  Z_Nop },
-  { Zoctstr,  Cx0B01, 0x0008,  Z(ProductRevision),      1,  Z_Nop },
-  { Zoctstr,  Cx0B01, 0x000A,  Z(SoftwareRevision),     1,  Z_Nop },
-  { Zstring,  Cx0B01, 0x000B,  Z(UtilityName),          1,  Z_Nop },
-  { Zstring,  Cx0B01, 0x000C,  Z(POD),                  1,  Z_Nop },
-  { Zint24,   Cx0B01, 0x000D,  Z(AvailablePower),       1,  Z_Nop },
-  { Zint24,   Cx0B01, 0x000E,  Z(PowerThreshold),       1,  Z_Nop },
+  { Zstring,  Cx0B01, 0x0000,  Z_(CompanyName),          1,  Z_Nop },
+  { Zuint16,  Cx0B01, 0x0001,  Z_(MeterTypeID),          1,  Z_Nop },
+  { Zuint16,  Cx0B01, 0x0004,  Z_(DataQualityID),        1,  Z_Nop },
+  { Zstring,  Cx0B01, 0x0005,  Z_(CustomerName),         1,  Z_Nop },
+  { Zoctstr,  Cx0B01, 0x0006,  Z_(Model),                1,  Z_Nop },
+  { Zoctstr,  Cx0B01, 0x0007,  Z_(PartNumber),           1,  Z_Nop },
+  { Zoctstr,  Cx0B01, 0x0008,  Z_(ProductRevision),      1,  Z_Nop },
+  { Zoctstr,  Cx0B01, 0x000A,  Z_(SoftwareRevision),     1,  Z_Nop },
+  { Zstring,  Cx0B01, 0x000B,  Z_(UtilityName),          1,  Z_Nop },
+  { Zstring,  Cx0B01, 0x000C,  Z_(POD),                  1,  Z_Nop },
+  { Zint24,   Cx0B01, 0x000D,  Z_(AvailablePower),       1,  Z_Nop },
+  { Zint24,   Cx0B01, 0x000E,  Z_(PowerThreshold),       1,  Z_Nop },
 
   // Diagnostics cluster
-  { Zuint16,  Cx0B05, 0x0000,  Z(NumberOfResets),       1,  Z_Nop },
-  { Zuint16,  Cx0B05, 0x0001,  Z(PersistentMemoryWrites),1,  Z_Nop },
-  { Zuint8,   Cx0B05, 0x011C,  Z(LastMessageLQI),       1,  Z_Nop },
-  { Zuint8,   Cx0B05, 0x011D,  Z(LastMessageRSSI),      1,  Z_Nop },
+  { Zuint16,  Cx0B05, 0x0000,  Z_(NumberOfResets),       1,  Z_Nop },
+  { Zuint16,  Cx0B05, 0x0001,  Z_(PersistentMemoryWrites),1,  Z_Nop },
+  { Zuint8,   Cx0B05, 0x011C,  Z_(LastMessageLQI),       1,  Z_Nop },
+  { Zuint8,   Cx0B05, 0x011D,  Z_(LastMessageRSSI),      1,  Z_Nop },
 
 };
 
@@ -630,13 +536,13 @@ const __FlashStringHelper* zigbeeFindAttributeByName(const char *command,
                                     uint8_t  *cb) {
   for (uint32_t i = 0; i < ARRAY_SIZE(Z_PostProcess); i++) {
     const Z_AttributeConverter *converter = &Z_PostProcess[i];
-    if (nullptr == converter->name) { continue; }         // avoid strcasecmp_P() from crashing
-    if (0 == strcasecmp_P(command, converter->name)) {
+    if (0 == pgm_read_word(&converter->name_offset)) { continue; }         // avoid strcasecmp_P() from crashing
+    if (0 == strcasecmp_P(command, Z_strings + pgm_read_word(&converter->name_offset))) {
       if (cluster)      { *cluster    = CxToCluster(pgm_read_byte(&converter->cluster_short)); }
       if (attribute)    { *attribute  = pgm_read_word(&converter->attribute); }
       if (multiplier)   { *multiplier = pgm_read_byte(&converter->multiplier); }
       if (cb)           { *cb         = pgm_read_byte(&converter->cb); }
-      return (const __FlashStringHelper*) converter->name;
+      return (const __FlashStringHelper*) (Z_strings + pgm_read_word(&converter->name_offset));
     }
   }
   return nullptr;
@@ -1132,7 +1038,7 @@ void ZCLFrame::parseReadAttributes(JsonObject& json, uint8_t offset) {
       uint16_t conv_attribute = pgm_read_word(&converter->attribute);
 
       if ((conv_cluster == _cluster_id) && (conv_attribute == attrid)) {
-        attr_names[(const __FlashStringHelper*) converter->name] = true;
+        attr_names[(const __FlashStringHelper*) (Z_strings + pgm_read_word(&converter->name_offset))] = true;
         break;
       }
     }
@@ -1178,7 +1084,7 @@ void ZCLFrame::parseReadConfigAttributes(JsonObject& json, uint8_t offset) {
       uint16_t conv_attribute = pgm_read_word(&converter->attribute);
 
       if ((conv_cluster == _cluster_id) && (conv_attribute == attrid)) {
-        attr_details[(const __FlashStringHelper*) converter->name] = true;
+        attr_details[(const __FlashStringHelper*) (Z_strings + pgm_read_word(&converter->name_offset))] = true;
         break;
       }
     }
@@ -1611,7 +1517,7 @@ void ZCLFrame::postProcessAttributes(uint16_t shortaddr, JsonObject& json) {
 
         if ((conv_cluster == cluster) &&
             ((conv_attribute == attribute) || (conv_attribute == 0xFFFF)) ) {
-          String new_name_str = (const __FlashStringHelper*) converter->name;
+          String new_name_str = (const __FlashStringHelper*) (Z_strings + pgm_read_word(&converter->name_offset));
           if (suffix > 1) { new_name_str += suffix; }   // append suffix number
           // else if (Settings.flag4.zb_index_ep) {
           //   if (zigbee_devices.countEndpoints(shortaddr) > 0) {

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -24,11 +24,11 @@
 \*********************************************************************************************/
 
 typedef struct Z_CommandConverter {
-  const char * tasmota_cmd;
+  uint16_t     tasmota_cmd_offset;
   uint16_t     cluster;
   uint8_t      cmd;         // normally 8 bits, 0xFF means it's a parameter
   uint8_t      direction;   // direction of the command. 0x01 client->server, 0x02 server->client, 0x03 both, 0x80 requires custom decoding
-  const char * param;
+  uint16_t     param_offset;
 } Z_CommandConverter;
 
 typedef struct Z_XYZ_Var {    // Holds values for vairables X, Y and Z
@@ -40,29 +40,6 @@ typedef struct Z_XYZ_Var {    // Holds values for vairables X, Y and Z
   uint8_t     z_type = 0;
 } Z_XYZ_Var;
 
-ZF(Identify) ZF(IdentifyQuery)
-ZF(AddGroup) ZF(ViewGroup) ZF(GetGroup) ZF(GetAllGroups) ZF(RemoveGroup) ZF(RemoveAllGroups)
-ZF(AddScene) ZF(ViewScene) ZF(RemoveScene) ZF(RemoveAllScenes) ZF(RecallScene) ZF(StoreScene) ZF(GetSceneMembership)
-//ZF(Power) ZF(Dimmer)
-ZF(PowerOffEffect) ZF(PowerOnRecall) ZF(PowerOnTimer)
-ZF(DimmerUp) ZF(DimmerDown) ZF(DimmerStop)
-ZF(ResetAlarm) ZF(ResetAllAlarms)
-//ZF(Hue) ZF(Sat) ZF(CT)
-ZF(HueSat) ZF(Color)
-ZF(ShutterOpen) ZF(ShutterClose) ZF(ShutterStop) ZF(ShutterLift) ZF(ShutterTilt) ZF(Shutter)
-//ZF(Occupancy)
-ZF(DimmerMove) ZF(DimmerStep) ZF(DimmerStepUp) ZF(DimmerStepDown)
-ZF(HueMove) ZF(HueStep) ZF(HueStepUp) ZF(HueStepDown) ZF(SatMove) ZF(SatStep) ZF(ColorMove) ZF(ColorStep)
-ZF(ColorTempMoveUp) ZF(ColorTempMoveDown) ZF(ColorTempMoveStop) ZF(ColorTempMove)
-ZF(ColorTempStep) ZF(ColorTempStepUp) ZF(ColorTempStepDown)
-ZF(ArrowClick) ZF(ArrowHold) ZF(ArrowRelease) ZF(ZoneStatusChange)
-
-ZF(xxxx00) ZF(xxxx) ZF(01xxxx) ZF(03xxxx) ZF(00) ZF(01) ZF() ZF(xxxxyy) ZF(00190200) ZF(01190200) ZF(xxyyyy) ZF(xx)
-ZF(xx000A00) ZF(xx0A00) ZF(xxyy0A00) ZF(xxxxyyyy0A00) ZF(xxxx0A00) ZF(xx0A) ZF(xxyy)
-ZF(xx190A00) ZF(xx19) ZF(xx190A) ZF(xxxxyyyy) ZF(xxxxyyzz) ZF(xxyyzzzz) ZF(xxyyyyzz) ZF(xxyyyyzzzz)
-ZF(01xxxx000000000000) ZF(03xxxx000000000000) ZF(00xxxx000000000000) ZF(xxyyyy000000000000)
-ZF(00xx0A00) ZF(01xx0A00) ZF(03xx0A00) ZF(01xxxx0A0000000000) ZF(03xxxx0A0000000000) ZF(xxyyyy0A0000000000)
-
 // Cluster specific commands
 // Note: the table is both for sending commands, but also displaying received commands
 // - tasmota_cmd: the human-readable name of the command as entered or displayed, use '|' to split into multiple commands when displayed
@@ -72,91 +49,91 @@ ZF(00xx0A00) ZF(01xx0A00) ZF(03xx0A00) ZF(01xxxx0A0000000000) ZF(03xxxx0A0000000
 // - param: the paylod template, x/y/z are substituted with arguments, little endian. For command display, payload must match until x/y/z character or until the end of the paylod. '??' means ignore.
 const Z_CommandConverter Z_Commands[] PROGMEM = {
   // Identify cluster
-  { Z(Identify),       0x0003, 0x00, 0x01,   Z(xxxx) },         // Identify device, time in seconds
-  { Z(IdentifyQuery),  0x0003, 0x01, 0x01,   Z() },             // Identify Query (no param)
+  { Z_(Identify),       0x0003, 0x00, 0x01,   Z_(xxxx) },         // Identify device, time in seconds
+  { Z_(IdentifyQuery),  0x0003, 0x01, 0x01,   Z_() },             // Identify Query (no param)
   // Group adress commands
-  { Z(AddGroup),       0x0004, 0x00, 0x01,   Z(xxxx00) },       // Add group id, group name is not supported
-  { Z(ViewGroup),      0x0004, 0x01, 0x01,   Z(xxxx) },         // Ask for the group name
-  { Z(GetGroup),       0x0004, 0x02, 0x01,   Z(01xxxx) },       // Get one group membership
-  { Z(GetAllGroups),   0x0004, 0x02, 0x01,   Z(00) },           // Get all groups membership
-  { Z(RemoveGroup),    0x0004, 0x03, 0x01,   Z(xxxx) },         // Remove one group
-  { Z(RemoveAllGroups),0x0004, 0x04, 0x01,   Z() },             // Remove all groups
+  { Z_(AddGroup),       0x0004, 0x00, 0x01,   Z_(xxxx00) },       // Add group id, group name is not supported
+  { Z_(ViewGroup),      0x0004, 0x01, 0x01,   Z_(xxxx) },         // Ask for the group name
+  { Z_(GetGroup),       0x0004, 0x02, 0x01,   Z_(01xxxx) },       // Get one group membership
+  { Z_(GetAllGroups),   0x0004, 0x02, 0x01,   Z_(00) },           // Get all groups membership
+  { Z_(RemoveGroup),    0x0004, 0x03, 0x01,   Z_(xxxx) },         // Remove one group
+  { Z_(RemoveAllGroups),0x0004, 0x04, 0x01,   Z_() },             // Remove all groups
   // Scenes
   //{ "AddScene",       0x0005, 0x00, 0x01,   "xxxxyy0100" },
-  { Z(ViewScene),      0x0005, 0x01, 0x01,   Z(xxxxyy) },
-  { Z(RemoveScene),    0x0005, 0x02, 0x01,   Z(xxxxyy) },
-  { Z(RemoveAllScenes),0x0005, 0x03, 0x01,   Z(xxxx) },
-  { Z(RecallScene),    0x0005, 0x05, 0x01,   Z(xxxxyy) },
-  { Z(GetSceneMembership),0x0005, 0x06, 0x01,   Z(xxxx) },
+  { Z_(ViewScene),      0x0005, 0x01, 0x01,   Z_(xxxxyy) },
+  { Z_(RemoveScene),    0x0005, 0x02, 0x01,   Z_(xxxxyy) },
+  { Z_(RemoveAllScenes),0x0005, 0x03, 0x01,   Z_(xxxx) },
+  { Z_(RecallScene),    0x0005, 0x05, 0x01,   Z_(xxxxyy) },
+  { Z_(GetSceneMembership),0x0005, 0x06, 0x01,   Z_(xxxx) },
   // Light & Shutter commands
-  { Z(PowerOffEffect), 0x0006, 0x40, 0x81,   Z(xxyy) },         // Power Off With Effect
-  { Z(PowerOnRecall),  0x0006, 0x41, 0x81,   Z() },             // Power On With Recall Global Scene
-  { Z(PowerOnTimer),   0x0006, 0x42, 0x81,   Z(xxyyyyzzzz) },   // Power On with Timed Off
-  { Z(Power),          0x0006, 0xFF, 0x01,   Z() },             // 0=Off, 1=On, 2=Toggle
-  { Z(Dimmer),         0x0008, 0x04, 0x01,   Z(xx0A00) },       // Move to Level with On/Off, xx=0..254 (255 is invalid)
-  { Z(DimmerUp),       0x0008, 0x06, 0x01,   Z(00190200) },       // Step up by 10%, 0.2 secs
-  { Z(DimmerDown),     0x0008, 0x06, 0x01,   Z(01190200) },       // Step down by 10%, 0.2 secs
-  { Z(DimmerStop),     0x0008, 0x03, 0x01,   Z() },             // Stop any Dimmer animation
-  { Z(ResetAlarm),     0x0009, 0x00, 0x01,   Z(xxyyyy) },       // Reset alarm (alarm code + cluster identifier)
-  { Z(ResetAllAlarms), 0x0009, 0x01, 0x01,   Z() },             // Reset all alarms
-  { Z(Hue),            0x0300, 0x00, 0x01,   Z(xx000A00) },     // Move to Hue, shortest time, 1s
-  { Z(Sat),            0x0300, 0x03, 0x01,   Z(xx0A00) },       // Move to Sat
-  { Z(HueSat),         0x0300, 0x06, 0x01,   Z(xxyy0A00) },     // Hue, Sat
-  { Z(Color),          0x0300, 0x07, 0x01,   Z(xxxxyyyy0A00) }, // x, y (uint16)
-  { Z(CT),             0x0300, 0x0A, 0x01,   Z(xxxx0A00) },     // Color Temperature Mireds (uint16)
-  { Z(ShutterOpen),    0x0102, 0x00, 0x01,   Z() },
-  { Z(ShutterClose),   0x0102, 0x01, 0x01,   Z() },
-  { Z(ShutterStop),    0x0102, 0x02, 0x01,   Z() },
-  { Z(ShutterLift),    0x0102, 0x05, 0x01,   Z(xx) },            // Lift percentage, 0%=open, 100%=closed
-  { Z(ShutterTilt),    0x0102, 0x08, 0x01,   Z(xx) },            // Tilt percentage
-  { Z(Shutter),        0x0102, 0xFF, 0x01,   Z() },
+  { Z_(PowerOffEffect), 0x0006, 0x40, 0x81,   Z_(xxyy) },         // Power Off With Effect
+  { Z_(PowerOnRecall),  0x0006, 0x41, 0x81,   Z_() },             // Power On With Recall Global Scene
+  { Z_(PowerOnTimer),   0x0006, 0x42, 0x81,   Z_(xxyyyyzzzz) },   // Power On with Timed Off
+  { Z_(Power),          0x0006, 0xFF, 0x01,   Z_() },             // 0=Off, 1=On, 2=Toggle
+  { Z_(Dimmer),         0x0008, 0x04, 0x01,   Z_(xx0A00) },       // Move to Level with On/Off, xx=0..254 (255 is invalid)
+  { Z_(DimmerUp),       0x0008, 0x06, 0x01,   Z_(00190200) },       // Step up by 10%, 0.2 secs
+  { Z_(DimmerDown),     0x0008, 0x06, 0x01,   Z_(01190200) },       // Step down by 10%, 0.2 secs
+  { Z_(DimmerStop),     0x0008, 0x03, 0x01,   Z_() },             // Stop any Dimmer animation
+  { Z_(ResetAlarm),     0x0009, 0x00, 0x01,   Z_(xxyyyy) },       // Reset alarm (alarm code + cluster identifier)
+  { Z_(ResetAllAlarms), 0x0009, 0x01, 0x01,   Z_() },             // Reset all alarms
+  { Z_(Hue),            0x0300, 0x00, 0x01,   Z_(xx000A00) },     // Move to Hue, shortest time, 1s
+  { Z_(Sat),            0x0300, 0x03, 0x01,   Z_(xx0A00) },       // Move to Sat
+  { Z_(HueSat),         0x0300, 0x06, 0x01,   Z_(xxyy0A00) },     // Hue, Sat
+  { Z_(Color),          0x0300, 0x07, 0x01,   Z_(xxxxyyyy0A00) }, // x, y (uint16)
+  { Z_(CT),             0x0300, 0x0A, 0x01,   Z_(xxxx0A00) },     // Color Temperature Mireds (uint16)
+  { Z_(ShutterOpen),    0x0102, 0x00, 0x01,   Z_() },
+  { Z_(ShutterClose),   0x0102, 0x01, 0x01,   Z_() },
+  { Z_(ShutterStop),    0x0102, 0x02, 0x01,   Z_() },
+  { Z_(ShutterLift),    0x0102, 0x05, 0x01,   Z_(xx) },            // Lift percentage, 0%=open, 100%=closed
+  { Z_(ShutterTilt),    0x0102, 0x08, 0x01,   Z_(xx) },            // Tilt percentage
+  { Z_(Shutter),        0x0102, 0xFF, 0x01,   Z_() },
   // Blitzwolf PIR
-  { Z(Occupancy),      0xEF00, 0x01, 0x82,   Z()},                // Specific decoder for Blitzwolf PIR, empty name means special treatment
+  { Z_(Occupancy),      0xEF00, 0x01, 0x82,   Z_()},                // Specific decoder for Blitzwolf PIR, empty name means special treatment
   // Decoders only - normally not used to send, and names may be masked by previous definitions
-  { Z(Dimmer),         0x0008, 0x00, 0x01,   Z(xx) },
-  { Z(DimmerMove),     0x0008, 0x01, 0x01,   Z(xx0A) },
-  { Z(DimmerStepUp),   0x0008, 0x02, 0x01,   Z(00xx0A00) },
-  { Z(DimmerStepDown), 0x0008, 0x02, 0x01,   Z(01xx0A00) },
-  { Z(DimmerStep),     0x0008, 0x02, 0x01,   Z(xx190A00) },
-  { Z(DimmerMove),     0x0008, 0x05, 0x01,   Z(xx0A) },
-  { Z(DimmerUp),       0x0008, 0x06, 0x01,   Z(00) },
-  { Z(DimmerDown),     0x0008, 0x06, 0x01,   Z(01) },
-  { Z(DimmerStop),     0x0008, 0x07, 0x01,   Z() },
-  { Z(HueMove),        0x0300, 0x01, 0x01,   Z(xx19) },
-  { Z(HueStepUp),      0x0300, 0x02, 0x01,   Z(01xx0A00) },
-  { Z(HueStepDown),    0x0300, 0x02, 0x01,   Z(03xx0A00) },
-  { Z(HueStep),        0x0300, 0x02, 0x01,   Z(xx190A00) },
-  { Z(SatMove),        0x0300, 0x04, 0x01,   Z(xx19) },
-  { Z(SatStep),        0x0300, 0x05, 0x01,   Z(xx190A) },
-  { Z(ColorMove),      0x0300, 0x08, 0x01,   Z(xxxxyyyy) },
-  { Z(ColorStep),      0x0300, 0x09, 0x01,   Z(xxxxyyyy0A00) },
-  { Z(ColorTempMoveUp),  0x0300, 0x4B, 0x01, Z(01xxxx000000000000) },
-  { Z(ColorTempMoveDown),0x0300, 0x4B, 0x01, Z(03xxxx000000000000) },
-  { Z(ColorTempMoveStop),0x0300, 0x4B, 0x01, Z(00xxxx000000000000) },
-  { Z(ColorTempMove),  0x0300, 0x4B, 0x01,   Z(xxyyyy000000000000) },
-  { Z(ColorTempStepUp),  0x0300, 0x4C, 0x01, Z(01xxxx0A0000000000) },
-  { Z(ColorTempStepDown),0x0300, 0x4C, 0x01, Z(03xxxx0A0000000000) },
-  { Z(ColorTempStep),  0x0300, 0x4C, 0x01,   Z(xxyyyy0A0000000000) },     //xx = 0x01 up, 0x03 down, yyyy = step
+  { Z_(Dimmer),         0x0008, 0x00, 0x01,   Z_(xx) },
+  { Z_(DimmerMove),     0x0008, 0x01, 0x01,   Z_(xx0A) },
+  { Z_(DimmerStepUp),   0x0008, 0x02, 0x01,   Z_(00xx0A00) },
+  { Z_(DimmerStepDown), 0x0008, 0x02, 0x01,   Z_(01xx0A00) },
+  { Z_(DimmerStep),     0x0008, 0x02, 0x01,   Z_(xx190A00) },
+  { Z_(DimmerMove),     0x0008, 0x05, 0x01,   Z_(xx0A) },
+  { Z_(DimmerUp),       0x0008, 0x06, 0x01,   Z_(00) },
+  { Z_(DimmerDown),     0x0008, 0x06, 0x01,   Z_(01) },
+  { Z_(DimmerStop),     0x0008, 0x07, 0x01,   Z_() },
+  { Z_(HueMove),        0x0300, 0x01, 0x01,   Z_(xx19) },
+  { Z_(HueStepUp),      0x0300, 0x02, 0x01,   Z_(01xx0A00) },
+  { Z_(HueStepDown),    0x0300, 0x02, 0x01,   Z_(03xx0A00) },
+  { Z_(HueStep),        0x0300, 0x02, 0x01,   Z_(xx190A00) },
+  { Z_(SatMove),        0x0300, 0x04, 0x01,   Z_(xx19) },
+  { Z_(SatStep),        0x0300, 0x05, 0x01,   Z_(xx190A) },
+  { Z_(ColorMove),      0x0300, 0x08, 0x01,   Z_(xxxxyyyy) },
+  { Z_(ColorStep),      0x0300, 0x09, 0x01,   Z_(xxxxyyyy0A00) },
+  { Z_(ColorTempMoveUp),  0x0300, 0x4B, 0x01, Z_(01xxxx000000000000) },
+  { Z_(ColorTempMoveDown),0x0300, 0x4B, 0x01, Z_(03xxxx000000000000) },
+  { Z_(ColorTempMoveStop),0x0300, 0x4B, 0x01, Z_(00xxxx000000000000) },
+  { Z_(ColorTempMove),  0x0300, 0x4B, 0x01,   Z_(xxyyyy000000000000) },
+  { Z_(ColorTempStepUp),  0x0300, 0x4C, 0x01, Z_(01xxxx0A0000000000) },
+  { Z_(ColorTempStepDown),0x0300, 0x4C, 0x01, Z_(03xxxx0A0000000000) },
+  { Z_(ColorTempStep),  0x0300, 0x4C, 0x01,   Z_(xxyyyy0A0000000000) },     //xx = 0x01 up, 0x03 down, yyyy = step
   // Tradfri
-  { Z(ArrowClick),     0x0005, 0x07, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right
-  { Z(ArrowHold),      0x0005, 0x08, 0x01,   Z(xx) },         // xx == 0x01 = left, 0x00 = right
-  { Z(ArrowRelease),   0x0005, 0x09, 0x01,   Z() },
+  { Z_(ArrowClick),     0x0005, 0x07, 0x01,   Z_(xx) },         // xx == 0x01 = left, 0x00 = right
+  { Z_(ArrowHold),      0x0005, 0x08, 0x01,   Z_(xx) },         // xx == 0x01 = left, 0x00 = right
+  { Z_(ArrowRelease),   0x0005, 0x09, 0x01,   Z_() },
   // Response for Indetify cluster
-  { Z(IdentifyQuery),  0x0003, 0x00, 0x02,   Z(xxxx) },             // timeout in seconds
+  { Z_(IdentifyQuery),  0x0003, 0x00, 0x02,   Z_(xxxx) },             // timeout in seconds
   // IAS - Intruder Alarm System + leak/fire detection
-  { Z(ZoneStatusChange),0x0500, 0x00, 0x82,  Z(xxxxyyzz) },   // xxxx = zone status, yy = extended status, zz = zone id, Delay is ignored
+  { Z_(ZoneStatusChange),0x0500, 0x00, 0x82,  Z_(xxxxyyzz) },   // xxxx = zone status, yy = extended status, zz = zone id, Delay is ignored
   // responses for Group cluster commands
-  { Z(AddGroup),       0x0004, 0x00, 0x82,   Z(xxyyyy) },       // xx = status, yy = group id
-  { Z(ViewGroup),      0x0004, 0x01, 0x82,   Z(xxyyyy) },       // xx = status, yy = group id, name ignored
-  { Z(GetGroup),       0x0004, 0x02, 0x82,   Z(xxyyzzzz) },     // xx = capacity, yy = count, zzzz = first group id, following groups ignored
-  { Z(RemoveGroup),    0x0004, 0x03, 0x82,   Z(xxyyyy) },       // xx = status, yy = group id
+  { Z_(AddGroup),       0x0004, 0x00, 0x82,   Z_(xxyyyy) },       // xx = status, yy = group id
+  { Z_(ViewGroup),      0x0004, 0x01, 0x82,   Z_(xxyyyy) },       // xx = status, yy = group id, name ignored
+  { Z_(GetGroup),       0x0004, 0x02, 0x82,   Z_(xxyyzzzz) },     // xx = capacity, yy = count, zzzz = first group id, following groups ignored
+  { Z_(RemoveGroup),    0x0004, 0x03, 0x82,   Z_(xxyyyy) },       // xx = status, yy = group id
   // responses for Scene cluster commands
-  { Z(AddScene),       0x0005, 0x00, 0x82,   Z(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
-  { Z(ViewScene),      0x0005, 0x01, 0x82,   Z(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
-  { Z(RemoveScene),    0x0005, 0x02, 0x82,   Z(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
-  { Z(RemoveAllScenes),0x0005, 0x03, 0x82,   Z(xxyyyy) },     // xx = status, yyyy = group id
-  { Z(StoreScene),     0x0005, 0x04, 0x82,   Z(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
-  { Z(GetSceneMembership),0x0005, 0x06, 0x82,Z(xxyyzzzz) },     // specific
+  { Z_(AddScene),       0x0005, 0x00, 0x82,   Z_(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
+  { Z_(ViewScene),      0x0005, 0x01, 0x82,   Z_(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
+  { Z_(RemoveScene),    0x0005, 0x02, 0x82,   Z_(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
+  { Z_(RemoveAllScenes),0x0005, 0x03, 0x82,   Z_(xxyyyy) },     // xx = status, yyyy = group id
+  { Z_(StoreScene),     0x0005, 0x04, 0x82,   Z_(xxyyyyzz) },     // xx = status, yyyy = group id, zz = scene id
+  { Z_(GetSceneMembership),0x0005, 0x06, 0x82,Z_(xxyyzzzz) },     // specific
 };
 
 /*********************************************************************************************\
@@ -376,7 +353,7 @@ void convertClusterSpecific(JsonObject& json, uint16_t cluster, uint8_t cmd, boo
           // Match if:
           //  - payload exactly matches conv->param (conv->param may be longer)
           //  - payload matches conv->param until 'x', 'y' or 'z'
-          const char * p = conv->param;
+          const char * p = Z_strings + pgm_read_word(&conv->param_offset);
   //AddLog_P2(LOG_LEVEL_INFO, PSTR(">>>++1 param = %s"), p);
           bool match = true;
           for (uint8_t i = 0; i < payload.len(); i++) {
@@ -396,8 +373,8 @@ void convertClusterSpecific(JsonObject& json, uint16_t cluster, uint8_t cmd, boo
             p += 2;
           }
           if (match) {
-            command_name = (const __FlashStringHelper*) conv->tasmota_cmd;
-            parseXYZ(conv->param, payload, &xyz);
+            command_name = (const __FlashStringHelper*) (Z_strings + pgm_read_word(&conv->tasmota_cmd_offset));
+            parseXYZ(Z_strings + pgm_read_word(&conv->param_offset), payload, &xyz);
             if (0xFF == conv_cmd) {
               // shift all values
               xyz.z = xyz.y;
@@ -541,10 +518,10 @@ const __FlashStringHelper* zigbeeFindCommand(const char *command, uint16_t *clus
     uint8_t conv_direction = pgm_read_byte(&conv->direction);
     uint8_t conv_cmd = pgm_read_byte(&conv->cmd);
     uint16_t conv_cluster = pgm_read_word(&conv->cluster);
-    if ((conv_direction & 0x01) && (0 == strcasecmp_P(command, conv->tasmota_cmd))) {
+    if ((conv_direction & 0x01) && (0 == strcasecmp_P(command, Z_strings + pgm_read_word(&conv->tasmota_cmd_offset)))) {
       *cluster = conv_cluster;
       *cmd = conv_cmd;
-      return (const __FlashStringHelper*) conv->param;
+      return (const __FlashStringHelper*) (Z_strings + pgm_read_word(&conv->param_offset));
     }
   }
 

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -253,9 +253,9 @@ void ZbSendReportWrite(const JsonObject &val_pubwrite, uint16_t device, uint16_t
             type_id = local_type_id;
             break;
           }
-        } else if (converter->name) {
+        } else if (pgm_read_word(&converter->name_offset)) {
           // AddLog_P2(LOG_LEVEL_DEBUG, PSTR("Comparing '%s' with '%s'"), attr_name, converter->name);
-          if (0 == strcasecmp_P(key, converter->name)) {
+          if (0 == strcasecmp_P(key, Z_strings + pgm_read_word(&converter->name_offset))) {
             // match
             cluster_id = local_cluster_id;
             attr_id = local_attr_id;
@@ -564,7 +564,7 @@ void ZbSendRead(const JsonVariant &val_attr, uint16_t device, uint16_t groupaddr
         uint16_t local_cluster_id = CxToCluster(pgm_read_byte(&converter->cluster_short));
         // uint8_t  local_type_id = pgm_read_byte(&converter->type);
 
-        if ((converter->name) && (0 == strcasecmp_P(key, converter->name))) {
+        if ((pgm_read_word(&converter->name_offset)) && (0 == strcasecmp_P(key, Z_strings + pgm_read_word(&converter->name_offset)))) {
           // match name
           // check if there is a conflict with cluster
           // TODO


### PR DESCRIPTION
## Description:

Zigbee size optimization, saving 936 bytes of Flash.

Strings are no more stored as 32 bits but as 16 bits offset in a string array.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
