### PR TITLE
silence compiler warning

### DIFF
--- a/tasmota/xsns_24_si1145.ino
+++ b/tasmota/xsns_24_si1145.ino
@@ -202,7 +202,7 @@ uint16_t Si1145ReadHalfWord(uint8_t reg)
   return I2cRead16LE(SI114X_ADDR, reg);
 }
 
-bool Si1145WriteByte(uint8_t reg, uint16_t val)
+void Si1145WriteByte(uint8_t reg, uint16_t val)
 {
   I2cWrite8(SI114X_ADDR, reg, val);
 }

--- a/tasmota/xsns_57_tsl2591.ino
+++ b/tasmota/xsns_57_tsl2591.ino
@@ -52,7 +52,7 @@ void Tsl2591Init(void)
   }
 }
 
-bool Tsl2591Read(void)
+void Tsl2591Read(void)
 {
   uint32_t lum = tsl.getFullLuminosity();
   uint16_t ir, full;


### PR DESCRIPTION
## Description:

Pure cosmetical change.
The functions are used as "void returning" in the rest of both drivers, so we declare them void now.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
