### PR TITLE
IR - Allows individual control of power and mode

### DIFF
--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -203,12 +203,11 @@ String sendACJsonState(const stdAc::state_t &state) {
   json.add(PSTR(D_JSON_IRHVAC_VENDOR), typeToString(state.protocol));
   json.add(PSTR(D_JSON_IRHVAC_MODEL), state.model);
 
-  // Home Assistant wants mode to be off if power is also off & vice-versa.
-  if (state.mode == stdAc::opmode_t::kOff || !state.power) {
-    json.add(PSTR(D_JSON_IRHVAC_MODE), IRac::opmodeToString(stdAc::opmode_t::kOff));
+  json.add(PSTR(D_JSON_IRHVAC_MODE), IRac::opmodeToString(state.mode));
+  // Home Assistant wants power to be off if mode is also off.
+  if (state.mode == stdAc::opmode_t::kOff) {
     json.add(PSTR(D_JSON_IRHVAC_POWER),  IRac::boolToString(false));
   } else {
-    json.add(PSTR(D_JSON_IRHVAC_MODE), IRac::opmodeToString(state.mode));
     json.add(PSTR(D_JSON_IRHVAC_POWER), IRac::boolToString(state.power));
   }
   json.add(PSTR(D_JSON_IRHVAC_CELSIUS), IRac::boolToString(state.celsius));


### PR DESCRIPTION
## Description:

Power and mode must be individually controllable. Some devices may not function properly if the mode is also turned off when the power is turned off.

see. https://github.com/crankyoldgit/IRremoteESP8266/issues/1402

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
