### PR TITLE
Disable by default ArduinoOTA lib

### DIFF
--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -30,6 +30,8 @@ lib_ignore =
     EspSoftwareSerial
     SPISlave
     Hash
+; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)    
+    ArduinoOTA
 
 [env:tasmota]
 

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -26,7 +26,9 @@ lib_ignore              =
     ESP32
     Preferences
     BluetoothSerial
-
+; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)    
+    ArduinoOTA
+    
 [env:tasmota32-webcam]
 extends = env:tasmota32
 board                   = esp32cam


### PR DESCRIPTION
## Description:

since it is not enabled in any Tasmota variant. -> Saves compile time in every Tasmota variant
Doing this we get feedback from users if ArduinoOTA support can be removed in future from Tasmota

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
