### PR TITLE
Zigbee fix 0x000 appearing in UI

### DIFF
--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1618,8 +1618,8 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
   if ((0x0000 == profileid) && (0x00 == srcendpoint))  {
     // ZDO request
     // Report LQI
-    Z_Device & device = zigbee_devices.getShortAddr(srcaddr);
     if (srcaddr != localShortAddr) {
+      Z_Device & device = zigbee_devices.getShortAddr(srcaddr);
       device.setLQI(linkquality);
       device.setLastSeenNow();
     }


### PR DESCRIPTION
## Description:

Prevents `0x0000` from appearing in the Web UI.
If it is already there, use `ZbForget 0x0000` to remove it.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
