### PR TITLE
Added `ZbReset 2`

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -513,6 +513,7 @@
 #define D_CMND_ZIGBEE_STATUS "Status"
 #define D_CMND_ZIGBEE_RESET "Reset"
   #define D_JSON_ZIGBEE_CC2530 "CC2530"
+  #define D_JSON_ZIGBEE_EZSP "EZSP"
 #define D_CMND_ZIGBEEZNPRECEIVE "ZNPReceive"      // only for debug
 #define D_CMND_ZIGBEE_EZSP_RECEIVE "EZSPReceive"      // only for debug
 #define D_CMND_ZIGBEE_EZSP_RECEIVE_RAW "EZSPReceiveRaw"      // only for debug

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -615,7 +615,7 @@ struct {
   uint64_t      zb_precfgkey_h;            // F28
   uint16_t      zb_pan_id;                 // F30
   uint8_t       zb_channel;                // F32
-  uint8_t       zb_txradio_dbm;            // F33
+  int8_t        zb_txradio_dbm;            // F33
   uint16_t      pms_wake_interval;         // F34
   uint8_t       config_version;            // F36
   uint8_t       windmeter_pulses_x_rot;    // F37

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -406,7 +406,7 @@ int32_t EZ_ReceiveCheckVersion(int32_t res, class SBuffer &buf) {
   }
 }
 
-static bool EZ_reset_config = false;
+bool EZ_reset_config = false;
 
 // Set or clear reset_config
 int32_t EZ_Set_ResetConfig(uint8_t value) {

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -589,6 +589,7 @@ int32_t ZigbeeProcessInputEZSP(class SBuffer &buf) {
       case EZSP_setConcentrator:          // 1000
       case EZSP_networkInit:              // 1700
       case EZSP_stackStatusHandler:       // 1900
+      case EZSP_formNetwork:              // 1E00
       case EZSP_permitJoining:            // 2200
       case EZSP_getEui64:                 // 2600
       case EZSP_getNodeId:                // 2700


### PR DESCRIPTION
## Description:

Added command `ZbReset 2` to force a factory reset of EZSP without erasing Tasmota's device configuration. Internally it forces a `formNetwork()` instead of ìnitNetwork()`. It should not be necessary to re-pair device, they should gracefully re-join.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
