### PR TITLE
Pid branch revived

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -811,10 +811,10 @@
 // -- Prometheus exporter ---------------------------
 //#define USE_PROMETHEUS                           // Add support for https://prometheus.io/ metrics exporting over HTTP /metrics endpoint
 
-// -- PID and Timeprop ------------------------------
-// #define use TIMEPROP                            // Add support for the timeprop feature (+0k8 code)
+// -- PID and Timeprop ------------------------------ // Both together will add +12k1 code
+// #define use TIMEPROP                            // Add support for the timeprop feature (+9k1 code)
                                                    // For details on the configuration please see the header of tasmota/xdrv_48_timeprop.ino
-// #define USE_PID                                 // Add suport for the PID  feature (+11k1 code)
+// #define USE_PID                                 // Add suport for the PID  feature (+11k2 code)
                                                    // For details on the configuration please see the header of tasmota/xdrv_49_pid.ino
 // -- End of general directives -------------------
 

--- a/tasmota/xdrv_48_timeprop.ino
+++ b/tasmota/xdrv_48_timeprop.ino
@@ -79,6 +79,7 @@
 
 
 #ifdef USE_TIMEPROP
+#ifndef FIRMWARE_MINIMAL
 
 # include "Timeprop.h"
 
@@ -153,6 +154,7 @@ bool Timeprop_Command()
   char command [CMDSZ];
   bool serviced = true;
   uint8_t ua_prefix_len = strlen(D_CMND_TIMEPROP); // to detect prefix of command
+  AddLog_P(LOG_LEVEL_ERROR, PSTR("TRP: Timeprop_Command called"));
   /*
   snprintf_P(log_data, sizeof(log_data), "Command called: "
     "index: %d data_len: %d payload: %d topic: %s data: %s\n",
@@ -220,4 +222,5 @@ bool Xdrv48(byte function)
   return result;
 }
 
+#endif // FIRMWARE_MINIMAL
 #endif // USE_TIMEPROP

--- a/tasmota/xdrv_49_pid.ino
+++ b/tasmota/xdrv_49_pid.ino
@@ -119,11 +119,6 @@
    #define PID_REPORT_MORE_SETTINGS                   // If defined, the SENSOR output will provide more extensive json
                                                  // output in the PID section
 
-//   #define PID_BACKWARD_COMPATIBLE             // Preserve the backward compatible reporting of PID power via
-                                                 // `%topic%/PID {"power":"0.000"}`  This is now available in
-                                                 // `%topic$/SENSOR {..., "PID":{"PidPower":0.00}}`
-                                                 // Don't use unless you know that you need it
-
  * Help with using the PID algorithm and with loop tuning can be found at
  * http://blog.clanlaw.org.uk/2018/01/09/PID-tuning-with-node-red-contrib-pid.html
  * This is directed towards using the algorithm in the node-red node node-red-contrib-pid but the algorithm here is based on
@@ -362,14 +357,14 @@ void PIDShowValues(void) {
 static void run_pid()
 {
   double power = pid.tick(pid_current_time_secs);
-#ifdef PID_BACKWARD_COMPATIBLE
+#ifdef PID_DONT_USE_PID_TOPIC
   // This part is left inside to regularly publish the PID Power via
   // `%topic%/PID {"power":"0.000"}`
   char str_buf[FLOATSZ];
   dtostrfd(power, 3, str_buf);
   snprintf_P(TasmotaGlobal.mqtt_data, sizeof(TasmotaGlobal.mqtt_data), PSTR("{\"%s\":\"%s\"}"), "power", str_buf);
   MqttPublishPrefixTopic_P(TELE, "PID", false);
-#endif // PID_BACKWARD_COMPATIBLE
+#endif // PID_DONT_USE_PID_TOPIC
 
 #if defined PID_SHUTTER
     // send output as a position from 0-100 to defined shutter

--- a/tasmota/xdrv_49_pid.ino
+++ b/tasmota/xdrv_49_pid.ino
@@ -237,6 +237,7 @@ void CmndSetPv(void) {
     // this runs it at the next second
     run_pid_now = true;
   }
+  ResponseCmndNumber(atof(XdrvMailbox.data));
 }
 
 void CmndSetSp(void) {
@@ -358,7 +359,7 @@ void PIDShowValues(void) {
 static void run_pid()
 {
   double power = pid.tick(pid_current_time_secs);
-#ifdef PID_DONT_USE_PID_TOPIC
+#ifndef PID_DONT_USE_PID_TOPIC
   // This part is left inside to regularly publish the PID Power via
   // `%topic%/PID {"power":"0.000"}`
   char str_buf[FLOATSZ];

--- a/tasmota/xdrv_49_pid.ino
+++ b/tasmota/xdrv_49_pid.ino
@@ -129,6 +129,7 @@
 
 
 #ifdef USE_PID
+#ifndef FIRMWARE_MINIMAL
 
 #include "PID.h"
 
@@ -410,4 +411,5 @@ bool Xdrv49(byte function)
   }
   return result;
 }
+#endif // FIRMWARE_MINIMAL
 #endif // USE_PID


### PR DESCRIPTION
## Description:

The additional commmits fix the following:
- Code now compiles with `tasmota-minimal` because I've surrounded it by `#ifndef FIRMWARE_MINIMAL`
- Now including publishing the `%topic%/PID {"power": <PidPower>}` by default (can be turned off), since it was requested by @colinl  . My issue with this was that it does access `TasmotaGlobal.mqtt_data`, which was discouraged earlier. I tried to find alternatives for publishing, but failed. Pointers be helpful.
- Re-inserted the code in `xdrv_48_timeprop.ino` for advanced handling of incoming commands (in bool Timeprop_Command), so that the `timeprop_setvalue_x` can be received to set the timeprop value for relay `x`. Also it is being used from `xdrv_49_pid.ino`.
I failed moving this to DecodeCommand, because of the `_x` feature. 
Is it really necessary to move to DecodeCommand? If so: How?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
