### PR TITLE
MI_ESP32: Improve HA auto discovery

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -967,6 +967,7 @@ void HAssDiscovery(void)
 
   if (Settings.flag.hass_discovery || (1 == hass_mode))
   { // SetOption19 - Control Home Assistantautomatic discovery (See SetOption59)
+    hass_mode = 2;
     // Send info about buttons
     HAssAnnounceButtons();
 
@@ -985,6 +986,7 @@ void HAssDiscovery(void)
     // Send info about status sensor
     HAssAnnounceDeviceInfoAndStatusSensor();
     masterlog_level = 0; // Restores weblog level
+    hass_mode = 3;
   }
 }
 


### PR DESCRIPTION
## Description:

This should improve the auto discovery a lot, but I can only test the output, because I am no HA user.
This adds very minor changes to the home_assistant-driver, which should not interfere and were already seen by @effelle
With many sensors the resulting mqtt message is really huge and I would not be overly surprised, if this may trigger a WDT or something else.

Minor changes:
- key + MAC for decryption are now case insensitive
- saved a few bytes for the MAC presentation in the web UI

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
