### PR TITLE
This is a fix for issue #10038 (first LED in a WS2812 string flicks c…

### DIFF
--- a/tasmota/xlgt_01_ws2812.ino
+++ b/tasmota/xlgt_01_ws2812.ino
@@ -304,22 +304,15 @@ void Ws2812Gradient(uint32_t schemenr)
   WsColor oldColor, currentColor;
   Ws2812GradientColor(schemenr, &oldColor, range, gradRange, offset);
   currentColor = oldColor;
+  speed = speed ? speed : 1;    // should never happen, just avoid div0
   for (uint32_t i = 0; i < Settings.light_pixels; i++) {
     if (kWsRepeat[Settings.light_width] > 1) {
-      Ws2812GradientColor(schemenr, &currentColor, range, gradRange, i +offset);
+      Ws2812GradientColor(schemenr, &currentColor, range, gradRange, i + offset + 1);
     }
-    if (Settings.light_speed > 0) {
-      // Blend old and current color based on time for smooth movement.
-      c.R = map(Light.strip_timer_counter % speed, 0, speed, oldColor.red, currentColor.red);
-      c.G = map(Light.strip_timer_counter % speed, 0, speed, oldColor.green, currentColor.green);
-      c.B = map(Light.strip_timer_counter % speed, 0, speed, oldColor.blue, currentColor.blue);
-    }
-    else {
-      // No animation, just use the current color.
-      c.R = currentColor.red;
-      c.G = currentColor.green;
-      c.B = currentColor.blue;
-    }
+    // Blend old and current color based on time for smooth movement.
+    c.R = map(Light.strip_timer_counter % speed, 0, speed, oldColor.red, currentColor.red);
+    c.G = map(Light.strip_timer_counter % speed, 0, speed, oldColor.green, currentColor.green);
+    c.B = map(Light.strip_timer_counter % speed, 0, speed, oldColor.blue, currentColor.blue);
     strip->SetPixelColor(i, c);
     oldColor = currentColor;
   }


### PR DESCRIPTION
…olors instead of fading)

## Description:
corrects fading code for WS2812 color schemes

**Related issue (if applicable):** fixes #10038

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
