### PR TITLE
Add Zigbee auto-config when pairing

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix crash in ``ZbRestore``
 - Add new shutter modes (#9244)
 - Add ``#define USE_MQTT_AWS_IOT_LIGHT`` for password based AWS IoT authentication
+- Add Zigbee auto-config when pairing
 
 ### 8.5.0 20200907
 

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -129,7 +129,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t virtual_ct_cw : 1;            // bit 25 (v8.4.0.1)  - SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
     uint32_t teleinfo_rawdata : 1;         // bit 26 (v8.4.0.2)  - SetOption108 - enable Teleinfo + Tasmota Energy device (0) or Teleinfo raw data only (1)
     uint32_t alexa_gen_1 : 1;              // bit 27 (v8.4.0.3)  - SetOption109 - Alexa gen1 mode - if you only have Echo Dot 2nd gen devices
-    uint32_t spare28 : 1;                  // bit 28
+    uint32_t zb_disable_autobind : 1;      // bit 28 (v8.5.0.1)  - SetOption110 - disable Zigbee auto-config when pairing new devices
     uint32_t spare29 : 1;                  // bit 29
     uint32_t spare30 : 1;                  // bit 30
     uint32_t spare31 : 1;                  // bit 31

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -36,6 +36,10 @@ public:
   char *                manufacturerId;
   char *                modelId;
   char *                friendlyName;
+  // _defer_last_time : what was the last time an outgoing message is scheduled
+  // this is designed for flow control and avoid messages to be lost or unanswered
+  uint32_t              defer_last_message_sent;
+
   uint8_t               endpoints[endpoints_max];   // static array to limit memory consumption, list of endpoints until 0x00 or end of array
   // Used for attribute reporting
   Z_attribute_list      attr_list;
@@ -78,6 +82,7 @@ public:
     manufacturerId(nullptr),
     modelId(nullptr),
     friendlyName(nullptr),
+    defer_last_message_sent(0),
     endpoints{ 0, 0, 0, 0, 0, 0, 0, 0 },
     attr_list(),
     shortaddr(_shortaddr),
@@ -145,21 +150,28 @@ public:
  * Structures for deferred callbacks
 \*********************************************************************************************/
 
-typedef int32_t (*Z_DeviceTimer)(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value);
+typedef void (*Z_DeviceTimer)(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value);
 
 // Category for Deferred actions, this allows to selectively remove active deferred or update them
 typedef enum Z_Def_Category {
-  Z_CAT_NONE = 0,             // no category, it will happen anyways
+  Z_CAT_ALWAYS = 0,           // no category, it will happen whatever new timers
+  // Below will clear any event in the same category for the same address (shortaddr / groupaddr)
+  Z_CLEAR_DEVICE = 0x01,
   Z_CAT_READ_ATTR,            // Attribute reporting, either READ_ATTRIBUTE or REPORT_ATTRIBUTE, we coalesce all attributes reported if we can
   Z_CAT_VIRTUAL_OCCUPANCY,    // Creation of a virtual attribute, typically after a time-out. Ex: Aqara presence sensor
   Z_CAT_REACHABILITY,         // timer set to measure reachability of device, i.e. if we don't get an answer after 1s, it is marked as unreachable (for Alexa)
-  Z_CAT_READ_0006,            // Read 0x0006 cluster
-  Z_CAT_READ_0008,            // Read 0x0008 cluster
-  Z_CAT_READ_0102,            // Read 0x0300 cluster
-  Z_CAT_READ_0300,            // Read 0x0300 cluster
+  // Below will clear based on device + cluster pair.
+  Z_CLEAR_DEVICE_CLUSTER,
+  Z_CAT_READ_CLUSTER,
+  // Below will clear based on device + cluster + endpoint
+  Z_CLEAR_DEVICE_CLUSTER_ENDPOINT,
+  Z_CAT_EP_DESC,              // read endpoint descriptor to gather clusters
+  Z_CAT_BIND,                 // send auto-binding to coordinator
+  Z_CAT_CONFIG_ATTR,          // send a config attribute reporting request
+  Z_CAT_READ_ATTRIBUTE,       // read a single attribute
 } Z_Def_Category;
 
-const uint32_t Z_CAT_REACHABILITY_TIMEOUT = 1000;     // 1000 ms or 1s
+const uint32_t Z_CAT_REACHABILITY_TIMEOUT = 2000;     // 1000 ms or 1s
 
 typedef struct Z_Deferred {
   // below are per device timers, used for example to query the new state of the device
@@ -258,8 +270,9 @@ public:
   bool isHueBulbHidden(uint16_t shortaddr) const ;
 
   // Timers
-  void resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category);
+  void resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster = 0xFFFF, uint8_t endpoint = 0xFF);
   void setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func);
+  void queueTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func);
   void runTimer(void);
 
   // Append or clear attributes Json structure
