### PR TITLE
allows switch pinmode from output to input

### DIFF
--- a/tasmota/xsns_29_mcp230xx.ino
+++ b/tasmota/xsns_29_mcp230xx.ino
@@ -645,7 +645,7 @@ bool MCP230xx_Command(void)
       return serviced;
     }
 #ifdef USE_MCP230xx_OUTPUT
-    if (Settings.mcp230xx_config[pin].pinmode >= 5) {
+    if (Settings.mcp230xx_config[pin].pinmode >= 5 && paramcount == 2) {
       uint8_t pincmd = Settings.mcp230xx_config[pin].pinmode - 5;
       uint8_t relay_no = 0;
       for (relay_no = 0; relay_no < mcp230xx_pincount ; relay_no ++) {


### PR DESCRIPTION
## Description:

Default `Sensor29` syntax is `Sensor29 pin, pinmode, pullup|outstate, repmode`
However when a MCP pin has been defined as an output (pinmode >= 5), a new Sensor29 syntax is enabled:
`Sensor29 pin, outstate` where outstate can be either:
- 0 or OFF
- 1 or ON
- 2 or T

Which means that once a pin as been defined as an output, it is not possible to reconfigure the pin as an input because the new syntax is process before the original syntax.

Adding a test on paramcount allows to distinguish between the 2 syntaxes and changing the configuration of the pin such as reverting the pin to an input.

Reported by user theRat on Discord #is-that-a-bug
https://discord.com/channels/479389167382691863/490244847568158751/813577991921205249

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
