### PR TITLE
Zigbee don't do auto-bind if device is already known

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -760,8 +760,8 @@
 
   // Auto-binding constants, see `Z_autoAttributeReporting`
   // Below are the threshold for attribute reporting
-  #define USE_ZIGBEE_AUTOBIND_BATTVOLTAGE   0.1     // V
-  #define USE_ZIGBEE_AUTOBIND_BATTPERCENT   1       // %
+  #define USE_ZIGBEE_AUTOBIND_BATTVOLTAGE   0.2     // V
+  #define USE_ZIGBEE_AUTOBIND_BATTPERCENT   5       // %
   #define USE_ZIGBEE_AUTOBIND_TEMPERATURE   0.5     // °C
   #define USE_ZIGBEE_AUTOBIND_HEATDEMAND    10      // %
   #define USE_ZIGBEE_AUTOBIND_PRESSURE      1       // hPA

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -105,7 +105,11 @@ public:
   ZB_RecvMsgFunc recv_func = nullptr;          // function to call when message is expected
   ZB_RecvMsgFunc recv_unexpected = nullptr;    // function called when unexpected message is received
 
+#ifdef USE_ZIGBEE_EZSP
   uint32_t permit_end_time = 0;       // timestamp when permit join ends
+#elif defined(USE_ZIGBEE_ZNP)
+  bool permit_end_time = false;       // in ZNP mode it's only a boolean
+#endif
 
 #ifdef USE_ZIGBEE_EZSP
   Eeprom24C512 eeprom;     // takes only 1 bytes of RAM

--- a/tasmota/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/xdrv_23_zigbee_2_devices.ino
@@ -965,6 +965,7 @@ public:
   Z_Device & devicesAt(size_t i) const;
 
   // Remove device from list
+  void clearDeviceRouterInfo(void);           // reset all router flags, done just before ZbMap
   bool removeDevice(uint16_t shortaddr);
 
   // Mark data as 'dirty' and requiring to save in Flash

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -218,6 +218,15 @@ Z_Device & Z_Devices::updateDevice(uint16_t shortaddr, uint64_t longaddr) {
   return device_unk;
 }
 
+// Clear the router flag for each device, called at the beginning of ZbMap
+void Z_Devices::clearDeviceRouterInfo(void) {
+  for (Z_Device & device : zigbee_devices._devices) {
+    if (device.valid()) {
+      device.setRouter(false);
+    }
+  }
+}
+
 //
 // Clear all endpoints
 //

--- a/tasmota/xdrv_23_zigbee_7_5_map.ino
+++ b/tasmota/xdrv_23_zigbee_7_5_map.ino
@@ -76,7 +76,7 @@ public:
     edges()
     {}
 
-  void reset(void) { edges.reset(); }
+  void reset(void) { edges.reset(); zigbee_devices.clearDeviceRouterInfo(); }
 
   Z_Mapper_Edge & findEdge(const Z_Mapper_Edge & edge2);
   bool addEdge(const Z_Mapper_Edge & edge2);


### PR DESCRIPTION
## Description:

Some devices (ex: IKEA PIR) tend to re-join and send `DeviceAnnounce` although they were already paired, which triggers a new auto-binding.

Now auto-binding happens only if PermitJoin is active, or if the IEEEAddress was not already known. Simple rejoins will not trigger auto-binding anymore.

Additional changes:
- fixed PermitJoin indicator on WebUI for CC2530
- changed BatteryVoltage reporting threshold to 5% instead of 1%, and 0.2V instead of 0.1V
- Fixed devices that were mistakenly shown as router in Zigbee map

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
