### PR TITLE
Add Zigbee ``ZbData`` command for better support of device specific data

### DIFF
--- a/lib/jsmn-shadinger-1.0/src/JsonGenerator.cpp
+++ b/lib/jsmn-shadinger-1.0/src/JsonGenerator.cpp
@@ -106,6 +106,13 @@ void JsonGeneratorObject::add(const char* key, const String & str) {
   post();
 }
 
+// Add up to 32 bits hex value
+void JsonGeneratorObject::addHex32(const char* key, uint32_t uval32) {
+  char hex[16];
+  snprintf_P(hex, sizeof(hex), PSTR("\"0x%8X\""), uval32);
+  addStrRaw(key, hex);
+}
+
 // Add a raw string, that will not be escaped.
 // Can be used to add a sub-array, sub-object or 'null', 'true', 'false' values
 void JsonGeneratorObject::addStrRaw(const char* key, const char * sval) {

--- a/lib/jsmn-shadinger-1.0/src/JsonGenerator.h
+++ b/lib/jsmn-shadinger-1.0/src/JsonGenerator.h
@@ -58,6 +58,7 @@ public:
   void add(const char* key, uint32_t uval32);
   void add(const char* key, int32_t uval32);
   void add(const char* key, const String & str);
+  void addHex32(const char* key, uint32_t uval32);
   void addStrRaw(const char* key, const char * sval);
   void addStr(const char* key, const char * sval);
 

--- a/tasmota/CHANGELOG.md
+++ b/tasmota/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add support for inverted NeoPixelBus data line by enabling ``#define USE_WS2812_INVERTED`` (#8988)
 - Add PWM dimmer color/trigger on tap, SO88 led, DGR WITH_LOCAL flag by Paul Diem (#9474)
 - Add support for stateful ACs using ``StateMode`` in tasmota-ir.bin by Arik Yavilevich (#9472)
+- Add Zigbee ``ZbData`` command for better support of device specific data
 
 ## Released
 

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -572,6 +572,7 @@
 #define D_CMND_ZIGBEE_RESTORE "Restore"
 #define D_CMND_ZIGBEE_CONFIG "Config"
   #define D_JSON_ZIGBEE_CONFIG "Config"
+#define D_CMND_ZIGBEE_DATA "Data"
 
 // Commands xdrv_25_A4988_Stepper.ino
 #define D_CMND_MOTOR "MOTOR"

--- a/tasmota/support_light_list.ino
+++ b/tasmota/support_light_list.ino
@@ -72,6 +72,10 @@ public:
   T & addHead(void);
   T & addHead(const T &val);
   T & addToLast(void);
+  // add an element allocated externally
+  // memory is free by us now -- don't free it!
+  T & addHead(LList_elt<T> * elt);
+  T & addToLast(LList_elt<T> * elt);
 
   // iterator
   // see https://stackoverflow.com/questions/8164567/how-to-make-my-custom-type-to-work-with-range-based-for-loops
@@ -175,6 +179,13 @@ T & LList<T>::addHead(const T &val) {
 }
 
 template <typename T>
+T & LList<T>::addHead(LList_elt<T> * elt) {
+  elt->next(_head);      // insert at the head
+  _head = elt;
+  return elt->_val;
+}
+
+template <typename T>
 T & LList<T>::addToLast(void) {
   LList_elt<T> **curr_ptr = &_head;
   while (*curr_ptr) {
@@ -182,5 +193,16 @@ T & LList<T>::addToLast(void) {
   }
   LList_elt<T> * elt = new LList_elt<T>();  // create element
   *curr_ptr = elt;
+  return elt->_val;
+}
+
+template <typename T>
+T & LList<T>::addToLast(LList_elt<T> * elt) {
+  LList_elt<T> **curr_ptr = &_head;
+  while (*curr_ptr) {
+    curr_ptr = &((*curr_ptr)->_next);
+  }
+  *curr_ptr = elt;
+  elt->_next = nullptr;
   return elt->_val;
 }

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -24,6 +24,361 @@
 #endif
 const uint16_t kZigbeeSaveDelaySeconds = ZIGBEE_SAVE_DELAY_SECONDS;    // wait for x seconds
 
+enum class Z_Data_Type : uint8_t {
+  Z_Unknown = 0x00,
+  Z_Light = 1,              // Lights 1-5 channels
+  Z_Plug = 2,               // Plug power consumption
+  Z_PIR = 3,
+  Z_Alarm = 4,
+  Z_Thermo = 5,             // Thermostat and sensor for home environment (temp, himudity, pressure)
+  Z_OnOff = 6,              // OnOff, Buttons and Relays (always complements Lights and Plugs)
+  Z_Ext = 0xF,              // extended for other values
+  Z_Device = 0xFF           // special value when parsing Device level attributes
+};
+
+class Z_Data_Set;
+/*********************************************************************************************\
+ * Device specific data, sensors...
+\*********************************************************************************************/
+class Z_Data {
+public:
+  Z_Data(Z_Data_Type type = Z_Data_Type::Z_Unknown, uint8_t endpoint = 0) : _type(type), _endpoint(endpoint), _config(-1), _power(0) {}
+  inline Z_Data_Type getType(void) const { return _type; }
+  inline int8_t getConfig(void) const { return _config; }
+  inline void setConfig(int8_t config) { _config = config; }
+
+  inline uint8_t getEndpoint(void) const { return _endpoint; }
+
+  static const Z_Data_Type type = Z_Data_Type::Z_Unknown;
+
+  friend class Z_Data_Set;
+protected:
+  Z_Data_Type _type;        // encoded on 4 bits, type of the device
+  uint8_t _endpoint;    // source endpoint, or 0x00 if any endpoint
+  int8_t  _config;      // encoded on 4 bits, customize behavior
+  uint8_t _power;       // power state if the type supports it
+};
+
+/*********************************************************************************************\
+ * Device specific: On/Off, power up to 8 relays
+\*********************************************************************************************/
+
+// _config contains the number of valid OnOff relays: 0..7
+// _power contains a bitfield of relays values
+class Z_Data_OnOff : public Z_Data {
+public:
+  Z_Data_OnOff(uint8_t endpoint = 0) :
+    Z_Data(Z_Data_Type::Z_OnOff, endpoint)
+    {
+      _config = 1;         // at least 1 OnOff
+    }
+
+
+  inline bool validPower(uint32_t relay = 0) const { return (_config > relay); }      // power is declared
+  inline bool getPower(uint32_t relay = 0)  const { return bitRead(_power, relay); }
+         void setPower(bool val, uint32_t relay = 0);
+
+  static void toAttributes(Z_attribute_list & attr_list, const Z_Data_OnOff & light);
+
+  static const Z_Data_Type type = Z_Data_Type::Z_OnOff;
+};
+
+
+void Z_Data_OnOff::setPower(bool val, uint32_t relay) {
+  if (relay < 8) {
+    if (_config < relay) { _config = relay; }     // we update the number of valid relays
+    bitWrite(_power, relay, val);
+  }
+}
+
+/*********************************************************************************************\
+ * Device specific: Light device
+\*********************************************************************************************/
+class Z_Data_Plug : public Z_Data {
+public:
+  Z_Data_Plug(uint8_t endpoint = 0) :
+    Z_Data(Z_Data_Type::Z_Plug, endpoint),
+    mains_voltage(0xFFFF),
+    mains_power(-0x8000)
+    {}
+
+  inline bool validMainsVoltage(void)   const { return 0xFFFF != mains_voltage; }
+  inline bool validMainsPower(void)     const { return -0x8000 != mains_power; }
+
+  inline uint16_t getMainsVoltage(void) const { return mains_voltage; }
+  inline int16_t  getMainsPower(void)   const { return mains_power; }
+
+  inline void setMainsVoltage(uint16_t _mains_voltage)  { mains_voltage = _mains_voltage; }
+  inline void setMainsPower(int16_t _mains_power)       { mains_power = _mains_power; }
+
+  static void toAttributes(Z_attribute_list & attr_list, const Z_Data_Plug & light);
+
+  static const Z_Data_Type type = Z_Data_Type::Z_Plug;
+  // 4 bytes
+  uint16_t              mains_voltage;  // AC voltage
+  int16_t               mains_power;    // Active power
+};
+
+/*********************************************************************************************\
+ * Device specific: Light device
+\*********************************************************************************************/
+class Z_Data_Light : public Z_Data {
+public:
+  Z_Data_Light(uint8_t endpoint = 0) :
+    Z_Data(Z_Data_Type::Z_Light, endpoint),
+    colormode(0xFF),
+    dimmer(0xFF),
+    sat(0xFF),
+    hue(0xFF),
+    ct(0xFFFF),
+    x(0xFFFF),
+    y(0xFFFF)
+    {}
+
+  inline bool validColormode(void)      const { return 0xFF != colormode; }
+  inline bool validDimmer(void)         const { return 0xFF != dimmer; }
+  inline bool validSat(void)            const { return 0xFF != sat; }
+  inline bool validHue(void)            const { return 0xFFFF != hue; }
+  inline bool validCT(void)             const { return 0xFFFF != ct; }
+  inline bool validX(void)              const { return 0xFFFF != x; }
+  inline bool validY(void)              const { return 0xFFFF != y; }
+
+  inline uint8_t  getColorMode(void)    const { return colormode; }
+  inline uint8_t  getDimmer(void)       const { return dimmer; }
+  inline uint8_t  getSat(void)          const { return sat; }
+  inline uint16_t getHue(void)          const { return changeUIntScale(hue, 0, 254, 0, 360); }
+  inline uint16_t getCT(void)           const { return ct; }
+  inline uint16_t getX(void)            const { return x; }
+  inline uint16_t getY(void)            const { return y; }
+
+  inline void setColorMode(uint8_t _colormode)  { colormode = _colormode; }
+  inline void setDimmer(uint8_t _dimmer)        { dimmer = _dimmer; }
+  inline void setSat(uint8_t _sat)              { sat = _sat; }
+  inline void setHue(uint16_t _hue)             { hue = changeUIntScale(_hue, 0, 360, 0, 254);; }
+  inline void setCT(uint16_t _ct)               { ct = _ct; }
+  inline void setX(uint16_t _x)                 { x = _x; }
+  inline void setY(uint16_t _y)                 { y = _y; }
+
+  static void toAttributes(Z_attribute_list & attr_list, const Z_Data_Light & light);
+
+  static const Z_Data_Type type = Z_Data_Type::Z_Light;
+  // 12 bytes
+  uint8_t               colormode;      // 0x00: Hue/Sat, 0x01: XY, 0x02: CT | 0xFF not set, default 0x01
+  uint8_t               dimmer;         // last Dimmer value: 0-254 | 0xFF not set, default 0x00
+  uint8_t               sat;            // last Sat: 0..254 | 0xFF not set, default 0x00
+  uint8_t               hue;            // last Hue: 0..359 | 0xFFFF not set, default 0
+  uint16_t              ct;             // last CT: 153-500 | 0xFFFF not set, default 200
+  uint16_t              x, y;           // last color [x,y] | 0xFFFF not set, default 0
+};
+
+/*********************************************************************************************\
+ * Device specific: Sensors: temp, humidity, pressure...
+\*********************************************************************************************/
+class Z_Data_Thermo : public Z_Data {
+public:
+  Z_Data_Thermo(uint8_t endpoint = 0) :
+    Z_Data(Z_Data_Type::Z_Thermo, endpoint),
+    temperature(-0x8000),
+    pressure(0xFFFF),
+    humidity(0xFFFF),
+    th_setpoint(0xFF),
+    temperature_target(-0x8000)
+    {}
+
+  inline bool validTemperature(void)    const { return -0x8000 != temperature; }
+  inline bool validPressure(void)       const { return 0xFFFF != pressure; }
+  inline bool validHumidity(void)       const { return 0xFFFF != humidity; }
+  inline bool validThSetpoint(void)     const { return 0xFF != th_setpoint; }
+  inline bool validTempTarget(void)     const { return -0x8000 != temperature_target; }
+
+  inline int16_t  getTemperature(void)  const { return temperature; }
+  inline uint16_t getPressure(void)     const { return pressure; }
+  inline uint16_t getHumidity(void)     const { return humidity; }
+  inline uint8_t  getThSetpoint(void)   const { return th_setpoint; }
+  inline int16_t  getTempTarget(void)   const { return temperature_target; }
+
+  inline void setTemperature(int16_t _temperature)      { temperature = _temperature; }
+  inline void setPressure(uint16_t _pressure)           { pressure = _pressure; }
+  inline void setHumidity(uint16_t _humidity)           { humidity = _humidity; }
+  inline void setThSetpoint(uint8_t _th_setpoint)       { th_setpoint = _th_setpoint; }
+  inline void setTempTarget(int16_t _temperature_target){ temperature_target = _temperature_target; }
+
+  static void toAttributes(Z_attribute_list & attr_list, const Z_Data_Thermo & thermo);
+
+  static const Z_Data_Type type = Z_Data_Type::Z_Thermo;
+  // 8 bytes
+  // sensor data
+  int16_t               temperature;    // temperature in 1/10th of Celsius, 0x8000 if unknown
+  uint16_t              pressure;       // air pressure in hPa, 0xFFFF if unknown
+  uint16_t              humidity;       // humidity in percent, 0..100, 0xFF if unknown
+  // thermostat
+  uint8_t               th_setpoint;    // percentage of heat/cool in percent
+  int16_t               temperature_target; // settings for the temparature
+};
+
+/*********************************************************************************************\
+ * Device specific: Alarm
+\*********************************************************************************************/
+class Z_Data_Alarm : public Z_Data {
+public:
+  Z_Data_Alarm(uint8_t endpoint = 0) :
+    Z_Data(Z_Data_Type::Z_Alarm, endpoint),
+    zone_type(0xFFFF)
+    {}
+
+  static const Z_Data_Type type = Z_Data_Type::Z_Alarm;
+
+  inline bool validZoneType(void)   const { return 0xFFFF != zone_type; }
+
+  inline uint16_t getZoneType(void) const { return zone_type; }
+
+  inline void setZoneType(uint16_t _zone_type)  { zone_type = _zone_type; }
+
+  static void toAttributes(Z_attribute_list & attr_list, const Z_Data_Alarm & alarm);
+
+  // 4 bytes
+  uint16_t               zone_type;       // mapped to the Zigbee standard
+    // 0x0000  Standard CIE
+    // 0x000d  Motion sensor
+    // 0x0015  Contact switch
+    // 0x0028  Fire sensor
+    // 0x002a  Water sensor
+    // 0x002b  Carbon Monoxide (CO) sensor
+    // 0x002c  Personal emergency device
+    // 0x002d  Vibration/Movement sensor
+    // 0x010f  Remote Control
+    // 0x0115  Key fob
+    // 0x021d  Keypad
+    // 0x0225  Standard Warning Device (see [N1] part 4)
+    // 0x0226  Glass break sensor
+    // 0x0229  Security repeater*
+};
+/*********************************************************************************************\
+ * 
+ * Device specific Linked List
+ * 
+\*********************************************************************************************/
+class Z_Data_Set : public LList<Z_Data> {
+public:
+  // List<Z_Data>() : List<Z_Data>() {}
+  Z_Data & getByType(Z_Data_Type type, uint8_t ep = 0);     // creates if non-existent
+  const Z_Data & find(Z_Data_Type type, uint8_t ep = 0) const;
+
+  // getX() always returns a valid object, and creates the object if there is none
+  // find() does not create an object if it does not exist, and returns *(X*)nullptr
+
+
+  template <class M>
+  M & get(uint8_t ep = 0);
+
+  template <class M>
+  const M & find(uint8_t ep = 0) const;
+
+  // check if the point is null, if so create a new object with the right sub-class
+  template <class M>
+  M & addIfNull(M & cur, uint8_t ep = 0);
+};
+
+Z_Data & Z_Data_Set::getByType(Z_Data_Type type, uint8_t ep) {
+  switch (type) {
+    case Z_Data_Type::Z_Light:
+      return get<Z_Data_Light>(ep);
+    case Z_Data_Type::Z_Plug:
+      return get<Z_Data_Plug>(ep);
+    case Z_Data_Type::Z_Alarm:
+      return get<Z_Data_Alarm>(ep);
+    case Z_Data_Type::Z_Thermo:
+      return get<Z_Data_Thermo>(ep);
+    case Z_Data_Type::Z_OnOff:
+      return get<Z_Data_OnOff>(ep);
+    default:
+      return *(Z_Data*)nullptr;
+  }
+}
+
+template <class M>
+M & Z_Data_Set::get(uint8_t ep) {
+  M & m = (M&) find(M::type, ep);
+  return addIfNull<M>(m, ep);
+}
+
+template <class M>
+const M & Z_Data_Set::find(uint8_t ep) const {
+ return (M&) find(M::type, ep);
+}
+
+// Input: reference to object
+// Output: if reference is null, instantiate object and add it at the end of the list
+template <class M>
+M & Z_Data_Set::addIfNull(M & cur, uint8_t ep) {
+  if (nullptr == &cur) {
+    LList_elt<M> * elt = new LList_elt<M>();
+    elt->val()._endpoint = ep;
+    this->addToLast((LList_elt<Z_Data>*)elt);
+    return elt->val();
+  } else {
+    if (cur._endpoint == 0) { cur._endpoint = ep; }     // be more specific on endpoint
+    return cur;
+  }
+}
+
+const Z_Data & Z_Data_Set::find(Z_Data_Type type, uint8_t ep) const {
+  for (auto & elt : *this) {
+    if (elt._type == type) {
+      // type matches, check if ep matches.
+      // 0 matches all endpoints
+      if ((ep == 0) || (elt._endpoint == 0) || (ep == elt._endpoint)) {
+        return elt;
+      }
+    }
+  }
+  return *(Z_Data*)nullptr;
+}
+
+
+// Low-level
+// Add light attributes, used by dumpLightState and by SbData
+//
+void Z_Data_Plug::toAttributes(Z_attribute_list & attr_list, const Z_Data_Plug & plug) {
+  if (&plug == nullptr) { return; }
+  // dump all known values
+  if (plug.validMainsVoltage())  { attr_list.addAttribute(PSTR("RMSVoltage")).setUInt(plug.getMainsVoltage()); }
+  if (plug.validMainsPower())    { attr_list.addAttribute(PSTR("ActivePower")).setInt(plug.getMainsPower()); }
+}
+
+void Z_Data_Light::toAttributes(Z_attribute_list & attr_list, const Z_Data_Light & light) {
+  if (&light == nullptr) { return; }
+  // expose the last known status of the bulb, for Hue integration
+  attr_list.addAttribute(PSTR(D_JSON_ZIGBEE_LIGHT)).setInt(light.getConfig());    // special case, since type is 0x00 we can assume getConfig() is good
+  // dump all known values
+  if (light.validDimmer())       { attr_list.addAttribute(PSTR("Dimmer")).setUInt(light.getDimmer()); }
+  if (light.validColormode())    { attr_list.addAttribute(PSTR("Colormode")).setUInt(light.getColorMode()); }
+  if (light.validCT())           { attr_list.addAttribute(PSTR("CT")).setUInt(light.getCT()); }
+  if (light.validSat())          { attr_list.addAttribute(PSTR("Sat")).setUInt(light.getSat()); }
+  if (light.validHue())          { attr_list.addAttribute(PSTR("Hue")).setUInt(light.getHue()); }
+  if (light.validX())            { attr_list.addAttribute(PSTR("X")).setUInt(light.getX()); }
+  if (light.validY())            { attr_list.addAttribute(PSTR("Y")).setUInt(light.getY()); }
+}
+
+void Z_Data_OnOff::toAttributes(Z_attribute_list & attr_list, const Z_Data_OnOff & onoff) {
+  if (&onoff == nullptr) { return; }
+  if (onoff.validPower())       { attr_list.addAttribute(PSTR("Power")).setUInt(onoff.getPower() ? 1 : 0); }
+}
+
+void Z_Data_Thermo::toAttributes(Z_attribute_list & attr_list, const Z_Data_Thermo & thermo) {
+  if (&thermo == nullptr) { return; }
+  if (thermo.validTemperature())  { attr_list.addAttribute(PSTR("Temperature")).setInt(thermo.getTemperature()); }
+  if (thermo.validPressure())     { attr_list.addAttribute(PSTR("Pressure")).setUInt(thermo.getPressure()); }
+  if (thermo.validHumidity())     { attr_list.addAttribute(PSTR("Humidity")).setUInt(thermo.getHumidity()); }
+  if (thermo.validThSetpoint())   { attr_list.addAttribute(PSTR("ThSetpoint")).setUInt(thermo.getThSetpoint()); }
+  if (thermo.validTempTarget())   { attr_list.addAttribute(PSTR("TempTarget")).setInt(thermo.getTempTarget()); }
+}
+
+void Z_Data_Alarm::toAttributes(Z_attribute_list & attr_list, const Z_Data_Alarm & alarm) {
+  if (&alarm == nullptr) { return; }
+  if (alarm.validZoneType())     { attr_list.addAttribute(PSTR("ZoneType")).setUInt(alarm.getZoneType()); }
+}
+
 /*********************************************************************************************\
  * Structures for Rules variables related to the last received message
 \*********************************************************************************************/
@@ -46,39 +401,17 @@ public:
   // sequence number for Zigbee frames
   uint16_t              shortaddr;      // unique key if not null, or unspecified if null
   uint8_t               seqNumber;
+  bool                  hidden;
+  bool                  reachable;
   // Light information for Hue integration integration, last known values
-  uint8_t               zb_profile;     // profile of the device
-    // high 4 bits is device type:
-    //   0x0. = bulb
-    //   0x1. = switch
-    //   0x2. = motion sensor
-    //   0x3. = other alarms
-    //   0xE. = reserved for extension
-    //   0xF. = unknown
-    // For Bulb (0x0.)
-    //   0x0N = number of channel for the bulb: 0-5
-    //   0x08 = the device is hidden from Alexa
+
+  // New version of device data handling
+  Z_Data_Set           data;            // Linkedlist of device data per endpoint
   // other status
-  uint8_t               power;          // power state (boolean), MSB (0x80) stands for reachable
-  uint8_t               colormode;      // 0x00: Hue/Sat, 0x01: XY, 0x02: CT | 0xFF not set, default 0x01
-  uint8_t               dimmer;         // last Dimmer value: 0-254 | 0xFF not set, default 0x00
-  uint8_t               sat;            // last Sat: 0..254 | 0xFF not set, default 0x00
-  uint16_t              ct;             // last CT: 153-500 | 0xFFFF not set, default 200
-  uint16_t              hue;            // last Hue: 0..359 | 0xFFFF not set, default 0
-  uint16_t              x, y;           // last color [x,y] | 0xFFFF not set, default 0
   uint8_t               lqi;            // lqi from last message, 0xFF means unknown
   uint8_t               batterypercent; // battery percentage (0..100), 0xFF means unknwon
-  // sensor data
-  int16_t               temperature;    // temperature in 1/10th of Celsius, 0x8000 if unknown
-  uint16_t              pressure;       // air pressure in hPa, 0xFFFF if unknown
-  uint8_t               humidity;       // humidity in percent, 0..100, 0xFF if unknown
-  // power plug data
-  uint16_t              mains_voltage;  // AC voltage
-  int16_t               mains_power;    // Active power
+  // power plug data-
   uint32_t              last_seen;      // Last seen time (epoch)
-  // thermostat
-  int16_t               temperature_target; // settings for the temparature
-  uint8_t               th_setpoint;    // percentage of heat/cool in percent
 
   // Constructor with all defaults
   Z_Device(uint16_t _shortaddr = BAD_SHORTADDR, uint64_t _longaddr = 0x00):
@@ -91,26 +424,12 @@ public:
     attr_list(),
     shortaddr(_shortaddr),
     seqNumber(0),
+    hidden(false),
+    reachable(false),
     // Hue support
-    zb_profile(0xFF),  // no profile
-    power(0x02),       // 0x80 = reachable, 0x01 = power on, 0x02 = power unknown
-    colormode(0xFF),
-    dimmer(0xFF),
-    sat(0xFF),
-    ct(0xFFFF),
-    hue(0xFFFF),
-    x(0xFFFF),
-    y(0xFFFF),
     lqi(0xFF),
     batterypercent(0xFF),
-    temperature(-0x8000),
-    pressure(0xFFFF),
-    humidity(0xFF),
-    mains_voltage(0xFFFF),
-    mains_power(-0x8000),
-    last_seen(0),
-    temperature_target(-0x8000),
-    th_setpoint(0xFF)
+    last_seen(0)
     { };
 
   inline bool valid(void)               const { return BAD_SHORTADDR != shortaddr; }    // is the device known, valid and found?
@@ -120,40 +439,53 @@ public:
   inline bool validModelId(void)        const { return nullptr != modelId; }
   inline bool validFriendlyName(void)   const { return nullptr != friendlyName; }
 
-  inline bool validPower(void)          const { return 0x00 == (power & 0x02); }
-  inline bool validColormode(void)      const { return 0xFF != colormode; }
-  inline bool validDimmer(void)         const { return 0xFF != dimmer; }
-  inline bool validSat(void)            const { return 0xFF != sat; }
-  inline bool validCT(void)             const { return 0xFFFF != ct; }
-  inline bool validHue(void)            const { return 0xFFFF != hue; }
-  inline bool validX(void)              const { return 0xFFFF != x; }
-  inline bool validY(void)              const { return 0xFFFF != y; }
+  inline bool validPower(uint8_t ep =0)          const;
 
   inline bool validLqi(void)            const { return 0xFF != lqi; }
   inline bool validBatteryPercent(void) const { return 0xFF != batterypercent; }
-
-  inline bool validTemperature(void)    const { return -0x8000 != temperature; }
-  inline bool validPressure(void)       const { return 0xFFFF != pressure; }
-  inline bool validHumidity(void)       const { return 0xFF != humidity; }
   inline bool validLastSeen(void)       const { return 0x0 != last_seen; }
 
-  inline bool validTemperatureTarget(void) const { return -0x8000 != temperature_target; }
-  inline bool validThSetpoint(void)     const { return 0xFF != th_setpoint; }
+  inline void setReachable(bool _reachable)   { reachable = _reachable; }
+  inline bool getReachable(void)        const { return reachable; }
+  inline bool getPower(uint8_t ep =0)   const;
 
-  inline bool validMainsVoltage(void)   const { return 0xFFFF != mains_voltage; }
-  inline bool validMainsPower(void)     const { return -0x8000 != mains_power; }
+  // dump device attributes to ZbData
+  void toAttributes(Z_attribute_list & attr_list) const;
 
-  inline void setReachable(bool reachable)    { bitWrite(power, 7, reachable); }
-  inline bool getReachable(void)        const { return bitRead(power, 7); }
-  inline void setPower(bool power_on)         { bitWrite(power, 0, power_on); bitWrite(power, 1, false); }
-  inline bool getPower(void)            const { return bitRead(power, 0); }
+  // Device data specific
+  void setPower(bool power_on, uint8_t ep = 0);
 
   // If light, returns the number of channels, or 0xFF if unknown
-  uint8_t getLightChannels(void)        const {
-    if ((zb_profile & 0xF0) == 0x00) {
-      return zb_profile & 0x07;
+  int8_t getLightChannels(void)        const {
+    const Z_Data_Light & light = data.find<Z_Data_Light>(0);
+    if (&light != nullptr) {
+      return light.getConfig();
+    } else {
+      return -1;
     }
-    return 0xFF;
+  }
+
+  // returns: dirty flag, did we change the value of the object
+  bool setLightChannels(int8_t channels) {
+    bool dirty = false;
+    if (channels >= 0) {
+      // retrieve of create light object
+      Z_Data_Light & light = data.get<Z_Data_Light>(0);
+      if (channels != light.getConfig()) {
+        light.setConfig(channels);
+        dirty = true;
+      }
+    } else {
+      // remove light object if any
+      for (auto & data_elt : data) {
+        if (data_elt.getType() == Z_Data_Type::Z_Light) {
+          // remove light object
+          data.remove(&data_elt);
+          dirty = true;
+        }
+      }
+    }
+    return dirty;
   }
 };
 
@@ -268,19 +600,20 @@ public:
   uint8_t getNextSeqNumber(uint16_t shortaddr);
 
   // Dump json
+  static void addLightState(Z_attribute_list & attr_list, const Z_Data_Light & light);
   String dumpLightState(uint16_t shortaddr) const;
   String dump(uint32_t dump_mode, uint16_t status_shortaddr = 0) const;
   int32_t deviceRestore(JsonParserObject json);
 
   // General Zigbee device profile support
-  void setZbProfile(uint16_t shortaddr, uint8_t zb_profile);
-  uint8_t getZbProfile(uint16_t shortaddr) const ;
+  void setLightProfile(uint16_t shortaddr, uint8_t light_profile);
+  uint8_t getLightProfile(uint16_t shortaddr) const ;
 
   // Hue support
-  void setHueBulbtype(uint16_t shortaddr, int8_t bulbtype);
   int8_t getHueBulbtype(uint16_t shortaddr) const ;
   void hideHueBulb(uint16_t shortaddr, bool hidden);
   bool isHueBulbHidden(uint16_t shortaddr) const ;
+  Z_Data_Light & getLight(uint16_t shortaddr);
 
   // Timers
   void resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster = 0xFFFF, uint8_t endpoint = 0xFF);
@@ -334,8 +667,6 @@ private:
   void freeDeviceEntry(Z_Device *device);
 
   void setStringAttribute(char*& attr, const char * str);
-
-  void updateZbProfile(uint16_t shortaddr);
 };
 
 /*********************************************************************************************\
@@ -347,787 +678,6 @@ Z_Devices zigbee_devices = Z_Devices();
 uint64_t localIEEEAddr = 0;
 uint16_t localShortAddr = 0;
 
-/*********************************************************************************************\
- * Implementation
-\*********************************************************************************************/
 
-//
-// Create a new Z_Device entry in _devices. Only to be called if you are sure that no
-// entry with same shortaddr or longaddr exists.
-//
-Z_Device & Z_Devices::createDeviceEntry(uint16_t shortaddr, uint64_t longaddr) {
-  if ((BAD_SHORTADDR == shortaddr) && !longaddr) { return (Z_Device&) device_unk; }      // it is not legal to create this entry
-  Z_Device device(shortaddr, longaddr);
-
-  dirty();
-  return _devices.addHead(device);
-}
-
-void Z_Devices::freeDeviceEntry(Z_Device *device) {
-  if (device->manufacturerId) { free(device->manufacturerId); }
-  if (device->modelId) { free(device->modelId); }
-  if (device->friendlyName) { free(device->friendlyName); }
-  free(device);
-}
-
-//
-// Scan all devices to find a corresponding shortaddr
-// Looks info device.shortaddr entry
-// In:
-//    shortaddr (not BAD_SHORTADDR)
-// Out:
-//    reference to device, or to device_unk if not found
-//    (use foundDevice() to check if found)
-Z_Device & Z_Devices::findShortAddr(uint16_t shortaddr) {
-  for (auto & elem : _devices) {
-    if (elem.shortaddr == shortaddr) { return elem; }
-  }
-  return (Z_Device&) device_unk;
-}
-const Z_Device & Z_Devices::findShortAddr(uint16_t shortaddr) const {
-  for (const auto & elem : _devices) {
-    if (elem.shortaddr == shortaddr) { return elem; }
-  }
-  return device_unk;
-}
-//
-// Scan all devices to find a corresponding longaddr
-// Looks info device.longaddr entry
-// In:
-//    longaddr (non null)
-// Out:
-//    index in _devices of entry, -1 if not found
-//
-Z_Device & Z_Devices::findLongAddr(uint64_t longaddr) {
-  if (!longaddr) { return (Z_Device&) device_unk; }
-  for (auto &elem : _devices) {
-    if (elem.longaddr == longaddr) { return elem; }
-  }
-  return (Z_Device&) device_unk;
-}
-const Z_Device & Z_Devices::findLongAddr(uint64_t longaddr) const {
-  if (!longaddr) { return device_unk; }
-  for (const auto &elem : _devices) {
-    if (elem.longaddr == longaddr) { return elem; }
-  }
-  return device_unk;
-}
-//
-// Scan all devices to find a corresponding friendlyNme
-// Looks info device.friendlyName entry
-// In:
-//    friendlyName (null terminated, should not be empty)
-// Out:
-//    index in _devices of entry, -1 if not found
-//
-int32_t Z_Devices::findFriendlyName(const char * name) const {
-  if (!name) { return -1; }              // if pointer is null
-  size_t name_len = strlen(name);
-  int32_t found = 0;
-  if (name_len) {
-    for (auto &elem : _devices) {
-      if (elem.friendlyName) {
-        if (strcasecmp(elem.friendlyName, name) == 0) { return found; }
-      }
-      found++;
-    }
-  }
-  return -1;
-}
-
-uint16_t Z_Devices::isKnownLongAddr(uint64_t longaddr) const {
-  const Z_Device & device = findLongAddr(longaddr);
-  if (foundDevice(device)) {
-    return device.shortaddr;    // can be zero, if not yet registered
-  } else {
-    return BAD_SHORTADDR;
-  }
-}
-
-uint16_t Z_Devices::isKnownIndex(uint32_t index) const {
-  if (index < devicesSize()) {
-    const Z_Device & device = devicesAt(index);
-    return device.shortaddr;
-  } else {
-    return BAD_SHORTADDR;
-  }
-}
-
-uint16_t Z_Devices::isKnownFriendlyName(const char * name) const {
-  if ((!name) || (0 == strlen(name))) { return BAD_SHORTADDR; }         // Error
-  int32_t found = findFriendlyName(name);
-  if (found >= 0) {
-    const Z_Device & device = devicesAt(found);
-    return device.shortaddr;    // can be zero, if not yet registered
-  } else {
-    return BAD_SHORTADDR;
-  }
-}
-
-uint64_t Z_Devices::getDeviceLongAddr(uint16_t shortaddr) const {
-  return findShortAddr(shortaddr).longaddr;     // if unknown, it reverts to the Unknown device and longaddr is 0x00
-}
-
-//
-// We have a seen a shortaddr on the network, get the corresponding device object
-//
-Z_Device & Z_Devices::getShortAddr(uint16_t shortaddr) {
-  if (BAD_SHORTADDR == shortaddr) { return (Z_Device&) device_unk; }   // this is not legal
-  Z_Device & device = findShortAddr(shortaddr);
-  if (foundDevice(device)) {
-    return device;
-  }
-  return createDeviceEntry(shortaddr, 0);
-}
-
-// find the Device object by its longaddr (unique key if not null)
-Z_Device & Z_Devices::getLongAddr(uint64_t longaddr) {
-  if (!longaddr) { return (Z_Device&) device_unk; }
-  Z_Device & device = findLongAddr(longaddr);
-  if (foundDevice(device)) {
-    return device;
-  }
-  return createDeviceEntry(0, longaddr);
-}
-
-// Remove device from list, return true if it was known, false if it was not recorded
-bool Z_Devices::removeDevice(uint16_t shortaddr) {
-  Z_Device & device = findShortAddr(shortaddr);
-  if (foundDevice(device)) {
-    _devices.remove(&device);
-    dirty();
-    return true;
-  }
-  return false;
-}
-
-//
-// We have just seen a device on the network, update the info based on short/long addr
-// In:
-//    shortaddr
-//    longaddr (both can't be null at the same time)
-void Z_Devices::updateDevice(uint16_t shortaddr, uint64_t longaddr) {
-  Z_Device * s_found = &findShortAddr(shortaddr); // is there already a shortaddr entry
-  Z_Device * l_found = &findLongAddr(longaddr);      // is there already a longaddr entry
-
-  if (foundDevice(*s_found) && foundDevice(*l_found)) {  // both shortaddr and longaddr are already registered
-    if (s_found == l_found) {
-    } else {                                        // they don't match
-      // the device with longaddr got a new shortaddr
-      l_found->shortaddr = shortaddr;      // update the shortaddr corresponding to the longaddr
-      // erase the previous shortaddr
-      freeDeviceEntry(s_found);
-      _devices.remove(s_found);
-      dirty();
-    }
-  } else if (foundDevice(*s_found)) {
-    // shortaddr already exists but longaddr not
-    // add the longaddr to the entry
-    s_found->longaddr = longaddr;
-    dirty();
-  } else if (foundDevice(*l_found)) {
-    // longaddr entry exists, update shortaddr
-    l_found->shortaddr = shortaddr;
-    dirty();
-  } else {
-    // neither short/lonf addr are found.
-    if ((BAD_SHORTADDR != shortaddr) || longaddr) {
-      createDeviceEntry(shortaddr, longaddr);
-    }
-  }
-}
-
-//
-// Clear all endpoints
-//
-void Z_Devices::clearEndpoints(uint16_t shortaddr) {
-  Z_Device &device = getShortAddr(shortaddr);
-  for (uint32_t i = 0; i < endpoints_max; i++) {
-    device.endpoints[i] = 0;
-    // no dirty here because it doesn't make sense to store it, does it?
-  }
-}
-
-//
-// Add an endpoint to a shortaddr
-//
-void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
-  if (0x00 == endpoint) { return; }
-  Z_Device &device = getShortAddr(shortaddr);
-
-  for (uint32_t i = 0; i < endpoints_max; i++) {
-    if (endpoint == device.endpoints[i]) {
-      return;     // endpoint already there
-    }
-    if (0 == device.endpoints[i]) {
-      device.endpoints[i] = endpoint;
-      dirty();
-      return;
-    }
-  }
-}
-
-//
-// Count the number of known endpoints
-//
-uint32_t Z_Devices::countEndpoints(uint16_t shortaddr) const {
-  uint32_t count_ep = 0;
-  const Z_Device & device =findShortAddr(shortaddr);
-  if (!foundDevice(device)) return 0;
-
-  for (uint32_t i = 0; i < endpoints_max; i++) {
-    if (0 != device.endpoints[i]) {
-      count_ep++;
-    }
-  }
-  return count_ep;
-}
-
-// Find the first endpoint of the device
-uint8_t Z_Devices::findFirstEndpoint(uint16_t shortaddr) const {
-  // When in router of end-device mode, the coordinator was not probed, in this case always talk to endpoint 1
-  if (0x0000 == shortaddr) { return 1; }
-  return findShortAddr(shortaddr).endpoints[0];   // returns 0x00 if no endpoint
-}
-
-void Z_Devices::setStringAttribute(char*& attr, const char * str) {
-  if (nullptr == str)  { return; }                    // ignore a null parameter
-  size_t str_len = strlen(str);
-
-  if ((nullptr == attr) && (0 == str_len)) { return; } // if both empty, don't do anything
-  if (attr) {
-    // we already have a value
-    if (strcmp(attr, str) != 0) {
-      // new value
-      free(attr);      // free previous value
-      attr = nullptr;
-    } else {
-      return;        // same value, don't change anything
-    }
-  }
-  if (str_len) {
-    attr = (char*) malloc(str_len + 1);
-    strlcpy(attr, str, str_len + 1);
-  }
-  dirty();
-}
-
-//
-// Sets the ManufId for a device.
-// No action taken if the device does not exist.
-// Inputs:
-// - shortaddr: 16-bits short address of the device. No action taken if the device is unknown
-// - str:       string pointer, if nullptr it is considered as empty string
-// Impact:
-// - Any actual change in ManufId (i.e. setting a different value) triggers a `dirty()` and saving to Flash
-//
-void Z_Devices::setManufId(uint16_t shortaddr, const char * str) {
-  setStringAttribute(getShortAddr(shortaddr).manufacturerId, str);
-}
-
-void Z_Devices::setModelId(uint16_t shortaddr, const char * str) {
-  setStringAttribute(getShortAddr(shortaddr).modelId, str);
-}
-
-void Z_Devices::setFriendlyName(uint16_t shortaddr, const char * str) {
-  setStringAttribute(getShortAddr(shortaddr).friendlyName, str);
-}
-
-
-void Z_Devices::setReachable(uint16_t shortaddr, bool reachable) {
-  getShortAddr(shortaddr).setReachable(reachable);
-}
-
-void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
-  if (shortaddr == localShortAddr) { return; }
-  getShortAddr(shortaddr).lqi = lqi;
-}
-
-void Z_Devices::setLastSeenNow(uint16_t shortaddr) {
-  if (shortaddr == localShortAddr) { return; }
-  // Only update time if after 2020-01-01 0000.
-  // Fixes issue where zigbee device pings before WiFi/NTP has set utc_time
-  // to the correct time, and "last seen" calculations are based on the
-  // pre-corrected last_seen time and the since-corrected utc_time.
-  if (Rtc.utc_time < 1577836800) { return; }
-  getShortAddr(shortaddr).last_seen = Rtc.utc_time;
-}
-
-
-void Z_Devices::setBatteryPercent(uint16_t shortaddr, uint8_t bp) {
-  getShortAddr(shortaddr).batterypercent = bp;
-}
-
-// get the next sequance number for the device, or use the global seq number if device is unknown
-uint8_t Z_Devices::getNextSeqNumber(uint16_t shortaddr) {
-  Z_Device & device = findShortAddr(shortaddr);
-  if (foundDevice(device)) {
-    device.seqNumber += 1;
-    return device.seqNumber;
-  } else {
-    _seqNumber += 1;
-    return _seqNumber;
-  }
-}
-
-// General Zigbee device profile support
-void Z_Devices::setZbProfile(uint16_t shortaddr, uint8_t zb_profile) {
-  Z_Device &device = getShortAddr(shortaddr);
-  if (zb_profile != device.zb_profile) {
-    device.zb_profile = zb_profile;
-    updateZbProfile(shortaddr);
-    dirty();
-  }
-}
-
-// Do all the required action when a profile is changed
-void Z_Devices::updateZbProfile(uint16_t shortaddr) {
-  Z_Device &device = getShortAddr(shortaddr);
-  uint8_t zb_profile = device.zb_profile;
-  if (0xFF == zb_profile) { return; }
-
-  switch (zb_profile & 0xF0) {
-  case 0x00:      // bulb profile
-    {
-      uint32_t channels = zb_profile & 0x07;
-      // depending on the bulb type, the default parameters from unknown to credible defaults
-      // if (!device.validPower()) { device.setPower(false); }
-      // if (1 <= channels) {
-      //   if (0xFF == device.dimmer) { device.dimmer = 0; }
-      // }
-      // if (3 <= channels) {
-      //   if (0xFF == device.sat) { device.sat = 0; }
-      //   if (0xFFFF == device.hue) { device.hue = 0; }
-      //   if (0xFFFF == device.x) { device.x = 0; }
-      //   if (0xFFFF == device.y) { device.y = 0; }
-      //   if (0xFF == device.colormode) { device.colormode = 0; }   // HueSat mode
-      // }
-      // if ((2 == channels) || (5 == channels)) {
-      //   if (0xFFFF == device.ct) { device.ct = 200; }
-      //   if (0xFF == device.colormode) { device.colormode = 2; }   // CT mode
-      // }
-    }
-    break;
-  }
-}
-
-// Returns the device profile or 0xFF if the device or profile is unknown
-uint8_t Z_Devices::getZbProfile(uint16_t shortaddr) const {
-  return findShortAddr(shortaddr).zb_profile;
-}
-
-// Hue support
-void Z_Devices::setHueBulbtype(uint16_t shortaddr, int8_t bulbtype) {
-  uint8_t zb_profile = (0 > bulbtype) ? 0xFF : (bulbtype & 0x07);
-  setZbProfile(shortaddr, zb_profile);
-}
-
-int8_t Z_Devices::getHueBulbtype(uint16_t shortaddr) const {
-  uint8_t zb_profile = getZbProfile(shortaddr);
-  if (0x00 == (zb_profile & 0xF0)) {
-    return (zb_profile & 0x07);
-  } else {
-    // not a bulb
-    return -1;
-  }
-}
-
-void Z_Devices::hideHueBulb(uint16_t shortaddr, bool hidden) {
-  uint8_t hue_hidden_flag = hidden ? 0x08 : 0x00;
-  
-  Z_Device &device = getShortAddr(shortaddr);
-  if (0x00 == (device.zb_profile & 0xF0)) {
-    // bulb type
-    // set bit 3 accordingly
-    if (hue_hidden_flag != (device.zb_profile & 0x08)) {
-      device.zb_profile = (device.zb_profile & 0xF7) | hue_hidden_flag;
-      dirty();
-    }
-  }
-}
-// true if device is not knwon or not a bulb - it wouldn't make sense to publish a non-bulb
-bool Z_Devices::isHueBulbHidden(uint16_t shortaddr) const {
-  const Z_Device & device = findShortAddr(shortaddr);
-  if (foundDevice(device)) {
-    uint8_t zb_profile = device.zb_profile;
-    if (0x00 == (zb_profile & 0xF0)) {
-      // bulb type
-      return (zb_profile & 0x08) ? true : false;
-    }
-  }
-  return true;      // Fallback - Device is considered as hidden
-}
-
-// Deferred actions
-// Parse for a specific category, of all deferred for a device if category == 0xFF
-// Only with specific cluster number or for all clusters if cluster == 0xFFFF
-void Z_Devices::resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster, uint8_t endpoint) {
-  // iterate the list of deferred, and remove any linked to the shortaddr
-  for (auto & defer : _deferred) {
-    if ((defer.shortaddr == shortaddr) && (defer.groupaddr == groupaddr)) {
-      if ((0xFF == category) || (defer.category == category)) {
-        if ((0xFFFF == cluster) || (defer.cluster == cluster)) {
-          if ((0xFF == endpoint) || (defer.endpoint == endpoint)) {
-            _deferred.remove(&defer);
-          }
-        }
-      }
-    }
-  }
-}
-
-// Set timer for a specific device
-void Z_Devices::setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
-  // First we remove any existing timer for same device in same category, except for category=0x00 (they need to happen anyway)
-  if (category >= Z_CLEAR_DEVICE) {     // if category == 0, we leave all previous timers
-    resetTimersForDevice(shortaddr, groupaddr, category, category >= Z_CLEAR_DEVICE_CLUSTER ? cluster : 0xFFFF, category >= Z_CLEAR_DEVICE_CLUSTER_ENDPOINT ? endpoint : 0xFF);    // remove any cluster
-  }
-
-  // Now create the new timer
-  Z_Deferred & deferred = _deferred.addHead();
-  deferred = { wait_ms + millis(),   // timer
-                          shortaddr,
-                          groupaddr,
-                          cluster,
-                          endpoint,
-                          category,
-                          value,
-                          func };
-}
-
-// Set timer after the already queued events
-// I.e. the wait_ms is not counted from now, but from the last event queued, which is 'now' or in the future
-void Z_Devices::queueTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
-  Z_Device & device = getShortAddr(shortaddr);
-  uint32_t now_millis = millis();
-  if (TimeReached(device.defer_last_message_sent)) {
-    device.defer_last_message_sent = now_millis;
-  }
-  // defer_last_message_sent equals now or a value in the future
-  device.defer_last_message_sent += wait_ms;
-
-  // for queueing we don't clear the backlog, so we force category to Z_CAT_ALWAYS
-  setTimer(shortaddr, groupaddr, (device.defer_last_message_sent - now_millis), cluster, endpoint, Z_CAT_ALWAYS, value, func);
-}
-
-// Run timer at each tick
-// WARNING: don't set a new timer within a running timer, this causes memory corruption
-void Z_Devices::runTimer(void) {
-  // visit all timers
-  for (auto & defer : _deferred) {
-    uint32_t timer = defer.timer;
-    if (TimeReached(timer)) {
-      (*defer.func)(defer.shortaddr, defer.groupaddr, defer.cluster, defer.endpoint, defer.value);
-      _deferred.remove(&defer);
-    }
-  }
-
-  // check if we need to save to Flash
-  if ((_saveTimer) && TimeReached(_saveTimer)) {
-    saveZigbeeDevices();
-    _saveTimer = 0;
-  }
-}
-
-// does the new payload conflicts with the existing payload, i.e. values would be overwritten
-// true - one attribute (except LinkQuality) woudl be lost, there is conflict
-// false - new attributes can be safely added
-bool Z_Devices::jsonIsConflict(uint16_t shortaddr, const Z_attribute_list &attr_list) const {
-  const Z_Device & device = findShortAddr(shortaddr);
-
-  if (!foundDevice(device)) { return false; }
-  if (attr_list.isEmpty()) {
-    return false;                                           // if no previous value, no conflict
-  }
-
-  // compare groups
-  if (device.attr_list.isValidGroupId() && attr_list.isValidGroupId()) {
-    if (device.attr_list.group_id != attr_list.group_id) { return true; }     // groups are in conflict
-  }
-
-  // compare src_ep
-  if (device.attr_list.isValidSrcEp() && attr_list.isValidSrcEp()) {
-    if (device.attr_list.src_ep != attr_list.src_ep) { return true; }
-  }
-  
-  // LQI does not count as conflicting
-
-  // parse all other parameters
-  for (const auto & attr : attr_list) {
-    const Z_attribute * curr_attr = device.attr_list.findAttribute(attr);
-    if (nullptr != curr_attr) {
-      if (!curr_attr->equalsVal(attr)) {
-        return true;    // the value already exists and is different - conflict!
-      }
-    }
-  }
-  return false;
-}
-
-void Z_Devices::jsonAppend(uint16_t shortaddr, const Z_attribute_list &attr_list) {
-  Z_Device & device = getShortAddr(shortaddr);
-  device.attr_list.mergeList(attr_list);
-}
-
-void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
-  Z_Device & device = getShortAddr(shortaddr);
-  if (!device.valid()) { return; }                 // safeguard
-  Z_attribute_list &attr_list = device.attr_list;
-
-  if (!attr_list.isEmpty()) {
-    const char * fname = zigbee_devices.getFriendlyName(shortaddr);
-    bool use_fname = (Settings.flag4.zigbee_use_names) && (fname);    // should we replace shortaddr with friendlyname?
-
-    // save parameters is global variables to be used by Rules
-    gZbLastMessage.device = shortaddr;                // %zbdevice%
-    gZbLastMessage.groupaddr = attr_list.group_id;      // %zbgroup%
-    gZbLastMessage.endpoint = attr_list.src_ep;    // %zbendpoint%
-
-    mqtt_data[0] = 0; // clear string
-    // Do we prefix with `ZbReceived`?
-    if (!Settings.flag4.remove_zbreceived) {
-      Response_P(PSTR("{\"" D_JSON_ZIGBEE_RECEIVED "\":"));
-    }
-    // What key do we use, shortaddr or name?
-    if (use_fname) {
-      Response_P(PSTR("%s{\"%s\":{"), mqtt_data, fname);
-    } else {
-      Response_P(PSTR("%s{\"0x%04X\":{"), mqtt_data, shortaddr);
-    }
-    // Add "Device":"0x...."
-    Response_P(PSTR("%s\"" D_JSON_ZIGBEE_DEVICE "\":\"0x%04X\","), mqtt_data, shortaddr);
-    // Add "Name":"xxx" if name is present
-    if (fname) {
-      Response_P(PSTR("%s\"" D_JSON_ZIGBEE_NAME "\":\"%s\","), mqtt_data, EscapeJSONString(fname).c_str());
-    }
-    // Add all other attributes
-    Response_P(PSTR("%s%s}}"), mqtt_data, attr_list.toString().c_str());
-    
-    if (!Settings.flag4.remove_zbreceived) {
-      Response_P(PSTR("%s}"), mqtt_data);
-    }
-    // AddLog_P2(LOG_LEVEL_INFO, PSTR(">>> %s"), mqtt_data);   // TODO
-    attr_list.reset();    // clear the attributes
-
-    if (Settings.flag4.zigbee_distinct_topics) {
-      if (Settings.flag4.zb_topic_fname && fname) {
-        //Clean special characters and check size of friendly name
-        char stemp[TOPSZ];
-        strlcpy(stemp, (!strlen(fname)) ? MQTT_TOPIC : fname, sizeof(stemp));
-        MakeValidMqtt(0, stemp);
-        //Create topic with Prefix3 and cleaned up friendly name
-        char frtopic[TOPSZ];
-        snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), stemp);
-        MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
-      } else {
-        char subtopic[16];
-        snprintf_P(subtopic, sizeof(subtopic), PSTR("%04X/" D_RSLT_SENSOR), shortaddr);
-        MqttPublishPrefixTopic_P(TELE, subtopic, Settings.flag.mqtt_sensor_retain);
-      }
-    } else {
-      MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
-    }
-    XdrvRulesProcess();     // apply rules
-  }
-}
-
-void Z_Devices::jsonPublishNow(uint16_t shortaddr, Z_attribute_list &attr_list) {
-  jsonPublishFlush(shortaddr);    // flush any previous buffer
-  jsonAppend(shortaddr, attr_list);
-  jsonPublishFlush(shortaddr);    // publish now
-}
-
-void Z_Devices::dirty(void) {
-  _saveTimer = kZigbeeSaveDelaySeconds * 1000 + millis();
-}
-void Z_Devices::clean(void) {
-  _saveTimer = 0;
-}
-
-// Parse the command parameters for either:
-// - a short address starting with "0x", example: 0x1234
-// - a long address starting with "0x", example: 0x7CB03EBB0A0292DD
-// - a number 0..99, the index number in ZigbeeStatus
-// - a friendly name, between quotes, example: "Room_Temp"
-uint16_t Z_Devices::parseDeviceParam(const char * param, bool short_must_be_known) const {
-  if (nullptr == param) { return BAD_SHORTADDR; }
-  size_t param_len = strlen(param);
-  char dataBuf[param_len + 1];
-  strcpy(dataBuf, param);
-  RemoveSpace(dataBuf);
-  uint16_t shortaddr = BAD_SHORTADDR;    // start with unknown
-
-  if (strlen(dataBuf) < 4) {
-    // simple number 0..99
-    if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= 99)) {
-      shortaddr = zigbee_devices.isKnownIndex(XdrvMailbox.payload - 1);
-    }
-  } else if ((dataBuf[0] == '0') && ((dataBuf[1] == 'x') || (dataBuf[1] == 'X'))) {
-    // starts with 0x
-    if (strlen(dataBuf) < 18) {
-      // expect a short address
-      shortaddr = strtoull(dataBuf, nullptr, 0);
-      if (short_must_be_known) {
-        shortaddr = zigbee_devices.findShortAddr(shortaddr).shortaddr;   // if not found, it reverts to the unknown_device with address BAD_SHORTADDR
-      }
-      // else we don't check if it's already registered to force unregistered devices
-    } else {
-      // expect a long address
-      uint64_t longaddr = strtoull(dataBuf, nullptr, 0);
-      shortaddr = zigbee_devices.isKnownLongAddr(longaddr);
-    }
-  } else {
-    // expect a Friendly Name
-    shortaddr = zigbee_devices.isKnownFriendlyName(dataBuf);
-  }
-
-  return shortaddr;
-}
-
-// Display the tracked status for a light
-String Z_Devices::dumpLightState(uint16_t shortaddr) const {
-  Z_attribute_list attr_list;
-  char hex[8];
-
-  const Z_Device & device = findShortAddr(shortaddr);
-  const char * fname = getFriendlyName(shortaddr);
-  bool use_fname = (Settings.flag4.zigbee_use_names) && (fname);    // should we replace shortaddr with friendlyname?
-  snprintf_P(hex, sizeof(hex), PSTR("0x%04X"), shortaddr);
-
-  attr_list.addAttribute(F(D_JSON_ZIGBEE_DEVICE)).setStr(hex);
-  if (fname) {
-    attr_list.addAttribute(F(D_JSON_ZIGBEE_NAME)).setStr(fname);
-  }
-
-  if (foundDevice(device)) {
-    // expose the last known status of the bulb, for Hue integration
-    attr_list.addAttribute(F(D_JSON_ZIGBEE_LIGHT)).setInt(getHueBulbtype(shortaddr));  // sign extend, 0xFF changed as -1
-    // dump all known values
-    attr_list.addAttribute(F("Reachable")).setBool(device.getReachable());
-    if (device.validPower())        { attr_list.addAttribute(F("Power")).setUInt(device.getPower()); }
-    if (device.validDimmer())       { attr_list.addAttribute(F("Dimmer")).setUInt(device.dimmer); }
-    if (device.validColormode())    { attr_list.addAttribute(F("Colormode")).setUInt(device.colormode); }
-    if (device.validCT())           { attr_list.addAttribute(F("CT")).setUInt(device.ct); }
-    if (device.validSat())          { attr_list.addAttribute(F("Sat")).setUInt(device.sat); }
-    if (device.validHue())          { attr_list.addAttribute(F("Hue")).setUInt(device.hue); }
-    if (device.validX())            { attr_list.addAttribute(F("X")).setUInt(device.x); }
-    if (device.validY())            { attr_list.addAttribute(F("Y")).setUInt(device.y); }
-  }
-  
-  Z_attribute_list attr_list_root;
-  Z_attribute * attr_root;
-  if (use_fname) {
-    attr_root = &attr_list_root.addAttribute(fname);
-  } else {
-    attr_root = &attr_list_root.addAttribute(hex);
-  }
-  attr_root->setStrRaw(attr_list.toString(true).c_str());
-  return attr_list_root.toString(true);
-}
-
-// Dump the internal memory of Zigbee devices
-// Mode = 1: simple dump of devices addresses
-// Mode = 2: simple dump of devices addresses and names, endpoints, light
-String Z_Devices::dump(uint32_t dump_mode, uint16_t status_shortaddr) const {
-  Z_json_array json_arr;
-
-  for (const auto & device : _devices) {
-    uint16_t shortaddr = device.shortaddr;
-    char hex[22];
-
-    // ignore non-current device, if device specified
-    if ((BAD_SHORTADDR != status_shortaddr) && (status_shortaddr != shortaddr)) { continue; }
-
-    Z_attribute_list attr_list;
-
-    snprintf_P(hex, sizeof(hex), PSTR("0x%04X"), shortaddr);
-    attr_list.addAttribute(F(D_JSON_ZIGBEE_DEVICE)).setStr(hex);
-
-    if (device.friendlyName > 0) {
-      attr_list.addAttribute(F(D_JSON_ZIGBEE_NAME)).setStr(device.friendlyName);
-    }
-
-    if (2 <= dump_mode) {
-      hex[0] = '0';   // prefix with '0x'
-      hex[1] = 'x';
-      Uint64toHex(device.longaddr, &hex[2], 64);
-      attr_list.addAttribute(F("IEEEAddr")).setStr(hex);
-      if (device.modelId) {
-        attr_list.addAttribute(F(D_JSON_MODEL D_JSON_ID)).setStr(device.modelId);
-      }
-      int8_t bulbtype = getHueBulbtype(shortaddr);
-      if (bulbtype >= 0) {
-        attr_list.addAttribute(F(D_JSON_ZIGBEE_LIGHT)).setInt(bulbtype);   // sign extend, 0xFF changed as -1
-      }
-      if (device.manufacturerId) {
-        attr_list.addAttribute(F("Manufacturer")).setStr(device.manufacturerId);
-      }
-      Z_json_array arr_ep;
-      for (uint32_t i = 0; i < endpoints_max; i++) {
-        uint8_t endpoint = device.endpoints[i];
-        if (0x00 == endpoint) { break; }
-        arr_ep.add(endpoint);
-      }
-      attr_list.addAttribute(F("Endpoints")).setStrRaw(arr_ep.toString().c_str());
-    }
-    json_arr.addStrRaw(attr_list.toString(true).c_str());
-  }
-  return json_arr.toString();
-}
-
-// Restore a single device configuration based on json export
-// Input: json element as expported by `ZbStatus2``
-// Mandatory attribue: `Device`
-//
-// Returns:
-//  0 : Ok
-// <0 : Error
-//
-// Ex: {"Device":"0x5ADF","Name":"IKEA_Light","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":["0x01","0xF2"]}
-int32_t Z_Devices::deviceRestore(JsonParserObject json) {
-
-  // params
-  uint16_t device = 0x0000;                 // 0x0000 is coordinator so considered invalid
-  uint64_t ieeeaddr = 0x0000000000000000LL; // 0 means unknown
-  const char * modelid = nullptr;
-  const char * manufid = nullptr;
-  const char * friendlyname = nullptr;
-  int8_t   bulbtype = -1;
-  size_t   endpoints_len = 0;
-
-  // read mandatory "Device"
-  JsonParserToken val_device = json[PSTR("Device")];
-  if (val_device) {
-    device = (uint32_t) val_device.getUInt(device);
-  } else {
-    return -1;        // missing "Device" attribute
-  }
-
-  ieeeaddr      = json.getULong(PSTR("IEEEAddr"), ieeeaddr); // read "IEEEAddr" 64 bits in format "0x0000000000000000"
-  friendlyname  = json.getStr(PSTR("Name"), nullptr);  // read "Name"
-  modelid       = json.getStr(PSTR("ModelId"), nullptr);
-  manufid       = json.getStr(PSTR("Manufacturer"), nullptr);
-  JsonParserToken tok_bulbtype = json[PSTR(D_JSON_ZIGBEE_LIGHT)];
-
-  // update internal device information
-  updateDevice(device, ieeeaddr);
-  if (modelid) { setModelId(device, modelid); }
-  if (manufid) { setManufId(device, manufid); }
-  if (friendlyname) { setFriendlyName(device, friendlyname); }
-  if (tok_bulbtype) { setHueBulbtype(device, tok_bulbtype.getInt()); }
-
-  // read "Endpoints"
-  JsonParserToken val_endpoints = json[PSTR("Endpoints")];
-  if (val_endpoints.isArray()) {
-    JsonParserArray arr_ep = JsonParserArray(val_endpoints);
-    clearEndpoints(device);     // clear even if array is empty
-    for (auto ep_elt : arr_ep) {
-      uint8_t ep = ep_elt.getUInt();
-      if (ep) { addEndpoint(device, ep); }
-    }
-  }
-
-  return 0;
-}
 
 #endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -1,0 +1,779 @@
