### PR TITLE
Zigbee support Philips presence sensor

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1018,6 +1018,16 @@ void ZCLFrame::parseReportAttributes(JsonObject& json, uint8_t offset) {
     }
     i += parseSingleAttribute(json, key, _payload, i);
   }
+
+  // Issue Philips outdoor motion sensor SML002, see https://github.com/Koenkk/zigbee2mqtt/issues/897
+  // The sensor expects the coordinator to send a Default Response to acknowledge the attribute reporting
+  if (0 == _frame_control.b.disable_def_resp) {
+    // the device expects a default response
+    SBuffer buf(2);
+    buf.add8(_cmd_id);
+    buf.add8(0x00);   // Status = OK
+    ZigbeeZCLSend_Raw(_srcaddr, 0x0000, 0x0000 /*cluster*/, _srcendpoint, ZCL_DEFAULT_RESPONSE, false /* not cluster specific */, _manuf_code, buf.getBuffer(), buf.len(), false /* noresponse */, zigbee_devices.getNextSeqNumber(_srcaddr));
+  }
 }
 
 // ZCL_READ_ATTRIBUTES


### PR DESCRIPTION
## Description:

Send a default response when required by sender when reporting attributes. This is required by Philips Presence sensor.
Mentioned by @tric111 and explained in Koenkk/zigbee2mqtt#897

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
