### PR TITLE
Use solo1-release_v3.3-7e63061fa

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -165,7 +165,7 @@ lib_extra_dirs              =
 ; *** EXPERIMENTAL Tasmota version for ESP32solo1 (used in some Xiaomi devices)
 [env:tasmota32solo1]
 extends                     = env:tasmota32
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-4b325f52e.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-solo1-release_v3.3-7e63061fa.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}


### PR DESCRIPTION
## Description:

... latest IDF 3.3 build.

Updated Arduino lib builder to use only Espressif github as source. No more custom repos used. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
