### PR TITLE
Use START_VALID_TIME

### DIFF
--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -315,7 +315,7 @@ void Z_Device::setLastSeenNow(void) {
   // Fixes issue where zigbee device pings before WiFi/NTP has set utc_time
   // to the correct time, and "last seen" calculations are based on the
   // pre-corrected last_seen time and the since-corrected utc_time.
-  if (Rtc.utc_time < 1577836800) { return; }
+  if (Rtc.utc_time < START_VALID_TIME) { return; }
   last_seen = Rtc.utc_time;
 }
 

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1949,19 +1949,19 @@ void ZCLFrame::autoResponder(const uint16_t *attr_list_ids, size_t attr_len) {
         break;
 #endif
       case 0x000A0000:    // Time
-        attr.setUInt((Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? Rtc.utc_time - 946684800 : Rtc.utc_time);
+        attr.setUInt((Rtc.utc_time > START_VALID_TIME) ? Rtc.utc_time - 946684800 : Rtc.utc_time);
         break;
       case 0x000AFF00:    // TimeEpoch - Tasmota specific
         attr.setUInt(Rtc.utc_time);
         break;
       case 0x000A0001:    // TimeStatus
-        attr.setUInt((Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? 0x02 : 0x00);  // if time is beyond 2010 then we are synchronized
+        attr.setUInt((Rtc.utc_time > START_VALID_TIME) ? 0x02 : 0x00);
         break;
       case 0x000A0002:    // TimeZone
         attr.setUInt(Settings.toffset[0] * 60);
         break;
       case 0x000A0007:    // LocalTime    // TODO take DST
-        attr.setUInt(Settings.toffset[0] * 60 + ((Rtc.utc_time > (60 * 60 * 24 * 365 * 10)) ? Rtc.utc_time - 946684800 : Rtc.utc_time));
+        attr.setUInt(Settings.toffset[0] * 60 + ((Rtc.utc_time > START_VALID_TIME) ? Rtc.utc_time - 946684800 : Rtc.utc_time));
         break;
     }
     if (!attr.isNone()) {


### PR DESCRIPTION
## Description:

Use `START_VALID_TIME` to detect if time is valid, to be consistent with the rest of Tasmota.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on core ESP32 V.1.12.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
