### PR TITLE
Zigbee don't report battery value for Philips devices

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -2159,13 +2159,13 @@ void Z_Data::toAttributes(Z_attribute_list & attr_list) const {
 
 //
 // Check if this device needs Battery reporting
-// This is usefule for IKEA device that tend to drain battery quickly when Battery reporting is set
+// This is useful for IKEA or Philips devices that tend to drain battery quickly when Battery reporting is set
 //
 bool Z_BatteryReportingDeviceSpecific(uint16_t shortaddr) {
   const Z_Device & device = zigbee_devices.findShortAddr(shortaddr);
   if (device.manufacturerId) {
     String manuf_c(device.manufacturerId);
-    if (manuf_c.startsWith(F("IKEA"))) {
+    if ((manuf_c.startsWith(F("IKEA"))) || (manuf_c.startsWith(F("Philips")))) {
       return false;
     }
   }


### PR DESCRIPTION
## Description:

Don't configure Battery reporting for Philips devices, as it is reported to drain the battery.

**Related issue (if applicable):** fixes #10413

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
