### PR TITLE
add ili9341-2

### DIFF
--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -1,0 +1,411 @@
+/*!
+* @file ILI9341_2.cpp
+*
+* @mainpage Adafruit ILI9341 TFT Displays
+*
+* @section intro_sec Introduction
+*
+* This is the documentation for Adafruit's ILI9341 driver for the
+* Arduino platform.
+*
+* This library works with the Adafruit 2.8" Touch Shield V2 (SPI)
+*    http://www.adafruit.com/products/1651
+*
+* Adafruit 2.4" TFT LCD with Touchscreen Breakout w/MicroSD Socket - ILI9341
+*    https://www.adafruit.com/product/2478
+*
+* 2.8" TFT LCD with Touchscreen Breakout Board w/MicroSD Socket - ILI9341
+*    https://www.adafruit.com/product/1770
+*
+* 2.2" 18-bit color TFT LCD display with microSD card breakout - ILI9340
+*    https://www.adafruit.com/product/1770
+*
+* TFT FeatherWing - 2.4" 320x240 Touchscreen For All Feathers
+*    https://www.adafruit.com/product/3315
+*
+* These displays use SPI to communicate, 4 or 5 pins are required
+* to interface (RST is optional).
+*
+* Adafruit invests time and resources providing this open source code,
+* please support Adafruit and open-source hardware by purchasing
+* products from Adafruit!
+*
+* @section dependencies Dependencies
+*
+* This library depends on <a href="https://github.com/adafruit/Adafruit_GFX">
+* Adafruit_GFX</a> being present on your system. Please make sure you have
+* installed the latest version before using this library.
+*
+* @section author Author
+*
+* Written by Limor "ladyada" Fried for Adafruit Industries.
+*
+* @section license License
+*
+* BSD license, all text here must be included in any redistribution.
+*
+*/
+
+#ifdef ESP32
+#include "ILI9341_2.h"
+#include <limits.h>
+
+
+// ESP32 uses 2. SPI BUS, ESP8266 uses software spi
+#ifdef ESP32
+#undef ILI9341_2_DIMMER
+#define ILI9341_2_DIMMER
+#undef ESP32_PWM_CHANNEL
+#define ESP32_PWM_CHANNEL 1
+#define ILI9341_2_HWSPI
+#endif
+
+
+const uint16_t ili9341_2_colors[]={ILI9341_2_BLACK,ILI9341_2_WHITE,ILI9341_2_RED,ILI9341_2_GREEN,ILI9341_2_BLUE,ILI9341_2_CYAN,ILI9341_2_MAGENTA,\
+  ILI9341_2_YELLOW,ILI9341_2_NAVY,ILI9341_2_DARKGREEN,ILI9341_2_DARKCYAN,ILI9341_2_MAROON,ILI9341_2_PURPLE,ILI9341_2_OLIVE,\
+ILI9341_2_LIGHTGREY,ILI9341_2_DARKGREY,ILI9341_2_ORANGE,ILI9341_2_GREENYELLOW,ILI9341_2_PINK};
+
+uint16_t ILI9341_2::GetColorFromIndex(uint8_t index) {
+  if (index>=sizeof(ili9341_2_colors)/2) index=0;
+  return ili9341_2_colors[index];
+}
+
+static const uint8_t PROGMEM ili9341_2_initcmd[] = {
+  0xEF, 3, 0x03, 0x80, 0x02,
+  0xCF, 3, 0x00, 0xC1, 0x30,
+  0xED, 4, 0x64, 0x03, 0x12, 0x81,
+  0xE8, 3, 0x85, 0x00, 0x78,
+  0xCB, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
+  0xF7, 1, 0x20,
+  0xEA, 2, 0x00, 0x00,
+  ILI9341_2_PWCTR1  , 1, 0x23,             // Power control VRH[5:0]
+  ILI9341_2_PWCTR2  , 1, 0x10,             // Power control SAP[2:0];BT[3:0]
+  ILI9341_2_VMCTR1  , 2, 0x3e, 0x28,       // VCM control
+  ILI9341_2_VMCTR2  , 1, 0x86,             // VCM control2
+  ILI9341_2_MADCTL  , 1, 0x48,             // Memory Access Control
+  ILI9341_2_VSCRSADD, 1, 0x00,             // Vertical scroll zero
+  ILI9341_2_PIXFMT  , 1, 0x55,
+  ILI9341_2_FRMCTR1 , 2, 0x00, 0x18,
+  ILI9341_2_DFUNCTR , 3, 0x08, 0x82, 0x27, // Display Function Control
+  0xF2, 1, 0x00,                         // 3Gamma Function Disable
+  ILI9341_2_GAMMASET , 1, 0x01,             // Gamma curve selected
+  ILI9341_2_GMCTRP1 , 15, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, // Set Gamma
+    0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00,
+  ILI9341_2_GMCTRN1 , 15, 0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, // Set Gamma
+    0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F,
+  ILI9341_2_SLPOUT  , 0x80,                // Exit Sleep
+  ILI9341_2_DISPON  , 0x80,                // Display on
+//  ILI9341_2_DISPOFF  , 0x80,                // Display on
+  0x00                                   // End of list
+};
+
+
+ILI9341_2::ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp) : Renderer(ILI9341_2_TFTWIDTH, ILI9341_2_TFTHEIGHT) {
+  _cs   = cs;
+  _mosi  = mosi;
+  _miso  = miso;
+  _sclk = sclk;
+  _res = res;
+  _dc = dc;
+  _bp = bp;
+  _hwspi = 0;
+}
+
+#define ILI9341_2_CS_LOW digitalWrite( _cs, LOW);
+#define ILI9341_2_CS_HIGH digitalWrite( _cs, HIGH);
+
+
+void ILI9341_2::writecmd(uint8_t d) {
+  digitalWrite( _dc, LOW);
+#ifdef ILI9341_2_HWSPI
+  spi2->write(d);
+#else
+  spiwrite(d);
+#endif
+  digitalWrite( _dc, HIGH);
+}
+
+void ILI9341_2::init(uint16_t width, uint16_t height) {
+  //sspi2 = SPISettings(2500000, MSBFIRST, SPI_MODE3);
+
+#ifdef ILI9341_2_HWSPI
+  spi2 = new SPIClass(HSPI);
+  spi2->setDataMode(SPI_MODE3);
+  spi2->setBitOrder(MSBFIRST);
+  spi2->setFrequency(40000000);
+  spi2->begin(_sclk, _miso, _mosi, -1);
+#else
+  pinMode(_mosi, OUTPUT);
+  digitalWrite(_mosi,HIGH);
+  pinMode(_sclk, OUTPUT);
+  digitalWrite(_sclk,LOW);
+  pinMode(_miso, INPUT);
+#endif
+
+  pinMode(_cs, OUTPUT);
+  digitalWrite(_cs,HIGH);
+  pinMode(_dc, OUTPUT);
+  digitalWrite(_dc,HIGH);
+  pinMode(_bp, OUTPUT);
+  digitalWrite(_bp,HIGH);
+  pinMode(_res, OUTPUT);
+  digitalWrite(_res,HIGH);
+
+
+  if (_bp>=0) {
+#ifdef ILI9341_2_DIMMER
+    ledcSetup(ESP32_PWM_CHANNEL,4000,8);
+    ledcAttachPin(_bp,ESP32_PWM_CHANNEL);
+    ledcWrite(ESP32_PWM_CHANNEL,128);
+#else
+    pinMode(_bp, OUTPUT);
+#endif
+  }
+
+  pinMode(_res, OUTPUT);
+  digitalWrite(_res, HIGH);
+  delay(100);
+  digitalWrite(_res, LOW);
+  delay(100);
+  digitalWrite(_res, HIGH);
+  delay(200);
+
+  uint8_t        cmd, x, numArgs;
+  const uint8_t *addr = ili9341_2_initcmd;
+
+  while ((cmd = pgm_read_byte(addr++)) > 0) {
+      ILI9341_2_CS_LOW
+      writecmd(cmd);
+      x = pgm_read_byte(addr++);
+      numArgs = x & 0x7F;
+
+#ifdef ILI9341_2_HWSPI
+      while (numArgs--) spi2->write(pgm_read_byte(addr++));
+#else
+      while (numArgs--) spiwrite(pgm_read_byte(addr++));
+#endif
+
+      ILI9341_2_CS_HIGH
+      if(x & 0x80) delay(120);
+  }
+
+//  endWrite();
+}
+
+void ILI9341_2::DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font) {
+  setRotation(rot);
+  setTextFont(font&3);
+  setTextSize(size&7);
+  setTextColor(ILI9341_2_WHITE,ILI9341_2_BLACK);
+  setCursor(0,0);
+  fillScreen(ILI9341_2_BLACK);
+}
+
+void ILI9341_2::setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+    uint32_t xa = ((uint32_t)x << 16) | (x+w-1);
+    uint32_t ya = ((uint32_t)y << 16) | (y+h-1);
+    writecmd(ILI9341_2_CASET); // Column addr set
+#ifdef ILI9341_2_HWSPI
+    spi2->write32(xa);
+#else
+    spiwrite32(xa);
+#endif
+    writecmd(ILI9341_2_PASET); // Row addr set
+
+#ifdef ILI9341_2_HWSPI
+    spi2->write32(ya);
+#else
+    spiwrite32(ya);
+#endif
+    writecmd(ILI9341_2_RAMWR); // write to RAM
+}
+
+void ILI9341_2::drawPixel(int16_t x, int16_t y, uint16_t color) {
+
+
+  if((x < 0) ||(x >= _width) || (y < 0) || (y >= _height)) return;
+
+  ILI9341_2_CS_LOW
+
+  setAddrWindow(x,y,1,1);
+
+#ifdef ILI9341_2_HWSPI
+  spi2->write16(color);
+#else
+  spiwrite16(color);
+#endif
+  ILI9341_2_CS_HIGH
+
+}
+
+void ILI9341_2::setRotation(uint8_t m) {
+    rotation = m % 4; // can't be higher than 3
+    switch (rotation) {
+        case 0:
+            m = (MADCTL_2_MX | MADCTL_2_BGR);
+            _width  = ILI9341_2_TFTWIDTH;
+            _height = ILI9341_2_TFTHEIGHT;
+            break;
+        case 1:
+            m = (MADCTL_2_MV | MADCTL_2_BGR);
+            _width  = ILI9341_2_TFTHEIGHT;
+            _height = ILI9341_2_TFTWIDTH;
+            break;
+        case 2:
+            m = (MADCTL_2_MY | MADCTL_2_BGR);
+            _width  = ILI9341_2_TFTWIDTH;
+            _height = ILI9341_2_TFTHEIGHT;
+            break;
+        case 3:
+            m = (MADCTL_2_MX | MADCTL_2_MY | MADCTL_2_MV | MADCTL_2_BGR);
+            _width  = ILI9341_2_TFTHEIGHT;
+            _height = ILI9341_2_TFTWIDTH;
+            break;
+    }
+
+    ILI9341_2_CS_LOW
+    writecmd(ILI9341_2_MADCTL);
+    spiwrite(m);
+    ILI9341_2_CS_HIGH
+}
+
+void ILI9341_2::drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color) {
+
+  // Rudimentary clipping
+  if((x >= _width) || (y >= _height)) return;
+  if((y+h-1) >= _height) h = _height-y;
+
+  ILI9341_2_CS_LOW
+
+  setAddrWindow(x, y, 1, h);
+
+  while (h--) {
+#ifdef ILI9341_2_HWSPI
+    spi2->write16(color);
+#else
+    spiwrite16(color);
+#endif
+  }
+
+  ILI9341_2_CS_HIGH
+
+}
+
+void ILI9341_2::drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color) {
+
+  // Rudimentary clipping
+  if((x >= _width) || (y >= _height)) return;
+  if((x+w-1) >= _width)  w = _width-x;
+
+  ILI9341_2_CS_LOW
+
+  setAddrWindow(x, y, w, 1);
+
+  while (w--) {
+#ifdef ILI9341_2_HWSPI
+    spi2->write16(color);
+#else
+    spiwrite16(color);
+#endif
+  }
+
+  ILI9341_2_CS_HIGH
+}
+
+void ILI9341_2::fillScreen(uint16_t color) {
+  fillRect(0, 0,  _width, _height, color);
+}
+
+// fill a rectangle
+void ILI9341_2::fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color) {
+
+  // rudimentary clipping (drawChar w/big text requires this)
+  if((x >= _width) || (y >= _height)) return;
+  if((x + w - 1) >= _width)  w = _width  - x;
+  if((y + h - 1) >= _height) h = _height - y;
+
+  ILI9341_2_CS_LOW
+
+  setAddrWindow(x, y, w-1, h-1);
+
+  for (y=h; y>0; y--) {
+    for (x=w; x>0; x--) {
+#ifdef ILI9341_2_HWSPI
+      spi2->write16(color);
+#else
+      spiwrite16(color);
+#endif
+    }
+  }
+  ILI9341_2_CS_HIGH
+}
+
+void ILI9341_2::DisplayOnff(int8_t on) {
+  if (on) {
+    writecmd(ILI9341_2_DISPON);    //Display on
+    if (_bp>=0) {
+#ifdef ILI9341_2_DIMMER
+      ledcWrite(ESP32_PWM_CHANNEL,dimmer);
+#else
+      digitalWrite(_bp,HIGH);
+#endif
+    }
+  } else {
+    writecmd(ILI9341_2_DISPOFF);
+    if (_bp>=0) {
+#ifdef ILI9341_2_DIMMER
+      ledcWrite(ESP32_PWM_CHANNEL,0);
+#else
+      digitalWrite(_bp,LOW);
+#endif
+    }
+  }
+}
+
+// dimmer 0-100
+void ILI9341_2::dim(uint8_t dim) {
+  dimmer = dim;
+  if (dimmer>15) dimmer=15;
+  dimmer=((float)dimmer/15.0)*255.0;
+#ifdef ESP32
+  ledcWrite(ESP32_PWM_CHANNEL,dimmer);
+#endif
+}
+
+
+void ILI9341_2::spiwrite(uint8_t c) {
+
+#ifdef ILI9341_2_HWSPI
+  spi2->write(c);
+#else
+  for (uint8_t bit = 0x80; bit; bit >>= 1) {
+	   digitalWrite(_sclk, LOW);
+	    if (c & bit) digitalWrite(_mosi, HIGH);
+	    else        digitalWrite(_mosi, LOW);
+	    digitalWrite(_sclk, HIGH);
+  }
+#endif
+
+}
+
+void ILI9341_2::spiwrite16(uint16_t c) {
+#ifdef ILI9341_2_HWSPI
+    spi2->write16(c);
+#else
+    spiwrite(c>>8);
+    spiwrite(c);
+#endif
+}
+
+void ILI9341_2::spiwrite32(uint32_t c) {
+#ifdef ILI9341_2_HWSPI
+    spi2->write32(c);
+#else
+    spiwrite(c>>24);
+    spiwrite(c>>16);
+    spiwrite(c>>8);
+    spiwrite(c);
+#endif
+}
+
+#endif

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
@@ -1,0 +1,179 @@
+/***************************************************
+  STM32 Support added by Jaret Burkett at OSHlab.com
+
+  This is our library for the Adafruit  ILI9341_2 Breakout and Shield
+  ----> http://www.adafruit.com/products/1651
+
+  Check out the links above for our tutorials and wiring diagrams
+  These displays use SPI to communicate, 4 or 5 pins are required to
+  interface (RST is optional)
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+
+#ifndef _ILI9341_2H_
+#define _ILI9341_2H_
+
+#include "Arduino.h"
+#include <renderer.h>
+#include <SPI.h>
+
+#define ILI9341_2_TFTWIDTH  320
+#define ILI9341_2_TFTHEIGHT 480
+
+#define ILI9341_2_NOP        0x00     ///< No-op register
+#define ILI9341_2_SWRESET    0x01     ///< Software reset register
+#define ILI9341_2_RDDID      0x04     ///< Read display identification information
+#define ILI9341_2_RDDST      0x09     ///< Read Display Status
+
+#define ILI9341_2_SLPIN      0x10     ///< Enter Sleep Mode
+#define ILI9341_2_SLPOUT     0x11     ///< Sleep Out
+#define ILI9341_2_PTLON      0x12     ///< Partial Mode ON
+#define ILI9341_2_NORON      0x13     ///< Normal Display Mode ON
+
+#define ILI9341_2_RDMODE     0x0A     ///< Read Display Power Mode
+#define ILI9341_2_RDMADCTL   0x0B     ///< Read Display MADCTL
+#define ILI9341_2_RDPIXFMT   0x0C     ///< Read Display Pixel Format
+#define ILI9341_2_RDIMGFMT   0x0D     ///< Read Display Image Format
+#define ILI9341_2_RDSELFDIAG 0x0F     ///< Read Display Self-Diagnostic Result
+
+#define ILI9341_2_INVOFF     0x20     ///< Display Inversion OFF
+#define ILI9341_2_INVON      0x21     ///< Display Inversion ON
+#define ILI9341_2_GAMMASET   0x26     ///< Gamma Set
+#define ILI9341_2_DISPOFF    0x28     ///< Display OFF
+#define ILI9341_2_DISPON     0x29     ///< Display ON
+
+#define ILI9341_2_CASET      0x2A     ///< Column Address Set
+#define ILI9341_2_PASET      0x2B     ///< Page Address Set
+#define ILI9341_2_RAMWR      0x2C     ///< Memory Write
+#define ILI9341_2_RAMRD      0x2E     ///< Memory Read
+
+#define ILI9341_2_PTLAR      0x30     ///< Partial Area
+#define ILI9341_2_MADCTL     0x36     ///< Memory Access Control
+#define ILI9341_2_VSCRSADD   0x37     ///< Vertical Scrolling Start Address
+#define ILI9341_2_PIXFMT     0x3A     ///< COLMOD: Pixel Format Set
+
+#define ILI9341_2_FRMCTR1    0xB1     ///< Frame Rate Control (In Normal Mode/Full Colors)
+#define ILI9341_2_FRMCTR2    0xB2     ///< Frame Rate Control (In Idle Mode/8 colors)
+#define ILI9341_2_FRMCTR3    0xB3     ///< Frame Rate control (In Partial Mode/Full Colors)
+#define ILI9341_2_INVCTR     0xB4     ///< Display Inversion Control
+#define ILI9341_2_DFUNCTR    0xB6     ///< Display Function Control
+
+#define ILI9341_2_PWCTR1     0xC0     ///< Power Control 1
+#define ILI9341_2_PWCTR2     0xC1     ///< Power Control 2
+#define ILI9341_2_PWCTR3     0xC2     ///< Power Control 3
+#define ILI9341_2_PWCTR4     0xC3     ///< Power Control 4
+#define ILI9341_2_PWCTR5     0xC4     ///< Power Control 5
+#define ILI9341_2_VMCTR1     0xC5     ///< VCOM Control 1
+#define ILI9341_2_VMCTR2     0xC7     ///< VCOM Control 2
+
+#define ILI9341_2_RDID1      0xDA     ///< Read ID 1
+#define ILI9341_2_RDID2      0xDB     ///< Read ID 2
+#define ILI9341_2_RDID3      0xDC     ///< Read ID 3
+#define ILI9341_2_RDID4      0xDD     ///< Read ID 4
+
+#define ILI9341_2_GMCTRP1    0xE0     ///< Positive Gamma Correction
+#define ILI9341_2_GMCTRN1    0xE1     ///< Negative Gamma Correction
+
+
+// Color definitions
+#define ILI9341_2_BLACK       0x0000      /*   0,   0,   0 */
+#define ILI9341_2_NAVY        0x000F      /*   0,   0, 128 */
+#define ILI9341_2_DARKGREEN   0x03E0      /*   0, 128,   0 */
+#define ILI9341_2_DARKCYAN    0x03EF      /*   0, 128, 128 */
+#define ILI9341_2_MAROON      0x7800      /* 128,   0,   0 */
+#define ILI9341_2_PURPLE      0x780F      /* 128,   0, 128 */
+#define ILI9341_2_OLIVE       0x7BE0      /* 128, 128,   0 */
+#define ILI9341_2_LIGHTGREY   0xC618      /* 192, 192, 192 */
+#define ILI9341_2_DARKGREY    0x7BEF      /* 128, 128, 128 */
+#define ILI9341_2_BLUE        0x001F      /*   0,   0, 255 */
+#define ILI9341_2_GREEN       0x07E0      /*   0, 255,   0 */
+#define ILI9341_2_CYAN        0x07FF      /*   0, 255, 255 */
+#define ILI9341_2_RED         0xF800      /* 255,   0,   0 */
+#define ILI9341_2_MAGENTA     0xF81F      /* 255,   0, 255 */
+#define ILI9341_2_YELLOW      0xFFE0      /* 255, 255,   0 */
+#define ILI9341_2_WHITE       0xFFFF      /* 255, 255, 255 */
+#define ILI9341_2_ORANGE      0xFD20      /* 255, 165,   0 */
+#define ILI9341_2_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
+#define ILI9341_2_PINK        0xF81F
+
+
+#define MADCTL_2_MY  0x80  ///< Bottom to top
+#define MADCTL_2_MX  0x40  ///< Right to left
+#define MADCTL_2_MV  0x20  ///< Reverse Mode
+#define MADCTL_2_ML  0x10  ///< LCD refresh Bottom to top
+#define MADCTL_2_RGB 0x00  ///< Red-Green-Blue pixel order
+#define MADCTL_2_BGR 0x08  ///< Blue-Green-Red pixel order
+#define MADCTL_2_MH  0x04  ///< LCD refresh right to left
+
+
+class ILI9341_2 : public Renderer {
+
+ public:
+
+  ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp);
+
+  void init(uint16_t width, uint16_t height);
+  /*
+  void begin(void);
+  void DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font);
+  void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
+  void setScrollArea(uint16_t topFixedArea, uint16_t bottomFixedArea);
+  void scroll(uint16_t pixels);
+  void pushColor(uint16_t color);
+  void pushColors(uint16_t *data, uint8_t len, boolean first);
+  //void drawImage(const uint8_t* img, uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h,uint16_t color);
+  void setRotation(uint8_t r);
+  void invertDisplay(boolean i);
+  uint16_t color565(uint8_t r, uint8_t g, uint8_t b);
+  void DisplayOnff(int8_t on);
+  void writecommand(uint8_t c);
+  void writedata(uint8_t d);
+  void write16BitColor(uint16_t color);
+  void commandList(uint8_t *addr);
+  void hw_spi_init();
+  void dim(uint8_t contrast);*/
+  uint16_t GetColorFromIndex(uint8_t index);
+
+ private:
+  SPIClass *spi2;
+  SPISettings sspi2;
+  void writecmd(uint8_t d);
+  void setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void DisplayOnff(int8_t on);
+  void setRotation(uint8_t m);
+  void DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font);
+  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void fillScreen(uint16_t color);
+  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  void dim(uint8_t dim);
+
+
+  void spiwrite(uint8_t c);
+  void spiwrite16(uint16_t c);
+  void spiwrite32(uint32_t c);
+
+  uint8_t  tabcolor;
+  uint8_t dimmer;
+  int8_t _cs;
+  int8_t _mosi;
+  int8_t _miso;
+  int8_t _sclk;
+  int8_t _res;
+  int8_t _dc;
+  int8_t _bp;
+  int8_t _hwspi;
+};
+
+#endif

