### PR TITLE
Fixed issue of cannot read data when restart and using Sensor18

### DIFF
--- a/tasmota/xsns_18_pms5003.ino
+++ b/tasmota/xsns_18_pms5003.ino
@@ -247,6 +247,14 @@ void PmsInit(void)
       if (!PinUsed(GPIO_PMS5003_TX)) {  // setting interval not supported if TX pin not connected
         Settings.pms_wake_interval = 0;
         Pms.ready = 1;
+      } else {
+        if (Settings.pms_wake_interval >= MIN_INTERVAL_PERIOD) {
+          // Passive Mode
+          PmsSendCmd(CMD_MODE_PASSIVE);
+          Pms.wake_mode = 0;
+          Pms.ready = 0;
+          Pms.time = Settings.pms_wake_interval - WARMUP_PERIOD; // Let it wake up in the next second
+        }
       }
 
       Pms.type = 1;


### PR DESCRIPTION
## Description:

issue: #9552
The ESP restart occurs after the PMSx003 goes to sleep, the first thing after restarts is to read the sensor data but not wakeup.
Note that the flag Pms.wake_mode is initialized to 1, it means the sensor will always be asleep, the device will not be able to read data from it.
I just add only the initialization code to ensure that the initial state is correct.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
