### PR TITLE
Fix compilation error

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -639,8 +639,7 @@ public:
     last_seen(0),
     lqi(0xFF),
     batterypercent(0xFF),
-    reserved_for_alignment(0xFFFF
-    )
+    reserved_for_alignment(0xFFFF)
     { };
 
   inline bool valid(void)               const { return BAD_SHORTADDR != shortaddr; }    // is the device known, valid and found?

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -636,9 +636,11 @@ public:
     hidden(false),
     reachable(false),
     data(),
+    last_seen(0),
     lqi(0xFF),
     batterypercent(0xFF),
-    last_seen(0)
+    reserved_for_alignment(0xFFFF
+    )
     { };
 
   inline bool valid(void)               const { return BAD_SHORTADDR != shortaddr; }    // is the device known, valid and found?


### PR DESCRIPTION
## Description:

Fix wrong order of initializers.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
