### PR TITLE
ESP32 1.0.5-rc2 for stage core

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -126,10 +126,10 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [core32_stage]
 platform                    = espressif32 @ 2.0.0
 platform_packages           = tool-esptoolpy @ https://github.com/Jason2866/esptool/releases/download/v3.0/esptool-3.0.zip
-                              framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#idf-release/v3.3
+                              framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc2/esp32-1.0.5-rc2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -DESP32_STAGE=true
+                              ;-DESP32_STAGE=true
 
 [library]
 lib_ldf_mode                = chain+


### PR DESCRIPTION
## Description:

espressif released today Arduino Esp32 1.05.rc2. Just added the needed package.json for platformio.
Build tested with Odroid-go
![image](https://user-images.githubusercontent.com/24528715/99273105-dc043c00-2828-11eb-8da5-4adf6d9a5c33.png)


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5.rc2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
