### PR TITLE
Use compiler option no target align for stage

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -116,8 +116,8 @@ build_flags                 = -Wno-deprecated-declarations
 [esp82xx_defaults]
 build_flags                 = ${esp_defaults.build_flags}
                               -Wl,-Map,firmware.map
-                              -D CORE_DEBUG_LEVEL=0
-                              -D NDEBUG
+                              -DCORE_DEBUG_LEVEL=0
+                              -DNDEBUG
                               -mtarget-align
                               -DFP_IN_IROM
                               -DBEARSSL_SSL_BASIC
@@ -140,7 +140,7 @@ build_flags                 = -DUSE_IR_REMOTE_FULL
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
 platform                    = espressif8266@2.6.2
-platform_packages           = framework-arduinoespressif8266@https://github.com/tasmota/Arduino/releases/download/2.7.4.5/esp8266-2.7.4.5.zip
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.5/esp8266-2.7.4.5.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,6 +103,7 @@ extra_scripts               = pio/strip-floats.py
 build_unflags               = -Wall
                               -Wdeprecated-declarations
 build_flags                 = -Wno-deprecated-declarations
+                              -mtarget-align
                               -D_IR_ENABLE_DEFAULT_=false
                               -DDECODE_HASH=true -DDECODE_NEC=true -DSEND_NEC=true
                               -DDECODE_RC5=true -DSEND_RC5=true -DDECODE_RC6=true -DSEND_RC6=true
@@ -118,7 +119,6 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,-Map,firmware.map
                               -DCORE_DEBUG_LEVEL=0
                               -DNDEBUG
-                              -mtarget-align
                               -DFP_IN_IROM
                               -DBEARSSL_SSL_BASIC
                               ; NONOSDK22x_190703 = 2.2.2-dev(38a443e)
@@ -139,7 +139,7 @@ build_flags                 = -DUSE_IR_REMOTE_FULL
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
-platform                    = espressif8266@2.6.2
+platform                    = espressif8266 @ 2.6.2
 platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.5/esp8266-2.7.4.5.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -126,7 +126,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 
 [core_stage]
 ; *** Esp8266 core for Arduino version stage
-platform_packages           = framework-arduinoespressif8266@https://github.com/esp8266/Arduino.git
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 ; *** Use Xtensa build chain 10.2. GNU13 from https://github.com/earlephilhower/esp-quick-toolchain
                               mcspr/toolchain-xtensa @ 5.100200.200918
                               platformio/tool-esptool @ 1.413.0
@@ -192,10 +192,12 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
-platform_packages           = tool-esptoolpy@1.20800.0
+platform_packages           = tool-esptoolpy @ 1.20800.0
                               framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#f7fb00632e04d74a7890a77fa7dbbb8ae572e866
 build_unflags               = ${esp32_defaults.build_unflags}
+                              -mtarget-align
 build_flags                 = ${esp32_defaults.build_flags}
+                              -mno-target-align
                               -DESP32_STAGE=true
 
 [library]

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -88,10 +88,12 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage (PR7231 and Backport PR7514)
-platform_packages           = framework-arduinoespressif8266@https://github.com/Jason2866/Arduino.git#2.7.4.4
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino/releases/download/2.7.4.7/esp8266-2.7.4.7.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
+                              -mtarget-align
 build_flags                 = ${esp82xx_defaults.build_flags}
+                              -mno-target-align
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221
@@ -126,13 +128,14 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Esp8266 core for Arduino version stage
 platform_packages           = framework-arduinoespressif8266@https://github.com/esp8266/Arduino.git
 ; *** Use Xtensa build chain 10.2. GNU13 from https://github.com/earlephilhower/esp-quick-toolchain
-                              mcspr/toolchain-xtensa@5.100200.200918
+                              mcspr/toolchain-xtensa @ 5.100200.200918
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
+                              -mtarget-align
 build_flags                 = ${esp82xx_defaults.build_flags}
                               -Wno-switch-unreachable
-
+                              -mno-target-align
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
@@ -188,12 +191,12 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 
 [core32_stage]
-platform                    = espressif32@2.0.0
+platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy@1.20800.0
                               framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#f7fb00632e04d74a7890a77fa7dbbb8ae572e866
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -D ESP32_STAGE=true
+                              -DESP32_STAGE=true
 
 [library]
 lib_ldf_mode                = chain+

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -71,21 +71,21 @@ lib_extra_dirs              =
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wpointer-arith
 build_flags                 = ${esp_defaults.build_flags}
