### PR TITLE
add and fix new string ops in rules

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -99,8 +99,10 @@
 #define COMPARE_OPERATOR_STRING_ENDS_WITH      8
 #define COMPARE_OPERATOR_STRING_STARTS_WITH    9
 #define COMPARE_OPERATOR_STRING_CONTAINS      10
-#define MAXIMUM_COMPARE_OPERATOR              COMPARE_OPERATOR_STRING_CONTAINS
-const char kCompareOperators[] PROGMEM = "=\0>\0<\0|\0==!=>=<=$>$<$|";
+#define COMPARE_OPERATOR_STRING_NOT_EQUAL     11
+#define COMPARE_OPERATOR_STRING_NOT_CONTAINS  12
+#define MAXIMUM_COMPARE_OPERATOR              COMPARE_OPERATOR_STRING_NOT_CONTAINS
+const char kCompareOperators[] PROGMEM = "=\0>\0<\0|\0==!=>=<=$>$<$|$!$^";
 
 #ifdef USE_EXPRESSION
   #include <LinkedList.h>                 // Import LinkedList library
@@ -589,7 +591,13 @@ bool RulesRuleMatch(uint8_t rule_set, String &event, String &rule, bool stop_all
         match = str_str_value.startsWith(rule_svalue);
         break;
       case COMPARE_OPERATOR_STRING_CONTAINS:
-        match = (str_str_value.indexOf(rule_svalue) > 0);
+        match = (str_str_value.indexOf(rule_svalue) >= 0);
+        break;
+      case  COMPARE_OPERATOR_STRING_NOT_EQUAL:
+        match = (0!=strcasecmp(str_value, rule_svalue));  // Compare strings - this also works for hexadecimals
+        break;
+      case  COMPARE_OPERATOR_STRING_NOT_CONTAINS:
+        match = (str_str_value.indexOf(rule_svalue) < 0);
         break;
       default:
         match = true;
@@ -1634,7 +1642,13 @@ bool evaluateComparisonExpression(const char *expression, int len)
       bResult = leftExpr.startsWith(rightExpr);
       break;
     case COMPARE_OPERATOR_STRING_CONTAINS:
-      bResult = (leftExpr.indexOf(rightExpr) > 0);
+      bResult = (leftExpr.indexOf(rightExpr) >= 0);
+      break;
+    case  COMPARE_OPERATOR_STRING_NOT_EQUAL:
+      bResult = !leftExpr.equalsIgnoreCase(rightExpr);  // Compare strings - this also works for hexadecimals
+      break;
+    case  COMPARE_OPERATOR_STRING_NOT_CONTAINS:
+      bResult = (leftExpr.indexOf(rightExpr) < 0);
       break;
   }
   return bResult;


### PR DESCRIPTION
## Description:

Fix string operator `$|` (aka string-contains) which was not detecting a pattern at the start of the string
Add new operator `$!` as string-not-equal (`!=` works only for numbers)
Add new operator `$^` as string-not-contains

Tested with the following rules :
```
on var1#state do if (%value%=TEST) publish debug/equal %value% endif endon
on var1#state do if (%value%$|TEST) publish debug/contains %value% endif endon
on var1#state do if (%value%$<TEST) publish debug/startwith %value% endif endon
on var1#state do if (%value%$>TEST) publish debug/endwith %value% endif endon
on var1#state do if (%value%$!TEST) publish debug/notequal %value% endif endon
on var1#state do if (%value%$^TEST) publish debug/notcontains %value% endif endon

on var1#state$|TEST do publish debug/contains %value% endon
on var1#state$<TEST do publish debug/startwith %value% endon
on var1#state$>TEST do publish debug/endwith %value% endon
on var1#state$!TEST do publish debug/notequal %value% endon
on var1#state$^TEST do publish debug/notcontains %value% endon
on var1#state=TEST do publish debug/equal %value% endon
```


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
