### PR TITLE
Update contributing doc to point to development branch.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,13 @@ The process is straight-forward.
  - Fork the Tasmota Repository [git repository](https://github.com/arendst/Tasmota).
  - Write/Change the code in your Fork for a new feature, bug fix, new sensor, optimization, etc.
  - Ensure tests work.
- - Create a Pull Request against the [**dev**](https://github.com/arendst/Tasmota/tree/dev) branch of Tasmota.
+ - Create a Pull Request against the [**development**](https://github.com/arendst/Tasmota/tree/development) branch of Tasmota.
 
-1. All pull requests must be done against the dev branch.
+1. All pull requests must be done against the development branch.
 2. Only relevant files should be touched (Also beware if your editor has auto-formatting feature enabled).
 3. Only one feature/fix should be added per PR.
 4. If adding a new functionality (new hardware, new library support) not related to an existing component move it to it's own modules (.ino file).
-5. PRs that don't compile (fail in CI Tests) or cause coding errors will not be merged. Please fix the issue. Same goes for PRs that are raised against older commit in dev - you might need to rebase and resolve conflicts.
+5. PRs that don't compile (fail in CI Tests) or cause coding errors will not be merged. Please fix the issue. Same goes for PRs that are raised against older commit in development - you might need to rebase and resolve conflicts.
 6. All pull requests should undergo peer review by at least one contributor other than the creator, excepts for the owner.
 7. All pull requests should consider updates to the documentation.
 8. Pull requests that address an outstanding issue, particularly an issue deemed to be severe, should be given priority.


### PR DESCRIPTION
I think this was a typo, as the dev branch doesn't exist, yet development
does.

## Description:
Update contributing doc to point to development branch.

## Checklist:
  - [X] The pull request is done against the latest dev branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