--- a/tasmota/xdsp_08_ILI9488.ino
+++ b/tasmota/xdsp_08_ILI9488.ino
@@ -102,6 +102,7 @@ void ILI9488_InitDriver()
     ili9488->begin();
     renderer = ili9488;
     renderer->DisplayInit(DISPLAY_INIT_MODE,Settings.display_size,Settings.display_rotate,Settings.display_font);
+    renderer->dim(Settings.display_dimmer);
 
 #ifdef SHOW_SPLASH
     // Welcome text

--- a/tasmota/xdsp_12_ST7789.ino
+++ b/tasmota/xdsp_12_ST7789.ino
@@ -121,6 +121,7 @@ void ST7789_InitDriver()
     st7789->init(Settings.display_width,Settings.display_height);
     renderer = st7789;
     renderer->DisplayInit(DISPLAY_INIT_MODE,Settings.display_size,Settings.display_rotate,Settings.display_font);
+    renderer->dim(Settings.display_dimmer);
 
 #ifdef SHOW_SPLASH
     // Welcome text

--- a/tasmota/xdsp_13_ILI9341-2.ino
+++ b/tasmota/xdsp_13_ILI9341-2.ino
@@ -1,0 +1,121 @@
+/*
+  xdsp_13_ILI9341-TTGO-TS.ino - Display ILI9341 support for Tasmota
+
+  Copyright (C) 2020  Gerhard Mutz and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//#ifdef USE_SPI
+#ifdef USE_SPI
+#ifdef USE_DISPLAY
+#ifdef USE_DISPLAY_ILI9341_2
+
+#define XDSP_13                13
+
+#undef COLORED
+#define COLORED                1
+#undef UNCOLORED
+#define UNCOLORED              0
+
+
+// using font 8 is opional (num=3)
+// very badly readable, but may be useful for graphs
+#undef USE_TINY_FONT
+#define USE_TINY_FONT
+
+
+#include <ILI9341_2.h>
+
+extern uint8_t *buffer;
+extern uint8_t color_type;
+ILI9341_2 *ili9341_2;
+
+
+#undef BACKPLANE_PIN
+#define BACKPLANE_PIN 4
+
+/*********************************************************************************************/
+
+void ILI9341_2_InitDriver()
+{
+  if (!Settings.display_model) {
+    Settings.display_model = XDSP_13;
+  }
+
+  if (XDSP_13 == Settings.display_model) {
+
+    if (Settings.display_width != ILI9341_2_TFTWIDTH) {
+      Settings.display_width = ILI9341_2_TFTWIDTH;
+    }
+    if (Settings.display_height != ILI9341_2_TFTHEIGHT) {
+      Settings.display_height = ILI9341_2_TFTHEIGHT;
+    }
+
+    // disable screen buffer
+    buffer=NULL;
+
+    // default colors
+    fg_color = ILI9341_2_WHITE;
+    bg_color = ILI9341_2_BLACK;
+
+
+    // init renderer, may use hardware spi, however we use SSPI defintion because SD card uses SPI definition  (2 spi busses)
+    if (PinUsed(GPIO_SSPI_CS) && PinUsed(GPIO_OLED_RESET) && PinUsed(GPIO_BACKLIGHT) && PinUsed(GPIO_SSPI_MOSI) && PinUsed(GPIO_SSPI_MISO) && PinUsed(GPIO_SSPI_SCLK) && PinUsed(GPIO_SSPI_DC)) {
+        ili9341_2  = new ILI9341_2(Pin(GPIO_SSPI_CS), Pin(GPIO_SSPI_MOSI), Pin(GPIO_SSPI_MISO), Pin(GPIO_SSPI_SCLK), Pin(GPIO_OLED_RESET), Pin(GPIO_SSPI_DC), Pin(GPIO_BACKLIGHT));
+    } else {
+      return;
+    }
+    ili9341_2->init(Settings.display_width,Settings.display_height);
+    renderer = ili9341_2;
+    renderer->DisplayInit(DISPLAY_INIT_MODE,Settings.display_size,Settings.display_rotate,Settings.display_font);
+    renderer->dim(Settings.display_dimmer);
+
+#ifdef SHOW_SPLASH
+    // Welcome text
+    renderer->setTextFont(2);
+    renderer->setTextColor(ILI9341_2_WHITE,ILI9341_2_BLACK);
+    renderer->DrawStringAt(30, 100, "ILI9341 TFT!", ILI9341_2_WHITE,0);
+    delay(1000);
+#endif
+
+    color_type = COLOR_COLOR;
+
+  }
+}
+
+/*********************************************************************************************/
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+bool Xdsp13(uint8_t function)
+{
+  bool result = false;
+
+  if (FUNC_DISPLAY_INIT_DRIVER == function) {
+    ILI9341_2_InitDriver();
+  }
+  else if (XDSP_13 == Settings.display_model) {
+      switch (function) {
+        case FUNC_DISPLAY_MODEL:
+          result = true;
+          break;
+    }
+  }
+  return result;
+}
+
+#endif  // USE_DISPLAY_ILI9341_2
+#endif  // USE_DISPLAY
+#endif  // USE_SPI


### PR DESCRIPTION
## Description:

support for ILI9341 with support for 2. Hardware SPI BUS needed by TTGO-T4
since Tasmota supports only 1 Hardware SPI BUS the second has to be defined by SSPI. On ESP32 the 2. Hardware SPI is used on ESP8266 software SPI
remark:
the TTGO-T4 is a very nice all in One ESP32 board which is easy to expand since a lot of pins are externally available and and also contains a grid circuit board for your own expansions
<img width="400" alt="Bildschirmfoto 2020-11-16 um 06 47 44" src="https://user-images.githubusercontent.com/11647075/99217139-a5ea9c00-27d7-11eb-9146-7dd3227ce8e3.png">


missing dimmer init added 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR.
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
