### PR TITLE
use esptool.py 3.0 release

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -149,5 +149,6 @@ platform                    = espressif8266 @ 2.6.2
 platform_packages           = tasmota/framework-arduinoespressif8266 @ 3.20704.7
                               platformio/toolchain-xtensa @ 2.40802.200502
                               platformio/tool-esptool @ 1.413.0
+                              tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
-;core_dir = .platformio
+core_dir = .platformio
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
@@ -77,6 +77,8 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage (PR7231 and Backport PR7514)
 platform_packages           = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+                              platformio/toolchain-xtensa @ 2.40802.200502
+                              tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
@@ -86,6 +88,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 ; *** Use Xtensa build chain 10.2. GNU13 from https://github.com/earlephilhower/esp-quick-toolchain
                               mcspr/toolchain-xtensa @ 5.100200.200918
+                              tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
                               platformio/tool-esptool @ 1.413.0
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
@@ -122,7 +125,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
-platform_packages           = tool-esptoolpy @ 1.20800.0
+platform_packages           = tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
                               framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#idf-release/v3.3
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
-core_dir = .platformio
+;core_dir = .platformio
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -86,7 +86,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = espressif32 @ 2.0.0
-platform_packages           = tool-esptoolpy@1.20800.0
+platform_packages           = tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
                               framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

Bug Fixes
Added temporary workaround for a pyserial failure on macOS Big Sur Preview 
Fixed gcc9 warning in the stub 
Fixed some memory types printed in the memory map output
Fixed the check for zero bytes before applying an ELF SHA-256 with elf2image --elf-sha256-offset option 
Fixed displaying some single core ESP32 features incorrectly, i.e. ESP32-S0WD
Fixed exception on Python 3 if the same flash address was repeated twice 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
