### PR TITLE
Use tasmota core 2.7.4.9 from Platformio registry

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -77,7 +77,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [tasmota_stage]
 ; *** Esp8266 core for Arduino version Tasmota stage. Backport for PWM selection
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/Jason2866/Arduino.git#2.7.4.9
+platform_packages           = tasmota/framework-arduinoespressif8266 @ ~2.7.4
                               platformio/toolchain-xtensa @ 2.40802.200502
                               platformio/tool-esptool @ 1.413.0
                               platformio/tool-esptoolpy @ ~1.30000.0


### PR DESCRIPTION
## Description:

Tasmota Core 2.7.4.9 as package from PlatformIO registry

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
