### PR TITLE
Update xnrg_01_hlw8012.ino

### DIFF
--- a/tasmota/xnrg_01_hlw8012.ino
+++ b/tasmota/xnrg_01_hlw8012.ino
@@ -205,10 +205,10 @@ void HlwEverySecond(void)
     unsigned long hlw_len;
 
     if (Hlw.energy_period_counter) {
-      hlw_len = 10000 / Hlw.energy_period_counter;
+      hlw_len = 10000 * 1000 / Hlw.energy_period_counter; 
       Hlw.energy_period_counter = 0;
       if (hlw_len) {
-        Energy.kWhtoday_delta += ((Hlw.power_ratio * Settings.energy_power_calibration) / hlw_len) / 36;
+        Energy.kWhtoday_delta += ((Hlw.power_ratio * Settings.energy_power_calibration) * 1000 / hlw_len) / 36;
         EnergyUpdateToday();
       }
     }


### PR DESCRIPTION
Fix rounding error in kWhtoday_delta calculation. 
At 3.6kW load, hlw_len could be as low as 5, so rounding could make the value 20% off. Multiply hlw_len by 1000 and the dividend a few lines below as well fixes this. With integer math only, dividends should keep precision as long as possible.

## Description:

**Related issue (if applicable):** fixes #9146

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
