### PR TITLE
Zigbee better support for attribute Reachable

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -832,6 +832,9 @@ public:
   bool isHueBulbHidden(uint16_t shortaddr) const ;
   Z_Data_Light & getLight(uint16_t shortaddr);
 
+  // device is reachable
+  void deviceWasReached(uint16_t shortaddr);
+
   // Timers
   void resetTimersForDevice(uint16_t shortaddr, uint16_t groupaddr, uint8_t category, uint16_t cluster = 0xFFFF, uint8_t endpoint = 0xFF);
   void setTimer(uint16_t shortaddr, uint16_t groupaddr, uint32_t wait_ms, uint16_t cluster, uint8_t endpoint, uint8_t category, uint32_t value, Z_DeviceTimer func);

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -320,6 +320,15 @@ void Z_Device::setLastSeenNow(void) {
   last_seen = Rtc.utc_time;
 }
 
+void Z_Devices::deviceWasReached(uint16_t shortaddr) {
+  // since we just receveived data from the device, it is reachable
+  zigbee_devices.resetTimersForDevice(shortaddr, 0 /* groupaddr */, Z_CAT_REACHABILITY);    // remove any reachability timer already there
+  Z_Device & device = findShortAddr(shortaddr);
+  if (device.valid()) {
+    device.setReachable(true);     // mark device as reachable
+  }
+}
+
 // get the next sequance number for the device, or use the global seq number if device is unknown
 uint8_t Z_Devices::getNextSeqNumber(uint16_t shortaddr) {
   Z_Device & device = findShortAddr(shortaddr);

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -200,6 +200,10 @@ void Z_ReadAttrCallback(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster
 void Z_Unreachable(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
   if (BAD_SHORTADDR != shortaddr) {
     zigbee_devices.getShortAddr(shortaddr).setReachable(false);     // mark device as reachable
+    Z_attribute_list attr_list;
+    attr_list.addAttribute(F("Reachable")).setBool(false);        // "Reachable":false
+    // Z_postProcessAttributes(shortaddr, endpoint, attr_list);  // make sure all is updated accordingly
+    zigbee_devices.jsonPublishNow(shortaddr, attr_list);
   }
 }
 

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1044,6 +1044,9 @@ void CmndZbProbeOrPing(boolean probe) {
   uint16_t shortaddr = zigbee_devices.parseDeviceFromName(XdrvMailbox.data, true).shortaddr;
   if (BAD_SHORTADDR == shortaddr) { ResponseCmndChar_P(PSTR("Unknown device")); return; }
 
+  // set a timer for Reachable - 2s default value
+  zigbee_devices.setTimer(shortaddr, 0, Z_CAT_REACHABILITY_TIMEOUT, 0, 0, Z_CAT_REACHABILITY, 0 /* value */, &Z_Unreachable);
+
   // everything is good, we can send the command
   Z_SendIEEEAddrReq(shortaddr);
   if (probe) {


### PR DESCRIPTION
## Description:

Add reporting of attribute `"Reachable":false` when a command is sent to a device but it is unrachable.
Reachability can also be tested with `ZbPing <device>`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