+/*
+  xdrv_23_zigbee_2a_devices_impl.ino - zigbee support for Tasmota
+
+  Copyright (C) 2020  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+/*********************************************************************************************\
+ * Implementation
+\*********************************************************************************************/
+
+//
+// Create a new Z_Device entry in _devices. Only to be called if you are sure that no
+// entry with same shortaddr or longaddr exists.
+//
+Z_Device & Z_Devices::createDeviceEntry(uint16_t shortaddr, uint64_t longaddr) {
+  if ((BAD_SHORTADDR == shortaddr) && !longaddr) { return (Z_Device&) device_unk; }      // it is not legal to create this entry
+  Z_Device device(shortaddr, longaddr);
+
+  dirty();
+  return _devices.addHead(device);
+}
+
+void Z_Devices::freeDeviceEntry(Z_Device *device) {
+  if (device->manufacturerId) { free(device->manufacturerId); }
+  if (device->modelId) { free(device->modelId); }
+  if (device->friendlyName) { free(device->friendlyName); }
+  free(device);
+}
+
+//
+// Scan all devices to find a corresponding shortaddr
+// Looks info device.shortaddr entry
+// In:
+//    shortaddr (not BAD_SHORTADDR)
+// Out:
+//    reference to device, or to device_unk if not found
+//    (use foundDevice() to check if found)
+Z_Device & Z_Devices::findShortAddr(uint16_t shortaddr) {
+  for (auto & elem : _devices) {
+    if (elem.shortaddr == shortaddr) { return elem; }
+  }
+  return (Z_Device&) device_unk;
+}
+const Z_Device & Z_Devices::findShortAddr(uint16_t shortaddr) const {
+  for (const auto & elem : _devices) {
+    if (elem.shortaddr == shortaddr) { return elem; }
+  }
+  return device_unk;
+}
+//
+// Scan all devices to find a corresponding longaddr
+// Looks info device.longaddr entry
+// In:
+//    longaddr (non null)
+// Out:
+//    index in _devices of entry, -1 if not found
+//
+Z_Device & Z_Devices::findLongAddr(uint64_t longaddr) {
+  if (!longaddr) { return (Z_Device&) device_unk; }
+  for (auto &elem : _devices) {
+    if (elem.longaddr == longaddr) { return elem; }
+  }
+  return (Z_Device&) device_unk;
+}
+const Z_Device & Z_Devices::findLongAddr(uint64_t longaddr) const {
+  if (!longaddr) { return device_unk; }
+  for (const auto &elem : _devices) {
+    if (elem.longaddr == longaddr) { return elem; }
+  }
+  return device_unk;
+}
+//
+// Scan all devices to find a corresponding friendlyNme
+// Looks info device.friendlyName entry
+// In:
+//    friendlyName (null terminated, should not be empty)
+// Out:
+//    index in _devices of entry, -1 if not found
+//
+int32_t Z_Devices::findFriendlyName(const char * name) const {
+  if (!name) { return -1; }              // if pointer is null
+  size_t name_len = strlen(name);
+  int32_t found = 0;
+  if (name_len) {
+    for (auto &elem : _devices) {
+      if (elem.friendlyName) {
+        if (strcasecmp(elem.friendlyName, name) == 0) { return found; }
+      }
+      found++;
+    }
+  }
+  return -1;
+}
+
+uint16_t Z_Devices::isKnownLongAddr(uint64_t longaddr) const {
+  const Z_Device & device = findLongAddr(longaddr);
+  if (foundDevice(device)) {
+    return device.shortaddr;    // can be zero, if not yet registered
+  } else {
+    return BAD_SHORTADDR;
+  }
+}
+
+uint16_t Z_Devices::isKnownIndex(uint32_t index) const {
+  if (index < devicesSize()) {
+    const Z_Device & device = devicesAt(index);
+    return device.shortaddr;
+  } else {
+    return BAD_SHORTADDR;
+  }
+}
+
+uint16_t Z_Devices::isKnownFriendlyName(const char * name) const {
+  if ((!name) || (0 == strlen(name))) { return BAD_SHORTADDR; }         // Error
+  int32_t found = findFriendlyName(name);
+  if (found >= 0) {
+    const Z_Device & device = devicesAt(found);
+    return device.shortaddr;    // can be zero, if not yet registered
+  } else {
+    return BAD_SHORTADDR;
+  }
+}
+
+uint64_t Z_Devices::getDeviceLongAddr(uint16_t shortaddr) const {
+  return findShortAddr(shortaddr).longaddr;     // if unknown, it reverts to the Unknown device and longaddr is 0x00
+}
+
+//
+// We have a seen a shortaddr on the network, get the corresponding device object
+//
+Z_Device & Z_Devices::getShortAddr(uint16_t shortaddr) {
+  if (BAD_SHORTADDR == shortaddr) { return (Z_Device&) device_unk; }   // this is not legal
+  Z_Device & device = findShortAddr(shortaddr);
+  if (foundDevice(device)) {
+    return device;
+  }
+  return createDeviceEntry(shortaddr, 0);
+}
+
+// find the Device object by its longaddr (unique key if not null)
+Z_Device & Z_Devices::getLongAddr(uint64_t longaddr) {
+  if (!longaddr) { return (Z_Device&) device_unk; }
+  Z_Device & device = findLongAddr(longaddr);
+  if (foundDevice(device)) {
+    return device;
+  }
+  return createDeviceEntry(0, longaddr);
+}
+
+// Remove device from list, return true if it was known, false if it was not recorded
+bool Z_Devices::removeDevice(uint16_t shortaddr) {
+  Z_Device & device = findShortAddr(shortaddr);
+  if (foundDevice(device)) {
+    _devices.remove(&device);
+    dirty();
+    return true;
+  }
+  return false;
+}
+
+//
+// We have just seen a device on the network, update the info based on short/long addr
+// In:
+//    shortaddr
+//    longaddr (both can't be null at the same time)
+void Z_Devices::updateDevice(uint16_t shortaddr, uint64_t longaddr) {
+  Z_Device * s_found = &findShortAddr(shortaddr); // is there already a shortaddr entry
+  Z_Device * l_found = &findLongAddr(longaddr);      // is there already a longaddr entry
+
+  if (foundDevice(*s_found) && foundDevice(*l_found)) {  // both shortaddr and longaddr are already registered
+    if (s_found == l_found) {
+    } else {                                        // they don't match
+      // the device with longaddr got a new shortaddr
+      l_found->shortaddr = shortaddr;      // update the shortaddr corresponding to the longaddr
+      // erase the previous shortaddr
+      freeDeviceEntry(s_found);
+      _devices.remove(s_found);
+      dirty();
+    }
+  } else if (foundDevice(*s_found)) {
+    // shortaddr already exists but longaddr not
+    // add the longaddr to the entry
+    s_found->longaddr = longaddr;
+    dirty();
+  } else if (foundDevice(*l_found)) {
+    // longaddr entry exists, update shortaddr
+    l_found->shortaddr = shortaddr;
+    dirty();
+  } else {
+    // neither short/lonf addr are found.
+    if ((BAD_SHORTADDR != shortaddr) || longaddr) {
+      createDeviceEntry(shortaddr, longaddr);
+    }
+  }
+}
+
+//
+// Clear all endpoints
+//
+void Z_Devices::clearEndpoints(uint16_t shortaddr) {
+  Z_Device &device = getShortAddr(shortaddr);
+  for (uint32_t i = 0; i < endpoints_max; i++) {
+    device.endpoints[i] = 0;
+    // no dirty here because it doesn't make sense to store it, does it?
+  }
+}
+
+//
+// Add an endpoint to a shortaddr
+//
+void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
+  if (0x00 == endpoint) { return; }
+  Z_Device &device = getShortAddr(shortaddr);
+
+  for (uint32_t i = 0; i < endpoints_max; i++) {
+    if (endpoint == device.endpoints[i]) {
+      return;     // endpoint already there
+    }
+    if (0 == device.endpoints[i]) {
+      device.endpoints[i] = endpoint;
+      dirty();
+      return;
+    }
+  }
+}
+
+//
+// Count the number of known endpoints
+//
+uint32_t Z_Devices::countEndpoints(uint16_t shortaddr) const {
+  uint32_t count_ep = 0;
+  const Z_Device & device =findShortAddr(shortaddr);
+  if (!foundDevice(device)) return 0;
+
+  for (uint32_t i = 0; i < endpoints_max; i++) {
+    if (0 != device.endpoints[i]) {
+      count_ep++;
+    }
+  }
+  return count_ep;
+}
+
+// Find the first endpoint of the device
+uint8_t Z_Devices::findFirstEndpoint(uint16_t shortaddr) const {
+  // When in router of end-device mode, the coordinator was not probed, in this case always talk to endpoint 1
+  if (0x0000 == shortaddr) { return 1; }
+  return findShortAddr(shortaddr).endpoints[0];   // returns 0x00 if no endpoint
+}
+
+void Z_Devices::setStringAttribute(char*& attr, const char * str) {
+  if (nullptr == str)  { return; }                    // ignore a null parameter
+  size_t str_len = strlen(str);
+
+  if ((nullptr == attr) && (0 == str_len)) { return; } // if both empty, don't do anything
+  if (attr) {
+    // we already have a value
+    if (strcmp(attr, str) != 0) {
+      // new value
+      free(attr);      // free previous value
+      attr = nullptr;
+    } else {
+      return;        // same value, don't change anything
+    }
+  }
+  if (str_len) {
+    attr = (char*) malloc(str_len + 1);
+    strlcpy(attr, str, str_len + 1);
+  }
+  dirty();
+}
+
+//
+// Sets the ManufId for a device.
+// No action taken if the device does not exist.
+// Inputs:
+// - shortaddr: 16-bits short address of the device. No action taken if the device is unknown
+// - str:       string pointer, if nullptr it is considered as empty string
+// Impact:
+// - Any actual change in ManufId (i.e. setting a different value) triggers a `dirty()` and saving to Flash
+//
+void Z_Devices::setManufId(uint16_t shortaddr, const char * str) {
+  setStringAttribute(getShortAddr(shortaddr).manufacturerId, str);
+}
+
+void Z_Devices::setModelId(uint16_t shortaddr, const char * str) {
+  setStringAttribute(getShortAddr(shortaddr).modelId, str);
+}
+
+void Z_Devices::setFriendlyName(uint16_t shortaddr, const char * str) {
+  setStringAttribute(getShortAddr(shortaddr).friendlyName, str);
+}
+
+
+void Z_Devices::setReachable(uint16_t shortaddr, bool reachable) {
+  getShortAddr(shortaddr).setReachable(reachable);
+}
+
+void Z_Devices::setLQI(uint16_t shortaddr, uint8_t lqi) {
+  if (shortaddr == localShortAddr) { return; }
+  getShortAddr(shortaddr).lqi = lqi;
+}
+
+void Z_Devices::setLastSeenNow(uint16_t shortaddr) {
+  if (shortaddr == localShortAddr) { return; }
+  // Only update time if after 2020-01-01 0000.
+  // Fixes issue where zigbee device pings before WiFi/NTP has set utc_time
+  // to the correct time, and "last seen" calculations are based on the
+  // pre-corrected last_seen time and the since-corrected utc_time.
+  if (Rtc.utc_time < 1577836800) { return; }
+  getShortAddr(shortaddr).last_seen = Rtc.utc_time;
+}
+
+
+void Z_Devices::setBatteryPercent(uint16_t shortaddr, uint8_t bp) {
+  getShortAddr(shortaddr).batterypercent = bp;
+}
+
+// get the next sequance number for the device, or use the global seq number if device is unknown
+uint8_t Z_Devices::getNextSeqNumber(uint16_t shortaddr) {
+  Z_Device & device = findShortAddr(shortaddr);
+  if (foundDevice(device)) {
+    device.seqNumber += 1;
+    return device.seqNumber;
+  } else {
+    _seqNumber += 1;
+    return _seqNumber;
+  }
+}
+
+// General Zigbee device profile support
+void Z_Devices::setLightProfile(uint16_t shortaddr, uint8_t light_profile) {
+  Z_Device &device = getShortAddr(shortaddr);
+  if (device.setLightChannels(light_profile)) {
+    dirty();
+  }
+}
+
+// Returns the device profile or 0xFF if the device or profile is unknown
+uint8_t Z_Devices::getLightProfile(uint16_t shortaddr) const {
+  const Z_Device &device = findShortAddr(shortaddr);
+  return device.getLightChannels();
+}
+
+int8_t Z_Devices::getHueBulbtype(uint16_t shortaddr) const {
+  int8_t light_profile = getLightProfile(shortaddr);
+  if (0x00 == (light_profile & 0xF0)) {
+    return (light_profile & 0x07);
+  } else {
+    // not a bulb
+    return -1;
+  }
+}
+
+void Z_Devices::hideHueBulb(uint16_t shortaddr, bool hidden) {
+  Z_Device &device = getShortAddr(shortaddr);
+  if (device.hidden != hidden) {
+    device.hidden = hidden;
+    dirty();
+  }
+}
+// true if device is not knwon or not a bulb - it wouldn't make sense to publish a non-bulb
+bool Z_Devices::isHueBulbHidden(uint16_t shortaddr) const {
+  const Z_Device & device = findShortAddr(shortaddr);
+  if (foundDevice(device)) {
+    return device.hidden;
+  }
+  return true;      // Fallback - Device is considered as hidden
+}
+
+// Deferred actions
+// Parse for a specific category, of all deferred for a device if category == 0xFF
+// Only with specific cluster number or for all clusters if cluster == 0xFFFF
+void Z_Devices::resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster, uint8_t endpoint) {
+  // iterate the list of deferred, and remove any linked to the shortaddr
+  for (auto & defer : _deferred) {
+    if ((defer.shortaddr == shortaddr) && (defer.groupaddr == groupaddr)) {
+      if ((0xFF == category) || (defer.category == category)) {
+        if ((0xFFFF == cluster) || (defer.cluster == cluster)) {
+          if ((0xFF == endpoint) || (defer.endpoint == endpoint)) {
+            _deferred.remove(&defer);
+          }
+        }
+      }
+    }
+  }
+}
+
+// Set timer for a specific device
+void Z_Devices::setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
+  // First we remove any existing timer for same device in same category, except for category=0x00 (they need to happen anyway)
+  if (category >= Z_CLEAR_DEVICE) {     // if category == 0, we leave all previous timers
+    resetTimersForDevice(shortaddr, groupaddr, category, category >= Z_CLEAR_DEVICE_CLUSTER ? cluster : 0xFFFF, category >= Z_CLEAR_DEVICE_CLUSTER_ENDPOINT ? endpoint : 0xFF);    // remove any cluster
+  }
+
+  // Now create the new timer
+  Z_Deferred & deferred = _deferred.addHead();
+  deferred = { wait_ms + millis(),   // timer
+                          shortaddr,
+                          groupaddr,
+                          cluster,
+                          endpoint,
+                          category,
+                          value,
+                          func };
+}
+
+// Set timer after the already queued events
+// I.e. the wait_ms is not counted from now, but from the last event queued, which is 'now' or in the future
+void Z_Devices::queueTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func) {
+  Z_Device & device = getShortAddr(shortaddr);
+  uint32_t now_millis = millis();
+  if (TimeReached(device.defer_last_message_sent)) {
+    device.defer_last_message_sent = now_millis;
+  }
+  // defer_last_message_sent equals now or a value in the future
+  device.defer_last_message_sent += wait_ms;
+
+  // for queueing we don't clear the backlog, so we force category to Z_CAT_ALWAYS
+  setTimer(shortaddr, groupaddr, (device.defer_last_message_sent - now_millis), cluster, endpoint, Z_CAT_ALWAYS, value, func);
+}
+
+// Run timer at each tick
+// WARNING: don't set a new timer within a running timer, this causes memory corruption
+void Z_Devices::runTimer(void) {
+  // visit all timers
+  for (auto & defer : _deferred) {
+    uint32_t timer = defer.timer;
+    if (TimeReached(timer)) {
+      (*defer.func)(defer.shortaddr, defer.groupaddr, defer.cluster, defer.endpoint, defer.value);
+      _deferred.remove(&defer);
+    }
+  }
+
+  // check if we need to save to Flash
+  if ((_saveTimer) && TimeReached(_saveTimer)) {
+    saveZigbeeDevices();
+    _saveTimer = 0;
+  }
+}
+
+// does the new payload conflicts with the existing payload, i.e. values would be overwritten
+// true - one attribute (except LinkQuality) woudl be lost, there is conflict
+// false - new attributes can be safely added
+bool Z_Devices::jsonIsConflict(uint16_t shortaddr, const Z_attribute_list &attr_list) const {
+  const Z_Device & device = findShortAddr(shortaddr);
+
+  if (!foundDevice(device)) { return false; }
+  if (attr_list.isEmpty()) {
+    return false;                                           // if no previous value, no conflict
+  }
+
+  // compare groups
+  if (device.attr_list.isValidGroupId() && attr_list.isValidGroupId()) {
+    if (device.attr_list.group_id != attr_list.group_id) { return true; }     // groups are in conflict
+  }
+
+  // compare src_ep
+  if (device.attr_list.isValidSrcEp() && attr_list.isValidSrcEp()) {
+    if (device.attr_list.src_ep != attr_list.src_ep) { return true; }
+  }
+  
+  // LQI does not count as conflicting
+
+  // parse all other parameters
+  for (const auto & attr : attr_list) {
+    const Z_attribute * curr_attr = device.attr_list.findAttribute(attr);
+    if (nullptr != curr_attr) {
+      if (!curr_attr->equalsVal(attr)) {
+        return true;    // the value already exists and is different - conflict!
+      }
+    }
+  }
+  return false;
+}
+
+void Z_Devices::jsonAppend(uint16_t shortaddr, const Z_attribute_list &attr_list) {
+  Z_Device & device = getShortAddr(shortaddr);
+  device.attr_list.mergeList(attr_list);
+}
+
+void Z_Devices::jsonPublishFlush(uint16_t shortaddr) {
+  Z_Device & device = getShortAddr(shortaddr);
+  if (!device.valid()) { return; }                 // safeguard
+  Z_attribute_list &attr_list = device.attr_list;
+
+  if (!attr_list.isEmpty()) {
+    const char * fname = zigbee_devices.getFriendlyName(shortaddr);
+    bool use_fname = (Settings.flag4.zigbee_use_names) && (fname);    // should we replace shortaddr with friendlyname?
+
+    // save parameters is global variables to be used by Rules
+    gZbLastMessage.device = shortaddr;                // %zbdevice%
+    gZbLastMessage.groupaddr = attr_list.group_id;      // %zbgroup%
+    gZbLastMessage.endpoint = attr_list.src_ep;    // %zbendpoint%
+
+    mqtt_data[0] = 0; // clear string
+    // Do we prefix with `ZbReceived`?
+    if (!Settings.flag4.remove_zbreceived) {
+      Response_P(PSTR("{\"" D_JSON_ZIGBEE_RECEIVED "\":"));
+    }
+    // What key do we use, shortaddr or name?
+    if (use_fname) {
+      Response_P(PSTR("%s{\"%s\":{"), mqtt_data, fname);
+    } else {
+      Response_P(PSTR("%s{\"0x%04X\":{"), mqtt_data, shortaddr);
+    }
+    // Add "Device":"0x...."
+    Response_P(PSTR("%s\"" D_JSON_ZIGBEE_DEVICE "\":\"0x%04X\","), mqtt_data, shortaddr);
+    // Add "Name":"xxx" if name is present
+    if (fname) {
+      Response_P(PSTR("%s\"" D_JSON_ZIGBEE_NAME "\":\"%s\","), mqtt_data, EscapeJSONString(fname).c_str());
+    }
+    // Add all other attributes
+    Response_P(PSTR("%s%s}}"), mqtt_data, attr_list.toString().c_str());
+    
+    if (!Settings.flag4.remove_zbreceived) {
+      Response_P(PSTR("%s}"), mqtt_data);
+    }
+    attr_list.reset();    // clear the attributes
+
+    if (Settings.flag4.zigbee_distinct_topics) {
+      if (Settings.flag4.zb_topic_fname && fname) {
+        //Clean special characters and check size of friendly name
+        char stemp[TOPSZ];
+        strlcpy(stemp, (!strlen(fname)) ? MQTT_TOPIC : fname, sizeof(stemp));
+        MakeValidMqtt(0, stemp);
+        //Create topic with Prefix3 and cleaned up friendly name
+        char frtopic[TOPSZ];
+        snprintf_P(frtopic, sizeof(frtopic), PSTR("%s/%s/" D_RSLT_SENSOR), SettingsText(SET_MQTTPREFIX3), stemp);
+        MqttPublish(frtopic, Settings.flag.mqtt_sensor_retain);
+      } else {
+        char subtopic[16];
+        snprintf_P(subtopic, sizeof(subtopic), PSTR("%04X/" D_RSLT_SENSOR), shortaddr);
+        MqttPublishPrefixTopic_P(TELE, subtopic, Settings.flag.mqtt_sensor_retain);
+      }
+    } else {
+      MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);
+    }
+    XdrvRulesProcess();     // apply rules
+  }
+}
+
+void Z_Devices::jsonPublishNow(uint16_t shortaddr, Z_attribute_list &attr_list) {
+  jsonPublishFlush(shortaddr);    // flush any previous buffer
+  jsonAppend(shortaddr, attr_list);
+  jsonPublishFlush(shortaddr);    // publish now
+}
+
+void Z_Devices::dirty(void) {
+  _saveTimer = kZigbeeSaveDelaySeconds * 1000 + millis();
+}
+void Z_Devices::clean(void) {
+  _saveTimer = 0;
+}
+
+// Parse the command parameters for either:
+// - a short address starting with "0x", example: 0x1234
+// - a long address starting with "0x", example: 0x7CB03EBB0A0292DD
+// - a number 0..99, the index number in ZigbeeStatus
+// - a friendly name, between quotes, example: "Room_Temp"
+uint16_t Z_Devices::parseDeviceParam(const char * param, bool short_must_be_known) const {
+  if (nullptr == param) { return BAD_SHORTADDR; }
+  size_t param_len = strlen(param);
+  char dataBuf[param_len + 1];
+  strcpy(dataBuf, param);
+  RemoveSpace(dataBuf);
+  uint16_t shortaddr = BAD_SHORTADDR;    // start with unknown
+
+  if (strlen(dataBuf) < 4) {
+    // simple number 0..99
+    if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= 99)) {
+      shortaddr = zigbee_devices.isKnownIndex(XdrvMailbox.payload - 1);
+    }
+  } else if ((dataBuf[0] == '0') && ((dataBuf[1] == 'x') || (dataBuf[1] == 'X'))) {
+    // starts with 0x
+    if (strlen(dataBuf) < 18) {
+      // expect a short address
+      shortaddr = strtoull(dataBuf, nullptr, 0);
+      if (short_must_be_known) {
+        shortaddr = zigbee_devices.findShortAddr(shortaddr).shortaddr;   // if not found, it reverts to the unknown_device with address BAD_SHORTADDR
+      }
+      // else we don't check if it's already registered to force unregistered devices
+    } else {
+      // expect a long address
+      uint64_t longaddr = strtoull(dataBuf, nullptr, 0);
+      shortaddr = zigbee_devices.isKnownLongAddr(longaddr);
+    }
+  } else {
+    // expect a Friendly Name
+    shortaddr = zigbee_devices.isKnownFriendlyName(dataBuf);
+  }
+
+  return shortaddr;
+}
+
+// Display the tracked status for a light
+String Z_Devices::dumpLightState(uint16_t shortaddr) const {
+  Z_attribute_list attr_list;
+  char hex[8];
+
+  const Z_Device & device = findShortAddr(shortaddr);
+  const char * fname = getFriendlyName(shortaddr);
+  bool use_fname = (Settings.flag4.zigbee_use_names) && (fname);    // should we replace shortaddr with friendlyname?
+  snprintf_P(hex, sizeof(hex), PSTR("0x%04X"), shortaddr);
+
+  attr_list.addAttribute(F(D_JSON_ZIGBEE_DEVICE)).setStr(hex);
+  if (fname) {
+    attr_list.addAttribute(F(D_JSON_ZIGBEE_NAME)).setStr(fname);
+  }
+
+  if (foundDevice(device)) {
+    // dump all known values
+    attr_list.addAttribute(F("Reachable")).setBool(device.getReachable());
+    if (device.validPower())        { attr_list.addAttribute(F("Power")).setUInt(device.getPower()); }
+    Z_Data_Light::toAttributes(attr_list, device.data.find<Z_Data_Light>(0));
+  }
+  
+  Z_attribute_list attr_list_root;
+  Z_attribute * attr_root;
+  if (use_fname) {
+    attr_root = &attr_list_root.addAttribute(fname);
+  } else {
+    attr_root = &attr_list_root.addAttribute(hex);
+  }
+  attr_root->setStrRaw(attr_list.toString(true).c_str());
+  return attr_list_root.toString(true);
+}
+
+// Dump the internal memory of Zigbee devices
+// Mode = 1: simple dump of devices addresses
+// Mode = 2: simple dump of devices addresses and names, endpoints, light
+String Z_Devices::dump(uint32_t dump_mode, uint16_t status_shortaddr) const {
+  Z_json_array json_arr;
+
+  for (const auto & device : _devices) {
+    uint16_t shortaddr = device.shortaddr;
+    char hex[22];
+
+    // ignore non-current device, if device specified
+    if ((BAD_SHORTADDR != status_shortaddr) && (status_shortaddr != shortaddr)) { continue; }
+
+    Z_attribute_list attr_list;
+
+    snprintf_P(hex, sizeof(hex), PSTR("0x%04X"), shortaddr);
+    attr_list.addAttribute(F(D_JSON_ZIGBEE_DEVICE)).setStr(hex);
+
+    if (device.friendlyName > 0) {
+      attr_list.addAttribute(F(D_JSON_ZIGBEE_NAME)).setStr(device.friendlyName);
+    }
+
+    if (2 <= dump_mode) {
+      hex[0] = '0';   // prefix with '0x'
+      hex[1] = 'x';
+      Uint64toHex(device.longaddr, &hex[2], 64);
+      attr_list.addAttribute(F("IEEEAddr")).setStr(hex);
+      if (device.modelId) {
+        attr_list.addAttribute(F(D_JSON_MODEL D_JSON_ID)).setStr(device.modelId);
+      }
+      int8_t bulbtype = getHueBulbtype(shortaddr);
+      if (bulbtype >= 0) {
+        attr_list.addAttribute(F(D_JSON_ZIGBEE_LIGHT)).setInt(bulbtype);   // sign extend, 0xFF changed as -1
+      }
+      if (device.manufacturerId) {
+        attr_list.addAttribute(F("Manufacturer")).setStr(device.manufacturerId);
+      }
+      Z_json_array arr_ep;
+      for (uint32_t i = 0; i < endpoints_max; i++) {
+        uint8_t endpoint = device.endpoints[i];
+        if (0x00 == endpoint) { break; }
+        arr_ep.add(endpoint);
+      }
+      attr_list.addAttribute(F("Endpoints")).setStrRaw(arr_ep.toString().c_str());
+    }
+    json_arr.addStrRaw(attr_list.toString(true).c_str());
+  }
+  return json_arr.toString();
+}
+
+// Restore a single device configuration based on json export
+// Input: json element as expported by `ZbStatus2``
+// Mandatory attribue: `Device`
+//
+// Returns:
+//  0 : Ok
+// <0 : Error
+//
+// Ex: {"Device":"0x5ADF","Name":"IKEA_Light","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":["0x01","0xF2"]}
+int32_t Z_Devices::deviceRestore(JsonParserObject json) {
+
+  // params
+  uint16_t device = 0x0000;                 // 0x0000 is coordinator so considered invalid
+  uint64_t ieeeaddr = 0x0000000000000000LL; // 0 means unknown
+  const char * modelid = nullptr;
+  const char * manufid = nullptr;
+  const char * friendlyname = nullptr;
+  int8_t   bulbtype = -1;
+  size_t   endpoints_len = 0;
+
+  // read mandatory "Device"
+  JsonParserToken val_device = json[PSTR("Device")];
+  if (val_device) {
+    device = (uint32_t) val_device.getUInt(device);
+  } else {
+    return -1;        // missing "Device" attribute
+  }
+
+  ieeeaddr      = json.getULong(PSTR("IEEEAddr"), ieeeaddr); // read "IEEEAddr" 64 bits in format "0x0000000000000000"
+  friendlyname  = json.getStr(PSTR("Name"), nullptr);  // read "Name"
+  modelid       = json.getStr(PSTR("ModelId"), nullptr);
+  manufid       = json.getStr(PSTR("Manufacturer"), nullptr);
+  JsonParserToken tok_bulbtype = json[PSTR(D_JSON_ZIGBEE_LIGHT)];
+
+  // update internal device information
+  updateDevice(device, ieeeaddr);
+  if (modelid) { setModelId(device, modelid); }
+  if (manufid) { setManufId(device, manufid); }
+  if (friendlyname) { setFriendlyName(device, friendlyname); }
+  if (tok_bulbtype) { setLightProfile(device, tok_bulbtype.getInt()); }
+
+  // read "Endpoints"
+  JsonParserToken val_endpoints = json[PSTR("Endpoints")];
+  if (val_endpoints.isArray()) {
+    JsonParserArray arr_ep = JsonParserArray(val_endpoints);
+    clearEndpoints(device);     // clear even if array is empty
+    for (auto ep_elt : arr_ep) {
+      uint8_t ep = ep_elt.getUInt();
+      if (ep) { addEndpoint(device, ep); }
+    }
+  }
+
+  return 0;
+}
+
+Z_Data_Light & Z_Devices::getLight(uint16_t shortaddr) {
+  return getShortAddr(shortaddr).data.get<Z_Data_Light>();
+}
+
+/*********************************************************************************************\
+ * Export device specific attributes to ZbData
+\*********************************************************************************************/
+void Z_Device::toAttributes(Z_attribute_list & attr_list) const {
+  if (validLqi())             { attr_list.addAttribute(PSTR(D_CMND_ZIGBEE_LINKQUALITY)).setUInt(lqi); }
+  if (validBatteryPercent())  { attr_list.addAttribute(PSTR("BatteryPercentage")).setUInt(batterypercent); }
+  if (validLastSeen())        { attr_list.addAttribute(PSTR("LastSeen")).setUInt(last_seen); }
+}
+
+/*********************************************************************************************\
+ * Device specific data handlers
+\*********************************************************************************************/
+void Z_Device::setPower(bool power_on, uint8_t ep) {
+  data.get<Z_Data_OnOff>(ep).setPower(power_on);
+}
+
+bool Z_Device::validPower(uint8_t ep) const {
+  const Z_Data_OnOff & onoff = data.find<Z_Data_OnOff>(ep);
+  return (&onoff != nullptr);
+}
+
+bool Z_Device::getPower(uint8_t ep) const {
+  const Z_Data_OnOff & onoff = data.find<Z_Data_OnOff>(ep);
+  if (&onoff != nullptr)  return onoff.getPower();
+  return false;
+}
+
+#endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -29,23 +29,29 @@ void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, Stri
     "\"effect\":\"none\","
     "\"reachable\":%s}";
 
