### PR TITLE
Sml obis fix

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -4,7 +4,7 @@
   Created by Gerhard Mutz on 07.10.11.
   adapted for Tasmota
 
-  Copyright (C) 2021  Gerhard Mutz and Theo Arends
+  Copyright (C) 2020  Gerhard Mutz and Theo Arends
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -1539,16 +1539,16 @@ void SML_Decode(uint8_t index) {
 #ifdef ED300L
         g_mindex=mindex;
 #endif
-        if (*mp=='#') {
+        if (*mp == '#') {
           // get string value
           mp++;
-          if (meter_desc_p[mindex].type=='o') {
-            for (uint8_t p=0;p<METER_ID_SIZE;p++) {
-              if (*cp==*mp) {
-                meter_id[mindex][p]=0;
+          if (meter_desc_p[mindex].type == 'o') {
+            for (uint8_t p=0; p<METER_ID_SIZE; p++) {
+              if (*cp == *mp) {
+                meter_id[mindex][p] = 0;
                 break;
               }
-              meter_id[mindex][p]=*cp++;
+              meter_id[mindex][p] = *cp++;
             }
           } else {
             sml_getvalue(cp,mindex);
@@ -1558,9 +1558,19 @@ void SML_Decode(uint8_t index) {
           if (meter_desc_p[mindex].type!='e' && meter_desc_p[mindex].type!='r' && meter_desc_p[mindex].type!='m' && meter_desc_p[mindex].type!='M' && meter_desc_p[mindex].type!='p') {
             // get numeric values
             if (meter_desc_p[mindex].type=='o' || meter_desc_p[mindex].type=='c') {
-              dval=CharToDouble((char*)cp);
+              if (*mp == '(') {
+                mp++;
+                // skip this bracket
+                char *bp = strchr((char*)cp, '(');
+                if (bp) {
+                  cp = (uint8_t*) (bp + 1);
+                }
+                dval=CharToDouble((char*)cp);
+              } else {
+                dval=CharToDouble((char*)cp);
+              }
             } else {
-              dval=sml_getvalue(cp,mindex);
+              dval = sml_getvalue(cp,mindex);
             }
           } else {
             // ebus pzem or mbus or raw

--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -4,7 +4,7 @@
   Created by Gerhard Mutz on 07.10.11.
   adapted for Tasmota
 
-  Copyright (C) 2020  Gerhard Mutz and Theo Arends
+  Copyright (C) 2021  Gerhard Mutz and Theo Arends
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Description:

option to fetch second (val) of obis payload

**Related issue (if applicable):** fixes #10644

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
