### PR TITLE
Zigbee UI: fix line height to 20px

### DIFF
--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1357,6 +1357,7 @@ void ZigbeeShow(bool json)
       ".ztd td:not(:first-child){width:20px;font-size:70%%}"
       ".ztd td:last-child{width:45px}"
       ".ztd .bt{margin-right:10px;}" // Margin right should be half of the not-first width
+      ".htr{line-height:20px}"
       // Lighting
       ".bx{height:14px;width:14px;display:inline-block;border:1px solid currentColor;background-color:var(--cl,#fff)}"
       // Signal Strength Indicator
@@ -1406,7 +1407,7 @@ void ZigbeeShow(bool json)
       }
 
       WSContentSend_PD(PSTR(
-        "<tr class='ztd'>"
+        "<tr class='ztd htr'>"
           "<td><b>%s</b></td>" // name
           "<td>%s</td>" // sbatt (Battery Indicator)
           "<td><div title='" D_LQI " %s' class='ssi'>" // slqi
@@ -1435,7 +1436,7 @@ void ZigbeeShow(bool json)
       bool pressure_ok    = device.validPressure();
 
       if (temperature_ok || humidity_ok || pressure_ok) {
-        WSContentSend_P(PSTR("<tr><td colspan=\"4\">&#9478;"));
+        WSContentSend_P(PSTR("<tr class='htr'><td colspan=\"4\">&#9478;"));
         if (temperature_ok) {
           char buf[12];
           dtostrf(device.temperature / 10.0f, 3, 1, buf);
@@ -1456,7 +1457,7 @@ void ZigbeeShow(bool json)
       if (power_ok) {
         uint8_t channels = device.getLightChannels();
         if (0xFF == channels) { channels = 5; }     // if number of channel is unknown, display all known attributes
-        WSContentSend_P(PSTR("<tr><td colspan=\"4\">&#9478; %s"), device.getPower() ? PSTR(D_ON) : PSTR(D_OFF));
+        WSContentSend_P(PSTR("<tr class='htr'><td colspan=\"4\">&#9478; %s"), device.getPower() ? PSTR(D_ON) : PSTR(D_OFF));
         if (device.validDimmer() && (channels >= 1)) {
           WSContentSend_P(PSTR(" &#128261; %d%%"), changeUIntScale(device.dimmer,0,254,0,100));
         }


### PR DESCRIPTION
## Description:

Sets a consistent line height of 20px to the Zigbee UI.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
