### PR TITLE
fix ili9342 selection

### DIFF
--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -136,7 +136,7 @@ static const uint8_t PROGMEM ili9342_initcmd[] = {
   0x00                                   // End of list
 };
 
-ILI9341_2::ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp, int8_t spibus) : Renderer(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT) {
+ILI9341_2::ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp, int8_t spibus, uint8_t dtype) : Renderer(ILI9341_TFTWIDTH, ILI9341_TFTHEIGHT) {
   _cs   = cs;
   _mosi  = mosi;
   _miso  = miso;
@@ -144,7 +144,7 @@ ILI9341_2::ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t re
   _res = res;
   _dc = dc;
   _bp = bp;
-  _hwspi = 1;  // sign ili9341
+  _hwspi = dtype;  // sign ili9341 or 2
   _spibus = spibus;
 }
 

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
@@ -115,7 +115,7 @@ class ILI9341_2 : public Renderer {
 
  public:
 
-  ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp, int8_t spibus);
+  ILI9341_2(int8_t cs, int8_t mosi, int8_t miso, int8_t sclk, int8_t res, int8_t dc, int8_t bp, int8_t spibus, uint8_t dtype);
   ILI9341_2(int8_t cs, int8_t res, int8_t dc, int8_t bp);
 
   void init(uint16_t width, uint16_t height);

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -36,6 +36,7 @@ uint8_t ili9342_ctouch_counter = 0;
 
 bool tft_init_done = false;
 
+
 /*********************************************************************************************/
 
 void ILI9341_InitDriver()
@@ -61,6 +62,12 @@ void ILI9341_InitDriver()
     // disable screen buffer
     buffer = NULL;
 
+#ifdef USE_DISPLAY_ILI9341
+    uint8_t dtype = 1;
+#else
+    uint8_t dtype = 2;
+#endif // USE_DISPLAY_ILI9341
+
     // default colors
     fg_color = ILI9341_WHITE;
     bg_color = ILI9341_BLACK;
@@ -73,11 +80,11 @@ void ILI9341_InitDriver()
     if (TasmotaGlobal.soft_spi_enabled) {
       // Init renderer, may use hardware spi, however we use SSPI defintion because SD card uses SPI definition  (2 spi busses)
       if (PinUsed(GPIO_SSPI_MOSI) && PinUsed(GPIO_SSPI_MISO) && PinUsed(GPIO_SSPI_SCLK)) {
-        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SSPI_MOSI), Pin(GPIO_SSPI_MISO), Pin(GPIO_SSPI_SCLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 2);
+        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SSPI_MOSI), Pin(GPIO_SSPI_MISO), Pin(GPIO_SSPI_SCLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 2, dtype);
       }
     } else if (TasmotaGlobal.spi_enabled) {
       if (PinUsed(GPIO_ILI9341_DC)) {
-        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SPI_MOSI), Pin(GPIO_SPI_MISO), Pin(GPIO_SPI_CLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 1);
+        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SPI_MOSI), Pin(GPIO_SPI_MISO), Pin(GPIO_SPI_CLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 1, dtype);
       }
     }
 #endif // USE_M5STACK_CORE2


### PR DESCRIPTION
## Description:

enables ILI9342 selection for other displays then m5stack core2

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
