### PR TITLE
Remove links to RC-Switch github

### DIFF
--- a/lib/lib_rf/rc-switch/README.md
+++ b/lib/lib_rf/rc-switch/README.md
@@ -1,26 +1,10 @@
-**Fork of RC-SWITCH by @sui77**
-
-# rc-switch
-[![Build Status](https://travis-ci.org/1technophile/rc-switch.svg?branch=master)](https://travis-ci.org/1technophile/rc-switch)
-
-Use your Arduino or Raspberry Pi to operate remote radio controlled devices
-
-## Download
-https://github.com/1technophile/rc-switch/releases/latest
-
-rc-switch is also listed in the arduino library manager.
-
-## Wiki
-https://github.com/1technophile/rc-switch/wiki
+**Modified Tasmota Fork of RC-SWITCH by @sui77 and @1technophile**
 
 ## Info
-### Send RC codes
 
-Use your Arduino or Raspberry Pi to operate remote radio controlled devices.
-This will most likely work with all popular low cost power outlet sockets. If
-yours doesn't work, you might need to adjust the pulse length.
+This will most likely work with all popular low cost power outlet sockets.
 
-All you need is a Arduino or Raspberry Pi, a 315/433MHz AM transmitter and one
+All you need is a 315/433MHz AM transmitter and one
 or more devices with one of the supported chipsets:
 
  - SC5262 / SC5272
@@ -30,14 +14,3 @@ or more devices with one of the supported chipsets:
  - Intertechno outlets
  - HT6P20X
 
-### Receive and decode RC codes
-
-Find out what codes your remote is sending. Use your remote to control your
-Arduino.
-
-All you need is an Arduino, a 315/433MHz AM receiver (altough there is no
-instruction yet, yes it is possible to hack an existing device) and a remote
-hand set.
-
-For the Raspberry Pi, clone the https://github.com/ninjablocks/433Utils project to
-compile a sniffer tool and transmission commands.

--- a/lib/lib_rf/rc-switch/library.json
+++ b/lib/lib_rf/rc-switch/library.json
@@ -1,21 +1,19 @@
 {
   "name": "rc-switch",
-  "description": "Use your Arduino or Raspberry Pi to operate remote radio controlled devices",
+  "description": "Use ESP8266/ESP32 to operate remote radio controlled devices",
   "keywords": "rf, radio, wireless",
   "authors":
   {
-    "name": "Suat Ozgur"
+    "name": "Theo Arends"
   },
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/sui77/rc-switch.git"
+    "url": "https://github.com/arendst/Tasmota.git"
   },
-  "version": "2.6.2",
+  "version": "1.0.0",
   "frameworks": [
-        "arduino",
-        "energia",
-        "wiringpi"
+        "arduino"
   ],
   "platforms": "*"
 }

--- a/lib/lib_rf/rc-switch/library.properties
+++ b/lib/lib_rf/rc-switch/library.properties
@@ -1,10 +1,10 @@
 name=rc-switch
-version=2.6.2
-author=sui77
-maintainer=sui77,fingolfin <noreply@sui.li>
+version=1.0.0
+author=@sui77 @1technophile and more
+maintainer=Theo Arends
 sentence=Operate 433/315Mhz devices.
-paragraph=Use your Arduino, ESP8266/ESP32 or Raspberry Pi to operate remote radio controlled devices. This will most likely work with all popular low cost power outlet sockets. 
+paragraph=Use ESP8266/ESP32 to operate remote radio controlled devices.
 category=Device Control
-url=https://github.com/sui77/rc-switch
-architectures=avr,esp8266,esp32
+url=https://github.com/arendst/Tasmota
+architectures=esp8266,esp32
 includes=RCSwitch.h


### PR DESCRIPTION
since Tasmota uses his own modified RC-Switch implementation.
Doing this contributors know the have to do PRs here.  

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
