### PR TITLE
Enable TLS in Tasmota-zbbridge

### DIFF
--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -101,6 +101,7 @@ build_flags = ${common.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_I
 
 [env:tasmota-zbbridge]
 build_flags = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
+board_build.f_cpu = 160000000L
 
 [env:tasmota-BG]
 build_flags = ${common.build_flags} -DMY_LANGUAGE=bg_BG

--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "my_user_config.h"
+#include "tasmota_configurations.h"
 #if defined(ESP8266) && defined(USE_TLS)
 
 // #define DEBUG_TLS

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -548,6 +548,14 @@
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code
 
+// -- MQTT - TLS - AWS IoT ------------------------
+#define USE_MQTT_TLS                             // Use TLS for MQTT connection (+34.5k code, +7.0k mem and +4.8k additional during connection handshake)
+ #define USE_MQTT_TLS_CA_CERT                    // Force full CA validation instead of fingerprints, slower, but simpler to use.  (+2.2k code, +1.9k mem during connection handshake)
+                                                 // This includes the LetsEncrypt CA in tasmota_ca.ino for verifying server certificates
+ #define USE_MQTT_TLS_FORCE_EC_CIPHER            // Force Elliptic Curve cipher (higher security) required by some servers (automatically enabled with USE_MQTT_AWS_IOT) (+11.4k code, +0.4k mem)
+ #define USE_MQTT_AWS_IOT_LIGHT                  // Enable MQTT for AWS IoT in light mode, with user/password instead of private certificate
+#define USE_TLS                                  // flag indicates we need to include TLS code
+
 #define USE_ZIGBEE
 #undef USE_ZIGBEE_ZNP
 #define USE_ZIGBEE_EZSP


### PR DESCRIPTION
## Description:

In Tasmota-zbbridge, enable optional TLS for MQTT, supporting both Letsencrypt and AWS IoT with password based authentication (no need anymore for private certificates). Also switched to 160MHz to make TLS handshake faster.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
