### PR TITLE
Added ``USE_MQTT_TLS_DROP_OLD_FINGERPRINT`` compile time option to drop old (less secure) TLS fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Support for up to 4 I2C SEESAW_SOIL Capacitance & Temperature sensors by Peter Franck (#10481)
 - ESP8266 Support for 2MB and up linker files with 1MB and up LittleFS
 - ESP32 support for TLS MQTT using BearSSL (same as ESP8266)
+- Added ``USE_MQTT_TLS_DROP_OLD_FINGERPRINT`` compile time option to drop old (less secure) TLS fingerprint
 
 ### Breaking Changed
 - ESP32 switch from default SPIFFS to default LittleFS file system loosing current (zigbee) files

--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -804,6 +804,7 @@ extern "C" {
         return 0;
       }
 
+#ifndef USE_MQTT_TLS_DROP_OLD_FINGERPRINT
       // No match under new algorithm, do some basic checking on the key.
       //
       // RSA keys normally have an e value of 65537, which is three bytes long.
@@ -838,6 +839,9 @@ extern "C" {
       pubkeyfingerprint_pubkey_fingerprint(xc, false);
 
       return 0;
+#else   // USE_TLS_OLD_FINGERPRINT_COMPAT
+      return 1;   // no match, error
+#endif  // USE_TLS_OLD_FINGERPRINT_COMPAT
     } else {
       // Default (no validation at all) or no errors in prior checks = success.
       return 0;

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -401,6 +401,9 @@
 //  #define USE_MQTT_AWS_IOT                       // [Deprecated] Enable MQTT for AWS IoT - requires a private key (+11.9k code, +0.4k mem)
                                                  //   Note: you need to generate a private key + certificate per device and update 'tasmota/tasmota_aws_iot.cpp'
                                                  //   Full documentation here: https://github.com/arendst/Tasmota/wiki/AWS-IoT
+//  #define USE_MQTT_TLS_DROP_OLD_FINGERPRINT      // If you use fingerprint (i.e. not CA) validation, the algorithm changed to a more secure one.
+                                                   // Any valid fingerprint with the old algo will be automatically updated to the new algo.
+                                                   // Enable this if you want to disable the old algo check, which should be more secure
 //  for USE_4K_RSA (support for 4096 bits certificates, instead of 2048), you need to uncommend `-DUSE_4K_RSA` in `build_flags` from `platform.ini` or `platform_override.ini`
 
 // -- Telegram Protocol ---------------------------


### PR DESCRIPTION
## Description:

Add a compile time option to drop the old algorithm for TLS Fingerprint.

All fingerprints are automatically updated to the new algo at first connection, however if the check fails, it will check against the old algo as well.

This new option disables the fallback to the old algo, so it should be enabled ONLY if you know that your fingerprint was updated. Not enabled by default.

See https://threadreaderapp.com/thread/1339101572832382981.html for details about the fingerprint vulnerability.

**Related issue (if applicable):** fixes #10571

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
