### PR TITLE
fix ble from accepting 12 char alias which does not match as a mac ad…

### DIFF
--- a/tasmota/xdrv_79_esp32_ble.ino
+++ b/tasmota/xdrv_79_esp32_ble.ino
@@ -1015,6 +1015,18 @@ int fromHex(uint8_t *dest, const char *src, int maxlen){
     t[0] = src[i*2];
     t[1] = src[i*2 + 1];
     t[2] = 0;
+    t[0] |= 0x20;
+    t[1] |= 0x20;
+    if (isalpha(t[0])){
+      if (t[0] < 'a' || t[0] > 'f'){
+        return 0;
+      }
+    }
+    if (isalpha(t[1])){
+      if (t[1] < 'a' || t[1] > 'f'){
+        return 0;
+      }
+    }
 
     int byte = strtol(t, NULL, 16);
     *dest++ = byte;


### PR DESCRIPTION
…dress

## Description:

ok, i lied.
very minor - feel free to reserve for next version, or check my code and commit.

Fixes an issue where a 12 char alias could be recognised instead incorrectly as a mac address...
As I said, a very niche case.... but well found by @ysbrand

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
