### PR TITLE
Zigbee save data to EEPROM every hour

### DIFF
--- a/tasmota/xdrv_23_zigbee_4b_eeprom.ino
+++ b/tasmota/xdrv_23_zigbee_4b_eeprom.ino
@@ -227,4 +227,22 @@ void hibernateAllData(void) {
 #endif // USE_ZIGBEE_EZSP
 }
 
+/*********************************************************************************************\
+ * Timer to save every 60 minutes
+\*********************************************************************************************/
+const uint32_t Z_SAVE_DATA_TIMER = 60 * 60 * 1000;       // save data every 60 minutes (in ms)
+
+//
+// Callback for setting the timer to save Zigbee Data in x seconds
+//
+int32_t Z_Set_Save_Data_Timer(uint8_t value) {
+  zigbee_devices.setTimer(0x0000, 0, Z_SAVE_DATA_TIMER, 0, 0, Z_CAT_ALWAYS, 0 /* value */, &Z_SaveDataTimer);
+  return 0;                              // continue
+}
+
+void Z_SaveDataTimer(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  hibernateAllData();
+  Z_Set_Save_Data_Timer(0);     // set a new timer
+}
+
 #endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -870,6 +870,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_CALL(&Z_Prepare_EEPROM, 0)
     ZI_CALL(&Z_Load_Devices, 0)
     ZI_CALL(&Z_Load_Data, 0)
+    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
     ZI_CALL(&Z_Query_Bulbs, 0)
 
   ZI_LABEL(ZIGBEE_LABEL_MAIN_LOOP)


### PR DESCRIPTION
## Description:

Automatically save Zigbee data every hour. Equivalent to `ZbSave 2`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
