### PR TITLE
Add DGR CW/RGBW light fixed color support

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2400,7 +2400,7 @@ void LightHandleDevGroupItem(void)
       send_state = true;
       break;
     case DGR_ITEM_LIGHT_FIXED_COLOR:
-      if (Light.subtype >= LST_RGBW) {
+      if (Light.subtype >= LST_COLDWARM) {
         send_state = true;
 #ifdef USE_LIGHT_PALETTE
         if (Light.palette_count) {
@@ -2409,21 +2409,28 @@ void LightHandleDevGroupItem(void)
           break;
         }
 #endif  // !USE_LIGHT_PALETTE
-        value = value % MAX_FIXED_COLOR + 1;
-        if (value) {
-          bool save_decimal_text = Settings.flag.decimal_text;
-          char str[16];
-          LightColorEntry(str, sprintf_P(str, PSTR("%u"), value));
-          Settings.flag.decimal_text = save_decimal_text;
-          uint32_t old_bri = light_state.getBri();
-          light_controller.changeChannels(Light.entry_color);
-          light_controller.changeBri(old_bri);
-          Settings.light_scheme = 0;
-          Light.devgrp_no_channels_out = false;
+        if (Light.subtype <= LST_COLDWARM) {
+          value = value % (MAX_FIXED_COLD_WARM - 1) + 201;
         }
         else {
-          light_state.setColorMode(LCM_CT);
+          uint32_t max = MAX_FIXED_COLOR;
+          if (Light.subtype >= LST_RGB) {
+            max++;
+            if (Light.subtype >= LST_RGBCW) max += (MAX_FIXED_COLD_WARM - 2);
+          }
+          value = value % max + 1;
+          if (value > MAX_FIXED_COLOR) value += 200 - MAX_FIXED_COLOR;
         }
+        Light.fixed_color_index = value;
+        bool save_decimal_text = Settings.flag.decimal_text;
+        char str[16];
+        LightColorEntry(str, sprintf_P(str, PSTR("%u"), value));
+        Settings.flag.decimal_text = save_decimal_text;
+        uint32_t old_bri = light_state.getBri();
+        light_controller.changeChannels(Light.entry_color);
+        light_controller.changeBri(old_bri);
+        Settings.light_scheme = 0;
+        Light.devgrp_no_channels_out = false;
         if (!restore_power && !Light.power) {
           Light.old_power = Light.power;
           Light.power = 0xff;

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -204,10 +204,15 @@ void PWMDimmerHandleDevGroupItem(void)
         remote_pwm_dimmer->power_button_increases_bri = (remote_pwm_dimmer->bri < 128);
       }
       break;
-    case DGR_ITEM_LIGHT_FIXED_COLOR:
-      if (!device_is_local) remote_pwm_dimmer->fixed_color_index = value;
-      break;
 #endif  // USE_PWM_DIMMER_REMOTE
+    case DGR_ITEM_LIGHT_FIXED_COLOR:
+#ifdef USE_PWM_DIMMER_REMOTE
+      if (!device_is_local)
+        remote_pwm_dimmer->fixed_color_index = value;
+      else
+#endif  // USE_PWM_DIMMER_REMOTE
+        local_fixed_color_index = value;
+      break;
     case DGR_ITEM_BRI_POWER_ON:
 #ifdef USE_PWM_DIMMER_REMOTE
       if (!device_is_local)


### PR DESCRIPTION
## Description:

Add device group fixed color support for CW and RGBW lights. Add warm white fixed colors to device group color sequence.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
