### PR TITLE
Zigbee display modelId and ManufacturerId in tooltip

### DIFF
--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1715,10 +1715,13 @@ void ZigbeeShow(bool json)
 
       WSContentSend_PD(PSTR(
         "<tr class='ztd htr'>"
-          "<td><b>%s</b></td>" // name
+          "<td><b title='0x%04X %s - %s'>%s</b></td>" // name
           "<td>%s</td>" // sbatt (Battery Indicator)
           "<td><div title='" D_LQI " %s' class='ssi'>" // slqi
-      ), name, sbatt, slqi);
+      ), shortaddr, 
+      device.modelId ? device.modelId : "", 
+      device.manufacturerId ? device.manufacturerId : "", 
+      name, sbatt, slqi);
 
       if(device.validLqi()) {
           for(uint32_t j = 0; j < 4; ++j) {


### PR DESCRIPTION
## Description:

Display the shortaddress, ModelId and ManufacturerId as tooltip in the web UI.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
