### PR TITLE
Zigbee refactoring

### DIFF
--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -257,7 +257,7 @@ void hydrateSingleDevice(const SBuffer & buf_d, uint32_t version) {
 
   // Hue bulbtype - if present
   if (1 == version) {
-    zigbee_devices.setLightProfile(shortaddr, buf_d.get8(d));
+    device.setLightChannels(buf_d.get8(d));
     d++;
   } else if (2 == version) {
     // v2 parser

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1853,7 +1853,7 @@ void Z_postProcessAttributes(uint16_t shortaddr, uint16_t src_ep, class Z_attrib
       switch (ccccaaaa) {
         case 0x00000004: device.setManufId(attr.getStr());                            break;
         case 0x00000005: device.setModelId(attr.getStr());                            break;
-        case 0x00010021: zigbee_devices.setBatteryPercent(shortaddr, uval16 / 2);     break;
+        case 0x00010021: device.setBatteryPercent(uval16 / 2);                        break;
         case 0x00060000:
         case 0x00068000: device.setPower(attr.getBool(), src_ep);                     break;
       }

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -199,7 +199,7 @@ void Z_ReadAttrCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster
 // This callback is registered after a an attribute read command was made to a light, and fires if we don't get any response after 1000 ms
 void Z_Unreachable(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
   if (BAD_SHORTADDR != shortaddr) {
-    zigbee_devices.setReachable(shortaddr, false);     // mark device as reachable
+    zigbee_devices.getShortAddr(shortaddr).setReachable(false);     // mark device as reachable
   }
 }
 


### PR DESCRIPTION
## Description:

Minor refactoring to pass around `Z_Device &` references instead of `uint16_T` shortaddresses.
Saves 192 bytes of Flash.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
