### PR TITLE
Add option to move ZbReceived from json into the mqtt subtopic.

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -143,7 +143,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t mi32_enable : 1;              // bit 1 (v9.1.0.1)   - SetOption115 - (ESP32 BLE) Enable ESP32 MI32 BLE (1)
     uint32_t zb_disable_autoquery : 1;     // bit 2 (v9.1.0.1)   - SetOption116 - (Zigbee) Disable auto-query of zigbee lights and devices (1)
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
-    uint32_t zbreceived_as_subtopic : 1;   // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
+    uint32_t zb_received_as_subtopic : 1;  // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
     uint32_t spare05 : 1;                  // bit 5
     uint32_t spare06 : 1;                  // bit 6
     uint32_t spare07 : 1;                  // bit 7

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -143,7 +143,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t mi32_enable : 1;              // bit 1 (v9.1.0.1)   - SetOption115 - (ESP32 BLE) Enable ESP32 MI32 BLE (1)
     uint32_t zb_disable_autoquery : 1;     // bit 2 (v9.1.0.1)   - SetOption116 - (Zigbee) Disable auto-query of zigbee lights and devices (1)
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
-    uint32_t spare04 : 1;                  // bit 4
+    uint32_t zbreceived_as_subtopic : 1;   // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
     uint32_t spare05 : 1;                  // bit 5
     uint32_t spare06 : 1;                  // bit 6
     uint32_t spare07 : 1;                  // bit 7

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -511,7 +511,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
 
   TasmotaGlobal.mqtt_data[0] = 0; // clear string
   // Do we prefix with `ZbReceived`?
-  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zb_received_as_subtopic) {
     Response_P(PSTR("{\"%s\":"), json_prefix);
   }
   // What key do we use, shortaddr or name?
@@ -529,7 +529,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
   // Add all other attributes
   ResponseAppend_P(PSTR("%s}}"), attr_list.toString(false).c_str());
 
-  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zb_received_as_subtopic) {
     ResponseAppend_P(PSTR("}"));
   }
 
@@ -545,7 +545,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
       snprintf_P(subtopic, sizeof(subtopic), PSTR("%s/%04X"), TasmotaGlobal.mqtt_topic, shortaddr);
     }
     char stopic[TOPSZ];
-    if (Settings.flag5.zbreceived_as_subtopic)
+    if (Settings.flag5.zb_received_as_subtopic)
       GetTopic_P(stopic, TELE, subtopic, json_prefix);
     else
       GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -511,7 +511,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
 
   TasmotaGlobal.mqtt_data[0] = 0; // clear string
   // Do we prefix with `ZbReceived`?
-  if (!Settings.flag4.remove_zbreceived) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
     Response_P(PSTR("{\"%s\":"), json_prefix);
   }
   // What key do we use, shortaddr or name?
@@ -529,7 +529,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
   // Add all other attributes
   ResponseAppend_P(PSTR("%s}}"), attr_list.toString(false).c_str());
 
-  if (!Settings.flag4.remove_zbreceived) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
     ResponseAppend_P(PSTR("}"));
   }
 
@@ -545,7 +545,10 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
       snprintf_P(subtopic, sizeof(subtopic), PSTR("%s/%04X"), TasmotaGlobal.mqtt_topic, shortaddr);
     }
     char stopic[TOPSZ];
-    GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);
+    if (Settings.flag5.zbreceived_as_subtopic)
+      GetTopic_P(stopic, TELE, subtopic, json_prefix);
+    else
+      GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);
     MqttPublish(stopic, Settings.flag.mqtt_sensor_retain);
   } else {
     MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);


### PR DESCRIPTION
This will make parsing simpler in homeassistant.

Example:

```
21:30:49.178 MQT: tele/tasmota_E302DA/3D41/SENSOR = {"ZbReceived":{"0x3D41":{"Device":"0x3D41","Name":"Stair_Light","Dimmer":101,"Power":0,"Endpoint":1,"LinkQuality":29}}}
21:30:50.496 MQT: tele/tasmota_E302DA/B42F/SENSOR = {"ZbReceived":{"0xB42F":{"Device":"0xB42F","Name":"KitchenTable_Light","Power":0,"Dimmer":176,"Endpoint":1,"LinkQuality":21}}} (retained)
21:30:54.778 MQT: tele/tasmota_E302DA/3D41/SENSOR = {"ZbReceived":{"0x3D41":{"Device":"0x3D41","Name":"Stair_Light","Power":0,"Dimmer":101,"Endpoint":1,"LinkQuality":29}}}

21:30:55.345 CMD: SetOption118 1
21:30:55.350 MQT: stat/tasmota_E302DA/RESULT = {"SetOption118":"ON"}

21:31:01.641 MQT: tele/tasmota_E302DA/1350/ZbReceived = {"0x1350":{"Device":"0x1350","Name":"Button_Mancave_Light","0006!02":"","Power":2,"Endpoint":1,"LinkQuality":29}}
21:32:42.788 MQT: tele/tasmota_E302DA/B3B1/ZbReceived = {"0xB3B1":{"Device":"0xB3B1","Name":"Temp_Mancave","Temperature":23.06,"Endpoint":1,"LinkQuality":26}}
21:32:50.825 MQT: tele/tasmota_E302DA/7EB5/ZbReceived = {"0x7EB5":{"Device":"0x7EB5","Name":"Temp_Livingroom","Humidity":30.83,"Endpoint":1,"LinkQuality":24}}
21:33:51.579 MQT: tele/tasmota_E302DA/F61C/ZbReceived = {"0xF61C":{"Device":"0xF61C","Name":"Temp_Spa","Temperature":21.69,"Endpoint":1,"LinkQuality":94}}
```

Example how this simplifies homeassistant:
```
diff --git a/data/homeassistant/config/configuration.yaml b/data/homeassistant/config/configuration.yaml
index e0a1748..4b7cf4b 100644
--- a/data/homeassistant/config/configuration.yaml
+++ b/data/homeassistant/config/configuration.yaml
@@ -148,10 +148,10 @@ sensor:
     device_class: humidity
   - platform: mqtt
     name: "Guestroom Temperature"
-    state_topic: "tele/tasmota_E302DA/3040/SENSOR"
+    state_topic: "tele/tasmota_E302DA/3040/ZbReceived"
     value_template: >
-      {%- if value_json.ZbReceived is defined and value_json.ZbReceived['0x3040'] is defined and value_json.ZbReceived['0x3040']['Temperature'] is defined -%}
-      {{ value_json.ZbReceived['0x3040']['Temperature'] }}
+      {%- if value_json['0x3040']['Temperature'] is defined -%}
+      {{ value_json['0x3040']['Temperature'] }}
       {%- else -%}
       {{ states('sensor.guestroom_temperature') }}
       {%- endif -%}
```

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
