### PR TITLE
Modbus direction pin

### DIFF
--- a/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.cpp
+++ b/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.cpp
@@ -32,7 +32,7 @@ TasmotaModbus::TasmotaModbus(int receive_pin, int transmit_pin, int dir_pin) : T
   if (99 != mb_dir_pin) {
     pinMode(mb_dir_pin, OUTPUT);
     digitalWrite(mb_dir_pin, MB_DIR_READ);
-    AddLog_P(2, PSTR("Mod: Dir pin: %d"), mb_dir_pin);
+    //AddLog_P(2, PSTR("Mod: Dir pin: %d"), mb_dir_pin);
   }
 }
 

--- a/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.h
+++ b/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.h
@@ -27,7 +27,7 @@
 
 class TasmotaModbus : public TasmotaSerial {
   public:
-    TasmotaModbus(int receive_pin, int transmit_pin);
+    TasmotaModbus(int receive_pin, int transmit_pin, int dir_pin = -1);
     virtual ~TasmotaModbus() {}
 
     int Begin(long speed = TM_MODBUS_BAUDRATE, int stop_bits = 1);
@@ -61,6 +61,7 @@ class TasmotaModbus : public TasmotaSerial {
   private:
     uint8_t mb_address;
     uint8_t mb_len;
+    uint8_t mb_dir_pin;
 };
 
 #endif  // TasmotaModbus_h

--- a/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.h
+++ b/lib/lib_basic/TasmotaModbus-1.2.0/src/TasmotaModbus.h
@@ -27,7 +27,7 @@
 
 class TasmotaModbus : public TasmotaSerial {
   public:
-    TasmotaModbus(int receive_pin, int transmit_pin, int dir_pin = -1);
+    TasmotaModbus(int receive_pin, int transmit_pin, int dir_pin = 99);
     virtual ~TasmotaModbus() {}
 
     int Begin(long speed = TM_MODBUS_BAUDRATE, int stop_bits = 1);

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -634,6 +634,7 @@
 #define D_SENSOR_SDM72_RX      "SDM72 Rx"
 #define D_SENSOR_SDM120_TX     "SDMx20 Tx"
 #define D_SENSOR_SDM120_RX     "SDMx20 Rx"
+#define D_SENSOR_SDM120_DIR    "SDMx20 Dir"
 #define D_SENSOR_SDM630_TX     "SDM630 Tx"
 #define D_SENSOR_SDM630_RX     "SDM630 Rx"
 #define D_SENSOR_WE517_TX      "WE517 Tx"

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -577,7 +577,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_SDM120
   AGPIO(GPIO_SDM120_TX),      // SDM120 Serial interface
   AGPIO(GPIO_SDM120_RX),      // SDM120 Serial interface
-  AGPIO(GPIO_SDM120_DIR),    // SDM120 RX485 interface direction
+  AGPIO(GPIO_SDM120_DIR),     // SDM120 Serial interface MAX485 direction pin
 #endif
 #ifdef USE_SDM630
   AGPIO(GPIO_SDM630_TX),      // SDM630 Serial interface

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -149,6 +149,7 @@ enum UserSelectablePins {
   GPIO_WIEGAND_D0, GPIO_WIEGAND_D1,    // Wiegand Data lines
   GPIO_NEOPOOL_TX, GPIO_NEOPOOL_RX,    // Sugar Valley RS485 interface
   GPIO_SDM72_TX, GPIO_SDM72_RX,        // SDM72 Serial interface
+  GPIO_SDM120_DIR,                     // SDM120 RS485 interface direction
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -318,6 +319,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_WIEGAND_D0 "|" D_SENSOR_WIEGAND_D1 "|"
   D_SENSOR_NEOPOOL_TX "|" D_SENSOR_NEOPOOL_RX "|"
   D_SENSOR_SDM72_TX "|" D_SENSOR_SDM72_RX "|"
+  D_SENSOR_SDM120_DIR "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -575,6 +577,7 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_SDM120
   AGPIO(GPIO_SDM120_TX),      // SDM120 Serial interface
   AGPIO(GPIO_SDM120_RX),      // SDM120 Serial interface
+  AGPIO(GPIO_SDM120_DIR),    // SDM120 RX485 interface direction
 #endif
 #ifdef USE_SDM630
   AGPIO(GPIO_SDM630_TX),      // SDM630 Serial interface

--- a/tasmota/xnrg_08_sdm120.ino
+++ b/tasmota/xnrg_08_sdm120.ino
@@ -80,7 +80,7 @@ void SDM120Every250ms(void)
     uint8_t buffer[14];  // At least 5 + (2 * 2) = 9
 
     uint32_t error = Sdm120Modbus->ReceiveBuffer(buffer, 2);
-    AddLogBuffer(LOG_LEVEL_DEBUG_MORE, buffer, Sdm120Modbus->ReceiveCount());
+    //AddLogBuffer(LOG_LEVEL_DEBUG_MORE, buffer, Sdm120Modbus->ReceiveCount());
 
     if (error) {
       AddLog(LOG_LEVEL_DEBUG, PSTR("SDM: SDM120 error %d"), error);

--- a/tasmota/xnrg_08_sdm120.ino
+++ b/tasmota/xnrg_08_sdm120.ino
@@ -176,7 +176,8 @@ void SDM120Every250ms(void)
 
 void Sdm120SnsInit(void)
 {
-  Sdm120Modbus = new TasmotaModbus(Pin(GPIO_SDM120_RX), Pin(GPIO_SDM120_TX));
+  AddLog_P(LOG_LEVEL_INFO, PSTR("Sdm120: RX:%d, TX:%d, DIR:%d"), Pin(GPIO_SDM120_RX), Pin(GPIO_SDM120_TX), Pin(GPIO_SDM120_DIR));
+  Sdm120Modbus = new TasmotaModbus(Pin(GPIO_SDM120_RX), Pin(GPIO_SDM120_TX), Pin(GPIO_SDM120_DIR));
   uint8_t result = Sdm120Modbus->Begin(SDM120_SPEED);
   if (result) {
     if (2 == result) { ClaimSerial(); }


### PR DESCRIPTION
## Description:

Some meters such as the SDM120 are using RS485 interface.
RS485 interface is a bi-directional bus where normally only 1 can talk at a given time. It normally requires a 3rd signal to control the direction such as the "flag" signal here:
![image](https://user-images.githubusercontent.com/2996042/107884124-4e9dba00-6ef3-11eb-9205-1613125a9565.png)

There are some boards that tweak a direction signal by inverting the TX data but that is not very clean because direction is changed on every bit. And it may happens that you don't have such board and just a standard MAX485 driver.

This PR aims at offering a new optional pin named `SDM120 Dir` which, when assigned to a GPIO connected to pins DE and nRE of the MAX485 change the driver's direction.

This is a draft for review has, while I have checked the timing on the logic analyser, I'm waiting for feedback from user Anwar on Discord.

Note that this is the 1st time I am adding  pin in Tasmota, so please check carefully what I've done here:
- Declaration of the pins in the various arrays
- Testing the pin is configured on not by comparing with 99

I have some questions:

- I understand that when a pin is not defined in the configuration, the return values from `Pin(...)` is 99. I used the same value in TasmotaModbus. Is that ok ? In other drivers I've seen undefined pin as -1 (like in TasmotaSerial) so it means a "translation" from 99 to -1 has to be done ?

- Is there a trick to had the Pin drop-down menu text in all language or should it be done manually ?

Thanks for your review

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
