### PR TITLE
Zigbee send ack to command

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1687,7 +1687,7 @@ void ZCLFrame::parseClusterSpecificCommand(Z_attribute_list& attr_list) {
       _srcendpoint,
       ZCL_DEFAULT_RESPONSE,
       _manuf_code,
-      true /* cluster specific */,
+      false /* not cluster specific */,
       false /* noresponse */,
       true /* direct no retry */,
       _transact_seq,  /* zcl transaction id */

--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1673,6 +1673,27 @@ void ZCLFrame::parseClusterSpecificCommand(Z_attribute_list& attr_list) {
       }
     }
   }
+  // Send Default Response to acknowledge the attribute reporting
+  if (0 == _frame_control.b.disable_def_resp) {
+    // the device expects a default response
+    SBuffer buf(2);
+    buf.add8(_cmd_id);
+    buf.add8(0x00);   // Status = OK
+
+    ZigbeeZCLSend_Raw(ZigbeeZCLSendMessage({
+      _srcaddr,
+      0x0000,
+      _cluster_id,
+      _srcendpoint,
+      ZCL_DEFAULT_RESPONSE,
+      _manuf_code,
+      true /* cluster specific */,
+      false /* noresponse */,
+      true /* direct no retry */,
+      _transact_seq,  /* zcl transaction id */
+      buf.getBuffer(), buf.len()
+    }));
+  }
 }
 
 // ======================================================================


### PR DESCRIPTION
## Description:

Send default response when a command is received without disable response.

**Related issue (if applicable):** fixes #10611

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
