### PR TITLE
PlatformIO: Build gz files only for ESP8266

### DIFF
--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -1603,8 +1603,6 @@ jobs:
         [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
-        rm ./firmware/tasmota32/*.gz
-        rm ./firmware/tasmota32/languages/*.gz
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
         [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1603,8 +1603,6 @@ jobs:
         [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
-        rm ./firmware/tasmota32/*.gz
-        rm ./firmware/tasmota32/languages/*.gz
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
         [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md

--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -3,26 +3,32 @@ import os
 import shutil
 import gzip
 
-OUTPUT_DIR = "build_output{}".format(os.path.sep)
+platform = env.PioPlatform()
+board = env.BoardConfig()
+mcu = board.get("build.mcu", "esp32")
+# gzip only for ESP8266
+if env["PIOPLATFORM"] != "espressif32":
 
-def bin_gzip(source, target, env):
-    variant = str(target[0]).split(os.path.sep)[2]
-    
-    # create string with location and file names based on variant
-    bin_file = "{}firmware{}{}.bin".format(OUTPUT_DIR, os.path.sep, variant)
-    gzip_file = "{}firmware{}{}.bin.gz".format(OUTPUT_DIR, os.path.sep, variant)
+    OUTPUT_DIR = "build_output{}".format(os.path.sep)
 
-    # check if new target files exist and remove if necessary
-    if os.path.isfile(gzip_file): os.remove(gzip_file)
+    def bin_gzip(source, target, env):
+        variant = str(target[0]).split(os.path.sep)[2]
 
-    # write gzip firmware file
-    with open(bin_file,"rb") as fp:
-        with gzip.open(gzip_file, "wb", compresslevel = 9) as f:
-            shutil.copyfileobj(fp, f)
-    
-    ORG_FIRMWARE_SIZE = os.stat(bin_file).st_size
-    GZ_FIRMWARE_SIZE = os.stat(gzip_file).st_size
+        # create string with location and file names based on variant
+        bin_file = "{}firmware{}{}.bin".format(OUTPUT_DIR, os.path.sep, variant)
+        gzip_file = "{}firmware{}{}.bin.gz".format(OUTPUT_DIR, os.path.sep, variant)
 
-    print("Compression reduced firmware size by {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
+        # check if new target files exist and remove if necessary
+        if os.path.isfile(gzip_file): os.remove(gzip_file)
 
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])
+        # write gzip firmware file
+        with open(bin_file,"rb") as fp:
+            with gzip.open(gzip_file, "wb", compresslevel = 9) as f:
+                shutil.copyfileobj(fp, f)
+
+        ORG_FIRMWARE_SIZE = os.stat(bin_file).st_size
+        GZ_FIRMWARE_SIZE = os.stat(gzip_file).st_size
+
+        print("Compression reduced firmware size by {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
+
+    env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])


### PR DESCRIPTION
## Description:

since ESP32 does not support gz firmware OTA update

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
