### PR TITLE
Fix HA Discovery Issue with Uninitialized Sensors

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -1172,7 +1172,7 @@ bool Xdrv12(uint8_t function)
       break;
     case FUNC_MQTT_INIT:
       hass_mode = 0;      // Discovery only if Settings.flag.hass_discovery is set
-      hass_init_step = 2; // Delayed discovery
+      hass_init_step = 10; // Delayed discovery
       // if (!Settings.flag.hass_discovery) {
       //   NewHAssDiscovery();
       // }


### PR DESCRIPTION
## Description:

Fix HA Discovery Issue with Uninitialized Sensors

Change HA Discovery's Init delay from 2 to 10 seconds

**Related issue (if applicable):** fixes #9982

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
