### PR TITLE
Add support for EZO RGB

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -87,3 +87,4 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   55  | USE_EZOPRS          | xsns_78 | EZOPRS   | 0x61 - 0x70 | Pressure sensor
   55  | USE_EZOFLO          | xsns_78 | EZOFLO   | 0x61 - 0x70 | Flow meter sensor
   55  | USE_EZODO           | xsns_78 | EZODO    | 0x61 - 0x70 | Disolved Oxygen sensor
+  55  | USE_EZORGB          | xsns_78 | EZORGB   | 0x61 - 0x70 | Color sensor

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -37,6 +37,7 @@
 #define D_JSON_BAUDRATE "Baudrate"
 #define D_JSON_BLINK "Blink"
 #define D_JSON_BLOCKED_LOOP "Blocked Loop"
+#define D_JSON_BLUE "Blue"
 #define D_JSON_BOOTVERSION "Boot"
 #define D_JSON_BOOTCOUNT "BootCount"
 #define D_JSON_BSSID "BSSId"
@@ -82,6 +83,7 @@
 #define D_JSON_FROM "from"
 #define D_JSON_GAS "Gas"
 #define D_JSON_GATEWAY "Gateway"
+#define D_JSON_GREEN "Green"
 #define D_JSON_GROUPS "Groups"
 #define D_JSON_HALTING "Halting"
 #define D_JSON_HEAPSIZE "Heap"
@@ -132,6 +134,7 @@
 #define D_JSON_PROGRAMSIZE "ProgramSize"
 #define D_JSON_PSRMAXMEMORY "PsrMax"
 #define D_JSON_PSRFREEMEMORY "PsrFree"
+#define D_JSON_RED "Red"
 #define D_JSON_REFERENCETEMPERATURE "ReferenceTemperature"
 #define D_JSON_REMAINING "Remaining"
 #define D_JSON_RESET "Reset"
@@ -787,6 +790,9 @@ const char HTTP_SNS_O2[]            PROGMEM = "{s}%s "  D_O2                  "{
 const char HTTP_SNS_LITERS[]        PROGMEM = "{s}%s "  D_VOLUME              "{m}%s " D_UNIT_LITERS              "{e}";
 const char HTTP_SNS_LPM[]           PROGMEM = "{s}%s "  D_FLOW_RATE           "{m}%s " D_UNIT_LITERS_PER_MIN      "{e}";
 const char HTTP_SNS_DO[]            PROGMEM = "{s}%s "  D_DO                  "{m}%s " D_UNIT_PARTS_PER_MILLION   "{e}";
+const char HTTP_SNS_COLOR_RED[]     PROGMEM = "{s}%s "  D_COLOR_RED           "{m}%u "                            "{e}";
+const char HTTP_SNS_COLOR_GREEN[]   PROGMEM = "{s}%s "  D_COLOR_GREEN         "{m}%u "                            "{e}";
+const char HTTP_SNS_COLOR_BLUE[]    PROGMEM = "{s}%s "  D_COLOR_BLUE          "{m}%u "                            "{e}";
 
 const char S_MAIN_MENU[]              PROGMEM = D_MAIN_MENU;
 const char S_CONFIGURATION[]          PROGMEM = D_CONFIGURATION;

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -501,9 +501,9 @@
 
 // xsns_27_apds9960.ino
 #define D_GESTURE "Gesture"
-#define D_COLOR_RED "Red"
-#define D_COLOR_GREEN "Green"
-#define D_COLOR_BLUE "Blue"
+#define D_COLOR_RED "红"
+#define D_COLOR_GREEN "绿"
+#define D_COLOR_BLUE "蓝"
 #define D_CCT "CCT"
 #define D_PROXIMITY "Proximity"
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -572,6 +572,7 @@
 //  #define USE_EZOPRS                             // [I2cDriver55] Enable support for EZO's PRS sensor (+0k7 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_EZOFLO                             // [I2cDriver55] Enable support for EZO's FLO sensor (+0k4 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_EZODO                              // [I2cDriver55] Enable support for EZO's DO sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
+//  #define USE_EZORGB                             // [I2cDriver55] Enable support for EZO's RGB sensor (+0k5 code) - Shared EZO code required for any EZO device (+1k2 code)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -136,7 +136,8 @@
 //#define USE_EZOO2                              // [I2cDriver55] Enable support for EZO's O2 sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
 //#define USE_EZOPRS                             // [I2cDriver55] Enable support for EZO's PRS sensor (+0k7 code) - Shared EZO code required for any EZO device (+1k2 code)
 //#define USE_EZOFLO                             // [I2cDriver55] Enable support for EZO's FLO sensor (+0k4 code) - Shared EZO code required for any EZO device (+1k2 code)
-//  #define USE_EZODO                              // [I2cDriver55] Enable support for EZO's DO sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
+//  #define USE_EZODO                            // [I2cDriver55] Enable support for EZO's DO sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
+//  #define USE_EZORGB                           // [I2cDriver55] Enable support for EZO's RGB sensor (+0k5 code) - Shared EZO code required for any EZO device (+1k2 code)
 
 #define USE_MHZ19                                // Add support for MH-Z19 CO2 sensor (+2k code)
 #define USE_SENSEAIR                             // Add support for SenseAir K30, K70 and S8 CO2 sensor (+2k3 code)

--- a/tasmota/xsns_27_apds9960.ino
+++ b/tasmota/xsns_27_apds9960.ino
@@ -86,9 +86,6 @@ const char HTTP_SNS_GESTURE[]     PROGMEM = "{s}%s " D_GESTURE "{m}%s{e}";
 #endif  // USE_APDS9960_GESTURE
 
 #ifdef USE_APDS9960_COLOR
