### PR TITLE
support 0.5 degree increments that are mapped to 0.5 degrees above max temperature

### DIFF
--- a/lib/lib_basic/IRremoteESP8266-2.7.14/src/ir_Mitsubishi.cpp
+++ b/lib/lib_basic/IRremoteESP8266-2.7.14/src/ir_Mitsubishi.cpp
@@ -457,7 +457,10 @@ bool IRMitsubishiAC::getPower(void) const {
 /// @param[in] degrees The temperature in degrees celsius.
 void IRMitsubishiAC::setTemp(const uint8_t degrees) {
   uint8_t temp = std::max(kMitsubishiAcMinTemp, degrees);
-  temp = std::min(kMitsubishiAcMaxTemp, temp);
+  // Devices that support 0.5 degree increments are mapped to 0.5 degrees above maximum temperature
+  if (kMitsubishiAcMaxTemp <= temp - kMitsubishiAcMinTemp) {
+    temp = std::min(kMitsubishiAcMaxTemp, temp);
+  }
   _.Temp = temp - kMitsubishiAcMinTemp;
 }
 


### PR DESCRIPTION
## Description:

With Mitsubishi air conditioners, temperatures of 0.5 degrees are mapped to 32 degrees or higher.

For example, 16.5-> 32, 17.5-> 33.

This PR corresponds to that mapping.

## Checklist:
  - [o] The pull request is done against the latest development branch
  - [o] Only relevant files were touched
  - [o] Only one feature/fix was added per PR and the code change compiles without warnings
  - [o] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [o] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
