### PR TITLE
Fingerprint reader translation

### DIFF
--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -881,7 +881,7 @@
 #define D_FP_IMAGEFAIL "Abbildungsfehler"               // 0x03 Failed to enroll the finger
 #define D_FP_IMAGEMESS "schlechtes Abbild"              // 0x06 Failed to generate character file due to overly disorderly fingerprint image
 #define D_FP_FEATUREFAIL "Fingerabdruck zu klein"       // 0x07 Failed to generate character file due to the lack of character point or small fingerprint image
-#define D_FP_NOMATCH "keine Übereinstimmung "           // 0x08 Finger doesn't match
+#define D_FP_NOMATCH "keine Übereinstimmung"           // 0x08 Finger doesn't match
 #define D_FP_NOTFOUND "keinen Eintrag gefunden"         // 0x09 Failed to find matching finger
 #define D_FP_ENROLLMISMATCH "Fingerabdruck fehlerhaft"  // 0x0A Failed to combine the character files
 #define D_FP_BADLOCATION "Eintrag Fehler"               // 0x0B Addressed PageID is beyond the finger library

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -488,7 +488,7 @@
 #define D_START_SIGNAL_LOW "Startausschlag niedrig"
 #define D_START_SIGNAL_HIGH "Startausschlag hoch"
 #define D_PULSE "Puls"
-#define D_CHECKSUM_FAILURE "Checksum-Fehler"
+#define D_CHECKSUM_FAILURE "Prüfsummen-Fehler"
 
 // xsns_07_sht1x.ino
 #define D_SENSOR_DID_NOT_ACK_COMMAND "Sensor hat ACK-Befehl nicht ausgeführt"
@@ -866,37 +866,37 @@
 #define D_MAX_CURRENT     "max. Stromstärke"
 
 // xsns_79_as608.ino
-#define D_FP_ENROLL_PLACEFINGER "Place finger"
-#define D_FP_ENROLL_REMOVEFINGER "Remove finger"
-#define D_FP_ENROLL_PLACESAMEFINGER "Place same finger again"
-#define D_FP_ENROLL_RETRY "Error so retry"
-#define D_FP_ENROLL_RESTART "Restart"
-#define D_FP_ENROLL_ERROR "Error"
-#define D_FP_ENROLL_RESET "Reset"
-#define D_FP_ENROLL_ACTIVE "Active"
-#define D_FP_ENROLL_INACTIVE "Inactive"
+#define D_FP_ENROLL_PLACEFINGER "Finger auflegen"
+#define D_FP_ENROLL_REMOVEFINGER "Finger entfernen"
+#define D_FP_ENROLL_PLACESAMEFINGER "gleichen Finger auflegen"
+#define D_FP_ENROLL_RETRY "Fehler - wiederholen"
+#define D_FP_ENROLL_RESTART "Neustart"
+#define D_FP_ENROLL_ERROR "Fehler"
+#define D_FP_ENROLL_RESET "Zurücksetzen"
+#define D_FP_ENROLL_ACTIVE "Aktiv"
+#define D_FP_ENROLL_INACTIVE "Inaktiv"
 // Indexed by Adafruit_Fingerprint.h defines
