### PR TITLE
Add support for EZO PRS

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -84,3 +84,4 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   55  | USE_EZOEC           | xsns_78 | EZOEC    | 0x61 - 0x70 | Electric conductivity sensor
   55  | USE_EZOCO2          | xsns_78 | EZOCO2   | 0x61 - 0x70 | CO2 sensor
   55  | USE_EZOO2           | xsns_78 | EZOO2    | 0x61 - 0x70 | O2 sensor
+  55  | USE_EZOPRS          | xsns_78 | EZOPRS   | 0x61 - 0x70 | Pressure sensor

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -569,6 +569,7 @@
 //  #define USE_EZOEC                              // [I2cDriver55] Enable support for EZO's EC sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_EZOCO2                             // [I2cDriver55] Enable support for EZO's CO2 sensor (+0k2 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_EZOO2                              // [I2cDriver55] Enable support for EZO's O2 sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
+//  #define USE_EZOPRS                             // [I2cDriver55] Enable support for EZO's PRS sensor (+0k7 code) - Shared EZO code required for any EZO device (+1k2 code)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -726,6 +726,14 @@ float ConvertPressure(float p)
   return result;
 }
 
+float ConvertPressureForSeaLevel(float pressure)
+{
+  if (pressure == 0.0f)
+    return pressure;
+
+  return ConvertPressure((pressure / FastPrecisePow(1.0 - ((float)Settings.altitude / 44330.0f), 5.255f)) - 21.6f);
+}
+
 String PressureUnit(void)
 {
   return (Settings.flag.pressure_conversion) ? String(D_UNIT_MILLIMETER_MERCURY) : String(D_UNIT_PRESSURE);

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -134,6 +134,7 @@
 //#define USE_EZOEC                              // [I2cDriver55] Enable support for EZO's EC sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
 //#define USE_EZOCO2                             // [I2cDriver55] Enable support for EZO's CO2 sensor (+0k2 code) - Shared EZO code required for any EZO device (+1k2 code)
 //#define USE_EZOO2                              // [I2cDriver55] Enable support for EZO's O2 sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
+//#define USE_EZOPRS                             // [I2cDriver55] Enable support for EZO's PRS sensor (+0k7 code) - Shared EZO code required for any EZO device (+1k2 code)
 
 #define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
 #define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)

--- a/tasmota/xsns_09_bmp.ino
+++ b/tasmota/xsns_09_bmp.ino
@@ -517,11 +517,7 @@ void BmpShow(bool json)
 {
   for (uint32_t bmp_idx = 0; bmp_idx < bmp_count; bmp_idx++) {
     if (bmp_sensors[bmp_idx].bmp_type) {
-      float bmp_sealevel = 0.0;
-      if (bmp_sensors[bmp_idx].bmp_pressure != 0.0) {
-        bmp_sealevel = (bmp_sensors[bmp_idx].bmp_pressure / FastPrecisePow(1.0 - ((float)Settings.altitude / 44330.0), 5.255)) - 21.6;
-        bmp_sealevel = ConvertPressure(bmp_sealevel);
-      }
+      float bmp_sealevel = ConvertPressureForSeaLevel(bmp_sensors[bmp_idx].bmp_pressure);
       float bmp_temperature = ConvertTemp(bmp_sensors[bmp_idx].bmp_temperature);
       float bmp_pressure = ConvertPressure(bmp_sensors[bmp_idx].bmp_pressure);
 

--- a/tasmota/xsns_73_hp303b.ino
+++ b/tasmota/xsns_73_hp303b.ino
@@ -105,11 +105,7 @@ void HP303B_Show(bool json) {
         snprintf_P(sensor_name, sizeof(sensor_name), PSTR("%s%c%02X"), sensor_name, IndexSeparator(), hp303b_sensor[i].address); // HP303B-76, HP303B-77
       }
 
-      float sealevel = 0.0;
-      if (hp303b_sensor[i].pressure != 0.0) {
-        sealevel = (hp303b_sensor[i].pressure / FastPrecisePow(1.0 - ((float)Settings.altitude / 44330.0), 5.255)) - 21.6;
-        sealevel = ConvertPressure(sealevel);
-      }
+      float sealevel = ConvertPressureForSeaLevel(hp303b_sensor[i].pressure);
 
       char str_temperature[33];
       dtostrfd(hp303b_sensor[i].temperature, Settings.flag2.temperature_resolution, str_temperature);

--- a/tasmota/xsns_78_ezo.ino
+++ b/tasmota/xsns_78_ezo.ino
@@ -18,7 +18,7 @@
 */
 #ifdef USE_I2C
 
-#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD) || defined(USE_EZOHUM) || defined(USE_EZOEC) || defined(USE_EZOCO2) || defined(USE_EZOO2)
+#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD) || defined(USE_EZOHUM) || defined(USE_EZOEC) || defined(USE_EZOCO2) || defined(USE_EZOO2) || defined(USE_EZOPRS)
   #define USE_EZO
 #endif
 #if defined(USE_EZO)

--- a/tasmota/xsns_78_ezoprs.ino
+++ b/tasmota/xsns_78_ezoprs.ino
@@ -1,0 +1,69 @@
+/*
+  xsns_78_ezoprs.ino - EZO PRS I2C PRS sensor support for Tasmota
+
+  Copyright (C) 2020  Christopher Tremblay
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_EZOPRS
+
+#define EZO_PRS_READ_LATENCY   900
+
+struct EZOPRS : public EZOStruct {
+  EZOPRS(uint32_t addr) : EZOStruct(addr), pressure(NAN) {}
+
+  virtual void ProcessMeasurement(void)
+  {
+    char data[D_EZO_MAX_BUF];
+
+    EZOStruct::ProcessMeasurement(data, sizeof(data), EZO_PRS_READ_LATENCY);
+    pressure = CharToFloat(data) * 68.9476f; // Convert to hPa
+  }
+
+  virtual void Show(bool json, const char *name)
+  {
+    char str[33];
+    char sealevelstr[33];
+    dtostrfd(ConvertPressure(pressure), Settings.flag2.pressure_resolution, str);
+    dtostrfd(ConvertPressureForSeaLevel(pressure), Settings.flag2.pressure_resolution, sealevelstr);
+
+    if (json) {
+      ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_PRESSURE "\":%s"), name, str);
+      if (Settings.altitude != 0) {
+        ResponseAppend_P(PSTR(",\"" D_JSON_PRESSUREATSEALEVEL "\":%s"), sealevelstr);
+      }
+      ResponseJsonEnd();
+    }
+#ifdef USE_WEBSERVER  
+    else {
+      WSContentSend_PD(HTTP_SNS_PRESSURE, name, str, PressureUnit().c_str());
+      if (Settings.altitude != 0) {
+        WSContentSend_PD(HTTP_SNS_SEAPRESSURE, name, sealevelstr, PressureUnit().c_str());
+      }
+#endif  // USE_WEBSERVER
+    }
+  }
+
+  static const char id[] PROGMEM;
+
+private:
+  float     pressure;
+};
+
+const char EZOPRS::id[]  PROGMEM = "PRS";
+
+#endif  // USE_EZOPRS
+#endif  // USE_I2C

--- a/tasmota/xsns_78_xezo.ino
+++ b/tasmota/xsns_78_xezo.ino
@@ -80,7 +80,11 @@ const char *const EZOSupport[EZO_ADDR_n] PROGMEM = {
 #else
   EZOStruct::id,
 #endif
-  EZOStruct::id,  // "PRS"
+#ifdef USE_EZOPRS
+  EZOPRS::id,
+#else
+  EZOStruct::id,
+#endif
   EZOStruct::id,
 #ifdef USE_EZOO2
   EZOO2::id,
@@ -240,6 +244,9 @@ private:
 #endif
 #ifdef USE_EZOCO2
                   CREATE_EZO_CLASS(CO2)
+#endif
+#ifdef USE_EZOPRS
+                  CREATE_EZO_CLASS(PRS)
 #endif
 #ifdef USE_EZOO2
                   CREATE_EZO_CLASS(O2)


### PR DESCRIPTION
Adds support for EZO PRS sensors

Adds support for EZO PRS
Also took the opportunity to create a function to compute the sea level pressure given that multiple sensors were doing the same calculation already.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
