### PR TITLE
Fixes

### DIFF
--- a/lib/lib_display/Arduino_ST7789-gemu-1.0/Arduino_ST7789.cpp
+++ b/lib/lib_display/Arduino_ST7789-gemu-1.0/Arduino_ST7789.cpp
@@ -96,8 +96,11 @@ Arduino_ST7789::Arduino_ST7789(int8_t dc, int8_t rst, int8_t cs, int8_t bp)
 
 void Arduino_ST7789::DisplayInit(int8_t p,int8_t size,int8_t rot,int8_t font) {
   setRotation(rot);
-  //invertDisplay(false);
-  invertDisplay(true);
+  if (_width==320 || _height==320) {
+    invertDisplay(false);
+  } else {
+    invertDisplay(true);
+  }
   //setTextWrap(false);         // Allow text to run off edges
   //cp437(true);
   setTextFont(font&3);

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1,7 +1,7 @@
 /*
   xdrv_10_scripter.ino - script support for Tasmota
 
-  Copyright (C) 2020  Gerhard Mutz and Theo Arends
+  Copyright (C) 2021  Gerhard Mutz and Theo Arends
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -5821,8 +5821,8 @@ void Script_Handle_Hue(String *path) {
       String x_str = tok_x.getStr();
       String y_str = tok_y.getStr();
       uint8_t rr,gg,bb;
-      LightStateClass::XyToRgb(x, y, &rr, &gg, &bb);
-      LightStateClass::RgbToHsb(rr, gg, bb, &hue, &sat, nullptr);
+      XyToRgb(x, y, &rr, &gg, &bb);
+      RgbToHsb(rr, gg, bb, &hue, &sat, nullptr);
       if (resp) { response += ","; }
       response += FPSTR(sHUE_LIGHT_RESPONSE_JSON);
       response.replace("{id", String(device));

--- a/tasmota/xdsp_12_ST7789.ino
+++ b/tasmota/xdsp_12_ST7789.ino
@@ -45,6 +45,10 @@
 
 // currently fixed
 #define BACKPLANE_PIN 2
+  #ifdef USE_LANBON_L8
+  #undef BACKPLANE_PIN
+  #define BACKPLANE_PIN 5
+  #endif // USE_LANBON_L8
 
 extern uint8_t *buffer;
 extern uint8_t color_type;
@@ -126,6 +130,12 @@ void ST7789_InitDriver(void) {
     // start digitizer with fixed adress and pins for esp32
     #define SDA_2 23
     #define SCL_2 32
+  #ifdef USE_LANBON_L8
+    #undef SDA_2 
+    #undef SCL_2 
+    #define SDA_2 4
+    #define SCL_2 0
+  #endif // USE_LANBON_L8
     Wire1.begin(SDA_2, SCL_2, 400000);
     Touch_Init(Wire1);
 #endif // USE_FT5206


### PR DESCRIPTION
## Description:

adds support fo USE_LANBON_L8  display and touch (thanks to @blakadder)
fixes a problem when variable names with the same name as index vars were defined
e.g.  var sw conflicts with sw[x]

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
