### PR TITLE
Add P9813 support

### DIFF
--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -730,6 +730,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD - Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD - Reset"
 #define D_SENSOR_RC522_RST     "RC522 - Reset"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE                    "А"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -734,6 +734,8 @@
 #define D_SENSOR_SHELLY_DIMMER_BOOT0 "SHD Boot 0"
 #define D_SENSOR_SHELLY_DIMMER_RST_INV "SHD Reset"
 #define D_SENSOR_RC522_RST     "RC522 Rst"
+#define D_SENSOR_P9813_CLK     "P9813 Clock"
+#define D_SENSOR_P9813_DAT     "P9813 Data"
 
 // Units
 #define D_UNIT_AMPERE "安培"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -484,7 +484,7 @@
 #define USE_WS2812                               // WS2812 Led string using library NeoPixelBus (+5k code, +1k mem, 232 iram) - Disable by //
 //  #define USE_WS2812_DMA                         // DMA supports only GPIO03 (= Serial RXD) (+1k mem). When USE_WS2812_DMA is enabled expect Exceptions on Pow
 //  #define USE_WS2812_INVERTED                    // Use inverted data signal
-  #define USE_WS2812_HARDWARE  NEO_HW_WS2812     // Hardware type (NEO_HW_WS2812, NEO_HW_WS2812X, NEO_HW_WS2813, NEO_HW_SK6812, NEO_HW_LC8812, NEO_HW_APA106)
+  #define USE_WS2812_HARDWARE  NEO_HW_WS2812     // Hardware type (NEO_HW_WS2812, NEO_HW_WS2812X, NEO_HW_WS2813, NEO_HW_SK6812, NEO_HW_LC8812, NEO_HW_APA106, NEO_HW_P9813)
   #define USE_WS2812_CTYPE     NEO_GRB           // Color type (NEO_RGB, NEO_GRB, NEO_BRG, NEO_RBG, NEO_RGBW, NEO_GRBW)
 #define USE_MY92X1                               // Add support for MY92X1 RGBCW led controller as used in Sonoff B1, Ailight and Lohas
 #define USE_SM16716                              // Add support for SM16716 RGB LED controller (+0k7 code)

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -183,6 +183,7 @@ const uint32_t LOOP_SLEEP_DELAY = 50;       // Lowest number of milliseconds to 
 #define NEO_HW_SK6812          2            // NeoPixelBus hardware SK6812
 #define NEO_HW_LC8812          2            // NeoPixelBus hardware LC8812
 #define NEO_HW_APA106          3            // NeoPixelBus hardware APA106
