### PR TITLE
Auto-binding for TRV

### DIFF
--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -562,7 +562,7 @@ int32_t Z_ReceiveActiveEp(int32_t res, const class SBuffer &buf) {
 
 // list of clusters that need bindings
 const uint8_t Z_bindings[] PROGMEM = {
-  Cx0001, Cx0006, Cx0008, Cx0300,
+  Cx0001, Cx0006, Cx0008, Cx0201, Cx0300,
   Cx0400, Cx0402, Cx0403, Cx0405, Cx0406,
   Cx0500,
 };
@@ -1216,6 +1216,9 @@ const Z_autoAttributeReporting_t Z_autoAttributeReporting[] PROGMEM = {
   { 0x0001, 0x0020,   15*60,    15*60,  0.1 },      // BatteryVoltage
   { 0x0001, 0x0021,   15*60,    15*60,    1 },      // BatteryPercentage
   { 0x0006, 0x0000,        1,   60*60,    0 },      // Power
+  { 0x0201, 0x0000,       60,   60*10,  0.5 },      // LocalTemperature
+  { 0x0201, 0x0008,       60,   60*10,   10 },      // PIHeatingDemand
+  { 0x0201, 0x0012,       60,   60*10,  0.5 },      // OccupiedHeatingSetpoint
   { 0x0008, 0x0000,        1,   60*60,    5 },      // Dimmer
   { 0x0300, 0x0000,        1,   60*60,    5 },      // Hue
   { 0x0300, 0x0001,        1,   60*60,    5 },      // Sat


### PR DESCRIPTION
## Description:

Added TRV, especially Eurotronic Zigbee TRV to the auto-binding. When pairing the following commands are automatically sent:
```
ZbSend {"Device":"Radiator","Config":{"LocalTemperature":{"MinInterval":60,"MaxInterval":600,"ReportableChange":0.5},"OccupiedHeatingSetpoint":{"MinInterval":60,"MaxInterval":600,"ReportableChange":0.5},"PIHeatingDemand":{"MinInterval":60,"MaxInterval":600,"ReportableChange":5}}}
ZbBind {"Device":"Radiator","Cluster":"LocalTemperature"}
```

Also fixed `ReadConfig` would not apply the multiplier to `ReportableChange` values.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
