### PR TITLE
Add last seen time to zigbee devices

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -75,6 +75,7 @@ public:
   // powe plug data
   uint16_t              mains_voltage;  // AC voltage
   int16_t               mains_power;    // Active power
+  uint32_t              last_seen;      // Last seen time (epoch)
 
   // Constructor with all defaults
   Z_Device(uint16_t _shortaddr = BAD_SHORTADDR, uint64_t _longaddr = 0x00):
@@ -103,7 +104,8 @@ public:
     pressure(0xFFFF),
     humidity(0xFF),
     mains_voltage(0xFFFF),
-    mains_power(-0x8000)
+    mains_power(-0x8000),
+    last_seen(0)
     { };
 
   inline bool valid(void)               const { return BAD_SHORTADDR != shortaddr; }    // is the device known, valid and found?
@@ -128,6 +130,7 @@ public:
   inline bool validTemperature(void)    const { return -0x8000 != temperature; }
   inline bool validPressure(void)       const { return 0xFFFF != pressure; }
   inline bool validHumidity(void)       const { return 0xFF != humidity; }
+  inline bool validLastSeen(void)       const { return 0x0 != last_seen; }
 
   inline bool validMainsVoltage(void)   const { return 0xFFFF != mains_voltage; }
   inline bool validMainsPower(void)     const { return -0x8000 != mains_power; }
@@ -247,6 +250,7 @@ public:
 
   void setReachable(uint16_t shortaddr, bool reachable);
   void setLQI(uint16_t shortaddr, uint8_t lqi);
+  void setLastSeenNow(uint16_t shortaddr);
   // uint8_t getLQI(uint16_t shortaddr) const;
   void setBatteryPercent(uint16_t shortaddr, uint8_t bp);
   uint8_t getBatteryPercent(uint16_t shortaddr) const;
@@ -629,6 +633,12 @@ void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
   if (shortaddr == localShortAddr) { return; }
   getShortAddr(shortaddr).lqi = lqi;
 }
+
+void Z_Devices::setLastSeenNow(uint16_t shortaddr) {
+  if (shortaddr == localShortAddr) { return; }
+  getShortAddr(shortaddr).last_seen= Rtc.utc_time;
+}
+
 
 void Z_Devices::setBatteryPercent(uint16_t shortaddr, uint8_t bp) {
   getShortAddr(shortaddr).batterypercent = bp;

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1348,7 +1348,8 @@ void Z_IncomingMessage(class ZCLFrame &zcl_received) {
   // log the packet details
   zcl_received.log();
 
-  zigbee_devices.setLQI(srcaddr, linkquality);       // EFR32 has a different scale for LQI
+  zigbee_devices.setLQI(srcaddr, linkquality != 0xFF ? linkquality : 0xFE);       // EFR32 has a different scale for LQI
+  zigbee_devices.setLastSeenNow(srcaddr);
 
   char shortaddr[8];
   snprintf_P(shortaddr, sizeof(shortaddr), PSTR("0x%04X"), srcaddr);
@@ -1492,6 +1493,7 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
     // ZDO request
     // Report LQI
     zigbee_devices.setLQI(srcaddr, linkquality);
+    zigbee_devices.setLastSeenNow(srcaddr);
     // Since ZDO messages start with a sequence number, we skip it
     // but we add the source address in the last 2 bytes
     SBuffer zdo_buf(buf.get8(20) - 1 + 2);


### PR DESCRIPTION
## Description:
This PR adds a last seen time to zigbee devices whenever `USE_ZIGBEE` is enabled. It converts to human-readable XXdXXhXXmXXs format for the web interface.

This was originally built for a prometheus /metrics endpoint, which will come in a future PR, but this work is standalone and I believe provides value on its own.

I currently have this running on my ESP8266/Zigbee Bridge. I unfortunately do not have an ESP32 to test on.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
