### PR TITLE
Correct frame and buffer size for PMS3003 sensor

### DIFF
--- a/tasmota/xsns_18_pms5003.ino
+++ b/tasmota/xsns_18_pms5003.ino
@@ -98,7 +98,7 @@ bool PmsReadData(void)
     PmsSerial->read();
   }
 #ifdef PMS_MODEL_PMS3003
-  if (PmsSerial->available() < 22) {
+  if (PmsSerial->available() < 24) {
 #else
   if (PmsSerial->available() < 32) {
 #endif  // PMS_MODEL_PMS3003
@@ -106,8 +106,8 @@ bool PmsReadData(void)
   }
 
 #ifdef PMS_MODEL_PMS3003
-  uint8_t buffer[22];
-  PmsSerial->readBytes(buffer, 22);
+  uint8_t buffer[24];
+  PmsSerial->readBytes(buffer, 24);
 #else
   uint8_t buffer[32];
   PmsSerial->readBytes(buffer, 32);
@@ -116,14 +116,14 @@ bool PmsReadData(void)
   PmsSerial->flush();  // Make room for another burst
 
 #ifdef PMS_MODEL_PMS3003
-  AddLogBuffer(LOG_LEVEL_DEBUG_MORE, buffer, 22);
+  AddLogBuffer(LOG_LEVEL_DEBUG_MORE, buffer, 24);
 #else
   AddLogBuffer(LOG_LEVEL_DEBUG_MORE, buffer, 32);
 #endif  // PMS_MODEL_PMS3003
 
   // get checksum ready
 #ifdef PMS_MODEL_PMS3003
-  for (uint32_t i = 0; i < 20; i++) {
+  for (uint32_t i = 0; i < 22; i++) {
 #else
   for (uint32_t i = 0; i < 30; i++) {
 #endif  // PMS_MODEL_PMS3003
@@ -131,8 +131,8 @@ bool PmsReadData(void)
   }
   // The data comes in endian'd, this solves it so it works on all platforms
 #ifdef PMS_MODEL_PMS3003
-  uint16_t buffer_u16[10];
-  for (uint32_t i = 0; i < 10; i++) {
+  uint16_t buffer_u16[11];
+  for (uint32_t i = 0; i < 11; i++) {
 #else
   uint16_t buffer_u16[15];
   for (uint32_t i = 0; i < 15; i++) {
@@ -141,7 +141,7 @@ bool PmsReadData(void)
     buffer_u16[i] += (buffer[2 + i*2] << 8);
   }
 #ifdef PMS_MODEL_PMS3003
-  if (sum != buffer_u16[9]) {
+  if (sum != buffer_u16[10]) {
 #else
   if (sum != buffer_u16[14]) {
 #endif  // PMS_MODEL_PMS3003
@@ -150,7 +150,7 @@ bool PmsReadData(void)
   }
 
 #ifdef PMS_MODEL_PMS3003
-  memcpy((void *)&pms_data, (void *)buffer_u16, 20);
+  memcpy((void *)&pms_data, (void *)buffer_u16, 22);
 #else
   memcpy((void *)&pms_data, (void *)buffer_u16, 30);
 #endif  // PMS_MODEL_PMS3003


### PR DESCRIPTION
The PMS3003 had wrong size of frames and buffer set, so the sensor did not work. These changes correct the sizes to the ones found on the datasheet. Tested on real hardware.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
