### PR TITLE
Changed pzem DC device address

### DIFF
--- a/tasmota/xnrg_06_pzem_dc.ino
+++ b/tasmota/xnrg_06_pzem_dc.ino
@@ -31,7 +31,7 @@
 
 #define XNRG_06                    6
 
-const uint8_t PZEM_DC_DEVICE_ADDRESS = 0x01;  // PZEM default address
+const uint8_t PZEM_DC_DEVICE_ADDRESS = 0xF8;  // PZEM address for single slave environment (0x01 is the default)
 const uint32_t PZEM_DC_STABILIZE = 30;        // Number of seconds to stabilize configuration
 
 #include <TasmotaModbus.h>


### PR DESCRIPTION
## Description: Changed the default MODBUS address for PZEM003/017 DC Energy Meter from 0x01 to 0XF8.  While 0x01 is the default device address from the factory, it can subsequently be changed by sending the appropriate MODBUS command to the device.  0xF8 will always work in a single slave environment, avoiding a situation where the device address has been previously changed and is no longer known

[https://peacefair.en.made-in-china.com/product/FCsEdQqvwkVl/China-Pzem-017-DC-0-300V-Electric-Solar-Power-Meter-with-RS485-Modbus-with-300A-Shunt.html](url)

_"The address range of the slave is 0x01 ~ 0xF7. The address 0x00 is used as the broadcast address, the slave does not need to reply the master. The address 0xF8 is used as the general address, this address can be only used in single-slave environment and can be used for calibration etc.operation."_

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
