### PR TITLE
Add support for pulsetime on all 32 relays

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -333,9 +333,9 @@ void SetPowerOnState(void)
         bitWrite(power, i, digitalRead(Pin(GPIO_REL1, i)) ^ bitRead(rel_inverted, i));
       }
     }
-    if ((i < MAX_PULSETIMERS) && (bitRead(power, i) || (POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate))) {
-      SetPulseTimer(i, Settings.pulse_timer[i]);
-    }
+    if ( (bitRead(power, i) || (POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate))) {
+      SetPulseTimer(i%MAX_PULSETIMERS, Settings.pulse_timer[i%MAX_PULSETIMERS]);
+    }	    
   }
   blink_powersave = power;
 }
@@ -531,9 +531,8 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
   }
   active_device = device;
 
-  if (device <= MAX_PULSETIMERS) {
-    SetPulseTimer(device -1, 0);
-  }
+  SetPulseTimer((device -1)%MAX_PULSETIMERS, 0);
+	
   power_t mask = 1 << (device -1);        // Device to control
   if (state <= POWER_TOGGLE) {
     if ((blink_mask & mask)) {
@@ -589,9 +588,8 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
     if (publish_power && Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
       MqttPublishTeleState();
     }
-    if (device <= MAX_PULSETIMERS) {  // Restart PulseTime if powered On
-      SetPulseTimer(device -1, (((POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate) ? ~power : power) & mask) ? Settings.pulse_timer[device -1] : 0);
-    }
+    SetPulseTimer((device -1)%MAX_PULSETIMERS, (((POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate) ? ~power : power) & mask) ? Settings.pulse_timer[(device -1)%MAX_PULSETIMERS] : 0);
+
   }
   else if (POWER_BLINK == state) {
     if (!(blink_mask & mask)) {
@@ -887,7 +885,9 @@ void Every100mSeconds(void)
     if (pulse_timer[i] != 0L) {           // Timer active?
       if (TimeReached(pulse_timer[i])) {  // Timer finished?
         pulse_timer[i] = 0L;              // Turn off this timer
-        ExecuteCommandPower(i +1, (POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate) ? POWER_ON : POWER_OFF, SRC_PULSETIMER);
+        for (uint8_t j=0; j < devices_present; j=j+MAX_PULSETIMERS) {
+          ExecuteCommandPower(i+j +1, (POWER_ALL_OFF_PULSETIME_ON == Settings.poweronstate) ? POWER_ON : POWER_OFF, SRC_PULSETIMER);
+	}
       }
     }
   }
@@ -1067,8 +1067,8 @@ void Every250mSeconds(void)
       if (save_data_counter <= 0) {
         if (Settings.flag.save_state) {                   // SetOption0 - Save power state and use after restart
           power_t mask = POWER_MASK;
-          for (uint32_t i = 0; i < MAX_PULSETIMERS; i++) {
-            if ((Settings.pulse_timer[i] > 0) && (Settings.pulse_timer[i] < 30)) {  // 3 seconds
+          for (uint32_t i = 0; i < devices_present; i++) {
+            if ((Settings.pulse_timer[i%MAX_PULSETIMERS] > 0) && (Settings.pulse_timer[i%MAX_PULSETIMERS] < 30)) {  // 3 seconds
               mask &= ~(1 << i);
             }
           }


### PR DESCRIPTION
# Description:
Instead of increasing pulsetimers to 32 I reused pulsetime every 8 relays. Therefore 1,9,17,24 are sharing pulsetime1. Normally > 8 relays are unusual. Therefore breaking existing functional is unusual. maybe changing the documentation is required to hint to this special behavior.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#9272 fixed by reusing pulsetime for relays > 8
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
