### PR TITLE
Use core 2.7.4.9 as default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
   - [ ] The pull request is done against the latest dev branch
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
-  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
+  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
   - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -144,11 +144,14 @@ build_flags                 = -DUSE_IR_REMOTE_FULL
 
 
 [core]
-; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4
+; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
 platform                    = espressif8266 @ 2.6.2
-platform_packages           = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+platform_packages           = tasmota/framework-arduinoespressif8266 @ ~2.7.4
                               platformio/toolchain-xtensa @ 2.40802.200502
                               platformio/tool-esptool @ 1.413.0
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
+; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
+                              ;-DWAVEFORM_LOCKED_PHASE
+                              -DWAVEFORM_LOCKED_PWM


### PR DESCRIPTION
## Description:
based on Tasmota core 2.7.4.7. Added Backport of PWM selection from Arduino Esp8266 stage

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.7
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
