### PR TITLE
Sonoff L1 module - add Music Sync mode

### DIFF
--- a/tasmota/xlgt_05_sonoff_l1.ino
+++ b/tasmota/xlgt_05_sonoff_l1.ino
@@ -57,6 +57,12 @@ struct SNFL1 {
   uint8_t power;
 } Snfl1;
 
+const char kL1Commands[] PROGMEM = "L1|" // prefix
+  "MusicSync";
+
+void (* const L1Command[])(void) PROGMEM = {
+  &CmndMusicSync };
+
 /********************************************************************************************/
 
 #ifdef SONOFF_L1_START_DELAY
@@ -318,6 +324,55 @@ bool SnfL1ModuleSelected(void)
   return false;
 }
 
+// SONOFF_L1_MODE_COLORFUL
+void SnfL1ModeColorful() {
+  char buffer[SONOFF_L1_BUFFER_SIZE];
+  snprintf_P(buffer, sizeof(buffer), PSTR("AT+UPDATE=\"sequence\":\"%d%03d\",\"switch\":\"%s\",\"colorR\":%d,\"colorG\":%d,\"colorB\":%d,\"bright\":%d,\"mode\":%d"),
+    LocalTime(), millis()%1000,
+    Snfl1.power ? "on" : "off",
+    Snfl1.color[0], Snfl1.color[1], Snfl1.color[2],
+    Snfl1.dimmer,
+    SONOFF_L1_MODE_COLORFUL);
+
+  SnfL1Send(buffer);
+}
+
+// SONOFF_L1_MODE_SYNC_TO_MUSIC
+void SnfL1ModeMusic(uint32_t sensitive, uint32_t speed) {
+  char buffer[SONOFF_L1_BUFFER_SIZE];
+  snprintf_P(buffer, sizeof(buffer), PSTR("AT+UPDATE=\"sequence\":\"%d%03d\",\"mode\":%d,\"sensitive\":%d,\"speed\":%d"),
+  LocalTime(), millis()%1000,
+  SONOFF_L1_MODE_SYNC_TO_MUSIC,
+  sensitive,
+  speed
+  );
+
+  SnfL1Send(buffer);
+}
+
+void CmndMusicSync(void) 
+{
+  // Format is L1MusicSync sensitivity,speed 
+  // sensitivity 1..10, speed 1..100
+  char *p;
+  strtok_r(XdrvMailbox.data, ",", &p);
+  if (0 == XdrvMailbox.payload) {
+    SnfL1SetChannels();
+
+    ResponseCmndDone();
+  } 
+  else if (p != nullptr) {
+    uint32_t sen = strtol(XdrvMailbox.data, nullptr, 0);
+    uint32_t spd = strtol(p, nullptr, 0);
+    if ( (sen >= 0) && (sen <= 10) && (spd >= 0) && (spd <= 100) ) {
+      SnfL1ModeMusic(sen, spd);
+    ResponseCmndDone();
+    } 
+  else {
+      return;     // error
+    }
+  } 
+}
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/
@@ -335,6 +390,9 @@ bool Xlgt05(uint8_t function)
       break;
     case FUNC_MODULE_INIT:
       result = SnfL1ModuleSelected();
+      break;
+    case FUNC_COMMAND:
+      result = DecodeCommand(kL1Commands, L1Command);
       break;
   }
   return result;

--- a/tasmota/xlgt_05_sonoff_l1.ino
+++ b/tasmota/xlgt_05_sonoff_l1.ino
@@ -324,19 +324,6 @@ bool SnfL1ModuleSelected(void)
   return false;
 }
 
-// SONOFF_L1_MODE_COLORFUL
-void SnfL1ModeColorful() {
-  char buffer[SONOFF_L1_BUFFER_SIZE];
-  snprintf_P(buffer, sizeof(buffer), PSTR("AT+UPDATE=\"sequence\":\"%d%03d\",\"switch\":\"%s\",\"colorR\":%d,\"colorG\":%d,\"colorB\":%d,\"bright\":%d,\"mode\":%d"),
-    LocalTime(), millis()%1000,
-    Snfl1.power ? "on" : "off",
-    Snfl1.color[0], Snfl1.color[1], Snfl1.color[2],
-    Snfl1.dimmer,
-    SONOFF_L1_MODE_COLORFUL);
-
-  SnfL1Send(buffer);
-}
-
 // SONOFF_L1_MODE_SYNC_TO_MUSIC
 void SnfL1ModeMusic(uint32_t sensitive, uint32_t speed) {
   char buffer[SONOFF_L1_BUFFER_SIZE];


### PR DESCRIPTION
## Description:

Added music sync mode for Sonoff L1/Spider Z LED Controller that uses the built in microphone and MCU for it. Did not bother implementing other modes since those can be achieved using Tasmota lights or its provided IR controller.

New command: 
`L1MusicSync <sensitivity>,<speed>`

`sensitivity` range 1-10

`speed` range 1-100

`L1MusicSync 0` returns to standard mode

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
