### PR TITLE
Zigbee minor fixes

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1080,6 +1080,11 @@ void ZCLFrame::generateSyntheticAttributes(Z_attribute_list& attr_list) {
     uint32_t ccccaaaa = (attr.key.id.cluster << 16) | attr.key.id.attr_id;
 
     switch (ccccaaaa) {      // 0xccccaaaa . c=cluster, a=attribute
+      case 0x00010020:       // BatteryVoltage
+        if (attr_list.countAttribute(0x0001,0x0021) == 0) {   // if it does not already contain BatteryPercentage
+          uint32_t mv = attr.getUInt()*100;
+          attr_list.addAttribute(0x0001, 0x0021).setUInt(toPercentageCR2032(mv) * 2);
+        }
       case 0x0000FF01:
         syntheticAqaraSensor(attr_list, attr);
         break;

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1774,7 +1774,7 @@ void Z_AutoResponder(uint16_t srcaddr, uint16_t cluster, uint8_t endpoint, const
 
   for (uint32_t i=0; i<attr_len; i++) {
     uint16_t attr = attr_list[i];
-    uint32_t ccccaaaa = (cluster << 16) || attr;
+    uint32_t ccccaaaa = (cluster << 16) | attr;
 
     switch (ccccaaaa) {
       case 0x00000004: json_out[F("Manufacturer")] = F(USE_ZIGBEE_MANUFACTURER);  break;    // Manufacturer

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -556,6 +556,7 @@ void ZbSendRead(const JsonVariant &val_attr, uint16_t device, uint16_t groupaddr
 
   uint16_t val = strToUInt(val_attr);
   if (val_attr.is<JsonArray>()) {
+    // value is an array []
     const JsonArray& attr_arr = val_attr.as<const JsonArray&>();
     attrs_len = attr_arr.size() * attr_item_len;
     attrs = (uint8_t*) calloc(attrs_len, 1);
@@ -569,6 +570,7 @@ void ZbSendRead(const JsonVariant &val_attr, uint16_t device, uint16_t groupaddr
       i += attr_item_len - 2 - attr_item_offset;    // normally 0
     }
   } else if (val_attr.is<JsonObject>()) {
+    // value is an object {}
     const JsonObject& attr_obj = val_attr.as<const JsonObject&>();
     attrs_len = attr_obj.size() * attr_item_len;
     attrs = (uint8_t*) calloc(attrs_len, 1);
@@ -619,10 +621,13 @@ void ZbSendRead(const JsonVariant &val_attr, uint16_t device, uint16_t groupaddr
 
     attrs_len = actual_attr_len;
   } else {
-    attrs_len = attr_item_len;
-    attrs = (uint8_t*) calloc(attrs_len, 1);
-    attrs[0 + attr_item_offset] = val & 0xFF;    // little endian
-    attrs[1 + attr_item_offset] = val >> 8;
+    // value is a literal
+    if (0xFFFF != cluster) {
+      attrs_len = attr_item_len;
+      attrs = (uint8_t*) calloc(attrs_len, 1);
+      attrs[0 + attr_item_offset] = val & 0xFF;    // little endian
+      attrs[1 + attr_item_offset] = val >> 8;
+    }
   }
 
   if (attrs_len > 0) {


### PR DESCRIPTION
## Description:

- generate a synthetic `BatteryPercentage` attribute if only `BatteryVoltage` is present
- auto-responder was not working
-fix in parsing wrong attributes for Read and ReadConfig

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
