### PR TITLE
Fix problem of config loss if deepsleep loop is less than 10seconds

### DIFF
--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -142,6 +142,7 @@ void DeepSleepStart(void)
   WifiShutdown();
   RtcSettings.ultradeepsleep = RtcSettings.nextwakeup - UtcTime();
   RtcSettingsSave();
+  RtcRebootReset();
 #ifdef ESP8266
   ESP.deepSleep(100 * RtcSettings.deepsleep_slip * deepsleep_sleeptime);
 #endif  // ESP8266


### PR DESCRIPTION
## Description: 
Sometimes the deepsleep loop is too fast and causes a config reset. Fixed


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest dev branch
  - [x ] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
