### PR TITLE
Swapped strstr for strchr where applicable

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1242,7 +1242,7 @@ void CmndTemplate(void)
 
   bool error = false;
 
-  if (strstr(XdrvMailbox.data, "{") == nullptr) {  // If no JSON it must be parameter
+  if (strchr(XdrvMailbox.data, '{') == nullptr) {  // If no JSON it must be parameter
     if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= MAXMODULE)) {
       XdrvMailbox.payload--;
       if (ValidTemplateModule(XdrvMailbox.payload)) {
@@ -1550,7 +1550,7 @@ void CmndHostname(void)
 {
   if (!XdrvMailbox.grpflg && (XdrvMailbox.data_len > 0)) {
     SettingsUpdateText(SET_HOSTNAME, (SC_DEFAULT == Shortcut()) ? WIFI_HOSTNAME : XdrvMailbox.data);
-    if (strstr(SettingsText(SET_HOSTNAME), "%") != nullptr) {
+    if (strchr(SettingsText(SET_HOSTNAME), '%') != nullptr) {
       SettingsUpdateText(SET_HOSTNAME, WIFI_HOSTNAME);
     }
     TasmotaGlobal.restart_flag = 2;
@@ -1643,7 +1643,7 @@ void CmndInterlock(void)
   if (max_relays > sizeof(Settings.interlock[0]) * 8) { max_relays = sizeof(Settings.interlock[0]) * 8; }
   if (max_relays > 1) {                                         // Only interlock with more than 1 relay
     if (XdrvMailbox.data_len > 0) {
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {                    // Interlock entry
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {                    // Interlock entry
         for (uint32_t i = 0; i < MAX_INTERLOCKS; i++) { Settings.interlock[i] = 0; }  // Reset current interlocks
         char *group;
         char *q;
@@ -1801,7 +1801,7 @@ void CmndTimeStdDst(uint32_t ts)
 {
   // TimeStd 0/1, 0/1/2/3/4, 1..12, 1..7, 0..23, +/-780
   if (XdrvMailbox.data_len > 0) {
-    if (strstr(XdrvMailbox.data, ",") != nullptr) {   // Process parameter entry
+    if (strchr(XdrvMailbox.data, ',') != nullptr) {   // Process parameter entry
       uint32_t tpos = 0;                      // Parameter index
       int value = 0;
       char *p = XdrvMailbox.data;                           // Parameters like "1, 2,3 , 4 ,5, -120" or ",,,,,+240"

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -25,10 +25,10 @@ char* Format(char* output, const char* input, int size)
   char *token;
   uint32_t digits = 0;
 
-  if (strstr(input, "%") != nullptr) {
+  if (strchr(input, '%') != nullptr) {
     strlcpy(output, input, size);
     token = strtok(output, "%");
-    if (strstr(input, "%") == input) {
+    if (strchr(input, '%') == input) {
       output[0] = '\0';
     } else {
       token = strtok(nullptr, "");

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -280,7 +280,7 @@ void setup(void) {
 
   Format(TasmotaGlobal.mqtt_client, SettingsText(SET_MQTT_CLIENT), sizeof(TasmotaGlobal.mqtt_client));
   Format(TasmotaGlobal.mqtt_topic, SettingsText(SET_MQTT_TOPIC), sizeof(TasmotaGlobal.mqtt_topic));
-  if (strstr(SettingsText(SET_HOSTNAME), "%") != nullptr) {
+  if (strchr(SettingsText(SET_HOSTNAME), '%') != nullptr) {
     SettingsUpdateText(SET_HOSTNAME, WIFI_HOSTNAME);
     snprintf_P(TasmotaGlobal.hostname, sizeof(TasmotaGlobal.hostname)-1, SettingsText(SET_HOSTNAME), TasmotaGlobal.mqtt_topic, ESP_getChipId() & 0x1FFF);
   } else {

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2185,7 +2185,7 @@ void WifiSaveSettings(void)
 
   WebGetArg("h", tmp, sizeof(tmp));
   SettingsUpdateText(SET_HOSTNAME, (!strlen(tmp)) ? WIFI_HOSTNAME : tmp);
-  if (strstr(SettingsText(SET_HOSTNAME), "%") != nullptr) {
+  if (strchr(SettingsText(SET_HOSTNAME), '%') != nullptr) {
     SettingsUpdateText(SET_HOSTNAME, WIFI_HOSTNAME);
   }
   WebGetArg("c", tmp, sizeof(tmp));
@@ -3429,7 +3429,7 @@ void CmndWebSend(void)
 void CmndWebColor(void)
 {
   if (XdrvMailbox.data_len > 0) {
-    if (strstr(XdrvMailbox.data, "{") == nullptr) {  // If no JSON it must be parameter
+    if (strchr(XdrvMailbox.data, '{') == nullptr) {  // If no JSON it must be parameter
       if ((XdrvMailbox.data_len > 3) && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= COL_LAST)) {
         WebHexCode(XdrvMailbox.index -1, XdrvMailbox.data);
       }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2513,7 +2513,7 @@ bool LightColorEntry(char *buffer, uint32_t buffer_length)
     buffer_length--;  // remove all trailing '='
     memcpy(&Light.entry_color, &Light.current_color, sizeof(Light.entry_color));
   }
-  if (strstr(buffer, ",") != nullptr) {             // Decimal entry
+  if (strchr(buffer, ',') != nullptr) {             // Decimal entry
     int8_t i = 0;
     for (str = strtok_r(buffer, ",", &p); str && i < 6; str = strtok_r(nullptr, ",", &p)) {
       if (i < LST_MAX) {

--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -318,7 +318,7 @@ void CmndIrSend(void)
   uint8_t error = IE_SYNTAX_IRSEND;
 
   if (XdrvMailbox.data_len) {
-    if (strstr(XdrvMailbox.data, "{") == nullptr) {
+    if (strchr(XdrvMailbox.data, '{') == nullptr) {
       error = IE_INVALID_JSON;
     } else {
       error = IrRemoteCmndIrSendJson();

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -805,7 +805,7 @@ void CmndIrSend(void)
   uint8_t error = IE_SYNTAX_IRSEND;
 
   if (XdrvMailbox.data_len) {
-    if (strstr(XdrvMailbox.data, "{") == nullptr) {
+    if (strchr(XdrvMailbox.data, '{') == nullptr) {
       error = IrRemoteCmndIrSendRaw();
     } else {
       error = IrRemoteCmndIrSendJson();

--- a/tasmota/xdrv_07_domoticz.ino
+++ b/tasmota/xdrv_07_domoticz.ino
@@ -497,7 +497,7 @@ void CmndDomoticzSend(void) {
 
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= 5)) {
     if (XdrvMailbox.data_len > 0) {
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Process parameter entry
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {  // Process parameter entry
         char *data;
         uint32_t index = strtoul(strtok_r(XdrvMailbox.data, ",", &data), nullptr, 10);
         if ((index > 0) && (data != nullptr)) {

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -2249,7 +2249,7 @@ void CmndScale(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_RULE_VARS)) {
     if (XdrvMailbox.data_len > 0) {
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Process parameter entry
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {  // Process parameter entry
         char sub_string[XdrvMailbox.data_len +1];
 
         float valueIN = CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 1));

--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -1120,7 +1120,7 @@ void CmndKnxEnhanced(void)
 void CmndKnxPa(void)
 {
   if (XdrvMailbox.data_len) {
-    if (strstr(XdrvMailbox.data, ".") != nullptr) {  // Process parameter entry
+    if (strchr(XdrvMailbox.data, '.') != nullptr) {  // Process parameter entry
       char sub_string[XdrvMailbox.data_len];
 
       int pa_area = atoi(subStr(sub_string, XdrvMailbox.data, ".", 1));
@@ -1148,7 +1148,7 @@ void CmndKnxGa(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_KNX_GA)) {
     if (XdrvMailbox.data_len) {
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Process parameter entry
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {  // Process parameter entry
         char sub_string[XdrvMailbox.data_len];
 
         int ga_option = atoi(subStr(sub_string, XdrvMailbox.data, ",", 1));
@@ -1199,7 +1199,7 @@ void CmndKnxCb(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_KNX_CB)) {
     if (XdrvMailbox.data_len) {
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {  // Process parameter entry
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {  // Process parameter entry
         char sub_string[XdrvMailbox.data_len];
 
         int cb_option = atoi(subStr(sub_string, XdrvMailbox.data, ",", 1));

--- a/tasmota/xsns_02_analog.ino
+++ b/tasmota/xsns_02_analog.ino
@@ -132,7 +132,7 @@ void AdcGetSettings(uint32_t idx) {
   Adc[idx].param2 = 0;
   Adc[idx].param3 = 0;
   Adc[idx].param4 = 0;
-  if (strstr(SettingsText(SET_ADC_PARAM1 + idx), ",") != nullptr) {
+  if (strchr(SettingsText(SET_ADC_PARAM1 + idx), ',') != nullptr) {
     Adcs.type = atoi(subStr(parameters, SettingsText(SET_ADC_PARAM1 + idx), ",", 1));
     Adc[idx].param1 = atoi(subStr(parameters, SettingsText(SET_ADC_PARAM1 + idx), ",", 2));
     Adc[idx].param2 = atoi(subStr(parameters, SettingsText(SET_ADC_PARAM1 + idx), ",", 3));

--- a/tasmota/xsns_34_hx711.ino
+++ b/tasmota/xsns_34_hx711.ino
@@ -205,7 +205,7 @@ bool HxCommand(void)
       Response_P(S_JSON_SENSOR_INDEX_SVALUE, XSNS_34, "Reset");
       break;
     case 2:  // Calibrate
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.weight_reference = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       Hx.scale = 1;
@@ -215,26 +215,26 @@ bool HxCommand(void)
       HxCalibrationStateTextJson(3);
       break;
     case 3:  // WeightRef to user reference
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.weight_reference = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       show_parms = true;
       break;
     case 4:  // WeightCal to user calculated value
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.weight_calibration = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
         Hx.scale = Settings.weight_calibration;
       }
       show_parms = true;
       break;
     case 5:  // WeightMax
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.weight_max = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10) / 1000;
       }
       show_parms = true;
       break;
     case 6:  // WeightItem
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.weight_item = (unsigned long)(CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 2)) * 10);
       }
       show_parms = true;
@@ -244,13 +244,13 @@ bool HxCommand(void)
       Response_P(S_JSON_SENSOR_INDEX_SVALUE, XSNS_34, D_JSON_DONE);
       break;
     case 8:  // Json on weight change
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.SensorBits1.hx711_json_weight_change = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10) & 1;
       }
       show_parms = true;
       break;
     case 9:  // WeightDelta
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
 	Settings.weight_change = strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
 	SetWeightDelta();
       }

--- a/tasmota/xsns_68_windmeter.ino
+++ b/tasmota/xsns_68_windmeter.ino
@@ -294,27 +294,27 @@ bool Xsns68Cmnd(void)
   char sub_string[XdrvMailbox.data_len +1];
   switch (XdrvMailbox.payload) {
     case 1:
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.windmeter_radius = (uint16_t)strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       break;
     case 2:
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.windmeter_pulses_x_rot = (uint8_t)strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       break;
     case 3:
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.windmeter_pulse_debounce = (uint16_t)strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       break;
     case 4:
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.windmeter_speed_factor = (int16_t)(CharToFloat(subStr(sub_string, XdrvMailbox.data, ",", 2)) * 1000);
       }
       break;
     case 5:
-      if (strstr(XdrvMailbox.data, ",") != nullptr) {
+      if (strchr(XdrvMailbox.data, ',') != nullptr) {
         Settings.windmeter_tele_pchange = (uint8_t)strtol(subStr(sub_string, XdrvMailbox.data, ",", 2), nullptr, 10);
       }
       break;


### PR DESCRIPTION
strstr calls with a single character were changed to strchr which should be more efficient.

## Description:

This is a very minor change.  While doing changes in the past, I noticed that in a few areas, calls were made to strstr where a single character was provided.  This isn't as efficient because the strings are forced to be 2 bytes (they're ASCIIZ) and it's extra work since the function needs to handle the arbitrary length of the second argument.

I wasn't able to test every change given that I don't have the appropriate sensors, however the change is pretty benign and should work without a hitch.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
