### PR TITLE
Fix WS2812 ESP32

### DIFF
--- a/tasmota/xlgt_01_ws2812.ino
+++ b/tasmota/xlgt_01_ws2812.ino
@@ -123,6 +123,113 @@ void (* const Ws2812Command[])(void) PROGMEM = {
 
 #endif  // No USE_WS2812_DMA
 
+#ifdef ESP32
+//
+// Below is a quick work-around to ESP32 gcc that prevents templated methods to be in IRAM unless explicitly marked per specialization
+// It will work only for the default WS2812 (800KHz) and inverted and non-inverted
+//
+template <>
+void IRAM_ATTR NeoEspBitBangBase<NeoEspSpeed800Mhz, NeoEspPinset>::send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin)
+{
+    const uint32_t pinRegister = _BV(pin);
+    uint8_t mask = 0x80;
+    uint8_t subpix = *pixels++;
+    uint32_t cyclesStart = 0; // trigger emediately
+    uint32_t cyclesNext = 0;
+
+    for (;;)
+    {
+        // do the checks here while we are waiting on time to pass
+        uint32_t cyclesBit = NeoEspSpeed800Mhz::T0H;
+        if (subpix & mask)
+        {
+            cyclesBit = NeoEspSpeed800Mhz::T1H;
+        }
+
+        // after we have done as much work as needed for this next bit
+        // now wait for the HIGH
+        while (((cyclesStart = getCycleCount()) - cyclesNext) < NeoEspSpeed800Mhz::Period);
+
+        // set pin state
+        NeoEspPinset::setPin(pinRegister);
+
+        // wait for the LOW
+        while ((getCycleCount() - cyclesStart) < cyclesBit);
+
+        // reset pin start
+        NeoEspPinset::resetPin(pinRegister);
+
+        cyclesNext = cyclesStart;
+
+        // next bit
+        mask >>= 1;
+        if (mask == 0)
+        {
+            // no more bits to send in this byte
+            // check for another byte
+            if (pixels >= end)
+            {
+                // no more bytes to send so stop
+                break;
+            }
+            // reset mask to first bit and get the next byte
+            mask = 0x80;
+            subpix = *pixels++;
+        }
+    }
+}
+template <>
+void IRAM_ATTR NeoEspBitBangBase<NeoEspSpeed800Mhz, NeoEspPinsetInverted>::send_pixels(uint8_t* pixels, uint8_t* end, uint8_t pin)
+{
+    const uint32_t pinRegister = _BV(pin);
+    uint8_t mask = 0x80;
+    uint8_t subpix = *pixels++;
+    uint32_t cyclesStart = 0; // trigger emediately
+    uint32_t cyclesNext = 0;
+
+    for (;;)
+    {
+        // do the checks here while we are waiting on time to pass
+        uint32_t cyclesBit = NeoEspSpeed800Mhz::T0H;
+        if (subpix & mask)
+        {
+            cyclesBit = NeoEspSpeed800Mhz::T1H;
+        }
+
+        // after we have done as much work as needed for this next bit
+        // now wait for the HIGH
+        while (((cyclesStart = getCycleCount()) - cyclesNext) < NeoEspSpeed800Mhz::Period);
+
+        // set pin state
+        NeoEspPinsetInverted::setPin(pinRegister);
+
+        // wait for the LOW
+        while ((getCycleCount() - cyclesStart) < cyclesBit);
+
+        // reset pin start
+        NeoEspPinsetInverted::resetPin(pinRegister);
+
+        cyclesNext = cyclesStart;
+
+        // next bit
+        mask >>= 1;
+        if (mask == 0)
+        {
+            // no more bits to send in this byte
+            // check for another byte
+            if (pixels >= end)
+            {
+                // no more bytes to send so stop
+                break;
+            }
+            // reset mask to first bit and get the next byte
+            mask = 0x80;
+            subpix = *pixels++;
+        }
+    }
+}
+#endif // ESP32
+
 NeoPixelBus<selectedNeoFeatureType, selectedNeoSpeedType> *strip = nullptr;
 
 struct WsColor {


### PR DESCRIPTION
## Description:

The latest version of GCC prevent the assignment of attributes to methods and requires to specify for each specialization.
See https://stackoverflow.com/questions/36279162/section-attribute-of-a-function-template-is-silently-ignored-in-gcc

This creates a fundamental problem with NeoPixelBus BitBang implementation, and prevents the BitBang code from being into IRAM, which triggers display errors because of timing inaccuracies.

I've tried many options, but the only work-around for now it to explicitly create specialization of the `send_pixels` method for each option. This creates duplication of source code, but has no impact on compiled code.

Currently this work-around is only applied to `WS2812` inverted and non-inverted.

There will be more improvements to make `I2S` and `RMT` schemes available too, which are required for long led stripes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
