### PR TITLE
show relay state in prometheus metrics

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -75,6 +75,11 @@ void HandleMetrics(void)
   WSContentSend_P(PSTR("# TYPE energy_power_kilowatts_total counter\nenergy_power_kilowatts_total %s\n"), parameter);
 #endif
 
+  for (uint32_t device = 0; device < TasmotaGlobal.devices_present; device++) {
+    power_t mask = 1 << device;
+    WSContentSend_P(PSTR("# TYPE relay%d_state gauge\nrelay%d_state %d\n"), device+1, device+1, (TasmotaGlobal.power & mask));
+  }
+
 /*
   // Alternative method using the complete sensor JSON data
   // For prometheus it may need to be decoded to # TYPE messages


### PR DESCRIPTION
## Description:

I use Tasmota as a thermostat to switch heater relay on and off.
Then, a Prometheus instance scrapes [the metrics exporter at the tasmota thermostat](https://github.com/arendst/Tasmota/blob/development/tasmota/xsns_75_prometheus.ino) to collect temperature and relay state gauges.

Current development branch already exports temperature data on `/metrics`, but it didn't export the relay states.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
