### PR TITLE
update max31855 json temperature name publication

### DIFF
--- a/tasmota/xsns_39_max31855.ino
+++ b/tasmota/xsns_39_max31855.ino
@@ -143,7 +143,7 @@ void MAX31855_Show(bool Json) {
   GetTextIndexed(sensor_name, sizeof(sensor_name), Settings.flag4.max6675, kMax31855Types);
 
   if (Json) {
-    ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_PROBETEMPERATURE "\":%*_f,\"" D_JSON_REFERENCETEMPERATURE "\":%*_f,\"" D_JSON_ERROR "\":%d}"), \
+    ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_TEMPERATURE "\":%*_f,\"" D_JSON_REFERENCETEMPERATURE "\":%*_f,\"" D_JSON_ERROR "\":%d}"), \
       sensor_name,
       Settings.flag2.temperature_resolution, &MAX31855_Result.ProbeTemperature,
       Settings.flag2.temperature_resolution, &MAX31855_Result.ReferenceTemperature,


### PR DESCRIPTION
For using the thermostat function, publication of the measured temperature was using the wrong name. Changed to the common used name.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
