### PR TITLE
sml several fixes

### DIFF
--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -162,6 +162,7 @@ void Script_ticker4_end(void) {
 #endif
 #endif
 
+extern uint8_t sml_json_enable;
 
 #if defined(EEP_SCRIPT_SIZE) && !defined(ESP32)
 
@@ -208,7 +209,7 @@ void alt_eeprom_readBytes(uint32_t adr, uint32_t len, uint8_t *buf) {
 #define EPOCH_OFFSET 1546300800
 
 enum {OPER_EQU=1,OPER_PLS,OPER_MIN,OPER_MUL,OPER_DIV,OPER_PLSEQU,OPER_MINEQU,OPER_MULEQU,OPER_DIVEQU,OPER_EQUEQU,OPER_NOTEQU,OPER_GRTEQU,OPER_LOWEQU,OPER_GRT,OPER_LOW,OPER_PERC,OPER_XOR,OPER_AND,OPER_OR,OPER_ANDEQU,OPER_OREQU,OPER_XOREQU,OPER_PERCEQU};
-enum {SCRIPT_LOGLEVEL=1,SCRIPT_TELEPERIOD,SCRIPT_EVENT_HANDLED};
+enum {SCRIPT_LOGLEVEL=1,SCRIPT_TELEPERIOD,SCRIPT_EVENT_HANDLED,SML_JSON_ENABLE};
 
 
 #ifdef USE_UFILESYS
@@ -2985,6 +2986,11 @@ chknext:
           len = 0;
           goto exit;
         }
+        if (!strncmp(vname, "smlj", 4)) {
+          fvar = sml_json_enable;
+          tind->index = SML_JSON_ENABLE;
+          goto exit_settable;
+        }
 #endif //USE_SML_M
         break;
       case 't':
@@ -4527,6 +4533,11 @@ int16_t Run_script_sub(const char *type, int8_t tlen, struct GVARS *gv) {
                           case SCRIPT_EVENT_HANDLED:
                             glob_script_mem.event_handeled = *dfvar;
                             break;
+#if defined(USE_SML_M) && defined (USE_SML_SCRIPT_CMD)
+                          case SML_JSON_ENABLE:
+                            sml_json_enable = *dfvar;
+                            break;
+#endif
                         }
                         sysv_type = 0;
                       }

--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -49,8 +49,9 @@
 #define SPECIAL_SS
 #endif
 
-#undef TMSBSIZ
+#ifndef TMSBSIZ
 #define TMSBSIZ 256
+#endif
 
 // addresses a bug in meter DWS74
 //#define DWS74_BUG
@@ -469,7 +470,7 @@ uint8_t dvalid[SML_MAX_VARS];
 
 struct METER_DESC const *meter_desc_p;
 const uint8_t *meter_p;
-uint8_t meter_spos[MAX_METERS];
+uint16_t meter_spos[MAX_METERS];
 
 // software serial pointers
 #ifdef ESP8266
@@ -820,13 +821,12 @@ uint8_t Serial_peek() {
 }
 
 uint8_t sml_logindex;
