### PR TITLE
ili9341/2 software configurable

### DIFF
--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
@@ -549,6 +549,9 @@ void Renderer::setDrawMode(uint8_t mode) {
 void Renderer::invertDisplay(boolean i) {
 }
 
+void Renderer::reverseDisplay(boolean i) {
+}
+
 void Renderer::setScrollMargins(uint16_t top, uint16_t bottom) {
 
 }

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -38,6 +38,7 @@ public:
   virtual void pushColors(uint16_t *data, uint16_t len, boolean first);
   virtual void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
   virtual void invertDisplay(boolean i);
+  virtual void reverseDisplay(boolean i);
   virtual void setScrollMargins(uint16_t top, uint16_t bottom);
   virtual void scrollTo(uint16_t y);
   void setDrawMode(uint8_t mode);

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.cpp
@@ -568,6 +568,28 @@ void ILI9341_2::invertDisplay(boolean i) {
   SPI_END_TRANSACTION();
 }
 
+void ILI9341_2::reverseDisplay(boolean i) {
+  SPI_BEGIN_TRANSACTION();
+  ILI9341_2_CS_LOW
+  if (i) {
+    writecmd(ILI9341_2_FRMCTR1);
+    spiwrite(0x00);
+    spiwrite(0x13);
+    writecmd(ILI9341_2_MADCTL);
+    spiwrite(0x01);
+    spiwrite(0x08);
+  } else {
+    writecmd(ILI9341_2_FRMCTR1);
+    spiwrite(0x00);
+    spiwrite(0x18);
+    writecmd(ILI9341_2_MADCTL);
+    spiwrite(0x01);
+    spiwrite(0x48);
+  }
+  ILI9341_2_CS_HIGH
+  SPI_END_TRANSACTION();
+}
+
 void ili9342_dimm(uint8_t dim);
 
 // dimmer 0-100

--- a/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
+++ b/lib/lib_display/ILI9341-gemu-1.0/ILI9341_2.h
@@ -138,6 +138,7 @@ class ILI9341_2 : public Renderer {
   void dim(uint8_t dim);
   void pushColors(uint16_t *data, uint16_t len, boolean first);
   void invertDisplay(boolean i);
+  void reverseDisplay(boolean i);
   void spiwrite(uint8_t c);
   void spiwrite16(uint16_t c);
   void spiwrite32(uint32_t c);

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -327,6 +327,18 @@ typedef struct {
   uint8_t dpid = 0;
 } TuyaFnidDpidMap;
 
+typedef union {
+  uint8_t data;
+  struct {
+  uint8_t ilimode : 3;
+  uint8_t Invert : 1;
+  uint8_t spare2 : 1;
+  uint8_t spare3 : 1;
+  uint8_t spare4 : 1;
+  uint8_t spare5 : 1;
+  };
+} DisplayOptions;
+
 const uint32_t settings_text_size = 699;   // Settings.text_pool[size] = Settings.display_model (2D2) - Settings.text_pool (017)
 const uint8_t MAX_TUYA_FUNCTIONS = 16;
 
@@ -355,7 +367,6 @@ struct {
   uint8_t       text_pool_290[66];         // 290
 
   // End of single char array of 698 chars max ****************
-
   uint8_t       display_model;             // 2D2
   uint8_t       display_mode;              // 2D3
   uint8_t       display_refresh;           // 2D4
@@ -375,8 +386,9 @@ struct {
   uint8_t       param[PARAM8_SIZE];        // 2FC  SetOption32 .. SetOption49
   int16_t       toffset[2];                // 30E
   uint8_t       display_font;              // 312
+  DisplayOptions  display_options;         // 313
 
-  uint8_t       free_313[44];              // 313
+  uint8_t       free_314[43];              // 314
 
   uint8_t       tuyamcu_topic;             // 33F  Manage tuyaSend topic. ex_energy_power_delta on 6.6.0.20, replaced on 8.5.0.1
   uint16_t      domoticz_update_timer;     // 340

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -2630,7 +2630,7 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 2       IO                  GPIO2, SPKR_DATA
     AGPIO(GPIO_USER),            // 3       IO     RXD0         GPIO3, U0RXD
     AGPIO(GPIO_SDCARD_CS),       // 4       IO                  GPIO4, SPI_CS_CARD
-    0,                           // 5       IO                  GPIO5, SPI_CS_LCD
+    AGPIO(GPIO_ILI9341_CS),      // 5       IO                  GPIO5, SPI_CS_LCD
                                  // 6       IO                  GPIO6, Flash CLK
                                  // 7       IO                  GPIO7, Flash D0
                                  // 8       IO                  GPIO8, Flash D1
@@ -2640,7 +2640,7 @@ const mytmplt kModules[] PROGMEM = {
     0,                           // 12      (I)O                GPIO12, SPKR_CLK
     AGPIO(GPIO_USER),            // 13      IO                  GPIO13, ADC2_CH4, TOUCH4, RTC_GPIO14, MTCK, HSPID, HS2_DATA3, SD_DATA3, EMAC_RX_ER
     AGPIO(GPIO_USER),            // 14      IO                  GPIO14, ADC2_CH6, TOUCH6, RTC_GPIO16, MTMS, HSPICLK, HS2_CLK, SD_CLK, EMAC_TXD2
-    0,                           // 15      (I)O                GPIO15, SPI_DC_LCD
+    AGPIO(GPIO_ILI9341_DC),      // 15      (I)O                GPIO15, SPI_DC_LCD
     0,                           // 16      IO                  GPIO16, PSRAM_CS
     0,                           // 17      IO                  GPIO17, PSRAM_CLK
     AGPIO(GPIO_SPI_CLK),         // 18      IO                  GPIO18, SPI_CLK

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -19,7 +19,7 @@
 
 #ifdef USE_SPI
 #ifdef USE_DISPLAY
-#if (defined(USE_DISPLAY_ILI9341) || defined(USE_DISPLAY_ILI9342))
+#ifdef USE_DISPLAY_ILI9341
 
 #define XDSP_04                4
 
@@ -37,21 +37,22 @@ uint8_t ili9342_ctouch_counter = 0;
 uint8_t ili9342_ctouch_counter = 0;
 #endif // USE_FT5206
 
+
 bool tft_init_done = false;
 
+#define ILI9341_ID 1
+#define ILI9342_ID 2
+
+//Settings.display_options.ilimode = ILI9341_ID;
 
 /*********************************************************************************************/
 
 void ILI9341_InitDriver()
 {
 
-#if (defined(USE_M5STACK_CORE2) || defined(USE_M5STACK_CORE_BASIC))
-  if (TasmotaGlobal.spi_enabled) {
-#else
   // There are displays without CS
   if (PinUsed(GPIO_ILI9341_CS) || PinUsed(GPIO_ILI9341_DC) &&
       (TasmotaGlobal.spi_enabled || TasmotaGlobal.soft_spi_enabled)) {
-#endif
 
     Settings.display_model = XDSP_04;
 
@@ -65,35 +66,25 @@ void ILI9341_InitDriver()
     // disable screen buffer
     buffer = NULL;
 
-#ifdef USE_DISPLAY_ILI9341
-    uint8_t dtype = 1;
-#else
-    uint8_t dtype = 3; // sign ili9342 with variable spi pins
-#endif // USE_DISPLAY_ILI9341
+    if (!Settings.display_options.ilimode) {
+      Settings.display_options.ilimode = ILI9341_ID;
+    }
 
     // default colors
     fg_color = ILI9341_WHITE;
     bg_color = ILI9341_BLACK;
 
-#ifdef USE_M5STACK_CORE2
-    // fixed pins on m5stack core2
-    ili9341_2 = new ILI9341_2(5, -2, 15, -2);
-#elif defined(USE_M5STACK_CORE_BASIC)
-    // int8_t cs, int8_t res, int8_t dc, int8_t bp)
-    ili9341_2 = new ILI9341_2(14, 33, 27, 32);
-#else
     // check for special case with 2 SPI busses (ESP32 bitcoin)
     if (TasmotaGlobal.soft_spi_enabled) {
       // Init renderer, may use hardware spi, however we use SSPI defintion because SD card uses SPI definition  (2 spi busses)
       if (PinUsed(GPIO_SSPI_MOSI) && PinUsed(GPIO_SSPI_MISO) && PinUsed(GPIO_SSPI_SCLK)) {
-        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SSPI_MOSI), Pin(GPIO_SSPI_MISO), Pin(GPIO_SSPI_SCLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 2, dtype);
+        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SSPI_MOSI), Pin(GPIO_SSPI_MISO), Pin(GPIO_SSPI_SCLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 2, Settings.display_options.ilimode & 3);
       }
     } else if (TasmotaGlobal.spi_enabled) {
       if (PinUsed(GPIO_ILI9341_DC)) {
-        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SPI_MOSI), Pin(GPIO_SPI_MISO), Pin(GPIO_SPI_CLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 1, dtype);
+        ili9341_2 = new ILI9341_2(Pin(GPIO_ILI9341_CS), Pin(GPIO_SPI_MOSI), Pin(GPIO_SPI_MISO), Pin(GPIO_SPI_CLK), Pin(GPIO_OLED_RESET), Pin(GPIO_ILI9341_DC), Pin(GPIO_BACKLIGHT), 1, Settings.display_options.ilimode & 3);
       }
     }
-#endif // USE_M5STACK_CORE2
 
     if (ili9341_2 == nullptr) {
       AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI934x invalid GPIOs"));
@@ -102,19 +93,20 @@ void ILI9341_InitDriver()
 
     ili9341_2->init(Settings.display_width, Settings.display_height);
     renderer = ili9341_2;
+
     renderer->DisplayInit(DISPLAY_INIT_MODE, Settings.display_size, Settings.display_rotate, Settings.display_font);
     renderer->dim(Settings.display_dimmer);
+
+    if (Settings.display_options.ilimode & 4) {
+      renderer->reverseDisplay(1);
+    }
 
 #ifdef SHOW_SPLASH
     // Welcome text
     renderer->setTextFont(2);
     renderer->setTextSize(1);
     renderer->setTextColor(ILI9341_WHITE, ILI9341_BLACK);
-#ifdef USE_DISPLAY_ILI9341
-    renderer->DrawStringAt(50, (Settings.display_height/2)-12, "ILI9341 TFT!", ILI9341_WHITE, 0);
-#else
-    renderer->DrawStringAt(50, (Settings.display_height/2)-12, "ILI9342 TFT!", ILI9341_WHITE, 0);
-#endif
+    renderer->DrawStringAt(50, (Settings.display_height/2)-12, (Settings.display_options.ilimode & 3)==ILI9341_ID?"ILI9341 TFT!":"ILI9342 TFT!", ILI9341_WHITE, 0);
     delay(1000);
 #endif // SHOW_SPLASH
 
@@ -140,17 +132,14 @@ void ILI9341_InitDriver()
 #endif // ESP32
 
 #ifdef USE_XPT2046
-	Touch_Init(Pin(GPIO_XPT2046_CS));
+	  Touch_Init(Pin(GPIO_XPT2046_CS));
 #endif
 
     tft_init_done = true;
-#ifdef USE_DISPLAY_ILI9341
     AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI9341"));
-#else
-    AddLog(LOG_LEVEL_INFO, PSTR("DSP: ILI9342"));
-#endif
   }
 }
+
 
 void core2_disp_pwr(uint8_t on);
 void core2_disp_dim(uint8_t dim);
@@ -235,12 +224,12 @@ ili9342_ctouch_counter++;
   if (2 == ili9342_ctouch_counter) {
     // every 100 ms should be enough
     ili9342_ctouch_counter = 0;
-	
     Touch_Check(TS_RotConvert);
   }
 }
 #endif // USE_TOUCH_BUTTONS
 #endif // USE_FT5206
+
 
 
 #ifdef USE_DISPLAY_MODES1TO5
@@ -274,7 +263,7 @@ bool Ili9341Header(void) {
 void Ili9341InitMode(void) {
 //  renderer->setRotation(Settings.display_rotate);  // 0
 #ifdef USE_DISPLAY_ILI9341
-  renderer->invertDisplay(0);
+//  renderer->invertDisplay(0);
 #endif
   renderer->fillScreen(ILI9341_BLACK);
   renderer->setTextWrap(false);         // Allow text to run off edges

--- a/tasmota/xdsp_04_ili9341.ino
+++ b/tasmota/xdsp_04_ili9341.ino
@@ -97,10 +97,6 @@ void ILI9341_InitDriver()
     renderer->DisplayInit(DISPLAY_INIT_MODE, Settings.display_size, Settings.display_rotate, Settings.display_font);
     renderer->dim(Settings.display_dimmer);
 
-    if (Settings.display_options.ilimode & 4) {
-      renderer->reverseDisplay(1);
-    }
-
 #ifdef SHOW_SPLASH
     // Welcome text
     renderer->setTextFont(2);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #11189

now ili9341/2 ist treated as ili9341 CS and DC
displayilimode the sets the display to mode for chip type 1 or 2 (3 = mode 2 + reinit spi )
displayinvert 0,1 inverts ili display colors

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
