### PR TITLE
D_COUNT is used as a noun, not as a verb

### DIFF
--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -73,7 +73,7 @@
 #define D_COMMAND "Befehl"
 #define D_CONNECTED "verbunden"
 #define D_CORS_DOMAIN "CORS Domain"
-#define D_COUNT "zählen"
+#define D_COUNT "Anzahl"             // used as a noun throughout
 #define D_COUNTER "Zähler"
 #define D_CT_POWER "CT Power"
 #define D_CURRENT "Strom"          // As in Voltage and Current


### PR DESCRIPTION
## Description:
minor correction in language file de_DE
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
