### PR TITLE
ESP32 use 4K RSA for TLS

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -86,6 +86,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Dsint16_t=int16_t
                               -Dmemcpy_P=memcpy
                               -Dmemcmp_P=memcmp
+                              ;for TLS we can afford compiling for 4K RSA keys
+                              -DUSE_4K_RSA
 
 
 [core32]


### PR DESCRIPTION
## Description:

For ESP32, whenever TLS is enabled, always enable 4096 RSA keys (instead of 2048). ESP8266 is very limited in memory but we have way over headroom on ESP32.

This setting does not change anything if TLS is not enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
