### PR TITLE
Change compile option to no-target-align

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,8 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
-  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.5
-  - [ ] The code change is tested and works on core ESP32 V.1.12.2
+  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
+  - [ ] The code change is tested and works on core ESP32 V.1.12.4
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio.ini
+++ b/platformio.ini
@@ -100,10 +100,11 @@ extra_scripts               = pio/strip-floats.py
 
 [esp_defaults]
 ; *** remove undesired all warnings
-build_unflags               = -Wall
+build_unflags               = -mtarget-align
+                              -Wall
                               -Wdeprecated-declarations
-build_flags                 = -Wno-deprecated-declarations
-                              -mtarget-align
+build_flags                 = -mno-target-align
+                              -Wno-deprecated-declarations
                               -D_IR_ENABLE_DEFAULT_=false
                               -DDECODE_HASH=true -DDECODE_NEC=true -DSEND_NEC=true
                               -DDECODE_RC5=true -DSEND_RC5=true -DDECODE_RC6=true -DSEND_RC6=true
@@ -140,7 +141,7 @@ build_flags                 = -DUSE_IR_REMOTE_FULL
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
 platform                    = espressif8266 @ 2.6.2
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.5/esp8266-2.7.4.5.zip
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino/releases/download/2.7.4.7/esp8266-2.7.4.7.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -91,9 +91,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 platform_packages           = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino/releases/download/2.7.4.7/esp8266-2.7.4.7.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
-                              -mtarget-align
 build_flags                 = ${esp82xx_defaults.build_flags}
-                              -mno-target-align
 
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221
@@ -132,10 +130,8 @@ platform_packages           = framework-arduinoespressif8266 @ https://github.co
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
-                              -mtarget-align
 build_flags                 = ${esp82xx_defaults.build_flags}
                               -Wno-switch-unreachable
-                              -mno-target-align
 ; *********** Alternative Options, enable only if you know exactly what you do ********
 ; NONOSDK221
 ;                            -DPIO_FRAMEWORK_ARDUINO_ESPRESSIF_SDK221
@@ -195,9 +191,7 @@ platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy @ 1.20800.0
                               framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#f7fb00632e04d74a7890a77fa7dbbb8ae572e866
 build_unflags               = ${esp32_defaults.build_unflags}
-                              -mtarget-align
 build_flags                 = ${esp32_defaults.build_flags}
-                              -mno-target-align
                               -DESP32_STAGE=true
 
 [library]


### PR DESCRIPTION
## Description:

as default. Reduces code size between 1k-3k.
Use Tasmota core 2.7.4.7. Minor change. Uses latest updated https://github.com/esp8266/Arduino/pull/7553
with core 2.7.4.5 we used already a older version form PR 7553
corrected PR YML 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on core ESP32 V.1.12.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