-                              -D CORE_DEBUG_LEVEL=0
-                              -D BUFFER_LENGTH=128
-                              -D MQTT_MAX_PACKET_SIZE=1200
-                              -D uint32=uint32_t
-                              -D uint16=uint16_t
-                              -D uint8=uint8_t
-                              -D sint8_t=int8_t
-                              -D sint32_t=int32_t
-                              -D sint16_t=int16_t
-                              -D memcpy_P=memcpy
-	                      -D memcmp_P=memcmp
+                              -DCORE_DEBUG_LEVEL=0
+                              -DBUFFER_LENGTH=128
+                              -DMQTT_MAX_PACKET_SIZE=1200
+                              -Duint32=uint32_t
+                              -Duint16=uint16_t
+                              -Duint8=uint8_t
+                              -Dsint8_t=int8_t
+                              -Dsint32_t=int32_t
+                              -Dsint16_t=int16_t
+                              -Dmemcpy_P=memcpy
+	                          -Dmemcmp_P=memcmp
 
 
 [core32]
-platform                    = espressif32@2.0.0
+platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy@1.20800.0
                               platformio/framework-arduinoespressif32 @ 3.10004.201016
 build_unflags               = ${esp32_defaults.build_unflags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -81,7 +81,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Dsint32_t=int32_t
                               -Dsint16_t=int16_t
                               -Dmemcpy_P=memcpy
-	                          -Dmemcmp_P=memcmp
+	                      -Dmemcmp_P=memcmp
 
 
 [core32]

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -1,21 +1,21 @@
 [env]
-platform = ${common.platform}
-platform_packages = ${common.platform_packages}
-framework = ${common.framework}
-board = ${common.board}
-board_build.ldscript  = ${common.board_build.ldscript}
-board_build.flash_mode = ${common.board_build.flash_mode}
-board_build.f_flash = ${common.board_build.f_flash}
-board_build.f_cpu = ${common.board_build.f_cpu}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags}
-monitor_speed = ${common.monitor_speed}
-upload_port = ${common.upload_port}
-upload_resetmethod = ${common.upload_resetmethod}
-upload_speed = ${common.upload_speed}
-extra_scripts = ${common.extra_scripts}
-lib_extra_dirs = ${common.lib_extra_dirs}
-lib_ignore = 
+platform                = ${common.platform}
+platform_packages       = ${common.platform_packages}
+framework               = ${common.framework}
+board                   = ${common.board}
+board_build.ldscript    = ${common.board_build.ldscript}
+board_build.flash_mode  = ${common.board_build.flash_mode}
+board_build.f_flash     = ${common.board_build.f_flash}
+board_build.f_cpu       = ${common.board_build.f_cpu}
+build_unflags           = ${common.build_unflags}
+build_flags             = ${common.build_flags}
+monitor_speed           = ${common.monitor_speed}
+upload_port             = ${common.upload_port}
+upload_resetmethod      = ${common.upload_resetmethod}
+upload_speed            = ${common.upload_speed}
+extra_scripts           = ${common.extra_scripts}
+lib_extra_dirs          = ${common.lib_extra_dirs}
+lib_ignore              =
     Servo(esp8266)
     ESP8266AVRISP
     ESP8266LLMNR
@@ -30,108 +30,108 @@ lib_ignore =
     EspSoftwareSerial
     SPISlave
     Hash
-; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)    
+; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
     ArduinoOTA
 
 [env:tasmota]
 
 [env:tasmota-minimal]
-build_flags = ${common.build_flags} -DFIRMWARE_MINIMAL
-lib_extra_dirs = 
+build_flags             = ${common.build_flags} -DFIRMWARE_MINIMAL
+lib_extra_dirs          =
 
 [env:tasmota-lite]
-build_flags = ${common.build_flags} -DFIRMWARE_LITE
-lib_extra_dirs =
+build_flags             = ${common.build_flags} -DFIRMWARE_LITE
+lib_extra_dirs          =
 
 [env:tasmota-knx]
-build_flags = ${common.build_flags} -DFIRMWARE_KNX_NO_EMULATION
-lib_extra_dirs = lib/lib_basic, lib/lib_div
+build_flags             = ${common.build_flags} -DFIRMWARE_KNX_NO_EMULATION
+lib_extra_dirs          = lib/lib_basic, lib/lib_div
 
 [env:tasmota-sensors]
-build_flags = ${common.build_flags} -DFIRMWARE_SENSORS
-lib_extra_dirs = lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div
+build_flags             = ${common.build_flags} -DFIRMWARE_SENSORS
+lib_extra_dirs          = lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div
 
 [env:tasmota-display]
-build_flags = ${common.build_flags} -DFIRMWARE_DISPLAYS
-lib_extra_dirs = lib/lib_basic, lib/lib_display
+build_flags             = ${common.build_flags} -DFIRMWARE_DISPLAYS
+lib_extra_dirs          = lib/lib_basic, lib/lib_display
 
 [env:tasmota-ir]
