### PR TITLE
Berry add `yield` and `delay` commands

### DIFF
--- a/lib/lib_div/Berry-0.1.10/src/port/be_tasmotalib.c
+++ b/lib/lib_div/Berry-0.1.10/src/port/be_tasmotalib.c
@@ -11,6 +11,7 @@ extern int l_cmd(bvm *vm);
 extern int l_getoption(bvm *vm);
 extern int l_millis(bvm *vm);
 extern int l_timereached(bvm *vm);
+extern int l_yield(bvm *vm);
 
 // #if !BE_USE_PRECOMPILED_OBJECT
 #if 1           // TODO we will do pre-compiled later
@@ -21,6 +22,7 @@ be_native_module_attr_table(tasmota) {
     be_native_module_function("getoption", l_getoption),
     be_native_module_function("millis", l_millis),
     be_native_module_function("timereached", l_timereached),
+    be_native_module_function("yield", l_yield),
 };
 
 be_define_native_module(tasmota, NULL);

--- a/tasmota/berry/tasmota.be
+++ b/tasmota/berry/tasmota.be
@@ -100,6 +100,13 @@ tasmota.exec_rules = def (ev_json)
   return ret
 end
 
+tasmota.delay = def(ms)
+  tend = tasmota.millis(ms)
+  while !tasmota.timereached(tend)
+    tasmota.yield()
+  end
+end
+
 #- Test
 #################################################################
 
@@ -153,5 +160,12 @@ end
 br def backlog(cmd_list) delay_backlog = tasmota.getoption(34) delay = 0 for cmd:cmd_list tasmota.timer(delay, /-> tasmota.cmd(cmd)) delay = delay + delay_backlog end end
 
 br backlog( [ "Power 0", "Status 4", "Power 1" ] )
+
+-#
+
+#-
+
+tasmota.delay = def(ms) tend = tasmota.millis(ms) log(str(tasmota.millis())) while !tasmota.timereached(tend) end log(str(tasmota.millis())) end
+tasmota.delay = def(ms) a=0 tend = tasmota.millis(ms) log(str(tasmota.millis())) while !tasmota.timereached(tend) a=a+1 end log(str(tasmota.millis())) log(str(a)) end
 
 -#


### PR DESCRIPTION
## Description:

Add `tasmota.yield()` to call the Arduino `yield()` function and avoid WDT restart when berry function needs to run for a long time. Internally we call `optimistic_yield(10)` to call `yield()` at most every 10ms.

Add `tasmota.delay(ms)` function to wait for `ms` millisecond. This is implemented with a spin loop until the time is achieved. `yield()` is called to avoid WDT. This command should be used for delays below 100ms as it freezes Tasmota. For longer pauses, use `tasmota.timer()`.

Various code cleaning, the dual-threading mode will not be implemented. Using `timer()` and closures are a better alternative.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
