### PR TITLE
Proposal for SetOption synonyms

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -420,6 +420,13 @@
   #define D_JSON_MAXENERGYREACHED "MaxEnergyReached"
 
 // Commands xdrv_04_light.ino
+#define D_SO_CHANNELREMAP "ChannelRemap"    // SO37
+#define D_SO_MULTIPWM "MultiPWM"            // SO68
+#define D_SO_ALEXACTRANGE "AlexaCTRange"    // SO82
+#define D_SO_POWERONFADE "PowerOnFade"      // SO91
+#define D_SO_PWMCT "PWMCT"                  // SO92
+#define D_SO_WHITEBLEND "WhiteBlend"        // SO105
+#define D_SO_VIRTUALCT "VirtualCT"          // SO106
 #define D_CMND_CHANNEL "Channel"
 #define D_CMND_COLOR "Color"
 #define D_CMND_COLORTEMPERATURE "CT"

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -916,7 +916,7 @@ int GetCommandCode(char* destination, size_t destination_size, const char* needl
   return result;
 }
 
-bool DecodeCommandSynonyms(const char* haystack, void (* const MyCommand[])(void), const uint8_t *synonyms, size_t syn_count)
+bool DecodeCommandSynonyms(const char* haystack, void (* const MyCommand[])(void), const uint8_t *synonyms)
 {
   GetTextIndexed(XdrvMailbox.command, CMDSZ, 0, haystack);  // Get prefix if available
   int prefix_length = strlen(XdrvMailbox.command);
@@ -927,6 +927,7 @@ bool DecodeCommandSynonyms(const char* haystack, void (* const MyCommand[])(void
       return false;                                         // Prefix not in command
     }
   }
+  size_t syn_count = synonyms ? pgm_read_byte(synonyms) : 0;
   int command_code = GetCommandCode(XdrvMailbox.command + prefix_length, CMDSZ, XdrvMailbox.topic + prefix_length, haystack);
   if (command_code > 0) {                                   // Skip prefix
     if (command_code > syn_count) {
@@ -935,7 +936,7 @@ bool DecodeCommandSynonyms(const char* haystack, void (* const MyCommand[])(void
       MyCommand[XdrvMailbox.command_code]();
     } else {
       // we have a SetOption synonym
-      XdrvMailbox.index = pgm_read_byte(synonyms + command_code - 1);
+      XdrvMailbox.index = pgm_read_byte(synonyms + command_code);
       CmndSetoptionBase(0);
     }
     return true;
@@ -945,7 +946,7 @@ bool DecodeCommandSynonyms(const char* haystack, void (* const MyCommand[])(void
 
 bool DecodeCommand(const char* haystack, void (* const MyCommand[])(void))
 {
-  return DecodeCommandSynonyms(haystack, MyCommand, nullptr, 0);
+  return DecodeCommandSynonyms(haystack, MyCommand, nullptr);
 }
 
 const char kOptions[] PROGMEM = "OFF|" D_OFF "|FALSE|" D_FALSE "|STOP|" D_STOP "|" D_CELSIUS "|"              // 0

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -149,6 +149,7 @@ const char kLightCommands[] PROGMEM = "|"  // No prefix
    "|UNDOCA" ;
 
 const uint8_t kLightSynonyms[] PROGMEM = {
+  7,                    // number of entries
   37, 68, 82, 91, 92,
   105, 106, 
 };
@@ -3088,7 +3089,7 @@ bool Xdrv04(uint8_t function)
         LightSetPower();
         break;
       case FUNC_COMMAND:
-        result = DecodeCommandSynonyms(kLightCommands, LightCommand, kLightSynonyms, sizeof(kLightSynonyms));
+        result = DecodeCommandSynonyms(kLightCommands, LightCommand, kLightSynonyms);
         if (!result) {
           result = XlgtCall(FUNC_COMMAND);
         }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -129,6 +129,10 @@ enum LightSchemes { LS_POWER, LS_WAKEUP, LS_CYCLEUP, LS_CYCLEDN, LS_RANDOM, LS_M
 const uint8_t LIGHT_COLOR_SIZE = 25;   // Char array scolor size
 
 const char kLightCommands[] PROGMEM = "|"  // No prefix
+  // SetOptions synonyms
+  D_SO_CHANNELREMAP "|" D_SO_MULTIPWM "|" D_SO_ALEXACTRANGE "|" D_SO_POWERONFADE "|" D_SO_PWMCT "|"
+  D_SO_WHITEBLEND "|" D_SO_VIRTUALCT "|" 
+  // other commands
   D_CMND_COLOR "|" D_CMND_COLORTEMPERATURE "|" D_CMND_DIMMER "|" D_CMND_DIMMER_RANGE "|" D_CMND_DIMMER_STEP "|" D_CMND_LEDTABLE "|" D_CMND_FADE "|"
   D_CMND_RGBWWTABLE "|" D_CMND_SCHEME "|" D_CMND_SPEED "|" D_CMND_WAKEUP "|" D_CMND_WAKEUPDURATION "|"
   D_CMND_WHITE "|" D_CMND_CHANNEL "|" D_CMND_HSBCOLOR
@@ -144,7 +148,13 @@ const char kLightCommands[] PROGMEM = "|"  // No prefix
 #endif  // USE_DGR_LIGHT_SEQUENCE
    "|UNDOCA" ;
 
+const uint8_t kLightSynonyms[] PROGMEM = {
+  37, 68, 82, 91, 92,
+  105, 106, 
+};
+
 void (* const LightCommand[])(void) PROGMEM = {
+  // Skip synonyms
   &CmndColor, &CmndColorTemperature, &CmndDimmer, &CmndDimmerRange, &CmndDimmerStep, &CmndLedTable, &CmndFade,
   &CmndRgbwwTable, &CmndScheme, &CmndSpeed, &CmndWakeup, &CmndWakeupDuration,
   &CmndWhite, &CmndChannel, &CmndHsbColor,
@@ -3078,7 +3088,7 @@ bool Xdrv04(uint8_t function)
         LightSetPower();
         break;
       case FUNC_COMMAND:
-        result = DecodeCommand(kLightCommands, LightCommand);
+        result = DecodeCommandSynonyms(kLightCommands, LightCommand, kLightSynonyms, sizeof(kLightSynonyms));
         if (!result) {
           result = XlgtCall(FUNC_COMMAND);
         }


### PR DESCRIPTION
## Description:

SetOption synonyms are placed first in the `kCommands` array, index of setoptions is passed in a separate array of `uint_8` to the new `DecodeCommandSynonyms()`, and the synonyms are skipped, meaning that they don't an function address.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