@@ -723,12 +736,17 @@ bool Z_Devices::isHueBulbHidden(uint16_t shortaddr) const {
 
 // Deferred actions
 // Parse for a specific category, of all deferred for a device if category == 0xFF
-void Z_Devices::resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category) {
+// Only with specific cluster number or for all clusters if cluster == 0xFFFF
+void Z_Devices::resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster, uint8_t endpoint) {
   // iterate the list of deferred, and remove any linked to the shortaddr
   for (auto & defer : _deferred) {
     if ((defer.shortaddr == shortaddr) && (defer.groupaddr == groupaddr)) {
       if ((0xFF == category) || (defer.category == category)) {
-        _deferred.remove(&defer);
+        if ((0xFFFF == cluster) || (defer.cluster == cluster)) {
+          if ((0xFF == endpoint) || (defer.endpoint == endpoint)) {
+            _deferred.remove(&defer);
+          }
+        }
       }
     }
   }
@@ -737,8 +755,8 @@ void Z_Devices::resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uin
 // Set timer for a specific device
 void Z_Devices::setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
   // First we remove any existing timer for same device in same category, except for category=0x00 (they need to happen anyway)
-  if (category) {     // if category == 0, we leave all previous
-    resetTimersForDevice(shortaddr, groupaddr, category);    // remove any cluster
+  if (category >= Z_CLEAR_DEVICE) {     // if category == 0, we leave all previous timers
+    resetTimersForDevice(shortaddr, groupaddr, category, category >= Z_CLEAR_DEVICE_CLUSTER ? cluster : 0xFFFF, category >= Z_CLEAR_DEVICE_CLUSTER_ENDPOINT ? endpoint : 0xFF);    // remove any cluster
   }
 
   // Now create the new timer
@@ -751,6 +769,21 @@ void Z_Devices::setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_m
                           category,
                           value,
                           func };
+}
+
+// Set timer after the already queued events
+// I.e. the wait_ms is not counted from now, but from the last event queued, which is 'now' or in the future
+void Z_Devices::queueTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
+  Z_Device & device = getShortAddr(shortaddr);
+  uint32_t now_millis = millis();
+  if (TimeReached(device.defer_last_message_sent)) {
+    device.defer_last_message_sent = now_millis;
+  }
+  // defer_last_message_sent equals now or a value in the future
+  device.defer_last_message_sent += wait_ms;
+
+  // for queueing we don't clear the backlog, so we force category to Z_CAT_ALWAYS
+  setTimer(shortaddr, groupaddr, (device.defer_last_message_sent - now_millis), cluster, endpoint, Z_CAT_ALWAYS, value, func);
 }
 
 // Run timer at each tick

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -533,7 +533,11 @@ int32_t Z_ReceiveActiveEp(int32_t res, const class SBuffer &buf) {
 #endif
 
   for (uint32_t i = 0; i < activeEpCount; i++) {
-    zigbee_devices.addEndpoint(nwkAddr, activeEpList[i]);
+    uint8_t ep = activeEpList[i];
+    zigbee_devices.addEndpoint(nwkAddr, ep);
+    if ((i < 4) && (ep < 0x10)) {
+      zigbee_devices.queueTimer(nwkAddr, 0 /* groupaddr */, 1500, ep /* fake cluster as ep */, ep, Z_CAT_EP_DESC, 0 /* value */, &Z_SendSimpleDescReq);
+    }
   }
 
   Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
@@ -546,7 +550,132 @@ int32_t Z_ReceiveActiveEp(int32_t res, const class SBuffer &buf) {
   ResponseAppend_P(PSTR("]}}"));
   MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZCL_RECEIVED));
 
