### PR TITLE
Reduce tasmota-minmal by 4kb

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1284,12 +1284,14 @@ void CmndTemplate(void)
     }
   }
   else {
-    if (JsonTemplate(XdrvMailbox.data)) {    // Free 336 bytes StaticJsonBuffer stack space by moving code to function
+#ifndef FIRMWARE_MINIMAL      // if tasmota-minimal, `Template` is read-only
+    if (JsonTemplate(XdrvMailbox.data)) {
       if (USER_MODULE == Settings.module) { TasmotaGlobal.restart_flag = 2; }
     } else {
       ResponseCmndChar_P(PSTR(D_JSON_INVALID_JSON));
       error = true;
     }
+#endif // FIRMWARE_MINIMAL
   }
   if (!error) { TemplateJson(); }
 }

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3401,7 +3401,9 @@ void CmndWebColor(void)
       }
     }
     else {
+#ifndef FIRMWARE_MINIMAL      // if tasmota-minimal, read only and don't parse JSON
       JsonWebColor(XdrvMailbox.data);
+#endif // FIRMWARE_MINIMAL
     }
   }
   Response_P(PSTR("{\"" D_CMND_WEBCOLOR "\":["));


### PR DESCRIPTION
## Description:

Reduce `tasmota-minimal` size by 4kb. The main savings come from not embedding the JSON parser code, that is only used by `WebColor` and `Template`.
Hence `WebColor` and `Template` are made read-only on `tasmota-minimal`. No changes for other versions.

## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
