### PR TITLE
fix ili9342

### DIFF
--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -189,9 +189,11 @@ void ILI9341_2::init(uint16_t width, uint16_t height) {
 
   if (_hwspi >= 2) {
     spi2 = &SPI;
+#ifdef ESP32
     if (_hwspi > 2) {
       spi2->begin(_sclk, _miso, _mosi, -1);
     }
+#endif // ESP32
   } else {
 #ifdef ESP32
     if (_spibus == 2) {

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -175,7 +175,7 @@ void ILI9341_2::writecmd(uint8_t d) {
 void ILI9341_2::init(uint16_t width, uint16_t height) {
   //sspi2 = SPISettings(2500000, MSBFIRST, SPI_MODE3);
 
-  if (_hwspi == 2) {
+  if (_hwspi >= 2) {
     iwidth = ILI9341_TFTWIDTH;
     iheight = ILI9341_TFTHEIGHT;
   } else {
@@ -187,8 +187,11 @@ void ILI9341_2::init(uint16_t width, uint16_t height) {
 
   sspi2 = SPISettings(40000000, MSBFIRST, SPI_MODE0);
 
-  if (_hwspi==2) {
-    spi2=&SPI;
+  if (_hwspi >= 2) {
+    spi2 = &SPI;
+    if (_hwspi > 2) {
+      spi2->begin(_sclk, _miso, _mosi, -1);
+    }
   } else {
 #ifdef ESP32
     if (_spibus == 2) {
@@ -522,7 +525,7 @@ void ili9342_bpwr(uint8_t on);
 
 void ILI9341_2::DisplayOnff(int8_t on) {
 
-  if (_hwspi==2) {
+  if (_hwspi>=2) {
     ili9342_bpwr(on);
   }
 
@@ -572,7 +575,7 @@ void ILI9341_2::dim(uint8_t dim) {
   if (_bp>=0) {
     ledcWrite(ESP32_PWM_CHANNEL,dimmer);
   } else {
-    if (_hwspi==2) {
+    if (_hwspi>=2) {
       ili9342_dimm(dim);
     }
   }

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -65,7 +65,7 @@ void ILI9341_InitDriver()
 #ifdef USE_DISPLAY_ILI9341
     uint8_t dtype = 1;
 #else
-    uint8_t dtype = 2;
+    uint8_t dtype = 3; // sign ili9342 with variable spi pins
 #endif // USE_DISPLAY_ILI9341
 
     // default colors


### PR DESCRIPTION
## Description:

fix ili9342 next try, now initializes the spi bus with specified pins

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
