### PR TITLE
Add support for device groups where members temporarily have some items of sync

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -571,6 +571,9 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
       interlock_mutex = false;
     }
 
+#ifdef USE_DEVICE_GROUPS
+    power_t old_power = TasmotaGlobal.power;
+#endif  // USE_DEVICE_GROUPS
     switch (state) {
     case POWER_OFF: {
       TasmotaGlobal.power &= (POWER_MASK ^ mask);
@@ -582,7 +585,7 @@ void ExecuteCommandPower(uint32_t device, uint32_t state, uint32_t source)
       TasmotaGlobal.power ^= mask;
     }
 #ifdef USE_DEVICE_GROUPS
-    if (SRC_REMOTE != source && SRC_RETRY != source) {
+    if (TasmotaGlobal.power != old_power && SRC_REMOTE != source && SRC_RETRY != source) {
       if (Settings.flag4.multiple_device_groups)  // SetOption88 - Enable relays in separate device groups
         SendDeviceGroupMessage(device - 1, DGR_MSGTYP_UPDATE, DGR_ITEM_POWER, (TasmotaGlobal.power >> (device - 1)) & 1 | 0x01000000);  // Explicitly set number of relays to one
       else

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -347,13 +347,15 @@ enum DevGroupItem { DGR_ITEM_EOL, DGR_ITEM_STATUS, DGR_ITEM_FLAGS,
                     //DGR_ITEM_ANALOG1, DGR_ITEM_ANALOG2, DGR_ITEM_ANALOG3, DGR_ITEM_ANALOG4, DGR_ITEM_ANALOG5,
                     // Add new 16-bit items before this line
                     DGR_ITEM_LAST_16BIT, DGR_ITEM_MAX_16BIT = 127,
-                    DGR_ITEM_POWER,
+                    DGR_ITEM_POWER, DGR_ITEM_NO_STATUS_SHARE,
                     // Add new 32-bit items before this line
                     DGR_ITEM_LAST_32BIT, DGR_ITEM_MAX_32BIT = 191,
                     DGR_ITEM_EVENT, DGR_ITEM_COMMAND,
                     // Add new string items before this line
                     DGR_ITEM_LAST_STRING, DGR_ITEM_MAX_STRING = 223,
                     DGR_ITEM_LIGHT_CHANNELS };
+
+enum DevGroupItemFlag { DGR_ITEM_FLAG_NO_SHARE = 1 };
 
 enum DevGroupShareItem { DGR_SHARE_POWER = 1, DGR_SHARE_LIGHT_BRI = 2, DGR_SHARE_LIGHT_FADE = 4, DGR_SHARE_LIGHT_SCHEME = 8,
                          DGR_SHARE_LIGHT_COLOR = 16, DGR_SHARE_DIMMER_SETTINGS = 32, DGR_SHARE_EVENT = 64 };

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1730,7 +1730,7 @@ void LightAnimate(void)
     }
     if (Light.update) {
 #ifdef USE_DEVICE_GROUPS
-      if (Light.power && !Light.devgrp_no_channels_out) LightSendDeviceGroupStatus(false);
+      if (Light.power && !Light.devgrp_no_channels_out) LightSendDeviceGroupStatus();
 #endif  // USE_DEVICE_GROUPS
 
       uint16_t cur_col_10[LST_MAX];   // 10 bits resolution
@@ -2172,21 +2172,24 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
 }
 
 #ifdef USE_DEVICE_GROUPS
-void LightSendDeviceGroupStatus(bool status)
+void LightSendDeviceGroupStatus()
 {
   static uint8_t last_bri;
   uint8_t bri = light_state.getBri();
-  bool send_bri_update = (status || bri != last_bri);
+  bool send_bri_update = (building_status_message || bri != last_bri);
   if (Light.subtype > LST_SINGLE) {
-    static uint8_t channels[LST_MAX + 1] = { 0, 0, 0, 0, 0, 0 };
-    if (status) {
-      light_state.getChannels(channels);
+    static uint8_t last_channels[LST_MAX + 1] = { 0, 0, 0, 0, 0, 0 };
+    uint8_t channels[LST_MAX];
+
+    light_state.getChannelsRaw(channels);
+    uint8_t color_mode = light_state.getColorMode();
+    if (!(color_mode & LCM_RGB)) channels[0] = channels[1] = channels[2] = 0;
+    if (!(color_mode & LCM_CT)) channels[3] = channels[4] = 0;
+    if (building_status_message || memcmp(channels, last_channels, LST_MAX)) {
+      memcpy(last_channels, channels, LST_MAX);
+      last_channels[LST_MAX]++;
+      SendDeviceGroupMessage(Light.device_group_index, (send_bri_update ? DGR_MSGTYP_PARTIAL_UPDATE : DGR_MSGTYP_UPDATE), DGR_ITEM_LIGHT_CHANNELS, last_channels);
     }
-    else {
-      memcpy(channels, Light.new_color, LST_MAX);
-      channels[LST_MAX]++;
-    }
-    SendDeviceGroupMessage(Light.device_group_index, (send_bri_update ? DGR_MSGTYP_PARTIAL_UPDATE : DGR_MSGTYP_UPDATE), DGR_ITEM_LIGHT_CHANNELS, channels);
   }
   if (send_bri_update) {
     last_bri = bri;
@@ -2199,9 +2202,6 @@ void LightHandleDevGroupItem(void)
   static bool send_state = false;
   static bool restore_power = false;
 
-//#ifdef USE_PWM_DIMMER_REMOTE
-//  if (!(XdrvMailbox.index & DGR_FLAG_LOCAL)) return;
-//#endif  // USE_PWM_DIMMER_REMOTE
   if (*XdrvMailbox.topic != Light.device_group_index) return;
   bool more_to_come;
   uint32_t value = XdrvMailbox.payload;
@@ -2218,7 +2218,7 @@ void LightHandleDevGroupItem(void)
 
       LightAnimate();
 
-      TasmotaGlobal.skip_light_fade = true;
+      TasmotaGlobal.skip_light_fade = false;
       if (send_state && !more_to_come) {
         light_controller.saveSettings();
         if (Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
@@ -2242,8 +2242,9 @@ void LightHandleDevGroupItem(void)
       }
       break;
     case DGR_ITEM_LIGHT_CHANNELS:
-#ifdef USE_DGR_LIGHT_SEQUENCE
       {
+        uint8_t bri = light_state.getBri();
+#ifdef USE_DGR_LIGHT_SEQUENCE
         static uint8_t last_sequence = 0;
 
         // If a sequence offset is set, set the channels to the ones we received <SequenceOffset>
@@ -2259,13 +2260,11 @@ void LightHandleDevGroupItem(void)
             memcpy(&Light.channels_fifo[last_entry], XdrvMailbox.data, LST_MAX);
           }
         }
-        else {
+        else
 #endif  // USE_DGR_LIGHT_SEQUENCE
           light_controller.changeChannels((uint8_t *)XdrvMailbox.data);
-#ifdef USE_DGR_LIGHT_SEQUENCE
-        }
+        light_controller.changeBri(bri);
       }
-#endif  // USE_DGR_LIGHT_SEQUENCE
       send_state = true;
       break;
     case DGR_ITEM_LIGHT_FIXED_COLOR:
@@ -2321,7 +2320,7 @@ void LightHandleDevGroupItem(void)
     case DGR_ITEM_STATUS:
       SendLocalDeviceGroupMessage(DGR_MSGTYP_PARTIAL_UPDATE, DGR_ITEM_LIGHT_FADE, Settings.light_fade,
         DGR_ITEM_LIGHT_SPEED, Settings.light_speed, DGR_ITEM_LIGHT_SCHEME, Settings.light_scheme);
-      LightSendDeviceGroupStatus(true);
+      LightSendDeviceGroupStatus();
       break;
   }
 }


### PR DESCRIPTION
## Description:

A typical device group use case is a group of lights set up in a device group with one or more masters such as a dimmer switches that control the power, dimming and colors of the lights. There are times when the lights may be set to a mix of powers, colors and/or brightnesses via automation software. In this case, the masters should not send power, color and/or brightness updates to the group until one of the masters receives a power, color or brightness update.

This PR adds support for mask to indicate which items are not shared in status updates. Bits in the mask are set by specifying a prefix of N to a DevGroupSend item value and are cleared when an item is specified in an outgoing message. Other than status updates, modules should only send items to the device group when they are changed. The support_tasmota and light modules have been updated to support this.

In order to support device groups member with different colors and/or brightness-es, it is necessary to send the full brightness channel values for light channels item instead of the current brightness-adjust channels. THIS IS A BREAKING CHANGE that will require other light-based devices in the device group to be upgraded as well.

This PR also includes the following changes:
-Add support for hexidecimal channel specification in DevGroupSend.
-Add support for bitwise AND (&) and OR (|) and DevGroupSend operators.
-Use a dynamically allocated log buffer in SendReceiveDeviceGroupMessage to prevent stack overflow.
-Fix power item device count to be 1 when SO88 is enabled.

This PR uses an additional 464 byte of program space.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
