### PR TITLE
Filemanager

### DIFF
--- a/esp32_partition_app1984k_spiffs60k.csv
+++ b/esp32_partition_app1984k_spiffs60k.csv
@@ -1,8 +1,0 @@
-# ESP-IDF Partition Table
-# Name, Type, SubType, Offset, Size, Flags
-nvs,data,nvs,0x9000,20K,
-otadata,data,ota,0xe000,8K,
-app0,app,ota_0,0x10000,1984K,
-app1,app,ota_1,0x200000,1984K,
-spiffs,data,spiffs,0x3f0000,60K,
-eeprom,data,nvs,0x3ff000,4K,


### PR DESCRIPTION
## Description:

optional delete file gui  (just for fun)
#define GUI_TRASH_FILE

remove ESP32 EEPROM linker file because also obsolete 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
