### PR TITLE
Add compile option for PWM variant

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -93,6 +93,9 @@ platform_packages           = framework-arduinoespressif8266 @ https://github.co
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
 build_flags                 = ${esp82xx_defaults.build_flags}
+; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
+                              ;-DWAVEFORM_LOCKED_PHASE
+                              -DWAVEFORM_LOCKED_PWM
                               -Wno-switch-unreachable
 
 


### PR DESCRIPTION
in latest Arduino Stage there is now the possibility to choose between two variants how software PWM is implemented.
Arduino PR 7022 and PR 7231.

Tasmota can use both. 

**Default for Tasmota is the PR7231 (Locked PWM).** This variant is used in Tasmota ESP8266 core 2.7.4.7 too 
With PR7022 (Locked Phase) in some seldom cases a WDT occours when using PWMi

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 stage
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
