### PR TITLE
Fix ENERGY.Period after midnight

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -273,13 +273,14 @@ void Energy200ms(void)
 
         RtcSettings.energy_kWhtotal += RtcSettings.energy_kWhtoday;
         Settings.energy_kWhtotal = RtcSettings.energy_kWhtotal;
+
+        Energy.period -= RtcSettings.energy_kWhtoday;                // this becomes a large unsigned, effectively a negative for EnergyShow calculation
         Energy.kWhtoday = 0;
         Energy.kWhtoday_offset = 0;
         RtcSettings.energy_kWhtoday = 0;
         Energy.start_energy = 0;
+//        Energy.kWhtoday_delta = 0;                                 // dont zero this, we need to carry the remainder over to tomorrow
 
-        Energy.kWhtoday_delta = 0;
-        Energy.period = Energy.kWhtoday;
         EnergyUpdateToday();
 #if defined(USE_ENERGY_MARGIN_DETECTION) && defined(USE_ENERGY_POWER_LIMIT)
         Energy.max_energy_state  = 3;
@@ -1066,10 +1067,7 @@ void EnergyShow(bool json)
     }
 
     if (show_energy_period) {
-      float energy = 0;
-      if (Energy.period) {
-        energy = (float)(RtcSettings.energy_kWhtoday - Energy.period) / 100;
-      }
+      float energy = (float)(RtcSettings.energy_kWhtoday - Energy.period) / 100;
       Energy.period = RtcSettings.energy_kWhtoday;
       char energy_period_chr[FLOATSZ];
       dtostrfd(energy, Settings.flag2.wattage_resolution, energy_period_chr);


### PR DESCRIPTION
**ENERGY.Period incorrectly shows 0 for the first teleperiod after midnight**

## Description:

Below is a Grafana of ENERGY.Period with teleperiod of 60. The data is cleared at midnight, which results in Period incorrectly reporting 0 at the next teleperiod due to the if check in EnergyShow. Remove the if check because Energy.period is always valid with the revised calculation.

I've been running this patch for a couple weeks with no ill effects.

![ENERGYPeriod](https://user-images.githubusercontent.com/902094/95923765-3589ce80-0d84-11eb-9ecb-1043f15a431c.png)

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
