### PR TITLE
Make hass use white level also for RGBWW lights

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -95,7 +95,7 @@ const char HASS_DISCOVER_LIGHT_WHITE[] PROGMEM =
   ",\"whit_val_cmd_t\":\"%s\","                   // cmnd/led2/White
   "\"whit_val_stat_t\":\"%s\","                   // stat/led2/RESULT
   "\"whit_val_scl\":100,"
-  "\"whit_val_tpl\":\"{{value_json.Channel[3]}}\"";
+  "\"whit_val_tpl\":\"{{value_json." D_CMND_WHITE "}}\"";
 
 const char HASS_DISCOVER_LIGHT_CT[] PROGMEM =
   ",\"clr_temp_cmd_t\":\"%s\","                   // cmnd/led2/CT
@@ -336,7 +336,7 @@ void HAssAnnounceRelayLight(void)
               GetTopic_P(effect_command_topic, CMND, mqtt_topic, D_CMND_SCHEME);
               TryResponseAppend_P(HASS_DISCOVER_LIGHT_SCHEME, effect_command_topic, state_topic);
             }
-            if (LST_RGBW == Light.subtype) { wt_light = true; }
+            if (LST_RGBW <= Light.subtype) { wt_light = true; }
             if (LST_RGBCW == Light.subtype) { ct_light = true; }
           }
 
@@ -348,7 +348,7 @@ void HAssAnnounceRelayLight(void)
               TryResponseAppend_P(HASS_DISCOVER_LIGHT_CT, color_temp_command_topic, state_topic);
               ct_light = false;
           }
-          if ((!ind_light && wt_light) || (LST_RGBW == Light.subtype &&
+          if ((!ind_light && wt_light) || (LST_RGBW <= Light.subtype &&
               !PwmMulti && LightControl)) {
               char *white_temp_command_topic = stemp1;
 


### PR DESCRIPTION
## Description:
Make hass use white level also for RGBWW lights, to make hass know if RGBWW light is in color mode or light mode.

**Related issue (if applicable):** home-assistant/core#30618

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
