### PR TITLE
Zigbee better support for WSDCGQ01LM variants

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1280,6 +1280,7 @@ void ZCLFrame::syntheticAqaraSensor(Z_attribute_list &attr_list, class Z_attribu
       } else if ((nullptr != modelId) && (0 == getManufCode())) {
         translated = true;
         if (modelId.startsWith(F("lumi.sensor_ht")) ||
+            modelId.equals(F("lumi.sens")) ||
             modelId.startsWith(F("lumi.weather"))) {     // Temp sensor
           // Filter according to prefix of model name
           // onla Aqara Temp/Humidity has manuf_code of zero. If non-zero we skip the parameters


### PR DESCRIPTION
## Description:

Support decoding for Xiaomi specific field for WSDCGQ01LM with `ModelId==lumi.sens.

**Related issue (if applicable):** fixes #9217 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
