### PR TITLE
Use Platformio espressif32 @ 2.1.0

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -131,9 +131,8 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 
 [core32_stage]
-platform                    = espressif32 @ 2.0.0
-platform_packages           = platformio/tool-esptoolpy @ ~1.30000.0
-                              framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc4/esp32-1.0.5-rc4.zip
+platform                    = espressif32 @ 2.1.0
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc4/esp32-1.0.5-rc4.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
                               ;-DESP32_STAGE=true

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -86,8 +86,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 
 [core32]
-platform                    = espressif32 @ 2.0.0
-platform_packages           = platformio/tool-esptoolpy @ ~1.30000.0
-                              framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
+platform                    = espressif32 @ 2.1.0
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.4.2/esp32-1.0.4.2.zip
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

as base. So not needed anymore to load esptool.py 3.0 via config 

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
