### PR TITLE
Zigbee fix missing Light attribute in ZbLight

### DIFF
--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -702,14 +702,19 @@ void Z_Device::jsonLightState(Z_attribute_list & attr_list) const {
     // dump all known values
     attr_list.addAttribute(F("Reachable")).setBool(getReachable());
     if (validPower())        { attr_list.addAttribute(F("Power")).setUInt(getPower()); }
+    int32_t light_mode = -1;
     const Z_Data_Light & light = data.find<Z_Data_Light>(0);
     if (&light != nullptr) {
+      if (light.validConfig()) {
+        light_mode = light.getConfig();
+      }
       light.toAttributes(attr_list);
       // Exception, we need to convert Hue to 0..360 instead of 0..254
       if (light.validHue()) {
         attr_list.findOrCreateAttribute(PSTR("Hue")).setUInt(light.getHue());
       }
     }
+    attr_list.addAttribute(F("Light")).setInt(light_mode);
   }
 }
 


### PR DESCRIPTION
## Description:

Recent refactoring mistakenly removed `"Light":<n>` attribute to the response of `ZbLight`. This attribute contains the number of channels of the light 0..5 or -1 if it is not set up as a light.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
