### PR TITLE
Zigbee more consistent messages for ZbInfo and ZbLight

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -565,6 +565,7 @@
 #define D_CMND_ZIGBEE_RESPONSE "Response"
   #define D_JSON_ZIGBEE_ZCL_SENT "ZbZCLSent"
 #define D_JSON_ZIGBEE_RECEIVED "ZbReceived"
+#define D_JSON_ZIGBEE_INFO "ZbInfo"
 #define D_CMND_ZIGBEE_BIND "Bind"
   #define D_JSON_ZIGBEE_BIND "ZbBind"
 #define D_CMND_ZIGBEE_UNBIND "Unbind"

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -73,7 +73,7 @@ public:
 
   inline uint8_t getEndpoint(void) const { return _endpoint; }
 
-  void toAttributes(Z_attribute_list & attr_list, Z_Data_Type type) const;
+  void toAttributes(Z_attribute_list & attr_list) const;
 
   // update internal structures after an attribut update
   // True if a configuration was changed
@@ -215,7 +215,7 @@ public:
   inline bool validColormode(void)      const { return 0xFF != colormode; }
   inline bool validDimmer(void)         const { return 0xFF != dimmer; }
   inline bool validSat(void)            const { return 0xFF != sat; }
-  inline bool validHue(void)            const { return 0xFFFF != hue; }
+  inline bool validHue(void)            const { return 0xFF != hue; }
   inline bool validCT(void)             const { return 0xFFFF != ct; }
   inline bool validX(void)              const { return 0xFFFF != x; }
   inline bool validY(void)              const { return 0xFFFF != y; }
@@ -674,6 +674,18 @@ public:
 
   void setLastSeenNow(void);
 
+  // multiple function to dump part of the Device state into JSON
+  void jsonAddDeviceNamme(Z_attribute_list & attr_list) const;
+  void jsonAddIEEE(Z_attribute_list & attr_list) const;
+  void jsonAddModelManuf(Z_attribute_list & attr_list) const;
+  void jsonAddEndpoints(Z_attribute_list & attr_list) const;
+  void jsonAddConfig(Z_attribute_list & attr_list) const;
+  void jsonAddDataAttributes(Z_attribute_list & attr_list) const;
+  void jsonAddDeviceAttributes(Z_attribute_list & attr_list) const;
+  void jsonDumpSingleDevice(Z_attribute_list & attr_list, uint32_t dump_mode, bool add_name) const;
+  void jsonPublishAttrList(const char * json_prefix, const Z_attribute_list &attr_list) const;
+  void jsonLightState(Z_attribute_list & attr_list) const;
+
   // dump device attributes to ZbData
   void toAttributes(Z_attribute_list & attr_list) const;
 
@@ -791,9 +803,7 @@ public:
   uint8_t getNextSeqNumber(uint16_t shortaddr);
 
   // Dump json
-  static String dumpLightState(const Z_Device & device);
   String dumpDevice(uint32_t dump_mode, const Z_Device & device) const;
-  static String dumpSingleDevice(uint32_t dump_mode, const class Z_Device & device, bool add_device_name = true, bool add_brackets = true);
   int32_t deviceRestore(JsonParserObject json);
 
   // Hue support
@@ -810,7 +820,6 @@ public:
 
   // Append or clear attributes Json structure
   void jsonAppend(uint16_t shortaddr, const Z_attribute_list &attr_list);
-  static void jsonPublishFlushAttrList(const Z_Device & device, const String & attr_list_string);
   void jsonPublishFlush(uint16_t shortaddr);    // publish the json message and clear buffer
   bool jsonIsConflict(uint16_t shortaddr, const Z_attribute_list &attr_list) const;
   void jsonPublishNow(uint16_t shortaddr, Z_attribute_list &attr_list);

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1967,7 +1967,8 @@ bool Z_parseAttributeKey(class Z_attribute & attr) {
 // Input:
 //  the Json object to add attributes to
 //  the type of object (necessary since the type system is unaware of the actual sub-type)
-void Z_Data::toAttributes(Z_attribute_list & attr_list, Z_Data_Type type) const {
+void Z_Data::toAttributes(Z_attribute_list & attr_list) const {
+  Z_Data_Type type = getType();
   // iterate through attributes to see which ones need to be exported
   for (uint32_t i = 0; i < ARRAY_SIZE(Z_PostProcess); i++) {
     const Z_AttributeConverter *converter = &Z_PostProcess[i];

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1111,10 +1111,11 @@ void CmndZbLight(void) {
     if (bulbtype < -1) { bulbtype = -1; }
     device.setLightChannels(bulbtype);
   }
-  String dump = zigbee_devices.dumpLightState(device);
-  Response_P(PSTR("{\"" D_PRFX_ZB D_CMND_ZIGBEE_LIGHT "\":%s}"), dump.c_str());
+  Z_attribute_list attr_list;
+  device.jsonLightState(attr_list);
+  
+  device.jsonPublishAttrList(PSTR(D_PRFX_ZB D_CMND_ZIGBEE_LIGHT), attr_list);         // publish as ZbReceived
 
-  MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_PRFX_ZB D_CMND_ZIGBEE_LIGHT));
   ResponseCmndDone();
 }
 //
@@ -1194,8 +1195,9 @@ void CmndZbInfo(void) {
 
   // everything is good, we can send the command
 
-  String device_info = Z_Devices::dumpSingleDevice(3, device, false, false);
-  Z_Devices::jsonPublishFlushAttrList(device, device_info);
+  Z_attribute_list attr_list;
+  device.jsonDumpSingleDevice(attr_list, 3, false);   // don't add Device/Name
+  device.jsonPublishAttrList(PSTR(D_JSON_ZIGBEE_INFO), attr_list);         // publish as ZbReceived
 
   ResponseCmndDone();
 }


### PR DESCRIPTION
## Description:

Small refactoring about how messages are sent out, for more consistency between `ZbReceived`, `ZbInfo` and `ZbLight`. Now all three follow the same scheme with regards to SetOptions.

** **BREAKING CHANGE** **
`ZbInfo` now reports messages as `{"ZbInfo":{...}}` instead of `{"ZbRecevied":{...}}`, this avoids infinite loops in Rules, see #9788 

Also fixed a small bug of `"Hue"` being sent in `ZbLight` when it shouldn't.

**Related issue (if applicable):** fixes #9807 #9788 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
