### PR TITLE
Remove compiler warnings

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -65,6 +65,7 @@ void OsWatchTicker(void)
     // Force an exception to get a stackdump
     volatile uint32_t dummy;
     dummy = *((uint32_t*) 0x00000000);
+    (void)dummy;    // avoid compiler warning
   }
 }
 

--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -50,6 +50,7 @@ void CmndCrash(void)
 {
   volatile uint32_t dummy;
   dummy = *((uint32_t*) 0x00000000);
+  (void)dummy;
 }
 
 // Do an infinite loop to trigger WDT watchdog

--- a/tasmota/support_light_list.ino
+++ b/tasmota/support_light_list.ino
@@ -113,7 +113,7 @@ protected:
 template <typename T>
 size_t LList<T>::length(void) const {
   size_t count = 0;
-  for (auto & elt : *this) {count++; }
+  for (auto & elt : *this) { (void)elt; count++; }
   return count;
 }
 

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1848,7 +1848,6 @@ void LightSetPower(void)
 // Light.power tells which lights or channels (SetOption68) are on/off
 void LightAnimate(void)
 {
-  uint16_t light_still_on = 0;
   bool power_off = false;
 
   // make sure we update CT range in case SetOption82 was changed
@@ -2727,7 +2726,7 @@ void CmndHsbColor(void)
         uint32_t paramcount = ParseParameters(3, HSB);
         if (HSB[0] > 360) { HSB[0] = 360; }
         for (uint32_t i = 1; i < paramcount; i++) {
-          if (HSB[i] > 100) { HSB[i] == 100; }
+          if (HSB[i] > 100) { HSB[i] = 100; }
           HSB[i] = changeUIntScale(HSB[i], 0, 100, 0, 255); // change sat and bri to 0..255
         }
       }

--- a/tasmota/xdrv_09_timers.ino
+++ b/tasmota/xdrv_09_timers.ino
@@ -101,7 +101,6 @@ float TimeFormula(float *DK, uint32_t Tdays) {
   float M = InPi( (pi2 * 0.993133f) + (pi2 * 99.997361f / 36525.0f) * Tdays);
   float L = InPi( (pi2 * 0.7859453f) + M + (6893.0f * sinf(M) + 72.0f * sinf(M+M) + (6191.2f / 36525.0f) * Tdays) * (pi2 / 1296.0e3f));
 
-  float eps = 0.40904f;         // we take this angle as constant over the next decade
   float cos_eps = 0.91750f;     // precompute cos(eps)
   float sin_eps = 0.39773f;     // precompute sin(eps)
 
@@ -359,7 +358,6 @@ void CmndTimer(void)
             error = 1;
           }
           else {
-            char parm_uc[10];
             index--;
             JsonParserToken val = root[PSTR(D_JSON_TIMER_ARM)];
             if (val) {

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -533,7 +533,6 @@ void CheckHue(String * response, bool &appending) {
 }
 
 void HueLightsCommand(uint8_t device, uint32_t device_id, String &response) {
-  uint16_t tmp = 0;
   uint16_t hue = 0;
   uint8_t  sat = 0;
   uint8_t  bri = 254;

--- a/tasmota/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/xdrv_23_zigbee_1z_libs.ino
@@ -135,6 +135,7 @@ public:
     freeKey();
     freeVal();
     deepCopy(rhs);
+    return *this;
   }
 
   // Destructor, free memory that was allocated
@@ -658,6 +659,8 @@ void Z_attribute::freeVal(void) {
       break;
     case Za_type::Za_arr:
       if (val.arrval) { delete val.arrval; val.arrval = nullptr; }
+      break;
+    default:
       break;
   }
 }

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -405,6 +405,7 @@ public:
         }
       }
     }
+    return false;
   }
   
   // 4 bytes

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -215,6 +215,7 @@ Z_Device & Z_Devices::updateDevice(uint16_t shortaddr, uint64_t longaddr) {
     }
     return device_unk;
   }
+  return device_unk;
 }
 
 //
