### PR TITLE
Zigbee save data to EEPROM only if time is valid

### DIFF
--- a/tasmota/xdrv_23_zigbee_4b_eeprom.ino
+++ b/tasmota/xdrv_23_zigbee_4b_eeprom.ino
@@ -203,7 +203,7 @@ class SBuffer hibernateDeviceData(const struct Z_Device & device, bool mqtt = fa
  * 
 \*********************************************************************************************/
 void hibernateAllData(void) {
-
+  if (Rtc.utc_time < START_VALID_TIME) { return; }
   if (!zigbee.eeprom_ready) { return; }
 
   ZFS_Write_File write_data(ZIGB_DATA2);


### PR DESCRIPTION
## Description:

Make sure the current time is valid before storing to EEPROM, to avoid any nasty side effect.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
