### PR TITLE
Use always latest ESP32 stage version in override

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -189,7 +189,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy @ 1.20800.0
-                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#f7fb00632e04d74a7890a77fa7dbbb8ae572e866
+                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
                               -DESP32_STAGE=true


### PR DESCRIPTION
## Description:

Since we use with PR #9776 commit 28a80730 as Tasmota 32 core

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on core ESP32 stage
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
