### PR TITLE
Zigbee use of ZbRestore for backup

### DIFF
--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1676,8 +1676,6 @@ int32_t EZ_IncomingMessage(int32_t res, const class SBuffer &buf) {
       case ZDO_Parent_annce_rsp:
         return EZ_ParentAnnceRsp(res, zdo_buf, true);
       default:
-        // TODO move later to LOG_LEVEL_DEBUG
-        AddLog_P(LOG_LEVEL_INFO, PSTR("ZIG: Internal ZDO message 0x%04X sent from 0x%04X %s"), clusterid, srcaddr, wasbroadcast ? PSTR("(broadcast)") : "");
         break;
     }
   } else {


### PR DESCRIPTION
## Description:

You can now use `ZbRestore` command to backup all devices information.

Ex:
```
ZbRestore

15:41:25 MQT: stat/tasmota/ZBBridge/RESULT = {"ZbRestore":"ZbRestore 23D1DD45DC2822004B12004D534F31006557654C696E6B005072657A320001413FFFFF"}
15:41:25 MQT: stat/tasmota/ZBBridge/RESULT = {"ZbRestore":"ZbRestore 27054ABD1DFE02018817004C5742303130005068696C697073005068696C697073000B116FFFFF"}
...
```

To restore a single device, use the command as above.
Ex: `ZbRestore":"ZbRestore 23D1DD45DC2822004B12004D534F31006557654C696E6B005072657A320001413FFFFF`

The device short id is contained in the bytes 2 and 3, here D1DD (little endian), which is device 0xDD1D.

The dump of all devices is always done right before restart or flash and may be recorded in MQTT or syslog.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
