### PR TITLE
Bring ModeSet value out of the for loop, this ModeSet is repeated for…

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -1336,13 +1336,16 @@ void TuyaSensorsShow(bool json)
             break;
         }
       }
-      if (AsModuleTuyaMS()) {
-        WSContentSend_P(PSTR("{s}" D_JSON_IRHVAC_MODE "{m}%d{e}"), Tuya.ModeSet);
-      }
 
   #endif  // USE_WEBSERVER
     }
   }
+  #ifdef USE_WEBSERVER
+  if (AsModuleTuyaMS()) {
+    WSContentSend_P(PSTR("{s}" D_JSON_IRHVAC_MODE "{m}%d{e}"), Tuya.ModeSet);
+  }
+  #endif  // USE_WEBSERVER
+
   if (RootName) { ResponseJsonEnd();}
 }
 


### PR DESCRIPTION
… every other value on the webpage.

## Description:

When working on my Thermostat it appears that the ModeSet is repeated for every value displayed on the WebPage. This commit fixes this.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [/] The pull request is done against the latest development branch
  - [/] Only relevant files were touched
  - [/] Only one feature/fix was added per PR and the code change compiles without warnings
  - [/] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [/] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
