### PR TITLE
support for vbus

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -912,6 +912,16 @@ void Dump2log(void) {
 #endif
               break;
             }
+          } else if (meter_desc_p[(dump2log&7)-1].type=='v') {
+            // vbus
+            c=SML_SREAD;
+            if (c==EBUS_SYNC) {
+              index = 0;
+            }
+            sprintf(&log_data[index],"%02x ",c);
+            if (index<sizeof(log_data)-3) {
+              index+=3;
+            }
           } else {
             // sml
             if (sml_start==0x77) {

--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -917,6 +917,7 @@ void Dump2log(void) {
             c=SML_SREAD;
             if (c==EBUS_SYNC) {
               index = 0;
+              AddLogData(LOG_LEVEL_INFO, log_data);
             }
             sprintf(&log_data[index],"%02x ",c);
             if (index<sizeof(log_data)-3) {
@@ -939,7 +940,7 @@ void Dump2log(void) {
           }
         }
       }
-      if (index>2) {
+      if (index>2 && (meter_desc_p[(dump2log&7)-1].type!='v')) {
         log_data[index]=0;
         AddLogData(LOG_LEVEL_INFO, log_data);
       }


### PR DESCRIPTION
## Description:

add support for vbus to sml driver
fix a bug that text item (obis and sml) was not send with MQTT


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works on Tasmota core ESP32 V.1.0.5-rc6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
