### PR TITLE
Use eagle.flash.2m256.ld for zbbridge

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -54,7 +54,7 @@ build_flags                 = ${core.build_flags}
 ;
 ; Build variant 1MB = 1MB firmware no filesystem (default)
 ;board_build.ldscript        = eagle.flash.1m.ld
-; Build variant 2MB = 1MB firmware, 1MB filesystem (ZigbeeBridge, most Shelly devices)
+; Build variant 2MB = 1MB firmware, 1MB filesystem (most Shelly devices)
 ;board_build.ldscript        = eagle.flash.2m1m.ld
 ; Build variant 4MB = 1MB firmware, 3MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
 ;board_build.ldscript        = eagle.flash.4m3m.ld

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -64,6 +64,7 @@ build_flags             = ${common.build_flags} ${irremoteesp_full.build_flags} 
 
 [env:tasmota-zbbridge]
 build_flags             = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
+board_build.ldscript    = eagle.flash.2m256.ld
 board_build.f_cpu       = 160000000L
 lib_extra_dirs          = lib/lib_ssl
 


### PR DESCRIPTION
## Description:

makes 1 MB OTA possible via gzip OTA and adds 256k filesystem for future use.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
