### PR TITLE
Zigbee added ``ZbOccupancy`` command to configure the time-out for PIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee reduce battery drain (#9642)
 - Zigbee added ``ZbMap`` command to describe Zigbee topology (#9651)
 - Command ``Gpios 255`` to show all possible GPIO configurations
+- Zigbee added ``ZbOccupancy`` command to configure the time-out for PIR
 
 ### Changed
 - PlatformIO library structure redesigned for compilation speed by Jason2866

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -577,6 +577,8 @@
   #define D_JSON_ZIGBEE_STATUS_MSG "StatusMessage"
 #define D_CMND_ZIGBEE_LIGHT "Light"
   #define D_JSON_ZIGBEE_LIGHT "Light"
+#define D_CMND_ZIGBEE_OCCUPANCY "Occupancy"
+  #define D_JSON_ZIGBEE_OCCUPANCY "Occupancy"
 #define D_CMND_ZIGBEE_RESTORE "Restore"
 #define D_CMND_ZIGBEE_CONFIG "Config"
   #define D_JSON_ZIGBEE_CONFIG "Config"

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -172,7 +172,7 @@ void Z_Data_OnOff::setPower(bool val, uint32_t relay) {
 }
 
 /*********************************************************************************************\
- * Device specific: Light device
+ * Device specific: Plug device
 \*********************************************************************************************/
 class Z_Data_Plug : public Z_Data {
 public:
@@ -249,6 +249,18 @@ public:
 
 /*********************************************************************************************\
  * Device specific: PIR
+ * 
+  // List of occupancy time-outs:
+  // 0xF = default (90 s)
+  // 0x0 = no time-out
+  // 0x1 = 15 s
+  // 0x2 = 30 s
+  // 0x3 = 45 s
+  // 0x4 = 60 s
+  // 0x5 = 75 s
+  // 0x6 = 90 s -- default
+  // 0x7 = 105 s
+  // 0x8 = 120 s
 \*********************************************************************************************/
 class Z_Data_PIR : public Z_Data {
 public:
@@ -265,13 +277,34 @@ public:
   inline uint16_t getIlluminance(void)  const { return illuminance; }
   
   inline void setOccupancy(uint8_t _occupancy)          { occupancy = _occupancy; }
-  inline void setilluminance(uint16_t _illuminance)     { illuminance = _illuminance; }
+  inline void setIlluminance(uint16_t _illuminance)     { illuminance = _illuminance; }
+
+  uint32_t getTimeoutSeconds(void) const;
+  void setTimeoutSeconds(int32_t value);
 
   static const Z_Data_Type type = Z_Data_Type::Z_PIR;
   // PIR
   uint8_t               occupancy;      // map8
   uint16_t              illuminance;    // illuminance
 };
+
+uint32_t Z_Data_PIR::getTimeoutSeconds(void) const {
+  if (_config != 0xF) {
+    return _config * 15;
+  } else {
+    return 90;
+  }
+}
+
+void Z_Data_PIR::setTimeoutSeconds(int32_t value) {
+  if (value < 0) {
+    _config = 0xF;
+  } else {
+    uint32_t val_15 = (value + 14)/ 15;   // always round up
+    if (val_15 > 8) { val_15 = 8; }
+    _config = val_15;
+  }
+}
 
 /*********************************************************************************************\
  * Device specific: Sensors: temp, humidity, pressure...
@@ -510,6 +543,7 @@ public:
   inline bool getReachable(void)        const { return reachable; }
   inline bool getPower(uint8_t ep =0)   const;
 
+  bool addEndpoint(uint8_t endpoint);
   // dump device attributes to ZbData
   void toAttributes(Z_attribute_list & attr_list) const;
 

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -228,20 +228,26 @@ void Z_Devices::clearEndpoints(uint16_t shortaddr) {
 
 //
 // Add an endpoint to a shortaddr
+// return true if a change was made
 //
-void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
-  if ((0x00 == endpoint) || (endpoint > 240)) { return; }
-  Z_Device &device = getShortAddr(shortaddr);
+bool Z_Device::addEndpoint(uint8_t endpoint) {
+  if ((0x00 == endpoint) || (endpoint > 240)) { return false; }
 
   for (uint32_t i = 0; i < endpoints_max; i++) {
-    if (endpoint == device.endpoints[i]) {
-      return;     // endpoint already there
+    if (endpoint == endpoints[i]) {
+      return false;     // endpoint already there
     }
-    if (0 == device.endpoints[i]) {
-      device.endpoints[i] = endpoint;
-      dirty();
-      return;
+    if (0 == endpoints[i]) {
+      endpoints[i] = endpoint;
+      return true;
     }
+  }
+  return false;
+}
+
+void Z_Devices::addEndpoint(uint16_t shortaddr, uint8_t endpoint) {
+  if (getShortAddr(shortaddr).addEndpoint(endpoint)) {
+    dirty();
   }
 }
 

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -265,7 +265,7 @@ void hydrateSingleDevice(const SBuffer & buf_d, uint32_t version) {
       uint8_t ep = buf_d.get8(d++);
       if (0xFF == ep) { break; }        // ep 0xFF marks the end of the endpoints
       if (ep > 240) { ep = 0xFF; }      // ep == 0xFF means ignore
-      if ((ep > 0) && (ep != 0xFF)) { zigbee_devices.addEndpoint(shortaddr, ep); }     // don't add endpoint if it is 0x00
+      device.addEndpoint(ep);           // it will ignore invalid endpoints
       while (d < buf_len) {
         uint8_t config_type = buf_d.get8(d++);
         if (0xFF == config_type) { break; }                                // 0xFF marks the end of congiguration

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1285,7 +1285,12 @@ void ZCLFrame::generateCallBacks(Z_attribute_list& attr_list) {
       case 0x04060000:        // Occupancy
         uint32_t occupancy = attr.getUInt();
         if (occupancy) {
-          zigbee_devices.setTimer(_srcaddr, 0 /* groupaddr */, OCCUPANCY_TIMEOUT, _cluster_id, _srcendpoint, Z_CAT_VIRTUAL_OCCUPANCY, 0, &Z_OccupancyCallback);
+          uint32_t pir_timer = OCCUPANCY_TIMEOUT;
+          const Z_Data_PIR & pir_found = (const Z_Data_PIR&) zigbee_devices.getShortAddr(_srcaddr).data.find(Z_Data_Type::Z_PIR, _srcendpoint);
+          if (&pir_found != nullptr) {
+            pir_timer = pir_found.getTimeoutSeconds() * 1000;
+          }
+          zigbee_devices.setTimer(_srcaddr, 0 /* groupaddr */, pir_timer, _cluster_id, _srcendpoint, Z_CAT_VIRTUAL_OCCUPANCY, 0, &Z_OccupancyCallback);
         } else {
           zigbee_devices.resetTimersForDevice(_srcaddr, 0 /* groupaddr */, Z_CAT_VIRTUAL_OCCUPANCY);
         }


### PR DESCRIPTION
## Description:

Added `ZbOccupancy` command tu configure the time-out after `"Occupancy":1` to send a synthetic `"Occupancy":0`. Some PIR sensors don't send `"Occupancy":0`, but the lack of consecutive `"Occupancy":1` means that there is no more occupancy.

Setting a value:
`ZbOccupancy <device>,<s>` where `<device>` is the device to configure, `<s>` the number of seconds before the `"Occupancy":0` is generated. Possible values are:
- `0`: no time-out, the device actually generates `"Occupancy":0`
- `n`: the number of seconds. The possible values are 15, 30, 45, 60, 75, 90, 105, 120. If the number is different, it is rounded up 
- `-1`: apply the default (90 seconds)

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
