### PR TITLE
RC-Switch Protocol Disable via Console

### DIFF
--- a/lib/lib_rf/rc-switch/src/RCSwitch.cpp
+++ b/lib/lib_rf/rc-switch/src/RCSwitch.cpp
@@ -146,10 +146,7 @@ const unsigned int RCSwitch::nSeparationLimit = 2600;    // 4300 default
 // should be set to the minimum value of pulselength * the sync signal
 unsigned int RCSwitch::timings[RCSWITCH_MAX_CHANGES];
 unsigned int RCSwitch::buftimings[4];
-#ifdef BAZMODS
 uint64_t_t RCSwitch::enabled_protocol_mask;
-
-#endif
 #endif
 
 RCSwitch::RCSwitch() {
@@ -160,16 +157,12 @@ RCSwitch::RCSwitch() {
   this->nReceiverInterrupt = -1;
   this->setReceiveTolerance(60);
   RCSwitch::nReceivedValue = 0;
-#ifdef BAZMODS
   RCSwitch::enabled_protocol_mask.value =  (1ULL << numProto)-1 ;//pow(2,numProto)-1;
-#endif
   #endif
 }
-#ifdef BAZMODS
 uint8_t RCSwitch::getNumProtos(){
   return numProto;
 }
-#endif
 /**
   * Sets the protocol to send.
   */
@@ -845,21 +838,15 @@ void RECEIVE_ATTR RCSwitch::handleInterrupt() {
       repeatCount++;
       // при приеме второго повторного начинаем анализ принятого первым
       if (repeatCount == 1) {
- #ifdef BAZMODS
         unsigned long long thismask = 1;
-  #endif
         for(unsigned int i = 1; i <= numProto; i++) {
- #ifdef BAZMODS
           if(enabled_protocol_mask.value & thismask){
-#endif
             if (receiveProtocol(i, changeCount)) {
               // receive succeeded for protocol i
               break;
             }
- #ifdef BAZMODS
           }
           thismask <<= 1;
-#endif
         }
         // очищаем количество повторных пакетов
         repeatCount = 0;

--- a/lib/lib_rf/rc-switch/src/RCSwitch.h
+++ b/lib/lib_rf/rc-switch/src/RCSwitch.h
@@ -61,6 +61,17 @@
 // Для keeloq нужно увеличить RCSWITCH_MAX_CHANGES до 23+1+66*2+1=157
 #define RCSWITCH_MAX_CHANGES 67        // default 67
 
+typedef union __uint64
+{
+  uint64_t value;
+  struct
+  {
+    uint32_t low32;
+    uint32_t high32;
+    
+  } longs;
+} uint64_t_t;
+
 class RCSwitch {
 
   public:
@@ -93,6 +104,10 @@ class RCSwitch {
     unsigned int getReceivedDelay();
     unsigned int getReceivedProtocol();
     unsigned int* getReceivedRawdata();
+  #ifdef BAZMODS
+    uint8_t getNumProtos();
+    static uint64_t_t enabled_protocol_mask; //perhaps need function to change because used in interrupt
+  #endif  
     #endif
   
     void enableTransmit(int nTransmitterPin);
@@ -164,7 +179,9 @@ class RCSwitch {
     static void handleInterrupt();
     static bool receiveProtocol(const int p, unsigned int changeCount);
     int nReceiverInterrupt;
+    
     #endif
+    
     int nTransmitterPin;
     int nRepeatTransmit;
     
@@ -183,6 +200,8 @@ class RCSwitch {
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
     // буфер длительностей последних четырех пакетов, [0] - последний
     static unsigned int buftimings[4];
+
+    
     #endif
 
     

--- a/lib/lib_rf/rc-switch/src/RCSwitch.h
+++ b/lib/lib_rf/rc-switch/src/RCSwitch.h
@@ -104,10 +104,8 @@ class RCSwitch {
     unsigned int getReceivedDelay();
     unsigned int getReceivedProtocol();
     unsigned int* getReceivedRawdata();
-  #ifdef BAZMODS
     uint8_t getNumProtos();
-    static uint64_t_t enabled_protocol_mask; //perhaps need function to change because used in interrupt
-  #endif  
+    static uint64_t_t enabled_protocol_mask; //perhaps need function to change because used in interrupt 
     #endif
   
     void enableTransmit(int nTransmitterPin);

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -221,7 +221,8 @@
 
 #define D_LOG_SOME_SETTINGS_RESET "Some settings have been reset"
 
-// Commands tasmota.ino
+// Commands tasmota.ino 
+
 #define D_CMND_BACKLOG "Backlog"
 #define D_CMND_DELAY "Delay"
 #define D_CMND_NODELAY "NoDelay"
@@ -495,6 +496,9 @@
 #define D_CMND_RFSYNC "RfSync"
   #define D_JSON_RFRECEIVED "RfReceived"
 #define D_CMND_RFRAW "RfRaw"
+
+#define D_CMND_RFRXPROTOCOL "RfRxProtocol"
+#define D_JSON_ENABLED_MASK "Enabled-Mask"
 
 // Commands xdrv_08_serial_bridge.ino
 #define D_CMND_SSERIALSEND "SSerialSend"

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -497,9 +497,6 @@
   #define D_JSON_RFRECEIVED "RfReceived"
 #define D_CMND_RFRAW "RfRaw"
 
-#define D_CMND_RFRXPROTOCOL "RfRxProtocol"
-#define D_JSON_ENABLED_MASK "Enabled-Mask"
-
 // Commands xdrv_08_serial_bridge.ino
 #define D_CMND_SSERIALSEND "SSerialSend"
 #define D_CMND_SBAUDRATE "SBaudrate"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -18,6 +18,11 @@
 */
 
 const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
+#ifdef BAZMODS
+#ifdef USE_RC_SWITCH
+  D_CMND_RFRXPROTOCOL "|" 
+#endif
+#endif
   D_CMND_BACKLOG "|" D_CMND_DELAY "|" D_CMND_POWER "|" D_CMND_STATUS "|" D_CMND_STATE "|" D_CMND_SLEEP "|" D_CMND_UPGRADE "|" D_CMND_UPLOAD "|" D_CMND_OTAURL "|"
   D_CMND_SERIALLOG "|" D_CMND_RESTART "|" D_CMND_POWERONSTATE "|" D_CMND_PULSETIME "|" D_CMND_BLINKTIME "|" D_CMND_BLINKCOUNT "|" D_CMND_SAVEDATA "|"
   D_CMND_SO "|" D_CMND_SETOPTION "|" D_CMND_TEMPERATURE_RESOLUTION "|" D_CMND_HUMIDITY_RESOLUTION "|" D_CMND_PRESSURE_RESOLUTION "|" D_CMND_POWER_RESOLUTION "|"
@@ -43,8 +48,12 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
    "|Info|" D_CMND_TOUCH_CAL "|" D_CMND_TOUCH_THRES "|" D_CMND_TOUCH_NUM "|" D_CMND_CPU_FREQUENCY "|" D_CMND_WIFI
 #endif  // ESP32
   ;
-
 void (* const TasmotaCommand[])(void) PROGMEM = {
+  #ifdef BAZMODS
+#ifdef USE_RC_SWITCH
+  &CmndRfRxProtocol,
+#endif
+#endif
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
   &CmndSeriallog, &CmndRestart, &CmndPowerOnState, &CmndPulsetime, &CmndBlinktime, &CmndBlinkcount, &CmndSavedata,
   &CmndSetoption, &CmndSetoption, &CmndTemperatureResolution, &CmndHumidityResolution, &CmndPressureResolution, &CmndPowerResolution,

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -18,9 +18,6 @@
 */
 
 const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
-#ifdef USE_RC_SWITCH
-  D_CMND_RFRXPROTOCOL "|" 
-#endif
   D_CMND_BACKLOG "|" D_CMND_DELAY "|" D_CMND_POWER "|" D_CMND_STATUS "|" D_CMND_STATE "|" D_CMND_SLEEP "|" D_CMND_UPGRADE "|" D_CMND_UPLOAD "|" D_CMND_OTAURL "|"
   D_CMND_SERIALLOG "|" D_CMND_RESTART "|" D_CMND_POWERONSTATE "|" D_CMND_PULSETIME "|" D_CMND_BLINKTIME "|" D_CMND_BLINKCOUNT "|" D_CMND_SAVEDATA "|"
   D_CMND_SO "|" D_CMND_SETOPTION "|" D_CMND_TEMPERATURE_RESOLUTION "|" D_CMND_HUMIDITY_RESOLUTION "|" D_CMND_PRESSURE_RESOLUTION "|" D_CMND_POWER_RESOLUTION "|"
@@ -47,9 +44,6 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #endif  // ESP32
   ;
 void (* const TasmotaCommand[])(void) PROGMEM = {
-#ifdef USE_RC_SWITCH
-  &CmndRfRxProtocol,
-#endif
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
   &CmndSeriallog, &CmndRestart, &CmndPowerOnState, &CmndPulsetime, &CmndBlinktime, &CmndBlinkcount, &CmndSavedata,
   &CmndSetoption, &CmndSetoption, &CmndTemperatureResolution, &CmndHumidityResolution, &CmndPressureResolution, &CmndPowerResolution,

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -18,10 +18,8 @@
 */
 
 const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
-#ifdef BAZMODS
 #ifdef USE_RC_SWITCH
   D_CMND_RFRXPROTOCOL "|" 
-#endif
 #endif
   D_CMND_BACKLOG "|" D_CMND_DELAY "|" D_CMND_POWER "|" D_CMND_STATUS "|" D_CMND_STATE "|" D_CMND_SLEEP "|" D_CMND_UPGRADE "|" D_CMND_UPLOAD "|" D_CMND_OTAURL "|"
   D_CMND_SERIALLOG "|" D_CMND_RESTART "|" D_CMND_POWERONSTATE "|" D_CMND_PULSETIME "|" D_CMND_BLINKTIME "|" D_CMND_BLINKCOUNT "|" D_CMND_SAVEDATA "|"
@@ -49,10 +47,8 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
 #endif  // ESP32
   ;
 void (* const TasmotaCommand[])(void) PROGMEM = {
-  #ifdef BAZMODS
 #ifdef USE_RC_SWITCH
   &CmndRfRxProtocol,
-#endif
 #endif
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
   &CmndSeriallog, &CmndRestart, &CmndPowerOnState, &CmndPulsetime, &CmndBlinktime, &CmndBlinkcount, &CmndSavedata,

--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -90,10 +90,8 @@ void RfInit(void)
   if (PinUsed(GPIO_RFRECV)) {
     pinMode( Pin(GPIO_RFRECV), INPUT);
     mySwitch.enableReceive(Pin(GPIO_RFRECV));
-#ifdef BAZMODS 
   mySwitch.enabled_protocol_mask.longs.high32 =  Settings.ex_adc_param1;
   mySwitch.enabled_protocol_mask.longs.low32 = Settings.ex_adc_param2;
-#endif
   }
 }
 
@@ -101,7 +99,6 @@ void RfInit(void)
  * Commands
 \*********************************************************************************************/
 
-#ifdef BAZMODS
 void CmndRfRxProtocol(void){
   uint64_t thisbit;
  // AddLog_P(LOG_LEVEL_INFO, PSTR("RFR: index:%d usridx:%d data_len:%d data:%s"),XdrvMailbox.index, XdrvMailbox.usridx, XdrvMailbox.data_len,XdrvMailbox.data);
@@ -149,7 +146,7 @@ void CmndRfRxProtocol(void){
   ResponseJsonEnd();
 
 }
-#endif
+
 void CmndRfSend(void)
 {
   bool error = false;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
Hope there is a spare 64bit space in settings.
still has the ifdef BAZMODS  tags in the code.
created the uint64_t_t  because printf didn't play nice with 64bit and was easy way to split it up.