### PR TITLE
Use ESP32 stage core for entry `[core32_stage]`

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -125,7 +125,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy @ 1.20800.0
-                              framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
+                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#idf-release/v3.3
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
                               -DESP32_STAGE=true


### PR DESCRIPTION
since the core 1.0.4.2 is Tasmota standard and not stage anymore

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
