### PR TITLE
fix day_of_week in tuyamcu

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -1221,7 +1221,7 @@ void TuyaSetTime(void) {
   payload_buffer[4] = RtcTime.hour;
   payload_buffer[5] = RtcTime.minute;
   payload_buffer[6] = RtcTime.second;
-  payload_buffer[7] = RtcTime.day_of_week;
+  payload_buffer[7] = RtcTime.day_of_week-1; // 1 for Monday as in TUYA Doc
 
   TuyaSendCmd(TUYA_CMD_SET_TIME, payload_buffer, payload_len);
 }

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -1214,6 +1214,13 @@ void TuyaSetTime(void) {
 
   uint16_t payload_len = 8;
   uint8_t payload_buffer[8];
+  uint8_t tuya_day_of_week;
+  if (RtcTime.day_of_week == 1) {
+    tuya_day_of_week = 7;
+  } else {
+    tuya_day_of_week = RtcTime.day_of_week-1;
+  }
+
   payload_buffer[0] = 0x01;
   payload_buffer[1] = RtcTime.year %100;
   payload_buffer[2] = RtcTime.month;
@@ -1221,7 +1228,7 @@ void TuyaSetTime(void) {
   payload_buffer[4] = RtcTime.hour;
   payload_buffer[5] = RtcTime.minute;
   payload_buffer[6] = RtcTime.second;
-  payload_buffer[7] = RtcTime.day_of_week-1; // 1 for Monday as in TUYA Doc
+  payload_buffer[7] = tuya_day_of_week; //1 for Monday in TUYA Doc
 
   TuyaSendCmd(TUYA_CMD_SET_TIME, payload_buffer, payload_len);
 }


### PR DESCRIPTION
Tasmota begin with 1 for sunday but Tuya MCU Protokoll begin with 1 at monday in "day_of_week"

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
