### PR TITLE
Remove not needed, add stage core32 in Platformio override file

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -36,7 +36,6 @@ default_envs =
 
 
 [common]
-platform                  = ${core.platform}
 platform_packages         = ${core.platform_packages}
 build_unflags             = ${core.build_unflags}
 build_flags               = ${core.build_flags}
@@ -74,20 +73,17 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 [core]
 ; Activate only (one set) if you want to override the standard core defined in platformio.ini !!!
 
-;platform                  = ${tasmota_stage.platform}
 ;platform_packages         = ${tasmota_stage.platform_packages}
 ;build_unflags             = ${tasmota_stage.build_unflags}
 ;build_flags               = ${tasmota_stage.build_flags}
 
-;platform                  = ${core_stage.platform}
-;platform_packages         = ${core_stage.platform_packages}
-;build_unflags             = ${core_stage.build_unflags}
-;build_flags               = ${core_stage.build_flags}
+platform_packages         = ${core_stage.platform_packages}
+build_unflags             = ${core_stage.build_unflags}
+build_flags               = ${core_stage.build_flags}
 
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-platform                  = espressif8266@2.6.2
 platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino.git#2.7.4.2
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
@@ -123,9 +119,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core version. Tasmota stage or Arduino stage version. Built with GCC 10.1 toolchain
-platform                  = espressif8266@2.6.2
-platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/framework-arduinoespressif8266-3.20900.0.tar.gz
-                            ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/framework-arduinoespressif8266-3.20900.0.tar.gz
+                            framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
                             toolchain-xtensa @ ~2.100100.0
 build_unflags             = ${esp_defaults.build_unflags}
                             -Wswitch-unreachable
@@ -158,6 +153,16 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Exception code in firmware /needs much space!
 ;                           -fexceptions
 ;                           -lstdc++-exc
+
+
+[core32]
+; Activate Stage Core32 by removing ";" in next line, if you want to override the standard core32
+;platform_packages       = ${core32_stage.platform_packages}
+
+
+[core32_stage]
+platform_packages       = tool-esptoolpy@1.20800.0
+                          arduino-esp32@https://github.com/espressif/arduino-esp32.git#esp32s2
 
 
 ; *** Debug version used for PlatformIO Home Project Inspection

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -39,9 +39,13 @@ default_envs =  ${build_envs.default_envs}
 ;                tasmota32-UK
 
 
-[common32]
+[core32]
 platform                = espressif32@2.0.0
 platform_packages       = tool-esptoolpy@1.20800.0
+
+[common32]
+platform                = ${core32.platform}
+platform_packages       = ${core32.platform_packages}
 board                   = esp32dev
 board_build.ldscript    = esp32_out.ld
 board_build.partitions  = esp32_partition_app1984k_spiffs64k.csv


### PR DESCRIPTION
not needed entrys removed. Added stage core32 as possibility to select in Platformio override file

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
