### PR TITLE
Re-Design Seesaw Soil Moisture Driver as State Machine

### DIFF
--- a/tasmota/xsns_81_seesaw_soil.ino
+++ b/tasmota/xsns_81_seesaw_soil.ino
@@ -22,16 +22,24 @@
 #ifdef USE_SEESAW_SOIL
 
 /*********************************************************************************************\
- * SEESAW_SOIL - Capacitance & Temperature Sensor
+ * SEESAW_SOIL - Capacitice Soil Moisture & Temperature Sensor
  *
  * I2C Address: 0x36, 0x37, 0x38, 0x39
  *
- * Memory footprint: 1296 bytes flash, 64 bytes RAM
+ * This version of the driver replaces all delay loops by a state machine. So the number
+ * of instruction cycles consumed has been reduced dramatically. The sensors are reset,
+ * detected, commanded and read all at once. So the reading times won't increase with the
+ * number of sensors attached. The detection of sensors does not happen in FUNC_INIT any
+ * more. All i2c handling happens in the 50ms state machine.
+ * The memory footprint has suffered a little bit from this redesign, naturally.
+ *
+ * Memory footprint: 1444 bytes flash / 68 bytes RAM
  *
  * NOTE:  #define SEESAW_SOIL_PUBLISH enables immediate MQTT on soil moisture change
  *        otherwise the moisture value will only be emitted every TelePeriod
  *        #define SEESAW_SOIL_RAW enables displaying analog capacitance input in the
  *        web page for calibration purposes
+ *        #define SEESAW_SOIL_PERSISTENT_NAMING to get sensor names indexed by i2c address
 \*********************************************************************************************/
 
 #define XSNS_81              81
@@ -39,209 +47,281 @@
 
 #include "Adafruit_seesaw.h"                    // we only use definitions, no code
 
-//#define SEESAW_SOIL_RAW                       // enable raw readings
-//#define SEESAW_SOIL_PUBLISH                   // enable immediate publish
-//#define SEESAW_SOIL_PERSISTENT_NAMING         // enable naming sensors by i2c address
-//#define DEBUG_SEESAW_SOIL                     // enable debugging
-
 #define SEESAW_SOIL_MAX_SENSORS     4
 #define SEESAW_SOIL_START_ADDRESS   0x36
+                                                // I2C state machine
+#define STATE_IDLE                  0x00
+#define STATE_RESET                 0x01
+#define STATE_INIT                  0x02
+#define STATE_DETECT                0x04
+#define STATE_COMMAND_TEMP          0x08
+#define STATE_READ_TEMP             0x10
+#define STATE_COMMAND_MOIST         0x20
+#define STATE_READ_MOIST            0x40
+                                                // I2C commands
+#define COMMAND_RESET               0x01
+#define COMMAND_ID                  0x02
+#define COMMAND_TEMP                0x04
+#define COMMAND_MOIST               0x08
+                                                // I2C delays
+#define DELAY_DETECT                1           // ms delay before reading ID
+#define DELAY_TEMP                  1           // ms delay between command and reading
+#define DELAY_MOIST                 5           // ms delay between command and reading
+#define DELAY_RESET                 500         // ms delay after slave reset
 
-const char SeeSoilName[]  = "SeeSoil";          // spaces not allowed for Homeassistant integration/mqtt topics
-uint8_t    SeeSoilCount   = 0;                  // global sensor count
+// Convert capacitance into a moisture.
+// From observation, a free air reading is at 320, immersed in tap water, reading is 1014
+// So let's make a scale that converts those (apparent) facts into a percentage
+#define MAX_CAPACITANCE 1020.0f                 // subject to calibration
+#define MIN_CAPACITANCE 320                     // subject to calibration
+#define CAP_TO_MOIST(c) ((max((int)(c),MIN_CAPACITANCE)-MIN_CAPACITANCE)/(MAX_CAPACITANCE-MIN_CAPACITANCE)*100)
 
 struct SEESAW_SOIL {
-  uint8_t   address;                            // i2c address
-  float     moisture;
-  float     temperature;
-#ifdef SEESAW_SOIL_RAW
-  uint16_t  capacitance;                        // raw analog reading
-#endif // SEESAW_SOIL_RAW
-} SeeSoil[SEESAW_SOIL_MAX_SENSORS];
+  const char  name[8]   = "SeeSoil";            // spaces not allowed for Homeassistant integration/mqtt topics
+  uint8_t     count     = 0;                    // global sensor count (0xFF = not initialized)
+  uint8_t     state     = STATE_IDLE;           // current state
+  bool        present   = false;                // driver active
+} SeeSoil;
 
