### PR TITLE
Use dgr name for MQTT if SO88

### DIFF
--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -619,13 +619,13 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
   if (mqtt_trigger) {
     char topic[TOPSZ];
     sprintf_P(TasmotaGlobal.mqtt_data, PSTR("Trigger%u"), mqtt_trigger);
-#ifdef USE_PWM_DIMMER_REMOTE
-    if (Settings.flag4.multiple_device_groups) {
+#ifdef USE_DEVICE_GROUPS
+    if (Settings.flag4.device_groups_enabled) {
       snprintf_P(topic, sizeof(topic), PSTR("cmnd/%s/EVENT"), device_groups[power_button_index].group_name);
       MqttPublish(topic);
     }
     else
-#endif  // USE_PWM_DIMMER_REMOTE
+#endif  // USE_DEVICE_GROUPS
       MqttPublishPrefixTopic_P(CMND, PSTR("EVENT"));
   }
 


### PR DESCRIPTION
## Description:

Use the device group name for MQTT event triggers when SO88 is enabled.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
