### PR TITLE
if pulse is not specified, let the lib use its default value

### DIFF
--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -157,7 +157,7 @@ void CmndRfSend(void)
     unsigned int bits = 24;
     int protocol = 1;
     int repeat = 10;
-    int pulse = 350;
+    int pulse = 0; // 0 leave the library use the default value depending on protocol
 
     JsonParser parser(XdrvMailbox.data);
     JsonParserObject root = parser.getRootObject();
@@ -195,8 +195,8 @@ void CmndRfSend(void)
 
     if (!protocol) { protocol = 1; }
     mySwitch.setProtocol(protocol);
-    if (!pulse) { pulse = 350; }      // Default pulse length for protocol 1
-    mySwitch.setPulseLength(pulse);
+    // if pulse is specified in the command, enforce the provided value (otherwise lib takes default)
+    if (!pulse) { mySwitch.setPulseLength(pulse); }
     if (!repeat) { repeat = 10; }     // Default at init
     mySwitch.setRepeatTransmit(repeat);
     if (!bits) { bits = 24; }         // Default 24 bits


### PR DESCRIPTION
## Description:

Following [discussion](https://github.com/arendst/Tasmota/discussions/10864) reported by @PepeTheFroggie
Current code: when `pulse` is not specified, value 350 is used which the default only for protocol 1. If a different protocol is used, 350 is a wrong value.
Update: when `pulse` is not specified, let the library decide the value from its internal table. Only if `pulse` is specified the value is enforced.

Tests performed by @PepeTheFroggie

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
