### PR TITLE
MGC3130: more debug infos

### DIFF
--- a/tasmota/xsns_36_mgc3130.ino
+++ b/tasmota/xsns_36_mgc3130.ino
@@ -69,7 +69,8 @@ const char HTTP_MGC_3130_SNS[] PROGMEM =
   "{s}" "%s" "{m}%s{e}"
   "{s}" "HwRev" "{m}%u.%u{e}"
   "{s}" "loaderVer" "{m}%u.%u{e}"
-  "{s}" "platVer" "{m}%u{e}";      // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+  "{s}" "platVer" "{m}%u{e}"
+  "{s}" "NoisePower" "{m}%s{e}";      // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 #endif  // USE_WEBSERVER
 
 
@@ -152,17 +153,18 @@ union MGC3130_Union{
     float SDData[4]; // signal deviation
   } out;
   struct {
-    uint8_t header[3];
+    uint8_t header[4];
     // payload
-    uint8_t valid;
+    uint8_t valid; // 0xAA is valid
     uint8_t hwRev[2];
     uint8_t parameterStartAddr;
     uint8_t loaderVersion[2];
     uint8_t loaderPlatform;
-    uint8_t fwStartAddr;
+    uint8_t fwStartAddr; // should be 0x20
     char fwVersion[120];
   } fw;
   struct{
+    uint8_t header[4];
     uint8_t id;
     uint8_t size;
     uint16_t error;
@@ -180,7 +182,7 @@ int16_t MGC3130_rotValue, MGC3130_lastSentRotValue = 0;
 uint16_t MGC3130_lastSentX, MGC3130_lastSentY, MGC3130_lastSentZ = 0;
 
 uint8_t hwRev[2], loaderVersion[2], loaderPlatform = 0;
-char MGC3130_firmwareInfo[20];
+float MGC3130_noisePower = -1;
 
 uint8_t MGC3130_touchTimeout = 0;
 uint16_t MGC3130_touchCounter = 1; // measure how long you touch the surface in loop cycles
@@ -194,6 +196,7 @@ uint8_t MGC3130_mode = 1; // 1-gesture; 2-airwheel; 3-position
 uint8_t MGC3130autoCal[] = {0x10, 0x00, 0x00, 0xA2, 0x80, 0x00 , 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF};
 uint8_t MGC3130disableAirwheel[] = {0x10, 0x00, 0x00, 0xA2, 0x90, 0x00 , 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00};
 uint8_t MGC3130enableAirwheel[] = {0x10, 0x00, 0x00, 0xA2, 0x90, 0x00 , 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00};
+uint8_t MGC3130enableAll[] = {0x10, 0x00, 0x00, 0xA2, 0xA0, 0x00 , 0x00, 0x00, 0x3f, 0x18, 0x00, 0x00, 0x3f, 0x18, 0x00, 0x00};
 
 void MGC3130_handleSensorData(){
       if ( MGC_data.out.outputConfigMask.touchInfo && MGC3130_touchTimeout == 0){
@@ -219,6 +222,9 @@ void MGC3130_handleSensorData(){
         if(MGC_data.out.systemInfo.positionValid && (MGC_data.out.z > MGC3130_MIN_ZVALUE)){
           MqttPublishSensor();
         }
+      }
+      if(MGC_data.out.systemInfo.noisePowerValid){
+        MGC3130_noisePower = MGC_data.out.noisePower;
       }
 }
 
@@ -394,7 +400,7 @@ void MGC3130_handleAirWheel(){
 }
 
 void MGC3130_handleSystemStatus(){
-  //Serial.println("Got System status");
+    AddLog_P(LOG_LEVEL_DEBUG,PSTR("MGC3130: system_status: response to ID:%02x, error code: %04x"),MGC_data.status.id, MGC_data.status.error);
 }
 
 bool MGC3130_receiveMessage(){
@@ -407,16 +413,15 @@ bool MGC3130_receiveMessage(){
           MGC3130_handleSystemStatus();
           break;
         case MGC3130_FW_VERSION:
-          hwRev[0] = MGC_data.fw.hwRev[1];
-          hwRev[1] = MGC_data.fw.hwRev[0];
-          loaderVersion[0] = MGC_data.fw.loaderVersion[0];
-          loaderVersion[1] = MGC_data.fw.loaderVersion[1];
+          hwRev[1] = MGC_data.fw.hwRev[1];
+          hwRev[0] = MGC_data.fw.hwRev[0];
+          loaderVersion[1] = MGC_data.fw.loaderVersion[0];
+          loaderVersion[0] = MGC_data.fw.loaderVersion[1];
           loaderPlatform = MGC_data.fw.loaderPlatform;
-          snprintf_P(MGC3130_firmwareInfo, sizeof(MGC3130_firmwareInfo), PSTR("FW: %s"), MGC_data.fw.fwVersion);
-          MGC3130_firmwareInfo[20] = '\0';
-          // Serial.print(MGC3130_firmwareInfo);
+          AddLog_P(LOG_LEVEL_INFO,PSTR("MGC3130: GestIC:%s"),MGC_data.fw.fwVersion);
           break;
       }
+    MGC_data.out.id  = 0;
     return true;
   }
   return false;
@@ -424,11 +429,12 @@ bool MGC3130_receiveMessage(){
 
 bool MGC3130_readData()
 {
+  static uint8_t _lastCounter = 0;
   bool success = false;
   if (!digitalRead(MGC3130_xfer)){
     pinMode(MGC3130_xfer, OUTPUT);
     digitalWrite(MGC3130_xfer, LOW);
-    Wire.requestFrom(MGC3130_I2C_ADDR, (uint16_t)32); // request usual data output
+    Wire.requestFrom(MGC3130_I2C_ADDR, (uint16_t)132); // request maximal data output
 
     MGC_data.buffer[0] = 4; // read at least header, but update after first read anyway
     unsigned char i = 0;
@@ -438,6 +444,14 @@ bool MGC3130_readData()
       }
     digitalWrite(MGC3130_xfer, HIGH);
     pinMode(MGC3130_xfer, INPUT);
+    uint8_t _mismatch = MGC_data.out.counter - _lastCounter;
+    if(_mismatch != 1){
+      if(i>4 && MGC_data.out.id != MGC3130_FW_VERSION){
+        AddLog_P(LOG_LEVEL_DEBUG,PSTR("MGC3130: missed a packet, mismatch: %u"), _mismatch - 1);
+        AddLogBuffer(LOG_LEVEL_DEBUG,MGC_data.buffer,i);
+      } 
+    }
+    _lastCounter = MGC_data.out.counter;
     success = true;
   }
   return success;
@@ -537,7 +551,9 @@ void MGC3130_show(bool json)
     }
 #ifdef USE_WEBSERVER
   } else {
-    WSContentSend_PD(HTTP_MGC_3130_SNS, MGC3130stype, status_chr, hwRev[0], hwRev[1], loaderVersion[0], loaderVersion[1], loaderPlatform );
+    char _noise[FLOATSZ];
+    dtostrfd(MGC3130_noisePower, 2, _noise);
+    WSContentSend_PD(HTTP_MGC_3130_SNS, MGC3130stype, status_chr, hwRev[0], hwRev[1], loaderVersion[0], loaderVersion[1], loaderPlatform, _noise);
 #endif  // USE_WEBSERVER
   }
 }
