### PR TITLE
Fix ignore Occupancy timeout

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1294,7 +1294,9 @@ void ZCLFrame::generateCallBacks(Z_attribute_list& attr_list) {
           if (&pir_found != nullptr) {
             pir_timer = pir_found.getTimeoutSeconds() * 1000;
           }
-          zigbee_devices.setTimer(_srcaddr, 0 /* groupaddr */, pir_timer, _cluster_id, _srcendpoint, Z_CAT_VIRTUAL_OCCUPANCY, 0, &Z_OccupancyCallback);
+          if (pir_timer > 0) {
+            zigbee_devices.setTimer(_srcaddr, 0 /* groupaddr */, pir_timer, _cluster_id, _srcendpoint, Z_CAT_VIRTUAL_OCCUPANCY, 0, &Z_OccupancyCallback);
+          }
         } else {
           zigbee_devices.resetTimersForDevice(_srcaddr, 0 /* groupaddr */, Z_CAT_VIRTUAL_OCCUPANCY);
         }


### PR DESCRIPTION
## Description:

Fix a bug, `ZbOccupancy 0` would trigger immediately `"Occupancy":0` instead of disabling the timeout.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
