### PR TITLE
Zigbee add TRV to UI

### DIFF
--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1432,15 +1432,25 @@ void ZigbeeShow(bool json)
 
       // Sensors
       bool temperature_ok = device.validTemperature();
+      bool tempareture_target_ok = device.validTemperatureTarget();
+      bool th_setpoint_ok = device.validThSetpoint();
       bool humidity_ok    = device.validHumidity();
       bool pressure_ok    = device.validPressure();
 
-      if (temperature_ok || humidity_ok || pressure_ok) {
+      if (temperature_ok || tempareture_target_ok || th_setpoint_ok || humidity_ok || pressure_ok) {
         WSContentSend_P(PSTR("<tr class='htr'><td colspan=\"4\">&#9478;"));
         if (temperature_ok) {
           char buf[12];
           dtostrf(device.temperature / 10.0f, 3, 1, buf);
           WSContentSend_PD(PSTR(" &#x2600;&#xFE0F; %s°C"), buf);
+        }
+        if (tempareture_target_ok) {
+          char buf[12];
+          dtostrf(device.temperature_target / 10.0f, 3, 1, buf);
+          WSContentSend_PD(PSTR(" &#127919; %s°C"), buf);
+        }
+        if (th_setpoint_ok) {
+          WSContentSend_PD(PSTR(" &#9881;&#65039; %d%%"), device.th_setpoint);
         }
         if (humidity_ok) {
           WSContentSend_P(PSTR(" &#x1F4A7; %d%%"), device.humidity);


### PR DESCRIPTION
## Description:

Add Thermostat and TRV to Web UI: shows current temperature, target temperature and valve position (%)
<img width="330" alt="TRV" src="https://user-images.githubusercontent.com/49731213/94967196-e7acd500-04fe-11eb-8f5f-b973b07966c7.png">

**Related issue (if applicable):** fixes #9358

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