@@ -341,6 +342,7 @@ void Z_Device::setLightChannels(int8_t channels) {
       zigbee_devices.dirty();
     }
     Z_Data_OnOff & onoff = data.get<Z_Data_OnOff>(0);
+    (void)onoff;
   } else {
     // remove light / onoff object if any
     for (auto & data_elt : data) {
@@ -754,7 +756,6 @@ int32_t Z_Devices::deviceRestore(JsonParserObject json) {
   const char * modelid = nullptr;
   const char * manufid = nullptr;
   const char * friendlyname = nullptr;
-  size_t   endpoints_len = 0;
 
   // read mandatory "Device"
   JsonParserToken val_device = json[PSTR("Device")];

--- a/tasmota/xdrv_23_zigbee_3_hue.ino
+++ b/tasmota/xdrv_23_zigbee_3_hue.ino
@@ -76,7 +76,7 @@ void HueLightStatus1Zigbee(uint16_t shortaddr, uint8_t local_light_subtype, Stri
     } else {
       float x_f = x / 65536.0f;
       float y_f = y / 65536.0f;
-      snprintf_P(buf, buf_size, PSTR("%s\"xy\":[%s,%s],"), buf, String(x, 5).c_str(), String(y, 5).c_str());
+      snprintf_P(buf, buf_size, PSTR("%s\"xy\":[%s,%s],"), buf, String(x_f, 5).c_str(), String(y_f, 5).c_str());
     }
     snprintf_P(buf, buf_size, PSTR("%s\"hue\":%d,\"sat\":%d,"), buf, hue16, sat);
   }
@@ -208,9 +208,8 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
 }
 
 void ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, String &response) {
-  uint8_t  power, colormode, bri, sat;
+  uint8_t  bri, sat;
   uint16_t ct, hue;
-  float    x, y;
   int code = 200;
 
   bool resp = false;  // is the response non null (add comma between parameters)

--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -218,7 +218,7 @@ void hydrateSingleDevice(const SBuffer & buf_d, uint32_t version) {
     uint32_t endpoints = buf_d.get8(d++);
     for (uint32_t j = 0; j < endpoints; j++) {
       uint8_t ep = buf_d.get8(d++);
-      uint16_t ep_profile = buf_d.get16(d);  d += 2;
+      // uint16_t ep_profile = buf_d.get16(d);  d += 2;
       device.addEndpoint(ep);
 
       // in clusters

--- a/tasmota/xdrv_23_zigbee_4a_eeprom.ino
+++ b/tasmota/xdrv_23_zigbee_4a_eeprom.ino
@@ -74,6 +74,7 @@ bool hydrateDeviceData(class Z_Device & device, const SBuffer & buf, size_t star
   while (offset + 5 <= len) {    // each entry is at least 5 bytes
     uint8_t data_len = buf.get8(start + offset);
     Z_Data & data_elt = device.data.createFromBuffer(buf, offset + 1, data_len);
+    (void)data_elt;   // avoid compiler warning
     offset += data_len + 1;
   }
   return true;
@@ -124,6 +125,7 @@ bool hydrateDevicesDataBlob(const class SBuffer & buf, size_t start, size_t len)
     if (segment_len <= 0) { return false; }
     offset += segment_len;
   }
+  return true;
 }
 
 class SBuffer hibernateDeviceData(const struct Z_Device & device, bool log = false) {

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -883,7 +883,6 @@ int32_t encodeSingleAttribute(class SBuffer &buf, double val_d, const char *val_
       break;
 
     case Zsingle:      // float
-      uint32_t *f_ptr;
       buf.add32( *((uint32_t*)&f32) );    // cast float as uint32_t
       break;
 
@@ -1023,7 +1022,7 @@ uint32_t parseSingleAttribute(Z_attribute & attr, const SBuffer &buf,
       {
         int32_t int32_val = buf.get32(i);
         // i += 4;
-        if (0x80000000 != int32_val) {
+        if (-0x80000000 != int32_val) {
           attr.setInt(int32_val);
         }
       }
@@ -1805,9 +1804,9 @@ void Z_postProcessAttributes(uint16_t shortaddr, uint16_t src_ep, class Z_attrib
       // Look for an entry in the converter table
       bool found = false;
       const char * conv_name;
-      Z_Data_Type map_type;
-      uint8_t map_offset;
-      uint8_t zigbee_type;
+      Z_Data_Type map_type = Z_Data_Type::Z_Unknown;
+      uint8_t map_offset = 0;
+      uint8_t zigbee_type = Znodata;
       int8_t conv_multiplier;
       for (uint32_t i = 0; i < ARRAY_SIZE(Z_PostProcess); i++) {
         const Z_AttributeConverter *converter = &Z_PostProcess[i];
@@ -1861,7 +1860,6 @@ void Z_postProcessAttributes(uint16_t shortaddr, uint16_t src_ep, class Z_attrib
 
       uint16_t uval16 = attr.getUInt();     // call converter to uint only once
       int16_t  ival16 = attr.getInt();     // call converter to int only once
-      Z_Data_Set & data = device.data;
       // update any internal structure
       switch (ccccaaaa) {
         case 0x00000004: device.setManufId(attr.getStr());                            break;
@@ -1937,7 +1935,6 @@ bool Z_parseAttributeKey(class Z_attribute & attr) {
     // scan attributes to find by name, and retrieve type
     for (uint32_t i = 0; i < ARRAY_SIZE(Z_PostProcess); i++) {
       const Z_AttributeConverter *converter = &Z_PostProcess[i];
-      bool match = false;
       uint16_t local_attr_id = pgm_read_word(&converter->attribute);
       uint16_t local_cluster_id = CxToCluster(pgm_read_byte(&converter->cluster_short));
       uint8_t  local_type_id = pgm_read_byte(&converter->type);

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -297,7 +297,7 @@ void convertClusterSpecific(class Z_attribute_list &attr_list, uint16_t cluster,
           bool match = true;
           for (uint8_t i = 0; i < payload.len(); i++) {
             const char c1 = pgm_read_byte(p);
-            const char c2 = pgm_read_byte(p+1);
+            // const char c2 = pgm_read_byte(p+1);
   //AddLog_P(LOG_LEVEL_INFO, PSTR(">>>++2 c1 = %c, c2 = %c"), c1, c2);
             if ((0x00 == c1) || isXYZ(c1)) {
               break;
@@ -524,7 +524,7 @@ String zigbeeCmdAddParams(const char *zcl_cmd_P, uint32_t x, uint32_t y, uint32_
   char *p = zcl_cmd;
   while (*p) {
     if (isXYZ(*p) && (*p == *(p+1))) {    // if char is [x-z] and followed by same char
-      uint8_t val;
+      uint8_t val = 0;
       switch (*p) {
         case 'x':
           val = x & 0xFF;

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -902,7 +902,6 @@ uint8_t ZigbeeGetInstructionSize(uint8_t instr) {   // in Zigbee_Instruction lin
 
 void ZigbeeGotoLabel(uint8_t label) {
   // look for the label scanning entire code
-  uint16_t goto_pc = 0xFFFF;    // 0xFFFF means not found
   uint8_t  cur_instr = 0;
   uint8_t  cur_d8 = 0;
   uint8_t  cur_instr_len = 1;       // size of current instruction in words

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -35,7 +35,7 @@ uint8_t ZNP_RSSI2Lqi(int8_t rssi) {
 \*********************************************************************************************/
 
 // EZSP: received ASH "RSTACK" frame, indicating that the MCU finished boot
-int32_t EZ_RSTACK(uint8_t reset_code) {
+void EZ_RSTACK(uint8_t reset_code) {
   const char *reason_str;
 
   switch (reset_code) {
@@ -57,7 +57,7 @@ int32_t EZ_RSTACK(uint8_t reset_code) {
 }
 
 // EZSP: received ASH "ERROR" frame, indicating that the MCU finished boot
-int32_t EZ_ERROR(uint8_t error_code) {
+void EZ_ERROR(uint8_t error_code) {
   const char *reason_str;
 
   switch (error_code) {
@@ -75,7 +75,7 @@ int32_t EZ_ERROR(uint8_t error_code) {
 int32_t EZ_ReadAPSUnicastMessage(int32_t res, class SBuffer &buf) {
   // Called when receiving a response from getConfigurationValue
   // Value is in bytes 2+3
-  uint16_t value = buf.get16(2);
+  // uint16_t value = buf.get16(2);
   return res;
 }
 
@@ -129,8 +129,8 @@ int32_t EZ_NetworkParameters(int32_t res, class SBuffer &buf) {
 // Analyze response to "getKey" and check NWK key
 //
 int32_t EZ_CheckKeyNWK(int32_t res, class SBuffer &buf) {
-  uint8_t  status = buf.get8(2);
-  uint16_t bitmask = buf.get16(3);
+  // uint8_t  status = buf.get8(2);
+  // uint16_t bitmask = buf.get16(3);
   uint8_t  key_type = buf.get8(5);
   uint64_t key_low  = buf.get64(6);
   uint64_t key_high = buf.get64(14);
@@ -314,11 +314,11 @@ int32_t ZNP_Reboot(int32_t res, class SBuffer &buf) {
   // 4180.02.02.00.02.06.03
   //
   uint8_t reason = buf.get8(2);
-  uint8_t transport_rev = buf.get8(3);
-  uint8_t product_id = buf.get8(4);
+  // uint8_t transport_rev = buf.get8(3);
+  // uint8_t product_id = buf.get8(4);
   uint8_t major_rel = buf.get8(5);
   uint8_t minor_rel = buf.get8(6);
-  uint8_t hw_rev = buf.get8(7);
+  // uint8_t hw_rev = buf.get8(7);
   const char *reason_str;
 
   switch (reason) {
@@ -481,18 +481,18 @@ int32_t ZNP_ReceivePermitJoinStatus(int32_t res, const class SBuffer &buf) {
 //
 int32_t ZNP_ReceiveNodeDesc(int32_t res, const class SBuffer &buf) {
   // Received ZDO_NODE_DESC_RSP
-  Z_ShortAddress    srcAddr = buf.get16(2);
+  // Z_ShortAddress    srcAddr = buf.get16(2);
   uint8_t           status  = buf.get8(4);
-  Z_ShortAddress    nwkAddr = buf.get16(5);
+  // Z_ShortAddress    nwkAddr = buf.get16(5);
   uint8_t           logicalType = buf.get8(7);
-  uint8_t           apsFlags = buf.get8(8);
-  uint8_t           MACCapabilityFlags = buf.get8(9);
-  uint16_t          manufacturerCapabilities = buf.get16(10);
-  uint8_t           maxBufferSize = buf.get8(12);
-  uint16_t          maxInTransferSize = buf.get16(13);
-  uint16_t          serverMask = buf.get16(15);
-  uint16_t          maxOutTransferSize = buf.get16(17);
-  uint8_t           descriptorCapabilities = buf.get8(19);
+  // uint8_t           apsFlags = buf.get8(8);
+  // uint8_t           MACCapabilityFlags = buf.get8(9);
+  // uint16_t          manufacturerCapabilities = buf.get16(10);
+  // uint8_t           maxBufferSize = buf.get8(12);
+  // uint16_t          maxInTransferSize = buf.get16(13);
+  // uint16_t          serverMask = buf.get16(15);
+  // uint16_t          maxOutTransferSize = buf.get16(17);
+  // uint8_t           descriptorCapabilities = buf.get8(19);
 
 
   if (0 == status) {
@@ -525,13 +525,13 @@ int32_t Z_ReceiveActiveEp(int32_t res, const class SBuffer &buf) {
   // Received ZDO_ACTIVE_EP_RSP
 #ifdef USE_ZIGBEE_ZNP
   // Z_ShortAddress    srcAddr = buf.get16(2);
-  uint8_t           status  = buf.get8(4);
+  // uint8_t           status  = buf.get8(4);
   Z_ShortAddress    nwkAddr = buf.get16(5);
   uint8_t           activeEpCount = buf.get8(7);
   uint8_t*          activeEpList = (uint8_t*) buf.charptr(8);
 #endif
 #ifdef USE_ZIGBEE_EZSP
-  uint8_t           status  = buf.get8(0);
+  // uint8_t           status  = buf.get8(0);
   Z_ShortAddress    nwkAddr = buf.get16(1);
   uint8_t           activeEpCount = buf.get8(3);
   uint8_t*          activeEpList = (uint8_t*) buf.charptr(4);
@@ -635,7 +635,7 @@ int32_t Z_ReceiveSimpleDesc(int32_t res, const class SBuffer &buf) {
   // Z_ShortAddress    srcAddr = buf.get16(2);
   uint8_t           status  = buf.get8(4);
   Z_ShortAddress    nwkAddr = buf.get16(5);
-  uint8_t           lenDescriptor = buf.get8(7);
+  // uint8_t           lenDescriptor = buf.get8(7);
   uint8_t           endpoint = buf.get8(8);
   uint16_t          profileId = buf.get16(9);  // The profile Id for this endpoint.
   uint16_t          deviceId = buf.get16(11);   // The Device Description Id for this endpoint.
@@ -648,7 +648,7 @@ int32_t Z_ReceiveSimpleDesc(int32_t res, const class SBuffer &buf) {
 #ifdef USE_ZIGBEE_EZSP
   uint8_t           status = buf.get8(0);
   Z_ShortAddress    nwkAddr = buf.get16(1);
-  uint8_t           lenDescriptor = buf.get8(3);
+  // uint8_t           lenDescriptor = buf.get8(3);
   uint8_t           endpoint = buf.get8(4);
   uint16_t          profileId = buf.get16(5);  // The profile Id for this endpoint.
   uint16_t          deviceId = buf.get16(7);   // The Device Description Id for this endpoint.
@@ -1661,7 +1661,6 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
         break;
     }
   } else {
-    bool            defer_attributes = false;     // do we defer attributes reporting to coalesce
     ZCLFrame zcl_received = ZCLFrame::parseRawFrame(buf, 21, buf.get8(20), clusterid, groupid,
                                 srcaddr,
                                 srcendpoint, dstendpoint, wasbroadcast,

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -446,8 +446,6 @@ void ZigbeeEZSPSendRaw(const uint8_t *msg, size_t len, bool send_cancel) {
 		AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_JSON_ZIGBEE_EZSP_SENT ": bad message len %d"), len);
 		return;
 	}
-	uint8_t data_len = len - 2;		// removing CMD1 and CMD2
-
   // turn send led on
   Z_LedStatusSet(true);
 
@@ -554,14 +552,14 @@ void ZigbeeEZSPSendDATA(const uint8_t *msg, size_t len) {
 }
 
 // Receive a high-level EZSP command/response, starting with 16-bits frame ID
-int32_t ZigbeeProcessInputEZSP(class SBuffer &buf) {
+void ZigbeeProcessInputEZSP(class SBuffer &buf) {
   // verify errors in first 2 bytes.
   // TODO
   // uint8_t  sequence_num = buf.get8(0);
   uint16_t frame_control = buf.get16(1);
   bool truncated = frame_control & 0x02;
   bool overflow = frame_control & 0x01;
-  bool callbackPending = frame_control & 0x04;
+  // bool callbackPending = frame_control & 0x04;
   bool security_enabled = frame_control & 0x8000;
   if (truncated || overflow || security_enabled) {
     AddLog_P(LOG_LEVEL_INFO, PSTR("ZIG: specific frame_control 0x%04X"), frame_control);
@@ -634,7 +632,7 @@ void EZSP_HandleAck(uint8_t new_ack) {
 }
 
 // Receive raw ASH frame (CRC was removed, data unstuffed) but still contains frame numbers
-int32_t ZigbeeProcessInputRaw(class SBuffer &buf) {
+void ZigbeeProcessInputRaw(class SBuffer &buf) {
   uint8_t control_byte = buf.get8(0);
   uint8_t ack_num = control_byte & 0x07;        // keep 3 LSB
   if (control_byte & 0x80) {  // non DATA frame

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -593,7 +593,6 @@ void ZbSendRead(JsonParserToken val_attr, ZigbeeZCLSendMessage & packet) {
       // scan attributes to find by name, and retrieve type
       for (uint32_t i = 0; i < ARRAY_SIZE(Z_PostProcess); i++) {
         const Z_AttributeConverter *converter = &Z_PostProcess[i];
-        bool match = false;
         uint16_t local_attr_id = pgm_read_word(&converter->attribute);
         uint16_t local_cluster_id = CxToCluster(pgm_read_byte(&converter->cluster_short));
         // uint8_t  local_type_id = pgm_read_byte(&converter->type);
@@ -833,7 +832,6 @@ void ZbBindUnbind(bool unbind) {    // false = bind, true = unbind
   uint8_t  toendpoint = 0x01;       // default dest endpoint to 0x01
   uint16_t toGroup = 0x0000;        // group address
   uint16_t cluster  = 0;            // cluster 0 is default
-  uint32_t group = 0xFFFFFFFF;      // 16 bits values, otherwise 0xFFFFFFFF is unspecified
 
   // Information about source device: "Device", "Endpoint", "Cluster"
   //  - the source endpoint must have a known IEEE address
@@ -1040,7 +1038,7 @@ void CmndZbName(void) {
 
   // check if parameters contain a comma ','
   char *p;
-  char *str = strtok_r(XdrvMailbox.data, ",", &p);
+  strtok_r(XdrvMailbox.data, ",", &p);
 
   // parse first part, <device_id>
   Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, false);  // it's the only case where we create a new device
@@ -1072,7 +1070,7 @@ void CmndZbModelId(void) {
 
   // check if parameters contain a comma ','
   char *p;
-  char *str = strtok_r(XdrvMailbox.data, ",", &p);
+  strtok_r(XdrvMailbox.data, ",", &p);
 
   // parse first part, <device_id>
   Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, true);  // in case of short_addr, it must be already registered
@@ -1101,7 +1099,7 @@ void CmndZbLight(void) {
 
   // check if parameters contain a comma ','
   char *p;
-  char *str = strtok_r(XdrvMailbox.data, ", ", &p);
+  strtok_r(XdrvMailbox.data, ", ", &p);
 
   // parse first part, <device_id>
   Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, true);  // in case of short_addr, it must be already registered
@@ -1144,7 +1142,7 @@ void CmndZbOccupancy(void) {
 
   // check if parameters contain a comma ','
   char *p;
-  char *str = strtok_r(XdrvMailbox.data, ", ", &p);
+  strtok_r(XdrvMailbox.data, ", ", &p);
 
   // parse first part, <device_id>
   Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, true);  // in case of short_addr, it must be already registered
@@ -1293,8 +1291,6 @@ void CmndZbPermitJoin(void) {
     duration = 0xFF;                    // unlimited time
   }
 
-  uint16_t dstAddr = 0xFFFC;            // default addr
-
   SBuffer buf(34);
   buf.add8(Z_SREQ | Z_ZDO);             // 25
   buf.add8(ZDO_MGMT_PERMIT_JOIN_REQ);   // 36
@@ -1426,7 +1422,7 @@ void CmndZbData(void) {
 
   // check if parameters contain a comma ','
   char *p;
-  char *str = strtok_r(XdrvMailbox.data, ",", &p);
+  strtok_r(XdrvMailbox.data, ",", &p);
 
   // parse first part, <device_id>
   Z_Device & device = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, true);  // in case of short_addr, it must be already registered


### PR DESCRIPTION
## Description:

Removed some warnings after running gcc in `-Wall` mode. Mainly removing unused variables and fixing minor issues.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
