### PR TITLE
Select strongest AP if duplicate SSID exist

### DIFF
--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -291,7 +291,10 @@ void WifiBeginAfterScan(void)
                 memcpy((void*) &Wifi.bssid, (void*) bssid_scan, sizeof(Wifi.bssid));
               }
             }
-            break;
+            // Do NOT terminate at first matching SSID as it may not be the strongest one where multiple access points are visible.
+            // NOTE: The scan results are not sorted in descending order of RSSI, rather they are grouped by channel number
+            // Early termination means a very weak match on channel 1 will be selected over a very strong match for the same SSID on channel 6.
+            // break;
           }
         }
         char hex_char[18];


### PR DESCRIPTION
## Description:
When performing WiFi scan, do not terminate at first matching SSID as it may not be the strongest one if multiple access points are visible.
NOTE: The scan results are not sorted in descending order of RSSI, rather they are grouped by channel number
Early termination means a very weak match on channel 1 will be selected over a very strong match for the same SSID on channel 6.

## To reproduce: Setup two access points, with identical SSID:
AP1: Set to channel 1, and place it perhaps 20m away (about -80dBm RSSI)
AP2: Set to channel 11, and place it about 2m away (about -60dBm RSSI)
NOTE: Channel number matters - the bug causes Tasmota to select the lowest numbered channel for a given SSID.
SetOption56 1 to initiate a new scan on each restart.
Result: The device will consistently select AP1, despite AP2 being much closer/stronger.
Using the WiFi scan feature will confirm AP2 is stronger.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: I have not run any CI tests on this change, however I have confirmed the fix on a SONOFF mini and a ESP32 D1 mini dev board. 