### PR TITLE
Mi32bugfix

### DIFF
--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -1937,13 +1937,24 @@ void MI32Every50mSecond(){
 
 void MI32EverySecond(bool restart){
 
+#ifdef USE_HOME_ASSISTANT
+  if(Settings.flag.hass_discovery){
+    // fixes bug introduced - just by forcing this mode.
+    MI32.option.MQTTType = 1;
+  }
+#endif
+
 //  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: onesec"));
   MI32TimeoutSensors();
 
   if (MI32.option.MQTTType == 0){
+    // show tas style sensor MQTT
     MI32ShowSomeSensors();
   } else { 
+    // these two share a counter
+    // discovery only sent if hass_discovery
     MI32DiscoveryOneMISensor();
+    // show independent style sensor MQTT
     MI32ShowOneMISensor();
   }
 

--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -1937,24 +1937,25 @@ void MI32Every50mSecond(){
 
 void MI32EverySecond(bool restart){
 
-#ifdef USE_HOME_ASSISTANT
-  if(Settings.flag.hass_discovery){
-    // fixes bug introduced - just by forcing this mode.
-    MI32.option.MQTTType = 1;
-  }
-#endif
-
 //  AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("M32: onesec"));
   MI32TimeoutSensors();
 
   if (MI32.option.MQTTType == 0){
     // show tas style sensor MQTT
     MI32ShowSomeSensors();
-  } else { 
+  }
+  
+  if (MI32.option.MQTTType == 1 
+#ifdef USE_HOME_ASSISTANT
+    ||
+    Settings.flag.hass_discovery
+#endif
+  ) { 
     // these two share a counter
     // discovery only sent if hass_discovery
     MI32DiscoveryOneMISensor();
     // show independent style sensor MQTT
+    // note - if !MQTTType, then this is IN ADDITION to 'normal'
     MI32ShowOneMISensor();
   }
 


### PR DESCRIPTION
## Description:

bugfix for bug reported in Discord.
MI32 sensors no longer auto-discovered in HASS.

There is a workaround by setting BOTH 'setopion19 1' and 'MI32Option6 1' - this will work for the release version

These changes fix this issue.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
