### PR TITLE
Adding Lat/Long IP-based detection

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -245,8 +245,8 @@
 #define TIME_STD_OFFSET        +60               // Offset from UTC in minutes (-780 to +780)
 
 // -- Location ------------------------------------
-#define LATITUDE               48.858360         // [Latitude] Your location to be used with sunrise and sunset
-#define LONGITUDE              2.294442          // [Longitude] Your location to be used with sunrise and sunset
+#define LATITUDE               0.0               // [Latitude] Your location to be used with sunrise and sunset
+#define LONGITUDE              0.0               // [Longitude] Your location to be used with sunrise and sunset
 
 // -- Application ---------------------------------
 #define APP_TIMEZONE           1                 // [Timezone] +1 hour (Amsterdam) (-13 .. 14 = hours from UTC, 99 = use TIME_DST/TIME_STD)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -468,6 +468,7 @@
   #define USE_PWM_DIMMER_REMOTE                  // Add support for remote switches to PWM Dimmer (requires USE_DEVICE_GROUPS) (+0k9 code)
 //#define USE_KEELOQ                               // Add support for Jarolift rollers by Keeloq algorithm (+4k5 code)
 #define USE_SONOFF_D1                            // Add support for Sonoff D1 Dimmer (+0k7 code)
+//#define USE_AUTOLATLONG                          // Add supoprt for automatic lat/long detection based on IP
 
 // -- Optional light modules ----------------------
 #define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -245,8 +245,8 @@
 #define TIME_STD_OFFSET        +60               // Offset from UTC in minutes (-780 to +780)
 
 // -- Location ------------------------------------
-#define LATITUDE               0.0               // [Latitude] Your location to be used with sunrise and sunset
-#define LONGITUDE              0.0               // [Longitude] Your location to be used with sunrise and sunset
+#define LATITUDE               48.858360         // [Latitude] Your location to be used with sunrise and sunset
+#define LONGITUDE              2.294442          // [Longitude] Your location to be used with sunrise and sunset
 
 // -- Application ---------------------------------
 #define APP_TIMEZONE           1                 // [Timezone] +1 hour (Amsterdam) (-13 .. 14 = hours from UTC, 99 = use TIME_DST/TIME_STD)

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -20,6 +20,7 @@
 /*********************************************************************************************\
  * RTC memory
 \*********************************************************************************************/
+#include <ArduinoJson.h>
 
 const uint16_t RTC_MEM_VALID = 0xA55A;
 
@@ -1134,6 +1135,72 @@ void SettingsDefaultSet2(void)
   Settings.flag3 = flag3;
   Settings.flag4 = flag4;
 }
+
+/********************************************************************************************/
+
+#ifndef FIRMWARE_MINIMAL
+void SettingsAutoConf(void)
+{
+  bool updated = false;
+
+  double lat = LATITUDE;
+  double lng = LONGITUDE;
+
+  // (lat=0, long=0) => Attempt to detect Lat/Long based on the IP address
+  if ((Settings.latitude == 0) && (Settings.longitude == 0)) {
+    struct RevGeoSite {
+        String url;
+        String lat;
+        String lng;
+        String utc;
+    } site[] = {
+        {"http://ip-api.com/json/?fields=33603776", "lat", "lon", "offset"},
+        {"http://ipwhois.app/json/", "latitude", "longitude", "timezone_gmtOffset"}
+    };
+
+    for (auto &elem: site) {
+      HTTPClient http;
+
+      http.begin(elem.url.c_str());
+      int httpResponseCode = http.GET();
+
+      if (httpResponseCode > 0) {
+        String response = http.getString();
+        DynamicJsonBuffer jsonBuf;
+        JsonObject &doc = jsonBuf.parseObject(response.c_str());
+
+        if (!doc.success()) {
+          AddLog_P2(LOG_LEVEL_ERROR, PSTR("Failed to parse JSON from (%s)"), response.c_str());
+        } else {
+          if ((Settings.latitude == 0) && doc.containsKey(elem.lat)) {
+            lat = doc[elem.lat];
+            updated = true;
+          }
+
+          if ((Settings.longitude == 0) && doc.containsKey(elem.lng)) {
+            lng = doc[elem.lng];
+            updated = true;
+          }
+        }
+      } else {
+        AddLog_P2(LOG_LEVEL_ERROR, PSTR("AutoConf Error: %d"), httpResponseCode);
+      }
+
+      http.end();
+
+      if ((lat != 0.0) && (lng != 0.0))
+        break;
+    }
+  }
+
+  Settings.latitude = (int)(lat * 1000000);
+  Settings.longitude = (int)(lng * 1000000);
+
+  if (updated) {
+    SettingsSaveAll();
+  }
+}
+#endif
 
 /********************************************************************************************/
 

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1138,7 +1138,7 @@ void SettingsDefaultSet2(void)
 
 /********************************************************************************************/
 
-#ifndef FIRMWARE_MINIMAL
+#ifdef USE_AUTOLATLONG
 void SettingsAutoConf(void)
 {
   bool updated = false;

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -395,6 +395,9 @@ void WifiCheckIp(void)
       Settings.ip_address[2] = (uint32_t)WiFi.subnetMask();
       Settings.ip_address[3] = (uint32_t)WiFi.dnsIP();
 
+#ifndef FIRMWARE_MINIMAL
+      SettingsAutoConf();
+#endif
       // Save current AP parameters for quick reconnect
       Settings.wifi_channel = WiFi.channel();
       uint8_t *bssid = WiFi.BSSID();

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -395,7 +395,7 @@ void WifiCheckIp(void)
       Settings.ip_address[2] = (uint32_t)WiFi.subnetMask();
       Settings.ip_address[3] = (uint32_t)WiFi.dnsIP();
 
-#ifndef FIRMWARE_MINIMAL
+#ifdef USE_AUTOLATLONG
       SettingsAutoConf();
 #endif
       // Save current AP parameters for quick reconnect

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -193,10 +193,10 @@ String EthernetMacAddress(void);
 #endif
 
 #ifndef LATITUDE
-#define LATITUDE                    48.858360  // [Latitude] Your location to be used with sunrise and sunset
+#define LATITUDE                    0.0        // [Latitude] Your location to be used with sunrise and sunset
 #endif
 #ifndef LONGITUDE
-#define LONGITUDE                   2.294442   // [Longitude] Your location to be used with sunrise and sunset
+#define LONGITUDE                   0.0        // [Longitude] Your location to be used with sunrise and sunset
 #endif
 
 #ifndef IR_RCV_MIN_UNKNOWN_SIZE

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -193,10 +193,10 @@ String EthernetMacAddress(void);
 #endif
 
 #ifndef LATITUDE
-#define LATITUDE                    0.0        // [Latitude] Your location to be used with sunrise and sunset
+#define LATITUDE                    48.858360  // [Latitude] Your location to be used with sunrise and sunset
 #endif
 #ifndef LONGITUDE
-#define LONGITUDE                   0.0        // [Longitude] Your location to be used with sunrise and sunset
+#define LONGITUDE                   2.294442   // [Longitude] Your location to be used with sunrise and sunset
 #endif
 
 #ifndef IR_RCV_MIN_UNKNOWN_SIZE


### PR DESCRIPTION
This patch adds the ability for Tasmota to detect the user's latitude & longitude based on their IP

This is triggered by setting the latitude/longitude to 0.0 (nowhere in the Ocean)

This is done through 2 web services (one is a backup) that are both free and don't require keys.

Tested:
* Each site individually
* Failure case

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
