### PR TITLE
Changes for ESP32-S2

### DIFF
--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -4,21 +4,23 @@
       "ldscript": "esp32s2_out.ld"
     },
     "core": "esp32",
-    "mcu": "esp32s2",
-    "extra_flags": "-Desp32S2_dev_module",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "qio",
+    "flash_mode": "dio",
     "mcu": "esp32s2",
     "variant": "esp32s2"
   },
   "connectivity": [
     "wifi"
   ],
+  "debug": {
+    "openocd_target": "esp32s2.cfg"
+  },
   "frameworks": [
+    "espidf",
     "arduino"
   ],
-  "name": "ESP32S2 Dev Module",
+  "name": "Espressif ESP32-S2-Saola-1",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,
@@ -26,6 +28,6 @@
     "require_upload_port": true,
     "speed": 460800
   },
-  "url": "https://espressif.com",
-  "vendor": "espressif"
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/hw-reference/esp32s2/user-guide-saola-1-v1.2.html",
+  "vendor": "Espressif"
 }

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -171,6 +171,7 @@ build_flags                 = ${common32.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32
 board                       = esp32s2
+board_build.flash_mode      = qio
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/s2-1.0.5-rc6/esp32-s2-1.0.5-rc6.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0


### PR DESCRIPTION
## Description:

removes SHA256 error messages when booting ESP32-S2. Still bootlooping Tasmota!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
