### PR TITLE
Webserver->on() optimization phase 2

### DIFF
--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -1398,7 +1398,7 @@ bool Xdrv02(uint8_t function)
         WSContentSend_P(HTTP_BTN_MENU_MQTT);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/" WEB_HANDLE_MQTT, HandleMqttConfiguration);
+        WebServer_on(PSTR("/" WEB_HANDLE_MQTT), HandleMqttConfiguration);
         break;
 #endif  // USE_WEBSERVER
       case FUNC_COMMAND:

--- a/tasmota/xdrv_07_domoticz.ino
+++ b/tasmota/xdrv_07_domoticz.ino
@@ -638,7 +638,7 @@ bool Xdrv07(uint8_t function) {
         WSContentSend_P(HTTP_BTN_MENU_DOMOTICZ);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/" WEB_HANDLE_DOMOTICZ, HandleDomoticzConfiguration);
+        WebServer_on(PSTR("/" WEB_HANDLE_DOMOTICZ), HandleDomoticzConfiguration);
         break;
 #endif  // USE_WEBSERVER
       case FUNC_MQTT_SUBSCRIBE:

--- a/tasmota/xdrv_09_timers.ino
+++ b/tasmota/xdrv_09_timers.ino
@@ -928,7 +928,7 @@ bool Xdrv09(uint8_t function)
 #endif  // USE_RULES
       break;
     case FUNC_WEB_ADD_HANDLER:
-      Webserver->on("/" WEB_HANDLE_TIMER, HandleTimerConfiguration);
+      WebServer_on(PSTR("/" WEB_HANDLE_TIMER), HandleTimerConfiguration);
       break;
 #endif  // USE_TIMERS_WEB
 #endif  // USE_WEBSERVER

--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -1271,7 +1271,7 @@ bool Xdrv11(uint8_t function)
         WSContentSend_P(HTTP_BTN_MENU_KNX);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/kn", HandleKNXConfiguration);
+        WebServer_on(PSTR("/kn"), HandleKNXConfiguration);
         break;
 #endif // USE_KNX_WEB_MENU
 #endif  // USE_WEBSERVER

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -897,7 +897,7 @@ bool Xdrv20(uint8_t function)
 #endif
     switch (function) {
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on(F("/description.xml"), HandleUpnpSetupHue);
+        WebServer_on(PSTR("/description.xml"), HandleUpnpSetupHue);
         break;
     }
   }

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -353,10 +353,10 @@ bool Xdrv21(uint8_t function)
   if (devices_present && (EMUL_WEMO == Settings.flag2.emulation)) {
     switch (function) {
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on(F("/upnp/control/basicevent1"), HTTP_POST, HandleUpnpEvent);
-        Webserver->on(F("/eventservice.xml"), HandleUpnpService);
-        Webserver->on(F("/metainfoservice.xml"), HandleUpnpMetaService);
-        Webserver->on(F("/setup.xml"), HandleUpnpSetupWemo);
+        WebServer_on(PSTR("/upnp/control/basicevent1"), HandleUpnpEvent, HTTP_POST);
+        WebServer_on(PSTR("/eventservice.xml"), HandleUpnpService);
+        WebServer_on(PSTR("/metainfoservice.xml"), HandleUpnpMetaService);
+        WebServer_on(PSTR("/setup.xml"), HandleUpnpSetupWemo);
         break;
     }
   }

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1848,7 +1848,7 @@ bool Xdrv23(uint8_t function)
 #ifdef USE_ZIGBEE_EZSP
       // GUI xmodem
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/" WEB_HANDLE_ZIGBEE_XFER, HandleZigbeeXfer);
+        WebServer_on(PSTR("/" WEB_HANDLE_ZIGBEE_XFER), HandleZigbeeXfer);
         break;
 #endif  // USE_ZIGBEE_EZSP
 #endif  // USE_WEBSERVER

--- a/tasmota/xdrv_28_pcf8574.ino
+++ b/tasmota/xdrv_28_pcf8574.ino
@@ -248,7 +248,7 @@ bool Xdrv28(uint8_t function)
         WSContentSend_P(HTTP_BTN_MENU_PCF8574);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/" WEB_HANDLE_PCF8574, HandlePcf8574);
