### PR TITLE
Zibee add ``SetOption120 1`` or ``ZbEndpointTopic`` to add the endpoint as suffix in topic when using ``SetOption89 1``

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -539,6 +539,7 @@
 #define D_SO_ZIGBEE_ENDPOINTSUFFIX "EndpointSuffix"
 #define D_SO_ZIGBEE_NOAUTOBIND "NoAutoBind"
 #define D_SO_ZIGBEE_NAMETOPIC "NameTopic"
+#define D_SO_ZIGBEE_ENDPOINTTOPIC "EndpointTopic"
 #define D_ZIGBEE_NOT_STARTED "Zigbee not started"
 #define D_CMND_ZIGBEE_PERMITJOIN "PermitJoin"
 #define D_CMND_ZIGBEE_STATUS "Status"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -145,7 +145,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t fade_fixed_duration : 1;      // bit 3 (v9.1.0.2)   - SetOption117 - (Light) run fading at fixed duration instead of fixed slew rate
     uint32_t zb_received_as_subtopic : 1;  // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived from JSON message and into the subtopic replacing "SENSOR" default
     uint32_t zb_omit_json_addr : 1;        // bit 5 (v9.2.0.3)   - SetOption119 - (Zigbee) Remove the device addr from json payload, can be used with zb_topic_fname where the addr is already known from the topic
-    uint32_t spare06 : 1;                  // bit 6
+    uint32_t zb_topic_endpoint : 1;        // bit 6 (v9.2.0.4)   - SetOption120 - (Zigbee) Append endpoint number to topic if device dependent (use with SetOption89)
     uint32_t spare07 : 1;                  // bit 7
     uint32_t spare08 : 1;                  // bit 8
     uint32_t spare09 : 1;                  // bit 9

--- a/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/xdrv_23_zigbee_2a_devices_impl.ino
@@ -561,6 +561,11 @@ void Z_Device::jsonPublishAttrList(const char * json_prefix, const Z_attribute_l
     } else {
       snprintf_P(subtopic, sizeof(subtopic), PSTR("%s/%04X"), TasmotaGlobal.mqtt_topic, shortaddr);
     }
+    if (Settings.flag5.zb_topic_endpoint) {
+      if (attr_list.isValidSrcEp()) {
+        snprintf_P(subtopic, sizeof(subtopic), PSTR("%s_%d"), subtopic, attr_list.src_ep);
+      }
+    }
     char stopic[TOPSZ];
     if (Settings.flag5.zb_received_as_subtopic)
       GetTopic_P(stopic, TELE, subtopic, json_prefix);

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -26,7 +26,7 @@
 const char kZbCommands[] PROGMEM = D_PRFX_ZB "|"    // prefix
   // SetOption synonyms
   D_SO_ZIGBEE_NAMEKEY "|" D_SO_ZIGBEE_DEVICETOPIC "|" D_SO_ZIGBEE_NOPREFIX "|" D_SO_ZIGBEE_ENDPOINTSUFFIX "|" D_SO_ZIGBEE_NOAUTOBIND "|"
-  D_SO_ZIGBEE_NAMETOPIC "|"
+  D_SO_ZIGBEE_NAMETOPIC "|" D_SO_ZIGBEE_ENDPOINTTOPIC "|"
 #ifdef USE_ZIGBEE_ZNP
   D_CMND_ZIGBEEZNPSEND "|" D_CMND_ZIGBEEZNPRECEIVE "|"
 #endif // USE_ZIGBEE_ZNP
@@ -44,7 +44,7 @@ const char kZbCommands[] PROGMEM = D_PRFX_ZB "|"    // prefix
 
 SO_SYNONYMS(kZbSynonyms,
   83, 89, 100, 101, 110,
-  112,
+  112, 120,
 );
 
 void (* const ZigbeeCommand[])(void) PROGMEM = {


### PR DESCRIPTION
## Description:

`SetOption120 1` (or `ZbEndpointTopic 1`) adds the source endpoint in the subtopic when `SetOption89 1` (or `ZbDeviceTopic 1`). Works also with `SetOption112 1` (or `ZbNameTopic 1`).

Example:
```
MQT: tele/tasmota/ZBBridge/F5EC_1/SENSOR = {"Plug_Mac":{"Device":"0xF5EC","Name":"Plug_Mac","RMSVoltage":235,"ActivePower":32,"Endpoint":1,"LinkQuality":92}}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
