### PR TITLE
Zigbee ensure HTML encoding

### DIFF
--- a/tasmota/xdrv_23_zigbee_7_5_map.ino
+++ b/tasmota/xdrv_23_zigbee_7_5_map.ino
@@ -142,6 +142,15 @@ bool Z_Mapper::addEdge(const Z_Mapper_Edge & edge2) {
   return true;
 }
 
+String EscapeHTMLString(const char *s_P) {
+  String s((const __FlashStringHelper*) s_P);
+  s.replace(F("&"), F("&amp;"));
+  s.replace(F("\""), F("&quot;"));
+  s.replace(F("<"), F("&lt;"));
+  s.replace(F(">"), F("&gt;"));
+  return s;
+}
+
 void Z_Mapper::dumpInternals(void) const {
   WSContentSend_P(PSTR("nodes:[" "{id:\"0x0000\",label:\"Coordinator\",group:\"o\",title:\"0x0000\"}"));
   for (const auto & device : zigbee_devices.getDevices()) {
@@ -150,7 +159,7 @@ void Z_Mapper::dumpInternals(void) const {
 
     const char *fname = device.friendlyName;
     if (fname != nullptr) {
-      WSContentSend_P(PSTR("%s"), fname);
+      WSContentSend_P(PSTR("%s"), EscapeJSONString(fname).c_str());
     } else {
       WSContentSend_P(PSTR("0x%04X"), device.shortaddr);
     }

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1960,9 +1960,9 @@ void ZigbeeShow(bool json)
 
         WSContentSend_PD(msg[ZB_WEB_STATUS_LINE],
         shortaddr,
-        device.modelId ? device.modelId : "",
-        device.manufacturerId ? device.manufacturerId : "",
-        name, sbatt, slqi);
+        device.modelId ? EscapeHTMLString(device.modelId).c_str() : "",
+        device.manufacturerId ? EscapeHTMLString(device.manufacturerId).c_str() : "",
+        EscapeHTMLString(name).c_str(), sbatt, slqi);
 
         if(device.validLqi()) {
             for(uint32_t j = 0; j < 4; ++j) {


### PR DESCRIPTION
## Description:

Ensure correct HTML encoding for Zigbee device names, manufid and modelid.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
