### PR TITLE
Support rules that override button holds

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -171,6 +171,7 @@ struct RULES {
   uint16_t mems_event = 0;   // Bitmask supporting MAX_RULE_MEMS bits
   bool teleperiod = false;
   bool busy = false;
+  bool no_execute = false;   // Don't actually execute rule commands
 
   char event_data[100];
 } Rules;
@@ -708,6 +709,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
 #endif
 
     if (RulesRuleMatch(rule_set, event, event_trigger, stop_all_rules)) {
+      if (Rules.no_execute) return true;
       if (plen == plen2) { stop_all_rules = true; }       // If BREAK was used on a triggered rule, Stop execution of this rule set
       commands.trim();
       String ucommand = commands;

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -767,10 +767,19 @@ bool Xdrv35(uint8_t function)
 #endif  // USE_PWM_DIMMER_REMOTE
           }
 
-          // If hold time has arrived, handle it.
+          // If hold time has arrived and a rule is enabled that handles the button hold, handle it.
           else if (button_hold_time[button_index] <= now) {
-            PWMDimmerHandleButton(button_index, true);
-            button_held[button_index] = true;
+#ifdef USE_RULES
+            sprintf(TasmotaGlobal.mqtt_data, PSTR("{\"Button%u\":{\"State\":3}}"), button_index + 1);
+            Rules.no_execute = true;
+            if (!XdrvRulesProcess()) {
+#endif  // USE_RULES
+              PWMDimmerHandleButton(button_index, true);
+              button_held[button_index] = true;
+#ifdef USE_RULES
+            }
+            Rules.no_execute = false;
+#endif  // USE_RULES
           }
         }
 


### PR DESCRIPTION
## Description:

Add support for rules that override button holds. Because the hold time of buttons in PWM Dimmer is different than the SetOption32 value, button hold are processed outside the normal Tasmota button processing. This PR adds support for checking to see if a rule is active that would override a button hold. If there is, the button hold is not processed by PWM Dimmer.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
