### PR TITLE
Shelly Dimmer: Use global setting value for brightness and fade rate at startup

### DIFF
--- a/tasmota/xdrv_45_shelly_dimmer.ino
+++ b/tasmota/xdrv_45_shelly_dimmer.ino
@@ -626,9 +626,9 @@ bool ShdSendVersion(void)
 void ShdGetSettings(void)
 {
     char parameters[32];
-    Shd.req_brightness      = 0;
+    // Shd.req_brightness      = 0;
     Shd.leading_edge        = 0;
-    Shd.req_fade_rate       = 0;
+    // Shd.req_fade_rate       = 0;
     Shd.warmup_brightness   = 0;
     Shd.warmup_time         = 0;
     if (strstr(SettingsText(SET_SHD_PARAM), ",") != nullptr)
@@ -636,9 +636,9 @@ void ShdGetSettings(void)
 #ifdef SHELLY_DIMMER_DEBUG
         AddLog_P(LOG_LEVEL_INFO, PSTR(SHD_LOGNAME "Loading params: %s"), SettingsText(SET_SHD_PARAM));
 #endif  // SHELLY_DIMMER_DEBUG
-        Shd.req_brightness      = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 1));
+        // Shd.req_brightness      = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 1));
         Shd.leading_edge        = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 2));
-        Shd.req_fade_rate       = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 3));
+        // Shd.req_fade_rate       = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 3));
         Shd.warmup_brightness   = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 4));
         Shd.warmup_time         = atoi(subStr(parameters, SettingsText(SET_SHD_PARAM), ",", 5));
     }


### PR DESCRIPTION
## Description:

Use global setting value for brightness and fade rate at startup. This way the Shelly Dimmer obeys PowerOnState.
**Related issue (if applicable):** fixes #10154

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.4.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
