### PR TITLE
Fix Hue emulation for ESP32

### DIFF
--- a/tasmota/support_udp.ino
+++ b/tasmota/support_udp.ino
@@ -32,7 +32,6 @@ IPAddress udp_remote_ip;                 // M-Search remote IP address
 uint16_t udp_remote_port;                // M-Search remote port
 
 bool udp_connected = false;
-bool udp_response_mutex = false;         // M-Search response mutex to control re-entry
 
 #ifdef ESP8266
 #ifndef UDP_MAX_PACKETS
@@ -89,14 +88,12 @@ bool UdpConnect(void)
       if (UdpCtx.listen(&addr, 1900)) {         // port 1900
         // OK
         AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_UPNP D_MULTICAST_REJOINED));
-        udp_response_mutex = false;
         udp_connected = true;
       }
 #endif  // ESP8266
 #ifdef ESP32
     if (PortUdp.beginMulticast(WiFi.localIP(), IPAddress(239,255,255,250), 1900)) {
       AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_UPNP D_MULTICAST_REJOINED));
-      udp_response_mutex = false;
       udp_connected = true;
 #endif  // ESP32
     }
@@ -123,28 +120,29 @@ void PollUdp(void)
       packet->buf[packet->len] = 0;   // add NULL at the end of the packet
       char * packet_buffer = (char*) &packet->buf;
       int32_t len = packet->len;
+      AddLog_P(LOG_LEVEL_DEBUG_MORE, PSTR("UDP: Packet (%d)"), len);
 #endif  // ESP8266
 #ifdef ESP32
-    while (PortUdp.parsePacket()) {
+    while (uint32_t pack_len = PortUdp.parsePacket()) {
       char packet_buffer[UDP_BUFFER_SIZE];     // buffer to hold incoming UDP/SSDP packet
 
       int32_t len = PortUdp.read(packet_buffer, UDP_BUFFER_SIZE -1);
       packet_buffer[len] = 0;
+      PortUdp.flush();
+      AddLog_P(LOG_LEVEL_DEBUG_MORE, PSTR("UDP: Packet (%d/%d)"), len, pack_len);
 #endif  // ESP32
-      AddLog_P(LOG_LEVEL_DEBUG_MORE, PSTR("UDP: Packet (%d)"), len);
+
       // AddLog_P(LOG_LEVEL_DEBUG_MORE, PSTR("\n%s"), packet_buffer);
 
       // Simple Service Discovery Protocol (SSDP)
       if (Settings.flag2.emulation) {
 #if defined(USE_SCRIPT_HUE) || defined(USE_ZIGBEE)
-        if (!udp_response_mutex && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
+        if ((TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
 #else
-        if (TasmotaGlobal.devices_present && !udp_response_mutex && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
+        if (TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
 #endif
           if (0 == udp_last_received) {
             udp_last_received = millis();
-            udp_response_mutex = true;
-
 #ifdef ESP8266
             udp_remote_ip = packet->srcaddr;
             udp_remote_port = packet->srcport;
@@ -159,35 +157,34 @@ void PollUdp(void)
             LowerCase(packet_buffer, packet_buffer);
             RemoveSpace(packet_buffer);
 
+            bool udp_proccessed = false;      // make sure we process the packet only once
 #ifdef USE_EMULATION_WEMO
-            if (EMUL_WEMO == Settings.flag2.emulation) {
+            if (!udp_proccessed && (EMUL_WEMO == Settings.flag2.emulation)) {
               if (strstr_P(packet_buffer, URN_BELKIN_DEVICE) != nullptr) {     // type1 echo dot 2g, echo 1g's
                 WemoRespondToMSearch(1);
-                return;
+                udp_proccessed = true;
               }
               else if ((strstr_P(packet_buffer, UPNP_ROOTDEVICE) != nullptr) ||  // type2 Echo 2g (echo & echo plus)
                       (strstr_P(packet_buffer, SSDPSEARCH_ALL) != nullptr) ||
                       (strstr_P(packet_buffer, SSDP_ALL) != nullptr)) {
                 WemoRespondToMSearch(2);
-                return;
+                udp_proccessed = true;
               }
             }
 #endif  // USE_EMULATION_WEMO
 
 #ifdef USE_EMULATION_HUE
-            if (EMUL_HUE == Settings.flag2.emulation) {
+            if (!udp_proccessed && (EMUL_HUE == Settings.flag2.emulation)) {
+              AddLog_P(LOG_LEVEL_DEBUG_MORE, PSTR("UDP: HUE"));
               if ((strstr_P(packet_buffer, PSTR(":device:basic:1")) != nullptr) ||
                   (strstr_P(packet_buffer, UPNP_ROOTDEVICE) != nullptr) ||
                   (strstr_P(packet_buffer, SSDPSEARCH_ALL) != nullptr) ||
                   (strstr_P(packet_buffer, SSDP_ALL) != nullptr)) {
                 HueRespondToMSearch();
-                return;
+                udp_proccessed = true;
               }
             }
 #endif  // USE_EMULATION_HUE
-
-            udp_response_mutex = false;
-            continue;
           }
         }
       }

--- a/tasmota/support_udp.ino
+++ b/tasmota/support_udp.ino
@@ -137,7 +137,7 @@ void PollUdp(void)
       // Simple Service Discovery Protocol (SSDP)
       if (Settings.flag2.emulation) {
 #if defined(USE_SCRIPT_HUE) || defined(USE_ZIGBEE)
-        if ((TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
+        if (TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
 #else
         if (TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
 #endif

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -225,8 +225,6 @@ void HueRespondToMSearch(void)
   // Do not use AddLog_P( here (interrupt routine) if syslog or mqttlog is enabled. UDP/TCP will force exception 9
   AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPNP D_HUE " %s " D_TO " %s:%d"),
     message, udp_remote_ip.toString().c_str(), udp_remote_port);
-
-  udp_response_mutex = false;
 }
 
 /*********************************************************************************************\

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -76,8 +76,6 @@ void WemoRespondToMSearch(int echo_type)
   // Do not use AddLog_P( here (interrupt routine) if syslog or mqttlog is enabled. UDP/TCP will force exception 9
   AddLog_P(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPNP D_WEMO " " D_JSON_TYPE " %d, %s " D_TO " %s:%d"),
     echo_type, message, udp_remote_ip.toString().c_str(), udp_remote_port);
-
-  udp_response_mutex = false;
 }
 
 /*********************************************************************************************\

--- a/tasmota/xdrv_21_wemo_multi.ino
+++ b/tasmota/xdrv_21_wemo_multi.ino
@@ -422,8 +422,6 @@ void WemoRespondToMSearch(int echo_type) {
   for (uint32_t i = 0; i < numOfWemoSwitch; i++) {
     wemoDevice[i]->WemoRespondToMSearch(echo_type);
   }
-
-  udp_response_mutex = false;
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Also removed the `udp_response_mutex` which does not seem to be useful, unless we have callback or multi-threadin - which we don't.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
