### PR TITLE
Fingerprint library: add missing casts to silence compiler warnings

### DIFF
--- a/lib/lib_div/Adafruit-Fingerprint-Sensor-Library-2.0.4-Tasmota/Adafruit_Fingerprint.cpp
+++ b/lib/lib_div/Adafruit-Fingerprint-Sensor-Library-2.0.4-Tasmota/Adafruit_Fingerprint.cpp
@@ -368,8 +368,8 @@ uint8_t Adafruit_Fingerprint::LEDcontrol(uint8_t control, uint8_t speed,
 /**************************************************************************/
 uint8_t Adafruit_Fingerprint::fingerSearch(uint8_t slot) {
   // search of slot starting thru the capacity
-  GET_CMD_PACKET(FINGERPRINT_SEARCH, slot, 0x00, 0x00, capacity >> 8,
-                 capacity & 0xFF);
+  GET_CMD_PACKET(FINGERPRINT_SEARCH, slot, 0x00, 0x00, (uint8_t)(capacity >> 8),
+                 (uint8_t)(capacity & 0xFF));
 
   fingerID = 0xFFFF;
   confidence = 0xFFFF;
@@ -413,8 +413,8 @@ uint8_t Adafruit_Fingerprint::getTemplateCount(void) {
 */
 /**************************************************************************/
 uint8_t Adafruit_Fingerprint::setPassword(uint32_t password) {
-  SEND_CMD_PACKET(FINGERPRINT_SETPASSWORD, (password >> 24), (password >> 16),
-                  (password >> 8), password);
+  SEND_CMD_PACKET(FINGERPRINT_SETPASSWORD, (uint8_t)(password >> 24), (uint8_t)(password >> 16),
+                  (uint8_t)(password >> 8), (uint8_t)password);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
## Description:

This PR adds the missing casts to silence compiler warnings, that were already present at other places of the file.
No real changes to the code.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