-build_flags = ${common.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR
-lib_extra_dirs = lib/lib_basic
+build_flags             = ${common.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR
+lib_extra_dirs          = lib/lib_basic
 
 [env:tasmota-ircustom]
-build_flags = ${common.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR_CUSTOM
+build_flags             = ${common.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR_CUSTOM
 
 [env:tasmota-zbbridge]
-build_flags = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
-board_build.f_cpu = 160000000L
-lib_extra_dirs = lib/lib_ssl 
+build_flags             = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
+board_build.f_cpu       = 160000000L
+lib_extra_dirs          = lib/lib_ssl
 
 [env:tasmota-BG]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=bg_BG
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=bg_BG
 
 [env:tasmota-BR]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=pt_BR
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=pt_BR
 
 [env:tasmota-CN]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=zh_CN
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=zh_CN
 
 [env:tasmota-CZ]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=cs_CZ
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=cs_CZ
 
 [env:tasmota-DE]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=de_DE
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=de_DE
 
 [env:tasmota-ES]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=es_ES
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=es_ES
 
 [env:tasmota-FR]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=fr_FR
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=fr_FR
 
 [env:tasmota-GR]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=el_GR
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=el_GR
 
 [env:tasmota-HE]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=he_HE
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=he_HE
 
 [env:tasmota-HU]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=hu_HU
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=hu_HU
 
 [env:tasmota-IT]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=it_IT
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=it_IT
 
 [env:tasmota-KO]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=ko_KO
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=ko_KO
 
 [env:tasmota-NL]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=nl_NL
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=nl_NL
 
 [env:tasmota-PL]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=pl_PL
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=pl_PL
 
 [env:tasmota-PT]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=pt_PT
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=pt_PT
 
 [env:tasmota-RO]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=ro_RO
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=ro_RO
 
 [env:tasmota-RU]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=ru_RU
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=ru_RU
 
 [env:tasmota-SE]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=sv_SE
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=sv_SE
 
 [env:tasmota-SK]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=sk_SK
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=sk_SK
 
 [env:tasmota-TR]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=tr_TR
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=tr_TR
 
 [env:tasmota-TW]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=zh_TW
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=zh_TW
 
 [env:tasmota-UK]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=uk_UA
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=uk_UA
 
 [env:tasmota-VN]
-build_flags = ${common.build_flags} -DMY_LANGUAGE=vi_VN
+build_flags             = ${common.build_flags} -DMY_LANGUAGE=vi_VN

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -26,138 +26,138 @@ lib_ignore              =
     ESP32
     Preferences
     BluetoothSerial
-; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)    
+; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
     ArduinoOTA
-    
+
 [env:tasmota32-webcam]
-extends = env:tasmota32
+extends                 = env:tasmota32
 board                   = esp32cam
 board_build.f_cpu       = 240000000L
 build_flags             = ${common32.build_flags} -DFIRMWARE_WEBCAM
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-minimal]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_MINIMAL
 lib_extra_dirs          = lib/libesp32
 
 [env:tasmota32-lite]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_LITE
 lib_extra_dirs          = lib/libesp32
 
 [env:tasmota32-knx]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_KNX_NO_EMULATION
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_div
 
 [env:tasmota32-sensors]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_SENSORS
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div
 
 [env:tasmota32-display]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_DISPLAYS
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display
 
 [env:tasmota32-ir]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-ircustom]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} ${irremoteesp_full.build_flags} -DFIRMWARE_IR_CUSTOM
 
 [env:tasmota32-BG]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=bg_BG
 
 [env:tasmota32-BR]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pt_BR
 
 [env:tasmota32-CN]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=zh_CN
 
 [env:tasmota32-CZ]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=cs_CZ
 
 [env:tasmota32-DE]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=de_DE
 
 [env:tasmota32-ES]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=es_ES
 
 [env:tasmota32-FR]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=fr_FR
 
 [env:tasmota32-GR]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=el_GR
 
 [env:tasmota32-HE]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=he_HE
 
 [env:tasmota32-HU]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=hu_HU
 
 [env:tasmota32-IT]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=it_IT
 
 [env:tasmota32-KO]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ko_KO
 
 [env:tasmota32-NL]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=nl_NL
 
 [env:tasmota32-PL]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pl_PL
 
 [env:tasmota32-PT]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pt_PT
 
 [env:tasmota32-RO]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ro_RO
 
 [env:tasmota32-RU]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ru_RU
 
 [env:tasmota32-SE]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=sv_SE
 
 [env:tasmota32-SK]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=sk_SK
 
 [env:tasmota32-TR]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=tr_TR
 
 [env:tasmota32-TW]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=zh_TW
 
 [env:tasmota32-UK]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=uk_UA
 
 [env:tasmota32-VN]
-extends = env:tasmota32
+extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DMY_LANGUAGE=vi_VN


### PR DESCRIPTION
## Description:

resulting in code size decrease between 1k and 3k. 

+ updating Tasmota stage core 2.7.4.7 (same as 2.7.4.5 + more wstring optimization)
+ some optic beautifying

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5 + stage core
  - [x] The code change is tested and works on core ESP32 V.1.12.2 + stage core
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
