### PR TITLE
comparison should be >=

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1168,7 +1168,7 @@ int ResponseJsonEndEnd(void)
 
 #ifdef ESP8266
 uint16_t GpioConvert(uint8_t gpio) {
-  if (gpio > ARRAY_SIZE(kGpioConvert)) {
+  if (gpio >= ARRAY_SIZE(kGpioConvert)) {
     return AGPIO(GPIO_USER);
   }
   return pgm_read_word(kGpioConvert + gpio);


### PR DESCRIPTION
## Description:

I feel the comparison should be `>=` instead of `>` in 
```
uint16_t GpioConvert(uint8_t gpio) {
  if (gpio > ARRAY_SIZE(kGpioConvert)) {
    return AGPIO(GPIO_USER);
  }
  return pgm_read_word(kGpioConvert + gpio);
}
```
## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [-] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
