### PR TITLE
HM10: do not crash with zero sensors

### DIFF
--- a/tasmota/xsns_62_MI_HM10.ino
+++ b/tasmota/xsns_62_MI_HM10.ino
@@ -1520,6 +1520,10 @@ void HM10EverySecond(bool restart){
   }
 
   if(_counter==0) {
+    if(MIBLEsensors.size() == 0){
+      _counter++;
+      return;
+    }
     HM10.state.sensor = _nextSensorSlot;
     _nextSensorSlot++;
     HM10.mode.pending_task = 1;


### PR DESCRIPTION
## Description:

Handle zero sensors without crashing.
Special thanks go to the empty batteries of @Jason2866.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
