### PR TITLE
use ESP32 API sleep

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -128,8 +128,6 @@ platform_packages           = tool-esptoolpy @ 1.20800.0
                               framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              ; ESP32 needs wifi modem sleep for working BT !!!
-                              -DAPP_NORMAL_SLEEP=true
                               -DESP32_STAGE=true
 
 [library]

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -90,5 +90,3 @@ platform_packages           = tool-esptoolpy@1.20800.0
                               framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -DAPP_NORMAL_SLEEP=true
-

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -357,8 +357,8 @@ const char kWebColors[] PROGMEM =
 #define FALLBACK_MODULE             WEMOS          // [Module2] Select default module on fast reboot where USER_MODULE is user template
 #endif
 
-#undef APP_NORMAL_SLEEP                            // ESP32 with BT needs API sleep! Platformio "-DAPP_NORMAL_SLEEP=true"
-#define APP_NORMAL_SLEEP            false          // [SetOption60] Enable normal sleep instead of dynamic sleep
+#undef APP_NORMAL_SLEEP                            // ESP32 with BT needs API sleep!
+#define APP_NORMAL_SLEEP            true           // [SetOption60] Enable normal sleep instead of dynamic sleep
 
 #ifndef ARDUINO_ESP32_RELEASE
 #define ARDUINO_CORE_RELEASE        "STAGE"


### PR DESCRIPTION
## Description:

instead of Tasmota Dynamic sleep.
Use of Wifi and BT together needs ESP32 API sleep. Without BT does not work. 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