-#define D_FP_PACKETRECIEVEERR "Comms error"    // 0x01 Error when receiving data package
-#define D_FP_NOFINGER ""                       // 0x02 No finger on the sensor
-#define D_FP_IMAGEFAIL "Imaging error"         // 0x03 Failed to enroll the finger
-#define D_FP_IMAGEMESS "Image too messy"       // 0x06 Failed to generate character file due to overly disorderly fingerprint image
-#define D_FP_FEATUREFAIL "Fingerprint too small" // 0x07 Failed to generate character file due to the lack of character point or small fingerprint image
-#define D_FP_NOMATCH "No match"                // 0x08 Finger doesn't match
-#define D_FP_NOTFOUND "Did not find a match"   // 0x09 Failed to find matching finger
-#define D_FP_ENROLLMISMATCH "Fingerprint did not match" // 0x0A Failed to combine the character files
-#define D_FP_BADLOCATION "Bad location"        // 0x0B Addressed PageID is beyond the finger library
-#define D_FP_DBRANGEFAIL "DB range error"      // 0x0C Error when reading template from library or invalid template
-#define D_FP_UPLOADFEATUREFAIL "Upload feature error" // 0x0D Error when uploading template
-#define D_FP_PACKETRESPONSEFAIL "Packet response error" // 0x0E Module failed to receive the following data packages
-#define D_FP_UPLOADFAIL "Upload error"         // 0x0F Error when uploading image
-#define D_FP_DELETEFAIL "Delete error"         // 0x10 Failed to delete the template
-#define D_FP_DBCLEARFAIL "DB Clear error"      // 0x11 Failed to clear finger library
-#define D_FP_PASSFAIL "Password error"         // 0x13 Find whether the fingerprint passed or failed
-#define D_FP_INVALIDIMAGE "Image invalid"      // 0x15 Failed to generate image because of lac of valid primary image
-#define D_FP_FLASHERR "Flash write error"      // 0x18 Error when writing flash
-#define D_FP_INVALIDREG "Invalid number"       // 0x1A Invalid register number
-#define D_FP_ADDRCODE "Address code"           // 0x20 Address code
-#define D_FP_PASSVERIFY "Password verified"    // 0x21 Verify the fingerprint passed
-#define D_FP_UNKNOWNERROR "Error"              // Any other error
+#define D_FP_PACKETRECIEVEERR "Kommunikationsfehler"    // 0x01 Error when receiving data package
+#define D_FP_NOFINGER ""                                // 0x02 No finger on the sensor
+#define D_FP_IMAGEFAIL "Abbildungsfehler"               // 0x03 Failed to enroll the finger
+#define D_FP_IMAGEMESS "schlechtes Abbild"              // 0x06 Failed to generate character file due to overly disorderly fingerprint image
+#define D_FP_FEATUREFAIL "Fingerabdruck zu klein"       // 0x07 Failed to generate character file due to the lack of character point or small fingerprint image
+#define D_FP_NOMATCH "keine Übereinstimmung "           // 0x08 Finger doesn't match
+#define D_FP_NOTFOUND "keinen Eintrag gefunden"         // 0x09 Failed to find matching finger
+#define D_FP_ENROLLMISMATCH "Fingerabdruck fehlerhaft"  // 0x0A Failed to combine the character files
+#define D_FP_BADLOCATION "Eintrag Fehler"               // 0x0B Addressed PageID is beyond the finger library
+#define D_FP_DBRANGEFAIL "Datenbankfehler"              // 0x0C Error when reading template from library or invalid template
+#define D_FP_UPLOADFEATUREFAIL "Speicherfehler"         // 0x0D Error when uploading template
+#define D_FP_PACKETRESPONSEFAIL "Auslesefehler"         // 0x0E Module failed to receive the following data packages
+#define D_FP_UPLOADFAIL "Bildspeicherfehler"            // 0x0F Error when uploading image
+#define D_FP_DELETEFAIL "Löschfehler"                   // 0x10 Failed to delete the template
+#define D_FP_DBCLEARFAIL "Datenbanklöschfehler"         // 0x11 Failed to clear finger library
+#define D_FP_PASSFAIL "keine Übereinstimmung"           // 0x13 Find whether the fingerprint passed or failed
+#define D_FP_INVALIDIMAGE "Abbild ungültig"             // 0x15 Failed to generate image because of lac of valid primary image
+#define D_FP_FLASHERR "Flash Schreibfehler"             // 0x18 Error when writing flash
+#define D_FP_INVALIDREG "Ungültige ID-Nummer"           // 0x1A Invalid register number
+#define D_FP_ADDRCODE "Addresse"                        // 0x20 Address code
+#define D_FP_PASSVERIFY "Übereinstimmung"               // 0x21 Verify the fingerprint passed
+#define D_FP_UNKNOWNERROR "Fehler"                      // Any other error
 
 #endif  // _LANGUAGE_DE_DE_H_


### PR DESCRIPTION
Is the entry line 218 `#define D_PATCH_ISSUE_2186` still used anywhere?

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
