### PR TITLE
Fix renaming and placing of compiled firmware variants

### DIFF
--- a/pio/gzip-firmware.py
+++ b/pio/gzip-firmware.py
@@ -6,7 +6,7 @@ import gzip
 OUTPUT_DIR = "build_output{}".format(os.path.sep)
 
 def bin_gzip(source, target, env):
-    variant = str(target[0]).split(os.path.sep)[1]
+    variant = str(target[0]).split(os.path.sep)[2]
     
     # create string with location and file names based on variant
     bin_file = "{}firmware{}{}.bin".format(OUTPUT_DIR, os.path.sep, variant)

--- a/pio/name-firmware.py
+++ b/pio/name-firmware.py
@@ -5,7 +5,7 @@ import shutil
 OUTPUT_DIR = "build_output{}".format(os.path.sep)
 
 def bin_map_copy(source, target, env):
-    variant = str(target[0]).split(os.path.sep)[1]
+    variant = str(target[0]).split(os.path.sep)[2]
     
     # check if output directories exist and create if necessary
     if not os.path.isdir(OUTPUT_DIR):


### PR DESCRIPTION
through the change from PR #9281 the path of the compiled firmware has changed

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
