### PR TITLE
Fix support for using multiple MAX31865 sensors

### DIFF
--- a/tasmota/xsns_47_max31865.ino
+++ b/tasmota/xsns_47_max31865.ino
@@ -53,7 +53,7 @@ void MAX31865_Init(void) {
   for (uint32_t i = 0; i < MAX_MAX31865S; i++) {
     if (PinUsed(GPIO_SSPI_MAX31865_CS1, i)) {
       max31865_pins_used |= 1 << i;  //set lowest bit
-      max31865[0].setPins(
+      max31865[i].setPins(
         Pin(GPIO_SSPI_MAX31865_CS1, i),
         Pin(GPIO_SSPI_MOSI),
         Pin(GPIO_SSPI_MISO),


### PR DESCRIPTION
## Description:

MAX31865 sensors didn't work using more than one sensor defined

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