-  Z_SendAFInfoRequest(nwkAddr);       // probe for ModelId and ManufId
+  Z_SendDeviceInfoRequest(nwkAddr);       // probe for ModelId and ManufId
+
+  return -1;
+}
+
+// list of clusters that need bindings
+const uint8_t Z_bindings[] PROGMEM = {
+  Cx0001, Cx0006, Cx0008, Cx0300,
+  Cx0400, Cx0402, Cx0403, Cx0405, Cx0406,
+  Cx0500,
+};
+
+int32_t Z_ClusterToCxBinding(uint16_t cluster) {
+  uint8_t cx = ClusterToCx(cluster);
+  for (uint32_t i=0; i<ARRAY_SIZE(Z_bindings); i++) {
+    if (pgm_read_byte(&Z_bindings[i]) == cx) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void Z_AutoBindDefer(uint16_t shortaddr, uint8_t endpoint, const SBuffer &buf,
+                    size_t in_index, size_t in_len, size_t out_index, size_t out_len) {
+  // We use bitmaps to mark clusters that need binding and config attributes
+  // All clusters in 'in' and 'out' are bounded
+  // Only cluster in 'in' receive configure attribute requests
+  uint32_t cluster_map = 0;     // max 32 clusters to bind
+  uint32_t cluster_in_map = 0;  // map of clusters only in 'in' group, to be bounded
+
+  // First enumerate all clusters to bind, from in or out clusters
+  // scan in clusters
+  for (uint32_t i=0; i<in_len; i++) {
+    uint16_t cluster = buf.get16(in_index + i*2);
+    uint32_t found_cx = Z_ClusterToCxBinding(cluster);    // convert to Cx of -1 if not found
+    if (found_cx >= 0) {
+      bitSet(cluster_map, found_cx);
+      bitSet(cluster_in_map, found_cx);
+    }
+  }
+  // scan out clusters
+  for (uint32_t i=0; i<out_len; i++) {
+    uint16_t cluster = buf.get16(out_index + i*2);
+    uint32_t found_cx = Z_ClusterToCxBinding(cluster);    // convert to Cx of -1 if not found
+    if (found_cx >= 0) {
+      bitSet(cluster_map, found_cx);
+    }
+  }
+
+  // if IAS device, request the device type
+  if (bitRead(cluster_map, Z_ClusterToCxBinding(0x0500))) {
+    // send a read command to cluster 0x0500, attribute 0x0001 (ZoneType) - to read the type of sensor
+    zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, 0x0500, endpoint, Z_CAT_READ_ATTRIBUTE, 0x0001, &Z_SendSingleAttributeRead);
+  }
+
+  // enqueue bind requests
+  for (uint32_t i=0; i<ARRAY_SIZE(Z_bindings); i++) {
+    if (bitRead(cluster_map, i)) {
+      uint16_t cluster = CxToCluster(pgm_read_byte(&Z_bindings[i]));
+      zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, cluster, endpoint, Z_CAT_BIND, 0 /* value */, &Z_AutoBind);
+    }
+  }
+
+  // enqueue config attribute requests
+  for (uint32_t i=0; i<ARRAY_SIZE(Z_bindings); i++) {
+    if (bitRead(cluster_in_map, i)) {
+      uint16_t cluster = CxToCluster(pgm_read_byte(&Z_bindings[i]));
+      zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, cluster, endpoint, Z_CAT_CONFIG_ATTR, 0 /* value */, &Z_AutoConfigReportingForCluster);
+    }
+  }
+}
+
+int32_t Z_ReceiveSimpleDesc(int32_t res, const class SBuffer &buf) {
+#ifdef USE_ZIGBEE_ZNP
+  // Received ZDO_SIMPLE_DESC_RSP
+  // Z_ShortAddress    srcAddr = buf.get16(2);
+  uint8_t           status  = buf.get8(4);
+  Z_ShortAddress    nwkAddr = buf.get16(5);
+  uint8_t           lenDescriptor = buf.get8(7);
+  uint8_t           endpoint = buf.get8(8);
+  uint16_t          profileId = buf.get16(9);  // The profile Id for this endpoint.
+  uint16_t          deviceId = buf.get16(11);   // The Device Description Id for this endpoint.
+  uint8_t           deviceVersion = buf.get8(13); // 0 – Version 1.00
+  uint8_t           numInCluster = buf.get8(14);
+  uint8_t           numOutCluster = buf.get8(15 + numInCluster*2);
+  const size_t      numInIndex = 15;
+  const size_t      numOutIndex = 16 + numInCluster*2;
+#endif
+#ifdef USE_ZIGBEE_EZSP
+  uint8_t           status = buf.get8(0);
+  Z_ShortAddress    nwkAddr = buf.get16(1);
+  uint8_t           lenDescriptor = buf.get8(3);
+  uint8_t           endpoint = buf.get8(4);
+  uint16_t          profileId = buf.get16(5);  // The profile Id for this endpoint.
+  uint16_t          deviceId = buf.get16(7);   // The Device Description Id for this endpoint.
+  uint8_t           deviceVersion = buf.get8(9); // 0 – Version 1.00
+  uint8_t           numInCluster = buf.get8(10);
+  uint8_t           numOutCluster = buf.get8(11 + numInCluster*2);
+  const size_t      numInIndex = 11;
+  const size_t      numOutIndex = 12 + numInCluster*2;
+#endif
+
+  if (0 == status) {
+    if (!Settings.flag4.zb_disable_autobind) {
+      Z_AutoBindDefer(nwkAddr, endpoint, buf, numInIndex, numInCluster, numOutIndex, numOutCluster);
+    }
+
+    Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
+                    "\"Status\":%d,\"Endpoint\":\"0x%02X\""
+                    ",\"ProfileId\":\"0x%04X\",\"DeviceId\":\"0x%04X\",\"DeviceVersion\":%d"
+                    "\"InClusters\":["),
+                    ZIGBEE_STATUS_SIMPLE_DESC, endpoint,
+                    profileId, deviceId, deviceVersion);
+    for (uint32_t i = 0; i < numInCluster; i++) {
+      if (i > 0) { ResponseAppend_P(PSTR(",")); }
+      ResponseAppend_P(PSTR("\"0x%04X\""), buf.get16(numInIndex + i*2));
+    }
+    ResponseAppend_P(PSTR("],\"OutClusters\":["));
+    for (uint32_t i = 0; i < numOutCluster; i++) {
+      if (i > 0) { ResponseAppend_P(PSTR(",")); }
+      ResponseAppend_P(PSTR("\"0x%04X\""), buf.get16(numOutIndex + i*2));
+    }
+    ResponseAppend_P(PSTR("]}}"));
+    MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEEZCL_RECEIVED));
+    XdrvRulesProcess();
+  }
 
   return -1;
 }