-// Used to convert capacitance into a moisture.
-// From observation, a free air reading is at 320
-// Immersed in tap water, reading is 1014
-// Appears to be a 10-bit device, readings close to 1020
-// So let's make a scale that converts those (apparent) facts into a percentage
-#define MAX_CAPACITANCE 1020.0f   // subject to calibration
-#define MIN_CAPACITANCE 320       // subject to calibration
-#define CAP_TO_MOIST(c) ((max((int)(c),MIN_CAPACITANCE)-MIN_CAPACITANCE)/(MAX_CAPACITANCE-MIN_CAPACITANCE)*100)
+struct SEESAW_SOIL_SNS {
+  uint8_t     address;                          // i2c address
+  float       moisture;
+  float       temperature;
+#ifdef SEESAW_SOIL_RAW
+  uint16_t    capacitance;                      // raw analog reading
+#endif // SEESAW_SOIL_RAW
+} SeeSoilSNS[SEESAW_SOIL_MAX_SENSORS];
 
 /*********************************************************************************************\
  * i2c routines
 \*********************************************************************************************/
 
-void SEESAW_SOILDetect(void) {
-  uint8_t buf;
-  uint32_t i, addr;
-
-  for (i = 0; i < SEESAW_SOIL_MAX_SENSORS; i++) {
-    addr = SEESAW_SOIL_START_ADDRESS + i;
-    if ( ! I2cSetDevice(addr)) { continue; }
-    delay(1);
-    SEESAW_Reset(addr);                         // reset all seesaw MCUs at once
+void seeSoilInit(void) {
+  for (int i = 0; i < SEESAW_SOIL_MAX_SENSORS; i++) {
+    int addr = SEESAW_SOIL_START_ADDRESS + i;
+    if ( ! I2cSetDevice(addr) ) { continue; }
+    seeSoilCommand(COMMAND_RESET);
   }
-  delay(500);                                   // give MCUs time to boot
-  for (i = 0; i < SEESAW_SOIL_MAX_SENSORS; i++) {
-    addr = SEESAW_SOIL_START_ADDRESS + i;
+  SeeSoil.state = STATE_RESET;
+  SeeSoil.present = true;
+}
+
+void seeSoilEvery50ms(void){                    // i2c state machine
+  static uint32_t state_time;
+
+  uint32_t time_diff = millis() - state_time;
+
+  switch (SeeSoil.state) {
+    case STATE_RESET:                           // reset was just issued
+      SeeSoil.state = STATE_INIT;
+      break;
+    case STATE_INIT:                            // wait for sensors to settle
+      if (time_diff < DELAY_RESET) { return; }
+      seeSoilCommand(COMMAND_ID);               // send hardware id commands
+      SeeSoil.state = STATE_DETECT;
+      break;
+    case STATE_DETECT:                          // detect sensors
+      if (time_diff < DELAY_DETECT) { return; }
+      seeSoilDetect();
+      SeeSoil.state=STATE_COMMAND_TEMP;
+      break;
+    case STATE_COMMAND_TEMP:                    // send temperature commands
+      seeSoilCommand(COMMAND_TEMP);
+      SeeSoil.state = STATE_READ_TEMP;
+      break;
+    case STATE_READ_TEMP:
+      if (time_diff < DELAY_TEMP) { return; }
+      seeSoilRead(COMMAND_TEMP);                // read temperature values
+      SeeSoil.state = STATE_COMMAND_MOIST;
+      break;
+    case STATE_COMMAND_MOIST:                   // send moisture commands
+      seeSoilCommand(COMMAND_MOIST);
+      SeeSoil.state = STATE_READ_MOIST;
+      break;
+    case STATE_READ_MOIST:
+      if (time_diff < DELAY_MOIST) { return; }
+      seeSoilRead(COMMAND_MOIST);               // read moisture values
+      SeeSoil.state = STATE_COMMAND_TEMP;
+      break;
+  }
+  state_time = millis();
+}
+
+void seeSoilDetect(void) {                      // detect sensors
+  uint8_t buf;
+
+  SeeSoil.count = 0;
+  SeeSoil.present = false;
+  for (int i = 0; i < SEESAW_SOIL_MAX_SENSORS; i++) {
+    uint32_t addr = SEESAW_SOIL_START_ADDRESS + i;
     if ( ! I2cSetDevice(addr)) { continue; }
-    if ( ! SEESAW_ValidRead(addr, SEESAW_STATUS_BASE, SEESAW_STATUS_HW_ID, &buf, 1, 0)) {
-      continue;
-    }
-    if (buf != SEESAW_HW_ID_CODE) {
+    if (1 != Wire.requestFrom((uint8_t) addr, (uint8_t) 1)) { continue; }
+    buf = (uint8_t) Wire.read();
+    if (buf != SEESAW_HW_ID_CODE) {             // check hardware id
 #ifdef DEBUG_SEESAW_SOIL
       AddLog_P(LOG_LEVEL_DEBUG, PSTR("SEE: HWID mismatch ADDR=%X, ID=%X"), addr, buf);
 #endif // DEBUG_SEESAW_SOIL
       continue;
     }
-    SeeSoil[SeeSoilCount].address = addr;
-    SeeSoil[SeeSoilCount].temperature = NAN;
-    SeeSoil[SeeSoilCount].moisture = NAN;
- #ifdef SEESAW_SOIL_RAW
-    SeeSoil[SeeSoilCount].capacitance = 0;      // raw analog reading
-#endif // SEESAW_SOIL_RAW
-    I2cSetActiveFound(SeeSoil[SeeSoilCount].address, SeeSoilName);
-    SeeSoilCount++;
-  }
-}
-
-float SEESAW_Temp(uint8_t addr) {               // get temperature from seesaw at addr
-  uint8_t buf[4];
-
-  if (SEESAW_ValidRead(addr, SEESAW_STATUS_BASE, SEESAW_STATUS_TEMP, buf, 4, 1000)) {
-    int32_t ret = ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) |
-                  ((uint32_t)buf[2] << 8) | (uint32_t)buf[3];
-    return ConvertTemp((1.0 / (1UL << 16)) * ret);
-  }
-  return NAN;
-}
-
-float SEESAW_Moist(uint8_t addr) {              // get moisture from seesaw at addr
-  uint8_t buf[2];
-  uint16_t ret;
-  int32_t tries = 2;
-
-  while (tries--) {
-    delay(1);
-    if (SEESAW_ValidRead(addr, SEESAW_TOUCH_BASE, SEESAW_TOUCH_CHANNEL_OFFSET, buf, 2, 3000)) {
-      ret = ((uint16_t)buf[0] << 8) | buf[1];
+    SeeSoilSNS[SeeSoil.count].address = addr;
+    SeeSoilSNS[SeeSoil.count].temperature = NAN;
+    SeeSoilSNS[SeeSoil.count].moisture = NAN;
 #ifdef SEESAW_SOIL_RAW
-      for (int i=0; i < SeeSoilCount; i++) {
-        if (SeeSoil[i].address == addr) {
-          SeeSoil[i].capacitance = ret;
-          break;
-        }
-      }
+    SeeSoilSNS[SeeSoil.count].capacitance = 0;  // raw analog reading
 #endif // SEESAW_SOIL_RAW
-      if (ret != 0xFFFF) { return (float) CAP_TO_MOIST(ret); }
+    I2cSetActiveFound(SeeSoilSNS[SeeSoil.count].address, SeeSoil.name);
+    SeeSoil.count++;
+    SeeSoil.present = true;
+#ifdef DEBUG_SEESAW_SOIL
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR("SEE: FOUND sensor %u at %02X"), i, addr);
+#endif // DEBUG_SEESAW_SOIL
+  }
+}
+
+void seeSoilCommand(uint32_t command) {         // issue commands to sensors
+  uint8_t  regLow;
+  uint8_t  regHigh = SEESAW_STATUS_BASE;
+  uint32_t count   = SeeSoil.count;
+
+  switch (command) {
+    case COMMAND_RESET:
+      count   = SEESAW_SOIL_MAX_SENSORS;
+      regLow  = SEESAW_STATUS_SWRST;
+      break;
+    case COMMAND_ID:
+      count   = SEESAW_SOIL_MAX_SENSORS;
+      regLow  = SEESAW_STATUS_HW_ID;
+      break;
+    case COMMAND_TEMP:
+      regLow  = SEESAW_STATUS_TEMP;
+      break;
+    case COMMAND_MOIST:
+      regHigh = SEESAW_TOUCH_BASE;
+      regLow  = SEESAW_TOUCH_CHANNEL_OFFSET;
+      break;
+    default:
+#ifdef DEBUG_SEESAW_SOIL
+      AddLog_P(LOG_LEVEL_DEBUG, PSTR("SEE: ILL CMD:%02X"), command);
+#endif // DEBUG_SEESAW_SOIL
+      return;
+  }
+  for (int i = 0; i < count; i++) {
+    uint32_t addr = (command & (COMMAND_RESET|COMMAND_ID)) ? SEESAW_SOIL_START_ADDRESS + i : SeeSoilSNS[i].address;
+    Wire.beginTransmission((uint8_t) addr);
+    Wire.write((uint8_t) regHigh);
+    Wire.write((uint8_t) regLow);
+    uint32_t err = Wire.endTransmission();
+#ifdef DEBUG_SEESAW_SOIL
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR("SEE: SNS=%u ADDR=%02X CMD=%02X ERR=%u"), i, addr, command, err);
+#endif // DEBUG_SEESAW_SOIL
     }
-  }
-  return NAN;
 }
 
-bool SEESAW_ValidRead(uint8_t addr, uint8_t regHigh, uint8_t regLow,        // read from seesaw sensor
-                 uint8_t *buf, uint8_t num, uint16_t delay) {
+void seeSoilRead(uint32_t command) {            // read values from sensors
+  uint8_t   buf[4];
+  uint32_t  num;
+  int32_t   ret;
 
-  Wire.beginTransmission((uint8_t) addr);
-  Wire.write((uint8_t) regHigh);
-  Wire.write((uint8_t) regLow);
-  int err = Wire.endTransmission();
-  if (err) { return false; }
-  delayMicroseconds(delay);
-  if (num != Wire.requestFrom((uint8_t) addr, (uint8_t) num)) {
-    return false;
-  }
-  for (int i = 0; i < num; i++) {
-    buf[i] = (uint8_t) Wire.read();
-  }
-  return true;
-}
+  num = (command == COMMAND_TEMP) ? 4 : 2;      // response size in bytes
 
-bool SEESAW_Reset(uint8_t addr) {               // init sensor MCU
-  Wire.beginTransmission((uint8_t) addr);
-  Wire.write((uint8_t) SEESAW_STATUS_BASE);
-  Wire.write((uint8_t) SEESAW_STATUS_SWRST);
-  return (Wire.endTransmission() == 0);
+  for (int i = 0; i < SeeSoil.count; i++) {     // for all sensors
+    if (num != Wire.requestFrom((uint8_t) SeeSoilSNS[i].address, (uint8_t) num)) { continue; }
+    bzero(buf, sizeof(buf));
+    for (int b = 0; b < num; b++) {
+      buf[b] = (uint8_t) Wire.read();
+    }
+    if (command == COMMAND_TEMP) {
+      ret = ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) |
+            ((uint32_t)buf[2] << 8) | (uint32_t)buf[3];
+      SeeSoilSNS[i].temperature = ConvertTemp((1.0 / (1UL << 16)) * ret);
+    } else {                                    // COMMAND_MOIST
+      ret = (uint32_t)buf[0] << 8 | (uint32_t)buf[1];
+      SeeSoilSNS[i].moisture = CAP_TO_MOIST(ret);
+#ifdef SEESAW_SOIL_RAW
+      SeeSoilSNS[i].capacitance = ret;
+#endif // SEESAW_SOIL_RAW
+    }
+#ifdef DEBUG_SEESAW_SOIL
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR("SEE: READ #%u ADDR=%02X NUM=%u RET=%X"), i, SeeSoilSNS[i].address, num, ret);
+#endif // DEBUG_SEESAW_SOIL
+  }
 }
 
 /*********************************************************************************************\
  * JSON routines
 \*********************************************************************************************/
 
