### PR TITLE
Add `DimmerStep` command

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -421,6 +421,7 @@
 #define D_CMND_COLORTEMPERATURE "CT"
 #define D_CMND_DIMMER "Dimmer"
 #define D_CMND_DIMMER_RANGE "DimmerRange"
+#define D_CMND_DIMMER_STEP "DimmerStep"
 #define D_CMND_HSBCOLOR "HSBColor"
 #define D_CMND_LED "Led"
 #define D_CMND_LEDTABLE "LedTable"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -635,8 +635,9 @@ struct {
   uint8_t       shutter_mode;              // F43
   uint16_t      energy_power_delta[3];     // F44
   uint16_t      shutter_pwmrange[2][MAX_SHUTTERS];  // F4A
-
-  uint8_t       free_f5a[89];             // F5A  Decrement if adding new Setting variables just above and below
+  uint8_t       dimmer_step;               // F5A
+  
+  uint8_t       free_f5b[88];              // F5B - Decrement if adding new Setting variables just above and below
 
   // Only 32 bit boundary variables below
   SysBitfield5  flag5;                     // FB4

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1015,6 +1015,8 @@ void SettingsDefaultSet2(void)
   Settings.dimmer_hw_max = DEFAULT_DIMMER_MAX;
   Settings.dimmer_hw_min = DEFAULT_DIMMER_MIN;
 
+  Settings.dimmer_step = DEFAULT_DIMMER_STEP;
+
   // Display
 //  Settings.display_model = 0;
   Settings.display_mode = 1;

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -219,6 +219,9 @@ String EthernetMacAddress(void);
 #ifndef DEFAULT_DIMMER_MIN
 #define DEFAULT_DIMMER_MIN          0
 #endif
+#ifndef DEFAULT_DIMMER_STEP
+#define DEFAULT_DIMMER_STEP         10
+#endif
 #ifndef DEFAULT_LIGHT_DIMMER
 #define DEFAULT_LIGHT_DIMMER        10
 #endif

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2910,21 +2910,21 @@ void CmndDimmerRange(void)
 void CmndDimmerStep(void)
 {
   // DimmerStep       - Show current dimmer step as used by Dimmer +/-
-  // DimmerStep       - Set dimmer step
+  // DimmerStep 1..50 - Set dimmer step
   if (XdrvMailbox.data_len > 0) {
     uint32_t parm[1];
     parm[0] = Settings.dimmer_step;
     ParseParameters(1, parm);
     if (parm[0] < 1) {
          Settings.dimmer_step = 1;
-    } else if (parm[0] > 10) {
-        Settings.dimmer_step = 10;
+    } else if (parm[0] > 50) {
+        Settings.dimmer_step = 50;
     } else {
         Settings.dimmer_step = parm[0];
     }
   }
   Response_P(PSTR("{\"" D_CMND_DIMMER_STEP "\":%d}"), Settings.dimmer_step);
-
+}
 
 void CmndLedTable(void)
 {

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2912,18 +2912,15 @@ void CmndDimmerStep(void)
   // DimmerStep       - Show current dimmer step as used by Dimmer +/-
   // DimmerStep 1..50 - Set dimmer step
   if (XdrvMailbox.data_len > 0) {
-    uint32_t parm[1];
-    parm[0] = Settings.dimmer_step;
-    ParseParameters(1, parm);
-    if (parm[0] < 1) {
-         Settings.dimmer_step = 1;
-    } else if (parm[0] > 50) {
-        Settings.dimmer_step = 50;
+    if (XdrvMailbox.payload < 1) {
+       Settings.dimmer_step = 1;
+    } else if (XdrvMailbox.payload > 50) {
+      Settings.dimmer_step = 50;
     } else {
-        Settings.dimmer_step = parm[0];
+      Settings.dimmer_step = XdrvMailbox.payload;
     }
   }
-  Response_P(PSTR("{\"" D_CMND_DIMMER_STEP "\":%d}"), Settings.dimmer_step);
+  ResponseCmndNumber(Settings.dimmer_step);
 }
 
 void CmndLedTable(void)


### PR DESCRIPTION
Signed-off-by: Scoobler <jamienwood@hotmail.com>

## Description:
Add `DimmerStep` to allow an auto (+/-) value to be set between 1...50 instead of the fixed value of 10 which creates a very quick step when using rules for dimming. Default value remains 10.

**Related issue (if applicable):** fixes arendst#9669

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [x] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
