### PR TITLE
animate PWM dimmer brightness LEDs during transitions and with variable brightness

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -505,9 +505,6 @@ class LightStateClass {
       uint8_t prev_bri = _briRGB;
       _briRGB = bri_rgb;
       if (bri_rgb > 0) { addRGBMode(); }
-#ifdef USE_PWM_DIMMER
-      if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(-1);
-#endif  // USE_PWM_DIMMER
       return prev_bri;
     }
 
@@ -516,9 +513,6 @@ class LightStateClass {
       uint8_t prev_bri = _briCT;
       _briCT = bri_ct;
       if (bri_ct > 0) { addCTMode(); }
-#ifdef USE_PWM_DIMMER
-      if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(-1);
-#endif  // USE_PWM_DIMMER
       return prev_bri;
     }
 
@@ -1958,6 +1952,10 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         if (!Settings.flag4.zerocross_dimmer) {
           analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col);
         }
+#ifdef USE_PWM_DIMMER
+        // Animate brightness LEDs to follow PWM dimmer brightness
+        if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(change10to8(cur_col));
+#endif  // USE_PWM_DIMMER
       }
     }
   }

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -167,6 +167,7 @@ void PWMDimmerSetBrightnessLeds(int32_t bri)
     uint32_t level = 0;
     led = -1;
     mask = 0;
+    uint16_t pwm_led_bri = 0;
     for (uint32_t count = 0; count < leds; count++) {
       level += step;
       for (;;) {
@@ -175,7 +176,8 @@ void PWMDimmerSetBrightnessLeds(int32_t bri)
         if (!mask) mask = 1;
         if (Settings.ledmask & mask) break;
       }
-      SetLedPowerIdx(led, bri >= level);
+      pwm_led_bri = changeUIntScale((bri > level ? bri - level : 0), 0, step, 0, Settings.pwm_range);
+      analogWrite(Pin(GPIO_LED1, led), bitRead(TasmotaGlobal.led_inverted, led) ? Settings.pwm_range - pwm_led_bri : pwm_led_bri);
     }
   }
 }
@@ -193,7 +195,6 @@ void PWMDimmerSetPoweredOffLed(void)
 void PWMDimmerSetPower(void)
 {
   DigitalWrite(GPIO_REL1, 0, bitRead(TasmotaGlobal.rel_inverted, 0) ? !TasmotaGlobal.power : TasmotaGlobal.power);
-  PWMDimmerSetBrightnessLeds(-1);
   PWMDimmerSetPoweredOffLed();
 }
 


### PR DESCRIPTION
## Description:

I have several Martin Jerry SD-01 dimmers using the PWM Dimmer module. When adjusting dimmer level either using buttons on the device or by remote command, the brightness LEDs instantly update to the target dimmer level regardless of FADE and SPEED setting. I would prefer the brightness LEDs to follow the brightness of the light controlled by the PWM dimmer over the course of any dimmer adjustment. If the turn-on takes 3 seconds from 0% to 100%, then I want the brightness LEDs to animate up over the course of 3 seconds.

This change ensures the brightness LEDs are updated whenever the PWM's output is changed. Additionally, it uses `analogWrite()` to set a brightness of each individual LED, adjusting the brightness of the "topmost" lit status LED to be proportional to the (marginal) dimmer amount for that LED. For example, if the dimmer is set to 30%, the brightness LEDs would be lit as following::

```
            led4 [  0%]  (dimmer levels 81-100)
            led3 [  0%]  (dimmer levels 61-80)
            led2 [  0%]  (dimmer levels 41-60)
            led1 [ 50%]  (dimmer levels 21-40)
relay_linked_led [100%]  (dimmer levels 0–20)
```
If the dimmer is set to 75%, the brightness LEDs would be lit as following:
```
            led4 [  0%]  (dimmer levels 81-100)
            led3 [ 75%]  (dimmer levels 61-80)
            led2 [100%]  (dimmer levels 41-60)
            led1 [100%]  (dimmer levels 21-40)
relay_linked_led [100%]  (dimmer levels 0–20)
```

Note that since the bottom LED is relay-linked, its brightness is not controllable, so there is no visible animation for dimmer levels 0%-20%.

I posted [a short video demonstrating the smooth animation](https://www.youtube.com/watch?v=V7eOUQuRClw
) on YouTube:
[![Watch the video](https://img.youtube.com/vi/V7eOUQuRClw/maxresdefault.jpg)](https://youtu.be/V7eOUQuRClw)

As this is my first contribution to this project, I've done my best to review the contribution guidelines, but I'm not sure (1) how to do more thorough testing and (2) if the approach I've taken to implementation is correct. I think this is a neat feature that SD-01 dimmer owners will appreciate, so I'm happy to make whatever changes are needed to get it merged in. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
