### PR TITLE
MAX31865 Fahrenheit Units Display Incorrectly

### DIFF
--- a/tasmota/xsns_47_max31865.ino
+++ b/tasmota/xsns_47_max31865.ino
@@ -79,7 +79,7 @@ void MAX31865_GetResult(void) {
       rtd = max31865[i].readRTD();
       MAX31865_Result[i].Rtd = rtd;
       MAX31865_Result[i].PtdResistance = max31865[i].rtd_to_resistance(rtd, MAX31865_REF_RES);
-      MAX31865_Result[i].PtdTemp = max31865[i].rtd_to_temperature(rtd, MAX31865_PTD_RES, MAX31865_REF_RES) + MAX31865_PTD_BIAS;
+      MAX31865_Result[i].PtdTemp = ConvertTemp(max31865[i].rtd_to_temperature(rtd, MAX31865_PTD_RES, MAX31865_REF_RES) + MAX31865_PTD_BIAS);
     }
   }
 }


### PR DESCRIPTION
## Description:

When using the MAX31865 with temperature units set to Fahrenheit, the Celsius value is displayed instead. When comparing to other temperature sensor implementations, it appears the `ConvertTemp` function was missing.

I was able to test this on an ESP8266 NodeMCU and found the change to work correctly. I don't have an ESP32 target to test this change against, however, due to the trivial nature of this change, the risk this will not work properly on an ESP32 target is low.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
