### PR TITLE
IR fix SAMSUNG_AC

### DIFF
--- a/lib/lib_basic/IRremoteESP8266-2.7.12/src/IRac.cpp
+++ b/lib/lib_basic/IRremoteESP8266-2.7.12/src/IRac.cpp
@@ -2532,9 +2532,11 @@ bool IRac::sendAc(const stdAc::state_t desired, const stdAc::state_t *prev) {
     case SAMSUNG_AC:
     {
       IRSamsungAc ac(_pin, _inverted, _modulation);
+      bool prev_power = !send.power;
+      if (prev != NULL) prev_power = prev->power;
       samsung(&ac, send.power, send.mode, degC, send.fanspeed, send.swingv,
               send.quiet, send.turbo, send.light, send.filter, send.clean,
-              send.beep, prev->power);
+              send.beep, prev_power);
       break;
     }
 #endif  // SEND_SAMSUNG_AC

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -162,7 +162,7 @@ uint64_t reverseBitsInBytes64(uint64_t b) {
 \*********************************************************************************************/
 
 const bool IR_FULL_RCV_SAVE_BUFFER = false;         // false = do not use buffer, true = use buffer for decoding
-const uint32_t IR_TIME_AVOID_DUPLICATE = 500;  // Milliseconds
+const uint32_t IR_TIME_AVOID_DUPLICATE = 50;  // Milliseconds
 
 // Below is from IRrecvDumpV2.ino
 // As this program is a special purpose capture/decoder, let us use a larger
@@ -463,6 +463,7 @@ uint32_t IrRemoteCmndIrHvacJson(void)
   state.sleep = root.getInt(PSTR(D_JSON_IRHVAC_SLEEP), state.sleep);
   //if (json[D_JSON_IRHVAC_CLOCK]) { state.clock = json[D_JSON_IRHVAC_CLOCK]; }   // not sure it's useful to support 'clock'
 
+  if (irrecv != nullptr) { irrecv->disableIRIn(); }
   if (stateMode == StateModes::SEND_ONLY || stateMode == StateModes::SEND_STORE) {
     IRac ac(Pin(GPIO_IRSEND));
     bool success = ac.sendAc(state, irhvac_stateful && irac_prev_state.protocol == state.protocol ? &irac_prev_state : nullptr);
@@ -471,6 +472,7 @@ uint32_t IrRemoteCmndIrHvacJson(void)
   if (stateMode == StateModes::STORE_ONLY || stateMode == StateModes::SEND_STORE) { // store state in memory
     irac_prev_state = state;
   }
+  if (irrecv != nullptr) { irrecv->enableIRIn(); }
 
   Response_P(PSTR("{\"" D_CMND_IRHVAC "\":%s}"), sendACJsonState(state).c_str());
   return IE_RESPONSE_PROVIDED;


### PR DESCRIPTION
## Description:

Fix crash when sending commands to SAMSUNG_AC, until fixed in the library.
https://github.com/crankyoldgit/IRremoteESP8266/issues/1339

Reduce inter-messages pause to receive both SAMSUNG_AC messages.
Also disable receiving of IR messages while sending them, avoiding mirror effect and receiving the messages just sent.

**Related issue (if applicable):** fixes #9711

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
