### PR TITLE
Added option to configure ledlink to show a heartbeat

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -82,6 +82,7 @@ The attached binaries can also be downloaded from http://ota.tasmota.com/tasmota
 ### Added
 - Animate PWM dimmer brightness LEDs during transitions and with variable brightness [#11076](https://github.com/arendst/Tasmota/issues/11076)
 - Commands ``StateRetain`` and ``InfoRetain`` [#11084](https://github.com/arendst/Tasmota/issues/11084)
+- Command ``LedLinkHeartbeat`` https://github.com/arendst/Tasmota/pull/11087
 
 ### Changed
 - Remove the need to start filenames with a slash (/) in Ufs commands

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -82,7 +82,7 @@ The attached binaries can also be downloaded from http://ota.tasmota.com/tasmota
 ### Added
 - Animate PWM dimmer brightness LEDs during transitions and with variable brightness [#11076](https://github.com/arendst/Tasmota/issues/11076)
 - Commands ``StateRetain`` and ``InfoRetain`` [#11084](https://github.com/arendst/Tasmota/issues/11084)
-- Command ``LedLinkHeartbeat`` https://github.com/arendst/Tasmota/pull/11087
+- Command ``LedLinkHeartbeat`` (https://github.com/arendst/Tasmota/pull/11087)
 
 ### Changed
 - Remove the need to start filenames with a slash (/) in Ufs commands

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -381,6 +381,7 @@
 #define D_CMND_POWERRETAIN "PowerRetain"
 #define D_CMND_SENSORRETAIN "SensorRetain"
 #define D_CMND_PUBLISH "Publish"
+#define D_CMND_LEDLINKHEARTBEAT "LedLinkHeartbeat"
 
 // Commands xdrv_01_webserver.ino
 #define D_CMND_WEBSERVER "Webserver"

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -250,6 +250,7 @@
 #define D_CMND_PULSETIME "PulseTime"
 #define D_CMND_BLINKTIME "BlinkTime"
 #define D_CMND_BLINKCOUNT "BlinkCount"
+#define D_CMND_LEDLINK_HEARTBEAT "LedLinkHeartbeat"
 #define D_CMND_SENSOR "Sensor"
 #define D_CMND_DRIVER "Driver"
 #define D_CMND_SAVEDATA "SaveData"
@@ -383,7 +384,6 @@
 #define D_CMND_INFORETAIN "InfoRetain"
 #define D_CMND_STATERETAIN "StateRetain"
 #define D_CMND_PUBLISH "Publish"
-#define D_CMND_LEDLINKHEARTBEAT "LedLinkHeartbeat"
 
 // Commands xdrv_01_webserver.ino
 #define D_CMND_WEBSERVER "Webserver"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -330,6 +330,7 @@
 #define ZIGBEE_FRIENDLY_NAMES  false             // [SetOption83] Enable Zigbee FriendlyNames instead of ShortAddresses when possible
 #define ZIGBEE_RMV_ZBRECEIVED  false             // [SetOption100] Remove ZbReceived form JSON message
 #define ZIGBEE_INDEX_EP        false             // [SetOption101] Add the source endpoint as suffix to attributes, ex `Power3` instead of `Power` if sent from endpoint 3
+#define LEDLINK_HEARTBEAT      false             // [LedLinkHeartbeat] Linkled will show heartbeat (false = off, true = on)
 
 /*********************************************************************************************\
  * END OF SECTION 1

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -146,7 +146,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t zb_received_as_subtopic : 1;  // bit 4 (v9.2.0.3)   - SetOption118 - (Zigbee) Move ZbReceived from JSON message and into the subtopic replacing "SENSOR" default
     uint32_t zb_omit_json_addr : 1;        // bit 5 (v9.2.0.3)   - SetOption119 - (Zigbee) Remove the device addr from json payload, can be used with zb_topic_fname where the addr is already known from the topic
     uint32_t zb_topic_endpoint : 1;        // bit 6 (v9.2.0.4)   - SetOption120 - (Zigbee) Append endpoint number to topic if device dependent (use with SetOption89)
-    uint32_t spare07 : 1;                  // bit 7
+    uint32_t ledlink_heartbeat : 1;        // bit 7 (v9.3.0.1)   - CMND_LEDLINKHEARTBEAT
     uint32_t spare08 : 1;                  // bit 8
     uint32_t spare09 : 1;                  // bit 9
     uint32_t spare10 : 1;                  // bit 10

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -148,7 +148,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t zb_topic_endpoint : 1;        // bit 6 (v9.2.0.4)   - SetOption120 - (Zigbee) Append endpoint number to topic if device dependent (use with SetOption89)
     uint32_t mqtt_state_retain : 1;        // bit 7 (v9.3.0.1)   - CMND_STATERETAIN
     uint32_t mqtt_info_retain  : 1;        // bit 8 (v9.3.0.1)   - CMND_INFORETAIN
-    uint32_t ledlink_heartbeat : 1;        // bit 9 (v9.3.0.1)   - CMND_LEDLINKHEARTBEAT
+    uint32_t ledlink_heartbeat : 1;        // bit 9 (v9.3.0.1)   - CMND_LEDLINK_HEARTBEAT
     uint32_t spare10 : 1;                  // bit 10
     uint32_t spare11 : 1;                  // bit 11
     uint32_t spare12 : 1;                  // bit 12

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -734,6 +734,7 @@ void SettingsDefaultSet2(void) {
   if (Settings.sleep < 50) {
     Settings.sleep = 50;                // Default to 50 for sleep, for now
   }
+  flag5.ledlink_heartbeat |= LEDLINK_HEARTBEAT;
 
   // Module
   flag.interlock |= APP_INTERLOCK_MODE;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -426,7 +426,8 @@ void CmndStatus(void)
     Response_P(PSTR("{\"" D_CMND_STATUS "\":{\"" D_CMND_MODULE "\":%d,\"" D_CMND_DEVICENAME "\":\"%s\",\"" D_CMND_FRIENDLYNAME "\":[%s],\"" D_CMND_TOPIC "\":\"%s\",\""
                           D_CMND_BUTTONTOPIC "\":\"%s\",\"" D_CMND_POWER "\":%d,\"" D_CMND_POWERONSTATE "\":%d,\"" D_CMND_LEDSTATE "\":%d,\""
                           D_CMND_LEDMASK "\":\"%04X\",\"" D_CMND_SAVEDATA "\":%d,\"" D_JSON_SAVESTATE "\":%d,\"" D_CMND_SWITCHTOPIC "\":\"%s\",\""
-                          D_CMND_SWITCHMODE "\":[%s],\"" D_CMND_BUTTONRETAIN "\":%d,\"" D_CMND_SWITCHRETAIN "\":%d,\"" D_CMND_SENSORRETAIN "\":%d,\"" D_CMND_POWERRETAIN "\":%d}}"),
+                          D_CMND_SWITCHMODE "\":[%s],\"" D_CMND_BUTTONRETAIN "\":%d,\"" D_CMND_SWITCHRETAIN "\":%d,\"" D_CMND_SENSORRETAIN "\":%d,\"" D_CMND_POWERRETAIN "\":%d,\""
+                          D_CMND_LEDLINKHEARTBEAT "\":%d}}"),
                           ModuleNr(), EscapeJSONString(SettingsText(SET_DEVICENAME)).c_str(), stemp, TasmotaGlobal.mqtt_topic,
                           SettingsText(SET_MQTT_BUTTON_TOPIC), TasmotaGlobal.power, Settings.poweronstate, Settings.ledstate,
                           Settings.ledmask, Settings.save_data,
@@ -436,7 +437,8 @@ void CmndStatus(void)
                           Settings.flag.mqtt_button_retain,   // CMND_BUTTONRETAIN
                           Settings.flag.mqtt_switch_retain,   // CMND_SWITCHRETAIN
                           Settings.flag.mqtt_sensor_retain,   // CMND_SENSORRETAIN
-                          Settings.flag.mqtt_power_retain);   // CMND_POWERRETAIN
+                          Settings.flag.mqtt_power_retain,    // CMND_POWERRETAIN
+                          Settings.flag5.ledlink_heartbeat);   // CMND_LIKLEDHEARTBEAT
     MqttPublishPrefixTopic_P(STAT, PSTR(D_CMND_STATUS));
   }
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -27,7 +27,7 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
   D_CMND_SERIALDELIMITER "|" D_CMND_IPADDRESS "|" D_CMND_NTPSERVER "|" D_CMND_AP "|" D_CMND_SSID "|" D_CMND_PASSWORD "|" D_CMND_HOSTNAME "|" D_CMND_WIFICONFIG "|"
   D_CMND_DEVICENAME "|" D_CMND_FRIENDLYNAME "|" D_CMND_SWITCHMODE "|" D_CMND_INTERLOCK "|" D_CMND_TELEPERIOD "|" D_CMND_RESET "|" D_CMND_TIME "|" D_CMND_TIMEZONE "|" D_CMND_TIMESTD "|"
   D_CMND_TIMEDST "|" D_CMND_ALTITUDE "|" D_CMND_LEDPOWER "|" D_CMND_LEDSTATE "|" D_CMND_LEDMASK "|" D_CMND_LEDPWM_ON "|" D_CMND_LEDPWM_OFF "|" D_CMND_LEDPWM_MODE "|"
-  D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|" D_CMND_HUMOFFSET "|" D_CMND_SPEEDUNIT "|" D_CMND_GLOBAL_TEMP "|" D_CMND_GLOBAL_HUM"|" D_CMND_SWITCHTEXT "|"
+  D_CMND_WIFIPOWER "|" D_CMND_TEMPOFFSET "|" D_CMND_HUMOFFSET "|" D_CMND_SPEEDUNIT "|" D_CMND_GLOBAL_TEMP "|" D_CMND_GLOBAL_HUM"|" D_CMND_SWITCHTEXT "|" D_CMND_LEDLINK_HEARTBEAT "|"
 #ifdef USE_I2C
   D_CMND_I2CSCAN "|" D_CMND_I2CDRIVER "|"
 #endif
@@ -54,7 +54,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndSerialDelimiter, &CmndIpAddress, &CmndNtpServer, &CmndAp, &CmndSsid, &CmndPassword, &CmndHostname, &CmndWifiConfig,
   &CmndDevicename, &CmndFriendlyname, &CmndSwitchMode, &CmndInterlock, &CmndTeleperiod, &CmndReset, &CmndTime, &CmndTimezone, &CmndTimeStd,
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndLedPwmOn, &CmndLedPwmOff, &CmndLedPwmMode,
-  &CmndWifiPower, &CmndTempOffset, &CmndHumOffset, &CmndSpeedUnit, &CmndGlobalTemp, &CmndGlobalHum, &CmndSwitchText,
+  &CmndWifiPower, &CmndTempOffset, &CmndHumOffset, &CmndSpeedUnit, &CmndGlobalTemp, &CmndGlobalHum, &CmndSwitchText, &CmndLedLinkHeartbeat,
 #ifdef USE_I2C
   &CmndI2cScan, CmndI2cDriver,
 #endif
@@ -427,7 +427,7 @@ void CmndStatus(void)
                           D_CMND_BUTTONTOPIC "\":\"%s\",\"" D_CMND_POWER "\":%d,\"" D_CMND_POWERONSTATE "\":%d,\"" D_CMND_LEDSTATE "\":%d,\""
                           D_CMND_LEDMASK "\":\"%04X\",\"" D_CMND_SAVEDATA "\":%d,\"" D_JSON_SAVESTATE "\":%d,\"" D_CMND_SWITCHTOPIC "\":\"%s\",\""
                           D_CMND_SWITCHMODE "\":[%s],\"" D_CMND_BUTTONRETAIN "\":%d,\"" D_CMND_SWITCHRETAIN "\":%d,\"" D_CMND_SENSORRETAIN "\":%d,\"" D_CMND_POWERRETAIN "\":%d,\""
-                          D_CMND_INFORETAIN "\":%d,\"" D_CMND_STATERETAIN "\":%d,\"" D_CMND_LEDLINKHEARTBEAT "\":%d}}"),
+                          D_CMND_INFORETAIN "\":%d,\"" D_CMND_STATERETAIN "\":%d,\"" D_CMND_LEDLINK_HEARTBEAT "\":%d}}"),
                           ModuleNr(), EscapeJSONString(SettingsText(SET_DEVICENAME)).c_str(), stemp, TasmotaGlobal.mqtt_topic,
                           SettingsText(SET_MQTT_BUTTON_TOPIC), TasmotaGlobal.power, Settings.poweronstate, Settings.ledstate,
                           Settings.ledmask, Settings.save_data,
@@ -1939,6 +1939,14 @@ void CmndAltitude(void)
     Settings.altitude = XdrvMailbox.payload;
   }
   ResponseCmndNumber(Settings.altitude);
+}
+
+void CmndLedLinkHeartbeat(void)
+{
+  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 1)) {
+    Settings.flag5.ledlink_heartbeat = XdrvMailbox.payload;
+  }
+  ResponseCmndNumber(Settings.flag5.ledlink_heartbeat);
 }
 
 void CmndLedPower(void) {

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -990,7 +990,7 @@ void Every250mSeconds(void)
     }
     else if (Settings.flag5.ledlink_heartbeat)                   // No problems, status led wil show heartbeat if enabled
     {
-      blinkinterval = 7;
+      blinkinterval = 13;
       blinkoffinterval = 1;
       TasmotaGlobal.blinks = 201;
     }

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -992,6 +992,7 @@ void Every250mSeconds(void)
     {
       blinkinterval = 7;
       blinkoffinterval = 1;
+      TasmotaGlobal.blinks = 201;
     }
   }
   if (TasmotaGlobal.blinks || TasmotaGlobal.restart_flag || TasmotaGlobal.ota_state_flag) {


### PR DESCRIPTION
## Description:
The link led is a status led which is often off or on when connections (wifi and mqtt) are established. This option enables the user to use the command "ledlinkheartbeat" with payload 0 or 1 to enable or to disable this feature which is disabled by default to prevent changing default behaviour of the led.

When enabled the linkled will be (depending on the inverted flag) on for 3750ms and off for 250ms continuously when connections are established.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
