### PR TITLE
Odroid go has 4MB PSRAM

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -36,6 +36,7 @@ default_envs =
 ;                tasmota32-ir
 ;                tasmota32-ircustom
 ;                tasmota32solo1
+;                tasmota32-odroidgo
 
 
 [common]

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -41,7 +41,7 @@ extends                 = env:tasmota32
 board                   = odroid_esp32
 board_build.f_cpu       = 240000000L
 board_build.partitions  = esp32_partition_app1984k_ffat12M.csv
-build_flags             = ${common32.build_flags} -DFIRMWARE_ODROID_GO
+build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM=true -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-minimal]


### PR DESCRIPTION
## Description:

enable the PSRAM. Add odroidgo build variant to Platformio override

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