-  bool     power, reachable;
-  uint8_t  colormode, bri, sat;
-  uint16_t ct, hue;
-  uint16_t x, y;
+  bool      power = false;
+  bool      reachable = false;
+  uint8_t   colormode = 0xFF;
+  uint8_t   bri = 0xFF;
+  uint8_t   sat = 0xFF;
+  uint16_t  ct = 0xFFFF;
+  uint16_t  hue = 0xFFFF;
+  uint16_t  x = 0xFFFF, y = 0xFFFF;
   String light_status = "";
   uint32_t echo_gen = findEchoGeneration();   // 1 for 1st gen =+ Echo Dot 2nd gen, 2 for 2nd gen and above
 
   const Z_Device & device = zigbee_devices.findShortAddr(shortaddr);
-  // TODO TODO check also validity
-  bri = device.dimmer;
+  const Z_Data_Light & light = device.data.find<Z_Data_Light>();
+  if (&light != nullptr) {
+    bri = light.getDimmer();
+    colormode = light.getColorMode();
+    sat = light.getSat();
+    ct = light.getCT();
+    hue = light.getHue();
+    x = light.getX();
+    y = light.getY();
+  }
   power = device.getPower();
-  colormode = device.colormode;
-  sat = device.sat;
-  ct = device.ct;
-  hue = device.hue;
-  x = device.x;
-  y = device.y;
   reachable = device.getReachable();
 
   if (bri > 254)   bri = 254;    // Philips Hue bri is between 1 and 254
