### PR TITLE
Fix wraparound bug in backlog

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -244,8 +244,8 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len)
 
     DEBUG_CORE_LOG(PSTR("CMD: Payload %d"), payload);
 
-//    TasmotaGlobal.backlog_delay = millis() + (100 * MIN_BACKLOG_DELAY);
-    TasmotaGlobal.backlog_delay = millis() + Settings.param[P_BACKLOG_DELAY];
+//    TasmotaGlobal.backlog_timer = millis() + (100 * MIN_BACKLOG_DELAY);
+    TasmotaGlobal.backlog_timer = millis() + Settings.param[P_BACKLOG_DELAY];
 
     char command[CMDSZ] = { 0 };
     XdrvMailbox.command = command;
@@ -344,7 +344,7 @@ void CmndBacklog(void)
     }
 //    ResponseCmndChar(D_JSON_APPENDED);
     ResponseClear();
-    TasmotaGlobal.backlog_delay = 0;
+    TasmotaGlobal.backlog_timer = millis();
   } else {
     bool blflag = BACKLOG_EMPTY;
 #ifdef SUPPORT_IF_STATEMENT
@@ -359,10 +359,10 @@ void CmndBacklog(void)
 void CmndDelay(void)
 {
   if ((XdrvMailbox.payload >= (MIN_BACKLOG_DELAY / 100)) && (XdrvMailbox.payload <= 3600)) {
-    TasmotaGlobal.backlog_delay = millis() + (100 * XdrvMailbox.payload);
+    TasmotaGlobal.backlog_timer = millis() + (100 * XdrvMailbox.payload);
   }
   uint32_t bl_delay = 0;
-  long bl_delta = TimePassedSince(TasmotaGlobal.backlog_delay);
+  long bl_delta = TimePassedSince(TasmotaGlobal.backlog_timer);
   if (bl_delta < 0) { bl_delay = (bl_delta *-1) / 100; }
   ResponseCmndNumber(bl_delay);
 }

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -687,7 +687,7 @@ void stationKeepAliveNow(void) {
 }
 
 void wifiKeepAlive(void) {
-  static uint32_t wifi_timer = 0;                            // Wifi keepalive timer
+  static uint32_t wifi_timer = millis();                     // Wifi keepalive timer
 
   uint32_t wifiTimerSec = Settings.param[P_ARP_GRATUITOUS];  // 8-bits number of seconds, or minutes if > 100
 

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -84,7 +84,7 @@ struct {
   uint32_t baudrate;                        // Current Serial baudrate
   uint32_t pulse_timer[MAX_PULSETIMERS];    // Power off timer
   uint32_t blink_timer;                     // Power cycle timer
-  uint32_t backlog_delay;                   // Command backlog delay
+  uint32_t backlog_timer;                   // Timer for next command in backlog
   uint32_t loop_load_avg;                   // Indicative loop load average
   uint32_t web_log_index;                   // Index in Web log buffer
   uint32_t uptime;                          // Counting every second until 4294967295 = 130 year
@@ -319,7 +319,7 @@ void setup(void) {
 }
 
 void BacklogLoop(void) {
-  if (TimeReached(TasmotaGlobal.backlog_delay)) {
+  if (TimeReached(TasmotaGlobal.backlog_timer)) {
     if (!BACKLOG_EMPTY && !TasmotaGlobal.backlog_mutex) {
       TasmotaGlobal.backlog_mutex = true;
       bool nodelay = false;
@@ -341,7 +341,7 @@ void BacklogLoop(void) {
         ExecuteCommand((char*)cmd.c_str(), SRC_BACKLOG);
       }
       if (nodelay) {
-        TasmotaGlobal.backlog_delay = 0;  // Reset backlog_delay which has been set by ExecuteCommand (CommandHandler)
+        TasmotaGlobal.backlog_timer = millis();  // Reset backlog_timer which has been set by ExecuteCommand (CommandHandler)
       }
       TasmotaGlobal.backlog_mutex = false;
     }


### PR DESCRIPTION
## Description:

Fix wraparound bug in backlog caused by assuming that `millis` time `0` would always be in the past.
After around 25 days of uptime, `millis()` passed 2^31 and the backlog stopped working.

Also rename `backlog_delay` to `backlog_timer` + fix a similar (but more harmless) assumption in `wifiKeepAlive`

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
