### PR TITLE
Tasmota core 2.7.4.9

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -76,13 +76,16 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 
 [tasmota_stage]
-; *** Esp8266 core for Arduino version Tasmota stage (PR7231 and Backport PR7514)
-platform_packages           = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+; *** Esp8266 core for Arduino version Tasmota stage. Backport for PWM selection
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino.git#2.7.4.9
                               platformio/toolchain-xtensa @ 2.40802.200502
-                              platformio/tool-esptoolpy @ ~1.30000.0
                               platformio/tool-esptool @ 1.413.0
+                              platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
+; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
+                              ;-DWAVEFORM_LOCKED_PHASE
+                              -DWAVEFORM_LOCKED_PWM
 
 [core_stage]
 ; *** Esp8266 core for Arduino version stage


### PR DESCRIPTION
## Description:

The core 2.7.4.9 is based on core 2.7.4.7 and includes a Backport of the PWM implementation from Arduino Esp8266 stage.
Now it is possible to choose between the two new different PWM variants **Locked Phase and Locked PWM**
Tasmota uses variant Locked PWM since Tasmota core 2.7.4.7

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