@@ -148,7 +154,7 @@ void ZigbeeHueGroups(String * lights) {
 // Power On/Off
 void ZigbeeHuePower(uint16_t shortaddr, bool power) {
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0006, power ? 1 : 0, "");
-  zigbee_devices.getShortAddr(shortaddr).setPower(power);
+  zigbee_devices.getShortAddr(shortaddr).setPower(power, 0);
 }
 
 // Dimmer
@@ -157,7 +163,7 @@ void ZigbeeHueDimmer(uint16_t shortaddr, uint8_t dimmer) {
   char param[8];
   snprintf_P(param, sizeof(param), PSTR("%02X0A00"), dimmer);
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0008, 0x04, param);
-  zigbee_devices.getShortAddr(shortaddr).dimmer = dimmer;
+  zigbee_devices.getLight(shortaddr).setDimmer(dimmer);
 }
 
 // CT
@@ -168,9 +174,9 @@ void ZigbeeHueCT(uint16_t shortaddr, uint16_t ct) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0A00"), ct & 0xFF, ct >> 8);
   uint8_t colormode = 2;      // "ct"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x0A, param);
-  Z_Device & device = zigbee_devices.getShortAddr(shortaddr);
-  device.colormode = colormode;
-  device.ct = ct;
+  Z_Data_Light & light = zigbee_devices.getLight(shortaddr);
+  light.setColorMode(colormode);
+  light.setCT(ct);
 }
 
 // XY
