### PR TITLE
Zigbee keep 'null' attributes

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -818,8 +818,8 @@ void CopyJsonVariant(JsonObject &to, const String &key, const JsonVariant &val) 
   to.remove(key);    // force remove to have metadata like LinkQuality at the end
 
   if (val.is<char*>()) {
-    String sval = val.as<String>();       // force a copy of the String value, avoiding crash
-    to.set(key, sval);
+    const char * sval = val.as<char*>();    // using char* forces a copy, and also captures 'null' values
+    to.set(key, (char*) sval);
   } else if (val.is<JsonArray>()) {
     JsonArray &nested_arr = to.createNestedArray(key);
     CopyJsonArray(nested_arr, val.as<JsonArray>());   // deep copy


### PR DESCRIPTION
## Description:

Prevents from changing `null` attributes to `"null"`.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
