### PR TITLE
Added macro for SO synonyms and MQTT

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -349,7 +349,11 @@
 #define D_CMND_CPU_FREQUENCY "CpuFrequency"
 #endif  // ESP32
 
-// Commands xdrv_01_mqtt.ino
+// Commands xdrv_02_mqtt.ino
+#define D_SO_MQTTJSONONLY "MqttJSONOnly"
+#define D_SO_MQTTTLS "MqttTLS"
+#define D_SO_MQTTNORETAIN "MqttNoRetain"
+#define D_SO_MQTTDETACHRELAY "MqttDetachRelay"
 #define D_CMND_MQTTLOG "MqttLog"
 #define D_CMND_MQTTHOST "MqttHost"
 #define D_CMND_MQTTPORT "MqttPort"
@@ -375,7 +379,7 @@
 #define D_CMND_SENSORRETAIN "SensorRetain"
 #define D_CMND_PUBLISH "Publish"
 
-// Commands xdrv_02_webserver.ino
+// Commands xdrv_01_webserver.ino
 #define D_CMND_WEBSERVER "Webserver"
   #define D_JSON_WEBSERVER_MODE "WebServerMode"
   #define D_JSON_ACTIVE_FOR "Active for"

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -472,6 +472,43 @@ bool first_device_group_is_local = true;
 #define DEBUG_TRACE_LOG(...)
 #endif
 
+
+/*********************************************************************************************\
+ * Macro for SetOption synonyms
+ * 
+ * SetOption synonyms come first in the list of commands, right after the prefix.
+ * They don't need any matching function pointer, since they are handled internally.
+ * So don't forget to NOT put pointers in the functions pointers list.
+ * 
+ * The additionnal list of unsigned bytes contains the Option numbers of each synonyms
+ * in the same order. The first byte of the list contains the number of synonyms
+ * (not including the number itself). The is the number of names to skip to find the first command.
+ * 
+ * As it si cumbersome to calculate the first byte (number of synonyms), we provide the following
+ * macro `SO_SYNONYMS(<name>, <list of bytes>)`
+ * 
+ * For example:
+ * ```
+ *   SO_SYNONYMS(kLightSynonyms,
+ *     37, 68, 82, 91, 92, 105,
+ *     106,
+ *   );
+ * ```
+ * 
+ * is equivalent to:
+ * ```
+ *   const static uint8_t kLightSynonyms[] PROGMEM = {
+ *     7,   // number of synonyms, automatically calculated
+ *     37, 68, 82, 91, 92, 105,
+ *     106,
+ *   };
+ * ```
+ * 
+ * This comes very handy if you need to adjust the number of synonyms depending on #defines
+\*********************************************************************************************/
+
+#define SO_SYNONYMS(N,...) const static uint8_t __syn_array_len_ ## N[] = { __VA_ARGS__ }; /* this first array will not be kept by linker, just used for sizeof() */ const static uint8_t N[] PROGMEM = { sizeof(__syn_array_len_ ## N), __VA_ARGS__ };
+
 /*********************************************************************************************/
 
 #endif  // _TASMOTA_GLOBALS_H_

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -32,6 +32,13 @@
 WiFiClient EspClient;                     // Wifi Client - non-TLS
 
 const char kMqttCommands[] PROGMEM = "|"  // No prefix
+  // SetOption synonyms
+  D_SO_MQTTJSONONLY "|" 
+#ifdef USE_MQTT_TLS
+  D_SO_MQTTTLS "|"
+#endif
+  D_SO_MQTTNORETAIN "|" D_SO_MQTTDETACHRELAY "|"
+  // regular commands
 #if defined(USE_MQTT_TLS) && !defined(USE_MQTT_TLS_CA_CERT)
   D_CMND_MQTTFINGERPRINT "|"
 #endif
@@ -42,6 +49,19 @@ const char kMqttCommands[] PROGMEM = "|"  // No prefix
   D_CMND_MQTTHOST "|" D_CMND_MQTTPORT "|" D_CMND_MQTTRETRY "|" D_CMND_STATETEXT "|" D_CMND_MQTTCLIENT "|"
   D_CMND_FULLTOPIC "|" D_CMND_PREFIX "|" D_CMND_GROUPTOPIC "|" D_CMND_TOPIC "|" D_CMND_PUBLISH "|" D_CMND_MQTTLOG "|"
   D_CMND_BUTTONTOPIC "|" D_CMND_SWITCHTOPIC "|" D_CMND_BUTTONRETAIN "|" D_CMND_SWITCHRETAIN "|" D_CMND_POWERRETAIN "|" D_CMND_SENSORRETAIN ;
+
+SO_SYNONYMS(kMqttSynonyms,
+  90,
+#ifdef USE_MQTT_TLS
+  103,
+#endif
+  104, 114
+);
+
+// const uint8_t kMqttSynonyms[] PROGMEM = {
+//   4,  // number of synonyms
+//   90, 103, 104, 114,
+// };
 
 void (* const MqttCommand[])(void) PROGMEM = {
 #if defined(USE_MQTT_TLS) && !defined(USE_MQTT_TLS_CA_CERT)
@@ -1353,7 +1373,7 @@ bool Xdrv02(uint8_t function)
         break;
 #endif  // USE_WEBSERVER
       case FUNC_COMMAND:
-        result = DecodeCommand(kMqttCommands, MqttCommand);
+        result = DecodeCommand(kMqttCommands, MqttCommand, kMqttSynonyms);
         break;
     }
   }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -148,11 +148,10 @@ const char kLightCommands[] PROGMEM = "|"  // No prefix
 #endif  // USE_DGR_LIGHT_SEQUENCE
    "|UNDOCA" ;
 
-const uint8_t kLightSynonyms[] PROGMEM = {
-  7,                    // number of entries
+SO_SYNONYMS(kLightSynonyms,
   37, 68, 82, 91, 92,
   105, 106,
-};
+);
 
 void (* const LightCommand[])(void) PROGMEM = {
   &CmndColor, &CmndColorTemperature, &CmndDimmer, &CmndDimmerRange, &CmndDimmerStep, &CmndLedTable, &CmndFade,

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -42,11 +42,10 @@ const char kZbCommands[] PROGMEM = D_PRFX_ZB "|"    // prefix
   D_CMND_ZIGBEE_CONFIG "|" D_CMND_ZIGBEE_DATA
   ;
 
-const uint8_t kZbSynonyms[] PROGMEM = {
-  6,    // number of synonyms
+SO_SYNONYMS(kZbSynonyms,
   83, 89, 100, 101, 110,
-  112, 
-};
+  112,
+);
 
 void (* const ZigbeeCommand[])(void) PROGMEM = {
 #ifdef USE_ZIGBEE_ZNP


### PR DESCRIPTION
## Description:

Added SetOption synonyms to MQTT.

Added `SO_SYNONYMS` macro to define automatically the internal data structure and compute the prefix length.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
