### PR TITLE
Bug fix: Incorrect JSON output for EZO FLO

### DIFF
--- a/tasmota/xsns_78_ezoflo.ino
+++ b/tasmota/xsns_78_ezoflo.ino
@@ -53,7 +53,7 @@ struct EZOFLO : public EZOStruct {
     if (json) {
       ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_VOLUME "\":%s"), name, volume);
       if (hasFlow) {
-        ResponseAppend_P(PSTR(",\"" D_JSON_FLOWRATE "\":%s"), name, rate);
+        ResponseAppend_P(PSTR(",\"" D_JSON_FLOWRATE "\":%s"), rate);
       }
       ResponseJsonEnd();
 


### PR DESCRIPTION
There was a copy/paste mistake in the EZO FLO implementation that this fixes.

## Description:

A simple copy/paste mistake was introduced when implementing the EZO FLO where the device name was insert in lieu of the actual data that was supposed to exist in the JSON output.  This corrects the JSON output for that device.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
N/A

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
