### PR TITLE
Fix shutter PWM command to include device number and update logging information.

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -458,8 +458,12 @@ void ShutterPowerOff(uint8_t i) {
   switch (ShutterGlobal.position_mode) {
     case SHT_PWM_VALUE:
     char scmnd[20];
-    AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Setting PWM%d. value: %d"), i+1,Shutter[i].pwm_value);
-    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d %d" ),i+1 ,Shutter[i].pwm_value); // Add device number to PWM command
+#ifdef SHUTTER_CLEAR_PWM_ONSTOP 
+    // free the PWM servo lock on stop.
+    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d 0" ), i+1);
+#else
+    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d %d" ), i+1,Shutter[i].pwm_value);
+#endif
     ExecuteCommand(scmnd, SRC_BUTTON);
     break;
   }

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -429,7 +429,7 @@ void ShutterDecellerateForStop(uint8_t i)
 }
 
 void ShutterPowerOff(uint8_t i) {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Stop Shutter %d. Switchmode %d"), i,Shutter[i].switch_mode);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Stop Shutter %d. Switchmode %d"), i+1,Shutter[i].switch_mode); // fix log to indicate correct shutter number
   ShutterDecellerateForStop(i);
   switch (Shutter[i].switch_mode) {
     case SHT_SWITCH:
@@ -458,7 +458,8 @@ void ShutterPowerOff(uint8_t i) {
   switch (ShutterGlobal.position_mode) {
     case SHT_PWM_VALUE:
     char scmnd[20];
-    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d %d" ),i ,Shutter[i].pwm_value); // Add device number to PWM command
+    AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Setting PWM%d. value: %d"), i+1,Shutter[i].pwm_value);
+    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d %d" ),i+1 ,Shutter[i].pwm_value); // Add device number to PWM command
     ExecuteCommand(scmnd, SRC_BUTTON);
     break;
   }

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -458,7 +458,7 @@ void ShutterPowerOff(uint8_t i) {
   switch (ShutterGlobal.position_mode) {
     case SHT_PWM_VALUE:
     char scmnd[20];
-    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM " %d" ),Shutter[i].pwm_value);
+    snprintf_P(scmnd, sizeof(scmnd), PSTR(D_CMND_PWM "%d %d" ),i ,Shutter[i].pwm_value); // Add device number to PWM command
     ExecuteCommand(scmnd, SRC_BUTTON);
     break;
   }


### PR DESCRIPTION
## Description:

Fix problem with Shutter with Servo not sending correct PWMx. Added device number to PWMx command to set final PWMx command. 
Add #define to allow for compile time to release PWM motor control (by setting PWM 0) on servo in ShutterPowerOff routine. 

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
