### PR TITLE
Zigbee added ``ZbMap`` command to describe Zigbee topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - TLS in binary tasmota-zbbridge (#9635)
 - Support for EZO O2 sensors by Christopher Tremblay (#9619)
 - Zigbee reduce battery drain (#9642)
-- Zigbee added ``ZbMap`` command to describe Zigbee topology
+- Zigbee added ``ZbMap`` command to describe Zigbee topology (#9651)
 
 ### Changed
 - PlatformIO library structure redesigned for compilation speed by Jason2866

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - TLS in binary tasmota-zbbridge (#9635)
 - Support for EZO O2 sensors by Christopher Tremblay (#9619)
 - Zigbee reduce battery drain (#9642)
+- Zigbee added ``ZbMap`` command to describe Zigbee topology
 
 ### Changed
 - PlatformIO library structure redesigned for compilation speed by Jason2866

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -565,6 +565,8 @@
   #define D_JSON_ZIGBEE_UNBIND "ZbUnbind"
 #define D_CMND_ZIGBEE_BIND_STATE "BindState"
   #define D_JSON_ZIGBEE_BIND_STATE "ZbBindState"
+#define D_CMND_ZIGBEE_MAP "Map"
+  #define D_JSON_ZIGBEE_MAP "ZbMap"
 #define D_JSON_ZIGBEE_PARENT "ZbParent"
 #define D_CMND_ZIGBEE_PING "Ping"
   #define D_JSON_ZIGBEE_PING "ZbPing"


### PR DESCRIPTION
## Description:

New command `ZbMap<n> <device>` to ask each device or router their view of the Zigbee topology. Device usually return 3 items so you need to iterate for each device. Ex: `ZbMap 0x1234` then `ZbMap4 0x1234`.

Example:
```
ZbMap IKEA

{
    "ZbMap": {
        "Device": "0xA0E5",
        "Name": "IKEA",
        "Status": 0,
        "StatusMessage": "SUCCESS",
        "MapTotal": 6,
        "MapStart": 1,
        "Map": [{
            "Device": "0x0000",
            "DeviceType": "Coordinator",
            "RxOnWhenIdle": true,
            "Relationship": "Parent",
            "PermitJoin": null,
            "Depth": 0,
            "LinkQuality": 200
        }, {
            "Device": "0x3AEE",
            "Name": "Plug",
            "DeviceType": "Router",
            "RxOnWhenIdle": true,
            "Relationship": "Sibling",
            "PermitJoin": null,
            "Depth": 15,
            "LinkQuality": 75
        }, {
            "Device": "0x6871",
            "Name": "Philips Bulb",
            "DeviceType": "Router",
            "RxOnWhenIdle": true,
            "Relationship": "Sibling",
            "PermitJoin": null,
            "Depth": 15,
            "LinkQuality": 56
        }]
    }
}

ZbMap4 IKEA

{
    "ZbMap": {
        "Device": "0xA0E5",
        "Name": "IKEA",
        "Status": 0,
        "StatusMessage": "SUCCESS",
        "MapTotal": 6,
        "MapStart": 4,
        "Map": [{
            "Device": "0xD1CD",
            "Name": "OSRAM Plug",
            "DeviceType": "Router",
            "RxOnWhenIdle": true,
            "Relationship": "Sibling",
            "PermitJoin": null,
            "Depth": 15,
            "LinkQuality": 152
        }, {
            "Device": "0x7985",
            "Name": "Radiator",
            "DeviceType": "Device",
            "RxOnWhenIdle": false,
            "Relationship": "Child",
            "PermitJoin": false,
            "Depth": 2,
            "LinkQuality": 199
        }, {
            "Device": "0xA491",
            "Name": "Thermometer",
            "DeviceType": "Device",
            "RxOnWhenIdle": false,
            "Relationship": "Child",
            "PermitJoin": false,
            "Depth": 2,
            "LinkQuality": 130
        }]
    }
}
```

This features allow through iteration to map the entire Zigbee network. This feature needs to be done externally from ESP8266 whose resources are too limited.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