+#define NEO_HW_P9813           4            // NeoPixelBus hardware P9813
 
 #define MQTT_PUBSUBCLIENT      1            // Mqtt PubSubClient library
 #define MQTT_TASMOTAMQTT       2            // Mqtt TasmotaMqtt library based on esp-mqtt-arduino - soon obsolete

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -129,6 +129,7 @@ enum UserSelectablePins {
   GPIO_AS608_TX, GPIO_AS608_RX,        // Serial interface AS608 / R503
   GPIO_SHELLY_DIMMER_BOOT0, GPIO_SHELLY_DIMMER_RST_INV,
   GPIO_RC522_RST,                      // RC522 reset
+  GPIO_P9813_CLK, GPIO_P9813_DAT,      // P9813 Clock and Data
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -237,7 +238,8 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_WE517_TX "|" D_SENSOR_WE517_RX "|"
   D_SENSOR_AS608_TX "|" D_SENSOR_AS608_RX "|"
   D_SENSOR_SHELLY_DIMMER_BOOT0 "|" D_SENSOR_SHELLY_DIMMER_RST_INV "|"
-  D_SENSOR_RC522_RST
+  D_SENSOR_RC522_RST "|"
+  D_SENSOR_P9813_CLK "|" D_SENSOR_P9813_DAT
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -337,6 +339,8 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_LIGHT
 #ifdef USE_WS2812
   AGPIO(GPIO_WS2812),         // WS2812 Led string
+  AGPIO(GPIO_P9813_CLK),      // P9813 CLOCK
+  AGPIO(GPIO_P9813_DAT),      // P9813 DATA
 #endif
 #ifdef USE_ARILUX_RF
   AGPIO(GPIO_ARIRFRCV),       // AriLux RF Receive input
@@ -1001,6 +1005,8 @@ enum LegacyUserSelectablePins {
   GPI8_IEM3000_RX,     // IEM3000 Serial interface
   GPI8_ZIGBEE_RST,     // Zigbee reset
   GPI8_DYP_RX,
+  GPI8_P9813_CLK,
+  GPI8_P9813_DAT,
   GPI8_SENSOR_END };
 
 // Programmer selectable GPIO functionality

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -1005,8 +1005,8 @@ enum LegacyUserSelectablePins {
   GPI8_IEM3000_RX,     // IEM3000 Serial interface
   GPI8_ZIGBEE_RST,     // Zigbee reset
   GPI8_DYP_RX,
-  GPI8_P9813_CLK,
-  GPI8_P9813_DAT,
+  GPI8_P9813_CLK,      // P9813 Clock
+  GPI8_P9813_DAT,      // P9813 Data
   GPI8_SENSOR_END };
 
 // Programmer selectable GPIO functionality

--- a/tasmota/xlgt_01_ws2812.ino
+++ b/tasmota/xlgt_01_ws2812.ino
@@ -47,7 +47,9 @@ void (* const Ws2812Command[])(void) PROGMEM = {
 
 #include <NeoPixelBus.h>
 
-#if (USE_WS2812_CTYPE == NEO_GRB)
+#if (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  typedef P9813BgrFeature selectedNeoFeatureType;
+#elif (USE_WS2812_CTYPE == NEO_GRB)
   typedef NeoGrbFeature selectedNeoFeatureType;
 #elif (USE_WS2812_CTYPE == NEO_BRG)
   typedef NeoBrgFeature selectedNeoFeatureType;
@@ -72,6 +74,8 @@ void (* const Ws2812Command[])(void) PROGMEM = {
   typedef NeoEsp8266DmaInvertedSk6812Method selectedNeoSpeedType;
 #elif (USE_WS2812_HARDWARE == NEO_HW_APA106)
   typedef NeoEsp8266DmaInvertedApa106Method selectedNeoSpeedType;
+#elif (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  #error "P9813 don't support DMA"
 #else   // USE_WS2812_HARDWARE
   typedef NeoEsp8266DmaInverted800KbpsMethod selectedNeoSpeedType;
 #endif  // USE_WS2812_HARDWARE
@@ -84,6 +88,8 @@ void (* const Ws2812Command[])(void) PROGMEM = {
   typedef NeoEsp8266DmaSk6812Method selectedNeoSpeedType;
 #elif (USE_WS2812_HARDWARE == NEO_HW_APA106)
   typedef NeoEsp8266DmaApa106Method selectedNeoSpeedType;
+#elif (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  #error "P9813 don't support DMA"
 #else   // USE_WS2812_HARDWARE
   typedef NeoEsp8266Dma800KbpsMethod selectedNeoSpeedType;
 #endif  // USE_WS2812_HARDWARE
@@ -99,6 +105,8 @@ void (* const Ws2812Command[])(void) PROGMEM = {
   typedef NeoEsp8266BitBangWs2812xInvertedMethod selectedNeoSpeedType;
 #elif (USE_WS2812_HARDWARE == NEO_HW_SK6812)
   typedef NeoEsp8266BitBangSk6812InvertedMethod selectedNeoSpeedType;
+#elif (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  #error "P9813 don't support inverted"
 #else   // USE_WS2812_HARDWARE
   typedef NeoEsp8266BitBang400KbpsInvertedMethod selectedNeoSpeedType;
 #endif  // USE_WS2812_HARDWARE
@@ -109,6 +117,8 @@ void (* const Ws2812Command[])(void) PROGMEM = {
   typedef NeoEsp8266BitBangWs2812xMethod selectedNeoSpeedType;
 #elif (USE_WS2812_HARDWARE == NEO_HW_SK6812)
   typedef NeoEsp8266BitBangSk6812Method selectedNeoSpeedType;
+#elif (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  typedef P9813Method selectedNeoSpeedType;
 #else   // USE_WS2812_HARDWARE
   typedef NeoEsp8266BitBang800KbpsMethod selectedNeoSpeedType;
 #endif  // USE_WS2812_HARDWARE
@@ -472,10 +482,15 @@ void Ws2812ShowScheme(void)
 
 void Ws2812ModuleSelected(void)
 {
+#if (USE_WS2812_HARDWARE == NEO_HW_P9813)
+  if (PinUsed(GPIO_P9813_CLK) && PinUsed(GPIO_P9813_DAT)) {  // RGB led
+    strip = new NeoPixelBus<selectedNeoFeatureType, selectedNeoSpeedType>(WS2812_MAX_LEDS, Pin(GPIO_P9813_CLK), Pin(GPIO_P9813_DAT));
+#else
   if (PinUsed(GPIO_WS2812)) {  // RGB led
-
     // For DMA, the Pin is ignored as it uses GPIO3 due to DMA hardware use.
     strip = new NeoPixelBus<selectedNeoFeatureType, selectedNeoSpeedType>(WS2812_MAX_LEDS, Pin(GPIO_WS2812));
+#endif
+
     strip->Begin();
 
     Ws2812Clear();


### PR DESCRIPTION
## Description:

I have added support for P9813 RGB LED controller based on NeoPixelBus.

For use P9813 support you must define the following variables:
```
#define USE_WS2812
#define USE_WS2812_HARDWARE  NEO_HW_P9813
#define USE_WS2812_CTYPE     NEO_RGB 
```

Then 2 pins must be configured to P9813 Clock and P9813 Data.

**Related issue (if applicable):** fixes #8457

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
