### PR TITLE
Update xdrv_08_serial_bridge.ino

### DIFF
--- a/tasmota/xdrv_08_serial_bridge.ino
+++ b/tasmota/xdrv_08_serial_bridge.ino
@@ -23,6 +23,7 @@
 \*********************************************************************************************/
 
 #define XDRV_08                    8
+#define HARDWARE_FALLBACK          2
 
 const uint8_t SERIAL_BRIDGE_BUFFER_SIZE = 130;
 
@@ -104,7 +105,7 @@ void SerialBridgeInit(void)
 {
   serial_bridge_active = false;
   if (PinUsed(GPIO_SBR_RX) && PinUsed(GPIO_SBR_TX)) {
-    SerialBridgeSerial = new TasmotaSerial(Pin(GPIO_SBR_RX), Pin(GPIO_SBR_TX));
+    SerialBridgeSerial = new TasmotaSerial(Pin(GPIO_SBR_RX), Pin(GPIO_SBR_TX), HARDWARE_FALLBACK);
     if (SerialBridgeSerial->begin(Settings.sbaudrate * 300)) {  // Baud rate is stored div 300 so it fits into 16 bits
       if (SerialBridgeSerial->hardwareSerial()) {
         ClaimSerial();


### PR DESCRIPTION
serial.swap (GPIO13/15) will not work because hardware_fallback==2 is not set. Now it does.

## Description:

serial.swap doesn't work because of the missing hardware_fallback option.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [] The code change is tested and works on core ESP32 V.1.12.2 (will not have impact)
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
