### PR TITLE
Don't try to connect to TLS with Tasmota-minimal

### DIFF
--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -608,10 +608,12 @@ void MqttReconnect(void)
   global_state.mqtt_down = 1;
 
 #ifdef FIRMWARE_MINIMAL
+#ifndef USE_MQTT_TLS
   // Don't try to connect if MQTT requires TLS but TLS is not supported
   if (Settings.flag4.mqtt_tls) {
     return;
   }
+#endif
 #endif
 
   AddLog_P(LOG_LEVEL_INFO, S_LOG_MQTT, PSTR(D_ATTEMPTING_CONNECTION));

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -603,11 +603,18 @@ void MqttReconnect(void)
   UdpDisconnect();
 #endif  // USE_EMULATION
 
-  AddLog_P(LOG_LEVEL_INFO, S_LOG_MQTT, PSTR(D_ATTEMPTING_CONNECTION));
-
   Mqtt.connected = false;
   Mqtt.retry_counter = Settings.mqtt_retry;
   global_state.mqtt_down = 1;
+
+#ifdef FIRMWARE_MINIMAL
+  // Don't try to connect if MQTT requires TLS but TLS is not supported
+  if (Settings.flag4.mqtt_tls) {
+    return;
+  }
+#endif
+
+  AddLog_P(LOG_LEVEL_INFO, S_LOG_MQTT, PSTR(D_ATTEMPTING_CONNECTION));
 
   char *mqtt_user = nullptr;
   char *mqtt_pwd = nullptr;


### PR DESCRIPTION
## Description:

This fix aborts any tentative to make a TLS connection with Tasmota-minimal. Otherwise it freezes tasmota until timeout at each connection tentative.

Note: I have moved the log a bit lower to avoid having useless `MQT: Attempting connection...` messages in tasmota-minimal

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
