### PR TITLE
Only apply mcp230xx_oldoutpincount when USE_MCP230xx_OUTPUT set

### DIFF
--- a/tasmota/xsns_29_mcp230xx.ino
+++ b/tasmota/xsns_29_mcp230xx.ino
@@ -196,6 +196,7 @@ void MCP230xx_ApplySettings(void)
     I2cWrite8(USE_MCP230xx_ADDR, MCP230xx_GPIO+mcp230xx_port, reg_portpins);
 #endif // USE_MCP230xx_OUTPUT
   }
+#ifdef USE_MCP230xx_OUTPUT
   TasmotaGlobal.devices_present -= mcp230xx_oldoutpincount;
   mcp230xx_oldoutpincount = 0;
   for (uint32_t idx=0;idx<mcp230xx_pincount;idx++) {
@@ -206,6 +207,7 @@ void MCP230xx_ApplySettings(void)
     int_millis[idx]=millis();
   }
   TasmotaGlobal.devices_present += mcp230xx_oldoutpincount;
+#endif // USE_MCP230xx_OUTPUT
   mcp230xx_int_en = int_en;
   MCP230xx_CheckForIntCounter();  // update register on whether or not we should be counting interrupts
   MCP230xx_CheckForIntRetainer(); // update register on whether or not we should be retaining interrupt events for teleperiod


### PR DESCRIPTION
## Description:
In #9023 @stefanbode added the ability to expose the MCP230xx pins as Relays. However this breaks using it as an input.
```
Tasmota/tasmota/xsns_29_mcp230xx.ino: In function 'void MCP230xx_ApplySettings()':
Tasmota/tasmota/xsns_29_mcp230xx.ino:203:7: error: 'mcp230xx_outpinmapping' was not declared in this scope
       mcp230xx_outpinmapping[mcp230xx_oldoutpincount] = idx;
       ^
*** [.pio/build/tasmota-housemotion/src/tasmota.ino.cpp.o] Error 1
```
These changes allow it to build and work as an INPUT.


## Checklist:
  - [x] The pull request is done against the latest dev branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
