### PR TITLE
Zigbee extend SO101 to attributes

### DIFF
--- a/tasmota/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/xdrv_23_zigbee_1z_libs.ino
@@ -809,11 +809,10 @@ Z_attribute & Z_attribute_list::findOrCreateAttribute(const char * name, uint8_t
 
 // same but passing a Z_attribute as key
 Z_attribute & Z_attribute_list::findOrCreateAttribute(const Z_attribute &attr) {
-  if (attr.key_is_str) {
-    return findOrCreateAttribute(attr.key.key, attr.key_suffix);
-  } else {
-    return findOrCreateAttribute(attr.key.id.cluster, attr.key.id.attr_id, attr.key_suffix);
-  }
+  Z_attribute & ret = attr.key_is_str ? findOrCreateAttribute(attr.key.key, attr.key_suffix)
+                                      : findOrCreateAttribute(attr.key.id.cluster, attr.key.id.attr_id, attr.key_suffix);
+  ret.key_suffix = attr.key_suffix;
+  return ret;
 }
 // replace the entire content with new attribute or create
 Z_attribute & Z_attribute_list::replaceOrCreate(const Z_attribute &attr) {

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1763,14 +1763,23 @@ void Z_OccupancyCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluste
 void ZCLFrame::postProcessAttributes(uint16_t shortaddr, Z_attribute_list& attr_list) {
   // source endpoint
   uint8_t src_ep = _srcendpoint;
+  uint8_t count_ep = zigbee_devices.countEndpoints(shortaddr);
+  Z_Device & device = zigbee_devices.getShortAddr(shortaddr);
   
   for (auto &attr : attr_list) {
+    // add endpoint suffix if needed
+    if ((Settings.flag4.zb_index_ep) && (src_ep != 1) && (count_ep > 1)) {
+      // we need to add suffix if the suffix is not already different from 1
+      if (attr.key_suffix == 1) {
+        attr.key_suffix = src_ep;
+      }
+    }
+
     // attr is Z_attribute&
     if (!attr.key_is_str) {
       uint16_t cluster = attr.key.id.cluster;
       uint16_t attribute = attr.key.id.attr_id;
       uint32_t ccccaaaa = (attr.key.id.cluster << 16) | attr.key.id.attr_id;
-      Z_Device & device = zigbee_devices.getShortAddr(shortaddr);
 
       // Look for an entry in the converter table
       bool found = false;


### PR DESCRIPTION
## Description:

Make `SetOption101 1` work also for attributes. If enabled, it will append the endpoint number to the attribute name.

Ex:
```
{"ZbReceived":{"0x07AC":{"Device":"0x07AC","Name":"BadSchalter","MultiInValue2":1,"click2":"single","Endpoint":2,"LinkQuality":107}}}
```

For this feature to actually append the endpoint, you need the following conditions:
- `SetOption101 1`
- The device must have more than 1 endpoint registered. Check via `ZbStatus2 <device>`
- The source endpoint must not be `1`. If source endpoint is `1`,  there is no suffix

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
