### PR TITLE
Ebus interpretation improvements

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -904,7 +904,12 @@ void Dump2log(void) {
             c=SML_SREAD;
             sprintf(&log_data[index],"%02x ",c);
             index+=3;
-            if (c==EBUS_SYNC) break;
+            if (c==EBUS_SYNC) {
+#if SML_EBUS_SKIP_SYNC_DUMPS
+              index = index == 5 ? 0 : index;
+#endif
+              break;
+            }
           } else {
             // sml
             if (sml_start==0x77) {


### PR DESCRIPTION
## Description:

currently, when defining a signed value for the ebus sml interface, it is going to be parsed into an unsigned value and then into a double value. Therefore it loses its original value. This patch omits using the unsigned field and uses a float field directly. For development I also added a define to skip EMPTY sync-telegrams during the dump.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
