### PR TITLE
HATasmota: Fix for shutters

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -298,6 +298,7 @@ void NewHAssDiscovery(void)
   }
 
   stemp3[0] = '\0';
+  stemp4[0] = '\0';
   // Enable Discovery for Switches only if SetOption114 is enabled
   for (uint32_t i = 0; i < MAX_SWITCHES; i++) {
     char sname[TOPSZ];
@@ -315,12 +316,13 @@ void NewHAssDiscovery(void)
     snprintf_P(stemp5, sizeof(stemp5), PSTR("%s%s%d"), stemp5, (i > 0 ? "," : ""), (SerialButton ? 1 : (PinUsed(GPIO_KEY1, i)) & Settings.flag3.mqtt_buttons));
     SerialButton = false;
   }
-
-#ifdef USE_SHUTTER
   stemp6[0] = '\0';
+#ifdef USE_SHUTTER
   for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
     snprintf_P(stemp6, sizeof(stemp6), PSTR("%s%s%d"), stemp6, (i > 0 ? "," : ""), Settings.shutter_options[i]);
   }
+#else
+   snprintf_P(stemp6, sizeof(stemp6), PSTR("0,0,0,0"));
 #endif // USE_SHUTTER
 
   ResponseClear(); // Clear retained message


### PR DESCRIPTION
## Description:
Fix shutter settings vector when `USE_SHUTTER` is not selected at compiler time.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
