### PR TITLE
some updates in stage cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyc
 
 ## Project files ######
+.platformio
 .pioenvs
 .piolibdeps
 .clang_complete

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -9,6 +9,8 @@
 ; http://docs.platformio.org/en/stable/projectconf.html
 
 [platformio]
+; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
+;core_dir = .platformio
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
@@ -77,14 +79,14 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 ;build_unflags             = ${tasmota_stage.build_unflags}
 ;build_flags               = ${tasmota_stage.build_flags}
 
-platform_packages         = ${core_stage.platform_packages}
-build_unflags             = ${core_stage.build_unflags}
-build_flags               = ${core_stage.build_flags}
+;platform_packages         = ${core_stage.platform_packages}
+;build_unflags             = ${core_stage.build_unflags}
+;build_flags               = ${core_stage.build_flags}
 
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage
-platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino.git#2.7.4.2
+platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino/releases/download/2.7.4.2/esp8266-2.7.4.2.zip
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 
@@ -119,8 +121,8 @@ build_flags               = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core version. Tasmota stage or Arduino stage version. Built with GCC 10.1 toolchain
-platform_packages         = ;framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.0/framework-arduinoespressif8266-3.20900.0.tar.gz
-                            framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+platform_packages         = framework-arduinoespressif8266 @ https://github.com/Jason2866/platform-espressif8266/releases/download/2.9.1/framework-arduinoespressif8266-3.20901.0.tar.gz
+                            ;framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
                             toolchain-xtensa @ ~2.100100.0
 build_unflags             = ${esp_defaults.build_unflags}
                             -Wswitch-unreachable


### PR DESCRIPTION
use zip file for Tasmota stage 2.4.2 (faster install), updated Core Stage to 2.9.1 (uses Arduino commit 0x5539301),  added a (commented) PlatformIO option for better Gitpod usage

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
