### PR TITLE
add compiler flag -Wreturn-type

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -105,6 +105,7 @@ build_unflags               = -mtarget-align
                               -Wdeprecated-declarations
 build_flags                 = -mno-target-align
                               -Wno-deprecated-declarations
+                              -Wreturn-type
                               -D_IR_ENABLE_DEFAULT_=false
                               -DDECODE_HASH=true -DDECODE_NEC=true -DSEND_NEC=true
                               -DDECODE_RC5=true -DSEND_RC5=true -DDECODE_RC6=true -DSEND_RC6=true


### PR DESCRIPTION
to get a warning for "unclear" returns

suggested from @s-hadinger 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
