### PR TITLE
LITTLEFS.h casing for ESP32 in sendmail.ino

### DIFF
--- a/tasmota/sendemail.ino
+++ b/tasmota/sendemail.ino
@@ -416,7 +416,12 @@ void xsend_message_txt(char *msg) {
 }
 
 #if (defined(USE_SCRIPT_FATFS) && defined(USE_SCRIPT)) || defined(USE_UFILESYS)
+#ifdef ESP8266
 #include <LittleFS.h>
+#endif  // ESP8266
+#ifdef ESP32
+#include <LITTLEFS.h>
+#endif  // ESP32
 extern FS *ufsp;
 
 void attach_File(char *path) {


### PR DESCRIPTION
## Description:

Solve building with USE_SENDMAIL on ESP32 as `LITTLEFS.h` include has a different casing than `LittleFS.h`.
Visible only when building on Linux.

There doesn't seem to be another occurence of #include LittleFS.
xdrv_50_filesystem.ino and tasmota.ino already include the adatation

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
