### PR TITLE
common anode 7 segment display support

### DIFF
--- a/tasmota/xdsp_11_sevenseg.ino
+++ b/tasmota/xdsp_11_sevenseg.ino
@@ -34,9 +34,30 @@ uint8_t sevenseg_state = 0;
 
 /*********************************************************************************************/
 
+#ifdef USE_DISPLAY_SEVENSEG_COMMON_ANODE
+void bufferStuffer(uint32_t i) {
+  uint8_t outArray[8] = {0,0,0,0,0,0,0,0};
+  uint8_t v;
+
+  for (int j = 0; j < 8; j++) {
+    for (int k = 0; k < 8; k++) {
+      v = ((sevenseg[i]->displaybuffer[j] >> k) & 1);
+      outArray[k] |= (v << j);
+    }
+  }
+
+  for (int j = 0; j < 8; j++) {
+    sevenseg[i]->displaybuffer[j] = outArray[j];
+  }
+}
+#endif
+
 void SevensegWrite(void)
 {
   for (uint32_t i = 0; i < sevensegs; i++) {
+#ifdef USE_DISPLAY_SEVENSEG_COMMON_ANODE
+    bufferStuffer(i);
+#endif
     sevenseg[i]->writeDisplay();
   }
 }
@@ -48,7 +69,6 @@ void SevensegClear(void)
   }
   SevensegWrite();
 }
-
 
 /*********************************************************************************************/
 
@@ -254,6 +274,9 @@ void SevensegDrawStringAt(uint16_t x, uint16_t y, char *str, uint16_t color, uin
     sevenseg[unit]->writeDigitRaw(2, dots);
   }
 
+#ifdef USE_DISPLAY_SEVENSEG_COMMON_ANODE
+  bufferStuffer(unit);
+#endif
   sevenseg[unit]->writeDisplay();
 }
 
@@ -309,6 +332,9 @@ void SevensegTime(boolean time_24)
   }
 
   sevenseg[0]->writeDigitRaw(2, dots |= ((second%2) << 1));
+#ifdef USE_DISPLAY_SEVENSEG_COMMON_ANODE
+  bufferStuffer(0);
+#endif
   sevenseg[0]->writeDisplay();
 }
 


### PR DESCRIPTION
## Description:
This patch adds support for common anode 7 segment displays. Though there aren't any notable commercial units in the market, there's still some use in supporting common anode wiring when hacking an ESP into an existing device which uses a CA display.

The actual code change required is effectively a 90 degree rotation of the display buffer matrix, which splits a 7-segment display character into 8 bits spread across the same bit position in 8 register bytes of the HT16K33 driver chip.

This is fully tested on the ESP8266, and although I don't currently have an ESP32 to test with, there's basically no reason it wouldn't work identically on the ESP32 cpu.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
