### PR TITLE
Zigbee fix TRADFRI battery percentage

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1238,6 +1238,15 @@ void ZCLFrame::computeSyntheticAttributes(Z_attribute_list& attr_list) {
           attr_list.addAttribute(0x0001, 0x0021).setUInt(toPercentageCR2032(mv) * 2);
         }
         break;
+      case 0x00010021:       // BatteryPercentage
+        {
+          const char * model_c = zigbee_devices.getModelId(_srcaddr);  // null if unknown
+          String modelId((char*) model_c);
+          if (modelId.startsWith(F("TRADFRI"))) {
+            attr.setUInt(attr.getUInt() * 2);   // bug in TRADFRI battery, need to double the value
+          }
+        }
+        break;
       case 0x02010008:    // Pi Heating Demand - solve Eutotronic bug
         {
           const char * manufacturer_c = zigbee_devices.getManufacturerId(_srcaddr);  // null if unknown


### PR DESCRIPTION
## Description:

IKEA TRADFRI reports battery percentage in a range 0..100 instead of 0..200 as required by ZCL standard. It seems that IKEA's developers misread the ZCL documentation.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
