### PR TITLE
ESP32 support for TLS MQTT using BearSSL (same as ESP8266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Support for BS814A-2 8-button touch buttons by Peter Franck (#10447)
 - Support for up to 4 I2C SEESAW_SOIL Capacitance & Temperature sensors by Peter Franck (#10481)
 - ESP8266 Support for 2MB and up linker files with 1MB and up LittleFS
+- ESP32 support for TLS MQTT using BearSSL (same as ESP8266)
 
 ### Breaking Changed
 - ESP32 switch from default SPIFFS to default LittleFS file system loosing current (zigbee) files

--- a/tasmota/StackThunk_light.cpp
+++ b/tasmota/StackThunk_light.cpp
@@ -28,6 +28,7 @@
 #include "my_user_config.h"
 #include "tasmota_configurations.h"
 
+#if defined(ESP8266) && defined(USE_TLS)
 #include <stdint.h>
 #include <stdlib.h>
 #include "StackThunk_light.h"
@@ -145,3 +146,5 @@ void stack_thunk_light_fatal_overflow()
 }
 
 };
+
+#endif

--- a/tasmota/WiFiClientSecureLightBearSSL.h
+++ b/tasmota/WiFiClientSecureLightBearSSL.h
@@ -43,7 +43,11 @@ class WiFiClientSecure_light : public WiFiClient {
 
     uint8_t connected() override;
     size_t write(const uint8_t *buf, size_t size) override;
+  #ifdef ESP8266
     size_t write_P(PGM_P buf, size_t size) override;
+  #else
+    size_t write_P(PGM_P buf, size_t size);
+  #endif
     size_t write(const char *buf) {
       return write((const uint8_t*)buf, strlen(buf));
     }
@@ -55,11 +59,17 @@ class WiFiClientSecure_light : public WiFiClient {
     int available() override;
     int read() override;
     int peek() override;
+  #ifdef ESP8266
     size_t peekBytes(uint8_t *buffer, size_t length) override;
     bool flush(unsigned int maxWaitMs);
     bool stop(unsigned int maxWaitMs);
     void flush() override { (void)flush(0); }
     void stop() override { (void)stop(0); }
+  #else
+    size_t peekBytes(uint8_t *buffer, size_t length);
+    void flush() override;
+    void stop() override;
+  #endif
 
     // Only check SHA1 fingerprint of public key
     void setPubKeyFingerprint(const uint8_t *f1, const uint8_t *f2,

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -679,8 +679,13 @@ void MqttReconnect(void) {
   if (MqttClient.connect(TasmotaGlobal.mqtt_client, mqtt_user, mqtt_pwd, stopic, 1, lwt_retain, TasmotaGlobal.mqtt_data, MQTT_CLEAN_SESSION)) {
 #ifdef USE_MQTT_TLS
     if (Mqtt.mqtt_tls) {
+#ifdef ESP8266
       AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "TLS connected in %d ms, max ThunkStack used %d"),
         millis() - mqtt_connect_time, tlsClient->getMaxThunkStackUse());
+#elif defined(ESP32)
+      AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "TLS connected in %d ms, stack low mark %d"),
+        millis() - mqtt_connect_time, uxTaskGetStackHighWaterMark(nullptr));
+#endif
       if (!tlsClient->getMFLNStatus()) {
         AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_MQTT "MFLN not supported by TLS server"));
       }


### PR DESCRIPTION
## Description:

Support for TLS (MQTT only) using the same lib BearSSL as ESP8266.

It is not using mbedTLS provided by ESP32 stack so behavior is expected to be identical to ESP8266.

It includes: letsencrypt certificates, AWS IoT and fingerprint security.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
