### PR TITLE
Switches: MQTT decoupling and regression fix

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -139,7 +139,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
 typedef union {                            // Restricted by MISRA-C Rule 18.4 but so useful...
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption114 .. SetOption145
-    uint32_t spare00 : 1;                  // bit 0
+    uint32_t mqtt_switches : 1;            // bit 0 (V9.0.0.3) Detach Swiches from relays and enable MQTT action state for all the SwitchModes
+    //uint32_t spare00 : 1;                  // bit 0
     uint32_t spare01 : 1;                  // bit 1
     uint32_t spare02 : 1;                  // bit 2
     uint32_t spare03 : 1;                  // bit 3

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -139,7 +139,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
 typedef union {                            // Restricted by MISRA-C Rule 18.4 but so useful...
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption114 .. SetOption145
-    uint32_t mqtt_switches : 1;            // bit 0 (V9.0.0.3) Detach Swiches from relays and enable MQTT action state for all the SwitchModes
+    uint32_t mqtt_switches : 1;            // bit 0 (V9.0.0.3)  - SetOption114 - Detach Swiches from relays and enable MQTT action state for all the SwitchModes
     //uint32_t spare00 : 1;                  // bit 0
     uint32_t spare01 : 1;                  // bit 1
     uint32_t spare02 : 1;                  // bit 2

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -497,7 +497,7 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
   XdrvCall(FUNC_ANY_KEY);
   XdrvMailbox.payload = payload_save;
 #ifdef USE_PWM_DIMMER
-    result = true;
+    if (PWM_DIMMER == TasmotaGlobal.module_type) result = true;
   }
 #endif  // USE_PWM_DIMMER
   return result;


### PR DESCRIPTION
## Description:
Adds `SetOption114` (default to `0`) to decouple the switches from the POWER devices similar to what I did with `SetOption73` for the buttons.
All the switchmodes are supported.
@arendst is a bit different from `PUSH_IGNORE` (SwitchMode15) because with this PR all the payloads are mapped. 
I left it there, up to you to remove it or not, but I think is not necessary anymore.
A few examples:
```py
00:52:17 CMD: switchmode 0
00:52:17 MQT: tasmota_49A3BC/stat/RESULT = {"SwitchMode1":0}
00:52:20 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"TOGGLE"}

00:52:26 CMD: switchmode 1
00:52:26 MQT: tasmota_49A3BC/stat/RESULT = {"SwitchMode1":1}
00:52:28 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"OFF"}
00:52:31 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"ON"}

00:52:41 CMD: switchmode 5
00:52:41 MQT: tasmota_49A3BC/stat/RESULT = {"SwitchMode1":5}
00:52:45 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"HOLD"}

00:52:56 CMD: switchmode 11
00:52:56 MQT: tasmota_49A3BC/stat/RESULT = {"SwitchMode1":11}
00:52:58 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"POWER_RELEASE"}
00:52:59 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"POWER_CLEAR"}
00:53:03 MQT: tasmota_49A3BC/stat/SWITCH1 = {"ACTION":"POWER_INCREMENT"}
```

Also fixes a regression introduced on #9589 that was blocking the communication between switches/buttons and relays. 
@emontnemery fixed `HAssAnyKey` on #9700 , regression generated by the same PR, but after a bisect we realized there was another problem too: the relays were not responding after a button/switch press.
 
**Related issue (if applicable):** fixes #9719 and #9715

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [X] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
