### PR TITLE
Fix ESP32 Flash BAT for Odroid and Core2

### DIFF
--- a/tools/Esptool/Odroid_go_and_core2/Core2_flash.bat
+++ b/tools/Esptool/Odroid_go_and_core2/Core2_flash.bat
@@ -1,1 +1,1 @@
-esptool.py --chip esp32 --baud 2000000 --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect 0x1000 bootloader_qio_80m.bin 0x8000 partitions_spiffs_12M.bin 0xe000 boot_app0.bin 0x10000 tasmota32-core2.bin
+esptool.py --chip esp32 --baud 2000000 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect 0x1000 bootloader_qio_80m.bin 0x8000 partitions_spiffs_12M.bin 0xe000 boot_app0.bin 0x10000 tasmota32-core2.bin

--- a/tools/Esptool/Odroid_go_and_core2/Odroid_flash.bat
+++ b/tools/Esptool/Odroid_go_and_core2/Odroid_flash.bat
@@ -1,1 +1,1 @@
-esptool.py --chip esp32 --baud 2000000 --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size detect 0x1000 bootloader_qio_80m.bin 0x8000 partitions_spiffs_12M.bin 0xe000 boot_app0.bin 0x10000 tasmota32-odroid.bin
+esptool.py --chip esp32 --baud 2000000 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect 0x1000 bootloader_qio_80m.bin 0x8000 partitions_spiffs_12M.bin 0xe000 boot_app0.bin 0x10000 tasmota32-odroid.bin


### PR DESCRIPTION
## Description:

For flash mode dio has to be used. Even when later mode qio is active and used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
