### PR TITLE
Zigbee command ``ZbScan`` to do an energy scan on each radio channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Command ``L1MusicSync <0|Off>|<1|On>|<2|Toggle>, 1..10, 1..100>`` to control Sonoff L1 Music Sync mode sensitivity and speed (#10722)
 - Command ``Speed2`` to control a once off fade (#10741)
 - Zigbee command ``SetOption120 1`` or ``ZbEndpointTopic 1`` to add the endpoint as suffix in topic when using ``SetOption89 1``
+- Zigbee command ``ZbScan`` to do an energy scan on each radio channel
 
 ### Changed
 - Maximum chars in ``AddLog_P`` logging restored from 128 to 700 (MAX_LOGSZ) to solve broken error messages

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -615,6 +615,8 @@
 #define D_CMND_ZIGBEE_CONFIG "Config"
   #define D_JSON_ZIGBEE_CONFIG "Config"
 #define D_CMND_ZIGBEE_DATA "Data"
+#define D_CMND_ZIGBEE_SCAN "Scan"
+  #define D_JSON_ZIGBEE_SCAN "ZbScan"
 
 // Commands xdrv_25_A4988_Stepper.ino
 #define D_CMND_MOTOR "MOTOR"

--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -23,6 +23,11 @@
 #include "Eeprom24C512.h"
 #endif // USE_ZIGBEE_EZSP
 
+// channels numbers for Zigbee radio energy scan
+#define USE_ZIGBEE_CHANNEL_MIN    11
+#define USE_ZIGBEE_CHANNEL_MAX    26
+#define USE_ZIGBEE_CHANNEL_COUNT  (USE_ZIGBEE_CHANNEL_MAX - USE_ZIGBEE_CHANNEL_MIN + 1)
+
 // contains some definitions for functions used before their declarations
 
 //
@@ -122,6 +127,9 @@ public:
 
   ZB_RecvMsgFunc recv_func = nullptr;          // function to call when message is expected
   ZB_RecvMsgFunc recv_unexpected = nullptr;    // function called when unexpected message is received
+
+  // Energy scan
+  int8_t energy[USE_ZIGBEE_CHANNEL_COUNT];
 
 #ifdef USE_ZIGBEE_EZSP
   uint32_t permit_end_time = 0;       // timestamp when permit join ends

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -570,6 +570,8 @@ void ZigbeeProcessInputEZSP(SBuffer &buf) {
       case EZSP_setConcentrator:          // 1000
       case EZSP_networkInit:              // 1700
       case EZSP_stackStatusHandler:       // 1900
+      case EZSP_startScan:                // 1A00
+      case EZSP_scanCompleteHandler:      // 1C00
       case EZSP_formNetwork:              // 1E00
       case EZSP_permitJoining:            // 2200
       case EZSP_getEui64:                 // 2600
@@ -580,6 +582,7 @@ void ZigbeeProcessInputEZSP(SBuffer &buf) {
       case EZSP_sendMulticast:            // 3800
       case EZSP_messageSentHandler:       // 3F00
       case EZSP_incomingMessageHandler:   // 4500
+      case EZSP_energyScanResultHandler:  // 4800
       case EZSP_setConfigurationValue:    // 5300
       case EZSP_setPolicy:                // 5500
       case 0x0059:                        // 5900 - supposedly removed by still happening


### PR DESCRIPTION
## Description:

EZSP only: performs an energy scan on channels 11-26. The result (RSSI) are published in MQTT and displayed in visual form in the logs.

Example:
```
ZIG: Channel 11: #######################################################
ZIG: Channel 12: #######################
ZIG: Channel 13: ######################
ZIG: Channel 14: ####################
ZIG: Channel 15: ########################
ZIG: Channel 16: ########################
ZIG: Channel 17: ###########################
ZIG: Channel 18: ##########################
ZIG: Channel 19: #####
ZIG: Channel 20: ########################
ZIG: Channel 21: ####################
ZIG: Channel 22: ######
ZIG: Channel 23: ##############
ZIG: Channel 24: ####
ZIG: Channel 25: ######################
ZIG: Channel 26: ###########################
MQT: tele/tasmota_7FC36F/RESULT = {"ZbScan":["11":2,"12":-50,"13":-52,"14":-55,"15":-49,"16":-49,"17":-43,"18":-45,"19":-79,"20":-48,"21":-54,"22":-78,"23":-64,"24":-81,"25":-51,"26":-44]}
```

As you can see here, my wifi is on channel 1 and overlaps with Zigbee channel 11.
Refer to this article to understand the implications: https://www.metageek.com/training/resources/zigbee-wifi-coexistence.html

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
