### PR TITLE
add missing quotes around %s in JSON response

### DIFF
--- a/tasmota/xsns_34_hx711.ino
+++ b/tasmota/xsns_34_hx711.ino
@@ -264,7 +264,7 @@ bool HxCommand(void)
     char item[33];
     dtostrfd((float)Settings.weight_item / 10, 1, item);
     Response_P(PSTR("{\"Sensor34\":{\"" D_JSON_WEIGHT_REF "\":%d,\"" D_JSON_WEIGHT_CAL "\":%d,\"" D_JSON_WEIGHT_MAX "\":%d,\""
-		    D_JSON_WEIGHT_ITEM "\":%s,\"" D_JSON_WEIGHT_CHANGE "\":%s,\"" D_JSON_WEIGHT_DELTA "\":%d}}"),
+		    D_JSON_WEIGHT_ITEM "\":%s,\"" D_JSON_WEIGHT_CHANGE "\":\"%s\",\"" D_JSON_WEIGHT_DELTA "\":%d}}"),
 	       Settings.weight_reference, Settings.weight_calibration, Settings.weight_max * 1000,
 	       item, GetStateText(Settings.SensorBits1.hx711_json_weight_change), Settings.weight_change);
   }


### PR DESCRIPTION
## Description:

The JSON response for Sensor HX711 has a string field (OFF or ON) which format string is missing the `\"` around `%s`.
Reported by Discord user 2safe4you (@wlan4you on Gihub)
Tested by him once I provided him with the change (I don't myself own a HX711 scale)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