@@ -552,6 +568,7 @@ void MGC3130_show(bool json)
  * Sensor36 | 1       | Gesture Mode
  * Sensor36 | 2       | Airwheel Mode
  * Sensor36 | 3       | Position Mode with x,y,z - z must be higher than half of the max. sensing height
+ * Sensor36 | 4       | Enable all data for debugging (noise level in web GUI)
 \*********************************************************************************************/
 
 bool MGC3130CommandSensor()
@@ -573,8 +590,12 @@ bool MGC3130CommandSensor()
     case 3: // position & touch
       MGC3130_mode = 3;
       MGC3130_sendMessage(MGC3130disableAirwheel,16);
-    break;
+      break;
+    case 4: // enable all readings for noise level for web GUI
+      MGC3130_sendMessage(MGC3130enableAll,16);
+      break;
   }
+  Response_P(PSTR("{\"MGC3130\":{\"mode\":%d}}"), MGC3130_mode);
   return serviced;
 }
 


### PR DESCRIPTION
## Description:

This is not really a bugfix as my new skywriter boards works flawless with the old driver. But it may help to find out, why things do not work.
Fix: No error message after launching `sensor36 x`- this is only cosmetical
Added: 'sensor36 4' to enable full sensor reading for debugging, this will show noise level in the web GUI.

Note: First reading after boot will probably always show: MGC3130: missed a packet, mismatch: 4294967295. This is only cosmetical.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
