### PR TITLE
Fix PWM Dimmer to properly handle more-to-come finalization

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -312,6 +312,7 @@ void SendReceiveDeviceGroupMessage(struct device_group * device_group, struct de
 
 #ifdef DEVICE_GROUPS_DEBUG
     switch (item) {
+      case DGR_ITEM_FLAGS:
       case DGR_ITEM_LIGHT_FADE:
       case DGR_ITEM_LIGHT_SPEED:
       case DGR_ITEM_LIGHT_BRI:

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -279,7 +279,7 @@ void PWMDimmerHandleButton(void)
   int32_t bri_offset = 0;
   uint8_t power_on_bri = 0;
   uint8_t dgr_item = 0;
-  uint8_t dgr_value;
+  uint8_t dgr_value = 0;
   uint8_t dgr_more_to_come = false;
   uint32_t button_index = XdrvMailbox.index;
   uint32_t now = millis();
@@ -475,7 +475,7 @@ void PWMDimmerHandleButton(void)
 #endif  // USE_PWM_DIMMER_REMOTE
               power_button_increases_bri ^= 1;
 #ifdef USE_PWM_DIMMER_REMOTE
-            dgr_item = 255;
+            dgr_item = DGR_ITEM_FLAGS;
             state_updated = true;
 #endif  // USE_PWM_DIMMER_REMOTE
           }
@@ -510,7 +510,7 @@ void PWMDimmerHandleButton(void)
             // If the down button was tapped and held, we changed the fixed color. Send a final
             // update.
             else if (down_button_tapped) {
-              dgr_item = 255;
+              dgr_item = DGR_ITEM_FLAGS;
             }
           }
         }
@@ -551,7 +551,7 @@ void PWMDimmerHandleButton(void)
             // button is pressed. The new brightness will be calculated below.
             if (button_hold_time[button_index] >= now) {
               bri_offset = (is_down_button ? -1 : 1);
-              dgr_item = 255;
+              dgr_item = DGR_ITEM_FLAGS;
               state_updated = true;
             }
 
@@ -559,7 +559,7 @@ void PWMDimmerHandleButton(void)
             // brightness and sent updates with the more-to-come message type while the button was
             // held. Send a final update.
             else if (!button_hold_processed[button_index]) {
-              dgr_item = 255;
+              dgr_item = DGR_ITEM_FLAGS;
               state_updated = true;
             }
           }
@@ -666,7 +666,7 @@ void PWMDimmerHandleButton(void)
   // update.
   if (dgr_item) {
 #ifdef USE_DEVICE_GROUPS
-    if (dgr_item == 255) dgr_item = 0;
+AddLog_P2(LOG_LEVEL_ERROR, PSTR("PWMDimmer: sending DGR item %u"), dgr_item);
     SendDeviceGroupMessage(power_button_index, (dgr_more_to_come ? DGR_MSGTYP_UPDATE_MORE_TO_COME : DGR_MSGTYP_UPDATE_DIRECT), dgr_item, dgr_value);
 #endif  // USE_DEVICE_GROUPS
 #ifdef USE_PWM_DIMMER_REMOTE


### PR DESCRIPTION
## Description:

Fix PWM Dimmer to send DGR_ITEM_FLAGS after more-to-come msgs to finalize changes so remote devices send tele updates.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
