### PR TITLE
Support power tap and hold; increase hold from .5 to .75 seconds

### DIFF
--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -289,7 +289,9 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
     // button interval had not elapsed, 
     if (button_unprocessed[button_index]) {
       mqtt_trigger = 5;
+#ifdef USE_PWM_DIMMER_REMOTE
       if (!active_remote_pwm_dimmer) mqtt_trigger += button_index;
+#endif  // USE_PWM_DIMMER_REMOTE
       button_hold_time[button_index] = now + 750;
     }
 

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -76,6 +76,7 @@ bool tap_handled = false;
 bool invert_power_button_bri_direction = false;
 bool button_pressed[3] = { false, false, false };
 bool button_held[3];
+bool button_unprocessed[3] = { false, false, false };
 #ifdef USE_PWM_DIMMER_REMOTE
 struct remote_pwm_dimmer remote_pwm_dimmers[MAX_PWM_DIMMER_KEYS];
 struct remote_pwm_dimmer * active_remote_pwm_dimmer;
@@ -284,8 +285,16 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
   if (pressed) {
     uint32_t now = millis();
 
-    // If this is about the power button, ...
-    if (is_power_button) {
+    // If the button was pressed and released but was not processed by support_button because the
+    // button interval had not elapsed, 
+    if (button_unprocessed[button_index]) {
+      mqtt_trigger = 5;
+      if (!active_remote_pwm_dimmer) mqtt_trigger += button_index;
+      button_hold_time[button_index] = now + 750;
+    }
+
+    // Otherwise, if this is about the power button, ...
+    else if (is_power_button) {
 
       // If we're not ignoring the power button and no other buttons are pressed, ...
       if (!ignore_power_button && buttons_pressed == 1) {
@@ -325,8 +334,8 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
         // If the up or down button was tapped while holding the power button before this, handle
         // the operation below.
         if (button_tapped) {
-          handle_tap = true;
-          button_hold_time[button_index] = now + 500;
+          handle_tap = ignore_power_button = true;
+          button_hold_time[button_index] = now + 750;
         }
 
         // Otherwise, if the power is on and remote mode is enabled, adjust the brightness. Set the
@@ -568,7 +577,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
   // If the up or down button was tapped while holding the power button and the up or down button
   // is being held or was just released after not being held, handle the operation.
   if (handle_tap) {
-    ignore_power_button = tap_handled = true;
+    tap_handled = true;
 
     // If the down button was tapped while holding the power button, send a device group update to
     // select the previous/next fixed color.
@@ -591,9 +600,10 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
 #endif // USE_DEVICE_GROUPS
       ;
     }
-    // If the down button was tapped while holding the power button, publish an MQTT Event Trigger#.
+    // If the up button was tapped while holding the power button, publish an MQTT Event Trigger#.
     else {
-      mqtt_trigger = (is_down_button ? 3 : 4);
+      mqtt_trigger = 3;
+      if (is_down_button) mqtt_trigger = 4;
     }
   }
 
@@ -739,7 +749,15 @@ bool Xdrv35(uint8_t function)
           // increment the buttons pressed count.
           if (!button_pressed[button_index]) {
             button_pressed[button_index] = true;
-            button_hold_time[button_index] = now + (button_index == power_button_index ? 500 : 250);
+            uint32_t hold_delay = 250;
+            if (button_index == power_button_index) {
+#ifdef USE_PWM_DIMMER_REMOTE
+              if (!(active_remote_pwm_dimmer ? active_remote_pwm_dimmer->power_on : TasmotaGlobal.power)) hold_delay = 500;
+#else // USE_PWM_DIMMER_REMOTE
+              if (!TasmotaGlobal.power) hold_delay = 500;
+#endif  // USE_PWM_DIMMER_REMOTE
+            }
+            button_hold_time[button_index] = now + hold_delay;
             buttons_pressed++;
             if (buttons_pressed > 1) multibutton_in_progress = true;
 
@@ -796,6 +814,16 @@ bool Xdrv35(uint8_t function)
             // Set a timer so FUNC_ANY_KEY ignores the button if support_button winds up sending a
             // key because of this.
             ignore_any_key_time = now + 500;
+
+            // If a multi-button operation is in progress or the button was pressed, released and
+            // then held, tell support_button that we've handled it.
+            result = true;
+            Button.press_counter[button_index] = 0;
+            if (buttons_pressed == 0) multibutton_in_progress = false;
+            button_unprocessed[button_index] = false;
+          }
+          else {
+            button_unprocessed[button_index] = true;
           }
 
           // If the power button was just released, clear the flags associated with it.
@@ -806,12 +834,6 @@ bool Xdrv35(uint8_t function)
           }
           button_held[button_index] = false;
         }
-
-        // If a multi-button operation is in progress, tell support_button that we've handled it.
-        if (multibutton_in_progress) {
-          result = true;
-          if (buttons_pressed == 0) multibutton_in_progress = false;
-        }
       }
       break;
 
@@ -819,7 +841,9 @@ bool Xdrv35(uint8_t function)
       {
         uint32_t state = (XdrvMailbox.payload >> 8) & 0xFF;  // 0 = Off, 1 = On, 2 = Toggle, 3 = Hold, 10,11,12,13 and 14 for Button Multipress
         if ((state == 2 || state == 10) && ignore_any_key_time < millis()) {
-          PWMDimmerHandleButton((XdrvMailbox.payload & 0xFF) - 1, false);
+          uint32_t button_index = (XdrvMailbox.payload & 0xFF) - 1;
+          button_unprocessed[button_index] = false;
+          PWMDimmerHandleButton(button_index, false);
         }
       }
       break;


### PR DESCRIPTION
## Description:

Support power tap and hold.

Increase hold from .5 to .75 seconds.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
