### PR TITLE
Add option to remove the device addr from json payload

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -143,7 +143,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t mi32_enable : 1;              // bit 1 (v9.1.0.1)   - SetOption115 - (ESP32 BLE) Enable ESP32 MI32 BLE (1)
     uint32_t zb_disable_autoquery : 1;     // bit 2 (v9.1.0.1)   - SetOption116 - (Zigbee) Disable auto-query of zigbee lights and devices (1)
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
-    uint32_t zbreceived_as_subtopic : 1;   // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
+    uint32_t zb_received_as_subtopic : 1;  // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
     uint32_t spare05 : 1;                  // bit 5
     uint32_t spare06 : 1;                  // bit 6
     uint32_t spare07 : 1;                  // bit 7

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -144,7 +144,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t zb_disable_autoquery : 1;     // bit 2 (v9.1.0.1)   - SetOption116 - (Zigbee) Disable auto-query of zigbee lights and devices (1)
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
     uint32_t zb_received_as_subtopic : 1;  // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
-    uint32_t spare05 : 1;                  // bit 5
+    uint32_t zb_omit_json_addr : 1;        // bit 5 (v9.2.0.3)   - SetOption119 - (Zigbee) Remove the device addr from json payload, can be used with zb_topic_fname where the addr is already known from the topic
     uint32_t spare06 : 1;                  // bit 6
     uint32_t spare07 : 1;                  // bit 7
     uint32_t spare08 : 1;                  // bit 8

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -143,7 +143,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t mi32_enable : 1;              // bit 1 (v9.1.0.1)   - SetOption115 - (ESP32 BLE) Enable ESP32 MI32 BLE (1)
     uint32_t zb_disable_autoquery : 1;     // bit 2 (v9.1.0.1)   - SetOption116 - (Zigbee) Disable auto-query of zigbee lights and devices (1)
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
-    uint32_t spare04 : 1;                  // bit 4
+    uint32_t zbreceived_as_subtopic : 1;   // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived form JSON message and into the subtopic replacing "SENSOR" default
     uint32_t spare05 : 1;                  // bit 5
     uint32_t spare06 : 1;                  // bit 6
     uint32_t spare07 : 1;                  // bit 7

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -511,7 +511,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
 
   TasmotaGlobal.mqtt_data[0] = 0; // clear string
   // Do we prefix with `ZbReceived`?
-  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zb_received_as_subtopic) {
     Response_P(PSTR("{\"%s\":"), json_prefix);
   }
   // What key do we use, shortaddr or name?
@@ -529,7 +529,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
   // Add all other attributes
   ResponseAppend_P(PSTR("%s}}"), attr_list.toString(false).c_str());
 
-  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zb_received_as_subtopic) {
     ResponseAppend_P(PSTR("}"));
   }
 
@@ -545,7 +545,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
       snprintf_P(subtopic, sizeof(subtopic), PSTR("%s/%04X"), TasmotaGlobal.mqtt_topic, shortaddr);
     }
     char stopic[TOPSZ];
-    if (Settings.flag5.zbreceived_as_subtopic)
+    if (Settings.flag5.zb_received_as_subtopic)
       GetTopic_P(stopic, TELE, subtopic, json_prefix);
     else
       GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -511,7 +511,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
 
   TasmotaGlobal.mqtt_data[0] = 0; // clear string
   // Do we prefix with `ZbReceived`?
-  if (!Settings.flag4.remove_zbreceived) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
     Response_P(PSTR("{\"%s\":"), json_prefix);
   }
   // What key do we use, shortaddr or name?
@@ -529,7 +529,7 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
   // Add all other attributes
   ResponseAppend_P(PSTR("%s}}"), attr_list.toString(false).c_str());
 
-  if (!Settings.flag4.remove_zbreceived) {
+  if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zbreceived_as_subtopic) {
     ResponseAppend_P(PSTR("}"));
   }
 
@@ -545,7 +545,10 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
       snprintf_P(subtopic, sizeof(subtopic), PSTR("%s/%04X"), TasmotaGlobal.mqtt_topic, shortaddr);
     }
     char stopic[TOPSZ];
-    GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);
+    if (Settings.flag5.zbreceived_as_subtopic)
+      GetTopic_P(stopic, TELE, subtopic, json_prefix);
+    else
+      GetTopic_P(stopic, TELE, subtopic, D_RSLT_SENSOR);
     MqttPublish(stopic, Settings.flag.mqtt_sensor_retain);
   } else {
     MqttPublishPrefixTopic_P(TELE, PSTR(D_RSLT_SENSOR), Settings.flag.mqtt_sensor_retain);

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -515,11 +515,15 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
     Response_P(PSTR("{\"%s\":"), json_prefix);
   }
   // What key do we use, shortaddr or name?
