### PR TITLE
Revert "Use Tasmota Core 2.7.4.1 from PlatformIO registry"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,6 @@ build_flags               = -DUSE_IR_REMOTE_FULL
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
 platform                  = espressif8266@2.6.2
-platform_packages         = framework-arduinoespressif8266 @ jason2866/framework-arduinoespressif8266
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,7 +89,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.6.2
-platform_packages         = framework-arduinoespressif8266 @ jason2866/framework-arduinoespressif8266
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.1/esp8266-2.7.4.1.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 


### PR DESCRIPTION
Since the actual release version of PlatformIO does not handle user packages correct.
