### PR TITLE
Fix switchmode 15 publish old switch state

### DIFF
--- a/tasmota/support_switch.ino
+++ b/tasmota/support_switch.ino
@@ -404,6 +404,7 @@ void SwitchHandler(uint32_t mode) {
           }
           break;
         case PUSH_IGNORE:
+          Switch.last_state[i] = button;                        // Update switch state before publishing
           MqttPublishSensor();
           break;
         }


### PR DESCRIPTION
##Description:

When using SwitchMode15, every change of the switch state sends an immediate forced SENSOR message
But the message is sent with the switch's last_state.
So the last_state must be updated before the SENSOR message is sent.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR.
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
