### PR TITLE
Zigbee improved CIE handling

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -847,6 +847,8 @@ typedef enum Z_Def_Category {
   Z_CAT_BIND,                 // send auto-binding to coordinator
   Z_CAT_CONFIG_ATTR,          // send a config attribute reporting request
   Z_CAT_READ_ATTRIBUTE,       // read a single attribute
+  Z_CAT_CIE_ATTRIBUTE,        // write CIE address
+  Z_CAT_CIE_ENROLL,           // enroll CIE zone
 } Z_Def_Category;
 
 const uint32_t Z_CAT_REACHABILITY_TIMEOUT = 2000;     // 1000 ms or 1s

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -652,6 +652,8 @@ void Z_AutoBindDefer(uint16_t shortaddr, uint8_t endpoint, const SBuffer &buf,
   if (bitRead(cluster_map, Z_ClusterToCxBinding(0x0500))) {
     // send a read command to cluster 0x0500, attribute 0x0001 (ZoneType) - to read the type of sensor
     zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, 0x0500, endpoint, Z_CAT_READ_ATTRIBUTE, 0x0001, &Z_SendSingleAttributeRead);
+    zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, 0x0500, endpoint, Z_CAT_CIE_ATTRIBUTE, 0 /* value */, &Z_WriteCIEAddress);
+    zigbee_devices.queueTimer(shortaddr, 0 /* groupaddr */, 2000, 0x0500, endpoint, Z_CAT_CIE_ENROLL, 1 /* zone */, &Z_SendCIEZoneEnrollResponse);
   }
 
   // enqueue bind requests
@@ -1346,7 +1348,7 @@ void Z_SendDeviceInfoRequest(uint16_t shortaddr) {
 }
 
 //
-// Send sing attribute read request in Timer
+// Send single attribute read request in Timer
 //
 void Z_SendSingleAttributeRead(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
   uint8_t transacid = zigbee_devices.getNextSeqNumber(shortaddr);
@@ -1364,6 +1366,56 @@ void Z_SendSingleAttributeRead(uint16_t shortaddr, uint16_t groupaddr, uint16_t 
       false /* discover route */,
     transacid,  /* zcl transaction id */
     InfoReq, sizeof(InfoReq)
+  }));
+}
+
+//
+// Write CIE address
+//
+void Z_WriteCIEAddress(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  uint8_t transacid = zigbee_devices.getNextSeqNumber(shortaddr);
+  SBuffer buf(12);
+  buf.add16(0x0010);    // attribute 0x0010
+  buf.add8(ZEUI64);
+  buf.add64(localIEEEAddr);
+
+  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Writing CIE address"));
+  ZigbeeZCLSend_Raw(ZigbeeZCLSendMessage({
+    shortaddr,
+    0x0000, /* group */
+    0x0500 /*cluster*/,
+    endpoint,
+    ZCL_WRITE_ATTRIBUTES,
+    0x0000,  /* manuf */
+    false /* not cluster specific */,
+    true /* response */,
+    false /* discover route */,
+    transacid,  /* zcl transaction id */
+    buf.getBuffer(), buf.len()
+  }));
+}
+
+
+//
+// Write CIE address
+//
+void Z_SendCIEZoneEnrollResponse(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  uint8_t transacid = zigbee_devices.getNextSeqNumber(shortaddr);
+  uint8_t EnrollRSP[2] = { 0x00 /* Sucess */, Z_B0(value) /* ZoneID */ };
+
+  AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Sending Enroll Zone %d"), Z_B0(value));
+  ZigbeeZCLSend_Raw(ZigbeeZCLSendMessage({
+    shortaddr,
+    0x0000, /* group */
+    0x0500 /*cluster*/,
+    endpoint,
+    0x00,   // Zone Enroll Response
+    0x0000,  /* manuf */
+    true /* cluster specific */,
+    true /* response */,
+    false /* discover route */,
+    transacid,  /* zcl transaction id */
+    EnrollRSP, sizeof(EnrollRSP)
   }));
 }
 
@@ -1600,6 +1652,8 @@ void Z_IncomingMessage(class ZCLFrame &zcl_received) {
       zcl_received.parseReadConfigAttributes(attr_list);
     } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_CONFIGURE_REPORTING_RESPONSE == zcl_received.getCmdId())) {
       zcl_received.parseConfigAttributes(attr_list);
+    } else if ( (!zcl_received.isClusterSpecificCommand()) && (ZCL_WRITE_ATTRIBUTES_RESPONSE == zcl_received.getCmdId())) {
+      zcl_received.parseWriteAttributesResponse(attr_list);
     } else if (zcl_received.isClusterSpecificCommand()) {
       zcl_received.parseClusterSpecificCommand(attr_list);
     }


### PR DESCRIPTION
## Description:

Improved handling of Alarm devices during pairing:
- writes the IEEEAddress of coordinator as CIE 
- reports the device as enrolled to zone `1` - this may be refined later

Also, give simple feedback after writing an attribute (helps debugging).

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
