### PR TITLE
Add ``SetOption109 1`` to force gen1 Alexa mode, for Echo Dot 2nd gen device only

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add command ``PowerDelta1`` to ``PowerDelta3`` to trigger on up to three phases (#9134)
 - Add Zigbee web ui widget for Lights
+- Add ``SetOption109 1`` to force gen1 Alexa mode, for Echo Dot 2nd gen devices only
 
 ### 8.4.0.2 20200813
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -127,8 +127,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t white_blend_mode : 1;         // bit 23 (v8.4.0.1)  - SetOption105 - White Blend Mode - used to be `RGBWWTable` last value `0`, now deprecated in favor of this option
     uint32_t virtual_ct : 1;               // bit 24 (v8.4.0.1)  - SetOption106 - Virtual CT - Creates a virtual White ColorTemp for RGBW lights
     uint32_t virtual_ct_cw : 1;            // bit 25 (v8.4.0.1)  - SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
-    uint32_t teleinfo_rawdata : 1;         // bit 21 (v8.4.0.2)  - SetOption108 - enable Teleinfo + Tasmota Energy device (0) or Teleinfo raw data only (1)
-    uint32_t spare27 : 1;
+    uint32_t teleinfo_rawdata : 1;         // bit 26 (v8.4.0.2)  - SetOption108 - enable Teleinfo + Tasmota Energy device (0) or Teleinfo raw data only (1)
+    uint32_t alexa_gen_1 : 1;              // bit 27 (v8.4.0.3)  - SetOption109 - Alexa gen1 mode - if you only have Echo Dot 2nd gen devices
     uint32_t spare28 : 1;                  // bit 28
     uint32_t spare29 : 1;                  // bit 29
     uint32_t spare30 : 1;                  // bit 30

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -46,8 +46,6 @@ uint8_t *efm8bb1_update = nullptr;
 
 enum UploadTypes { UPL_TASMOTA, UPL_SETTINGS, UPL_EFM8BB1, UPL_TASMOTACLIENT, UPL_EFR32 };
 
-static const char * HEADER_KEYS[] = { "User-Agent", };
-
 #ifdef USE_UNISHOX_COMPRESSION
 #ifdef USE_JAVASCRIPT_ES6
 // insert D_HTML_LANGUAGE later
@@ -890,10 +888,6 @@ void StartWebserver(int type, IPAddress ipweb)
 #endif  // Not FIRMWARE_MINIMAL
     }
     Web.reset_web_log_flag = false;
-
-    // Collect User-Agent for Alexa Hue Emulation
-    // This is used in xdrv_20_hue.ino in function findEchoGeneration()
-    Webserver->collectHeaders(HEADER_KEYS, sizeof(HEADER_KEYS)/sizeof(char*));
 
     Webserver->begin(); // Web server start
   }

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -510,24 +510,9 @@ static const char * FIRST_GEN_UA[] = {  // list of User-Agents signature
 };
 
 // Check if the Echo device is of 1st generation, which triggers different results
-uint32_t findEchoGeneration(void) {
-  // result is 1 for 1st gen, 2 for 2nd gen and further
-  String user_agent = Webserver->header("User-Agent");
-  uint32_t gen = 2;
-
-  for (uint32_t i = 0; i < sizeof(FIRST_GEN_UA)/sizeof(char*); i++) {
-    if (user_agent.indexOf(FIRST_GEN_UA[i]) >= 0) {  // found
-      gen = 1;
-      break;
-    }
-  }
-  if (0 == user_agent.length()) {
-    gen = 1;        // if no user-agent, also revert to gen v1
-  }
-
-  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_HTTP D_HUE " User-Agent: %s, gen=%d"), user_agent.c_str(), gen);  // Header collection is set in xdrv_01_webserver.ino, in StartWebserver()
-
-  return gen;
+inline uint32_t findEchoGeneration(void) {
+  // don't try to guess from User-Agent anymore but use SetOption109
+  return Settings.flag4.alexa_gen_1 ? 1 : 2;
 }
 
 void HueGlobalConfig(String *path) {
@@ -893,7 +878,7 @@ void HandleHueApi(String *path)
 
   path->remove(0, 4);                                // remove /api
   uint16_t apilen = path->length();
-  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_HTTP D_HUE_API " (%s)"), path->c_str());         // HTP: Hue API (//lights/1/state
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_HTTP D_HUE_API " (%s) from %s"), path->c_str(), Webserver->client().remoteIP().toString().c_str());         // HTP: Hue API (//lights/1/state) from 192.168.1.20
   for (args = 0; args < Webserver->args(); args++) {
     String json = Webserver->arg(args);
     AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_HTTP D_HUE_POST_ARGS " (%s)"), json.c_str());  // HTP: Hue POST args ({"on":false})

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -505,10 +505,6 @@ uint32_t DecodeLightId(uint32_t hue_id, uint16_t * shortaddr = nullptr)
   return relay_id;
 }
 
