### PR TITLE
Zigbee added config attributes

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -752,6 +752,23 @@
   #define USE_ZBBRIDGE_TLS                       // TLS support for zbbridge
   #define USE_ZIGBEE_ZBBRIDGE_EEPROM 0x50        // I2C id for the ZBBridge EEPROM
 
+  // Auto-binding constants, see `Z_autoAttributeReporting`
+  // Below are the threshold for attribute reporting
+  #define USE_ZIGBEE_AUTOBIND_BATTVOLTAGE   0.1     // V
+  #define USE_ZIGBEE_AUTOBIND_BATTPERCENT   1       // %
+  #define USE_ZIGBEE_AUTOBIND_TEMPERATURE   0.5     // °C
+  #define USE_ZIGBEE_AUTOBIND_HEATDEMAND    10      // %
+  #define USE_ZIGBEE_AUTOBIND_PRESSURE      1       // hPA
+  #define USE_ZIGBEE_AUTOBIND_ILLUMINANCE   5       // lux
+  #define USE_ZIGBEE_AUTOBIND_HUMIDITY      1.0     // %
+  // Below are the Max Thresholds for reporting time (in seconds)
+  #define USE_ZIGBEE_MAXTIME_BATT           4*60*60   // 4h
+  #define USE_ZIGBEE_MAXTIME_TRV            60*10     // 10m
+  #define USE_ZIGBEE_MAXTIME_SENSOR         60*60     // 1h
+  #define USE_ZIGBEE_MAXTIME_LIGHT          60*60     // 1h
+
+
+
 // -- Other sensors/drivers -----------------------
 
 //#define USE_TM1638                               // Add support for TM1638 switches copying Switch1 .. Switch8 (+1k code)

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1472,25 +1472,25 @@ typedef struct Z_autoAttributeReporting_t {
 
 // Note the attribute must be registered in the converter list, used to retrieve the type of the attribute
 const Z_autoAttributeReporting_t Z_autoAttributeReporting[] PROGMEM = {
-  { 0x0001, 0x0020,    60*60, 4*60*60,  0.1 },      // BatteryVoltage
-  { 0x0001, 0x0021,    60*60, 4*60*60,    1 },      // BatteryPercentage
-  { 0x0006, 0x0000,        1,   60*60,    0 },      // Power
-  { 0x0201, 0x0000,       60,   60*10,  0.5 },      // LocalTemperature
-  { 0x0201, 0x0008,       60,   60*10,   10 },      // PIHeatingDemand
-  { 0x0201, 0x0012,       60,   60*10,  0.5 },      // OccupiedHeatingSetpoint
-  { 0x0008, 0x0000,        1,   60*60,    5 },      // Dimmer
-  { 0x0300, 0x0000,        1,   60*60,    5 },      // Hue
-  { 0x0300, 0x0001,        1,   60*60,    5 },      // Sat
-  { 0x0300, 0x0003,        1,   60*60,  100 },      // X
-  { 0x0300, 0x0004,        1,   60*60,  100 },      // Y
-  { 0x0300, 0x0007,        1,   60*60,    5 },      // CT
-  { 0x0300, 0x0008,        1,   60*60,    0 },      // ColorMode
-  { 0x0400, 0x0000,       10,   60*60,    5 },      // Illuminance (5 lux)
-  { 0x0402, 0x0000,       30,   60*60,  0.2 },      // Temperature (0.2 °C)
-  { 0x0403, 0x0000,       30,   60*60,    1 },      // Pressure (1 hPa)
-  { 0x0405, 0x0000,       30,   60*60,  1.0 },      // Humidity (1 %)
-  { 0x0406, 0x0000,       10,   60*60,    0 },      // Occupancy
-  { 0x0500, 0x0002,        1,   60*60,    0 },      // ZoneStatus
+  { 0x0001, 0x0020,    60*60, USE_ZIGBEE_MAXTIME_BATT,  USE_ZIGBEE_AUTOBIND_BATTVOLTAGE },      // BatteryVoltage
+  { 0x0001, 0x0021,    60*60, USE_ZIGBEE_MAXTIME_BATT,  USE_ZIGBEE_AUTOBIND_BATTPERCENT },      // BatteryPercentage
+  { 0x0006, 0x0000,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    0 },      // Power
+  { 0x0201, 0x0000,       60,   USE_ZIGBEE_MAXTIME_TRV,  USE_ZIGBEE_AUTOBIND_TEMPERATURE },      // LocalTemperature
+  { 0x0201, 0x0008,       60,   USE_ZIGBEE_MAXTIME_TRV,  USE_ZIGBEE_AUTOBIND_HEATDEMAND  },      // PIHeatingDemand
+  { 0x0201, 0x0012,       60,   USE_ZIGBEE_MAXTIME_TRV,  USE_ZIGBEE_AUTOBIND_TEMPERATURE },      // OccupiedHeatingSetpoint
+  { 0x0008, 0x0000,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    5 },      // Dimmer
+  { 0x0300, 0x0000,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    5 },      // Hue
+  { 0x0300, 0x0001,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    5 },      // Sat
+  { 0x0300, 0x0003,        1,   USE_ZIGBEE_MAXTIME_LIGHT,  100 },      // X
+  { 0x0300, 0x0004,        1,   USE_ZIGBEE_MAXTIME_LIGHT,  100 },      // Y
+  { 0x0300, 0x0007,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    5 },      // CT
+  { 0x0300, 0x0008,        1,   USE_ZIGBEE_MAXTIME_LIGHT,    0 },      // ColorMode
+  { 0x0400, 0x0000,       10,   USE_ZIGBEE_MAXTIME_SENSOR,  USE_ZIGBEE_AUTOBIND_ILLUMINANCE },      // Illuminance (5 lux)
+  { 0x0402, 0x0000,       30,   USE_ZIGBEE_MAXTIME_SENSOR,  USE_ZIGBEE_AUTOBIND_TEMPERATURE },      // Temperature (0.2 °C)
+  { 0x0403, 0x0000,       30,   USE_ZIGBEE_MAXTIME_SENSOR,  USE_ZIGBEE_AUTOBIND_PRESSURE    },      // Pressure (1 hPa)
+  { 0x0405, 0x0000,       30,   USE_ZIGBEE_MAXTIME_SENSOR,  USE_ZIGBEE_AUTOBIND_HUMIDITY    },      // Humidity (1 %)
+  { 0x0406, 0x0000,       10,   USE_ZIGBEE_MAXTIME_SENSOR,    0 },      // Occupancy
+  { 0x0500, 0x0002,        1,   USE_ZIGBEE_MAXTIME_SENSOR,    0 },      // ZoneStatus
 };
 
 //


### PR DESCRIPTION
## Description:

Added compile time constants to `my_user_config.h` to configure some of the main attributes for Zigbee Attribute Reporting while auto-binding (when pairing):

```

  // Auto-binding constants, see `Z_autoAttributeReporting`
  // Below are the threshold for attribute reporting
  #define USE_ZIGBEE_AUTOBIND_BATTVOLTAGE   0.1     // V
  #define USE_ZIGBEE_AUTOBIND_BATTPERCENT   1       // %
  #define USE_ZIGBEE_AUTOBIND_TEMPERATURE   0.5     // °C
  #define USE_ZIGBEE_AUTOBIND_HEATDEMAND    10      // %
  #define USE_ZIGBEE_AUTOBIND_PRESSURE      1       // hPA
  #define USE_ZIGBEE_AUTOBIND_ILLUMINANCE   5       // lux
  #define USE_ZIGBEE_AUTOBIND_HUMIDITY      1.0     // %
  // Below are the Max Thresholds for reporting time (in seconds)
  #define USE_ZIGBEE_MAXTIME_BATT           4*60*60   // 4h
  #define USE_ZIGBEE_MAXTIME_TRV            60*10     // 10m
  #define USE_ZIGBEE_MAXTIME_SENSOR         60*60     // 1h
  #define USE_ZIGBEE_MAXTIME_LIGHT          60*60     // 1h
```

**Related issue (if applicable):** fixes #10418

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
