### PR TITLE
support for DY_SV17F mp3 player

### DIFF
--- a/tasmota/xdrv_14_mp3.ino
+++ b/tasmota/xdrv_14_mp3.ino
@@ -22,6 +22,7 @@
   1.0.0.5 20210121  added   - support for DY_SV17F Player (#define USE_DY_SV17F)
                             - cmds supported:
                             - track
+                            - stop
                             - volume
                             - play
                             - play /path

--- a/tasmota/xdrv_14_mp3.ino
+++ b/tasmota/xdrv_14_mp3.ino
@@ -19,6 +19,13 @@
   --------------------------------------------------------------------------------------------
   Version yyyymmdd  Action    Description
   --------------------------------------------------------------------------------------------
+  1.0.0.5 20210121  added   - support for DY_SV17F Player (#define USE_DY_SV17F)
+                            - cmds supported:
+                            - track
+                            - volume
+                            - play
+                            - play /path
+
   1.0.0.4 20181003  added   - MP3Reset command in case that the player do rare things
                             - and needs a reset, the default volume will be set again too
                     added   - MP3_CMD_RESET_VALUE for the player reset function
@@ -148,6 +155,60 @@ void MP3PlayerInit(void) {
   return;
 }
 
+
+#ifdef USE_DY_SV17F
+
+/*********************************************************************************************\
+ * specific for DY_SV17F
+ * create the MP3 commands payload, and send it via serial interface to the MP3 player
+ * only track,play,stop and volume supported
+\*********************************************************************************************/
+
+void MP3_SendCmd(uint8_t *scmd, uint8_t len) {
+uint16_t sum = 0;
+  for (uint32_t cnt = 0; cnt < len; cnt++) {
+    sum += scmd[cnt];
+  }
+  scmd[len] = sum;
+  MP3Player->write(scmd, len + 1);
+}
+
+void MP3_CMD(uint8_t mp3cmd, uint16_t val) {
+  uint8_t scmd[8];
+  uint8_t len = 0;
+  scmd[0]=0xAA;
+  switch (mp3cmd) {
+    case MP3_CMD_TRACK:
+      scmd[1]=0x07;
+      scmd[2]=0x02;
+      scmd[3]=val>>8;
+      scmd[4]=val;
+      MP3_SendCmd(scmd, 5);
+    case MP3_CMD_PLAY:
+      scmd[1]=0x02;
+      scmd[2]=0x00;
+      scmd[3]=0xAC;
+      len = 4;
+      break;
+    case MP3_CMD_STOP:
+      scmd[1]=0x10;
+      scmd[2]=0x00;
+      scmd[3]=0xBA;
+      len = 4;
+      break;
+    case MP3_CMD_VOLUME:
+      scmd[1]=0x13;
+      scmd[2]=0x01;
+      scmd[3]=val;
+      len = 4;
+      break;
+    default:
+      return;
+  }
+  MP3_SendCmd(scmd, len);
+}
+
+#else
 /*********************************************************************************************\
  * create the MP3 commands payload, and send it via serial interface to the MP3 player
  * data length is 6 = 6 bytes [FF 06 09 00 00 00] but not counting the start, end, and verification.
@@ -173,7 +234,7 @@ void MP3_CMD(uint8_t mp3cmd,uint16_t val) {
   }
   return;
 }
-
+#endif // USE_DY_SV17F
 /*********************************************************************************************\
  * check the MP3 commands
 \*********************************************************************************************/
@@ -202,7 +263,9 @@ bool MP3PlayerCmd(void) {
         }
         Response_P(S_JSON_MP3_COMMAND_NVALUE, command, XdrvMailbox.payload);
         break;
+#ifndef USE_DY_SV17F
       case CMND_MP3_PLAY:
+#endif // USE_DY_SV17F
       case CMND_MP3_PAUSE:
       case CMND_MP3_STOP:
       case CMND_MP3_RESET:
@@ -213,6 +276,32 @@ bool MP3PlayerCmd(void) {
         if (command_code == CMND_MP3_RESET)    { MP3_CMD(MP3_CMD_RESET,  0); }
         Response_P(S_JSON_MP3_COMMAND, command, XdrvMailbox.payload);
         break;
+
+#ifdef USE_DY_SV17F
+      case CMND_MP3_PLAY:
+        if (XdrvMailbox.data_len > 0) {
+          uint8_t scmd[64];
+          scmd[0] = 0xAA;
+          scmd[1] = 0x08;
+          scmd[2] = XdrvMailbox.data_len + 1;
+          scmd[3] = 2;
+          char *cp = XdrvMailbox.data;
+          scmd[4] = *cp;
+          for (uint8_t i = 1; i < XdrvMailbox.data_len; i++) {
+            if (cp[i]=='.') {
+              scmd[i + 4] = '*';
+            } else {
+              scmd[i + 4] = toupper(cp[i]);
+            }
+          }
+          MP3_SendCmd(scmd, XdrvMailbox.data_len + 4);
+          Response_P(S_JSON_COMMAND_SVALUE, command, XdrvMailbox.data);
+        } else {
+          MP3_CMD(MP3_CMD_PLAY, 0);
+          Response_P(S_JSON_MP3_COMMAND, command, XdrvMailbox.payload);
+        }
+        break;
+#endif // USE_DY_SV17F
       default:
     	  // else for Unknown command
     	  serviced = false;


### PR DESCRIPTION
## Description:

this player has the advantage to play files by path
( pathname max 8 chars including initial slash + .mp3)
#define USE_MP3_PLAYER
and
#define USE_DY_SV17F

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
