### PR TITLE
Resolve #9632 after sethalfway back to 50

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1342,7 +1342,7 @@ void CmndShutterSetHalfway(void)
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= shutters_present)) {
     if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 100)) {
       Settings.shutter_set50percent[XdrvMailbox.index -1] = (Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - XdrvMailbox.payload : XdrvMailbox.payload;
-      Settings.shuttercoeff[0][0] = 0;
+      Settings.shuttercoeff[XdrvMailbox.index -1][0] = 0;
       ShutterInit();
     }
   ResponseCmndIdxNumber((Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - Settings.shutter_set50percent[XdrvMailbox.index -1] : Settings.shutter_set50percent[XdrvMailbox.index -1]);

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1342,6 +1342,7 @@ void CmndShutterSetHalfway(void)
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= shutters_present)) {
     if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 100)) {
       Settings.shutter_set50percent[XdrvMailbox.index -1] = (Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - XdrvMailbox.payload : XdrvMailbox.payload;
+      Settings.shuttercoeff[0][0] = 0;
       ShutterInit();
     }
   ResponseCmndIdxNumber((Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - Settings.shutter_set50percent[XdrvMailbox.index -1] : Settings.shutter_set50percent[XdrvMailbox.index -1]);

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1342,7 +1342,7 @@ void CmndShutterSetHalfway(void)
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= shutters_present)) {
     if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 100)) {
       Settings.shutter_set50percent[XdrvMailbox.index -1] = (Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - XdrvMailbox.payload : XdrvMailbox.payload;
-      Settings.shuttercoeff[XdrvMailbox.index -1][0] = 0;
+      Settings.shuttercoeff[0][XdrvMailbox.index -1] = 0;
       ShutterInit();
     }
   ResponseCmndIdxNumber((Settings.shutter_options[XdrvMailbox.index -1] & 1) ? 100 - Settings.shutter_set50percent[XdrvMailbox.index -1] : Settings.shutter_set50percent[XdrvMailbox.index -1]);
@@ -1430,6 +1430,7 @@ void CmndShutterCalibration(void)
         }
         messwerte[i] = field;
       }
+      Settings.shutter_set50percent[XdrvMailbox.index -1] = 50;
       for (i = 0; i < 5; i++) {
         Settings.shuttercoeff[i][XdrvMailbox.index -1] = SHT_DIV_ROUND((uint32_t)messwerte[i] * 1000, messwerte[4]);
         AddLog_P2(LOG_LEVEL_DEBUG, PSTR("Settings.shuttercoeff: %d, i: %d, value: %d, messwert %d"), i,XdrvMailbox.index -1,Settings.shuttercoeff[i][XdrvMailbox.index -1], messwerte[i]);


### PR DESCRIPTION
## Description: Reset calibration mask back to default if halfway is set to 50
#9458 fixed
maybe also: #9632
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR.
  - [x ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ x] The code change is tested and works on core ESP32 V.1.12.2
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
