### PR TITLE
Update MFRC522.cpp

### DIFF
--- a/lib/lib_div/rfid-1.4.7/src/MFRC522.cpp
+++ b/lib/lib_div/rfid-1.4.7/src/MFRC522.cpp
@@ -233,6 +233,7 @@ void MFRC522::PCD_Init() {
 	
 	PCD_WriteRegister(TxASKReg, 0x40);		// Default 0x00. Force a 100 % ASK modulation independent of the ModGsPReg register setting
 	PCD_WriteRegister(ModeReg, 0x3D);		// Default 0x3F. Set the preset value for the CRC coprocessor for the CalcCRC command to 0x6363 (ISO 14443-3 part 6.2.4)
+	PCD_WriteRegister(RFCfgReg, (0x07<<4));         // Set Rx Gain to max
 	PCD_AntennaOn();						// Enable the antenna driver pins TX1 and TX2 (they were disabled by the reset)
 } // End PCD_Init()
 


### PR DESCRIPTION
## Description: Extend range for MFRC522 RFID Reader. Set RFCfgReg to 48db gain

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
