### PR TITLE
Add support for EZORTD

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -79,3 +79,4 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   54  | USE_VL53L1X         | xsns_77 | VL53L1X  | 0x29        | Time-of-flight (ToF) distance sensor
   55  | USE_EZO_PH          | xsns_78 | EZOPH    | 0x61 - 0x70 | pH Sensor
   55  | USE_EZO_ORP         | xsns_79 | EZOORP   | 0x61 - 0x70 | ORP Sensor
+  55  | USE_EZO_RTD         | xsns_80 | EZORTD   | 0x61 - 0x70 | Temperature Sensor

--- a/tasmota/ezo.ino
+++ b/tasmota/ezo.ino
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifdef USE_I2C
-#if defined(USE_EZOPH) || defined(USE_EZOORP)
+#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD)
 
 #define D_EZO_DELAY   300   // Minimum delay for any instruction
 #define D_EZO_MAX_BUF 40    // Maximum response

--- a/tasmota/ezoManager.ino
+++ b/tasmota/ezoManager.ino
@@ -17,7 +17,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #ifdef USE_I2C
-#if defined(USE_EZOPH) || defined(USE_EZOORP)
+#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD)
 
 #define XI2C_55     55    // See I2CDEVICES.md
 
@@ -54,7 +54,9 @@ const char EZO_ORP_NAME[] PROGMEM = "ORP";
 const char EZO_PH_NAME[]  PROGMEM = "pH";
 #endif
 //const char EZO_EC_NAME[]  PROGMEM = "EC";
-//const char EZO_RTD_NAME[] PROGMEM = "RTD";
+#ifdef USE_EZORTD
+const char EZO_RTD_NAME[] PROGMEM = "RTD";
+#endif
 //const char EZO_PMP_NAME[] PROGMEM = "PMP";
 //const char EZO_FLO_NAME[] PROGMEM = "FLO";
 //const char EZO_CO2_NAME[] PROGMEM = "CO2";
@@ -80,7 +82,13 @@ const char *const EZOSupport[EZO_ADDR_n] PROGMEM = {
 
   EZO_EMPTY,
   EZO_EMPTY,
+
+#ifdef USE_EZORTD
+  EZO_RTD_NAME,
+#else
   EZO_EMPTY,
+#endif
+
   EZO_EMPTY,
   EZO_EMPTY,
   EZO_EMPTY,
@@ -181,7 +189,7 @@ private:
                 data[0] = 'E';
                 data[1] = 'Z';
                 data[2] = 'O';
-                I2cSetActiveFound(addr, data);
+                I2cSetActiveFound(addr + EZO_ADDR_0, data);
                 devices[addr >> 3] |= j << ((addr & 7) * 4);
               }
             }

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -564,6 +564,7 @@
 //  #define USE_MLX90640                           // [I2cDriver53] Enable MLX90640 IR array temperature sensor (I2C address 0x33) (+20k code)
 //  #define USE_EZOPH                              // [I2cDriver55] Enable support for EZO's pH sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
 //  #define USE_EZOORP                             // [I2cDriver55] Enable support for EZO's ORP sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
+  #define USE_EZORTD                             // [I2cDriver55] Enable support for EZO's RTD sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -564,7 +564,7 @@
 //  #define USE_MLX90640                           // [I2cDriver53] Enable MLX90640 IR array temperature sensor (I2C address 0x33) (+20k code)
 //  #define USE_EZOPH                              // [I2cDriver55] Enable support for EZO's pH sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
 //  #define USE_EZOORP                             // [I2cDriver55] Enable support for EZO's ORP sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
-  #define USE_EZORTD                             // [I2cDriver55] Enable support for EZO's RTD sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
+//  #define USE_EZORTD                             // [I2cDriver55] Enable support for EZO's RTD sensor (+0k6 code) - Shared EZO code required for any EZO device (+1k0 code)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/support_features.ino
+++ b/tasmota/support_features.ino
@@ -633,7 +633,9 @@ void GetFeatures(void)
 #if defined(USE_I2C) && defined(USE_EZOORP)
   feature7 |= 0x00000001;  // xsns_79_ezoorp.ino
 #endif
-//  feature7 |= 0x00000002;
+#if defined(USE_I2C) && defined(USE_EZORTD)
+  feature7 |= 0x00000002; // xsns_80_ezortd.ino
+#endif
 //  feature7 |= 0x00000004;
 //  feature7 |= 0x00000008;
 

--- a/tasmota/xsns_80_ezortd.ino
+++ b/tasmota/xsns_80_ezortd.ino
@@ -1,0 +1,79 @@
+/*
+  xsns_80_ezortd.ino - EZO RTD I2C RTD sensor support for Tasmota
+
+  Copyright (C) 2020  Christopher Tremblay
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_EZORTD
+
+#define XSNS_80 80
+
+#define EZO_RTD_READ_LATENCY   600
+
+struct EZORTD : public EZOStruct {
+  void ProcessMeasurement(void)
+  {
+    char data[D_EZO_MAX_BUF];
+
+    EZOStruct::ProcessMeasurement(data, sizeof(data), EZO_RTD_READ_LATENCY);
+    RTD = CharToFloat(data);
+  }
+
+  void Show(bool json, uint32_t index)
+  {
+    if (valid) {
+      char str[10];
+      dtostrfd(ConvertTemp(RTD), 2, str);
+
+      char name[10];
+      snprintf_P(name, sizeof(name), PSTR("%s%c%X"), EZORTD::name, IndexSeparator(), index + 1);
+
+      if (count == 1) {
+        name[sizeof("EZORTD") - 1] = 0;
+      }
+
+      if (json) {
+        ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_TEMPERATURE "\":%s}"), name, str);
+      }
+#ifdef USE_WEBSERVER  
+      else {
+        WSContentSend_PD(HTTP_SNS_TEMP, name, str, TempUnit());
+#endif  // USE_WEBSERVER
+      }
+    }
+  }
+
+  static int8_t     count;
+  static EZORTD    *list;
+  static const char name[];
+
+private:
+  float     RTD = NAN;
+};
+
+int8_t      EZORTD::count           = -1;
+EZORTD     *EZORTD::list            = NULL;
+const char  EZORTD::name[]  PROGMEM = "EZORTD";
+
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+#define Xsns80 XsnsEZO<EZORTD, EZO_RTD>
+
+#endif  // USE_EZORTD
+#endif  // USE_I2C


### PR DESCRIPTION
Adding support for EZO RTD resistance temperature sensor

## Description:

Adding support for EZO RTD.  I tested it by simulating it with a pH device and changing the ID to recognize the pH device as a temperature device.  According to the spec, it returns a float just like the pH device so I'm fairly confident that this will work on a real device.  Properly tested to handle unit conversion.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
