### PR TITLE
Fixing MQTT Discovery Hostname

### DIFF
--- a/tasmota/support_network.ino
+++ b/tasmota/support_network.ino
@@ -61,10 +61,10 @@ void MqttDiscoverServer(void)
       }
     }
 #endif  // MDNS_HOSTNAME
-    SettingsUpdateText(SET_MQTT_HOST, MDNS.IP(i).toString().c_str());
+    SettingsUpdateText(SET_MQTT_HOST, MDNS.hostname(i).c_str());
     Settings.mqtt_port = MDNS.port(i);
 
-    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_MDNS D_MQTT_SERVICE_FOUND " %s, " D_IP_ADDRESS " %s, " D_PORT " %d"), MDNS.hostname(i).c_str(), SettingsText(SET_MQTT_HOST), Settings.mqtt_port);
+    AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_MDNS D_MQTT_SERVICE_FOUND " %s," D_PORT " %d"), SettingsText(SET_MQTT_HOST), Settings.mqtt_port);
   }
 }
 #endif  // MQTT_HOST_DISCOVERY


### PR DESCRIPTION
## Description:

MQTT discovery was trying to use the resolved IP address in the MDNS discovery phase, this is unneeded because MQTT can use a full hostname, and wasn't working.

I've tested it on an esp8266 and ESP32, it doesn't seem to have any effect on the ESP32 board.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
