### PR TITLE
Publish more precise Free Heap metric

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -477,7 +477,7 @@ void CmndStatus(void)
   }
 
   if ((0 == payload) || (4 == payload)) {
-    float freeMem = ((float)ESP_getFreeHeap()) / 1024;
+    float freeMem = ESP_getFreeHeap1024();
     Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS4_MEMORY "\":{\"" D_JSON_PROGRAMSIZE "\":%d,\"" D_JSON_FREEMEMORY "\":%d,\"" D_JSON_HEAPSIZE "\":%1_f,\""
 #ifdef ESP32
                           D_JSON_PSRMAXMEMORY "\":%d,\"" D_JSON_PSRFREEMEMORY "\":%d,\""

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -477,7 +477,8 @@ void CmndStatus(void)
   }
 
   if ((0 == payload) || (4 == payload)) {
-    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS4_MEMORY "\":{\"" D_JSON_PROGRAMSIZE "\":%d,\"" D_JSON_FREEMEMORY "\":%d,\"" D_JSON_HEAPSIZE "\":%d,\""
+    float freeMem = ((float)ESP_getFreeHeap()) / 1024;
+    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS4_MEMORY "\":{\"" D_JSON_PROGRAMSIZE "\":%d,\"" D_JSON_FREEMEMORY "\":%d,\"" D_JSON_HEAPSIZE "\":%1_f,\""
 #ifdef ESP32
                           D_JSON_PSRMAXMEMORY "\":%d,\"" D_JSON_PSRFREEMEMORY "\":%d,\""
 #endif  // ESP32
@@ -486,7 +487,7 @@ void CmndStatus(void)
                           ",\"" D_JSON_FLASHCHIPID "\":\"%06X\""
 #endif  // ESP8266
                           ",\"FlashFrequency\":%d,\"" D_JSON_FLASHMODE "\":%d"),
-                          ESP_getSketchSize()/1024, ESP.getFreeSketchSpace()/1024, ESP_getFreeHeap()/1024,
+                          ESP_getSketchSize()/1024, ESP.getFreeSketchSpace()/1024, &freeMem,
 #ifdef ESP32
                           ESP.getPsramSize()/1024, ESP.getFreePsram()/1024,
 #endif  // ESP32

--- a/tasmota/support_esp32.ino
+++ b/tasmota/support_esp32.ino
@@ -47,29 +47,6 @@ uint32_t ESP_getFreeHeap(void) {
   return ESP.getFreeHeap();
 }
 