@@ -831,7 +960,7 @@ int32_t Z_MgmtBindRsp(int32_t res, const class SBuffer &buf) {
 
     //uint64_t    srcaddr   = buf.get16(idx);     // unused
     uint8_t     srcep     = buf.get8(idx + 8);
-    uint8_t     cluster   = buf.get16(idx + 9);
+    uint16_t    cluster   = buf.get16(idx + 9);
     uint8_t     addrmode  = buf.get8(idx + 11);
     uint16_t    group     = 0x0000;
     uint64_t    dstaddr   = 0;
@@ -960,9 +1089,31 @@ void Z_SendActiveEpReq(uint16_t shortaddr) {
 }
 
 //
-// Send AF Info Request
+// Probe the clusters_out on the first endpoint
 //
-void Z_SendAFInfoRequest(uint16_t shortaddr) {
+// Send ZDO_SIMPLE_DESC_REQ to get full list of supported Clusters for a specific endpoint
+void Z_SendSimpleDescReq(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+#ifdef USE_ZIGBEE_ZNP
+  uint8_t SimpleDescReq[] = { Z_SREQ | Z_ZDO, ZDO_SIMPLE_DESC_REQ,  // 2504
+              Z_B0(shortaddr), Z_B1(shortaddr), Z_B0(shortaddr), Z_B1(shortaddr),
+              endpoint };
+  ZigbeeZNPSend(SimpleDescReq, sizeof(SimpleDescReq));
+#endif
+#ifdef USE_ZIGBEE_EZSP
+  uint8_t SimpleDescReq[] = { Z_B0(shortaddr), Z_B1(shortaddr), endpoint };
+  EZ_SendZDO(shortaddr, ZDO_SIMPLE_DESC_REQ, SimpleDescReq, sizeof(SimpleDescReq));
+#endif
+}
+
+
+//
+// Send AF Info Request
+// Queue requests for the device
+// 1. Request for 'ModelId' and 'Manufacturer': 0000/0005, 0000/0006
+// 2. Auto-bind to coordinator:
+//    Iterate among 
+//
+void Z_SendDeviceInfoRequest(uint16_t shortaddr) {
   uint8_t endpoint = zigbee_devices.findFirstEndpoint(shortaddr);
   if (0x00 == endpoint) { endpoint = 0x01; }    // if we don't know the endpoint, try 0x01
   uint8_t transacid = zigbee_devices.getNextSeqNumber(shortaddr);
@@ -983,6 +1134,170 @@ void Z_SendAFInfoRequest(uint16_t shortaddr) {
   }));
 }
 
