### PR TITLE
Zigbee command ``ZbLeave`` to unpair a device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee command ``ZbInfo`` and prepare support for EEPROM
 - Support for AS608 optical and R503 capacitive fingerprint sensor
 - Command ``SetOption115 1`` to enable ESP32 MiBle
+- Zigbee command ``ZbLeave`` to unpair a device
 
 ### Changed
 - Core library from v2.7.4.5 to v2.7.4.7

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -572,6 +572,7 @@
   #define D_JSON_ZIGBEE_UNBIND "ZbUnbind"
 #define D_CMND_ZIGBEE_BIND_STATE "BindState"
   #define D_JSON_ZIGBEE_BIND_STATE "ZbBindState"
+#define D_CMND_ZIGBEE_LEAVE "Leave"
 #define D_CMND_ZIGBEE_MAP "Map"
   #define D_JSON_ZIGBEE_MAP "ZbMap"
 #define D_JSON_ZIGBEE_PARENT "ZbParent"


### PR DESCRIPTION
## Description:

Added command `ZbLeave <device>` to ask a device to leave the network. For battery powered devices, you need to wake up the device first (e.g. press a button). If you send to a router, it will not ask the devices connected to the router to leave the network, and they should find another router.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
