### PR TITLE
MFRC522 change to new GPIO name

### DIFF
--- a/tasmota/xsns_80_mfrc522.ino
+++ b/tasmota/xsns_80_mfrc522.ino
@@ -25,7 +25,7 @@
  * Connections:
  * MFRC522  ESP8266         Tasmota
  * -------  --------------  ----------
- *  SDA     GPIO0..5,15,16  SPI CS
+ *  SDA     GPIO0..5,15,16  RC522 CS
  *  SCK     GPIO14          SPI CLK
  *  MOSI    GPIO13          SPI MOSI
  *  MISO    GPIO12          SPI MISO


### PR DESCRIPTION
## Description:

Changed incode documentation to new SPI GPIO name

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