+//
+// Send sing attribute read request in Timer
+//
+void Z_SendSingleAttributeRead(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  uint8_t transacid = zigbee_devices.getNextSeqNumber(shortaddr);
+  uint8_t InfoReq[2] = { Z_B0(value), Z_B1(value) };    // list of single attribute
+
+  ZigbeeZCLSend_Raw(ZigbeeZCLSendMessage({
+    shortaddr,
+    0x0000, /* group */
+    cluster /*cluster*/,
+    endpoint,
+    ZCL_READ_ATTRIBUTES,
+    0x0000,  /* manuf */
+    false /* not cluster specific */,
+    true /* response */,
+    transacid,  /* zcl transaction id */
+    InfoReq, sizeof(InfoReq)
+  }));
+}
+
+//
+// Auto-bind some clusters to the coordinator's endpoint 0x01
+//
+void Z_AutoBind(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  uint64_t srcLongAddr = zigbee_devices.getDeviceLongAddr(shortaddr);
+  
+  AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "auto-bind `ZbBind {\"Device\":\"0x%04X\",\"Endpoint\":%d,\"Cluster\":\"0x%04X\"}`"),
+                                  shortaddr, endpoint, cluster);
+#ifdef USE_ZIGBEE_ZNP
+  SBuffer buf(34);
+  buf.add8(Z_SREQ | Z_ZDO);
+  buf.add8(ZDO_BIND_REQ);
+  buf.add16(shortaddr);
+  buf.add64(srcLongAddr);
+  buf.add8(endpoint);
+  buf.add16(cluster);
+  buf.add8(Z_Addr_IEEEAddress);         // DstAddrMode - 0x03 = ADDRESS_64_BIT
+  buf.add64(localIEEEAddr);
+  buf.add8(0x01);   // toEndpoint
+
+  ZigbeeZNPSend(buf.getBuffer(), buf.len());
+#endif // USE_ZIGBEE_ZNP
+
+#ifdef USE_ZIGBEE_EZSP
+  SBuffer buf(24);
+
+  // ZDO message payload (see Zigbee spec 2.4.3.2.2)
+  buf.add64(srcLongAddr);
+  buf.add8(endpoint);
+  buf.add16(cluster);
+  buf.add8(Z_Addr_IEEEAddress);         // DstAddrMode - 0x03 = ADDRESS_64_BIT
+  buf.add64(localIEEEAddr);
+  buf.add8(0x01);   // toEndpoint
+
+  EZ_SendZDO(shortaddr, ZDO_BIND_REQ, buf.buf(), buf.len());
+#endif // USE_ZIGBEE_EZSP
+}
+
+//
+// Auto-bind some clusters to the coordinator's endpoint 0x01
+//
+
+// the structure below indicates which attributes need to be configured for attribute reporting
+typedef struct Z_autoAttributeReporting_t {
+  uint16_t cluster;
+  uint16_t attr_id;
+  uint16_t min_interval;    // minimum interval in seconds (consecutive reports won't happen before this value)
+  uint16_t max_interval;    // maximum interval in seconds (attribut will always be reported after this interval)
+  float    report_change;   // for non discrete attributes, the value change that triggers a report
+} Z_autoAttributeReporting_t;
+
+// Note the attribute must be registered in the converter list, used to retrieve the type of the attribute
+const Z_autoAttributeReporting_t Z_autoAttributeReporting[] PROGMEM = {
+  { 0x0001, 0x0020,   15*60,    15*60,  0.1 },      // BatteryVoltage
+  { 0x0001, 0x0021,   15*60,    15*60,    1 },      // BatteryPercentage
+  { 0x0006, 0x0000,        1,   60*60,    0 },      // Power
+  { 0x0008, 0x0000,        1,   60*60,    5 },      // Dimmer
+  { 0x0300, 0x0000,        1,   60*60,    5 },      // Hue
+  { 0x0300, 0x0001,        1,   60*60,    5 },      // Sat
+  { 0x0300, 0x0003,        1,   60*60,  100 },      // X
+  { 0x0300, 0x0004,        1,   60*60,  100 },      // Y
+  { 0x0300, 0x0007,        1,   60*60,    5 },      // CT
+  { 0x0300, 0x0008,        1,   60*60,    0 },      // ColorMode
+  { 0x0400, 0x0000,       10,   60*60,    5 },      // Illuminance (5 lux)
+  { 0x0402, 0x0000,       30,   60*60,  0.2 },      // Temperature (0.2 °C)
+  { 0x0403, 0x0000,       30,   60*60,    1 },      // Pressure (1 hPa)
+  { 0x0405, 0x0000,       30,   60*60,  1.0 },      // Humidity (1 %)
+  { 0x0406, 0x0000,       10,   60*60,    0 },      // Occupancy
+  { 0x0500, 0x0002,        1,   60*60,    0 },      // ZoneStatus
+};
+
+//
+// Called by Device Auto-config
+// Configures default values for the most common Attribute Rerporting configurations
+//
+// Note: must be of type `Z_DeviceTimer`
+void Z_AutoConfigReportingForCluster(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  // Buffer, max 12 bytes per attribute
+  SBuffer buf(12*6);
+
+
+  Response_P(PSTR("ZbSend {\"Device\":\"0x%04X\",\"Config\":{"), shortaddr);
+
+  boolean comma = false;
+  for (uint32_t i=0; i<ARRAY_SIZE(Z_autoAttributeReporting); i++) {
+    uint16_t conv_cluster = pgm_read_word(&(Z_autoAttributeReporting[i].cluster));
+    uint16_t attr_id = pgm_read_word(&(Z_autoAttributeReporting[i].attr_id));
+
+    if (conv_cluster == cluster) {
+      uint16_t min_interval = pgm_read_word(&(Z_autoAttributeReporting[i].min_interval));
+      uint16_t max_interval = pgm_read_word(&(Z_autoAttributeReporting[i].max_interval));
+      float  report_change_raw = Z_autoAttributeReporting[i].report_change;
+      double report_change = report_change_raw;
+      uint8_t attr_type;
+      int8_t  multiplier;
+
+      const __FlashStringHelper* attr_name = zigbeeFindAttributeById(cluster, attr_id, &attr_type, &multiplier);
+
+      if (attr_name) {
+        if (comma) { ResponseAppend_P(PSTR(",")); }
+        comma = true;
+        ResponseAppend_P(PSTR("\"%s\":{\"MinInterval\":%d,\"MaxInterval\":%d"), attr_name, min_interval, max_interval);
+
+        buf.add8(0);            // direction, always 0
+        buf.add16(attr_id);
+        buf.add8(attr_type);
+        buf.add16(min_interval);
+        buf.add16(max_interval);
+        if (!Z_isDiscreteDataType(attr_type)) {   // report_change is only valid for non-discrete data types (numbers)
+          ZbApplyMultiplier(report_change, multiplier);
+          // encode value
+          int32_t res = encodeSingleAttribute(buf, report_change, "", attr_type);
+          if (res < 0) {
+            AddLog_P2(LOG_LEVEL_ERROR, PSTR(D_LOG_ZIGBEE "internal error, unsupported attribute type"));
+          } else {
+            Z_attribute attr;
+            attr.setKeyName(PSTR("ReportableChange"), true);    // true because in PMEM
+            attr.setFloat(report_change_raw);
+            ResponseAppend_P(PSTR(",%s"), attr.toString().c_str());
+          }
+        }
+        ResponseAppend_P(PSTR("}"));
+      }
+    }
+  }
+  ResponseAppend_P(PSTR("}}"));
+
+  if (buf.len() > 0) {
+    AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "auto-bind `%s`"), mqtt_data);
+    ZigbeeZCLSend_Raw(ZigbeeZCLSendMessage({
+      shortaddr,
+      0x0000, /* group */
+      cluster /*cluster*/,
+      endpoint,
+      ZCL_CONFIGURE_REPORTING,
+      0x0000,  /* manuf */
+      false /* not cluster specific */,
+      false /* no response */,
+      zigbee_devices.getNextSeqNumber(shortaddr),  /* zcl transaction id */
+      buf.buf(), buf.len()
+    }));
+  }
+}
 
 //
 // Handle trustCenterJoinHandler
