### PR TITLE
In case of lost comms with PZEM, avoid losing Today Energy

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -530,7 +530,7 @@ void EnergyEverySecond(void)
     }
   }
   if (!data_valid) {
-    Energy.start_energy = 0;
+    //Energy.start_energy = 0;
     AddLog(LOG_LEVEL_DEBUG, PSTR("NRG: Energy reset by " STR(ENERGY_WATCHDOG) " seconds invalid data"));
 
     XnrgCall(FUNC_ENERGY_RESET);


### PR DESCRIPTION
## Description:

In case of lost comms with PZEM, avoid losing Today Energy.

If the PZEM is left without power but the Tasmota device is still powered (by UPS or other mean), the temporary lost of communication with PZEM shouldn't reset the Today Energy Counter. This PR avoids the reset.

_* Note:
**Tasmota's Today Energy** is saved to flash only at midnight. It is lost **_only_** if the Tasmota device is left without power. If Tasmota is restarted, or even OTA updated, the Energy Today Value will remain._

**Related issue (if applicable):** fixes NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