@@ -181,10 +187,10 @@ void ZigbeeHueXY(uint16_t shortaddr, uint16_t x, uint16_t y) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X%02X%02X0A00"), x & 0xFF, x >> 8, y & 0xFF, y >> 8);
   uint8_t colormode = 1;      // "xy"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x07, param);
-  Z_Device & device = zigbee_devices.getShortAddr(shortaddr);
-  device.colormode = colormode;
-  device.x = x;
-  device.y = y;
+  Z_Data_Light & light = zigbee_devices.getLight(shortaddr);
+  light.setColorMode(colormode);
+  light.setX(x);
+  light.setY(y);
 }
 
 // HueSat
@@ -195,10 +201,10 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
   snprintf_P(param, sizeof(param), PSTR("%02X%02X0000"), hue8, sat);
   uint8_t colormode = 0;      // "hs"
   zigbeeZCLSendStr(shortaddr, 0, 0, true, 0, 0x0300, 0x06, param);
-  Z_Device device = zigbee_devices.getShortAddr(shortaddr);
-  device.colormode = colormode;
-  device.sat = sat;
-  device.hue = hue;
+  Z_Data_Light & light = zigbee_devices.getLight(shortaddr);
+  light.setColorMode(colormode);
+  light.setSat(sat);
+  light.setHue(hue);
 }
 
 void ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, String &response) {

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -127,7 +127,7 @@ class SBuffer hibernateDevice(const struct Z_Device &device) {
   buf.add8(0x00);     // end of string marker
 
   // Zigbee Profile
-  buf.add8(device.zb_profile);
+  buf.add8(device.getLightChannels());
 
   // update overall length
   buf.set8(0, buf.len());
@@ -170,7 +170,6 @@ void hydrateDevices(const SBuffer &buf) {
 
   uint32_t k = 0;
   uint32_t num_devices = buf.get8(k++);
-//size_t before = 0;
   for (uint32_t i = 0; (i < num_devices) && (k < buf_len); i++) {
     uint32_t dev_record_len = buf.get8(k);
 
@@ -200,7 +199,6 @@ void hydrateDevices(const SBuffer &buf) {
         // ignore
       }
     }
-//AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Device 0x%04X Memory3.shrink = %d"), shortaddr, ESP_getFreeHeap());
 
     // parse 3 strings
     char empty[] = "";
@@ -225,13 +223,12 @@ void hydrateDevices(const SBuffer &buf) {
 
     // Hue bulbtype - if present
     if (d < dev_record_len) {
-      zigbee_devices.setZbProfile(shortaddr, buf_d.get8(d));
+      zigbee_devices.setLightProfile(shortaddr, buf_d.get8(d));
       d++;
     }
 
     // next iteration
     k += dev_record_len;
-//AddLog_P2(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Device %d After  Memory = %d"), i, ESP_getFreeHeap());
   }
 }
 


### PR DESCRIPTION
## Description:
Refactoring of internal storage of device current data. It is optimized to minimize memory footpring while allowing rich content for devices.

New command `ZbData` to export or import device data.

`ZbData <device>` exports in JSON format the latest values for the specified device.

Ex:

```
ZbData 0xCCA6
MQT: tele/tasmota/ZBBridge/SENSOR = {"ZbData":{"0xCCA6":{"_00":{"LinkQuality":66,"BatteryPercentage":172,"LastSeen":1602092857},"T01":{"Temperature":2144,"Pressure":1020,"Humidity":5770}}}}
```

The JSON objects keys are encoded as follows:
- Single char for device type, with attributes in their native Zigbee format
  - **'L'** Light: `Dimmer`, `Colormode`, `CT`, `Sat`, `Hue`, `X`, `Y`
  - **'P'** Plug: `RMSVoltage`, `ActivePower`
  - **'O'** On/off = relays, `Power`
  - **'T'** Thermostat and environment sensors, `Temperature`, `Pressure`, `Humidity`, `ThSetpoint`, `TempTarget`
  - **'A'** Alarm including PIR and water/gas leak, `ZoneType`
  - **'_'** non-device specific data, `LinkQuality`, `BatteryPercentage`, `LastSeen`
- Endpoint number in HEX format. If endpoint is `00` it means unknown and matches any incoming data

Data can also be imported in the same JSON format, mainly for testing purposes:
`ZbData {"0xCCA6":"T01":{"Temperature":2144,"Pressure":1020,"Humidity":5770}}}`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
