### PR TITLE
Remove VirtualCT synonym

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -433,7 +433,6 @@
 #define D_SO_POWERONFADE "PowerOnFade"      // SO91
 #define D_SO_PWMCT "PWMCT"                  // SO92
 #define D_SO_WHITEBLEND "WhiteBlend"        // SO105
-#define D_SO_VIRTUALCT "VirtualCT"          // SO106
 #define D_CMND_CHANNEL "Channel"
 #define D_CMND_COLOR "Color"
 #define D_CMND_COLORTEMPERATURE "CT"

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -131,7 +131,7 @@ const uint8_t LIGHT_COLOR_SIZE = 25;   // Char array scolor size
 const char kLightCommands[] PROGMEM = "|"  // No prefix
   // SetOptions synonyms
   D_SO_CHANNELREMAP "|" D_SO_MULTIPWM "|" D_SO_ALEXACTRANGE "|" D_SO_POWERONFADE "|" D_SO_PWMCT "|"
-  D_SO_WHITEBLEND "|" D_SO_VIRTUALCT "|"
+  D_SO_WHITEBLEND "|"
   // Other commands
   D_CMND_COLOR "|" D_CMND_COLORTEMPERATURE "|" D_CMND_DIMMER "|" D_CMND_DIMMER_RANGE "|" D_CMND_DIMMER_STEP "|" D_CMND_LEDTABLE "|" D_CMND_FADE "|"
   D_CMND_RGBWWTABLE "|" D_CMND_SCHEME "|" D_CMND_SPEED "|" D_CMND_WAKEUP "|" D_CMND_WAKEUPDURATION "|"
@@ -150,7 +150,7 @@ const char kLightCommands[] PROGMEM = "|"  // No prefix
 
 SO_SYNONYMS(kLightSynonyms,
   37, 68, 82, 91, 92,
-  105, 106,
+  105,
 );
 
 void (* const LightCommand[])(void) PROGMEM = {


### PR DESCRIPTION
## Description:

Remove `VirtualCT` as synonym to `SetOption106` as this conflicts with the `VirtualCT` command.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
