### PR TITLE
Github action workflows: add variant FY and map files

### DIFF
--- a/.github/workflows/CI_github.yml
+++ b/.github/workflows/CI_github.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-minimal:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-lite:
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-knx:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-sensors:
     runs-on: ubuntu-latest
@@ -97,7 +97,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-display:
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-ir:
     runs-on: ubuntu-latest
@@ -135,7 +135,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-zbbridge:
     runs-on: ubuntu-latest
@@ -154,7 +154,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-AF:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-BG:
     runs-on: ubuntu-latest
@@ -192,7 +192,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-BR:
     runs-on: ubuntu-latest
@@ -211,7 +211,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-CN:
     runs-on: ubuntu-latest
@@ -230,7 +230,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-CZ:
     runs-on: ubuntu-latest
@@ -249,7 +249,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-DE:
     runs-on: ubuntu-latest
@@ -268,7 +268,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-ES:
     runs-on: ubuntu-latest
@@ -287,7 +287,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-FR:
     runs-on: ubuntu-latest
@@ -306,7 +306,26 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
+
+  tasmota-FY:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U platformio
+        platformio upgrade --dev
+        platformio update
+    - name: Run PlatformIO
+      run: platformio run -e tasmota-FY
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
 
   tasmota-GR:
     runs-on: ubuntu-latest
@@ -325,7 +344,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-HE:
     runs-on: ubuntu-latest
@@ -344,7 +363,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-HU:
     runs-on: ubuntu-latest
@@ -363,7 +382,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-IT:
     runs-on: ubuntu-latest
@@ -382,7 +401,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-KO:
     runs-on: ubuntu-latest
@@ -401,7 +420,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-NL:
     runs-on: ubuntu-latest
@@ -420,7 +439,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-PL:
     runs-on: ubuntu-latest
@@ -439,7 +458,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-PT:
     runs-on: ubuntu-latest
@@ -458,7 +477,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-RO:
     runs-on: ubuntu-latest
@@ -477,7 +496,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-RU:
     runs-on: ubuntu-latest
@@ -496,7 +515,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-SE:
     runs-on: ubuntu-latest
@@ -515,7 +534,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-SK:
     runs-on: ubuntu-latest
@@ -534,7 +553,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-TR:
     runs-on: ubuntu-latest
@@ -553,7 +572,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-TW:
     runs-on: ubuntu-latest
@@ -572,7 +591,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-UK:
     runs-on: ubuntu-latest
@@ -591,7 +610,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota-VN:
     runs-on: ubuntu-latest
@@ -610,4 +629,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output

--- a/.github/workflows/CI_github_ESP32.yml
+++ b/.github/workflows/CI_github_ESP32.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-webcam:
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-odroidgo:
     runs-on: ubuntu-latest
@@ -62,7 +62,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-core2:
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-minimal:
     runs-on: ubuntu-latest
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-lite:
     runs-on: ubuntu-latest
@@ -122,7 +122,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-knx:
     runs-on: ubuntu-latest
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-sensors:
     runs-on: ubuntu-latest
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-display:
     runs-on: ubuntu-latest
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-ir:
     runs-on: ubuntu-latest
@@ -202,7 +202,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-AF:
     runs-on: ubuntu-latest
@@ -222,7 +222,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-BG:
     runs-on: ubuntu-latest
@@ -242,7 +242,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-BR:
     runs-on: ubuntu-latest
@@ -262,7 +262,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-CN:
     runs-on: ubuntu-latest
@@ -282,7 +282,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-CZ:
     runs-on: ubuntu-latest
@@ -302,7 +302,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-DE:
     runs-on: ubuntu-latest
@@ -322,7 +322,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-ES:
     runs-on: ubuntu-latest
@@ -342,7 +342,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-FR:
     runs-on: ubuntu-latest
@@ -362,7 +362,27 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
+
+  tasmota32-FY:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U platformio
+        platformio upgrade --dev
+        platformio update
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota32-FY
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
 
   tasmota32-GR:
     runs-on: ubuntu-latest
@@ -382,7 +402,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-HE:
     runs-on: ubuntu-latest
@@ -402,7 +422,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-HU:
     runs-on: ubuntu-latest
@@ -422,7 +442,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-IT:
     runs-on: ubuntu-latest
@@ -442,7 +462,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-KO:
     runs-on: ubuntu-latest
@@ -462,7 +482,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-NL:
     runs-on: ubuntu-latest
@@ -482,7 +502,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-PL:
     runs-on: ubuntu-latest
@@ -502,7 +522,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-PT:
     runs-on: ubuntu-latest
