### PR TITLE
Add mutex/semaphore for logging - protects new logging_buffer

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -171,6 +171,7 @@ struct {
   char mqtt_topic[TOPSZ];                   // Composed MQTT topic
   char mqtt_data[MESSZ];                    // MQTT publish buffer and web page ajax buffer
   char log_buffer[LOG_BUFFER_SIZE];         // Web log buffer
+  void *log_buffer_mutex;                   // control, access to log buffer
 } TasmotaGlobal;
 
 #ifdef SUPPORT_IF_STATEMENT


### PR DESCRIPTION
## Description:

on ESP32 only, add a mutex to protect logging.
@arendst - let other test this....

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
