### PR TITLE
warning if ESP8266 firmware is too big

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -29,6 +29,9 @@ if env["PIOPLATFORM"] != "espressif32":
         ORG_FIRMWARE_SIZE = os.stat(bin_file).st_size
         GZ_FIRMWARE_SIZE = os.stat(gzip_file).st_size
 
-        print("Compression reduced firmware size by {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
-
+        if ORG_FIRMWARE_SIZE > 995326:
+            print("\u001b[31;1m!!! Tasmota firmware size is too big with {} bytes. Max size is 995326 bytes !!! \u001b[0m".format(ORG_FIRMWARE_SIZE))
+        else:
+            print("Compression reduced firmware size by {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
+            
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])


### PR DESCRIPTION
## Description:

it is possible to successfull compile a too big firmware for ESP8266.

This change adds a red colored warning if this happens.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
