### PR TITLE
Use Tasmota ESP32 core 1.0.4.2 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR.
   - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
-  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.1
+  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -76,7 +76,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage (PR7231 and Backport PR7514)
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino/releases/download/2.7.4.7/esp8266-2.7.4.7.zip
+platform_packages           = tasmota/framework-arduinoespressif8266 @ 3.20704.7
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
@@ -125,9 +125,11 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy @ 1.20800.0
-                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
+                              framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+                              ; ESP32 needs wifi modem sleep for working BT !!!
+                              -DAPP_NORMAL_SLEEP=true
                               -DESP32_STAGE=true
 
 [library]

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -87,8 +87,8 @@ build_flags                 = ${esp_defaults.build_flags}
 [core32]
 platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy@1.20800.0
-                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#56a7ae871204cdf24fab8520ab9f76782d94b599
+                              framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -DESP32_STAGE=true
+                              -DAPP_NORMAL_SLEEP=true
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -262,7 +262,9 @@
 #define APP_BLINKTIME          10                // [BlinkTime] Time in 0.1 Sec to blink/toggle power for relay 1
 #define APP_BLINKCOUNT         10                // [BlinkCount] Number of blinks (0 = 32000)
 
-#define APP_NORMAL_SLEEP       false             // [SetOption60] Enable normal sleep instead of dynamic sleep
+#ifndef APP_NORMAL_SLEEP                         // ESP32 with BT needs API sleep! Platformio "-DAPP_NORMAL_SLEEP=true"
+  #define APP_NORMAL_SLEEP     false             // [SetOption60] Enable normal sleep instead of dynamic sleep
+#endif
 #define APP_SLEEP              0                 // [Sleep] Sleep time to lower energy consumption (0 = Off, 1 - 250 mSec),
 #define PWM_MAX_SLEEP          10                // Sleep will be lowered to this value when light is on, to avoid flickering, and when buzzer is on for better on/off period accuracy
 


### PR DESCRIPTION
## Description:

Fixes BT not working from Tasmota Core 1.0.4.1
Credits go all to @Staars who nailed the problem with PR #9814 and PR #9796

**W A R N I N G**:  No OTA update possible.  ESP32 **needs** to be erased completly with esptool.py before flashing.
This is neccessary since the new IDF v3.3 44ec7972b version has major changes! 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
