### PR TITLE
Independent dimmer range

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -561,16 +561,18 @@ struct {
   uint8_t       ot_boiler_setpoint;        // E8D
   uint8_t       ot_flags;                  // E8E
   uint8_t       ledpwm_mask;               // E8F
-  uint16_t      dimmer_hw_min;             // E90
-  uint16_t      dimmer_hw_max;             // E92
+  uint16_t      ex_dimmer_hw_min;          // E90
+  uint16_t      ex_dimmer_hw_max;          // E92
   uint32_t      deepsleep;                 // E94
   uint16_t      hass_new_discovery;        // E98  ex2_energy_power_delta on 8.4.0.3, replaced on 8.5.0.1
   uint8_t       shutter_motordelay[MAX_SHUTTERS];    // E9A
   int8_t        temp_comp;                 // E9E
   uint8_t       weight_change;             // E9F
   uint8_t       web_color2[2][3];          // EA0  Needs to be on integer / 3 distance from web_color
+  uint16_t      dimmer_hw_min[LST_MAX];    // TODO
+  uint16_t      dimmer_hw_max[LST_MAX];    // TODO
 
-  uint8_t       free_ea6[33];              // EA6
+  uint8_t       free_ea6[13];              // EA6
 
   uint8_t       sta_config;                // EC7
   uint8_t       sta_active;                // EC8

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -990,8 +990,10 @@ void SettingsDefaultSet2(void) {
 //  Settings.ws_color[WS_HOUR][WS_GREEN] = 0;
 //  Settings.ws_color[WS_HOUR][WS_BLUE] = 0;
 
-  Settings.dimmer_hw_max = DEFAULT_DIMMER_MAX;
-  Settings.dimmer_hw_min = DEFAULT_DIMMER_MIN;
+  for (uint32_t i=0; i<ARRAY_SIZE(Settings.dimmer_hw_min); i++) {
+    Settings.dimmer_hw_max[i] = DEFAULT_DIMMER_MAX;
+    Settings.dimmer_hw_min[i] = DEFAULT_DIMMER_MIN;
+  }
 
   Settings.dimmer_step = DEFAULT_DIMMER_STEP;
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -309,6 +309,48 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len)
   TasmotaGlobal.fallback_topic_flag = false;
 }
 
