### PR TITLE
Reduce memory usage of BackLog

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -323,7 +323,7 @@ void CmndBacklog(void)
           backlog.add(blcommand);
         }
 #else
-        backlog[backlog_index] = String(blcommand);
+        backlog[backlog_index] = blcommand;
         backlog_index++;
         if (backlog_index >= MAX_BACKLOG) backlog_index = 0;
 #endif

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -339,6 +339,7 @@ void BacklogLoop(void) {
 #else
       backlog_mutex = true;
       ExecuteCommand((char*)backlog[backlog_pointer].c_str(), SRC_BACKLOG);
+      backlog[backlog_pointer] = (const char*) nullptr;   // force deallocation of the String internal memory
       backlog_pointer++;
       if (backlog_pointer >= MAX_BACKLOG) { backlog_pointer = 0; }
       backlog_mutex = false;


### PR DESCRIPTION
## Description:

Reduce memory usage of `BackLog` by disallocating String memory as soon as it is consumed.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
