### PR TITLE
Platformio support for ESP32S2

### DIFF
--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s2_out.ld"
+    },
+    "core": "esp32",
+    "mcu": "esp32s2",
+    "extra_flags": "-Desp32S2_dev_module",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32s2",
+    "variant": "esp32s2"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ESP32S2 Dev Module",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://espressif.com",
+  "vendor": "espressif"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,6 +56,7 @@ default_envs =
 description                 = Provide ESP8266 / ESP32 based devices with Web, MQTT and OTA firmware
 src_dir                     = tasmota
 lib_dir                     = lib/default
+boards_dir                  = boards
 build_cache_dir             = .cache
 extra_configs               = platformio_tasmota32.ini
                               platformio_tasmota_env.ini

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -172,6 +172,14 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${common32.build_flags}
 
+; *** EXPERIMENTAL Tasmota version for ESP32-S2
+[env:tasmota32s2]
+extends                     = env:tasmota32
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc1/esp32-s2-1.0.5-rc1.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
+                              platformio/tool-esptoolpy @ ~1.30000.0
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${common32.build_flags}
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -10,13 +10,13 @@
 
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
-core_dir = .platformio
+;core_dir = .platformio
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
 default_envs =
 ; *** Uncomment the line(s) below to select version(s)
-;                tasmota
+                tasmota
 ;                tasmota-debug
 ;                tasmota-ircustom
 ;                tasmota-minimal
@@ -36,7 +36,7 @@ default_envs =
 ;                tasmota32-ir
 ;                tasmota32-ircustom
 ;                tasmota32solo1
-                tasmota32s2
+;                tasmota32s2
 ;                tasmota32-odroidgo
 ;                tasmota32-core2
 
@@ -176,6 +176,7 @@ build_flags                 = ${common32.build_flags}
 ; *** EXPERIMENTAL Tasmota version for ESP32-S2
 [env:tasmota32s2]
 extends                     = env:tasmota32
+board                       = esp32s2
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc1/esp32-s2-1.0.5-rc1.zip
                               toolchain-xtensa32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -178,7 +178,6 @@ build_flags                 = ${common32.build_flags}
 extends                     = env:tasmota32
 board                       = esp32s2
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc1/esp32-s2-1.0.5-rc1.zip
-                              toolchain-xtensa32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -10,13 +10,13 @@
 
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
-;core_dir = .platformio
+core_dir = .platformio
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
 default_envs =
 ; *** Uncomment the line(s) below to select version(s)
-                tasmota
+;                tasmota
 ;                tasmota-debug
 ;                tasmota-ircustom
 ;                tasmota-minimal
@@ -36,6 +36,7 @@ default_envs =
 ;                tasmota32-ir
 ;                tasmota32-ircustom
 ;                tasmota32solo1
+                tasmota32s2
 ;                tasmota32-odroidgo
 ;                tasmota32-core2
 
@@ -176,6 +177,7 @@ build_flags                 = ${common32.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc1/esp32-s2-1.0.5-rc1.zip
+                              toolchain-xtensa32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}


### PR DESCRIPTION
## Description:

**Compile fails since Tasmota needs code changes for ESP32S2 !!!!**

PlatformIO compile command for ESP32S2:

rename `platformi_override_sample.ini` to `platformio_override.ini`
Execute `pio run -e tasmota32s2`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
