### PR TITLE
Fix bearssl compilation for arduino stage

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/pgmspace_bearssl.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/pgmspace_bearssl.h
@@ -5,8 +5,8 @@
 //#include <sys/pgmspace.h>
 
 
-#ifndef _PGMSPACE_BEARSSL_H_
-#define _PGMSPACE_BEARSSL_H_
+#ifndef _PGMSPACE_H_
+#define _PGMSPACE_H_
 
 #include <stdint.h>
 


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
