### PR TITLE
Add support for backlog with no delay

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -212,6 +212,7 @@
 // Commands tasmota.ino
 #define D_CMND_BACKLOG "Backlog"
 #define D_CMND_DELAY "Delay"
+#define D_CMND_NODELAY "NoDelay"
 #define D_CMND_STATUS "Status"
   #define D_STATUS1_PARAMETER "PRM"
   #define D_STATUS2_FIRMWARE "FWR"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -311,6 +311,7 @@ void CmndBacklog(void)
 {
   if (XdrvMailbox.data_len) {
 
+    bool firstcommand = true;
 #ifdef SUPPORT_IF_STATEMENT
     char *blcommand = strtok(XdrvMailbox.data, ";");
     while ((blcommand != nullptr) && (backlog.size() < MAX_BACKLOG))
@@ -329,6 +330,15 @@ void CmndBacklog(void)
           break;
         }
       }
+      // If the first command in backlog sequence is NoDelay, set flag to skip delay before executing the next command
+      if (firstcommand) {
+        if (!strncasecmp_P(blcommand, PSTR(D_CMND_NODELAY), strlen(D_CMND_NODELAY))) {
+          blcommand += strlen(D_CMND_NODELAY);
+          backlog_no_delay = true;
+        }
+        firstcommand = false;
+      }
+
       if (*blcommand != '\0') {
 #ifdef SUPPORT_IF_STATEMENT
         if (backlog.size() < MAX_BACKLOG) {


### PR DESCRIPTION
## Description:
Add support for executing backlog with no delay without setting `SetOption34 = 0`

The delay defined by `SetOption34` is omitted for any command in a backlog sequence following immediately after the special command `NoDelay`.
This must be used with care, and only for simple commands.

The main driver is to allow HomeAssistant to more precisely control lights, in particular transitions (`Fade` and `Speed` in Tasmota).

## Example:

Disable fade, and turn off a light without any delays:
`Backlog NoDelay;Fade 0;NoDelay;Power4 OFF`
Enable fade, and turn on a light without any additional delays:
`Backlog NoDelay;Fade 1;NoDelay;Speed 4;NoDelay;Power4 ON`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
