### PR TITLE
Ci build refactor

### DIFF
--- a/.github/workflows/CI_github_ESP32.yml
+++ b/.github/workflows/CI_github_ESP32.yml
@@ -17,8 +17,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32
    
   tasmota32-webcam:
@@ -34,8 +33,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-webcam
 
   tasmota32-minimal:
@@ -51,8 +49,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-minimal
   tasmota32-lite:
     runs-on: ubuntu-latest
@@ -67,8 +64,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-lite
   tasmota32-knx:
     runs-on: ubuntu-latest
@@ -83,8 +79,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-knx
        
   tasmota32-sensors:
@@ -100,8 +95,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-sensors
   tasmota32-display:
     runs-on: ubuntu-latest
@@ -116,8 +110,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-display
   tasmota32-ir:
     runs-on: ubuntu-latest
@@ -132,8 +125,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-ir
   tasmota32-BG:
     runs-on: ubuntu-latest
@@ -148,8 +140,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-BG
   
   tasmota32-BR:
@@ -165,8 +156,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-BR
   tasmota32-CN:
     runs-on: ubuntu-latest
@@ -181,8 +171,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-CN
   tasmota32-CZ:
     runs-on: ubuntu-latest
@@ -197,8 +186,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-CZ
   tasmota32-DE:
     runs-on: ubuntu-latest
@@ -213,8 +201,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-DE
        
   tasmota32-ES:
@@ -230,8 +217,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-ES
   tasmota32-FR:
     runs-on: ubuntu-latest
@@ -246,8 +232,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-FR
   tasmota32-GR:
     runs-on: ubuntu-latest
@@ -262,8 +247,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-GR
   tasmota32-HE:
     runs-on: ubuntu-latest
@@ -278,8 +262,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-HE
         
   tasmota32-HU:
@@ -295,8 +278,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-HU
   tasmota32-IT:
     runs-on: ubuntu-latest
@@ -311,8 +293,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-IT
   tasmota32-KO:
     runs-on: ubuntu-latest
@@ -327,8 +308,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-KO
   tasmota32-NL:
     runs-on: ubuntu-latest
@@ -343,8 +323,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-NL
        
   tasmota32-PL:
@@ -360,8 +339,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-PL
   tasmota32-PT:
     runs-on: ubuntu-latest
@@ -376,8 +354,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-PT
   tasmota32-RO:
     runs-on: ubuntu-latest
@@ -392,8 +369,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-RO
   tasmota32-RU:
     runs-on: ubuntu-latest
@@ -408,8 +384,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-RU
   
   tasmota32-SE:
@@ -425,8 +400,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-SE
   tasmota32-SK:
     runs-on: ubuntu-latest
@@ -441,8 +415,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-SK
   tasmota32-TR:
     runs-on: ubuntu-latest
@@ -457,8 +430,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-TR
   tasmota32-TW:
     runs-on: ubuntu-latest
@@ -473,8 +445,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-TW
        
   tasmota32-UK:
@@ -490,6 +461,5 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-UK

--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -750,8 +750,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32
     - uses: actions/upload-artifact@v2
       with:
@@ -774,8 +773,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-minimal
     - uses: actions/upload-artifact@v2
       with:
@@ -798,8 +796,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-lite
     - uses: actions/upload-artifact@v2
       with:
@@ -822,8 +819,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-webcam
     - uses: actions/upload-artifact@v2
       with:
@@ -846,8 +842,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-knx
     - uses: actions/upload-artifact@v2
       with:
@@ -870,8 +865,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-sensors
     - uses: actions/upload-artifact@v2
       with:
@@ -894,8 +888,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-display
     - uses: actions/upload-artifact@v2
       with:
@@ -918,8 +911,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-ir
     - uses: actions/upload-artifact@v2
       with:
@@ -942,8 +934,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-ircustom
     - uses: actions/upload-artifact@v2
       with:
@@ -966,8 +957,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-BG
     - uses: actions/upload-artifact@v2
       with:
@@ -990,8 +980,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-BR
     - uses: actions/upload-artifact@v2
       with:
@@ -1014,8 +1003,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-CN
     - uses: actions/upload-artifact@v2
       with:
@@ -1038,8 +1026,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-CZ
     - uses: actions/upload-artifact@v2
       with:
@@ -1062,8 +1049,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-DE
     - uses: actions/upload-artifact@v2
       with:
@@ -1086,8 +1072,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-ES
     - uses: actions/upload-artifact@v2
       with:
@@ -1110,8 +1095,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-FR
     - uses: actions/upload-artifact@v2
       with:
@@ -1134,8 +1118,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-GR
     - uses: actions/upload-artifact@v2
       with:
@@ -1158,8 +1141,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-HE
     - uses: actions/upload-artifact@v2
       with:
@@ -1182,8 +1164,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-HU
     - uses: actions/upload-artifact@v2
       with:
@@ -1206,8 +1187,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-IT
     - uses: actions/upload-artifact@v2
       with:
@@ -1230,8 +1210,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-KO
     - uses: actions/upload-artifact@v2
       with:
@@ -1254,8 +1233,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-NL
     - uses: actions/upload-artifact@v2
       with:
@@ -1278,8 +1256,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-PL
     - uses: actions/upload-artifact@v2
       with:
@@ -1302,8 +1279,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-PT
     - uses: actions/upload-artifact@v2
       with:
@@ -1326,8 +1302,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-RO
     - uses: actions/upload-artifact@v2
       with:
@@ -1350,8 +1325,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-RU
     - uses: actions/upload-artifact@v2
       with:
@@ -1374,8 +1348,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-SE
     - uses: actions/upload-artifact@v2
       with:
@@ -1398,8 +1371,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-SK
     - uses: actions/upload-artifact@v2
       with:
@@ -1422,8 +1394,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-TR
     - uses: actions/upload-artifact@v2
       with:
@@ -1446,8 +1417,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-TW
     - uses: actions/upload-artifact@v2
       with:
@@ -1470,8 +1440,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
-        mv -f platformio_override_sample.ini platformio_override.ini
+      run: |
         platformio run -e tasmota32-UK
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
override file is not needed anymore since #9286 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
