### PR TITLE
fix ili9342 rotation

### DIFF
--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -411,17 +411,17 @@ void ILI9341_2::setRotation(uint8_t m) {
             _height = iheight;
             break;
         case 1:
-            m = (MADCTL_MV | MADCTL_BGR);
+            m = (MADCTL_MY | MADCTL_MV | MADCTL_BGR);
             _width  = iheight;
             _height = iwidth;
             break;
         case 2:
-            m = (MADCTL_MY | MADCTL_BGR);
+            m = (MADCTL_MY | MADCTL_MX | MADCTL_BGR);
             _width  = iwidth;
             _height = iheight;
             break;
         case 3:
-            m = (MADCTL_MX | MADCTL_MY | MADCTL_MV | MADCTL_BGR);
+            m = (MADCTL_MX | MADCTL_MV | MADCTL_BGR);
             _width  = iheight;
             _height = iwidth;
             break;
@@ -561,9 +561,11 @@ void ILI9341_2::DisplayOnff(int8_t on) {
 }
 
 void ILI9341_2::invertDisplay(boolean i) {
+  SPI_BEGIN_TRANSACTION();
   ILI9341_2_CS_LOW
   writecmd(i ? ILI9341_2_INVON : ILI9341_2_INVOFF);
   ILI9341_2_CS_HIGH
+  SPI_END_TRANSACTION();
 }
 
 void ili9342_dimm(uint8_t dim);

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -527,7 +527,7 @@ void ili9342_bpwr(uint8_t on);
 
 void ILI9341_2::DisplayOnff(int8_t on) {
 
-  if (_hwspi>=2) {
+  if ((_hwspi >= 2) && (_bp < 0)) {
     ili9342_bpwr(on);
   }
 
@@ -537,11 +537,11 @@ void ILI9341_2::DisplayOnff(int8_t on) {
     writecmd(ILI9341_2_DISPON);
     ILI9341_2_CS_HIGH
     SPI_END_TRANSACTION();
-    if (_bp>=0) {
+    if (_bp >= 0) {
 #ifdef ILI9341_2_DIMMER
-      ledcWrite(ESP32_PWM_CHANNEL,dimmer);
+      ledcWrite(ESP32_PWM_CHANNEL, dimmer);
 #else
-      digitalWrite(_bp,HIGH);
+      digitalWrite(_bp, HIGH);
 #endif
     }
   } else {
@@ -550,11 +550,11 @@ void ILI9341_2::DisplayOnff(int8_t on) {
     writecmd(ILI9341_2_DISPOFF);
     ILI9341_2_CS_HIGH
     SPI_END_TRANSACTION();
-    if (_bp>=0) {
+    if (_bp >= 0) {
 #ifdef ILI9341_2_DIMMER
-      ledcWrite(ESP32_PWM_CHANNEL,0);
+      ledcWrite(ESP32_PWM_CHANNEL, 0);
 #else
-      digitalWrite(_bp,LOW);
+      digitalWrite(_bp, LOW);
 #endif
     }
   }

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -72,8 +72,6 @@ void ILI9341_InitDriver()
     fg_color = ILI9341_WHITE;
     bg_color = ILI9341_BLACK;
 
-    AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x 0"));
-
 #ifdef USE_M5STACK_CORE2
     // fixed pins on m5stack core2
     ili9341_2 = new ILI9341_2(5, -2, 15, -2);
@@ -98,8 +96,6 @@ void ILI9341_InitDriver()
       AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x invalid GPIOs"));
       return;
     }
-
-    AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x 1"));
 
     ili9341_2->init(Settings.display_width, Settings.display_height);
     renderer = ili9341_2;

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -42,7 +42,7 @@ bool tft_init_done = false;
 void ILI9341_InitDriver()
 {
 
-#ifdef USE_M5STACK_CORE2
+#if (defined(USE_M5STACK_CORE2) || defined(USE_M5STACK_CORE_BASIC))
   if (TasmotaGlobal.spi_enabled) {
 #else
   // There are displays without CS
@@ -72,9 +72,14 @@ void ILI9341_InitDriver()
     fg_color = ILI9341_WHITE;
     bg_color = ILI9341_BLACK;
 
+    AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x 0"));
+
 #ifdef USE_M5STACK_CORE2
     // fixed pins on m5stack core2
     ili9341_2 = new ILI9341_2(5, -2, 15, -2);
+#elif defined(USE_M5STACK_CORE_BASIC)
+    // int8_t cs, int8_t res, int8_t dc, int8_t bp)
+    ili9341_2 = new ILI9341_2(14, 33, 27, 32);
 #else
     // check for special case with 2 SPI busses (ESP32 bitcoin)
     if (TasmotaGlobal.soft_spi_enabled) {
@@ -93,6 +98,8 @@ void ILI9341_InitDriver()
       AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x invalid GPIOs"));
       return;
     }
+
+    AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x 1"));
 
     ili9341_2->init(Settings.display_width, Settings.display_height);
     renderer = ili9341_2;


### PR DESCRIPTION
## Description:

fix ili9342 rotation also applies to m5stack  core2

general remarks on ILI9342:
this chip is only used by m5stack core1 and 2 so far. i did not find a single other vendor
to make it a general selection we would need a separate chip select definition.

so i decided by the time being to use another define for CORE Basic
#define USE_M5STACK_CORE_BASIC
to select the appropriate pins for that board (this board is actually outdated and replaced by core2)









 



## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