@@ -1189,6 +1504,8 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
         return Z_ReceiveActiveEp(res, zdo_buf);
       case ZDO_IEEE_addr_rsp:
         return Z_ReceiveIEEEAddr(res, zdo_buf);
+      case ZDO_Simple_Desc_rsp:
+        return Z_ReceiveSimpleDesc(res, zdo_buf);
       case ZDO_Bind_rsp:
         return Z_BindRsp(res, zdo_buf);
       case ZDO_Unbind_rsp:
@@ -1279,9 +1596,8 @@ int32_t EZ_Recv_Default(int32_t res, const class SBuffer &buf) {
 \*********************************************************************************************/
 
 // Publish the received values once they have been coalesced
-int32_t Z_PublishAttributes(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+void Z_PublishAttributes(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
   zigbee_devices.jsonPublishFlush(shortaddr);
-  return 1;
 }
 
 /*********************************************************************************************\
@@ -1363,6 +1679,7 @@ const Z_Dispatcher Z_DispatchTable[] PROGMEM = {
   { { Z_AREQ | Z_ZDO, ZDO_PERMIT_JOIN_IND },        &ZNP_ReceivePermitJoinStatus },   // 45CB
   { { Z_AREQ | Z_ZDO, ZDO_NODE_DESC_RSP },          &ZNP_ReceiveNodeDesc },           // 4582
   { { Z_AREQ | Z_ZDO, ZDO_ACTIVE_EP_RSP },          &Z_ReceiveActiveEp },             // 4585
+  { { Z_AREQ | Z_ZDO, ZDO_SIMPLE_DESC_RSP},         &Z_ReceiveSimpleDesc},            // 4584
   { { Z_AREQ | Z_ZDO, ZDO_IEEE_ADDR_RSP },          &Z_ReceiveIEEEAddr },             // 4581
   { { Z_AREQ | Z_ZDO, ZDO_BIND_RSP },               &Z_BindRsp },                   // 45A1
   { { Z_AREQ | Z_ZDO, ZDO_UNBIND_RSP },             &Z_UnbindRsp },                 // 45A2
@@ -1413,11 +1730,11 @@ void Z_Query_Bulb(uint16_t shortaddr, uint32_t &wait_ms) {
     uint8_t endpoint = zigbee_devices.findFirstEndpoint(shortaddr);
 
     if (endpoint) {   // send only if we know the endpoint
-      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0006, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0006, endpoint, Z_CAT_READ_CLUSTER, 0 /* value */, &Z_ReadAttrCallback);
       wait_ms += inter_message_ms;
-      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0008, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0008, endpoint, Z_CAT_READ_CLUSTER, 0 /* value */, &Z_ReadAttrCallback);
       wait_ms += inter_message_ms;
