### PR TITLE
Return to previous output of IPADDRESS1 command

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1509,7 +1509,7 @@ void CmndIpAddress(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= 4)) {
     char network_address[22];
-    ext_snprintf_P(network_address, sizeof(network_address), PSTR(" = %_I"), (uint32_t)NetworkAddress());
+    ext_snprintf_P(network_address, sizeof(network_address), PSTR(" (%_I)"), (uint32_t)NetworkAddress());
     if (!XdrvMailbox.usridx) {
       ResponseClear();
       for (uint32_t i = 0; i < 4; i++) {


### PR DESCRIPTION
## Description:

The recent commit https://github.com/arendst/Tasmota/commit/db615c5b0ba0053c3991cf40dd47b0d484ac77ae changed the output of command `IPADDRESS1`

* In Old Tasmota versions the output is:
```lua
22:32:25 CMD: ipaddress1
22:32:25 MQT: stat/patio/RESULT = {"IPAddress1":"192.168.1.23 (192.168.1.23)"}
```

* In 9.2 the output is:
```lua
22:52:15.120 CMD: ipaddress1
22:52:15.132 MQT: stat/bridgerf/RESULT = {"IPAddress1":"(IP unset) 192.168.88.20"}
```

* and in 9.2.0.4 the output is:
```lua
02:49:49.206 CMD: ipaddress1
02:49:49.218 MQT: stat/testing/RESULT = {"IPAddress1":"0.0.0.0 = 192.168.88.70"}
```

This last output's type breaks the backwards compatibility, and some softwares like **_Tasmotizer 1.2_** can not parse it.
**_Tasmotizer 1.2_** works fine with `"IPAddress1":"0.0.0.0 (192.168.1.23)"`

------

So, the proposed change with this PR is to return to the previous output type:
```lua
03:12:05.911 CMD: IPAddress1
03:12:05.924 MQT: stat/testing/RESULT = {"IPAddress1":"0.0.0.0 (192.168.88.70)"}
```

-----

For debate,

Looking at other Tasmota Responses like:

```lua
02:49:41.197 CMD: seriallog
02:49:41.211 MQT: stat/testing/RESULT = {"SerialLog":{"0":{"Active":"2"}}}
```

may be we can standarize all these type of responses into JSON parseable outputs with independent keys like:

```lua
02:49:41.197 CMD: seriallog
02:49:41.211 MQT: stat/testing/RESULT = {"SerialLog":0,"SerialLog_Active":2}

03:17:15.674 CMD: IPAddress1
03:17:15.687 MQT: stat/testing/RESULT = {"IPAddress1":"0.0.0.0","IPAddress_Active":"192.168.88.70"}
```

**_Note:_** the key `IPAddress_Active` can be formed with `PSTR(D_CMND_IPADDRESS) and PSTR(D_JSON_ACTIVE)` so a new `#DEFINE` is not needed.

-----

**Related issue (if applicable):** fixes Backwards Compatibility

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
