### PR TITLE
add option to use DS18x20 ID in naming

### DIFF
--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -26,6 +26,7 @@
 #define XSNS_05              5
 
 //#define USE_DS18x20_RECONFIGURE    // When sensor is lost keep retrying or re-configure
+//#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
 #define DS1822_CHIPID        0x22  // +/-2C 12-bit
@@ -56,7 +57,7 @@ uint8_t ds18x20_sensors = 0;
 uint8_t ds18x20_pin = 0;           // Shelly GPIO3 input only
 uint8_t ds18x20_pin_out = 0;       // Shelly GPIO00 output only
 bool ds18x20_dual_mode = false;    // Single pin mode
-char ds18x20_types[12];
+char ds18x20_types[17];
 #ifdef W1_PARASITE_POWER
 uint8_t ds18x20_sensor_curr = 0;
 unsigned long w1_power_until = 0;
@@ -443,7 +444,15 @@ void Ds18x20Name(uint8_t sensor)
   }
   GetTextIndexed(ds18x20_types, sizeof(ds18x20_types), index, kDs18x20Types);
   if (ds18x20_sensors > 1) {
+#ifdef DS18x20_USE_ID_AS_NAME
+    char address[17];
+    for (uint32_t j = 0; j < 3; j++) {
+      sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
+    }
+    snprintf_P(ds18x20_types, sizeof(ds18x20_types), PSTR("%s%c%s"), ds18x20_types, IndexSeparator(), address);
+#else
     snprintf_P(ds18x20_types, sizeof(ds18x20_types), PSTR("%s%c%d"), ds18x20_types, IndexSeparator(), sensor +1);
+#endif
   }
 }
 

--- a/tasmota/xsns_05_ds18x20_esp32.ino
+++ b/tasmota/xsns_05_ds18x20_esp32.ino
@@ -25,6 +25,8 @@
 
 #define XSNS_05              5
 
+//#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
+
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
 #define DS1822_CHIPID        0x22  // +/-2C 12-bit
 #define DS18B20_CHIPID       0x28  // +/-0.5C 12-bit
@@ -44,7 +46,7 @@ uint8_t ds18x20_address[DS18X20_MAX_SENSORS][8];
 uint8_t ds18x20_index[DS18X20_MAX_SENSORS];
 uint8_t ds18x20_valid[DS18X20_MAX_SENSORS];
 uint8_t ds18x20_sensors = 0;
-char ds18x20_types[12];
+char ds18x20_types[17];
 
 /********************************************************************************************/
 
@@ -157,7 +159,15 @@ void Ds18x20Name(uint8_t sensor)
   }
   GetTextIndexed(ds18x20_types, sizeof(ds18x20_types), index, kDs18x20Types);
   if (ds18x20_sensors > 1) {
+#ifdef DS18x20_USE_ID_AS_NAME
+    char address[17];
+    for (uint32_t j = 0; j < 3; j++) {
+      sprintf(address+2*j, "%02X", ds18x20_sensor[ds18x20_sensor[sensor].index].address[3-j]);  // Only last 3 bytes
+    }
+    snprintf_P(ds18x20_types, sizeof(ds18x20_types), PSTR("%s%c%s"), ds18x20_types, IndexSeparator(), address);
+#else
     snprintf_P(ds18x20_types, sizeof(ds18x20_types), PSTR("%s%c%d"), ds18x20_types, IndexSeparator(), sensor +1);
+#endif
   }
 }
 


### PR DESCRIPTION
## Description:

When using multiple DS18B20 sensors with one Tasmota instance, Tasmota is using incrementing numbers to uniquely identify the sensors against external entities. Unfortunately, if I remove sensors or add new ones, the identification of the sensors is lost and has to be reestablished.

When using a part of the serial number for identifying the sensors I can add or remove sensors without losing identification of the sensors that were already used before.

When defining DS18x20_USE_ID_AS_NAME in user_config_override.h, this change gets activated.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