+/**
+ * This function can be used to iterate over all indices selected by the user.
+ * The following lines give an example implementation:
+ *   uint32_t i = MAX_ITERATION_COUNT:
+ *   while (NextUserIndex(i))
+ *     printf("%u ", i);
+ * In case a command is given without an index (e.g. "dimmer ...") this function
+ * will iterate through the following values:
+ *   {MAX_ITERATION_COUNT-1, MAX_ITERATION_COUNT-2, ..., 1, 0}
+ * Keep in mind that it will start form highest value and go to 0.
+ * In case a command is given with an index (e.g. "dimmer2 ...") this function
+ * will only iterate through one value:
+ *   {2}
+ */
+bool NextUserIndex(uint32_t& index)
+{
+  if (XdrvMailbox.usridx) {
+    /* do nothing when index is out of range.
+     * On first call is index == MAX_ITERATION_COUNT. Therefore
+     * XdrvMailbox.index would be out of range when greater then index.
+     * On second call is index == XdrvMailbox.index. Therefore later condition
+     * will take care to return false t abort the loop.
+     */
+    if ( (XdrvMailbox.index <= 0) || (XdrvMailbox.index > index) ) {
+      return false;
+    }
+
+    const uint32_t userIndex = XdrvMailbox.index - 1;
+    if (index != userIndex) {
+      index = userIndex;
+      return true;
+    }
+  } else {
+    if (index > 0) {
+      index--;
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /********************************************************************************************/
 
 void CmndBacklog(void)

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -625,10 +625,10 @@ void LightSerialDuty(uint16_t duty, char *hex_char, uint8_t TuyaIdx)
 
     if (duty > 0 && !Tuya.ignore_dim && TuyaSerial && dpid > 0) {
       if (TuyaIdx == 2 && CTLight) {
-        duty = changeUIntScale(duty, Tuya.CTMin, Tuya.CTMax, Settings.dimmer_hw_max, 0);
-      } else { duty = changeUIntScale(duty, 0, 100, 0, Settings.dimmer_hw_max); }
+        duty = changeUIntScale(duty, Tuya.CTMin, Tuya.CTMax, Settings.dimmer_hw_max[0], 0);
+      } else { duty = changeUIntScale(duty, 0, 100, 0, Settings.dimmer_hw_max[0]); }
 
-      if (duty < Settings.dimmer_hw_min) { duty = Settings.dimmer_hw_min; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
+      if (duty < Settings.dimmer_hw_min[0]) { duty = Settings.dimmer_hw_min[0]; }  // dimming acts odd below 25(10%) - this mirrors the threshold set on the faceplate itself
         Tuya.ignore_dimmer_cmd_timeout = millis() + 250; // Ignore serial received dim commands for the next 250ms
         if (Tuya.ModeSet && (TuyaGetDpId(TUYA_MCU_FUNC_MODESET) != 0) && TasmotaGlobal.light_type > LT_RGB) {
           TuyaSendEnum(TuyaGetDpId(TUYA_MCU_FUNC_MODESET), 0);
@@ -640,9 +640,9 @@ void LightSerialDuty(uint16_t duty, char *hex_char, uint8_t TuyaIdx)
       Tuya.ignore_dim = false;  // reset flag
 
       if (TuyaIdx == 2 && CTLight) {
-        duty = changeUIntScale(duty, Tuya.CTMin, Tuya.CTMax, Settings.dimmer_hw_max, 0);
+        duty = changeUIntScale(duty, Tuya.CTMin, Tuya.CTMax, Settings.dimmer_hw_max[0], 0);
       } else {
-        duty = changeUIntScale(duty, 0, 100, 0, Settings.dimmer_hw_max);
+        duty = changeUIntScale(duty, 0, 100, 0, Settings.dimmer_hw_max[0]);
       }
       AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: Send dim skipped value %d for dpid %d"), duty, dpid);  // due to 0 or already set
     } else {
@@ -760,9 +760,9 @@ void TuyaProcessStatePacket(void) {
         if (fnId == TUYA_MCU_FUNC_DIMMER2 || fnId == TUYA_MCU_FUNC_REPORT2 || fnId == TUYA_MCU_FUNC_CT) { dimIndex = 1; }
 
         if (dimIndex == 1 && !Settings.flag3.pwm_multi_channels) {
-          Tuya.Levels[1] = changeUIntScale(packetValue, 0, Settings.dimmer_hw_max, Tuya.CTMax, Tuya.CTMin);
+          Tuya.Levels[1] = changeUIntScale(packetValue, 0, Settings.dimmer_hw_max[0], Tuya.CTMax, Tuya.CTMin);
         } else {
-          Tuya.Levels[dimIndex] = changeUIntScale(packetValue, 0, Settings.dimmer_hw_max, 0, 100);
+          Tuya.Levels[dimIndex] = changeUIntScale(packetValue, 0, Settings.dimmer_hw_max[0], 0, 100);
         }
 
         AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: RX value %d from dpId %d "), packetValue, Tuya.buffer[dpidStart]);

--- a/tasmota/xdrv_19_ps16dz_dimmer.ino
+++ b/tasmota/xdrv_19_ps16dz_dimmer.ino
@@ -64,8 +64,8 @@ void PS16DZSerialSendUpdateCommand(void)
 {
   uint8_t light_state_dimmer = light_state.getDimmer();
   // Dimming acts odd below 10% - this mirrors the threshold set on the faceplate itself
-  light_state_dimmer = (light_state_dimmer < Settings.dimmer_hw_min) ? Settings.dimmer_hw_min : light_state_dimmer;
-  light_state_dimmer = (light_state_dimmer > Settings.dimmer_hw_max) ? Settings.dimmer_hw_max : light_state_dimmer;
+  light_state_dimmer = (light_state_dimmer < Settings.dimmer_hw_min[0]) ? Settings.dimmer_hw_min[0] : light_state_dimmer;
+  light_state_dimmer = (light_state_dimmer > Settings.dimmer_hw_max[0]) ? Settings.dimmer_hw_max[0] : light_state_dimmer;
 
   char tx_buffer[80];
   snprintf_P(tx_buffer, sizeof(tx_buffer), PSTR("AT+UPDATE=\"sequence\":\"%d%03d\",\"switch\":\"%s\",\"bright\":%d"),

--- a/tasmota/xdrv_37_sonoff_d1.ino
+++ b/tasmota/xdrv_37_sonoff_d1.ino
@@ -147,8 +147,8 @@ bool SonoffD1SendPower(void)
 bool SonoffD1SendDimmer(void)
 {
   uint8_t dimmer = LightGetDimmer(1);
-  dimmer = (dimmer < Settings.dimmer_hw_min) ? Settings.dimmer_hw_min : dimmer;
-  dimmer = (dimmer > Settings.dimmer_hw_max) ? Settings.dimmer_hw_max : dimmer;
+  dimmer = (dimmer < Settings.dimmer_hw_min[0]) ? Settings.dimmer_hw_min[0] : dimmer;
+  dimmer = (dimmer > Settings.dimmer_hw_max[0]) ? Settings.dimmer_hw_max[0] : dimmer;
   if (dimmer != SnfD1.dimmer) {
     SnfD1.dimmer = dimmer;
 

--- a/tasmota/xdrv_45_shelly_dimmer.ino
+++ b/tasmota/xdrv_45_shelly_dimmer.ino
@@ -746,7 +746,7 @@ bool ShdSetChannels(void)
     uint16_t brightness = ((uint32_t *)XdrvMailbox.data)[0];
     // Use dimmer_hw_min and dimmer_hw_max to constrain our values if the light should be on
     if (brightness > 0)
-        brightness = changeUIntScale(brightness, 0, 255, Settings.dimmer_hw_min * 10, Settings.dimmer_hw_max * 10);
+        brightness = changeUIntScale(brightness, 0, 255, Settings.dimmer_hw_min[0] * 10, Settings.dimmer_hw_max[0] * 10);
     Shd.req_brightness = brightness;
 
     ShdDebugState();


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** non

With this PR each PWM dimmer channel can be configured with a
different DimmerRange. Therefore the minimal and maximal brightness of
each channel can be configured independently.
With `dimmerrange ...` still the range for all PWM channels will be set.
But for example with `dimmerrange2 ...` only the range of PWM channel 2 will be modified.

The migration of `Settings` is not yet implemented. First I would like to get a feedback if this PR gets a chance to be merged.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
