### PR TITLE
Fix regression introduced by #9589

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -490,7 +490,7 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
     result = XdrvRulesProcess();
   }
 #ifdef USE_PWM_DIMMER
-  if (PWM_DIMMER == TasmotaGlobal.module_type && !result) {
+  if (PWM_DIMMER != TasmotaGlobal.module_type || !result) {
 #endif  // USE_PWM_DIMMER
   int32_t payload_save = XdrvMailbox.payload;
   XdrvMailbox.payload = device_save << 24 | key << 16 | state << 8 | device;


### PR DESCRIPTION
## Description:

Attempt to fix regression introduced by #9589

#9589 modifies behavior of switches and buttons if module type is `PWM_DIMMER`.
However, it also breaks switches and buttons for all other module types.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
