### PR TITLE
SD Card enable for Odroid

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -41,7 +41,7 @@ extends                 = env:tasmota32
 board                   = odroid_esp32
 board_build.f_cpu       = 240000000L
 board_build.partitions  = esp32_partition_app1984k_spiffs12M.csv
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM=true -DFIRMWARE_ODROID_GO
+build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-minimal]

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -54,7 +54,7 @@
 #define USE_ODROID_GO                            // Add support for Odroid Go
 #define USE_UFILESYS
 #define USE_SDCARD
-//#define SDCARD_CS_PIN     4                      // Need to look which is the Odroid Gpio for
+#define SDCARD_CS_PIN     22
 #define USE_ADC
 #define USE_SPI
   #define USE_DISPLAY                            // Add SPI Display Support (+2k code)

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -54,7 +54,6 @@
 #define USE_ODROID_GO                            // Add support for Odroid Go
 #define USE_UFILESYS
 #define USE_SDCARD
-#define SDCARD_CS_PIN     22
 #define USE_ADC
 #define USE_SPI
   #define USE_DISPLAY                            // Add SPI Display Support (+2k code)

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -52,6 +52,9 @@
 #define FALLBACK_MODULE        ODROID_GO         // [Module2] Select default module on fast reboot where USER_MODULE is user template
 
 #define USE_ODROID_GO                            // Add support for Odroid Go
+#define USE_UFILESYS
+#define USE_SDCARD
+//#define SDCARD_CS_PIN     4                      // Need to look which is the Odroid Gpio for
 #define USE_ADC
 #define USE_SPI
   #define USE_DISPLAY                            // Add SPI Display Support (+2k code)


### PR DESCRIPTION
and adding the missing compile option for fixing the psram cache issue.
(Odroid Platformio board definition is incomplete / faulty PR https://github.com/platformio/platform-espressif32/pull/467)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
