### PR TITLE
Delete Issue Statistic Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ _Written for PlatformIO with limited support for Arduino IDE._
 [![GitHub download](https://img.shields.io/github/downloads/arendst/Tasmota/total.svg)](https://github.com/arendst/Tasmota/releases/latest)
 [![License](https://img.shields.io/github/license/arendst/Tasmota.svg)](LICENSE.txt)
 [![Chat](https://img.shields.io/discord/479389167382691863.svg)](https://discord.gg/Ks2Kzd4)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/arendst/Tasmota.svg)](http://isitmaintained.com/project/arendst/Tasmota "Average time to resolve an issue")
-[![Percentage of issues still open](http://isitmaintained.com/badge/open/arendst/Tasmota.svg)](http://isitmaintained.com/project/arendst/Tasmota "Percentage of issues still open")
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/arendst/Tasmota)
 
 If you like **Tasmota**, give it a star, or fork it and contribute!


### PR DESCRIPTION
Description:

Deleted Issue Statistic Badges due to they are not representing the reality at this moment.
The Issue Resolution time is very biased by the Closing-Bot, so it is most measuring the time required by the bot to close an issue without a template, rather than how much time is required for the community to solve an issue.
The Percentage of opened issue will be all the time 1%. In large projects like Tasmota, where there is a base of 43 opened issues against near 10.000 closed issues, plus that the stale bot is active, this value won't change.

So, this PR is just to clean the readme a little.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