-const char HTTP_SNS_COLOR_RED[]   PROGMEM = "{s}%s " D_COLOR_RED "{m}%u{e}";
-const char HTTP_SNS_COLOR_GREEN[] PROGMEM = "{s}%s " D_COLOR_GREEN "{m}%u{e}";
-const char HTTP_SNS_COLOR_BLUE[]  PROGMEM = "{s}%s " D_COLOR_BLUE "{m}%u{e}";
 const char HTTP_SNS_CCT[]         PROGMEM = "{s}%s " D_CCT "{m}%u " D_UNIT_KELVIN  "{e}";
 #endif  // USE_APDS9960_COLOR
 

--- a/tasmota/xsns_78_ezo.ino
+++ b/tasmota/xsns_78_ezo.ino
@@ -18,13 +18,13 @@
 */
 #ifdef USE_I2C
 
-#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD) || defined(USE_EZOHUM) || defined(USE_EZOEC) || defined(USE_EZOCO2) || defined(USE_EZOO2) || defined(USE_EZOPRS) || defined(USE_EZOFLO) || defined(USE_EZODO)
+#if defined(USE_EZOPH) || defined(USE_EZOORP) || defined(USE_EZORTD) || defined(USE_EZOHUM) || defined(USE_EZOEC) || defined(USE_EZOCO2) || defined(USE_EZOO2) || defined(USE_EZOPRS) || defined(USE_EZOFLO) || defined(USE_EZODO) || defined(USE_EZORGB)
   #define USE_EZO
 #endif
 #if defined(USE_EZO)
 
 #define D_EZO_DELAY   300   // Minimum delay for any instruction
-#define D_EZO_MAX_BUF 40    // Maximum response
+#define D_EZO_MAX_BUF 52    // Maximum response
 
 const char D_EZO_NAME[] PROGMEM = "EZO";
 

--- a/tasmota/xsns_78_ezorgb.ino
+++ b/tasmota/xsns_78_ezorgb.ino
@@ -1,0 +1,82 @@
+/*
+  xsns_78_ezorgb.ino - EZO RGB I2C RGB sensor support for Tasmota
+
+  Copyright (C) 2020  Christopher Tremblay
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_EZORGB
+
+#define EZO_RGB_READ_LATENCY   400
+
+struct EZORGB : public EZOStruct {
+  EZORGB(uint32_t addr) : EZOStruct(addr), R(-1), G(-1), B(-6), Lux(0), hasLux(false) {}
+
+  virtual void ProcessMeasurement(void)
+  {
+    char data[D_EZO_MAX_BUF];
+    char *next;
+    // R, G, B, Lux
+
+    EZOStruct::ProcessMeasurement(data, sizeof(data), EZO_RGB_READ_LATENCY);
+
+    R = atoi(data);
+    next = strchr(data, ',') + 1;
+    G = atoi(next);
+    next = strchr(next, ',') + 1;
+    B = atoi(next);
+
+    next    = strstr_P(next, PSTR(",Lux"));
+    hasLux  = (next != nullptr);
+    if (hasLux) {
+      Lux = atoi(next + sizeof(",Lux") - 1);
+    }
+  }
+
+  virtual void Show(bool json, const char *name)
+  {
+    if (json) {
+      ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_RED "\":%d,\"" D_JSON_GREEN "\":%d,\"" D_JSON_BLUE "\":%d"), name, R, G, B);
+      if (hasLux) {
+        ResponseAppend_P(PSTR(",\"" D_JSON_ILLUMINANCE "\":%d"), Lux);
+      }
+      ResponseJsonEnd();
+
+#ifdef USE_WEBSERVER
+    } else {
+      WSContentSend_PD(HTTP_SNS_COLOR_RED,   name, R);
+      WSContentSend_PD(HTTP_SNS_COLOR_GREEN, name, G);
+      WSContentSend_PD(HTTP_SNS_COLOR_BLUE,  name, B);
+
+      if (hasLux) {
+        WSContentSend_PD(HTTP_SNS_ILLUMINANCE, name, Lux);
+      }
+#endif
+    }
+  }
+
+  static const char id[] PROGMEM;
+
+private:
+  uint16_t  R, G, B;
+  uint16_t  Lux;
+  bool      hasLux;
+};
+
+const char EZORGB::id[] PROGMEM = "RGB";
+
+#endif  // USE_EZORGB
+#endif  // USE_I2C

--- a/tasmota/xsns_78_xezo.ino
+++ b/tasmota/xsns_78_xezo.ino
@@ -106,7 +106,11 @@ const char *const EZOSupport[EZO_ADDR_n] PROGMEM = {
 #else
   EZOStruct::id,
 #endif
-  EZOStruct::id,  // "RGB"
+#ifdef USE_EZORGB
+  EZORGB::id,
+#else
+  EZOStruct::id,
+#endif
 };
 
 #define CREATE_EZO_CLASS(CLASS)             \
@@ -267,6 +271,9 @@ private:
 #endif
 #ifdef USE_EZOHUM
                   CREATE_EZO_CLASS(HUM)
+#endif
+#ifdef USE_EZORGB
+                  CREATE_EZO_CLASS(RGB)
 #endif
                 }
                 count++;


### PR DESCRIPTION
Adds support for EZO RGB sensor

## Description:

* Adding support for the EZO RGB sensor
* Also made common some strings that another driver was already using to show the Red,Green,Bblue values on the webserver

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
N/A

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
