### PR TITLE
Fix EZO sensors on ESP32

### DIFF
--- a/tasmota/xsns_78_ezo.ino
+++ b/tasmota/xsns_78_ezo.ino
@@ -53,7 +53,7 @@ struct EZOStruct {
   {
     // Transmit our command verbatim
     Wire.beginTransmission(addr);
-    Wire.write(cmd, len);
+    Wire.write((uint8_t*)cmd, len);
     if (Wire.endTransmission() != 0) {
       return;
     }


### PR DESCRIPTION
## Description:
When adding EZO sensors define, it fails to compile for the target ESP32
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
