### PR TITLE
Use ESP32 1.0.5 rc7 for core32 stage

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -124,12 +124,12 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 
 [core32]
 ; Activate Stage Core32 by removing ";" in next 3 lines, if you want to override the standard core32
-;platform_packages           = ${core32_stage.platform_packages}
-;build_unflags               = ${core32_stage.build_unflags}
-;build_flags                 = ${core32_stage.build_flags}
+platform_packages           = ${core32_stage.platform_packages}
+build_unflags               = ${core32_stage.build_unflags}
+build_flags                 = ${core32_stage.build_flags}
 
 [core32_stage]
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc6/esp32-1.0.5-rc6.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/1.0.5-rc7/esp32-1.0.5-rc7.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

bug fixes in ESP32 core

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
