### PR TITLE
KNX: Add Read reply for Power

### DIFF
--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -644,6 +644,76 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           knx.answer_4byte_float(msg.received_on, last_hum);
         }
       }
+      else if (chan->type == KNX_ENERGY_VOLTAGE) // Reply KNX_ENERGY_VOLTAGE
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.voltage[0]);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.voltage[0]);
+            knx.answer_4byte_float(msg.received_on, Energy.voltage[0]);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_CURRENT) // Reply KNX_ENERGY_CURRENT
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.current[0]);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.current[0]);
+            knx.answer_4byte_float(msg.received_on, Energy.current[0]);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_POWER) // Reply KNX_ENERGY_POWER
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.active_power[0]);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.active_power[0]);
+            knx.answer_4byte_float(msg.received_on, Energy.active_power[0]);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_POWERFACTOR) // Reply KNX_ENERGY_POWERFACTOR
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.power_factor[0]);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.power_factor[0]);
+            knx.answer_4byte_float(msg.received_on, Energy.power_factor[0]);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_START) // Reply KNX_ENERGY_START
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.start_energy);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.start_energy);
+            knx.answer_4byte_float(msg.received_on, Energy.start_energy);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_DAILY) // Reply KNX_ENERGY_DAILY
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.daily);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.daily);
+            knx.answer_4byte_float(msg.received_on, Energy.daily);
+          }
+        }
+      }
+      else if (chan->type == KNX_ENERGY_TOTAL) // Reply KNX_ENERGY_TOTAL
+      {
+        if (Energy.data_valid[0]) {
+          knx.answer_4byte_float(msg.received_on, Energy.total);
+          if (Settings.flag.knx_enable_enhancement) {
+            knx.answer_4byte_float(msg.received_on, Energy.total);
+            knx.answer_4byte_float(msg.received_on, Energy.total);
+          }
+        }
+      }
 #ifdef USE_RULES
       else if ((chan->type >= KNX_SLOT1) && (chan->type <= KNX_SLOT5)) // KNX RX SLOTs (read command)
       {


### PR DESCRIPTION
## Description:

KNX: Add Read reply for Power

This fix adds:

_RAM: + 0 bytes
Flash: + 384 bytes for KNX version_

**Related issue (if applicable):** fixes #9236

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
