### PR TITLE
remove *.gz firmwares from Tasmota32 builds in branch firmwares

### DIFF
--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v1 
+    - uses: actions/checkout@v1
     - name: Use latest Tasmota development
-      run: | 
+      run: |
         git config --local user.name "Platformio BUILD"
-        git switch -c master
+        git switch -c work
         git remote add -f Tasmota "https://github.com/arendst/Tasmota.git"
-        git merge Tasmota/development --allow-unrelated-histories          
+        git merge Tasmota/development --allow-unrelated-histories
     - name: Push Tasmota   # Push updates of latest Tasmota development to repo
       uses: ad-m/github-push-action@master
       with:
@@ -39,14 +39,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-minimal:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -62,14 +62,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-lite:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -85,14 +85,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-knx:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -108,14 +108,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-sensors:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -131,14 +131,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-display:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -154,14 +154,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ir:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -177,14 +177,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ircustom:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -200,14 +200,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-zbbridge:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -223,13 +223,13 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-zbbridge
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
-  
+
   tasmota-BG:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -245,14 +245,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-BR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -268,14 +268,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-CN:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -291,14 +291,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-CZ:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -314,14 +314,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-DE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -337,14 +337,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ES:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -360,14 +360,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-FR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -383,14 +383,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-GR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -406,14 +406,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-HE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -429,14 +429,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-HU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -452,14 +452,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-IT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -475,14 +475,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-KO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -498,14 +498,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-NL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -521,14 +521,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-PL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -544,14 +544,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-PT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -567,14 +567,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-RO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -590,14 +590,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-RU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -613,14 +613,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-SE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -636,14 +636,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-SK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -659,14 +659,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-TR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -682,14 +682,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-TW:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -705,14 +705,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-UK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -728,7 +728,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-UK
     - uses: actions/upload-artifact@v2
       with:
@@ -751,7 +751,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-VN
     - uses: actions/upload-artifact@v2
       with:
@@ -781,7 +781,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-minimal:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -804,7 +804,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-lite:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -850,7 +850,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-    
+
   tasmota32-knx:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -873,7 +873,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-sensors:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -896,7 +896,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-display:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -919,7 +919,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ir:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -942,7 +942,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ircustom:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -965,7 +965,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-BG:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -988,7 +988,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-BR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1011,7 +1011,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-CN:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1034,7 +1034,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-CZ:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1057,7 +1057,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-DE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1080,7 +1080,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ES:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1103,7 +1103,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-FR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1126,7 +1126,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-GR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1149,7 +1149,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-HE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1172,7 +1172,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-HU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1195,7 +1195,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-IT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1218,7 +1218,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-KO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1241,7 +1241,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-NL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1264,7 +1264,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-PL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1287,7 +1287,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-PT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1310,7 +1310,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-RO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1333,7 +1333,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-RU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1356,7 +1356,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-SE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1379,7 +1379,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-SK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1402,7 +1402,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-TR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1425,7 +1425,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-TW:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1448,7 +1448,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-UK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1496,7 +1496,7 @@ jobs:
 
 
   Upload:
-    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]    
+    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -1520,7 +1520,7 @@ jobs:
         [ ! -f ./mv_firmware/tasmota-ir*.* ] || mv ./mv_firmware/tasmota-ir*.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/tasmota-display.* ] || mv ./mv_firmware/tasmota-display.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/tasmota-knx.* ] || mv ./mv_firmware/tasmota-knx.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/tasmota-zbbridge.* ./firmware/tasmota/        
+        [ ! -f ./mv_firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/tasmota-zbbridge.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/tasmota32.* ] || mv ./mv_firmware/tasmota32.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32-sensors.* ] || mv ./mv_firmware/tasmota32-sensors.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32-minimal.* ] || mv ./mv_firmware/tasmota32-minimal.* ./firmware/tasmota32/
@@ -1531,8 +1531,10 @@ jobs:
         [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
+        rm ./firmware/tasmota32/*.gz
+        rm ./firmware/tasmota32/languages/*.gz
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md        
+        [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
         git config --local user.name "Platformio BUILD"

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v1 
+    - uses: actions/checkout@v1
     - name: Use Tasmota master
-      run: | 
+      run: |
         git config --local user.name "Platformio BUILD"
         git switch -c work
         git remote add -f Tasmota "https://github.com/arendst/Tasmota.git"
-        git merge Tasmota/master --allow-unrelated-histories          
+        git merge Tasmota/master --allow-unrelated-histories
     - name: Push Tasmota   # Push updates of latest Tasmota master to repo
       uses: ad-m/github-push-action@master
       with:
@@ -39,14 +39,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-minimal:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -62,14 +62,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-lite:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -85,14 +85,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-knx:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -108,14 +108,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-sensors:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -131,14 +131,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-display:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -154,14 +154,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ir:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -177,14 +177,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ircustom:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -200,14 +200,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-zbbridge:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -223,13 +223,13 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-zbbridge
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
-  
+
   tasmota-BG:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -245,14 +245,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-BR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -268,14 +268,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-CN:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -291,14 +291,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-CZ:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -314,14 +314,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-DE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -337,14 +337,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-ES:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -360,14 +360,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-FR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -383,14 +383,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-GR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -406,14 +406,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-HE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -429,14 +429,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-HU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -452,14 +452,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-IT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -475,14 +475,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-KO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -498,14 +498,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-NL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -521,14 +521,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-PL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -544,14 +544,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-PT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -567,14 +567,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-RO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -590,14 +590,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-RU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -613,14 +613,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-SE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -636,14 +636,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-SK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -659,14 +659,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-TR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -682,14 +682,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-TW:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -705,14 +705,14 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota-UK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -728,7 +728,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-UK
     - uses: actions/upload-artifact@v2
       with:
@@ -751,7 +751,7 @@ jobs:
         platformio upgrade --dev
         platformio update
     - name: Run PlatformIO
-      run: | 
+      run: |
         platformio run -e tasmota-VN
     - uses: actions/upload-artifact@v2
       with:
@@ -781,7 +781,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-minimal:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -804,7 +804,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-lite:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -850,7 +850,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-    
+
   tasmota32-knx:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -873,7 +873,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-sensors:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -896,7 +896,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-display:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -919,7 +919,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ir:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -942,7 +942,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ircustom:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -965,7 +965,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-BG:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -988,7 +988,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-BR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1011,7 +1011,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-CN:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1034,7 +1034,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-CZ:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1057,7 +1057,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-DE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1080,7 +1080,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-ES:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1103,7 +1103,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-FR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1126,7 +1126,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-GR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1149,7 +1149,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-HE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1172,7 +1172,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-HU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1195,7 +1195,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-IT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1218,7 +1218,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-KO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1241,7 +1241,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-NL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1264,7 +1264,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-PL:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1287,7 +1287,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-PT:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1310,7 +1310,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-RO:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1333,7 +1333,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-RU:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1356,7 +1356,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-SE:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1379,7 +1379,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-SK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1402,7 +1402,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-TR:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1425,7 +1425,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-TW:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1448,7 +1448,7 @@ jobs:
         name: firmware
         path: ./build_output/firmware
 
-  
+
   tasmota32-UK:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1496,7 +1496,7 @@ jobs:
 
 
   Upload:
-    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]    
+    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -1531,8 +1531,10 @@ jobs:
         [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
+        rm ./firmware/tasmota32/*.gz
+        rm ./firmware/tasmota32/languages/*.gz
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md        
+        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
         git config --local user.name "Platformio BUILD"


### PR DESCRIPTION
## Description:
as requested

## Checklist:
  - [ ] The pull request is done against the latest dev branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
