### PR TITLE
fix wrong test on pulse

### DIFF
--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -196,7 +196,7 @@ void CmndRfSend(void)
     if (!protocol) { protocol = 1; }
     mySwitch.setProtocol(protocol);
     // if pulse is specified in the command, enforce the provided value (otherwise lib takes default)
-    if (!pulse) { mySwitch.setPulseLength(pulse); }
+    if (pulse) { mySwitch.setPulseLength(pulse); }
     if (!repeat) { repeat = 10; }     // Default at init
     mySwitch.setRepeatTransmit(repeat);
     if (!bits) { bits = 24; }         // Default 24 bits


### PR DESCRIPTION
## Description:

fix the fix
That's the problem when you don't test yourself :(
Sorry for that

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
