### PR TITLE
MI_ESP32: small bugfixes and reduced memory usage

### DIFF
--- a/tasmota/xsns_62_MI_ESP32.ino
+++ b/tasmota/xsns_62_MI_ESP32.ino
@@ -373,6 +373,7 @@ class MI32SensorCallback : public NimBLEClientCallbacks {
   }
   void onDisconnect(NimBLEClient* pclient) {
     MI32.mode.connected = 0;
+    MI32.mode.willReadBatt = 0;
     AddLog_P2(LOG_LEVEL_DEBUG,PSTR("disconnected %s"), kMI32DeviceType[(MIBLEsensors[MI32.state.sensor].type)-1]);
   }
   bool onConnParamsUpdateRequest(NimBLEClient* MI32Client, const ble_gap_upd_params* params) {
@@ -859,7 +860,7 @@ void MI32StartScanTask(){
     xTaskCreatePinnedToCore(
     MI32ScanTask,    /* Function to implement the task */
     "MI32ScanTask",  /* Name of the task */
-    4096,             /* Stack size in words */
+    2048,             /* Stack size in words */
     NULL,             /* Task input parameter */
     0,                /* Priority of the task */
     NULL,             /* Task handle. */
@@ -1660,7 +1661,7 @@ void MI32EverySecond(bool restart){
     if(_beacon.active == false) continue;
     _activeBeacons++;
     _beacon.time++;
-    Response_P(PSTR("{\"Beacon%u\":{\"Time\":%u}}"), _beacon.time);
+    Response_P(PSTR("{\"Beacon%u\":{\"Time\":%u}}"), _idx, _beacon.time);
     XdrvRulesProcess();
   }
   if(_activeBeacons==0) MI32.mode.activeBeacon = 0;
@@ -1843,7 +1844,7 @@ bool MI32Cmd(void) {
             switch(XdrvMailbox.index){
               case 0:
               MI32.state.beaconScanCounter = 8;
-              Response_P(S_JSON_MI32_BCOMMAND_SVALUE, command, XdrvMailbox.index,PSTR("\"scanning\""));
+              Response_P(S_JSON_MI32_BCOMMAND_SVALUE, command, XdrvMailbox.index,PSTR("scanning"));
               break;
               case 1: case 2: case 3: case 4:
               char _MAC[18];
@@ -1880,7 +1881,7 @@ bool MI32Cmd(void) {
  * Presentation
 \*********************************************************************************************/
 
-const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 v0916{m}%u%s / %u{e}";
+const char HTTP_MI32[] PROGMEM = "{s}MI ESP32 v0916a{m}%u%s / %u{e}";
 const char HTTP_MI32_MAC[] PROGMEM = "{s}%s %s{m}%s{e}";
 const char HTTP_RSSI[] PROGMEM = "{s}%s " D_RSSI "{m}%d dBm{e}";
 const char HTTP_BATTERY[] PROGMEM = "{s}%s" " Battery" "{m}%u %%{e}";


### PR DESCRIPTION
## Description:

bugfixes:
- prevents lock-out from the main loop, if BLE device disconnects unexpectedly while reading battery
- adds a forgotten index value for a format specifier
- delete some quotation marks

minor improvement:
- after measuring the free stack space in the scanner task, it showed roughly 3kb unused of 4kb. So allocating 2kb with 1kb safety margin should be working and frees some memory for other stuff. 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
