### PR TITLE
Allow DS18X20_MAX_SENSORS to be redefined

### DIFF
--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -38,7 +38,9 @@
 #define W1_WRITE_SCRATCHPAD  0x4E
 #define W1_READ_SCRATCHPAD   0xBE
 
+#ifndef DS18X20_MAX_SENSORS // DS18X20_MAX_SENSORS fallback to 8 if not defined in user_config_override.h
 #define DS18X20_MAX_SENSORS  8
+#endif
 
 const char kDs18x20Types[] PROGMEM = "DS18x20|DS18S20|DS1822|DS18B20|MAX31850";
 


### PR DESCRIPTION
## Description:

Following discussion with users on discord, this PR allows `DS18X20_MAX_SENSORS`  to be redefined in `user_config_override.h`.
If merged I will document with warnings regarding MQTT buffer size and 1-wire length reliability.
Build as been tested with discord user earthquake on ESP8266 only

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
