### PR TITLE
Added support for multiple arguments to a script subroutine.

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -4550,53 +4550,59 @@ int16_t Run_script_sub(const char *type, int8_t tlen, JsonParserObject *jo) {
                 if (*ctype=='#') {
                   // check for parameter
                   ctype += tlen;
-                  if (*ctype=='(' && *(lp+tlen)=='(') {
-                    float fparam;
-                    numeric = 1;
-                    glob_script_mem.glob_error = 0;
-                    GetNumericArgument((char*)ctype, OPER_EQU, &fparam, 0);
-                    if (glob_script_mem.glob_error==1) {
-                      // was string, not number
-                      numeric = 0;
-                      // get the string
-                      GetStringArgument((char*)ctype + 1, OPER_EQU, cmpstr, 0);
-                    }
-                    lp += tlen;
-                    if (*lp=='(') {
-                      // fetch destination
-                      lp++;
-                      lp = isvar(lp, &vtype, &ind, 0, 0, 0);
-                      if (vtype!=VAR_NV) {
-                        // found variable as result
-                        uint8_t index = glob_script_mem.type[ind.index].index;
-                        if ((vtype&STYPE)==0) {
-                            // numeric result
-                            dfvar = &glob_script_mem.fvars[index];
-                            if (numeric) {
-                              *dfvar = fparam;
-                            } else {
-                              // mismatch
-                              *dfvar = CharToFloat(cmpstr);
-                            }
-                        } else {
-                            // string result
-                            sindex = index;
-                            if (!numeric) {
-                              strlcpy(glob_script_mem.glob_snp + (sindex * glob_script_mem.max_ssize), cmpstr, glob_script_mem.max_ssize);
-                            } else {
-                              // mismatch
-                              dtostrfd(fparam, 6, glob_script_mem.glob_snp + (sindex * glob_script_mem.max_ssize));
-                            }
+                  char nxttok = '(';
+                  char *argptr = ctype+tlen;
+                  
+                  lp += tlen;
+                  do {
+                    if (*ctype==nxttok && *lp==nxttok) {
+                      float fparam;
+                      numeric = 1;
+                      glob_script_mem.glob_error = 0;
+                      argptr = GetNumericArgument((char*)ctype + 1, OPER_EQU, &fparam, 0);
+                      if (glob_script_mem.glob_error==1) {
+                        // was string, not number
+                        numeric = 0;
+                        // get the string
+                        argptr = GetStringArgument((char*)ctype + 1, OPER_EQU, cmpstr, 0);
+                      }
+                      if (*lp==nxttok) {
+                        // fetch destination
+                        lp++;
+                        lp = isvar(lp, &vtype, &ind, 0, 0, 0);
+                        if (vtype!=VAR_NV) {
+                          // found variable as result
+                          uint8_t index = glob_script_mem.type[ind.index].index;
+                          if ((vtype&STYPE)==0) {
+                              // numeric result
+                              dfvar = &glob_script_mem.fvars[index];
+                              if (numeric) {
+                                *dfvar = fparam;
+                              } else {
+                                // mismatch
+                                *dfvar = CharToFloat(cmpstr);
+                              }
+                          } else {
+                              // string result
+                              sindex = index;
+                              if (!numeric) {
+                                strlcpy(glob_script_mem.glob_snp + (sindex * glob_script_mem.max_ssize), cmpstr, glob_script_mem.max_ssize);
+                              } else {
+                                // mismatch
+                                dtostrfd(fparam, 6, glob_script_mem.glob_snp + (sindex * glob_script_mem.max_ssize));
+                              }
+                          }
                         }
                       }
+                    } else {
+                      if (*ctype==nxttok || (*lp!=SCRIPT_EOL && *lp!='?')) {
+                        // revert
+                        section = 0;
+                      }
                     }
-                  } else {
-                    lp += tlen;
-                    if (*ctype=='(' || (*lp!=SCRIPT_EOL && *lp!='?')) {
-                      // revert
-                      section = 0;
-                    }
-                  }
+                    nxttok = ' ';
+                    ctype = argptr;
+                  } while (*lp==' ' && (section == 1) );
                 }
             }
         }


### PR DESCRIPTION
## Description:
Core scripts logic only supports 1 subroutine parameter/argument.  This change supports multiple arguments/parameters.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
