### PR TITLE
Esp32 sleep override not needed

### DIFF
--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -357,9 +357,6 @@ const char kWebColors[] PROGMEM =
 #define FALLBACK_MODULE             WEMOS          // [Module2] Select default module on fast reboot where USER_MODULE is user template
 #endif
 
-#undef APP_NORMAL_SLEEP                            // ESP32 with BT needs API sleep!
-#define APP_NORMAL_SLEEP            true           // [SetOption60] Enable normal sleep instead of dynamic sleep
-
 #ifndef ARDUINO_ESP32_RELEASE
 #define ARDUINO_CORE_RELEASE        "STAGE"
 #else


### PR DESCRIPTION
anymore since code does take care now

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
