### PR TITLE
TuyaMCU Precise Temperature

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -318,6 +318,23 @@ int StrCmpNoCase(char const *Str1, char const *Str2) // Compare case sensistive 
   }
 }
 
+float TuyaAdjustedTemperature(uint8_t packetValue, uint8_t res)
+{
+    switch (res)
+    {
+    case 1:
+        return packetValue/10;
+        break;
+    case 2:
+        return packetValue/100;
+        break;
+    case 3:
+        return packetValue/1000;
+        break;    
+    default:
+        return (float)packetValue;
+    } 
+}
 /*********************************************************************************************\
  * Internal Functions
 \*********************************************************************************************/
@@ -1295,7 +1312,7 @@ void TuyaSensorsShow(bool json)
 
         GetTextIndexed(sname, sizeof(sname), (sensor-71), kTuyaSensors);
         ResponseAppend_P(PSTR("\"%s\":%s"), sname,
-                        (Tuya.SensorsValid[sensor-71] ? dtostrfd((float)Tuya.Sensors[sensor-71] / pow(10, res), res, tempval) : PSTR("null")));
+                        (Tuya.SensorsValid[sensor-71] ? dtostrfd(TuyaAdjustedTemperature(Tuya.Sensors[sensor-71], res), res, tempval) : PSTR("null")));
         added = true;
       }
   #ifdef USE_WEBSERVER
@@ -1303,11 +1320,11 @@ void TuyaSensorsShow(bool json)
       if (TuyaGetDpId(sensor) != 0) {
         switch (sensor) {
           case 71:
-            WSContentSend_Temp("", (float)Tuya.Sensors[0] / pow(10, Settings.flag2.temperature_resolution));
+            WSContentSend_Temp("", TuyaAdjustedTemperature(Tuya.Sensors[0], Settings.flag2.temperature_resolution));
             break;
           case 72:
             WSContentSend_PD(PSTR("{s}" D_TEMPERATURE " Set{m}%s " D_UNIT_DEGREE "%c{e}"),
-                            dtostrfd((float)Tuya.Sensors[1] / pow(10, Settings.flag2.temperature_resolution), Settings.flag2.temperature_resolution, tempval), TempUnit());
+                            dtostrfd(TuyaAdjustedTemperature(Tuya.Sensors[1], Settings.flag2.temperature_resolution), Settings.flag2.temperature_resolution, tempval), TempUnit());
             break;
           case 73:
             WSContentSend_PD(HTTP_SNS_HUM, "", dtostrfd(Tuya.Sensors[2], Settings.flag2.temperature_resolution, tempval));

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -318,18 +318,18 @@ int StrCmpNoCase(char const *Str1, char const *Str2) // Compare case sensistive 
   }
 }
 
-float TuyaAdjustedTemperature(uint8_t packetValue, uint8_t res)
+float TuyaAdjustedTemperature(uint16_t packetValue, uint8_t res)
 {
     switch (res)
     {
     case 1:
-        return (float)packetValue / 10;
+        return (float)packetValue / 10.0;
         break;
     case 2:
-        return (float)packetValue / 100;
+        return (float)packetValue / 100.0;
         break;
     case 3:
-        return (float)packetValue / 1000;
+        return (float)packetValue / 1000.0;
         break;    
     default:
         return (float)packetValue;

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -323,16 +323,17 @@ float TuyaAdjustedTemperature(uint8_t packetValue, uint8_t res)
     switch (res)
     {
     case 1:
-        return packetValue/10;
+        return (float)packetValue / 10;
         break;
     case 2:
-        return packetValue/100;
+        return (float)packetValue / 100;
         break;
     case 3:
-        return packetValue/1000;
+        return (float)packetValue / 1000;
         break;    
     default:
         return (float)packetValue;
+        break;
     } 
 }
 /*********************************************************************************************\

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -1295,7 +1295,7 @@ void TuyaSensorsShow(bool json)
 
         GetTextIndexed(sname, sizeof(sname), (sensor-71), kTuyaSensors);
         ResponseAppend_P(PSTR("\"%s\":%s"), sname,
-                        (Tuya.SensorsValid[sensor-71] ? dtostrfd(Tuya.Sensors[sensor-71], res, tempval) : PSTR("null")));
+                        (Tuya.SensorsValid[sensor-71] ? dtostrfd((float)Tuya.Sensors[sensor-71] / pow(10, res), res, tempval) : PSTR("null")));
         added = true;
       }
   #ifdef USE_WEBSERVER
@@ -1303,11 +1303,11 @@ void TuyaSensorsShow(bool json)
       if (TuyaGetDpId(sensor) != 0) {
         switch (sensor) {
           case 71:
-            WSContentSend_Temp("", Tuya.Sensors[0]);
+            WSContentSend_Temp("", (float)Tuya.Sensors[0] / pow(10, Settings.flag2.temperature_resolution));
             break;
           case 72:
             WSContentSend_PD(PSTR("{s}" D_TEMPERATURE " Set{m}%s " D_UNIT_DEGREE "%c{e}"),
-                            dtostrfd(Tuya.Sensors[1], Settings.flag2.temperature_resolution, tempval), TempUnit());
+                            dtostrfd((float)Tuya.Sensors[1] / pow(10, Settings.flag2.temperature_resolution), Settings.flag2.temperature_resolution, tempval), TempUnit());
             break;
           case 73:
             WSContentSend_PD(HTTP_SNS_HUM, "", dtostrfd(Tuya.Sensors[2], Settings.flag2.temperature_resolution, tempval));

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -749,7 +749,7 @@ void TuyaProcessStatePacket(void) {
             } else { res = Settings.flag2.temperature_resolution; }
             GetTextIndexed(sname, sizeof(sname), (fnId-71), kTuyaSensors);
             ResponseClear(); // Clear retained message
-            Response_P(PSTR("{\"TuyaSNS\":{\"%s\":%s}}"), sname, dtostrfd(packetValue, res, tempval)); // sensor update is just on change
+            Response_P(PSTR("{\"TuyaSNS\":{\"%s\":%s}}"), sname, dtostrfd(TuyaAdjustedTemperature(packetValue, res), res, tempval)); // sensor update is just on change
             MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_CMND_SENSOR));
           }
         }


### PR DESCRIPTION
Sensor packetValue now interpreted as float based on configuration of  TempRes command.

## Description:

**Related issue (if applicable):** fixes #10917

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
