### PR TITLE
TSL2591 Dark Measurement Results in Divide-by-Zero Error

### DIFF
--- a/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
+++ b/lib/lib_i2c/Adafruit_TSL2591_Library/Adafruit_TSL2591.cpp
@@ -338,7 +338,15 @@ float Adafruit_TSL2591::calculateLux(uint16_t ch0, uint16_t ch1)
 
   // Alternate lux calculation 1
   // See: https://github.com/adafruit/Adafruit_TSL2591_Library/issues/14
-  lux = ( ((float)ch0 - (float)ch1 )) * (1.0F - ((float)ch1/(float)ch0) ) / cpl;
+  if(ch0 > 0)
+  {
+    lux = ( ((float)ch0 - (float)ch1 )) * (1.0F - ((float)ch1/(float)ch0) ) / cpl;
+  }
+  else
+  {
+    lux = 0.0F;
+  }
+  
 
   // Alternate lux calculation 2
   //lux = ( (float)ch0 - ( 1.7F * (float)ch1 ) ) / cpl;


### PR DESCRIPTION
## Description:

When measuring a dark environment, the sensor's channel 0 measurement returns zero. Since the lux calculation uses this parameter as the denominator of a division, a divide by zero error occurs. This update checks the value of channel 0 before dividing.

I was able to test this on an ESP8266 NodeMCU and found the change to work correctly. I don't have an ESP32 target to test this change against, however, due to the trivial nature of this change, the risk this will not work properly on an ESP32 target is low.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
