### PR TITLE
silence the last remaining compiler warning

### DIFF
--- a/lib/libesp32/TTGO_TWatch_Library/src/bma.cpp
+++ b/lib/libesp32/TTGO_TWatch_Library/src/bma.cpp
@@ -187,7 +187,7 @@ void BMA::attachInterrupt()
 
 bool BMA::set_remap_axes(struct bma423_axes_remap *remap_data)
 {
-    bma423_set_remap_axes(remap_data, &_dev);
+    return bma423_set_remap_axes(remap_data, &_dev);
 }
 
 bool BMA::readInterrupt()

--- a/tasmota/support_esp32.ino
+++ b/tasmota/support_esp32.ino
@@ -247,26 +247,24 @@ void DisableBrownout(void) {
 
 String ESP32GetResetReason(uint32_t cpu_no) {
 	// tools\sdk\include\esp32\rom\rtc.h
-  RESET_REASON reset_reason = rtc_get_reset_reason(cpu_no);
-  switch (reset_reason) {
-    case POWERON_RESET          : return "Vbat power on reset";                              // 1
-    case SW_RESET               : return "Software reset digital core";                      // 3
-    case OWDT_RESET             : return "Legacy watch dog reset digital core";              // 4
-    case DEEPSLEEP_RESET        : return "Deep Sleep reset digital core";                    // 5
-    case SDIO_RESET             : return "Reset by SLC module, reset digital core";          // 6
-    case TG0WDT_SYS_RESET       : return "Timer Group0 Watch dog reset digital core";        // 7
-    case TG1WDT_SYS_RESET       : return "Timer Group1 Watch dog reset digital core";        // 8
-    case RTCWDT_SYS_RESET       : return "RTC Watch dog Reset digital core";                 // 9
-    case INTRUSION_RESET        : return "Instrusion tested to reset CPU";                   // 10
-    case TGWDT_CPU_RESET        : return "Time Group reset CPU";                             // 11
-    case SW_CPU_RESET           : return "Software reset CPU";                               // 12
-    case RTCWDT_CPU_RESET       : return "RTC Watch dog Reset CPU";                          // 13
-    case EXT_CPU_RESET          : return "For APP CPU, reseted by PRO CPU";                  // 14
-    case RTCWDT_BROWN_OUT_RESET : return "Reset when the vdd voltage is not stable";         // 15
-    case RTCWDT_RTC_RESET       : return "RTC Watch dog reset digital core and rtc module";  // 16
-    default                     : return "No meaning";                                       // 0
+  switch (rtc_get_reset_reason(cpu_no)) {
+    case POWERON_RESET          : return F("Vbat power on reset");                              // 1
+    case SW_RESET               : return F("Software reset digital core");                      // 3
+    case OWDT_RESET             : return F("Legacy watch dog reset digital core");              // 4
+    case DEEPSLEEP_RESET        : return F("Deep Sleep reset digital core");                    // 5
+    case SDIO_RESET             : return F("Reset by SLC module, reset digital core");          // 6
+    case TG0WDT_SYS_RESET       : return F("Timer Group0 Watch dog reset digital core");        // 7
+    case TG1WDT_SYS_RESET       : return F("Timer Group1 Watch dog reset digital core");        // 8
+    case RTCWDT_SYS_RESET       : return F("RTC Watch dog Reset digital core");                 // 9
+    case INTRUSION_RESET        : return F("Instrusion tested to reset CPU");                   // 10
+    case TGWDT_CPU_RESET        : return F("Time Group reset CPU");                             // 11
+    case SW_CPU_RESET           : return F("Software reset CPU");                               // 12
+    case RTCWDT_CPU_RESET       : return F("RTC Watch dog Reset CPU");                          // 13
+    case EXT_CPU_RESET          : return F("or APP CPU, reseted by PRO CPU");                   // 14
+    case RTCWDT_BROWN_OUT_RESET : return F("Reset when the vdd voltage is not stable");         // 15
+    case RTCWDT_RTC_RESET       : return F("RTC Watch dog reset digital core and rtc module");  // 16            
   }
-  return "No meaning";                                                                       // 0
+  return F("No meaning");                                                                       // 0 and undefined
 }
 
 String ESP_getResetReason(void) {
@@ -279,6 +277,7 @@ uint32_t ESP_ResetInfoReason(void) {
   if (SW_CPU_RESET == reason) { return REASON_SOFT_RESTART; }
   if (DEEPSLEEP_RESET == reason)  { return REASON_DEEP_SLEEP_AWAKE; }
   if (SW_RESET == reason) { return REASON_EXT_SYS_RST; }
+  return -1; //no "official error code", but should work with the current code base
 }
 
 uint32_t ESP_getChipId(void) {


### PR DESCRIPTION
## Description:

Only cosmetical, no real code changes.
The TTGO wrapper library casts an uint16_t to a boolean at other places too, so I did the same here. The return value is discarded anyway.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
