### PR TITLE
Zigbee `ZbReset 1` also erases EEPROM

### DIFF
--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -391,6 +391,9 @@ void saveZigbeeDevices(void) {
 // Erase the flash area containing the ZigbeeData
 void eraseZigbeeDevices(void) {
   zigbee_devices.clean();     // avoid writing data to flash after erase
+#ifdef USE_ZIGBEE_EZSP
+  ZFS_Erase();
+#endif // USE_ZIGBEE_EZSP
 #ifdef ESP8266
   // first copy SPI buffer into ram
   uint8_t *spi_buffer = (uint8_t*) malloc(z_spi_len);
@@ -410,7 +413,7 @@ void eraseZigbeeDevices(void) {
   }
 
   free(spi_buffer);
-  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data erased (0x%08X - %d bytes)"), z_dev_start, z_block_len);
+  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data erased in %s"), PSTR("Flash"));
 #else  // ESP32
   ZigbeeErase();
   AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data erased (%d bytes)"), z_block_len);

--- a/tasmota/xdrv_23_zigbee_4b_eeprom.ino
+++ b/tasmota/xdrv_23_zigbee_4b_eeprom.ino
@@ -314,6 +314,14 @@ bool loadZigbeeDevicesFromEEPROM(void) {
   zigbee_devices.clean();   // don't write back to Flash what we just loaded
   return true;
 }
+
+void ZFS_Erase(void) {
+  if (zigbee.eeprom_present) {
+    ZFS::erase();
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Zigbee Devices Data erased in %s"), PSTR("EEPROM"));
+  }
+}
+
 #endif // USE_ZIGBEE_EZSP
 
 #endif // USE_ZIGBEE

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -136,6 +136,7 @@ void CmndZbReset(void) {
       ZigbeeZNPSend(ZIGBEE_FACTORY_RESET, sizeof(ZIGBEE_FACTORY_RESET));
 #endif // USE_ZIGBEE_ZNP
       eraseZigbeeDevices();
+      // no break - this is intended
     case 2:   // fall through
       Settings.zb_txradio_dbm = - abs(Settings.zb_txradio_dbm);
       TasmotaGlobal.restart_flag = 2;


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
