### PR TITLE
Zigbee store devices information in EEPROM

### DIFF
--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -190,11 +190,6 @@ class SBuffer hibernateDevices(void) {
     buf.addBuffer(buf_device);
   }
 
-  size_t buf_len = buf.len();
-  if (buf_len > 2040) {
-    AddLog_P(LOG_LEVEL_ERROR, PSTR(D_LOG_ZIGBEE "Devices list too big to fit in Flash (%d)"), buf_len);
-  }
-
   return buf;
 }
 
@@ -296,6 +291,11 @@ void hydrateDevices(const SBuffer &buf, uint32_t version) {
 
 // dump = true, only dump to logs, don't actually load
 void loadZigbeeDevices(bool dump_only = false) {
+#ifdef USE_ZIGBEE_EZSP
+  if (loadZigbeeDevicesFromEEPROM()) {
+    return;       // we succesfully loaded from EEPROM, skip the read from Flash
+  }
+#endif
 #ifdef ESP32
   // first copy SPI buffer into ram
   uint8_t *spi_buffer = (uint8_t*) malloc(z_spi_len);
@@ -319,7 +319,7 @@ void loadZigbeeDevices(bool dump_only = false) {
     // parse what seems to be a valid entry
     SBuffer buf(buf_len);
     buf.addBuffer(z_dev_start + sizeof(Z_Flashentry), buf_len);
-    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee device information in Flash (%d bytes)"), buf_len);
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee device information in %s (%d bytes)"), PSTR("Flash"), buf_len);
 
     if (dump_only) {
       size_t buf_len = buf.len();
@@ -333,7 +333,7 @@ void loadZigbeeDevices(bool dump_only = false) {
       zigbee_devices.clean();   // don't write back to Flash what we just loaded
     }
   } else {
-    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "No Zigbee device information in Flash"));
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "No Zigbee device information in %s"), PSTR("Flash"));
   }
 #ifdef ESP32
   free(spi_buffer);
@@ -341,9 +341,16 @@ void loadZigbeeDevices(bool dump_only = false) {
 }
 
 void saveZigbeeDevices(void) {
+#ifdef USE_ZIGBEE_EZSP
+  if (zigbee.eeprom_ready) {
+    if (hibernateDevicesInEEPROM()) {
+      return;   // saved in EEPROM successful, non need to write in Flash
+    }
+  }
+#endif
   SBuffer buf = hibernateDevices();
   size_t buf_len = buf.len();
-  if (buf_len > Z_MAX_FLASH) {
+  if (buf_len > 2040) {
     AddLog_P(LOG_LEVEL_ERROR, PSTR(D_LOG_ZIGBEE "Buffer too big to fit in Flash (%d bytes)"), buf_len);
     return;
   }
@@ -376,7 +383,7 @@ void saveZigbeeDevices(void) {
   AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data store in Flash (0x%08X - %d bytes)"), z_dev_start, buf_len);
 #else  // ESP32
   ZigbeeWrite(&spi_buffer, z_spi_len);
-  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data saved (%d bytes)"), buf_len);
+  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data saved in %s (%d bytes)"), PSTR("Flash"), buf_len);
 #endif  // ESP8266 - ESP32
   free(spi_buffer);
 }

--- a/tasmota/xdrv_23_zigbee_4a_nano_fs.ino
+++ b/tasmota/xdrv_23_zigbee_4a_nano_fs.ino
@@ -20,7 +20,6 @@
 #ifdef USE_ZIGBEE
 #ifdef USE_ZIGBEE_EZSP
 
-#include <memory>
 #define Z_EEPROM_DEBUG
 
 // The EEPROM is 64KB in size with individually writable bytes.
@@ -274,7 +273,7 @@ public:
   static void erase(void);              // erase EEPROM
 
   // read file
-  static int32_t readBytes(uint32_t name, uint8_t* buffer, size_t buffer_len, uint16_t start, uint16_t len);
+  static int32_t readBytes(uint32_t name, void* buffer, size_t buffer_len, uint16_t start, uint16_t len);
 };
 
 /*********************************************************************************************\
@@ -322,7 +321,7 @@ void ZFS::erase(void) {
  * Reading a file
  * 
 \*********************************************************************************************/
-int32_t ZFS::readBytes(uint32_t name, uint8_t* buffer, size_t buffer_len, uint16_t read_start, uint16_t read_len) {
+int32_t ZFS::readBytes(uint32_t name, void* buffer, size_t buffer_len, uint16_t read_start, uint16_t read_len) {
   if (!zigbee.eeprom_ready) { return -1; }
 #ifdef Z_EEPROM_DEBUG
     // AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "readBytes name=%08X, buffer_len=%d, read_start=0x%04X, read_len=%d"), name, buffer_len, read_start, read_len);
@@ -365,9 +364,9 @@ void ZFS::initOrFormat(void) {
     char hex_char[(256 * 2) + 2];
     zigbee.eeprom.readBytes(0x0000, 256, map);
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "BLK 00 %s"), ToHex_P(map, sizeof(map), hex_char, sizeof(hex_char)));
-    zigbee.eeprom.readBytes(0x0100, 256, map);
+    // zigbee.eeprom.readBytes(0x0100, 256, map);
     // AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "BLK 01 %s"), ToHex_P(map, sizeof(map), hex_char, sizeof(hex_char)));
-    // zigbee.eeprom.readBytes(0x0200, 256, map);
+    zigbee.eeprom.readBytes(0x0200, 256, map);
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "BLK 02 %s"), ToHex_P(map, sizeof(map), hex_char, sizeof(hex_char)));
     zigbee.eeprom.readBytes(0x2100, 256, map);
     AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "BLK 21 %s"), ToHex_P(map, sizeof(map), hex_char, sizeof(hex_char)));