@@ -522,7 +542,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-RO:
     runs-on: ubuntu-latest
@@ -542,7 +562,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-RU:
     runs-on: ubuntu-latest
@@ -562,7 +582,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-SE:
     runs-on: ubuntu-latest
@@ -582,7 +602,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-SK:
     runs-on: ubuntu-latest
@@ -602,7 +622,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-TR:
     runs-on: ubuntu-latest
@@ -622,7 +642,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-TW:
     runs-on: ubuntu-latest
@@ -642,7 +662,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-UK:
     runs-on: ubuntu-latest
@@ -662,7 +682,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
   tasmota32-VN:
     runs-on: ubuntu-latest
@@ -682,4 +702,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output

--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -34,17 +34,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-minimal:
@@ -57,17 +54,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-lite:
@@ -80,17 +74,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-knx:
@@ -103,17 +94,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-sensors:
@@ -126,17 +114,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-display:
@@ -149,17 +134,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ir:
@@ -172,17 +154,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ircustom:
@@ -195,17 +174,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-zbbridge:
@@ -218,17 +194,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-zbbridge
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-AF:
@@ -241,17 +214,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-AF
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-BG:
@@ -264,17 +234,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-BR:
@@ -287,17 +254,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-CN:
@@ -310,17 +274,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-CZ:
@@ -333,17 +294,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-DE:
@@ -356,17 +314,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ES:
@@ -379,17 +334,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-FR:
@@ -402,17 +354,34 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
+
+
+  tasmota-FY:
+    needs: tasmota_pull
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota-FY
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
 
 
   tasmota-GR:
@@ -425,17 +394,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-HE:
@@ -448,17 +414,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-HU:
@@ -471,17 +434,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-IT:
@@ -494,17 +454,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-KO:
@@ -517,17 +474,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-NL:
@@ -540,17 +494,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-PL:
@@ -563,17 +514,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-PT:
@@ -586,17 +534,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-RO:
@@ -609,17 +554,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-RU:
@@ -632,17 +574,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-SE:
@@ -655,17 +594,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-SK:
@@ -678,17 +614,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-TR:
@@ -701,17 +634,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-TW:
@@ -724,17 +654,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-UK:
@@ -747,17 +674,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-UK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-VN:
@@ -770,17 +694,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-VN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32:
@@ -793,17 +714,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-minimal:
@@ -816,17 +734,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-lite:
@@ -839,17 +754,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-webcam:
@@ -862,17 +774,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-webcam
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-odroidgo:
@@ -885,17 +794,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-odroidgo
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-core2:
@@ -908,17 +814,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-core2
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-knx:
@@ -931,17 +834,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-sensors:
@@ -954,17 +854,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-display:
@@ -977,17 +874,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ir:
@@ -1000,17 +894,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ircustom:
@@ -1023,17 +914,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-AF:
@@ -1046,17 +934,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-AF
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-BG:
@@ -1069,17 +954,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-BR:
@@ -1092,17 +974,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-CN:
@@ -1115,17 +994,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-CZ:
@@ -1138,17 +1014,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-DE:
@@ -1161,17 +1034,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ES:
@@ -1184,17 +1054,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-FR:
@@ -1207,17 +1074,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-GR:
@@ -1230,17 +1094,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-HE:
@@ -1253,17 +1114,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-HU:
@@ -1276,17 +1134,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-IT:
@@ -1299,17 +1154,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-KO:
@@ -1322,17 +1174,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-NL:
@@ -1345,17 +1194,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-PL:
@@ -1368,17 +1214,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-PT:
@@ -1391,17 +1234,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-RO:
@@ -1414,17 +1254,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-RU:
@@ -1437,17 +1274,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-SE:
@@ -1460,17 +1294,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-SK:
@@ -1483,17 +1314,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-TR:
@@ -1506,17 +1334,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-TW:
@@ -1529,17 +1354,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-UK:
@@ -1552,17 +1374,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-UK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-VN:
@@ -1575,17 +1394,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-VN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   Upload:
@@ -1607,26 +1423,28 @@ jobs:
         mkdir -p ./firmware/tasmota32/languages
         mkdir -p ./firmware/tasmota32/ESP32_needed_files/
         mkdir -p ./firmware/tasmota32/Odroid_go_needed_files/
