### PR TITLE
Insert hook to rule BEFORE moving

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -515,6 +515,17 @@ bool ShutterState(uint32_t device)
           (ShutterGlobal.RelayShutterMask & (1 << (Settings.shutter_startrelay[device]-1))) );
 }
 
+void ShutterAllowPreStartProcedure(uint8_t i)
+{
+  uint32_t uptime_Local=0;
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SH: Delay Start. uptime %d, var%d 99=<%s>, max10s?"),uptime,i, rules_vars[i]);
+  rules_flag.shutter_moving = 1;
+  XdrvRulesProcess();
+  uptime_Local = uptime;
+  while (uptime_Local+10 > uptime && (String)rules_vars[i] == "99") {
+    loop();
+  }
+}
 void ShutterStartInit(uint32_t i, int32_t direction, int32_t target_pos)
 {
   //AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: dir %d, delta1 %d, delta2 %d, grant %d"),direction, (Shutter[i].open_max - Shutter[i].real_position) / Shutter[i].close_velocity, Shutter[i].real_position / Shutter[i].close_velocity, 2+Shutter[i].motordelay);
@@ -535,10 +546,11 @@ void ShutterStartInit(uint32_t i, int32_t direction, int32_t target_pos)
     Shutter[i].accelerator = ShutterGlobal.open_velocity_max / (Shutter[i].motordelay>0 ? Shutter[i].motordelay : 1);
     Shutter[i].target_position = target_pos;
     Shutter[i].start_position = Shutter[i].real_position;
-    Shutter[i].time = 0;
-    ShutterGlobal.skip_relay_change = 0;
-    Shutter[i].direction = direction;
     rules_flag.shutter_moving = 1;
+    ShutterAllowPreStartProcedure(i);
+    Shutter[i].time = 0;
+    Shutter[i].direction = direction;
+    ShutterGlobal.skip_relay_change = 0;
     rules_flag.shutter_moved  = 0;
     ShutterGlobal.start_reported = 0;
     //AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: real %d, start %d, counter %d,freq_max %d, dir %d, freq %d"),Shutter[i].real_position, Shutter[i].start_position ,RtcSettings.pulse_counter[i],ShutterGlobal.open_velocity_max , Shutter[i].direction ,ShutterGlobal.open_velocity_max );

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -518,11 +518,11 @@ bool ShutterState(uint32_t device)
 void ShutterAllowPreStartProcedure(uint8_t i)
 {
   uint32_t uptime_Local=0;
-  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Delay Start. var%d 99==%s, max10s?"),i+1, rules_vars[i+1]);
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Delay Start. var%d <99>=<%s>, max10s?"),i+i, rules_vars[i]);
   rules_flag.shutter_moving = 1;
   XdrvRulesProcess();
   uptime_Local = uptime;
-  while (uptime_Local+10 > uptime && (String)rules_vars[i+1] == "99") {
+  while (uptime_Local+10 > uptime && (String)rules_vars[i] == "99") {
     loop();
   }
   AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Delay Start. Done"));

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -518,14 +518,16 @@ bool ShutterState(uint32_t device)
 void ShutterAllowPreStartProcedure(uint8_t i)
 {
   uint32_t uptime_Local=0;
-  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SH: Delay Start. uptime %d, var%d 99=<%s>, max10s?"),uptime,i, rules_vars[i]);
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Delay Start. var%d 99==%s, max10s?"),i+1, rules_vars[i+1]);
   rules_flag.shutter_moving = 1;
   XdrvRulesProcess();
   uptime_Local = uptime;
-  while (uptime_Local+10 > uptime && (String)rules_vars[i] == "99") {
+  while (uptime_Local+10 > uptime && (String)rules_vars[i+1] == "99") {
     loop();
   }
+  AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Delay Start. Done"));
 }
+
 void ShutterStartInit(uint32_t i, int32_t direction, int32_t target_pos)
 {
   //AddLog_P2(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: dir %d, delta1 %d, delta2 %d, grant %d"),direction, (Shutter[i].open_max - Shutter[i].real_position) / Shutter[i].close_velocity, Shutter[i].real_position / Shutter[i].close_velocity, 2+Shutter[i].motordelay);


### PR DESCRIPTION
New hook that can guarantee a rule will be executed before the movement starts. Will change documentation:
change "var<shutternumber>" to 99 to enable hook. Create a rule that executes on shutter#moving ONCE and set VARx to 0. Add rule at shutter#moved=1 to set VARx=99 and enable ONCE again.
example:
{"Rule1":"ON","Once":"ON","StopOnError":"OFF","Length":62,"Free":449,"Rules":"on shutter#moving=1 do backlog power3 on;delay 10;var1 0 endon"}
{"Rule2":"ON","Once":"OFF","StopOnError":"OFF","Length":51,"Free":460,"Rules":"on shutter#moved=1 do backlog var1 99;rule1 5 endon"}

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.1
  - [ x] The code change is tested and works on core ESP32 V.1.12.2
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
