### PR TITLE
Zigbee fix for Lights

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -508,10 +508,12 @@ public:
         light.setConfig(channels);
         dirty = true;
       }
+      Z_Data_OnOff & onoff = data.get<Z_Data_OnOff>(0);
     } else {
-      // remove light object if any
+      // remove light / onoff object if any
       for (auto & data_elt : data) {
-        if (data_elt.getType() == Z_Data_Type::Z_Light) {
+        if ((data_elt.getType() == Z_Data_Type::Z_Light) ||
+            (data_elt.getType() == Z_Data_Type::Z_OnOff)) {
           // remove light object
           data.remove(&data_elt);
           dirty = true;


### PR DESCRIPTION
## Description:

Minor fix. When setting `ZbLight` also create a `Z_OnOff` object.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
