### PR TITLE
Prevent crashes on high counter pulse. e.g. AC-Dimmer, Current-Counte…

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -673,7 +673,7 @@ typedef struct {
   uint8_t       ota_loader;                // 293
   unsigned long energy_kWhtoday;              // 294
   unsigned long energy_kWhtotal;              // 298
-  unsigned long pulse_counter[MAX_COUNTERS];  // 29C
+  volatile unsigned long pulse_counter[MAX_COUNTERS];  // 29C
   power_t       power;                     // 2AC
   EnergyUsage   energy_usage;              // 2B0
   unsigned long nextwakeup;                // 2C8


### PR DESCRIPTION
…r...

I had reproducible Hardware Watchdog resets and hangs with the AC-Dimmer, but only if the 100Hz from the main hammered the device. I found this help and change the code. Now the AC-Dimmer is ON for >3days. I assume this change is responsible because it was the only change.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
