### PR TITLE
Fix compile error with latest Platformio development

### DIFF
--- a/lib/default/PubSubClient-EspEasy-2.7.12/library.json
+++ b/lib/default/PubSubClient-EspEasy-2.7.12/library.json
@@ -10,8 +10,5 @@
     "exclude": "tests",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino",
-    "platforms": [
-        "atmelavr",
-        "espressif"
-    ]
+    "platforms": ["espressif8266", "espressif32"]
 }

--- a/lib/lib_basic/OneWire-Stickbreaker-20190506-1.1/library.properties
+++ b/lib/lib_basic/OneWire-Stickbreaker-20190506-1.1/library.properties
@@ -6,5 +6,5 @@ sentence=Access 1-wire temperature sensors, memory and other chips.
 paragraph= Mod of Paul Stoffregen code to support ESP32
 category=Communication
 url=http://www.pjrc.com/teensy/td_libs_OneWire.html
-architectures=esp32
+architectures=esp8266,esp32
 

--- a/lib/lib_basic/TasmotaModbus-1.2.0/library.json
+++ b/lib/lib_basic/TasmotaModbus-1.2.0/library.json
@@ -11,5 +11,5 @@
         "url": "https://github.com/arendst/Tasmota/lib/TasmotaModbus"
     },
     "frameworks": "arduino",
-    "platforms": "espressif8266"
+    "platforms": ["espressif8266", "espressif32"]
 }

--- a/lib/lib_basic/TasmotaModbus-1.2.0/library.properties
+++ b/lib/lib_basic/TasmotaModbus-1.2.0/library.properties
@@ -6,4 +6,4 @@ sentence=Basic modbus wrapper for TasmotaSerial for ESP8266.
 paragraph=
 category=Signal Input/Output
 url=
-architectures=esp8266
+architectures=esp8266,esp32

--- a/lib/lib_display/FT5206_Library/library.properties
+++ b/lib/lib_display/FT5206_Library/library.properties
@@ -7,4 +7,3 @@ paragraph=Arduino library for FT5206 chip. Tested with ESP32
 category=Communication
 url=https://github.com/lewisxhe/FT5206_Library
 architectures=*
-architectures=esp32

--- a/lib/lib_display/LiquidCrystal_I2C-1.1.3/library.json
+++ b/lib/lib_display/LiquidCrystal_I2C-1.1.3/library.json
@@ -10,6 +10,6 @@
   "frameworks": "arduino",
   "platforms":
   [
-    "atmelavr"
+    "*"
   ]
 }

--- a/lib/lib_display/esp-epaper-29-ws-20171230-gemu-1.1/library.properties
+++ b/lib/lib_display/esp-epaper-29-ws-20171230-gemu-1.1/library.properties
@@ -6,4 +6,4 @@ sentence=ESP8266 library for Waveshare e-paper display.
 paragraph=
 category=Display
 url=https://github.com/gemu2015/Sonoff-Tasmota/tree/displays/lib/esp-epaper-29-ws-20171230-gemu-1.0#
-architectures=esp8266
+architectures=*

--- a/lib/lib_i2c/BME680_driver-bme680_v3.5.9/library.properties
+++ b/lib/lib_i2c/BME680_driver-bme680_v3.5.9/library.properties
@@ -6,4 +6,4 @@ sentence=Sensor driver for BME680 sensor
 paragraph=Sensor driver for BME680 sensor
 category=Sensor
 url=
-architectures=esp8266
+architectures=esp8266,esp32

--- a/lib/lib_i2c/I2Cdevlib-Core/.library.json
+++ b/lib/lib_i2c/I2Cdevlib-Core/.library.json
@@ -5,7 +5,7 @@
         "type": "git"
     }, 
     "platforms": [
-        "atmelavr"
+        "*"
     ], 
     "frameworks": [
         "arduino"

--- a/lib/lib_i2c/I2Cdevlib-Core/library.json
+++ b/lib/lib_i2c/I2Cdevlib-Core/library.json
@@ -9,5 +9,5 @@
     "url": "https://github.com/jrowberg/i2cdevlib.git"
   },
   "frameworks": "arduino",
-  "platforms": "atmelavr"
+  "platforms": "*"
 }

--- a/lib/lib_rf/cc1101/library.properties
+++ b/lib/lib_rf/cc1101/library.properties
@@ -6,4 +6,4 @@ sentence=.
 paragraph=
 category=
 url=
-architectures=esp8266
+architectures=esp8266,esp32

--- a/lib/lib_ssl/bearssl-esp8266/library.properties
+++ b/lib/lib_ssl/bearssl-esp8266/library.properties
@@ -6,4 +6,4 @@ sentence=BearSSL implementation of the SSL/TLS protocol optimized for ESP8266 by
 paragraph=
 category=Other
 url=https://github.com/earlephilhower/bearssl-esp8266.git
-architectures=esp8266
+architectures=esp8266,esp32

--- a/lib/libesp32/CORE2_Library/library.properties
+++ b/lib/libesp32/CORE2_Library/library.properties
@@ -1,0 +1,9 @@
+name=M5 Stack Core2 library
+version=1.0
+author=Gerhard Mutz
+maintainer=Gerhard Mutz
+sentence=Allows Tasmota to use Core2
+paragraph=Allows Tasmota to Core2 for esp32
+category=ESP32
+url=
+architectures=*


### PR DESCRIPTION
## Description:

Latest platformio development version has a change in library dependency finder. It is now by default strict. This means only libs which are defined as compatible to esp8266 and esp32 will be used. Added changed entrys accordingly. Perhaps i missed some...

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
