### PR TITLE
Zigbee allow numbers as string

### DIFF
--- a/lib/default/jsmn-shadinger-1.0/src/JsonParser.h
+++ b/lib/default/jsmn-shadinger-1.0/src/JsonParser.h
@@ -114,6 +114,9 @@ public:
   JsonParserObject getObject(void) const;
   JsonParserArray getArray(void) const;
 
+  // general parser from string to int/hex/float
+  static double json_strtof(const char* s);
+
 public:
   // the following should be 'protected' but then it can't be accessed by iterators
   const jsmntok_t   * t;

--- a/tasmota/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/xdrv_23_zigbee_1z_libs.ino
@@ -191,6 +191,9 @@ public:
   int32_t getInt(void) const;
   uint32_t getUInt(void) const;
   bool getBool(void) const;
+  // optimistically try to get any value as literal or in string - double to not lose precision for 32 bits
+  double getOptimisticDouble(void) const;
+  //
   const SBuffer * getRaw(void) const;
 
   // always return a point to a string, if not defined then empty string.
@@ -437,6 +440,17 @@ JsonGeneratorArray & Z_attribute::newJsonArray(void) {
 }
 
 // get num values
+double Z_attribute::getOptimisticDouble(void) const {
+  switch (type) {
+    case Za_type::Za_bool:
+    case Za_type::Za_uint:    return (double) val.uval32;
+    case Za_type::Za_int:     return (double) val.ival32;
+    case Za_type::Za_float:   return (double) val.fval;
+    case Za_type::Za_str:     return JsonParserToken::json_strtof(val.sval);
+    default:                  return 0.0;
+  }
+}
+
 float Z_attribute::getFloat(void) const {
   switch (type) {
     case Za_type::Za_bool:

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -235,7 +235,7 @@ void ZbApplyMultiplier(double &val_d, int8_t multiplier) {
 // Write Tuya-Moes attribute
 //
 bool ZbTuyaWrite(SBuffer & buf, const Z_attribute & attr) {
-  double val_d = attr.getFloat();
+  double val_d = attr.getOptimisticDouble();
   const char * val_str = attr.getStr();
 
   if (attr.key_is_str) { return false; }    // couldn't find attr if so skip
@@ -294,7 +294,7 @@ bool ZbTuyaWrite(SBuffer & buf, const Z_attribute & attr) {
 // Send Attribute Write, apply mutlipliers before
 //
 bool ZbAppendWriteBuf(SBuffer & buf, const Z_attribute & attr, bool prepend_status_ok) {
-  double val_d = attr.getFloat();
+  double val_d = attr.getOptimisticDouble();
   const char * val_str = attr.getStr();
 
   if (attr.key_is_str) { return false; }    // couldn't find attr if so skip


### PR DESCRIPTION
## Description:

Allow numbers to be passed as JSON numbers or as strings in Write commands.

For example, both commands are valid: (previously only the first one would work)
```
ZbSend {"Device":"TRV","Write":{"TuyaTempTarget":20.5}}
ZbSend {"Device":"TRV","Write":{"TuyaTempTarget":"20.5"}}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
