### PR TITLE
Add ``#define USE_MQTT_AWS_IOT_LIGHT`` for password based AWS IoT authentication

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 8.5.0.1 20200907
 
-- New released
+- Add ``#define USE_MQTT_AWS_IOT_LIGHT`` for password based AWS IoT authentication
 
 ### 8.5.0 20200907
 

--- a/tasmota/StackThunk_light.cpp
+++ b/tasmota/StackThunk_light.cpp
@@ -40,8 +40,10 @@ uint32_t *stack_thunk_light_save = NULL;  /* Saved A1 while in BearSSL */
 uint32_t stack_thunk_light_refcnt = 0;
 
 //#define _stackSize (5600/4)
-#ifdef USE_MQTT_TLS_FORCE_EC_CIPHER
+#if defined(USE_MQTT_AWS_IOT)
   #define _stackSize (5300/4)   // using a light version of bearssl we can save 300 bytes
+#elif defined(USE_MQTT_TLS_FORCE_EC_CIPHER)
+  #define _stackSize (4800/4)   // no private key, we can reduce a little, max observed 4300
 #else
   #define _stackSize (3600/4)   // using a light version of bearssl we can save 2k
 #endif

--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -872,7 +872,11 @@ extern "C" {
 
 #ifdef USE_MQTT_TLS_FORCE_EC_CIPHER
 		// we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
-		br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);
+		br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);    // TODO
+#endif
+#ifdef USE_MQTT_AWS_IOT_LIGHT
+    static const char * alpn_mqtt = "mqtt";
+    br_ssl_engine_set_protocol_names(&cc->eng, &alpn_mqtt, 1);
 #endif
   }
 }
@@ -880,13 +884,6 @@ extern "C" {
 // Called by connect() to do the actual SSL setup and handshake.
 // Returns if the SSL handshake succeeded.
 bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
-// #ifdef USE_MQTT_AWS_IOT
-// 	if ((!_chain_P) || (!_sk_ec_P)) {
-// 		setLastError(ERR_MISSING_EC_KEY);
-// 		return false;
-// 	}
-// #endif
-
 	// Validation context, either full CA validation or checking only fingerprints
 #ifdef USE_MQTT_TLS_CA_CERT
 	br_x509_minimal_context *x509_minimal;

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -389,7 +389,8 @@
 //  #define USE_MQTT_TLS_CA_CERT                   // Force full CA validation instead of fingerprints, slower, but simpler to use.  (+2.2k code, +1.9k mem during connection handshake)
                                                    // This includes the LetsEncrypt CA in tasmota_ca.ino for verifying server certificates
 //  #define USE_MQTT_TLS_FORCE_EC_CIPHER           // Force Elliptic Curve cipher (higher security) required by some servers (automatically enabled with USE_MQTT_AWS_IOT) (+11.4k code, +0.4k mem)
-//  #define USE_MQTT_AWS_IOT                       // Enable MQTT for AWS IoT - requires a private key (+11.9k code, +0.4k mem)
+//  #define USE_MQTT_AWS_IOT_LIGHT                 // Enable MQTT for AWS IoT in light mode, with user/password instead of private certificate
+//  #define USE_MQTT_AWS_IOT                       // [Deprecated] Enable MQTT for AWS IoT - requires a private key (+11.9k code, +0.4k mem)
                                                  //   Note: you need to generate a private key + certificate per device and update 'tasmota/tasmota_aws_iot.cpp'
                                                  //   Full documentation here: https://github.com/arendst/Tasmota/wiki/AWS-IoT
 //  #define USE_4K_RSA                             // Support 4096 bits certificates, instead of 2048
@@ -820,7 +821,7 @@
   #include "user_config_override.h"         // Configuration overrides for my_user_config.h
 #endif
 
-#if defined(USE_DISCOVERY) && defined(USE_MQTT_AWS_IOT)
+#if defined(USE_DISCOVERY) && (defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT))
   #error "Select either USE_DISCOVERY or USE_MQTT_AWS_IOT, mDNS takes too much code space and is not needed for AWS IoT"
 #endif
 

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -154,7 +154,7 @@ void MqttInit(void)
   String host = String(SettingsText(SET_MQTT_HOST));
   if (host.indexOf(".iot.") && host.endsWith(".amazonaws.com")) {  // look for ".iot." and ".amazonaws.com" in the domain name
     Settings.flag4.mqtt_no_retain = true;
-    Mqtt.tls_private_key = true;
+    // Mqtt.tls_private_key = true;
   }
 
   if (Settings.flag4.mqtt_tls) {
@@ -353,7 +353,7 @@ void MqttPublishPrefixTopic_P(uint32_t prefix, const char* subtopic, bool retain
   GetTopic_P(stopic, prefix, mqtt_topic, romram);
   MqttPublish(stopic, retained);
 
-#ifdef USE_MQTT_AWS_IOT
+#if defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT)
   if ((prefix > 0) && (Settings.flag4.awsiot_shadow) && (Mqtt.connected)) {    // placeholder for SetOptionXX
     // compute the target topic
     char *topic = SettingsText(SET_MQTT_TOPIC);
@@ -1350,7 +1350,7 @@ void MqttSaveSettings(void)
 #endif
   WebGetArg("mc", tmp, sizeof(tmp));
   SettingsUpdateText(SET_MQTT_CLIENT, (!strlen(tmp)) ? MQTT_CLIENT_ID : tmp);
-#if defined(USE_MQTT_TLS) && defined(USE_MQTT_AWS_IOT)
+#if defined(USE_MQTT_TLS) && (defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT))
   AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT D_CMND_MQTTHOST " %s, " D_CMND_MQTTPORT " %d, " D_CMND_MQTTCLIENT " %s, " D_CMND_TOPIC " %s, " D_CMND_FULLTOPIC " %s"),
     SettingsText(SET_MQTT_HOST), Settings.mqtt_port, SettingsText(SET_MQTT_CLIENT), SettingsText(SET_MQTT_TOPIC), SettingsText(SET_MQTT_FULLTOPIC));
 #else // USE_MQTT_AWS_IOT


### PR DESCRIPTION
## Description:

AWS IoT recently introduced user/password authentication in addition to private key/certificate authentication. The new `#define USE_MQTT_AWS_IOT_LIGHT` option enables this new authentication mode and saves ~4KB of Flash.

The TLS documentation will be updated accordingly.

The legacy `#define USE_MQTT_AWS_IOT` with private certificate mode will be progressively deprecated; since ESP8266 doesn't have secure storage, a private certificate does not bring additional security compared to a password.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
