### PR TITLE
Added SetOption112 - Use friendly name in zigbee topic

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -131,7 +131,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t alexa_gen_1 : 1;              // bit 27 (v8.4.0.3)  - SetOption109 - Alexa gen1 mode - if you only have Echo Dot 2nd gen devices
     uint32_t zb_disable_autobind : 1;      // bit 28 (v8.5.0.1)  - SetOption110 - disable Zigbee auto-config when pairing new devices
     uint32_t buzzer_freq_mode : 1;         // bit 29 (v8.5.0.1)  - SetOption111 - Use frequency output for buzzer pin instead of on/off signal
-    uint32_t spare30 : 1;                  // bit 30
+    uint32_t zb_topic_fname : 1;           // bit 30 (v8.5.0.1)  - SetOption112 - Use friendly name in zigbee topic (use with SetOption89)
     uint32_t spare31 : 1;                  // bit 31
   };
 } SysBitfield4;

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -896,9 +896,15 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
     attr_list.reset();    // clear the attributes
 
     if (Settings.flag4.zigbee_distinct_topics) {
-      char subtopic[16];
-      snprintf_P(subtopic, sizeof(subtopic), PSTR("%04X/" D_RSLT_SENSOR), shortaddr);
-      MqttPublishPrefixTopic_P(TELE, subtopic, Settings.flag.mqtt_sensor_retain);
+      if (Settings.flag4.zb_topic_fname && fname) {
+        char frtopic[13];
+        snprintf_P(frtopic, sizeof(frtopic) + strlen(fname), PSTR("tele/%s/" D_RSLT_SENSOR), fname);
+        MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
+      } else {
+        char subtopic[16];
+        snprintf_P(subtopic, sizeof(subtopic), PSTR("%04X/" D_RSLT_SENSOR), shortaddr);
+        MqttPublishPrefixTopic_P(TELE, subtopic, Settings.flag.mqtt_sensor_retain);
+      }
     } else {
       MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
     }

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -902,7 +902,7 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
         strlcpy(stemp, (!strlen(fname)) ? MQTT_TOPIC : fname, sizeof(stemp));
         MakeValidMqtt(0, stemp);
         //Create topic with Prefix3 and cleaned up friendly name
-        char frtopic[13 + strlen(stemp)];
+        char frtopic[TOPSZ];
         snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), stemp);
         MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
       } else {

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -897,8 +897,8 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
 
     if (Settings.flag4.zigbee_distinct_topics) {
       if (Settings.flag4.zb_topic_fname && fname) {
-        char frtopic[13];
-        snprintf_P(frtopic, sizeof(frtopic) + strlen(fname), PSTR("tele/%s/" D_RSLT_SENSOR), fname);
+        char frtopic[13 + strlen(fname)];
+        snprintf_P(frtopic, sizeof(frtopic), PSTR("tele/%s/" D_RSLT_SENSOR), fname);
         MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
       } else {
         char subtopic[16];

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -898,7 +898,7 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
     if (Settings.flag4.zigbee_distinct_topics) {
       if (Settings.flag4.zb_topic_fname && fname) {
         char frtopic[13 + strlen(fname)];
-        snprintf_P(frtopic, sizeof(frtopic), PSTR("tele/%s/" D_RSLT_SENSOR), fname);
+        snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), fname);
         MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
       } else {
         char subtopic[16];

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -897,8 +897,13 @@ void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
 
     if (Settings.flag4.zigbee_distinct_topics) {
       if (Settings.flag4.zb_topic_fname && fname) {
-        char frtopic[13 + strlen(fname)];
-        snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), fname);
+        //Clean special characters and check size of friendly name
+        char stemp[TOPSZ];
+        strlcpy(stemp, (!strlen(fname)) ? MQTT_TOPIC : fname, sizeof(stemp));
+        MakeValidMqtt(0, stemp);
+        //Create topic with Prefix3 and cleaned up friendly name
+        char frtopic[13 + strlen(stemp)];
+        snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), stemp);
         MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
       } else {
         char subtopic[16];


### PR DESCRIPTION
Use friendly name in zigbee topic (use with SetOption89)

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
