### PR TITLE
Fixed last_seen calculation with zigbee devices.

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -645,7 +645,12 @@ void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
 
 void Z_Devices::setLastSeenNow(uint16_t shortaddr) {
   if (shortaddr == localShortAddr) { return; }
-  getShortAddr(shortaddr).last_seen= Rtc.utc_time;
+  // Only update time if after 2020-01-01 0000.
+  // Fixes issue where zigbee device pings before WiFi/NTP has set utc_time
+  // to the correct time, and "last seen" calculations are based on the
+  // pre-corrected last_seen time and the since-corrected utc_time.
+  if (Rtc.utc_time < 1577836800) { return; }
+  getShortAddr(shortaddr).last_seen = Rtc.utc_time;
 }
 
 


### PR DESCRIPTION
The specific circumstances of this bug typically involve a restart, after which a zigbee
device pings the bridge before the Rtc.utc_time is set by NTP. This results in a large "last seen"
time calculation. This is cosmetic only. This patch ensures the "last seen" time is after
2020-01-01 0000 UTC when pulled from the Rtc.utc_time field, otherwise, last_seen updates are
ignored.

@s-hadinger 

## Description:

**Related issue (if applicable):** Fixes bug, but no bug was filed.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
