### PR TITLE
Fix for shutter position percentage

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -430,10 +430,6 @@ void ShutterDecellerateForStop(uint8_t i)
 void ShutterPowerOff(uint8_t i) {
   AddLog_P(LOG_LEVEL_DEBUG, PSTR("SHT: Stop Shutter %d. Switchmode %d"), i,Shutter[i].switch_mode);
   ShutterDecellerateForStop(i);
-  if (Shutter[i].direction !=0) {
-    Shutter[i].direction = 0;
-    delay(MOTOR_STOP_TIME);
-  }
   switch (Shutter[i].switch_mode) {
     case SHT_SWITCH:
       if ((1 << (Settings.shutter_startrelay[i]-1)) & TasmotaGlobal.power) {
@@ -464,6 +460,10 @@ void ShutterPowerOff(uint8_t i) {
     snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM " %d" ),Shutter[i].pwm_value);
     ExecuteCommand(scmnd, SRC_BUTTON);
     break;
+  }
+  if (Shutter[i].direction !=0) {
+    Shutter[i].direction = 0;
+    delay(MOTOR_STOP_TIME);
   }
 }
 

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -616,7 +616,7 @@ void ShutterRelayChanged(void)
         break;
         default:
           TasmotaGlobal.last_source = SRC_SHUTTER; // avoid switch off in the next loop
-          if (Shutter[i].direction != 0 ) ShutterPowerOff(i);
+          if (Shutter[i].direction != 0 ) ShutterUpdatePosition();
       }
       switch (ShutterGlobal.position_mode) {
         // enum Shutterposition_mode {SHT_TIME, SHT_TIME_UP_DOWN, SHT_TIME_GARAGE, SHT_COUNTER, SHT_PWM_VALUE, SHT_PWM_TIME,};


### PR DESCRIPTION
## Description:

Fix for shutter position percentage not updated and stat SHUTTER1 not published.

reporting now also after manual relay change

**Related issue (if applicable):** fixes #9906 

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
