### PR TITLE
Fix Hue support when zigbee is disabled

### DIFF
--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -724,7 +724,7 @@ void HueLights(String *path)
     device_id = atoi(path->c_str());
     device = DecodeLightId(device_id);
 #ifdef USE_ZIGBEE
-    uint16_t shortaddr;
+    uint16_t shortaddr = 0x0000;
     device = DecodeLightId(device_id, &shortaddr);
     if (shortaddr) {
       return ZigbeeHandleHue(shortaddr, device_id, response);
@@ -747,7 +747,7 @@ void HueLights(String *path)
     device_id = atoi(path->c_str());
     device = DecodeLightId(device_id);
 #ifdef USE_ZIGBEE
-    uint16_t shortaddr;
+    uint16_t shortaddr = 0x0000;
     device = DecodeLightId(device_id, &shortaddr);
     if (shortaddr) {
       ZigbeeHueStatus(&response, shortaddr);

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -432,6 +432,7 @@ uint32_t DecodeLightId(uint32_t hue_id, uint16_t * shortaddr = nullptr)
     relay_id = 32;
   }
 #ifdef USE_ZIGBEE
+  if (shortaddr) { *shortaddr = 0x0000; }
   if (hue_id & (1 << 29)) {
     // this is actually a Zigbee ID
     if (shortaddr) { *shortaddr = hue_id & 0xFFFF; }


### PR DESCRIPTION
## Description:

Fix Zigbee when compiling a Zigbee version but Zigbee is not enabled.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
