### PR TITLE
Use specific commit for ESP32 stage

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -162,7 +162,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core32_stage]
 platform_packages       = tool-esptoolpy@1.20800.0
-                          arduino-esp32@https://github.com/espressif/arduino-esp32.git#esp32s2
+                          ; latest working commit
+                          framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#c09ec5bd3d35ba7dfc135755ab300e2b45416def
 
 
 ; *** Debug version used for PlatformIO Home Project Inspection


### PR DESCRIPTION
because with later ones Tasmota32 does not compile.


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
