### PR TITLE
Change Thunk Stack size for 4K RSA #9704

### DIFF
--- a/tasmota/StackThunk_light.cpp
+++ b/tasmota/StackThunk_light.cpp
@@ -43,7 +43,7 @@ uint32_t stack_thunk_light_refcnt = 0;
 //#define _stackSize (5600/4)
 #if defined(USE_MQTT_AWS_IOT)
   #define _stackSize (5300/4)   // using a light version of bearssl we can save 300 bytes
-#elif defined(USE_MQTT_TLS_FORCE_EC_CIPHER)
+#elif defined(USE_MQTT_TLS_FORCE_EC_CIPHER) || defined(USE_4K_RSA)
   #define _stackSize (4800/4)   // no private key, we can reduce a little, max observed 4300
 #else
   #define _stackSize (3600/4)   // using a light version of bearssl we can save 2k


### PR DESCRIPTION
## Description:

Force bigger Thunk Stack if 4K RSA even without EC ciphers.

**Related issue (if applicable):** fixes #9704

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
