### PR TITLE
MAC address VAR for rules

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -719,9 +719,13 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%UPTIME%"), String(MinutesUptime()));
       RulesVarReplace(commands, F("%TIMESTAMP%"), GetDateAndTime(DT_LOCAL));
       RulesVarReplace(commands, F("%TOPIC%"), mqtt_topic);
-      char unique_id[7];
-      snprintf_P(unique_id, sizeof(unique_id), PSTR("%06X"), ESP_getChipId());
-      RulesVarReplace(commands, F("%DEVICEID%"), unique_id);
+      snprintf_P(stemp, sizeof(stemp), PSTR("%06X"), ESP_getChipId());
+      RulesVarReplace(commands, F("%DEVICEID%"), stemp);
+      char macaddr[13];
+      String mac_address = WiFi.macAddress();
+      mac_address.replace(":", "");
+      snprintf_P(macaddr, sizeof(macaddr), PSTR("%s"), mac_address.c_str());
+      RulesVarReplace(commands, F("%MACADDR%"), macaddr);
 #if defined(USE_TIMERS) && defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));
       RulesVarReplace(commands, F("%SUNSET%"), String(SunMinutes(1)));


### PR DESCRIPTION
## Description:
Adds full MAC address in hex format `%MACADDR%` as variable to rules. 

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
