### PR TITLE
Fix PlatformIO build for zbbridge.

### DIFF
--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -65,7 +65,7 @@ build_flags             = ${common.build_flags} ${irremoteesp_full.build_flags} 
 [env:tasmota-zbbridge]
 build_flags             = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
 board_build.f_cpu       = 160000000L
-lib_extra_dirs          = lib/lib_ssl
+lib_extra_dirs          = lib/lib_ssl, lib/lib_i2c
 
 [env:tasmota-BG]
 build_flags             = ${common.build_flags} -DMY_LANGUAGE=bg_BG


### PR DESCRIPTION
Compilation using PIO environment tasmota-zbbridge fails with error:
...Tasmota/tasmota/xdrv_10_rules.ino:103:26: fatal error: LinkedList.h: No such file or directory

LinkedList.h is part of i2c library and lib_extra_dirs include only lib_ssl.
Adding lib/lib_i2c to lib_extra_dirs for env:tasmota-zbbridge fixes build.

## Description:

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