-  if (use_fname) {
-    Response_P(PSTR("%s{\"%s\":{"), TasmotaGlobal.mqtt_data, friendlyName);
-  } else {
-    Response_P(PSTR("%s{\"0x%04X\":{"), TasmotaGlobal.mqtt_data, shortaddr);
+  if (!Settings.flag5.zb_omit_json_addr) {
+    if (use_fname) {
+      Response_P(PSTR("%s{\"%s\":"), TasmotaGlobal.mqtt_data, friendlyName);
+    } else {
+      Response_P(PSTR("%s{\"0x%04X\":"), TasmotaGlobal.mqtt_data, shortaddr);
+    }
   }
+  ResponseAppend_P(PSTR("{"));
+
   // Add "Device":"0x...."
   ResponseAppend_P(PSTR("\"" D_JSON_ZIGBEE_DEVICE "\":\"0x%04X\","), shortaddr);
   // Add "Name":"xxx" if name is present
@@ -527,7 +531,11 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
     ResponseAppend_P(PSTR("\"" D_JSON_ZIGBEE_NAME "\":\"%s\","), EscapeJSONString(friendlyName).c_str());
   }
   // Add all other attributes
-  ResponseAppend_P(PSTR("%s}}"), attr_list.toString(false).c_str());
+  ResponseAppend_P(PSTR("%s}"), attr_list.toString(false).c_str());
+
+  if (!Settings.flag5.zb_omit_json_addr) {
+    ResponseAppend_P(PSTR("}"));
+  }
 
   if (!Settings.flag4.remove_zbreceived && !Settings.flag5.zb_received_as_subtopic) {
     ResponseAppend_P(PSTR("}"));


### PR DESCRIPTION
## Description:

Built on top of #10353 that should be merged first. Could not add this as a separate commit as it conflicts with previous pull request.

Zigbee: Remove the device addr from json payload, which can be used with zb_topic_fname where the addr is already known from the topic. Simplifies home assistant integration

Example:

```
21:56:18.664 CMD: SetOption119 0
21:56:18.670 MQT: stat/tasmota_E302DA/RESULT = {"SetOption119":"OFF"}
21:56:29.415 MQT: tele/tasmota_E302DA/1350/ZbReceived = {"0x1350":{"Device":"0x1350","Name":"Button_Mancave_Light","0006!02":"","Power":2,"Endpoint":1,"LinkQuality":37}} 
21:56:38.364 CMD: SetOption119 1
21:56:38.370 MQT: stat/tasmota_E302DA/RESULT = {"SetOption119":"ON"}
21:56:41.246 MQT: tele/tasmota_E302DA/1350/ZbReceived = {"Device":"0x1350","Name":"Button_Mancave_Light","0006!02":"","Power":2,"Endpoint":1,"LinkQuality":37} 

```

Homeassistant could be simplified this way

```
--- a/data/homeassistant/config/configuration.yaml
+++ b/data/homeassistant/config/configuration.yaml
@@ -150,8 +150,8 @@ sensor:
     name: "Guestroom Temperature"
     state_topic: "tele/tasmota_E302DA/3040/zbReceived"
     value_template: >
-      {%- if value_json['0x3040']['Temperature'] is defined -%}
-      {{ value_json['0x3040']['Temperature'] }}
+      {%- if value_json['Temperature'] is defined -%}
+      {{ value_json['Temperature'] }}
       {%- else -%}
       {{ states('sensor.guestroom_temperature') }}
       {%- endif -%}


```

Or just 

```
--- a/data/homeassistant/config/configuration.yaml
+++ b/data/homeassistant/config/configuration.yaml
@@ -150,8 +150,8 @@ sensor:
     name: "Guestroom Temperature"
     state_topic: "tele/tasmota_E302DA/3040/zbReceived"
     value_template: >
-      {%- if value_json['0x3040']['Temperature'] is defined -%}
-      {{ value_json['0x3040']['Temperature'] }}
+      {{ value_json['Temperature'] }}
-      {%- else -%}
-      {{ states('sensor.guestroom_temperature') }}
-     {%- endif -%}


```

If its a sensor that just returns one value every time.

**Related issue (if applicable):** Builds on top of #10353

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
