### PR TITLE
remove superfluous closing brace on GPIO result

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1188,7 +1188,7 @@ void CmndGpio(void)
         }
         char stemp1[TOPSZ];
         if ((ResponseAppend_P(PSTR("\"" D_CMND_GPIO "%d\":{\"%d\":\"%s%s\"}"), i, sensor_type, GetTextIndexed(stemp1, sizeof(stemp1), sensor_name_idx, sensor_names), sindex) > (LOGSZ - TOPSZ)) || (i == ARRAY_SIZE(Settings.my_gp.io) -1)) {
-          ResponseJsonEndEnd();
+          ResponseJsonEnd();
           MqttPublishPrefixTopic_P(RESULT_OR_STAT, XdrvMailbox.command);
           jsflg2 = true;
           jsflg = false;


### PR DESCRIPTION
## Description:

Since https://github.com/arendst/Tasmota/commit/761281e55c5d91f75dca742ffc10e87316884e45, GPIO result has a superfluous closing brace because it has 1 less level than most other RESULT:
`stat/rfbridge/RESULT = {"GPIO0":{"32":"Button1"}, .... "GPIO16":{"0":"None"},"GPIO17":{"0":"None"}}}`

Fixed by replacing the call to `ResponseJsonEndEnd();` by `ResponseJsonEnd();`

Note: A breaking but coherent change would be to introduce a "GPIO" level :
`stat/rfbridge/RESULT = {"GPIO":{"GPIO0":{"32":"Button1"}, .... "GPIO16":{"0":"None"},"GPIO17":{"0":"None"}}}`

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