-uint32_t ESP_getMaxAllocHeap(void) {
-/*
-  From libraries.rst
-  ESP.getMaxFreeBlockSize() returns the largest contiguous free RAM block in
-  the heap, useful for checking heap fragmentation.  **NOTE:** Maximum
-  ``malloc()``able block will be smaller due to memory manager overheads.
-
-  From HeapMetric.ino
-  ESP.getMaxFreeBlockSize() does not indicate the amount of memory that is
-  available for use in a single malloc call.  It indicates the size of a
-  contiguous block of (raw) memory before the umm_malloc overhead is removed.
-
-  It should also be pointed out that, if you allow for the needed overhead in
-  your malloc call, it could still fail in the general case. An IRQ handler
-  could have allocated memory between the time you call
-  ESP.getMaxFreeBlockSize() and your malloc call, reducing the available
-  memory.
-*/
-  uint32_t free_block_size = ESP.getMaxFreeBlockSize();
-  if (free_block_size > 100) { free_block_size -= 100; }
-  return free_block_size;
-}
-
 void ESP_Restart(void) {
 //  ESP.restart();            // This results in exception 3 on restarts on core 2.3.0
   ESP.reset();
@@ -431,8 +408,7 @@ uint32_t ESP_getSketchSize(void) {
 }
 
 uint32_t ESP_getFreeHeap(void) {
-//  return ESP.getFreeHeap();
-  return ESP.getMaxAllocHeap();
+  return ESP.getFreeHeap();
 }
 
 uint32_t ESP_getMaxAllocHeap(void) {

--- a/tasmota/support_esp32.ino
+++ b/tasmota/support_esp32.ino
@@ -47,6 +47,10 @@ uint32_t ESP_getFreeHeap(void) {
   return ESP.getFreeHeap();
 }
 
+float ESP_getFreeHeap1024(void) {
+  return ((float)ESP_getFreeHeap()) / 1024;
+}
+
 void ESP_Restart(void) {
 //  ESP.restart();            // This results in exception 3 on restarts on core 2.3.0
   ESP.reset();
@@ -409,6 +413,10 @@ uint32_t ESP_getSketchSize(void) {
 
 uint32_t ESP_getFreeHeap(void) {
   return ESP.getFreeHeap();
+}
+
+float ESP_getFreeHeap1024(void) {
+  return ((float)ESP_getFreeHeap()) / 1024;
 }
 
 uint32_t ESP_getMaxAllocHeap(void) {

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -658,7 +658,7 @@ void MqttShowPWMState(void)
 void MqttShowState(void)
 {
   char stemp1[TOPSZ];
-  float freeMem = ((float)ESP_getFreeHeap()) / 1024;
+  float freeMem = ESP_getFreeHeap1024();
 
   ResponseAppendTime();
   ResponseAppend_P(PSTR(",\"" D_JSON_UPTIME "\":\"%s\",\"UptimeSec\":%u"), GetUptime().c_str(), UpTime());

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -658,6 +658,7 @@ void MqttShowPWMState(void)
 void MqttShowState(void)
 {
   char stemp1[TOPSZ];
+  float freeMem = ((float)ESP_getFreeHeap()) / 1024;
 
   ResponseAppendTime();
   ResponseAppend_P(PSTR(",\"" D_JSON_UPTIME "\":\"%s\",\"UptimeSec\":%u"), GetUptime().c_str(), UpTime());
@@ -669,8 +670,8 @@ void MqttShowState(void)
 #endif  // USE_ADC_VCC
 #endif  // ESP8266
 
-  ResponseAppend_P(PSTR(",\"" D_JSON_HEAPSIZE "\":%d,\"SleepMode\":\"%s\",\"Sleep\":%u,\"LoadAvg\":%u,\"MqttCount\":%u"),
-    ESP_getFreeHeap()/1024, GetTextIndexed(stemp1, sizeof(stemp1), Settings.flag3.sleep_normal, kSleepMode),  // SetOption60 - Enable normal sleep instead of dynamic sleep
+  ResponseAppend_P(PSTR(",\"" D_JSON_HEAPSIZE "\":%1_f,\"SleepMode\":\"%s\",\"Sleep\":%u,\"LoadAvg\":%u,\"MqttCount\":%u"),
+    &freeMem, GetTextIndexed(stemp1, sizeof(stemp1), Settings.flag3.sleep_normal, kSleepMode),  // SetOption60 - Enable normal sleep instead of dynamic sleep
     TasmotaGlobal.sleep, TasmotaGlobal.loop_load_avg, MqttConnectCount());
 
   for (uint32_t i = 1; i <= TasmotaGlobal.devices_present; i++) {

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2063,7 +2063,7 @@ void HandleInformation(void)
 
   char stopic[TOPSZ];
 
-  float freeMem = ((float)ESP_getFreeHeap()) / 1024;
+  float freeMem = ESP_getFreeHeap1024();
 
   WSContentStart_P(PSTR(D_INFORMATION));
   // Save 1k of code space replacing table html with javascript replace codes

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2063,7 +2063,7 @@ void HandleInformation(void)
 
   char stopic[TOPSZ];
 
-  int freeMem = ESP_getFreeHeap();
+  float freeMem = ((float)ESP_getFreeHeap()) / 1024;
 
   WSContentStart_P(PSTR(D_INFORMATION));
   // Save 1k of code space replacing table html with javascript replace codes
@@ -2178,13 +2178,16 @@ void HandleInformation(void)
   WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d kB"), ESP.getFlashChipSize() / 1024);
   WSContentSend_P(PSTR("}1" D_PROGRAM_SIZE "}2%d kB"), ESP_getSketchSize() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_PROGRAM_SPACE "}2%d kB"), ESP.getFreeSketchSpace() / 1024);
-  WSContentSend_P(PSTR("}1" D_FREE_MEMORY "}2%d kB"), freeMem / 1024);
 #ifdef ESP32
+  int32_t freeMaxMem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
+  WSContentSend_P(PSTR("}1" D_FREE_MEMORY "}2%1_f kB (frag. %d%%)"), &freeMem, freeMaxMem);
   if (psramFound()) {
     WSContentSend_P(PSTR("}1" D_PSR_MAX_MEMORY "}2%d kB"), ESP.getPsramSize() / 1024);
     WSContentSend_P(PSTR("}1" D_PSR_FREE_MEMORY "}2%d kB"), ESP.getFreePsram() / 1024);
   }
-#endif
+#else // ESP32
+  WSContentSend_P(PSTR("}1" D_FREE_MEMORY "}2%1_f kB"), &freeMem);
+#endif // ESP32
   WSContentSend_P(PSTR("</td></tr></table>"));
 
   WSContentSend_P(HTTP_SCRIPT_INFO_END);


### PR DESCRIPTION
## Description:

Free heap metric has now 1 digit do give a more precise indication of free memory.
On ESP32, Free Heap gives the actual bytes allocatable and a fragmentation % giving the size of the biggest single chunk allocatable. A number around 50% is normal for ESP32.

![ESP32 free mem](https://user-images.githubusercontent.com/49731213/106800804-390dd200-6661-11eb-83b0-00dc4c4eec4d.png)

Note: fragmentation is not calculated for ESP8266, because the additional lib size would cause a Flash size increase of 2kb. For this same reason I removed `ESP_getMaxAllocHeap()` on ESP8266, to avoid bad surprises.

Code size increase: 40 bytes

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
