### PR TITLE
Add device group count/index checks

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -119,6 +119,7 @@ void DeviceGroupsInit(void)
       for (uint32_t relay_index = 0; relay_index < MAX_RELAYS; relay_index++) {
         if (PinUsed(GPIO_REL1, relay_index)) device_group_count = relay_index + 1;
       }
+      if (device_group_count > MAX_DEV_GROUP_NAMES) device_group_count = MAX_DEV_GROUP_NAMES;
     }
 
     // Otherwise, set the device group count to 1.
@@ -463,6 +464,9 @@ bool _SendDeviceGroupMessage(uint8_t device_group_index, DevGroupMessageType mes
 {
   // If device groups is not up, ignore this request.
   if (!device_groups_up) return 1;
+
+  // If the device group index is higher then the number of device groups, ignore this request.
+  if (device_group_index >= device_group_count) return 0;
 
   // If we're currently processing a remote device message, ignore this request.
   if (ignore_dgr_sends && message_type != DGR_MSGTYPE_UPDATE_COMMAND) return 0;


### PR DESCRIPTION
## Description:

Add device group count/index checks. Previously, if the template included more than 4 relays, an exception would occur when the power state of a relay number higher than 4 was changed.

**Related issue (if applicable):** fixes #9459

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
