### PR TITLE
RuleTimer0 applies to all RuleTimers

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -974,9 +974,8 @@ void RulesEvery100ms(void)
 
 void RulesEverySecond(void)
 {
+  char json_event[120];
   if (Settings.rule_enabled && !Rules.busy) {  // Any rule enabled
-    char json_event[120];
-
     if (RtcTime.valid) {
       if ((TasmotaGlobal.uptime > 60) && (RtcTime.minute != Rules.last_minute)) {  // Execute from one minute after restart every minute only once
         Rules.last_minute = RtcTime.minute;
@@ -984,10 +983,12 @@ void RulesEverySecond(void)
         RulesProcessEvent(json_event);
       }
     }
-    for (uint32_t i = 0; i < MAX_RULE_TIMERS; i++) {
-      if (Rules.timer[i] != 0L) {           // Timer active?
-        if (TimeReached(Rules.timer[i])) {  // Timer finished?
-          Rules.timer[i] = 0L;              // Turn off this timer
+  }
+  for (uint32_t i = 0; i < MAX_RULE_TIMERS; i++) {
+    if (Rules.timer[i] != 0L) {           // Timer active?
+      if (TimeReached(Rules.timer[i])) {  // Timer finished?
+        Rules.timer[i] = 0L;              // Turn off this timer
+        if (Settings.rule_enabled && !Rules.busy) {  // Any rule enabled
           snprintf_P(json_event, sizeof(json_event), PSTR("{\"Rules\":{\"Timer\":%d}}"), i +1);
           RulesProcessEvent(json_event);
         }


### PR DESCRIPTION
## Description:

Following request https://github.com/arendst/Tasmota/discussions/10338
This implements `RuleTimer0` which applies to all rules timer simultaneously.
The major interest is `RuleTimer0 0` to clear all pending rule timers.

Independently of this change (already present in older version of Tasmota), I noticed during the test that if no rule is enabled and a RuleTimer is started, RuleTimers do not "stop" at 0 because `RulesEverySecond()` do not process rules nor rules timers. This means if a rule is enabled later on, the RuleTimer may trigger unexpectedly. (testing `if (Settings.rule_enabled && !Rules.busy)` 
This doesn't seems to be a major issue. However a small rewrite, moving the test inside the Timer loop would do the trick.

Happy to add it to this PR if you want.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
