### PR TITLE
Zigbee fix sequence number for default response

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1057,7 +1057,7 @@ void ZCLFrame::parseReportAttributes(JsonObject& json, uint8_t offset) {
     SBuffer buf(2);
     buf.add8(_cmd_id);
     buf.add8(0x00);   // Status = OK
-    ZigbeeZCLSend_Raw(_srcaddr, 0x0000, 0x0000 /*cluster*/, _srcendpoint, ZCL_DEFAULT_RESPONSE, false /* not cluster specific */, _manuf_code, buf.getBuffer(), buf.len(), false /* noresponse */, zigbee_devices.getNextSeqNumber(_srcaddr));
+    ZigbeeZCLSend_Raw(_srcaddr, 0x0000, 0x0000 /*cluster*/, _srcendpoint, ZCL_DEFAULT_RESPONSE, false /* not cluster specific */, _manuf_code, buf.getBuffer(), buf.len(), false /* noresponse */, _transact_seq);
   }
 }
 

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -792,7 +792,7 @@ void ZigbeeZCLSend_Raw(uint16_t shortaddr, uint16_t groupaddr, uint16_t clusterI
   if (manuf) {
     buf.add16(manuf);               // add Manuf Id if not null
   }
-  buf.add8(transacId);              // Transaction Sequance Number
+  buf.add8(transacId);              // Transaction Sequence Number
   buf.add8(cmdId);
   if (len > 0) {
     buf.addBuffer(msg, len);        // add the payload


### PR DESCRIPTION
## Description:

Set the right sequence number when sending a Default Response to an Attribute Report. It seems to be needed by Philips motion sensors.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
