### PR TITLE
Fix USE_4K_RSA define location

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -132,6 +132,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               -DPSTR_ALIGN=1
                               ; restrict to minimal mime-types
                               -DMIMETYPE_MINIMAL
+                              ; uncomment the following to enable TLS with 4096 RSA certificates
+                              ;-DUSE_4K_RSA
 
 [irremoteesp_full]
 build_flags                 = -DUSE_IR_REMOTE_FULL

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -398,7 +398,7 @@
 //  #define USE_MQTT_AWS_IOT                       // [Deprecated] Enable MQTT for AWS IoT - requires a private key (+11.9k code, +0.4k mem)
                                                  //   Note: you need to generate a private key + certificate per device and update 'tasmota/tasmota_aws_iot.cpp'
                                                  //   Full documentation here: https://github.com/arendst/Tasmota/wiki/AWS-IoT
-//  #define USE_4K_RSA                             // Support 4096 bits certificates, instead of 2048
+//  for USE_4K_RSA (support for 4096 bits certificates, instead of 2048), you need to uncommend `-DUSE_4K_RSA` in `build_flags` from `platform.ini` or `platform_override.ini`
 
 // -- Telegram Protocol ---------------------------
 //#define USE_TELEGRAM                             // Support for Telegram protocol (+49k code, +7.0k mem and +4.8k additional during connection handshake)


### PR DESCRIPTION
## Description:

The `#define USE_4K_RSA` needs to be in the compile options for libs, not in Tasmota includes.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
