### PR TITLE
add EXPERIMENTAL ESP32solo1 support

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -35,6 +35,7 @@ default_envs =
 ;                tasmota32-display
 ;                tasmota32-ir
 ;                tasmota32-ircustom
+;                tasmota32solo1
 
 
 [common]
@@ -158,6 +159,13 @@ lib_extra_dirs              =
 ; *** Mostly not used functions. Recommended to disable
                               lib/lib_div
 
+; *** EXPERIMENTAL Tasmota version for ESP32solo1 (used in some Xiaomi devices)
+[env:tasmota32solo1]
+extends                     = env:tasmota32
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-96a8ff518.tar.gz
+                              platformio/tool-esptoolpy @ ~1.30000.0
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${common32.build_flags} -DFIRMWARE_LITE
 
 
 ; *** Debug version used for PlatformIO Home Project Inspection

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -162,7 +162,7 @@ lib_extra_dirs              =
 ; *** EXPERIMENTAL Tasmota version for ESP32solo1 (used in some Xiaomi devices)
 [env:tasmota32solo1]
 extends                     = env:tasmota32
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-96a8ff518.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-4b325f52e.tar.gz
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${common32.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -165,7 +165,7 @@ extends                     = env:tasmota32
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-96a8ff518.tar.gz
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${common32.build_flags} -DFIRMWARE_LITE
+build_flags                 = ${common32.build_flags}
 
 
 ; *** Debug version used for PlatformIO Home Project Inspection


### PR DESCRIPTION
## Description:

support is EXPERIMENTAL!! -> You walk alone :-)  Feedback is welcome in Discord

Adds in `Platformio_override_sample.ini ` the env: tasmota32solo1
To enable remove `;` in line 38 

All the researches for and the needed code changes are done from @Staars 
With this PR the needed framwork is provided to get #9943 going :-)

Have Phun hacking your Xiaomi devices which often do have this special OEM ESP32 variant

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32solo1-4b325f52e
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
