### PR TITLE
Better support for PIR devices

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -427,6 +427,8 @@ public:
     }
     return false;
   }
+
+  void convertZoneStatus(Z_attribute_list & attr_list, uint16_t val) const;
   
   // 4 bytes
   uint16_t              zone_status;      // last known state for sensor 1 & 2
@@ -446,6 +448,57 @@ public:
     // 0x0226  Glass break sensor
     // 0x0229  Security repeater*
 };
+
+void Z_Data_Alarm::convertZoneStatus(Z_attribute_list & attr_list, uint16_t val) const {
+  if (validConfig()) {
+    // indicator #1, published for false and true
+    if (isPIR()) {                  // set Occupancy
+      attr_list.addAttribute(0x0406, 0x0000).setUInt(val & 0x01 ? 1 : 0);
+    } else {                              // all other cases
+      attr_list.addAttribute(0x0500, 0xFFF0 + getConfig()).setUInt(val & 0x01 ? 1 : 0);
+    }
+    // indicator #2 published only if true
+    if (val & 0x02) {
+      if (isPIR()) {                  // set Occupancy
+        attr_list.addAttribute(0x0406, 0x0000, 2).setUInt(val & 0x02 ? 1 : 0);
+      } else {                              // all other cases
+        attr_list.addAttribute(0x0500, 0xFFF0 + getConfig(), 2).setUInt(val & 0x02 ? 1 : 0);
+      }
+    }
+    // Tamper
+    if (val & 0x04) {
+      attr_list.addAttributePMEM(PSTR("Tamper")).setUInt(1);
+    }
+    // BatteryLow
+    if (val & 0x08) {
+      attr_list.addAttributePMEM(PSTR("BatteryLow")).setUInt(1);
+    }
+    // // SupervisionReports
+    // if (val & 0x10) {
+    //   attr_list.addAttributePMEM(PSTR("SupervisionReports")).setUInt(1);
+    // }
+    // // RestoreReports
+    // if (val & 0x20) {
+    //   attr_list.addAttributePMEM(PSTR("RestoreReports")).setUInt(1);
+    // }
+    // Failure
+    if (val & 0x40) {
+      attr_list.addAttributePMEM(PSTR("Failure")).setUInt(1);
+    }
+    // MainsFault
+    if (val & 0x80) {
+      attr_list.addAttributePMEM(PSTR("MainsFault")).setUInt(1);
+    }
+    // Test
+    if (val & 0x100) {
+      attr_list.addAttributePMEM(PSTR("Test")).setUInt(1);
+    }
+    // BatteryDefect
+    if (val & 0x200) {
+      attr_list.addAttributePMEM(PSTR("BatteryDefect")).setUInt(1);
+    }
+  }
+}
 
 const uint8_t Z_Data_Type_len[] PROGMEM = {
   0,                        // 0x00 Z_Data_Type::Z_Unknown

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1312,6 +1312,12 @@ void ZCLFrame::computeSyntheticAttributes(Z_attribute_list& attr_list) {
           // We create a synthetic attribute 0403/FFF0 to indicate sea level
         }
         break;
+      case 0x05000002:    // ZoneStatus
+        const Z_Data_Alarm & alarm = (const Z_Data_Alarm&) zigbee_devices.getShortAddr(_srcaddr).data.find(Z_Data_Type::Z_Alarm, _srcendpoint);
+        if (&alarm != nullptr) {
+          alarm.convertZoneStatus(attr_list, attr.getUInt());
+        }
+        break;
     }
   }
 }

--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -360,12 +360,8 @@ void convertClusterSpecific(class Z_attribute_list &attr_list, uint16_t cluster,
           }
           // Convert to "Occupancy" or to "Contact" if the device is PIR or Contact sensor
           const Z_Data_Alarm & alarm = (const Z_Data_Alarm&) zigbee_devices.getShortAddr(shortaddr).data.find(Z_Data_Type::Z_Alarm, srcendpoint);
-          if ((&alarm != nullptr) && (alarm.validConfig())) {
-            if (alarm.isPIR()) {                  // set Occupancy
-              attr_list.addAttribute(0x0406, 0x0000).setUInt((xyz.x) & 0x01 ? 1 : 0);
-            } else {                              // all other cases
-              attr_list.addAttribute(0x0500, 0xFFF0 + alarm.getConfig()).setUInt(xyz.x);
-            }
+          if (&alarm != nullptr) {
+            alarm.convertZoneStatus(attr_list, xyz.x);
           }
         }
         break;


### PR DESCRIPTION
## Description:

Better support for 0x0500 cluster (IAS) especially for devices doing attribute reporting like Lidl PIR sensor.
No need to re-pair anything to get the improvement.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
