### PR TITLE
Fix TLS crash

### DIFF
--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -874,10 +874,8 @@ extern "C" {
 		// we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
 		br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15);    // TODO
 #endif
-#ifdef USE_MQTT_AWS_IOT_LIGHT
     static const char * alpn_mqtt = "mqtt";
     br_ssl_engine_set_protocol_names(&cc->eng, &alpn_mqtt, 1);
-#endif
   }
 }
 


### PR DESCRIPTION
## Description:

Fixes TLS crash in two situations:
- enabling MQTT `SetOption3 1` while TLS tries to connect just before reboot
- when private certificate is not set

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