--- a/tasmota/xdrv_23_zigbee_7_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_statemachine.ino
@@ -369,7 +369,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_RECV_UNEXPECTED(&ZNP_Recv_Default)
-    ZI_WAIT(10500)                             // wait for 10 seconds for Tasmota to stabilize
+    ZI_WAIT(15500)                             // wait for 15 seconds for Tasmota to stabilize
 
     //ZI_MQTT_STATE(ZIGBEE_STATUS_BOOT, "Booting")
     ZI_LOG(LOG_LEVEL_INFO, D_LOG_ZIGBEE "rebooting CC2530 device")
@@ -769,7 +769,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_ON_ERROR_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_TIMEOUT_GOTO(ZIGBEE_LABEL_ABORT)
     ZI_ON_RECV_UNEXPECTED(&EZ_Recv_Default)
-    ZI_WAIT(10500)                             // wait for 10 seconds for Tasmota to stabilize
+    ZI_WAIT(15500)                             // wait for 15 seconds for Tasmota to stabilize
 
     // Hardware reset
     ZI_LOG(LOG_LEVEL_INFO, kResettingDevice)     // Log Debug: resetting EZSP device
@@ -869,8 +869,8 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_CALL(&Z_State_Ready, 1)                    // Now accept incoming messages
     ZI_CALL(&Z_Prepare_EEPROM, 0)
     ZI_CALL(&Z_Load_Devices, 0)
-    ZI_CALL(&Z_Load_Data, 0)
-    ZI_CALL(&Z_Set_Save_Data_Timer, 0)
+    ZI_CALL(&Z_Load_Data_EEPROM, 0)
+    ZI_CALL(&Z_Set_Save_Data_Timer_EEPROM, 0)
     ZI_CALL(&Z_Query_Bulbs, 0)
 
   ZI_LABEL(ZIGBEE_LABEL_MAIN_LOOP)

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1891,7 +1891,7 @@ int32_t Z_Load_Devices(uint8_t value) {
 //
 // Callback for loading Zigbee data from EEPROM, called by the state machine
 //
-int32_t Z_Load_Data(uint8_t value) {
+int32_t Z_Load_Data_EEPROM(uint8_t value) {
   hydrateDevicesDataFromEEPROM();
   return 0;                              // continue
 }


### PR DESCRIPTION
## Description:

Last step in EEPROM changes for ZBBridge. Now devices information is stored in EEPROM instead of Flash (ZBBridge only). This makes a better use of EEPROM, frees bank FF of Flash and resists `Reset 3`.

There is nothing to do, data is silently copied from Flash to EEPROM if needed.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
