### PR TITLE
Make ESP32 Stage compile possible

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -184,12 +184,12 @@ build_flags               = ${esp82xx_defaults.build_flags}
 ; Activate Stage Core32 by removing ";" in next line, if you want to override the standard core32
 ;platform_packages       = ${core32_stage.platform_packages}
 
-
 [core32_stage]
-platform_packages       = tool-esptoolpy@1.20800.0
-                          ; latest working commit
-                          framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#c09ec5bd3d35ba7dfc135755ab300e2b45416def
+platform_packages        = tool-esptoolpy@1.20800.0
+                           framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#f7fb00632e04d74a7890a77fa7dbbb8ae572e866
 
+build_flags               = ${common32.build_flags}
+                            -D ESP32_STAGE=true
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -34,7 +34,9 @@
 \*********************************************************************************************/
 
 // Location specific includes
+#ifndef ESP32_STAGE                         // ESP32 Stage has no core_version.h file. Disable include via PlatformIO Option
 #include <core_version.h>                   // Arduino_Esp8266 version information (ARDUINO_ESP8266_RELEASE and ARDUINO_ESP8266_RELEASE_2_7_1)
+#endif
 #include "tasmota_compat.h"
 #include "tasmota_version.h"                // Tasmota version information
 #include "tasmota.h"                        // Enumeration used in my_user_config.h


### PR DESCRIPTION
## Description:

since ESP32 stage has no core_version.h file we have to disable the include.
This is done with setting ESP32_STAGE=true in Platformio

Changed ESP32 stage to latest commit `f7fb00632e0....`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
