### PR TITLE
Zigbee add RGB and RGBb to ZbInfo

### DIFF
--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -236,6 +236,11 @@ public:
   inline void setX(uint16_t _x)                 { x = _x; }
   inline void setY(uint16_t _y)                 { y = _y; }
 
+  void toRGBAttributes(Z_attribute_list & attr_list) const ;
+  static void toRGBAttributesHSB(Z_attribute_list & attr_list, uint16_t hue, uint8_t sat, uint8_t brightness);
+  static void toRGBAttributesXYB(Z_attribute_list & attr_list, uint16_t x, uint16_t y, uint8_t brightness);
+  static void toRGBAttributesRGBb(Z_attribute_list & attr_list, uint8_t r, uint8_t g, uint8_t b, uint8_t brightness);
+
   static const Z_Data_Type type = Z_Data_Type::Z_Light;
   // 12 bytes
   uint8_t               colormode;      // 0x00: Hue/Sat, 0x01: XY, 0x02: CT | 0xFF not set, default 0x01

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -695,6 +695,9 @@ void Z_Device::jsonAddDataAttributes(Z_attribute_list & attr_list) const {
   // show internal data - mostly last known values
   for (auto & data_elt : data) {
     data_elt.toAttributes(attr_list);
+    if (data_elt.getType() == Z_Data_Type::Z_Light) {   // since we don't have virtual methods, do an explicit test
+      ((Z_Data_Light&)data_elt).toRGBAttributes(attr_list);
+    }
   }
 }
 // Add "BatteryPercentage", "LastSeen", "LastSeenEpoch", "LinkQuality"
@@ -728,6 +731,7 @@ void Z_Device::jsonLightState(Z_attribute_list & attr_list) const {
       if (light.validHue()) {
         attr_list.findOrCreateAttribute(PSTR("Hue")).setUInt(light.getHue());
       }
+      light.toRGBAttributes(attr_list);
     }
     attr_list.addAttributePMEM(PSTR("Light")).setInt(light_mode);
   }


### PR DESCRIPTION
## Description:

Follow up to #10597 and #10599.

Now `RGB` and `RGBb` are also reported with `ZbInfo` and `ZbLight`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
