### PR TITLE
Add Fade2 for backwards compatibility

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2828,6 +2828,12 @@ void CmndRgbwwTable(void)
 
 void CmndFade(void)
 {
+  if (XdrvMailbox.index == 2) {
+    // Home Assistant backwards compatibility, can be removed mid 2021
+    ResponseCmndStateText(Settings.light_fade);
+    return
+  }
+
   // Fade        - Show current Fade state
   // Fade 0      - Turn Fade Off
   // Fade On     - Turn Fade On
@@ -2858,6 +2864,7 @@ void CmndSpeed(void)
       Light.speed_once_value = XdrvMailbox.payload;
       if (!Light.fade_once_value) { Light.fade_running = false; }
     }
+    ResponseCmndNumber(Light.speed_once_value);
     return;
   }
 


### PR DESCRIPTION
## Description:

Add command `fade2` which does nothing.
In this way, the new `speed2` command can be used in a backwards compatible way:
- Home Assistant can always send `speed2` and `fade2`. Old Tasmota will simply interpret as `speed` and `fade`, new Tasmota will ignore fade2 and the speed2 will work as intended.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
