### PR TITLE
fixes DisplayMode 1-5 support for ILI9342_2 driver

### DIFF
--- a/tasmota/xdsp_13_ILI9341-2.ino
+++ b/tasmota/xdsp_13_ILI9341-2.ino
@@ -95,8 +95,9 @@ void ILI9341_2_InitDriver()
     // Welcome text
     renderer->setTextFont(2);
     renderer->setTextColor(ILI9341_2_WHITE,ILI9341_2_BLACK);
-    renderer->DrawStringAt(30, 100, "ILI9341 TFT!", ILI9341_2_WHITE,0);
+    renderer->DrawStringAt(20, 140, "ILI9341 TFT!", ILI9341_2_RED,0);
     delay(1000);
+    renderer->clearDisplay();
 #endif
 
     color_type = COLOR_COLOR;
@@ -174,6 +175,77 @@ ili9342_ctouch_counter++;
 #endif // ESP32
 
 
+#ifdef USE_DISPLAY_MODES1TO5
+
+void ILI9341_2_PrintLog(bool withDateTime) {
+  disp_refresh--;
+  if (!disp_refresh) {
+    disp_refresh = Settings.display_refresh;
+    if (!disp_screen_buffer_cols) { DisplayAllocScreenBuffer(); }
+
+    char* txt = DisplayLogBuffer('\370');
+    if (txt != NULL) {
+      uint8_t last_row = Settings.display_rows -1;
+
+      renderer->clearDisplay(); /** TODO: Would be smoother without clear, like ILI9341_2_Time() does. **/
+      renderer->setCursor(0,0);
+
+      if (withDateTime) {
+        char line[21];
+        snprintf_P(line, sizeof(line), PSTR("%02d" D_HOUR_MINUTE_SEPARATOR "%02d" D_MINUTE_SECOND_SEPARATOR "%02d  %02d" D_MONTH_DAY_SEPARATOR "%02d" D_YEAR_MONTH_SEPARATOR "%04d"), RtcTime.hour, RtcTime.minute, RtcTime.second, RtcTime.day_of_month, RtcTime.month, RtcTime.year);  // [12:34:56  31-12-2021]
+        renderer->setTextColor(ILI9341_2_BLUE);
+        renderer->println(line);
+        renderer->setTextColor(fg_color);
+        last_row--;
+      }
+
+      for (byte i = 0; i < last_row; i++) {
+        strlcpy(disp_screen_buffer[i], disp_screen_buffer[i +1], disp_screen_buffer_cols);
+        renderer->println(disp_screen_buffer[i]);
+      }
+      strlcpy(disp_screen_buffer[last_row], txt, disp_screen_buffer_cols);
+      DisplayFillScreen(last_row);
+
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "[%s]"), disp_screen_buffer[last_row]);
+
+      renderer->println(disp_screen_buffer[last_row]);
+      renderer->Updateframe();
+    }
+  }
+}
+
+void ILI9341_2_Time(void) {
+  char line[12];
+  /** TODO: DisplaySize is working, but renderer->println() does not respect DisplayFont **/
+  snprintf_P(line, sizeof(line), PSTR(" %02d" D_HOUR_MINUTE_SEPARATOR "%02d" D_MINUTE_SECOND_SEPARATOR "%02d"), RtcTime.hour, RtcTime.minute, RtcTime.second);  // [ 12:34:56 ]
+  renderer->setCursor(60, 140);
+  renderer->println(line);
+  snprintf_P(line, sizeof(line), PSTR("%02d" D_MONTH_DAY_SEPARATOR "%02d" D_YEAR_MONTH_SEPARATOR "%04d"), RtcTime.day_of_month, RtcTime.month, RtcTime.year);   // [01-02-2018]
+  renderer->setCursor(60, 160);
+  renderer->println(line);
+  renderer->Updateframe();
+}
+
+void ILI9341_2_Refresh(void) {  // Every second
+  if (Settings.display_mode) {  // Mode 0 is User text
+    switch (Settings.display_mode) {
+      case 1:  // Time
+        ILI9341_2_Time();
+        break;
+      case 2:  // Local
+      case 4:  // Mqtt
+        ILI9341_2_PrintLog(false);
+        break;
+      case 3:  // Local + Time
+      case 5:  // Mqtt + Time
+        ILI9341_2_PrintLog(true);
+        break;
+    }
+  }
+}
+
+#endif  // USE_DISPLAY_MODES1TO5
+
 /*********************************************************************************************/
 /*********************************************************************************************\
  * Interface
@@ -190,6 +262,11 @@ bool Xdsp13(uint8_t function)
         case FUNC_DISPLAY_MODEL:
           result = true;
           break;
+        case FUNC_DISPLAY_TEXT_SIZE:
+        case FUNC_DISPLAY_FONT_SIZE:
+        case DISPLAY_INIT_MODE:
+          renderer->clearDisplay();
+          break;
 #ifdef USE_FT5206
 #ifdef USE_TOUCH_BUTTONS
         case FUNC_DISPLAY_EVERY_50_MSECOND:
@@ -199,6 +276,11 @@ bool Xdsp13(uint8_t function)
           break;
 #endif // USE_TOUCH_BUTTONS
 #endif // USE_FT5206
+#ifdef USE_DISPLAY_MODES1TO5
+        case FUNC_DISPLAY_EVERY_SECOND:
+          ILI9341_2_Refresh();
+          break;
+#endif  // USE_DISPLAY_MODES1TO5
     }
   }
   return result;


### PR DESCRIPTION
## Description:
fixes DisplayMode 1-5 support for ILI9342_2 driver

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9 => **ILI9342_2 [is disabled](https://github.com/arendst/Tasmota/blob/development/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp#L49) for ESP8622**
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
