### PR TITLE
Zigbee fix invalid temperature #9978

### DIFF
--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1546,6 +1546,7 @@ void Z_IncomingMessage(class ZCLFrame &zcl_received) {
     }
 
     zcl_received.generateSyntheticAttributes(attr_list);
+    zcl_received.removeInvalidAttributes(attr_list);
     zcl_received.computeSyntheticAttributes(attr_list);
     zcl_received.generateCallBacks(attr_list);      // set deferred callbacks, ex: Occupancy
     Z_postProcessAttributes(srcaddr, zcl_received.getSrcEndpoint(), attr_list);


### PR DESCRIPTION
## Description:

Fixes a bug in ZbInfo when reporting negative values.
Exclude temperatures below -100°C, sometimes sent by Aqara lumi.weather.

**Related issue (if applicable):** fixes #9978 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
