### PR TITLE
Backport New flash writing method (Tasmota Stage core)

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -85,8 +85,8 @@ extra_scripts             = ${scripts_defaults.extra_scripts}
 
 
 [tasmota_stage]
-; *** Esp8266 core for Arduino version Tasmota stage
-platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino/releases/download/2.7.4.2/esp8266-2.7.4.2.zip
+; *** Esp8266 core for Arduino version Tasmota stage (PR7231 and Backport PR7514)
+platform_packages         = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino.git#2.7.4.4
 build_unflags             = ${esp_defaults.build_unflags}
 build_flags               = ${esp82xx_defaults.build_flags}
 


### PR DESCRIPTION
Not activated for standard development build! Only Tasmota Stage Core
Testing of changed Flash method (merged in Arduino Master). Should give better Puya support.
(PR https://github.com/esp8266/Arduino/pull/7514)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.4
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
