### PR TITLE
Document state of USE_PING at BUILDS.md

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -28,8 +28,8 @@
 | USE_EXPRESSION        | - | - | - | - | - | - | - |
 | SUPPORT_IF_STATEMENT  | - | - | - | - | - | - | - |
 | USE_HOTPLUG           | - | - | - | - | - | - | - |
-| USE_PROMETHEUS        | - | - | - | - | - | - | - | Enables the `/metrics` endpoint
-| USE_PING              | - | - | - | - | - | - | - | Enables the `ping` command
+| USE_PROMETHEUS        | - | - | - | - | - | - | - |
+| USE_PING              | - | - | - | - | - | - | - |
 |                       |   |   |   |   |   |   |   |
 | Feature or Sensor     | minimal | lite | tasmota | knx | sensors | ir | display | Remarks
 | ROTARY_V1             | - | - | x | - | x | - | - |

--- a/BUILDS.md
+++ b/BUILDS.md
@@ -29,6 +29,7 @@
 | SUPPORT_IF_STATEMENT  | - | - | - | - | - | - | - |
 | USE_HOTPLUG           | - | - | - | - | - | - | - |
 | USE_PROMETHEUS        | - | - | - | - | - | - | - | Enables the `/metrics` endpoint
+| USE_PING              | - | - | - | - | - | - | - | Enables the `ping` command
 |                       |   |   |   |   |   |   |   |
 | Feature or Sensor     | minimal | lite | tasmota | knx | sensors | ir | display | Remarks
 | ROTARY_V1             | - | - | x | - | x | - | - |


### PR DESCRIPTION
## Description:

As far I can see it's disabled for all builds, as according to `tasmota/my_user_config.h` it is `+2k code`.

**Related issue (if applicable):** fixes #9939 and fixes #9078
## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
