### PR TITLE
Move ESP32 build variants selection out of pio override file...

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,16 +7,9 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/en/stable/projectconf.html
 
-[platformio]
-description = Provide ESP8266 based devices with Web, MQTT and OTA firmware
-src_dir = tasmota
-build_cache_dir = .cache
-extra_configs = platformio_tasmota32.ini
-                platformio_tasmota_env.ini
-                platformio_tasmota_env32.ini
-                platformio_override.ini
 
-; *** Build/upload environment
+; *** Tasmota build variant selection
+[build_envs]
 default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
 ;                tasmota
@@ -51,10 +44,21 @@ default_envs =
 ;                tasmota-TW
 ;                tasmota-UK
 ;
+; *** Selection for Tasmota ESP32 is done in platformio_tasmota32.ini
+;
 ; *** alternatively can be done in: platformio_override.ini
 ; *** See example: platformio_override_sample.ini
 ; *********************************************************************
 
+[platformio]
+description = Provide ESP8266 / ESP32 based devices with Web, MQTT and OTA firmware
+src_dir = tasmota
+build_cache_dir = .cache
+extra_configs = platformio_tasmota32.ini
+                platformio_tasmota_env.ini
+                platformio_tasmota_env32.ini
+                platformio_override.ini
+default_envs =  ${build_envs.default_envs}
 
 [common]
 framework                 = arduino

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -1,6 +1,44 @@
 ; ***              BETA ESP32 Tasmota version                 ***
 ; ***  expect the unexpected. Some features not working!!!    ***
 
+[platformio]
+
+; *** Tasmota build variant selection
+default_envs =  ${build_envs.default_envs}
+; *** Uncomment by deleting ";" in the line(s) below to select version(s)
+;                tasmota32
+;                tasmota32-webcam
+;                tasmota32-minimal
+;                tasmota32-lite
+;                tasmota32-knx
+;                tasmota32-sensors
+;                tasmota32-display
+;                tasmota32-ir
+;                tasmota32-ircustom
+;                tasmota32-BG
+;                tasmota32-BR
+;                tasmota32-CN
+;                tasmota32-CZ
+;                tasmota32-DE
+;                tasmota32-ES
+;                tasmota32-FR
+;                tasmota32-GR
+;                tasmota32-HE
+;                tasmota32-HU
+;                tasmota32-IT
+;                tasmota32-KO
+;                tasmota32-NL
+;                tasmota32-PL
+;                tasmota32-PT
+;                tasmota32-RO
+;                tasmota32-RU
+;                tasmota32-SE
+;                tasmota32-SK
+;                tasmota32-TR
+;                tasmota32-TW
+;                tasmota32-UK
+
+
 [common32]
 platform                = espressif32@2.0.0
 platform_packages       = tool-esptoolpy@1.20800.0


### PR DESCRIPTION
since ESP32 build variants are normal builds. 
Activating ESP32 build variant selection moved to `platformio_tasmota32.ini` 
so all ESP32 standard definitions are there. All variants can now be builded without changing setup files.

`Platformio_override.ini` is now needed only for special use cases

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
