### PR TITLE
Use for Tasmota stage, core 2.7.4.2

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -88,7 +88,7 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
 platform                  = espressif8266@2.6.2
-platform_packages         = jason2866/framework-arduinoespressif8266
+platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino.git#2.7.4.2
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 


### PR DESCRIPTION
core 2.7.4.2 includes some backports from arduino / master
https://github.com/esp8266/Arduino/pull/7547
https://github.com/esp8266/Arduino/pull/7586
https://github.com/esp8266/Arduino/pull/7585
https://github.com/esp8266/Arduino/pull/7595

Feedback welcome for the changes. Curios if other stuff is broken ;-) 

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
