### PR TITLE
Fix Hue discovery for Zigbee and Scripting #10950

### DIFF
--- a/tasmota/support_udp.ino
+++ b/tasmota/support_udp.ino
@@ -137,7 +137,7 @@ void PollUdp(void)
       // Simple Service Discovery Protocol (SSDP)
       if (Settings.flag2.emulation) {
 #if defined(USE_SCRIPT_HUE) || defined(USE_ZIGBEE)
-        if (TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
+        if (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr) {
 #else
         if (TasmotaGlobal.devices_present && (strstr_P(packet_buffer, PSTR("M-SEARCH")) != nullptr)) {
 #endif


### PR DESCRIPTION
## Description:

Fix UDP packet not always sent when Zigbee or Scripting.

**Related issue (if applicable):** fixes #10950

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