-void SEESAW_SOILEverySecond(void) {             // update sensor values and publish if changed
 #ifdef SEESAW_SOIL_PUBLISH
-  uint32_t old_moist;
-#endif // SEESAW_SOIL_PUBLISH
+void seeSoilEverySecond(void) {                 // update sensor values and publish if changed
+  static uint16_t old_moist[SEESAW_SOIL_MAX_SENSORS];
+  static bool firstcall = true;
 
-  for (int i = 0; i < SeeSoilCount; i++) {
-    SeeSoil[i].temperature = SEESAW_Temp(SeeSoil[i].address);
-#ifdef SEESAW_SOIL_PUBLISH
-    old_moist = (uint32_t) SeeSoil[i].moisture;
-#endif // SEESAW_SOIL_PUBLISH
-    SeeSoil[i].moisture = SEESAW_Moist(SeeSoil[i].address);
-#ifdef SEESAW_SOIL_PUBLISH
-    if ((uint32_t) SeeSoil[i].moisture != old_moist) {
-      Response_P(PSTR("{"));                    // send values to MQTT & rules
-      SEESAW_SOILJson(i);
-      ResponseJsonEnd();
-      MqttPublishTeleSensor();
+  for (int i = 0; i < SeeSoil.count; i++) {
+    if (firstcall) { firstcall = false; }
+    else {
+      if ((uint32_t) SeeSoilSNS[i].moisture != old_moist[i]) {
+        Response_P(PSTR("{"));                  // send values to MQTT & rules
+        seeSoilJson(i);
+        ResponseJsonEnd();
+        MqttPublishTeleSensor();
+      }
     }
-#endif // SEESAW_SOIL_PUBLISH
+    old_moist[i] = (uint32_t) SeeSoilSNS[i].moisture;
   }
 }
+#endif // SEESAW_SOIL_PUBLISH
 
-void SEESAW_SOILShow(bool json) {
+void seeSoilShow(bool json) {
   char temperature[FLOATSZ];
-  char sensor_name[sizeof(SeeSoilName) + 3];
+  char sensor_name[sizeof(SeeSoil.name) + 3];
 
-  for (uint32_t i = 0; i < SeeSoilCount; i++) {
-    dtostrfd(SeeSoil[i].temperature, Settings.flag2.temperature_resolution, temperature);
-    SEESAW_SOILName(i, sensor_name, sizeof(sensor_name));
+  for (uint32_t i = 0; i < SeeSoil.count; i++) {
+    dtostrfd(SeeSoilSNS[i].temperature, Settings.flag2.temperature_resolution, temperature);
+    seeSoilName(i, sensor_name, sizeof(sensor_name));
     if (json) {
-      ResponseAppend_P(PSTR(","));                                          // compose tele json
-      SEESAW_SOILJson(i);
+      ResponseAppend_P(PSTR(","));              // compose tele json
+      seeSoilJson(i);
       if (0 == TasmotaGlobal.tele_period) {
 #ifdef USE_DOMOTICZ
-        DomoticzTempHumPressureSensor(SeeSoil[i].temperature, SeeSoil[i].moisture, -42.0f);
+        DomoticzTempHumPressureSensor(SeeSoilSNS[i].temperature, SeeSoilSNS[i].moisture, -42.0f);
 #endif  // USE_DOMOTICZ
 #ifdef USE_KNX
-        KnxSensor(KNX_TEMPERATURE, SeeSoil[i].temperature);
-        KnxSensor(KNX_HUMIDITY, SeeSoil[i].moisture);
+        KnxSensor(KNX_TEMPERATURE, SeeSoilSNS[i].temperature);
+        KnxSensor(KNX_HUMIDITY, SeeSoilSNS[i].moisture);
 #endif // USE_KNX
       }
 #ifdef USE_WEBSERVER
     } else {
 #ifdef SEESAW_SOIL_RAW
-      WSContentSend_PD(HTTP_SNS_ANALOG, sensor_name, 0, SeeSoil[i].capacitance);
+      WSContentSend_PD(HTTP_SNS_ANALOG, sensor_name, 0, SeeSoilSNS[i].capacitance);
 #endif // SEESAW_SOIL_RAW
-      WSContentSend_PD(HTTP_SNS_MOISTURE, sensor_name, (uint32_t) SeeSoil[i].moisture);
+      WSContentSend_PD(HTTP_SNS_MOISTURE, sensor_name, (uint32_t) SeeSoilSNS[i].moisture);
       WSContentSend_PD(HTTP_SNS_TEMP, sensor_name, temperature, TempUnit());
 #endif // USE_WEBSERVER
     }
   } // for each sensor connected
 }
 
-void SEESAW_SOILJson(int no) {                        // common json
+void seeSoilJson(int no) {                      // common json
   char temperature[FLOATSZ];
-  char sensor_name[sizeof(SeeSoilName) + 3];
+  char sensor_name[sizeof(SeeSoil.name) + 3];
 
-  SEESAW_SOILName(no, sensor_name, sizeof(sensor_name));
-  dtostrfd(SeeSoil[no].temperature, Settings.flag2.temperature_resolution, temperature);
+  seeSoilName(no, sensor_name, sizeof(sensor_name));
+  dtostrfd(SeeSoilSNS[no].temperature, Settings.flag2.temperature_resolution, temperature);
   ResponseAppend_P(PSTR ("\"%s\":{\"" D_JSON_ID "\":\"%02X\",\"" D_JSON_TEMPERATURE "\":%s,\"" D_JSON_MOISTURE "\":%u}"),
-                   sensor_name, SeeSoil[no].address, temperature, (uint32_t) SeeSoil[no].moisture);
+                   sensor_name, SeeSoilSNS[no].address, temperature, (uint32_t) SeeSoilSNS[no].moisture);
 }
 
-void SEESAW_SOILName(int no, char *name, int len)    // generates a sensor name
+void seeSoilName(int no, char *name, int len)   // generates a sensor name
 {
 #ifdef SEESAW_SOIL_PERSISTENT_NAMING
-  snprintf_P(name, len, PSTR("%s%c%02X"), SeeSoilName, IndexSeparator(), SeeSoil[no].address);
+  snprintf_P(name, len, PSTR("%s%c%02X"), SeeSoil.name, IndexSeparator(), SeeSoilSNS[no].address);
 #else
-  if (SeeSoilCount > 1) {
-    snprintf_P(name, len, PSTR("%s%c%u"), SeeSoilName, IndexSeparator(), no + 1);
+  if (SeeSoil.count > 1) {
+    snprintf_P(name, len, PSTR("%s%c%u"), SeeSoil.name, IndexSeparator(), no + 1);
   }
   else {
-    strlcpy(name, SeeSoilName, len);
+    strlcpy(name, SeeSoil.name, len);
   }
 #endif // SEESAW_SOIL_PERSISTENT_NAMING
 }
@@ -256,19 +336,24 @@ bool Xsns81(uint8_t function)
   bool result = false;
 
   if (FUNC_INIT == function) {
-    SEESAW_SOILDetect();
+    seeSoilInit();
   }
-  else if (SeeSoilCount){
+  else if (SeeSoil.present){
     switch (function) {
-      case FUNC_EVERY_SECOND:
-        SEESAW_SOILEverySecond();
+      case FUNC_EVERY_50_MSECOND:
+        seeSoilEvery50ms();
         break;
+  #ifdef SEESAW_SOIL_PUBLISH
+      case FUNC_EVERY_SECOND:
+        seeSoilEverySecond();
+        break;
+  #endif   // SEESAW_SOIL_PUBLISH
       case FUNC_JSON_APPEND:
-        SEESAW_SOILShow(1);
+        seeSoilShow(1);
         break;
   #ifdef USE_WEBSERVER
       case FUNC_WEB_SENSOR:
-        SEESAW_SOILShow(0);
+        seeSoilShow(0);
         break;
   #endif  // USE_WEBSERVER
     }


### PR DESCRIPTION
## Description:
The previous version was wasting too many CPU cycles in delay loops so i decided to design a state machine instead, to get rid of blocking delays entirely. Unfortunately i had to sacrifice 148 bytes of Flash as well as 4 bytes of RAM for the purpose. (Now: 1444 / 68)
In this version of the code the sensors are reset, detected, commanded and read all at once, at intervals defined by time slots of a state machine. All previous features are retained.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
