### PR TITLE
Zigbee don't report Battery for IKEA devices

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -2004,4 +2004,19 @@ void Z_Data::toAttributes(Z_attribute_list & attr_list, Z_Data_Type type) const 
   }
 }
 
+//
+// Check if this device needs Battery reporting
+// This is usefule for IKEA device that tend to drain battery quickly when Battery reporting is set
+//
+bool Z_BatteryReportingDeviceSpecific(uint16_t shortaddr) {
+  const Z_Device & device = zigbee_devices.findShortAddr(shortaddr);
+  if (device.manufacturerId) {
+    String manuf_c(device.manufacturerId);
+    if (manuf_c.startsWith(F("IKEA"))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 #endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -614,6 +614,7 @@ void Z_AutoBindDefer(uint16_t shortaddr, uint8_t endpoint, const SBuffer &buf,
   for (uint32_t i=0; i<ARRAY_SIZE(Z_bindings); i++) {
     if (bitRead(cluster_map, i)) {
       uint16_t cluster = CxToCluster(pgm_read_byte(&Z_bindings[i]));
+      if ((cluster == 0x0001) && (!Z_BatteryReportingDeviceSpecific(shortaddr))) { continue; }
       zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, cluster, endpoint, Z_CAT_BIND, 0 /* value */, &Z_AutoBind);
     }
   }
@@ -622,6 +623,7 @@ void Z_AutoBindDefer(uint16_t shortaddr, uint8_t endpoint, const SBuffer &buf,
   for (uint32_t i=0; i<ARRAY_SIZE(Z_bindings); i++) {
     if (bitRead(cluster_in_map, i)) {
       uint16_t cluster = CxToCluster(pgm_read_byte(&Z_bindings[i]));
+      if ((cluster == 0x0001) && (!Z_BatteryReportingDeviceSpecific(shortaddr))) { continue; }
       zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, cluster, endpoint, Z_CAT_CONFIG_ATTR, 0 /* value */, &Z_AutoConfigReportingForCluster);
     }
   }


### PR DESCRIPTION
## Description:

IKEA devices seem to have a bug. Whenever you set Battery Reporting, it drains quickly the battery in a few days. This change avoids setting Battery reporting for IKEA devices.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on core ESP32 V.1.12.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
