### PR TITLE
Use ESP32 1.0.5rc6 for ESP32 stage

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -144,11 +144,11 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 
 [core32_stage]
-platform_packages           = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2452c1fb539246e47a715b74a3ad25b8a7ebbec7
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/tag/1.0.5-rc6
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -DESP32_STAGE=true
+                              ;-DESP32_STAGE=true
 
 [library]
 lib_ldf_mode                = chain+


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
