### PR TITLE
Disable Wemo emulation for ZBBridge

### DIFF
--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -445,7 +445,7 @@
 //#undef USE_WEBSEND_RESPONSE                      // Disable command WebSend response message (+1k code)
 #define USE_EMULATION                             // Disable Wemo or Hue emulation
 #define USE_EMULATION_HUE                         // Disable Hue Bridge emulation for Alexa (+14k code, +2k mem common)
-//#undef USE_EMULATION_WEMO                        // Disable Belkin WeMo emulation for Alexa (+6k code, +2k mem common)
+#undef USE_EMULATION_WEMO                        // Disable Belkin WeMo emulation for Alexa (+6k code, +2k mem common)
 #undef USE_CUSTOM                                // Disable Custom features
 #undef USE_DISCOVERY                             // Disable Discovery services for both MQTT and web server
 //#undef USE_TIMERS                                // Disable support for up to 16 timers


### PR DESCRIPTION
## Description:

Zigbee does not support Wemo emulation, only Philips Hue. This saves 3KB of Flash for `tasmota-zbbridge`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
