### PR TITLE
Attempt to fix broken settings without filesystem

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -512,7 +512,7 @@ void SettingsSave(uint8_t rotate)
       TasmotaGlobal.stop_flash_rotate = 1;
     }
     if (2 == rotate) {   // Use eeprom flash slot and erase next flash slots if stop_flash_rotate is off (default)
-      settings_location = FLASH_EEPROM_START;
+      settings_location = FLASH_EEPROM_START + 1;
     }
     if (TasmotaGlobal.stop_flash_rotate) {
       settings_location = FLASH_EEPROM_START;


### PR DESCRIPTION
## Description:
After 85b2d622258e66c7fb338873de348a03f5906284 handling of settings does not work correctly.

This is an attempt to fix it, but I must admit I don't understand the code in `settings.ino` so it may very well be an incorrect fix.

I have tested the following scenario on ESP8285 with 1MB Flash (no FS) 
- Erase + reflash with `esptool`
- OTA binary 1 with different settings - `reset 1` does not apply settings from binary
- OTA binary 2 with different settings - `reset 1` does not apply settings from binary
- OTA binary 3 with different settings + bumped `CFG_HOLDER` - Settings applied from binary at each reboot
- OTA binary 4 with different settings + same `CFG_HOLDER` as binary 3 - Settings no longer applied from binary at each reboot, but `reset 1` does not apply settings from binary

After applying patch, settings work normally.

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
