### PR TITLE
Respond correctly to the time request from the MCU

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -948,7 +948,11 @@ void TuyaNormalPowerModePacketProcess(void)
       }
       TuyaRequestState(0);
       break;
-
+#ifdef USE_TUYA_TIME
+    case TUYA_CMD_SET_TIME:
+      TuyaSetTime();
+      break;
+#endif
     default:
       AddLog_P(LOG_LEVEL_DEBUG, PSTR("TYA: RX unknown command"));
   }


### PR DESCRIPTION
My Thermostat does a time request using the command 0x1c (=28) and should respond with the set time command. It looks like it was missing. I added it now and time is now updated on my Tasmotized Wifi thermostat.


## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
