### PR TITLE
Fix IRsend raw

### DIFF
--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -688,8 +688,7 @@ uint32_t IrRemoteParseRawCompact(char * str, uint16_t * arr, size_t arr_len) {
 //   count: number of commas in parameters, i.e. it contains count+1 values
 //   repeat: number of repeats (0 means no repeat)
 //
-uint32_t IrRemoteSendRawStandard(char ** pp, uint32_t count, uint32_t repeat) {
-  uint16_t freq = parsqeFreq(*pp);
+uint32_t IrRemoteSendRawStandard(char ** pp, uint16_t freq, uint32_t count, uint32_t repeat) {
   // IRsend 0,896,876,900,888,894,876,1790,874,872,1810,1736,948,872,880,872,936,872,1792,900,888,1734
   // IRsend 0,+8570-4240+550-1580C-510+565-1565F-505Fh+570gFhIdChIgFeFgFgIhFgIhF-525C-1560IhIkI-520ChFhFhFgFhIkIhIgIgIkIkI-25270A-4225IkIhIgIhIhIkFhIkFjCgIhIkIkI-500IkIhIhIkFhIgIl+545hIhIoIgIhIkFhFgIkIgFgI
 
@@ -766,7 +765,7 @@ uint32_t IrRemoteCmndIrSendRaw(void)
     // standard raw
     // IRsend <freq>,<rawdata>,<rawdata> ...
     // IRsend <freq>,<compact_rawdata>
-    return IrRemoteSendRawStandard(&p, count, repeat);
+    return IrRemoteSendRawStandard(&p, parsqeFreq(str), count, repeat);
   }
 }
 

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -719,36 +719,6 @@ uint32_t IrRemoteSendRawStandard(char ** pp, uint32_t count, uint32_t repeat) {
     free(arr);
   }
   return IE_NO_ERROR;
-
-
-
-  count++;
-  if (count < 200) {
-    uint16_t raw_array[count];  // It's safe to use stack for up to 200 packets (limited by mqtt_data length)
-    for (uint32_t i = 0; i < count; i++) {
-      raw_array[i] = strtol(strtok_r(nullptr, ", ", pp), nullptr, 0);  // Allow decimal (20496) and hexadecimal (0x5010) input
-    }
-
-    irsend_active = true;
-    for (uint32_t r = 0; r <= repeat; r++) {
-      irsend->sendRaw(raw_array, count, freq);
-    }
-  } else {
-    uint16_t *raw_array = reinterpret_cast<uint16_t*>(malloc(count * sizeof(uint16_t)));
-    if (raw_array == nullptr) {
-      return IE_INVALID_RAWDATA;
-    }
-
-    for (uint32_t i = 0; i < count; i++) {
-      raw_array[i] = strtol(strtok_r(nullptr, ", ", pp), nullptr, 0);  // Allow decimal (20496) and hexadecimal (0x5010) input
-    }
-
-    irsend_active = true;
-    for (uint32_t r = 0; r <= repeat; r++) {
-      irsend->sendRaw(raw_array, count, freq);
-    }
-    free(raw_array);
-  }
 }
 
 // parse the frequency value


### PR DESCRIPTION
## Description:

The frequency parameter was inconsistently handled. It was removed from the data string by the outermost handler `IrRemoteCmndIrSendRaw`, which then called `IrRemoteSendRawStandard`, which parsed the entire data string as the frequency.

While i was here, i removed some dead code. This goes against the checklist but I thought it was appropriate since I'm changing the affected function. Let me know if I should drop that commit.

cc @s-hadinger as author of #9444

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
  - [ ] The code change is tested and works on core ESP32 V.1.12.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
