### PR TITLE
Zigbee increase timeout to 5s for first command

### DIFF
--- a/tasmota/xdrv_23_zigbee_7_0_statemachine.ino
+++ b/tasmota/xdrv_23_zigbee_7_0_statemachine.ino
@@ -785,7 +785,7 @@ static const Zigbee_Instruction zb_prog[] PROGMEM = {
     ZI_WAIT_UNTIL(5000, ZBR_RSTACK)     // wait for RSTACK message
 
     // Init device and probe version
-    ZI_SEND(ZBS_VERSION)                ZI_WAIT_RECV_FUNC(1000, ZBR_VERSION, &EZ_ReceiveCheckVersion)       // check EXT PAN ID
+    ZI_SEND(ZBS_VERSION)                ZI_WAIT_RECV_FUNC(5000, ZBR_VERSION, &EZ_ReceiveCheckVersion)       // check EXT PAN ID
 
     // configure EFR32
     ZI_MQTT_STATE(ZIGBEE_STATUS_STARTING, kConfiguredCoord)


### PR DESCRIPTION
## Description:

Some issues reported on Discord show that the first "version" command can take up to 2 seconds for the MCU to respond. Increasing the first timeout from 1s to 5s.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
