### PR TITLE
workaround for Platformio PSRAM issue...

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -34,7 +34,9 @@ lib_ignore              =
 extends                 = env:tasmota32
 board                   = esp32cam
 board_build.f_cpu       = 240000000L
-build_flags             = ${common32.build_flags} -DFIRMWARE_WEBCAM
+board_build.flash_mode  = qio
+board_build.f_flash     = 80000000L
+build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_WEBCAM
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-odroidgo]
@@ -45,7 +47,7 @@ board_build.flash_mode  = qio
 board_build.f_flash     = 80000000L
 upload_speed            = 2000000
 board_build.partitions  = esp32_partition_app1984k_spiffs12M.csv
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DFIRMWARE_ODROID_GO
+build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-core2]
@@ -56,7 +58,7 @@ board_build.flash_mode  = qio
 board_build.f_flash     = 80000000L
 upload_speed            = 2000000
 board_build.partitions  = esp32_partition_app1984k_spiffs12M.csv
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -DFIRMWARE_M5STACK_CORE2
+build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_M5STACK_CORE2
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32-bluetooth]


### PR DESCRIPTION
not including needed psram-workaround libraries.
Fixed in upcoming next Arduino ESP32 release with merged PR https://github.com/espressif/arduino-esp32/pull/4911/files
See https://community.platformio.org/t/very-bad-performance-if-i-compile-the-example-for-esp32-cam/19730/17 too.
Thx @jsg who addressed this in Discord chat.

This issue does not affect all boards with PSRAM. Many boards run without.
Adding this fix does not harm this boards.

Tested with Ai-Tinker ESP32-CAM (works without and with this change)

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
