### PR TITLE
Fix zigbee32 compile error

### DIFF
--- a/tasmota/xdrv_23_zigbee_6_commands.ino
+++ b/tasmota/xdrv_23_zigbee_6_commands.ino
@@ -479,10 +479,12 @@ void parseSingleTuyaAttribute(Z_attribute & attr, const SBuffer &buf,
       attr.setUInt(buf.get32BigEndian(i));
       break;
     case 0x03:      // String (we expect it is not ended with \00)
+     {
       char str[len+1];
       strncpy(str, buf.charptr(i), len);
       str[len] = 0x00;
       attr.setStr(str);
+     }
       break;
     case 0x05:      // enum in 1/2/4 bytes, Big Endian
       if (1 == len) {


### PR DESCRIPTION
## Description:

by generating a local scope. 

@s-hadinger  i hope i did not mess it up 😀

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
