### PR TITLE
JSMN iterator fix

### DIFF
--- a/lib/jsmn-shadinger-1.0/src/JsonParser.cpp
+++ b/lib/jsmn-shadinger-1.0/src/JsonParser.cpp
@@ -178,7 +178,7 @@ JsonParserArray::const_iterator::const_iterator(const JsonParserArray t): tok(t)
 }
 
 JsonParserArray::const_iterator JsonParserArray::const_iterator::const_iterator::operator++() {
-  if (remaining == 0) { tok.t = nullptr; }
+  if (remaining <= 1) { tok.t = nullptr; }
   else {
     remaining--;
     tok.skipToken();  // munch value
@@ -234,7 +234,7 @@ JsonParserObject::const_iterator::const_iterator(const JsonParserObject t): tok(
 }
 
 JsonParserObject::const_iterator JsonParserObject::const_iterator::operator++() {
-  if (remaining == 0) { tok.t = nullptr; }
+  if (remaining <= 1) { tok.t = nullptr; }
   else {
     remaining--;
     tok.nextOne();          // munch key
@@ -336,7 +336,7 @@ float JsonParserToken::getFloat(float val) const {
 const char * JsonParserToken::getStr(const char * val) const {
   if (t->type == JSMN_INVALID) { return val; }
   if (t->type == JSMN_NULL) return "";
-  return (t->type >= JSMN_STRING) ? &k_current_json_buffer[t->start] : "";
+  return (t->type >= JSMN_STRING) ? &k_current_json_buffer[t->start] : val;
 }
 
 
@@ -467,6 +467,9 @@ JsonParserToken JsonParserObject::operator[](const char * needle) const {
   return JsonParserToken(&token_bad);
 }
 
+JsonParserToken JsonParserObject::operator[](const String & needle) const {
+  return (*this)[needle.c_str()];
+}
 
 JsonParserToken JsonParserObject::findStartsWith(const char * needle) const {
   // key can be in PROGMEM

--- a/lib/jsmn-shadinger-1.0/src/JsonParser.h
+++ b/lib/jsmn-shadinger-1.0/src/JsonParser.h
@@ -23,6 +23,7 @@
 #include "jsmn.h"
 #include <string.h>
 #include <stdlib.h>
+#include <Arduino.h>
 
 // #define strcmp_P(x, y) strcmp(x,y)
 // #define strcasecmp_P(x,y) strcasecmp(x,y)
@@ -146,10 +147,12 @@ public:
 class JsonParserObject : public JsonParserToken {
 public:
   JsonParserObject(const jsmntok_t * token);
-  explicit JsonParserObject(const JsonParserToken token);
+  JsonParserObject(const JsonParserToken token);
+  JsonParserObject() : JsonParserToken() { }
 
   // find key with name, case-insensitive, '?' matches any key. Returns Invalid Token if not found
   JsonParserToken operator[](const char * needle) const;
+  JsonParserToken operator[](const String & needle) const;
   // find a key starting with `needle`, case insensitive
   JsonParserToken findStartsWith(const char * needle) const;
   // find a key, case-insensitive, return nullptr if not found (instead of "")
@@ -190,6 +193,7 @@ class JsonParserArray : public JsonParserToken {
 public:
   JsonParserArray(const jsmntok_t * token);
   JsonParserArray(const JsonParserToken token);
+  JsonParserArray() : JsonParserToken() { }
 
   // get the element if index `i` from 0 to `size() - 1`
   JsonParserToken operator[](int32_t i) const;


### PR DESCRIPTION
## Description:

The iterator would iterate 1 time too far. Now fixed.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
