### PR TITLE
Add tool-mklittlefs to ESP32 Platformio setup

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -134,6 +134,7 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 [core32_stage]
 platform                    = espressif32 @ 2.1.0
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc4/esp32-1.0.5-rc4.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
                               ;-DESP32_STAGE=true

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -90,5 +90,6 @@ build_flags                 = ${esp_defaults.build_flags}
 [core32]
 platform                    = espressif32 @ 2.1.0
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc4/esp32-1.0.5-rc4.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

For ESP32: tool-mklittlefs to upload files to file system partition. 
For ESP8266 PlatformIO downloads the tool when needed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
