### PR TITLE
Change new IR Raw compact format

### DIFF
--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add Zigbee auto-config when pairing
 - Add support for MLX90640 IR array temperature sensor by Christian Baars
 - Add support for VL53L1X time of flight sensor by Johann Obermeier
+- Change new IR Raw compact format
 
 ### 8.5.0 20200907
 


### PR DESCRIPTION
## Description:

### New IR Raw compact encoding (tasmota-ir only)

We had numerous requests from users to expand the buffer sizes because many IR codes would exceed the MQTT/Web/Serial buffer size. Instead, we changed the IR Raw encoding to shrink the size necessary to encode almost any IR code.

**Before** (buffer overflow):
`{"IrReceived":{"Protocol":"PIONEER","Bits":64,"Data":"0xA55A50AFA55A50AF","DataLSB":"0xA55A0AF5A55A0AF5","Repeat":0,"RawData":[8574,4224,574,1558,572,502,570,1562,570,502,572,502,570,1562,570,502,570,1562,572,500,572,1560,572,500,572,1560,572,1560,570,504,568,1560,570,502,572,502,570,1562,570,502,570,1560,570,502,572,500,570,502,572,502,570,1560,570,504,572,1558,572,502,570,1564,568,1562,570,1560,572,1560,572,25258,8574,4222,572,1560,570,502,572,1558,572,502,570,502,572,1558,572,500,570,1560,570,502,570,1560,570,502,570,1560,570,1560,570,504,570,1560,572,502,570,502,570,1560,572,502,570,1560,570,502,570,502,570,502,570,502,570,1560,570,502,570,1560,572,502,570 ...`

**After** (no overflow):
`{"IrReceived":{"Protocol":"PIONEER","Bits":64,"Data":"0xA55A50AFA55A50AF","DataLSB":"0xA55A0AF5A55A0AF5","Repeat":0,"RawData":[+8570-4240+550-1580C-510+565-1565F-505Fh+570gFhIdChIgFeFgFgIhFgIhF-525C-1560IhIkI-520ChFhFhFgFhIkIhIgIgIkIkI-25270A-4225IkIhIgIhIhIkFhIkFjCgIhIkIkI-500IkIhIhIkFhIgIl+545hIhIoIgIhIkFhFgIkIgFgI],"RawDataInfo":[135,135,0]}}`

The new format still encodes timings for High/low pulses.
- First the timings are rounded to the closest 5 microsec value.
- Instead of using commas, values are prefixed with `+` if it's a HIGH signal, or `-` if it's a LOW signal.
- Each new timing value is assigned a letter starting with 'A'
- If a timing value matches a previously found value, it is replaced with the letter, in uppercase for a HIGH signal, or lowercase for a LOW signal.

Ex:

```
+8570-4240+550-1580C-510+565-1565F-505Fh
\___/ \__/ \_/ \__/C \_/ \_/ \__/F \_/Fh
  A    B    C   D     E   F   G     H
```

Which translates to:
```
+8570-4240+550-1580+550-510+565-1565+556-505+565-505
or
8570,4240,550,1580,550,510,565,1565,556,505,565,505
```

If you need to transform the compact format in the legacy format, you can use the online tool: https://tasmota.hadinger.fr/util

For developers, here is the Python3 code:
```
import re

def ir_expand(ir_compact):
  count = ir_compact.count(',')   # number of occurence of comma

  if count > 1:
    return "Unsupported format"

  if count == 1:
    ir_compact = input.split(',')[1]  # if 1 comma, skip the frequency

  arr = re.findall("(\d+|[A-Za-z])", ir_compact)

  comp_table = []     # compression history table
  arr2 = []       # output

  for elt in arr:
    if len(elt) == 1:
      c = ord(elt.upper()) - ord('A')
      if c >= len(arr): return "Error index undefined"
      arr2.append(comp_table[c])
    else:
      comp_table.append(elt)
      arr2.append(elt)

  out = ",".join(arr2)

  return out
```

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
