### PR TITLE
KNX: Change DPT9 to DPT14 for sensors and KnxTX

### DIFF
--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-conversion.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-conversion.cpp
@@ -83,5 +83,7 @@ uint32_t ESPKNXIP::data_to_4byte_uint(uint8_t *data)
 
 float ESPKNXIP::data_to_4byte_float(uint8_t *data)
 {
-	return (float)((data[1] << 24) | (data[2] << 16) | (data[3] << 8) |data[4]);
+	union { float f; uint32_t i; } num;
+    num.i = (uint32_t)((data[1] << 24) | (data[2] << 16) | (data[3] << 8) | (data[4] << 0));
+	return num.f;
 }

--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
@@ -182,7 +182,13 @@ void ESPKNXIP::send_4byte_uint(address_t const &receiver, knx_command_type_t ct,
 
 void ESPKNXIP::send_4byte_float(address_t const &receiver, knx_command_type_t ct, float val)
 {
-	uint8_t buf[] = {0x00, ((uint8_t *)&val)[3], ((uint8_t *)&val)[2], ((uint8_t *)&val)[1], ((uint8_t *)&val)[0]};
+	union { float f; uint32_t i; } num;
+    num.f = val;
+	uint8_t buf[] = {0x00,
+	                 (uint8_t)((num.i & 0xFF000000) >> 24),
+	                 (uint8_t)((num.i & 0x00FF0000) >> 16),
+	                 (uint8_t)((num.i & 0x0000FF00) >> 8),
+	                 (uint8_t)((num.i & 0x000000FF) >> 0)};
 	send(receiver, ct, 5, buf);
 }
 

--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -561,7 +561,7 @@ void KNX_CB_Action(message_t const &msg, void *arg)
     dtostrfd(tempvar,0,tempchar);
   } else {
     // VALUE
-    float tempvar = knx.data_to_2byte_float(msg.data);
+    float tempvar = knx.data_to_4byte_float(msg.data);
     dtostrfd(tempvar,2,tempchar);
   }
   AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_KNX D_RECEIVED_FROM " %d.%d.%d " D_COMMAND " %s: %s " D_TO " %s"),
@@ -630,18 +630,18 @@ void KNX_CB_Action(message_t const &msg, void *arg)
       }
       else if (chan->type == KNX_TEMPERATURE) // Reply Temperature
       {
-        knx.answer_2byte_float(msg.received_on, last_temp);
+        knx.answer_4byte_float(msg.received_on, last_temp);
         if (Settings.flag.knx_enable_enhancement) {
-          knx.answer_2byte_float(msg.received_on, last_temp);
-          knx.answer_2byte_float(msg.received_on, last_temp);
+          knx.answer_4byte_float(msg.received_on, last_temp);
+          knx.answer_4byte_float(msg.received_on, last_temp);
         }
       }
       else if (chan->type == KNX_HUMIDITY) // Reply Humidity
       {
-        knx.answer_2byte_float(msg.received_on, last_hum);
+        knx.answer_4byte_float(msg.received_on, last_hum);
         if (Settings.flag.knx_enable_enhancement) {
-          knx.answer_2byte_float(msg.received_on, last_hum);
-          knx.answer_2byte_float(msg.received_on, last_hum);
+          knx.answer_4byte_float(msg.received_on, last_hum);
+          knx.answer_4byte_float(msg.received_on, last_hum);
         }
       }
 #ifdef USE_RULES
@@ -737,10 +737,10 @@ void KnxSensor(uint8_t sensor_type, float value)
   uint8_t i = KNX_GA_Search(sensor_type);
   while ( i != KNX_Empty ) {
     KNX_addr.value = Settings.knx_GA_addr[i];
-    knx.write_2byte_float(KNX_addr, value);
+    knx.write_4byte_float(KNX_addr, value);
     if (Settings.flag.knx_enable_enhancement) {
-      knx.write_2byte_float(KNX_addr, value);
-      knx.write_2byte_float(KNX_addr, value);
+      knx.write_4byte_float(KNX_addr, value);
+      knx.write_4byte_float(KNX_addr, value);
     }
 
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_KNX "%s " D_SENT_TO " %d.%d.%d "),
@@ -1050,10 +1050,10 @@ void CmndKnxTxVal(void)
       float tempvar = CharToFloat(XdrvMailbox.data);
       dtostrfd(tempvar,2,XdrvMailbox.data);
 
-      knx.write_2byte_float(KNX_addr, tempvar);
+      knx.write_4byte_float(KNX_addr, tempvar);
       if (Settings.flag.knx_enable_enhancement) {
-        knx.write_2byte_float(KNX_addr, tempvar);
-        knx.write_2byte_float(KNX_addr, tempvar);
+        knx.write_4byte_float(KNX_addr, tempvar);
+        knx.write_4byte_float(KNX_addr, tempvar);
       }
 
       AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_KNX "%s = %s " D_SENT_TO " %d.%d.%d"),


### PR DESCRIPTION
## Description:

Tasmota is using DPT9 (16bit Float) for `KnxTx_Valn` commands and for sensors. This makes impossible to send 32bits values, so a change in KNX encoding from DPT9 to DPT14 (32bit Float) is needed. This increment in resolution makes no increase for RAM/Flash usage due to Tasmota was already using internally 32 Bits Float Variables. In fact, the KNX encoding for DPT14 don't need the use of POW or LOG, reducing Flash/RAM usage.

**RAM: -68 bytes
FLASH: -5.6 Kbytes**

This is going to be a **_breaking change_**

Any user sending any sensor value with Tasmota KNX, or using `KnxTx_Valn` commands, should upgrade all their interconnected Tasmota devices and also upgrade this DPT in its KNX Network.

The KNX DataPointTypes (DPT) are listed [here](https://support.knx.org/hc/en-us/articles/115001133744-Datapoint-Type) and more detailed [here](https://www.knx.org/wAssets/docs/downloads/Certification/Interworking-Datapoint-types/03_07_02-Datapoint-Types-v02.01.02-AS.pdf).

```
Tasmota-KNX Without this FIX
RAM:   [======    ]  62.1% (used 50892 bytes from 81920 bytes)
Flash: [======    ]  59.8% (used 612287 bytes from 1023984 bytes)

Tasmota-KNX With this FIX
RAM:   [======    ]  62.0% (used 50824 bytes from 81920 bytes)
Flash: [======    ]  59.2% (used 606671 bytes from 1023984 bytes)

Standard Tasmota - Just for reference
RAM:   [======    ]  57.8% (used 47364 bytes from 81920 bytes)
Flash: [======    ]  59.4% (used 608355 bytes from 1023984 bytes)
```

**Related issue (if applicable):** fixes #9811

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x]  Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
