### PR TITLE
Delete duplicated entry in i18n.h

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -543,7 +543,6 @@
 #define D_SO_ZIGBEE_NOAUTOQUERY "NoAutoQuery"
 #define D_SO_ZIGBEE_ZBRECEIVEDTOPIC "ReceivedTopic"
 #define D_SO_ZIGBEE_OMITDEVICE "OmitDevice"
-#define D_ZIGBEE_NOT_STARTED "Zigbee not started"
 #define D_CMND_ZIGBEE_PERMITJOIN "PermitJoin"
 #define D_CMND_ZIGBEE_STATUS "Status"
 #define D_CMND_ZIGBEE_RESET "Reset"


### PR DESCRIPTION
## Description:

The entry: `#define D_ZIGBEE_NOT_STARTED "Zigbee not started"` is duplicated in _i18n.h_ from all language files. This produces a warning while compiling due to redefinition if changing the language in _my_user_config.h_

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
