### PR TITLE
Zigbee command ``ZbInfo`` and prepare support for EEPROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee alarm persistence (#9785)
 - Support for EZO PMP sensors by Christopher Tremblay (#9760)
 - Commands ``TuyaRGB``, ``TuyaEnum`` and ``TuyaEnumList`` (#9769)
+- Zigbee command ``ZbInfo`` and prepare support for EEPROM
 
 ### Changed
 - Core library from v2.7.4.5 to v2.7.4.7

--- a/lib/default/AT24C256_512/Eeprom24C512.cpp
+++ b/lib/default/AT24C256_512/Eeprom24C512.cpp
@@ -227,7 +227,9 @@ Eeprom24C512::readBytes
 
     byte remainingBytes = length % EEPROM__RD_BUFFER_SIZE;
     word offset = length - remainingBytes;
-    readBuffer(address + offset, remainingBytes, p_data + offset);
+    if (remainingBytes > 0) {
+        readBuffer(address + offset, remainingBytes, p_data + offset);
+    }
 }
 
 /******************************************************************************

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -547,6 +547,7 @@
   #define D_JSON_ZIGBEE_MODELID "ModelId"
 #define D_CMND_ZIGBEE_PROBE "Probe"
 #define D_CMND_ZIGBEE_FORGET "Forget"
+#define D_CMND_ZIGBEE_INFO "Info"
 #define D_CMND_ZIGBEE_SAVE "Save"
   #define D_CMND_ZIGBEE_LINKQUALITY "LinkQuality"
   #define D_CMND_ZIGBEE_CLUSTER "Cluster"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -729,7 +729,8 @@
   #define USE_ZIGBEE_COALESCE_ATTR_TIMER 350     // timer to coalesce attribute values (in ms)
   #define USE_ZIGBEE_MODELID      "Tasmota Z2T"  // reported "ModelId"      (cluster 0000 / attribute 0005)
   #define USE_ZIGBEE_MANUFACTURER "Tasmota"      // reported "Manufacturer" (cluster 0000 / attribute 0004)
-  #define USE_ZBBRIDGE_TLS                       // TLS support for zbbridge
+  #define USE_ZBBRIDGE_TLS                       // TLS support for zbbridge 
+  #define USE_ZIGBEE_ZBBRIDGE_EEPROM 0x50        // I2C id for the ZBBridge EEPROM
 
 // -- Other sensors/drivers -----------------------
 

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -19,6 +19,10 @@
 
 #ifdef USE_ZIGBEE
 
+#ifdef USE_ZIGBEE_EZSP
+#include "Eeprom24C512.h"
+#endif // USE_ZIGBEE_EZSP
+
 // contains some definitions for functions used before their declarations
 
 //
@@ -69,7 +73,14 @@ const uint8_t  ZIGBEE_LABEL_CONFIGURE_EZSP = 53;   // main loop
 const uint8_t  ZIGBEE_LABEL_ABORT = 99;   // goto label 99 in case of fatal error
 const uint8_t  ZIGBEE_LABEL_UNSUPPORTED_VERSION = 98;  // Unsupported ZNP version
 
-struct ZigbeeStatus {
+class ZigbeeStatus {
+public:
+  ZigbeeStatus()
+#ifdef USE_ZIGBEE_EZSP
+    : eeprom(USE_ZIGBEE_ZBBRIDGE_EEPROM)
+#endif // USE_ZIGBEE_EZSP
+  {}
+
   bool active = true;                 // is Zigbee active for this device, i.e. GPIOs configured
   bool state_machine = false;		      // the state machine is running
   bool state_waiting = false;         // the state machine is waiting for external event or timeout
@@ -77,6 +88,7 @@ struct ZigbeeStatus {
   bool ready = false;								  // cc2530 initialization is complet, ready to operate
   bool init_phase = true;             // initialization phase, before accepting zigbee traffic
   bool recv_until = false;            // ignore all messages until the received frame fully matches
+  bool eeprom_present = false;        // is the ZBBridge EEPROM present?
 
   uint8_t on_error_goto = ZIGBEE_LABEL_ABORT;         // on error goto label, 99 default to abort
   uint8_t on_timeout_goto = ZIGBEE_LABEL_ABORT;       // on timeout goto label, 99 default to abort
@@ -89,6 +101,10 @@ struct ZigbeeStatus {
   ZB_RecvMsgFunc recv_unexpected = nullptr;    // function called when unexpected message is received
 
   uint32_t permit_end_time = 0;       // timestamp when permit join ends
+
+#ifdef USE_ZIGBEE_EZSP
+  Eeprom24C512 eeprom;     // takes only 1 bytes of RAM
+#endif // USE_ZIGBEE_EZSP
 };
 struct ZigbeeStatus zigbee;
 SBuffer *zigbee_buffer = nullptr;

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -194,14 +194,6 @@ class SBuffer hibernateDevices(void) {
     AddLog_P(LOG_LEVEL_ERROR, PSTR(D_LOG_ZIGBEE "Devices list too big to fit in Flash (%d)"), buf_len);
   }
 
-  // Log
-  char *hex_char = (char*) malloc((buf_len * 2) + 2);
-  if (hex_char) {
-    AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "ZbFlashStore %s"),
-                                    ToHex_P(buf.getBuffer(), buf_len, hex_char, (buf_len * 2) + 2));
-    free(hex_char);
-  }
-
   return buf;
 }
 
@@ -301,8 +293,8 @@ void hydrateDevices(const SBuffer &buf, uint32_t version) {
   }
 }
 
-
-void loadZigbeeDevices(void) {
+// dump = true, only dump to logs, don't actually load
+void loadZigbeeDevices(bool dump_only = false) {
 #ifdef ESP32
   // first copy SPI buffer into ram
   uint8_t *spi_buffer = (uint8_t*) malloc(z_spi_len);
@@ -316,7 +308,7 @@ void loadZigbeeDevices(void) {
   Z_Flashentry flashdata;
   memcpy_P(&flashdata, z_dev_start, sizeof(Z_Flashentry));
 //  AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Memory %d"), ESP_getFreeHeap());
-  AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Zigbee signature in Flash: %08X - %d"), flashdata.name, flashdata.len);
+  // AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Zigbee signature in Flash: %08X - %d"), flashdata.name, flashdata.len);
 
   // Check the signature
   if ( ((flashdata.name == ZIGB_NAME1) || (flashdata.name == ZIGB_NAME2))
@@ -327,15 +319,21 @@ void loadZigbeeDevices(void) {
     SBuffer buf(buf_len);
     buf.addBuffer(z_dev_start + sizeof(Z_Flashentry), buf_len);
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee devices data in Flash v%d (%d bytes)"), version, buf_len);
-    // Serial.printf(">> Buffer=");
-    // for (uint32_t i=0; i<buf.len(); i++) Serial.printf("%02X ", buf.get8(i));
-    // Serial.printf("\n");
-    hydrateDevices(buf, version);
-    zigbee_devices.clean();   // don't write back to Flash what we just loaded
+
+    if (dump_only) {
+      size_t buf_len = buf.len();
+      if (buf_len > 192) { buf_len = 192; }
+      AddLogBuffer(LOG_LEVEL_INFO, buf.getBuffer(), buf_len);
+      // Serial.printf(">> Buffer=");
+      // for (uint32_t i=0; i<buf.len(); i++) Serial.printf("%02X ", buf.get8(i));
+      // Serial.printf("\n");
+    } else {
+      hydrateDevices(buf, version);
+      zigbee_devices.clean();   // don't write back to Flash what we just loaded
+    }
   } else {
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "No zigbee devices data in Flash"));
   }
-//  AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE "Memory %d"), ESP_getFreeHeap());
 #ifdef ESP32
   free(spi_buffer);
 #endif  // ESP32

--- a/tasmota/xdrv_23_zigbee_4a_eeprom.ino
+++ b/tasmota/xdrv_23_zigbee_4a_eeprom.ino
@@ -1,0 +1,185 @@
+/*
+  xdrv_23_zigbee_4a_eeprom.ino - zigbee support for Tasmota - saving configuration in I2C Eeprom of ZBBridge
+
+  Copyright (C) 2020  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+
+// =======================
+// ZbData v1
+// File structure:
+//
+// uint8 - number of devices, 0=none, 0xFF=invalid entry (probably Flash was erased)
+//
+// [Array of devices]
+// [Offset = 2]
+// uint8  - length of device record (excluding the length byte)
+// uint16 - short address
+//
+// [Device specific data first]
+// uint8 - length of structure (excluding the length byte)
+// uint8[] - device wide data
+//
+// [Array of data structures]
+// uint8  - length of structure
+// uint8[] - list of data
+//
+
+void dumpZigbeeDevicesData(void) {
+#ifdef USE_ZIGBEE_EZSP
+  if (zigbee.eeprom_present) {
+    SBuffer buf(192);
+
+    zigbee.eeprom.readBytes(64, 192, buf.getBuffer());
+    AddLogBuffer(LOG_LEVEL_INFO, buf.getBuffer(), 192);
+  }
+#endif // USE_ZIGBEE_EZSP
+}
+
+// returns the lenght of consumed buffer, or -1 if error
+int32_t hydrateDeviceWideData(class Z_Device & device, const SBuffer & buf, size_t start, size_t len) {
+  size_t segment_len = buf.get8(start);
+  if ((segment_len < 6) || (segment_len > len)) {
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "invalid device wide data length=%d"), segment_len);
+    return -1;
+  }
+  device.last_seen = buf.get32(start+1);
+  device.lqi = buf.get8(start + 5);
+  device.batterypercent = buf.get8(start + 6);
+  return segment_len + 1;
+}
+
+// return true if success
+bool hydrateDeviceData(class Z_Device & device, const SBuffer & buf, size_t start, size_t len) {
+  // First hydrate device wide data
+  int32_t ret = hydrateDeviceWideData(device, buf, start, len);
+  if (ret < 0) { return false; }
+
+  size_t offset = 0 + ret;
+  while (offset + 5 <= len) {    // each entry is at least 5 bytes
+    uint8_t data_len = buf.get8(start + offset);
+    Z_Data & data_elt = device.data.createFromBuffer(buf, offset + 1, data_len);
+    offset += data_len + 1;
+  }
+  return true;
+}
+
+// negative means error
+// positive is the segment length
+int32_t hydrateSingleDevice(const class SBuffer & buf, size_t start, size_t len) {
+  uint8_t segment_len = buf.get8(start);
+  if ((segment_len < 4) || (start + segment_len > len)) {
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "invalid segment_len=%d"), segment_len);
+    return -1;
+  }
+  // read shortaddr
+  uint16_t shortaddr = buf.get16(start + 1);
+  if (shortaddr >= 0xFFF0) {
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "invalid shortaddr=0x%04X"), shortaddr);
+    return -1;
+  }
+
+  // check if the device exists, if not skip the record
+  Z_Device & device = zigbee_devices.findShortAddr(shortaddr);
+  if (&device != nullptr) {
+
+    // parse the rest
+    bool ret = hydrateDeviceData(device, buf, start + 3, segment_len - 3);
+
+    if (!ret) { return -1; }
+  }
+  return segment_len + 1;
+}
+
+// Parse the entire blob
+// return true if ok
+bool hydrateDevicesDataBlob(const class SBuffer & buf, size_t start, size_t len) {
+  // read number of devices
+  uint8_t num_devices = buf.get8(start);
+  if (num_devices > 0x80) {
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "wrong number of devices=%d"), num_devices);
+    return false;
+  }
+
+  size_t offset = 0;
+  for (uint32_t cur_dev_num = 0; (cur_dev_num < num_devices) && (offset + 4 <= len); cur_dev_num++) {
+    int32_t segment_len = hydrateSingleDevice(buf, offset, len);
+
+    // advance buffer
+    if (segment_len <= 0) { return false; }
+    offset += segment_len;
+  }
+}
+
+class SBuffer hibernateDeviceData(const struct Z_Device & device, bool log = false) {
+  SBuffer buf(192);
+
+  // If we have zero information about the device, just skip ir
+  if (device.validLqi() ||
+      device.validBatteryPercent() ||
+      device.validLastSeen() ||
+      !device.data.isEmpty()) {
+
+    buf.add8(0x00);     // overall length, will be updated later
+    buf.add16(device.shortaddr);
+
+    // device wide data
+    buf.add8(6);        // 6 bytes
+    buf.add32(device.last_seen);
+    buf.add8(device.lqi);
+    buf.add8(device.batterypercent);
+
+    for (const auto & data_elt : device.data) {
+      size_t item_len = data_elt.DataTypeToLength(data_elt.getType());
+      buf.add8(item_len);      // place-holder for length
+      buf.addBuffer((uint8_t*) &data_elt, item_len);
+    }
+
+    // update overall length
+    buf.set8(0, buf.len() - 1);
+
+    if (log) {
+      size_t buf_len = buf.len() - 3;
+      char hex[2*buf_len + 1];
+      // skip first 3 bytes
+      ToHex_P(buf.buf(3), buf_len, hex, sizeof(hex));
+
+      Response_P(PSTR("{\"" D_PRFX_ZB D_CMND_ZIGBEE_DATA "\":\"ZbData 0x%04X,%s\"}"), device.shortaddr, hex);
+      MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_PRFX_ZB D_CMND_ZIGBEE_DATA));
+    }
+  }
+
+  return buf;
+}
+
+void hibernateAllData(void) {
+
+  // first prefix is number of devices
+  uint8_t device_num = zigbee_devices.devicesSize();
+
+  for (const auto & device : zigbee_devices.getDevices()) {
+    // allocte a buffer for a single device
+    SBuffer buf = hibernateDeviceData(device, true);    // log
+    if (buf.len() > 0) {
+      // TODO store in EEPROM
+    }
+  }
+
+}
+
+#endif // USE_ZIGBEE


### PR DESCRIPTION
## Description:

Improved handling of Zigbee device data in memory.

Main feature is the addition of `ZbInfo <device>` which dumps all known information and last values for a device.
Ex:
```
ZbInfo IKEA

MQT: tele/tasmota/ZBBridge/SENSOR = {"IKEA":{"Device":"0xA0E5","Name":"IKEA","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":[1],"Config":["L01.2","O01.1"],"Dimmer":165,"X":30138,"Y":26909,"CT":350,"ColorMode":2,"Power":0,"LastSeen":48,"LastSeenEpoch":1605092986,"LinkQuality":92}}
```

`ZbInfo` is equivalent to the new `ZbStatus3` but produces a simpler JSON format, consistent to JSON returned by sensor values.

Added `ZbData <device>` and `ZbData <device>,<hex>`  command to read or write the current data know for each device in HEX format.

Also added `ZbSave 2` to iterate over all devices and display the `ZbData` information if there is relevant (non-default) information. This prepares a future storage of those values in EEPROM of the ZBBridge.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
