### PR TITLE
Prep for Official Home Assistant Discovery 

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -557,7 +557,7 @@ struct {
   uint16_t      dimmer_hw_min;             // E90
   uint16_t      dimmer_hw_max;             // E92
   uint32_t      deepsleep;                 // E94
-  uint16_t      ex2_energy_power_delta;    // E98 - Free since 8.4.0.3
+  uint16_t      hass_new_discovery;       // E98 - ex2_energy_power_delta on 8.4.0.3, replaced on 8.5.0.1
   uint8_t       shutter_motordelay[MAX_SHUTTERS];    // E9A
   int8_t        temp_comp;                 // E9E
   uint8_t       weight_change;             // E9F
@@ -613,7 +613,8 @@ struct {
   uint16_t      energy_power_delta[3];     // F44
   uint16_t      shutter_pwmrange[2][MAX_SHUTTERS];  // F4A
 
-  uint8_t       free_f5a[90];             // F5A - Decrement if adding new Setting variables just above and below
+  
+  uint8_t       free_f5a[89];             // F5A - Decrement if adding new Setting variables just above and below
 
   // Only 32 bit boundary variables below
   SysBitfield5  flag5;                     // FB4

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1356,7 +1356,7 @@ void SettingsDelta(void)
       Settings.ex_sbaudrate = 0;
 */
       Settings.flag3.fast_power_cycle_disable = 0;
-      Settings.ex2_energy_power_delta = Settings.tuyamcu_topic;
+      Settings.hass_new_discovery = Settings.tuyamcu_topic; // replaced ex2_energy_power_delta on 8.5.0.1
       Settings.tuyamcu_topic = 0; // replaced ex_energy_power_delta on 8.5.0.1
     }
     if (Settings.version < 0x06060015) {
@@ -1514,7 +1514,7 @@ void SettingsDelta(void)
       Settings.fallback_module = FALLBACK_MODULE;
     }
     if (Settings.version < 0x08040003) {
-      Settings.energy_power_delta[0] = Settings.ex2_energy_power_delta;
+      Settings.energy_power_delta[0] = Settings.hass_new_discovery; // replaced ex2_energy_power_delta on 8.5.0.1
       Settings.energy_power_delta[1] = 0;
       Settings.energy_power_delta[2] = 0;
     }


### PR DESCRIPTION
## Description:
The new discovery joins the classic offered by Tasmota, a feature that will remain active indefinitely.
**Although `SetOption19` will remain available as a setting, please consider it deprecated**. Use the new command `HaDis` instead.
Usage: `HaDis 0|1|2`
`0`and `1` will mimic the behavior of `SetOption19` (the same is true in the other sense) but when set to `2` it will enable the new discovery, still WIP. The new command will be expanded even more in the future.
Although it is possible to change the value manually, HA will handle the flag remotely for you.
The new discovery will send al the needed information at `MQTT INIT` time (commonly at boot time) to the broker, no other information will be sent out until the user confirm the discovery for a device under Home Assistant. The topic will be transmitted just when `HaDis | SetOption19` is set to `0`.

@arendst : I've reused the old E98 on `Settings.h`

**Related issue (if applicable):** fixes # None

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
