### PR TITLE
Fix shutterstop

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -984,15 +984,10 @@ void CmndShutterStop(void)
       if (Shutter[i].direction != 0) {
 
         AddLog_P(LOG_LEVEL_DEBUG, PSTR("SHT: Stop moving %d: dir: %d"), XdrvMailbox.index, Shutter[i].direction);
-
-        int32_t temp_realpos = ShutterCalculatePosition(i);
-        XdrvMailbox.payload = ShutterRealToPercentPosition(temp_realpos, i)-Shutter[i].direction;
-        TasmotaGlobal.last_source = SRC_WEBGUI;
-        CmndShutterPosition();
-      } else {
-        if (XdrvMailbox.command)
-          ResponseCmndDone();
-      }
+        Shutter[i].target_position = Shutter[i].real_position;
+      } 
+      if (XdrvMailbox.command)
+        ResponseCmndDone();
     } else {
       if (XdrvMailbox.command)
         ResponseCmndIdxChar("Locked");


### PR DESCRIPTION
improved stop procedure to avoid overrun due to rounding issues between % and the real_position

## Description:

**Related issue (if applicable):** fixes #10166

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ x] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
