### PR TITLE
Berry add load/save

### DIFF
--- a/lib/libesp32/Berry-0.1.10/src/port/be_port.cpp
+++ b/lib/libesp32/Berry-0.1.10/src/port/be_port.cpp
@@ -64,15 +64,15 @@ BERRY_API void be_writebuffer(const char *buffer, size_t length)
     uint32_t idx = 0;
     while (idx < length) {
         int32_t cr_pos = -1;
-        // find next occurence of '\n'
+        // find next occurence of '\n' or '\r'
         for (uint32_t i = idx; i < length; i++) {
-            if (buffer[i] == '\n') {
+            if ((pgm_read_byte(&buffer[i]) == '\n') || (pgm_read_byte(&buffer[i]) == '\r')) {
                 cr_pos = i;
                 break;
             }
         }
         uint32_t chars_to_append = (cr_pos >= 0) ? cr_pos - idx : length - idx;     // note cr_pos < length
-        snprintf(log_berry_buffer, sizeof(log_berry_buffer), "%s%.*s", log_berry_buffer, chars_to_append, buffer);   // append at most `length` chars
+        snprintf(log_berry_buffer, sizeof(log_berry_buffer), "%s%.*s", log_berry_buffer, chars_to_append, &buffer[idx]);   // append at most `length` chars
         if (cr_pos >= 0) {
             // flush
             berry_log(log_berry_buffer);

--- a/tasmota/berry/tasmota.be
+++ b/tasmota/berry/tasmota.be
@@ -1,8 +1,15 @@
 import json import string
 tasmota = module("tasmota")
 def log(m) print(m) end
+def save() end
 
 #######
+import string
+import json
+import gc
+import tasmota
+#// import alias
+import tasmota as t
 
 def charsinstring(s,c)
   for i:0..size(s)-1
@@ -108,6 +115,15 @@ tasmota.delay = def(ms)
   tend = tasmota.millis(ms)
   while !tasmota.timereached(tend)
     tasmota.yield()
+  end
+end
+
+def load(f)
+  try
+    if f[0] != '/' f = '/' + f end
+    compile(f,'file')()
+  except .. as e
+    log(string.format("BRY: could not load file '%s' - %s",f,e))
   end
 end
 


### PR DESCRIPTION
## Description:

Berry improvements:
- fix in handling CR LF in `print()` function
- added `load("filename.be")` function which also saves the compiled bytecode in "filename.bec"
- added `save("filename.bec",f)` to save bytecode representation of a function/closure (used internally and should generally not be used)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
