### PR TITLE
Fix LM75AD detection on different address then 0x48.

### DIFF
--- a/tasmota/xsns_26_lm75ad.ino
+++ b/tasmota/xsns_26_lm75ad.ino
@@ -56,7 +56,7 @@ void LM75ADDetect(void)
     if (I2cActive(lm75ad_address)) {
       continue; }
     if (!I2cSetDevice(lm75ad_address)) {
-      break; // do not make the next step without a confirmed device on the bus
+      continue; // do not make the next step without a confirmed device on the bus
     }
     uint16_t buffer;
     if (I2cValidRead16(&buffer, lm75ad_address, LM75_THYST_REGISTER)) {


### PR DESCRIPTION
## Description:
If LM75AD is configured with different address then 0x48 it will not be detected.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
