### PR TITLE
Use Tasmota Core 2.7.4.1 from PlatformIO registry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,6 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
 platform                  = espressif8266@2.6.2
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
+platform_packages         = framework-arduinoespressif8266 @ jason2866/framework-arduinoespressif8266
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,7 +89,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.6.2
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
+platform_packages         = framework-arduinoespressif8266 @ jason2866/framework-arduinoespressif8266
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 


### PR DESCRIPTION
all needed PlatformIO resources are on the same place. 

To be found here: https://platformio.org/platforms/espressif8266/packages
First entry ;-)
![image](https://user-images.githubusercontent.com/24528715/91200269-3fd20980-e6ff-11ea-93f1-5aba5d9bbfd5.png)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