-      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0300, endpoint, Z_CAT_NONE, 0 /* value */, &Z_ReadAttrCallback);
+      zigbee_devices.setTimer(shortaddr, 0 /* groupaddr */, wait_ms, 0x0300, endpoint, Z_CAT_READ_CLUSTER, 0 /* value */, &Z_ReadAttrCallback);
       wait_ms += inter_message_ms;
       zigbee_devices.setTimer(shortaddr, 0, wait_ms + Z_CAT_REACHABILITY_TIMEOUT, 0, endpoint, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
       wait_ms += 1000;              // wait 1 second between devices


### PR DESCRIPTION
## Description:

**MAJOR ZIGBEE FEATURE: auto-config**

**What does it mean?** Simply that most devices won't need any configuration and work out-of-the box with this auto-binding and auto-config.

This feature was tested successfully on all my Zigbee devices. However there may be some glitches.

To disable this auto-config mode, use `SetOption110 1`. To re-enable it use `SetOption110 0`.

### Why this feature?

While Xiaomi Aqara sensors generally require no configuration and automatically report values to the coordinator, other brands like Sonoff or Philips require that you 'bind' the device to the coordinator and potentially ask for attributes via `Attribute Reporting Configuration`. This wouls require `Zbbind` commands and `ZbSend {..."Config":{...}}` commands. While this is cumbersome and error-prone, it can be challenging with battery powered device: you need to wake-up the device for a few seconds when sending those commands.

Z2T is now releasing automatic configuration for the most commonly used Zigbee features.

This feature works for the following clusters and attributes:
- 0x0001 (Battery): `BatteryVoltage`, `BatteryPercentage`
- 0x0006 (On/Off): `Power`
- 0x0008 (Dimmer): `Dimmer`
- 0x0300 (Color): `Hue`, `Sat`, `X`, `Y`, `CT`, `ColorMode`
- 0x0400 (Illuminance): `Illuminance`
- 0x0402 (Temperature): `Temperature`
- 0x0403 (Pressure): `Pressure`
- 0x0405 (Humidity): `Humidity`
- 0x0406 (Occupancy): `Occupancy`
- 0x0500 (IAS): `ZoneStatus`, `Occupancy`

### How does it work? (internals for those who are interested)

The limited resources of ESP8266 means that we can't afford to have a list of devices and brands like Zigbee2MQTT does. So we need a more programmatic way of 'guessing' what configuration the device needs. Fortunately, the Zigbee ZCL standard provides us tools to query a new device about its capabilities.

This auto-binding happens whenever it receives a `Device Announce` message which happens when a device first pairs to the coordinator, when it automatically re-pairs if it was disconnected for a long time, or when you send the `ZbProbe`command.

For the example below, I will use an OSRAM mini-remote.

Z2T will first request the list of endpoints of the device:
```
{"ZbState":{"Status":32,"ActiveEndpoints":["0x01","0x02","0x03"]}}
```

Then it will query endpoints for clusters of interest. To reduce the noise of vendor-specifc features, we limit to the first 4 endpoints if their numbers are below 0x10 (high numbered endpoints are often vendor specific). These queries shows for each endpoint the clusters accepting messages (InClusters) or sending messages (OutClusters):

```
{"ZbState":{"Status":33,"Endpoint":"0x01","ProfileId":"0x0104","DeviceId":"0x0810","DeviceVersion":2"InClusters":["0x0000","0x0001","0x0020","0x1000","0xFD00"],"OutClusters":["0x0003","0x0004","0x0005","0x0006","0x0008","0x0019","0x0300","0x1000"]}}
{"ZbState":{"Status":33,"Endpoint":"0x02","ProfileId":"0x0104","DeviceId":"0x0810","DeviceVersion":2"InClusters":["0x0000","0x1000","0xFD00"],"OutClusters":["0x0003","0x0004","0x0005","0x0006","0x0008","0x0300","0x1000"]}}
{"ZbState":{"Status":33,"Endpoint":"0x03","ProfileId":"0x0104","DeviceId":"0x0810","DeviceVersion":2"InClusters":["0x0000","0x1000","0xFD00"],"OutClusters":["0x0003","0x0004","0x0005","0x0006","0x0008","0x0300","0x1000"]}}
```

Note: `InClusters` typically contain attribute value and sensors, while `OutClusters` contain clusters for which the device may send commands (like a remote).

Then it will send commands to bind all clusters in the above list from endpoints to the coordinator:
```
ZIG: auto-bind `ZbBind {"Device":"0x0708","Endpoint":1,"Cluster":"0x0001"}`
RSL: RESULT = {"ZbBind":{"Device":"0x0708","Status":0,"StatusMessage":"SUCCESS"}}
ZIG: auto-bind `ZbBind {"Device":"0x0708","Endpoint":1,"Cluster":"0x0006"}`
RSL: RESULT = {"ZbBind":{"Device":"0x0708","Status":0,"StatusMessage":"SUCCESS"}}
ZIG: auto-bind `ZbBind {"Device":"0x0708","Endpoint":1,"Cluster":"0x0008"}`
RSL: RESULT = {"ZbBind":{"Device":"0x0708","Status":0,"StatusMessage":"SUCCESS"}}
ZIG: auto-bind `ZbBind {"Device":"0x0708","Endpoint":1,"Cluster":"0x0300"}`
RSL: RESULT = {"ZbBind":{"Device":"0x0708","Status":0,"StatusMessage":"SUCCESS"}}
....
```

Finally it will configure Attribute Reporting Configuration for attributes of interest (in the above list) and if they appear in the InClusters list.
```
ZIG: auto-bind `ZbSend {"Device":"0x0708","Config":{"BatteryVoltage":{"MinInterval":900,"MaxInterval":900,"ReportableChange":0.1},"BatteryPercentage":{"MinInterval":900,"MaxInterval":900,"ReportableChange":1}}}`
RSL: SENSOR = {"ZbReceived":{"0x0708":{"Device":"0x0708","ConfigResponse":{"BatteryPercentage":{"Status":134,"StatusMsg":"UNSUPPORTED_ATTRIBUTE"}},"Endpoint":1,"LinkQuality":99}}}
```

In the example above, attribute configuration was sent for 2 attributes: `BatteryVoltage` and `BatteryPercentage`. The response shows `UNSUPPORTED_ATTRIBUTE` error only for `BatteryPercentage` attribute and no error for `BatteryVoltage`. This is nothing to worry about, just that we won't get values for `BatteryPercentage`.

### Example: Sonoff SNZB-02 Temperature/Humidity sensor

Here is the pairing and auto-config sequence for Sonoff SNZB-02:
```
10:20:09 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":34,"IEEEAddr":"0x00124B001F841E41","ShortAddr":"0x7E87","ParentNetwork":"0x0000","Status":1,"Decision":0}}
10:20:10 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":30,"IEEEAddr":"0x00124B001F841E41","ShortAddr":"0x7E87","PowerSource":false,"ReceiveWhenIdle":false,"Security":false}}
10:20:11 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":32,"ActiveEndpoints":["0x01"]}}
10:20:11 MQT: tele/tasmota/ZBBridge/SENSOR = {"Sonoff_Temp":{"Device":"0x7E87","Name":"Sonoff_Temp","Manufacturer":"eWeLink","ModelId":"TH01","Endpoint":1,"LinkQuality":145}}
10:20:13 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbState":{"Status":33,"Endpoint":"0x01","ProfileId":"0x0104","DeviceId":"0x0302","DeviceVersion":0"InClusters":["0x0000","0x0003","0x0402","0x0405","0x0001"],"OutClusters":["0x0003"]}}
10:20:15 ZIG: auto-bind `ZbBind {"Device":"0x7E87","Endpoint":1,"Cluster":"0x0001"}`
10:20:15 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbBind":{"Device":"0x7E87","Name":"Sonoff_Temp","Status":0,"StatusMessage":"SUCCESS"}}
10:20:17 ZIG: auto-bind `ZbBind {"Device":"0x7E87","Endpoint":1,"Cluster":"0x0402"}`
10:20:17 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbBind":{"Device":"0x7E87","Name":"Sonoff_Temp","Status":0,"StatusMessage":"SUCCESS"}}
10:20:19 ZIG: auto-bind `ZbBind {"Device":"0x7E87","Endpoint":1,"Cluster":"0x0405"}`
10:20:20 MQT: tele/tasmota/ZBBridge/RESULT = {"ZbBind":{"Device":"0x7E87","Name":"Sonoff_Temp","Status":0,"StatusMessage":"SUCCESS"}}
10:20:21 ZIG: auto-bind `ZbSend {"Device":"0x7E87","Config":{"BatteryVoltage":{"MinInterval":900,"MaxInterval":900,"ReportableChange":0.1},"BatteryPercentage":{"MinInterval":900,"MaxInterval":900,"ReportableChange":1}}}`
10:20:22 MQT: tele/tasmota/ZBBridge/SENSOR = {"Sonoff_Temp":{"Device":"0x7E87","Name":"Sonoff_Temp","ConfigResponse":{},"Endpoint":1,"LinkQuality":145}}
10:20:23 ZIG: auto-bind `ZbSend {"Device":"0x7E87","Config":{"Temperature":{"MinInterval":30,"MaxInterval":3600,"ReportableChange":0.2}}}`
10:20:23 MQT: tele/tasmota/ZBBridge/SENSOR = {"Sonoff_Temp":{"Device":"0x7E87","Name":"Sonoff_Temp","ConfigResponse":{},"Endpoint":1,"LinkQuality":147}}
10:20:25 ZIG: auto-bind `ZbSend {"Device":"0x7E87","Config":{"Humidity":{"MinInterval":30,"MaxInterval":3600,"ReportableChange":1}}}`
10:20:26 MQT: tele/tasmota/ZBBridge/SENSOR = {"Sonoff_Temp":{"Device":"0x7E87","Name":"Sonoff_Temp","ConfigResponse":{},"Endpoint":1,"LinkQuality":142}}
10:20:30 MQT: tele/tasmota/ZBBridge/SENSOR = {"Sonoff_Temp":{"Device":"0x7E87","Name":"Sonoff_Temp","Temperature":23.74,"Endpoint":1,"LinkQuality":145}}
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