-static const char * FIRST_GEN_UA[] = {  // list of User-Agents signature
-  "AEOBC",                              // Echo Dot 2ng Generation
-};
-
 // Check if the Echo device is of 1st generation, which triggers different results
 inline uint32_t findEchoGeneration(void) {
   // don't try to guess from User-Agent anymore but use SetOption109

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -267,9 +267,13 @@ const char WEMO_SETUP_XML[] PROGMEM =
 
 /********************************************************************************************/
 
+void LogUpnpWithClient(const char *msg) {
+  AddLog_P2(LOG_LEVEL_DEBUG, PSTR(D_LOG_HTTP "%s from %s"), msg, Webserver->client().remoteIP().toString().c_str());
+}
+
 void HandleUpnpEvent(void)
 {
-  AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_BASIC_EVENT));
+  LogUpnpWithClient(PSTR(D_WEMO_BASIC_EVENT));
 
   char event[500];
   strlcpy(event, Webserver->arg(0).c_str(), sizeof(event));
@@ -303,7 +307,7 @@ void HandleUpnpEvent(void)
 
 void HandleUpnpService(void)
 {
-  AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_EVENT_SERVICE));
+  LogUpnpWithClient(PSTR(D_WEMO_EVENT_SERVICE));
 
 #ifdef USE_UNISHOX_COMPRESSION
   WSSend(200, CT_PLAIN, Decompress(WEMO_EVENTSERVICE_XML, WEMO_EVENTSERVICE_XML_SIZE));
@@ -314,7 +318,7 @@ void HandleUpnpService(void)
 
 void HandleUpnpMetaService(void)
 {
-  AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_META_SERVICE));
+  LogUpnpWithClient(PSTR(D_WEMO_META_SERVICE));
 
 #ifdef USE_UNISHOX_COMPRESSION
   WSSend(200, CT_PLAIN, Decompress(WEMO_METASERVICE_XML, WEMO_METASERVICE_XML_SIZE));
@@ -325,7 +329,7 @@ void HandleUpnpMetaService(void)
 
 void HandleUpnpSetupWemo(void)
 {
-  AddLog_P(LOG_LEVEL_DEBUG, S_LOG_HTTP, PSTR(D_WEMO_SETUP));
+  LogUpnpWithClient(PSTR(D_WEMO_SETUP));
 
 #ifdef USE_UNISHOX_COMPRESSION
   String setup_xml = Decompress(WEMO_SETUP_XML, WEMO_SETUP_XML_SIZE);


### PR DESCRIPTION
## Description:

Echo Dot 2nd gen devices do not support simple switches devices with Hue Emulation - they need to always have a (fake) dimmer. The issue happens if you have only this type of device. If you have more modern Echo devices on the same network, there is no issue.

Before, the detection was automatic via User-Agent, but it does not work anymore. Instead you must now use `SetOption109 1` to force legacy support of Echo Dot 2nd gen only.

Also added more logging in Hue and Wemo emulation to track the source IP of the requests.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
