### PR TITLE
NimBLE-lib: support single core ESP32 variants

### DIFF
--- a/lib/libesp32/NimBLE-Arduino/src/esp-hci/src/esp_nimble_hci.c
+++ b/lib/libesp32/NimBLE-Arduino/src/esp-hci/src/esp_nimble_hci.c
@@ -30,7 +30,9 @@
 #include "esp_bt.h"
 #include "freertos/semphr.h"
 #include "esp_compiler.h"
+#ifndef CONFIG_FREERTOS_UNICORE
 #include "esp_ipc.h"
+#endif
 
 #define NIMBLE_VHCI_TIMEOUT_MS  2000
 
@@ -98,7 +100,9 @@ int ble_hci_trans_hs_cmd_tx(uint8_t *cmd)
 
     if (xSemaphoreTake(vhci_send_sem, NIMBLE_VHCI_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
         if (xPortGetCoreID() != 0) {
+#ifndef CONFIG_FREERTOS_UNICORE
             esp_ipc_call_blocking(0, ble_hci_trans_hs_cmd_tx_on_core_0, cmd);
+#endif
         } else {
             ble_hci_trans_hs_cmd_tx_on_core_0(cmd);
         }
@@ -147,7 +151,9 @@ int ble_hci_trans_hs_acl_tx(struct os_mbuf *om)
 
     if (xSemaphoreTake(vhci_send_sem, NIMBLE_VHCI_TIMEOUT_MS / portTICK_PERIOD_MS) == pdTRUE) {
         if (xPortGetCoreID() != 0) {
+#ifndef CONFIG_FREERTOS_UNICORE
             esp_ipc_call_blocking(0, ble_hci_trans_hs_acl_tx_on_core_0, om);
+#endif
         } else {
             ble_hci_trans_hs_acl_tx_on_core_0(om);
         }


### PR DESCRIPTION
## Description:

In preparation for upcoming single core support, this change is necessary for the NimBLE-lib. It was already tested with an experimental core build with the MI_ESP32 driver and seems to work fine.
The needed additions to the build system will be done by @Jason2866 in the next few days.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
