### PR TITLE
Make some setoptions overridable

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -275,8 +275,11 @@
 #define KEY_SWAP_DOUBLE_PRESS  false             // [SetOption11] Swap button single and double press functionality
 #define KEY_ONLY_SINGLE_PRESS  false             // [SetOption13] Enable only single press to speed up button press recognition
 
+#define MQTT_BUTTONS           false             // [SetOption73] Detach buttons from relays and send multi-press and hold MQTT messages instead
+
 #define SWITCH_DEBOUNCE_TIME   50                // [SwitchDebounce] Number of mSeconds switch press debounce time
 #define SWITCH_MODE            TOGGLE            // [SwitchMode] TOGGLE, FOLLOW, FOLLOW_INV, PUSHBUTTON, PUSHBUTTON_INV, PUSHBUTTONHOLD, PUSHBUTTONHOLD_INV, PUSHBUTTON_TOGGLE, TOGGLEMULTI, FOLLOWMULTI, FOLLOWMULTI_INV (the wall switch state)
+#define MQTT_SWITCHES          false             // [SetOption114] Detach switches from relays and send MQTT messages instead
 
 #define TEMP_CONVERSION        false             // [SetOption8] Return temperature in (false = Celsius or true = Fahrenheit)
 #define PRESSURE_CONVERSION    false             // [SetOption24] Return pressure in (false = hPa or true = mmHg)
@@ -330,6 +333,7 @@
 #define SHUTTER_SUPPORT        false             // [SetOption80] Enable shutter support
 #define PCF8574_INVERT_PORTS   false             // [SetOption81] Invert all ports on PCF8574 devices
 #define ZIGBEE_FRIENDLY_NAMES  false             // [SetOption83] Enable Zigbee FriendlyNames instead of ShortAddresses when possible
+#define ZIGBEE_DISTINCT_TOPICS false             // [SetOption89] Enable unique device topic based on Zigbee device ShortAddr
 #define ZIGBEE_RMV_ZBRECEIVED  false             // [SetOption100] Remove ZbReceived form JSON message
 #define ZIGBEE_INDEX_EP        false             // [SetOption101] Add the source endpoint as suffix to attributes, ex `Power3` instead of `Power` if sent from endpoint 3
 
@@ -515,6 +519,9 @@
 
 // -- I2C sensors ---------------------------------
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
+#define I2CDRIVERS_0_31        0xFFFFFFFF          // Enable I2CDriver0  to I2CDriver31
+#define I2CDRIVERS_32_63       0xFFFFFFFF          // Enable I2CDriver32 to I2CDriver63
+#define I2CDRIVERS_64_95       0xFFFFFFFF          // Enable I2CDriver64 to I2CDriver95
 
 #ifdef USE_I2C
 //  #define USE_SHT                                // [I2cDriver8] Enable SHT1X sensor (+1k4 code)

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -726,6 +726,7 @@ void SettingsDefaultSet2(void) {
   flag3.no_power_feedback |= APP_NO_RELAY_SCAN;
   flag3.fast_power_cycle_disable |= APP_DISABLE_POWERCYCLE;
   flag3.bootcount_update |= DEEPSLEEP_BOOTCOUNT;
+  flag3.mqtt_buttons |= MQTT_BUTTONS;
   Settings.save_data = SAVE_DATA;
   Settings.param[P_BACKLOG_DELAY] = MIN_BACKLOG_DELAY;
   Settings.param[P_BOOT_LOOP_OFFSET] = BOOT_LOOP_OFFSET;  // SetOption36
@@ -833,6 +834,7 @@ void SettingsDefaultSet2(void) {
   flag.mqtt_sensor_retain |= MQTT_SENSOR_RETAIN;
   flag5.mqtt_info_retain |= MQTT_INFO_RETAIN;
   flag5.mqtt_state_retain |= MQTT_STATE_RETAIN;
+  flag5.mqtt_switches |= MQTT_SWITCHES;
 //  flag.mqtt_serial |= 0;
   flag.device_index_enable |= MQTT_POWER_FORMAT;
   flag3.time_append_timezone |= MQTT_APPEND_TIMEZONE;
@@ -1058,6 +1060,7 @@ void SettingsDefaultSet2(void) {
   flag3.shutter_mode |= SHUTTER_SUPPORT;
   flag3.pcf8574_ports_inverted |= PCF8574_INVERT_PORTS;
   flag4.zigbee_use_names |= ZIGBEE_FRIENDLY_NAMES;
+  flag4.zigbee_distinct_topics |= ZIGBEE_DISTINCT_TOPICS;
   flag4.remove_zbreceived |= ZIGBEE_RMV_ZBRECEIVED;
   flag4.zb_index_ep |= ZIGBEE_INDEX_EP;
   flag4.mqtt_tls |= MQTT_TLS_ENABLED;
@@ -1072,6 +1075,7 @@ void SettingsDefaultSet2(void) {
   Settings.flag2 = flag2;
   Settings.flag3 = flag3;
   Settings.flag4 = flag4;
+  Settings.flag5 = flag5;
 }
 
 /********************************************************************************************/
@@ -1102,9 +1106,9 @@ void SettingsDefaultWebColor(void) {
 }
 
 void SettingsEnableAllI2cDrivers(void) {
-  Settings.i2c_drivers[0] = 0xFFFFFFFF;
-  Settings.i2c_drivers[1] = 0xFFFFFFFF;
-  Settings.i2c_drivers[2] = 0xFFFFFFFF;
+  Settings.i2c_drivers[0] = I2CDRIVERS_0_31;
+  Settings.i2c_drivers[1] = I2CDRIVERS_32_63;
+  Settings.i2c_drivers[2] = I2CDRIVERS_64_95;
 }
 
 /********************************************************************************************/


### PR DESCRIPTION
## Description:

https://github.com/arendst/Tasmota/discussions/11194
https://github.com/arendst/Tasmota/discussions/11195
+ my own wish on i2cdriver

Make overridable with:

```
#define MQTT_BUTTONS          true             // [SetOption73] Detach buttons from relays and send multi-press and hold MQTT messages instead
#define MQTT_SWITCHES          true             // [SetOption114] Detach switches from relays and send MQTT messages instead

#define ZIGBEE_DISTINCT_TOPICS true             // [SetOption89] Enable unique device topic based on Zigbee device ShortAddr

#define I2CDRIVERS_0_31        0xAAAAAAAA          // Enable I2CDriver0  to I2CDriver31
#define I2CDRIVERS_32_63       0x55555555          // Enable I2CDriver32 to I2CDriver63
#define I2CDRIVERS_64_95       0xA5A5A5A5          // Enable I2CDriver64 to I2CDriver95
```

Should have very limited impact on code size when override is used. No impact if not used ( |= false is optimized to no-op).

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
