### PR TITLE
Make TLS resilient to NTP failure

### DIFF
--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -69,6 +69,7 @@ void _Log_heap_size(const char *msg) {
 
 // get UTC time from Tasmota
 extern uint32_t UtcTime(void);
+extern uint32_t CfgTime(void);
 
 // Stack thunked versions of calls
 // Initially in BearSSLHelpers.h
@@ -921,6 +922,8 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
 		br_x509_minimal_set_hash(x509_minimal, br_sha256_ID, &br_sha256_vtable);
 		br_ssl_engine_set_x509(_eng, &x509_minimal->vtable);
     uint32_t now = UtcTime();
+    uint32_t cfg_time = CfgTime();
+    if (cfg_time > now) { now = cfg_time; }
     br_x509_minimal_set_time(x509_minimal, now / 86400 + 719528, now % 86400);
 
 	#else

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -613,6 +613,11 @@ void SettingsLoad(void) {
   RtcSettingsLoad();
 }
 
+// Used in TLS - returns the timestamp of the last Flash settings write
+uint32_t CfgTime(void) {
+  return Settings.cfg_timestamp;
+}
+
 void EspErase(uint32_t start_sector, uint32_t end_sector)
 {
   bool serial_output = (LOG_LEVEL_DEBUG_MORE <= TasmotaGlobal.seriallog_level);


### PR DESCRIPTION
## Description:

Sometimes NTP fails or takes time to stabilize. In such cases the current time is set to Jan 1st 1970, and TLS connections fails due to invalid dates of the certificate.
This PR takes the timestamp of the last Flash setting write, which in most cases will be good enough to validate the server certificate.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on core ESP32 V.1.12.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
