### PR TITLE
Zigbee reduce battery drain

### DIFF
--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1215,8 +1215,8 @@ typedef struct Z_autoAttributeReporting_t {
 
 // Note the attribute must be registered in the converter list, used to retrieve the type of the attribute
 const Z_autoAttributeReporting_t Z_autoAttributeReporting[] PROGMEM = {
-  { 0x0001, 0x0020,   15*60,    15*60,  0.1 },      // BatteryVoltage
-  { 0x0001, 0x0021,   15*60,    15*60,    1 },      // BatteryPercentage
+  { 0x0001, 0x0020,    60*60, 4*60*60,  0.1 },      // BatteryVoltage
+  { 0x0001, 0x0021,    60*60, 4*60*60,    1 },      // BatteryPercentage
   { 0x0006, 0x0000,        1,   60*60,    0 },      // Power
   { 0x0201, 0x0000,       60,   60*10,  0.5 },      // LocalTemperature
   { 0x0201, 0x0008,       60,   60*10,   10 },      // PIHeatingDemand


### PR DESCRIPTION
## Description:

Configure reporting of battery every 4 hours instead of every 15 minutes to reduce battery drain.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