+char log_data[128];
 
 void Dump2log(void) {
-
   int16_t index=0,hcnt=0;
   uint32_t d_lastms;
   uint8_t dchars[16];
-  char log_data[128];
 
   //if (!SML_SAVAILABLE) return;
 
@@ -1258,7 +1258,7 @@ void sml_shift_in(uint32_t meters,uint32_t shard) {
       // QQ,ZZ,PB,SB,NN ..... CRC, ACK SYNC
       if (meter_spos[meters]>4+5) {
       	// get telegramm lenght
-        uint8_t tlen=smltbuf[meters][4]+5;
+        uint16_t tlen=smltbuf[meters][4]+5;
         // test crc
         if (smltbuf[meters][tlen]=ebus_CalculateCRC(smltbuf[meters],tlen)) {
             ebus_esc(smltbuf[meters],tlen);
@@ -1548,15 +1548,17 @@ void SML_Decode(uint8_t index) {
 #endif
         if (*mp == '#') {
           // get string value
+          getstr:
           mp++;
           if (meter_desc_p[mindex].type == 'o') {
-            for (uint8_t p=0; p<METER_ID_SIZE; p++) {
+            uint32_t p;
+            for (p = 0; p < METER_ID_SIZE - 2; p++) {
               if (*cp == *mp) {
-                meter_id[mindex][p] = 0;
                 break;
               }
               meter_id[mindex][p] = *cp++;
             }
+            meter_id[mindex][p] = 0;
           } else {
             sml_getvalue(cp,mindex);
           }
@@ -1567,12 +1569,26 @@ void SML_Decode(uint8_t index) {
             if (meter_desc_p[mindex].type=='o' || meter_desc_p[mindex].type=='c') {
               if (*mp == '(') {
                 mp++;
-                // skip this bracket
-                char *bp = strchr((char*)cp, '(');
-                if (bp) {
-                  cp = (uint8_t*) (bp + 1);
+                // skip this number of brackets
+                uint8_t toskip = strtol((char*)mp,(char**)&mp, 10);
+                mp++;
+                char *lcp = (char*)cp;
+                if (toskip) {
+                  char *bp = (char*)cp;
+                  for (uint32_t cnt = 0; cnt < toskip; cnt++) {
+                    bp = strchr(bp, '(');
+                    if (!bp) {
+                      break;
+                    }
+                    bp++;
+                    lcp = bp;
+                  }
                 }
-                dval=CharToDouble((char*)cp);
+                if (*mp=='#') {
+                  cp = (uint8_t*)lcp;
+                  goto getstr;
+                }
+                dval=CharToDouble((char*)lcp);
               } else {
                 dval=CharToDouble((char*)cp);
               }
@@ -1623,13 +1639,14 @@ void SML_Decode(uint8_t index) {
 #else
           meter_vars[vindex]=dval;
 #endif
-          dvalid[vindex] = 1;
+        
 //AddLog_P(LOG_LEVEL_INFO, PSTR(">> %s"),mp);
           // get scaling factor
           double fac=CharToDouble((char*)mp);
           meter_vars[vindex]/=fac;
           SML_Immediate_MQTT((const char*)mp,vindex,mindex);
         }
+        dvalid[vindex] = 1;
       }
     }
 nextsect:
@@ -1737,10 +1754,20 @@ void SML_Show(boolean json) {
         cp=strchr(mp,'@');
         if (cp) {
           cp++;
+          tststr:
           if (*cp=='#') {
             // meter id
             sprintf(tpowstr,"\"%s\"",&meter_id[mindex][0]);
             mid=1;
+          } else if (*cp=='(') {
+            if (meter_desc_p[mindex].type=='o') {
+              cp++;
+              strtol((char*)cp,(char**)&cp, 10);
+              cp++;
+              goto tststr;
+            } else {
+              mid=0;
+            }
           } else {
             mid=0;
           }
@@ -1987,154 +2014,181 @@ void SML_Init(void) {
   if (meter_script==99) {
     // use script definition
     if (script_meter) free(script_meter);
-    script_meter=0;
-    uint8_t *tp=0;
-    uint16_t index=0;
-    uint8_t section=0;
-    uint8_t srcpin=0;
-    char *lp=glob_script_mem.scriptptr;
-    sml_send_blocks=0;
+    script_meter = 0;
+    uint8_t *tp = 0;
+    uint16_t index = 0;
+    uint8_t section = 0;
+    uint8_t srcpin = 0;
+    uint8_t dec_line = 0;
+    char *lp = glob_script_mem.scriptptr;
+    sml_send_blocks = 0;
     while (lp) {
       if (!section) {
-        if (*lp=='>' && *(lp+1)=='M') {
-          lp+=2;
-          meters_used=strtol(lp,0,10);
-          section=1;
-          uint32_t mlen=SML_getscriptsize(lp);
-          if (mlen==0) return; // missing end #
-          script_meter=(uint8_t*)calloc(mlen,1);
+        if (*lp == '>' && *(lp+1) == 'M') {
+          lp += 2;
+          meters_used = strtol(lp, 0, 10);
+          section = 1;
+          uint32_t mlen = SML_getscriptsize(lp);
+          if (mlen == 0) return; // missing end #
+          script_meter = (uint8_t*)calloc(mlen, 1);
           if (!script_meter) {
             goto dddef_exit;
           }
-          tp=script_meter;
+          tp = script_meter;
           goto next_line;
         }
       }
       else {
-        if (!*lp || *lp=='#' || *lp=='>') {
-          if (*(tp-1)=='|') *(tp-1)=0;
+        if (!*lp || *lp == '#' || *lp == '>') {
+          if (*(tp-1) == '|') *(tp-1) = 0;
           break;
         }
-        if (*lp=='+') {
+        if (*lp == '+') {
           // add descriptor +1,1,c,0,10,H20
           //toLogEOL(">>",lp);
           lp++;
-          index=*lp&7;
-          lp+=2;
-          if (index<1 || index>meters_used) goto next_line;
+          index = *lp&7;
+          lp += 2;
+          if (index < 1 || index > meters_used) {
+            AddLog(LOG_LEVEL_INFO, PSTR("illegal meter number!"));
+            goto next_line;
+          }
           index--;
-          srcpin=strtol(lp,&lp,10);
+          srcpin  = strtol(lp,&lp,10);
           if (Gpio_used(srcpin)) {
             AddLog(LOG_LEVEL_INFO, PSTR("gpio rx double define!"));
 dddef_exit:
             if (script_meter) free(script_meter);
-            script_meter=0;
-            meters_used=METERS_USED;
+            script_meter = 0;
+            meters_used = METERS_USED;
             goto init10;
           }
-          script_meter_desc[index].srcpin=srcpin;
-          if (*lp!=',') goto next_line;
+          script_meter_desc[index].srcpin = srcpin;
+          if (*lp != ',') goto next_line;
           lp++;
-          script_meter_desc[index].type=*lp;
+          script_meter_desc[index].type = *lp;
           lp++;
-          if (*lp!=',') {
-            script_meter_desc[index].sopt=*lp&7;
+          if (*lp != ',') {
+            script_meter_desc[index].sopt = *lp&7;
             lp++;
           } else {
-            script_meter_desc[index].sopt=0;
+            script_meter_desc[index].sopt = 0;
           }
           lp++;
-          script_meter_desc[index].flag=strtol(lp,&lp,10);
-          if (*lp!=',') goto next_line;
+          script_meter_desc[index].flag = strtol(lp, &lp, 10);
+          if (*lp != ',') goto next_line;
           lp++;
-          script_meter_desc[index].params=strtol(lp,&lp,10);
-          if (*lp!=',') goto next_line;
+          script_meter_desc[index].params = strtol(lp, &lp, 10);
+          if (*lp != ',') goto next_line;
           lp++;
-          script_meter_desc[index].prefix[7]=0;
-          for (uint32_t cnt=0; cnt<8; cnt++) {
-            if (*lp==SCRIPT_EOL || *lp==',') {
-              script_meter_desc[index].prefix[cnt]=0;
+          script_meter_desc[index].prefix[7] = 0;
+          for (uint32_t cnt = 0; cnt < 8; cnt++) {
+            if (*lp == SCRIPT_EOL || *lp == ',') {
+              script_meter_desc[index].prefix[cnt] = 0;
               break;
             }
-            script_meter_desc[index].prefix[cnt]=*lp++;
+            script_meter_desc[index].prefix[cnt] = *lp++;
           }
-          if (*lp==',') {
+          if (*lp == ',') {
             lp++;
-            script_meter_desc[index].trxpin=strtol(lp,&lp,10);
+            script_meter_desc[index].trxpin = strtol(lp, &lp, 10);
             if (Gpio_used(script_meter_desc[index].trxpin)) {
               AddLog(LOG_LEVEL_INFO, PSTR("gpio tx double define!"));
               goto dddef_exit;
             }
-            if (*lp!=',') goto next_line;
+            if (*lp != ',') goto next_line;
             lp++;
-            script_meter_desc[index].tsecs=strtol(lp,&lp,10);
-            if (*lp==',') {
+            script_meter_desc[index].tsecs = strtol(lp, &lp, 10);
+            if (*lp == ',') {
               lp++;
               char txbuff[256];
-              uint32_t txlen=0,tx_entries=1;
-              for (uint32_t cnt=0; cnt<sizeof(txbuff); cnt++) {
-                if (*lp==SCRIPT_EOL) {
-                  txbuff[cnt]=0;
-                  txlen=cnt;
+              uint32_t txlen = 0, tx_entries = 1;
+              for (uint32_t cnt = 0; cnt < sizeof(txbuff); cnt++) {
+                if (*lp == SCRIPT_EOL) {
+                  txbuff[cnt] = 0;
+                  txlen = cnt;
                   break;
                 }
-                if (*lp==',') tx_entries++;
-                txbuff[cnt]=*lp++;
+                if (*lp == ',') tx_entries++;
+                txbuff[cnt] = *lp++;
               }
               if (txlen) {
-                script_meter_desc[index].txmem=(char*)calloc(txlen+2,1);
+                script_meter_desc[index].txmem = (char*)calloc(txlen+2, 1);
                 if (script_meter_desc[index].txmem) {
                   strcpy(script_meter_desc[index].txmem,txbuff);
                 }
-                script_meter_desc[index].index=0;
-                script_meter_desc[index].max_index=tx_entries;
+                script_meter_desc[index].index = 0;
+                script_meter_desc[index].max_index = tx_entries;
                 sml_send_blocks++;
               }
             }
           }
-          if (*lp==SCRIPT_EOL) lp--;
+          if (*lp == SCRIPT_EOL) lp--;
           goto next_line;
         }
 
 #ifdef SML_REPLACE_VARS
         char dstbuf[SML_SRCBSIZE*2];
-        Replace_Cmd_Vars(lp,1,dstbuf,sizeof(dstbuf));
-        lp+=SML_getlinelen(lp);
+        Replace_Cmd_Vars(lp, 1, dstbuf,sizeof(dstbuf));
+        lp += SML_getlinelen(lp);
         //AddLog_P(LOG_LEVEL_INFO, PSTR("%s"),dstbuf);
-        char *lp1=dstbuf;
-        if (*lp1=='-' || isdigit(*lp1)) {
+        char *lp1 = dstbuf;
+        if (*lp1 == '-' || isdigit(*lp1)) {
           //toLogEOL(">>",lp);
           // add meters line -1,1-0:1.8.0*255(@10000,H2OIN,cbm,COUNTER,4|
-          if (*lp1=='-') lp1++;
-          uint8_t mnum=strtol(lp1,0,10);
-          if (mnum<1 || mnum>meters_used) goto next_line;
-          while (1) {
-            if (*lp1==0) {
-              *tp++='|';
+          if (*lp1 == '-') lp1++;
+          uint8_t mnum = strtol(lp1, 0, 10);
+          if (mnum < 1 || mnum > meters_used) {
+            AddLog(LOG_LEVEL_INFO, PSTR("illegal meter number!"));
+            goto next_line;
+          }
+          // 1,=h—————————————
+          if (strncmp(lp1 + 1, ",=h", 3)) {
+            dec_line++;
+            if (dec_line >= SML_MAX_VARS) {
+              AddLog(LOG_LEVEL_INFO, PSTR("too many decode lines: %d !"), dec_line);
               goto next_line;
             }
-            *tp++=*lp1++;
+          }
+          while (1) {
+            if (*lp1 == 0) {
+              *tp++ = '|';
+              goto next_line;
+            }
+            *tp++ = *lp1++;
             index++;
-            if (index>=METER_DEF_SIZE) break;
+            if (index >= METER_DEF_SIZE) break;
           }
         }
 #else
 
-        if (*lp=='-' || isdigit(*lp)) {
+        if (*lp == '-' || isdigit(*lp)) {
           //toLogEOL(">>",lp);
           // add meters line -1,1-0:1.8.0*255(@10000,H2OIN,cbm,COUNTER,4|
-          if (*lp=='-') lp++;
-          uint8_t mnum=strtol(lp,0,10);
-          if (mnum<1 || mnum>meters_used) goto next_line;
-          while (1) {
-            if (*lp==SCRIPT_EOL) {
-              if (*(tp-1)!='|') *tp++='|';
+          if (*lp == '-') lp++;
+          uint8_t mnum = strtol(lp,0,10);
+          if (mnum < 1 || mnum > meters_used) {
+            AddLog(LOG_LEVEL_INFO, PSTR("illegal meter number!"));
+            goto next_line;
+          }
+          if (strncmp(lp + 1, ",=h", 3)) {
+            dec_line++;
+            if (dec_line >= SML_MAX_VARS) {
+              AddLog(LOG_LEVEL_INFO, PSTR("too many decode lines: %d !"), dec_line);
               goto next_line;
             }
-            *tp++=*lp++;
-            index++;
-            if (index>=METER_DEF_SIZE) break;
           }
+
+          while (1) {
+            if (*lp == SCRIPT_EOL) {
+              if (*(tp-1) != '|') *tp++ = '|';
+              goto next_line;
+            }
+            *tp++ = *lp++;
+            index++;
+            if (index >= METER_DEF_SIZE) break;
+          }
+
         }
 #endif
 


### PR DESCRIPTION
## Description:

fixes some issues:
possible text variable buffer overflow
dump mode
missing text vars from MQTT

add:
obis indexed braket mode
decode line overflow check
global SML mqtt disable from script


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