+        WebServer_on(PSTR("/" WEB_HANDLE_PCF8574), HandlePcf8574);
         break;
 #endif  // USE_WEBSERVER
     }

--- a/tasmota/xdrv_43_mlx90640.ino
+++ b/tasmota/xdrv_43_mlx90640.ino
@@ -611,7 +611,7 @@ bool Xdrv43(uint8_t function)
         WSContentSend_P(HTTP_BTN_MENU_MLX90640);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/mlx", MLX90640HandleWebGui);
+        WebServer_on(PSTR("/mlx"), MLX90640HandleWebGui);
         break;
 #endif  // USE_WEBSERVER
       case FUNC_COMMAND:

--- a/tasmota/xdrv_81_webcam.ino
+++ b/tasmota/xdrv_81_webcam.ino
@@ -814,10 +814,10 @@ uint32_t WcSetStreamserver(uint32_t flag) {
   if (flag) {
     if (!CamServer) {
       CamServer = new ESP8266WebServer(81);
-      CamServer->on("/", HandleWebcamRoot);
-      CamServer->on("/cam.mjpeg", HandleWebcamMjpeg);
-      CamServer->on("/cam.jpg", HandleWebcamMjpeg);
-      CamServer->on("/stream", HandleWebcamMjpeg);
+      WebServer_on(PSTR("/"), HandleWebcamRoot);
+      WebServer_on(PSTR("/cam.mjpeg"), HandleWebcamMjpeg);
+      WebServer_on(PSTR("/cam.jpg"), HandleWebcamMjpeg);
+      WebServer_on(PSTR("/stream"), HandleWebcamMjpeg);
       AddLog_P2(LOG_LEVEL_DEBUG, PSTR("CAM: Stream init"));
       CamServer->begin();
     }
@@ -896,9 +896,9 @@ void WcLoop(void) {
 }
 
 void WcPicSetup(void) {
-  Webserver->on("/wc.jpg", HandleImage);
-  Webserver->on("/wc.mjpeg", HandleImage);
-  Webserver->on("/snapshot.jpg", HandleImageBasic);
+  WebServer_on(PSTR("/wc.jpg"), HandleImage);
+  WebServer_on(PSTR("/wc.mjpeg"), HandleImage);
+  WebServer_on(PSTR("/snapshot.jpg"), HandleImage);
 }
 
 void WcShowStream(void) {

--- a/tasmota/xsns_34_hx711.ino
+++ b/tasmota/xsns_34_hx711.ino
@@ -593,7 +593,7 @@ bool Xsns34(uint8_t function)
         WSContentSend_P(HTTP_BTN_MENU_HX711);
         break;
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/" WEB_HANDLE_HX711, HandleHxAction);
+        WebServer_on(PSTR("/" WEB_HANDLE_HX711), HandleHxAction);
         break;
 #endif  // USE_HX711_GUI
 #endif  // USE_WEBSERVER

--- a/tasmota/xsns_60_GPS.ino
+++ b/tasmota/xsns_60_GPS.ino
@@ -912,7 +912,7 @@ bool Xsns60(uint8_t function)
         break;
 #ifdef USE_FLOG
       case FUNC_WEB_ADD_HANDLER:
-        Webserver->on("/UBX", UBXsendFile);
+        WebServer_on(PSTR("/UBX"), UBXsendFile);
         break;
 #endif //USE_FLOG
       case FUNC_JSON_APPEND:

--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -102,7 +102,7 @@ bool Xsns75(uint8_t function)
 
   switch (function) {
     case FUNC_WEB_ADD_HANDLER:
-      Webserver->on("/metrics", HandleMetrics);
+      WebServer_on(PSTR("/metrics"), HandleMetrics);
       break;
   }
   return result;


### PR DESCRIPTION
## Description:

Follow-up of #9580, changed all `Webserver->on()` to a direct call, which isolates the implicit creation of transient object in only one place, instead of duplicating code everywhere.

Code impact: **-428 bytes** on Tasmota (default version), savings vary from variant to variant
No memory impact.

Edit: I left the Scripter unchanged.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.3
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