-        [ ! -f ./mv_firmware/tasmota.* ] || mv ./mv_firmware/tasmota.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-sensors.* ] || mv ./mv_firmware/tasmota-sensors.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-minimal.* ] || mv ./mv_firmware/tasmota-minimal.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-lite.* ] || mv ./mv_firmware/tasmota-lite.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-ir*.* ] || mv ./mv_firmware/tasmota-ir*.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-display.* ] || mv ./mv_firmware/tasmota-display.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-knx.* ] || mv ./mv_firmware/tasmota-knx.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/tasmota-zbbridge.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota32.* ] || mv ./mv_firmware/tasmota32.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-sensors.* ] || mv ./mv_firmware/tasmota32-sensors.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-minimal.* ] || mv ./mv_firmware/tasmota32-minimal.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-lite.* ] || mv ./mv_firmware/tasmota32-lite.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-ir*.* ] || mv ./mv_firmware/tasmota32-ir*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-display.* ] || mv ./mv_firmware/tasmota32-display.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-web*.* ] || mv ./mv_firmware/tasmota32-web*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-core2.* ] || mv ./mv_firmware/tasmota32-core2.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
-        [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
+        mkdir -p ./firmware/map
+        [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./firmware/map/
+        [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-sensors.* ] || mv ./mv_firmware/firmware/tasmota-sensors.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-minimal.* ] || mv ./mv_firmware/firmware/tasmota-minimal.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-lite.* ] || mv ./mv_firmware/firmware/tasmota-lite.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-ir*.* ] || mv ./mv_firmware/firmware/tasmota-ir*.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-knx.* ] || mv ./mv_firmware/firmware/tasmota-knx.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-sensors.* ] || mv ./mv_firmware/firmware/tasmota32-sensors.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-minimal.* ] || mv ./mv_firmware/firmware/tasmota32-minimal.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-lite.* ] || mv ./mv_firmware/firmware/tasmota32-lite.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-knx.* ] || mv ./mv_firmware/firmware/tasmota32-knx.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./firmware/tasmota32/languages/
+        [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
         [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -34,17 +34,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-minimal:
@@ -57,17 +54,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-lite:
@@ -80,17 +74,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-knx:
@@ -103,17 +94,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-sensors:
@@ -126,17 +114,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-display:
@@ -149,17 +134,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ir:
@@ -172,17 +154,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ircustom:
@@ -195,17 +174,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-zbbridge:
@@ -218,17 +194,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-zbbridge
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-AF:
@@ -241,17 +214,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-AF
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-BG:
@@ -264,17 +234,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-BR:
@@ -287,17 +254,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-CN:
@@ -310,17 +274,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-CZ:
@@ -333,17 +294,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-DE:
@@ -356,17 +314,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-ES:
@@ -379,17 +334,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-FR:
@@ -402,17 +354,34 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
+
+
+  tasmota-FY:
+    needs: tasmota_pull
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota-FY
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
 
 
   tasmota-GR:
@@ -425,17 +394,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-HE:
@@ -448,17 +414,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-HU:
@@ -471,17 +434,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-IT:
@@ -494,17 +454,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-KO:
@@ -517,17 +474,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-NL:
@@ -540,17 +494,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-PL:
@@ -563,17 +514,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-PT:
@@ -586,17 +534,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-RO:
@@ -609,17 +554,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-RU:
@@ -632,17 +574,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-SE:
@@ -655,17 +594,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-SK:
@@ -678,17 +614,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-TR:
@@ -701,17 +634,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-TW:
@@ -724,17 +654,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-UK:
@@ -747,17 +674,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-UK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota-VN:
@@ -770,17 +694,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota-VN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32:
@@ -793,17 +714,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-minimal:
@@ -816,17 +734,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-minimal
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-lite:
@@ -839,17 +754,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-lite
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-webcam:
@@ -862,17 +774,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-webcam
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-odroidgo:
@@ -885,17 +794,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-odroidgo
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-core2:
@@ -908,17 +814,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-core2
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-knx:
@@ -931,17 +834,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-knx
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-sensors:
@@ -954,17 +854,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-sensors
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-display:
@@ -977,17 +874,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-display
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ir:
@@ -1000,17 +894,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ir
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ircustom:
@@ -1023,17 +914,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ircustom
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-AF:
@@ -1046,17 +934,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-AF
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-BG:
@@ -1069,17 +954,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-BG
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-BR:
@@ -1092,17 +974,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-BR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-CN:
@@ -1115,17 +994,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-CN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-CZ:
@@ -1138,17 +1014,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-CZ
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-DE:
@@ -1161,17 +1034,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-DE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-ES:
@@ -1184,17 +1054,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-ES
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-FR:
@@ -1207,17 +1074,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-FR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-GR:
@@ -1230,17 +1094,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-GR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-HE:
@@ -1253,17 +1114,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-HE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-HU:
@@ -1276,17 +1134,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-HU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-IT:
@@ -1299,17 +1154,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-IT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-KO:
@@ -1322,17 +1174,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-KO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-NL:
@@ -1345,17 +1194,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-NL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-PL:
@@ -1368,17 +1214,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-PL
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-PT:
@@ -1391,17 +1234,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-PT
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-RO:
@@ -1414,17 +1254,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-RO
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-RU:
@@ -1437,17 +1274,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-RU
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-SE:
@@ -1460,17 +1294,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-SE
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-SK:
@@ -1483,17 +1314,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-SK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-TR:
@@ -1506,17 +1334,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-TR
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-TW:
@@ -1529,17 +1354,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-TW
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-UK:
@@ -1552,17 +1374,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-UK
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   tasmota32-VN:
@@ -1575,17 +1394,14 @@ jobs:
       uses: actions/setup-python@v1
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install -U platformio
-        platformio upgrade --dev
-        platformio update
     - name: Run PlatformIO
       run: |
         platformio run -e tasmota32-VN
     - uses: actions/upload-artifact@v2
       with:
         name: firmware
-        path: ./build_output/firmware
+        path: ./build_output
 
 
   Upload:
@@ -1607,29 +1423,31 @@ jobs:
         mkdir -p ./firmware/tasmota32/languages
         mkdir -p ./firmware/tasmota32/ESP32_needed_files/
         mkdir -p ./firmware/tasmota32/Odroid_go_needed_files/
-        [ ! -f ./mv_firmware/tasmota.* ] || mv ./mv_firmware/tasmota.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-sensors.* ] || mv ./mv_firmware/tasmota-sensors.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-minimal.* ] || mv ./mv_firmware/tasmota-minimal.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-lite.* ] || mv ./mv_firmware/tasmota-lite.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-ir*.* ] || mv ./mv_firmware/tasmota-ir*.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-display.* ] || mv ./mv_firmware/tasmota-display.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-knx.* ] || mv ./mv_firmware/tasmota-knx.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/tasmota-zbbridge.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/tasmota32.* ] || mv ./mv_firmware/tasmota32.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-sensors.* ] || mv ./mv_firmware/tasmota32-sensors.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-minimal.* ] || mv ./mv_firmware/tasmota32-minimal.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-lite.* ] || mv ./mv_firmware/tasmota32-lite.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-ir*.* ] || mv ./mv_firmware/tasmota32-ir*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-display.* ] || mv ./mv_firmware/tasmota32-display.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-web*.* ] || mv ./mv_firmware/tasmota32-web*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-core2.* ] || mv ./mv_firmware/tasmota32-core2.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32-knx.* ] || mv ./mv_firmware/tasmota32-knx.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/tasmota32* ] || mv ./mv_firmware/tasmota32* ./firmware/tasmota32/languages/
-        [ ! -f ./mv_firmware/* ] || mv ./mv_firmware/* ./firmware/tasmota/languages/
+        mkdir -p ./firmware/map
+        [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./firmware/map/
+        [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-sensors.* ] || mv ./mv_firmware/firmware/tasmota-sensors.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-minimal.* ] || mv ./mv_firmware/firmware/tasmota-minimal.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-lite.* ] || mv ./mv_firmware/firmware/tasmota-lite.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-ir*.* ] || mv ./mv_firmware/firmware/tasmota-ir*.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-knx.* ] || mv ./mv_firmware/firmware/tasmota-knx.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-sensors.* ] || mv ./mv_firmware/firmware/tasmota32-sensors.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-minimal.* ] || mv ./mv_firmware/firmware/tasmota32-minimal.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-lite.* ] || mv ./mv_firmware/firmware/tasmota32-lite.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-knx.* ] || mv ./mv_firmware/firmware/tasmota32-knx.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./firmware/tasmota32/languages/
+        [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md
+        [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
         git config --local user.name "Platformio BUILD"

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1447,7 +1447,7 @@ jobs:
         [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES ./README.md
+        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
         git config --local user.name "Platformio BUILD"

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1447,7 +1447,7 @@ jobs:
         [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go/*.* ] || mv ./tools/Esptool/Odroid_go/*.* ./firmware/tasmota32/Odroid_go_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md
+        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES ./README.md
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
         git config --local user.name "Platformio BUILD"


### PR DESCRIPTION
## Description:

- add language variant "FY"
- use stable Platformio to build firmwares. For CI test Platformio develop is still used
- add `MAP` files to the firmware files in the repo

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
