### PR TITLE
Expose the devicetype on mDNS

### DIFF
--- a/tasmota/support_network.ino
+++ b/tasmota/support_network.ino
@@ -72,6 +72,7 @@ void MdnsAddServiceHttp(void) {
   if (1 == Mdns.begun) {
     Mdns.begun = 2;
     MDNS.addService("http", "tcp", WEB_PORT);
+    MDNS.addServiceTxt("http", "tcp", "devicetype", "tasmota");
   }
 }
 


### PR DESCRIPTION
Add txt field to tell the network this is a tasmota device.

## Description:

**Related issue (if applicable):** see #6020

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
