### PR TITLE
Improve robustness

### DIFF
--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -814,7 +814,8 @@ void EZ_UpdateConfig(uint8_t zb_channel, uint16_t zb_pan_id, uint64_t zb_ext_pan
 
 static const Zigbee_Instruction zb_prog[] PROGMEM = {
   ZI_LABEL(0)
-    ZI_NOOP()
+    ZI_CALL(&EZ_Reset_Device, 0)         // immediately drive reset low
+    ZI_LOG(LOG_LEVEL_INFO, kResettingDevice)     // Log Debug: resetting EZSP device
     // ZI_CALL(EZ_Set_ResetConfig, 0)           // for the firt pass, don't do a reset_config
   ZI_LABEL(ZIGBEE_LABEL_RESTART)
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -672,6 +672,7 @@ int32_t ZigbeeProcessInputRaw(class SBuffer &buf) {
       // ERROR
       EZ_ERROR(buf.get8(2));
       zigbee.active = false;           // stop all zigbee activities
+      restart_flag = 2;                // there is nothing more we can do except restart
     } else {
 
       // Unknown


### PR DESCRIPTION
## Description:

Improve robustness of ZBBridge:
- pull reset line LOW at boot, which avoids data to come during initialization of EZSP
- automatically restart Tasmota in case EZSP is in Fatal Error mode

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
