### PR TITLE
Zigbee fix group id reporting

### DIFF
--- a/tasmota/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/xdrv_23_zigbee_1z_libs.ino
@@ -829,9 +829,17 @@ bool Z_attribute_list::mergeList(const Z_attribute_list &attr_list) {
   } else if (0xFF != attr_list.src_ep) {
     if (src_ep != attr_list.src_ep) { return false; }
   }
+  // Check group address
+  if (0xFFFF == group_id) {
+    group_id = attr_list.group_id;
+  } else if (0xFFFF != attr_list.group_id) {
+    if (group_id != attr_list.group_id) { return false; }
+  }
+  // copy LQI
   if (0xFF != attr_list.lqi) {
     lqi = attr_list.lqi;
   }
+  // merge attributes
   for (auto & attr : attr_list) {
     replaceOrCreate(attr);
   }


### PR DESCRIPTION
## Description:

Fix the group address not reported in messages.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
