### PR TITLE
support for apple homekit on esp32

### DIFF
--- a/lib/libesp32/ESP32-HomeKit/.gitattributes
+++ b/lib/libesp32/ESP32-HomeKit/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/lib/libesp32/ESP32-HomeKit/.gitignore
+++ b/lib/libesp32/ESP32-HomeKit/.gitignore
@@ -1,0 +1,32 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/lib/libesp32/ESP32-HomeKit/LICENSE
+++ b/lib/libesp32/ESP32-HomeKit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Mixiaoxiao (Wang Bin)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/libesp32/ESP32-HomeKit/README.md
+++ b/lib/libesp32/ESP32-HomeKit/README.md
@@ -1,0 +1,31 @@
+# Arduino-HomeKit-ESP
+Arduino library version of espressif's official [esp-homekit-sdk](https://github.com/espressif/esp-homekit-sdk).
+
+Currently, only for ESP32 with hardware acceleration. ESP32-S2, ESP32-C3 and future IDF based chips are all on the way.
+
+Tested on my ESP32 board, works fine. 
+
+The performance is awesome!!!
+
+The serial log is [here](https://raw.github.com/Mixiaoxiao/Arduino-HomeKit-ESP/master/extras/SerialLog.txt)
+
+## Setup code
+
+``111-11-111``
+
+## Manual Installation 
+
+Refer to the official guide: [Manual installation](https://www.arduino.cc/en/guide/libraries#toc5)
+Note: this library will not publish the release version for Arduino IDE. 
+
+
+#### Manual Installation for Windows
+
+1. Click on _"Clone or Download"_ button, then click _"[Download ZIP](https://github.com/Mixiaoxiao/Arduino-HomeKit-ESP/archive/master.zip)"_ on the page.
+1. Extract the contents of the downloaded zip file.
+1. Rename the extracted folder to _"Arduino-HomeKit-ESP"_.
+1. Move this folder to your libraries directory. (under windows: `C:\Users\<USERNAME>\Documents\Arduino\libraries\`)
+1. Restart your Arduino IDE.
+1. Check out the examples.
+
+

--- a/lib/libesp32/ESP32-HomeKit/SerialLog.txt
+++ b/lib/libesp32/ESP32-HomeKit/SerialLog.txt
@@ -1,0 +1,43 @@
+Boot OK
+WiFi connecting...
+...............
+WiFi connected, IP: 192.168.6.134
+[   1657] Keystore initialised
+[   1662] Accessory is not Paired with any controller
+[   1664] Database initialised. Accessory Device ID: 90:60:09:AB:F0:1D 
+[   1664] HAP Initialization succeeded. Version : 4.0
+[   1670] MFi auth not supported. Falling back to HAP_MFI_AUTH_NONE
+[   1675] Setup ID: ES32
+[   1681] HAP Main Loop Started
+[   1684] mDNS initialised
+[   1684] Registering HomeKit web handlers
+[   1687] Announcing _hap._tcp mDNS service
+[  10032] ######## Starting Pair Setup ########
+[  10032] Pair Setup M1 Received
+[  12073] Pair Setup M2 Successful
+[  12501] Pair Setup M3 Received
+[  14540] Using pair-setup without MFi.
+[  14540] Pair Setup M4 Successful
+[  14929] Pair Setup M5 Received
+[  15023] Pair Setup Successful for CF87DA6B-7078-44BB-AC04-27B6F2B26D37
+[  15027] Updated state number to 11
+[  15028] Cleaning Pair Setup Context
+[  15032] Re-announcing _hap._tcp mDNS service
+[  16205] ######## Starting Pair Verify ########
+[  16205] Pair Verify M1 Received
+[  16327] Pair Verify M2 Successful
+[  16385] Pair Verify M3 Received
+[  16444] HomeKit Session active
+[  16445] Pair Verify Successful for CF87DA6B-7078-44BB-AC04-27B6F2B26D37
+[  16781] Events Enabled for aid=1 iid=12
+[  16781] Events Enabled for aid=1 iid=13
+[  17080] Events Enabled for aid=1 iid=12
+[  17080] Events Enabled for aid=1 iid=13
+[  22311] ######## Starting Pair Verify ########
+[  22311] Pair Verify M1 Received
+[  22435] Pair Verify M2 Successful
+[  22470] Pair Verify M3 Received
+[  22528] HomeKit Session active
+[  22528] Pair Verify Successful for CF87DA6B-7078-44BB-AC04-27B6F2B26D37
+[  25069] Value Changed
+[  26605] Value Changed

--- a/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/HomeKit_IDF.ino
+++ b/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/HomeKit_IDF.ino
@@ -1,0 +1,20 @@
+#include "Arduino.h"
+#include "wifi_info.h"
+#include "hap.h"
+
+extern "C" void homekit_main();
+
+void setup() {
+	Serial.begin(115200);
+	Serial.println("Boot OK");
+	wifi_connect();
+	// Useful apis: (see hap.h)
+	// hap_reset_to_factory();
+	// hap_reset_homekit_data();
+	// hap_reset_pairings();
+	homekit_main();
+	vTaskDelete(NULL);
+}
+
+void loop() {
+}

--- a/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/homekit_main.c
+++ b/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/homekit_main.c
@@ -1,0 +1,244 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/* HomeKit Smart Outlet Example
+*/
+#include <stdio.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/queue.h>
+#include <esp_log.h>
+#include <driver/gpio.h>
+
+#include <hap.h>
+
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+
+//#include <app_wifi.h>
+//#include <app_hap_setup_payload.h>
+
+static const char *TAG = "HAP outlet";
+
+#define SMART_OUTLET_TASK_PRIORITY  1
+#define SMART_OUTLET_TASK_STACKSIZE 4 * 1024
+#define SMART_OUTLET_TASK_NAME      "hap_outlet"
+
+//#define OUTLET_IN_USE_GPIO GPIO_NUM_0
+#define OUTLET_IN_USE_GPIO -1
+
+#define ESP_INTR_FLAG_DEFAULT 0
+
+static xQueueHandle s_esp_evt_queue = NULL;
+/**
+ * @brief the recover outlet in use gpio interrupt function
+ */
+static void IRAM_ATTR outlet_in_use_isr(void* arg)
+{
+    uint32_t gpio_num = (uint32_t) arg;
+    xQueueSendFromISR(s_esp_evt_queue, &gpio_num, NULL);
+}
+
+/**
+ * Enable a GPIO Pin for Outlet in Use Detection
+ */
+static void outlet_in_use_key_init(uint32_t key_gpio_pin)
+{
+    gpio_config_t io_conf;
+    /* Interrupt for both the edges  */
+    io_conf.intr_type = GPIO_INTR_ANYEDGE;
+    /* Bit mask of the pins */
+    io_conf.pin_bit_mask = 1 << key_gpio_pin;
+    /* Set as input mode */
+    io_conf.mode = GPIO_MODE_INPUT;
+    /* Enable internal pull-up */
+    io_conf.pull_up_en = 1;
+    /* Disable internal pull-down */
+    io_conf.pull_down_en = 0;
+    /* Set the GPIO configuration */
+    gpio_config(&io_conf);
+
+    /* Install gpio isr service */
+    gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT);
+    /* Hook isr handler for specified gpio pin */
+    gpio_isr_handler_add(key_gpio_pin, outlet_in_use_isr, (void*)key_gpio_pin);
+}
+
+/**
+ * Initialize the Smart Outlet Hardware.Here, we just enebale the Outlet-In-Use detection.
+ */
+void smart_outlet_hardware_init(gpio_num_t gpio_num)
+{
+    s_esp_evt_queue = xQueueCreate(2, sizeof(uint32_t));
+    if (s_esp_evt_queue != NULL) {
+        outlet_in_use_key_init(gpio_num);
+    }
+}
+
+/* Mandatory identify routine for the accessory.
+ * In a real accessory, something like LED blink should be implemented
+ * got visual identification
+ */
+static int outlet_identify(hap_acc_t *ha)
+{
+    ESP_LOGI(TAG, "Accessory identified");
+    return HAP_SUCCESS;
+}
+
+/* A dummy callback for handling a write on the "On" characteristic of Outlet.
+ * In an actual accessory, this should control the hardware
+ */
+static int outlet_write(hap_write_data_t write_data[], int count,
+        void *serv_priv, void *write_priv)
+{
+    int i, ret = HAP_SUCCESS;
+    hap_write_data_t *write;
+    for (i = 0; i < count; i++) {
+        write = &write_data[i];
+        if (!strcmp(hap_char_get_type_uuid(write->hc), HAP_CHAR_UUID_ON)) {
+            //ESP_LOGI(TAG, "Received Write. Outlet %s", write->val.b ? "On" : "Off");
+        	ESP_LOG_LEVEL(ESP_LOG_INFO, TAG, "Received Write. Outlet %s", write->val.b ? "On" : "Off");
+            /* TODO: Control Actual Hardware */
+            hap_char_update_val(write->hc, &(write->val));
+            *(write->status) = HAP_STATUS_SUCCESS;
+        } else {
+            *(write->status) = HAP_STATUS_RES_ABSENT;
+        }
+    }
+    return ret;
+}
+
+/*The main thread for handling the Smart Outlet Accessory */
+static void smart_outlet_thread_entry(void *p)
+{
+    hap_acc_t *accessory;
+    hap_serv_t *service;
+
+    /* Initialize the HAP core */
+    hap_init(HAP_TRANSPORT_WIFI);
+
+    /* Initialise the mandatory parameters for Accessory which will be added as
+     * the mandatory services internally
+     */
+    hap_acc_cfg_t cfg = {
+        .name = "Esp-Smart-Outlet",
+        .manufacturer = "Espressif",
+        .model = "EspSmartOutlet01",
+        .serial_num = "001122334455",
+        .fw_rev = "0.9.0",
+        .hw_rev = NULL,
+        .pv = "1.1.0",
+        .identify_routine = outlet_identify,
+        .cid = HAP_CID_OUTLET,
+    };
+    /* Create accessory object */
+    accessory = hap_acc_create(&cfg);
+
+    /* Add a dummy Product Data */
+    uint8_t product_data[] = {'E','S','P','3','2','H','A','P'};
+    hap_acc_add_product_data(accessory, product_data, sizeof(product_data));
+
+    /* Create the Outlet Service. Include the "name" since this is a user visible service  */
+    service = hap_serv_outlet_create(false, false);
+    hap_serv_add_char(service, hap_char_name_create("My Smart Outlet"));
+
+    /* Get pointer to the outlet in use characteristic which we need to monitor for state changes */
+    hap_char_t *outlet_in_use = hap_serv_get_char_by_uuid(service, HAP_CHAR_UUID_OUTLET_IN_USE);
+
+    /* Set the write callback for the service */
+    hap_serv_set_write_cb(service, outlet_write);
+
+    /* Add the Outlet Service to the Accessory Object */
+    hap_acc_add_serv(accessory, service);
+
+    /* Add the Accessory to the HomeKit Database */
+    hap_add_accessory(accessory);
+
+    /* Initialize the appliance specific hardware. This enables out-in-use detection */
+    smart_outlet_hardware_init(OUTLET_IN_USE_GPIO);
+
+    /* For production accessories, the setup code shouldn't be programmed on to
+     * the device. Instead, the setup info, derived from the setup code must
+     * be used. Use the factory_nvs_gen utility to generate this data and then
+     * flash it into the factory NVS partition.
+     *
+     * By default, the setup ID and setup info will be read from the factory_nvs
+     * Flash partition and so, is not required to set here explicitly.
+     *
+     * However, for testing purpose, this can be overridden by using hap_set_setup_code()
+     * and hap_set_setup_id() APIs, as has been done here.
+     */
+    hap_set_setup_code("111-11-111");
+    hap_set_setup_id("ES32");
+#ifdef CONFIG_EXAMPLE_USE_HARDCODED_SETUP_CODE
+    /* Unique Setup code of the format xxx-xx-xxx. Default: 111-22-333 */
+    hap_set_setup_code(CONFIG_EXAMPLE_SETUP_CODE);
+    /* Unique four character Setup Id. Default: ES32 */
+    hap_set_setup_id(CONFIG_EXAMPLE_SETUP_ID);
+#ifdef CONFIG_APP_WIFI_USE_WAC_PROVISIONING
+    app_hap_setup_payload(CONFIG_EXAMPLE_SETUP_CODE, CONFIG_EXAMPLE_SETUP_ID, true, cfg.cid);
+#else
+    app_hap_setup_payload(CONFIG_EXAMPLE_SETUP_CODE, CONFIG_EXAMPLE_SETUP_ID, false, cfg.cid);
+#endif
+#endif
+
+    /* Enable Hardware MFi authentication (applicable only for MFi variant of SDK) */
+    hap_enable_mfi_auth(HAP_MFI_AUTH_HW);
+
+    /* Initialize Wi-Fi */
+    //app_wifi_init();
+
+    /* After all the initializations are done, start the HAP core */
+    hap_start();
+    /* Start Wi-Fi */
+    //app_wifi_start(portMAX_DELAY);
+
+    uint32_t io_num = OUTLET_IN_USE_GPIO;
+    hap_val_t appliance_value = {
+        .b = true,
+    };
+    /* Listen for Outlet-In-Use state change events. Other read/write functionality will be handled
+     * by the HAP Core.
+     * When the Outlet in Use GPIO goes low, it means Outlet is not in use.
+     * When the Outlet in Use GPIO goes high, it means Outlet is in use.
+     * Applications can define own logic as per their hardware.
+     */
+    while (1) {
+        if (xQueueReceive(s_esp_evt_queue, &io_num, portMAX_DELAY) == pdFALSE) {
+            ESP_LOGI(TAG, "Outlet-In-Use trigger FAIL");
+        } else {
+            appliance_value.b = gpio_get_level(io_num);
+            /* If any state change is detected, update the Outlet In Use characteristic value */
+            hap_char_update_val(outlet_in_use, &appliance_value);
+            ESP_LOGI(TAG, "Outlet-In-Use triggered [%d]", appliance_value.b);
+        }
+    }
+}
+
+void homekit_main()
+{
+    /* Create the application thread */
+    xTaskCreate(smart_outlet_thread_entry, SMART_OUTLET_TASK_NAME, SMART_OUTLET_TASK_STACKSIZE,
+                NULL, SMART_OUTLET_TASK_PRIORITY, NULL);
+}

--- a/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/wifi_info.h
+++ b/lib/libesp32/ESP32-HomeKit/examples/HomeKit_IDF/wifi_info.h
@@ -1,0 +1,34 @@
+/*
+ * wifi_info.h
+ *
+ *  Created on: 2020-05-15
+ *      Author: Mixiaoxiao (Wang Bin)
+ */
+
+#ifndef WIFI_INFO_H_
+#define WIFI_INFO_H_
+
+#if defined(ESP8266)
+#include <ESP8266WiFi.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+#endif
+
+const char *ssid = "your-ssid";
+const char *password = "your-password";
+
+void wifi_connect() {
+	WiFi.persistent(false);
+	WiFi.mode(WIFI_STA);
+	WiFi.setAutoReconnect(true);
+	WiFi.begin(ssid, password);
+	Serial.println("WiFi connecting...");
+	while (!WiFi.isConnected()) {
+		delay(100);
+		Serial.print(".");
+	}
+	Serial.print("\n");
+	Serial.printf("WiFi connected, IP: %s\n", WiFi.localIP().toString().c_str());
+}
+
+#endif /* WIFI_INFO_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/_esp_hap_config.h
+++ b/lib/libesp32/ESP32-HomeKit/src/_esp_hap_config.h
@@ -1,0 +1,20 @@
+/*
+ * _esp_hap_config.h
+ *
+ *  Created on: 2020-11-23
+ *      Author: Mixiaoxiao
+ */
+
+#ifndef ESP_HAP_CONFIG_H_
+#define ESP_HAP_CONFIG_H_
+
+#define HAP_SDK_VER         "4.0"
+#define MFI_VER       HAP_SDK_VER
+
+#define CONFIG_HAP_HTTP_STACK_SIZE     12288
+#define CONFIG_HAP_HTTP_SERVER_PORT     5556 // 80 for normal webserver
+#define CONFIG_HAP_HTTP_CONTROL_PORT   32859
+#define CONFIG_HAP_HTTP_MAX_OPEN_SOCKETS   6
+#define CONFIG_HAP_HTTP_MAX_URI_HANDLERS  16
+
+#endif /* ESP_HAP_CONFIG_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/base36.h
+++ b/lib/libesp32/ESP32-HomeKit/src/base36.h
@@ -1,0 +1,60 @@
+/*
+ * Base36 PostgreSQL input/output function for bigint
+ *
+ * Author: Dimitri Fontaine <dimitri@2ndQuadrant.fr>
+ *
+ * Taken from https://github.com/dimitri/base36/blob/master/base36.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define BASE36_LENGTH      13
+
+typedef long long int base36;
+
+static int base36_digits[36] =
+  {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+   'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+   'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+   'U', 'V', 'W', 'X', 'Y', 'Z'
+  };
+
+static base36 base36_powers[BASE36_LENGTH] =
+  {
+1ULL,
+    36ULL,
+    1296ULL,
+    46656ULL,
+    1679616ULL,
+    60466176ULL,
+    2176782336ULL,
+	78364164096ULL,
+	2821109907456ULL,
+	101559956668416ULL,
+	3656158440062976ULL,
+	131621703842267136ULL,
+	4738381338321616896ULL
+  };
+
+static inline
+char *base36_to_str(base36 c)
+{
+  int i, d, p = 0;
+  base36 m = c;
+  bool discard = true;
+  char *str = calloc((BASE36_LENGTH + 1),  sizeof(char));
+
+  for(i=BASE36_LENGTH-1; i>=0; i--)
+  {
+    d = m / base36_powers[i];
+    m = m - base36_powers[i] * d;
+
+    discard = discard && (d == 0 && i >0);
+
+    if( !discard )
+       str[p++] = base36_digits[d];
+  }
+
+  return str;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/byte_convert.c
+++ b/lib/libesp32/ESP32-HomeKit/src/byte_convert.c
@@ -1,0 +1,173 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdint.h>
+#include <ctype.h>
+
+/* Functions to convert Little Endian byte stream to
+ * uint16, uint32 and uint64
+ */
+uint16_t get_u16_le(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint16_t val;
+
+	val  = (uint16_t)p[0];
+	val |= (uint16_t)p[1] << 8;
+
+	return val;
+}
+
+uint32_t get_u32_le(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint32_t val;
+
+	val  = (uint32_t)p[0];
+	val |= (uint32_t)p[1] << 8;
+	val |= (uint32_t)p[2] << 16;
+	val |= (uint32_t)p[3] << 24;
+
+	return val;
+}
+
+uint64_t get_u64_le(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint64_t val;
+
+	val  = (uint64_t)p[0];
+	val |= (uint64_t)p[1] << 8;
+	val |= (uint64_t)p[2] << 16;
+	val |= (uint64_t)p[3] << 24;
+	val |= (uint64_t)p[4] << 32;
+	val |= (uint64_t)p[5] << 40;
+	val |= (uint64_t)p[6] << 48;
+	val |= (uint64_t)p[7] << 56;
+
+	return val;
+}
+
+/* Functions to convert Big Endian byte stream to
+ * uint16, uint32 and uint64
+ */
+uint16_t get_u16_be(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint16_t val;
+
+	val  = (uint16_t)p[0] << 8;
+	val |= (uint16_t)p[1];
+
+	return val;
+}
+
+uint32_t get_u32_be(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint32_t val;
+
+	val  = (uint32_t)p[0] << 24;
+	val |= (uint32_t)p[1] << 16;
+	val |= (uint32_t)p[2] << 8;
+	val |= (uint32_t)p[3];
+
+	return val;
+}
+
+uint64_t get_u64_be(const void *val_ptr)
+{
+	const uint8_t *p = (const uint8_t *)val_ptr;
+	uint64_t val;
+
+	val  = (uint64_t)p[0] << 56;
+	val |= (uint64_t)p[1] << 48;
+	val |= (uint64_t)p[2] << 40;
+	val |= (uint64_t)p[3] << 32;
+	val |= (uint64_t)p[4] << 24;
+	val |= (uint64_t)p[5] << 16;
+	val |= (uint64_t)p[6] << 8;
+	val |= (uint64_t)p[7];
+
+	return val;
+}
+
+/* Functions to convert uint16, uint32 and uint64
+ * to Little Endian
+ */
+void put_u16_le(void *val_ptr, const uint16_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)val & 0xff;
+	p[1] = (uint8_t)(val >> 8) & 0xff;
+}
+
+void put_u32_le(void *val_ptr, const uint32_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)val & 0xff;
+	p[1] = (uint8_t)(val >> 8) & 0xff;
+	p[2] = (uint8_t)(val >> 16) & 0xff;
+	p[3] = (uint8_t)(val >> 24) & 0xff;
+}
+
+void put_u64_le(void *val_ptr, const uint64_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)val & 0xff;
+	p[1] = (uint8_t)(val >> 8) & 0xff;
+	p[2] = (uint8_t)(val >> 16) & 0xff;
+	p[3] = (uint8_t)(val >> 24) & 0xff;
+	p[4] = (uint8_t)(val >> 32) & 0xff;
+	p[5] = (uint8_t)(val >> 40) & 0xff;
+	p[6] = (uint8_t)(val >> 48) & 0xff;
+	p[7] = (uint8_t)(val >> 56) & 0xff;
+}
+
+/* Functions to convert uint16, uint32 and uint64
+ * to Big Endian
+ */
+void put_u16_be(void *val_ptr, const uint16_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)(val >> 8) & 0xff;
+	p[1] = (uint8_t)val & 0xff;
+}
+
+void put_u32_be(void *val_ptr, const uint32_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)((val >> 24) & 0xff);
+	p[1] = (uint8_t)((val >> 16) & 0xff);
+	p[2] = (uint8_t)((val >> 8) & 0xff);
+	p[3] = (uint8_t)(val & 0xff);
+}
+
+void put_u64_be(void *val_ptr, const uint64_t val)
+{
+	uint8_t *p = (uint8_t *)val_ptr;
+
+	p[0] = (uint8_t)(val >> 56) & 0xff;
+	p[1] = (uint8_t)(val >> 48) & 0xff;
+	p[2] = (uint8_t)(val >> 40) & 0xff;
+	p[3] = (uint8_t)(val >> 32) & 0xff;
+	p[4] = (uint8_t)(val >> 24) & 0xff;
+	p[5] = (uint8_t)(val >> 16) & 0xff;
+	p[6] = (uint8_t)(val >> 8) & 0xff;
+	p[7] = (uint8_t)val & 0xff;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/byte_convert.h
+++ b/lib/libesp32/ESP32-HomeKit/src/byte_convert.h
@@ -1,0 +1,139 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * \file byte_convert.h
+ * \brief Conversion between integers and byte streams
+ *
+ * This module offers APIs to convert 16bit, 32bit and 64 bit unsigned integers
+ * into Little/Big Endian byte streams
+ */
+#ifndef _BYTE_CONVERT_H
+#define _BYTE_CONVERT_H
+
+#include <stdint.h>
+
+/** Little Endian to uint16 Conversion
+ * Get a uint16 integer from a little Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 2 byte stream
+ *
+ * \return The converted uint16 integer
+ */
+uint16_t get_u16_le(const void *val_ptr);
+
+/** Little Endian to uint32 Conversion
+ * Get a uint32 integer from a little Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 4 byte stream
+ *
+ * \return The converted uint32 integer
+ */
+uint32_t get_u32_le(const void *val_ptr);
+
+/** Little Endian to uint64 Conversion
+ * Get a uint64 integer from a little Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 8 byte stream
+ *
+ * \return The converted uint32 integer
+ */
+uint64_t get_u64_le(const void *val_ptr);
+
+/** Big Endian to uint16 Conversion
+ * Get a uint16 integer from a Big Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 2 byte stream
+ *
+ * \return The converted uint16 integer
+ */
+uint16_t get_u16_be(const void *val_ptr);
+
+/** Big Endian to uint32 Conversion
+ * Get a uint32 integer from a Big Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 4 byte stream
+ *
+ * \return The converted uint32 integer
+ */
+uint32_t get_u32_be(const void *val_ptr);
+
+/** Big Endian to uint64 Conversion
+ * Get a uint64 integer from a Big Endian byte stream
+ *
+ * \param[in] val_ptr Pointer to the 8 byte stream
+ *
+ * \return The converted uint16 integer
+ */
+uint64_t get_u64_be(const void *val_ptr);
+
+/** Uint16 to Little Endian Conversion
+ *
+ * Put a uint16 integer into a Little Endian byte stream
+ *
+ * \param[out] Pointer to a 2 byte stream that will be filled with the value
+ *
+ * \param[in] The uint16 integer
+ */
+void put_u16_le(void *val_ptr, const uint16_t val);
+
+/** Uint32 to Little Endian Conversion
+ *
+ * Put a uint32 integer into a Little Endian byte stream
+ *
+ * \param[out] Pointer to a 4 byte stream that will be filled with the value
+ *
+ * \param[in] The uint32 integer
+ */
+void put_u32_le(void *val_ptr, const uint32_t val);
+
+/** Uint64 to Little Endian Conversion
+ *
+ * Put a uint64 integer into a Little Endian byte stream
+ *
+ * \param[out] Pointer to a 8 byte stream that will be filled with the value
+ *
+ * \param[in] The uint64 integer
+ */
+void put_u64_le(void *val_ptr, const uint64_t val);
+
+/** Uint16 to Big Endian Conversion
+ *
+ * Put a uint16 integer into a Big Endian byte stream
+ *
+ * \param[out] Pointer to a 2 byte stream that will be filled with the value
+ *
+ * \param[in] The uint16 integer
+ */
+void put_u16_be(void *val_ptr, const uint16_t val);
+
+/** Uint32 to Big Endian Conversion
+ *
+ * Put a uint32 integer into a Big Endian byte stream
+ *
+ * \param[out] Pointer to a 4 byte stream that will be filled with the value
+ *
+ * \param[in] The uint32 integer
+ */
+void put_u32_be(void *val_ptr, const uint32_t val);
+
+/** Uint64 to Big Endian Conversion
+ *
+ * Put a uint64 integer into a Big Endian byte stream
+ *
+ * \param[out] Pointer to a 8 byte stream that will be filled with the value
+ *
+ * \param[in] The uint64 integer
+ */
+void put_u64_be(void *val_ptr, const uint64_t val);
+#endif /* _BYTE_CONVERT_H */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_acc.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_acc.c
@@ -1,0 +1,491 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <string.h>
+#include <esp_wifi.h>
+#include <hap_platform_memory.h>
+#include <esp_hap_acc.h>
+#include <esp_mfi_debug.h>
+#include <esp_mfi_debug.h>
+
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+#include <esp_hap_database.h>
+#include <esp_hap_keystore.h>
+#include <esp_hap_main.h>
+
+/* Primary Accessory Pointer */
+static __hap_acc_t *primary_acc;
+
+/*****************************************************************************************************/
+
+hap_acc_t *hap_get_first_acc()
+{
+    return (hap_acc_t *)primary_acc;
+}
+
+hap_acc_t *hap_acc_get_next(hap_acc_t *ha)
+{
+    if (!ha)
+        return NULL;
+
+    __hap_acc_t *_ha = (__hap_acc_t *)ha;
+    return (hap_acc_t *)_ha->next;
+}
+/* Service write callback to handle "Identify"  */
+static int hap_acc_info_write(hap_write_data_t write_data[], int count,
+        void *serv_priv, void *write_priv)
+{
+	int i;
+    __hap_char_t *_hc;
+	for (i = 0; i < count; i++) {
+        _hc = (__hap_char_t *)write_data[i].hc;
+		if (!strcmp(_hc->type_uuid, HAP_CHAR_UUID_IDENTIFY)) {
+            __hap_acc_t *_ha = (__hap_acc_t *)serv_priv;
+            if (_ha) {
+                _ha->identify_routine((hap_acc_t *)_ha);
+                *(write_data->status) = HAP_STATUS_SUCCESS;
+                continue;
+            }
+        }
+        *(write_data->status) = HAP_STATUS_VAL_INVALID;
+	}
+	return HAP_SUCCESS;
+}
+
+/**
+ * @brief HAP create an accessory
+ */
+hap_acc_t *hap_acc_create(hap_acc_cfg_t *acc_cfg)
+{
+    static bool first = true;
+    int ret = 0;
+    __hap_acc_t *_ha = hap_platform_memory_calloc(1, sizeof(__hap_acc_t));
+    if (!_ha) {
+        return NULL;
+    }
+
+    _ha->identify_routine = acc_cfg->identify_routine;
+    _ha->next_iid = 1;
+
+    /* Add the Accessory Information Service internally */
+    hap_serv_t *hs = hap_serv_create("3E");
+    if (!hs) {
+        goto acc_create_fail;
+    }
+    ret = hap_serv_add_char(hs, hap_char_bool_create(HAP_CHAR_UUID_IDENTIFY, HAP_CHAR_PERM_PW, false));
+    ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_MANUFACTURER, HAP_CHAR_PERM_PR, acc_cfg->manufacturer));
+    ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_MODEL, HAP_CHAR_PERM_PR, acc_cfg->model));
+    ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_NAME, HAP_CHAR_PERM_PR, acc_cfg->name));
+    ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_SERIAL_NUMBER, HAP_CHAR_PERM_PR, acc_cfg->serial_num));
+    ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_FIRMWARE_REVISION, HAP_CHAR_PERM_PR, acc_cfg->fw_rev));
+    if (acc_cfg->hw_rev) {
+        ret |= hap_serv_add_char(hs, hap_char_string_create(HAP_CHAR_UUID_HARDWARE_REVISION, HAP_CHAR_PERM_PR, acc_cfg->hw_rev));
+    }
+    
+    if (ret) {
+        goto acc_create_fail;
+    }
+
+    hap_serv_set_write_cb(hs, hap_acc_info_write);
+    hap_serv_set_priv(hs,(void *)_ha);
+    hap_acc_add_serv((hap_acc_t *)_ha, hs);
+
+    if (first) {
+        /* Add the Procol Information Service Internally */
+        hs = hap_serv_create("A2");
+        if (!hs) {
+            goto acc_create_fail;
+        }
+        ret = hap_serv_add_char(hs, hap_char_string_create("37", HAP_CHAR_PERM_PR, "1.1.0"));
+
+        if (ret) {
+            goto acc_create_fail;
+        }
+        hap_acc_add_serv((hap_acc_t *)_ha, hs);
+        hap_priv.cid = acc_cfg->cid;
+        first = false;
+    }
+
+    return (hap_acc_t *)_ha;
+
+acc_create_fail:
+    hap_acc_delete((hap_acc_t *)_ha);
+    return NULL;
+}
+
+int hap_acc_add_accessory_flags(hap_acc_t *ha, uint32_t flags)
+{
+    if (!ha) {
+        return HAP_FAIL;
+    }
+    hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    if (!hs) {
+        return HAP_FAIL;
+    }
+    return hap_serv_add_char(hs, hap_char_accessory_flags_create(flags));
+
+}
+
+int hap_acc_update_accessory_flags(hap_acc_t *ha, uint32_t flags)
+{
+    if (!ha) {
+        return HAP_FAIL;
+    }
+    hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    if (!hs) {
+        return HAP_FAIL;
+    }
+    hap_char_t *hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_ACCESSORY_FLAGS);
+    if (!hc) {
+        return HAP_FAIL;
+    }
+    hap_val_t val = {
+        .u = flags,
+    };
+    return hap_char_update_val(hc, &val);
+}
+
+int hap_acc_add_product_data(hap_acc_t *ha, uint8_t *product_data, size_t data_size)
+{
+    if (!ha) {
+        return HAP_FAIL;
+    }
+    hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    if (!hs) {
+        return HAP_FAIL;
+    }
+    if (data_size != 8) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Product data size is not 8");
+    }
+    uint8_t *buf = calloc(1, data_size);
+    if (!buf) {
+        return HAP_FAIL;
+    }
+    memcpy(buf, product_data, data_size);
+    hap_data_val_t data_val = {
+        .buf = buf,
+        .buflen = data_size
+    };
+    return hap_serv_add_char(hs, hap_char_product_data_create(&data_val));
+}
+
+const hap_val_t *hap_get_product_data()
+{
+    hap_char_t *acc_info = hap_acc_get_serv_by_uuid(hap_get_first_acc(), HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    if (acc_info) {
+        hap_char_t *product_data = hap_serv_get_char_by_uuid(acc_info, HAP_CHAR_UUID_PRODUCT_DATA);
+        if (product_data) {
+            return hap_char_get_val(product_data);
+        }
+    }
+    return NULL;
+}
+/**
+ * @brief check if accessory's AID matches the target AID
+ */
+bool hap_check_aid(__hap_acc_t *accessory, int32_t aid)
+{
+    return accessory->aid == aid ? true : false;
+}
+
+hap_serv_t *hap_acc_get_first_serv(hap_acc_t *ha)
+{
+    return ((__hap_acc_t *)ha)->servs;
+}
+/**
+ * @brief get target service by it's type description string
+ */
+hap_serv_t *hap_acc_get_serv_by_iid(hap_acc_t *ha, int32_t iid)
+{
+    if (!ha)
+        return NULL;
+
+    hap_serv_t *hs;
+    for (hs = hap_acc_get_first_serv(ha); hs; hs = hap_serv_get_next(hs)) {
+        if (((__hap_serv_t *)hs)->iid == iid)
+            return hs;
+    }
+    return NULL;
+}
+
+hap_serv_t *hap_acc_get_serv_by_uuid(hap_acc_t *ha, const char *uuid)
+{
+    if (!ha)
+        return NULL;
+
+    hap_serv_t *hs;
+    for (hs = hap_acc_get_first_serv(ha); hs; hs = hap_serv_get_next(hs)) {
+        if (!strcmp(((__hap_serv_t *)hs)->type_uuid, uuid))
+            return hs;
+    }
+    return NULL;
+}
+
+/**
+ * @brief get target characteristics by it's IID
+ */
+hap_char_t *hap_acc_get_char_by_iid(hap_acc_t *ha, int32_t iid)
+{
+    if (!ha)
+        return NULL;
+    hap_serv_t *hs;
+    hap_char_t *hc;
+    for (hs = hap_acc_get_first_serv(ha); hs; hs = hap_serv_get_next(hs)) {
+        hc = hap_serv_get_char_by_iid(hs, iid);
+        if (hc)
+            return hc;
+    }
+    return NULL;
+}
+
+int hap_acc_get_info(hap_acc_cfg_t *acc_cfg)
+{
+    ESP_MFI_ASSERT(acc_cfg);
+    hap_acc_t *ha = hap_get_first_acc();
+
+    ESP_MFI_ASSERT(ha);
+
+    hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+
+    hap_char_t *hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_NAME);
+    acc_cfg->name = ((__hap_char_t *)hc)->val.s;
+    
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_MODEL);
+    acc_cfg->model = ((__hap_char_t *)hc)->val.s;
+    
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_MANUFACTURER);
+    acc_cfg->manufacturer = ((__hap_char_t *)hc)->val.s;
+
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_SERIAL_NUMBER);
+    acc_cfg->serial_num = ((__hap_char_t *)hc)->val.s;
+    
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_FIRMWARE_REVISION);
+    acc_cfg->fw_rev = ((__hap_char_t *)hc)->val.s;
+
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_HARDWARE_REVISION);
+    if (hc) {
+        acc_cfg->hw_rev = ((__hap_char_t *)hc)->val.s;
+    } else {
+        acc_cfg->hw_rev = NULL;
+    }
+
+    hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_PROTOCOL_INFORMATION);
+
+    hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_VERSION);
+    acc_cfg->pv = ((__hap_char_t *)hc)->val.s;
+
+    return 0;
+}
+
+/**
+ * @brief add a characteristics to a service
+ */
+int hap_acc_add_serv(hap_acc_t *ha, hap_serv_t *hs)
+{
+    ESP_MFI_ASSERT(ha);
+    ESP_MFI_ASSERT(hs);
+    __hap_acc_t *_ha = (__hap_acc_t *)ha;
+    __hap_serv_t *_hs = (__hap_serv_t *)hs;
+
+    if (_hs->parent) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Service already added");
+        return HAP_FAIL;
+    }
+
+    /* If the accessory has no services, add this as the first */
+    if (!_ha->servs) {
+        _ha->servs = hs;
+    } else {
+        /* Else loop through the services to get to the last one,
+         * and add this at the end
+         */
+        __hap_serv_t *temp = (__hap_serv_t *)_ha->servs;
+        while (temp->next_serv)
+            temp = (__hap_serv_t *)temp->next_serv;
+        temp->next_serv = hs;
+    }
+	_hs->iid = _ha->next_iid++;
+	__hap_char_t *_hc = (__hap_char_t *)_hs->chars;
+	while(_hc) {
+		_hc->iid = _ha->next_iid++;
+		_hc = (__hap_char_t *)_hc->next_char;
+	}
+    _hs->parent = ha;
+    return 0;
+}
+
+static void hap_add_acc_to_list(__hap_acc_t *primary, __hap_acc_t *new)
+{
+    __hap_acc_t *cur = primary;
+    while (cur->next) {
+        cur = cur->next;
+    }
+    cur->next = new;
+}
+
+static void hap_remove_acc_from_list(__hap_acc_t *primary, __hap_acc_t *old)
+{
+    __hap_acc_t *cur = primary;
+    while (cur->next != old) {
+        cur = cur->next;
+    }
+    cur->next = cur->next->next;
+}
+
+#define HAP_BRIDGE_KEYSTORE     "hap_bridge"
+
+int hap_get_unique_aid(const char *id)
+{
+    if (!id) {
+        return -1;
+    }
+    int aid = 0;
+    size_t aid_size = sizeof(aid);
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, id, (uint8_t *)&aid, &aid_size) != HAP_SUCCESS) {
+        aid = hap_get_next_aid();
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Assigning aid = %d for Bridged accessory %s", aid, id);
+        hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, id, (uint8_t *)&aid, sizeof(aid));
+    } else {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Using aid = %d for Bridged accessory %s", aid, id);
+    }
+    return aid;
+}
+
+/**
+ * @brief HAP add accessory to HAP kernel
+ */
+void hap_add_accessory(hap_acc_t *ha)
+{
+    if (!ha) {
+        return;
+    }
+    if (primary_acc) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Primary Accessory already added. Use hap_add_bridged_accessory() instead");
+        return;
+    }
+    __hap_acc_t *_ha = (__hap_acc_t *)ha;
+    _ha->aid = 1;
+    primary_acc = _ha;
+    if (hap_priv.cfg.unique_param >= UNIQUE_NAME) {
+        char name[74];
+        uint8_t eth_mac[6];
+        esp_wifi_get_mac(WIFI_IF_STA, eth_mac);
+        hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+        hap_char_t *hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_NAME);
+        snprintf(name, sizeof(name), "%s-%02X%02X%02X", ((__hap_char_t *)hc)->val.s,
+                eth_mac[3], eth_mac[4], eth_mac[5]);
+        hap_platform_memory_free(((__hap_char_t *)hc)->val.s);
+        ((__hap_char_t *)hc)->val.s = strdup(name);
+    }
+    hap_acc_get_info(&hap_priv.primary_acc);
+}
+
+void hap_add_bridged_accessory(hap_acc_t *ha, int aid)
+{
+    if (!ha) {
+        return;
+    }
+    __hap_acc_t *_ha = (__hap_acc_t *)ha;
+    if (aid) {
+        _ha->aid = aid;
+    } else {
+        _ha->aid = hap_get_next_aid();
+    }
+
+    hap_add_acc_to_list(primary_acc, _ha);
+    if (!hap_priv.cfg.disable_config_num_update) {
+        hap_update_config_number();
+    }
+}
+
+void hap_remove_bridged_accessory(hap_acc_t *ha)
+{
+    if ((__hap_acc_t *)ha == primary_acc) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Cannot remove primary accessory");
+    } else {
+        if (ha) {
+            hap_remove_acc_from_list(primary_acc, (__hap_acc_t *)ha);
+            if (!hap_priv.cfg.disable_config_num_update) {
+                hap_update_config_number();
+            }
+        }
+
+    }
+}
+/**
+ * @brief HAP delete target accessory
+ */
+void hap_acc_delete(hap_acc_t *ha)
+{
+	/* Returning success even if pointer is NULL, because it means
+	 * that the accessory is absent and as good as deleted
+	 */
+	if (!ha)
+		return;
+	__hap_acc_t *_ha = (__hap_acc_t *)ha;
+	__hap_serv_t *_hs = (__hap_serv_t *)_ha->servs;
+	while (_hs) {
+		_ha->servs = _hs->next_serv;
+		hap_serv_delete((hap_serv_t *)_hs);
+		_hs = (__hap_serv_t *)_ha->servs;
+	}
+    hap_platform_memory_free(_ha);
+}
+
+/**
+ * @brief HAP get target accessory AID
+ */
+uint32_t hap_acc_get_aid(hap_acc_t *ha)
+{
+    ESP_MFI_ASSERT(ha);
+    __hap_acc_t *_ha = (__hap_acc_t *)ha;
+
+    return _ha->aid;
+}
+
+/**
+ * @brief delete all accessories
+ */
+void hap_delete_all_accessories(void)
+{
+    __hap_acc_t *next, *ha = primary_acc;
+    while (ha) {
+        next = ha->next;
+        hap_acc_delete((hap_acc_t *)ha);
+        ha = next;
+    }
+}
+/**
+ * @brief get target accessory by AID
+ */
+hap_acc_t *hap_acc_get_by_aid(int32_t aid)
+{
+	hap_acc_t *ha;
+	for (ha = hap_get_first_acc(); ha; ha = hap_acc_get_next(ha)) {
+        if (((__hap_acc_t *)ha)->aid == aid) {
+            return ha;
+        }
+    }
+    return NULL;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_acc.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_acc.h
@@ -1,0 +1,51 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_ACC_H_
+#define _HAP_ACC_H_
+
+#include <hap.h>
+#include <esp_hap_serv.h>
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+typedef struct esp_mfi_accessory {
+    struct esp_mfi_accessory *next;
+    uint32_t             aid;            /* accessory AID */
+    hap_serv_t      *servs;   /* service list */
+    bool                power_off;
+    uint32_t next_iid;
+    hap_identify_routine_t identify_routine;
+} __hap_acc_t;
+hap_char_t *hap_acc_get_char_by_iid(hap_acc_t *ha, int32_t iid);
+hap_acc_t *hap_acc_get_by_aid(int32_t aid);
+int hap_acc_get_info(hap_acc_cfg_t *acc_cfg);
+const hap_val_t *hap_get_product_data();
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_ACC_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_bct.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_bct.c
@@ -1,0 +1,71 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <string.h>
+#include <esp_wifi.h>
+#include <hap_platform_memory.h>
+#include <esp_hap_main.h>
+#include <esp_hap_mdns.h>
+#include <esp_hap_wifi.h>
+#include <esp_hap_database.h>
+#include <esp_mfi_debug.h>
+
+static char *new_name;
+
+void hap_bct_change_name(const char *name)
+{
+    if (new_name) {
+        hap_platform_memory_free(new_name);
+    }
+    new_name = strdup(name);
+    hap_send_event(HAP_INTERNAL_EVENT_BCT_CHANGE_NAME);
+}
+
+void hap_bct_hot_plug()
+{
+    hap_send_event(HAP_INTERNAL_EVENT_BCT_HOT_PLUG);
+}
+
+void hap_handle_bct_change_name()
+{
+    if (!new_name) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "No BCT name specified");
+        return;
+    } else {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Changing BCT Name to %s", new_name);
+    }
+    if (hap_mdns_serv_name_change(&hap_priv.hap_mdns_handle, new_name) != HAP_SUCCESS) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to change BCT name");
+    }
+    hap_platform_memory_free(new_name);
+    new_name = NULL;
+}
+
+void hap_handle_hot_plug()
+{
+    esp_wifi_stop();
+    vTaskDelay((10 * 1000) / portTICK_PERIOD_MS); /* Wait for 10 seconds */
+    esp_wifi_start();
+    esp_wifi_connect();
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_bct_priv.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_bct_priv.h
@@ -1,0 +1,28 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_BCT_PRIV_H_
+#define _HAP_BCT_PRIV_H_
+void hap_handle_bct_change_name();
+void hap_handle_hot_plug();
+#endif /* _HAP_BCT_PRIV_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_char.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_char.c
@@ -1,0 +1,601 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <hap_platform_memory.h>
+#include <math.h>
+#include <string.h>
+#include "esp_mfi_debug.h"
+
+#include <esp_hap_main.h>
+#include <esp_hap_acc.h>
+#include <esp_hap_char.h>
+#include <esp_hap_ip_services.h>
+#include <esp_hap_database.h>
+
+static QueueHandle_t hap_event_queue;
+
+/**
+ * @brief get characteristics's value
+ */
+hap_val_t *esp_mfi_characteristics_get_value(__hap_char_t *_hc)
+{
+    return &_hc->val;
+}
+
+/**
+ * @brief check if characteristics has the specific permission
+ */
+bool hap_char_has_permission(__hap_char_t *_hc, uint16_t permission)
+{
+    return _hc->permission & permission ? true : false;
+}
+
+/**
+ * @brief compute the mod of a and b: a % b
+ */
+static double esp_mfi_fmod(double a, double b)
+{
+    if (a < 1e-06 || b < 1e-06)
+        return 0;
+
+    while (!((long long)a) || !((long long)b)) {
+        a *= 10.0;
+        b *= 10.0;
+    }
+
+    return fmod(a, b);
+}
+
+int hap_event_queue_init()
+{
+    hap_event_queue = xQueueCreate( hap_priv.cfg.max_event_notif_chars,
+                    sizeof(hap_char_t *) );
+    if (hap_event_queue) {
+        return HAP_SUCCESS;
+    } else {
+        return HAP_FAIL;
+    }
+}
+
+hap_char_t * hap_get_pending_notif_char()
+{
+    hap_char_t *hc;
+    if (xQueueReceive(hap_event_queue, &hc, 0) != pdTRUE) {
+        return NULL;
+    }
+    return hc;
+}
+
+static int hap_queue_event(hap_char_t *hc)
+{
+    int ret;
+    if (!hap_event_queue) {
+        return HAP_FAIL;
+    }
+    if (xPortInIsrContext() == pdTRUE) {
+        ret = xQueueSendFromISR(hap_event_queue, &hc, NULL);
+    } else {
+        ret = xQueueSend(hap_event_queue, &hc, 0);
+    }
+    if (ret == pdTRUE) {
+        hap_send_event(HAP_INTERNAL_EVENT_TRIGGER_NOTIF);
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+
+/**
+ * @brief check if characteristics value is at the range
+ */
+int hap_char_check_val_constraints(__hap_char_t *_hc, hap_val_t *val)
+{
+    if (!_hc->constraint_flags)
+        return HAP_SUCCESS;
+
+    if (_hc->format == HAP_CHAR_FORMAT_INT) {
+        int value = val->i;
+        int remainder;
+
+        if (value > _hc->max.i
+            || value < _hc->min.i)
+            return HAP_FAIL;
+
+        if (!_hc->step.i)
+            return HAP_SUCCESS;
+
+        remainder = (value - _hc->min.i) % _hc->step.i;
+        if (remainder)
+            return HAP_FAIL;
+    } else if (_hc->format == HAP_CHAR_FORMAT_FLOAT) {
+        float value = val->f;
+
+        if (value > _hc->max.f
+            || value < _hc->min.f)
+            return HAP_FAIL;
+# if 0
+        /* Check for step value for floats has a high chance of failure,
+         * because of precision issues. Hence, better to skip it.
+         */
+        double remainder;
+        if (_hc->step.f == 0.0)
+            return HAP_SUCCESS;
+
+        remainder = esp_mfi_fmod(value - _hc->min.f, _hc->step.f);
+        if (remainder != 0.0)
+            return HAP_FAIL;
+#endif
+    } else if (_hc->format == HAP_CHAR_FORMAT_UINT8
+               || _hc->format == HAP_CHAR_FORMAT_UINT16
+               || _hc->format == HAP_CHAR_FORMAT_UINT32) {
+        uint32_t value = val->u;
+        uint32_t remainder;
+
+
+        if (value > _hc->max.u
+            || value < _hc->min.u)
+            return HAP_FAIL;
+
+        if (!_hc->step.u)
+            return HAP_SUCCESS;
+
+        remainder = (value - _hc->min.u) % _hc->step.u;
+        if (remainder)
+            return HAP_FAIL;
+    } else if (_hc->format == HAP_CHAR_FORMAT_UINT64) {
+        /* TODO: Add support. Currently, there is no particular 64-bit characteristic */
+    }
+
+    return HAP_SUCCESS;
+}
+
+/**
+ * @brief user update characteristics value, preparing for notification
+ */
+int hap_char_update_val(hap_char_t *hc, hap_val_t *val)
+{
+    if (!hc || !val) {
+        return HAP_FAIL;
+    }
+    __hap_char_t *_hc = (__hap_char_t *)hc;
+    _hc->update_called = true;
+    if (hap_char_check_val_constraints(_hc, val) != HAP_SUCCESS)
+        return HAP_FAIL;
+	/* Boolean to track if the value has changed.
+	 * This will be later used to decide if an event notification
+	 * is required or not. If the new and old values are same,
+	 * there is no need of a notification
+	 */
+	bool value_changed = false;
+
+	switch (_hc->format) {
+		case HAP_CHAR_FORMAT_BOOL:
+			if (_hc->val.b != val->b) {
+				_hc->val.b = val->b;
+				value_changed = true;
+			}
+			break;
+		case HAP_CHAR_FORMAT_INT:
+		case HAP_CHAR_FORMAT_UINT8:
+		case HAP_CHAR_FORMAT_UINT16:
+		case HAP_CHAR_FORMAT_UINT32:
+			if (_hc->val.i != val->i) {
+				_hc->val.i = val->i;
+				value_changed = true;
+			}
+			break;
+		case HAP_CHAR_FORMAT_FLOAT:
+			if (_hc->val.f != val->f) {
+				_hc->val.f = val->f;
+				value_changed = true;
+			}
+			break;
+		case HAP_CHAR_FORMAT_STRING:
+			/* Not checking all combinations to find if value has changed,
+			 * since generally we do not expect dynamic string values
+			 *
+			 * Eg.
+			 * Both (old and new) values being NULL
+			 * Old value NULL, New non-NULL
+			 * Old value non-NULL, new NULL
+			 */
+			if (_hc->val.s && val->s && !strcmp(_hc->val.s, val->s))
+				value_changed = false;
+			else
+				value_changed = true;
+
+			if (_hc->val.s) {
+				hap_platform_memory_free(_hc->val.s);
+                _hc->val.s = NULL;
+            }
+
+			if (val->s) {
+				_hc->val.s = strdup(val->s);
+				if (!_hc->val.s)
+					return HAP_FAIL;
+			}
+			break;
+        case HAP_CHAR_FORMAT_DATA:
+        case HAP_CHAR_FORMAT_TLV8: {
+            _hc->val.d.buf = val->d.buf;
+            _hc->val.d.buflen = val->d.buflen;
+            value_changed = true;
+            }
+            break;
+		default:
+			break;
+	}
+	if (value_changed || (_hc->permission & HAP_CHAR_PERM_SPECIAL_READ)) {
+		ESP_MFI_DEBUG_INTR(ESP_MFI_DEBUG_INFO, "Value Changed");
+        hap_queue_event(hc);
+	} else {
+        /* If there is no value change, reset the owner flag here itself, as no notification
+         * is being sent anyways. In the absence of this, if there is a GET /characteristics
+         * followed by some value change from hardware, the owner_ctrl stays assigned to a
+         * stale value, and so the controller misses a notification.
+         */
+        _hc->owner_ctrl = 0;
+    }
+	return HAP_SUCCESS;
+}
+
+const hap_val_t *hap_char_get_val(hap_char_t *hc)
+{
+    if (!hc)
+        return NULL;
+    return &((__hap_char_t *)hc)->val;
+}
+
+/**
+ * @brief Get the minimum value of characteristic
+ */
+const hap_val_t *hap_char_get_min_val(hap_char_t *hc)
+{
+    if (hc) {
+        if(((__hap_char_t *)hc)->constraint_flags & HAP_CHAR_MIN_FLAG) {
+            return &((__hap_char_t *)hc)->min;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Get the maximum value of characteristic
+ */
+const hap_val_t *hap_char_get_max_val(hap_char_t *hc)
+{
+    if (hc) {
+        if(((__hap_char_t *)hc)->constraint_flags & HAP_CHAR_MAX_FLAG || ((__hap_char_t *)hc)->constraint_flags & HAP_CHAR_MAXLEN_FLAG) {
+            return &((__hap_char_t *)hc)->max;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Get the step value of characteristic
+ */
+const hap_val_t *hap_char_get_step_val(hap_char_t *hc)
+{
+    if (hc) {
+        if (((__hap_char_t *)hc)->constraint_flags & HAP_CHAR_STEP_FLAG) {
+            return &((__hap_char_t *)hc)->step;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief HAP create a characteristics
+ */
+static hap_char_t *hap_char_create(char *type_uuid, uint32_t permission, hap_char_format_t format, hap_val_t val)
+{
+    __hap_char_t *new_ch;
+
+    ESP_MFI_ASSERT(type_uuid);
+
+    if (HAP_CHAR_FORMAT_STRING == format && val.s) {
+        if (strlen(val.s) > HAP_CHAR_STRING_MAX_LEN)
+            return NULL;
+    }
+
+    new_ch = hap_platform_memory_calloc(1, sizeof(__hap_char_t));
+    if (!new_ch) {
+        return NULL;
+    }
+
+    new_ch->val = val;
+    new_ch->type_uuid = type_uuid;
+    new_ch->format = format;
+    new_ch->permission = permission;
+
+    return (hap_char_t *) new_ch;
+}
+
+hap_char_t *hap_char_bool_create(char *type_uuid, uint16_t perms, bool b)
+{
+    hap_val_t val = {.b = b};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_BOOL, val);
+}
+hap_char_t *hap_char_uint8_create(char *type_uuid, uint16_t perms, uint8_t u8)
+{
+    hap_val_t val = {.u = u8};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_UINT8, val);
+}
+hap_char_t *hap_char_uint16_create(char *type_uuid, uint16_t perms, uint16_t u16)
+{
+    hap_val_t val = {.u = u16};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_UINT16, val);
+}
+hap_char_t *hap_char_uint32_create(char *type_uuid, uint16_t perms, uint32_t u32)
+{
+    hap_val_t val = {.u = u32};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_UINT32, val);
+}
+hap_char_t *hap_char_uint64_create(char *type_uuid, uint16_t perms, uint64_t u64)
+{
+    hap_val_t val = {.i64 = u64};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_UINT64, val);
+}
+hap_char_t *hap_char_int_create(char *type_uuid, uint16_t perms, int i32)
+{
+    hap_val_t val = {.i = i32};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_INT, val);
+}
+hap_char_t *hap_char_float_create(char *type_uuid, uint16_t perms, float f)
+{
+    hap_val_t val = {.f = f};
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_FLOAT, val);
+}
+hap_char_t *hap_char_string_create(char *type_uuid, uint16_t perms, char *s)
+{
+    hap_val_t val;
+    if (s)
+        val.s = strdup(s);
+    else
+        val.s = NULL;
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_STRING, val);
+}
+
+hap_char_t *hap_char_data_create(char *type_uuid, uint16_t perms, hap_data_val_t *d)
+{
+    hap_val_t val = {0};
+    if (d) {
+        val.d = *d;
+    }
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_DATA, val);
+}
+
+hap_char_t *hap_char_tlv8_create(char *type_uuid, uint16_t perms, hap_tlv8_val_t *t)
+{
+    hap_val_t val = {0};
+    if (t) {
+        val.t = *t;
+    }
+    return hap_char_create(type_uuid, perms, HAP_CHAR_FORMAT_TLV8, val);
+}
+
+/**
+ * @brief HAP get target characteristics IID
+ */
+uint32_t hap_char_get_iid(hap_char_t *hc)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+
+    return tmp->iid;
+}
+
+/**
+ * @brief HAP get target characteristics type UUID
+ */
+const char * hap_char_get_type_uuid(hap_char_t *hc)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+
+    return tmp->type_uuid;
+}
+
+uint16_t hap_char_get_perm(hap_char_t *hc)
+{
+    if (!hc)
+        return 0;
+
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    return tmp->permission;
+}
+
+hap_char_format_t hap_char_get_format(hap_char_t *hc)
+{
+    if (!hc)
+        return 0;
+
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    return tmp->format;
+}
+
+/**
+ * @brief HAP delete target characteristics
+ */
+void hap_char_delete(hap_char_t *hc)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *_hc = (__hap_char_t *)hc;
+    if (_hc->format == HAP_CHAR_FORMAT_STRING) {
+        if (_hc->val.s) {
+            hap_platform_memory_free(_hc->val.s);
+        }
+    }
+    if (_hc->valid_vals) {
+        hap_platform_memory_free(_hc->valid_vals);
+    }
+    if (_hc->valid_vals_range) {
+        hap_platform_memory_free(_hc->valid_vals_range);
+    }
+    hap_platform_memory_free(_hc);
+}
+
+/**
+ * @brief HAP configure the characteristics's value description
+ */
+void hap_char_int_set_constraints(hap_char_t *hc, int min, int max, int step)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    tmp->min.i = min;
+    tmp->max.i = max;
+    tmp->step.i = step;
+    if (step) {
+        tmp->constraint_flags |= (HAP_CHAR_MIN_FLAG | HAP_CHAR_MAX_FLAG | HAP_CHAR_STEP_FLAG);
+    } else {
+        tmp->constraint_flags |= (HAP_CHAR_MIN_FLAG | HAP_CHAR_MAX_FLAG);
+    }
+}
+void hap_char_float_set_constraints(hap_char_t *hc, float min, float max, float step)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    tmp->min.f = min;
+    tmp->max.f = max;
+    tmp->step.f = step;
+    if (step) {
+        tmp->constraint_flags |= (HAP_CHAR_MIN_FLAG | HAP_CHAR_MAX_FLAG | HAP_CHAR_STEP_FLAG);
+    } else {
+        tmp->constraint_flags |= (HAP_CHAR_MIN_FLAG | HAP_CHAR_MAX_FLAG);
+    }
+}
+
+void hap_char_string_set_maxlen(hap_char_t *hc, int maxlen)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    if (maxlen > HAP_CHAR_STRING_MAX_LEN) {
+        maxlen = HAP_CHAR_STRING_MAX_LEN;
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_WARN, "Characteristic string length larger than maximum value(%d), falling back to the maximum value.", HAP_CHAR_STRING_MAX_LEN);
+    }
+    tmp->max.i = maxlen;
+    tmp->constraint_flags |= HAP_CHAR_MAXLEN_FLAG;
+}
+
+void hap_char_add_description(hap_char_t *hc, const char *description)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    tmp->description = (char *)description;
+}
+void hap_char_add_unit(hap_char_t *hc, const char *unit)
+{
+    ESP_MFI_ASSERT(hc);
+    __hap_char_t *tmp = (__hap_char_t *)hc;
+    tmp->unit = (char *)unit;
+}
+hap_char_t *hap_char_get_next(hap_char_t *hc)
+{
+    return ((__hap_char_t *)hc)->next_char;
+}
+
+hap_serv_t *hap_char_get_parent(hap_char_t *hc)
+{
+    return ((__hap_char_t *)hc)->parent;
+
+}
+
+#define set_bit(val, index)	((val) |= (1 << index))
+#define reset_bit(val, index)	((val) &= ~(1 << index))
+void hap_char_manage_notification(hap_char_t *hc, int index, bool ev)
+{
+	__hap_char_t *_hc = (__hap_char_t *)hc;
+	if (ev)
+		set_bit(_hc->ev_ctrls, index);
+	else
+		reset_bit(_hc->ev_ctrls, index);
+}
+
+bool hap_char_is_ctrl_subscribed(hap_char_t *hc, int index)
+{
+	__hap_char_t *_hc = (__hap_char_t *)hc;
+	return (_hc->ev_ctrls & (1 << index)) ? true : false;
+}
+
+void hap_char_set_owner_ctrl(hap_char_t *hc, int index)
+{
+	__hap_char_t *_hc = (__hap_char_t *)hc;
+    _hc->owner_ctrl = 0;
+    set_bit(_hc->owner_ctrl, index);
+}
+
+bool hap_char_is_ctrl_owner(hap_char_t *hc, int index)
+{
+	__hap_char_t *_hc = (__hap_char_t *)hc;
+	return (_hc->owner_ctrl & (1 << index)) ? true : false;
+}
+
+void hap_char_set_iid(hap_char_t *hc, int32_t iid)
+{
+    if (hc) {
+        ((__hap_char_t *)hc)->iid = iid;
+    }
+}
+
+void hap_disable_all_char_notif(int index)
+{
+    /* Just loop through all characteristic objects and reset the
+     * bit indicating event notifications. This is the simplest way
+     */
+    hap_acc_t *ha;
+    hap_serv_t *hs;
+    hap_char_t *hc;
+    for (ha = hap_get_first_acc(); ha; ha = hap_acc_get_next(ha)) {
+        for (hs = hap_acc_get_first_serv(ha); hs; hs = hap_serv_get_next(hs)) {
+            for (hc = hap_serv_get_first_char(hs); hc; hc = hap_char_get_next(hc)) {
+                reset_bit(((__hap_char_t *)hc)->ev_ctrls, index);
+            }
+        }
+    }
+}
+
+void hap_char_add_valid_vals(hap_char_t *hc, const uint8_t *valid_vals, size_t valid_val_cnt)
+{
+    if (!hc)
+        return;
+    __hap_char_t *_hc = (__hap_char_t *)hc;
+    _hc->valid_vals = hap_platform_memory_malloc(valid_val_cnt);
+    if (_hc->valid_vals) {
+        memcpy(_hc->valid_vals, valid_vals, valid_val_cnt);
+        _hc->valid_vals_cnt = valid_val_cnt;
+    }
+}
+
+void hap_char_add_valid_vals_range(hap_char_t *hc, uint8_t start_val, uint8_t end_val)
+{
+    if (!hc)
+        return;
+    __hap_char_t *_hc = (__hap_char_t *)hc;
+    _hc->valid_vals_range = hap_platform_memory_malloc(sizeof(uint8_t));
+    if (_hc->valid_vals_range) {
+        _hc->valid_vals_range[0] = start_val;
+        _hc->valid_vals_range[1] = end_val;
+    }
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_char.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_char.h
@@ -1,0 +1,98 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_CHAR_H_
+#define _HAP_CHAR_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/errno.h>
+
+#include <hap.h>
+#include <esp_hap_serv.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define HAP_CHAR_MIN_FLAG		(1 << 0)
+#define HAP_CHAR_MAX_FLAG		(1 << 1)
+#define HAP_CHAR_STEP_FLAG		(1 << 2)
+#define HAP_CHAR_MAXLEN_FLAG		(1 << 3)
+#define HAP_CHAR_MAXDATALEN_FLAG	(1 << 4)
+
+/**
+ * @brief characteristics object information
+ */
+typedef struct  {
+    uint32_t iid;        /* Characteristic instance ID */
+    const char *type_uuid;       /* Apple's characteristic UUID */
+    uint16_t permission; /* Characteristic permission */
+    hap_char_format_t      format;   /* data type of the value */
+    hap_val_t       val;
+    bool ev;         /* check if characteristics supports event */
+    char *description;      /* characteristics's description */
+    char *unit;
+
+    /* Characteristics's father subsystem */
+    hap_serv_t                *parent;
+
+    uint8_t constraint_flags;
+
+    hap_val_t       max;       /* maximum value, maxlen, max data len*/
+    hap_val_t       min;       /* minimum value */
+    hap_val_t       step;      /* step value */
+
+    hap_char_t *next_char;
+    /* Bitmap to indicate which controllers have enabled notifications
+     */
+	uint16_t ev_ctrls;
+
+    /* Bitmap indicating the last controller that modified the value.
+     * No notification should be sent to the owner
+     */
+    uint16_t owner_ctrl;
+
+    /* Pointer to a valid values range. It will be a 2 byte array, if set from application */
+    uint8_t *valid_vals_range;
+    /* Since a list of valid values can have any length, using a pointer here,
+     * which will be allocated if valid values are set for a characteristic
+     */
+    uint8_t *valid_vals;
+    size_t valid_vals_cnt;
+    bool update_called;
+} __hap_char_t;
+
+void hap_char_manage_notification(hap_char_t *hc, int index, bool ev);
+bool hap_char_is_ctrl_subscribed(hap_char_t *hc, int index);
+void hap_char_set_owner_ctrl(hap_char_t *hc, int index);
+bool hap_char_is_ctrl_owner(hap_char_t *hc, int index);
+void hap_disable_all_char_notif(int index);
+int hap_char_check_val_constraints(__hap_char_t *_hc, hap_val_t *val);
+int hap_event_queue_init();
+hap_char_t * hap_get_pending_notif_char();
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_CHAR_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_controllers.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_controllers.c
@@ -1,0 +1,149 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <string.h>
+#include <hap.h>
+#include <esp_mfi_debug.h>
+
+#include <esp_hap_main.h>
+#include <esp_hap_database.h>
+#include <esp_hap_controllers.h>
+#include <esp_hap_keystore.h>
+
+#define HAP_KEYSTORE_NAMESPACE_CTRL "hap_ctrl"
+
+int hap_controllers_init()
+{
+	memset(hap_priv.controllers, 0, sizeof(hap_priv.controllers));
+    char index_str[4];
+    uint8_t i;
+    size_t info_size;
+    bool acc_paired = false;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+        snprintf(index_str, sizeof(index_str), "%d", i);
+        info_size = sizeof(hap_ctrl_info_t);
+        if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_CTRL, index_str,
+                    (uint8_t *)&hap_priv.controllers[i].info, &info_size) == HAP_SUCCESS) {
+            if (info_size == sizeof(hap_ctrl_info_t)) {
+                hap_priv.controllers[i].index = i;
+                hap_priv.controllers[i].valid = true;
+                acc_paired = true;
+            }
+        }
+    }
+    if (acc_paired) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Accessory is Paired with atleast one controller");
+    } else {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Accessory is not Paired with any controller");
+    }
+	return HAP_SUCCESS;
+}
+
+hap_ctrl_data_t *hap_controller_get_empty_loc()
+{
+	int i;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (!hap_priv.controllers[i].valid) {
+            hap_priv.controllers[i].index = i;
+			return &hap_priv.controllers[i];
+        }
+	}
+	return NULL;
+}
+
+int hap_get_paired_controller_count()
+{
+	int i, cnt = 0;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (hap_priv.controllers[i].valid) {
+            cnt++;
+        }
+	}
+	return cnt;
+}
+
+bool is_accessory_paired()
+{
+	int i;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (hap_priv.controllers[i].valid)
+			return true;
+	}
+	return false;
+}
+
+bool is_admin_paired()
+{
+	int i;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (hap_priv.controllers[i].valid && hap_priv.controllers[i].info.perms)
+			return true;
+	}
+	return false;
+}
+
+int hap_controller_save(hap_ctrl_data_t *ctrl_data)
+{
+	ctrl_data->valid = true;
+    char index_str[4];
+    snprintf(index_str, sizeof(index_str), "%d", ctrl_data->index);
+    int ret = hap_keystore_set(HAP_KEYSTORE_NAMESPACE_CTRL, index_str,
+            (const uint8_t *)&ctrl_data->info, (size_t)sizeof(hap_ctrl_info_t));
+
+    if (ret != HAP_SUCCESS) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to store controller %d", ctrl_data->index);
+        return HAP_FAIL;
+    }
+    hap_report_event(HAP_EVENT_CTRL_PAIRED, ctrl_data->info.id, sizeof(ctrl_data->info.id));
+    return HAP_SUCCESS;
+}
+
+void hap_controller_remove(hap_ctrl_data_t *ctrl_data)
+{
+	if (!ctrl_data)
+        return;
+    char index_str[4];
+    snprintf(index_str, sizeof(index_str), "%d", ctrl_data->index);
+    char id[HAP_CTRL_ID_LEN];
+    strncpy(id, ctrl_data->info.id, sizeof(id));
+    hap_keystore_delete(HAP_KEYSTORE_NAMESPACE_CTRL, index_str);
+    memset(ctrl_data, 0, sizeof(hap_ctrl_data_t));
+    hap_report_event(HAP_EVENT_CTRL_UNPAIRED, id, sizeof(id));
+}
+
+hap_ctrl_data_t *hap_get_controller(char *ctrl_id)
+{
+	int i;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (hap_priv.controllers[i].valid
+				&& (!strcmp(hap_priv.controllers[i].info.id, ctrl_id)))
+			return &hap_priv.controllers[i];
+	}
+	return NULL;
+}
+
+void hap_erase_controller_info()
+{
+    hap_keystore_delete_namespace(HAP_KEYSTORE_NAMESPACE_CTRL);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_controllers.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_controllers.h
@@ -1,0 +1,61 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_CONTROLLERS_H_
+#define _HAP_CONTROLLERS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define HAP_MAX_CONTROLLERS 16
+#define HAP_CTRL_ID_LEN		64
+#define ED_KEY_LEN		32
+
+
+typedef struct {
+	char id[HAP_CTRL_ID_LEN];
+	uint8_t ltpk[ED_KEY_LEN];
+	uint8_t perms;
+} __attribute__((packed)) hap_ctrl_info_t;
+
+typedef struct {
+    hap_ctrl_info_t info;
+	/* If "valid" is false, it means that the entry is invalid,
+	 * irrespective of the values of other members, and can be
+	 * used to store new controller info
+	 */
+	bool valid;
+    /* Index is used just for better managing the keystore data */
+    uint8_t index;
+} hap_ctrl_data_t;
+
+int hap_controllers_init();
+bool is_accessory_paired();
+bool is_admin_paired();
+hap_ctrl_data_t *hap_controller_get_empty_loc();
+int hap_controller_save(hap_ctrl_data_t *ctrl_data);
+void hap_controller_remove(hap_ctrl_data_t *ctrl_data);
+hap_ctrl_data_t *hap_get_controller(char *ctrl_id);
+void hap_erase_controller_info();
+
+#endif /* _HAP_CONTROLLERS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_database.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_database.c
@@ -1,0 +1,334 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdio.h>
+#include <sodium/crypto_sign_ed25519.h>
+#include <string.h>
+#include <hap_platform_memory.h>
+
+#include <esp_mfi_rand.h>
+#include <esp_mfi_sha.h>
+#include <esp_mfi_debug.h>
+
+#include <esp_hap_main.h>
+#include <esp_hap_keystore.h>
+#include <esp_hap_database.h>
+#include <esp_hap_controllers.h>
+
+#include <esp_mfi_base64.h>
+
+#define HAP_KEY_ACC_ID                  "acc_id"
+#define HAP_KEY_LTSKA                   "ltska"
+#define HAP_KEY_LTPKA                   "ltpka"
+#define HAP_KEY_CONFIG_NUM              "config_num"
+#define HAP_KEY_FW_REV                  "fw_rev"
+#define HAP_KEY_CUR_AID                 "cur_aid"
+#define HAP_KEY_STATE_NUM              "state_num"
+
+#define HAP_KEY_SETUP_ID                "setup_id"
+#define HAP_KEY_SETUP_SALT              "setup_salt"
+#define HAP_KEY_SETUP_VERIFIER          "setup_verifier"
+
+#define HAP_LOOP_STACK              (4 * 1024)
+#define HAP_MAIN_THREAD_PRIORITY    7
+#define HAP_MAX_NOTIF_CHARS         8
+#define HAP_SOCK_RECV_TIMEOUT       10
+#define HAP_SOCK_SEND_TIMEOUT       10
+
+hap_priv_t hap_priv = {
+    .cfg = {
+        .task_stack_size = HAP_LOOP_STACK,
+        .task_priority = HAP_MAIN_THREAD_PRIORITY,
+        .max_event_notif_chars = HAP_MAX_NOTIF_CHARS,
+        .unique_param = UNIQUE_SSID,
+        .recv_timeout = HAP_SOCK_RECV_TIMEOUT,
+        .send_timeout = HAP_SOCK_SEND_TIMEOUT,
+        .sw_token_max_len = HAP_SW_TOKEN_MAX_LEN,
+    }
+};
+
+static void hap_save_config_number()
+{
+
+    hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_CONFIG_NUM,
+            (uint8_t *)&hap_priv.config_num, sizeof(hap_priv.config_num));
+}
+
+static void hap_get_config_number()
+{
+    size_t config_num_len = sizeof(hap_priv.config_num);
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_CONFIG_NUM,
+                (uint8_t *)&hap_priv.config_num, &config_num_len) != HAP_SUCCESS) {
+        hap_priv.config_num = 1;
+        hap_save_config_number();
+    }
+    if (hap_priv.config_num > 65535) {
+        hap_priv.config_num = 1;
+        hap_save_config_number();
+    }
+}
+
+void hap_increment_and_save_config_num()
+{
+    hap_priv.config_num++;
+    if (hap_priv.config_num > 65535) {
+        hap_priv.config_num = 1;
+    }
+    hap_save_config_number();
+}
+
+
+static void hap_save_state_number()
+{
+    hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_STATE_NUM,
+            (uint8_t *)&hap_priv.state_num, sizeof(hap_priv.state_num));
+}
+
+void hap_increment_and_save_state_num()
+{
+    if (is_accessory_paired()) {
+        hap_priv.state_num++;
+        /* If value becomes 0 after incrementing, it means that it has wrapped around.
+         * So, reset to 1
+         */
+        if (hap_priv.state_num == 0) {
+            hap_priv.state_num = 1;
+        }
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Updated state number to %d", hap_priv.state_num);
+        hap_save_state_number();
+    }
+}
+
+static void hap_init_state_number()
+{
+    size_t state_num_len = sizeof(hap_priv.state_num);
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_STATE_NUM,
+                (uint8_t *)&hap_priv.state_num, &state_num_len) != HAP_SUCCESS) {
+        /* If state number is not found, initialise with 1 and store.
+         */
+        hap_priv.state_num = 1;
+        hap_save_state_number();
+    } else {
+        hap_increment_and_save_state_num();
+    }
+}
+
+static void hap_save_cur_aid()
+{
+    hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_CUR_AID,
+            (uint8_t *)&hap_priv.cur_aid, sizeof(hap_priv.cur_aid));
+}
+
+static void hap_get_cur_aid()
+{
+    size_t aid_len = sizeof(hap_priv.cur_aid);
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_CUR_AID,
+                (uint8_t *)&hap_priv.cur_aid, &aid_len) != HAP_SUCCESS) {
+        /* AID = 1 is reserved for Primary Accessory. So, we set the initial
+         * value to 1, so that the bridged accessories get assigned aid from
+         * 2 onwards
+         */
+        hap_priv.cur_aid = 1;
+        hap_save_cur_aid();
+    }
+}
+
+static int hap_get_setup_id()
+{
+    /* Read setup id from NVS, only if it is not already set from the accessory code */
+    if (!strlen(hap_priv.setup_id)) {
+        size_t setup_id_len = sizeof(hap_priv.setup_id);
+        if (hap_factory_keystore_get(HAP_FACTORY_NAMESPACE_HAP_SETUP, HAP_KEY_SETUP_ID,
+                (uint8_t *)hap_priv.setup_id, &setup_id_len) != HAP_SUCCESS) {
+            return HAP_FAIL;
+        }
+    }
+    return HAP_SUCCESS;
+}
+
+static int hap_get_setup_info()
+{
+    /* If the setup code has been set directly, no need to check for setup info */
+    if (hap_priv.setup_code) {
+        return HAP_SUCCESS;
+    }
+    /* If the setup info has been set externally, directly from the accessory code,
+     * no need to check in the NVS
+     */
+    if (!hap_priv.setup_info) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Getting setup info from factory NVS");
+        hap_priv.setup_info = hap_platform_memory_calloc(1, sizeof(hap_setup_info_t));
+        if (!hap_priv.setup_info)
+            return HAP_FAIL;
+        size_t salt_len = sizeof(hap_priv.setup_info->salt);
+        size_t verifier_len = sizeof(hap_priv.setup_info->verifier);
+        int ret = hap_factory_keystore_get(HAP_FACTORY_NAMESPACE_HAP_SETUP, HAP_KEY_SETUP_SALT,
+                hap_priv.setup_info->salt, &salt_len);
+        ret |= hap_factory_keystore_get(HAP_FACTORY_NAMESPACE_HAP_SETUP, HAP_KEY_SETUP_VERIFIER,
+                hap_priv.setup_info->verifier, &verifier_len);
+        if (ret != HAP_SUCCESS) {
+            hap_platform_memory_free(hap_priv.setup_info);
+            hap_priv.setup_info = NULL;
+            return HAP_FAIL;
+        }
+    }
+    return HAP_SUCCESS;
+}
+
+static void hap_check_fw_version()
+{
+    char fw_rev[64] = {0};
+    size_t fw_rev_len = sizeof(fw_rev);
+    /* Check if the firmware revision is stored in NVS */
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_FW_REV,
+                (uint8_t *)fw_rev, &fw_rev_len) == HAP_SUCCESS) {
+        /* If the firmware revision is found, compare with the current revision.
+         * If it is the same, no need to do anything. So, just return
+         */
+        if (strncmp(fw_rev, hap_priv.primary_acc.fw_rev, sizeof(fw_rev)) == 0) {
+            return;
+        } else {
+            /* If there is a version mismatch, it means that the firmware was upgraded.
+             * Update config number in that case
+             */
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "FW Update detected. Incrementing config number");
+            hap_increment_and_save_config_num();
+        }
+    }
+    /* Save the new firmare revision to NVS */
+    hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_FW_REV,
+            (uint8_t *)hap_priv.primary_acc.fw_rev,
+            strlen(hap_priv.primary_acc.fw_rev));
+}
+
+int hap_acc_setup_init()
+{
+    if (hap_get_setup_id() != HAP_SUCCESS) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Setup ID absent");
+        return HAP_FAIL;
+    } else {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Setup ID: %s", hap_priv.setup_id);
+    }
+
+    if (hap_get_setup_info() != HAP_SUCCESS) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Setup Info absent");
+        return HAP_FAIL;
+    }
+
+    uint8_t digest[MFI_SHA512_SIZE] = {0};
+    esp_mfi_sha_ctx_t ctx = 0;
+    ctx = esp_mfi_sha512_new();
+    if (!ctx) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Out of Memory");
+        return HAP_FAIL;
+    }
+    /* Compute setup hash by taking a SHA512 hash of the setup id and device id */
+    esp_mfi_sha512_init(ctx);
+    esp_mfi_sha512_update(ctx, (const uint8_t *)hap_priv.setup_id, strlen(hap_priv.setup_id));
+    esp_mfi_sha512_update(ctx, (const uint8_t *)hap_priv.acc_id, strlen(hap_priv.acc_id));
+    esp_mfi_sha512_final(ctx, digest);
+    /* Copy only the first 4 bytes as the setup hash */
+    memcpy(hap_priv.setup_hash, digest, SETUP_HASH_LEN);
+    esp_mfi_sha512_free(ctx);
+
+    int hash_size = sizeof(hap_priv.setup_hash_str);
+    esp_mfi_base64_encode((const char *)hap_priv.setup_hash, SETUP_HASH_LEN,
+            hap_priv.setup_hash_str, hash_size, &hash_size);
+
+    hap_check_fw_version();
+
+    return HAP_SUCCESS;
+}
+
+int hap_database_init(void)
+{
+    uint8_t id[6];
+    size_t val_size = sizeof(id);
+    if (hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_ACC_ID, id, &val_size) == HAP_SUCCESS) {
+        val_size = sizeof(hap_priv.ltska);
+        hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_LTSKA, hap_priv.ltska, &val_size);
+        val_size = sizeof(hap_priv.ltpka);
+        hap_keystore_get(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_LTPKA, hap_priv.ltpka, &val_size);
+    } else {
+        /* If the accessory ID is not found in keystore, create and store a new random ID */
+	    esp_mfi_get_random(id, sizeof(id));
+        hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_ACC_ID, id, sizeof(id));
+        /* Also create a new ED25519 key pair */
+	    esp_mfi_get_random(hap_priv.ltska, sizeof(hap_priv.ltska));
+        crypto_sign_ed25519_keypair(hap_priv.ltpka, hap_priv.ltska);
+        hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_LTSKA, hap_priv.ltska, sizeof(hap_priv.ltska));
+        hap_keystore_set(HAP_KEYSTORE_NAMESPACE_HAPMAIN, HAP_KEY_LTPKA, hap_priv.ltpka, sizeof(hap_priv.ltpka));
+    }
+
+    memcpy(hap_priv.raw_acc_id, id, sizeof(hap_priv.raw_acc_id));
+	snprintf(hap_priv.acc_id, sizeof(hap_priv.acc_id), "%02X:%02X:%02X:%02X:%02X:%02X",
+			id[0], id[1], id[2], id[3], id[4], id[5]);
+
+	hap_controllers_init();
+    hap_get_config_number();
+    hap_get_cur_aid();
+    hap_init_state_number();
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Database initialised. Accessory Device ID: %s", hap_priv.acc_id);
+	return HAP_SUCCESS;
+}
+
+char *hap_get_acc_id()
+{
+	return hap_priv.acc_id;
+}
+
+int hap_get_next_aid(char *id)
+{
+    hap_priv.cur_aid++;
+    hap_save_cur_aid();
+    return hap_priv.cur_aid;
+}
+
+void hap_erase_accessory_info()
+{
+    hap_keystore_delete_namespace(HAP_KEYSTORE_NAMESPACE_HAPMAIN);
+}
+
+void hap_configure_unique_param(hap_unique_param_t param)
+{
+    hap_priv.cfg.unique_param = param;
+}
+
+int hap_get_config(hap_cfg_t *cfg)
+{
+    if (!cfg) {
+        return HAP_FAIL;
+    }
+    *cfg = hap_priv.cfg;
+    return HAP_SUCCESS;
+}
+
+int hap_set_config(const hap_cfg_t *cfg)
+{
+    if (!cfg) {
+        return HAP_FAIL;
+    }
+    hap_priv.cfg = *cfg;
+    return HAP_SUCCESS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_database.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_database.h
@@ -1,0 +1,92 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_DATABASE_H_
+#define _HAP_DATABASE_H_
+
+#include <hap.h>
+#include <esp_hap_controllers.h>
+#include <esp_hap_pair_common.h>
+#include <esp_hap_mdns.h>
+#include <esp_hap_secure_message.h>
+#include <esp_http_server.h>
+
+#define HAP_KEYSTORE_NAMESPACE_HAPMAIN  "hap_main"
+#define HAP_FACTORY_NAMESPACE_HAP_SETUP "hap_setup"
+
+#define HAP_MAX_SESSIONS	8
+#define SETUP_ID_LEN        4
+#define SETUP_HASH_LEN      4
+
+#define HAP_ACC_ID_LEN		18 /* AA:BB:CC:XX:YY:ZZ\0 */
+#define ED_KEY_LEN		32
+#define HAP_SW_TOKEN_MAX_LEN        1200
+
+
+typedef struct {
+    hap_acc_cfg_t primary_acc;
+    uint32_t config_num;
+    uint32_t cur_aid;
+    uint8_t raw_acc_id[6];
+	char acc_id[HAP_ACC_ID_LEN];
+    char setup_id[SETUP_ID_LEN + 1];
+    uint8_t setup_hash[SETUP_HASH_LEN];
+    char setup_hash_str[SETUP_HASH_LEN * 2 + 1];
+	uint8_t ltska[ED_KEY_LEN];
+	uint8_t ltpka[ED_KEY_LEN];
+	hap_cid_t cid;
+	hap_ctrl_data_t controllers[HAP_MAX_CONTROLLERS];
+	hap_secure_session_t *sessions[HAP_MAX_SESSIONS];
+	uint8_t pair_attempts;
+    hap_mdns_handle_t wac_mdns_handle;
+    hap_mdns_handle_t hap_mdns_handle;
+    hap_setup_info_t *setup_info;
+    char *setup_code;
+    char *ssid;
+    char *password;
+    hap_software_token_info_t *token_info;
+    uint8_t features;
+    hap_event_handler_t hap_event_handler;
+    char *softap_ssid;
+    void (*ext_nw_prov_start)(void *data, const char *name);
+    void (*ext_nw_prov_stop)(void *data);
+    void *ext_nw_prov_data;
+    hap_cfg_t cfg;
+    hap_transport_t transport;
+    uint32_t pairing_flags;
+    httpd_handle_t server;
+    uint8_t *product_data;
+    uint16_t state_num;
+    bool disconnected_event_sent;
+    hap_mfi_auth_type_t auth_type;
+} hap_priv_t;
+
+extern hap_priv_t hap_priv;
+int hap_database_init(void);
+char *hap_get_acc_id();
+int hap_get_next_aid();
+int hap_acc_setup_init();
+void hap_erase_accessory_info();
+void hap_increment_and_save_config_num();
+void hap_increment_and_save_state_num();
+#endif /* _HAP_DATABASE_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_ip_services.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_ip_services.c
@@ -1,0 +1,1630 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+
+#include <json_parser.h>
+#include <hap_platform_memory.h>
+#include <esp_mfi_debug.h>
+#include <esp_hap_main.h>
+#include <esp_hap_pair_setup.h>
+#include <esp_hap_pair_verify.h>
+#include <esp_hap_pairings.h>
+#include <esp_hap_network_io.h>
+#include <esp_hap_secure_message.h>
+#include <esp_hap_acc.h>
+#include <esp_hap_serv.h>
+#include <esp_hap_char.h>
+#include <esp_hap_mdns.h>
+#include <esp_hap_wac.h>
+#include <esp_hap_wifi.h>
+#include <esp_hap_database.h>
+#include <esp_mfi_base64.h>
+#include <esp_timer.h>
+#include <hexdump.h>
+#include <lwip/sockets.h>
+#include <esp_http_server.h>
+#include <hap_platform_httpd.h>
+#include <hap_platform_os.h>
+#include <esp_hap_ip_services.h>
+#include <json_generator.h> //???
+
+#ifdef ESP_MFI_DEBUG_ENABLE
+#define ESP_MFI_DEBUG_PLAIN(fmt, ...)   \
+    if (http_debug) {                   \
+        printf("\e[1;35m" fmt "\e[0m", ##__VA_ARGS__); \
+    }
+#else /* ESP_MFI_DEBUG_ENABLE */
+#define ESP_MFI_DEBUG_PLAIN(fmt, ...)
+#endif /* ESP_MFI_DEBUG_ENABLE */
+
+static bool http_debug;
+
+int hap_http_session_not_authorized(httpd_req_t *req)
+{
+    char buf[50];
+    httpd_resp_set_status(req, "470 Connection Authorization Required");
+    httpd_resp_set_type(req, "application/hap+json");
+    snprintf(buf, sizeof(buf),"{\"status\":-70401}");
+    httpd_resp_send(req, buf, strlen(buf));
+    return HAP_SUCCESS;
+
+}
+
+int hap_httpd_get_data(httpd_req_t *req, char *buffer, int len)
+{
+    int read_len = 0;
+    while (read_len < len) {
+        int tmp_len = httpd_req_recv(req, buffer + read_len, len - read_len);
+        if (tmp_len <= 0) {
+            return read_len;
+        }
+        read_len += tmp_len;
+    }
+    return read_len;
+}
+
+static int hap_http_pair_setup_handler(httpd_req_t *req)
+{
+	uint8_t buf[1200];
+	int ret, ret1, outlen;
+	void *ctx = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    int fd = httpd_req_to_sockfd(req);
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+	if (!ctx) {
+		if (hap_pair_setup_context_init(fd, &ctx, buf, sizeof(buf), &outlen) == HAP_SUCCESS) {
+            hap_platform_httpd_set_sess_ctx(req, ctx, hap_pair_setup_ctx_clean, true);
+		} else {
+			httpd_resp_set_type(req, "application/pairing+tlv8");
+			httpd_resp_send(req, (char *)buf, outlen);
+			return HAP_SUCCESS;
+		}
+	}
+	int data_len = httpd_req_recv(req, (char *)buf, sizeof(buf));
+	ret = hap_pair_setup_process(&ctx, buf, data_len, sizeof(buf), &outlen);
+	httpd_resp_set_type(req, "application/pairing+tlv8");
+	ret1 = httpd_resp_send(req, (char *)buf, outlen);
+	if (ret != HAP_SUCCESS) {
+		hap_pair_setup_ctx_clean(ctx);
+		ctx = NULL;
+	} else {
+        /* A pair verify function is called here, because for Software Token Authentication,
+         * secure session keys are generated at the step M4 of Pair Setup, and there onwards,
+         * the behavior is like a pair verified session.
+         */
+		if (hap_pair_verify_get_state(ctx) == STATE_VERIFIED) {
+			/* Saving socket fd since it will later be required for
+			 * event notifications.
+			 */
+			((hap_secure_session_t *)ctx)->conn_identifier = fd;
+            hap_platform_httpd_set_sess_ctx(req, ctx, hap_free_session, true);
+            httpd_sess_set_send_override(hap_priv.server, fd, hap_httpd_send);
+            httpd_sess_set_recv_override(hap_priv.server, fd, hap_httpd_recv);
+		}
+    }
+	/* Context will be NULL, either if there was an error and a cleanup was required,
+	 * or if the pair_setup_process cleared it after successful pairing.
+	 * For both the cases, we will set the sess_ctx and free_ctx to NULL
+	 */
+	if (!ctx) {
+        hap_platform_httpd_set_sess_ctx(req, NULL, NULL, true);
+	}
+	return ret1;
+}
+static struct httpd_uri hap_pair_setup = {
+	.uri = "/pair-setup",
+    .method = HTTP_POST,
+    .handler = hap_http_pair_setup_handler,
+};
+
+static int hap_http_pair_verify_handler(httpd_req_t *req)
+{
+	uint8_t buf[512];
+	int ret, outlen;
+	void *ctx = hap_platform_httpd_get_sess_ctx(req);
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+	if (!ctx) {
+		if (hap_pair_verify_context_init(&ctx, buf, sizeof(buf), &outlen) == HAP_SUCCESS) {
+            hap_platform_httpd_set_sess_ctx(req, ctx, NULL, true);
+		}
+	}
+	int data_len = httpd_req_recv(req, (char *)buf, sizeof(buf));
+	ret = hap_pair_verify_process(&ctx, buf, data_len, sizeof(buf), &outlen);
+	httpd_resp_set_type(req, "application/pairing+tlv8");
+	int ret1 = httpd_resp_send(req, (char *)buf, outlen);
+	if (ret == HAP_SUCCESS) {
+		if (hap_pair_verify_get_state(ctx) == STATE_VERIFIED) {
+			/* Saving socket fd since it will later be required for
+			 * event notifications.
+			 */
+            int fd = httpd_req_to_sockfd(req);
+			((hap_secure_session_t *)ctx)->conn_identifier = fd;
+
+            struct timeval timeout;
+            timeout.tv_sec = hap_priv.cfg.recv_timeout;
+            timeout.tv_usec = 0;
+            if (setsockopt (fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout,
+                        sizeof(timeout)) < 0) {
+                 ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "setsockopt on pair verified socket failed for SO_RCVTIMEO");
+            }
+
+            timeout.tv_sec = hap_priv.cfg.send_timeout;
+            timeout.tv_usec = 0;
+            if (setsockopt (fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeout,
+                        sizeof(timeout)) < 0) {
+                 ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "setsockopt on pair verified socket failed for SO_SNDTIMEO");
+            }
+
+
+            // ----
+            const int s = fd;
+            const int yes = 1; /* enable sending keepalive probes for socket */
+			setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+
+			const int idle = 15; /* 180 sec idle before start sending probes */
+			setsockopt(s, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+
+			const int interval = 5; /* 30 sec between probes */
+			setsockopt(s, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval));
+
+			const int maxpkt = 3; /* Drop connection after 4 probes without response */
+			setsockopt(s, IPPROTO_TCP, TCP_KEEPCNT, &maxpkt, sizeof(maxpkt));
+            // ----
+
+            hap_platform_httpd_set_sess_ctx(req, ctx, hap_free_session, true);
+            httpd_sess_set_send_override(hap_priv.server, fd, hap_httpd_send);
+            httpd_sess_set_recv_override(hap_priv.server, fd, hap_httpd_recv);
+
+
+            hap_secure_session_t* session  = (hap_secure_session_t *)ctx;
+            int socket = session->conn_identifier;
+
+            //struct sockaddr_storage addr;
+            struct sockaddr_in6 addr;
+            socklen_t len = sizeof addr;
+            getpeername(fd, (struct sockaddr*)&addr, &len);
+            /*
+            struct sockaddr_in *sockaddr = (struct sockaddr_in *)&addr;
+            in_addr_t a = sockaddr->sin_addr.s_addr;
+            union {
+            	uint8_t ui8[4];
+            	uint32_t ui32;
+            }ip;
+            ip.ui32 = (uint32_t)a;
+			*/
+            //uint16_t port = ntohs(sockaddr->sin6_port);
+            uint16_t port = addr.sin6_port;
+            printf("---- STATE_VERIFIED ----\n");
+            //printf("ip32: %u\n", a);
+            //printf("fd: %d, %u.%u.%u.%u:%u \n", socket,
+            		//ip.ui8[0], ip.ui8[1], ip.ui8[2], ip.ui8[3], port);
+            //https://github.com/espressif/esp-idf/issues/4863
+            printf("fd: %d, remote: %s:%u\n", fd, inet_ntoa(addr.sin6_addr.un.u32_addr[3]), port);
+            printf("ctrl: %s\n", session->ctrl->info.id);
+
+            printf("------------------------\n");
+		}
+	}
+	return ret1;
+}
+
+static struct httpd_uri hap_pair_verify = {
+	.uri = "/pair-verify",
+    .method = HTTP_POST,
+    .handler = hap_http_pair_verify_handler,
+};
+
+static int hap_add_char_val_json(hap_char_format_t format, char *key,
+		hap_val_t *val, json_gen_str_t *jptr)
+{
+	switch (format) {
+		case HAP_CHAR_FORMAT_BOOL : {
+			json_gen_obj_set_bool(jptr, key, val->b);
+			break;
+		}
+		case HAP_CHAR_FORMAT_UINT8:
+		case HAP_CHAR_FORMAT_UINT16:
+		case HAP_CHAR_FORMAT_UINT32:
+		case HAP_CHAR_FORMAT_INT: {
+			json_gen_obj_set_int(jptr, key, val->i);
+			break;
+		}
+		case HAP_CHAR_FORMAT_FLOAT : {
+			json_gen_obj_set_float(jptr, key, val->f);
+			break;
+		}
+		case HAP_CHAR_FORMAT_STRING : {
+            if (val->s) {
+			    json_gen_obj_set_string(jptr, key, val->s);
+            } else {
+                json_gen_obj_set_null(jptr, key);
+            }
+			break;
+		}
+        case HAP_CHAR_FORMAT_DATA:
+        case HAP_CHAR_FORMAT_TLV8: {
+            if (val->d.buf) {
+                json_gen_obj_start_long_string(jptr, key, NULL);
+                uint8_t *buf = val->d.buf;
+                uint32_t buflen = val->d.buflen;
+                char tmp[100];
+                while (buflen) {
+                    int tmp_len = sizeof(tmp);
+                    if (buflen > 60) {
+                        esp_mfi_base64_encode((char *)buf, 60, tmp, tmp_len, &tmp_len);
+                        buflen -= 60;
+                        buf += 60;
+                    } else {
+                        esp_mfi_base64_encode((char *)buf, buflen, tmp, tmp_len, &tmp_len);
+                        buflen -= buflen;
+                    }
+                    tmp[tmp_len] = 0;
+                    json_gen_add_to_long_string(jptr, tmp);
+                }
+                json_gen_end_long_string(jptr);
+            } else {
+                json_gen_obj_set_null(jptr, key);
+            }
+            break;
+        }
+		default :
+			break;
+	}
+	return HAP_SUCCESS;
+}
+
+static int hap_add_char_format_json(__hap_char_t *hc, json_gen_str_t *jptr)
+{
+	switch (hc->format) {
+		case HAP_CHAR_FORMAT_UINT8:
+			return json_gen_obj_set_string(jptr, "format", "uint8");
+		case HAP_CHAR_FORMAT_UINT16:
+			return json_gen_obj_set_string(jptr, "format", "uint16");
+		case HAP_CHAR_FORMAT_UINT32:
+			return json_gen_obj_set_string(jptr, "format", "uint32");
+		case HAP_CHAR_FORMAT_INT:
+			return json_gen_obj_set_string(jptr, "format", "int");
+		case HAP_CHAR_FORMAT_BOOL:
+			return json_gen_obj_set_string(jptr, "format", "bool");
+		case HAP_CHAR_FORMAT_STRING:
+			return json_gen_obj_set_string(jptr, "format", "string");
+		case HAP_CHAR_FORMAT_FLOAT:
+			return json_gen_obj_set_string(jptr, "format", "float");
+		case HAP_CHAR_FORMAT_DATA:
+			return json_gen_obj_set_string(jptr, "format", "data");
+		case HAP_CHAR_FORMAT_TLV8:
+			return json_gen_obj_set_string(jptr, "format", "tlv8");
+		default:
+			break;
+	}
+	return HAP_SUCCESS;
+}
+
+static int hap_add_char_type(__hap_char_t *hc, json_gen_str_t *jptr)
+{
+	return json_gen_obj_set_string(jptr, "type", (char *)hc->type_uuid);
+}
+
+static int hap_add_char_meta(__hap_char_t *hc, json_gen_str_t *jptr)
+{
+	hap_add_char_format_json(hc, jptr);
+
+	if (hc->constraint_flags & HAP_CHAR_MIN_FLAG)
+		hap_add_char_val_json(hc->format, "minValue", &hc->min, jptr);
+	if (hc->constraint_flags & HAP_CHAR_MAX_FLAG)
+		hap_add_char_val_json(hc->format, "maxValue", &hc->max, jptr);
+	if (hc->constraint_flags & HAP_CHAR_STEP_FLAG)
+		hap_add_char_val_json(hc->format, "minStep", &hc->step, jptr);
+
+	/* maxLen and maxDataLen are constraints for "string" and "data" format
+	 * of characteristics, respectively. However, the constraints themselves
+	 * are integers. So, we pass the format as HAP_CHAR_FORMAT_INT
+	 */
+	if (hc->constraint_flags & HAP_CHAR_MAXLEN_FLAG)
+		hap_add_char_val_json(HAP_CHAR_FORMAT_INT, "maxLen", &hc->max, jptr);
+	if (hc->constraint_flags & HAP_CHAR_MAXDATALEN_FLAG)
+		hap_add_char_val_json(HAP_CHAR_FORMAT_INT, "maxDataLen", &hc->max, jptr);
+
+	if (hc->description)
+		json_gen_obj_set_string(jptr, "description", hc->description);
+	if (hc->unit)
+		json_gen_obj_set_string(jptr, "unit", hc->unit);
+
+	return HAP_SUCCESS;
+}
+
+static int hap_add_char_perms(__hap_char_t *hc, json_gen_str_t *jptr)
+{
+	json_gen_push_array(jptr, "perms");
+	if (hc->permission & HAP_CHAR_PERM_PR)
+		json_gen_arr_set_string(jptr, "pr");
+	if (hc->permission & HAP_CHAR_PERM_PW)
+		json_gen_arr_set_string(jptr, "pw");
+	if (hc->permission & HAP_CHAR_PERM_EV)
+		json_gen_arr_set_string(jptr, "ev");
+	if (hc->permission & HAP_CHAR_PERM_AA)
+		json_gen_arr_set_string(jptr, "aa");
+	if (hc->permission & HAP_CHAR_PERM_TW)
+		json_gen_arr_set_string(jptr, "tw");
+	if (hc->permission & HAP_CHAR_PERM_HD)
+		json_gen_arr_set_string(jptr, "hd");
+	json_gen_pop_array(jptr);
+	return HAP_SUCCESS;
+}
+
+static int hap_add_char_ev(__hap_char_t *hc, json_gen_str_t *jptr, uint8_t session_index)
+{
+    if (hap_char_is_ctrl_subscribed((hap_char_t *)hc, session_index)) {
+        return json_gen_obj_set_bool(jptr, "ev", true);
+    } else {
+	    return json_gen_obj_set_bool(jptr, "ev", false);
+    }
+}
+
+static int hap_add_char_valid_vals(__hap_char_t *hc, json_gen_str_t *jptr)
+{
+    if (hc->valid_vals) {
+        json_gen_push_array(jptr, "valid-values");
+        int i;
+        for (i = 0; i < hc->valid_vals_cnt; i++) {
+            json_gen_arr_set_int(jptr, hc->valid_vals[i]);
+        }
+        json_gen_pop_array(jptr);
+    }
+    if (hc->valid_vals_range) {
+        json_gen_push_array(jptr, "valid-values-range");
+        json_gen_arr_set_int(jptr, hc->valid_vals_range[0]);
+        json_gen_arr_set_int(jptr, hc->valid_vals_range[1]);
+        json_gen_pop_array(jptr);
+    }
+    return HAP_SUCCESS;
+}
+
+static int hap_prepare_char_db(__hap_char_t *hc, json_gen_str_t *jptr, int session_index)
+{
+	json_gen_start_object(jptr);
+
+	json_gen_obj_set_int(jptr, "iid", hc->iid);
+
+    /* If the Update API has not been called from the service read routine,
+     * reset the owner controller value.
+     * Else, the controller will  miss the next notification.
+     */
+    if (!hc->update_called)   {
+        hc->owner_ctrl = 0;
+    }
+    hc->update_called = false;
+
+	if (hc->permission & HAP_CHAR_PERM_PR) {
+        if (hc->permission & HAP_CHAR_PERM_SPECIAL_READ) {
+            json_gen_obj_set_null(jptr, "value");
+        } else {
+            hap_add_char_val_json(hc->format, "value", &hc->val, jptr);
+        }
+	}
+	hap_add_char_type(hc, jptr);
+	hap_add_char_perms(hc, jptr);
+	hap_add_char_ev(hc, jptr, session_index);
+	hap_add_char_meta(hc, jptr);
+    hap_add_char_valid_vals(hc, jptr);
+
+	json_gen_end_object(jptr);
+
+	return HAP_SUCCESS;
+}
+
+static int hap_prepare_serv_db(__hap_serv_t *hs, json_gen_str_t *jptr, int session_index)
+{
+	json_gen_start_object(jptr);
+	json_gen_obj_set_int(jptr, "iid", hs->iid);
+	json_gen_obj_set_string(jptr, "type", hs->type_uuid);
+	if (hs->hidden)
+		json_gen_obj_set_bool(jptr, "hidden", "true");
+	if (hs->primary)
+		json_gen_obj_set_bool(jptr, "primary", "true");
+    if (hs->linked_servs) {
+        hap_linked_serv_t *linked = hs->linked_servs;
+        json_gen_push_array(jptr, "linked");
+        while (linked) {
+            json_gen_arr_set_int(jptr, ((__hap_serv_t *)linked->hs)->iid);
+            linked = linked->next;
+        }
+        json_gen_pop_array(jptr);
+    }
+
+	json_gen_push_array(jptr, "characteristics");
+    int char_cnt = 0;
+	hap_char_t *hc;
+    for (hc = hap_serv_get_first_char((hap_serv_t *)hs); hc; hc = hap_char_get_next(hc)) {
+        if (((__hap_char_t *)hc)->permission & HAP_CHAR_PERM_PR) {
+            char_cnt++;
+        }
+    }
+    if (char_cnt) {
+        hap_read_data_t *read_arr = hap_platform_memory_calloc(char_cnt, sizeof(hap_read_data_t));
+        if (!read_arr) {
+            return HAP_FAIL;
+        }
+
+        hap_status_t *status_codes = hap_platform_memory_calloc(char_cnt, sizeof(hap_status_t));
+        if (!status_codes) {
+            hap_platform_memory_free(read_arr);
+            return HAP_FAIL;
+        }
+
+        /* Create an array of characteristics to read, and then read them in one go */
+        char_cnt = 0;
+        for (hc = hap_serv_get_first_char((hap_serv_t *)hs); hc; hc = hap_char_get_next(hc)) {
+            if (((__hap_char_t *)hc)->permission & HAP_CHAR_PERM_PR) {
+                hap_char_set_owner_ctrl(hc, session_index);
+                ((__hap_char_t *)hc)->update_called = false;
+                read_arr[char_cnt].hc = hc;
+                status_codes[char_cnt] = HAP_STATUS_SUCCESS;
+                read_arr[char_cnt].status = &status_codes[char_cnt];
+                char_cnt++;
+            }
+        }
+
+        hs->bulk_read(&read_arr[0], char_cnt, hs->priv, NULL);
+        hap_platform_memory_free(read_arr);
+        hap_platform_memory_free(status_codes);
+    }
+    for (hc = hap_serv_get_first_char((hap_serv_t *)hs); hc; hc = hap_char_get_next(hc)) {
+		hap_prepare_char_db((__hap_char_t *)hc, jptr, session_index);
+	}
+
+	json_gen_pop_array(jptr);
+	json_gen_end_object(jptr);
+	return HAP_SUCCESS;
+}
+
+static int hap_prepare_acc_db(__hap_acc_t *ha, json_gen_str_t *jptr, int session_index)
+{
+	json_gen_start_object(jptr);
+	json_gen_obj_set_int(jptr, "aid", ha->aid);
+	json_gen_push_array(jptr, "services");
+	hap_serv_t *hs;
+	for (hs = hap_acc_get_first_serv((hap_acc_t *)ha); hs; hs = hap_serv_get_next(hs)) {
+		hap_prepare_serv_db((__hap_serv_t *)hs, jptr, session_index);
+	}
+	json_gen_pop_array(jptr);
+	json_gen_end_object(jptr);
+	return HAP_SUCCESS;
+}
+
+static int hap_prepare_json_database(char *buf, int bufsize, json_gen_flush_cb_t flush_cb, httpd_req_t *req)
+{
+    if (!req) {
+        return HAP_FAIL;
+    }
+    hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!session) {
+        return HAP_FAIL;
+    }
+	json_gen_str_t jstr;
+	json_gen_str_start(&jstr, buf, bufsize, flush_cb, req);
+	json_gen_start_object(&jstr);
+	json_gen_push_array(&jstr, "accessories");
+	hap_acc_t *ha;
+	for (ha = hap_get_first_acc(); ha; ha = hap_acc_get_next(ha)) {
+		hap_prepare_acc_db((__hap_acc_t *)ha, &jstr, hap_get_ctrl_session_index(session));
+	}
+	json_gen_pop_array(&jstr);
+	json_gen_end_object(&jstr);
+	json_gen_str_end(&jstr);
+	return HAP_SUCCESS;
+}
+
+static void hap_http_json_flush_chunk(char *data, void *priv)
+{
+    ESP_MFI_DEBUG_PLAIN("%s", data);
+	httpd_resp_send_chunk((httpd_req_t *)priv, data, strlen(data));
+}
+
+static int hap_http_get_accessories(httpd_req_t *req)
+{
+	char buf[1000];
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+    hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!hap_is_req_secure(session)) {
+        return hap_http_session_not_authorized(req);
+    }
+	httpd_resp_set_type(req, "application/hap+json");
+    ESP_MFI_DEBUG_PLAIN("Generating HTTP Response\n");
+    /* Using chunked encoding since the response can be large, especially for bridges */
+	hap_prepare_json_database(buf, sizeof(buf), hap_http_json_flush_chunk, req);
+    /* This indicates the last chunk */
+    httpd_resp_send_chunk(req, NULL, 0);
+    ESP_MFI_DEBUG_PLAIN("\n");
+
+    hap_report_event(HAP_EVENT_GET_ACC_COMPLETED, NULL, 0);
+	return HAP_SUCCESS;
+}
+static struct httpd_uri hap_accessories = {
+	.uri = "/accessories",
+    .method = HTTP_GET,
+    .handler = hap_http_get_accessories,
+};
+
+static void hap_set_char_report_status(bool *include_status, json_gen_str_t *jstr,
+		int aid, int iid, int status)
+{
+	if (!*include_status) {
+		json_gen_start_object(jstr);
+		json_gen_push_array(jstr, "characteristics");
+		*include_status = true;
+	}
+	json_gen_start_object(jstr);
+	json_gen_obj_set_int(jstr, "aid", aid);
+	json_gen_obj_set_int(jstr, "iid", iid);
+	json_gen_obj_set_int(jstr, "status", status);
+	json_gen_end_object(jstr);
+}
+
+static int hap_http_handle_set_char(jparse_ctx_t *jctx, char *outbuf, int buf_size,
+		httpd_req_t *req)
+{
+	int cnt = 0, char_cnt = 0, i;
+	bool include_status = false;
+    uint64_t pid;
+    bool valid_tw = false;
+    bool req_tw = false;
+	hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!session)
+        return HAP_FAIL;
+
+    int64_t cur_time = esp_timer_get_time() / 1000;
+    int64_t prepare_time = session->prepare_time;
+    if (prepare_time) {
+        /* If prepare time is non zero, it means that a prepare was received
+         * before this request, and so this write needs to be timed write
+         */
+        req_tw = true;
+        /* Reset prepare_time to 0, since a prepare is valid only for the immediate
+         * following write
+         */
+        session->prepare_time = 0;
+    }
+    if (json_obj_get_int64(jctx, "pid", (int64_t *)&pid) == OS_SUCCESS) {
+        /* If the pid value is present, this must be a timed write.
+         * However, if there was no preceding prepare, the check below will
+         * fail (as ttl will be 0) and appropriate error will be reported subsequently
+         */
+        req_tw = true;
+        if ((pid == session->pid) && ((cur_time - prepare_time) <= session->ttl)) {
+            valid_tw = true;
+        }
+    }
+    /* Resetting the values so that the session is ready for next prepare or write */
+    session->pid = 0;
+    session->ttl = 0;
+
+	json_obj_get_array(jctx, "characteristics", &cnt);
+	if (cnt <= 0)
+		return HAP_FAIL;
+
+    hap_write_data_t *write_arr = hap_platform_memory_calloc(cnt, sizeof(hap_write_data_t));
+	hap_status_t *status_arr = hap_platform_memory_calloc(cnt, sizeof(hap_status_t));
+	if (!write_arr || !status_arr)
+		goto set_char_end;
+
+	json_gen_str_t jstr;
+	json_gen_str_start(&jstr, outbuf, buf_size, hap_http_json_flush_chunk, req);
+    /* Dummy get, so that the loop can start by leaving the previous
+     * object and getting newer one
+     */
+    json_arr_get_object(jctx, 0);
+	/* Loop through all characteristic objects {aid,iid,value}, handle
+	 * errors if any, and if there are no errors, put the characteristic
+	 * pointer and value in an array (with char_cnt)
+	 */
+	for (i = 0; i < cnt; i++) {
+        /* Leave the previous object and get a newer one from the array */
+        json_arr_leave_object(jctx);
+		int aid = 0, iid = 0;
+		json_arr_get_object(jctx, i);
+		json_obj_get_int(jctx, "aid", &aid);
+		json_obj_get_int(jctx, "iid", &iid);
+		hap_acc_t *ha = hap_acc_get_by_aid(aid);
+		__hap_char_t *hc = (__hap_char_t *)hap_acc_get_char_by_iid(ha, iid);
+		if (!ha || !hc) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_RES_ABSENT);
+			continue;
+		}
+
+        /* If the previous request was a prepare, but the current
+         * one was not a valid timed write, report error.
+         */
+        if (req_tw == true && valid_tw == false) {
+            hap_set_char_report_status(&include_status, &jstr,
+                    aid, iid, HAP_STATUS_VAL_INVALID);
+            continue;
+        }
+
+        /* For characteristic that require a Mandatory Timed Write, return
+         * error if this write is not a valid timed write
+         */
+        if (hc->permission & HAP_CHAR_PERM_TW) {
+            if (valid_tw == false) {
+                hap_set_char_report_status(&include_status, &jstr,
+                        aid, iid, HAP_STATUS_VAL_INVALID);
+                continue;
+            }
+        }
+
+        /* Check if this write is just to enable/disable event notifications.
+         * This is valid even for read-only characteristics that support event
+         * notifications (like sensor readings), so we do not check the HAP_CHAR_PERM_PW
+         * here.
+         */
+		bool ev;
+		if (json_obj_get_bool(jctx, "ev", &ev) == HAP_SUCCESS) {
+            if (hc->permission & HAP_CHAR_PERM_EV) {
+                int index = hap_get_ctrl_session_index(session);
+                hap_char_manage_notification((hap_char_t *)hc, index, ev);
+                ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Events %s for aid=%d iid=%d",
+                        ev ? "Enabled" : "Disabled", aid, iid);
+            } else {
+				hap_set_char_report_status(&include_status, &jstr,
+						aid, iid, HAP_STATUS_NO_NOTIF);
+			}
+			continue;
+		}
+
+        /* Check if the characteristic has write permission */
+		if (!(hc->permission & HAP_CHAR_PERM_PW)) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_WR_ON_RDONLY);
+			continue;
+		}
+
+        /* Check if the characteristic needs Authorization Data.
+         * Actual authData value will be read later.
+         */
+        if (hc->permission & HAP_CHAR_PERM_AA) {
+            int tmp_len;
+            if (json_obj_get_strlen(jctx, "authData", &tmp_len) != HAP_SUCCESS) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_INSUFFICIENT_AUTH);
+			continue;
+            }
+        }
+        /* If there is no write routine registered, there is no point of having
+         * this write request. Return an error.
+         */
+		if (!((__hap_serv_t *)(hap_char_get_parent((hap_char_t *)hc)))->write_cb) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_VAL_INVALID);
+			continue;
+		}
+
+        hap_auth_data_t auth_data = {
+            .data = NULL,
+            .len = 0,
+        };
+		hap_val_t val;
+		int json_ret = HAP_FAIL;
+		switch (hc->format) {
+			case HAP_CHAR_FORMAT_BOOL:
+				json_ret = json_obj_get_bool(jctx, "value", &val.b);
+				break;
+			case HAP_CHAR_FORMAT_UINT8:
+			case HAP_CHAR_FORMAT_UINT16:
+			case HAP_CHAR_FORMAT_UINT32:
+			case HAP_CHAR_FORMAT_INT:
+				json_ret = json_obj_get_int(jctx, "value", &val.i);
+				break;
+			case HAP_CHAR_FORMAT_FLOAT:
+				json_ret = json_obj_get_float(jctx, "value", &val.f);
+				break;
+			case HAP_CHAR_FORMAT_STRING: {
+				int str_len = 0;
+				json_ret = json_obj_get_strlen(jctx, "value", &str_len);
+				if (json_ret == HAP_SUCCESS) {
+                    /* Increment string length, for NULL termination byte */
+                    str_len++;
+                    val.s = hap_platform_memory_calloc(str_len, 1);
+                    if (!val.s) {
+                        hap_set_char_report_status(&include_status, &jstr,
+                                aid, iid, HAP_STATUS_OO_RES);
+                        continue;
+                    }
+                    json_obj_get_string(jctx, "value", val.s, str_len);
+				}
+				break;
+			}
+            case HAP_CHAR_FORMAT_DATA:
+            case HAP_CHAR_FORMAT_TLV8: {
+				int str_len = 0;
+				json_ret = json_obj_get_strlen(jctx, "value", &str_len);
+				if (json_ret == HAP_SUCCESS) {
+					val.d.buf = hap_platform_memory_calloc(1, str_len + 1);
+                    if (!val.d.buf) {
+                        hap_set_char_report_status(&include_status, &jstr,
+                                aid, iid, HAP_STATUS_OO_RES);
+                        continue;
+                    }
+                    val.d.buflen = str_len + 1;
+					json_obj_get_string(jctx, "value", (char *)val.d.buf, val.d.buflen);
+                    if (esp_mfi_base64_decode((const char *)val.d.buf, strlen((char *)val.d.buf),
+                                (char *)val.d.buf, val.d.buflen, (int *)&val.d.buflen) != 0) {
+                        hap_platform_memory_free(val.d.buf);
+                        hap_set_char_report_status(&include_status, &jstr,
+                                aid, iid, HAP_STATUS_VAL_INVALID);
+                        continue;
+                    }
+				}
+				break;
+			}
+			default:
+				json_ret = HAP_FAIL;
+		}
+		if (json_ret != HAP_SUCCESS) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_VAL_INVALID);
+			continue;
+		}
+
+        /* Check if the value is within constraints */
+        if (hap_char_check_val_constraints(hc, &val) != HAP_SUCCESS) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_VAL_INVALID);
+			continue;
+        }
+
+        if (json_obj_get_strlen(jctx, "authData", &auth_data.len) == HAP_SUCCESS) {
+            auth_data.data = hap_platform_memory_calloc(1, auth_data.len + 1);
+            json_obj_get_string(jctx, "authData", (char *)auth_data.data, auth_data.len + 1);
+            esp_mfi_base64_decode((const char *)auth_data.data, auth_data.len, (char *)auth_data.data, auth_data.len + 1, &auth_data.len);
+        }
+        bool remote = false;
+        json_obj_get_bool(jctx, "remote", &remote);
+
+        int index = hap_get_ctrl_session_index(session);
+        hap_char_set_owner_ctrl((hap_char_t *)hc, index);
+		/* No errors in the object data itself. Save the characteristic
+		 * pointer and value, to be used later
+		 */
+		write_arr[char_cnt].hc = (hap_char_t *)hc;
+		write_arr[char_cnt].val = val;
+        write_arr[char_cnt].auth_data = auth_data;
+        write_arr[char_cnt].remote = remote;
+        write_arr[char_cnt].status = &status_arr[char_cnt];
+		char_cnt++;
+	}
+	if (!char_cnt)
+		goto set_char_end;
+
+	/* The logic here is to loop through all the saved characteristic
+	 * pointers, and invoke a single write callback for all consecutive
+	 * characteristics of the same service.
+	 * The write callback will be invoked if the service changes or
+	 * if the last characteristic in the array is reached
+	 */
+	int hs_index = 0;
+	bool write_err = false;
+	__hap_serv_t *hs = (__hap_serv_t *)hap_char_get_parent(write_arr[0].hc);
+	/* The counter here will go till char_cnt instead of char_cnt - 1.
+	 * When i == char_cnt, it will mean that all elements in the array
+	 * have been looped through.
+	 * So, last iteration will invoke the write callback for the last
+	 * set of characteritics.
+	 */
+	for (i = 0; i <= char_cnt; i++) {
+		if ((i < char_cnt) && ((hap_serv_t *)hs == hap_char_get_parent(write_arr[i].hc)))
+			continue;
+		else {
+			/* Passing the pointers to the first elements of the array
+			 * for a given service (indicated by hs_index).
+			 * Number of elements of the array are indicated by
+			 * i - hs_index
+			 */
+			if (hs->write_cb(&write_arr[hs_index], i - hs_index,
+					hs->priv, hap_platform_httpd_get_sess_ctx(req)) != HAP_SUCCESS)
+				write_err = true;
+			if (i < char_cnt) {
+				hs = (__hap_serv_t *)hap_char_get_parent(write_arr[i].hc);
+				hs_index = i;
+			}
+		}
+	}
+	if (write_err || include_status) {
+		for (i = 0; i < char_cnt; i++) {
+            /* TODO: The code to get aid looks complex. Simplify */
+			hap_set_char_report_status(&include_status, &jstr,
+				((__hap_acc_t *)hap_serv_get_parent(hap_char_get_parent(write_arr[i].hc)))->aid,
+				((__hap_char_t *)(write_arr[i].hc))->iid, *write_arr[i].status);
+		}
+	}
+
+	int ret = HAP_SUCCESS;
+set_char_end:
+	if (include_status) {
+		json_gen_pop_array(&jstr);
+		json_gen_end_object(&jstr);
+		json_gen_str_end(&jstr);
+		ret = HAP_FAIL;
+	}
+
+	if (write_arr) {
+		for (i = 0; i < char_cnt; i++) {
+			if (((__hap_char_t *)write_arr[i].hc)->format == HAP_CHAR_FORMAT_STRING) {
+				if (write_arr[i].val.s) {
+                    hap_platform_memory_free(write_arr[i].val.s);
+                }
+			} else if ((((__hap_char_t *)write_arr[i].hc)->format == HAP_CHAR_FORMAT_DATA) ||
+                    (((__hap_char_t *)write_arr[i].hc)->format == HAP_CHAR_FORMAT_TLV8)) {
+                    hap_platform_memory_free(write_arr[i].val.d.buf);
+            }
+            if (write_arr[i].auth_data.data) {
+                hap_platform_memory_free(write_arr[i].auth_data.data);
+            }
+		}
+	}
+	if (write_arr)
+		hap_platform_memory_free(write_arr);
+	if (status_arr)
+		hap_platform_memory_free(status_arr);
+	return ret;
+}
+
+static int hap_http_put_characteristics(httpd_req_t *req)
+{
+    char stack_inbuf[512] = {0};
+    char outbuf[512] = {0};
+    char *heap_inbuf = NULL;
+    char *inbuf = stack_inbuf;
+
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+    hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!hap_is_req_secure(session)) {
+        return hap_http_session_not_authorized(req);
+    }
+
+    /* If received content is larger than the buffer on stack, allocate one from heap.
+     * This will mostly be required only in case of bridges, wherein there could be a request to
+     * control all/many accessories at once.
+     */
+    int content_len = hap_platform_httpd_get_content_len(req);
+    if (content_len > sizeof(stack_inbuf)) {
+        heap_inbuf = hap_platform_memory_calloc(content_len + 1, 1); /* Allocating an extra byte for NULL termination */
+        if (!heap_inbuf) {
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to read HTTPD Data");
+            httpd_resp_set_status(req, HTTPD_500);
+            return httpd_resp_send(req, NULL, 0);
+        }
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Allocated buffer of size %d for the large PUT",
+                    content_len + 1)
+        inbuf = heap_inbuf;
+    }
+	int data_len = hap_httpd_get_data(req, inbuf, content_len);
+	if (data_len < 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to read HTTPD Data");
+		httpd_resp_set_status(req, HTTPD_500);
+        if (heap_inbuf) {
+            hap_platform_memory_free(heap_inbuf);
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Freed allocated buffer for PUT");
+        }
+		return httpd_resp_send(req, NULL, 0);
+	}
+    ESP_MFI_DEBUG_PLAIN("Data Received: %s\n", inbuf);
+	jparse_ctx_t jctx;
+	if (json_parse_start(&jctx, inbuf, data_len) != HAP_SUCCESS) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to parse HTTPD JSON Data");
+		httpd_resp_set_status(req, HTTPD_500);
+        if (heap_inbuf) {
+            hap_platform_memory_free(heap_inbuf);
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Freed allocated buffer for PUT");
+        }
+		return httpd_resp_send(req, NULL, 0);
+	}
+
+	httpd_resp_set_type(req, "application/hap+json");
+	/* Setting response type to indicate error.
+	 * This will be actually sent out only if there is some error
+	 * to be reported while handling the characteristic writes.
+	 * Else, the response type will be set to 204
+	 */
+	httpd_resp_set_status(req, HTTPD_207);
+	if (hap_http_handle_set_char(&jctx, outbuf, sizeof(outbuf), req) == HAP_SUCCESS)
+	{
+		snprintf(outbuf, sizeof(outbuf), "HTTP/1.1 %s\r\n\r\n", HTTPD_204);
+		httpd_send(req, outbuf, strlen(outbuf));
+	} else {
+        /* If a failure was encountered, it would mean that a response has been generated,
+         * which will be chunk encoded. So, sending the last chunk here and also printing
+         * a new line to end the prints of the error string.
+         */
+        httpd_resp_send_chunk(req, NULL, 0);
+        ESP_MFI_DEBUG_PLAIN("\n");
+    }
+    json_parse_end(&jctx);
+
+    if (heap_inbuf) {
+        hap_platform_memory_free(heap_inbuf);
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Freed allocated buffer for PUT");
+    }
+
+    hap_report_event(HAP_EVENT_SET_CHAR_COMPLETED, NULL, 0);
+    return HAP_SUCCESS;
+}
+
+static bool hap_get_bool_url_param(char *query_str, char *key)
+{
+	char val[6]; /* Max string will be "false" */
+	if (httpd_query_key_value(query_str, key, val, sizeof(val)) == HAP_SUCCESS) {
+		if (!strcmp(val, "true") || !strcmp(val, "1"))
+			return true;
+	}
+	return false;
+}
+
+static int hap_http_get_characteristics(httpd_req_t *req)
+{
+    char outbuf[512];
+    char stack_val_buf[512] = {0};
+    char *heap_val_buf = NULL;
+    char *val = stack_val_buf;
+
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+
+    hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!hap_is_req_secure(session)) {
+        return hap_http_session_not_authorized(req);
+    }
+    const char *uri = hap_platform_httpd_get_req_uri(req);
+    /* Allocate on heap, if URI is longer */
+    if (strlen(uri) > sizeof(stack_val_buf)) {
+        heap_val_buf = hap_platform_memory_calloc(strlen(uri) + 1, 1); /* Allocating an extra byte for NULL termination */
+        if (!heap_val_buf) {
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to read URL");
+            httpd_resp_set_status(req, HTTPD_500);
+            return httpd_resp_send(req, NULL, 0);
+        }
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Allocated buffer of size %d for the large GET",
+                    strlen(uri) + 1)
+        val = heap_val_buf;
+    }
+    size_t url_query_str_len = httpd_req_get_url_query_len(req);
+    char * url_query_str = hap_platform_memory_calloc(1, url_query_str_len + 1);
+    if (!url_query_str) {
+		httpd_resp_set_status(req, HTTPD_400);
+		httpd_resp_set_type(req, "application/hap+json");
+		snprintf(outbuf, sizeof(outbuf),"{\"status\":-70409}");
+		httpd_resp_send(req, outbuf, strlen(outbuf));
+        goto get_char_return;
+    }
+    httpd_req_get_url_query_str(req, url_query_str, url_query_str_len + 1);
+	/* Check for all the optional URL query paramaters */
+	bool meta = hap_get_bool_url_param(url_query_str, "meta");
+	bool perms = hap_get_bool_url_param(url_query_str, "perms");
+	bool type = hap_get_bool_url_param(url_query_str, "type");
+	bool ev = hap_get_bool_url_param(url_query_str, "ev");
+
+	/* Check for the mandatory "id" URL query parameter.
+	 * If not found, return success
+	 */
+	if (httpd_query_key_value(url_query_str, "id", val, strlen(uri) + 1) != HAP_SUCCESS) {
+		httpd_resp_set_status(req, HTTPD_400);
+		httpd_resp_set_type(req, "application/hap+json");
+		snprintf(outbuf, sizeof(outbuf),"{\"status\":-70409}");
+		httpd_resp_send(req, outbuf, strlen(outbuf));
+        goto get_char_return;
+    }
+
+	/* Get the total count of characteristics in the request. This will be
+	 * required to decide the size of the characteristic pointers' array
+	 */
+	int char_cnt = 0;
+	char *val_ptr = val;
+	/* We do not do any error checking here and just assume that the id
+	 * tag has a characteristic list which is a comma separated list
+	 * of <aid>.<iid> elements
+	 */
+	char *p = strsep(&val_ptr, ",");
+	while (p) {
+		char_cnt++;
+		p = strsep(&val_ptr, ",");
+	}
+
+	/* Normally, it would have been fine to just go on parsing the
+	 * characteristics in the URL, fetch their values and prepare
+	 * the response. However, if there is error for any characteristic
+	 * a "status" field needs to be added for all characteristics.
+	 *
+	 * So, it is better to maintain a list of characteristics pointers,
+	 * read all the values, and only then create the response
+	 */
+	hap_read_data_t *read_arr = hap_platform_memory_calloc(char_cnt, sizeof(hap_read_data_t));
+    if (!read_arr) {
+		httpd_resp_set_status(req, HTTPD_500);
+		httpd_resp_set_type(req, "application/hap+json");
+		snprintf(outbuf, sizeof(outbuf),"{\"status\":-70407}");
+		httpd_resp_send(req, outbuf, strlen(outbuf));
+        goto get_char_return;
+    }
+    hap_status_t *status_codes = hap_platform_memory_calloc(char_cnt, sizeof(hap_status_t));
+    if (!status_codes) {
+        hap_platform_memory_free(read_arr);
+		httpd_resp_set_status(req, HTTPD_500);
+		httpd_resp_set_type(req, "application/hap+json");
+		snprintf(outbuf, sizeof(outbuf),"{\"status\":-70407}");
+		httpd_resp_send(req, outbuf, strlen(outbuf));
+        goto get_char_return;
+    }
+
+    ESP_MFI_DEBUG_PLAIN("Generating HTTP Response\n");
+	/* Generate the JSON response */
+	bool include_status = 0;
+	httpd_resp_set_status(req, HTTPD_207);
+	httpd_resp_set_type(req, "application/hap+json");
+	json_gen_str_t jstr;
+	json_gen_str_start(&jstr, outbuf, sizeof(outbuf), hap_http_json_flush_chunk, req);
+
+	/* Get the ids once again. Not checking for success since that
+	 * would be redundant
+	 */
+	httpd_query_key_value(url_query_str, "id", val, strlen(uri) + 1);
+    char_cnt = 0;
+	int aid, iid;
+	val_ptr = val;
+	/* Parse the AIDs and IIDs in the "id" field and fetch the
+	 * characteristic pointer for each
+	 */
+	p = strsep(&val_ptr, ".");
+	while (p) {
+		aid = atoi(p);
+		p = strsep(&val_ptr, ",");
+		iid = atoi(p);
+		p = strsep(&val_ptr, ".");
+		hap_char_t *hc = hap_acc_get_char_by_iid(hap_acc_get_by_aid(aid), iid);
+		if (!hc) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_RES_ABSENT);
+			continue;
+		}
+		if (!(((__hap_char_t *)hc)->permission & HAP_CHAR_PERM_PR)) {
+			hap_set_char_report_status(&include_status, &jstr,
+					aid, iid, HAP_STATUS_RD_ON_WRONLY);
+			continue;
+		}
+        hap_char_set_owner_ctrl(hc, hap_get_ctrl_session_index(session));
+        ((__hap_char_t *)hc)->update_called = false;
+        /* Add the characteristic to the read array */
+		read_arr[char_cnt].hc = hc;
+        status_codes[char_cnt] = HAP_STATUS_SUCCESS;
+        read_arr[char_cnt].status = &status_codes[char_cnt];
+		char_cnt++;
+	}
+
+    if (!char_cnt) {
+        goto get_char_end;
+    }
+
+
+	int hs_index = 0;
+	bool read_err = false;
+	__hap_serv_t *hs = (__hap_serv_t *)hap_char_get_parent(read_arr[0].hc);
+    /* Read all the values first, before preparing the response, so that it
+     * would be known in advance, if any read error is encountered
+     */
+    int i;
+	/* The counter here will go till char_cnt instead of char_cnt - 1.
+	 * When i == char_cnt, it will mean that all elements in the array
+	 * have been looped through.
+	 * So, last iteration will invoke the read callback for the last
+	 * set of characteritics.
+	 */
+	for (i = 0; i <= char_cnt; i++) {
+		if ((i < char_cnt) && ((hap_serv_t *)hs == hap_char_get_parent(read_arr[i].hc)))
+			continue;
+		else {
+			/* Passing the pointers to the first elements of the array
+			 * for a given service (indicated by hs_index).
+			 * Number of elements of the array are indicated by
+			 * i - hs_index
+			 */
+			if (hs->bulk_read(&read_arr[hs_index], i - hs_index, hs->priv, hap_platform_httpd_get_sess_ctx(req)) != HAP_SUCCESS)
+				read_err = true;
+			if (i < char_cnt) {
+				hs = (__hap_serv_t *)hap_char_get_parent(read_arr[i].hc);
+				hs_index = i;
+			}
+		}
+	}
+    if (!include_status) {
+        if (!read_err) {
+            /* If "include_status" is false, it means there
+             * were no errors.
+             * So, set response type to 200 OK
+             */
+            httpd_resp_set_status(req, HTTPD_200);
+        }
+        json_gen_start_object(&jstr);
+        json_gen_push_array(&jstr, "characteristics");
+    }
+	/* Loop through the characteristics and include their data
+	 */
+	for (i = 0; i < char_cnt; i++) {
+		__hap_char_t *hc = (__hap_char_t *)read_arr[i].hc;
+        /* If the Update API has not been called from the service read routine,
+         * reset the owner controller value.
+         * Else, the controller will  miss the next notification.
+         */
+        if (!hc->update_called) {
+            hc->owner_ctrl = 0;
+        }
+        hc->update_called = false;
+
+		json_gen_start_object(&jstr);
+		__hap_acc_t *ha = (__hap_acc_t *)hap_serv_get_parent(hc->parent);
+		json_gen_obj_set_int(&jstr, "aid", ha->aid);
+		json_gen_obj_set_int(&jstr, "iid", hc->iid);
+
+        if (hc->permission & HAP_CHAR_PERM_SPECIAL_READ) {
+            json_gen_obj_set_null(&jstr, "value");
+        } else {
+            /* Include "value" only if status is SUCCESS */
+            if (*read_arr[i].status == HAP_STATUS_SUCCESS) {
+                hap_add_char_val_json(hc->format, "value", &hc->val, &jstr);
+            }
+        }
+		/* Include status only if it was already included because of
+		 * some parsing errors, or if an error was encountered while
+         * actually reading the characteristics.
+		 */
+		if (include_status || read_err) {
+			json_gen_obj_set_int(&jstr, "status", *read_arr[i].status);
+		}
+		if (type)
+			hap_add_char_type(hc, &jstr);
+		if (perms)
+			hap_add_char_perms(hc, &jstr);
+		if (ev) {
+			hap_add_char_ev(hc, &jstr, hap_get_ctrl_session_index(session));
+        }
+		if (meta)
+			hap_add_char_meta(hc, &jstr);
+		json_gen_end_object(&jstr);
+	}
+get_char_end:
+	json_gen_pop_array(&jstr);
+	json_gen_end_object(&jstr);
+	json_gen_str_end(&jstr);
+
+	hap_platform_memory_free(read_arr);
+    hap_platform_memory_free(status_codes);
+
+    /* This indicates the last chunk */
+    httpd_resp_send_chunk(req, NULL, 0);
+    ESP_MFI_DEBUG_PLAIN("\n");
+get_char_return:
+    if (heap_val_buf) {
+        hap_platform_memory_free(heap_val_buf);
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Freed allocated buffer for GET");
+    }
+
+    if (url_query_str) {
+        hap_platform_memory_free(url_query_str);
+    }
+
+    hap_report_event(HAP_EVENT_GET_CHAR_COMPLETED, NULL, 0);
+	return HAP_SUCCESS;
+}
+static struct httpd_uri hap_characteristics_get = {
+	.uri = "/characteristics",
+    .method = HTTP_GET,
+    .handler = hap_http_get_characteristics,
+};
+static struct httpd_uri hap_characteristics_put = {
+	.uri = "/characteristics",
+    .method = HTTP_PUT,
+    .handler = hap_http_put_characteristics,
+};
+
+static int hap_http_pairings_handler(httpd_req_t *req)
+{
+	uint8_t buf[2048]; /* Large buffer to accommodate 16 pairings list */
+	void *ctx = hap_platform_httpd_get_sess_ctx(req);
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+	int data_len = httpd_req_recv(req, (char *)buf, sizeof(buf));
+	int outlen;
+    hap_secure_session_t *session = (hap_secure_session_t *)ctx;
+    if (!hap_is_req_secure(session)) {
+        /* Only setting the HTTP status here. Actual error TLV will be added
+         * by the hap_pairings_process() call
+         */
+        httpd_resp_set_status(req, "470 Connection Authorization Required");
+    }
+	hap_pairings_process(ctx, buf, data_len, sizeof(buf), &outlen);
+	httpd_resp_set_type(req, "application/pairing+tlv8");
+	return httpd_resp_send(req, (char *)buf, outlen);
+}
+static struct httpd_uri hap_pairings = {
+	.uri = "/pairings",
+    .method = HTTP_POST,
+    .handler = hap_http_pairings_handler,
+};
+
+static int hap_http_post_identify(httpd_req_t *req)
+{
+	char buf[100];
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d\nHTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+	if (is_accessory_paired()) {
+		httpd_resp_set_status(req, HTTPD_400);
+		httpd_resp_set_type(req, "application/hap+json");
+		snprintf(buf, sizeof(buf),"{\"status\":-70401}");
+		httpd_resp_send(req, buf, strlen(buf));
+	} else {
+		hap_acc_t *ha = hap_get_first_acc();
+        __hap_acc_t *_ha = (__hap_acc_t *)ha;
+		_ha->identify_routine(ha);
+		snprintf(buf, sizeof(buf), "HTTP/1.1 %s\r\n\r\n", HTTPD_204);
+		httpd_send(req, buf, strlen(buf));
+	}
+	return HAP_SUCCESS;
+}
+
+static struct httpd_uri hap_identify = {
+	.uri = "/identify",
+    .method = HTTP_POST,
+    .handler = hap_http_post_identify,
+};
+
+static int hap_http_put_prepare(httpd_req_t *req)
+{
+    char buf[512] = {0};
+
+    ESP_MFI_DEBUG_PLAIN("Socket fd: %d; HTTP Request %s %s\n", httpd_req_to_sockfd(req), hap_platform_httpd_get_req_method(req), hap_platform_httpd_get_req_uri(req));
+    hap_secure_session_t *session = (hap_secure_session_t *)hap_platform_httpd_get_sess_ctx(req);
+    if (!hap_is_req_secure(session)) {
+        return hap_http_session_not_authorized(req);
+    }
+	int data_len = httpd_req_recv(req, (char *)buf, sizeof(buf));
+	if (data_len < 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to read HTTPD Data");
+		httpd_resp_set_status(req, HTTPD_500);
+		return httpd_resp_send(req, NULL, 0);
+	}
+    ESP_MFI_DEBUG_PLAIN("Data Received: %s\n", buf);
+	jparse_ctx_t jctx;
+	if (json_parse_start(&jctx, buf, data_len) != HAP_SUCCESS) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to parse HTTPD JSON Data");
+		httpd_resp_set_status(req, HTTPD_500);
+		return httpd_resp_send(req, NULL, 0);
+	}
+
+	httpd_resp_set_type(req, "application/hap+json");
+    uint64_t pid;
+    int64_t ttl;
+    if ((json_obj_get_int64(&jctx, "pid", (int64_t *)&pid) != OS_SUCCESS) ||
+        (json_obj_get_int64(&jctx, "ttl", &ttl) != OS_SUCCESS)) {
+		snprintf(buf, sizeof(buf),"{\"status\":-70410}");
+    } else {
+        session->pid = pid;
+        session->ttl = ttl;
+        session->prepare_time = esp_timer_get_time() / 1000; /* Set current time in msec */
+        snprintf(buf, sizeof(buf),"{\"status\":0}");
+    }
+    json_parse_end(&jctx);
+    httpd_resp_send(req, buf, strlen(buf));
+    return HAP_SUCCESS;
+}
+
+static struct httpd_uri hap_prepare = {
+	.uri = "/prepare",
+    .method = HTTP_PUT,
+    .handler = hap_http_put_prepare,
+};
+
+static void hap_send_notification(void *arg)
+{
+    int num_char = hap_priv.cfg.max_event_notif_chars;
+    hap_char_t *hc;
+    hap_char_t **char_arr = hap_platform_memory_calloc(num_char, sizeof(hap_char_t *));
+
+    if (!char_arr) {
+        return;
+    }
+
+    int i, num_notif_chars;
+    for (i = 0; i < num_char; i++) {
+        hc = hap_get_pending_notif_char();
+        if (hc) {
+            char_arr[i] = hc;
+        } else {
+            break;
+        }
+    }
+    /* If no characteristic notifications are pending, free char_arr and exit */ 
+    if (i == 0) {
+	hap_platform_memory_free(char_arr); 
+        return;
+    }
+    num_notif_chars = i;
+	hap_secure_session_t *session;
+    /* Flag to indicate if any controller was connected */
+    bool ctrl_connected = false;
+	char buf[250];
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+		session = hap_priv.sessions[i];
+		if (!session)
+			continue;
+        ctrl_connected = true;
+		int fd = session->conn_identifier;
+#define HTTPD_HDR_STR      "EVENT/1.0 200 OK\r\n"                   \
+		"Content-Type: application/hap+json\r\n"           \
+		"Content-Length: %d\r\n"
+		char notif_json[1024];
+		json_gen_str_t jstr;
+		json_gen_str_start(&jstr, notif_json, sizeof(notif_json), NULL, NULL);
+		json_gen_start_object(&jstr);
+		json_gen_push_array(&jstr, "characteristics");
+
+        int j;
+        bool notif_to_send = false;
+        for (j = 0; j < num_notif_chars; j++) {
+            hc = char_arr[j];
+            __hap_char_t *_hc = ( __hap_char_t *)hc;
+            /* If the controller is the owner, dont send notification to it */
+            if (hap_char_is_ctrl_owner(hc, i)) {
+                /* Since there can be only one owner, which we are anyways skipping,
+                 * we can reset owner value to 0
+                 */
+                _hc->owner_ctrl = 0;
+                continue;
+            }
+            if (!hap_char_is_ctrl_subscribed(hc, i))
+                continue;
+
+            json_gen_start_object(&jstr);
+            hap_acc_t *ha = hap_serv_get_parent(hap_char_get_parent(hc));
+            int aid = ((__hap_acc_t *)ha)->aid;
+            json_gen_obj_set_int(&jstr, "aid", aid);
+            json_gen_obj_set_int(&jstr, "iid", _hc->iid);
+            hap_add_char_val_json(_hc->format, "value", &_hc->val, &jstr);
+            json_gen_end_object(&jstr);
+            notif_to_send = true;
+        }
+        if (!notif_to_send) {
+            /* No notification required for this controller. Just continue */
+            continue;
+        }
+
+        json_gen_pop_array(&jstr);
+		json_gen_end_object(&jstr);
+		json_gen_str_end(&jstr);
+
+		snprintf(buf, sizeof(buf), HTTPD_HDR_STR,
+				strlen(notif_json));
+		hap_httpd_send(hap_priv.server, fd, buf, strlen(buf), 0);
+		/* Space for sending additional headers based on set_header */
+		hap_httpd_send(hap_priv.server, fd, "\r\n", strlen("\r\n"), 0);
+		hap_httpd_send(hap_priv.server, fd, notif_json, strlen(notif_json), 0);
+        httpd_sess_update_lru_counter(hap_priv.server, fd);
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Notification Sent");
+        ESP_MFI_DEBUG_PLAIN("Socket fd: %d; Event message: %s\n", fd, notif_json);
+	}
+    /* If no controller was connected and no disconnected event was sent,
+     * reannaounce mDNS. That will increment state number as required
+     * by HAP Spec R15.
+     */
+    if (!ctrl_connected && !hap_priv.disconnected_event_sent) {
+        hap_mdns_announce(false);
+        hap_priv.disconnected_event_sent = true;
+    }
+    hap_platform_memory_free(char_arr);
+}
+
+void hap_http_debug_enable()
+{
+    http_debug = true;
+}
+
+void hap_http_debug_disable()
+{
+    http_debug = false;
+}
+
+void hap_http_send_notif()
+{
+	httpd_queue_work(hap_priv.server, hap_send_notification, NULL);
+}
+
+static bool hap_http_registered;
+int hap_register_http_handlers()
+{
+    if (!hap_http_registered) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Registering HomeKit web handlers");
+        httpd_register_uri_handler(hap_priv.server, &hap_pair_setup);
+        httpd_register_uri_handler(hap_priv.server, &hap_pair_verify);
+        httpd_register_uri_handler(hap_priv.server, &hap_pairings);
+        httpd_register_uri_handler(hap_priv.server, &hap_accessories);
+        httpd_register_uri_handler(hap_priv.server, &hap_characteristics_get);
+        httpd_register_uri_handler(hap_priv.server, &hap_characteristics_put);
+        httpd_register_uri_handler(hap_priv.server, &hap_identify);
+        httpd_register_uri_handler(hap_priv.server, &hap_prepare);
+        if (hap_priv.features & HAP_FF_SW_TOKEN_AUTH) {
+            hap_register_secure_message_handler(hap_priv.server);
+        }
+    }
+    hap_http_registered = true;
+    return HAP_SUCCESS;
+}
+
+int hap_unregister_http_handlers()
+{
+    if (hap_http_registered) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Unegistering HomeKit web handlers");
+        httpd_unregister_uri_handler(hap_priv.server, "/pair-setup", HTTP_POST);
+        httpd_unregister_uri_handler(hap_priv.server, "/pair-verify", HTTP_POST);
+        httpd_unregister_uri_handler(hap_priv.server, "/pairings", HTTP_POST);
+        httpd_unregister_uri_handler(hap_priv.server, "/accessories", HTTP_GET);
+        httpd_unregister_uri_handler(hap_priv.server, "/characteristics", HTTP_GET);
+        httpd_unregister_uri_handler(hap_priv.server, "/characteristics", HTTP_PUT);
+        httpd_unregister_uri_handler(hap_priv.server, "/identify", HTTP_POST);
+        httpd_unregister_uri_handler(hap_priv.server, "/prepare", HTTP_PUT);
+        if (hap_priv.features & HAP_FF_SW_TOKEN_AUTH) {
+            hap_unregister_secure_message_handler(hap_priv.server);
+        }
+    }
+    hap_http_registered = false;
+    return HAP_SUCCESS;
+}
+
+int hap_httpd_start(void)
+{
+    if (hap_platform_httpd_start(&hap_priv.server) == ESP_OK) {
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+httpd_handle_t * hap_httpd_get_handle()
+{
+    return &hap_priv.server;
+}
+static bool first_announce_done;
+
+int hap_mdns_deannounce(void)
+{
+    int ret = HAP_SUCCESS;
+    if (first_announce_done) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Deannouncing _hap._tcp mDNS service");
+        ret = hap_mdns_serv_stop(&hap_priv.hap_mdns_handle);
+        if (ret == HAP_SUCCESS) {
+            /* Wait for some time for the packets to go out on network */
+            vTaskDelay(2000 / hap_platform_os_get_msec_per_tick());
+            first_announce_done = false;
+        }
+    }
+    return ret;
+}
+
+int hap_mdns_announce(bool first)
+{
+    /* If the API is called with the "first" argument as true, Force announce the service,
+     * rather than just sending a re-announce packet
+     */
+    if (first) {
+        first_announce_done = false;
+    }
+    static char config_num[6]; /* Max value can be 65535 */
+    static char state_num[6]; /* Max value can be 65535 */
+    static char ff[4];
+    static char sf[4];
+    static char ci[4];
+
+    mdns_txt_item_t txt[9];
+    int i = 0;
+
+    snprintf(config_num, sizeof(config_num), "%d", hap_priv.config_num);
+    txt[i].key = "c#";
+    txt[i++].value = config_num;
+
+
+    uint8_t features = 0;
+    /* Either hardware authentication, or software authentication
+     * can be enabled at a time.
+     */
+    if (hap_priv.features & HAP_FF_HARDWARE_AUTH) {
+        features |= HAP_FF_HARDWARE_AUTH;
+    } else if (hap_priv.features & HAP_FF_SW_TOKEN_AUTH) {
+        features |= HAP_FF_SW_TOKEN_AUTH;
+    }
+    snprintf(ff, sizeof(ff), "%d", features);
+    txt[i].key = "ff";
+    txt[i++].value = ff;
+
+    txt[i].key = "id";
+    txt[i++].value = hap_priv.acc_id;
+
+    txt[i].key = "md";
+    txt[i++].value = hap_priv.primary_acc.model;
+
+    txt[i].key = "pv";
+    txt[i++].value = "1.1"; /* As per HAP Spec R10 */
+
+    if (first_announce_done) {
+        /* If first announcement was already done, this is a republish.
+         * Update the state number, since HAP Spec R15 requires that any Bonjour republish
+         * should update state number.
+         */
+        if (is_accessory_paired()) {
+            hap_increment_and_save_state_num();
+        }
+    }
+    snprintf(state_num, sizeof(state_num), "%u", hap_priv.state_num);
+    txt[i].key = "s#";
+    txt[i++].value = state_num;
+
+    uint8_t status_flags = is_accessory_paired() ? 0 : HAP_SF_ACC_UNPAIRED;
+    if (!hap_is_network_configured())
+        status_flags |= HAP_SF_ACC_UNCONFIGURED;
+    snprintf(sf, sizeof(sf), "%d", status_flags);
+    txt[i].key = "sf";
+    txt[i++].value = sf;
+
+    snprintf(ci, sizeof(ci), "%d", hap_priv.cid);
+    txt[i].key = "ci";
+    txt[i++].value = ci;
+
+    txt[i].key = "sh";
+    txt[i++].value = hap_priv.setup_hash_str;
+
+    int ret;
+    /* If first announce is not done, the service will be added instead of just updating.
+     * Else, first add the service, instead of just updating.
+     */
+    if (!first_announce_done) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Announcing _hap._tcp mDNS service");
+        ret = hap_mdns_serv_start(&hap_priv.hap_mdns_handle,
+            hap_priv.primary_acc.name, "_hap", "_tcp", hap_platform_httpd_get_port(), txt, i);
+        first_announce_done = true;
+    } else {
+        /* Else, just update TXT records. Not add new service.*/
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Re-announcing _hap._tcp mDNS service");
+        ret = hap_mdns_serv_update_txt(&hap_priv.hap_mdns_handle, txt, i);
+    }
+    if (ret != 0) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to announce _hap mDNS service");
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_ip_services_start()
+{
+    static bool hap_ip_services_started;
+    if (hap_ip_services_started) {
+        return HAP_SUCCESS;
+    }
+    hap_register_http_handlers();
+    if (hap_mdns_announce(false) != HAP_SUCCESS) {
+        hap_unregister_http_handlers();
+        return HAP_FAIL;
+    }
+    hap_ip_services_started = true;
+    return HAP_SUCCESS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_ip_services.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_ip_services.h
@@ -1,0 +1,35 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_IP_SERVICES_H_
+#define _HAP_IP_SERVICES_H_
+#include <stdbool.h>
+#include <esp_http_server.h>
+int hap_http_session_not_authorized(httpd_req_t *req);
+int hap_httpd_get_data(httpd_req_t *req, char *buffer, int len);
+int hap_httpd_start();
+int hap_ip_services_start();
+int hap_mdns_announce(bool first);
+int hap_mdns_deannounce();
+void hap_http_send_notif();
+#endif /* _HAP_IP_SERVICES_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_keystore.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_keystore.c
@@ -1,0 +1,133 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <hap.h>
+#include <esp_mfi_debug.h>
+#include <hap_platform_keystore.h>
+
+static bool keystore_init_done;
+static char *hap_platform_nvs_partition;
+static char *hap_platform_factory_nvs_partition;
+
+int hap_keystore_init()
+{
+    if (keystore_init_done) {
+        return HAP_SUCCESS;
+    }
+
+
+
+    hap_platform_nvs_partition = hap_platform_keystore_get_nvs_partition_name();
+
+  //  hap_platfrom_keystore_erase_partition(hap_platform_nvs_partition);
+
+    int err = hap_platform_keystore_init_partition(hap_platform_nvs_partition, false);
+    if (err != 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Error (%d) NVS init failed", err);
+        return HAP_FAIL;
+    }
+    /* Not cheking the return value, as this partition may be absent */
+    hap_platform_factory_nvs_partition = hap_platform_keystore_get_factory_nvs_partition_name();
+    hap_platform_keystore_init_partition(hap_platform_factory_nvs_partition, true);
+
+    keystore_init_done = true;
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Keystore initialised");
+    return HAP_SUCCESS;
+}
+
+int __hap_keystore_get(const char *part_name, const char *name_space, const char *key, uint8_t *val, size_t *val_size)
+{
+    if (!keystore_init_done) {
+        return HAP_FAIL;
+    }
+
+    int err  = hap_platform_keystore_get(part_name, name_space, key, val, val_size);
+    if (err != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+int hap_keystore_get(const char *name_space, const char *key, uint8_t *val, size_t *val_size)
+{
+
+    return __hap_keystore_get(hap_platform_nvs_partition, name_space, key, val, val_size);
+}
+int hap_factory_keystore_get(const char *name_space, const char *key, uint8_t *val, size_t *val_size)
+{
+    return __hap_keystore_get(hap_platform_factory_nvs_partition, name_space, key, val, val_size);
+}
+
+int __hap_keystore_set(const char *part_name, const char *name_space, const char *key, const uint8_t *val, const size_t val_len)
+
+{
+    if (!keystore_init_done) {
+        return HAP_FAIL;
+    }
+
+    int err  = hap_platform_keystore_set(part_name, name_space, key, val, val_len);
+    if (err != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_keystore_set(const char *name_space, const char *key, const uint8_t *val, const size_t val_len)
+{
+    return __hap_keystore_set(hap_platform_nvs_partition, name_space, key, val, val_len);
+}
+
+int hap_factory_keystore_set(const char *name_space, const char *key, const uint8_t *val, const size_t val_len)
+{
+    return __hap_keystore_set(hap_platform_factory_nvs_partition, name_space, key, val, val_len);
+}
+
+int hap_keystore_delete(const char *name_space, const char *key)
+{
+    if (!keystore_init_done) {
+        return HAP_FAIL;
+    }
+
+    int err = hap_platform_keystore_delete(hap_platform_nvs_partition, name_space, key);
+    if (err != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_keystore_delete_namespace(const char *name_space)
+{
+    if (!keystore_init_done) {
+        return HAP_FAIL;
+    }
+
+    int err = hap_platform_keystore_delete_namespace(hap_platform_nvs_partition, name_space);
+    if (err != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+void hap_keystore_erase_all_data()
+{
+    hap_platfrom_keystore_erase_partition(hap_platform_nvs_partition);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_keystore.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_keystore.h
@@ -1,0 +1,34 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_KEYSTORE_H_
+#define _HAP_KEYSTORE_H_
+#include <hap.h>
+int hap_keystore_init();
+int hap_keystore_get(const char *name_space, const char *key, uint8_t *val, size_t *val_size);
+int hap_keystore_set(const char *name_space, const char *key, const uint8_t *val, const size_t val_len);
+int hap_keystore_delete(const char *name_space, const char *key);
+int hap_keystore_delete_namespace(const char *name_space);
+int hap_factory_keystore_set(const char *name_space, const char *key, const uint8_t *val, const size_t val_len);
+void hap_keystore_erase_all_data();
+#endif /* _HAP_KEYSTORE_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_main.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_main.c
@@ -1,0 +1,372 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <errno.h>
+#include <unistd.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/queue.h>
+#include <esp_event.h>
+#include <esp_wifi.h>
+
+#include <esp_mfi_debug.h>
+#include <esp_hap_acc.h>
+#include <esp_hap_char.h>
+#include <esp_hap_database.h>
+#include <esp_hap_ip_services.h>
+#include <esp_hap_wifi.h>
+#include <esp_hap_mdns.h>
+#include <esp_hap_keystore.h>
+#include <esp_hap_main.h>
+#include <esp_hap_wac.h>
+#include <esp_hap_bct_priv.h>
+#include <esp_hap_pair_verify.h>
+#include <hap_platform_os.h>
+#include <_esp_hap_config.h>
+
+static QueueHandle_t xQueue;
+ESP_EVENT_DEFINE_BASE(HAP_EVENT);
+
+const char * hap_get_version(void)
+{
+    return MFI_VER;
+}
+static void hap_nw_configured_sm(hap_internal_event_t event, hap_state_t *state)
+{
+    switch (event) {
+        case HAP_INTERNAL_EVENT_ACC_PAIRED:
+            hap_mdns_announce(false);
+            break;
+        case HAP_INTERNAL_EVENT_ACC_UNPAIRED:
+            hap_mdns_announce(false);
+            break;
+        case HAP_INTERNAL_EVENT_CONFIG_NUM_UPDATED:
+            hap_increment_and_save_config_num();
+            hap_mdns_announce(false);
+            break;
+        case HAP_INTERNAL_EVENT_BCT_CHANGE_NAME:
+            /* Waiting for sometime to allow the response to reach the host */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_handle_bct_change_name();
+            break;
+        case HAP_INTERNAL_EVENT_BCT_HOT_PLUG:
+            /* Waiting for sometime to allow the response to reach the host */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_handle_hot_plug();
+            break;
+        default:
+            break;
+    }
+}
+
+static void hap_common_sm(hap_internal_event_t event)
+{
+    char *reboot_reason = HAP_REBOOT_REASON_UNKNOWN;
+    switch (event) {
+        case HAP_INTERNAL_EVENT_RESET_PAIRINGS:
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Resetting all Pairing Information");
+            /* Wait for some time before erasing the information, so that the callee
+             * gets some time for any additional operations
+             */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_close_all_sessions();
+            hap_mdns_deannounce();
+            hap_erase_controller_info();
+            hap_erase_accessory_info();
+            reboot_reason = HAP_REBOOT_REASON_RESET_PAIRINGS;
+            break;
+        case HAP_INTERNAL_EVENT_RESET_TO_FACTORY:
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Resetting to Factory Defaults");
+            /* Wait for some time before erasing the information, so that the callee
+             * gets some time for any additional operations
+             */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_close_all_sessions();
+            hap_mdns_deannounce();
+            hap_keystore_erase_all_data();
+            reboot_reason = HAP_REBOOT_REASON_RESET_TO_FACTORY;
+            break;
+        case HAP_INTERNAL_EVENT_RESET_HOMEKIT_DATA:
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Resetting all HomeKit Data");
+            /* Wait for some time before erasing the information, so that the callee
+             * gets some time for any additional operations
+             */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_close_all_sessions();
+            hap_mdns_deannounce();
+            hap_erase_controller_info();
+            hap_erase_network_info();
+            hap_erase_accessory_info();
+            reboot_reason = HAP_REBOOT_REASON_RESET_HOMEKIT_DATA;
+            break;
+        case HAP_INTERNAL_EVENT_REBOOT:
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            /* Wait for some time and then close all the active sessions
+             */
+            hap_close_all_sessions();
+            hap_mdns_deannounce();
+            reboot_reason = HAP_REBOOT_REASON_REBOOT_ACC;
+            break;
+        case HAP_INTERNAL_EVENT_RESET_NETWORK:
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Resetting Network Credentials");
+            /* Wait for some time, close all the active sessions and then
+             * erase network info.
+             */
+            vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+            hap_close_all_sessions();
+            hap_mdns_deannounce();
+            hap_erase_network_info();
+            reboot_reason = HAP_REBOOT_REASON_RESET_NETWORK;
+            break;
+        case HAP_INTERNAL_EVENT_TRIGGER_NOTIF:
+/* TODO: Avoid direct http function. Notification could be even for iCloud or BLE.
+ */
+            hap_http_send_notif();
+            return;
+        default:
+            return;
+        }
+
+    /* Wait for some time after peeforming the operations and then reboot */
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Rebooting...");
+    hap_report_event(HAP_EVENT_ACC_REBOOTING, reboot_reason, strlen(reboot_reason) + 1);
+    vTaskDelay(1000 / hap_platform_os_get_msec_per_tick());
+    esp_restart();
+}
+
+static void hap_loop_task(void *param)
+{
+    hap_state_t cur_state = HAP_STATE_NONE;
+    xQueue = xQueueCreate( 10, sizeof(hap_event_ctx_t) );
+    hap_event_ctx_t hap_event;
+    bool loop_continue = true;
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HAP Main Loop Started");
+    while (loop_continue) {
+        if (xQueueReceive(xQueue, &hap_event, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+        if (hap_event.event == HAP_INTERNAL_EVENT_LOOP_STOP) {
+            loop_continue = false;
+            continue;
+        }
+        hap_common_sm(hap_event.event);
+        hap_nw_configured_sm(hap_event.event, &cur_state);
+    }
+    vQueueDelete(xQueue);
+    xQueue = NULL;
+    vTaskDelete(NULL);
+}
+
+static bool loop_started;
+int hap_loop_start()
+{
+    if (!loop_started) {
+        loop_started = true;
+        xTaskCreate(hap_loop_task, "hap-loop", hap_priv.cfg.task_stack_size, NULL,
+                        hap_priv.cfg.task_priority, NULL);
+    }
+    return HAP_SUCCESS;
+}
+
+bool is_hap_loop_started()
+{
+    return loop_started;
+}
+int hap_send_event(hap_internal_event_t event)
+{
+    if (!is_hap_loop_started()) {
+        return HAP_FAIL;
+    }
+    if (!xQueue) {
+        return HAP_FAIL;
+    }
+    hap_event_ctx_t hap_event = {
+        .event = event,
+    };
+    BaseType_t ret;
+    if (xPortInIsrContext() == pdTRUE) {
+        ret = xQueueSendFromISR(xQueue, &hap_event, NULL);
+    } else {
+        ret = xQueueSend(xQueue, &hap_event, 0);
+    }
+    if (ret == pdTRUE) {
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+int hap_update_config_number()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_CONFIG_NUM_UPDATED);
+}
+
+int hap_loop_stop()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_LOOP_STOP);
+}
+
+#if 0
+static void hap_network_event_handler(void* arg, esp_event_base_t event_base,
+        int event_id, void* event_data)
+{
+    if (((event_base == WIFI_EVENT) && (event_id == WIFI_EVENT_STA_CONNECTED)) ||
+        ((event_base == ETH_EVENT) && (event_id == ETHERNET_EVENT_CONNECTED))){
+        hap_send_event(HAP_INTERNAL_EVENT_NETWORK_CONNECTED);
+    }
+}
+#endif
+int hap_init(hap_transport_t method)
+{
+    int ret = HAP_SUCCESS;
+    if (!(method & (HAP_TRANSPORT_WIFI | HAP_TRANSPORT_ETHERNET))) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid Transport");
+        return HAP_FAIL;
+    }
+
+    hap_priv.transport = method;
+
+    ret = hap_keystore_init();
+    if (ret != 0 ) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HAP Key Store Init failed");
+        return ret;
+    }
+
+    ret = hap_database_init();
+    if (ret != 0 ) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HAP Database Init failed");
+        return ret;
+    }
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HAP Initialization succeeded. Version : %s", hap_get_version());
+
+    return ret;
+}
+
+int hap_deinit(void)
+{
+    int ret = HAP_SUCCESS;
+    //todo
+    return ret;
+}
+
+int hap_reset_to_factory()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_RESET_TO_FACTORY);
+}
+
+int hap_reset_homekit_data()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_RESET_HOMEKIT_DATA);
+}
+
+int hap_reset_pairings()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_RESET_PAIRINGS);
+}
+
+int hap_reboot_accessory()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_REBOOT);
+}
+
+int hap_reset_network()
+{
+    return hap_send_event(HAP_INTERNAL_EVENT_RESET_NETWORK);
+}
+
+int hap_start(void)
+{
+    int ret = 0;
+#ifdef CONFIG_HAP_MFI_ENABLE
+    if (hap_priv.auth_type == HAP_MFI_AUTH_HW) {
+        ret = hap_enable_hw_auth();
+    } else if (hap_priv.auth_type == HAP_MFI_AUTH_SW) {
+        ret =  hap_enable_sw_auth();
+    }
+#endif /* CONFIG_HAP_MFI_ENABLE */
+    if (ret != 0) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to enable MFi %s authentication",
+                hap_priv.auth_type == HAP_MFI_AUTH_HW ? "HW" : "SW");
+        return HAP_FAIL;
+    }
+
+    if (!hap_get_first_acc()) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to start HAP. Please add an Accessory before hap_start()");
+        return HAP_FAIL;
+    }
+
+    ret = hap_acc_setup_init();
+    if (ret != HAP_SUCCESS) {
+         ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Accessory Setup init failed");
+         return ret;
+    }
+
+    ret = hap_httpd_start();
+    if (ret != HAP_SUCCESS) {
+         ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HTTPD START Failed [%d]", ret);
+         return ret;
+    }
+
+    ret = hap_event_queue_init();
+    if (ret != HAP_SUCCESS) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Queue Initialisation for Event Notifications Failed");
+        return ret;
+    }
+
+    ret = hap_loop_start();
+    if (ret != 0) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HAP Loop Failed: [%d]", ret);
+        return ret;
+    }
+    ret = hap_mdns_init();
+    if (ret != 0 ) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HAP mDNS Init failed");
+        return ret;
+    }
+
+    ret = hap_ip_services_start();
+    if (ret != 0) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "HAP IP Services Start Failed [%d]", ret);
+        return ret;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_stop(void)
+{
+    int ret = HAP_SUCCESS;
+    //todo
+    return ret;
+}
+
+void hap_report_event(hap_event_t event, void *data, size_t data_size)
+{
+    if (hap_priv.hap_event_handler) {
+        hap_priv.hap_event_handler(event, data);
+    }
+    esp_event_post(HAP_EVENT, event, data, data_size, portMAX_DELAY);
+}
+
+void hap_register_event_handler(hap_event_handler_t handler)
+{
+    hap_priv.hap_event_handler = handler;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_main.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_main.h
@@ -1,0 +1,72 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_MAIN_LOOP_H_
+#define _HAP_MAIN_LOOP_H_
+#include <stdbool.h>
+#include <hap.h>
+
+#define HAP_FF_HARDWARE_AUTH    0x01
+#define HAP_FF_SW_TOKEN_AUTH    0x02
+
+
+#define HAP_SF_ACC_UNPAIRED         0x01
+#define HAP_SF_ACC_UNCONFIGURED     0x02
+#define HAP_SF_PROBLEM_DETECTED     0x04
+
+typedef enum {
+    HAP_INTERNAL_EVENT_LOOP_STOP = 1,
+    HAP_INTERNAL_EVENT_ACC_PAIRED,
+    HAP_INTERNAL_EVENT_ACC_UNPAIRED,
+    HAP_INTERNAL_EVENT_CONFIG_NUM_UPDATED,
+    HAP_INTERNAL_EVENT_BCT_CHANGE_NAME,
+    HAP_INTERNAL_EVENT_BCT_HOT_PLUG,
+    HAP_INTERNAL_EVENT_RESET_PAIRINGS,
+    HAP_INTERNAL_EVENT_RESET_TO_FACTORY,
+    HAP_INTERNAL_EVENT_REBOOT,
+    HAP_INTERNAL_EVENT_RESET_NETWORK,
+    HAP_INTERNAL_EVENT_TRIGGER_NOTIF,
+    HAP_INTERNAL_EVENT_RESET_HOMEKIT_DATA,
+} hap_internal_event_t;
+
+typedef struct {
+    hap_internal_event_t event;
+} hap_event_ctx_t;
+
+typedef enum {
+    HAP_STATE_NONE = 0,
+    HAP_STATE_NW_UNCONFIGURED,
+    HAP_STATE_NW_CONFIGURED,
+} hap_state_t;
+
+int hap_loop_start();
+int hap_loop_stop();
+int hap_send_event(hap_internal_event_t event);
+int hap_update_config_number();
+bool is_hap_loop_started();
+void hap_report_event(hap_event_t event, void *data, size_t data_size);
+int hap_enable_hw_auth(void);
+int hap_enable_sw_auth(void);
+
+#endif /* _HAP_MAIN_LOOP_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_mdns.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_mdns.c
@@ -1,0 +1,85 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <string.h>
+#include <esp_hap_mdns.h>
+#include <esp_mfi_debug.h>
+
+static bool mdns_init_done;
+
+int hap_mdns_serv_start(hap_mdns_handle_t *handle, const char *name, const char *type,
+        const char *protocol, int port, mdns_txt_item_t *txt_records, size_t num_txt)
+{
+    strcpy(handle->type, type);
+    strcpy(handle->proto, protocol);
+    if (mdns_service_add(name, type, protocol, port, txt_records, num_txt) != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_mdns_serv_update_txt(hap_mdns_handle_t *handle, mdns_txt_item_t *txt_records, size_t num_txt)
+{
+    if (mdns_service_txt_set(handle->type, handle->proto, txt_records, num_txt) != 0) {
+        return HAP_FAIL;
+    }
+    return HAP_SUCCESS;
+}
+
+int hap_mdns_serv_name_change(hap_mdns_handle_t *handle, const char * instance_name)
+{
+    if (mdns_service_instance_name_set(handle->type, handle->proto, instance_name) == ESP_OK) {
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+int hap_mdns_serv_stop(hap_mdns_handle_t *handle)
+{
+    if (mdns_service_remove(handle->type, handle->proto) == ESP_OK) {
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+int hap_mdns_init()
+{
+    int ret = HAP_SUCCESS;
+    if (!mdns_init_done) {
+        ret = mdns_init();
+        if (ret == ESP_OK) {
+            mdns_hostname_set("MyHost");
+            mdns_init_done = true;
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "mDNS initialised");
+            return HAP_SUCCESS;
+        }
+    }
+    return HAP_FAIL;
+}
+
+int hap_mdns_deinit()
+{
+    mdns_free();
+    mdns_init_done = false;
+    return HAP_SUCCESS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_mdns.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_mdns.h
@@ -1,0 +1,43 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_MDNS_H_
+#define _HAP_MDNS_H_
+
+#include <mdns.h>
+#include <hap.h>
+
+typedef struct {
+    char type[32];
+    char proto[32];
+} hap_mdns_handle_t;
+
+int hap_mdns_serv_start(hap_mdns_handle_t *handle, const char *name, const char *type,
+        const char *protocol, int port, mdns_txt_item_t *txt_records, size_t num_txt);
+int hap_mdns_serv_update_txt(hap_mdns_handle_t *handle, mdns_txt_item_t *txt_records, size_t num_txt);
+int hap_mdns_serv_name_change(hap_mdns_handle_t *handle, const char * instance_name);
+int hap_mdns_serv_stop(hap_mdns_handle_t *handle);
+int hap_mdns_init();
+int hap_mdns_deinit();
+
+#endif /* _HAP_MDNS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_network_io.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_network_io.c
@@ -1,0 +1,237 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include <sodium/crypto_aead_chacha20poly1305.h>
+#include <byte_convert.h>
+
+#include <esp_mfi_debug.h>
+#include <hap.h>
+#include <esp_hap_database.h>
+#include <esp_hap_pair_common.h>
+#include <esp_hap_pair_verify.h>
+
+#define HAP_MAX_NW_FRAME_SIZE	1024 /* As per HAP Specifications */
+#define AUTH_TAG_LEN            16
+typedef struct {
+	uint8_t pkt_size[2];
+	uint8_t data[HAP_MAX_NW_FRAME_SIZE];
+	/* The Poly auth tag buffer will get used only if the data length is
+	 * greater than HAP_MAX_NW_FRAME_SIZE - 16.
+	 * Else, the auth tag would be included in the data buffer itself
+	 */
+	uint8_t poly_auth_tag[AUTH_TAG_LEN];
+} hap_encrypt_frame_t;
+
+typedef struct {
+	uint16_t pkt_size;
+	uint16_t bytes_read;
+	uint8_t data[HAP_MAX_NW_FRAME_SIZE + AUTH_TAG_LEN];
+	hap_secure_session_t *session;
+} hap_decrypt_frame_t;
+
+typedef int (*hap_decrypt_read_fn_t) (uint8_t *buf, int buf_size, void *context);
+static int min(int val1, int val2)
+{
+	if (val1 < val2)
+		return val1;
+	return val2;
+}
+static int hap_httpd_raw_recv(uint8_t *buf, int buf_size, void *context)
+{
+	int sock = *((int *)context);
+	return recv(sock, buf, buf_size, 0);
+}
+
+/* Frame format as per HAP Specifications:
+ * <2: AAD for Little Endian length of encrypted data (n) in bytes>
+ * <n: Encrypted data according to AEAD algorithm, upto 1024 bytes>
+ * <16: authTag according to AEAD algorithm>
+ */
+int hap_encrypt_data(hap_encrypt_frame_t *frame, hap_secure_session_t *session,
+		uint8_t *buf, int buflen)
+{
+	if (!session)
+		return HAP_FAIL;
+	put_u16_le(frame->pkt_size, buflen);
+	/* Encrypt the received data as per Chacha20-Poly1305 AEAD algorithm.
+	 * The authTag will be appended at the end of data. Hence, pointer given as
+	 * frame->data + nlen
+	 */
+    unsigned long long mlen = 16;
+    uint8_t newnonce[12];
+    memset(newnonce, 0, sizeof newnonce);
+    memcpy(newnonce+4, session->encrypt_nonce, 8);
+    crypto_aead_chacha20poly1305_ietf_encrypt_detached(frame->data, frame->data + buflen, &mlen,
+                buf, buflen, frame->pkt_size, 2, NULL, newnonce, session->encrypt_key);
+
+	/* Increment nonce after every frame */
+	uint64_t int_nonce = get_u64_le(session->encrypt_nonce);
+	int_nonce++;
+	put_u64_le(session->encrypt_nonce, int_nonce);
+	return 2 + buflen + 16; /* Total length of the encrypted data */
+}
+
+#include <esp_hap_main.h>
+void hap_close_ctrl_sessions_fix(hap_secure_session_t *session)
+{
+	if (!session)
+		return;
+	int i;
+	printf("---- hap_close_ctrl_sessions_fix begin -----\n");
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+        if (!hap_priv.sessions[i])
+            continue;
+		if (hap_priv.sessions[i] == session) {
+            hap_report_event(HAP_EVENT_CTRL_DISCONNECTED, (session->ctrl->info.id),
+                    sizeof((session->ctrl->info.id)));
+			/* TODO: Use some generic function and not a direct HTTPD function
+			 */
+            printf("---- trigger_close fd: %d\n", hap_priv.sessions[i]->conn_identifier);
+            httpd_sess_trigger_close(hap_priv.server, hap_priv.sessions[i]->conn_identifier);
+		}
+	}
+	printf("---- hap_close_ctrl_sessions_fix end ----\n");
+}
+
+int hap_decrypt_error(hap_secure_session_t *session)
+{
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Decryption error/Connection lost. Marking session as invalid");
+	if (session) {
+		session->state = STATE_INVALID;
+        //hap_close_ctrl_sessions(session->ctrl);
+        hap_close_ctrl_sessions_fix(session);
+	}
+	return HAP_FAIL;
+}
+
+int hap_decrypt_data(hap_decrypt_frame_t *frame, hap_secure_session_t *session,
+	void *buf, int buf_size, hap_decrypt_read_fn_t read_fn, void *context)
+{
+	if (!frame || !session)
+		return -1;
+	if (frame->session != session) {
+		memset(frame, 0, sizeof(hap_decrypt_frame_t));
+		frame->session = session;
+	}
+	if ((frame->pkt_size - frame->bytes_read) == 0) {
+		int len = read_fn(frame->data, 2, context);
+		if (len == 0) { //nothing received, but we should NOT consider this is a 'decrypt_error'
+			return 0;
+		}
+		if (len < 2) {
+			//len is -1 or 1
+			//len = -1: socket disconnected
+			//len =  1: try receiving 2 bytes timeout (SO_RCVTIMEO is set in esp_hap_ip_services.c)
+			printf("---- error 1 ----, len: %d\n", len);
+			//Decryption error/Connection lost on ESP32 with multiple Apple devices running Home
+			//https://github.com/espressif/esp-homekit-sdk/issues/14
+			//---- error 1 ----, len: 0
+			return hap_decrypt_error(session);
+		}
+
+		frame->pkt_size = get_u16_le(frame->data);
+		frame->bytes_read = 0;
+		uint16_t bytes_to_read = frame->pkt_size + AUTH_TAG_LEN; /* +AUTH_TAG_LEN as the receivedd packet will also have the auth Tag */
+		while (bytes_to_read) {
+			int num_bytes = read_fn(&frame->data[frame->bytes_read],
+					bytes_to_read, context);
+			if (num_bytes <= 0) {
+				printf("---- error 2 ----\n");
+				return hap_decrypt_error(session);
+			}
+			bytes_to_read -= num_bytes;
+			frame->bytes_read += num_bytes;
+		}
+		frame->bytes_read -= AUTH_TAG_LEN; /* -AUTH_TAG_LEN to get only the data length */
+		uint8_t aad[2];
+        int ret;
+		put_u16_le(aad, frame->pkt_size); /* Packet size is the AAD for AEAD */
+        uint8_t newnonce[12];
+        memset(newnonce, 0, sizeof newnonce);
+        memcpy(newnonce+4, session->decrypt_nonce, 8);
+        ret = crypto_aead_chacha20poly1305_ietf_decrypt_detached(frame->data, NULL, frame->data, frame->pkt_size,
+                    &frame->data[frame->bytes_read], aad, 2, newnonce, session->decrypt_key);
+        if (ret != 0) { 
+			ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "AEAD decryption failure");
+			printf("---- error 3 ----\n");
+			return hap_decrypt_error(session);
+		}
+		frame->bytes_read = 0;
+		/* Increment nonce after every frame */
+		int64_t int_nonce = get_u64_le(session->decrypt_nonce);
+		int_nonce++;
+		put_u64_le(session->decrypt_nonce, int_nonce);
+	}
+	int bytes = min(frame->pkt_size - frame->bytes_read, buf_size);
+	memcpy(buf, &frame->data[frame->bytes_read], bytes);
+	frame->bytes_read += bytes;
+	return bytes;
+}
+
+int hap_httpd_send(httpd_handle_t hd, int sockfd, const char *buf, unsigned buf_len, int flags)
+{
+	hap_secure_session_t *session = httpd_sess_get_ctx(hap_priv.server, sockfd);
+	if (session && (session->state == STATE_VERIFIED)) {
+		uint8_t *buf_ptr = (uint8_t *)buf;
+		int tmp_buf_len = buf_len;
+		while (tmp_buf_len) {
+			hap_encrypt_frame_t encrypt_frame;
+			memset(&encrypt_frame, 0, sizeof(encrypt_frame));
+			int len = min(tmp_buf_len, HAP_MAX_NW_FRAME_SIZE);
+			int send_len = hap_encrypt_data(&encrypt_frame, session, buf_ptr, len);
+			if (send(sockfd, (uint8_t *)&encrypt_frame, send_len, flags) <= 0)
+				return HAP_FAIL;
+			tmp_buf_len -= len;
+			buf_ptr += len;
+		}
+		/* Return the total length at the end since this API expects so
+		 */
+		return buf_len;
+	}
+	return send(sockfd, buf, buf_len, flags);
+}
+
+int hap_httpd_recv(httpd_handle_t hd, int sockfd, char *buf, unsigned buf_len, int flags)
+{
+	static hap_decrypt_frame_t decrypt_frame;
+	hap_secure_session_t *session = httpd_sess_get_ctx(hap_priv.server, sockfd);
+	if (session) {
+		if (session->state == STATE_VERIFIED) {
+			return hap_decrypt_data(&decrypt_frame, session, buf, buf_len,
+					hap_httpd_raw_recv, &sockfd);
+		} else {
+			/* If the session state is invalid, we return an error.
+			 * The errno is set here explicitly, so that even if the higher layers
+			 * query for it, they do not get a stale value.
+			 * EACCES means permission denied, which indeed is the case here.
+			 */
+			errno = EACCES;
+			return HAP_FAIL;
+		}
+	}
+	return recv(sockfd, buf, buf_len, sockfd);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_network_io.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_network_io.h
@@ -1,0 +1,31 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_NETWORK_IO_H_
+#define _HAP_NETWORK_IO_H_
+#include <stdint.h>
+#include <hap_platform_httpd.h>
+int hap_httpd_send(httpd_handle_t hd, int sockfd, const char *buf, unsigned buf_len, int flags);
+int hap_httpd_recv(httpd_handle_t hd, int sockfd, char *buf, unsigned buf_len, int flags);
+
+#endif /* _HAP_NETWORK_IO_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_common.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_common.c
@@ -1,0 +1,127 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <esp_hap_pair_common.h>
+
+void hap_tlv_data_init(hap_tlv_data_t *tlv_data, uint8_t *buf, int buf_size)
+{
+	tlv_data->bufptr = buf;
+	tlv_data->bufsize = buf_size;
+	tlv_data->curlen = 0;
+}
+
+int get_tlv_length(uint8_t *buf, int buflen, uint8_t type)
+{
+	if (!buf )
+		return -1;
+	int curlen = 0;
+	int val_len = 0;
+	bool found = false;
+	while (buflen > 0) {
+		if (buf[curlen] == type) {
+			uint8_t len = buf[curlen + 1];
+			if ((buflen - len) < 2)
+				return -1;
+			val_len += len;
+			if (len < 255)
+				return val_len;
+			else
+				found = true;
+
+		} else if (found)
+			return val_len;
+
+		/* buf[curlen +1] will give the Length */
+		buflen -= (2 + buf[curlen + 1]);
+		curlen += (2 + buf[curlen + 1]);
+	}
+	return -1;
+}
+int get_value_from_tlv(uint8_t *buf, int buflen, uint8_t type, void *val, int val_size)
+{
+	if (!buf || !val)
+		return -1;
+	int curlen = 0;
+	int val_len = 0;
+	bool found = false;
+	while (buflen > 0) {
+		if (buf[curlen] == type) {
+			uint8_t len = buf[curlen + 1];
+			if ((val_size < len) || ((buflen - len) < 2))
+				return -1;
+			memcpy(val + val_len, &buf[curlen + 2], len);
+			val_len += len;
+			val_size -= len;
+			if (len < 255)
+				return val_len;
+			else
+				found = true;
+
+		} else if (found)
+			return val_len;
+
+		/* buf[curlen +1] will give the Length */
+		buflen -= (2 + buf[curlen + 1]);
+		curlen += (2 + buf[curlen + 1]);
+	}
+	return -1;
+}
+
+int add_tlv(hap_tlv_data_t *tlv_data, uint8_t type, int len, void *val)
+{
+	if(!tlv_data->bufptr || ((len + 2) > (tlv_data->bufsize - tlv_data->curlen)))
+		return -1;
+	uint8_t *buf_ptr = (uint8_t *)val;
+	int orig_len = tlv_data->curlen;
+	do {
+		tlv_data->bufptr[tlv_data->curlen++] = type;
+		int tmp_len;
+		if (len > 255)
+			tmp_len = 255;
+		else
+			tmp_len = len;
+		tlv_data->bufptr[tlv_data->curlen++] = tmp_len;
+		memcpy(&tlv_data->bufptr[tlv_data->curlen], buf_ptr, tmp_len);
+		tlv_data->curlen += tmp_len;
+		buf_ptr += tmp_len;
+		len -= tmp_len;
+	} while (len);
+	return tlv_data->curlen - orig_len;
+}
+void hap_prepare_error_tlv(uint8_t state, uint8_t error, void *buf, int bufsize, int *outlen)
+{
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	/* Not doing any error handling because the size required for "state" and "error" will
+	 * be too small to cause any error, and we anyways dont have any specific action to
+	 * do in case if error in add_tlv()
+	 */
+	add_tlv(&tlv_data, kTLVType_State, sizeof(state), &state);
+	add_tlv(&tlv_data, kTLVType_Error, sizeof(error), &error);
+	*outlen = tlv_data.curlen;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_common.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_common.h
@@ -1,0 +1,114 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PAIR_COMMON_H_
+#define _HAP_PAIR_COMMON_H_
+
+#include <stdint.h>
+#include <esp_hap_controllers.h>
+#define ENCRYPT_KEY_LEN		32
+#define POLY_AUTHTAG_LEN	16
+#define CURVE_KEY_LEN		32
+#define ED_SIGN_LEN		64
+#define NONCE_LEN		8
+
+#define STATE_M0		0
+#define STATE_M1		1
+#define STATE_M2		2
+#define STATE_M3		3
+#define STATE_M4		4
+#define STATE_M5		5
+#define STATE_M6		6
+#define STATE_VERIFIED		0x55
+#define STATE_INVALID		0xaa
+
+typedef enum {
+	HAP_METHOD_RESERVED = 0,
+	HAP_METHOD_PAIR_SETUP = 1,
+	HAP_METHOD_PAIR_VERIFY = 2,
+	HAP_METHOD_ADD_PAIRING = 3,
+	HAP_METHOD_REMOVE_PAIRING = 4,
+	HAP_METHOD_LIST_PAIRINGS = 5,
+} hap_pairing_methods_t;
+
+
+typedef enum {
+	kTLVError_Unknown = 0x01,
+	kTLVError_Authentication = 0x02,
+	kTLVError_Backoff = 0x03,
+	kTLVError_MaxPeers = 0x04,
+	kTLVError_MaxTries = 0x05,
+	kTLVError_Unavailable = 0x06,
+	kTLVError_Busy = 0x07,
+} hap_tlv_error_t;
+
+typedef enum {
+	kTLVType_Method = 0x00,
+	kTLVType_Identifier = 0x01,
+	kTLVType_Salt = 0x02,
+	kTLVType_PublicKey = 0x03,
+	kTLVType_Proof = 0x04,
+	kTLVType_EncryptedData = 0x05,
+	kTLVType_State = 0x06,
+	kTLVType_Error = 0x07,
+	kTLVType_RetryDelay = 0x08,
+	kTLVType_Certificate = 0x09,
+	kTLVType_Signature = 0x0a,
+	kTLVType_Permissions = 0x0b,
+	kTLVType_FragmentedData = 0x0c,
+	kTLVType_FragmentLast = 0x0d,
+    kTLVType_Flags = 0x13,
+    kTLVType_OwnershipProofToken = 0x1A,
+    kTLVType_ProductData = 0x1C,
+	kTLVType_Separator = 0xff,
+} hap_tlv_type_t;
+
+typedef struct {
+	uint8_t *bufptr;
+	int bufsize;
+	int curlen;
+} hap_tlv_data_t;
+
+typedef struct {
+	uint8_t state;
+	uint8_t encrypt_key[ENCRYPT_KEY_LEN];
+	uint8_t decrypt_key[ENCRYPT_KEY_LEN];
+	uint8_t encrypt_nonce[NONCE_LEN];
+	uint8_t decrypt_nonce[NONCE_LEN];
+	hap_ctrl_data_t *ctrl;
+    uint64_t pid;
+    int64_t ttl;
+    int64_t prepare_time;
+	/* TODO: As of now, this identifier will be the socket
+	 * number, since only http is supported.
+	 * Need to make this generic later.
+	 */
+	int conn_identifier;
+} hap_secure_session_t;
+
+void hap_tlv_data_init(hap_tlv_data_t *tlv_data, uint8_t *buf, int buf_size);
+int get_value_from_tlv(uint8_t *buf, int buf_len, uint8_t type, void *val, int val_size);
+int get_tlv_length(uint8_t *buf, int buflen, uint8_t type);
+int add_tlv(hap_tlv_data_t *tlv_data, uint8_t type, int len, void *val);
+void hap_prepare_error_tlv(uint8_t state, uint8_t error, void *buf, int buf_size, int *out_len);
+#endif /* _HAP_PAIR_COMMON_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_setup.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_setup.c
@@ -1,0 +1,563 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/timers.h>
+#include <mu_srp.h>
+#include <sodium/crypto_aead_chacha20poly1305.h>
+#include <hkdf-sha.h>
+#include <sodium/crypto_sign_ed25519.h>
+#include <hexdump.h>
+#include <hap_platform_memory.h>
+#include <hap_platform_os.h>
+
+#include <esp_hap_pair_common.h>
+#include <esp_hap_pair_setup.h>
+#include <esp_hap_database.h>
+#include <esp_hap_main.h>
+#include <esp_hap_acc.h>
+#include <esp_mfi_debug.h>
+
+/* Maximum attempts allowed for Pair Setup, as per HAP Specifications */
+#define HAP_PAIR_SETUP_MAX_ATTEMPTS	100
+
+#define PAIR_SETUP_ENCRYPT_SALT		"Pair-Setup-Encrypt-Salt"
+#define PAIR_SETUP_ENCRYPT_INFO		"Pair-Setup-Encrypt-Info"
+#define PAIR_SETUP_CTRL_SIGN_SALT	"Pair-Setup-Controller-Sign-Salt"
+#define PAIR_SETUP_CTRL_SIGN_INFO	"Pair-Setup-Controller-Sign-Info"
+#define PAIR_SETUP_ACC_SIGN_SALT	"Pair-Setup-Accessory-Sign-Salt"
+#define PAIR_SETUP_ACC_SIGN_INFO	"Pair-Setup-Accessory-Sign-Info"
+
+#define PS_CTX_INIT	1
+#define PS_CTX_DEINIT	2
+
+/* Timeout if pair setup not completed in 1 minute (60sec)*/
+#define HAP_SETUP_TIMEOUT_IN_TICKS  ((40 * 1000) / hap_platform_os_get_msec_per_tick())
+
+static int hap_pair_setup_process_srp_start(pair_setup_ctx_t *ps_ctx, uint8_t *buf, int inlen,
+		int bufsize, int *outlen)
+{
+	/* Pair setup is not allowed if the accessory is already paired */
+	if (is_accessory_paired()) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Accessory is already paired. "
+				"Please use \"Add Pairing\" to add more controllers");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unavailable, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	/* Pair Setup is not allowed if the failed attempts have exceeded the
+	 * maximum allowed attempts.
+	 */
+	if (hap_priv.pair_attempts >= HAP_PAIR_SETUP_MAX_ATTEMPTS) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Too many attempts. Aborting");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_MaxTries, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	ps_ctx->ctrl = hap_controller_get_empty_loc();
+	if (!ps_ctx->ctrl) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "No empty controller slot. Aborting");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	uint8_t state;
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+		(get_value_from_tlv(buf, inlen, kTLVType_Method,
+				    &ps_ctx->method, sizeof(ps_ctx->method)) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if (state != STATE_M1) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Incorrect State received");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup M1 Received");
+
+    int flags_len;
+    if ((flags_len = get_value_from_tlv(buf, inlen, kTLVType_Flags, &ps_ctx->pairing_flags, sizeof(ps_ctx->pairing_flags))) > 0) {
+        ps_ctx->pairing_flags_len = flags_len;
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Got pairing flags %x", ps_ctx->pairing_flags);
+
+        /* If the Split pairing flag is not set, it is an error */
+        if (!(ps_ctx->pairing_flags & PAIR_FLAG_SPLIT)) {
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Pairing Flags received, but the Split flag is not set");
+            hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+            return HAP_FAIL;
+        }
+
+        /* If either the current or the previous request didn't have transient flag set, return authentication error */
+        if (!((ps_ctx->pairing_flags | hap_priv.pairing_flags) & PAIR_FLAG_TRANSIENT)) {
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Split pairing received before preceding Transient Pairing");
+            hap_prepare_error_tlv(STATE_M2, kTLVError_Authentication, buf, bufsize, outlen);
+            return HAP_FAIL;
+        }
+    }
+    hap_priv.pairing_flags = ps_ctx->pairing_flags;
+
+	int len_B = 0;
+	char *bytes_B;
+
+	/* Create SRP Salt and Verifier for the provided pairing PIN */
+    mu_srp_init(&ps_ctx->srp_hd, MU_NG_3072);
+
+    /* If a setup code is explicitly set, use it */
+    if (hap_priv.setup_code) {
+        ps_ctx->len_s = 16;
+        mu_srp_srv_pubkey(&ps_ctx->srp_hd, "Pair-Setup", (const char*)hap_priv.setup_code, strlen(hap_priv.setup_code),
+                ps_ctx->len_s, &bytes_B, &len_B, &ps_ctx->bytes_s);
+    } else {
+        /* Else, use the salt and verifier for SRP. This should be the default production case
+         */
+        if (mu_srp_set_salt_verifier(&ps_ctx->srp_hd, (char *)hap_priv.setup_info->salt, sizeof(hap_priv.setup_info->salt),
+                    (char *)hap_priv.setup_info->verifier, sizeof(hap_priv.setup_info->verifier)) < 0) {
+            ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "SRP-6a Salt-Verifier Init Failed");
+            hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+            return HAP_FAIL;
+        }
+        ps_ctx->bytes_s = (char *)hap_priv.setup_info->salt;
+        ps_ctx->len_s = sizeof(hap_priv.setup_info->salt);
+        mu_srp_srv_pubkey_from_salt_verifier(&ps_ctx->srp_hd, &bytes_B, &len_B);
+    }
+	if (!ps_ctx->bytes_s || !bytes_B) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "SRP-6a Verifier Creation Failed");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	hex_dbg_with_name("salt", (uint8_t *)ps_ctx->bytes_s, ps_ctx->len_s);
+	hex_dbg_with_name("acc_srp_public_key", (uint8_t *)bytes_B, len_B);
+
+	/* Construct the response M2 */
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	state = STATE_M2;
+	if ((add_tlv(&tlv_data, kTLVType_State, 1, &state) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_PublicKey, len_B, (void *)bytes_B) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_Salt, ps_ctx->len_s, ps_ctx->bytes_s) < 0 )) {
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+    /* Not adding any error check here, because without the pairing flags, the pairing will
+     * anyways fail later.
+     */
+    if (ps_ctx->pairing_flags_len) {
+        add_tlv(&tlv_data, kTLVType_Flags, ps_ctx->pairing_flags_len, &ps_ctx->pairing_flags);
+    }
+	*outlen = tlv_data.curlen;
+	ps_ctx->state = state;
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup M2 Successful");
+    hap_report_event(HAP_EVENT_PAIRING_STARTED, NULL, 0);
+	return HAP_SUCCESS;
+}
+
+
+static int hap_pair_setup_process_srp_verify(pair_setup_ctx_t *ps_ctx, uint8_t *buf, int inlen,
+		int bufsize, int *outlen)
+{
+	uint8_t state;
+	char ctrl_public_key[384];
+	int ctrl_public_key_len;
+	char ctrl_proof[64];
+	int ctrl_proof_len;
+
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+		((ctrl_public_key_len = get_value_from_tlv(buf, inlen, kTLVType_PublicKey,
+				ctrl_public_key, sizeof(ctrl_public_key))) < 0) ||
+		((ctrl_proof_len = get_value_from_tlv(buf, inlen, kTLVType_Proof,
+				ctrl_proof, sizeof(ctrl_proof))) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if (state != STATE_M3) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Incorrect State received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup M3 Received");
+
+	hex_dbg_with_name("ctrl_srp_public_key", (uint8_t *)ctrl_public_key, ctrl_public_key_len);
+	hex_dbg_with_name("ctrl_proof", (uint8_t *)ctrl_proof, ctrl_proof_len);
+    mu_srp_get_session_key(&ps_ctx->srp_hd, ctrl_public_key, ctrl_public_key_len, &ps_ctx->shared_secret, &ps_ctx->secret_len);
+    char host_proof[SHA512HashSize];
+    int ret = mu_srp_exchange_proofs(&ps_ctx->srp_hd, "Pair-Setup", ctrl_proof, host_proof);
+    if (ret != 1) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "SRP Verify: Controller Authentication failed");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Authentication, buf, bufsize, outlen);
+        hap_report_event(HAP_EVENT_PAIRING_ABORTED, NULL, 0);
+		return HAP_FAIL;
+    }
+    int acc_proof_length = SHA512HashSize;
+
+	hkdf(SHA512, (uint8_t *) PAIR_SETUP_ENCRYPT_SALT, strlen(PAIR_SETUP_ENCRYPT_SALT),
+			(uint8_t *)ps_ctx->shared_secret, ps_ctx->secret_len,
+			(uint8_t *) PAIR_SETUP_ENCRYPT_INFO, strlen(PAIR_SETUP_ENCRYPT_INFO),
+			ps_ctx->session_key, sizeof(ps_ctx->session_key));
+
+	/* Construct the response M4 */
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	state = STATE_M4;
+	if ((add_tlv(&tlv_data, kTLVType_State, 1, &state) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_Proof, acc_proof_length,
+				 (void *)host_proof) < 0)) {
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+		return HAP_FAIL;
+    }
+    hap_tlv_error_t tlv_error = 0;
+    if (hap_pair_setup_manage_mfi_auth(ps_ctx, &tlv_data, &tlv_error) != ESP_OK) {
+        hap_prepare_error_tlv(STATE_M4, tlv_error, buf, bufsize, outlen);
+        return HAP_FAIL;
+    }
+	*outlen = tlv_data.curlen;
+	ps_ctx->state = state;
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup M4 Successful");
+	return HAP_SUCCESS;
+}
+static int hap_pair_setup_process_exchange(pair_setup_ctx_t *ps_ctx, uint8_t *buf, int inlen,
+		int bufsize, int *outlen)
+{
+	uint8_t state;
+	uint8_t edata[220];
+	int edata_len;
+    int ret;
+
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+		((edata_len = get_value_from_tlv(buf, inlen, kTLVType_EncryptedData,
+				edata, sizeof(edata))) < 0))  {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M6, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	hex_dbg_with_name("recv_encrypted_data", edata, edata_len);
+	if (state != STATE_M5) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Incorrect State received");
+		hap_prepare_error_tlv(STATE_M6, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+    }
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup M5 Received");
+    edata_len -= 16; /* 16 bytes for the authTag */
+    uint8_t newnonce[12];
+    memset(newnonce, 0, sizeof newnonce);
+    memcpy(newnonce+4, (uint8_t *)PS_NONCE2, 8);
+    ret = crypto_aead_chacha20poly1305_ietf_decrypt_detached(edata, NULL, edata, edata_len,
+            &edata[edata_len], NULL, 0, newnonce, ps_ctx->session_key);
+    if (ret != 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Decryption Failed");
+		hap_prepare_error_tlv(STATE_M6, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	hex_dbg_with_name("subtlv", edata, edata_len);
+	int ctrl_id_len;
+	unsigned char ed_sign[64];
+    unsigned long long ed_sign_len;
+	if (((ctrl_id_len = get_value_from_tlv(edata, edata_len, kTLVType_Identifier,
+					ps_ctx->ctrl->info.id, sizeof(ps_ctx->ctrl->info.id))) < 0) ||
+			(get_value_from_tlv(edata, edata_len, kTLVType_PublicKey,
+					    ps_ctx->ctrl->info.ltpk, ED_KEY_LEN) != ED_KEY_LEN) ||
+			(get_value_from_tlv(edata, edata_len, kTLVType_Signature,
+					    ed_sign, sizeof(ed_sign)) != sizeof(ed_sign))) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid subTLV received");
+		hap_prepare_error_tlv(STATE_M6, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	ps_ctx->ctrl->info.id[ctrl_id_len] = 0; /* NULL termination */
+	hex_dbg_with_name("ctrl_id", (uint8_t *)ps_ctx->ctrl->info.id, ctrl_id_len);
+	hex_dbg_with_name("ltpkc", ps_ctx->ctrl->info.ltpk, ED_KEY_LEN);
+	hex_dbg_with_name("ctrl_sign", ed_sign, sizeof(ed_sign));
+
+	/* Derive iOSDeviceX from SRP shared secret using HKDF-SHA512 */
+	uint8_t ios_device_x[32];
+	hkdf(SHA512, (unsigned char *) PAIR_SETUP_CTRL_SIGN_SALT,
+			strlen(PAIR_SETUP_CTRL_SIGN_SALT), (uint8_t *)ps_ctx->shared_secret, ps_ctx->secret_len,
+			(unsigned char *) PAIR_SETUP_CTRL_SIGN_INFO,
+			strlen(PAIR_SETUP_CTRL_SIGN_INFO),
+			ios_device_x, sizeof(ios_device_x));
+	/* Construct iOSDeviceInfo by concatenating
+	 * iOSDeviceX
+	 * iOSDevicePairingID (ctrl_id)
+	 * iOSDeviceLTPK (ltpkc)
+	 */
+	uint8_t info_buf[HAP_CTRL_ID_LEN + 32 + ED_KEY_LEN];
+	uint8_t *ios_dev_info = info_buf;
+	int ios_dev_info_len = 0;
+	memcpy(ios_dev_info, ios_device_x, sizeof(ios_device_x));
+	ios_dev_info_len += sizeof(ios_device_x);
+	memcpy(&ios_dev_info[ios_dev_info_len], ps_ctx->ctrl->info.id, ctrl_id_len);
+	ios_dev_info_len += ctrl_id_len;
+	memcpy(&ios_dev_info[ios_dev_info_len], ps_ctx->ctrl->info.ltpk, ED_KEY_LEN);
+	ios_dev_info_len += ED_KEY_LEN;
+
+    ret = crypto_sign_ed25519_verify_detached(ed_sign, ios_dev_info, ios_dev_info_len, ps_ctx->ctrl->info.ltpk);
+	/* Verify Signature of constructed iOSDeviceInfo using the iOSDeviceLTPK */
+    if (ret != 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid Signature");
+		hap_prepare_error_tlv(STATE_M6, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	hex_dbg_with_name("ltpka", hap_priv.ltpka, sizeof(hap_priv.ltpka));
+
+	/* Derive AccessoryX from the SRP shared secret using HKDF-SHA512 */
+	uint8_t acc_x[32];
+	hkdf(SHA512, (unsigned char *) PAIR_SETUP_ACC_SIGN_SALT,
+			strlen(PAIR_SETUP_ACC_SIGN_SALT), (uint8_t *)ps_ctx->shared_secret, ps_ctx->secret_len,
+			(unsigned char *) PAIR_SETUP_ACC_SIGN_INFO,
+			strlen(PAIR_SETUP_ACC_SIGN_INFO),
+			acc_x, sizeof(acc_x));
+	/* Construct AccessoryInfo by concatenating
+	 * AccessoryX
+	 * AccessoryPairingID (acc_id)
+	 * AccessoryLTPK (ltpka)
+	 */
+	uint8_t *acc_info = info_buf;
+	int acc_info_len = 0;
+	memcpy(acc_info, acc_x, sizeof(acc_x));
+	acc_info_len += sizeof(acc_x);
+	memcpy(&ios_dev_info[acc_info_len], hap_priv.acc_id, strlen(hap_priv.acc_id));
+	acc_info_len += strlen(hap_priv.acc_id);
+	memcpy(&ios_dev_info[acc_info_len], hap_priv.ltpka, sizeof(hap_priv.ltpka));
+	acc_info_len += sizeof(hap_priv.ltpka);
+
+	/* Generate AccessorySignature by signing AccessoryInfo with AccessoryLTSK
+	 */
+    crypto_sign_ed25519_detached(ed_sign, &ed_sign_len, acc_info, acc_info_len, hap_priv.ltska);
+	hex_dbg_with_name("acc_sign", ed_sign, sizeof(ed_sign));
+
+	/* Create subTLV with:
+	 * kTLVType_Identifier : Accessory ID (acc_id)
+	 * kTLVType_PublicKey : Accessory LTPK
+	 * kTLVType_Signature : AccessorySignature
+	 */
+
+	uint8_t subtlv[6 + HAP_ACC_ID_LEN + ED_KEY_LEN + ED_SIGN_LEN + POLY_AUTHTAG_LEN];
+
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = subtlv;
+	tlv_data.bufsize = sizeof(subtlv);
+	tlv_data.curlen = 0;
+	add_tlv(&tlv_data, kTLVType_Identifier, strlen(hap_priv.acc_id), hap_priv.acc_id);
+	add_tlv(&tlv_data, kTLVType_PublicKey, sizeof(hap_priv.ltpka), hap_priv.ltpka);
+	add_tlv(&tlv_data, kTLVType_Signature, sizeof(ed_sign), ed_sign);
+	int subtlv_len = tlv_data.curlen;
+	hex_dbg_with_name("subtlv", subtlv, subtlv_len);
+
+	/* Encrypt the subTLV using the session key */
+
+    unsigned long long mlen = 16;
+    memset(newnonce, 0, sizeof newnonce);
+    memcpy(newnonce+4, (uint8_t *) PS_NONCE3, 8);
+    crypto_aead_chacha20poly1305_ietf_encrypt_detached(subtlv, &subtlv[subtlv_len], &mlen, subtlv,
+                subtlv_len, NULL, 0, NULL, newnonce, ps_ctx->session_key); 
+	hex_dbg_with_name("send_encrypt_data", subtlv, subtlv_len + 16);
+
+	/* Construct the response M6 */
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	state = STATE_M6;
+	if ((add_tlv(&tlv_data, kTLVType_State, 1, &state) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_EncryptedData, subtlv_len + 16,
+				 subtlv) < 0)) {
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	*outlen = tlv_data.curlen;
+	ps_ctx->state = state;
+	ps_ctx->ctrl->info.perms = 1; /* Controller added using pair setup is always an admin */
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Setup Successful for %s", ps_ctx->ctrl->info.id);
+    /* Reset the Pairing Attempts count */
+	hap_priv.pair_attempts = 0;
+    hap_controller_save(ps_ctx->ctrl);
+    hap_send_event(HAP_INTERNAL_EVENT_ACC_PAIRED);
+	return HAP_SUCCESS;
+}
+static uint8_t hap_pair_setup_get_received_state(uint8_t *buf, int inlen)
+{
+	uint8_t state = 0;
+	get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state));
+	return state;
+}
+
+static void hap_pair_setup_timeout(TimerHandle_t handle)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Clearing Pair Setup Context due to inactivity");
+    pair_setup_ctx_t *ps_ctx = pvTimerGetTimerID(handle);
+    if (ps_ctx) {
+        httpd_sess_trigger_close(hap_priv.server, ps_ctx->sock_fd);
+        hap_report_event(HAP_EVENT_PAIRING_ABORTED, NULL, 0);
+    }
+}
+
+/* Pair Setup can have only a single context at a time as the specification does not allow
+ * multiple controllers to perform Pair Setup Simultaneously.
+ *
+ * The purpose of this function is to manage allocation and resetting of the context by
+ * using a static variable rather than a global variable.
+ */
+static pair_setup_ctx_t *hap_pair_setup_ctx_action(int action)
+{
+	static pair_setup_ctx_t *ps_ctx;
+	/* If the call is to initialise the context, check if it is already
+	 * initialised.
+	 */
+	if (action == PS_CTX_INIT) {
+		/* If the context is already initialised, it means that pair setup
+		 * is already in progress. So, return NULL.
+		 * Else, allocate the context.
+		 */
+		if (ps_ctx)
+			return NULL;
+		else {
+			ps_ctx = hap_platform_memory_calloc(sizeof(pair_setup_ctx_t), 1);
+            if (ps_ctx) {
+                ps_ctx->timer = xTimerCreate("hap_setup_timer", HAP_SETUP_TIMEOUT_IN_TICKS,
+                            pdFALSE, (void *) ps_ctx, hap_pair_setup_timeout);
+                xTimerStart(ps_ctx->timer, 0);
+            }
+        }
+	} else if (action == PS_CTX_DEINIT) {
+		/* If the call is to de-initialise the context, clean it up
+		 * and set the pointer to NULL
+		 */
+		if (ps_ctx) {
+            if (ps_ctx->timer) {
+                xTimerStop(ps_ctx->timer, 0);
+                xTimerDelete(ps_ctx->timer, 100);
+            }
+            mu_srp_free(&ps_ctx->srp_hd);
+			hap_platform_memory_free(ps_ctx);
+		}
+		ps_ctx = NULL;
+	}
+	return ps_ctx;
+}
+
+
+void hap_pair_setup_ctx_clean(void *sess_ctx)
+{
+	if (sess_ctx) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Cleaning Pair Setup Context");
+		hap_pair_setup_ctx_action(PS_CTX_DEINIT);
+    }
+}
+
+int hap_pair_setup_context_init(int sock_fd, void **ctx, uint8_t *buf, int bufsize, int *outlen)
+{
+	pair_setup_ctx_t *ps_ctx = hap_pair_setup_ctx_action(PS_CTX_INIT);
+
+	if (!ps_ctx) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR,"######## Aborted! Pair Setup in Progress with another controller ########");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Busy, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+    ps_ctx->sock_fd = sock_fd;
+	*ctx = ps_ctx;
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "######## Starting Pair Setup ########");
+	return HAP_SUCCESS;
+
+}
+int hap_pair_setup_process(void **ctx, uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+	pair_setup_ctx_t *ps_ctx = (pair_setup_ctx_t *)(*ctx);
+
+	uint8_t recv_state = hap_pair_setup_get_received_state(buf, inlen);
+	if (!ps_ctx) {
+		hap_prepare_error_tlv(recv_state + 1, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	/* Receiving STATE_M1 in the message while the pair-setup was already in progress means
+	 * that pair setup was restarted. Handle it accordingly
+	 */
+	if ((recv_state == STATE_M1) && (ps_ctx->state != STATE_M0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Restarting Pair Setup");
+        int sock_fd = ps_ctx->sock_fd;
+		hap_pair_setup_ctx_clean(ps_ctx);
+		int ret = hap_pair_setup_context_init(sock_fd, ctx, buf, bufsize, outlen);
+		if (ret != HAP_SUCCESS)
+			return ret;
+		ps_ctx = (pair_setup_ctx_t *)(*ctx);
+	}
+	if (ps_ctx->state == STATE_M0) {
+		return hap_pair_setup_process_srp_start(ps_ctx, buf, inlen, bufsize, outlen);
+	} else if (ps_ctx->state == STATE_M2) {
+		hap_priv.pair_attempts++;
+		int ret = hap_pair_setup_process_srp_verify(ps_ctx, buf, inlen, bufsize, outlen);
+        if (ps_ctx->session) {
+            *ctx = ps_ctx->session;
+            hap_pair_setup_ctx_clean(ps_ctx);
+        }
+        return ret;
+	} else if (ps_ctx->state == STATE_M4) {
+		int ret = hap_pair_setup_process_exchange(ps_ctx, buf, inlen, bufsize, outlen);
+		/* If last step of pair setup is successful, it means that the context would
+		 * be no more required. Hence, clear it.
+		 */
+		if (ret == HAP_SUCCESS) {
+			hap_pair_setup_ctx_clean(ps_ctx);
+			*ctx = NULL;
+		}
+		return ret;
+	}
+	hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+	return HAP_FAIL;
+}
+
+void hap_set_setup_code(const char *setup_code)
+{
+    if (hap_priv.setup_code)
+        hap_platform_memory_free(hap_priv.setup_code);
+    hap_priv.setup_code = strdup(setup_code);
+}
+
+int hap_set_setup_info(const hap_setup_info_t *setup_info)
+{
+    if (!setup_info)
+        return HAP_FAIL;
+    if (hap_priv.setup_info)
+        hap_platform_memory_free(hap_priv.setup_info);
+    hap_priv.setup_info = hap_platform_memory_calloc(1, sizeof(hap_setup_info_t));
+    if (!hap_priv.setup_info)
+        return HAP_FAIL;
+    memcpy(hap_priv.setup_info, setup_info, sizeof(hap_setup_info_t));
+    return HAP_SUCCESS;
+}
+
+int hap_set_setup_id(const char *setup_id)
+{
+    if (setup_id == NULL || strlen(setup_id) != SETUP_ID_LEN)
+        return HAP_FAIL;
+    strcpy(hap_priv.setup_id, setup_id);
+    return HAP_SUCCESS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_setup.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_setup.h
@@ -1,0 +1,60 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PAIR_SETUP_H_
+#define _HAP_PAIR_SETUP_H_
+#include <stdint.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/timers.h>
+#include <mu_srp.h>
+#include <esp_hap_pair_common.h>
+
+#define PS_NONCE1	"PS-Msg04"
+#define PS_NONCE2	"PS-Msg05"
+#define PS_NONCE3	"PS-Msg06"
+
+#define PAIR_FLAG_TRANSIENT     0x00000010
+#define PAIR_FLAG_SPLIT         0x01000000
+
+
+typedef struct {
+	uint8_t state;
+	uint8_t method;
+    uint32_t pairing_flags;
+    int8_t pairing_flags_len;
+	int len_s;
+	char *bytes_s;
+    int secret_len;
+    char *shared_secret;
+    mu_srp_handle_t srp_hd;
+	hap_ctrl_data_t *ctrl;
+	uint8_t session_key[32];
+    TimerHandle_t timer;
+    hap_secure_session_t *session;
+    int sock_fd;
+} pair_setup_ctx_t;
+int hap_pair_setup_context_init(int sock_fd, void **ctx, uint8_t *buf, int bufsize, int *outlen);
+int hap_pair_setup_process(void **ctx, uint8_t *buf, int inlen, int bufsize, int *outlen);
+void hap_pair_setup_ctx_clean(void *sess_ctx);
+int hap_pair_setup_manage_mfi_auth(pair_setup_ctx_t *ps_ctx, hap_tlv_data_t *tlv_data, hap_tlv_error_t *tlv_error);
+#endif /* _HAP_PAIR_SETUP_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_verify.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_verify.c
@@ -1,0 +1,464 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sodium/crypto_scalarmult_curve25519.h>
+#include <sodium/crypto_sign_ed25519.h>
+#include <hkdf-sha.h>
+#include <sodium/crypto_aead_chacha20poly1305.h>
+#include <esp_http_server.h>
+#include <hap_platform_memory.h>
+
+#include <esp_hap_main.h>
+#include <esp_hap_pair_common.h>
+#include <esp_hap_database.h>
+#include <esp_hap_char.h>
+#include <hexdump.h>
+#include <esp_mfi_debug.h>
+#include <esp_mfi_rand.h>
+
+#define PAIR_VERIFY_ENCRYPT_SALT	"Pair-Verify-Encrypt-Salt"
+#define PAIR_VERIFY_ENCRYPT_INFO	"Pair-Verify-Encrypt-Info"
+#define PV_NONCE1 			"PV-Msg02"
+#define PV_NONCE2 			"PV-Msg03"
+#define CONTROL_SALT			"Control-Salt"
+#define CONTROL_READ_INFO		"Control-Read-Encryption-Key"
+#define CONTROL_WRITE_INFO		"Control-Write-Encryption-Key"
+
+typedef struct {
+	/* It is important that "state" should be the first element of the structure.
+	 * It will be the first element, even in hap_secure_session_t.
+	 * This will be useful while checking the state from the context, irrespective
+	 * of whether the context points to pair_verify_ctx_t or hap_secure_session_t.
+	 */
+	uint8_t state;
+	uint8_t ctrl_curve_pk[CURVE_KEY_LEN];
+	uint8_t acc_curve_pk[CURVE_KEY_LEN];
+	uint8_t hkdf_key[ENCRYPT_KEY_LEN];
+	uint8_t shared_secret[CURVE_KEY_LEN];
+	hap_secure_session_t *session;
+} pair_verify_ctx_t;
+
+void hap_close_ctrl_sessions(hap_ctrl_data_t *ctrl)
+{
+	if (!ctrl)
+		return;
+	int i;
+	printf("---- hap_close_ctrl_sessions begin -----\n");
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+        if (!hap_priv.sessions[i])
+            continue;
+		if (hap_priv.sessions[i]->ctrl == ctrl) {
+            hap_report_event(HAP_EVENT_CTRL_DISCONNECTED, (ctrl->info.id),
+                    sizeof((ctrl->info.id)));
+			/* TODO: Use some generic function and not a direct HTTPD function
+			 */
+            printf("---- trigger_close fd: %d\n", hap_priv.sessions[i]->conn_identifier);
+            httpd_sess_trigger_close(hap_priv.server, hap_priv.sessions[i]->conn_identifier);
+            break;
+		}
+	}
+	printf("----hap_close_ctrl_sessions end ----\n");
+}
+
+int hap_get_ctrl_session_index(hap_secure_session_t *session)
+{
+	int i;
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+		if (hap_priv.sessions[i] == session)
+			return i;
+	}
+	return -1;
+}
+
+void hap_close_all_sessions()
+{
+	int i;
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+		if (hap_priv.sessions[i]) {
+			ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Closing Session");
+            hap_close_ctrl_sessions(hap_priv.sessions[i]->ctrl);
+        }
+	}
+}
+
+static void hap_add_secure_session(hap_secure_session_t *session)
+{
+	int i;
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+		if (hap_priv.sessions[i] == NULL) {
+			hap_priv.sessions[i] = session;
+            hap_report_event(HAP_EVENT_CTRL_CONNECTED, session->ctrl->info.id,
+                            sizeof(session->ctrl->info.id));
+            /* Set the disconnected_event_sent flag here to false so that an
+             * event can be sent later for a state change, when no controller
+             * is connected.
+             * HAP Spec R15 say that the state number should change only once
+             * between accessory disconneted (from all controllers) to connected
+             * state.
+             */
+            hap_priv.disconnected_event_sent = false;
+			//ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HomeKit Session active");
+			ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HomeKit Session active, fd: %d", session->conn_identifier);
+			break;
+		}
+	}
+}
+
+void hap_free_session(void *session)
+{
+	if (!session)
+		return;
+	int i;
+	for (i = 0; i < HAP_MAX_SESSIONS; i++) {
+		if (hap_priv.sessions[i] == session) {
+			/* Disable all characteristic notifications on this session */
+			int fd = (hap_priv.sessions[i])->conn_identifier;
+			hap_disable_all_char_notif(i);
+			hap_priv.sessions[i] = NULL;
+			//ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HomeKit Session terminated");
+			ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "HomeKit Session terminated, fd: %d", fd);
+			break;
+		}
+	}
+	hap_platform_memory_free(session);
+}
+
+static int hap_pair_verify_process_start(pair_verify_ctx_t *pv_ctx, uint8_t *buf, int inlen,
+		int bufsize, int *outlen)
+{
+	/* Parse the data received from the controller */
+	uint8_t state;
+	if (!pv_ctx) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "No context");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+		(get_value_from_tlv(buf, inlen, kTLVType_PublicKey, pv_ctx->ctrl_curve_pk,
+				    CURVE_KEY_LEN) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if (state != STATE_M1) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Incorrect State received");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Verify M1 Received");
+	hex_dbg_with_name("ctrl curve pk", pv_ctx->ctrl_curve_pk, 32);
+
+	/* Generate a new Curve25519 Key Pair */
+	uint8_t acc_curve_sk[CURVE_KEY_LEN];
+	esp_mfi_get_random(acc_curve_sk, CURVE_KEY_LEN);
+	/* This particular value of basepoint is required to generate the public key
+	 * from secret key
+	 */
+	uint8_t basepoint[32] = {9};
+    if (crypto_scalarmult_curve25519(pv_ctx->acc_curve_pk, acc_curve_sk, basepoint) == -1) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Curve25519 Error");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+    }
+	hex_dbg_with_name("acc curve sk", acc_curve_sk, 32);
+	hex_dbg_with_name("acc curve pk", pv_ctx->acc_curve_pk, 32);
+    if (crypto_scalarmult_curve25519(pv_ctx->shared_secret, acc_curve_sk, pv_ctx->ctrl_curve_pk) == -1) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Curve25519 Error");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+    }
+
+	hex_dbg_with_name("shared secret", pv_ctx->shared_secret, 32);
+
+	/* Construct AccessoryInfo by concatenating
+	 * a. Accessory's Curve25519 Public Key
+	 * b. Accessory ID
+	 * c. Controller's Curve25519 Public Key received in M1
+	 */
+	uint8_t acc_info[2 * CURVE_KEY_LEN + HAP_ACC_ID_LEN];
+	int acc_info_len  = 0;
+	memcpy(acc_info, pv_ctx->acc_curve_pk, CURVE_KEY_LEN);
+	acc_info_len += CURVE_KEY_LEN;
+	memcpy(acc_info + acc_info_len, hap_priv.acc_id, strlen(hap_priv.acc_id));
+	acc_info_len += strlen(hap_priv.acc_id);
+	memcpy(acc_info + acc_info_len, pv_ctx->ctrl_curve_pk, CURVE_KEY_LEN);
+	acc_info_len += CURVE_KEY_LEN;
+
+	hex_dbg_with_name("acc_info", acc_info, acc_info_len);
+
+	/* Use Ed25519 to generate AccessorySignature by signing AccessoryInfo
+	 * with its Long Term Secret Key AccessoryLTSK
+	 */
+	unsigned char ed_sign[64];
+    unsigned long long ed_sign_len;
+    crypto_sign_ed25519_detached(ed_sign, &ed_sign_len, acc_info, acc_info_len, hap_priv.ltska);
+	hex_dbg_with_name("sign", ed_sign, 64);
+
+	/* Construct a subTLV with
+	 * kTLVType_Identifier : Accessory Identifier
+	 * kTLVType_Signature : AccessorySignature generated above
+	 */
+	uint8_t subtlv[4 + HAP_ACC_ID_LEN + ED_SIGN_LEN + POLY_AUTHTAG_LEN];
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = subtlv;
+	tlv_data.bufsize = sizeof(subtlv);
+	tlv_data.curlen = 0;
+	add_tlv(&tlv_data, kTLVType_Identifier, strlen(hap_priv.acc_id), hap_priv.acc_id);
+	add_tlv(&tlv_data, kTLVType_Signature, sizeof(ed_sign), ed_sign);
+	int subtlv_len = tlv_data.curlen;
+	hex_dbg_with_name("subtlv", subtlv, subtlv_len);
+
+	/* Derive Symmetric Session encryption key SessionKey from the curve
+	 * shared secret using HKDF-SHA-512
+	 */
+	hkdf(SHA512, (unsigned char *) PAIR_VERIFY_ENCRYPT_SALT,
+			strlen(PAIR_VERIFY_ENCRYPT_SALT),
+			pv_ctx->shared_secret, sizeof(pv_ctx->shared_secret),
+			(unsigned char *) PAIR_VERIFY_ENCRYPT_INFO,
+			strlen(PAIR_VERIFY_ENCRYPT_INFO),
+			pv_ctx->hkdf_key, sizeof(pv_ctx->hkdf_key));
+	/* Encrypt the sub TLV to get encryptedData and an authTag using
+	 * Chacha20-Poly1305 AEAD Algorithm
+	 */
+	uint8_t edata[4 + HAP_ACC_ID_LEN + ED_SIGN_LEN + POLY_AUTHTAG_LEN];
+    unsigned long long mlen = 16;
+    uint8_t newnonce[12];
+    memset(newnonce, 0, sizeof newnonce);
+    memcpy(newnonce+4, PV_NONCE1, 8);
+
+    crypto_aead_chacha20poly1305_ietf_encrypt_detached(edata, edata + subtlv_len, &mlen, subtlv, subtlv_len, NULL, 0, NULL, newnonce, pv_ctx->hkdf_key);
+
+	int edata_len = subtlv_len + POLY_AUTHTAG_LEN;
+
+	hex_dbg_with_name("encrypt_data", edata, edata_len);
+
+	/* Construct the response M2 */
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	state = STATE_M2;
+	if ((add_tlv(&tlv_data, kTLVType_State, 1, &state) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_PublicKey, CURVE_KEY_LEN,
+				 pv_ctx->acc_curve_pk) < 0) ||
+			(add_tlv(&tlv_data, kTLVType_EncryptedData, edata_len, edata) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	*outlen = tlv_data.curlen;
+	hex_dbg_with_name("M2", buf, *outlen);
+	pv_ctx->state = STATE_M2;
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Verify M2 Successful");
+	return HAP_SUCCESS;
+}
+
+static int hap_pair_verify_process_finish(pair_verify_ctx_t *pv_ctx, uint8_t *buf, int inlen,
+		int bufsize, int *outlen)
+{
+	/* Parse the data received from the controller */
+	uint8_t state;
+	if (!pv_ctx) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "No context");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	uint8_t edata[4 + HAP_CTRL_ID_LEN + ED_SIGN_LEN + POLY_AUTHTAG_LEN];
+	int edata_len;
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+		((edata_len = get_value_from_tlv(buf, inlen, kTLVType_EncryptedData,
+					 edata, sizeof(edata))) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if (state != STATE_M3) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Incorrect State received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Verify M3 Received");
+
+    /* Decrypt the received data to get the subTLV */
+    uint8_t newnonce[12];
+    memset(newnonce, 0, sizeof newnonce);
+    memcpy(newnonce+4, PV_NONCE2, 8);
+    int ret;
+    ret = crypto_aead_chacha20poly1305_ietf_decrypt_detached(edata, NULL, edata, edata_len - POLY_AUTHTAG_LEN, edata + edata_len - POLY_AUTHTAG_LEN, NULL, 0, newnonce, pv_ctx->hkdf_key); 
+    if (ret != 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Decryption error");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	/* Parse the subTLV to get the iOSDevicePairingID and iOSDeviceSignature
+	 */
+	edata_len = edata_len - POLY_AUTHTAG_LEN;
+    unsigned char ed_sign[64];
+	char ctrl_id[HAP_CTRL_ID_LEN];
+	memset(ctrl_id, 0, sizeof(ctrl_id));
+	if ((get_value_from_tlv(edata, edata_len, kTLVType_Identifier,
+					ctrl_id, sizeof(ctrl_id)) < 0) ||
+			(get_value_from_tlv(edata, edata_len, kTLVType_Signature,
+					ed_sign, sizeof(ed_sign)) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Wrong subTLV received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	/* Check if the controller is present in the database i.e. check
+	 * if the controller was paired with the accessory
+	 */
+	hap_ctrl_data_t *ctrl = hap_get_controller(ctrl_id);
+	if (!ctrl) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "No ctrl details found");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	/* Construct iOSDeviceInfo by concatenating
+	 * a. Controllers's Curve25519 Public Key (received in M1)
+	 * b. Controller ID
+	 * c. Accessory's Curve25519 Public Key (sent in M2)
+	 */
+	uint8_t ios_dev_info[2 * CURVE_KEY_LEN + HAP_CTRL_ID_LEN];
+	int ios_dev_info_len = 0;
+	memcpy(ios_dev_info, pv_ctx->ctrl_curve_pk, CURVE_KEY_LEN);
+	ios_dev_info_len += CURVE_KEY_LEN;
+	memcpy(ios_dev_info + ios_dev_info_len, ctrl_id, strlen(ctrl_id));
+	ios_dev_info_len += strlen(ctrl_id);
+	memcpy(ios_dev_info + ios_dev_info_len, pv_ctx->acc_curve_pk,
+			CURVE_KEY_LEN);
+	ios_dev_info_len += CURVE_KEY_LEN;
+
+	/* Validate the signature with the received iOSDeviceSignature */
+    if (crypto_sign_ed25519_verify_detached(ed_sign, ios_dev_info, ios_dev_info_len, ctrl->info.ltpk) != 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Signature mismatch");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	/* Allocate memory for the secure session information */
+	hap_secure_session_t *session = hap_platform_memory_calloc(sizeof(hap_secure_session_t), 1);
+	if (!session) {
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Memory allocation failed");
+		return HAP_FAIL;
+	}
+	/* Construct the response M4 */
+	hap_tlv_data_t tlv_data;
+	tlv_data.bufptr = buf;
+	tlv_data.bufsize = bufsize;
+	tlv_data.curlen = 0;
+	state = STATE_M4;
+	if (add_tlv(&tlv_data, kTLVType_State, 1, &state) < 0) {
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		hap_platform_memory_free(session);
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+		return HAP_FAIL;
+	}
+	*outlen = tlv_data.curlen;
+
+	/* Generate the Encryption and Decryption Keys.
+	 * Since, read and write are from the controller's point of view,
+	 * encryption key uses READ_INFO and decryption key uses WRITE_INFO
+	 *
+	 * Also, set the nonce to zero
+	 */
+	hkdf(SHA512, (unsigned char *) CONTROL_SALT, strlen(CONTROL_SALT),
+			pv_ctx->shared_secret, sizeof(pv_ctx->shared_secret),
+			(unsigned char *) CONTROL_READ_INFO, strlen(CONTROL_READ_INFO),
+			session->encrypt_key, sizeof(session->encrypt_key));
+
+	hkdf(SHA512, (unsigned char *) CONTROL_SALT, strlen(CONTROL_SALT),
+			pv_ctx->shared_secret, sizeof(pv_ctx->shared_secret),
+			(unsigned char *) CONTROL_WRITE_INFO, strlen(CONTROL_WRITE_INFO),
+			session->decrypt_key, sizeof(session->decrypt_key));
+
+	session->state = STATE_VERIFIED;
+	pv_ctx->state = STATE_VERIFIED;
+
+	memset(session->encrypt_nonce, 0, sizeof(session->encrypt_nonce));
+	memset(session->decrypt_nonce, 0, sizeof(session->decrypt_nonce));
+	session->ctrl = ctrl;
+
+	pv_ctx->session = session;
+
+	/* Add the session information to database */
+	hap_add_secure_session(session);
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Pair Verify Successful for %s", ctrl_id);
+	return HAP_SUCCESS;
+}
+
+int hap_pair_verify_process(void **ctx, uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+	pair_verify_ctx_t *pv_ctx = (pair_verify_ctx_t *)(*ctx);
+	if (pv_ctx) {
+		if (pv_ctx->state == STATE_M0)
+			return hap_pair_verify_process_start(pv_ctx, buf, inlen,
+					bufsize, outlen);
+		else if (pv_ctx->state == STATE_M2) {
+			int ret = hap_pair_verify_process_finish(pv_ctx, buf, inlen,
+					bufsize, outlen);
+			/* Successful finish means that the pair verify was successful.
+			 * So, we clear the old context and assign the secure_session
+			 * as the new context
+			 */
+			if (ret == HAP_SUCCESS) {
+				hap_secure_session_t *session = pv_ctx->session;
+				hap_platform_memory_free(pv_ctx);
+				*ctx = session;
+			}
+			return ret;
+		}
+	}
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Error processing Pair Verify Data");
+	hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+	return HAP_FAIL;
+}
+
+int hap_pair_verify_context_init(void **ctx, uint8_t *buf, int bufsize, int *outlen)
+{
+	pair_verify_ctx_t *pv_ctx;
+
+	pv_ctx = (pair_verify_ctx_t *) hap_platform_memory_calloc(sizeof(pair_verify_ctx_t), 1);
+	if (!pv_ctx) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Failed to create Pair Verify Context");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	*ctx = pv_ctx;
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "######## Starting Pair Verify ########");
+	return HAP_SUCCESS;
+}
+
+uint8_t hap_pair_verify_get_state(void *ctx)
+{
+	pair_verify_ctx_t *pv_ctx = (pair_verify_ctx_t *)ctx;
+	if (pv_ctx)
+		return pv_ctx->state;
+	return 0;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_verify.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pair_verify.h
@@ -1,0 +1,35 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PAIR_VERIFY_H_
+#define _HAP_PAIR_VERIFY_H_
+#include <esp_hap_pair_common.h>
+#include <esp_hap_controllers.h>
+int hap_pair_verify_context_init(void **ctx, uint8_t *buf, int bufsize, int *outlen);
+int hap_pair_verify_process(void **ctx, uint8_t *buf, int inlen, int bufsize, int *outlen);
+uint8_t hap_pair_verify_get_state(void *ctx);
+void hap_free_session(void *session);
+int hap_get_ctrl_session_index(hap_secure_session_t *session);
+void hap_close_ctrl_sessions(hap_ctrl_data_t *ctrl);
+void hap_close_all_sessions();
+#endif /* _HAP_PAIR_VERIFY_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pairings.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pairings.c
@@ -1,0 +1,255 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <esp_hap_database.h>
+#include <esp_hap_controllers.h>
+#include <esp_hap_pair_common.h>
+#include <esp_hap_pair_verify.h>
+#include <esp_hap_main.h>
+#include <esp_mfi_debug.h>
+
+bool hap_is_req_admin(void *__session)
+{
+    hap_secure_session_t *session = (hap_secure_session_t *)__session;
+    if (!session) {
+        return false;
+    }
+	if ((session->state == STATE_VERIFIED) && (session->ctrl->info.perms == 1)) {
+		return true;
+    }
+    return false;
+}
+
+char *hap_req_get_ctrl_id(void *__session)
+{
+    hap_secure_session_t *session = (hap_secure_session_t *)__session;
+    if (!session)
+        return NULL;
+
+    if (session->state == STATE_VERIFIED) {
+        return session->ctrl->info.id;
+    }
+    return NULL;
+}
+
+bool hap_is_req_secure(hap_secure_session_t *session)
+{
+    if (!session) {
+        return false;
+    }
+    if (session->state == STATE_VERIFIED) {
+        return true;
+    }
+    return false;
+}
+
+void hap_remove_all_controllers()
+{
+	int i;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		if (hap_priv.controllers[i].valid) {
+			hap_close_ctrl_sessions(&hap_priv.controllers[i]);
+			hap_controller_remove(&hap_priv.controllers[i]);
+		}
+	}
+}
+static int hap_process_pair_remove(uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+    bool acc_unpaired = false;
+	char ctrl_id[HAP_CTRL_ID_LEN];
+	memset(ctrl_id, 0, HAP_CTRL_ID_LEN);
+	if (get_value_from_tlv(buf, inlen, kTLVType_Identifier,
+					ctrl_id, sizeof(ctrl_id)) < 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Identifier not found");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Removing Controller %s", ctrl_id);
+	hap_ctrl_data_t *ctrl = hap_get_controller(ctrl_id);
+	hap_close_ctrl_sessions(ctrl);
+	hap_controller_remove(ctrl);
+
+	if (!is_admin_paired()) {
+        acc_unpaired = true;
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Last Admin controller removed. Removing all other controllers.");
+		hap_remove_all_controllers();
+    }
+
+	hap_tlv_data_t tlv_data = {
+		.bufptr = buf,
+		.bufsize = bufsize,
+		.curlen = 0,
+	};
+	uint8_t state = STATE_M2;
+	if (add_tlv(&tlv_data, kTLVType_State, sizeof(state), &state) < 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	*outlen = tlv_data.curlen;
+    if (acc_unpaired) {
+        hap_send_event(HAP_INTERNAL_EVENT_ACC_UNPAIRED);
+    }
+	return HAP_SUCCESS;
+}
+
+static int hap_process_pair_add(uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+	char ctrl_id[HAP_CTRL_ID_LEN];
+	uint8_t ltpkc[ED_KEY_LEN];
+	uint8_t perms;
+	memset(ctrl_id, 0, HAP_CTRL_ID_LEN);
+	if ((get_value_from_tlv(buf, inlen, kTLVType_Identifier,
+						ctrl_id, sizeof(ctrl_id)) < 0) ||
+		(get_value_from_tlv(buf, inlen, kTLVType_PublicKey,
+				    ltpkc, sizeof(ltpkc)) < 0) ||
+		 (get_value_from_tlv(buf, inlen, kTLVType_Permissions,
+				     &perms, sizeof(perms)) < 0)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M4, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+
+	hap_ctrl_data_t *ctrl = hap_get_controller(ctrl_id);
+	if (ctrl) {
+		/* If controller already exists, but the key does not match, return error */
+		if (memcmp(ltpkc, ctrl->info.ltpk, ED_KEY_LEN)) {
+			hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+			return HAP_FAIL;
+		} else {
+			/* Else, just change the permissions */
+			ctrl->info.perms = perms;
+	        ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Modifying Existing Controller %s", ctrl_id);
+			hap_controller_save(ctrl);
+		}
+	} else {
+		/* Check if there is space available for a new controller */
+		ctrl = 	hap_controller_get_empty_loc();
+		if (!ctrl) {
+			hap_prepare_error_tlv(STATE_M2, kTLVError_MaxPeers, buf, bufsize, outlen);
+			return HAP_FAIL;
+		}
+		strcpy(ctrl->info.id, ctrl_id);
+		memcpy(ctrl->info.ltpk, ltpkc, ED_KEY_LEN);
+		ctrl->info.perms = perms;
+		hap_controller_save(ctrl);
+	    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Added Controller %s", ctrl_id);
+	}
+	hap_tlv_data_t tlv_data = {
+		.bufptr = buf,
+		.bufsize = bufsize,
+		.curlen = 0,
+	};
+	uint8_t state = STATE_M2;
+	if (add_tlv(&tlv_data, kTLVType_State, sizeof(state), &state) < 0) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	*outlen = tlv_data.curlen;
+	return HAP_SUCCESS;
+
+}
+static int hap_process_pair_list(uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+	hap_tlv_data_t tlv_data = {
+		.bufptr = buf,
+		.bufsize = bufsize,
+		.curlen = 0,
+	};
+	int i;
+	hap_ctrl_data_t *ctrl;
+    hap_ctrl_info_t *ctrl_info;
+	bool entry_added = false;
+	for (i = 0; i < HAP_MAX_CONTROLLERS; i++) {
+		ctrl = &hap_priv.controllers[i];
+		if (!ctrl->valid)
+			continue;
+        /* If an entry is already added, include a separator */
+        if (entry_added) {
+            if (add_tlv(&tlv_data, kTLVType_Separator, 0, NULL) < 0) {
+                ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+                hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown,
+                        buf, bufsize, outlen);
+                return HAP_FAIL;
+            }
+        } else {
+            /* Else, since this is the first entry, add the state */
+	        uint8_t state = STATE_M2;
+            if (add_tlv(&tlv_data, kTLVType_State, sizeof(state), &state) < 0) {
+                ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+                hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown,
+                        buf, bufsize, outlen);
+                return HAP_FAIL;
+            }
+        }
+        ctrl_info = &ctrl->info;
+		if ((add_tlv(&tlv_data, kTLVType_Identifier,
+						strlen(ctrl_info->id), ctrl_info->id) < 0) ||
+				(add_tlv(&tlv_data, kTLVType_PublicKey,
+					 ED_KEY_LEN, ctrl_info->ltpk) < 0) ||
+				(add_tlv(&tlv_data, kTLVType_Permissions,
+					 1, &ctrl_info->perms) < 0)) {
+			ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "TLV creation failed");
+			hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+			return HAP_FAIL;
+		}
+		entry_added = true;
+	}
+	*outlen = tlv_data.curlen;
+	return HAP_SUCCESS;
+}
+
+int hap_pairings_process(void *ctx, uint8_t *buf, int inlen, int bufsize, int *outlen)
+{
+	if (!hap_is_req_admin(ctx)) {
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Authentication, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	uint8_t state, method;
+	if ((get_value_from_tlv(buf, inlen, kTLVType_State, &state, sizeof(state)) < 0) ||
+			(get_value_from_tlv(buf, inlen, kTLVType_Method,
+					    &method, sizeof(method)) < 0) ||
+			(state != STATE_M1)) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Invalid TLVs received");
+		hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+		return HAP_FAIL;
+	}
+	if (method == HAP_METHOD_ADD_PAIRING) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Add Pairing received");
+		return hap_process_pair_add(buf, inlen, bufsize, outlen);
+	} else if (method == HAP_METHOD_REMOVE_PAIRING) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Remove Pairing received");
+		return hap_process_pair_remove(buf, inlen, bufsize, outlen);
+	} else if (method == HAP_METHOD_LIST_PAIRINGS) {
+		ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "List Pairings received");
+		return hap_process_pair_list(buf, inlen, bufsize, outlen);
+	}
+	hap_prepare_error_tlv(STATE_M2, kTLVError_Unknown, buf, bufsize, outlen);
+	return HAP_FAIL;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_pairings.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_pairings.h
@@ -1,0 +1,29 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PAIRINGS_H_
+#define _HAP_PAIRINGS_H_
+#include <esp_hap_pair_common.h>
+int hap_pairings_process(void *ctx, uint8_t *buf, int inlen, int bufsize, int *outlen);
+bool hap_is_req_secure(hap_secure_session_t *session);
+#endif /* _HAP_PAIRINGS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_secure_message.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_secure_message.h
@@ -1,0 +1,42 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_SECURE_MESSAGE_H_
+#define _HAP_SECURE_MESSAGE_H_
+#include <stdint.h>
+#include <esp_http_server.h>
+/** Information for Software Token based authentication.
+ * To be used only if MFi chip is not present on the accessory
+ */
+typedef struct {
+    /** UUID for the accessory */
+    uint8_t uuid[16];
+    /** Token associated with the UUID */
+    uint8_t *token;
+    /* Length of the above token */
+    size_t token_len;
+} hap_software_token_info_t;
+
+int hap_register_secure_message_handler(httpd_handle_t handle);
+int hap_unregister_secure_message_handler(httpd_handle_t handle);
+#endif /* _HAP_SECURE_MESSAGE_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_serv.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_serv.c
@@ -1,0 +1,329 @@
+ /*
+  * ESPRESSIF MIT License
+  *
+  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+  *
+  * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+  * it is free of charge, to any person obtaining a copy of this software and associated
+  * documentation files (the "Software"), to deal in the Software without restriction, including
+  * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+  * to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all copies or
+  * substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  *
+  */
+#include <string.h>
+#include <hap_platform_memory.h>
+
+#include <esp_hap_serv.h>
+#include <esp_mfi_debug.h>
+
+void hap_serv_mark_primary(hap_serv_t *hs)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->primary = true;
+    }
+}
+
+void hap_serv_mark_hidden(hap_serv_t *hs)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->hidden = true;
+    }
+}
+
+/**
+ * @brief get service hidden attribute
+ */
+bool hap_serv_get_hidden(hap_serv_t *hs)
+{
+    if (hs) {
+        return ((__hap_serv_t *)hs)->hidden;
+    }
+    return false;
+}
+
+
+void hap_serv_set_iid(hap_serv_t *hs, int32_t iid)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->iid = iid;
+    }
+}
+
+/**
+ * @brief get service "primary" attribute
+ */
+bool hap_serv_get_primary(hap_serv_t *hs)
+{
+    if (hs) {
+        return ((__hap_serv_t *)hs)->primary;
+    }
+    return false;
+}
+
+hap_char_t *hap_serv_get_first_char(hap_serv_t *hs)
+{
+    return ((__hap_serv_t *)hs)->chars;
+}
+/**
+ * @brief get target characteristics by it's IID
+ */
+hap_char_t *hap_serv_get_char_by_iid(hap_serv_t *hs, int32_t iid)
+{
+    if (!hs)
+        return NULL;
+
+    hap_char_t *hc;
+    for (hc = hap_serv_get_first_char(hs); hc; hc = hap_char_get_next(hc)) {
+        if (((__hap_char_t *)hc)->iid == iid)
+            return hc;
+    }
+    return NULL;
+}
+
+/**
+ * @brief get target characteristics by it's UUID
+ */
+hap_char_t *hap_serv_get_char_by_uuid(hap_serv_t *hs, const char *uuid)
+{
+    if (!hs | !uuid)
+        return NULL;
+
+    hap_char_t *hc;
+    for (hc = hap_serv_get_first_char(hs); hc; hc = hap_char_get_next(hc)) {
+        if (!strcmp(((__hap_char_t *)hc)->type_uuid, uuid))
+            return hc;
+    }
+    return NULL;
+}
+
+/**
+ * @brief get characteristics UUID prefix number
+ */
+ char *hap_serv_get_uuid(hap_serv_t *hs)
+ {
+     return ((__hap_serv_t *)hs)->type_uuid;
+ }
+
+/**
+ * Default service bulk read callback, which will be registered while creating a service.
+ * It will internally call the actual read routines
+ */
+static int hap_serv_def_bulk_read_cb(hap_read_data_t read_data[], int count,
+        void *serv_priv, void *read_priv)
+{
+    int i;
+    if (!count) {
+        return HAP_FAIL;
+    }
+    __hap_serv_t *hs = (__hap_serv_t *)hap_char_get_parent(read_data[0].hc);
+    /* If no read routine is registered, just return success so that the cached values
+     * will be used
+     */
+    if (!hs->read_cb) {
+        return HAP_SUCCESS;
+    }
+
+    int ret = HAP_SUCCESS;
+    for (i = 0; i < count; i++) {
+       if (hs->read_cb(read_data[i].hc, read_data[i].status, serv_priv, read_priv) != HAP_SUCCESS) {
+           ret = HAP_FAIL;
+       }
+    }
+    return ret;
+}
+/**
+ * @brief HAP create a service
+ */
+hap_serv_t *hap_serv_create(char *type_uuid)
+{
+    ESP_MFI_ASSERT(type_uuid);
+    __hap_serv_t *_hs = hap_platform_memory_calloc(1, sizeof(__hap_serv_t));
+    if (!_hs) {
+        return NULL;
+    }
+
+    _hs->type_uuid = type_uuid;
+    _hs->bulk_read = hap_serv_def_bulk_read_cb;
+
+    return (hap_serv_t *)_hs;
+}
+
+int hap_serv_link_serv(hap_serv_t *hs, hap_serv_t *linked_serv)
+{
+    if (!hs || !linked_serv)
+        return HAP_FAIL;
+
+    hap_linked_serv_t *cur = hap_platform_memory_calloc(1, sizeof(hap_linked_serv_t));
+    if (!cur)
+        return HAP_FAIL;
+    cur->hs = linked_serv;
+
+    __hap_serv_t *_hs = (__hap_serv_t *)hs;
+    hap_linked_serv_t *linked = _hs->linked_servs;
+
+    if (!linked) {
+        _hs->linked_servs = cur;
+        return HAP_SUCCESS;
+    } else {
+        while(linked->next) {
+            linked = linked->next;
+        }
+        linked->next = cur;
+        return HAP_SUCCESS;
+    }
+    return HAP_FAIL;
+}
+
+/**
+ * @brief HAP get target service IID
+ */
+uint32_t hap_serv_get_iid(hap_serv_t *hs)
+{
+    if (!hs)
+       return 0;
+
+    __hap_serv_t *tmp = (__hap_serv_t *)hs;
+
+    return tmp->iid;
+}
+
+char *hap_serv_get_type_uuid(hap_serv_t *hs)
+{
+    if (!hs)
+       return 0;
+
+    __hap_serv_t *tmp = (__hap_serv_t *)hs;
+
+    return tmp->type_uuid;
+}
+
+/**
+ * @brief HAP delete target service
+ */
+void hap_serv_delete(hap_serv_t *hs)
+{
+	/* Returning success even if pointer is NULL, because it means
+	 * that the service is absent and as good as deleted
+	 */
+	if (!hs)
+		return;
+	__hap_serv_t *_hs = (__hap_serv_t *)hs;
+	__hap_char_t *_hc = (__hap_char_t *)_hs->chars;
+	while (_hc) {
+		_hs->chars = _hc->next_char;
+		hap_char_delete((hap_char_t *)_hc);
+		_hc = (__hap_char_t *)_hs->chars;
+	}
+    if (_hs->linked_servs) {
+        hap_linked_serv_t *cur = _hs->linked_servs;
+        hap_linked_serv_t *next = cur->next;
+        while (next) {
+            hap_platform_memory_free(cur);
+            cur = next;
+            next = cur->next;
+        }
+        hap_platform_memory_free(cur);
+    }
+    hap_platform_memory_free(hs);
+}
+
+/**
+ * @brief add a characteristics to a service
+ */
+int hap_serv_add_char(hap_serv_t *hs, hap_char_t *hc)
+{
+    if (!hs || !hc)
+        return -1;
+    __hap_serv_t *_hs = (__hap_serv_t *)hs;
+    __hap_char_t *_hc = (__hap_char_t *)hc;
+
+    if (_hc->parent) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Characteristic already added");
+        return HAP_FAIL;
+    }
+
+    /* If the service has no characteristics, add this as the first */
+    if (!_hs->chars) {
+        _hs->chars = hc;
+    } else {
+        /* Else loop through the characteristics to get to the last one,
+         * and add this at the end
+         */
+        __hap_char_t *temp = (__hap_char_t *)_hs->chars;
+        while (temp->next_char)
+            temp = (__hap_char_t *)temp->next_char;
+        temp->next_char = hc;
+    }
+    if (_hs->parent) {
+        _hc->iid = ((__hap_acc_t *)(_hs->parent))->next_iid++;
+    }
+    _hc->parent = hs;
+    return 0;
+}
+
+void hap_serv_set_write_cb(hap_serv_t *hs, hap_serv_write_t write)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->write_cb = write;
+    }
+}
+
+void hap_serv_set_read_cb(hap_serv_t *hs, hap_serv_read_t read)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->read_cb = read;
+    }
+}
+
+void hap_serv_set_bulk_read_cb(hap_serv_t *hs, hap_serv_bulk_read_t read)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->bulk_read = read;
+    }
+}
+
+
+hap_serv_t *hap_serv_get_next(hap_serv_t *hs)
+{
+    if (hs) {
+        return ((__hap_serv_t *)hs)->next_serv;
+    } else {
+        return NULL;
+    }
+}
+
+hap_acc_t *hap_serv_get_parent(hap_serv_t *hs)
+{
+    if (hs) {
+        return ((__hap_serv_t *)hs)->parent;
+    } else {
+        return NULL;
+    }
+}
+
+void hap_serv_set_priv(hap_serv_t *hs, void *priv)
+{
+    if (hs) {
+        ((__hap_serv_t *)hs)->priv = priv;
+    }
+}
+
+void *hap_serv_get_priv(hap_serv_t *hs)
+{
+    if (hs) {
+        return ((__hap_serv_t *)hs)->priv;
+    } else {
+        return NULL;
+    }
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_serv.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_serv.h
@@ -1,0 +1,80 @@
+ /*
+  * ESPRESSIF MIT License
+  *
+  * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+  *
+  * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+  * it is free of charge, to any person obtaining a copy of this software and associated
+  * documentation files (the "Software"), to deal in the Software without restriction, including
+  * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+  * to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in all copies or
+  * substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  *
+  */
+
+#ifndef _HAP_SERV_H_
+#define _HAP_SERV_H_
+
+#include <hap.h>
+#include <esp_hap_char.h>
+#include <esp_hap_acc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct hap_linked_serv {
+    hap_serv_t *hs;
+    struct hap_linked_serv *next;
+} hap_linked_serv_t;
+
+typedef struct hap_linked_serv hap_linked_serv_t;
+
+/**
+ * HAP service information
+ */
+typedef struct {
+    char                *type_uuid;      /* String that defines the type of the service. */
+
+    uint32_t             iid;        /* service instance ID */
+
+    bool                hidden;     /* If set it to be True, the service is not visible to user. */
+    bool                primary;    /* If set it to be True, this is the primary service of the accessory. */
+
+    /**
+     * List of Characteristic objects. Must not be empty. The maximum number of characteristics
+     * allowed is 100, and each characteristic in the array must have a unique type.
+     */
+    hap_char_t *chars;
+    hap_acc_t  *parent;
+    hap_serv_t *next_serv;
+    
+    hap_serv_write_t write_cb;
+    hap_serv_read_t read_cb;
+    hap_serv_bulk_read_t bulk_read;
+    hap_linked_serv_t *linked_servs;
+    void *priv;
+} __hap_serv_t;
+
+bool hap_serv_get_hidden(hap_serv_t *hs);
+bool hap_serv_get_primary(hap_serv_t *hs);
+hap_char_t *hap_serv_get_char_by_iid(hap_serv_t *hs, int32_t iid);
+ char *hap_serv_get_uuid(hap_serv_t *hs);
+hap_serv_t *hap_serv_create(char *type_uuid);
+void hap_serv_delete(hap_serv_t *hs);
+int hap_serv_add_char(hap_serv_t *hs, hap_char_t *hc);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_SERV_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_setup_payload.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_setup_payload.c
@@ -1,0 +1,81 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <esp_err.h>
+#include <esp_log.h>
+#include <hap.h>
+
+#include <base36.h>
+
+static const char *TAG = "esp_hap_setup_payload";
+
+#define SETUP_CODE_MASK     0x0000000007ffffff
+#define HAP_OVER_IP_MASK    0x0000000010000000
+#define WAC_MASK            0x0000000040000000
+#define SETUP_PAYLOAD_PREFIX              "X-HM://00"
+
+static void remove_chars(char *str, char c)
+{
+    int i = 0, j = 0;
+    while(str[i]) {
+        if (str[i] != c) {
+            str[j] = str[i];
+            j++;
+        }
+        i++;
+    }
+    str[j] = 0;
+}
+
+char *esp_hap_get_setup_payload(char *setup_code, char *setup_id, bool wac_support, hap_cid_t cid)
+{
+    if (!setup_code || !setup_id) {
+        ESP_LOGE(TAG, "Setup code or Setup ID cannot be NULL");
+        return NULL;
+    }
+    uint64_t payload = 0;
+    if (strlen(setup_code) != 10 || strlen(setup_id) != 4) {
+        ESP_LOGE(TAG, "Setup code or Setup ID not correct. Eg. 111-22-333, ES32");
+        return NULL;
+    }
+    char setup_code_copy[11];
+    strcpy(setup_code_copy, setup_code);
+    remove_chars(setup_code_copy, '-');
+    int64_t code = atoi(setup_code_copy);
+    int64_t category = cid;
+    category <<= 31;
+
+    payload |= code;
+    payload |= category;
+    payload |= HAP_OVER_IP_MASK;
+    if (wac_support) {
+        payload |= WAC_MASK;
+    }
+    char *base36_str = base36_to_str(payload);
+    char setup_payload[24];
+    snprintf(setup_payload, sizeof(setup_payload), "%s%s%s", SETUP_PAYLOAD_PREFIX, base36_str, setup_id);
+    free(base36_str);
+    return strdup(setup_payload);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_wac.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_wac.h
@@ -1,0 +1,32 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_WAC_H_
+#define _HAP_WAC_H_
+int hap_wac_start(void);
+int hap_wac2_network_switch(void);
+int hap_wac2_finish(void);
+int hap_wac2_stop(void);
+bool hap_is_mfi_auth_enabled();
+#endif /* _HAP_WAC_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_wifi.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_wifi.c
@@ -1,0 +1,121 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <esp_log.h>
+#include <esp_mfi_debug.h>
+#include <string.h>
+#include <esp_wifi.h>
+#include <esp_hap_database.h>
+
+esp_err_t hap_wifi_is_provisioned(bool *provisioned)
+{
+    if (!provisioned) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *provisioned = false;
+
+    /* Get Wi-Fi Station configuration */
+    wifi_config_t wifi_cfg;
+    if (esp_wifi_get_config(ESP_IF_WIFI_STA, &wifi_cfg) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    if (strlen((const char *) wifi_cfg.sta.ssid)) {
+        *provisioned = true;
+    }
+    return ESP_OK;
+}
+bool hap_is_network_configured(void)
+{
+    /* If only the Ethernet is enabled, return true */
+    if (hap_priv.transport == HAP_TRANSPORT_ETHERNET) {
+        return true;
+    }
+
+    bool provisioned = false;
+    hap_wifi_is_provisioned(&provisioned);
+    return provisioned;
+}
+
+void hap_erase_network_info(void)
+{
+    esp_wifi_restore();
+}
+
+esp_err_t hap_wifi_softap_start(char *ssid)
+{
+    if (!ssid) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "SSID cannot be NULL");
+    }
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Starting SoftAP with SSID: %s", ssid);
+    wifi_config_t wifi_config = {
+        .ap = {
+            .ssid = "",
+            .ssid_len = 0,
+            .max_connection = 4,
+            .password = "",
+            .authmode = WIFI_AUTH_OPEN
+        },
+    };
+    size_t ssid_len = strnlen(ssid, sizeof(wifi_config.ap.ssid));
+    memcpy(wifi_config.ap.ssid, ssid, ssid_len);
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if (mode == WIFI_MODE_STA) {
+        esp_wifi_set_mode(WIFI_MODE_APSTA);
+    } else {
+        esp_wifi_set_mode(WIFI_MODE_AP);
+    }
+    esp_wifi_set_config(ESP_IF_WIFI_AP, &wifi_config);
+    esp_wifi_start();
+    return ESP_OK;
+}
+
+esp_err_t hap_wifi_softap_stop(void)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Stopping SoftAP.");
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if (mode == WIFI_MODE_AP) {
+        esp_wifi_stop();
+    }
+    esp_wifi_set_mode(WIFI_MODE_STA);
+    return ESP_OK;
+}
+
+esp_err_t hap_wifi_sta_connect(wifi_config_t *config)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_INFO, "Connecting to Wi-Fi.");
+    wifi_mode_t mode;
+    esp_wifi_get_mode(&mode);
+    if (mode == WIFI_MODE_AP || mode == WIFI_MODE_APSTA) {
+        esp_wifi_set_mode(WIFI_MODE_APSTA);
+    } else {
+        esp_wifi_set_mode(WIFI_MODE_STA);
+    }
+    esp_wifi_set_config(ESP_IF_WIFI_STA, config);
+    esp_wifi_start();
+    esp_wifi_connect();
+    return ESP_OK;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_hap_wifi.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_hap_wifi.h
@@ -1,0 +1,30 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_WIFI_H_
+#define _HAP_WIFI_H_
+#include <hap.h>
+bool hap_is_network_configured();
+void hap_wifi_restart();
+void hap_erase_network_info();
+#endif /* _HAP_WIFI_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_aes.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_aes.c
@@ -1,0 +1,145 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/errno.h>
+
+#include "mbedtls/aes.h"
+#include "esp_log.h"
+
+#include "esp_mfi_aes.h"
+
+static const char* TAG = "mfi_aes_adapter";
+
+/*!
+ * @group AES 128-bit Counter Mode API
+
+ * @abstract API to encrypt or decrypt using AES-128 in counter mode.
+ *
+ * Call esp_mfi_aes_ctr_init to initialize the context. Don't use the context until it has been initialized.
+ * Call esp_mfi_aes_ctr_update to encrypt or decrypt N bytes of input and generate N bytes of output.
+ * Call esp_mfi_aes_ctr_final to finalize the context. After finalizing, you must call AES_CTR_Init to use it again.
+*/
+
+typedef struct {
+    uint8_t key[MFI_AES_CTR_SIZE];
+    uint8_t nonce[MFI_AES_CTR_SIZE];
+} aes_ctr_context_t;
+
+/**
+ * @bref Create AES context
+ *
+ * @param none
+ *
+ * @return the AES context point
+ */
+esp_mfi_aes_ctr_t esp_mfi_aes_ctr_new(void)
+{
+    aes_ctr_context_t *context = NULL;
+    context = (aes_ctr_context_t *) malloc(sizeof(aes_ctr_context_t));
+    return context;
+}
+
+/**
+ * @bref Initialize AES context, include initialize the key and nonce
+ *
+ * @param incontext AES context point
+ *        inkey AES key
+ *        innonce AES nonce
+ *
+ * @return the result
+ *      0 : sucessful
+ *      others : failed
+ */
+int esp_mfi_aes_ctr_init(esp_mfi_aes_ctr_t incontext, const uint8_t inkey[MFI_AES_CTR_SIZE], const uint8_t innonce[MFI_AES_CTR_SIZE])
+{
+    int ret = 0;
+
+    if (incontext == NULL)
+        return -EINVAL;
+
+    aes_ctr_context_t *context = incontext;
+
+    memcpy(context->key, inkey, MFI_AES_CTR_SIZE);
+    memcpy(context->nonce, innonce, MFI_AES_CTR_SIZE);
+
+    return ret;
+}
+
+/**
+ * @bref Update AES context
+ *
+ * @param incontext AES context point
+ *        insrc the data point of update
+ *        insrclen the data length
+ *        indst the data pint of output
+ *
+ * @return the result
+ *      0 : sucessful
+ *      others : failed
+ */
+int esp_mfi_aes_ctr_update(esp_mfi_aes_ctr_t incontext, const void *insrc, uint16_t insrclen, void *indst)
+{
+    int ret = 0;
+
+    if (incontext == NULL)
+        return -EINVAL;
+
+    aes_ctr_context_t *context = incontext;
+    size_t offset = 0;
+    uint8_t stream_block[MFI_AES_CTR_SIZE];
+    mbedtls_aes_context ctx;
+    mbedtls_aes_init(&ctx);
+
+    ret = mbedtls_aes_setkey_enc( &ctx, context->key, 128);
+
+    if (ret != 0) {
+        ESP_LOGE(TAG, "mfi aes setkey[%d]", ret);
+        ret = -EINVAL;
+    } else {
+        ret = mbedtls_aes_crypt_ctr(&ctx, insrclen, &offset, context->nonce, stream_block, (uint8_t *) insrc, indst);
+        if (ret != 0) {
+            ESP_LOGE(TAG, "mfi aes crypt[%d]", ret);
+            ret = -EINVAL;
+        }
+    }
+
+    return ret;
+}
+
+/**
+ * @bref Destory AES context point
+ *
+ * @param incontext AES context point
+ *
+ * @return none
+ */
+void esp_mfi_aes_ctr_final(esp_mfi_aes_ctr_t incontext)
+{
+    if (incontext) {
+        memset((aes_ctr_context_t *) incontext, 0, sizeof(aes_ctr_context_t));
+        free(incontext);
+    }
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_aes.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_aes.h
@@ -1,0 +1,82 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef ESP_MFI_AES_H_
+#define ESP_MFI_AES_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MFI_AES_CTR_SIZE 16
+
+typedef void* esp_mfi_aes_ctr_t;
+
+/**
+ * @brief Create AES context
+ *
+ * @return pointer of the AES context
+ */
+esp_mfi_aes_ctr_t esp_mfi_aes_ctr_new(void);
+
+/**
+ * @brief Initialize AES context, including the key and nonce
+ *
+ * @param incontext pointer of the AES context
+ * @param inkey AES key
+ * @param innonce AES nonce
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_aes_ctr_init(esp_mfi_aes_ctr_t incontext, const uint8_t inkey[MFI_AES_CTR_SIZE], const uint8_t innonce[MFI_AES_CTR_SIZE]);
+
+/**
+ * @brief Update AES context
+ *
+ * @param incontext  AES context point
+ * @param insrc  pointer of the source data to be updated
+ * @param insrclen  source data length
+ * @param indst  pointer of the updated data
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_aes_ctr_update(esp_mfi_aes_ctr_t incontext, const void *insrc, uint16_t insrclen, void *indst);
+
+/**
+ * @brief Destroy AES context pointer
+ *
+ * @param incontext  pointer of the AES context
+ */
+void esp_mfi_aes_ctr_final(esp_mfi_aes_ctr_t incontext);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_AES_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_base64.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_base64.c
@@ -1,0 +1,54 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <sys/errno.h>
+
+#include "mbedtls/base64.h"
+
+/**
+ * @brief transform bin data to base64 data
+ */
+int esp_mfi_base64_encode(const char *src, int len, char *dest, int dest_len, int *out_len)
+{
+    int ret = mbedtls_base64_encode((unsigned char *)dest, dest_len, (size_t *)out_len, (unsigned char *)src, len);
+    if (ret != 0){
+        return -EINVAL;
+    } else{
+        return 0;
+    }
+}
+
+/**
+ * @brief transform base64 data to bin data
+ */
+int esp_mfi_base64_decode(const char *src, int len, char *dest, int dest_len, int *out_len)
+{
+    int ret = 0;
+    ret = mbedtls_base64_decode((unsigned char *)dest, dest_len, (size_t *)out_len, (unsigned char *)src, len);
+    if (ret != 0) {
+        return -EINVAL;
+    } else {
+        return 0;
+    }
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_base64.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_base64.h
@@ -1,0 +1,67 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef ESP_MFI_BASE64_H_
+#define ESP_MFI_BASE64_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief transform bin data to base64 data
+ *
+ * @param src input data point
+ * @param len input data length
+ * @param dest output data point
+ * @param dest_len output data buffer length
+ * @param out_len output data length
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_base64_encode(const char *src, int len, char *dest, int dest_len, int *out_len);
+
+/**
+ * @brief transform base64 data to bin data
+ *
+ * @param src input data point
+ * @param len input data length
+ * @param dest output data point
+ * @param dest_len output data buffer length
+ * @param out_len output data length
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_base64_decode(const char *src, int len, char *dest, int dest_len, int *out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_BASE64_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_debug.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_debug.c
@@ -1,0 +1,80 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdio.h>
+#include <hap.h>
+#include <esp_mfi_debug.h>
+
+#define RED_CHAR    31
+#define GREEN_CHAR  32
+#define YELLOW_CHAR 33
+#define BLUE_CHAR   34
+#define CYAN_CHAR   36
+#define WHITE_CHAR  37
+
+#ifdef CONFIG_MFI_DEBUG_LEVEL_INIT
+#define MFI_DEBUG_LEVEL_INIT CONFIG_MFI_DEBUG_LEVEL_INIT
+#else /* CONFIG_MFI_DEBUG_LEVEL_INIT */
+#define MFI_DEBUG_LEVEL_INIT 0
+#endif /* CONFIG_MFI_DEBUG_LEVEL_INIT */
+
+static uint32_t mfi_debug_level = MFI_DEBUG_LEVEL_INIT;
+
+/**
+ * @bref set the MFI debugging level
+ */
+int esp_mfi_set_debug_level(uint32_t level)
+{
+    mfi_debug_level = level;
+    return 0;
+}
+
+/**
+ * @bref get the MFI debugging level and output data color
+ */
+uint32_t esp_mfi_get_debug_level(uint32_t level, uint32_t *color)
+{
+    const uint32_t prospect_table[] = {
+        0,              /* no                                   */
+        WHITE_CHAR,     /* information: 1, color(37: white)     */
+        GREEN_CHAR,     /* warn       : 3, color(32: green)     */
+        RED_CHAR,       /* error      : 3, color(31: red)       */
+        YELLOW_CHAR,    /* assert     : 4, color(33: yellow)    */
+        CYAN_CHAR       /* block      : 5, color(36: cyan)      */
+                        /* others     : n, color(34: blue)      */
+    };
+    const uint32_t prospect_table_size = sizeof(prospect_table) / sizeof(prospect_table[0]);
+
+    if (level < prospect_table_size)
+        *color = prospect_table[level];
+    else
+        *color = BLUE_CHAR;
+
+    return mfi_debug_level;
+}
+
+void hap_set_debug_level(hap_debug_level_t level)
+{
+    esp_mfi_set_debug_level(level);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_debug.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_debug.h
@@ -1,0 +1,183 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef ESP_MFI_DEBUG_H_
+#define ESP_MFI_DEBUG_H_
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+#define ESP_MFI_DEBUG_FL "\n"
+#define CONFIG_ESP_MFI_DEBUG_ENABLE
+#ifdef CONFIG_ESP_MFI_DEBUG_ENABLE
+#define ESP_MFI_DEBUG_ENABLE
+#endif /* CONFIG_ESP_MFI_DEBUG_ENABLE */
+
+#define CONFIG_ESP_MFI_ASSERT
+#ifdef CONFIG_ESP_MFI_ASSERT
+#define ESP_MFI_ASSERT_ENABLE
+#endif /* CONFIG_ESP_MFI_ASSERT */
+
+#define CONFIG_MFI_DEBUG_LEVEL_INIT 0
+#define CONFIG_ESP_MFI_ASSERT_BLOCK
+#ifdef CONFIG_ESP_MFI_ASSERT_BLOCK
+#define ESP_MFI_ASSERT_BLOCK()  while (1)
+#else /* CONFIG_ESP_MFI_ASSERT_BLOCK */
+#define ESP_MFI_ASSERT_BLOCK()
+#endif /* CONFIG_ESP_MFI_ASSERT_BLOCK */
+
+/* debug level with different color */
+#define ESP_MFI_DEBUG_INFO      1
+#define ESP_MFI_DEBUG_WARN      2
+#define ESP_MFI_DEBUG_ERR       3
+#define ESP_MFI_DEBUG_ASSERT    4
+#define ESP_MFI_DEBUG_BLOCK     5
+
+/**
+ * @bref set the MFI debugging level
+ *
+ * @param level debugging level
+ *
+ * @return the result
+ *     = 0 : OK
+ *     others : failed
+ */
+int esp_mfi_set_debug_level(uint32_t level);
+
+/**
+ * @bref get the MFI debugging level and output data color
+ *
+ * @param level input debug level
+ * @param color data color
+ *
+ * @return MFI debugging level
+ */
+uint32_t esp_mfi_get_debug_level(uint32_t level, uint32_t *color);
+
+/**
+ * @bref format the string and data, then output it
+ *
+ * @param level if level > MFI_DEBUG_LEVEL then output it
+ * @param fmt format string
+ * @param ... parameters of format string
+ *
+ * @return none
+ *
+ * void ESP_MFI_DEBUG(unsigned int level, const char *fmt, ...);
+ */
+#ifdef ESP_MFI_DEBUG_ENABLE
+/*
+#define ESP_MFI_DEBUG(l, fmt, ...)                                                          \
+    {                                                                                       \
+        uint32_t __color_LINE;                                                              \
+        if (l > esp_mfi_get_debug_level(l, &__color_LINE)) {                                \
+            printf("\e[1;%dm" fmt "\e[0m" ESP_MFI_DEBUG_FL,                         \
+                                __color_LINE,  ##__VA_ARGS__);                              \
+        }                                                                                   \
+    }
+#define ESP_MFI_DEBUG_INTR(l, fmt, ...)                                                          \
+    {                                                                                       \
+        uint32_t __color_LINE;                                                              \
+        if (l > esp_mfi_get_debug_level(l, &__color_LINE)) {                                \
+            ets_printf("\e[1;%dm" fmt "\e[0m" ESP_MFI_DEBUG_FL,                         \
+                                __color_LINE,  ##__VA_ARGS__);                              \
+        }                                                                                   \
+    }
+
+#define ESP_MFI_DEBUG(l, fmt, ...)                                                          \
+    {                                                                                       \
+        uint32_t __color_LINE;                                                              \
+        if (l > esp_mfi_get_debug_level(l, &__color_LINE)) {                                \
+            printf("[%7lu] " fmt "\n", ((unsigned long) (esp_timer_get_time() / 1000ULL)), ##__VA_ARGS__);                              \
+        }                                                                                   \
+    }
+#define ESP_MFI_DEBUG_INTR(l, fmt, ...)                                                          \
+    {                                                                                       \
+        uint32_t __color_LINE;                                                              \
+        if (l > esp_mfi_get_debug_level(l, &__color_LINE)) {                                \
+        	printf("[%7lu] " fmt "\n", ((unsigned long) (esp_timer_get_time() / 1000ULL)), ##__VA_ARGS__);                           \
+        }                                                                                   \
+    }*/
+
+#define ESP_MFI_DEBUG(l, fmt, ...)                                                          \
+    {                                                                                       \
+            printf("[%7lu] " fmt "\n", ((unsigned long) (esp_timer_get_time() / 1000ULL)), ##__VA_ARGS__);                              \
+    }
+#define ESP_MFI_DEBUG_INTR(l, fmt, ...)                                                          \
+    {                                                                                       \
+        	printf("[%7lu] " fmt "\n", ((unsigned long) (esp_timer_get_time() / 1000ULL)), ##__VA_ARGS__);                           \
+    }
+#else /* ESP_MFI_DEBUG_ENABLE */
+#define ESP_MFI_DEBUG(l, fmt, ...)
+#define ESP_MFI_DEBUG_INTR(l, fmt, ...)
+#endif /* ESP_MFI_DEBUG_ENABLE */
+
+/**
+ * @bref if the signal is false(0) do something depended on configuration
+ *
+ * @param conditions checking conditions
+ *
+ * @return none
+ *
+ * void ESP_MFI_ASSERT(int conditions);
+ */
+#ifdef ESP_MFI_ASSERT_ENABLE
+#define ESP_MFI_ASSERT(cond)                                                                \
+{                                                                                           \
+    if (!(cond)) {                                                                          \
+        printf("\e[1;33m" "ESP_MFI assert file %s line %d" ESP_MFI_DEBUG_FL,        \
+                                __FILE__, __LINE__);                                        \
+        ESP_MFI_ASSERT_BLOCK();                                                             \
+    }                                                                                       \
+}
+#else
+#define ESP_MFI_ASSERT(cond)
+#endif
+
+/**
+ * @bref check if data length matches given length
+ *
+ * @param optlen data length
+ * @param opttype data
+ *
+ * @return none
+ *
+ * void ESP_MFI_CHECK_OPTLEN(int conditions, (all type) data);
+ */
+#define ESP_MFI_CHECK_OPTLEN(optlen, opttype)                                               \
+    do {                                                                                    \
+        if ((optlen) > sizeof(opttype)) {                                                   \
+            return -1;                                                                      \
+        }                                                                                   \
+    } while(0)                                                                              \
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_DEBUG_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_dummy.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_dummy.c
@@ -1,0 +1,84 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <esp_http_server.h>
+#include <esp_mfi_debug.h>
+#include <esp_hap_pair_common.h>
+#include <esp_hap_pair_setup.h>
+#include <esp_hap_database.h>
+#include <hap.h>
+
+ESP_EVENT_DEFINE_BASE(HAP_WAC_EVENT);
+
+int hap_pair_setup_manage_mfi_auth(pair_setup_ctx_t *ps_ctx, hap_tlv_data_t *tlv_data, hap_tlv_error_t *tlv_error)
+{
+
+    if (ps_ctx->method == HAP_METHOD_PAIR_SETUP) {
+        ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "Secure pair setup not supported. Please use MFi variant of the SDK.");
+        *tlv_error = kTLVError_Unknown;
+        return HAP_FAIL;
+    }
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_WARN, "Using pair-setup without MFi.");
+    return ESP_OK;
+}
+
+int hap_enable_mfi_auth(hap_mfi_auth_type_t auth_type)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_WARN, "MFi auth not supported. Falling back to HAP_MFI_AUTH_NONE");
+    hap_priv.auth_type = HAP_MFI_AUTH_NONE;
+    return 0;
+}
+
+int hap_wac_start(void)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "WAC not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+}
+
+int hap_wac_stop(void)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "WAC not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+}
+int hap_enable_hw_auth(void)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "MFi HW Auth not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+
+}
+int hap_enable_sw_auth(void)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "MFi SW Auth not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+}
+int hap_register_secure_message_handler(httpd_handle_t handle)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "MFi SW Auth not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+}
+int hap_unregister_secure_message_handler(httpd_handle_t handle)
+{
+    ESP_MFI_DEBUG(ESP_MFI_DEBUG_ERR, "MFi SW Auth not supported. Please use MFi variant of the SDK.");
+    return ESP_FAIL;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_i2c.c.0
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_i2c.c.0
@@ -1,0 +1,689 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdio.h>
+#include <sys/errno.h>
+#include <sdkconfig.h>
+#ifdef CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/ets_sys.h"
+#else
+#include "esp32/rom/ets_sys.h"
+#endif
+
+#ifdef CONFIG_I2C_SOFTWARE
+#include "driver/gpio.h"
+#else
+#include "driver/i2c.h"
+#endif
+
+#include "esp_log.h"
+#include "esp_mfi_i2c.h"
+
+static const char *TAG = "mfi_i2c";
+
+#ifndef CONFIG_I2C_SOFTWARE
+
+#define I2C_MASTER_NUM              I2C_NUM_0
+#define I2C_MASTER_FREQ_HZ          CONFIG_IC2_SPEED
+#define I2C_MASTER_RX_BUF_DISABLE   0
+#define I2C_MASTER_TX_BUF_DISABLE   0
+#define ACK_CHECK_EN                1
+#define ACK_VAL                     0
+#define NACK_VAL                    1
+
+/* To use GPIOs 17/18 for the Hardware I2C, replace the numbers 26/27 below
+ */
+#define I2C_MASTER_SDA_GPIO         CONFIG_SDA_GPIO
+#define I2C_MASTER_SCL_GPIO         CONFIG_SCL_GPIO
+
+#define I2C_MASTER_MAX_READ         CONFIG_I2C_MAX_READ_COUNT
+#define I2C_MASTER_RETRY_TIMES      500
+#define I2C_MASTER_TICKS_TIMES      2 * I2C_MASTER_RETRY_TIMES
+#define I2C_MASTER_MAX_RETRY        10
+#define I2C_MASTER_INTERNAL_TIMES   8 * I2C_MASTER_RETRY_TIMES
+/**
+ * @brief Initialize I2C information
+ */
+int esp_mfi_i2c_init(void)
+{
+    int ret = 0;
+    i2c_config_t conf;
+    int i2c_master_port = I2C_MASTER_NUM;
+
+    conf.mode = I2C_MODE_MASTER;
+    conf.sda_io_num = I2C_MASTER_SDA_GPIO;
+    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.scl_io_num = I2C_MASTER_SCL_GPIO;
+    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+    conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
+
+    ret = i2c_param_config(i2c_master_port, &conf);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C parameter initial fail %d", ret);
+        return -EINVAL;
+    }
+
+    ret = i2c_driver_install(i2c_master_port, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "I2C driver initial fail %d", ret);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+/**
+ * @brief write data buffer to slave
+ */
+int esp_mfi_i2c_write(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len)
+{
+    uint16_t i;
+
+    if (!buff)
+        return -EINVAL;
+
+    ESP_LOGI(TAG, "Writing to HW I2C");
+
+    int ret = 0;
+    i2c_cmd_handle_t cmd = NULL;
+    i = 0;
+
+    do {
+        cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+
+        // Send write address of the CP
+        i2c_master_write_byte(cmd, slvaddr, ACK_CHECK_EN);
+        // Send register address to slave.
+        i2c_master_write_byte(cmd, regaddr, ACK_CHECK_EN);
+        // Send data out.
+        i2c_master_write(cmd, buff, len, ACK_CHECK_EN);
+
+        i2c_master_stop(cmd);
+        ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TICKS_TIMES / portTICK_RATE_MS);
+        i ++;
+        i2c_cmd_link_delete(cmd);
+        ets_delay_us(I2C_MASTER_RETRY_TIMES);
+    } while(ret != ESP_OK && i < I2C_MASTER_MAX_RETRY);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Write data to slave fail %d.", ret);
+    }
+    return ret;
+}
+
+/**
+ * @brief read data form slave
+ */
+int esp_mfi_i2c_read(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len)
+{
+    uint16_t i, j = 0;
+
+    if (!buff)
+        return -EINVAL;
+
+    ESP_LOGI(TAG, "Reading from HW I2C");
+
+    int ret = 0;
+    i2c_cmd_handle_t cmd = NULL;
+    i = 0;
+
+    do {
+        for (j = 0; j < I2C_MASTER_MAX_READ; j++) {
+            cmd = i2c_cmd_link_create();
+            i2c_master_start(cmd);
+
+            // Send write address of the CP
+            i2c_master_write_byte(cmd, slvaddr, ACK_CHECK_EN);
+            // Send register address to slave.
+            i2c_master_write_byte(cmd, regaddr, ACK_CHECK_EN);
+
+            i2c_master_stop(cmd);
+            ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TICKS_TIMES / portTICK_RATE_MS);
+            i2c_cmd_link_delete(cmd);
+            if (ret == ESP_OK) {
+                break;
+            } else {
+                ets_delay_us(I2C_MASTER_INTERNAL_TIMES);
+            }
+        }
+
+        ets_delay_us(I2C_MASTER_INTERNAL_TIMES);
+
+        cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+
+        i2c_master_write_byte(cmd, slvaddr + 1, ACK_CHECK_EN);
+        if (len == 1)
+            i2c_master_read_byte(cmd, buff, NACK_VAL);
+        else {
+            i2c_master_read(cmd, buff, len - 1, ACK_VAL);
+            i2c_master_read_byte(cmd, buff + len - 1, NACK_VAL);
+        }
+
+        i2c_master_stop(cmd);
+        ret = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, I2C_MASTER_TICKS_TIMES / portTICK_RATE_MS);
+        i ++;
+        i2c_cmd_link_delete(cmd);
+    } while (ret != ESP_OK && i < I2C_MASTER_MAX_RETRY);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Read data from slave fail %d.", ret);
+    }
+
+    return ret;
+}
+
+#else
+
+#define MFI_CP_BUSY_RETRY_TIMES CONFIG_I2C_RETRY_COUNT
+
+#define GPIO_Pin_26 GPIO_SEL_26
+#define GPIO_Pin_27 GPIO_SEL_27
+
+#define gpio_set_output_level(a, b)                 gpio_set_level(a, b)
+#define gpio_get_input_level(a)                     gpio_get_level(a)
+
+#define GPIO_Mode_Input_OutOD                       GPIO_MODE_INPUT_OUTPUT_OD
+#define GPIO_PullDown_DIS                           GPIO_PULLDOWN_DISABLE
+#define GPIO_PullUp_EN                              GPIO_PULLUP_ENABLE
+#define GPIO_Mode_Out_OD                            GPIO_MODE_OUTPUT_OD
+
+#define I2C_MASTER_SDA_MUX                          PERIPHS_IO_MUX_GPIO26_U
+#define I2C_MASTER_SCL_MUX                          PERIPHS_IO_MUX_GPIO27_U
+#define I2C_MASTER_SDA_GPIO                         26
+#define I2C_MASTER_SDA_PIN                          GPIO_Pin_26
+#define I2C_MASTER_SDA_FUNC                         FUNC_GPIO26_GPIO26
+#define I2C_MASTER_SCL_GPIO                         27
+#define I2C_MASTER_SCL_PIN                          GPIO_Pin_27
+#define I2C_MASTER_SCL_FUNC                         FUNC_GPIO27_GPIO27
+
+#define I2C_MASTER_SDA_HIGH_SCL_HIGH()              \
+    gpio_set_output_level(I2C_MASTER_SDA_GPIO,1);   \
+    gpio_set_output_level(I2C_MASTER_SCL_GPIO,1);
+
+#define I2C_MASTER_SDA_HIGH_SCL_LOW()               \
+    gpio_set_output_level(I2C_MASTER_SDA_GPIO,1);   \
+    gpio_set_output_level(I2C_MASTER_SCL_GPIO,0);
+
+#define I2C_MASTER_SDA_LOW_SCL_HIGH()               \
+    gpio_set_output_level(I2C_MASTER_SDA_GPIO,0);   \
+    gpio_set_output_level(I2C_MASTER_SCL_GPIO,1);
+
+#define I2C_MASTER_SDA_LOW_SCL_LOW()                \
+  gpio_set_output_level(I2C_MASTER_SDA_GPIO,0);     \
+  gpio_set_output_level(I2C_MASTER_SCL_GPIO,0);
+
+#define i2c_master_wait ets_delay_us
+
+static void i2c_master_init(void);
+static void i2c_master_stop(void);
+
+static uint8_t s_last_sda;
+static uint8_t s_last_scl;
+
+/**
+ * @brief set I2C SDA and SCL bit value for half CLK cycle
+ */
+static void i2c_master_setDC(uint8_t SDA, uint8_t SCL)
+{
+    SDA &= 0x01;
+    SCL &= 0x01;
+    s_last_sda = SDA;
+    s_last_scl = SCL;
+
+    if ((0 == SDA) && (0 == SCL)) {
+        I2C_MASTER_SDA_LOW_SCL_LOW();
+    } else if ((0 == SDA) && (1 == SCL)) {
+        I2C_MASTER_SDA_LOW_SCL_HIGH();
+    } else if ((1 == SDA) && (0 == SCL)) {
+        I2C_MASTER_SDA_HIGH_SCL_LOW();
+    } else {
+        I2C_MASTER_SDA_HIGH_SCL_HIGH();
+    }
+}
+
+/**
+ * @brief get I2C SDA bit value
+ */
+static uint8_t i2c_master_getDC(void)
+{
+    uint8_t sda_out;
+
+    sda_out = gpio_get_input_level(GPIO_ID_PIN(I2C_MASTER_SDA_GPIO));
+
+    return sda_out;
+}
+
+/**
+ * @brief initialize I2C bus to enable i2c operations
+ */
+static void i2c_master_init(void)
+{
+    uint8_t i;
+
+    i2c_master_setDC(1, 0);
+    i2c_master_wait(5);
+
+    // when SCL = 0, toggle SDA to clear up
+    i2c_master_setDC(0, 0) ;
+    i2c_master_wait(5);
+    i2c_master_setDC(1, 0) ;
+    i2c_master_wait(5);
+
+    // set data_cnt to max value
+    for (i = 0; i < 28; i++) {
+        i2c_master_setDC(1, 0);
+        i2c_master_wait(5); // sda 1, scl 0
+        i2c_master_setDC(1, 1);
+        i2c_master_wait(5); // sda 1, scl 1
+    }
+
+    // reset all
+    i2c_master_stop();
+}
+
+/**
+ * @brief configure SDA and SCL GPIO to open-drain output mode
+ */
+static void i2c_master_gpio_init(void)
+{
+
+    gpio_config_t io_config;
+    io_config.intr_type = GPIO_PIN_INTR_DISABLE;
+    io_config.mode = GPIO_MODE_INPUT_OUTPUT_OD;
+    io_config.pin_bit_mask = I2C_MASTER_SDA_PIN;
+    io_config.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_config.pull_up_en  = GPIO_PULLUP_ENABLE;
+
+    gpio_config(&io_config);
+
+    io_config.intr_type = GPIO_PIN_INTR_DISABLE;
+    io_config.mode = GPIO_MODE_OUTPUT_OD;
+    io_config.pin_bit_mask = I2C_MASTER_SCL_PIN;
+    io_config.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_config.pull_up_en  = GPIO_PULLUP_ENABLE;
+
+
+    gpio_config(&io_config);
+
+    gpio_pullup_en(I2C_MASTER_SDA_GPIO);
+    gpio_pullup_en(I2C_MASTER_SCL_GPIO);
+    gpio_pulldown_dis(I2C_MASTER_SDA_GPIO);
+    gpio_pulldown_dis(I2C_MASTER_SCL_GPIO);
+
+    i2c_master_init();
+}
+
+/**
+ * @brief set I2C to start operation
+ */
+static void i2c_master_start(void)
+{
+    i2c_master_setDC(1, s_last_scl);
+    i2c_master_wait(5);
+    i2c_master_setDC(1, 1);
+    i2c_master_wait(5); // sda 1, scl 1
+    i2c_master_setDC(0, 1);
+    i2c_master_wait(5); // sda 0, scl 1
+}
+
+/**
+ * @brief set i2c to stop sending state
+ */
+static void i2c_master_stop(void)
+{
+    i2c_master_wait(5);
+
+    i2c_master_setDC(0, s_last_scl);
+    i2c_master_wait(5); // sda 0
+    i2c_master_setDC(0, 1);
+    i2c_master_wait(5); // sda 0, scl 1
+    i2c_master_setDC(1, 1);
+    i2c_master_wait(5); // sda 1, scl 1
+}
+
+/**
+ * @brief set ack to i2c bus as level value
+ */
+static void i2c_master_setAck(uint8_t level)
+{
+    i2c_master_setDC(s_last_sda, 0);
+    i2c_master_wait(5);
+    i2c_master_setDC(level, 0);
+    i2c_master_wait(5); // sda level, scl 0
+    i2c_master_setDC(level, 1);
+    i2c_master_wait(8); // sda level, scl 1
+    i2c_master_setDC(level, 0);
+    i2c_master_wait(5); // sda level, scl 0
+    i2c_master_setDC(1, 0);
+    i2c_master_wait(5);
+}
+
+/**
+ * @brief confirm if peer send ack
+ */
+static uint8_t i2c_master_getAck(void)
+{
+    uint8_t retVal;
+
+    i2c_master_setDC(s_last_sda, 0);
+    i2c_master_wait(5);
+    i2c_master_setDC(1, 0);
+    i2c_master_wait(5);
+    i2c_master_setDC(1, 1);
+    i2c_master_wait(5);
+
+    retVal = i2c_master_getDC();
+    i2c_master_wait(5);
+    i2c_master_setDC(1, 0);
+    i2c_master_wait(5);
+
+    return retVal;
+}
+
+/**
+ * @brief get I2C response
+ */
+static bool i2c_master_checkAck(void)
+{
+    if (i2c_master_getAck()) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+/**
+ * @brief send I2C ack signal
+ */
+static void i2c_master_send_ack(void)
+{
+    i2c_master_setAck(0x0);
+}
+
+/**
+ * @brief send I2C not ack signal
+ */
+static void i2c_master_send_nack(void)
+{
+    i2c_master_setAck(0x1);
+}
+
+/**
+ * @brief read byte from i2c bus
+ */
+static uint8_t i2c_master_readByte(void)
+{
+    uint8_t retVal = 0;
+    uint8_t k, i;
+
+    i2c_master_wait(5);
+    i2c_master_setDC(s_last_sda, 0);
+    i2c_master_wait(5); // sda 1, scl 0
+
+    for (i = 0; i < 8; i++) {
+        i2c_master_wait(5);
+        i2c_master_setDC(1, 0);
+        i2c_master_wait(5); // sda 1, scl 0
+        i2c_master_setDC(1, 1);
+        i2c_master_wait(5); // sda 1, scl 1
+
+        k = i2c_master_getDC();
+        i2c_master_wait(5);
+
+        if (i == 7) {
+            i2c_master_wait(3);
+        }
+
+        k <<= (7 - i);
+        retVal |= k;
+    }
+
+    i2c_master_setDC(1, 0);
+    i2c_master_wait(5); // sda 1, scl 0
+
+    return retVal;
+}
+
+/**
+ * @brief write byte to i2c
+ */
+static void i2c_master_writeByte(uint8_t wrdata)
+{
+    uint8_t dat;
+    int8_t i;
+
+    i2c_master_wait(5);
+    i2c_master_setDC(s_last_sda, 0);
+    i2c_master_wait(5);
+
+    for (i = 7; i >= 0; i--) {
+        dat = wrdata >> i;
+        i2c_master_setDC(dat, 0);
+        i2c_master_wait(5);
+        i2c_master_setDC(dat, 1);
+        i2c_master_wait(5);
+
+        if (i == 0) {
+            i2c_master_wait(3);   ////
+        }
+
+        i2c_master_setDC(dat, 0);
+        i2c_master_wait(5);
+    }
+
+}
+
+/**
+ * @brief write byte to i2c and get check ack
+ */
+static bool i2c_write_byte(uint8_t data, uint8_t iter)
+{
+    if (iter == 0) {
+        iter = 1;
+    }
+
+    while (iter--) {
+        i2c_master_writeByte(data);
+
+        if (i2c_master_getAck()) {
+            i2c_master_stop();
+            ets_delay_us(500);  // Wait 500us and retry.
+            i2c_master_start();
+        } else {
+            return true;
+        }
+    }
+    i2c_master_stop();
+    return false;
+}
+
+/**
+ * @brief write byte to target register of target I2C slave
+ */
+static void i2c_write_reg(uint8_t slave_add, uint8_t reg_add, uint16_t data)
+{
+    i2c_master_start();
+    if (false == i2c_write_byte(slave_add, 30)) {
+        ESP_LOGE(TAG, "1Slave is busy, [%02x]TIME OUT\n", slave_add);
+    }
+    if (false == i2c_write_byte(reg_add, 30)) {
+        ESP_LOGE(TAG, "2Slave is busy, [%02x]TIME OUT\n", reg_add);
+    }
+    if (false == i2c_write_byte((data >> 8), 30)) {
+        ESP_LOGE(TAG, "3Slave is busy, [%02x]TIME OUT\n", data);
+    }
+    if (false == i2c_write_byte((data & 0xFF), 30)) {
+        ESP_LOGE(TAG, "3Slave is busy, [%02x]TIME OUT\n", data);
+    }
+    i2c_master_stop();
+}
+
+/**
+ * @brief a block of data to I2C
+ */
+static void i2s_write_arr(const uint8_t *data, size_t len)
+{
+    if (data == NULL || len <= 0) return;
+
+    i2c_master_start();
+
+    int i = 0;
+    for (i = 0; i < len; ++i) {
+        if (false == i2c_write_byte(data[i], 30)) {
+            ESP_LOGE(TAG, "Slave is busy, [%02x]TIME OUT\n", data[i]);
+        }
+    }
+    i2c_master_stop();
+}
+
+/**
+ * @brief Initialize I2C information
+ */
+int esp_mfi_i2c_init(void)
+{
+    i2c_master_gpio_init();
+    return 0;
+}
+
+/**
+ * @brief Finish I2C information
+ */
+int esp_mfi_i2c_end(void)
+{
+    return 0;
+}
+
+/**
+ * @brief write one byte data to slave
+ */
+static int esp_mfi_i2c_write_byte(uint8_t data, uint16_t retrytimes)
+{
+    uint16_t times = retrytimes;
+    if (0 == times) {
+        times = 1;
+    }
+
+    while (times--) {
+        i2c_master_writeByte(data);
+        if (i2c_master_getAck()) {
+            i2c_master_wait(500);  /**< Wait 500us and retry */
+            i2c_master_stop();
+            i2c_master_wait(500);  /**< Wait 500us and retry */
+            i2c_master_start();
+        } else {
+            return 0;
+        }
+    }
+
+    i2c_master_stop();
+
+    return -ETIME;
+}
+
+/**
+ * @brief write data buffer to slave
+ */
+int esp_mfi_i2c_write(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len)
+{
+    uint16_t i;
+
+    if (!buff)
+        return -EINVAL;
+
+    ESP_LOGI(TAG, "Writing to SW I2C");
+
+    i2c_master_start();
+
+    /**< Send write address of the CP */
+    if (esp_mfi_i2c_write_byte(slvaddr, MFI_CP_BUSY_RETRY_TIMES) != 0) {
+        ESP_LOGE(TAG, "Slave is busy, time out.");
+        return -ETIME;
+    }
+
+    /**< Send register address to slave */
+    if (esp_mfi_i2c_write_byte(regaddr, 0) != 0) {
+        ESP_LOGE(TAG, "Write register address[0x%02x] to slave.", regaddr);
+        return -ENODATA;
+    }
+
+    /**< Send data out */
+    for (i = 0; i < len; ++i) {
+        if (esp_mfi_i2c_write_byte(*buff++, 0) != 0) {
+            ESP_LOGE(TAG, "Write data[0x%02x] to slave.", *buff);
+            return -ENODATA;
+        }
+    }
+
+    i2c_master_stop();
+
+    return 0;
+}
+
+/**
+ * @brief read data form slave
+ */
+int esp_mfi_i2c_read(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len)
+{
+    uint16_t i;
+
+    if (!buff)
+        return -EINVAL;
+
+    ESP_LOGI(TAG, "Reading from SW I2C");
+
+    i2c_master_start();
+
+    /**< Send write address of the CP */
+    if (esp_mfi_i2c_write_byte(slvaddr, MFI_CP_BUSY_RETRY_TIMES) != 0) {
+        ESP_LOGE(TAG, "Slave is busy, time out.");
+        return -ETIME;
+    }
+
+    /**< Send register address to slave */
+    if (esp_mfi_i2c_write_byte(regaddr, 0) != 0) {
+        ESP_LOGE(TAG, "Write register address[0x%02x] to slave.", regaddr);
+        return -ENODATA;
+    }
+    i2c_master_stop();
+
+    i2c_master_wait(4000);
+
+    /**< Send read address of the CP */
+    if (esp_mfi_i2c_write_byte((slvaddr + 1), MFI_CP_BUSY_RETRY_TIMES) != 0) {
+        ESP_LOGE(TAG, "Slave is busy, time out.");
+        return -ETIME;
+    }
+
+    for (i = 0; i < len; ++i) {
+        buff[i] = i2c_master_readByte();
+
+        i2c_master_setAck((i == (len - 1)) ? 1 : 0);
+    }
+
+    i2c_master_stop();
+
+    return 0;
+}
+#endif

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_i2c.h.0
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_i2c.h.0
@@ -1,0 +1,84 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef ESP_MFI_I2C_H_
+#define ESP_MFI_I2C_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize I2C
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_i2c_init(void);
+
+/**
+ * @brief I2C operation end
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_i2c_end(void);
+
+/**
+ * @brief Write data to I2C slave
+ *
+ * @param slvaddr  address of slave
+ * @param regaddr  address of register
+ * @param buff     pointer of data to write
+ * @param len      the data length
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_i2c_write(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len);
+
+/**
+ * @brief Read data from I2C slave
+ *
+ * @param slvaddr  address of slave
+ * @param regaddr  address of register
+ * @param buff     pointer of data read
+ * @param len      the data length
+ *
+ * @return
+ *     - 0 : succeed
+ *     - others : fail
+ */
+int esp_mfi_i2c_read(uint8_t slvaddr, uint8_t regaddr, uint8_t *buff, uint32_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_I2C_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_rand.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_rand.c
@@ -1,0 +1,56 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdint.h>
+#include <esp_system.h>
+
+/**
+ * @bref Obtain a series of random bytes
+ *
+ * @param buf the random bytes were copied point
+ *        len the number of bytes requested
+ *
+ * @return the result
+ *      > 0 : the number of bytes that were copied to the buffer
+ *      others : failed
+ */
+int esp_mfi_get_random(uint8_t *buf, uint16_t len)
+{
+    int i, j;
+    unsigned long tmp;
+
+    for (i = 0; i < ((len + 3) & ~3) / 4; i++) {
+        tmp = esp_random();
+
+        for (j = 0; j < 4; j++) {
+            if ((i * 4 + j) < len) {
+                buf[i * 4 + j] = (uint8_t) (tmp >> (j * 8));
+            } else {
+                break;
+            }
+        }
+    }
+
+    return len;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_rand.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_rand.h
@@ -1,0 +1,50 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef ESP_MFI_RAND_H_
+#define ESP_MFI_RAND_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Get a random number of bytes specified.
+ *
+ * @param buf pointer of the random number it gets
+ * @param len specified bytes of the random number
+ *
+ * @return
+ *      - > 0 : the actual length(bytes) of the random number
+ *      - others : failure
+ */
+int esp_mfi_get_random(uint8_t *buf, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_RAND_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_sha.c
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_sha.c
@@ -1,0 +1,279 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+
+#include "mbedtls/sha1.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/sha512.h"
+
+#include "esp_mfi_sha.h"
+
+#ifdef CONFIG_IDF_TARGET_ESP8266
+#define mbedtls_sha512_starts mbedtls_sha512_starts_ret
+#define mbedtls_sha512_update mbedtls_sha512_update_ret
+#define mbedtls_sha512_finish mbedtls_sha512_finish_ret
+#endif
+
+/**
+ * @bref Create SHA1 context
+ *
+ * @param none
+ *
+ * @return the SHA1 context point
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha1_new(void)
+{
+    mbedtls_sha1_context *context = NULL;
+    context = (mbedtls_sha1_context *) malloc(sizeof(mbedtls_sha1_context));
+    mbedtls_sha1_init(context);
+    return context;
+}
+
+/**
+ * @bref Free SHA1 context
+ *
+ * @param ctx the SHA1 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha1_free(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx) {
+        mbedtls_sha1_free( (mbedtls_sha1_context *)ctx);
+        free(ctx);
+    }
+}
+
+/**
+ * @bref Init SHA1 context
+ *
+ * @param ctx the SHA1 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha1_init(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    mbedtls_sha1_starts((mbedtls_sha1_context *) ctx);
+}
+
+/**
+ * @bref Update SHA1 context
+ *
+ * @param ctx the SHA1 context point
+ *        msg input data point
+ *        len input data length
+ *
+ * @return none
+ */
+void esp_mfi_sha1_update(esp_mfi_sha_ctx_t ctx, const uint8_t * msg, int len)
+{
+    if (ctx == NULL || msg == NULL)
+        return;
+
+    mbedtls_sha1_update((mbedtls_sha1_context *) ctx, msg, len);
+}
+
+/**
+ * @bref Final SHA1 context
+ *
+ * @param digest output data point
+ *        ctx the SHA1 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha1_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest)
+{
+    if (ctx == NULL || digest == NULL)
+        return;
+
+    mbedtls_sha1_finish((mbedtls_sha1_context *) ctx, digest);
+}
+
+/*
+ * SHA256 declarations
+ */
+
+/**
+ * @bref Create SHA256 context
+ *
+ * @param none
+ *
+ * @return the SHA256 context point
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha256_new(void)
+{
+    mbedtls_sha256_context *context = NULL;
+    context = (mbedtls_sha256_context *) malloc(sizeof(mbedtls_sha256_context));
+    mbedtls_sha256_init(context);
+    return context;
+}
+
+/**
+ * @bref Free SHA256 context
+ *
+ * @param ctx the SHA256 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha256_free(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx) {
+        mbedtls_sha256_free((mbedtls_sha256_context *)ctx);
+        free(ctx);
+    }
+}
+
+/**
+ * @bref Init SHA256 context
+ *
+ * @param ctx the SHA256 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha256_init(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    mbedtls_sha256_starts((mbedtls_sha256_context *) ctx, 0);
+}
+
+/**
+ * @bref Update SHA256 context
+ *
+ * @param ctx the SHA256 context point
+ *        msg input data point
+ *        len input data length
+ *
+ * @return none
+ */
+void esp_mfi_sha256_update(esp_mfi_sha_ctx_t ctx, const uint8_t *input, int len)
+{
+    if (ctx == NULL || input == NULL)
+        return;
+
+    mbedtls_sha256_update((mbedtls_sha256_context *) ctx, input, len);
+}
+
+/**
+ * @bref Final SHA256 context
+ *
+ * @param digest output data point
+ *        ctx the SHA256 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha256_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest)
+{
+    if (ctx == NULL || digest == NULL)
+        return;
+
+    mbedtls_sha256_finish((mbedtls_sha256_context *) ctx, digest);
+}
+
+/*
+ * SHA512 declarations
+ */
+
+/**
+ * @bref Create SHA512 context
+ *
+ * @param none
+ *
+ * @return the SHA512 context point
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha512_new(void)
+{
+    mbedtls_sha512_context *context = NULL;
+    context = (mbedtls_sha512_context *) malloc(sizeof(mbedtls_sha512_context));
+    mbedtls_sha512_init(context);
+    return context;
+}
+
+/**
+ * @bref Free SHA512 context
+ *
+ * @param ctx the SHA512 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha512_free(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx) {
+        mbedtls_sha512_free((mbedtls_sha512_context *)ctx);
+        free(ctx);
+    }
+}
+
+/**
+ * @bref Init SHA512 context
+ *
+ * @param ctx the SHA512 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha512_init(esp_mfi_sha_ctx_t ctx)
+{
+    if (ctx == NULL)
+        return;
+
+    mbedtls_sha512_starts((mbedtls_sha512_context *) ctx, 0);
+}
+
+/**
+ * @bref Update SHA512 context
+ *
+ * @param ctx the SHA512 context point
+ *        msg input data point
+ *        len input data length
+ *
+ * @return none
+ */
+void esp_mfi_sha512_update(esp_mfi_sha_ctx_t ctx, const uint8_t *input, int len)
+{
+    if (ctx == NULL || input == NULL)
+        return;
+
+    mbedtls_sha512_update((mbedtls_sha512_context *) ctx, input, len);
+}
+
+/**
+ * @bref Final SHA512 context
+ *
+ * @param digest output data point
+ *        ctx the SHA512 context point
+ *
+ * @return none
+ */
+void esp_mfi_sha512_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest)
+{
+    if (ctx == NULL || digest == NULL)
+        return;
+
+    mbedtls_sha512_finish((mbedtls_sha512_context *) ctx, digest);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/esp_mfi_sha.h
+++ b/lib/libesp32/ESP32-HomeKit/src/esp_mfi_sha.h
@@ -1,0 +1,172 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef ESP_MFI_SHA_H_
+#define ESP_MFI_SHA_H_
+
+#include <stdint.h>
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+typedef void* esp_mfi_sha_ctx_t;
+
+/*
+ * SHA1 declarations
+ */
+
+#define MFI_SHA1_SIZE   20
+
+/**
+ * @brief Create SHA1 context
+ *
+ * @return pointer of the SHA1 context
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha1_new(void);
+
+/**
+ * @brief Init SHA1 context
+ *
+ * @param ctx pointer of the SHA1 context
+ */
+void esp_mfi_sha1_init(esp_mfi_sha_ctx_t ctx);
+
+/**
+ * @brief Update SHA1 context
+ *
+ * @param ctx pointer of the SHA1 context
+ * @param msg pointer of the input data
+ * @param len input data length
+ */
+void esp_mfi_sha1_update(esp_mfi_sha_ctx_t ctx, const uint8_t *msg, int len);
+
+/**
+ * @brief Final SHA1 context
+ *
+ * @param digest pointer of output data
+ * @param ctx pointer of the SHA1 context
+ */
+void esp_mfi_sha1_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest);
+
+/**
+ * @brief Free SHA1 context
+ *
+ * @param ctx pointer of the SHA1 context
+ */
+void esp_mfi_sha1_free(esp_mfi_sha_ctx_t ctx);
+
+/*
+ * SHA256 declarations
+ */
+
+#define MFI_SHA256_SIZE 32
+
+/**
+ * @brief Create SHA256 context
+ *
+ * @return pointer of the SHA256 context
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha256_new(void);
+
+/**
+ * @brief Init SHA256 context
+ *
+ * @param ctx pointer of the SHA256 context
+ */
+void esp_mfi_sha256_init(esp_mfi_sha_ctx_t ctx);
+
+/**
+ * @brief Update SHA256 context
+ *
+ * @param ctx pointer of the SHA256 context
+ * @param msg pointer of input data
+ * @param len input data length
+ */
+void esp_mfi_sha256_update(esp_mfi_sha_ctx_t ctx, const uint8_t *input, int len);
+
+/**
+ * @brief Final SHA256 context
+ *
+ * @param digest pointer of output data
+ * @param ctx pointer of the SHA256 context
+ */
+void esp_mfi_sha256_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest);
+
+/**
+ * @brief Free SHA256 context
+ *
+ * @param ctx pointer of the SHA256 context
+ */
+void esp_mfi_sha256_free(esp_mfi_sha_ctx_t ctx);
+
+/*
+ * SHA512 declarations
+ */
+
+#define MFI_SHA512_SIZE 64
+
+/**
+ * @brief Create SHA512 context
+ *
+ * @return pointer of the SHA512 context
+ */
+esp_mfi_sha_ctx_t esp_mfi_sha512_new(void);
+
+/**
+ * @brief Init SHA512 context
+ *
+ * @param ctx pointer of the SHA512 context
+ */
+void esp_mfi_sha512_init(esp_mfi_sha_ctx_t ctx);
+
+/**
+ * @brief Update SHA512 context
+ *
+ * @param ctx pointer of the SHA512 context
+ * @param msg pointer of input data
+ * @param len input data length
+ */
+void esp_mfi_sha512_update(esp_mfi_sha_ctx_t ctx, const uint8_t *input, int len);
+
+/**
+ * @brief Final SHA512 context
+ *
+ * @param digest pointer of output data
+ * @param ctx pointer of the SHA512 context
+ */
+void esp_mfi_sha512_final(esp_mfi_sha_ctx_t ctx, uint8_t *digest);
+
+/**
+ * @brief Free SHA512 context
+ *
+ * @param ctx pointer of the SHA512 context
+ */
+void esp_mfi_sha512_free(esp_mfi_sha_ctx_t ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ESP_MFI_SHA_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap.h
@@ -1,0 +1,1572 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_H_
+#define _HAP_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <esp_event.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAP_CHAR_STRING_MAX_LEN        256
+#define HAP_CHAR_STRING_MAX_DEF_LEN    64
+
+#define HAP_SUCCESS     0
+#define HAP_FAIL        -1
+
+typedef enum  {
+    HAP_MFI_AUTH_NONE = 0,
+    HAP_MFI_AUTH_HW,
+    HAP_MFI_AUTH_SW
+} hap_mfi_auth_type_t;
+
+/** HomeKit Transports to be enabled */
+typedef enum {
+    /** Unknown. Default uninitialized value */
+    HAP_TRANSPORT_UNKNOWN          = 0x00,
+    /** HAP over Wi-Fi */
+    HAP_TRANSPORT_WIFI             = 0x01,
+    /** HAP Over Ethernet (Wi-Fi disabled).
+     * To enable both Wi-Fi and Ethernet, use (HAP_TRANSPORT_WIFI | HAP_TRANSPORT_ETHERNET) for hap_init()
+     */
+    HAP_TRANSPORT_ETHERNET         = 0x02,
+} hap_transport_t;
+
+/**
+ * HAP characteristic value formats
+ */
+typedef enum {
+    /** No Type/Invalid type */
+    HAP_CHAR_FORMAT_NONE = 0,
+    /** Boolean (true or false)*/
+	HAP_CHAR_FORMAT_BOOL,
+    /** Unsigned 8-bit integer */
+	HAP_CHAR_FORMAT_UINT8,
+    /** Unsigned 16-bit integer */
+	HAP_CHAR_FORMAT_UINT16,
+    /** Unsigned 32-bit integer */
+	HAP_CHAR_FORMAT_UINT32,
+    /** Unsigned 64-bit integer */
+    HAP_CHAR_FORMAT_UINT64,
+    /** Signed 32-bit integer */
+	HAP_CHAR_FORMAT_INT,
+    /** Signed 32-bit floating point number */
+	HAP_CHAR_FORMAT_FLOAT,
+    /** Unicode string */
+	HAP_CHAR_FORMAT_STRING,
+    /** Base64 encoded set of one or more TLV8s */
+    HAP_CHAR_FORMAT_TLV8,
+    /** base64 encoded data blob */
+    HAP_CHAR_FORMAT_DATA,
+} hap_char_format_t;
+
+/** Data value */
+typedef struct {
+    /** Pointer to an allocated buffer holding the data. This should remain valid
+     * throughout the lifetime of the characteristic.
+     */
+    uint8_t *buf;
+    /** Length of the data */
+    uint32_t buflen;
+} hap_data_val_t;
+
+/** TLV8 value (Same as \ref hap_data_val_t) */
+typedef hap_data_val_t hap_tlv8_val_t;
+
+/** HAP Value */
+typedef union {
+    /** Boolean */
+	bool b;
+    /** Unsigned integer (uint8, uint16, uint32) */
+    uint32_t u;
+    /** Signed integer */
+	int i;
+    /** 64 bit Unsigned integer */
+    uint64_t i64;
+    /** Floating point number */
+	float f;
+    /** Pointer to string */
+	char *s;
+    /** Structure for Data */
+    hap_data_val_t d;
+    /** Structure for TLV8 */
+    hap_tlv8_val_t t;
+} hap_val_t;
+
+/** Information about the Provisioned Network to which the accessory will connect */
+typedef struct {
+    /** SSID for the network */
+    uint8_t ssid[64];
+    /** Length of the SSID */
+    size_t ssid_len;
+    /** Password for the network. Can be NULL for Open networks */
+    uint8_t password[64];
+    /** Length of the Password. Can be 0 for Open networks */
+    size_t password_len;
+} hap_provisioned_nw_t;
+
+/**
+ * HAP characteristics unit types
+ */
+#define HAP_CHAR_UNIT_CELSIUS       "celsius"
+#define HAP_CHAR_UNIT_PERCENTAGE    "percentage"
+#define HAP_CHAR_UNIT_ARCDEGREES    "arcdegrees"
+#define HAP_CHAR_UNIT_LUX           "lux"
+#define HAP_CHAR_UNIT_SECONDS       "seconds"
+
+/** HAP Characteristic properties/permissions */
+/** Characteristic supports Paired Read */
+#define HAP_CHAR_PERM_PR        (1 << 0)
+/** Characteristic supports Paired Write */
+#define HAP_CHAR_PERM_PW        (1 << 1)
+/** Characteristic supports Event Notifications */
+#define HAP_CHAR_PERM_EV        (1 << 2)
+/** Characteristic supports Additional Authorization Data */
+#define HAP_CHAR_PERM_AA        (1 << 3)
+/** Characteristic supports Timed Writes */
+#define HAP_CHAR_PERM_TW        (1 << 4)
+/** Characteristic is hidden from the user */
+#define HAP_CHAR_PERM_HD        (1 << 5)
+/** Characterictic is of special read only type.
+ * Valid for characteristics like "Programmable Switch Event" wherein the value
+ * needs to be reported as NULL for a read, even when it is a uint8. Actual value
+ * is reported only using event notifications.
+ */
+#define HAP_CHAR_PERM_SPECIAL_READ    (1 << 6)
+
+/** HAP object handle */
+typedef size_t                  hap_handle_t;
+
+/** HAP Characteristic handle */
+typedef hap_handle_t            hap_char_t;
+/** HAP Service handle */
+typedef hap_handle_t            hap_serv_t;
+/** HAP Accessory handle */
+typedef hap_handle_t            hap_acc_t;
+
+/** HAP Status codes as per the HAP Specifications */
+typedef enum {
+    /** This specifies a success for the request. */
+    HAP_STATUS_SUCCESS = 0,
+    /** Request denied due to insufficient privileges. */
+	HAP_STATUS_NO_PRIVILEGE = -70401,
+    /** Unable to communicate with requested service. */
+	HAP_STATUS_COMM_ERR = -70402,
+    /** Resource is busy, try again. */
+	HAP_STATUS_RES_BUSY = -70403,
+    /** Cannot write to read only characteristic. */
+	HAP_STATUS_WR_ON_RDONLY = -70404,
+    /** Cannot read from a write only characteristic. */
+	HAP_STATUS_RD_ON_WRONLY = -70405,
+    /** Notification is not supported for characteristic */
+	HAP_STATUS_NO_NOTIF = -70406,
+    /** Out of resources to process request. */
+	HAP_STATUS_OO_RES = -70407,
+    /** Operation timed out. */
+	HAP_STATUS_TIMEOUT = -70408,
+    /** Resource does not exist. */
+	HAP_STATUS_RES_ABSENT = -70409,
+    /** Accessory received an invalid value in a write request. */
+	HAP_STATUS_VAL_INVALID = -70410,
+    /** Insufficient Authorization. */
+	HAP_STATUS_INSUFFICIENT_AUTH = -70411,
+} hap_status_t;
+
+typedef enum {
+    HAP_CID_NONE = 0,
+    HAP_CID_OTHER,
+    HAP_CID_BRIDGE,
+    HAP_CID_FAN,
+    HAP_CID_GARAGE_DOOR_OPENER,
+    HAP_CID_LIGHTING,
+    HAP_CID_LOCK,
+    HAP_CID_OUTLET,
+    HAP_CID_SWITCH,
+    HAP_CID_THERMOSTAT,
+    HAP_CID_SENSOR,
+    HAP_CID_SECURITY_SYSTEM,
+    HAP_CID_DOOR,
+    HAP_CID_WINDOW,
+    HAP_CID_WINDOW_COVERING,
+    HAP_CID_PROGRAMMABLE_SWITCH,
+    HAP_CID_RESERVED,
+    HAP_CID_IP_CAMERA,
+    HAP_CID_VIDEO_DOORBELL,
+    HAP_CID_AIR_PURIFIER,
+    HAP_CID_HEATER,
+    HAP_CID_AIR_CONDITIONER,
+    HAP_CID_HUMIDIFIER,
+    HAP_CID_DEHUMIDIFIER,
+    HAP_CID_MAX,
+} hap_cid_t;
+
+/** Prototype for Identify routine for the accessory
+ *
+ * @param[in] acc Handle of the accessory object
+ */
+typedef int (*hap_identify_routine_t) (hap_acc_t *acc);
+
+/** HAP Accessory configuration */
+typedef struct {
+    /** Name (Mandatory) */
+	char *name;
+    /** Model (Mandatory) */
+	char *model;
+    /** Manufacturer (Mandatory) */
+	char *manufacturer;
+    /** Serial Number (Mandatory) */
+	char *serial_num;
+    /** Firmware Revision number in format x[.y[.z]] (Mandatory) */
+	char *fw_rev;
+    /** Hardware revision number in format x[.y[.z]] (Optional. Can be NULL )*/
+	char *hw_rev;
+    /** HAP Protocol version supported by the accessory. Should be set to "1.1"
+     * @note The value set here will currently be ignored and assumed to be 1.1
+     * as it is the only protocol version currently supported.
+     * This is valid only for the Primary accessory.
+     */
+    char *pv;
+    /** Category Identifier for the Accessory. This is valid only for the
+     * primary accessory
+     */
+    hap_cid_t cid;
+    /** Identify routine for the accessory (Mandatory) */
+	hap_identify_routine_t identify_routine;
+} hap_acc_cfg_t;
+
+/** HomeKit Debug prints level
+ */
+typedef enum {
+    /** Basic information indicating what's happening in the HomeKit core */
+    HAP_DEBUG_LEVEL_INFO = 0,
+    /** Warnings for incidents that can affect behavior, but not necessarily cause a failure*/
+    HAP_DEBUG_LEVEL_WARN,
+    /** Errors which will affect the working, and may even halt the process */
+    HAP_DEBUG_LEVEL_ERR,
+    /** Asserts for failures which will definitely cause system to halt */
+    HAP_DEBUG_LEVEL_ASSERT
+} hap_debug_level_t;
+
+/**
+ * @brief Set the HomeKit Debug prints level.
+ *
+ * This indicates the maximum level for which the debug messages
+ * will be printed. Default value is \ref HAP_DEBUG_LEVEL_INFO which means
+ * that all information, warnings, errors and asserts will be printed, as
+ * this is the lowest level. You can change it to any suitable higher level
+ * to reduce the prints. For Eg. Setting this to HAP_DEBUG_LEVEL_WARN will
+ * print all warnings, errors and asserts, but not the basic information.
+ *
+ * @param[in] level Maximum debug print level as per \ref hap_debug_level_t
+ */
+void hap_set_debug_level(hap_debug_level_t level);
+
+/**
+ *
+ * @brief Get the HAP SDK Version from the hap core
+ *
+ * @return Pointer to a NULL terminated Version string (Eg. 2.0.r1-0136161)
+ */
+const char *hap_get_version();
+
+/** Unique Paramaters for HomeKit */
+typedef enum {
+    /** Nothing unique.
+     * Application code should ensure uniqueness of name and ssid.
+     * HAP Core will not change anything.
+     */
+    UNIQUE_NONE = 0,
+    /** Unique SSID (default configuration).
+     * 3 bytes of MAC will be added to accessory name to create unique WAC SSID (Eg. Name-xxyyzz) */
+    UNIQUE_SSID,
+    /** Unique Name.
+     * Name will be changed by adding 3 bytes of MAC to original name.
+     * Thi swill automatically make the SSID unique as the accessory name will be used as SSID.
+     */
+    UNIQUE_NAME,
+} hap_unique_param_t;
+
+/** HomeKit Configuration.
+ * Please do not change unless you understand the purpose of these */
+typedef struct {
+    /** Internal HomeKit Task's stack size */
+    uint32_t task_stack_size;
+    /** Internal HomeKit Task's priority */
+    uint8_t task_priority;
+    /** Maximum characteristics to which event notifications can be sent simultaneously.
+     * Default value is enough for standalone accessories. Change may be required only
+     * for bridges.
+     */
+    uint8_t max_event_notif_chars;
+    /** Indicates what paramaters will be made unique by the HAP Core */
+    hap_unique_param_t unique_param;
+    /** Timeout (in seconds) after which a socket data receive call will return for a pair verified
+     * socket, in case the call blocks. This has been added to avoid the webserver getting stalled on a read,
+     * especially in case wherein some garbage data is received on a pair verified connection.
+     */
+    uint8_t recv_timeout;
+    /** Timeout (in seconds) after which a socket data send call will return for a pair verified
+     * socket, in case the call blocks. This has been added to avoid the webserver getting stalled on a write.
+     */
+    uint8_t send_timeout;
+    /** Max length of the buffer to be used for handling SW Token Requests. The Default value has been kept
+     * as 1200 to help pass HCA Tests. This can be changed to 512 for practical purposes as the actual Apple
+     * tokens never really need more than that.
+     */
+    size_t sw_token_max_len;
+    /** By default, config number (c#) incremenents on addition/removal of every bridged accessory after
+     * hap_start(). Setting this flag to true will disable this. Use hap_update_config_number()
+     * to increment c#. Note thar c# will still increment on a firmware upgrade though.
+     */
+    bool disable_config_num_update;
+} hap_cfg_t;
+
+/** Get HomeKit Configuration
+ *
+ * Gets the configuration that will be used by the HomeKit core.
+ *
+ * @param[out] cfg Pointer to an allocated \ref hap_cfg_t structure which will be populated
+ * with the configuration information.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on error
+ */
+int hap_get_config(hap_cfg_t *cfg);
+
+/** Set HomeKit Configuration
+ *
+ * This sets the HomeKit configuration. Please use hap_get_config() to get the old
+ * configuration first, before modifying any values. Eg.
+ *
+ * @code
+ *     hap_cfg_t hap_cfg;
+ *     hap_get_config(&hap_cfg);
+ *     hap_cfg.unique_param = UNIQUE_NAME;
+ *     hap_set_config(&hap_cfg);
+ * @endcode
+ *
+ * @note This should be called before hap_init().
+ *
+ * @param[in] cfg Pointer to an allocated \ref hap_cfg_t structure which has the new values
+ * to set.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on error
+ */
+int hap_set_config(const hap_cfg_t *cfg);
+
+/* Update config number (c#)
+ *
+ * This increments the config number (c#) by 1
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on error
+ */
+int hap_update_config_number();
+
+/**
+ * @brief Initialize HAP Framework
+ *
+ * This internally initializes the MFi auth chip, TCP-IP stack, HomeKit Key Store,
+ * HomeKit database, Wi-Fi and mDNS.
+ *
+ * @return HAP_SUCCESS on success
+ * @return others on error
+ */
+int hap_init(hap_transport_t transport);
+
+/**
+ * @brief De-initialize HAP Framework.
+ *
+ * @note This currently does not do anything
+ *
+ * @return HAP_SUCCESS on success
+ * @return others on error
+ */
+int hap_deinit();
+
+/**
+ * @brief Start the HAP framework
+ *
+ * This starts the webserver and also initializes WAC or HomeKit services
+ * as per the state of the accessory.
+ *
+ * @return HAP_SUCCESS on success
+ * @return others on error
+ */
+int hap_start(void);
+
+/**
+ * @brief Stop HAP framework and free all relevant resources
+ *
+ * @note This currently does not do anything
+ *
+ * @return HAP_SUCCESS on success
+ * @return others on error
+ */
+int hap_stop(void);
+
+/**
+ * @brief Create a HAP accessory object
+ *
+ * @param[in] acc_cfg Pointer to the accessory configuration \ref hap_acc_cfg_t
+ *
+ * @return Handle for the accessory object pre-populated with
+ * the Accessory Information Service (and Protocol Information Service
+ * for the first accessory created)
+ *
+ * @return NULL on error
+ */
+hap_acc_t *hap_acc_create(hap_acc_cfg_t *acc_cfg);
+
+/**
+ * @brief Add Accessory flags to the Accessory Info service
+ *
+ * This adds the optional Accessory Information Flag to the given accessory,
+ * with the value set to the one specified. Typically, the flags will be
+ * initialised with a value of 1, meaning that additional manufacturer specific
+ * setup is required. Once the setup is done, the flags should be reset to 0
+ * using hap_acc_update_accessory_flags()
+ *
+ * @note Use of these flags requires explicit approval from Apple.
+ *
+ * @param[in] ha HAP Accessory object handle
+ * @param[in] flags Initial value of flags. Check the specs for valid values
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_acc_add_accessory_flags(hap_acc_t *ha, uint32_t flags);
+
+/**
+ * @brief Update the Accessory flags
+ *
+ * This updates the Accessory flags characteristic of the Accessory Info service
+ * of the given accessory, if it has been added using hap_acc_add_accessory_flags().
+ *
+ * @param[in] ha HAP Accessory object handle
+ * @param[in] flags New value of flags. Check the specs for valid values
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_acc_update_accessory_flags(hap_acc_t *ha, uint32_t flags);
+
+/**
+ * @brief Add Product data
+ *
+ * As per HAP specs R15, this is the 8 byte product data assigned to the Product Plan.
+ *
+ * @param[in] ha HAP Accessory object handle
+ * @param[in] product_data Pointer to the product data value buffer
+ * @param[in] data_size Size of the buffer (should be 8 as per HAP Spec R15)
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_acc_add_product_data(hap_acc_t *ha, uint8_t *product_data, size_t data_size);
+
+/**
+ * @brief Add accessory to the HAP Object database
+ *
+ * @param[in] ha HAP Accessory object handle
+ */
+void hap_add_accessory(hap_acc_t *ha);
+
+/**
+ * @brief Add a bridged accessory to the HAP Object database
+ *
+ * This adds a bridged accessory to the Homekit Object database and assigns
+ * it the given AID. HomeKit requires that each accessory gets assigned a unique aid.
+ * To ensure this, a helper API hap_get_unique_aid() has been provided. This API
+ * requires some unique identifier of the accessory, say mac address, serial number, etc.
+ *
+ * Example: hap_add_bridged_accessory(ha, hap_get_unique_aid(mac_addr));
+ *
+ * @param[in] aid The AID desired for the bridged accessory. If a 0 is passed, the
+ * next available AID will be assigned. However, this should be used only for
+ * evaluation, not production.
+ *
+ * @param[in] ha HAP Accessory object handle
+ */
+void hap_add_bridged_accessory(hap_acc_t *ha, int aid);
+
+/**
+ * @brief Remove a bridged accessory from the HAP Object database
+ *
+ * @param[in] ha HAP Accessory object handle
+ */
+void hap_remove_bridged_accessory(hap_acc_t *ha);
+
+/**
+ * @brief Delete HAP Accessory Object
+ *
+ * @note Primary accessory cannot be deleted
+ *
+ * @param[in] ha HAP Accessory object handle
+ *
+ */
+void hap_acc_delete(hap_acc_t *ha);
+
+/**
+ * @brief Delete all accessories
+ */
+void hap_delete_all_accessories(void);
+
+/**
+ * Get unique AID for the given identifier
+ *
+ * This API can be used to ensure that the same AID gets assigned to an accessory
+ * every time, even across reboots and irrespective of when it is added to the
+ * HomeKit database. It requires a unique identifier of the accessory, say a
+ * mac addtess, serial number, etc. If it is a new accessory, a new AID gets
+ * assigned and the id:aid combination gets stored in NVS (Non Volatile Storage).
+ * If the accessory was already added some time later, the original AID is fetched
+ * from the NVS and returned. This API should be used as the "aid" argument for
+ * hap_add_bridged_accessory()
+ *
+ * @param[in] id Unique identifier for the accessory
+ *
+ * @return Unique AID for the accessory
+ * @return -1 on error (NULL id)
+ */
+int hap_get_unique_aid(const char *id);
+
+/**
+ * @brief Get Accessory using AID
+ *
+ * @param[in] aid Accessory ID of the required accessory
+ *
+ * @return Handle for the accessory with given aid
+ * @return NULL if accessory not found
+ */
+hap_acc_t *hap_acc_get_by_aid(int32_t aid);
+
+/**
+ * @brief Get first accessory in the database
+ *
+ * @return Handle for the first accessory
+ */
+hap_acc_t *hap_get_first_acc();
+
+/**
+ * @brief Get next accessory in the database
+ *
+ * @param[in] ha Current HAP Accessory object handle
+ *
+ * @return Pointer to the next accessory
+ * @return NULL if the current accessory is the last
+ */
+hap_acc_t *hap_acc_get_next(hap_acc_t *ha);
+
+/**
+ * @brief Get Service using IID
+ *
+ * @param[in] ha HAP Accessory object handle in which the service should be searched
+ * @param[in] iid Instance ID of the required service
+ *
+ * @return Handle for the service with given iid
+ * @return NULL if service not found
+ */
+hap_serv_t *hap_acc_get_serv_by_iid(hap_acc_t *ha, int32_t iid);
+
+/**
+ * @brief Get Service using Type UUID
+ *
+ * @param[in] ha HAP Accessory object handle in which the service should be searched
+ * @param[in] type_uuid UUID of the required service
+ *
+ * @return Handle for the service with given type_uuid
+ * @return NULL if service not found
+ */
+hap_serv_t *hap_acc_get_serv_by_uuid(hap_acc_t *ha, const char *type_uuid);
+
+/**
+ * @brief Get characteristic using IID
+ *
+ * @param[in] ha HAP Accessory object handle in which the characteristic should be searched
+ * @param[in] iid Instance ID of the required characteristic
+ *
+ * @return Handle for the characteristic with given iid
+ * @return NULL if characteristic not found
+ */
+hap_char_t *hap_acc_get_char_by_iid(hap_acc_t *ha, int32_t iid);
+
+/**
+ * @brief Get first service in a given accessory object
+ *
+ * This is useful for iterating over all services of an accessory.
+ * The subsequent services of the accessory can be iterated by using
+ * hap_serv_get_next().
+ *
+ * @param[in] ha HAP Accessory object handle
+ *
+ * @return Handle for the first service in the accessory object
+ */
+hap_serv_t *hap_acc_get_first_serv(hap_acc_t *ha);
+
+/**
+ * @brief Create a Boolean Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_bool_create(char *type_uuid, uint16_t perms, bool val);
+
+/**
+ * @brief Create an 8-bit unsigned integer Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_uint8_create(char *type_uuid, uint16_t perms, uint8_t val);
+
+/**
+ * @brief Create a 16-bit unsigned integer Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_uint16_create(char *type_uuid, uint16_t perms, uint16_t val);
+
+/**
+ * @brief Create a 32-bit unsigned integer Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_uint32_create(char *type_uuid, uint16_t perms, uint32_t val);
+
+/**
+ * @brief Create a 64-bit unsigned integer Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_uint64_create(char *type_uuid, uint16_t perms, uint64_t val);
+
+/**
+ * @brief Create a 32-bit signed integer Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_int_create(char *type_uuid, uint16_t perms, int val);
+
+/**
+ * @brief Create a Floating point Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_float_create(char *type_uuid, uint16_t perms, float val);
+
+/**
+ * @brief Create a String Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_string_create(char *type_uuid, uint16_t perms, char *val);
+
+/**
+ * @brief Create a Data Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Pointer to initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_data_create(char *type_uuid, uint16_t perms, hap_data_val_t *val);
+
+/**
+ * @brief Create a TLV8 Characteristic Object
+ *
+ * @param[in] type_uuid UUID for the characteristic as per the HAP Specs
+ * @param[in] perms Logically OR of the various permissions supported by the characteristic
+ * @param[in] val Pointer to initial value of the characteristic
+ *
+ * @return Handle for the characteristic object created
+ * @return NULL on error
+ */
+hap_char_t *hap_char_tlv8_create(char *type_uuid, uint16_t perms, hap_tlv8_val_t *val);
+
+/**
+ * @brief Delete a characteristic object
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ */
+void hap_char_delete(hap_char_t *hc);
+
+/**
+ * @brief Create a HAP Service Object
+ *
+ * @param[in] type_uuid UUID for the service as per the HAP Specs
+ *
+ * @return Handle for the service object created
+ * @return NULL on error
+ */
+hap_serv_t *hap_serv_create(char *type_uuid);
+
+/**
+ * @brief Delete a service object
+ *
+ * @param[in] hs HAP Service Object handle
+ */
+void hap_serv_delete(hap_serv_t *hs);
+
+/**
+ * @brief Get the AID for the given accessory
+ *
+ * @param[in] ha HAP Accessory Object handle
+ *
+ * @return aid for the accessory
+ */
+uint32_t hap_acc_get_aid(hap_acc_t *ha);
+
+/**
+ * @brief Get Characteristic using Type UUID
+ *
+ * @param[in] hs HAP Service object handle in which the characteristic should be searched
+ * @param[in] type_uuid UUID of the required characteristic
+ *
+ * @return Handle for the characteristic with given type_uuid
+ * @return NULL if characteristic not found
+ */
+hap_char_t *hap_serv_get_char_by_uuid(hap_serv_t *hs, const char *type_uuid);
+
+/**
+ * @brief Get parent Accessory for given Service
+ *
+ * @param[in] hs HAP Service object handle
+ *
+ * @return Handle for the parent accessory
+ * @return NULL if the service is not added in any accessory
+ */
+hap_acc_t *hap_serv_get_parent(hap_serv_t *hs);
+
+/**
+ * @brief Get the next service in a given accessory object
+ *
+ * This is useful for iterating over all services of an accessory.
+ *
+ * @param[in] Current service object handle
+ *
+ * @return Handle for next service in the accessory object
+ * @return NULL if the current service was the last one in the accessory
+ */
+hap_serv_t *hap_serv_get_next(hap_serv_t *hs);
+
+/**
+ * @brief Get first characteristic in a given service object
+ *
+ * This is useful for iterating over all characteristics of a service.
+ * The subsequent characteristics of the service can be
+ * iterated by using hap_char_get_next().
+ *
+ * @param[in] hs HAP Service object handle
+ *
+ * @return Handle for the first chatracteristic in the service object
+ */
+hap_char_t *hap_serv_get_first_char(hap_serv_t *hs);
+
+/**
+ * @brief Get the IID for the given characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ *
+ * @return iid for the characteristic
+ */
+uint32_t hap_char_get_iid(hap_char_t *hc);
+
+/**
+ * @brief Get the type UUID for the given characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ *
+ * @return Type UUID for the characteristic
+ */
+const char * hap_char_get_type_uuid(hap_char_t *hc);
+
+
+/**
+ * @brief Get the Permissions for the given characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ *
+ * @return The permissions for the characteristics, the same as the ones passed while creating it.
+ * It will be a logically OR of the various permissions supported by the characteristic.
+ */
+uint16_t hap_char_get_perm(hap_char_t *hc);
+
+
+/**
+ * @brief Get the format for the given characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ *
+ * @return Format of the characteristic value
+ */
+hap_char_format_t hap_char_get_format(hap_char_t *hc);
+
+/**
+ * @brief Get the IID for the given service
+ *
+ * @param[in] hs HAP Service Object handle
+ *
+ * @return iid for the service
+ */
+uint32_t hap_serv_get_iid(hap_serv_t *hs);
+
+/**
+ * @brief Get the type UUID for the given service
+ *
+ * @param[in] hs HAP Service Object handle
+ *
+ * @return Type UUID for the service
+ */
+char *hap_serv_get_type_uuid(hap_serv_t *hs);
+/**
+ * @brief Get parent Service for given Characteristic
+ *
+ * @param[in] hc HAP Characteristic object handle
+ *
+ * @return Handle for the parent service
+ * @return NULL if the characteristic is not added in any service
+ */
+hap_serv_t *hap_char_get_parent(hap_char_t *hc);
+
+/**
+ * @brief Get the next characteristic in a given service object
+ *
+ * This is useful for iterating over all characteristics of a service.
+ *
+ * @param[in] Current characteristic object handle
+ *
+ * @return Handle for next characteristic in the service object
+ * @return NULL if the current characteristic was the last one in the service
+ */
+hap_char_t *hap_char_get_next(hap_char_t *hc);
+
+/**
+ * @brief Add Integer characteristic constraints
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] min Minimum Value
+ * @param[in] max Maximum Value
+ * @param[in] step Step Value
+ */
+void hap_char_int_set_constraints(hap_char_t *hc, int min, int max, int step);
+
+/**
+ * @brief Add Integer characteristic constraints
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] min Minimum Value
+ * @param[in] max Maximum Value
+ * @param[in] step Step Value
+ */
+void hap_char_float_set_constraints(hap_char_t *hc, float min, float max, float step);
+
+/**
+ * @brief Add String characteristic constraints
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] maxlen Maximum Length of the string (default: 64, max: 256)
+ */
+void hap_char_string_set_maxlen(hap_char_t *hc, int maxlen);
+
+/**
+ * @brief Add Characteristic Description
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] description Manufacturer defined String description for the characteristic
+ */
+void hap_char_add_description(hap_char_t *hc, const char *description);
+
+/**
+ * @brief Add Characteristic Unit
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] unit Unit for the characteristic. Please see specs for valid strings.
+ */
+void hap_char_add_unit(hap_char_t *hc, const char *unit);
+
+/**
+ * @brief Add Valid Values for Characteristic
+ *
+ * Using this API will just add the valid-values metadata for a characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] valid_vals Pointer to an array of valid values
+ * @param[in] valid_val_cnt Number of entries in the array
+ */
+void hap_char_add_valid_vals(hap_char_t *hc, const uint8_t *valid_vals, size_t valid_val_cnt);
+
+/**
+ * @brief Add Valid Values Range for Characteristic
+ *
+ * Using this API will just add the valid-values-range metadata for a characteristic
+ *
+ * @param[in] hc HAP Characteristic Object handle
+ * @param[in] start_val Start value of the range
+ * @param[in] end_val End value of the range
+ */
+void hap_char_add_valid_vals_range(hap_char_t *hc, uint8_t start_val, uint8_t end_val);
+/**
+ * @brief Set IID for a given characteristic
+ *
+ * HomeKit specifications require that the IID for a given characteristic should remain the same,
+ * even after a firmware upgrade. Since the HomeKit core assigns the IIDs internally,
+ * it is possible that a different IID is getting assigned because of removal of
+ * some old service/characteristic or addition of a newer one in between. In such a case,
+ * in order to maintain the same IID, this API can be used.
+ *
+ * @note This must be used only if actually required, and that too after adding all services/
+ * characteristics to an accessory, but before hap_start().
+ *
+ * @param[in] hc HAP Characteristic Object Handle
+ * @param[in] iid Desired IID
+ */
+void hap_char_set_iid(hap_char_t *hc, int32_t iid);
+
+/**
+ * @brief Add a characteristic to a service
+ *
+ * @param[in] hs HAP service object handle
+ * @param[in] hc HAP characteristic object handle
+ *
+ * @return 0 on success
+ * @return other on error
+ */
+int hap_serv_add_char(hap_serv_t *hs, hap_char_t *hc);
+
+/**
+ * @brief HAP add a service to an accessory
+ *
+ * @param[in] ha HAP Accessory object handle
+ * @param[in] hs HAP Service object handle
+ *
+ * @return 0 on success
+ * @return other on error
+ */
+int hap_acc_add_serv(hap_acc_t *ha, hap_serv_t *hs);
+
+/**
+ * @brief Update characteristic value
+ *
+ * This should be called within service read/write callbacks to update the
+ * value of characteristic maintained by the HAP Core. This can also be called
+ * from some other thread, for accessories like sensors that periodically
+ * monitor some paramters.
+ *
+ * @param[in] hc HAP characteristic object handle
+ * @param[in] val Pointer to new value
+ *
+ * @return 0 on success
+ * @return other on error
+ */
+int hap_char_update_val(hap_char_t *hc, hap_val_t *val);
+
+/**
+ * @brief Get the current value of characteristic
+ *
+ * @param[in] hc HAP characteristic object handle
+ *
+ * @return Pointer to the current value
+ */
+const hap_val_t *hap_char_get_val(hap_char_t *hc);
+
+/** Authorization Data received in a write reqest
+ */
+typedef struct {
+    /** Pointer to the data. Will be NULL if no auth data was present */
+    uint8_t *data;
+    /** Length of the data. Will be 0 if no auth data was present */
+    int len;
+} hap_auth_data_t;
+
+/** Write data for a characteristics received over HAP
+ */
+typedef struct {
+    /** Pointer to the characteristic object */
+    hap_char_t *hc;
+    /** Value received in the write request.
+     * Appropriate value in the \ref hap_val_t union will be set as per the format.
+     */
+    hap_val_t val;
+    /** Authorization data \ref hap_auth_data_t id any, received in the write request.
+     * It is the application's responsibility to handle and validate this data and
+     * report the status accordingly.
+     */
+    hap_auth_data_t auth_data;
+    /** Indicates if the received request was a remote write
+     */
+    bool remote;
+    /** This is an output parameter, which should be set in the service write
+     * routine as per the status of the write.
+     */
+    hap_status_t *status;
+} hap_write_data_t;
+
+/** Read data for a characteristic
+ */
+typedef struct {
+    /** Pointer to the characteristic object */
+    hap_char_t *hc;
+    /** This is an output parameter, which should be set in the service read
+     * routine as per the status of the read
+     */
+    hap_status_t *status;
+} hap_read_data_t;
+
+
+/** Service Write Function Prototype
+ *
+ * A function with this prototype must be registered with the HAP framework to handle
+ * writes for the characteristics in the given service
+ *
+ * @note For writes, an array is sent instead of individual writes to avoid cases wherein
+ * writes to multiple properties of a single accessory can cause unexpected behavior.
+ * Eg. For a light which is off, a write could ask it to be turned on at 50% brightness,
+ * with blue color. If 3 writes are issued for this, the light could first turn on to
+ * 100% with white color, then dim down to 50% and then change color. A single write will
+ * ensure that the hardware control takes care of all these at the same time.
+ *
+ * @param[in] write_data Array of characteristic write objects of type \ref hap_write_data_t
+ * which has relevant information like the characteristic object handle, new value received, etc.
+ * @param[in] count Number of entries in the write_data array.
+ * @param[in] serv_priv The private data for the service set using hap_serv_set_priv()
+ * @param[in] write_priv Can be used with hap_is_req_admin()
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL if an error is encountered even for a single characteristic. Actual error
+ * value must be reported in the status under \ref hap_write_data_t.
+ */
+typedef int (*hap_serv_write_t) (hap_write_data_t write_data[], int count,
+		void *serv_priv, void *write_priv);
+
+/** Service Read Function Prototype
+ *
+ * A function with this prototype must be registered with the HAP framework to handle
+ * reads for the characteristics in the given service. The new value must be set
+ * by invoking hap_char_update_val().
+ *
+ * @param[in] hc HAP Characteristic Object Handle.
+ * @param[out] status_code Status of the read, to be populated by the callback with
+ *  values from \ref hap_status_t.
+ * @param[in] serv_priv The private data for the service set using hap_serv_set_priv()
+ * @param[in] read_priv Can be used with hap_is_req_admin()
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL if an error is encountered while reading. Actual error
+ * value must be reported in the status_code
+ */
+typedef int (*hap_serv_read_t) (hap_char_t *hc, hap_status_t *status_code,
+		void *serv_priv, void *read_priv);
+
+/** Service Bulk Read Function Prototype
+ *
+ * A function with this prototype can be registered with the HAP framework to handle
+ * bulk reads for the characteristics in the given service. The new values must be set
+ * by invoking hap_char_update_val() for each characteristic.
+ *
+ * @note This should be used only under special circumstances for cases like
+ * bridges, wherein fetching individual values from bridged accessories could
+ * be time consuming. If this is used, it will override the handler of
+ * type \ref hap_serv_read_t registered for the same service.
+ *
+ * @param[in] read_data Array of characteristic write objects of type \ref hap_read_data_t
+ * which has characteristic object handle and read status pointer.
+ * @param[in] count Number of entries in the read_data array.
+ * @param[in] serv_priv The private data for the service set using hap_serv_set_priv()
+ * @param[in] read_priv Can be used with hap_is_req_admin()
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL if an error is encountered even for a single characteristic.
+ * Actual error value must be reported in the status under \ref hap_read_data_t.
+ */
+typedef int (*hap_serv_bulk_read_t) (hap_read_data_t read_data[], int count,
+        void *serv_priv, void *read_priv);
+
+/**
+ * @brief Register Service Write callback
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] write Callback of type \ref hap_serv_write_t
+ */
+void hap_serv_set_write_cb(hap_serv_t *hs, hap_serv_write_t write);
+
+/**
+ * @brief Register Service Read callback
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] read Callback of type \ref hap_serv_read_t
+ */
+void hap_serv_set_read_cb(hap_serv_t *hs, hap_serv_read_t read);
+
+/**
+ * @brief Register Service Bulk read callback
+ *
+ * @note This should be used only under special circumstances for cases like
+ * bridges, wherein fetching individual values from bridged accessories could
+ * be time consuming. If this is used, the callback registered using
+ * @ref hap_serv_set_read_cb() will be overriden.
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] read Callback of type \ref hap_serv_bulk_read_t
+ */
+void hap_serv_set_bulk_read_cb(hap_serv_t *hs, hap_serv_bulk_read_t read);
+
+/**
+ * @brief Set service private data
+ *
+ * This will be available in the read/write callbacks
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] priv Private data for the service
+ */
+void hap_serv_set_priv(hap_serv_t *hs, void *priv);
+
+/**
+ * @brief Get Service private
+ *
+ * This will get the private data associated with the service, which
+ * was set using hap_serv_set_priv().
+ *
+ * @param[in] hs HAP Service Object Handle
+ *
+ * @return Pointer to the private data (can be NULL)
+ */
+void *hap_serv_get_priv(hap_serv_t *hs);
+
+/**
+ * @brief Mark service as primary
+ *
+ * @param[in] hs HAP Service Object Handle
+ */
+void hap_serv_mark_primary(hap_serv_t *hs);
+
+/**
+ * @brief Mark service as hidden
+ *
+ * @param[in] hs HAP Service Object Handle
+ */
+void hap_serv_mark_hidden(hap_serv_t *hs);
+
+/**
+ * @brief Link a HomeKit service to other service
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] linked_serv HAP Service Object Handle of the service to be linked
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_serv_link_serv(hap_serv_t *hs, hap_serv_t *linked_serv);
+
+/**
+ * @brief Set IID for a given sService
+ *
+ * HomeKit specifications require that the IID for a given service should remain the same,
+ * even after a firmware upgrade. Since the HomeKit core assigns the IIDs internally,
+ * it is possible that a different IID is getting assigned because of removal of
+ * some old service/characteristic or addition of a newer one in between. In such a case,
+ * in order to maintain the same IID, this API can be used.
+ *
+ * @note This must be used only if actually required, and that too after adding all services/
+ * characteristics to a service, but before hap_start().
+ *
+ * @param[in] hs HAP Service Object Handle
+ * @param[in] iid Desired IID
+ */
+void hap_serv_set_iid(hap_serv_t *hs, int32_t iid);
+
+/** HomeKit Setup Information */
+typedef struct {
+    /** SRP Salt */
+    uint8_t salt[16];
+    /** SRP Verifier */
+    uint8_t verifier[384];
+} hap_setup_info_t;
+
+/**
+ * @brief Set the Setup info for HomeKit Pairing
+ *
+ * HomeKit Pairing/Accessory Setup uses a Setup Code (Also called Pairing PIN).
+ * However, the specs recommend that, instead of storing the PIN on the accessory,
+ * the salt and verifier for the PIN should be stored.
+ *
+ * This API should be used to provide this information.
+ *
+ * @param[in] setup_info Pointer to the Setup Information structure which has
+ * the Salt and Verifier.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure (like setup_info being NULL);
+ */
+int hap_set_setup_info(const hap_setup_info_t *setup_info);
+
+/**
+ * @brief Set the setup code (i.e. pairing pin)
+ *
+ * @note Ideally, the PIN should not be present in the firmware. Instead,
+ * the salt and verifier should be stored on the accessory and provided using
+ * hap_set_setup_info(). This API should be used only for testing purposes.
+ *
+ * Using this API overrides the setup information provided by hap_set_setup_info().
+ *
+ * @param[in] setup_code NULL terminated Setup code of the format xxx-xx-xxx where each
+ * x is a number
+ */
+void hap_set_setup_code(const char *setup_code);
+
+/**
+ * @brief Set the setup ID
+ *
+ * @param[in] setup_id NULL terminated Setup ID, which will be a 4 character
+ * long alpha numeric string (with capital alphabets)
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_set_setup_id(const char *setup_id);
+
+/**
+ * Check if the MFi authentication co-processor is connected
+ *
+ * @note This should be called before hap_init()
+ *
+ * @return HAP_SUCCESS if an MFi co-processor is detected
+ * @return HAP_FAIL if no MFi co-processor is detected
+ */
+int hap_check_mfi_chip();
+
+/**
+ * @brief Reboot the accessory
+ *
+ * This closes all the active HomeKit sessions and reboots the accessory.
+ * It is recommended to use this API instead of the standard platform reboot/restart
+ * APIs, for cleaner operation.
+ *
+ * @note This is an asynchronous API (actual action executed in HomeKit core thread context)
+ * and can be invoked even from interrupt context. The \ref HAP_EVENT_ACC_REBOOTING
+ * event will be invoked after this.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_reboot_accessory();
+
+/**
+ * @brief Reset to Factory Settings
+ *
+ * This resets the accessory to factory settings and reboots it.
+ * All pairing information, network information and accessory specific information
+ * (like accessory ID, keys, config number, etc.) is erased. Even all application
+ * data written to NVS partition is erased.
+ *
+ * @note This is an asynchronous API (actual action executed in HomeKit core thread context)
+ * and can be invoked even from interrupt context. The \ref HAP_EVENT_ACC_REBOOTING
+ * event will be invoked after this.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_reset_to_factory();
+
+/**
+ * @brief Reset the Network Credentials
+ *
+ * This resets only the network credntials (keeping the pairing and any other information
+ * intact) and reboots the accessory.
+ *
+ * @note This is an asynchronous API (actual action executed in HomeKit core thread context)
+ * and can be invoked even from interrupt context. The \ref HAP_EVENT_ACC_REBOOTING
+ * event will be invoked after this.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_reset_network();
+
+/**
+ * @brief Reset HomeKit Data
+ *
+ * This resets all the data stored by the HomeKit Framework, which includes
+ * all pairing information, network information and accessory specific information
+ * (like accessory ID, keys, config number, etc.)
+ *
+ * @note This is an asynchronous API (actual action executed in HomeKit core thread context)
+ * and can be invoked even from interrupt context. The \ref HAP_EVENT_ACC_REBOOTING
+ * event will be invoked after this.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_reset_homekit_data();
+
+/**
+ * @brief Reset HomeKit Pairings
+ *
+ * This API resets the HomeKit Pairing Information and also the accessory specific
+ * information (like accessory ID, keys, config number, etc.). The accessory id is
+ * reset because else, the paired controllers would consider the accessory as paired,
+ * as they would still have the keys for the given accessory id.
+ *
+ * @note This is an asynchronous API (actual action executed in HomeKit core thread context)
+ * and can be invoked even from interrupt context. The \ref HAP_EVENT_ACC_REBOOTING
+ * event will be invoked after this.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_reset_pairings();
+
+/**
+ * @brief Check if the request is from Admin Controller
+ *
+ * This API can be used inside service read (\ref hap_serv_read_t) and service write
+ * (\ref hap_serv_write_t) callbacks to check if the request was from an admin controller.
+ * Pass the write_priv or read_priv pointer to this API
+ *
+ * @return true if request is from an admin controller
+ * @return false if request is from a non-admin controller
+ */
+bool hap_is_req_admin(void *priv);
+
+/**
+ * @brief Get the ID of the controller who sent the request
+ *
+ * This API can be used inside service read (\ref hap_serv_read_t) and service write
+ * (\ref hap_serv_write_t) callbacks to check the id of the controller who sent the request.
+ * Pass the write_priv or read_priv pointer to this API
+ *
+ * @return pointer to a null terminated controller id string on success.
+ * @return NULL on failure.
+ */
+char *hap_req_get_ctrl_id(void *priv);
+
+/**
+ *
+ * @brief Get a value from factory NVS keystore
+ *
+ * This API can be used to fetch information from the factory_nvs flash partition.
+ * This is treated as a Read-Only partition and so, no "set" API has been provided.
+ *
+ * @param[in] name_space NVS name space from which the value needs to be read.
+ * @param[in] key The NVS key for the value
+ * @param[out] val Buffer which will be used to hold the value, if found
+ * @param[in,out] val_size Holds the size of the val buffer. Will be populated with the length of
+ * the value by this function.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_factory_keystore_get(const char *name_space, const char *key, uint8_t *val, size_t *val_size);
+
+/**
+ * Enable MFi authentication
+ *
+ * @param[in] auth_type The authentication type desired.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL on failure
+ */
+int hap_enable_mfi_auth(hap_mfi_auth_type_t auth_type);
+
+/**
+ * @brief Enable Software Token based authentication.
+ *
+ * This is valid for HomeKit Accessory Protocol Spec R12 (or later) and works with iOS 11.3 (or later) only.
+ *
+ * This API enables the Software Token based authentication for HomeKit pairing. It requires the accessory
+ * UUID and Token to be programmed in the factory_nvs partition. Please check the README for more details.
+ *
+ * Please refer HomeKit Software Authentication Server Specification to understand the server side
+ * implications of using this method for HomeKit Pairing. The tokens fetched from Apple server need to
+ * be programmed on the accessory
+ *
+ * @note Software Authentication is not recommended for new accessories. It should be used only if HomeKit
+ * functionality needs to be enabled on accessories which are already in field, or if an existing hardware
+ * design needs to be re-used for cost or other considerations. For any other use cases, please get in touch
+ * with your Apple contact.
+ *
+ * @return HAP_SUCCESS on success
+ * @return HAP_FAIL if the correct UUID or Token is not provided in the factory_nvs partition
+ */
+static inline int hap_enable_software_auth()
+{
+    return hap_enable_mfi_auth(HAP_MFI_AUTH_SW);
+}
+
+#define HAP_REBOOT_REASON_UNKNOWN               "unknown"
+#define HAP_REBOOT_REASON_RESET_TO_FACTORY      "reset_to_factory"
+#define HAP_REBOOT_REASON_REBOOT_ACC            "reboot_acc"
+#define HAP_REBOOT_REASON_RESET_NETWORK         "reset_network"
+#define HAP_REBOOT_REASON_RESET_PAIRINGS        "reset_pairings"
+#define HAP_REBOOT_REASON_RESET_HOMEKIT_DATA    "reset_homekit_data"
+
+/** HomeKit Event Base */
+ESP_EVENT_DECLARE_BASE(HAP_EVENT);
+/** HomeKit Events */
+typedef enum {
+    /** A new controller was paired/added/modified.
+     * Associated data is a NULL terminated controller identifier string.
+     */
+    HAP_EVENT_CTRL_PAIRED = 1,
+    /** A controller was removed
+     * Associated data is a NULL terminated controller identifier string.
+     */
+    HAP_EVENT_CTRL_UNPAIRED,
+    /** A paired controller connected to the accessory (extablished a pair verified session).
+     * Associated data is a NULL terminated controller identifier string.
+     */
+    HAP_EVENT_CTRL_CONNECTED,
+    /** A controller disconnected from the accessory. This event is reported before the
+     * actual disconnection, because for cases like pair-remove, the controller information
+     * gets erased before the disconnection, and so the controller id is not available
+     * after disconnection.
+     * Associated data is a NULL terminated controller identifier string.
+     */
+    HAP_EVENT_CTRL_DISCONNECTED,
+    /** A Pair Setup attempt has started. Waiting for Setup Code */
+    HAP_EVENT_PAIRING_STARTED,
+    /** Pair Setup was aborted because of inactivity or a wrong setup code */
+    HAP_EVENT_PAIRING_ABORTED,
+    /** A GET on /accessories was successfully completed */
+    HAP_EVENT_GET_ACC_COMPLETED,
+    /** A GET on /characteristics was successfully completed */
+    HAP_EVENT_GET_CHAR_COMPLETED,
+    /** A PUT (Set value) on /characteristics was successfully completed.
+     * This event can also mean that notifications were enabled for some
+     * characteristics as the same is also done in PUT /characteristics */
+    HAP_EVENT_SET_CHAR_COMPLETED,
+    /* Accessory is about to reboot. Will be triggered for operations like hap_reset_to_factory(),
+     * hap_reboot_accessory(), hap_reset_network(), hap_reset_pairings() and hap_reset_homekit_data()
+     * just before rebooting. Associated data is a pointer to a string indicating the reboot reason.
+     * Reefer the HAP_REBOOT_REASON_* macros for possible values.
+     */
+    HAP_EVENT_ACC_REBOOTING,
+} hap_event_t;
+
+/** Prototype for HomeKit Event handler
+ *
+ * @param[in] event The event id of type \ref hap_event_t
+ * @param[in] data Data associated with the event (if applicable).
+ * Please refer \ref hap_event_t documentation for information regarding
+ * data for each event.
+ */
+typedef void (*hap_event_handler_t) (hap_event_t event, void *data);
+
+/** Register HomeKit Event Handler
+ *
+ * If applications are interested in HomeKit specific events, they can
+ * write their own event handler and register with HomeKit core using
+ * this API.
+ *
+ * @param[in] handler Application specific HomeKit event handler.
+ */
+void hap_register_event_handler(hap_event_handler_t handler);
+
+/** Get Paired controller count
+ *
+ * This API can be used to get a count of number of paired controllers.
+ * Thi can be used only after hap_init().
+ *
+ * @return Number of paired controllers
+ */
+int hap_get_paired_controller_count();
+
+/*
+ * Enable Simple HTTP Debugging
+ *
+ * Calling this API will enable HTTP Debugging which will show some HomeKit HTTP Debug
+ * info like the URL and data.
+ */
+void hap_http_debug_enable();
+
+/**
+ * Disable Simple HTTP Debugging
+ *
+ * Calling this API will disable HTTP Debugging which was enabled by hap_enable_http_debug()
+ */
+void hap_http_debug_disable();
+
+/** Get Setup payload
+ *
+ * This gives the setup payload for the given information
+ *
+ * @param[in] setup_code NULL terminated setup code. Eg. "111-22-333"
+ * @param[in] setup_id NULL terminated setup id. Eg. "ES32"
+ * @param[in] wac_support Boolean indicating if WAC provisioning is supported.
+ * @param[in] cid Accessory category identifier.
+ *
+ * @return On success, an allocated NULL terminal setup paylod string. Eg. "X-HM://003363Z4TES32". Should be freed by the caller.
+ * @return NULL on failure.
+ */
+char *esp_hap_get_setup_payload(char *setup_code, char *setup_id, bool wac_support, hap_cid_t cid);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ESP_HAP_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_apple_chars.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_apple_chars.c
@@ -1,0 +1,1482 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <hap.h>
+#include <hap_apple_chars.h>
+
+/* Char: Brightness */
+hap_char_t *hap_char_brightness_create(int brightness)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_BRIGHTNESS,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, brightness);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 100, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Cooling Threshold Temperature */
+hap_char_t *hap_char_cooling_threshold_temperature_create(float cooling_threshold_temp)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_COOLING_THRESHOLD_TEMPERATURE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, cooling_threshold_temp);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 10.0, 35.0, 0.1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_CELSIUS);
+
+    return hc;
+}
+
+/* Char: Current Door State */
+hap_char_t *hap_char_current_door_state_create(uint8_t curr_door_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_DOOR_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_door_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 4, 1);
+
+    return hc;
+}
+
+/* Char: Current Heating Cooling State */
+hap_char_t *hap_char_current_heating_cooling_state_create(uint8_t curr_heating_cooling_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_HEATING_COOLING_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_heating_cooling_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Current Relative Humidity */
+hap_char_t *hap_char_current_relative_humidity_create(float curr_rel_humidity)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CURRENT_RELATIVE_HUMIDITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_rel_humidity);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Current Temperature */
+hap_char_t *hap_char_current_temperature_create(float curr_temp)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CURRENT_TEMPERATURE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_temp);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 0.1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_CELSIUS);
+
+    return hc;
+}
+
+/* Char: Firmware Revision */
+hap_char_t *hap_char_firmware_revision_create(char *fw_rev)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_FIRMWARE_REVISION,
+                                            HAP_CHAR_PERM_PR, fw_rev);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Hardware Revision */
+hap_char_t *hap_char_hardware_revision_create(char *hw_rev)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_HARDWARE_REVISION,
+                                            HAP_CHAR_PERM_PR, hw_rev);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Heating Threshold Temperature */
+hap_char_t *hap_char_heating_threshold_temperature_create(float heating_threshold_temp)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_HEATING_THRESHOLD_TEMPERATURE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, heating_threshold_temp);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 25.0, 0.1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_CELSIUS);
+
+    return hc;
+}
+
+/* Char: Hue */
+hap_char_t *hap_char_hue_create(float hue)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_HUE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, hue);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 360.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Identify */
+hap_char_t *hap_char_identify_create(void)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_IDENTIFY, HAP_CHAR_PERM_PW, false);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Lock Current State */
+hap_char_t *hap_char_lock_current_state_create(uint8_t lock_curr_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_LOCK_CURRENT_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, lock_curr_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Lock Target State */
+hap_char_t *hap_char_lock_target_state_create(uint8_t lock_targ_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_LOCK_TARGET_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, lock_targ_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Manufacturer */
+hap_char_t *hap_char_manufacturer_create(char *manufacturer)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_MANUFACTURER,
+                                            HAP_CHAR_PERM_PR, manufacturer);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Model */
+hap_char_t *hap_char_model_create(char *model)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_MODEL,
+                                            HAP_CHAR_PERM_PR, model);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Motion Detected */
+hap_char_t *hap_char_motion_detected_create(bool motion_detected)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_MOTION_DETECTED,
+                                          HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, motion_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Name */
+hap_char_t *hap_char_name_create(char *name)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_NAME,
+                                            HAP_CHAR_PERM_PR, name);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Obstruction Detected */
+hap_char_t *hap_char_obstruction_detect_create(bool obstr_detect)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_OBSTRUCTION_DETECTED,
+                                          HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, obstr_detect);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: On */
+hap_char_t *hap_char_on_create(bool on)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_ON,
+                                          HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, on);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Outlet in Use */
+hap_char_t *hap_char_outlet_in_use_create(bool outlet_in_use)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_OUTLET_IN_USE,
+                                          HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, outlet_in_use);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Rotation Direction */
+hap_char_t *hap_char_rotation_direction_create(int rotation_direction)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_ROTATION_DIRECTION,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, rotation_direction);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Rotation Speed */
+hap_char_t *hap_char_rotation_speed_create(float rotation_speed)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_ROTATION_SPEED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, rotation_speed);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Saturation */
+hap_char_t *hap_char_saturation_create(float saturation)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_SATURATION,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, saturation);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Serial Number */
+hap_char_t *hap_char_serial_number_create(char *serial_num)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_SERIAL_NUMBER,
+                                            HAP_CHAR_PERM_PR, serial_num);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Target Door State */
+hap_char_t *hap_char_target_door_state_create(uint8_t targ_door_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_DOOR_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_door_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Target Heating Cooling State */
+hap_char_t *hap_char_target_heating_cooling_state_create(uint8_t targ_heating_cooling_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_HEATING_COOLING_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_heating_cooling_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Target Relative Humidity */
+hap_char_t *hap_char_target_relative_humidity_create(float targ_rel_humidity)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_TARGET_RELATIVE_HUMIDITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_rel_humidity);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Target Temperature */
+hap_char_t *hap_char_target_temperature_create(float targ_temp)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_TARGET_TEMPERATURE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_temp);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 10.0, 38.0, 0.1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_CELSIUS);
+
+    return hc;
+}
+
+/* Char: Temperature Display Units */
+hap_char_t *hap_char_temperature_display_units_create(uint8_t temp_disp_units)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TEMPERATURE_DISPLAY_UNITS,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, temp_disp_units);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Version */
+hap_char_t *hap_char_version_create(char *version)
+{
+    hap_char_t *hc = hap_char_string_create(HAP_CHAR_UUID_VERSION,
+                                            HAP_CHAR_PERM_PR, version);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Security System Current State */
+hap_char_t *hap_char_security_system_current_state_create(uint8_t security_sys_curr_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SECURITY_SYSTEM_CURRENT_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, security_sys_curr_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 4, 1);
+
+    return hc;
+}
+
+/* Char: Security System Target State */
+hap_char_t *hap_char_security_system_target_state_create(uint8_t security_sys_targ_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SECURITY_SYSTEM_TARGET_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, security_sys_targ_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Battery Level */
+hap_char_t *hap_char_battery_level_create(uint8_t battery_level)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_BATTERY_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, battery_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 100, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Carbon Monoxide Detected */
+hap_char_t *hap_char_carbon_monoxide_detected_create(uint8_t carbon_monoxide_detected)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CARBON_MONOXIDE_DETECTED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_monoxide_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Contact Sensor State */
+hap_char_t *hap_char_contact_sensor_state_create(uint8_t contact_sensor_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CONTACT_SENSOR_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, contact_sensor_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Current Ambient Light Level */
+hap_char_t *hap_char_current_ambient_light_level_create(float curr_ambient_light_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CURRENT_AMBIENT_LIGHT_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_ambient_light_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0001, 100000.0, 0.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_LUX);
+
+    return hc;
+}
+
+/* Char: Current Horizontal Tilt Angle */
+hap_char_t *hap_char_current_horizontal_tilt_angle_create(int curr_horiz_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_CURRENT_HORIZONTAL_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_horiz_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Current Position */
+hap_char_t *hap_char_current_position_create(uint8_t curr_pos)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_POSITION,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_pos);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 100, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Current Vertical Tilt Angle */
+hap_char_t *hap_char_current_vertical_tilt_angle_create(int curr_vert_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_CURRENT_VERTICAL_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_vert_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Hold Position */
+hap_char_t *hap_char_hold_position_create(bool hold_pos)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_HOLD_POSITION,
+                                          HAP_CHAR_PERM_PW, hold_pos);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Leak Detected */
+hap_char_t *hap_char_leak_detected_create(uint8_t leak_detected)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_LEAK_DETECTED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, leak_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Occupancy Detected */
+hap_char_t *hap_char_occupancy_detected_create(uint8_t occupancy_detected)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_OCCUPANCY_DETECTED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, occupancy_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Position State */
+hap_char_t *hap_char_position_state_create(uint8_t pos_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_POSITION_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, pos_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Programmable Switch Event */
+hap_char_t *hap_char_programmable_switch_event_create(uint8_t programmable_switch_event)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_PROGRAMMABLE_SWITCH_EVENT,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV | HAP_CHAR_PERM_SPECIAL_READ,
+                                           programmable_switch_event);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Status Active */
+hap_char_t *hap_char_status_active_create(bool status_active)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_STATUS_ACTIVE,
+                                          HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, status_active);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Smoke Detected */
+hap_char_t *hap_char_smoke_detected_create(uint8_t smoke_detected)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SMOKE_DETECTED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, smoke_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Status Fault */
+hap_char_t *hap_char_status_fault_create(uint8_t status_fault)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_STATUS_FAULT,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, status_fault);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Status Low Battery */
+hap_char_t *hap_char_status_low_battery_create(uint8_t status_low_battery)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_STATUS_LOW_BATTERY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, status_low_battery);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Status Tampered */
+hap_char_t *hap_char_status_tampered_create(uint8_t status_tampered)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_STATUS_TAMPERED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, status_tampered);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Target Horizontal Tilt Angle */
+hap_char_t *hap_char_target_horizontal_tilt_angle_create(int targ_horiz_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_TARGET_HORIZONTAL_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_horiz_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Target Position */
+hap_char_t *hap_char_target_position_create(uint8_t targ_pos)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_POSITION,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_pos);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 100, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Target Vertical Tilt Angle */
+hap_char_t *hap_char_target_vertical_tilt_angle_create(int targ_vert_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_TARGET_VERTICAL_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_vert_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Security System Alarm Type */
+hap_char_t *hap_char_security_system_alarm_type_create(uint8_t security_sys_alarm_type)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_STATUS_SECURITY_SYSTEM_ALARM_TYPE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, security_sys_alarm_type);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Charging State */
+hap_char_t *hap_char_charging_state_create(uint8_t charging_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CHARGING_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, charging_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Carbon Monoxide Level */
+hap_char_t *hap_char_carbon_monoxide_level_create(float carbon_monoxide_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CARBON_MONOXIDE_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_monoxide_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Carbon Monoxide Peak Level */
+hap_char_t *hap_char_carbon_monoxide_peak_level_create(float carbon_monoxide_peak_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CARBON_MONOXIDE_PEAK_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_monoxide_peak_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Carbon Dioxide Detected */
+hap_char_t *hap_char_carbon_dioxide_detected_create(uint8_t carbon_dioxide_detected)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CARBON_DIOXIDE_DETECTED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_dioxide_detected);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Carbon Dioxide Level */
+hap_char_t *hap_char_carbon_dioxide_level_create(float carbon_dioxide_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CARBON_DIOXIDE_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_dioxide_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Carbon Dioxide Peak Level */
+hap_char_t *hap_char_carbon_dioxide_peak_level_create(float carbon_dioxide_peak_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_CARBON_DIOXIDE_PEAK_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, carbon_dioxide_peak_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100000.0, 0.0);
+
+    return hc;
+}
+
+
+/* Char: Air Quality */
+hap_char_t *hap_char_air_quality_create(uint8_t air_quality)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_AIR_QUALITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, air_quality);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 5, 1);
+
+    return hc;
+}
+
+/* Char: Accessory Flags */
+hap_char_t *hap_char_accessory_flags_create(uint32_t flags)
+{
+    hap_char_t *hc = hap_char_uint32_create(HAP_CHAR_UUID_ACCESSORY_FLAGS,
+                                            HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, flags);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Product Data */
+hap_char_t *hap_char_product_data_create(hap_data_val_t *product_data)
+{
+    hap_char_t *hc = hap_char_data_create(HAP_CHAR_UUID_PRODUCT_DATA,
+                                            HAP_CHAR_PERM_PR , product_data);
+    if (!hc) {
+        return NULL;
+    }
+    return hc;
+}
+
+/* Char: Lock Physical Controls */
+hap_char_t *hap_char_lock_physical_controls_create(uint8_t lock_physical_controls)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_LOCK_PHYSICAL_CONTROLS,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, lock_physical_controls);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Current Air Purifier State */
+hap_char_t *hap_char_current_air_purifier_state_create(uint8_t curr_air_purifier_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_AIR_PURIFIER_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_air_purifier_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Current Slat State */
+hap_char_t *hap_char_current_slat_state_create(uint8_t curr_slat_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_SLAT_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_slat_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Slat Type */
+hap_char_t *hap_char_slat_type_create(uint8_t slat_type)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SLAT_TYPE,
+                                           HAP_CHAR_PERM_PR, slat_type);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Filter Life Level */
+hap_char_t *hap_char_filter_life_level_create(float filter_life_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_FILTER_LIFE_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, filter_life_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+
+    return hc;
+}
+
+/* Char: Filter Change Indication */
+hap_char_t *hap_char_filter_change_indication_create(uint8_t filter_change_indication)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_FILTER_CHANGE_INDICATION,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, filter_change_indication);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Reset Filter Indication */
+hap_char_t *hap_char_reset_filter_indication_create(uint8_t reset_filter_indication)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_RESET_FILTER_INDICATION,
+                                           HAP_CHAR_PERM_PW, reset_filter_indication);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 1, 1, 0);
+
+    return hc;
+}
+
+/* Char: Target Air Purifier State */
+hap_char_t *hap_char_target_air_purifier_state_create(uint8_t targ_air_purifier_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_AIR_PURIFIER_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_air_purifier_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Target Fan State */
+hap_char_t *hap_char_target_fan_state_create(uint8_t targ_fan_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_FAN_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_fan_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Current Fan State */
+hap_char_t *hap_char_current_fan_state_create(uint8_t curr_fan_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_FAN_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_fan_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Active State */
+hap_char_t *hap_char_active_create(uint8_t active)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_ACTIVE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, active);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Swing Mode */
+hap_char_t *hap_char_swing_mode_create(uint8_t swing_mode)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SWING_MODE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, swing_mode);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Current Tilt Angle */
+hap_char_t *hap_char_current_tilt_angle_create(int curr_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_CURRENT_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Target Tilt Angle */
+hap_char_t *hap_char_target_tilt_angle_create(int targ_tilt_angle)
+{
+    hap_char_t *hc = hap_char_int_create(HAP_CHAR_UUID_TARGET_TILT_ANGLE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_tilt_angle);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, -90, 90, 1);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_ARCDEGREES);
+
+    return hc;
+}
+
+/* Char: Ozone Density */
+hap_char_t *hap_char_ozone_density_create(float ozone_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_OZONE_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, ozone_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Nitrogen Dioxide Density */
+hap_char_t *hap_char_nitrogen_dioxide_density_create(float nitrogen_dioxide_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_NITROGEN_DIOXIDE_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, nitrogen_dioxide_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Sulphur Dioxide Density */
+hap_char_t *hap_char_sulphur_dioxide_density_create(float sulphur_dioxide_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_SULPHUR_DIOXIDE_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, sulphur_dioxide_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: PM2.5 Density */
+hap_char_t *hap_char_pm_2_5_density_create(float pm_2_5_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_PM_2_5_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, pm_2_5_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: PM10 Density */
+hap_char_t *hap_char_pm_10_density_create(float pm_10_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_PM_10_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, pm_10_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: VOC Density */
+hap_char_t *hap_char_voc_density_create(float voc_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_VOC_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, voc_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 1000.0, 0.0);
+
+    return hc;
+}
+
+/* Char: Service Label Index */
+hap_char_t *hap_char_service_label_index_create(uint8_t service_label_index)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SERVICE_LABEL_INDEX,
+                                         HAP_CHAR_PERM_PR, service_label_index);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Service Label Namespace */
+hap_char_t *hap_char_service_label_namespace_create(uint8_t service_label_namespace)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_SERVICE_LABEL_NAMESPACE,
+                                         HAP_CHAR_PERM_PR, service_label_namespace);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Color Temperature */
+hap_char_t *hap_char_color_temperature_create(uint32_t color_temp)
+{
+    hap_char_t *hc = hap_char_uint32_create(HAP_CHAR_UUID_COLOR_TEMPERATURE,
+                                            HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, color_temp);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 50, 400, 1);
+
+    return hc;
+}
+
+/* Char: Current Heater Cooler State */
+hap_char_t *hap_char_current_heater_cooler_state_create(uint8_t curr_heater_cooler_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_HEATER_COOLER_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_heater_cooler_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Target Heater Cooler State */
+hap_char_t *hap_char_target_heater_cooler_state_create(uint8_t targ_heater_cooler_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_HEATER_COOLER_STATE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_heater_cooler_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Current Humidifier Dehumidifier State */
+hap_char_t *hap_char_current_humidifier_dehumidifier_state_create(uint8_t curr_humidifier_dehumidifier_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_CURRENT_HUMIDIFIER_DEHUMIDIFIER_STATE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, curr_humidifier_dehumidifier_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Target Humidifier Dehumidifier State */
+hap_char_t *hap_char_target_humidifier_dehumidifier_state_create(uint8_t targ_humidifier_dehumidifier_state)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_TARGET_HUMIDIFIER_DEHUMIDIFIER_STATE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, targ_humidifier_dehumidifier_state);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: Water Level */
+hap_char_t *hap_char_water_level_create(float water_level)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_WATER_LEVEL,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, water_level);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+
+    return hc;
+}
+
+/* Char: Relative Humidity Dehumidifier Threshold  */
+hap_char_t *hap_char_relative_humidity_dehumidifier_threshold_create(float rel_humidity_dehumidifier_threshold)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_RELATIVE_HUMIDITY_DEHUMIDIFIER_THRESHOLD,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, rel_humidity_dehumidifier_threshold);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Relative Humidity Humidifier Threshold  */
+hap_char_t *hap_char_relative_humidity_humidifier_threshold_create(float rel_humidity_humidifier_threshold)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, rel_humidity_humidifier_threshold);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0.0, 100.0, 1.0);
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_PERCENTAGE);
+
+    return hc;
+}
+
+/* Char: Program Mode */
+hap_char_t *hap_char_program_mode_create(uint8_t prog_mode)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_PROGRAM_MODE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, prog_mode);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 2, 1);
+
+    return hc;
+}
+
+/* Char: In Use */
+hap_char_t *hap_char_in_use_create(uint8_t in_use)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_IN_USE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, in_use);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Set Duration */
+hap_char_t *hap_char_set_duration_create(uint32_t set_duration)
+{
+    hap_char_t *hc = hap_char_uint32_create(HAP_CHAR_UUID_SET_DURATION,
+                                            HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, set_duration);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3600, 1);
+
+    return hc;
+}
+
+/* Char: Remaining Duration */
+hap_char_t *hap_char_remaining_duration_create(uint32_t remaining_duration)
+{
+    hap_char_t *hc = hap_char_uint32_create(HAP_CHAR_UUID_REMAINING_DURATION,
+                                            HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, remaining_duration);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3600, 1);
+
+    return hc;
+}
+
+/* Char: Valve Type */
+hap_char_t *hap_char_valve_type_create(uint8_t valve_type)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_VALVE_TYPE,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, valve_type);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 3, 1);
+
+    return hc;
+}
+
+/* Char: Is Configured */
+hap_char_t *hap_char_is_configured_create(uint8_t is_configured)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_IS_CONFIGURED,
+                                         HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, is_configured);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Status Jammed */
+hap_char_t *hap_char_status_jammed_create(uint8_t status_jammed)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_STATUS_JAMMED,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV, status_jammed);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}
+
+/* Char: Administrator Only Access */
+hap_char_t *hap_char_administrator_only_access_create(bool administrator_only_access)
+{
+    hap_char_t *hc = hap_char_bool_create(HAP_CHAR_UUID_ADMINISTRATOR_ONLY_ACCESS,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, 
+                                           administrator_only_access);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Lock Control Point */
+hap_char_t *hap_char_lock_control_point_create(hap_tlv8_val_t *lock_control_point)
+{
+    hap_char_t *hc = hap_char_tlv8_create(HAP_CHAR_UUID_LOCK_CONTROL_POINT,
+                                           HAP_CHAR_PERM_PW , lock_control_point);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Lock Last Known Action */
+hap_char_t *hap_char_lock_last_known_action_create(uint8_t lock_last_known_action)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_LOCK_LAST_KNOWN_ACTION,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV , lock_last_known_action);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 8, 1);
+
+    return hc;
+}
+
+/* Char: Lock Management Auto Security Timeout */
+hap_char_t *hap_char_lock_management_auto_security_timeout_create(uint32_t lock_management_auto_security_timeout)
+{
+    hap_char_t *hc = hap_char_uint32_create(HAP_CHAR_UUID_LOCK_MANAGEMENT_AUTO_SECURITY_TIMEOUT,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_PW | HAP_CHAR_PERM_EV, 
+                                           lock_management_auto_security_timeout);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_add_unit(hc, HAP_CHAR_UNIT_SECONDS);
+
+    return hc;
+}
+
+/* Char: Logs */
+hap_char_t *hap_char_logs_create(hap_tlv8_val_t *logs)
+{
+    hap_char_t *hc = hap_char_tlv8_create(HAP_CHAR_UUID_LOGS,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV , logs);
+    if (!hc) {
+        return NULL;
+    }
+
+    return hc;
+}
+
+/* Char: Air Particulate Density */
+hap_char_t *hap_char_air_particulate_density_create(float air_particulate_density)
+{
+    hap_char_t *hc = hap_char_float_create(HAP_CHAR_UUID_AIR_PARTICULATE_DENSITY,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV , air_particulate_density);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_float_set_constraints(hc, 0, 1000, 0.0);
+
+    return hc;
+}
+
+/* Char: Air Particulate Size */
+hap_char_t *hap_char_air_particulate_size_create(uint8_t air_particulate_size)
+{
+    hap_char_t *hc = hap_char_uint8_create(HAP_CHAR_UUID_AIR_PARTICULATE_SIZE,
+                                           HAP_CHAR_PERM_PR | HAP_CHAR_PERM_EV , air_particulate_size);
+    if (!hc) {
+        return NULL;
+    }
+
+    hap_char_int_set_constraints(hc, 0, 1, 1);
+
+    return hc;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hap_apple_chars.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_apple_chars.h
@@ -1,0 +1,1422 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/** HAP Apple Characteristics
+ *
+ * This offers helper APIs for all the standard HomeKit Characteristics defined by Apple
+ */
+#ifndef _HAP_APPLE_CHARS_H_
+#define _HAP_APPLE_CHARS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <hap.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAP_CHAR_UUID_ADMINISTRATOR_ONLY_ACCESS                 "1"
+#define HAP_CHAR_UUID_BRIGHTNESS                                "8"
+#define HAP_CHAR_UUID_COOLING_THRESHOLD_TEMPERATURE             "D"
+#define HAP_CHAR_UUID_CURRENT_DOOR_STATE                        "E"
+#define HAP_CHAR_UUID_CURRENT_HEATING_COOLING_STATE             "F"
+#define HAP_CHAR_UUID_CURRENT_RELATIVE_HUMIDITY                 "10"
+#define HAP_CHAR_UUID_CURRENT_TEMPERATURE                       "11"
+#define HAP_CHAR_UUID_FIRMWARE_REVISION                         "52"
+#define HAP_CHAR_UUID_HARDWARE_REVISION                         "53"
+#define HAP_CHAR_UUID_HEATING_THRESHOLD_TEMPERATURE             "12"
+#define HAP_CHAR_UUID_HUE                                       "13"
+#define HAP_CHAR_UUID_IDENTIFY                                  "14"
+#define HAP_CHAR_UUID_LOCK_CONTROL_POINT                        "19"
+#define HAP_CHAR_UUID_LOCK_CURRENT_STATE                        "1D"
+#define HAP_CHAR_UUID_LOCK_LAST_KNOWN_ACTION                    "1C"
+#define HAP_CHAR_UUID_LOCK_MANAGEMENT_AUTO_SECURITY_TIMEOUT     "1A"
+#define HAP_CHAR_UUID_LOCK_TARGET_STATE                         "1E"
+#define HAP_CHAR_UUID_LOGS                                      "1F"
+#define HAP_CHAR_UUID_MANUFACTURER                              "20"
+#define HAP_CHAR_UUID_MODEL                                     "21"
+#define HAP_CHAR_UUID_MOTION_DETECTED                           "22"
+#define HAP_CHAR_UUID_NAME                                      "23"
+#define HAP_CHAR_UUID_OBSTRUCTION_DETECTED                      "24"
+#define HAP_CHAR_UUID_ON                                        "25"
+#define HAP_CHAR_UUID_OUTLET_IN_USE                             "26"
+#define HAP_CHAR_UUID_ROTATION_DIRECTION                        "28"
+#define HAP_CHAR_UUID_ROTATION_SPEED                            "29"
+#define HAP_CHAR_UUID_SATURATION                                "2F"
+#define HAP_CHAR_UUID_SERIAL_NUMBER                             "30"
+#define HAP_CHAR_UUID_TARGET_DOOR_STATE                         "32"
+#define HAP_CHAR_UUID_TARGET_HEATING_COOLING_STATE              "33"
+#define HAP_CHAR_UUID_TARGET_RELATIVE_HUMIDITY                  "34"
+#define HAP_CHAR_UUID_TARGET_TEMPERATURE                        "35"
+#define HAP_CHAR_UUID_TEMPERATURE_DISPLAY_UNITS                 "36"
+#define HAP_CHAR_UUID_VERSION                                   "37"
+#define HAP_CHAR_UUID_AIR_PARTICULATE_DENSITY                   "64"
+#define HAP_CHAR_UUID_AIR_PARTICULATE_SIZE                      "65"
+#define HAP_CHAR_UUID_SECURITY_SYSTEM_CURRENT_STATE             "66"
+#define HAP_CHAR_UUID_SECURITY_SYSTEM_TARGET_STATE              "67"
+#define HAP_CHAR_UUID_BATTERY_LEVEL                             "68"
+#define HAP_CHAR_UUID_CARBON_MONOXIDE_DETECTED                  "69"
+#define HAP_CHAR_UUID_CONTACT_SENSOR_STATE                      "6A"
+#define HAP_CHAR_UUID_CURRENT_AMBIENT_LIGHT_LEVEL               "6B"
+#define HAP_CHAR_UUID_CURRENT_HORIZONTAL_TILT_ANGLE             "6C"
+#define HAP_CHAR_UUID_CURRENT_POSITION                          "6D"
+#define HAP_CHAR_UUID_CURRENT_VERTICAL_TILT_ANGLE               "6E"
+#define HAP_CHAR_UUID_HOLD_POSITION                             "6F"
+#define HAP_CHAR_UUID_LEAK_DETECTED                             "70"
+#define HAP_CHAR_UUID_OCCUPANCY_DETECTED                        "71"
+#define HAP_CHAR_UUID_POSITION_STATE                            "72"
+#define HAP_CHAR_UUID_PROGRAMMABLE_SWITCH_EVENT                 "73"
+#define HAP_CHAR_UUID_STATUS_ACTIVE                             "75"
+#define HAP_CHAR_UUID_SMOKE_DETECTED                            "76"
+#define HAP_CHAR_UUID_STATUS_FAULT                              "77"
+#define HAP_CHAR_UUID_STATUS_JAMMED                             "78"
+#define HAP_CHAR_UUID_STATUS_LOW_BATTERY                        "79"
+#define HAP_CHAR_UUID_STATUS_TAMPERED                           "7A"
+#define HAP_CHAR_UUID_TARGET_HORIZONTAL_TILT_ANGLE              "7B"
+#define HAP_CHAR_UUID_TARGET_POSITION                           "7C"
+#define HAP_CHAR_UUID_TARGET_VERTICAL_TILT_ANGLE                "7D"
+#define HAP_CHAR_UUID_STATUS_SECURITY_SYSTEM_ALARM_TYPE         "8E"
+#define HAP_CHAR_UUID_CHARGING_STATE                            "8F"
+#define HAP_CHAR_UUID_CARBON_MONOXIDE_LEVEL                     "90"
+#define HAP_CHAR_UUID_CARBON_MONOXIDE_PEAK_LEVEL                "91"
+#define HAP_CHAR_UUID_CARBON_DIOXIDE_DETECTED                   "92"
+#define HAP_CHAR_UUID_CARBON_DIOXIDE_LEVEL                      "93"
+#define HAP_CHAR_UUID_CARBON_DIOXIDE_PEAK_LEVEL                 "94"
+#define HAP_CHAR_UUID_AIR_QUALITY                               "95"
+#define HAP_CHAR_UUID_ACCESSORY_FLAGS                           "A6"
+#define HAP_CHAR_UUID_LOCK_PHYSICAL_CONTROLS                    "A7"
+#define HAP_CHAR_UUID_CURRENT_AIR_PURIFIER_STATE                "A9"
+#define HAP_CHAR_UUID_CURRENT_SLAT_STATE                        "AA"
+#define HAP_CHAR_UUID_SLAT_TYPE                                 "C0"
+#define HAP_CHAR_UUID_FILTER_LIFE_LEVEL                         "AB"
+#define HAP_CHAR_UUID_FILTER_CHANGE_INDICATION                  "AC"
+#define HAP_CHAR_UUID_RESET_FILTER_INDICATION                   "AD"
+#define HAP_CHAR_UUID_TARGET_AIR_PURIFIER_STATE                 "A8"
+#define HAP_CHAR_UUID_TARGET_FAN_STATE                          "BF"
+#define HAP_CHAR_UUID_CURRENT_FAN_STATE                         "AF"
+#define HAP_CHAR_UUID_ACTIVE                                    "B0"
+#define HAP_CHAR_UUID_SWING_MODE                                "B6"
+#define HAP_CHAR_UUID_CURRENT_TILT_ANGLE                        "C1"
+#define HAP_CHAR_UUID_TARGET_TILT_ANGLE                         "C2"
+#define HAP_CHAR_UUID_OZONE_DENSITY                             "C3"
+#define HAP_CHAR_UUID_NITROGEN_DIOXIDE_DENSITY                  "C4"
+#define HAP_CHAR_UUID_SULPHUR_DIOXIDE_DENSITY                   "C5"
+#define HAP_CHAR_UUID_PM_2_5_DENSITY                            "C6"
+#define HAP_CHAR_UUID_PM_10_DENSITY                             "C7"
+#define HAP_CHAR_UUID_VOC_DENSITY                               "C8"
+#define HAP_CHAR_UUID_SERVICE_LABEL_INDEX                       "CB"
+#define HAP_CHAR_UUID_SERVICE_LABEL_NAMESPACE                   "CD"
+#define HAP_CHAR_UUID_COLOR_TEMPERATURE                         "CE"
+#define HAP_CHAR_UUID_CURRENT_HEATER_COOLER_STATE               "B1"
+#define HAP_CHAR_UUID_TARGET_HEATER_COOLER_STATE                "B2"
+#define HAP_CHAR_UUID_CURRENT_HUMIDIFIER_DEHUMIDIFIER_STATE     "B3"
+#define HAP_CHAR_UUID_TARGET_HUMIDIFIER_DEHUMIDIFIER_STATE      "B4"
+#define HAP_CHAR_UUID_WATER_LEVEL                               "B5"
+#define HAP_CHAR_UUID_RELATIVE_HUMIDITY_DEHUMIDIFIER_THRESHOLD  "C9"
+#define HAP_CHAR_UUID_RELATIVE_HUMIDITY_HUMIDIFIER_THRESHOLD    "CA"
+#define HAP_CHAR_UUID_PROGRAM_MODE                              "D1"
+#define HAP_CHAR_UUID_IN_USE                                    "D2"
+#define HAP_CHAR_UUID_SET_DURATION                              "D3"
+#define HAP_CHAR_UUID_REMAINING_DURATION                        "D4"
+#define HAP_CHAR_UUID_VALVE_TYPE                                "D5"
+#define HAP_CHAR_UUID_IS_CONFIGURED                             "D6"
+#define HAP_CHAR_UUID_PRODUCT_DATA                              "220"
+
+/** Create Brightness Characteristic
+ *
+ * This API creates the Brightness characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] brightness Initial value of brightness
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_brightness_create(int brightness);
+
+/** Cooling Threshold Temperature Characteristic
+ *
+ * This API creates the Cooling Threshold Temperature characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] cooling_threshold_temp Cooling Threshold Value of Cooling Threshold Temperature characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_cooling_threshold_temperature_create(float cooling_threshold_temp);
+
+/** Create Current Door State Characteristic
+ *
+ * This API creates the Current Door State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_door_state Initial value of Current Door State
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_door_state_create(uint8_t curr_door_state);
+
+/** Create Current Heating Cooling State Characteristic
+ *
+ * This API creates the Current Heating Cooling State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_heating_cooling_state Initial value of current heating cooling state characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_heating_cooling_state_create(uint8_t curr_heating_cooling_state);
+
+/** Current Relative Humidity Characteristic
+ *
+ * This API creates the Current Relative Humidity characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_rel_humidity Current Relative Humidity Value
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_relative_humidity_create(float curr_rel_humidity);
+
+/** Current Temperature Characteristic
+ *
+ * This API creates the Current Temperature characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_temp Initial value of current temperature characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_temperature_create(float curr_temp);
+
+/** Create Firmware Revision Characteristic
+ *
+ * This API creates the firmware revision characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] fw_rev Firmware Revision string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_firmware_revision_create(char *fw_rev);
+
+/** Create Hardware Revision Characteristic
+ *
+ * This API creates the name characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] hw_rev Hardware Revision string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_hardware_revision_create(char *hw_rev);
+
+/** Heating Threshold Temperature Characteristic
+ *
+ * This API creates the Heating Threshold Temperature characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] heating_threshold_temp Heating Threshold Value of Heating Threshold Temperature characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_heating_threshold_temperature_create(float heating_threshold_temp);
+
+/** Create Hue Characteristic
+ *
+ * This API creates the hue characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] hue Initial value of hue
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_hue_create(float hue);
+
+/** Create Identify Characteristic
+ *
+ * This API creates the Identify characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_identify_create(void);
+
+/** Lock Current State Characteristic
+ *
+ * This API creates the Lock Current State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_curr_state  Current lock state value of characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_current_state_create(uint8_t lock_curr_state);
+
+/** Lock Target State Characteristic
+ *
+ * This API creates the Lock Target State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_targ_state  Target lock state value of characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_target_state_create(uint8_t lock_targ_state);
+
+/** Create Manufacturer Characteristic
+ *
+ * This API creates the Manufacturer characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] manufacturer Manufacturer string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_manufacturer_create(char *manufacturer);
+
+/** Create Model Characteristic
+ *
+ * This API creates the Model characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] model Model string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_model_create(char *model);
+
+/** Create Motion Detected Characteristic
+ *
+ * This API creates the Motion Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] motion_detected   Value of Motion Detected Charateristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_motion_detected_create(bool motion_detected);
+
+/** Create Name Characteristic
+ *
+ * This API creates the Name characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] name Name string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_name_create(char *name);
+
+/** Create Obstruction Detected Characteristic
+ *
+ * This API creates the Obstruction Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] obstr_detect Initial value of obstruction detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_obstruction_detect_create(bool obstr_detect);
+
+/** Create On Characteristic
+ *
+ * This API creates the On characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] on Initial value of on
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_on_create(bool on);
+
+/** Create Outlet in Use Characteristic
+ *
+ * This API creates the Outlet in Use characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] outlet_in_use Initial value of outlet in use
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_outlet_in_use_create(bool outlet_in_use);
+
+/** Create Rotation Direction Characteristic
+ *
+ * This API creates the Rotation Direction characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] rotation_direction Initial value of Rotation Direction
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_rotation_direction_create(int rotation_direction);
+
+/** Create Rotation Speed Characteristic
+ *
+ * This API creates the Rotation Speed characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] rotation_speed Initial value of Rotation Speed
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_rotation_speed_create(float rotation_speed);
+
+/** Create Saturation Characteristic
+ *
+ * This API creates the saturation characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] saturation Initial value of saturation
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_saturation_create(float saturation);
+
+/** Create Serial Number Characteristic
+ *
+ * This API creates the serial number characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] serial_num Serial Number string
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_serial_number_create(char *serial_num);
+
+/** Create Target Door State Characteristic
+ *
+ * This API creates the Target Door State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_door_state Initial value of Target Door State
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_door_state_create(uint8_t targ_door_state);
+
+/** Create Target Heating Cooling State Characteristic
+ *
+ * This API creates the Target Heating Cooling State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_heating_cooling_state Value of target heating cooling state characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_heating_cooling_state_create(uint8_t targ_heating_cooling_state);
+
+/** Target Relative Humidity Characteristic
+ *
+ * This API creates the Target Relative Humidity characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_rel_humidity Target Relative Humidity Value
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_relative_humidity_create(float targ_rel_humidity);
+
+/** Target Temperature Characteristic
+ *
+ * This API creates the Target Temperature characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_temp Target value of target temperature characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_temperature_create(float targ_temp);
+
+/** Temperature Display Units Characteristic
+ *
+ * This API creates the Temperature Display Units characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] temp_disp_units Initial value of Temperature Display Units characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_temperature_display_units_create(uint8_t temp_disp_units);
+
+/** Create Version Characteristic
+ *
+ * This API creates the version characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] version Version String
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_version_create(char *version);
+
+/** Create Security System Current State Characteristic
+ *
+ * This API creates the Security System Current State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] security_sys_curr_state  Initial value of Security System Current State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_security_system_current_state_create(uint8_t security_sys_curr_state);
+
+/** Create Security System Target State Characteristic
+ *
+ * This API creates the Security System Target State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] security_sys_targ_state  Initial value of Security System Target State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_security_system_target_state_create(uint8_t security_sys_targ_state);
+
+/** Create Battery Level Characteristic
+ *
+ * This API creates the Battery Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] battery_level  Initial value of Battery Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_battery_level_create(uint8_t battery_level);
+
+/** Current Position Characteristic
+ *
+ * This API creates the Current Position characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_pos  Initial value of Cuurent Position characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_position_create(uint8_t curr_pos);
+
+/** Current Vertical Tilt Angle Characteristic
+ *
+ * This API creates the Current Vertical Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  curr_vert_tilt_angle Initial value of Current Vertical Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_vertical_tilt_angle_create(int curr_vert_tilt_angle);
+
+/** Hold Position Characteristic
+ *
+ * This API creates the Hold Position characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] hold_pos  Initial value of Hold Position characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_hold_position_create(bool hold_pos);
+
+/** Leak Detected Characteristic
+ *
+ * This API creates the Leak Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] leak_detected  Initial value of Leak Detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_leak_detected_create(uint8_t leak_detected);
+
+/** Occupancy Detected Characteristic
+ *
+ * This API creates the Occupancy Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] occupancy_detected  Initial value of Occupancy Detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_occupancy_detected_create(uint8_t occupancy_detected);
+
+/** Status Active Characteristic
+ *
+ * This API creates the Status Active characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] status_active  Initial value of Status Active characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_status_active_create(bool status_active);
+
+/** Smoke Detected Characteristic
+ *
+ * This API creates the Smoke Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] smoke_detected  Initial value of Smoke Detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_smoke_detected_create(uint8_t smoke_detected);
+
+/** Status Fault Characteristic
+ *
+ * This API creates the Status Fault characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] status_fault  Initial value of Status Fault characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_status_fault_create(uint8_t status_fault);
+
+/** Status Low Battery Characteristic
+ *
+ * This API creates the Status Low Battery characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] status_low_battery  Initial value of Status Low Battery characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_status_low_battery_create(uint8_t status_low_battery);
+
+/** Status Tampered Characteristic
+ *
+ * This API creates the Status Tampered characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] status_tampered  Initial value of Status Tampered characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_status_tampered_create(uint8_t status_tampered);
+
+/** Target Horizontal Tilt Angle Characteristic
+ *
+ * This API creates the Target Horizontal Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  targ_horiz_tilt_angle     Initial value of Target Horizontal Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_horizontal_tilt_angle_create(int targ_horiz_tilt_angle);
+
+/** Target Position Characteristic
+ *
+ * This API creates the Target Position characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_pos  Initial value of Target Position characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_position_create(uint8_t targ_pos);
+
+/** Target Vertical Tilt Angle Characteristic
+ *
+ * This API creates the Target Vertical Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  targ_vert_tilt_angle  Initial value of Target Vertical Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_vertical_tilt_angle_create(int targ_vert_tilt_angle);
+
+/** Security System Alarm Type Characteristic
+ *
+ * This API creates the Security System Alarm Type characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] security_sys_alarm_type  Initial value of Security System Alarm Type characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_security_system_alarm_type_create(uint8_t security_sys_alarm_type);
+
+/** Charging State Characteristic
+ *
+ * This API creates the Charging State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  charging_state   Charging State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_charging_state_create(uint8_t charging_state);
+
+/** Carbon Monoxide Level Characteristic
+ *
+ * This API creates the Carbon Monoxide Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_monoxide_level  Initial value of Carbon Monoxide Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_monoxide_level_create(float carbon_monoxide_level);
+
+/** Carbon Monoxide Peak Level Characteristic
+ *
+ * This API creates the Carbon Monoxide Peak Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_monoxide_peak_level  Initial value of Carbon Monoxide Peak Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_monoxide_peak_level_create(float carbon_monoxide_peak_level);
+
+/** Carbon Dioxide Detected Characteristic
+ *
+ * This API creates the Carbon Dioxide Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_dioxide_detected  Initial value of Carbon Dioxide Detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_dioxide_detected_create(uint8_t carbon_dioxide_detected);
+
+/** Carbon Dioxide Level Characteristic
+ *
+ * This API creates the Carbon Dioxide Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_dioxide_level  Initial value of Carbon Dioxide Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_dioxide_level_create(float carbon_dioxide_level);
+
+/** Carbon Dioxide Peak Level Characteristic
+ *
+ * This API creates the Carbon Dioxide Peak Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_dioxide_peak_level  Initial value of Carbon Dioxide Peak Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_dioxide_peak_level_create(float carbon_dioxide_peak_level);
+
+/** Carbon Monoxide Detected Characteristic
+ *
+ * This API creates the Carbon Monoxide Detected characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] carbon_monoxide_detected  Initial value of Carbon Monoxide Detected characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_carbon_monoxide_detected_create(uint8_t carbon_monoxide_detected);
+
+/** Contact Sensor State Characteristic
+ *
+ * This API creates the Contact Sensor State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] contact_sensor_state  Initial value of Contact Sensor State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_contact_sensor_state_create(uint8_t contact_sensor_state);
+
+/** Current Ambient Light Level Characteristic
+ *
+ * This API creates the Current Ambient Light Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  curr_ambient_light_level  Initial value of Current Ambient Light Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_ambient_light_level_create(float curr_ambient_light_level);
+
+/** Current Horizontal Tilt Angle Characteristic
+ *
+ * This API creates the Current Horizontal Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   curr_horiz_tilt_angle   Initial value of Current Horizontal Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_horizontal_tilt_angle_create(int curr_horiz_tilt_angle);
+
+/** Air Quality Characteristic
+ *
+ * This API creates the Air Quality characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] air_quality  Initial value of Air Quality characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_air_quality_create(uint8_t air_quality);
+
+/** Create Accessory Flags Characteristic
+ *
+ * This API creates the Accessory Flags characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] flags Initial value of flags
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_accessory_flags_create(uint32_t flags);
+
+
+/** Create Product Data Characteristic
+ *
+ * This API creates the Product Data characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] product_data Value of the product data
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_product_data_create(hap_data_val_t *product_data);
+
+/** Create Lock Physical Controls Characteristic
+ *
+ * This API creates the Lock Physical Controls characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_physical_controls Initial value of Lock Physical Controls characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_physical_controls_create(uint8_t lock_physical_controls);
+
+/** Current Air Purifier State Characteristic
+ *
+ * This API creates the Current Air Purifier State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   curr_air_purifier_state Initial value of Current Air Purifier State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_air_purifier_state_create(uint8_t curr_air_purifier_state);
+
+/** Current Slat State Characteristic
+ *
+ * This API creates the Current Slat State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_slat_state  Initial value of Current Slat State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_slat_state_create(uint8_t curr_slat_state);
+
+/** Slat Type Characteristic
+ *
+ * This API creates the Slat Type characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] slat_type  Value of Slat Type characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_slat_type_create(uint8_t slat_type);
+
+/** Filter Life Level Characteristic
+ *
+ * This API creates the Filter Life Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  filter_life_level  Initial value of Filter Life Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_filter_life_level_create(float filter_life_level);
+
+/** Current Filter Change Indication Characteristic
+ *
+ * This API creates the Filter Change Indication characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  filter_change_indication  Initial value of Filter Change Indication characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_filter_change_indication_create(uint8_t filter_change_indication);
+
+/** Reset Filter Indication Characteristic
+ *
+ * This API creates the Reset Filter Indication characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  reset_filter_indication  Initial value of Reset Filter Indication characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_reset_filter_indication_create(uint8_t reset_filter_indication);
+
+/** Target Air Purifier State Characteristic
+ *
+ * This API creates the Target Air Purifier State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   targ_air_purifier_state Initial value of Target Air Purifier State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_air_purifier_state_create(uint8_t targ_air_purifier_state);
+
+/** Target Fan State Characteristic
+ *
+ * This API creates the Target Fan State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   targ_fan_state  Initial value of Target Fan State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_fan_state_create(uint8_t targ_fan_state);
+
+/** Current Fan State Characteristic
+ *
+ * This API creates the Current Fan State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   curr_fan_state  Initial value of Current Fan State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_fan_state_create(uint8_t curr_fan_state);
+
+/** Position State Characteristic
+ *
+ * This API creates the Position State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] pos_state  Initial value of Position State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_position_state_create(uint8_t pos_state);
+
+/** Programmable Switch Event Characteristic
+ *
+ * This API creates the Programmable Switch Event characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] programmable_switch_event  Initial value of Programmable Switch Event characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_programmable_switch_event_create(uint8_t programmable_switch_event);
+
+/** Active Characteristic
+ *
+ * This API creates the Active characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   active  Initial value of active characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_active_create(uint8_t active);
+
+/** Swing Mode Characteristic
+ *
+ * This API creates the Swing Mode characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   swing_mode  Initial value of Swing Mode characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_swing_mode_create(uint8_t swing_mode);
+
+/** Current Tilt Angle Characteristic
+ *
+ * This API creates the Current Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   curr_tilt_angle Initial value of Current Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_tilt_angle_create(int curr_tilt_angle);
+
+/** Target Tilt Angle Characteristic
+ *
+ * This API creates the Target Tilt Angle characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]   targ_tilt_angle Initial value of Target Tilt Angle characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+ hap_char_t *hap_char_target_tilt_angle_create(int targ_tilt_angle);
+
+/** Ozone Density Characteristic
+ *
+ * This API creates the Ozone Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  ozone_density     Initial value of Ozone Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_ozone_density_create(float ozone_density);
+
+/** Nitrogen Dioxide Density Characteristic
+ *
+ * This API creates the Nitrogen Dioxide Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  nitrogen_dioxide_density  Initial value of Nitrogen Dioxide Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_nitrogen_dioxide_density_create(float nitrogen_dioxide_density);
+
+/** Sulphur Dioxide Density Characteristic
+ *
+ * This API creates the Sulphur Dioxide Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  sulphur_dioxide_density   Initial value of Sulphur Dioxide Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_sulphur_dioxide_density_create(float sulphur_dioxide_density);
+
+/** PM2.5 Density Characteristic
+ *
+ * This API creates the PM2.5 Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  pm_2_5_density    Initial value of PM2.5 Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_pm_2_5_density_create(float pm_2_5_density);
+
+/** PM10 Density Characteristic
+ *
+ * This API creates the PM10 Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  pm_10_density   Initial value of PM10 Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_pm_10_density_create(float pm_10_density);
+
+/** VOC Density Characteristic
+ *
+ * This API creates the VOC Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in]  voc_density   Initial value of VOC Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_voc_density_create(float voc_density);
+
+/** Create Service Label Index Characteristic
+ *
+ * This API creates the Service Label Index characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] service_label_index Initial value of Service Label Index characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_service_label_index_create(uint8_t service_label_index);
+
+/** Create Service Label Namespace Characteristic
+ *
+ * This API creates the Service Label Namespace characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] service_label_namespace Initial value of Service Label Namespace characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_service_label_namespace_create(uint8_t service_label_namespace);
+
+/** Create Color Temperature Characteristic
+ *
+ * This API creates the color temperature characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] color_temp Initial value of Color Temperature
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_color_temperature_create(uint32_t color_temp);
+
+/** Create Curr Heater Cooler State Characteristic
+ *
+ * This API creates the Curr Heater Cooler State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_heater_cooler_state  Initial value of Curr Heater Cooler State
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_heater_cooler_state_create(uint8_t curr_heater_cooler_state);
+
+/** Create Target Heater Cooler State Characteristic
+ *
+ * This API creates the Target Heater Cooler State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_heater_cooler_state  Initial value of Target Heater Cooler State
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_heater_cooler_state_create(uint8_t targ_heater_cooler_state);
+
+/** Create Current Humidifier Dehumidifier State Characteristic
+ *
+ * This API creates the Current Humidifier Dehumidifier State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] curr_humidifier_dehumidifier_state Initial value of Current Humidifier Dehumidifier State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_current_humidifier_dehumidifier_state_create(uint8_t curr_humidifier_dehumidifier_state);
+
+/** Create Target Humidifier Dehumidifier State Characteristic
+ *
+ * This API creates the Target Humidifier Dehumidifier State characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] targ_humidifier_dehumidifier_state Initial value of Target Humidifier Dehumidifier State characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_target_humidifier_dehumidifier_state_create(uint8_t targ_humidifier_dehumidifier_state);
+
+/** Create Water Level Characteristic
+ *
+ * This API creates the Water Level characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] water_level Initial value of Water Level characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_water_level_create(float water_level);
+
+/** Create Relative Humidity Dehumidifier Threshold Characteristic
+ *
+ * This API creates the Relative Humidity Dehumidifier Threshold characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] rel_humidity_dehumidifier_threshold Initial value of Relative Humidity Dehumidifier Threshold characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_relative_humidity_dehumidifier_threshold_create(float rel_humidity_dehumidifier_threshold);
+
+/** Create Relative Humidity Humidifier Threshold Characteristic
+ *
+ * This API creates the Relative Humidity Humidifier Threshold characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] rel_humidity_humidifier_threshold Initial value of Relative Humidity Humidifier Threshold characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_relative_humidity_humidifier_threshold_create(float rel_humidity_humidifier_threshold);
+
+/** Create Program Mode Characteristic
+ *
+ * This API creates the Program Mode characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] prog_mode Initial value of Program Mode characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_program_mode_create(uint8_t prog_mode);
+
+/** Create In Use Characteristic
+ *
+ * This API creates the In Use characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] in_use Initial value of In Use characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_in_use_create(uint8_t in_use);
+
+/** Create Set Duration Characteristic
+ *
+ * This API creates the Set Duration characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] set_duration Initial value of Set Duration characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_set_duration_create(uint32_t set_duration);
+
+/** Create Remaining Duration Characteristic
+ *
+ * This API creates the Remaining Duration characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] remaining_duration Initial value of Remaining Duration characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_remaining_duration_create(uint32_t remaining_duration);
+
+/** Create Valve Type Characteristic
+ *
+ * This API creates the Valve Type characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] valve_type Initial value of Valve Type characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_valve_type_create(uint8_t valve_type);
+
+/** Create Is Configured Characteristic
+ *
+ * This API creates the Is Configured characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] is_configured Initial value of Is Configured characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_is_configured_create(uint8_t is_configured);
+
+/** Status Jammed Characteristic
+ *
+ * This API creates the Status Jammed characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] status_jammed  Initial value of Status Jammed characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_status_jammed_create(uint8_t status_jammed);
+
+/** Administrator Only Access Characteristic
+ *
+ * This API creates the Administrator Only Access characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] administrator_only_access  Initial value of Administrator Only Access characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_administrator_only_access_create(bool administrator_only_access);
+
+/** Lock Control Point Characteristic
+ *
+ * This API creates the Lock Control Point characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_control_point  Initial value of Lock Control Point characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_control_point_create(hap_tlv8_val_t *lock_control_point);
+
+/** Lock Last Known Action Characteristic
+ *
+ * This API creates the Lock Last Known Action characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_last_known_action  Initial value of Lock Last Known Action characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_last_known_action_create(uint8_t lock_last_known_action);
+
+/** Lock Management Auto Security Timeout Characteristic
+ *
+ * This API creates the Lock Management Auto Security Timeout characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] lock_management_auto_security_timeout  Initial value of Lock Management Auto Security Timeout characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_lock_management_auto_security_timeout_create(uint32_t lock_management_auto_security_timeout);
+
+/** Logs Characteristic
+ *
+ * This API creates the Logs characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] logs  Initial value of Logs characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_logs_create(hap_tlv8_val_t *logs);
+
+/** Air Particulate Density Characteristic
+ *
+ * This API creates the Air Particulate Density characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] air_particulate_density  Initial value of Air Particulate Density characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_air_particulate_density_create(float air_particulate_density);
+
+/** Air Particulate Size Characteristic
+ *
+ * This API creates the Air Particulate Size characteristic object with other metadata
+ * (format, constraints, permissions, etc.) set as per the HAP Specs
+ *
+ * @param[in] air_particulate_size  Initial value of Air Particulate Size characteristic
+ *
+ * @return Pointer to the characteristic object on success
+ * @return NULL on failure
+ */
+hap_char_t *hap_char_air_particulate_size_create(uint8_t air_particulate_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_APPLE_CHARS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_apple_servs.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_apple_servs.c
@@ -1,0 +1,706 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <hap.h>
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+
+hap_serv_t *hap_serv_accessory_information_create(hap_acc_cfg_t *cfg)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_name_create(cfg->name)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (hap_serv_add_char(hs, hap_char_model_create(cfg->model)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (hap_serv_add_char(hs, hap_char_manufacturer_create(cfg->manufacturer)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (hap_serv_add_char(hs, hap_char_serial_number_create(cfg->serial_num)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (hap_serv_add_char(hs, hap_char_firmware_revision_create(cfg->fw_rev)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (hap_serv_add_char(hs, hap_char_identify_create()) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    if (cfg->hw_rev) {
+        if (hap_serv_add_char(hs, hap_char_hardware_revision_create(cfg->hw_rev)) != HAP_SUCCESS) {
+            goto err;
+        }
+    }
+
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_protocol_information_create(char *version)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_PROTOCOL_INFORMATION);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_version_create(version)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_fan_create(bool on)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_FAN);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_on_create(on)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_garage_door_opener_create(uint8_t curr_door_state, uint8_t targ_door_state, bool obstr_detect)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_GARAGE_DOOR_OPENER);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_door_state_create(curr_door_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_door_state_create(targ_door_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_obstruction_detect_create(obstr_detect)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_lightbulb_create(bool on)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_LIGHTBULB);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_on_create(on)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_lock_management_create(hap_tlv8_val_t *lock_control_point, char * version)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_LOCK_MANAGEMENT);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_lock_control_point_create(lock_control_point)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_version_create(version)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_lock_mechanism_create(uint8_t lock_curr_state, uint8_t lock_targ_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_LOCK_MECHANISM);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_lock_current_state_create(lock_curr_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_lock_target_state_create(lock_targ_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_outlet_create(bool on, bool outlet_in_use)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_OUTLET);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_on_create(on)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_outlet_in_use_create(outlet_in_use)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_switch_create(bool on)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_SWITCH);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_on_create(on)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_thermostat_create(uint8_t curr_heating_cooling_state, uint8_t targ_heating_cooling_state, float curr_temp,
+                                       float targ_temp, uint8_t temp_disp_units)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_THERMOSTAT);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_heating_cooling_state_create(curr_heating_cooling_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_heating_cooling_state_create(targ_heating_cooling_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_temperature_create(curr_temp)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_temperature_create(targ_temp)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_temperature_display_units_create(temp_disp_units)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_air_quality_sensor_create(uint8_t air_quality)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_AIR_QUALITY_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_air_quality_create(air_quality)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_security_system_create(uint8_t security_sys_curr_state, uint8_t security_sys_targ_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_SECURITY_SYSTEM);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_security_system_current_state_create(security_sys_curr_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_security_system_target_state_create(security_sys_targ_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_carbon_monoxide_sensor_create(uint8_t carbon_monoxide_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_CARBON_MONOXIDE_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_carbon_monoxide_detected_create(carbon_monoxide_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_contact_sensor_create(uint8_t contact_sensor_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_CONTACT_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_contact_sensor_state_create(contact_sensor_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_door_create(uint8_t curr_pos, uint8_t targ_pos, uint8_t pos_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_DOOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_position_create(curr_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_position_create(targ_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_position_state_create(pos_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_humidity_sensor_create(float curr_rel_humidity)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_HUMIDITY_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_relative_humidity_create(curr_rel_humidity)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_leak_sensor_create(uint8_t leak_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_LEAK_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_leak_detected_create(leak_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_light_sensor_create(float curr_ambient_light_level)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_LIGHT_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_ambient_light_level_create(curr_ambient_light_level)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_motion_sensor_create(bool motion_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_MOTION_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_motion_detected_create(motion_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_occupancy_sensor_create(uint8_t occupancy_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_OCCUPANCY_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_occupancy_detected_create(occupancy_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_smoke_sensor_create(uint8_t smoke_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_SMOKE_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_smoke_detected_create(smoke_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_stateless_programmable_switch_create(uint8_t programmable_switch_event)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_STATLESS_PROGRAMMABLE_SWITCH);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_programmable_switch_event_create(programmable_switch_event)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_temperature_sensor_create(float curr_temp)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_TEMPERATURE_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_temperature_create(curr_temp)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_window_create(uint8_t curr_pos, uint8_t targ_pos, uint8_t pos_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_WINDOW);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_position_create(curr_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_position_create(targ_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_position_state_create(pos_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_window_covering_create(uint8_t targ_pos, uint8_t curr_pos, uint8_t pos_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_WINDOW_COVERING);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_position_create(targ_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_position_create(curr_pos)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_position_state_create(pos_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_battery_service_create(uint8_t battery_level, uint8_t charging_state, uint8_t status_low_battery)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_BATTERY_SERVICE);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_battery_level_create(battery_level)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_charging_state_create(charging_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_status_low_battery_create(status_low_battery)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_carbon_dioxide_sensor_create(uint8_t carbon_dioxide_detected)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_CARBON_DIOXIDE_SENSOR);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_carbon_dioxide_detected_create(carbon_dioxide_detected)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_fan_v2_create(uint8_t active)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_FAN_V2);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_slat_create(uint8_t curr_slat_state, uint8_t slat_type)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_SLAT);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_slat_state_create(curr_slat_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_slat_type_create(slat_type)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_filter_maintenance_create(uint8_t filter_change_indication)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_FILTER_MAINTENANCE);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_filter_change_indication_create(filter_change_indication)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_air_purifier_create(uint8_t active, uint8_t curr_air_purifier_state, uint8_t
+        targ_air_purifier_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_AIR_PURIFIER);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_air_purifier_state_create(curr_air_purifier_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_air_purifier_state_create(targ_air_purifier_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_heater_cooler_create(uint8_t active, float curr_temp, uint8_t curr_heater_cooler_state, uint8_t targ_heater_cooler_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_HEATER_COOLER);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_temperature_create(curr_temp)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_heater_cooler_state_create(curr_heater_cooler_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_heater_cooler_state_create(targ_heater_cooler_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_humidifier_dehumidifier_create(uint8_t active, float curr_rel_humidity, uint8_t
+        curr_humid_dehumid_state, uint8_t targ_humid_dehumid_state)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_HUMIDIFIER_DEHUMIDIFIER);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_relative_humidity_create(curr_rel_humidity)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_current_humidifier_dehumidifier_state_create(curr_humid_dehumid_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_target_humidifier_dehumidifier_state_create(targ_humid_dehumid_state)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_service_label_create(uint8_t service_label_namespace)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_SERVICE_LABEL);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_service_label_namespace_create(service_label_namespace)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_irrigation_system_create(uint8_t active, uint8_t prog_mode, uint8_t in_use)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_IRRIGATION_SYSTEM);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_program_mode_create(prog_mode)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_in_use_create(in_use)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_valve_create(uint8_t active, uint8_t in_use, uint8_t valve_type)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_VALVE);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_in_use_create(in_use)) != HAP_SUCCESS) {
+        goto err;
+    }
+    if (hap_serv_add_char(hs, hap_char_valve_type_create(valve_type)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+
+hap_serv_t *hap_serv_faucet_create(uint8_t active)
+{
+    hap_serv_t *hs = hap_serv_create(HAP_SERV_UUID_FAUCET);
+    if (!hs) {
+        return NULL;
+    }
+    if (hap_serv_add_char(hs, hap_char_active_create(active)) != HAP_SUCCESS) {
+        goto err;
+    }
+    return hs;
+err:
+    hap_serv_delete(hs);
+    return NULL;
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/hap_apple_servs.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_apple_servs.h
@@ -1,0 +1,560 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/** HAP Apple Services
+ *
+ * This offers helper APIs for all the standard HomeKit Services defined by Apple
+ */
+#ifndef _HAP_APPLE_SERVS_H_
+#define _HAP_APPLE_SERVS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <hap.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HAP_SERV_UUID_ACCESSORY_INFORMATION         "3E"
+#define HAP_SERV_UUID_PROTOCOL_INFORMATION          "A2"
+#define HAP_SERV_UUID_FAN                           "40"
+#define HAP_SERV_UUID_GARAGE_DOOR_OPENER            "41"
+#define HAP_SERV_UUID_LIGHTBULB                     "43"
+#define HAP_SERV_UUID_LOCK_MANAGEMENT               "44"
+#define HAP_SERV_UUID_LOCK_MECHANISM                "45"
+#define HAP_SERV_UUID_SWITCH                        "49"
+#define HAP_SERV_UUID_OUTLET                        "47"
+#define HAP_SERV_UUID_THERMOSTAT                    "4A"
+#define HAP_SERV_UUID_AIR_QUALITY_SENSOR            "8D"
+#define HAP_SERV_UUID_SECURITY_SYSTEM               "7E"
+#define HAP_SERV_UUID_CARBON_MONOXIDE_SENSOR        "7F"
+#define HAP_SERV_UUID_CONTACT_SENSOR                "80"
+#define HAP_SERV_UUID_DOOR                          "81"
+#define HAP_SERV_UUID_HUMIDITY_SENSOR               "82"
+#define HAP_SERV_UUID_LEAK_SENSOR                   "83"
+#define HAP_SERV_UUID_LIGHT_SENSOR                  "84"
+#define HAP_SERV_UUID_MOTION_SENSOR                 "85"
+#define HAP_SERV_UUID_OCCUPANCY_SENSOR              "86"
+#define HAP_SERV_UUID_SMOKE_SENSOR                  "87"
+#define HAP_SERV_UUID_STATLESS_PROGRAMMABLE_SWITCH  "89"
+#define HAP_SERV_UUID_TEMPERATURE_SENSOR            "8A"
+#define HAP_SERV_UUID_WINDOW                        "8B"
+#define HAP_SERV_UUID_WINDOW_COVERING               "8C"
+#define HAP_SERV_UUID_BATTERY_SERVICE               "96"
+#define HAP_SERV_UUID_CARBON_DIOXIDE_SENSOR         "97"
+#define HAP_SERV_UUID_FAN_V2                        "B7"
+#define HAP_SERV_UUID_SLAT                          "B9"
+#define HAP_SERV_UUID_FILTER_MAINTENANCE            "BA"
+#define HAP_SERV_UUID_AIR_PURIFIER                  "BB"
+#define HAP_SERV_UUID_HEATER_COOLER                 "BC"
+#define HAP_SERV_UUID_HUMIDIFIER_DEHUMIDIFIER       "BD"
+#define HAP_SERV_UUID_SERVICE_LABEL                 "CC"
+#define HAP_SERV_UUID_IRRIGATION_SYSTEM             "CF"
+#define HAP_SERV_UUID_VALVE                         "D0"
+#define HAP_SERV_UUID_FAUCET                        "D7"
+
+/** Create Accessory Information Service
+ *
+ * This API will create the Accessory Information Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] cfg The accessory configuration to be used to create the service
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_accessory_information_create(hap_acc_cfg_t *cfg);
+
+/** Create Protocol Information Service
+ *
+ * This API will create the Protocol Information Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] version The Protocol Version string
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_protocol_information_create(char *version);
+
+/** Create Fan Service
+ *
+ * This API will create the Fan Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] on Initial "On" state of the service
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_fan_create(bool on);
+
+/** Create Garage Door Opener Service
+ *
+ * This API will create the Garage Door Opener Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] curr_door_state Initial value of the current door state characteristic
+ * @param[in] targ_door_state Value of the target door state characteristic
+ * @param[in] obstr_detect Value of the obstruction detected characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_garage_door_opener_create(uint8_t curr_door_state, uint8_t targ_door_state, bool obstr_detect)
+;
+
+/** Create Light Bulb Service
+ *
+ * This API will create the Light Bulb Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] on Initial "On" state of the service
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_lightbulb_create(bool on);
+
+/** Create Lock Management Service
+ *
+ * This API will create the Lock Management Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] lock_control_point Accepts data from TLV8 commands
+ * @param[in] version The Protocol Version string
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_lock_management_create(hap_tlv8_val_t *lock_control_point, char * version);
+
+/** Create Lock Mechanism Service
+ *
+ * This API will create the Lock Mechanism Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] lock_curr_state Current lock state of the service
+ * @param[in] lock_targ_state Target lock state of the service
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_lock_mechanism_create(uint8_t lock_curr_state, uint8_t lock_targ_state);
+
+/** Create Outlet Service
+ *
+ * This API will create the Outlet Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] on Initial "On" state of the service
+ * @param[in] outlet_in_use Initial value of the outlet in use characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_outlet_create(bool on, bool outlet_in_use);
+
+/** Create Switch Service
+ *
+ * This API will create the Switch Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] on Initial "On" state of the service
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_switch_create(bool on);
+
+/** Create Thermostat Service
+ *
+ * This API will create the Thermostat Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] curr_heating_cooling_state Initial value of Current Heating Cooling State characteristic
+ * @param[in] targ_heating_cooling_state Initial value of Target Heating Cooling State characteristic
+ * @param[in] curr_temp Initial value of Current Temperature characteristic
+ * @param[in] targ_temp Initial value of Target Temperature  characteristic
+ * @param[in] temp_disp_units Initial value of Temperature Display Units characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_thermostat_create(uint8_t curr_heating_cooling_state, uint8_t targ_heating_cooling_state, float curr_temp, float targ_temp, uint8_t temp_disp_units);
+
+/** Create Air Quality Sensor Service
+ *
+ * This API will create the Air Quality Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] air_quality Initial value of Air Quality characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_air_quality_sensor_create(uint8_t air_quality);
+
+/** Create Security System Current State Service
+ *
+ * This API will create the Security System Current State Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] security_sys_curr_state Initial value of Security System Current State characteristic
+ * @param[in] security_sys_targ_state Initial value of Security System Target State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_security_system_create(uint8_t security_sys_curr_state, uint8_t security_sys_targ_state);
+
+/** Create Carbon Monoxide Sensor Service
+ *
+ * This API will create the Carbon Monoxide Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] carbon_monoxide_detected Initial value of Carbon Monoxide Sensor characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_carbon_monoxide_sensor_create(uint8_t carbon_monoxide_detected);
+
+/** Create Contact Sensor Service
+ *
+ * This API will create the Contact Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] contact_sensor_state Initial value of Contact Sensor State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_contact_sensor_create(uint8_t contact_sensor_state);
+
+/** Create Door Service
+ *
+ * This API will create the Door Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  curr_pos   Initial value of Current Position characteristic
+ * @param[in]  targ_pos   Initial value of Target Position characteristic
+ * @param[in]  pos_state  Initial value of Position State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_door_create(uint8_t curr_pos, uint8_t targ_pos, uint8_t pos_state);
+
+/** Create Humidity Sensor Service
+ *
+ * This API will create the Humidity Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] curr_relative_humidity   Initial value of Humidity Sensor State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_humidity_sensor_create(float curr_relative_humidity);
+
+/** Leak Sensor Service
+ *
+ * This API will create the Leak Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] leak_detected   Initial value of Leak Detected State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_leak_sensor_create(uint8_t leak_detected);
+
+/** Light Sensor Service
+ *
+ * This API will create the Light Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] curr_ambient_light_level   Initial value of Current Ambient Light Level characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_light_sensor_create(float curr_ambient_light_level);
+
+/** Motion Sensor Service
+ *
+ * This API will create the Motion Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  motion_detected   Initial value of Motion Detected characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_motion_sensor_create(bool motion_detected);
+
+/** Occupancy Sensor Service
+ *
+ * This API will create the Occupancy Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  occupancy_detected   Initial value of Occupancy Detected characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_occupancy_sensor_create(uint8_t occupancy_detected);
+
+/** Smoke Sensor Service
+ *
+ * This API will create the Smoke Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  smoke_detected  Initial value of Smoke Detected characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_smoke_sensor_create(uint8_t smoke_detected);
+
+/** Stateless Programmable Switch Service
+ *
+ * This API will create the Stateless Programmable Switch Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  programmable_switch_event  Initial value of Programmable Switch Event characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_stateless_programmable_switch_create(uint8_t programmable_switch_event);
+
+/** Temperature Sensor Service
+ *
+ * This API will create the Temperature Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  curr_temp  Initial value of Current Temprature characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_temperature_sensor_create(float curr_temp);
+
+/** Window Service
+ *
+ * This API will create the Window Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  curr_pos   Initial value of Current Position characteristic
+ * @param[in]  targ_pos   Initial value of Target Position characteristic
+ * @param[in]  pos_state  Initial value of Position State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_window_create(uint8_t curr_pos, uint8_t targ_pos, uint8_t pos_state);
+
+/** Window Covering Service
+ *
+ * This API will create the Window Covering  Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  targ_pos   Initial value of Target Position characteristic
+ * @param[in]  curr_pos   Initial value of Current Position characteristic
+ * @param[in]  pos_state  Initial value of Position State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_window_covering_create(uint8_t targ_pos, uint8_t curr_pos, uint8_t pos_state);
+
+/** Battery Service
+ *
+ * This API will create the Battery Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in]  battery_level       Initial value of Battery Level characteristic
+ * @param[in]  charging_state      Initial value of Charging State characteristic
+ * @param[in]  status_low_battery  Initial value of Status Low Battery characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_battery_service_create(uint8_t battery_level, uint8_t charging_state, uint8_t status_low_battery);
+
+/** Create Carbon Dioxide Sensor Service
+ *
+ * This API will create the Carbon Dioxide Sensor Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] carbon_dioxide_detected Initial value of Carbon Dioxide Sensor characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_carbon_dioxide_sensor_create(uint8_t carbon_dioxide_detected);
+
+/** Fan v2 Service
+ *
+ * This API will create the Fan v2 Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active   Value of Active characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_fan_v2_create(uint8_t active);
+
+/** Slat Service
+ *
+ * This API will create the Slat Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] curr_slat_state   Value of Current Slat State characteristic
+ * @param[in] slat_type   Value of Slat Type characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_slat_create(uint8_t curr_slat_state, uint8_t slat_type);
+
+/** Filter Maintenance Service
+ *
+ * This API will create the Filter Maintenance Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] filter_change_indication  Value of Filter Change Indication characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_filter_maintenance_create(uint8_t filter_change_indication);
+
+/** Air Purifier Service
+ *
+ * This API will create the Air Purifier Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active Value of Active characteristic
+ * @param[in] curr_air_purifier_state Value of Current Air Purifier State characteristic
+ * @param[in] targ_air_purifier_state Value of Target Air Purifier State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_air_purifier_create(uint8_t active, uint8_t curr_air_purifier_state, uint8_t
+        targ_air_purifier_state);
+
+/** Heater Cooler Service
+ *
+ * This API will create the Heater Cooler Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active Value of Active characteristic
+ * @param[in] curr_temp Value of Current Temperature characteristic
+ * @param[in] curr_heater_cooler_state Value of Current Heater Cooler State characteristic
+ * @param[in] targ_heater_cooler_state Value of Target Heater Cooler State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_heater_cooler_create(uint8_t active, float curr_temp, uint8_t curr_heater_cooler_state, uint8_t targ_heater_cooler_state);
+
+/** Create Humidifer Dehumidfier Service
+ *
+ * This API will create the Humidifer Dehumidfier Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active  Initial value of Active characteristic
+ * @param[in] curr_rel_humid  Initial value of Current Relative Humidity characteristic
+ * @param[in] curr_humid_dehumid_state  Initial value of Current Humidifier Dehumidifier State characteristic
+ * @param[in] targ_humid_dehumid_state  Initial value of Target Humidifier Dehumidifier State characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_humidifier_dehumidifier_create(uint8_t active, float curr_rel_humid, uint8_t
+        curr_humid_dehumid_state, uint8_t targ_humid_dehumid_state);
+
+/** Create Service Label Service
+ *
+ * This API will create the Service Label Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] service_label_namespace Initial value of Service Label Service characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_service_label_create(uint8_t service_label_namespace);
+
+/** Create Irrigation System Service
+ *
+ * This API will create the Irrigation System Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active Initial value of active characteristic
+ * @param[in] prog_mode Initial value of Program Mode characteristic
+ * @param[in] in_use Initial value of In Use characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_irrigation_system_create(uint8_t active, uint8_t prog_mode, uint8_t in_use);
+
+/** Create Valve Service
+ *
+ * This API will create the Valve Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active      Initial value of active characteristic
+ * @param[in] in_use      Initial value of In Use characteristic
+ * @param[in] valve_type  Initial value of Valve Type characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_valve_create(uint8_t active, uint8_t in_use, uint8_t valve_type);
+
+/** Create Faucet Service
+ *
+ * This API will create the Faucet Service with the mandatory
+ * characteristics as per the HAP Specs.
+ *
+ * @param[in] active Initial value of active characteristic
+ *
+ * @return Pointer to the service object on success
+ * @return NULL on failure
+ */
+hap_serv_t *hap_serv_faucet_create(uint8_t active);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_APPLE_SERVS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_bct.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_bct.h
@@ -1,0 +1,54 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_BCT_H_
+#define _HAP_BCT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Change the name of the Bonjour Service for BCT
+ *
+ * This is required as per the "Manual Name Change" step of "Tester Interaction"
+ * section of Bonjour Conformance Test.
+ *
+ * @param[in] name The desired new name for the service. For BCT 1.4 or earlier: "New - Bonjour Service Name".
+ * For BCT 1.5 or later: "New-BCT"
+ */
+void hap_bct_change_name(const char *name);
+
+/**
+ * @brief Trigger a Hot plug of the network interface for BCT
+ *
+ * This is required as per the "Cable Change Handling" and "Hot Plugging" steps
+ * of "Tester Interaction" section of Bonjout Conformance Test
+ */
+void hap_bct_hot_plug();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HAP_BCT_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_httpd.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_httpd.c
@@ -1,0 +1,126 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <esp_http_server.h>
+#include <_esp_hap_config.h>
+
+httpd_handle_t *int_handle;
+int hap_platform_httpd_start(httpd_handle_t *handle)
+{
+    httpd_config_t config = {
+        .task_priority  = tskIDLE_PRIORITY+5,
+        .stack_size         = CONFIG_HAP_HTTP_STACK_SIZE,
+        .server_port        = CONFIG_HAP_HTTP_SERVER_PORT,
+        .ctrl_port          = CONFIG_HAP_HTTP_CONTROL_PORT,
+        .max_open_sockets   = CONFIG_HAP_HTTP_MAX_OPEN_SOCKETS,
+        .max_uri_handlers   = CONFIG_HAP_HTTP_MAX_URI_HANDLERS,
+        .max_resp_headers   = 8,
+        .backlog_conn       = 5,
+        .lru_purge_enable   = true,
+        .recv_wait_timeout  = 5,
+        .send_wait_timeout  = 5,
+    };
+    esp_err_t err =  httpd_start(handle, &config);
+    if (err == ESP_OK) {
+        int_handle = handle;
+    }
+    return err;
+}
+
+int hap_platform_httpd_stop(httpd_handle_t *handle)
+{
+    esp_err_t err = httpd_stop(*handle);
+    if (err == ESP_OK) {
+        int_handle = NULL;
+    }
+    return err;
+}
+
+int hap_platform_httpd_get_port()
+{
+    return CONFIG_HAP_HTTP_SERVER_PORT;
+}
+
+void * hap_platform_httpd_get_sess_ctx(httpd_req_t *req)
+{
+    if (req) {
+        return req->sess_ctx;
+    }
+    return NULL;
+}
+
+esp_err_t hap_platform_httpd_set_sess_ctx(httpd_req_t *req, void *ctx, httpd_free_ctx_fn_t free_ctx, bool ignore_ctx_changes)
+{
+    if (req) {
+        req->sess_ctx = ctx;
+        req->free_ctx =  free_ctx;
+#ifndef CONFIG_IDF_TARGET_ESP8266
+        req->ignore_sess_ctx_changes = ignore_ctx_changes;
+#endif
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+
+static char * hap_platform_httpd_rqtype_to_string(int method)
+{
+    switch (method) {
+        case HTTP_GET:
+            return "GET";
+        case HTTP_POST:
+            return "POST";
+        case HTTP_PUT:
+            return "PUT";
+        default:
+            return "INVALID";
+    }
+}
+
+const char *hap_platform_httpd_get_req_method(httpd_req_t *req)
+{
+    if (req) {
+        return hap_platform_httpd_rqtype_to_string(req->method);
+    }
+    return NULL;
+}
+
+const char *hap_platform_httpd_get_req_uri(httpd_req_t *req)
+{
+    if (req) {
+        return req->uri;
+    }
+    return NULL;
+}
+
+int hap_platform_httpd_get_content_len(httpd_req_t *req)
+{
+    if (req) {
+        return req->content_len;
+    }
+    return -1;
+}
+
+httpd_handle_t *hap_platform_httpd_get_handle()
+{
+    return int_handle;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_httpd.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_httpd.h
@@ -1,0 +1,136 @@
+
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PLATFORM_HTTPD_H_
+#define _HAP_PLATFORM_HTTPD_H_
+#include <esp_http_server.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Start the webserver
+ *
+ * This API will be called by the HAP Core to start the webserver.
+ *
+ * @param[out] handle Pointer to the handle that should be populated by this
+ * function on a success.
+ *
+ * @return ESP_OK on success
+ * @return error code otherwise
+ */
+int hap_platform_httpd_start(httpd_handle_t *handle);
+
+/** Stop the webserver
+ *
+ * This API will be called by the HAP Core to stop the webserver.
+ *
+ * @param[in] handle Pointer to the handle created in hap_platform_httpd_start
+ *
+ * @return ESP_OK on success
+ * @return error code otherwise
+ */
+int hap_platform_httpd_stop(httpd_handle_t *handle);
+
+/** Get the current HTTP Port
+ *
+ * This API will be called by the HAP Core to get the HTTP Port being used. This will
+ * be used for the mDNS announcement
+ *
+ * @return Configured HTTP Port
+ */
+int hap_platform_httpd_get_port();
+
+/** Get the HTTPD session context
+ *
+ * This API will be called by the HAP Core to get the context associated with a given
+ * session. It is generally used to maintain pairing information.
+ *
+ * @param[in] req HTTPD Request structure.
+ *
+ * @return pointer to the session context.
+ */
+void * hap_platform_httpd_get_sess_ctx(httpd_req_t *req);
+
+/** Set the HTTPD session context
+ *
+ * This API will be called by the HAP Core to set the context associated with a given
+ * session. It is generally used to maintain pairing information.
+ *
+ * @param[in] req HTTPD Request structure.
+ * @param[in] ctx The context to be set for the given session.
+ * @param[in] free_fn Pointer to a function that will be used by the HTTP Server to clear the context when the session closes
+ * @param[in] ignore_ctx_changes Flag to indicate if the HTTP Server should ignore changes to the context across different requests.
+ * If set to false, the server will try clearing the old context, if it detects any change.
+ *
+ * @return ESP_OK in success
+ * @return ESP_FAIL if req is nULL
+ */
+esp_err_t hap_platform_httpd_set_sess_ctx(httpd_req_t *req, void *ctx, httpd_free_ctx_fn_t free_ctx, bool ignore_ctx_changes);
+
+/** Get the HTTP request method
+ *
+ * This API will be called by the HAP Core to get the HTTP request method
+ * in string format (Eg. GET, POST, etc.)
+ *
+ * @param[in] HTTPD Request structure.
+ *
+ * @return Pointer to a string indicating the HTTP method.
+ */
+const char *hap_platform_httpd_get_req_method(httpd_req_t *req);
+
+/** Get the HTTP request URI
+ *
+ * This API will be called by the HAP Core to get the request URI string.
+ *
+ * @param[in] HTTPD Request structure.
+ *
+ * @return Pointer to the URI string.
+ */
+const char *hap_platform_httpd_get_req_uri(httpd_req_t *req);
+
+/** Get the HTTP request content length
+ *
+ * This API will be called by the HAP Core to get the content length of the request.
+ *
+ * @param[in] HTTPD Request structure.
+ *
+ * @return Content length.
+ */
+int hap_platform_httpd_get_content_len(httpd_req_t *req);
+
+/**
+ * Get the HAP HTTPD Handle
+ *
+ * If an application wants to register additional HTTPD endpoints on the same server
+ * instance being used by HomeKit, this API can be used to get the handle. This
+ * should be used only after hap_start().
+ *
+ * @return HomeKit HTTPD Handle
+ */
+httpd_handle_t *hap_platform_httpd_get_handle();
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _HAP_PLATFORM_HTTPD_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_keystore.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_keystore.c
@@ -1,0 +1,187 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <esp_log.h>
+#include <nvs_flash.h>
+#include <string.h>
+
+#define HAP_PLATFORM_DEF_NVS_PARTITION          "nvs"
+#define HAP_PLATFORM_DEF_FACTORY_NVS_PARTITION  "factory_nvs"
+
+static const char *TAG = "hap_platform_keystore";
+
+char * hap_platform_keystore_get_nvs_partition_name()
+{
+    return HAP_PLATFORM_DEF_NVS_PARTITION;
+}
+
+char * hap_platform_keystore_get_factory_nvs_partition_name()
+{
+    return HAP_PLATFORM_DEF_FACTORY_NVS_PARTITION;
+}
+
+#ifdef CONFIG_NVS_ENCRYPTION
+int hap_platform_keystore_init_partition(const char *part_name, bool read_only)
+{
+    esp_err_t err;
+    nvs_sec_cfg_t *cfg = NULL;
+    nvs_sec_cfg_t sec_cfg;
+    esp_partition_iterator_t iterator = esp_partition_find(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_NVS_KEYS, NULL);
+    if (iterator) {
+        const esp_partition_t *partition = esp_partition_get(iterator);
+        err = nvs_flash_read_security_cfg(partition, &sec_cfg);
+        if (err == ESP_OK) {
+            cfg = &sec_cfg;
+        } else {
+            ESP_LOGE(TAG, "No NVS keys found");
+        }
+    } else {
+        ESP_LOGE(TAG, "No NVS keys partition found");
+    }
+    if (!cfg) {
+        ESP_LOGE(TAG, "NVS partition '%s' not encrypted", part_name);
+    } else {
+        ESP_LOGI(TAG, "NVS partition '%s' is encrypted", part_name);
+    }
+    if (read_only) {
+        err = nvs_flash_secure_init_partition(part_name, cfg);
+    } else {
+        err = nvs_flash_secure_init_partition(part_name, cfg);
+        if (err == ESP_ERR_NVS_NO_FREE_PAGES) {
+            ESP_ERROR_CHECK(nvs_flash_erase_partition(part_name));
+            err = nvs_flash_secure_init_partition(part_name, cfg);
+        }
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+#else
+int hap_platform_keystore_init_partition(const char *part_name, bool read_only)
+{
+    esp_err_t err;
+    if (read_only) {
+        err = nvs_flash_init_partition(part_name);
+    } else {
+        err = nvs_flash_init_partition(part_name);
+        if (err == ESP_ERR_NVS_NO_FREE_PAGES) {
+            ESP_ERROR_CHECK(nvs_flash_erase_partition(part_name));
+            err = nvs_flash_init_partition(part_name);
+        }
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+#endif /* CONFIG_NVS_ENCRYPTION */
+
+int hap_platform_keystore_get(const char *part_name, const char *name_space, const char *key, uint8_t *val, size_t *val_size)
+{
+    nvs_handle handle;
+    esp_err_t err = nvs_open_from_partition(part_name, name_space, NVS_READONLY, &handle);
+    if (err != ESP_OK) {
+        return -1;
+    } else {
+        err = nvs_get_blob(handle, key, val, val_size);
+        nvs_close(handle);
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+
+int hap_platform_keystore_set(const char *part_name, const char *name_space, const char *key, const uint8_t *val, const size_t val_len)
+
+{
+    nvs_handle handle;
+    esp_err_t err = nvs_open_from_partition(part_name, name_space, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error (%d) opening NVS handle!", err);
+    } else {
+        err = nvs_set_blob(handle, key, val, val_len);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to write %s", key);
+        } else {
+            nvs_commit(handle);
+        }
+        nvs_close(handle);
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+
+int hap_platform_keystore_delete(const char *part_name, const char *name_space, const char *key)
+{
+    nvs_handle handle;
+    esp_err_t err = nvs_open_from_partition(part_name, name_space, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error (%d) opening NVS handle!", err);
+    } else {
+        err = nvs_erase_key(handle, key);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to delete %s", key);
+        } else {
+            nvs_commit(handle);
+        }
+        nvs_close(handle);
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+
+int hap_platform_keystore_delete_namespace(const char *part_name, const char *name_space)
+{
+    nvs_handle handle;
+    esp_err_t err = nvs_open_from_partition(part_name, name_space, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Error (%d) opening NVS handle!", err);
+    } else {
+        err = nvs_erase_all(handle);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to delete %s", name_space);
+        } else {
+            nvs_commit(handle);
+        }
+        nvs_close(handle);
+    }
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}
+
+int hap_platfrom_keystore_erase_partition(const char *part_name)
+{
+    esp_err_t err = nvs_flash_erase_partition(part_name);
+    if (err == ESP_OK) {
+        return 0;
+    }
+    return -1;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_keystore.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_keystore.h
@@ -1,0 +1,115 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_PLATFORM_KEYSTORE_H_
+#define _HAP_PLATFORM_KEYSTORE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Get NVS Partition Name
+ *
+ * @return pointer to an allocated string indicating NVS partition Name
+ */
+char * hap_platform_keystore_get_nvs_partition_name();
+
+
+/** Get Factory NVS Partition Name
+ *
+ * @return pointer to an allocated string indicating Factory NVS partition Name
+ */
+char * hap_platform_keystore_get_factory_nvs_partition_name();
+
+/** Initialise Key Store Partition
+ *
+ * @param[in] part_name Name of Partition
+ * @param[in] read_only True for Read-Only, False for Read-Write
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platform_keystore_init_partition(const char *part_name, bool read_only);
+
+/** Get Value from Key Store
+ *
+ * @param[in] part_name Name of Partition
+ * @param[in] name_space Name space for the key
+ * @param[in] key Name of the key
+ * @param[out] val Allocated buffer into which the value will be read
+ * @param[in,out] val_size Size of the allocated value buffer. Will hold the size of value read on success
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platform_keystore_get(const char *part_name, const char *name_space, const char *key, uint8_t *val, size_t *val_size);
+
+/** Set Value in Key Store
+ *
+ * @param[in] part_name Name of Partition
+ * @param[in] name_space Name space for the key
+ * @param[in] key Name of the key
+ * @param[in] val Pointer to the value buffer
+ * @param[in] val_len Length of the value buffer
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platform_keystore_set(const char *part_name, const char *name_space, const char *key, const uint8_t *val, const size_t val_len);
+
+/** Delete Entry from Key Store
+ *
+ * @param[in] part_name Name of Partition
+ * @param[in] name_space Name space for the key
+ * @param[in] key Name of the key
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platform_keystore_delete(const char *part_name, const char *name_space, const char *key);
+
+/** Delete Name space from Key Store
+ *
+ * @param[in] part_name Name of Partition
+ * @param[in] name_space Name space for the key
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platform_keystore_delete_namespace(const char *part_name, const char *name_space);
+
+/** Erase a Key Store partition
+ *
+ * @param[in] part_name Name of Partition
+ *
+ * @return 0 on success
+ * @return -1 on error
+ */
+int hap_platfrom_keystore_erase_partition(const char *part_name);
+#ifdef __cplusplus
+}
+#endif
+#endif /* _HAP_PLATFORM_KEYSTORE_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_memory.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_memory.c
@@ -1,0 +1,39 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdlib.h>
+
+void * hap_platform_memory_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void * hap_platform_memory_calloc(size_t count, size_t size)
+{
+    return calloc(count, size);
+}
+
+void hap_platform_memory_free(void *ptr)
+{
+    free(ptr);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_memory.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_memory.h
@@ -1,0 +1,67 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PLATFORM_MEMORY_H_
+#define _HAP_PLATFORM_MEMORY_H_
+#include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** Allocate memory
+ *
+ * This API allocates "size" bytes of memory and returns a pointer to the allocated memory.
+ *
+ * @param[in] size Number of bytes to be allocated
+ *
+ * @return pointer to the allocated memory
+ * @return NULL on failure
+ */
+void * hap_platform_memory_malloc(size_t size);
+
+/** Allocate contiguous memory for items
+ *
+ * This API contiguously allocates enough space for "count" objects that are "size" bytes of memory each
+ * and returns a pointer to the allocated memory.  The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] count Number of items
+ * @param[in] size Size of each item
+ *
+ * @return pointer to the allocated memory
+ * @return NULL on failure
+ */
+void * hap_platform_memory_calloc(size_t count, size_t size);
+
+/** Free allocate memory
+ *
+ * This API frees the memory allocated by hap_platform_memory_malloc() or hap_platform_memory_calloc()
+ *
+ * @param[in] ptr Pointer to the allocated memory
+ */
+void hap_platform_memory_free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _HAP_PLATFORM_MEMORY_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_os.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_os.c
@@ -1,0 +1,32 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdint.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/FreeRTOSConfig.h>
+#include <freertos/portmacro.h>
+
+uint16_t hap_platform_os_get_msec_per_tick()
+{
+    return portTICK_PERIOD_MS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hap_platform_os.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_platform_os.h
@@ -1,0 +1,41 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef _HAP_PLATFORM_OS_H_
+#define _HAP_PLATFORM_OS_H_
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** Return the OS tick period in milliseconds
+ *
+ * @return the milliseconds per tick as configured for the OS
+ */
+uint16_t hap_platform_os_get_msec_per_tick();
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _HAP_PLATFORM_OS_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hap_wac.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hap_wac.h
@@ -1,0 +1,121 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2020 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _HAP_WAC_H_
+#define _HAP_WAC_H_
+#include <stdint.h>
+#include <esp_event.h>
+#include <esp_wifi.h>
+#include <esp_err.h>
+/** HomeKit Event Base */
+ESP_EVENT_DECLARE_BASE(HAP_WAC_EVENT);
+/** HomeKit Events */
+typedef enum {
+    /* WAC has started. Associated data is NULL */
+    HAP_WAC_EVENT_STARTED,
+    /** WAC has timed out because of inactivity. Associated data is NULL.
+     * Appropriate indications should be given to the user, so that the accessory can be rebooted
+     * for restarting WAC.
+     */
+    HAP_WAC_EVENT_TIMEOUT,
+    /** WAC was successful and will stop after some time. Associated data is NULL.
+     */
+    HAP_WAC_EVENT_SUCCESS,
+    /** WAC is requesting to start SoftAP. Associated data is a pointer to a NULL terminated SSID.
+     * Using this SSID isn't required, but recommended. The network security should be "Open" for
+     * WAC to work. If SoftAP has already been started, nothing needs to be done for this event.
+     * The helper function hap_wifi_softap_start() can be used for this.
+     */
+    HAP_WAC_EVENT_REQ_SOFTAP_START,
+    /** WAC is requesting to stop SoftAP. Associated data is NULL.
+     * The helper function hap_wifi_softap_stop() can be used for this.
+     */
+    HAP_WAC_EVENT_REQ_SOFTAP_STOP,
+    /** WAC has received the Wi-Fi credentials. Associated data is a pointer to wifi_config_t
+     * structure. This should be used to connect to the Wi-Fi network.
+     * The helper function hap_wifi_sta_connect() can be used for this.
+     */
+    HAP_WAC_EVENT_RECV_CRED,
+    /** WAC has stopped */
+    HAP_WAC_EVENT_STOPPED
+} hap_wac_event_t;
+
+/** Start WAC Provisioning.
+ *
+ * This should be called when the accessory boots up in an unprovisioned mode.
+ * The helper function hap_wifi_is_provisioned() function can be used to find
+ * if the accessory is provisioned or not.
+ *
+ * @return 0 on success.
+ * @return -1 on failure.
+ */
+int hap_wac_start(void);
+
+/** Stop WAC Provisioning.
+ *
+ * This should be used only if WAC needs to be stopped explicitly (say, after
+ * provisioning was done using some other means). Else, WAC stops automatically,
+ * either after the timeout or after successful provisioning.
+ *
+ * @return 0 on success.
+ * @return -1 on failure.
+ */
+int hap_wac_stop(void);
+
+/** Check is accessory is provisioned
+ *
+ * @param[out] provisioned Pointer to an allocated boolean variable. Will
+ *      be set to true if accessory is provisioned, else false.
+ *
+ * @return ESP_OK on success.
+ * @return error on failure.
+ */
+esp_err_t hap_wifi_is_provisioned(bool *provisioned);
+
+/** Start SoftAP
+ *
+ * @param[in] ssid NULL terminated ssid string.
+ *
+ * @return ESP_OK on success.
+ * @return error on failure.
+ */
+esp_err_t hap_wifi_softap_start(char *ssid);
+
+/** Stop Soft AP
+ *
+ * @return ESP_OK on success.
+ * @return error on failure.
+ */
+esp_err_t hap_wifi_softap_stop(void);
+
+/** Connect to Wi-Fi network with given configuration
+ *
+ * @param[in] config Pointer to \ref wifi_config_t structure.
+ *
+ * @return ESP_OK on success.
+ * @return error on failure.
+ */
+esp_err_t hap_wifi_sta_connect(wifi_config_t *config);
+
+#endif /* _HAP_WAC_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hexbin.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hexbin.c
@@ -1,0 +1,51 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <hexbin.h>
+static int hex2bin_byte(uint8_t *byte)
+{
+    if (*byte >= '0' && *byte <= '9')
+        *byte -= '0';
+    else if (*byte >= 'a' && *byte <= 'f')
+        *byte -= ('a' - 0x0a);
+    else if (*byte >= 'A' && *byte <= 'F')
+        *byte -= ('A' - 0x0a);
+    else
+        return -1;
+    return 0;
+}
+
+int hex2bin(const char *ihex, size_t ilen, uint8_t *obin, size_t *olen)
+{
+    if (ilen > (2 * (*olen))) {
+        return -1;
+    } else if (ilen % 2) {
+        return -1;
+    }
+    int i, j;
+    uint8_t byte;
+    for (i = 0, j = 0; i < ilen / 2; i++) {
+       byte = ihex[j++];
+       if (hex2bin_byte(&byte) < 0) {
+           return -1;
+       }
+       obin[i] = (byte << 4);
+       byte = ihex[j++];
+       if (hex2bin_byte(&byte) < 0) {
+           return -1;
+       }
+       obin[i] |= byte;
+    }
+    *olen = i;
+    return 0;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/hexbin.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hexbin.h
@@ -1,0 +1,19 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef _HEXBIN_H_
+#define _HEXBIN_H_
+#include <stdint.h>
+#include <stddef.h>
+int hex2bin(const char *ihex, size_t ilen, uint8_t *obin, size_t *olen);
+#endif /* _HEXBIN_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hexdump.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hexdump.c
@@ -1,0 +1,34 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <stdio.h>
+
+//#define HEX_DBG_ENABLE
+
+#ifdef HEX_DBG_ENABLE
+void hex_dbg_with_name(char *name, unsigned char *buf, int buf_len)
+{
+	int i;
+	printf("%s: ", name);
+	for (i = 0; i < buf_len; i++) {
+		if (i % 16 == 0)
+			printf("\r\n");
+		printf("%02x ", buf[i]);
+	}
+	printf("\r\n");
+}
+#else
+void hex_dbg_with_name(char *name, unsigned char *buf, int buf_len)
+{
+}
+#endif /* HEX_DBG_ENABLED */

--- a/lib/libesp32/ESP32-HomeKit/src/hexdump.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hexdump.h
@@ -1,0 +1,18 @@
+// Copyright 2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef _HEXDUMP_H_
+#define _HEXDUMP_H_
+void hex_dbg_with_name(char *name, unsigned char *buf, int buf_len);
+
+#endif /* _HEXDUMP_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/hkdf-sha.h
+++ b/lib/libesp32/ESP32-HomeKit/src/hkdf-sha.h
@@ -1,0 +1,358 @@
+/**************************** sha.h ****************************/
+/***************** See RFC 6234 for details. *******************/
+/*
+   Copyright (c) 2011 IETF Trust and the persons identified as
+   authors of the code.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or
+   without modification, are permitted provided that the following
+   conditions are met:
+
+   - Redistributions of source code must retain the above
+     copyright notice, this list of conditions and
+     the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   - Neither the name of Internet Society, IETF or IETF Trust, nor
+     the names of specific contributors, may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef _SHA_H_
+#define _SHA_H_
+
+/*
+ *  Description:
+ *      This file implements the Secure Hash Algorithms
+ *      as defined in the U.S. National Institute of Standards
+ *      and Technology Federal Information Processing Standards
+ *      Publication (FIPS PUB) 180-3 published in October 2008
+ *      and formerly defined in its predecessors, FIPS PUB 180-1
+ *      and FIP PUB 180-2.
+ *
+ *      A combined document showing all algorithms is available at
+ *              http://csrc.nist.gov/publications/fips/
+ *                     fips180-3/fips180-3_final.pdf
+ *
+ *      The five hashes are defined in these sizes:
+ *              SHA-1           20 byte / 160 bit
+ *              SHA-224         28 byte / 224 bit
+ *              SHA-256         32 byte / 256 bit
+ *              SHA-384         48 byte / 384 bit
+ *              SHA-512         64 byte / 512 bit
+ *
+ *  Compilation Note:
+ *    These files may be compiled with two options:
+ *        USE_32BIT_ONLY - use 32-bit arithmetic only, for systems
+ *                         without 64-bit integers
+ *
+ *        USE_MODIFIED_MACROS - use alternate form of the SHA_Ch()
+ *                         and SHA_Maj() macros that are equivalent
+ *                         and potentially faster on many systems
+ *
+ */
+
+#include <stdint.h>
+/*
+ * If you do not have the ISO standard stdint.h header file, then you
+ * must typedef the following:
+ *    name              meaning
+ *  uint64_t         unsigned 64-bit integer
+ *  uint32_t         unsigned 32-bit integer
+ *  uint8_t          unsigned 8-bit integer (i.e., unsigned char)
+ *  int_least16_t    integer of >= 16 bits
+ *
+ * See stdint-example.h
+ */
+
+#ifndef _SHA_enum_
+#define _SHA_enum_
+/*
+ *  All SHA functions return one of these values.
+ */
+enum {
+    shaSuccess = 0,
+    shaNull,            /* Null pointer parameter */
+    shaInputTooLong,    /* input data too long */
+    shaStateError,      /* called Input after FinalBits or Result */
+    shaBadParam         /* passed a bad parameter */
+};
+#endif /* _SHA_enum_ */
+
+/*
+ *  These constants hold size information for each of the SHA
+ *  hashing operations
+ */
+enum {
+    SHA1_Message_Block_Size = 64, SHA224_Message_Block_Size = 64,
+    SHA256_Message_Block_Size = 64, SHA384_Message_Block_Size = 128,
+    SHA512_Message_Block_Size = 128,
+    USHA_Max_Message_Block_Size = SHA512_Message_Block_Size,
+
+    SHA1HashSize = 20, SHA224HashSize = 28, SHA256HashSize = 32,
+    SHA384HashSize = 48, SHA512HashSize = 64,
+    USHAMaxHashSize = SHA512HashSize,
+
+    SHA1HashSizeBits = 160, SHA224HashSizeBits = 224,
+    SHA256HashSizeBits = 256, SHA384HashSizeBits = 384,
+    SHA512HashSizeBits = 512, USHAMaxHashSizeBits = SHA512HashSizeBits
+};
+
+/*
+ *  These constants are used in the USHA (Unified SHA) functions.
+ */
+typedef enum SHAversion {
+    SHA1, SHA224, SHA256, SHA384, SHA512
+} SHAversion;
+
+/*
+ *  This structure will hold context information for the SHA-1
+ *  hashing operation.
+ */
+typedef struct SHA1Context {
+    uint32_t Intermediate_Hash[SHA1HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA1_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA1Context;
+
+/*
+ *  This structure will hold context information for the SHA-256
+ *  hashing operation.
+ */
+typedef struct SHA256Context {
+    uint32_t Intermediate_Hash[SHA256HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA256_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA256Context;
+
+/*
+ *  This structure will hold context information for the SHA-512
+ *  hashing operation.
+ */
+typedef struct SHA512Context {
+#ifdef USE_32BIT_ONLY
+    uint32_t Intermediate_Hash[SHA512HashSize/4]; /* Message Digest  */
+    uint32_t Length[4];                 /* Message length in bits */
+#else /* !USE_32BIT_ONLY */
+    uint64_t Intermediate_Hash[SHA512HashSize/8]; /* Message Digest */
+    uint64_t Length_High, Length_Low;   /* Message length in bits */
+#endif /* USE_32BIT_ONLY */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 1024-bit message blocks */
+    uint8_t Message_Block[SHA512_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed?*/
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA512Context;
+
+/*
+ *  This structure will hold context information for the SHA-224
+ *  hashing operation.  It uses the SHA-256 structure for computation.
+ */
+typedef struct SHA256Context SHA224Context;
+
+/*
+ *  This structure will hold context information for the SHA-384
+ *  hashing operation.  It uses the SHA-512 structure for computation.
+ */
+typedef struct SHA512Context SHA384Context;
+
+/*
+ *  This structure holds context information for all SHA
+ *  hashing operations.
+ */
+typedef struct USHAContext {
+    int whichSha;               /* which SHA is being used */
+    union {
+      SHA1Context sha1Context;
+      SHA224Context sha224Context; SHA256Context sha256Context;
+      SHA384Context sha384Context; SHA512Context sha512Context;
+    } ctx;
+
+} USHAContext;
+
+/*
+ *  This structure will hold context information for the HMAC
+ *  keyed-hashing operation.
+ */
+typedef struct HMACContext {
+    int whichSha;               /* which SHA is being used */
+    int hashSize;               /* hash size of SHA being used */
+    int blockSize;              /* block size of SHA being used */
+    USHAContext shaContext;     /* SHA context */
+    unsigned char k_opad[USHA_Max_Message_Block_Size];
+                        /* outer padding - key XORd with opad */
+    int Computed;               /* Is the MAC computed? */
+    int Corrupted;              /* Cumulative corruption code */
+
+} HMACContext;
+
+/*
+ *  This structure will hold context information for the HKDF
+ *  extract-and-expand Key Derivation Functions.
+ */
+typedef struct HKDFContext {
+    int whichSha;               /* which SHA is being used */
+    HMACContext hmacContext;
+    int hashSize;               /* hash size of SHA being used */
+    unsigned char prk[USHAMaxHashSize];
+                        /* pseudo-random key - output of hkdfInput */
+    int Computed;               /* Is the key material computed? */
+    int Corrupted;              /* Cumulative corruption code */
+} HKDFContext;
+
+/*
+ *  Function Prototypes
+ */
+
+/* SHA-1 */
+extern int SHA1Reset(SHA1Context *);
+extern int SHA1Input(SHA1Context *, const uint8_t *bytes,
+                     unsigned int bytecount);
+extern int SHA1FinalBits(SHA1Context *, uint8_t bits,
+                         unsigned int bit_count);
+extern int SHA1Result(SHA1Context *,
+                      uint8_t Message_Digest[SHA1HashSize]);
+
+/* SHA-224 */
+extern int SHA224Reset(SHA224Context *);
+extern int SHA224Input(SHA224Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA224FinalBits(SHA224Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA224Result(SHA224Context *,
+                        uint8_t Message_Digest[SHA224HashSize]);
+
+/* SHA-256 */
+extern int SHA256Reset(SHA256Context *);
+extern int SHA256Input(SHA256Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA256FinalBits(SHA256Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA256Result(SHA256Context *,
+                        uint8_t Message_Digest[SHA256HashSize]);
+
+/* SHA-384 */
+extern int SHA384Reset(SHA384Context *);
+extern int SHA384Input(SHA384Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA384FinalBits(SHA384Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA384Result(SHA384Context *,
+                        uint8_t Message_Digest[SHA384HashSize]);
+
+/* SHA-512 */
+extern int SHA512Reset(SHA512Context *);
+extern int SHA512Input(SHA512Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA512FinalBits(SHA512Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA512Result(SHA512Context *,
+                        uint8_t Message_Digest[SHA512HashSize]);
+
+/* Unified SHA functions, chosen by whichSha */
+extern int USHAReset(USHAContext *context, SHAversion whichSha);
+extern int USHAInput(USHAContext *context,
+                     const uint8_t *bytes, unsigned int bytecount);
+extern int USHAFinalBits(USHAContext *context,
+                         uint8_t bits, unsigned int bit_count);
+extern int USHAResult(USHAContext *context,
+                      uint8_t Message_Digest[USHAMaxHashSize]);
+extern int USHABlockSize(enum SHAversion whichSha);
+extern int USHAHashSize(enum SHAversion whichSha);
+extern int USHAHashSizeBits(enum SHAversion whichSha);
+extern const char *USHAHashName(enum SHAversion whichSha);
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows a fixed-length text input to be used.
+ */
+extern int hmac(SHAversion whichSha, /* which SHA algorithm to use */
+    const unsigned char *text,     /* pointer to data stream */
+    int text_len,                  /* length of data stream */
+    const unsigned char *key,      /* pointer to authentication key */
+    int key_len,                   /* length of authentication key */
+    uint8_t digest[USHAMaxHashSize]); /* caller digest to fill in */
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hmacReset(HMACContext *context, enum SHAversion whichSha,
+                     const unsigned char *key, int key_len);
+extern int hmacInput(HMACContext *context, const unsigned char *text,
+                     int text_len);
+extern int hmacFinalBits(HMACContext *context, uint8_t bits,
+                         unsigned int bit_count);
+extern int hmacResult(HMACContext *context,
+                      uint8_t digest[USHAMaxHashSize]);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ */
+extern int hkdf(SHAversion whichSha, const unsigned char *salt,
+                int salt_len, const unsigned char *ikm, int ikm_len,
+                const unsigned char *info, int info_len,
+                uint8_t okm[ ], int okm_len);
+extern int hkdfExtract(SHAversion whichSha, const unsigned char *salt,
+                       int salt_len, const unsigned char *ikm,
+                       int ikm_len, uint8_t prk[USHAMaxHashSize]);
+extern int hkdfExpand(SHAversion whichSha, const uint8_t prk[ ],
+                      int prk_len, const unsigned char *info,
+                      int info_len, uint8_t okm[ ], int okm_len);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hkdfReset(HKDFContext *context, enum SHAversion whichSha,
+                     const unsigned char *salt, int salt_len);
+extern int hkdfInput(HKDFContext *context, const unsigned char *ikm,
+                     int ikm_len);
+extern int hkdfFinalBits(HKDFContext *context, uint8_t ikm_bits,
+                         unsigned int ikm_bit_count);
+extern int hkdfResult(HKDFContext *context,
+                      uint8_t prk[USHAMaxHashSize],
+                      const unsigned char *info, int info_len,
+                      uint8_t okm[USHAMaxHashSize], int okm_len);
+#endif /* _SHA_H_ */
+

--- a/lib/libesp32/ESP32-HomeKit/src/hkdf.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hkdf.c
@@ -1,0 +1,335 @@
+/**************************** hkdf.c ***************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *      This file implements the HKDF algorithm (HMAC-based
+ *      Extract-and-Expand Key Derivation Function, RFC 5869),
+ *      expressed in terms of the various SHA algorithms.
+ */
+
+#include "sha.h"
+#include <string.h>
+#include <stdlib.h>
+
+/*
+ *  hkdf
+ *
+ *  Description:
+ *      This function will generate keying material using HKDF.
+ *
+ *  Parameters:
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      salt[ ]: [in]
+ *          The optional salt value (a non-secret random value);
+ *          if not provided (salt == NULL), it is set internally
+ *          to a string of HashLen(whichSha) zeros.
+ *      salt_len: [in]
+ *          The length of the salt value.  (Ignored if salt == NULL.)
+ *      ikm[ ]: [in]
+ *          Input keying material.
+ *      ikm_len: [in]
+ *          The length of the input keying material.
+ *      info[ ]: [in]
+ *          The optional context and application specific information.
+ *          If info == NULL or a zero-length string, it is ignored.
+ *      info_len: [in]
+ *          The length of the optional context and application specific
+ *          information.  (Ignored if info == NULL.)
+ *      okm[ ]: [out]
+ *          Where the HKDF is to be stored.
+ *      okm_len: [in]
+ *          The length of the buffer to hold okm.
+ *          okm_len must be <= 255 * USHABlockSize(whichSha)
+ *
+ *  Notes:
+ *      Calls hkdfExtract() and hkdfExpand().
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hkdf(SHAversion whichSha,
+    const unsigned char *salt, int salt_len,
+    const unsigned char *ikm, int ikm_len,
+    const unsigned char *info, int info_len,
+    uint8_t okm[ ], int okm_len)
+{
+  uint8_t prk[USHAMaxHashSize];
+  return hkdfExtract(whichSha, salt, salt_len, ikm, ikm_len, prk) ||
+         hkdfExpand(whichSha, prk, USHAHashSize(whichSha), info,
+                    info_len, okm, okm_len);
+}
+
+/*
+ *  hkdfExtract
+ *
+ *  Description:
+ *      This function will perform HKDF extraction.
+ *
+ *  Parameters:
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      salt[ ]: [in]
+ *          The optional salt value (a non-secret random value);
+ *          if not provided (salt == NULL), it is set internally
+ *          to a string of HashLen(whichSha) zeros.
+ *      salt_len: [in]
+ *          The length of the salt value.  (Ignored if salt == NULL.)
+ *      ikm[ ]: [in]
+ *          Input keying material.
+ *      ikm_len: [in]
+ *          The length of the input keying material.
+ *      prk[ ]: [out]
+ *          Array where the HKDF extraction is to be stored.
+ *          Must be larger than USHAHashSize(whichSha);
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hkdfExtract(SHAversion whichSha,
+    const unsigned char *salt, int salt_len,
+    const unsigned char *ikm, int ikm_len,
+    uint8_t prk[USHAMaxHashSize])
+{
+  unsigned char nullSalt[USHAMaxHashSize];
+  if (salt == 0) {
+    salt = nullSalt;
+    salt_len = USHAHashSize(whichSha);
+    memset(nullSalt, '\0', salt_len);
+  } else if (salt_len < 0) {
+    return shaBadParam;
+  }
+  return hmac(whichSha, ikm, ikm_len, salt, salt_len, prk);
+}
+
+/*
+ *  hkdfExpand
+ *
+ *  Description:
+ *      This function will perform HKDF expansion.
+ *
+ *  Parameters:
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      prk[ ]: [in]
+ *          The pseudo-random key to be expanded; either obtained
+ *          directly from a cryptographically strong, uniformly
+ *          distributed pseudo-random number generator, or as the
+ *          output from hkdfExtract().
+ *      prk_len: [in]
+ *          The length of the pseudo-random key in prk;
+ *          should at least be equal to USHAHashSize(whichSHA).
+ *      info[ ]: [in]
+ *          The optional context and application specific information.
+ *          If info == NULL or a zero-length string, it is ignored.
+ *      info_len: [in]
+ *          The length of the optional context and application specific
+ *          information.  (Ignored if info == NULL.)
+ *      okm[ ]: [out]
+ *          Where the HKDF is to be stored.
+ *      okm_len: [in]
+ *          The length of the buffer to hold okm.
+ *          okm_len must be <= 255 * USHABlockSize(whichSha)
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hkdfExpand(SHAversion whichSha, const uint8_t prk[ ], int prk_len,
+    const unsigned char *info, int info_len,
+    uint8_t okm[ ], int okm_len)
+{
+  int hash_len, N;
+  unsigned char T[USHAMaxHashSize];
+  int Tlen, where, i;
+
+  if (info == 0) {
+    info = (const unsigned char *)"";
+    info_len = 0;
+  } else if (info_len < 0) {
+    return shaBadParam;
+  }
+  if (okm_len <= 0) return shaBadParam;
+  if (!okm) return shaBadParam;
+
+  hash_len = USHAHashSize(whichSha);
+  if (prk_len < hash_len) return shaBadParam;
+  N = okm_len / hash_len;
+  if ((okm_len % hash_len) != 0) N++;
+  if (N > 255) return shaBadParam;
+
+  Tlen = 0;
+  where = 0;
+  for (i = 1; i <= N; i++) {
+    HMACContext context;
+    unsigned char c = i;
+    int ret = hmacReset(&context, whichSha, prk, prk_len) ||
+              hmacInput(&context, T, Tlen) ||
+              hmacInput(&context, info, info_len) ||
+              hmacInput(&context, &c, 1) ||
+              hmacResult(&context, T);
+    if (ret != shaSuccess) return ret;
+    memcpy(okm + where, T,
+           (i != N) ? hash_len : (okm_len - where));
+    where += hash_len;
+    Tlen = hash_len;
+  }
+  return shaSuccess;
+}
+
+/*
+ *  hkdfReset
+ *
+ *  Description:
+ *      This function will initialize the hkdfContext in preparation
+ *      for key derivation using the modular HKDF interface for
+ *      arbitrary length inputs.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The context to reset.
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      salt[ ]: [in]
+ *          The optional salt value (a non-secret random value);
+ *          if not provided (salt == NULL), it is set internally
+ *          to a string of HashLen(whichSha) zeros.
+ *      salt_len: [in]
+ *          The length of the salt value.  (Ignored if salt == NULL.)
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hkdfReset(HKDFContext *context, enum SHAversion whichSha,
+              const unsigned char *salt, int salt_len)
+{
+  unsigned char nullSalt[USHAMaxHashSize];
+  if (!context) return shaNull;
+
+  context->whichSha = whichSha;
+  context->hashSize = USHAHashSize(whichSha);
+  if (salt == 0) {
+    salt = nullSalt;
+    salt_len = context->hashSize;
+    memset(nullSalt, '\0', salt_len);
+  }
+
+  return hmacReset(&context->hmacContext, whichSha, salt, salt_len);
+}
+
+/*
+ *  hkdfInput
+ *
+ *  Description:
+ *      This function accepts an array of octets as the next portion
+ *      of the input keying material.  It may be called multiple times.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The HKDF context to update.
+ *      ikm[ ]: [in]
+ *          An array of octets representing the next portion of
+ *          the input keying material.
+ *      ikm_len: [in]
+ *          The length of ikm.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hkdfInput(HKDFContext *context, const unsigned char *ikm,
+              int ikm_len)
+{
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  return hmacInput(&context->hmacContext, ikm, ikm_len);
+}
+
+/*
+ * hkdfFinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the
+ *   input keying material.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The HKDF context to update
+ *   ikm_bits: [in]
+ *     The final bits of the input keying material, in the upper
+ *     portion of the byte.  (Use 0b###00000 instead of 0b00000###
+ *     to input the three bits ###.)
+ *   ikm_bit_count: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int hkdfFinalBits(HKDFContext *context, uint8_t ikm_bits,
+                  unsigned int ikm_bit_count)
+{
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  return hmacFinalBits(&context->hmacContext, ikm_bits, ikm_bit_count);
+}
+
+/*
+ * hkdfResult
+ *
+ * Description:
+ *   This function will finish the HKDF extraction and perform the
+ *   final HKDF expansion.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The HKDF context to use to calculate the HKDF hash.
+ *   prk[ ]: [out]
+ *     An optional location to store the HKDF extraction.
+ *     Either NULL, or pointer to a buffer that must be
+ *     larger than USHAHashSize(whichSha);
+ *   info[ ]: [in]
+ *     The optional context and application specific information.
+ *     If info == NULL or a zero-length string, it is ignored.
+ *   info_len: [in]
+ *     The length of the optional context and application specific
+ *     information.  (Ignored if info == NULL.)
+ *   okm[ ]: [out]
+ *     Where the HKDF is to be stored.
+ *   okm_len: [in]
+ *     The length of the buffer to hold okm.
+ *     okm_len must be <= 255 * USHABlockSize(whichSha)
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int hkdfResult(HKDFContext *context,
+               uint8_t prk[USHAMaxHashSize],
+               const unsigned char *info, int info_len,
+               uint8_t okm[ ], int okm_len)
+{
+  uint8_t prkbuf[USHAMaxHashSize];
+  int ret;
+
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (!okm) return context->Corrupted = shaBadParam;
+  if (!prk) prk = prkbuf;
+
+  ret = hmacResult(&context->hmacContext, prk) ||
+        hkdfExpand(context->whichSha, prk, context->hashSize, info,
+                   info_len, okm, okm_len);
+  context->Computed = 1;
+  return context->Corrupted = ret;
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/hmac.c
+++ b/lib/libesp32/ESP32-HomeKit/src/hmac.c
@@ -1,0 +1,249 @@
+/**************************** hmac.c ***************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *      This file implements the HMAC algorithm (Keyed-Hashing for
+ *      Message Authentication, [RFC 2104]), expressed in terms of
+ *      the various SHA algorithms.
+ */
+
+#include "sha.h"
+
+/*
+ *  hmac
+ *
+ *  Description:
+ *      This function will compute an HMAC message digest.
+ *
+ *  Parameters:
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      message_array[ ]: [in]
+ *          An array of octets representing the message.
+ *          Note: in RFC 2104, this parameter is known
+ *          as 'text'.
+ *      length: [in]
+ *          The length of the message in message_array.
+ *      key[ ]: [in]
+ *          The secret shared key.
+ *      key_len: [in]
+ *          The length of the secret shared key.
+ *      digest[ ]: [out]
+ *          Where the digest is to be returned.
+ *          NOTE: The length of the digest is determined by
+ *              the value of whichSha.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+
+int hmac(SHAversion whichSha,
+    const unsigned char *message_array, int length,
+    const unsigned char *key, int key_len,
+    uint8_t digest[USHAMaxHashSize])
+{
+  HMACContext context;
+  return hmacReset(&context, whichSha, key, key_len) ||
+         hmacInput(&context, message_array, length) ||
+         hmacResult(&context, digest);
+}
+
+/*
+ *  hmacReset
+ *
+ *  Description:
+ *      This function will initialize the hmacContext in preparation
+ *      for computing a new HMAC message digest.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The context to reset.
+ *      whichSha: [in]
+ *          One of SHA1, SHA224, SHA256, SHA384, SHA512
+ *      key[ ]: [in]
+ *          The secret shared key.
+ *      key_len: [in]
+ *          The length of the secret shared key.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hmacReset(HMACContext *context, enum SHAversion whichSha,
+    const unsigned char *key, int key_len)
+{
+  int i, blocksize, hashsize, ret;
+
+  /* inner padding - key XORd with ipad */
+  unsigned char k_ipad[USHA_Max_Message_Block_Size];
+
+  /* temporary buffer when keylen > blocksize */
+  unsigned char tempkey[USHAMaxHashSize];
+
+  if (!context) return shaNull;
+  context->Computed = 0;
+  context->Corrupted = shaSuccess;
+
+  blocksize = context->blockSize = USHABlockSize(whichSha);
+  hashsize = context->hashSize = USHAHashSize(whichSha);
+  context->whichSha = whichSha;
+
+  /*
+   * If key is longer than the hash blocksize,
+   * reset it to key = HASH(key).
+   */
+  if (key_len > blocksize) {
+    USHAContext tcontext;
+    int err = USHAReset(&tcontext, whichSha) ||
+              USHAInput(&tcontext, key, key_len) ||
+              USHAResult(&tcontext, tempkey);
+    if (err != shaSuccess) return err;
+
+    key = tempkey;
+    key_len = hashsize;
+  }
+
+  /*
+   * The HMAC transform looks like:
+   *
+   * SHA(K XOR opad, SHA(K XOR ipad, text))
+   *
+   * where K is an n byte key, 0-padded to a total of blocksize bytes,
+   * ipad is the byte 0x36 repeated blocksize times,
+   * opad is the byte 0x5c repeated blocksize times,
+   * and text is the data being protected.
+   */
+
+  /* store key into the pads, XOR'd with ipad and opad values */
+  for (i = 0; i < key_len; i++) {
+    k_ipad[i] = key[i] ^ 0x36;
+    context->k_opad[i] = key[i] ^ 0x5c;
+  }
+  /* remaining pad bytes are '\0' XOR'd with ipad and opad values */
+  for ( ; i < blocksize; i++) {
+    k_ipad[i] = 0x36;
+    context->k_opad[i] = 0x5c;
+  }
+
+  /* perform inner hash */
+  /* init context for 1st pass */
+  ret = USHAReset(&context->shaContext, whichSha) ||
+        /* and start with inner pad */
+        USHAInput(&context->shaContext, k_ipad, blocksize);
+  return context->Corrupted = ret;
+}
+
+/*
+ *  hmacInput
+ *
+ *  Description:
+ *      This function accepts an array of octets as the next portion
+ *      of the message.  It may be called multiple times.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The HMAC context to update.
+ *      text[ ]: [in]
+ *          An array of octets representing the next portion of
+ *          the message.
+ *      text_len: [in]
+ *          The length of the message in text.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int hmacInput(HMACContext *context, const unsigned char *text,
+    int text_len)
+{
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  /* then text of datagram */
+  return context->Corrupted =
+    USHAInput(&context->shaContext, text, text_len);
+}
+
+/*
+ * hmacFinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The HMAC context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int hmacFinalBits(HMACContext *context,
+    uint8_t bits, unsigned int bit_count)
+{
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  /* then final bits of datagram */
+  return context->Corrupted =
+    USHAFinalBits(&context->shaContext, bits, bit_count);
+}
+
+/*
+ * hmacResult
+ *
+ * Description:
+ *   This function will return the N-byte message digest into the
+ *   Message_Digest array provided by the caller.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the HMAC hash.
+ *   digest[ ]: [out]
+ *     Where the digest is returned.
+ *     NOTE 2: The length of the hash is determined by the value of
+ *      whichSha that was passed to hmacReset().
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int hmacResult(HMACContext *context, uint8_t *digest)
+{
+  int ret;
+  if (!context) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+
+  /* finish up 1st pass */
+  /* (Use digest here as a temporary buffer.) */
+  ret =
+    USHAResult(&context->shaContext, digest) ||
+
+         /* perform outer SHA */
+         /* init context for 2nd pass */
+         USHAReset(&context->shaContext, context->whichSha) ||
+
+         /* start with outer pad */
+         USHAInput(&context->shaContext, context->k_opad,
+                   context->blockSize) ||
+
+         /* then results of 1st hash */
+         USHAInput(&context->shaContext, digest, context->hashSize) ||
+         /* finish up 2nd pass */
+         USHAResult(&context->shaContext, digest);
+
+  context->Computed = 1;
+  return context->Corrupted = ret;
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/jsmn/jsmn.h
+++ b/lib/libesp32/ESP32-HomeKit/src/jsmn/jsmn.h
@@ -1,0 +1,471 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef JSMN_H
+#define JSMN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1,
+  JSMN_ARRAY = 2,
+  JSMN_STRING = 3,
+  JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
+ */
+typedef struct jsmntok {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
+#ifdef JSMN_PARENT_LINKS
+  int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string.
+ */
+typedef struct jsmn_parser {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
+ * a single JSON object.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens);
+
+#ifndef JSMN_HEADER
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+  tok->parent = -1;
+#endif
+  return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
+
+  start = parser->pos;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
+#endif
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    default:
+                   /* to quiet a warning from gcc*/
+      break;
+    }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
+#ifdef JSMN_STRICT
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+#endif
+
+found:
+  if (tokens == NULL) {
+    parser->pos--;
+    return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
+
+  int start = parser->pos;
+
+  parser->pos++;
+
+  /* Skip starting quote */
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
+
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+      token->parent = parser->toksuper;
+#endif
+      return 0;
+    }
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
+
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
+        }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
+    for (i = parser->toknext - 1; i >= 0; i--) {
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Creates a new parser based over a given buffer with an array of tokens
+ * available.
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
+}
+
+#endif /* JSMN_HEADER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSMN_H */

--- a/lib/libesp32/ESP32-HomeKit/src/json_generator.c
+++ b/lib/libesp32/ESP32-HomeKit/src/json_generator.c
@@ -1,0 +1,300 @@
+/*
+ *    Copyright 2020 Piyush Shah <shahpiyushv@gmail.com>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <json_generator.h>
+
+#define MAX_INT_IN_STR  	24
+#define MAX_FLOAT_IN_STR 	30
+
+static inline int json_gen_get_empty_len(json_gen_str_t *jstr)
+{
+	return (jstr->buf_size - (jstr->free_ptr - jstr->buf) - 1);
+}
+
+/* This will add the incoming string to the JSON string buffer
+ * and flush it out if the buffer is full. Note that the data being
+ * flushed out will always be equal to the size of the buffer unless
+ * this is the last chunk being flushed out on json_gen_end_str()
+ */
+static int json_gen_add_to_str(json_gen_str_t *jstr, char *str)
+{
+    if (!str) {
+        return 0;
+    }
+	int len = strlen(str);
+	char *cur_ptr = str;
+	while (1) {
+		int len_remaining = json_gen_get_empty_len(jstr);
+		int copy_len = len_remaining > len ? len : len_remaining;
+		memmove(jstr->free_ptr, cur_ptr, copy_len);
+		cur_ptr += copy_len;
+		jstr->free_ptr += copy_len;
+		len -= copy_len;
+		if (len) {
+			*jstr->free_ptr = '\0';
+			/* Report error if the buffer is full and no flush callback
+			 * is registered
+			 */
+			if (!jstr->flush_cb) {
+				return -1;
+			}
+			jstr->flush_cb(jstr->buf, jstr->priv);
+			jstr->free_ptr = jstr->buf;
+		} else
+			break;
+	}
+	return 0;
+}
+
+
+void json_gen_str_start(json_gen_str_t *jstr, char *buf, int buf_size,
+		json_gen_flush_cb_t flush_cb, void *priv)
+{
+	memset(jstr, 0, sizeof(json_gen_str_t));
+	jstr->buf = buf;
+	jstr->buf_size = buf_size;
+	jstr->flush_cb = flush_cb;
+	jstr->free_ptr = buf;
+	jstr->priv = priv;
+}
+
+void json_gen_str_end(json_gen_str_t *jstr)
+{
+	*jstr->free_ptr = '\0';
+	if (jstr->flush_cb)
+		jstr->flush_cb(jstr->buf, jstr->priv);
+	memset(jstr, 0, sizeof(json_gen_str_t));
+}
+
+static inline void json_gen_handle_comma(json_gen_str_t *jstr)
+{
+	if (jstr->comma_req)
+		json_gen_add_to_str(jstr, ",");
+}
+
+
+static int json_gen_handle_name(json_gen_str_t *jstr, char *name)
+{
+	json_gen_add_to_str(jstr, "\"");
+	json_gen_add_to_str(jstr, name);
+	return json_gen_add_to_str(jstr, "\":");
+}
+
+
+int json_gen_start_object(json_gen_str_t *jstr)
+{
+	json_gen_handle_comma(jstr);
+	jstr->comma_req = false;
+	return json_gen_add_to_str(jstr, "{");
+}
+
+int json_gen_end_object(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "}");
+}
+
+
+int json_gen_start_array(json_gen_str_t *jstr)
+{
+	json_gen_handle_comma(jstr);
+	jstr->comma_req = false;
+	return json_gen_add_to_str(jstr, "[");
+}
+
+int json_gen_end_array(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "]");
+}
+
+int json_gen_push_object(json_gen_str_t *jstr, char *name)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	jstr->comma_req = false;
+	return json_gen_add_to_str(jstr, "{");
+}
+
+int json_gen_pop_object(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "}");
+}
+
+int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, object_str);
+}
+
+int json_gen_push_array(json_gen_str_t *jstr, char *name)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	jstr->comma_req = false;
+	return json_gen_add_to_str(jstr, "[");
+}
+int json_gen_pop_array(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "]");
+}
+
+int json_gen_push_array_str(json_gen_str_t *jstr, char *name, char *array_str)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, array_str);
+}
+
+static int json_gen_set_bool(json_gen_str_t *jstr, bool val)
+{
+	jstr->comma_req = true;
+	if (val)
+		return json_gen_add_to_str(jstr, "true");
+	else
+		return json_gen_add_to_str(jstr, "false");
+}
+int json_gen_obj_set_bool(json_gen_str_t *jstr, char *name, bool val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_bool(jstr, val);
+}
+
+int json_gen_arr_set_bool(json_gen_str_t *jstr, bool val)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_bool(jstr, val);
+}
+
+static int json_gen_set_int(json_gen_str_t *jstr, int val)
+{
+	jstr->comma_req = true;
+	char str[MAX_INT_IN_STR];
+	snprintf(str, MAX_INT_IN_STR, "%d", val);
+	return json_gen_add_to_str(jstr, str);
+}
+
+int json_gen_obj_set_int(json_gen_str_t *jstr, char *name, int val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_int(jstr, val);
+}
+
+int json_gen_arr_set_int(json_gen_str_t *jstr, int val)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_int(jstr, val);
+}
+
+
+static int json_gen_set_float(json_gen_str_t *jstr, float val)
+{
+	jstr->comma_req = true;
+	char str[MAX_FLOAT_IN_STR];
+	snprintf(str, MAX_FLOAT_IN_STR, "%.*f", JSON_FLOAT_PRECISION, val);
+	return json_gen_add_to_str(jstr, str);
+}
+int json_gen_obj_set_float(json_gen_str_t *jstr, char *name, float val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_float(jstr, val);
+}
+int json_gen_arr_set_float(json_gen_str_t *jstr, float val)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_float(jstr, val);
+}
+
+static int json_gen_set_string(json_gen_str_t *jstr, char *val)
+{
+	jstr->comma_req = true;
+	json_gen_add_to_str(jstr, "\"");
+	json_gen_add_to_str(jstr, val);
+	return json_gen_add_to_str(jstr, "\"");
+}
+
+int json_gen_obj_set_string(json_gen_str_t *jstr, char *name, char *val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_string(jstr, val);
+}
+
+int json_gen_arr_set_string(json_gen_str_t *jstr, char *val)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_string(jstr, val);
+}
+
+static int json_gen_set_long_string(json_gen_str_t *jstr, char *val)
+{
+	jstr->comma_req = true;
+	json_gen_add_to_str(jstr, "\"");
+	return json_gen_add_to_str(jstr, val);
+}
+
+int json_gen_obj_start_long_string(json_gen_str_t *jstr, char *name, char *val)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+    return json_gen_set_long_string(jstr, val);
+}
+
+int json_gen_arr_start_long_string(json_gen_str_t *jstr, char *val)
+{
+	json_gen_handle_comma(jstr);
+    return json_gen_set_long_string(jstr, val);
+}
+
+int json_gen_add_to_long_string(json_gen_str_t *jstr, char *val)
+{
+    return json_gen_add_to_str(jstr, val);
+}
+
+int json_gen_end_long_string(json_gen_str_t *jstr)
+{
+    return json_gen_add_to_str(jstr, "\"");
+}
+static int json_gen_set_null(json_gen_str_t *jstr)
+{
+	jstr->comma_req = true;
+	return json_gen_add_to_str(jstr, "null");
+}
+int json_gen_obj_set_null(json_gen_str_t *jstr, char *name)
+{
+	json_gen_handle_comma(jstr);
+	json_gen_handle_name(jstr, name);
+	return json_gen_set_null(jstr);
+}
+
+int json_gen_arr_set_null(json_gen_str_t *jstr)
+{
+	json_gen_handle_comma(jstr);
+	return json_gen_set_null(jstr);
+}

--- a/lib/libesp32/ESP32-HomeKit/src/json_generator.h
+++ b/lib/libesp32/ESP32-HomeKit/src/json_generator.h
@@ -1,0 +1,507 @@
+/*
+ *    Copyright 2020 Piyush Shah <shahpiyushv@gmail.com>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/*
+ * JSON String Generator
+ *
+ * This module can be used to create JSON strings with a facility
+ * to flush out data if the destination buffer is full. All commas
+ * and colons as required are automatically added by the APIs
+ *
+ */
+#ifndef _JSON_GENERATOR_H
+#define _JSON_GENERATOR_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** Float precision i.e. number of digits after decimal point */
+#ifndef JSON_FLOAT_PRECISION
+#define JSON_FLOAT_PRECISION 5
+#endif
+
+/** JSON string flush callback prototype
+ *
+ * This is a prototype of the function that needs to be passed to
+ * json_gen_str_start() and which will be invoked by the JSON generator
+ * module either when the buffer is full or json_gen_str_end() ins invoked.
+ *
+ * \param[in] buf Pointer to a NULL terminated JSON string
+ * \param[in] priv Private data to be passed to the flush callback. Will
+ * be the same as the one passed to json_gen_str_start()
+ */
+typedef void (*json_gen_flush_cb_t) (char *buf, void *priv);
+
+/** JSON String structure
+ *
+ * Please do not set/modify any elements.
+ * Just define this structure and pass a pointer to it in the APIs below
+ */
+typedef struct {
+    /** Pointer to the JSON buffer provided by the calling function */
+	char *buf;
+    /** Size of the above buffer */
+	int buf_size;
+    /** (Optional) callback function to invoke when the buffer gets full */
+	json_gen_flush_cb_t flush_cb;
+    /** (Optional) Private data to pass to the callback function */
+	void *priv;
+    /** (For Internal use only) */
+	bool comma_req;
+    /** (For Internal use only) */
+	char *free_ptr;
+} json_gen_str_t;
+
+/** Start a JSON String
+ *
+ * This is the first function to be called for creating a JSON string.
+ * It initializes the internal data structures. After the JSON string
+ * generation is over, the json_gen_str_end() function should be called.
+ *
+ * \param[out] jstr Pointer to an allocated \ref json_gen_str_t structure.
+ * This will be initialised internally and needs to be passed to all
+ * subsequent function calls
+ * \param[out] buf Pointer to an allocated buffer into which the JSON
+ * string will be written
+ * \param[in] buf_size Size of the buffer
+ * \param[in] flush_cb Pointer to the flushing function of type \ref json_gen_flush_cb_t
+ * which will be invoked either when the buffer is full or when json_gen_str_end()
+ * is invoked. Can be left NULL.
+ * \param[in] priv Private data to be passed to the flushing function callback.
+ * Can be something like a session identifier (Eg. socket). Can be left NULL.
+ */
+void json_gen_str_start(json_gen_str_t *jstr, char *buf, int buf_size,
+		json_gen_flush_cb_t flush_cb, void *priv);
+
+/** End JSON string
+ *
+ * This should be the last function to be called after the entire JSON string
+ * has been generated.
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ */
+void json_gen_str_end(json_gen_str_t *jstr);
+
+/** Start a JSON object
+ *
+ * This starts a JSON object by adding a '{'
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_start_object(json_gen_str_t *jstr);
+
+/** End a JSON object
+ *
+ * This ends a JSON object by adding a '}'
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_end_object(json_gen_str_t *jstr);
+
+/** Start a JSON array
+ *
+ * This starts a JSON object by adding a '['
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_start_array(json_gen_str_t *jstr);
+
+/** End a JSON object
+ *
+ * This ends a JSON object by adding a ']'
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_end_array(json_gen_str_t *jstr);
+
+/** Push a named JSON object
+ *
+ * This adds a JSON object like "name":{
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the object
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_push_object(json_gen_str_t *jstr, char *name);
+
+/** Pop a named JSON object
+ *
+ * This ends a JSON object by adding a '}'. This is basically same as
+ * json_gen_end_object() but included so as to complement json_gen_push_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_pop_object(json_gen_str_t *jstr);
+
+/** Push a JSON object string
+ *
+ * This adds a complete pre-formatted JSON object string to the JSON object.
+ *
+ * Eg. json_gen_push_object_str(jstr, "pre-formatted", "{\"a\":1,\"b\":2}");
+ * This will add "pre-formatted":{"a":1,"b":2}
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the JSON object string
+ * \param[in] object_str The pre-formatted JSON object string
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that.
+ */
+int json_gen_push_object_str(json_gen_str_t *jstr, char *name, char *object_str);
+
+/** Push a named JSON array
+ *
+ * This adds a JSON array like "name":[
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the array
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_push_array(json_gen_str_t *jstr, char *name);
+
+/** Pop a named JSON array
+ *
+ * This ends a JSON array by adding a ']'. This is basically same as
+ * json_gen_end_array() but included so as to complement json_gen_push_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_pop_array(json_gen_str_t *jstr);
+
+/** Push a JSON array string
+ *
+ * This adds a complete pre-formatted JSON array string to the JSON object.
+ *
+ * Eg. json_gen_push_object_str(jstr, "pre-formatted", "[1,2,3]");
+ * This will add "pre-formatted":[1,2,3]
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the JSON array string
+ * \param[in] array_str The pre-formatted JSON array string
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that.
+ */
+int json_gen_push_array_str(json_gen_str_t *jstr, char *name, char *array_str);
+
+/** Add a boolean element to an object
+ *
+ * This adds a boolean element to an object. Eg. "bool_val":true
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val Boolean value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_bool(json_gen_str_t *jstr, char *name, bool val);
+
+/** Add an integer element to an object
+ *
+ * This adds an integer element to an object. Eg. "int_val":28
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val Integer value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_int(json_gen_str_t *jstr, char *name, int val);
+
+/** Add a float element to an object
+ *
+ * This adds a float element to an object. Eg. "float_val":23.8
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val Float value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_float(json_gen_str_t *jstr, char *name, float val);
+
+/** Add a string element to an object
+ *
+ * This adds a string element to an object. Eg. "string_val":"my_string"
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val Null terminated string value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_string(json_gen_str_t *jstr, char *name, char *val);
+
+/** Add a NULL element to an object
+ *
+ * This adds a NULL element to an object. Eg. "null_val":null
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_set_null(json_gen_str_t *jstr, char *name);
+
+/** Add a boolean element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val Boolean value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_bool(json_gen_str_t *jstr, bool val);
+
+/** Add an integer element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val Integer value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_int(json_gen_str_t *jstr, int val);
+
+/** Add a float element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val Float value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_float(json_gen_str_t *jstr, float val);
+
+/** Add a string element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val Null terminated string value of the element
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_string(json_gen_str_t *jstr, char *val);
+
+/** Add a NULL element to an array
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_set_null(json_gen_str_t *jstr);
+
+/** Start a Long string in an object
+ *
+ * This starts a string in an object, but does not end it (i.e., does not add the
+ * terminating quotes. This is useful for long strings. Eg. "string_val":"my_string.
+ * The API json_gen_add_to_long_string() must be used to add to this string and the API
+ * json_gen_end_long_string() must be used to terminate it (i.e. add the ending quotes).
+ *
+ * \note This must be called between json_gen_start_object()/json_gen_push_object()
+ * and json_gen_end_object()/json_gen_pop_object()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] name Name of the element
+ * \param[in] val Null terminated initial part of the string value. It can also be NULL
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_obj_start_long_string(json_gen_str_t *jstr, char *name, char *val);
+
+/** Start a Long string in an array
+ *
+ * This starts a string in an arrayt, but does not end it (i.e., does not add the
+ * terminating quotes. This is useful for long strings.
+ * The API json_gen_add_to_long_string() must be used to add to this string and the API
+ * json_gen_end_long_string() must be used to terminate it (i.e. add the ending quotes).
+ *
+ * \note This must be called between json_gen_start_array()/json_gen_push_array()
+ * and json_gen_end_array()/json_gen_pop_array()
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by
+ * json_gen_str_start()
+ * \param[in] val Null terminated initial part of the string value. It can also be NULL
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_arr_start_long_string(json_gen_str_t *jstr, char *val);
+
+/** Add to a JSON Long string
+ *
+ * This extends the string initialised by json_gen_obj_start_long_string() or
+ * json_gen_arr_start_long_string(). After the entire string is created, it should be terminated
+ * with json_gen_end_long_string().
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by json_gen_str_start()
+ * \param[in] val Null terminated extending part of the string value.
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_add_to_long_string(json_gen_str_t *jstr, char *val);
+
+/** End a JSON Long string
+ *
+ * This ends the string initialised by json_gen_obj_start_long_string() or
+ * json_gen_arr_start_long_string() by adding the ending quotes.
+ *
+ * \param[in] jstr Pointer to the \ref json_gen_str_t structure initialised by json_gen_str_start()
+ *
+ *
+ * \return 0 on Success
+ * \return -1 if buffer is out of space (possible only if no callback function
+ * is passed to json_gen_str_start(). Else, buffer will be flushed out and new data
+ * added after that
+ */
+int json_gen_end_long_string(json_gen_str_t *jstr);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/libesp32/ESP32-HomeKit/src/json_parser.c
+++ b/lib/libesp32/ESP32-HomeKit/src/json_parser.c
@@ -1,0 +1,398 @@
+/*
+ *    Copyright 2020 Piyush Shah <shahpiyushv@gmail.com>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+#define JSMN_PARENT_LINKS
+#define JSMN_STRICT
+#define JSMN_STATIC
+#include <jsmn/jsmn.h>
+#include <json_parser.h>
+
+static bool token_matches_str(jparse_ctx_t *ctx, json_tok_t *tok, char *str)
+{
+	char *js = ctx->js;
+	return ((strncmp(js + tok->start, str, strlen(str)) == 0)
+			&& (strlen(str) == (size_t) (tok->end - tok->start)));
+}
+
+static json_tok_t *json_skip_elem(json_tok_t *token)
+{
+	json_tok_t *cur = token;
+	int cnt = cur->size;
+	while (cnt--) {
+		cur++;
+		cur = json_skip_elem(cur);
+	}
+	return cur;
+}
+
+static int json_tok_to_bool(jparse_ctx_t *jctx, json_tok_t *tok, bool *val)
+{
+	if (token_matches_str(jctx, tok, "true") || token_matches_str(jctx, tok, "1")) {
+		*val = true;
+	} else if  (token_matches_str(jctx, tok, "false") || token_matches_str(jctx, tok, "0")) {
+		*val = false;
+	} else
+		return -OS_FAIL;
+	return OS_SUCCESS;
+}
+
+static int json_tok_to_int(jparse_ctx_t *jctx, json_tok_t *tok, int *val)
+{
+	char *tok_start = &jctx->js[tok->start];
+	char *tok_end = &jctx->js[tok->end];
+	char *endptr;
+	int i = strtoul(tok_start, &endptr, 10);
+	if (endptr == tok_end) {
+		*val = i;
+		return OS_SUCCESS;
+	}
+	return -OS_FAIL;
+}
+
+static int json_tok_to_int64(jparse_ctx_t *jctx, json_tok_t *tok, int64_t *val)
+{
+	char *tok_start = &jctx->js[tok->start];
+	char *tok_end = &jctx->js[tok->end];
+	char *endptr;
+	int64_t i64 = strtoull(tok_start, &endptr, 10);
+	if (endptr == tok_end) {
+		*val = i64;
+		return OS_SUCCESS;
+	}
+	return -OS_FAIL;
+}
+
+static int json_tok_to_float(jparse_ctx_t *jctx, json_tok_t *tok, float *val)
+{
+	char *tok_start = &jctx->js[tok->start];
+	char *tok_end = &jctx->js[tok->end];
+	char *endptr;
+	float f = strtof(tok_start, &endptr);
+	if (endptr == tok_end) {
+		*val = f;
+		return OS_SUCCESS;
+	}
+	return -OS_FAIL;
+}
+
+static int json_tok_to_string(jparse_ctx_t *jctx, json_tok_t *tok, char *val, int size)
+{
+	if ((tok->end - tok->start) > (size - 1))
+		return -OS_FAIL;
+	strncpy(val, jctx->js + tok->start, tok->end - tok->start);
+	val[tok->end - tok->start] = 0;
+	return OS_SUCCESS;
+}
+
+static json_tok_t *json_obj_search(jparse_ctx_t *jctx, char *key)
+{
+	json_tok_t *tok = jctx->cur;
+	int size = tok->size;
+	if (size <= 0)
+		return NULL;
+	if (tok->type != JSMN_OBJECT)
+		return NULL;
+
+	while (size--) {
+		tok++;
+		if (token_matches_str(jctx, tok, key))
+			return tok;
+		tok = json_skip_elem(tok);
+	}
+	return NULL;
+}
+
+static json_tok_t *json_obj_get_val_tok(jparse_ctx_t *jctx, char *name, jsmntype_t type)
+{
+	json_tok_t *tok = json_obj_search(jctx, name);
+	if (!tok)
+		return NULL;
+	tok++;
+	if (tok->type != type)
+		return NULL;
+	return tok;
+}
+
+int json_obj_get_array(jparse_ctx_t *jctx, char *name, int *num_elem)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_ARRAY);
+	if (!tok)
+		return -OS_FAIL;
+	jctx->cur = tok;
+	*num_elem = tok->size;
+	return OS_SUCCESS;
+}
+
+int json_obj_leave_array(jparse_ctx_t *jctx)
+{
+	/* The array's parent will be the key */
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+
+	/* The key's parent will be the actual parent object */
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+	return OS_SUCCESS;
+}
+
+int json_obj_get_object(jparse_ctx_t *jctx, char *name)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_OBJECT);
+	if (!tok)
+		return -OS_FAIL;
+	jctx->cur = tok;
+	return OS_SUCCESS;
+}
+
+int json_obj_leave_object(jparse_ctx_t *jctx)
+{
+	/* The objects's parent will be the key */
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+
+	/* The key's parent will be the actual parent object */
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+	return OS_SUCCESS;
+}
+
+int json_obj_get_bool(jparse_ctx_t *jctx, char *name, bool *val)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_bool(jctx, tok, val);
+}
+
+int json_obj_get_int(jparse_ctx_t *jctx, char *name, int *val)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_int(jctx, tok, val);
+}
+
+int json_obj_get_int64(jparse_ctx_t *jctx, char *name, int64_t *val)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_int64(jctx, tok, val);
+}
+
+int json_obj_get_float(jparse_ctx_t *jctx, char *name, float *val)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_float(jctx, tok, val);
+}
+
+int json_obj_get_string(jparse_ctx_t *jctx, char *name, char *val, int size)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_STRING);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_string(jctx, tok, val, size);
+}
+
+int json_obj_get_strlen(jparse_ctx_t *jctx, char *name, int *strlen)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_STRING);
+	if (!tok)
+		return -OS_FAIL;
+	*strlen = tok->end - tok->start;
+	return OS_SUCCESS;
+}
+
+int json_obj_get_object_str(jparse_ctx_t *jctx, char *name, char *val, int size)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_OBJECT);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_string(jctx, tok, val, size);
+}
+
+int json_obj_get_object_strlen(jparse_ctx_t *jctx, char *name, int *strlen)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_OBJECT);
+	if (!tok)
+		return -OS_FAIL;
+	*strlen = tok->end - tok->start;
+	return OS_SUCCESS;
+}
+int json_obj_get_array_str(jparse_ctx_t *jctx, char *name, char *val, int size)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_ARRAY);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_string(jctx, tok, val, size);
+}
+
+int json_obj_get_array_strlen(jparse_ctx_t *jctx, char *name, int *strlen)
+{
+	json_tok_t *tok = json_obj_get_val_tok(jctx, name, JSMN_ARRAY);
+	if (!tok)
+		return -OS_FAIL;
+	*strlen = tok->end - tok->start;
+	return OS_SUCCESS;
+}
+
+static json_tok_t *json_arr_search(jparse_ctx_t *ctx, uint32_t index)
+{
+	json_tok_t *tok = ctx->cur;
+	if ((tok->type != JSMN_ARRAY) || (tok->size <= 0))
+		return NULL;
+	if (index > (uint32_t)(tok->size - 1))
+		return NULL;
+	/* Increment by 1, so that token points to index 0 */
+	tok++;
+	while (index--) {
+		tok = json_skip_elem(tok);
+		tok++;
+	}
+	return tok;
+}
+static json_tok_t *json_arr_get_val_tok(jparse_ctx_t *jctx, uint32_t index, jsmntype_t type)
+{
+	json_tok_t *tok = json_arr_search(jctx, index);
+	if (!tok)
+		return NULL;
+	if (tok->type != type)
+		return NULL;
+	return tok;
+}
+
+int json_arr_get_array(jparse_ctx_t *jctx, uint32_t index)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_ARRAY);
+	if (!tok)
+		return -OS_FAIL;
+	jctx->cur = tok;
+	return OS_SUCCESS;
+}
+
+int json_arr_leave_array(jparse_ctx_t *jctx)
+{
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+	return OS_SUCCESS;
+}
+
+int json_arr_get_object(jparse_ctx_t *jctx, uint32_t index)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_OBJECT);
+	if (!tok)
+		return -OS_FAIL;
+	jctx->cur = tok;
+	return OS_SUCCESS;
+}
+
+int json_arr_leave_object(jparse_ctx_t *jctx)
+{
+	if (jctx->cur->parent < 0)
+		return -OS_FAIL;
+	jctx->cur = &jctx->tokens[jctx->cur->parent];
+	return OS_SUCCESS;
+}
+
+int json_arr_get_bool(jparse_ctx_t *jctx, uint32_t index, bool *val)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_bool(jctx, tok, val);
+}
+
+int json_arr_get_int(jparse_ctx_t *jctx, uint32_t index, int *val)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_int(jctx, tok, val);
+}
+
+int json_arr_get_int64(jparse_ctx_t *jctx, uint32_t index, int64_t *val)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_int64(jctx, tok, val);
+}
+
+int json_arr_get_float(jparse_ctx_t *jctx, uint32_t index, float *val)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_PRIMITIVE);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_float(jctx, tok, val);
+}
+
+int json_arr_get_string(jparse_ctx_t *jctx, uint32_t index, char *val, int size)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_STRING);
+	if (!tok)
+		return -OS_FAIL;
+	return json_tok_to_string(jctx, tok, val, size);
+}
+
+int json_arr_get_strlen(jparse_ctx_t *jctx, uint32_t index, int *strlen)
+{
+	json_tok_t *tok = json_arr_get_val_tok(jctx, index, JSMN_STRING);
+	if (!tok)
+		return -OS_FAIL;
+	*strlen = tok->end - tok->start;
+	return OS_SUCCESS;
+}
+
+int json_parse_start(jparse_ctx_t *jctx, char *js, int len)
+{
+	memset(jctx, 0, sizeof(jparse_ctx_t));
+	jsmn_init(&jctx->parser);
+	int num_tokens = jsmn_parse(&jctx->parser, js, len, NULL, 0);
+	if (num_tokens <= 0)
+		return -OS_FAIL;
+	jctx->num_tokens = num_tokens;
+	jctx->tokens = calloc(num_tokens, sizeof(json_tok_t));
+	if (!jctx->tokens)
+		return -OS_FAIL;
+	jctx->js = js;
+	jsmn_init(&jctx->parser);
+	int ret = jsmn_parse(&jctx->parser, js, len, jctx->tokens, jctx->num_tokens);
+	if (ret <= 0) {
+		free(jctx->tokens);
+		memset(jctx, 0, sizeof(jparse_ctx_t));
+		return -OS_FAIL;
+	}
+	jctx->cur = jctx->tokens;
+	return OS_SUCCESS;
+}
+
+int json_parse_end(jparse_ctx_t *jctx)
+{
+	if (jctx->tokens)
+		free(jctx->tokens);
+	memset(jctx, 0, sizeof(jparse_ctx_t));
+	return OS_SUCCESS;
+}

--- a/lib/libesp32/ESP32-HomeKit/src/json_parser.h
+++ b/lib/libesp32/ESP32-HomeKit/src/json_parser.h
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2020 Piyush Shah <shahpiyushv@gmail.com>
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+#ifndef _JSON_PARSER_H_
+#define _JSON_PARSER_H_
+
+#define JSMN_HEADER
+#include <jsmn/jsmn.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define OS_SUCCESS  0
+#define OS_FAIL     -1
+
+typedef jsmn_parser json_parser_t;
+typedef jsmntok_t json_tok_t;
+
+typedef struct {
+	json_parser_t parser;
+	char *js;
+	json_tok_t *tokens;
+	json_tok_t *cur;
+	int num_tokens;
+} jparse_ctx_t;
+
+int json_parse_start(jparse_ctx_t *jctx, char *js, int len);
+int json_parse_end(jparse_ctx_t *jctx);
+
+int json_obj_get_array(jparse_ctx_t *jctx, char *name, int *num_elem);
+int json_obj_leave_array(jparse_ctx_t *jctx);
+int json_obj_get_object(jparse_ctx_t *jctx, char *name);
+int json_obj_leave_object(jparse_ctx_t *jctx);
+int json_obj_get_bool(jparse_ctx_t *jctx, char *name, bool *val);
+int json_obj_get_int(jparse_ctx_t *jctx, char *name, int *val);
+int json_obj_get_int64(jparse_ctx_t *jctx, char *name, int64_t *val);
+int json_obj_get_float(jparse_ctx_t *jctx, char *name, float *val);
+int json_obj_get_string(jparse_ctx_t *jctx, char *name, char *val, int size);
+int json_obj_get_strlen(jparse_ctx_t *jctx, char *name, int *strlen);
+int json_obj_get_object_str(jparse_ctx_t *jctx, char *name, char *val, int size);
+int json_obj_get_object_strlen(jparse_ctx_t *jctx, char *name, int *strlen);
+int json_obj_get_array_str(jparse_ctx_t *jctx, char *name, char *val, int size);
+int json_obj_get_array_strlen(jparse_ctx_t *jctx, char *name, int *strlen);
+
+int json_arr_get_array(jparse_ctx_t *jctx, uint32_t index);
+int json_arr_leave_array(jparse_ctx_t *jctx);
+int json_arr_get_object(jparse_ctx_t *jctx, uint32_t index);
+int json_arr_leave_object(jparse_ctx_t *jctx);
+int json_arr_get_bool(jparse_ctx_t *jctx, uint32_t index, bool *val);
+int json_arr_get_int(jparse_ctx_t *jctx, uint32_t index, int *val);
+int json_arr_get_int64(jparse_ctx_t *jctx, uint32_t index, int64_t *val);
+int json_arr_get_float(jparse_ctx_t *jctx, uint32_t index, float *val);
+int json_arr_get_string(jparse_ctx_t *jctx, uint32_t index, char *val, int size);
+int json_arr_get_strlen(jparse_ctx_t *jctx, uint32_t index, int *strlen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _JSON_PARSER_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/mu_bignum.h
+++ b/lib/libesp32/ESP32-HomeKit/src/mu_bignum.h
@@ -1,0 +1,232 @@
+#ifndef _MU_BIGNUM_H_
+#define _MU_BIGNUM_H_
+
+#define BIGNUM_MBEDTLS
+
+#ifdef BIGNUM_OPENSSL
+#include <openssl/bn.h>
+
+
+typedef BIGNUM mu_bn_t;
+typedef BN_CTX mu_bn_ctx_t;
+
+
+static inline mu_bn_t *mu_bn_new_from_hex(const char *hex)
+{
+     mu_bn_t *a = BN_new();
+     if (a)
+	  BN_hex2bn(&a, hex);
+     return a;
+}
+
+static inline mu_bn_t *mu_bn_new_from_bin(const char *str, int str_len)
+{
+  return BN_bin2bn((unsigned char *)str, str_len, NULL);
+}
+
+static inline mu_bn_t *mu_bn_new()
+{
+     return BN_new();
+}
+
+static inline void mu_bn_free(mu_bn_t *bn)
+{
+     return BN_free(bn);
+}
+
+static inline mu_bn_ctx_t *mu_bn_ctx_new()
+{
+     return BN_CTX_new();
+}
+
+static inline void mu_bn_ctx_free(mu_bn_ctx_t *ctx)
+{
+     return BN_CTX_free(ctx);
+}
+
+static inline unsigned int mu_bn_sizeof(mu_bn_t *bn)
+{
+     return BN_num_bytes(bn);
+}
+
+
+static inline char *mu_bn_to_bin(mu_bn_t *bn, int *len)
+{
+	*len = mu_bn_sizeof(bn);
+	char *p = malloc(*len);
+	if (p) {
+		BN_bn2bin(bn, (unsigned char *)p);
+	}
+	return p;
+}
+
+static inline int mu_bn_get_rand(mu_bn_t *bn, int bits, int top, int bottom)
+{
+	return BN_rand(bn, bits, top, bottom);
+}
+
+static inline int mu_bn_a_exp_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+	return BN_mod_exp(result, a, b, c, ctx);
+}
+
+static inline int mu_bn_a_mul_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+	return BN_mod_mul(result, a, b, c, ctx);
+}
+
+static inline int mu_bn_a_add_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+	if (BN_add(result, a, b) != 1)
+		return 1;
+	return BN_mod(result, result, c, ctx);
+}
+#endif /* BIGNUM_OPENSSL */
+
+
+#ifdef BIGNUM_MBEDTLS
+#include <mbedtls/bignum.h>
+#include <esp_system.h>
+#ifdef CONFIG_IDF_TARGET_ESP8266
+#include <driver/rtc.h>
+#endif
+typedef mbedtls_mpi mu_bn_t;
+typedef mu_bn_t mu_bn_ctx_t;
+
+static inline mu_bn_t *mu_bn_new()
+{
+    mu_bn_t *a = malloc(sizeof (mu_bn_t));
+    if (!a)
+        return NULL;
+    mbedtls_mpi_init(a);
+    return a;
+}
+static inline mu_bn_t *mu_bn_new_from_hex(const char *hex)
+{
+    mu_bn_t *a = mu_bn_new();
+    if (!a)
+        return NULL;
+
+    mbedtls_mpi_read_string(a, 16, hex);
+    return a;
+}
+
+static inline mu_bn_t *mu_bn_new_from_bin(const char *str, int str_len)
+{
+
+    mu_bn_t *a = mu_bn_new();
+    if (!a) {
+        return NULL;
+    }
+    mbedtls_mpi_read_binary(a, (unsigned char *)str, str_len);
+    return a;
+}
+
+
+static inline void mu_bn_free(mu_bn_t *bn)
+{
+    if (bn) {
+        mbedtls_mpi_free(bn);
+        free(bn);
+    }
+}
+
+static inline mu_bn_ctx_t *mu_bn_ctx_new()
+{
+    mu_bn_t *bn = mu_bn_new();
+    return ( mu_bn_ctx_t *)bn;
+}
+
+static inline void mu_bn_ctx_free(mu_bn_ctx_t *ctx)
+{
+    mu_bn_free((mu_bn_t *)ctx);
+}
+
+static inline unsigned int mu_bn_sizeof(mu_bn_t *bn)
+{
+    return mbedtls_mpi_size(bn);
+}
+
+
+static inline char *mu_bn_to_bin(mu_bn_t *bn, int *len)
+{
+	*len = mu_bn_sizeof(bn);
+	char *p = malloc(*len);
+	if (p) {
+        mbedtls_mpi_write_binary(bn, (unsigned char *)p, *len);
+	}
+	return p;
+}
+
+static inline int mu_get_random(void *ctx, unsigned char *data, size_t len)
+{
+    esp_fill_random(data, len);
+    return 0;
+}
+static inline int mu_bn_get_rand(mu_bn_t *bn, int bits, int top, int bottom)
+{
+
+    return mbedtls_mpi_fill_random(bn, bits / 8,  mu_get_random, NULL);
+}
+
+#ifdef CONFIG_IDF_TARGET_ESP8266
+static inline int mu_bn_a_exp_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+    int ret;
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_160M);
+    ret =  mbedtls_mpi_exp_mod(result, a, b, c, (mu_bn_t *) ctx);
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_80M);
+    return ret;
+}
+static inline int mu_bn_a_mul_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+    mbedtls_mpi tmp_result;
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_160M);
+    mbedtls_mpi_init(&tmp_result);
+    mbedtls_mpi_mul_mpi(&tmp_result, a, b);
+    mbedtls_mpi_mod_mpi(result, &tmp_result, c);
+    mbedtls_mpi_free(&tmp_result);
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_80M);
+    return 0;
+}
+#else
+
+#include "port/bignum.h"
+#include "port/bignum_impl.h"
+
+static inline int mu_bn_a_exp_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+    //return mbedtls_mpi_exp_mod(result, a, b, c, (mu_bn_t *) ctx);
+	// wangbin changed
+	printf("esp_mpi_exp_mod\n");
+	return esp_mpi_exp_mod(result, a, b, c, (mu_bn_t *) ctx);
+}
+
+
+static inline int mu_bn_a_mul_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+	printf("esp_mpi_mul_mpi_mod\n");
+    return esp_mpi_mul_mpi_mod(result, a, b, c);
+}
+#endif /* !CONFIG_IDF_TARGET_ESP8266 */
+
+static inline int mu_bn_a_add_b_mod_c(mu_bn_t *result, mu_bn_t *a, mu_bn_t *b, mu_bn_t *c, mu_bn_ctx_t *ctx)
+{
+    int     res;
+    mbedtls_mpi  t;
+#ifdef CONFIG_IDF_TARGET_ESP8266
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_160M);
+#endif
+    mbedtls_mpi_init(&t);
+    res = mbedtls_mpi_add_mpi(&t, a, b);
+    if (res == 0) {
+        res = mbedtls_mpi_mod_mpi(result, &t, c);
+    }
+    mbedtls_mpi_free(&t);
+#ifdef CONFIG_IDF_TARGET_ESP8266
+    rtc_clk_cpu_freq_set(RTC_CPU_FREQ_80M);
+#endif
+    return res;
+}
+#endif /* BIGNUM_MBEDTLS */
+#endif /* ! _MU_BIGNUM_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/mu_srp.c
+++ b/lib/libesp32/ESP32-HomeKit/src/mu_srp.c
@@ -1,0 +1,489 @@
+#include <string.h>
+#include "hkdf-sha.h"
+#include "mu_bignum.h"
+#include "mu_srp.h"
+
+#ifdef SRP_DEBUG
+#include <stdio.h>
+#define srp_print   printf
+static void hex_dbg(char *name, void *buf, int buf_len)
+{
+	char *p = (char *)buf;
+	int i;
+	srp_print("%s (%d): ", name, buf_len);
+	for (i = 0; i < buf_len; i++) {
+		if (i % 16 == 0)
+			srp_print("\r\n");
+		srp_print("%02x ", (unsigned)(unsigned char)p[i]);
+	}
+	srp_print("\r\n");
+}
+
+static void hex_dbg_bn(char *name, mu_bn_t *bn)
+{
+	int len;
+	char *str = mu_bn_to_bin(bn, &len);
+	if (str) {
+		hex_dbg(name, str, len);
+		free(str);
+	}
+}
+#else
+#define srp_print(...)
+#define hex_dbg(...)
+#define hex_dbg_bn(...)
+#endif
+
+static inline void SHA512_hash(const uint8_t *bytes, unsigned int byte_count,
+		     uint8_t digest[SHA512HashSize])
+{
+	SHA512Context ctx;
+	SHA512Reset(&ctx);
+	SHA512Input(&ctx, bytes, byte_count);
+	SHA512Result(&ctx, digest);
+}
+
+/************************* SRP Stuff */
+char N_3072[] = {
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC9, 0x0F, 0xDA, 0xA2, 0x21, 0x68, 0xC2,
+	0x34, 0xC4, 0xC6, 0x62, 0x8B, 0x80, 0xDC, 0x1C, 0xD1, 0x29, 0x02, 0x4E, 0x08, 0x8A, 0x67,
+	0xCC, 0x74, 0x02, 0x0B, 0xBE, 0xA6, 0x3B, 0x13, 0x9B, 0x22, 0x51, 0x4A, 0x08, 0x79, 0x8E,
+	0x34, 0x04, 0xDD, 0xEF, 0x95, 0x19, 0xB3, 0xCD, 0x3A, 0x43, 0x1B, 0x30, 0x2B, 0x0A, 0x6D,
+	0xF2, 0x5F, 0x14, 0x37, 0x4F, 0xE1, 0x35, 0x6D, 0x6D, 0x51, 0xC2, 0x45, 0xE4, 0x85, 0xB5,
+	0x76, 0x62, 0x5E, 0x7E, 0xC6, 0xF4, 0x4C, 0x42, 0xE9, 0xA6, 0x37, 0xED, 0x6B, 0x0B, 0xFF,
+	0x5C, 0xB6, 0xF4, 0x06, 0xB7, 0xED, 0xEE, 0x38, 0x6B, 0xFB, 0x5A, 0x89, 0x9F, 0xA5, 0xAE,
+	0x9F, 0x24, 0x11, 0x7C, 0x4B, 0x1F, 0xE6, 0x49, 0x28, 0x66, 0x51, 0xEC, 0xE4, 0x5B, 0x3D,
+	0xC2, 0x00, 0x7C, 0xB8, 0xA1, 0x63, 0xBF, 0x05, 0x98, 0xDA, 0x48, 0x36, 0x1C, 0x55, 0xD3,
+	0x9A, 0x69, 0x16, 0x3F, 0xA8, 0xFD, 0x24, 0xCF, 0x5F, 0x83, 0x65, 0x5D, 0x23, 0xDC, 0xA3,
+	0xAD, 0x96, 0x1C, 0x62, 0xF3, 0x56, 0x20, 0x85, 0x52, 0xBB, 0x9E, 0xD5, 0x29, 0x07, 0x70,
+	0x96, 0x96, 0x6D, 0x67, 0x0C, 0x35, 0x4E, 0x4A, 0xBC, 0x98, 0x04, 0xF1, 0x74, 0x6C, 0x08,
+	0xCA, 0x18, 0x21, 0x7C, 0x32, 0x90, 0x5E, 0x46, 0x2E, 0x36, 0xCE, 0x3B, 0xE3, 0x9E, 0x77,
+	0x2C, 0x18, 0x0E, 0x86, 0x03, 0x9B, 0x27, 0x83, 0xA2, 0xEC, 0x07, 0xA2, 0x8F, 0xB5, 0xC5,
+	0x5D, 0xF0, 0x6F, 0x4C, 0x52, 0xC9, 0xDE, 0x2B, 0xCB, 0xF6, 0x95, 0x58, 0x17, 0x18, 0x39,
+	0x95, 0x49, 0x7C, 0xEA, 0x95, 0x6A, 0xE5, 0x15, 0xD2, 0x26, 0x18, 0x98, 0xFA, 0x05, 0x10,
+	0x15, 0x72, 0x8E, 0x5A, 0x8A, 0xAA, 0xC4, 0x2D, 0xAD, 0x33, 0x17, 0x0D, 0x04, 0x50, 0x7A,
+	0x33, 0xA8, 0x55, 0x21, 0xAB, 0xDF, 0x1C, 0xBA, 0x64, 0xEC, 0xFB, 0x85, 0x04, 0x58, 0xDB,
+	0xEF, 0x0A, 0x8A, 0xEA, 0x71, 0x57, 0x5D, 0x06, 0x0C, 0x7D, 0xB3, 0x97, 0x0F, 0x85, 0xA6,
+	0xE1, 0xE4, 0xC7, 0xAB, 0xF5, 0xAE, 0x8C, 0xDB, 0x09, 0x33, 0xD7, 0x1E, 0x8C, 0x94, 0xE0,
+	0x4A, 0x25, 0x61, 0x9D, 0xCE, 0xE3, 0xD2, 0x26, 0x1A, 0xD2, 0xEE, 0x6B, 0xF1, 0x2F, 0xFA,
+	0x06, 0xD9, 0x8A, 0x08, 0x64, 0xD8, 0x76, 0x02, 0x73, 0x3E, 0xC8, 0x6A, 0x64, 0x52, 0x1F,
+	0x2B, 0x18, 0x17, 0x7B, 0x20, 0x0C, 0xBB, 0xE1, 0x17, 0x57, 0x7A, 0x61, 0x5D, 0x6C, 0x77,
+	0x09, 0x88, 0xC0, 0xBA, 0xD9, 0x46, 0xE2, 0x08, 0xE2, 0x4F, 0xA0, 0x74, 0xE5, 0xAB, 0x31,
+	0x43, 0xDB, 0x5B, 0xFC, 0xE0, 0xFD, 0x10, 0x8E, 0x4B, 0x82, 0xD1, 0x20, 0xA9, 0x3A, 0xD2,
+	0xCA, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+char g_3072[] = { 5 };
+
+
+int mu_srp_init(mu_srp_handle_t *hd, mu_ng_type_t ng)
+{
+	if (hd->allocated)
+		mu_srp_free(hd);
+
+	memset(hd, 0, sizeof(*hd));
+	hd->allocated = 1;
+
+	hd->ctx = mu_bn_ctx_new();
+	if (! hd->ctx)
+		goto error;
+	if (ng != MU_NG_3072)
+		goto error;
+
+	hd->n = mu_bn_new_from_bin(N_3072, sizeof(N_3072));
+	hd->bytes_n = N_3072;
+	hd->len_n = sizeof(N_3072);
+	if (! hd->n)
+		goto error;
+
+	hd->g = mu_bn_new_from_bin(g_3072, sizeof(g_3072));
+	hd->bytes_g = g_3072;
+	hd->len_g = sizeof(g_3072);
+	if (! hd->g)
+		goto error;
+	hd->type = ng;
+	return 0;
+ error:
+	mu_srp_free(hd);
+	return -1;
+}
+
+void mu_srp_free(mu_srp_handle_t *hd)
+{
+	if (hd->allocated != 1)
+		return;
+
+	if (hd->ctx)
+		mu_bn_ctx_free(hd->ctx);
+	if (hd->n)
+		mu_bn_free(hd->n);
+	if (hd->g)
+		mu_bn_free(hd->g);
+	if (hd->s)
+		mu_bn_free(hd->s);
+	if (hd->bytes_s)
+		free(hd->bytes_s);
+	if (hd->v)
+		mu_bn_free(hd->v);
+	if (hd->B)
+		mu_bn_free(hd->B);
+	if (hd->bytes_B)
+		free(hd->bytes_B);
+	if (hd->b)
+		mu_bn_free(hd->b);
+	if (hd->A)
+		mu_bn_free(hd->A);
+	if (hd->bytes_A)
+		free(hd->bytes_A);
+	if (hd->session_key)
+		free(hd->session_key);
+	memset(hd, 0, sizeof(*hd));
+}
+
+static mu_bn_t *calculate_x(char *bytes_salt, int salt_len, const char *username, const char *pass, int pass_len)
+{
+	unsigned char digest[SHA512HashSize];
+	SHA512Context ctx;
+	srp_print("username:%s:\npass:%s:\npass_len:%d:\n", username, pass, pass_len);
+	hex_dbg("salt", bytes_salt, salt_len);
+	SHA512Reset(&ctx);
+	SHA512Input(&ctx, (unsigned char *)username, strlen(username));
+	SHA512Input(&ctx, (unsigned char *)":", 1);
+	SHA512Input(&ctx, (unsigned char *)pass, pass_len);
+	SHA512Result(&ctx, digest);
+	
+	SHA512Reset(&ctx);
+	SHA512Input(&ctx, (unsigned char *)bytes_salt, salt_len);
+	SHA512Input(&ctx, digest, sizeof(digest));
+	SHA512Result(&ctx, digest);
+
+	hex_dbg("Digest", digest, sizeof(digest));
+	return mu_bn_new_from_bin((char *)digest, sizeof(digest));
+}
+
+static mu_bn_t *calculate_padded_hash(mu_srp_handle_t *hd, char *a, int len_a, char *b, int len_b)
+{
+	unsigned char digest[SHA512HashSize];
+	SHA512Context ctx;
+	int pad_len;
+	char *s = NULL;
+
+	if (len_a > len_b) {
+		pad_len = hd->len_n - len_b;
+	} else {
+		pad_len = hd->len_n - len_a;
+	}
+
+    if (pad_len) {
+        s = malloc(pad_len);
+        if (s) {
+            memset(s, 0, pad_len);
+        }
+    }
+
+	SHA512Reset(&ctx);
+	/* PAD (a) */
+	if (s && (len_a != hd->len_n)) {
+		SHA512Input(&ctx, (unsigned char *)s, hd->len_n - len_a);
+	}
+
+	SHA512Input(&ctx, (unsigned char *)a, len_a);
+
+	/* PAD (b) */
+	if (s && (len_b != hd->len_n)) {
+		SHA512Input(&ctx, (unsigned char *)s, hd->len_n - len_b);
+	}
+
+	SHA512Input(&ctx, (unsigned char *)b, len_b);
+
+	SHA512Result(&ctx, digest);
+
+    if (s) {
+        free(s);
+    }
+
+	hex_dbg("value", digest, sizeof(digest));
+	return mu_bn_new_from_bin((char *)digest, sizeof(digest));
+}
+
+/* k = SHA (N, PAD(g))
+ *
+ * https://tools.ietf.org/html/draft-ietf-tls-srp-08
+ */
+static mu_bn_t *calculate_k(mu_srp_handle_t *hd)
+{
+	srp_print("k-->");
+	return calculate_padded_hash(hd, hd->bytes_n, hd->len_n, hd->bytes_g, hd->len_g);
+}
+
+static mu_bn_t *calculate_u(mu_srp_handle_t *hd, char *A, int len_A)
+{
+	srp_print("u-->");
+	return calculate_padded_hash(hd, A, len_A, hd->bytes_B, hd->len_B);
+}
+
+int __mu_srp_srv_pubkey(mu_srp_handle_t *hd, char **bytes_B, int *len_B)
+{
+	mu_bn_t *k = calculate_k(hd);
+	mu_bn_t *kv = NULL;
+	mu_bn_t *gb = NULL;
+	if (!k)
+		goto error;
+
+	hd->b = mu_bn_new();
+	if (!hd->b)
+		goto error;
+	mu_bn_get_rand(hd->b, 256, -1, 0);
+	hex_dbg_bn("b", hd->b);
+
+	/* B = kv + g^b */
+	kv = mu_bn_new();
+	gb = mu_bn_new();
+	hd->B = mu_bn_new();
+	if (!kv || !gb || ! hd->B)
+		goto error;
+	mu_bn_a_mul_b_mod_c(kv, k, hd->v, hd->n, hd->ctx);
+	mu_bn_a_exp_b_mod_c(gb, hd->g, hd->b, hd->n, hd->ctx);
+	mu_bn_a_add_b_mod_c(hd->B, kv, gb, hd->n, hd->ctx);
+	hd->bytes_B = mu_bn_to_bin(hd->B, len_B);
+	hd->len_B = *len_B;
+	*bytes_B = hd->bytes_B;
+
+	mu_bn_free(k);
+	mu_bn_free(kv);
+	mu_bn_free(gb);
+	return 0;
+ error:
+	if (k)
+		mu_bn_free(k);
+	if (kv)
+		mu_bn_free(kv);
+	if (gb)
+		mu_bn_free(gb);
+	if (hd->B) {
+		mu_bn_free(hd->B);
+		hd->B = NULL;
+	}
+	if (hd->b) {
+		mu_bn_free(hd->b);
+		hd->b = NULL;
+	}
+	return -1;
+	
+}
+
+int mu_srp_srv_pubkey(mu_srp_handle_t *hd, const char *username, const char *pass, int pass_len, int salt_len,
+		      char **bytes_B, int *len_B, char **bytes_salt)
+{
+	/* Get Salt */
+	int str_salt_len;
+	mu_bn_t *x = NULL;
+	hd->s = mu_bn_new();
+	if (! hd->s)
+		goto error;
+	mu_bn_get_rand(hd->s, 8 * salt_len, -1, 0);
+	*bytes_salt = mu_bn_to_bin(hd->s, &str_salt_len);
+	if (! *bytes_salt)
+		goto error;
+	hd->bytes_s = *bytes_salt;
+	hd->len_s = salt_len;
+	hex_dbg("Salt", *bytes_salt, str_salt_len);
+
+	/* Calculate X which is simply a hash for all these things */
+	x = calculate_x(*bytes_salt, str_salt_len, username, pass, pass_len);
+	if (! x)
+		goto error;
+	hex_dbg_bn("x", x);
+	
+	/* v = g^x % N */
+	hd->v = mu_bn_new();
+	if (! hd->v)
+		goto error;
+	mu_bn_a_exp_b_mod_c(hd->v, hd->g, x, hd->n, hd->ctx);
+	hex_dbg_bn("Verifier", hd->v);
+
+	if (__mu_srp_srv_pubkey(hd, bytes_B, len_B) < 0 )
+		goto error;
+
+	mu_bn_free(x);
+	return 0;
+
+error:
+	if (hd->s) {
+		mu_bn_free(hd->s);
+		hd->s = NULL;
+	}
+	if (*bytes_salt) {
+		free(*bytes_salt);
+		*bytes_salt = NULL;
+		hd->bytes_s = NULL;
+		hd->len_s = 0;
+	}
+	if (x) {
+		mu_bn_free(x);
+		x = NULL;
+	}
+	if (hd->v) {
+		mu_bn_free(hd->v);
+		hd->v = NULL;
+	}
+	return -1;
+}
+
+int mu_srp_srv_pubkey_from_salt_verifier(mu_srp_handle_t *hd, char **bytes_B, int *len_B)
+{
+    return __mu_srp_srv_pubkey(hd, bytes_B, len_B);
+}
+
+int mu_srp_set_salt_verifier(mu_srp_handle_t *hd, const char *salt, int salt_len,
+        const char *verifier, int verifier_len)
+{
+    hd->bytes_s = malloc(salt_len);
+    if (!hd->bytes_s) {
+        goto error;
+    }
+    memcpy(hd->bytes_s, salt, salt_len);
+    hd->len_s = salt_len;
+
+    hd->s = mu_bn_new_from_bin(salt, salt_len);
+    if (!hd->s) {
+        goto error;
+    }
+
+	hd->v = mu_bn_new_from_bin(verifier, verifier_len);
+    if (!hd->v) {
+        goto error;
+    }
+    return 0;
+
+error:
+    if (hd->bytes_s) {
+        free(hd->bytes_s);
+        hd->bytes_s = NULL;
+        hd->len_s = 0;
+    }
+    if (hd->s) {
+		mu_bn_free(hd->s);
+		hd->s = NULL;
+    }
+	if (hd->v) {
+		mu_bn_free(hd->v);
+		hd->v = NULL;
+	}
+	return -1;
+}
+
+int mu_srp_get_session_key(mu_srp_handle_t *hd, char *bytes_A, int len_A, char **bytes_key, int *len_key)
+{
+	mu_bn_t *u, *vu, *avu, *S;
+	char *bytes_S;
+	int len_S;
+
+	u = vu = avu = S = NULL;
+	bytes_S = NULL;
+
+	hd->bytes_A = malloc(len_A);
+	if (! hd->bytes_A)
+		goto error;
+	memcpy(hd->bytes_A, bytes_A, len_A);
+	hd->len_A = len_A;
+
+	hd->A = mu_bn_new_from_bin(bytes_A, len_A);
+	if (! hd->A)
+		goto error;
+	u = calculate_u(hd, bytes_A, len_A);
+	if (! u)
+		goto error;
+
+	/* S = (A v^u)^b */
+	vu = mu_bn_new();
+	avu = mu_bn_new();
+	S = mu_bn_new();
+	if (!vu || !avu || !S )
+		goto error;
+
+	mu_bn_a_exp_b_mod_c(vu, hd->v, u, hd->n, hd->ctx);
+	mu_bn_a_mul_b_mod_c(avu, hd->A, vu, hd->n, hd->ctx);
+	mu_bn_a_exp_b_mod_c(S, avu, hd->b, hd->n, hd->ctx);
+	hex_dbg_bn("S", S);
+
+	bytes_S = mu_bn_to_bin(S, &len_S);
+	hd->session_key = malloc(SHA512HashSize);
+	if (!hd->session_key || ! bytes_S)
+		goto error;
+
+	SHA512_hash((unsigned char *)bytes_S, len_S, (unsigned char *)hd->session_key);
+	*bytes_key = hd->session_key;
+	*len_key = SHA512HashSize;
+	
+	free(bytes_S);
+	mu_bn_free(vu);
+	mu_bn_free(avu);
+	mu_bn_free(S);
+	mu_bn_free(u);
+	return 0;
+ error:
+	if (bytes_S)
+		free(bytes_S);
+	if (vu)
+		mu_bn_free(vu);
+	if (avu)
+		mu_bn_free(avu);
+	if (S)
+		mu_bn_free(S);
+	if (u)
+		mu_bn_free(u);
+	if (hd->session_key) {
+		free(hd->session_key);
+		hd->session_key = NULL;
+	}
+	if (hd->A) {
+		mu_bn_free(hd->A);
+		hd->A = NULL;
+	}
+	if (hd->bytes_A) {
+		free(hd->bytes_A);
+		hd->bytes_A = NULL;
+	}
+	return -1;
+}
+
+int mu_srp_exchange_proofs(mu_srp_handle_t *hd, char *username, char *bytes_user_proof, char *bytes_host_proof)
+{
+	/* First calculate M */
+	unsigned char hash_n[SHA512HashSize];
+	unsigned char hash_g[SHA512HashSize];
+	unsigned char hash_n_xor_g[SHA512HashSize];
+	int i;
+	SHA512_hash((unsigned char *)hd->bytes_n, hd->len_n, (unsigned char *)hash_n);
+	SHA512_hash((unsigned char *)hd->bytes_g, hd->len_g, (unsigned char *)hash_g);
+	for (i = 0; i < SHA512HashSize; i++)
+		hash_n_xor_g[i] = hash_n[i] ^ hash_g[i];
+
+	unsigned char hash_I[SHA512HashSize];
+	SHA512_hash((unsigned char *)username, strlen(username), (unsigned char *)hash_I);
+	
+	SHA512Context ctx;
+	unsigned char digest[SHA512HashSize];
+	SHA512Reset(&ctx);
+	SHA512Input(&ctx, hash_n_xor_g, SHA512HashSize);
+	SHA512Input(&ctx, hash_I, SHA512HashSize);
+	SHA512Input(&ctx, (unsigned char *)hd->bytes_s, hd->len_s);
+	SHA512Input(&ctx, (unsigned char *)hd->bytes_A, hd->len_A);
+	SHA512Input(&ctx, (unsigned char *)hd->bytes_B, hd->len_B);
+	SHA512Input(&ctx, (unsigned char *)hd->session_key, SHA512HashSize);
+	SHA512Result(&ctx, digest);
+
+	hex_dbg("M", digest, sizeof(digest));
+	if (memcmp(bytes_user_proof, digest, SHA512HashSize) != 0)
+		return false;
+	/* M is now validated, let's proceed to H(AMK) */
+	SHA512Reset(&ctx);
+	SHA512Input(&ctx, (unsigned char *)hd->bytes_A, hd->len_A);
+	SHA512Input(&ctx, digest, SHA512HashSize);
+	SHA512Input(&ctx, (unsigned char *)hd->session_key, SHA512HashSize);
+	SHA512Result(&ctx, (unsigned char *)bytes_host_proof);
+	hex_dbg("AMK", bytes_host_proof, SHA512HashSize);
+
+	return true;
+}
+/************************* SRP Stuff Ends */

--- a/lib/libesp32/ESP32-HomeKit/src/mu_srp.h
+++ b/lib/libesp32/ESP32-HomeKit/src/mu_srp.h
@@ -1,0 +1,91 @@
+#ifndef _MU_SRP_H_
+#define _MU_SRP_H_
+
+#include <stdbool.h>
+#include "mu_bignum.h"
+
+typedef enum {
+	MU_NG_3072 = 0,
+} mu_ng_type_t;
+
+typedef struct mu_srp_handle {
+	int allocated;
+	mu_ng_type_t type;
+	mu_bn_ctx_t *ctx;
+
+	/* N
+	 * the bytes_n simply points to the static array
+	 */
+	mu_bn_t *n;
+	char    *bytes_n;
+	int      len_n;
+
+	/* g
+	 * the bytes_g simply points to the static array
+	 */
+	mu_bn_t *g;
+	char    *bytes_g;
+	int      len_g;
+
+	/* Salt */
+	mu_bn_t *s;
+	char    *bytes_s;
+	int      len_s;
+	/* Verifier */
+	mu_bn_t *v;
+	/* B */
+	mu_bn_t *B;
+	char    *bytes_B;
+	int      len_B;
+	/* b */
+	mu_bn_t *b;
+	/* A */
+	mu_bn_t *A;
+	char    *bytes_A;
+	int      len_A;
+	/* K - session key*/
+	char *session_key;
+} mu_srp_handle_t;
+
+int mu_srp_init(mu_srp_handle_t *hd, mu_ng_type_t ng);
+
+void mu_srp_free(mu_srp_handle_t *hd);
+/* Returns B (pub key) and salt
+ *
+ * *bytes_B MUST NOT BE FREED BY THE CALLER
+ * *bytes_salt MUST NOT BE FREE BY THE CALLER
+ *
+ */
+int mu_srp_srv_pubkey(mu_srp_handle_t *hd, const char *username, const char *pass, int pass_len, int salt_len,
+		      char **bytes_B, int *len_B, char **bytes_salt);
+
+/* Set the Salt and Verifier pre-generated for a given password.
+ * This should be used only if the actual password is not available.
+ * The public key can then be generated using mu_srp_srv_pubkey_from_salt_verifier()
+ * and not mu_srp_srv_pubkey()
+ */
+int mu_srp_set_salt_verifier(mu_srp_handle_t *hd, const char *salt, int salt_len,
+            const char *verifier, int verifier_len);
+
+/* Returns B (pub key) when the salt and verifier are set using mu_srp_set_salt_verifier()
+ *
+ * *bytes_B MUST NOT BE FREED BY THE CALLER
+ */
+int mu_srp_srv_pubkey_from_salt_verifier(mu_srp_handle_t *hd, char **bytes_B, int *len_B);
+
+/* Returns bytes_key
+ * *bytes_key MUST NOT BE FREED BY THE CALLER
+ */
+int mu_srp_get_session_key(mu_srp_handle_t *hd, char *bytes_A, int len_A, char **bytes_key, int *len_key);
+
+/* Exchange proofs
+ * Returns 1 if user's proof is ok. Also 1 when is returned, bytes_host_proof contains our proof.
+ *
+ * bytes_user_proof is parameter in
+ * bytes_host_proof is parameter out (should be SHA512_DIGEST_LENGTH) bytes in size
+ */
+int mu_srp_exchange_proofs(mu_srp_handle_t *hd, char *username, char *bytes_user_proof, char *bytes_host_proof);
+
+
+
+#endif /* ! _MU_SRP_H_ */

--- a/lib/libesp32/ESP32-HomeKit/src/port/bignum.c
+++ b/lib/libesp32/ESP32-HomeKit/src/port/bignum.c
@@ -1,0 +1,279 @@
+/**
+ * \brief  Multi-precision integer library, ESP-IDF hardware accelerated parts
+ *
+ *  based on mbedTLS implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  Additions Copyright (C) 2016-2020, Espressif Systems (Shanghai) PTE Ltd
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+//#include "soc/hwcrypto_periph.h"
+#include "soc/hwcrypto_reg.h"
+#include "driver/periph_ctrl.h"
+#include <mbedtls/bignum.h>
+#include "bignum_impl.h"
+#include <sys/param.h>
+#include <sys/lock.h>
+
+static _lock_t mpi_lock;
+
+/* Round up number of words to nearest
+   512 bit (16 word) block count.
+*/
+size_t esp_mpi_hardware_words(size_t words)
+{
+    return (words + 0xF) & ~0xF;
+}
+
+void esp_mpi_enable_hardware_hw_op( void )
+{
+    /* newlib locks lazy initialize on ESP-IDF */
+    _lock_acquire(&mpi_lock);
+
+    /* Enable RSA hardware */
+    periph_module_enable(PERIPH_RSA_MODULE);
+    DPORT_REG_CLR_BIT(DPORT_RSA_PD_CTRL_REG, DPORT_RSA_PD);
+
+    while (DPORT_REG_READ(RSA_CLEAN_REG) != 1)
+    { }
+    // Note: from enabling RSA clock to here takes about 1.3us
+}
+
+void esp_mpi_disable_hardware_hw_op( void )
+{
+    DPORT_REG_SET_BIT(DPORT_RSA_PD_CTRL_REG, DPORT_RSA_PD);
+
+    /* Disable RSA hardware */
+    periph_module_disable(PERIPH_RSA_MODULE);
+
+    _lock_release(&mpi_lock);
+}
+
+
+/* Copy mbedTLS MPI bignum 'mpi' to hardware memory block at 'mem_base'.
+
+   If hw_words is higher than the number of words in the bignum then
+   these additional words will be zeroed in the memory buffer.
+
+*/
+static inline void mpi_to_mem_block(uint32_t mem_base, const mbedtls_mpi *mpi, size_t hw_words)
+{
+    uint32_t *pbase = (uint32_t *)mem_base;
+    uint32_t copy_words = MIN(hw_words, mpi->n);
+
+    /* Copy MPI data to memory block registers */
+    for (int i = 0; i < copy_words; i++) {
+        pbase[i] = mpi->p[i];
+    }
+
+    /* Zero any remaining memory block data */
+    for (int i = copy_words; i < hw_words; i++) {
+        pbase[i] = 0;
+    }
+}
+
+/* Read mbedTLS MPI bignum back from hardware memory block.
+
+   Reads num_words words from block.
+
+   Bignum 'x' should already be grown to at least num_words by caller (can be done while
+   calculation is in progress, to save some cycles)
+*/
+static inline void mem_block_to_mpi(mbedtls_mpi *x, uint32_t mem_base, int num_words)
+{
+    assert(x->n >= num_words);
+
+    /* Copy data from memory block registers */
+    esp_dport_access_read_buffer(x->p, mem_base, num_words);
+
+    /* Zero any remaining limbs in the bignum, if the buffer is bigger
+       than num_words */
+    for (size_t i = num_words; i < x->n; i++) {
+        x->p[i] = 0;
+    }
+}
+
+
+/* Begin an RSA operation. op_reg specifies which 'START' register
+   to write to.
+*/
+static inline void start_op(uint32_t op_reg)
+{
+    /* Clear interrupt status */
+    DPORT_REG_WRITE(RSA_INTERRUPT_REG, 1);
+
+    /* Note: above REG_WRITE includes a memw, so we know any writes
+       to the memory blocks are also complete. */
+
+    DPORT_REG_WRITE(op_reg, 1);
+}
+
+/* Wait for an RSA operation to complete.
+*/
+static inline void wait_op_complete(void)
+{
+    while (DPORT_REG_READ(RSA_INTERRUPT_REG) != 1)
+    { }
+
+    /* clear the interrupt */
+    DPORT_REG_WRITE(RSA_INTERRUPT_REG, 1);
+}
+
+/* Read result from last MPI operation */
+void esp_mpi_read_result_hw_op(mbedtls_mpi *Z, size_t z_words)
+{
+    wait_op_complete();
+    mem_block_to_mpi(Z, RSA_MEM_Z_BLOCK_BASE, z_words);
+}
+
+/* Z = (X * Y) mod M */
+void esp_mpi_mul_mpi_mod_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M, const mbedtls_mpi *Rinv, mbedtls_mpi_uint Mprime, size_t hw_words)
+{
+    /* Load M, X, Rinv, Mprime (Mprime is mod 2^32) */
+    mpi_to_mem_block(RSA_MEM_M_BLOCK_BASE, M, hw_words);
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, X, hw_words);
+    mpi_to_mem_block(RSA_MEM_RB_BLOCK_BASE, Rinv, hw_words);
+    DPORT_REG_WRITE(RSA_M_DASH_REG, (uint32_t)Mprime);
+
+    /* "mode" register loaded with number of 512-bit blocks, minus 1 */
+    DPORT_REG_WRITE(RSA_MULT_MODE_REG, (hw_words / 16) - 1);
+
+    /* Execute first stage montgomery multiplication */
+    start_op(RSA_MULT_START_REG);
+
+    wait_op_complete();
+
+    /* execute second stage */
+    /* Load Y to X input memory block, rerun */
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, Y, hw_words);
+
+    start_op(RSA_MULT_START_REG);
+}
+
+/* Z = X * Y */
+void esp_mpi_mul_mpi_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t hw_words)
+{
+    /* Copy X (right-extended) & Y (left-extended) to memory block */
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, X, hw_words);
+    mpi_to_mem_block(RSA_MEM_Z_BLOCK_BASE + hw_words * 4, Y, hw_words);
+    /* NB: as Y is left-extended, we don't zero the bottom words_mult words of Y block.
+       This is OK for now because zeroing is done by hardware when we do esp_mpi_acquire_hardware().
+    */
+
+    DPORT_REG_WRITE(RSA_M_DASH_REG, 0);
+
+    /* "mode" register loaded with number of 512-bit blocks in result,
+       plus 7 (for range 9-12). (this is ((N~ / 32) - 1) + 8))
+    */
+    DPORT_REG_WRITE(RSA_MULT_MODE_REG, ((hw_words * 2) / 16) + 7);
+
+    start_op(RSA_MULT_START_REG);
+
+}
+
+
+int esp_mont_hw_op(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M,
+                   mbedtls_mpi_uint Mprime,
+                   size_t hw_words,
+                   bool again)
+{
+    // Note Z may be the same pointer as X or Y
+    int ret = 0;
+
+    // montgomery mult prepare
+    if (again == false) {
+        mpi_to_mem_block(RSA_MEM_M_BLOCK_BASE, M, hw_words);
+        DPORT_REG_WRITE(RSA_M_DASH_REG, Mprime);
+        DPORT_REG_WRITE(RSA_MULT_MODE_REG, hw_words / 16 - 1);
+    }
+
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, X, hw_words);
+    mpi_to_mem_block(RSA_MEM_RB_BLOCK_BASE, Y, hw_words);
+
+    start_op(RSA_MULT_START_REG);
+    Z->s = 1; // The sign of Z will be = M->s (but M->s is always 1)
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow(Z, hw_words) );
+
+    wait_op_complete();
+
+    /* Read back the result */
+    mem_block_to_mpi(Z, RSA_MEM_Z_BLOCK_BASE, hw_words);
+
+
+    /* from HAC 14.36 - 3. If Z >= M then Z = Z - M */
+    if (mbedtls_mpi_cmp_mpi(Z, M) >= 0) {
+        MBEDTLS_MPI_CHK(mbedtls_mpi_sub_mpi(Z, Z, M));
+    }
+cleanup:
+    return ret;
+}
+
+
+
+/* Special-case of mbedtls_mpi_mult_mpi(), where we use hardware montgomery mod
+   multiplication to calculate an mbedtls_mpi_mult_mpi result where either
+   A or B are >2048 bits so can't use the standard multiplication method.
+
+   Result (z_words, based on A bits + B bits) must still be less than 4096 bits.
+
+   This case is simpler than the general case modulo multiply of
+   esp_mpi_mul_mpi_mod() because we can control the other arguments:
+
+   * Modulus is chosen with M=(2^num_bits - 1) (ie M=R-1), so output
+   isn't actually modulo anything.
+   * Mprime and Rinv are therefore predictable as follows:
+   Mprime = 1
+   Rinv = 1
+
+   (See RSA Accelerator section in Technical Reference for more about Mprime, Rinv)
+*/
+void esp_mpi_mult_mpi_failover_mod_mult_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t num_words)
+{
+    size_t hw_words = num_words;
+
+    /* M = 2^num_words - 1, so block is entirely FF */
+    for (int i = 0; i < hw_words; i++) {
+        DPORT_REG_WRITE(RSA_MEM_M_BLOCK_BASE + i * 4, UINT32_MAX);
+    }
+    /* Mprime = 1 */
+    DPORT_REG_WRITE(RSA_M_DASH_REG, 1);
+
+    /* "mode" register loaded with number of 512-bit blocks, minus 1 */
+    DPORT_REG_WRITE(RSA_MULT_MODE_REG, (hw_words / 16) - 1);
+
+    /* Load X */
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, X, hw_words);
+
+    /* Rinv = 1, write first word */
+    DPORT_REG_WRITE(RSA_MEM_RB_BLOCK_BASE, 1);
+
+    /* Zero out rest of the Rinv words */
+    for (int i = 1; i < hw_words; i++) {
+        DPORT_REG_WRITE(RSA_MEM_RB_BLOCK_BASE + i * 4, 0);
+    }
+
+    start_op(RSA_MULT_START_REG);
+
+    wait_op_complete();
+
+    /* finish the modular multiplication */
+    /* Load Y to X input memory block, rerun */
+    mpi_to_mem_block(RSA_MEM_X_BLOCK_BASE, Y, hw_words);
+
+    start_op(RSA_MULT_START_REG);
+
+}

--- a/lib/libesp32/ESP32-HomeKit/src/port/bignum.h
+++ b/lib/libesp32/ESP32-HomeKit/src/port/bignum.h
@@ -1,0 +1,80 @@
+// Copyright 2015-2020 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include_next "mbedtls/bignum.h"
+#include "sdkconfig.h"
+
+/**
+ * This is a wrapper for the main mbedtls/bignum.h. This wrapper
+ * provides a few additional ESP32-only functions.
+ *
+ * This is because we don't set MBEDTLS_BIGNUM_ALT in the same way we
+ * do for AES, SHA, etc. Because we still use most of the bignum.h
+ * implementation and just replace a few hardware accelerated
+ * functions (see MBEDTLS_MPI_EXP_MOD_ALT & MBEDTLS_MPI_MUL_MPI_ALT in
+ * esp_config.h).
+ *
+ * @note Unlike the other hardware accelerator support functions in esp32/hwcrypto, there is no
+ * generic "hwcrypto/bignum.h" header for using these functions without mbedTLS. The reason for this
+ * is that all of the function implementations depend strongly upon the mbedTLS MPI implementation.
+ */
+
+/**
+ * @brief Lock access to RSA Accelerator (MPI/bignum operations)
+ *
+ * RSA Accelerator hardware unit can only be used by one
+ * consumer at a time.
+ *
+ * @note This function is non-recursive (do not call it twice from the
+ * same task.)
+ *
+ * @note You do not need to call this if you are using the mbedTLS bignum.h
+ * API or esp_mpi_xxx functions. This function is only needed if you
+ * want to call ROM RSA functions or access the registers directly.
+ *
+ */
+void esp_mpi_acquire_hardware(void);
+
+/**
+ * @brief Unlock access to RSA Accelerator (MPI/bignum operations)
+ *
+ * Has to be called once for each call to esp_mpi_acquire_hardware().
+ *
+ * @note You do not need to call this if you are using the mbedTLS bignum.h
+ * API or esp_mpi_xxx functions. This function is only needed if you
+ * want to call ROM RSA functions or access the registers directly.
+ */
+void esp_mpi_release_hardware(void);
+
+//#if CONFIG_MBEDTLS_HARDWARE_MPI
+
+/* @brief MPI modular mupltiplication function
+ *
+ * Calculates Z = (X * Y) mod M using MPI hardware acceleration.
+ *
+ * This is not part of the standard mbedTLS bignum API.
+ *
+ * @note All of X, Y & Z should be less than 4096 bit long or an error is returned.
+ *
+ * @param Z Result bignum, should be pre-initialised with mbedtls_mpi_init().
+ * @param X First multiplication argument.
+ * @param Y Second multiplication argument.
+ * @param M Modulus value for result.
+ *
+ * @return 0 on success, mbedTLS MPI error codes on failure.
+ */
+int esp_mpi_mul_mpi_mod(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M);
+
+//#endif // CONFIG_MBEDTLS_HARDWARE_MPI

--- a/lib/libesp32/ESP32-HomeKit/src/port/bignum_impl.h
+++ b/lib/libesp32/ESP32-HomeKit/src/port/bignum_impl.h
@@ -1,0 +1,92 @@
+#ifndef _ESP_BIGNUM_H_
+#define _ESP_BIGNUM_H_
+
+#include <mbedtls/bignum.h>
+#include <stdbool.h>
+
+/* Use montgomery exponentiation (HAC 14.94) for calculating X ^ Y mod M,
+   this may be faster for some targets. The hardware acceleration support for modular
+   exponentiation on the ESP32 is slow for public key operations, so use montgomery
+   exponentiation instead.
+*/
+
+#define CONFIG_IDF_TARGET_ESP32  1
+
+#if CONFIG_IDF_TARGET_ESP32
+#define ESP_MPI_USE_MONT_EXP
+
+#define MBEDTLS_MPI_EXP_MOD_ALT
+//#define MBEDTLS_MPI_MUL_MPI_ALT
+#endif
+
+
+int esp_mpi_exp_mod( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M, mbedtls_mpi *_Rinv );
+
+/**
+ * @brief Enable the MPI hardware and acquire the lock
+ *
+ */
+void esp_mpi_enable_hardware_hw_op( void );
+
+/**
+ * @brief Disable the MPI hardware and release the lock
+ *
+ */
+void esp_mpi_disable_hardware_hw_op( void );
+
+/**
+ * @brief Calculate the number of words needed to represent the input word in hardware
+ *
+ * @param words The number of words to be represented
+ *
+ * @return size_t Number of words required
+ */
+size_t esp_mpi_hardware_words(size_t words);
+
+/**
+ * @brief Starts a (X * Y) Mod M calculation in hardware. Rinv and M_prime needs to be precalculated in software.
+ *
+ */
+void esp_mpi_mul_mpi_mod_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M, const mbedtls_mpi *Rinv, mbedtls_mpi_uint Mprime, size_t hw_words);
+
+/**
+ * @brief Starts a (X * Y) calculation in hardware.
+ *
+ */
+void esp_mpi_mul_mpi_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t num_words);
+
+/**
+ * @brief Special-case of (X * Y), where we use hardware montgomery mod
+   multiplication to calculate result where either A or B are >2048 bits so
+   can't use the standard multiplication method.
+ *
+ */
+void esp_mpi_mult_mpi_failover_mod_mult_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t num_words);
+
+/**
+ * @brief Read out the result from the previous calculation.
+ *
+ */
+void esp_mpi_read_result_hw_op(mbedtls_mpi *Z, size_t z_words);
+
+#ifdef ESP_MPI_USE_MONT_EXP
+/**
+ * @brief Starts a montgomery multiplication calculation in hardware
+ *
+ */
+int esp_mont_hw_op(mbedtls_mpi* Z, const mbedtls_mpi* X, const mbedtls_mpi* Y, const mbedtls_mpi* M,
+                mbedtls_mpi_uint Mprime,
+                size_t hw_words,
+                bool again);
+
+#else
+
+/**
+ * @brief Starts a (X ^ Y) Mod M calculation in hardware. Rinv and M_prime needs to be precalculated in software.
+ *
+ */
+void esp_mpi_exp_mpi_mod_hw_op(const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M, const mbedtls_mpi *Rinv, mbedtls_mpi_uint Mprime, size_t hw_words);
+
+#endif //ESP_MPI_USE_MONT_EXP
+
+#endif

--- a/lib/libesp32/ESP32-HomeKit/src/port/esp_bignum.c
+++ b/lib/libesp32/ESP32-HomeKit/src/port/esp_bignum.c
@@ -1,0 +1,536 @@
+/**
+ * \brief  Multi-precision integer library, ESP32 hardware accelerated parts
+ *
+ *  based on mbedTLS implementation
+ *
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  Additions Copyright (C) 2016, Espressif Systems (Shanghai) PTE Ltd
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include <stdio.h>
+#include <string.h>
+#include <malloc.h>
+#include <limits.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <sys/param.h>
+//#include "soc/hwcrypto_periph.h"
+#include "esp_system.h"
+#include "esp_log.h"
+#include "esp_attr.h"
+#include "bignum_impl.h"
+//#include "soc/soc_caps.h"
+
+#include <mbedtls/bignum.h>
+
+// wangbin added
+#if !defined(SOC_RSA_MAX_BIT_LEN)
+#define SOC_RSA_MAX_BIT_LEN    (4096)
+#endif
+
+
+/* Some implementation notes:
+ *
+ * - Naming convention x_words, y_words, z_words for number of words (limbs) used in a particular
+ *   bignum. This number may be less than the size of the bignum
+ *
+ * - Naming convention hw_words for the hardware length of the operation. This number maybe be rounded up
+ *   for targets that requres this (e.g. ESP32), and may be larger than any of the numbers
+ *   involved in the calculation.
+ *
+ * - Timing behaviour of these functions will depend on the length of the inputs. This is fundamentally
+ *   the same constraint as the software mbedTLS implementations, and relies on the same
+ *   countermeasures (exponent blinding, etc) which are used in mbedTLS.
+ */
+
+static const __attribute__((unused)) char *TAG = "bignum";
+
+#define ciL    (sizeof(mbedtls_mpi_uint))         /* chars in limb  */
+#define biL    (ciL << 3)                         /* bits  in limb  */
+
+
+/* Convert bit count to word count
+ */
+static inline size_t bits_to_words(size_t bits)
+{
+    return (bits + 31) / 32;
+}
+
+/* Return the number of words actually used to represent an mpi
+   number.
+*/
+#if defined(MBEDTLS_MPI_EXP_MOD_ALT)
+static size_t mpi_words(const mbedtls_mpi *mpi)
+{
+    for (size_t i = mpi->n; i > 0; i--) {
+        if (mpi->p[i - 1] != 0) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+#endif //MBEDTLS_MPI_EXP_MOD_ALT
+
+/**
+ *
+ * There is a need for the value of integer N' such that B^-1(B-1)-N^-1N'=1,
+ * where B^-1(B-1) mod N=1. Actually, only the least significant part of
+ * N' is needed, hence the definition N0'=N' mod b. We reproduce below the
+ * simple algorithm from an article by Dusse and Kaliski to efficiently
+ * find N0' from N0 and b
+ */
+static mbedtls_mpi_uint modular_inverse(const mbedtls_mpi *M)
+{
+    int i;
+    uint64_t t = 1;
+    uint64_t two_2_i_minus_1 = 2;   /* 2^(i-1) */
+    uint64_t two_2_i = 4;           /* 2^i */
+    uint64_t N = M->p[0];
+
+    for (i = 2; i <= 32; i++) {
+        if ((mbedtls_mpi_uint) N * t % two_2_i >= two_2_i_minus_1) {
+            t += two_2_i_minus_1;
+        }
+
+        two_2_i_minus_1 <<= 1;
+        two_2_i <<= 1;
+    }
+
+    return (mbedtls_mpi_uint)(UINT32_MAX - t + 1);
+}
+
+/* Calculate Rinv = RR^2 mod M, where:
+ *
+ *  R = b^n where b = 2^32, n=num_words,
+ *  R = 2^N (where N=num_bits)
+ *  RR = R^2 = 2^(2*N) (where N=num_bits=num_words*32)
+ *
+ * This calculation is computationally expensive (mbedtls_mpi_mod_mpi)
+ * so caller should cache the result where possible.
+ *
+ * DO NOT call this function while holding esp_mpi_enable_hardware_hw_op().
+ *
+ */
+static int calculate_rinv(mbedtls_mpi *Rinv, const mbedtls_mpi *M, int num_words)
+{
+    int ret;
+    size_t num_bits = num_words * 32;
+    mbedtls_mpi RR;
+    mbedtls_mpi_init(&RR);
+    MBEDTLS_MPI_CHK(mbedtls_mpi_set_bit(&RR, num_bits * 2, 1));
+    MBEDTLS_MPI_CHK(mbedtls_mpi_mod_mpi(Rinv, &RR, M));
+
+cleanup:
+    mbedtls_mpi_free(&RR);
+
+    return ret;
+}
+
+
+
+
+
+
+/* Z = (X * Y) mod M
+
+   Not an mbedTLS function
+*/
+int esp_mpi_mul_mpi_mod(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M)
+{
+    int ret = 0;
+
+    size_t x_bits = mbedtls_mpi_bitlen(X);
+    size_t y_bits = mbedtls_mpi_bitlen(Y);
+    size_t m_bits = mbedtls_mpi_bitlen(M);
+    size_t z_bits = MIN(m_bits, x_bits + y_bits);
+    size_t x_words = bits_to_words(x_bits);
+    size_t y_words = bits_to_words(y_bits);
+    size_t m_words = bits_to_words(m_bits);
+    size_t z_words = bits_to_words(z_bits);
+    size_t hw_words = esp_mpi_hardware_words(MAX(x_words, MAX(y_words, m_words))); /* longest operand */
+    mbedtls_mpi Rinv;
+    mbedtls_mpi_uint Mprime;
+
+    /* Calculate and load the first stage montgomery multiplication */
+    mbedtls_mpi_init(&Rinv);
+    MBEDTLS_MPI_CHK(calculate_rinv(&Rinv, M, hw_words));
+    Mprime = modular_inverse(M);
+
+    esp_mpi_enable_hardware_hw_op();
+    /* Load and start a (X * Y) mod M calculation */
+    esp_mpi_mul_mpi_mod_hw_op(X, Y, M, &Rinv, Mprime, hw_words);
+
+    MBEDTLS_MPI_CHK(mbedtls_mpi_grow(Z, z_words));
+
+    esp_mpi_read_result_hw_op(Z, z_words);
+    Z->s = X->s * Y->s;
+
+cleanup:
+    mbedtls_mpi_free(&Rinv);
+    esp_mpi_disable_hardware_hw_op();
+
+    return ret;
+}
+
+#if defined(MBEDTLS_MPI_EXP_MOD_ALT)
+
+#ifdef ESP_MPI_USE_MONT_EXP
+/*
+ * Return the most significant one-bit.
+ */
+static size_t mbedtls_mpi_msb( const mbedtls_mpi *X )
+{
+    int i, j;
+    if (X != NULL && X->n != 0) {
+        for (i = X->n - 1; i >= 0; i--) {
+            if (X->p[i] != 0) {
+                for (j = biL - 1; j >= 0; j--) {
+                    if ((X->p[i] & (1 << j)) != 0) {
+                        return (i * biL) + j;
+                    }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+/*
+ * Montgomery exponentiation: Z = X ^ Y mod M  (HAC 14.94)
+ */
+static int mpi_montgomery_exp_calc( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M,
+                                    mbedtls_mpi *Rinv,
+                                    size_t hw_words,
+                                    mbedtls_mpi_uint Mprime )
+{
+    int ret = 0;
+    mbedtls_mpi X_, one;
+
+    mbedtls_mpi_init(&X_);
+    mbedtls_mpi_init(&one);
+    if ( ( ( ret = mbedtls_mpi_grow(&one, hw_words) ) != 0 ) ||
+            ( ( ret = mbedtls_mpi_set_bit(&one, 0, 1) )  != 0 ) ) {
+        goto cleanup2;
+    }
+
+    // Algorithm from HAC 14.94
+    {
+        // 0 determine t (highest bit set in y)
+        int t = mbedtls_mpi_msb(Y);
+
+        esp_mpi_enable_hardware_hw_op();
+
+        // 1.1 x_ = mont(x, R^2 mod m)
+        //        = mont(x, rb)
+        MBEDTLS_MPI_CHK( esp_mont_hw_op(&X_, X, Rinv, M, Mprime, hw_words, false) );
+
+        // 1.2 z = R mod m
+        // now z = R mod m = Mont (R^2 mod m, 1) mod M (as Mont(x) = X&R^-1 mod M)
+        MBEDTLS_MPI_CHK( esp_mont_hw_op(Z, Rinv, &one, M, Mprime, hw_words, true) );
+
+        // 2 for i from t down to 0
+        for (int i = t; i >= 0; i--) {
+            // 2.1 z = mont(z,z)
+            if (i != t) { // skip on the first iteration as is still unity
+                MBEDTLS_MPI_CHK( esp_mont_hw_op(Z, Z, Z, M, Mprime, hw_words, true) );
+            }
+
+            // 2.2 if y[i] = 1 then z = mont(A, x_)
+            if (mbedtls_mpi_get_bit(Y, i)) {
+                MBEDTLS_MPI_CHK( esp_mont_hw_op(Z, Z, &X_, M, Mprime, hw_words, true) );
+            }
+        }
+
+        // 3 z = Mont(z, 1)
+        MBEDTLS_MPI_CHK( esp_mont_hw_op(Z, Z, &one, M, Mprime, hw_words, true) );
+    }
+
+cleanup:
+    esp_mpi_disable_hardware_hw_op();
+
+cleanup2:
+    mbedtls_mpi_free(&X_);
+    mbedtls_mpi_free(&one);
+    return ret;
+}
+
+#endif //USE_MONT_EXPONENATIATION
+
+/*
+ * Z = X ^ Y mod M
+ *
+ * _Rinv is optional pre-calculated version of Rinv (via calculate_rinv()).
+ *
+ * (See RSA Accelerator section in Technical Reference for more about Mprime, Rinv)
+ *
+ */
+// wangbin changed mbedtls_mpi_exp_mod -> esp_mpi_exp_mod
+int esp_mpi_exp_mod( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, const mbedtls_mpi *M, mbedtls_mpi *_Rinv )
+{
+    int ret = 0;
+    size_t x_words = mpi_words(X);
+    size_t y_words = mpi_words(Y);
+    size_t m_words = mpi_words(M);
+
+
+    /* "all numbers must be the same length", so choose longest number
+       as cardinal length of operation...
+    */
+    size_t num_words = esp_mpi_hardware_words(MAX(m_words, MAX(x_words, y_words)));
+
+    mbedtls_mpi Rinv_new; /* used if _Rinv == NULL */
+    mbedtls_mpi *Rinv;    /* points to _Rinv (if not NULL) othwerwise &RR_new */
+    mbedtls_mpi_uint Mprime;
+
+    if (mbedtls_mpi_cmp_int(M, 0) <= 0 || (M->p[0] & 1) == 0) {
+        return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+    }
+
+    if (mbedtls_mpi_cmp_int(Y, 0) < 0) {
+        return MBEDTLS_ERR_MPI_BAD_INPUT_DATA;
+    }
+
+    if (mbedtls_mpi_cmp_int(Y, 0) == 0) {
+        return mbedtls_mpi_lset(Z, 1);
+    }
+
+    if (num_words * 32 > SOC_RSA_MAX_BIT_LEN) {
+        return MBEDTLS_ERR_MPI_NOT_ACCEPTABLE;
+    }
+
+    /* Determine RR pointer, either _RR for cached value
+       or local RR_new */
+    if (_Rinv == NULL) {
+        mbedtls_mpi_init(&Rinv_new);
+        Rinv = &Rinv_new;
+    } else {
+        Rinv = _Rinv;
+    }
+    if (Rinv->p == NULL) {
+        MBEDTLS_MPI_CHK(calculate_rinv(Rinv, M, num_words));
+    }
+
+    Mprime = modular_inverse(M);
+
+    // Montgomery exponentiation: Z = X ^ Y mod M  (HAC 14.94)
+#ifdef ESP_MPI_USE_MONT_EXP
+    ret = mpi_montgomery_exp_calc(Z, X, Y, M, Rinv, num_words, Mprime) ;
+    MBEDTLS_MPI_CHK(ret);
+#else
+    esp_mpi_enable_hardware_hw_op();
+
+    esp_mpi_exp_mpi_mod_hw_op(X, Y, M, Rinv, Mprime, num_words);
+    ret = mbedtls_mpi_grow(Z, m_words);
+    if (ret != 0) {
+        esp_mpi_disable_hardware_hw_op();
+        goto cleanup;
+    }
+    esp_mpi_read_result_hw_op(Z, m_words);
+    esp_mpi_disable_hardware_hw_op();
+#endif
+
+    // Compensate for negative X
+    if (X->s == -1 && (Y->p[0] & 1) != 0) {
+        Z->s = -1;
+        MBEDTLS_MPI_CHK(mbedtls_mpi_add_mpi(Z, M, Z));
+    } else {
+        Z->s = 1;
+    }
+
+cleanup:
+    if (_Rinv == NULL) {
+        mbedtls_mpi_free(&Rinv_new);
+    }
+    return ret;
+}
+
+#endif /* MBEDTLS_MPI_EXP_MOD_ALT */
+
+
+
+#if defined(MBEDTLS_MPI_MUL_MPI_ALT) /* MBEDTLS_MPI_MUL_MPI_ALT */
+
+static int mpi_mult_mpi_failover_mod_mult( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t z_words);
+static int mpi_mult_mpi_overlong(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t y_words, size_t z_words);
+
+/* Z = X * Y */
+int mbedtls_mpi_mul_mpi( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y )
+{
+    int ret = 0;
+    size_t x_bits = mbedtls_mpi_bitlen(X);
+    size_t y_bits = mbedtls_mpi_bitlen(Y);
+    size_t x_words = bits_to_words(x_bits);
+    size_t y_words = bits_to_words(y_bits);
+    size_t z_words = bits_to_words(x_bits + y_bits);
+    size_t hw_words = esp_mpi_hardware_words(MAX(x_words, y_words)); // length of one operand in hardware
+
+    /* Short-circuit eval if either argument is 0 or 1.
+
+       This is needed as the mpi modular division
+       argument will sometimes call in here when one
+       argument is too large for the hardware unit, but the other
+       argument is zero or one.
+    */
+    if (x_bits == 0 || y_bits == 0) {
+        mbedtls_mpi_lset(Z, 0);
+        return 0;
+    }
+    if (x_bits == 1) {
+        ret = mbedtls_mpi_copy(Z, Y);
+        Z->s *= X->s;
+        return ret;
+    }
+    if (y_bits == 1) {
+        ret = mbedtls_mpi_copy(Z, X);
+        Z->s *= Y->s;
+        return ret;
+    }
+
+    /* Grow Z to result size early, avoid interim allocations */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow(Z, z_words) );
+
+    /* If either factor is over 2048 bits, we can't use the standard hardware multiplier
+       (it assumes result is double longest factor, and result is max 4096 bits.)
+
+       However, we can fail over to mod_mult for up to 4096 bits of result (modulo
+       multiplication doesn't have the same restriction, so result is simply the
+       number of bits in X plus number of bits in in Y.)
+    */
+    if (hw_words * 32 > SOC_RSA_MAX_BIT_LEN/2) {
+        if (z_words * 32 <= SOC_RSA_MAX_BIT_LEN) {
+            /* Note: it's possible to use mpi_mult_mpi_overlong
+               for this case as well, but it's very slightly
+               slower and requires a memory allocation.
+            */
+            return mpi_mult_mpi_failover_mod_mult(Z, X, Y, z_words);
+        } else {
+            /* Still too long for the hardware unit... */
+            if (y_words > x_words) {
+                return mpi_mult_mpi_overlong(Z, X, Y, y_words, z_words);
+            } else {
+                return mpi_mult_mpi_overlong(Z, Y, X, x_words, z_words);
+            }
+        }
+    }
+
+    /* Otherwise, we can use the (faster) multiply hardware unit */
+    esp_mpi_enable_hardware_hw_op();
+
+    esp_mpi_mul_mpi_hw_op(X, Y, hw_words);
+    esp_mpi_read_result_hw_op(Z, z_words);
+
+    esp_mpi_disable_hardware_hw_op();
+
+    Z->s = X->s * Y->s;
+
+cleanup:
+    return ret;
+}
+
+
+
+/* Deal with the case when X & Y are too long for the hardware unit, by splitting one operand
+   into two halves.
+
+   Y must be the longer operand
+
+   Slice Y into Yp, Ypp such that:
+   Yp = lower 'b' bits of Y
+   Ypp = upper 'b' bits of Y (right shifted)
+
+   Such that
+   Z = X * Y
+   Z = X * (Yp + Ypp<<b)
+   Z = (X * Yp) + (X * Ypp<<b)
+
+   Note that this function may recurse multiple times, if both X & Y
+   are too long for the hardware multiplication unit.
+*/
+static int mpi_mult_mpi_overlong(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t y_words, size_t z_words)
+{
+    int ret = 0;
+    mbedtls_mpi Ztemp;
+    /* Rather than slicing in two on bits we slice on limbs (32 bit words) */
+    const size_t words_slice = y_words / 2;
+    /* Yp holds lower bits of Y (declared to reuse Y's array contents to save on copying) */
+    const mbedtls_mpi Yp = {
+        .p = Y->p,
+        .n = words_slice,
+        .s = Y->s
+    };
+    /* Ypp holds upper bits of Y, right shifted (also reuses Y's array contents) */
+    const mbedtls_mpi Ypp = {
+        .p = Y->p + words_slice,
+        .n = y_words - words_slice,
+        .s = Y->s
+    };
+    mbedtls_mpi_init(&Ztemp);
+
+    /* Get result Ztemp = Yp * X (need temporary variable Ztemp) */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi(&Ztemp, X, &Yp) );
+
+    /* Z = Ypp * Y */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_mul_mpi(Z, X, &Ypp) );
+
+    /* Z = Z << b */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_shift_l(Z, words_slice * 32) );
+
+    /* Z += Ztemp */
+    MBEDTLS_MPI_CHK( mbedtls_mpi_add_mpi(Z, Z, &Ztemp) );
+
+cleanup:
+    mbedtls_mpi_free(&Ztemp);
+
+    return ret;
+}
+
+/* Special-case of mbedtls_mpi_mult_mpi(), where we use hardware montgomery mod
+   multiplication to calculate an mbedtls_mpi_mult_mpi result where either
+   A or B are >2048 bits so can't use the standard multiplication method.
+
+   Result (number of words, based on A bits + B bits) must still be less than 4096 bits.
+
+   This case is simpler than the general case modulo multiply of
+   esp_mpi_mul_mpi_mod() because we can control the other arguments:
+
+   * Modulus is chosen with M=(2^num_bits - 1) (ie M=R-1), so output
+   * Mprime and Rinv are therefore predictable as follows:
+   isn't actually modulo anything.
+   Mprime 1
+   Rinv 1
+
+   (See RSA Accelerator section in Technical Reference for more about Mprime, Rinv)
+*/
+
+static int mpi_mult_mpi_failover_mod_mult( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t z_words)
+{
+    int ret;
+    size_t hw_words = esp_mpi_hardware_words(z_words);
+
+    esp_mpi_enable_hardware_hw_op();
+
+    esp_mpi_mult_mpi_failover_mod_mult_hw_op(X, Y, hw_words );
+    MBEDTLS_MPI_CHK( mbedtls_mpi_grow(Z, hw_words) );
+    esp_mpi_read_result_hw_op(Z, hw_words);
+
+    Z->s = X->s * Y->s;
+cleanup:
+    esp_mpi_disable_hardware_hw_op();
+    return ret;
+}
+
+#endif /* MBEDTLS_MPI_MUL_MPI_ALT */

--- a/lib/libesp32/ESP32-HomeKit/src/sha-private.h
+++ b/lib/libesp32/ESP32-HomeKit/src/sha-private.h
@@ -1,0 +1,29 @@
+/************************ sha-private.h ************************/
+/***************** See RFC 6234 for details. *******************/
+#ifndef _SHA_PRIVATE__H
+#define _SHA_PRIVATE__H
+/*
+ * These definitions are defined in FIPS 180-3, section 4.1.
+ * Ch() and Maj() are defined identically in sections 4.1.1,
+ * 4.1.2, and 4.1.3.
+ *
+ * The definitions used in FIPS 180-3 are as follows:
+ */
+
+#ifndef USE_MODIFIED_MACROS
+#define SHA_Ch(x,y,z)        (((x) & (y)) ^ ((~(x)) & (z)))
+#define SHA_Maj(x,y,z)       (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#else /* USE_MODIFIED_MACROS */
+/*
+ * The following definitions are equivalent and potentially faster.
+ */
+
+#define SHA_Ch(x, y, z)      (((x) & ((y) ^ (z))) ^ (z))
+#define SHA_Maj(x, y, z)     (((x) & ((y) | (z))) | ((y) & (z)))
+
+#endif /* USE_MODIFIED_MACROS */
+
+#define SHA_Parity(x, y, z)  ((x) ^ (y) ^ (z))
+
+#endif /* _SHA_PRIVATE__H */
+

--- a/lib/libesp32/ESP32-HomeKit/src/sha.h
+++ b/lib/libesp32/ESP32-HomeKit/src/sha.h
@@ -1,0 +1,358 @@
+/**************************** sha.h ****************************/
+/***************** See RFC 6234 for details. *******************/
+/*
+   Copyright (c) 2011 IETF Trust and the persons identified as
+   authors of the code.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or
+   without modification, are permitted provided that the following
+   conditions are met:
+
+   - Redistributions of source code must retain the above
+     copyright notice, this list of conditions and
+     the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   - Neither the name of Internet Society, IETF or IETF Trust, nor
+     the names of specific contributors, may be used to endorse or
+     promote products derived from this software without specific
+     prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+   LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef _SHA_H_
+#define _SHA_H_
+
+/*
+ *  Description:
+ *      This file implements the Secure Hash Algorithms
+ *      as defined in the U.S. National Institute of Standards
+ *      and Technology Federal Information Processing Standards
+ *      Publication (FIPS PUB) 180-3 published in October 2008
+ *      and formerly defined in its predecessors, FIPS PUB 180-1
+ *      and FIP PUB 180-2.
+ *
+ *      A combined document showing all algorithms is available at
+ *              http://csrc.nist.gov/publications/fips/
+ *                     fips180-3/fips180-3_final.pdf
+ *
+ *      The five hashes are defined in these sizes:
+ *              SHA-1           20 byte / 160 bit
+ *              SHA-224         28 byte / 224 bit
+ *              SHA-256         32 byte / 256 bit
+ *              SHA-384         48 byte / 384 bit
+ *              SHA-512         64 byte / 512 bit
+ *
+ *  Compilation Note:
+ *    These files may be compiled with two options:
+ *        USE_32BIT_ONLY - use 32-bit arithmetic only, for systems
+ *                         without 64-bit integers
+ *
+ *        USE_MODIFIED_MACROS - use alternate form of the SHA_Ch()
+ *                         and SHA_Maj() macros that are equivalent
+ *                         and potentially faster on many systems
+ *
+ */
+
+#include <stdint.h>
+/*
+ * If you do not have the ISO standard stdint.h header file, then you
+ * must typedef the following:
+ *    name              meaning
+ *  uint64_t         unsigned 64-bit integer
+ *  uint32_t         unsigned 32-bit integer
+ *  uint8_t          unsigned 8-bit integer (i.e., unsigned char)
+ *  int_least16_t    integer of >= 16 bits
+ *
+ * See stdint-example.h
+ */
+
+#ifndef _SHA_enum_
+#define _SHA_enum_
+/*
+ *  All SHA functions return one of these values.
+ */
+enum {
+    shaSuccess = 0,
+    shaNull,            /* Null pointer parameter */
+    shaInputTooLong,    /* input data too long */
+    shaStateError,      /* called Input after FinalBits or Result */
+    shaBadParam         /* passed a bad parameter */
+};
+#endif /* _SHA_enum_ */
+
+/*
+ *  These constants hold size information for each of the SHA
+ *  hashing operations
+ */
+enum {
+    SHA1_Message_Block_Size = 64, SHA224_Message_Block_Size = 64,
+    SHA256_Message_Block_Size = 64, SHA384_Message_Block_Size = 128,
+    SHA512_Message_Block_Size = 128,
+    USHA_Max_Message_Block_Size = SHA512_Message_Block_Size,
+
+    SHA1HashSize = 20, SHA224HashSize = 28, SHA256HashSize = 32,
+    SHA384HashSize = 48, SHA512HashSize = 64,
+    USHAMaxHashSize = SHA512HashSize,
+
+    SHA1HashSizeBits = 160, SHA224HashSizeBits = 224,
+    SHA256HashSizeBits = 256, SHA384HashSizeBits = 384,
+    SHA512HashSizeBits = 512, USHAMaxHashSizeBits = SHA512HashSizeBits
+};
+
+/*
+ *  These constants are used in the USHA (Unified SHA) functions.
+ */
+typedef enum SHAversion {
+    SHA1, SHA224, SHA256, SHA384, SHA512
+} SHAversion;
+
+/*
+ *  This structure will hold context information for the SHA-1
+ *  hashing operation.
+ */
+typedef struct SHA1Context {
+    uint32_t Intermediate_Hash[SHA1HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA1_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA1Context;
+
+/*
+ *  This structure will hold context information for the SHA-256
+ *  hashing operation.
+ */
+typedef struct SHA256Context {
+    uint32_t Intermediate_Hash[SHA256HashSize/4]; /* Message Digest */
+
+    uint32_t Length_High;               /* Message length in bits */
+    uint32_t Length_Low;                /* Message length in bits */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 512-bit message blocks */
+    uint8_t Message_Block[SHA256_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed? */
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA256Context;
+
+/*
+ *  This structure will hold context information for the SHA-512
+ *  hashing operation.
+ */
+typedef struct SHA512Context {
+#ifdef USE_32BIT_ONLY
+    uint32_t Intermediate_Hash[SHA512HashSize/4]; /* Message Digest  */
+    uint32_t Length[4];                 /* Message length in bits */
+#else /* !USE_32BIT_ONLY */
+    uint64_t Intermediate_Hash[SHA512HashSize/8]; /* Message Digest */
+    uint64_t Length_High, Length_Low;   /* Message length in bits */
+#endif /* USE_32BIT_ONLY */
+
+    int_least16_t Message_Block_Index;  /* Message_Block array index */
+                                        /* 1024-bit message blocks */
+    uint8_t Message_Block[SHA512_Message_Block_Size];
+
+    int Computed;                   /* Is the hash computed?*/
+    int Corrupted;                  /* Cumulative corruption code */
+} SHA512Context;
+
+/*
+ *  This structure will hold context information for the SHA-224
+ *  hashing operation.  It uses the SHA-256 structure for computation.
+ */
+typedef struct SHA256Context SHA224Context;
+
+/*
+ *  This structure will hold context information for the SHA-384
+ *  hashing operation.  It uses the SHA-512 structure for computation.
+ */
+typedef struct SHA512Context SHA384Context;
+
+/*
+ *  This structure holds context information for all SHA
+ *  hashing operations.
+ */
+typedef struct USHAContext {
+    int whichSha;               /* which SHA is being used */
+    union {
+      SHA1Context sha1Context;
+      SHA224Context sha224Context; SHA256Context sha256Context;
+      SHA384Context sha384Context; SHA512Context sha512Context;
+    } ctx;
+
+} USHAContext;
+
+/*
+ *  This structure will hold context information for the HMAC
+ *  keyed-hashing operation.
+ */
+typedef struct HMACContext {
+    int whichSha;               /* which SHA is being used */
+    int hashSize;               /* hash size of SHA being used */
+    int blockSize;              /* block size of SHA being used */
+    USHAContext shaContext;     /* SHA context */
+    unsigned char k_opad[USHA_Max_Message_Block_Size];
+                        /* outer padding - key XORd with opad */
+    int Computed;               /* Is the MAC computed? */
+    int Corrupted;              /* Cumulative corruption code */
+
+} HMACContext;
+
+/*
+ *  This structure will hold context information for the HKDF
+ *  extract-and-expand Key Derivation Functions.
+ */
+typedef struct HKDFContext {
+    int whichSha;               /* which SHA is being used */
+    HMACContext hmacContext;
+    int hashSize;               /* hash size of SHA being used */
+    unsigned char prk[USHAMaxHashSize];
+                        /* pseudo-random key - output of hkdfInput */
+    int Computed;               /* Is the key material computed? */
+    int Corrupted;              /* Cumulative corruption code */
+} HKDFContext;
+
+/*
+ *  Function Prototypes
+ */
+
+/* SHA-1 */
+extern int SHA1Reset(SHA1Context *);
+extern int SHA1Input(SHA1Context *, const uint8_t *bytes,
+                     unsigned int bytecount);
+extern int SHA1FinalBits(SHA1Context *, uint8_t bits,
+                         unsigned int bit_count);
+extern int SHA1Result(SHA1Context *,
+                      uint8_t Message_Digest[SHA1HashSize]);
+
+/* SHA-224 */
+extern int SHA224Reset(SHA224Context *);
+extern int SHA224Input(SHA224Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA224FinalBits(SHA224Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA224Result(SHA224Context *,
+                        uint8_t Message_Digest[SHA224HashSize]);
+
+/* SHA-256 */
+extern int SHA256Reset(SHA256Context *);
+extern int SHA256Input(SHA256Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA256FinalBits(SHA256Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA256Result(SHA256Context *,
+                        uint8_t Message_Digest[SHA256HashSize]);
+
+/* SHA-384 */
+extern int SHA384Reset(SHA384Context *);
+extern int SHA384Input(SHA384Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA384FinalBits(SHA384Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA384Result(SHA384Context *,
+                        uint8_t Message_Digest[SHA384HashSize]);
+
+/* SHA-512 */
+extern int SHA512Reset(SHA512Context *);
+extern int SHA512Input(SHA512Context *, const uint8_t *bytes,
+                       unsigned int bytecount);
+extern int SHA512FinalBits(SHA512Context *, uint8_t bits,
+                           unsigned int bit_count);
+extern int SHA512Result(SHA512Context *,
+                        uint8_t Message_Digest[SHA512HashSize]);
+
+/* Unified SHA functions, chosen by whichSha */
+extern int USHAReset(USHAContext *context, SHAversion whichSha);
+extern int USHAInput(USHAContext *context,
+                     const uint8_t *bytes, unsigned int bytecount);
+extern int USHAFinalBits(USHAContext *context,
+                         uint8_t bits, unsigned int bit_count);
+extern int USHAResult(USHAContext *context,
+                      uint8_t Message_Digest[USHAMaxHashSize]);
+extern int USHABlockSize(enum SHAversion whichSha);
+extern int USHAHashSize(enum SHAversion whichSha);
+extern int USHAHashSizeBits(enum SHAversion whichSha);
+extern const char *USHAHashName(enum SHAversion whichSha);
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows a fixed-length text input to be used.
+ */
+extern int hmac(SHAversion whichSha, /* which SHA algorithm to use */
+    const unsigned char *text,     /* pointer to data stream */
+    int text_len,                  /* length of data stream */
+    const unsigned char *key,      /* pointer to authentication key */
+    int key_len,                   /* length of authentication key */
+    uint8_t digest[USHAMaxHashSize]); /* caller digest to fill in */
+
+/*
+ * HMAC Keyed-Hashing for Message Authentication, RFC 2104,
+ * for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hmacReset(HMACContext *context, enum SHAversion whichSha,
+                     const unsigned char *key, int key_len);
+extern int hmacInput(HMACContext *context, const unsigned char *text,
+                     int text_len);
+extern int hmacFinalBits(HMACContext *context, uint8_t bits,
+                         unsigned int bit_count);
+extern int hmacResult(HMACContext *context,
+                      uint8_t digest[USHAMaxHashSize]);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ */
+extern int hkdf(SHAversion whichSha, const unsigned char *salt,
+                int salt_len, const unsigned char *ikm, int ikm_len,
+                const unsigned char *info, int info_len,
+                uint8_t okm[ ], int okm_len);
+extern int hkdfExtract(SHAversion whichSha, const unsigned char *salt,
+                       int salt_len, const unsigned char *ikm,
+                       int ikm_len, uint8_t prk[USHAMaxHashSize]);
+extern int hkdfExpand(SHAversion whichSha, const uint8_t prk[ ],
+                      int prk_len, const unsigned char *info,
+                      int info_len, uint8_t okm[ ], int okm_len);
+
+/*
+ * HKDF HMAC-based Extract-and-Expand Key Derivation Function,
+ * RFC 5869, for all SHAs.
+ * This interface allows any length of text input to be used.
+ */
+extern int hkdfReset(HKDFContext *context, enum SHAversion whichSha,
+                     const unsigned char *salt, int salt_len);
+extern int hkdfInput(HKDFContext *context, const unsigned char *ikm,
+                     int ikm_len);
+extern int hkdfFinalBits(HKDFContext *context, uint8_t ikm_bits,
+                         unsigned int ikm_bit_count);
+extern int hkdfResult(HKDFContext *context,
+                      uint8_t prk[USHAMaxHashSize],
+                      const unsigned char *info, int info_len,
+                      uint8_t okm[USHAMaxHashSize], int okm_len);
+#endif /* _SHA_H_ */
+

--- a/lib/libesp32/ESP32-HomeKit/src/sha1.c
+++ b/lib/libesp32/ESP32-HomeKit/src/sha1.c
@@ -1,0 +1,414 @@
+/**************************** sha1.c ***************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *      This file implements the Secure Hash Algorithm SHA-1
+ *      as defined in the U.S. National Institute of Standards
+ *      and Technology Federal Information Processing Standards
+ *      Publication (FIPS PUB) 180-3 published in October 2008
+ *      and formerly defined in its predecessors, FIPS PUB 180-1
+ *      and FIP PUB 180-2.
+ *
+ *      A combined document showing all algorithms is available at
+ *              http://csrc.nist.gov/publications/fips/
+ *                     fips180-3/fips180-3_final.pdf
+ *
+ *      The SHA-1 algorithm produces a 160-bit message digest for a
+ *      given data stream that can serve as a means of providing a
+ *      "fingerprint" for a message.
+ *
+ *  Portability Issues:
+ *      SHA-1 is defined in terms of 32-bit "words".  This code
+ *      uses <stdint.h> (included via "sha.h") to define 32- and
+ *      8-bit unsigned integer types.  If your C compiler does
+ *      not support 32-bit unsigned integers, this code is not
+ *      appropriate.
+ *
+ *  Caveats:
+ *      SHA-1 is designed to work with messages less than 2^64 bits
+ *      long.  This implementation uses SHA1Input() to hash the bits
+ *      that are a multiple of the size of an 8-bit octet, and then
+ *      optionally uses SHA1FinalBits() to hash the final few bits of
+ *      the input.
+ */
+
+#include "sha.h"
+#include "sha-private.h"
+
+/*
+ *  Define the SHA1 circular left shift macro
+ */
+#define SHA1_ROTL(bits,word) \
+                (((word) << (bits)) | ((word) >> (32-(bits))))
+
+/*
+ * Add "length" to the length.
+ * Set Corrupted when overflow has occurred.
+ */
+static uint32_t addTemp;
+#define SHA1AddLength(context, length)                     \
+    (addTemp = (context)->Length_Low,                      \
+     (context)->Corrupted =                                \
+        (((context)->Length_Low += (length)) < addTemp) && \
+        (++(context)->Length_High == 0) ? shaInputTooLong  \
+                                        : (context)->Corrupted )
+
+/* Local Function Prototypes */
+static void SHA1ProcessMessageBlock(SHA1Context *context);
+static void SHA1Finalize(SHA1Context *context, uint8_t Pad_Byte);
+static void SHA1PadMessage(SHA1Context *context, uint8_t Pad_Byte);
+
+/*
+ *  SHA1Reset
+ *
+ *  Description:
+ *      This function will initialize the SHA1Context in preparation
+ *      for computing a new SHA1 message digest.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The context to reset.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int SHA1Reset(SHA1Context *context)
+{
+  if (!context) return shaNull;
+
+  context->Length_High = context->Length_Low = 0;
+  context->Message_Block_Index = 0;
+
+  /* Initial Hash Values: FIPS 180-3 section 5.3.1 */
+  context->Intermediate_Hash[0]   = 0x67452301;
+  context->Intermediate_Hash[1]   = 0xEFCDAB89;
+  context->Intermediate_Hash[2]   = 0x98BADCFE;
+  context->Intermediate_Hash[3]   = 0x10325476;
+  context->Intermediate_Hash[4]   = 0xC3D2E1F0;
+
+  context->Computed   = 0;
+  context->Corrupted  = shaSuccess;
+
+  return shaSuccess;
+}
+
+/*
+ *  SHA1Input
+ *
+ *  Description:
+ *      This function accepts an array of octets as the next portion
+ *      of the message.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The SHA context to update.
+ *      message_array[ ]: [in]
+ *          An array of octets representing the next portion of
+ *          the message.
+ *      length: [in]
+ *          The length of the message in message_array.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int SHA1Input(SHA1Context *context,
+    const uint8_t *message_array, unsigned length)
+{
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (!message_array) return shaNull;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (context->Corrupted) return context->Corrupted;
+
+  while (length--) {
+    context->Message_Block[context->Message_Block_Index++] =
+      *message_array;
+
+    if ((SHA1AddLength(context, 8) == shaSuccess) &&
+      (context->Message_Block_Index == SHA1_Message_Block_Size))
+      SHA1ProcessMessageBlock(context);
+
+    message_array++;
+  }
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA1FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA1FinalBits(SHA1Context *context, uint8_t message_bits,
+    unsigned int length)
+{
+  static uint8_t masks[8] = {
+      /* 0 0b00000000 */ 0x00, /* 1 0b10000000 */ 0x80,
+      /* 2 0b11000000 */ 0xC0, /* 3 0b11100000 */ 0xE0,
+      /* 4 0b11110000 */ 0xF0, /* 5 0b11111000 */ 0xF8,
+      /* 6 0b11111100 */ 0xFC, /* 7 0b11111110 */ 0xFE
+  };
+
+  static uint8_t markbit[8] = {
+      /* 0 0b10000000 */ 0x80, /* 1 0b01000000 */ 0x40,
+      /* 2 0b00100000 */ 0x20, /* 3 0b00010000 */ 0x10,
+      /* 4 0b00001000 */ 0x08, /* 5 0b00000100 */ 0x04,
+      /* 6 0b00000010 */ 0x02, /* 7 0b00000001 */ 0x01
+  };
+
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (length >= 8) return context->Corrupted = shaBadParam;
+
+  SHA1AddLength(context, length);
+  SHA1Finalize(context,
+    (uint8_t) ((message_bits & masks[length]) | markbit[length]));
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA1Result
+ *
+ * Description:
+ *   This function will return the 160-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *      the last octet of hash in the element with index 19.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA-1 hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA1Result(SHA1Context *context,
+    uint8_t Message_Digest[SHA1HashSize])
+{
+  int i;
+
+  if (!context) return shaNull;
+  if (!Message_Digest) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+
+  if (!context->Computed)
+    SHA1Finalize(context, 0x80);
+
+  for (i = 0; i < SHA1HashSize; ++i)
+    Message_Digest[i] = (uint8_t) (context->Intermediate_Hash[i>>2]
+                                   >> (8 * ( 3 - ( i & 0x03 ) )));
+
+  return shaSuccess;
+}
+
+/*
+ * SHA1ProcessMessageBlock
+ *
+ * Description:
+ *   This helper function will process the next 512 bits of the
+ *   message stored in the Message_Block array.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *
+ * Returns:
+ *   Nothing.
+ *
+ * Comments:
+ *   Many of the variable names in this code, especially the
+ *   single character names, were used because those were the
+ *   names used in the Secure Hash Standard.
+ */
+static void SHA1ProcessMessageBlock(SHA1Context *context)
+{
+  /* Constants defined in FIPS 180-3, section 4.2.1 */
+  const uint32_t K[4] = {
+      0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6
+  };
+
+  int        t;               /* Loop counter */
+  uint32_t   temp;            /* Temporary word value */
+  uint32_t   W[80];           /* Word sequence */
+  uint32_t   A, B, C, D, E;   /* Word buffers */
+
+  /*
+   * Initialize the first 16 words in the array W
+   */
+  for (t = 0; t < 16; t++) {
+    W[t]  = ((uint32_t)context->Message_Block[t * 4]) << 24;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 1]) << 16;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 2]) << 8;
+    W[t] |= ((uint32_t)context->Message_Block[t * 4 + 3]);
+  }
+
+  for (t = 16; t < 80; t++)
+    W[t] = SHA1_ROTL(1, W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16]);
+
+  A = context->Intermediate_Hash[0];
+  B = context->Intermediate_Hash[1];
+  C = context->Intermediate_Hash[2];
+  D = context->Intermediate_Hash[3];
+  E = context->Intermediate_Hash[4];
+
+  for (t = 0; t < 20; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Ch(B, C, D) + E + W[t] + K[0];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 20; t < 40; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Parity(B, C, D) + E + W[t] + K[1];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 40; t < 60; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Maj(B, C, D) + E + W[t] + K[2];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 60; t < 80; t++) {
+    temp = SHA1_ROTL(5,A) + SHA_Parity(B, C, D) + E + W[t] + K[3];
+    E = D;
+    D = C;
+    C = SHA1_ROTL(30,B);
+    B = A;
+    A = temp;
+  }
+
+  context->Intermediate_Hash[0] += A;
+  context->Intermediate_Hash[1] += B;
+  context->Intermediate_Hash[2] += C;
+  context->Intermediate_Hash[3] += D;
+  context->Intermediate_Hash[4] += E;
+  context->Message_Block_Index = 0;
+}
+
+/*
+ * SHA1Finalize
+ *
+ * Description:
+ *   This helper function finishes off the digest calculations.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+static void SHA1Finalize(SHA1Context *context, uint8_t Pad_Byte)
+{
+  int i;
+  SHA1PadMessage(context, Pad_Byte);
+  /* message may be sensitive, clear it out */
+  for (i = 0; i < SHA1_Message_Block_Size; ++i)
+    context->Message_Block[i] = 0;
+  context->Length_High = 0;     /* and clear length */
+  context->Length_Low = 0;
+  context->Computed = 1;
+}
+
+/*
+ * SHA1PadMessage
+ *
+ * Description:
+ *   According to the standard, the message must be padded to the next
+ *   even multiple of 512 bits.  The first padding bit must be a '1'.
+ *   The last 64 bits represent the length of the original message.
+ *   All bits in between should be 0.  This helper function will pad
+ *   the message according to those rules by filling the Message_Block
+ *   array accordingly.  When it returns, it can be assumed that the
+ *   message digest has been computed.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to pad.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   Nothing.
+ */
+static void SHA1PadMessage(SHA1Context *context, uint8_t Pad_Byte)
+{
+  /*
+   * Check to see if the current message block is too small to hold
+   * the initial padding bits and length.  If so, we will pad the
+   * block, process it, and then continue padding into a second
+   * block.
+   */
+  if (context->Message_Block_Index >= (SHA1_Message_Block_Size - 8)) {
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+    while (context->Message_Block_Index < SHA1_Message_Block_Size)
+      context->Message_Block[context->Message_Block_Index++] = 0;
+
+    SHA1ProcessMessageBlock(context);
+  } else
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+
+  while (context->Message_Block_Index < (SHA1_Message_Block_Size - 8))
+    context->Message_Block[context->Message_Block_Index++] = 0;
+
+  /*
+   * Store the message length as the last 8 octets
+   */
+  context->Message_Block[56] = (uint8_t) (context->Length_High >> 24);
+  context->Message_Block[57] = (uint8_t) (context->Length_High >> 16);
+  context->Message_Block[58] = (uint8_t) (context->Length_High >> 8);
+  context->Message_Block[59] = (uint8_t) (context->Length_High);
+  context->Message_Block[60] = (uint8_t) (context->Length_Low >> 24);
+  context->Message_Block[61] = (uint8_t) (context->Length_Low >> 16);
+  context->Message_Block[62] = (uint8_t) (context->Length_Low >> 8);
+  context->Message_Block[63] = (uint8_t) (context->Length_Low);
+
+  SHA1ProcessMessageBlock(context);
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/sha224-256.c
+++ b/lib/libesp32/ESP32-HomeKit/src/sha224-256.c
@@ -1,0 +1,581 @@
+/************************* sha224-256.c ************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ * Description:
+ *   This file implements the Secure Hash Algorithms SHA-224 and
+ *   SHA-256 as defined in the U.S. National Institute of Standards
+ *   and Technology Federal Information Processing Standards
+ *   Publication (FIPS PUB) 180-3 published in October 2008
+ *   and formerly defined in its predecessors, FIPS PUB 180-1
+ *   and FIP PUB 180-2.
+ *
+ *   A combined document showing all algorithms is available at
+ *       http://csrc.nist.gov/publications/fips/
+ *              fips180-3/fips180-3_final.pdf
+ *
+ *   The SHA-224 and SHA-256 algorithms produce 224-bit and 256-bit
+ *   message digests for a given data stream.  It should take about
+ *   2**n steps to find a message with the same digest as a given
+ *   message and 2**(n/2) to find any two messages with the same
+ *   digest, when n is the digest size in bits.  Therefore, this
+ *   algorithm can serve as a means of providing a
+ *   "fingerprint" for a message.
+ *
+ * Portability Issues:
+ *   SHA-224 and SHA-256 are defined in terms of 32-bit "words".
+ *   This code uses <stdint.h> (included via "sha.h") to define 32-
+ *   and 8-bit unsigned integer types.  If your C compiler does not
+ *   support 32-bit unsigned integers, this code is not
+ *   appropriate.
+ *
+ * Caveats:
+ *   SHA-224 and SHA-256 are designed to work with messages less
+ *   than 2^64 bits long.  This implementation uses SHA224/256Input()
+ *   to hash the bits that are a multiple of the size of an 8-bit
+ *   octet, and then optionally uses SHA224/256FinalBits()
+ *   to hash the final few bits of the input.
+ */
+
+#include "sha.h"
+#include "sha-private.h"
+
+/* Define the SHA shift, rotate left, and rotate right macros */
+#define SHA256_SHR(bits,word)      ((word) >> (bits))
+#define SHA256_ROTL(bits,word)                         \
+  (((word) << (bits)) | ((word) >> (32-(bits))))
+#define SHA256_ROTR(bits,word)                         \
+  (((word) >> (bits)) | ((word) << (32-(bits))))
+
+/* Define the SHA SIGMA and sigma macros */
+#define SHA256_SIGMA0(word)   \
+  (SHA256_ROTR( 2,word) ^ SHA256_ROTR(13,word) ^ SHA256_ROTR(22,word))
+#define SHA256_SIGMA1(word)   \
+  (SHA256_ROTR( 6,word) ^ SHA256_ROTR(11,word) ^ SHA256_ROTR(25,word))
+#define SHA256_sigma0(word)   \
+  (SHA256_ROTR( 7,word) ^ SHA256_ROTR(18,word) ^ SHA256_SHR( 3,word))
+#define SHA256_sigma1(word)   \
+  (SHA256_ROTR(17,word) ^ SHA256_ROTR(19,word) ^ SHA256_SHR(10,word))
+
+/*
+ * Add "length" to the length.
+ * Set Corrupted when overflow has occurred.
+ */
+static uint32_t addTemp;
+#define SHA224_256AddLength(context, length)               \
+  (addTemp = (context)->Length_Low, (context)->Corrupted = \
+    (((context)->Length_Low += (length)) < addTemp) &&     \
+    (++(context)->Length_High == 0) ? shaInputTooLong :    \
+                                      (context)->Corrupted )
+
+/* Local Function Prototypes */
+static int SHA224_256Reset(SHA256Context *context, uint32_t *H0);
+static void SHA224_256ProcessMessageBlock(SHA256Context *context);
+static void SHA224_256Finalize(SHA256Context *context,
+  uint8_t Pad_Byte);
+static void SHA224_256PadMessage(SHA256Context *context,
+  uint8_t Pad_Byte);
+static int SHA224_256ResultN(SHA256Context *context,
+  uint8_t Message_Digest[ ], int HashSize);
+
+/* Initial Hash Values: FIPS 180-3 section 5.3.2 */
+static uint32_t SHA224_H0[SHA256HashSize/4] = {
+    0xC1059ED8, 0x367CD507, 0x3070DD17, 0xF70E5939,
+    0xFFC00B31, 0x68581511, 0x64F98FA7, 0xBEFA4FA4
+};
+
+/* Initial Hash Values: FIPS 180-3 section 5.3.3 */
+static uint32_t SHA256_H0[SHA256HashSize/4] = {
+  0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+  0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
+};
+
+/*
+ * SHA224Reset
+ *
+ * Description:
+ *   This function will initialize the SHA224Context in preparation
+ *   for computing a new SHA224 message digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA224Reset(SHA224Context *context)
+{
+  return SHA224_256Reset(context, SHA224_H0);
+}
+
+/*
+ * SHA224Input
+ *
+ * Description:
+ *   This function accepts an array of octets as the next portion
+ *   of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_array[ ]: [in]
+ *     An array of octets representing the next portion of
+ *     the message.
+ *   length: [in]
+ *     The length of the message in message_array.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA224Input(SHA224Context *context, const uint8_t *message_array,
+    unsigned int length)
+{
+  return SHA256Input(context, message_array, length);
+}
+
+/*
+ * SHA224FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA224FinalBits(SHA224Context *context,
+                    uint8_t message_bits, unsigned int length)
+{
+  return SHA256FinalBits(context, message_bits, length);
+}
+
+/*
+ * SHA224Result
+ *
+ * Description:
+ *   This function will return the 224-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 27.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA224Result(SHA224Context *context,
+    uint8_t Message_Digest[SHA224HashSize])
+{
+  return SHA224_256ResultN(context, Message_Digest, SHA224HashSize);
+}
+
+/*
+ * SHA256Reset
+ *
+ * Description:
+ *   This function will initialize the SHA256Context in preparation
+ *   for computing a new SHA256 message digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA256Reset(SHA256Context *context)
+{
+  return SHA224_256Reset(context, SHA256_H0);
+}
+
+/*
+ * SHA256Input
+ *
+ * Description:
+ *   This function accepts an array of octets as the next portion
+ *   of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_array[ ]: [in]
+ *     An array of octets representing the next portion of
+ *     the message.
+ *   length: [in]
+ *     The length of the message in message_array.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA256Input(SHA256Context *context, const uint8_t *message_array,
+    unsigned int length)
+{
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (!message_array) return shaNull;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (context->Corrupted) return context->Corrupted;
+
+  while (length--) {
+    context->Message_Block[context->Message_Block_Index++] =
+            *message_array;
+
+    if ((SHA224_256AddLength(context, 8) == shaSuccess) &&
+      (context->Message_Block_Index == SHA256_Message_Block_Size))
+      SHA224_256ProcessMessageBlock(context);
+
+    message_array++;
+  }
+
+  return context->Corrupted;
+
+}
+
+/*
+ * SHA256FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA256FinalBits(SHA256Context *context,
+                    uint8_t message_bits, unsigned int length)
+{
+  static uint8_t masks[8] = {
+      /* 0 0b00000000 */ 0x00, /* 1 0b10000000 */ 0x80,
+      /* 2 0b11000000 */ 0xC0, /* 3 0b11100000 */ 0xE0,
+      /* 4 0b11110000 */ 0xF0, /* 5 0b11111000 */ 0xF8,
+      /* 6 0b11111100 */ 0xFC, /* 7 0b11111110 */ 0xFE
+  };
+  static uint8_t markbit[8] = {
+      /* 0 0b10000000 */ 0x80, /* 1 0b01000000 */ 0x40,
+      /* 2 0b00100000 */ 0x20, /* 3 0b00010000 */ 0x10,
+      /* 4 0b00001000 */ 0x08, /* 5 0b00000100 */ 0x04,
+      /* 6 0b00000010 */ 0x02, /* 7 0b00000001 */ 0x01
+  };
+
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (length >= 8) return context->Corrupted = shaBadParam;
+
+  SHA224_256AddLength(context, length);
+  SHA224_256Finalize(context, (uint8_t)
+    ((message_bits & masks[length]) | markbit[length]));
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA256Result
+ *
+ * Description:
+ *   This function will return the 256-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 31.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int SHA256Result(SHA256Context *context,
+                 uint8_t Message_Digest[SHA256HashSize])
+{
+  return SHA224_256ResultN(context, Message_Digest, SHA256HashSize);
+}
+
+/*
+ * SHA224_256Reset
+ *
+ * Description:
+ *   This helper function will initialize the SHA256Context in
+ *   preparation for computing a new SHA-224 or SHA-256 message digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *   H0[ ]: [in]
+ *     The initial hash value array to use.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+static int SHA224_256Reset(SHA256Context *context, uint32_t *H0)
+{
+  if (!context) return shaNull;
+
+  context->Length_High = context->Length_Low = 0;
+  context->Message_Block_Index  = 0;
+
+  context->Intermediate_Hash[0] = H0[0];
+  context->Intermediate_Hash[1] = H0[1];
+  context->Intermediate_Hash[2] = H0[2];
+  context->Intermediate_Hash[3] = H0[3];
+  context->Intermediate_Hash[4] = H0[4];
+  context->Intermediate_Hash[5] = H0[5];
+  context->Intermediate_Hash[6] = H0[6];
+  context->Intermediate_Hash[7] = H0[7];
+
+  context->Computed  = 0;
+  context->Corrupted = shaSuccess;
+
+  return shaSuccess;
+}
+
+/*
+ * SHA224_256ProcessMessageBlock
+ *
+ * Description:
+ *   This helper function will process the next 512 bits of the
+ *   message stored in the Message_Block array.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *
+ * Returns:
+ *   Nothing.
+ *
+ * Comments:
+ *   Many of the variable names in this code, especially the
+ *   single character names, were used because those were the
+ *   names used in the Secure Hash Standard.
+ */
+static void SHA224_256ProcessMessageBlock(SHA256Context *context)
+{
+  /* Constants defined in FIPS 180-3, section 4.2.2 */
+  static const uint32_t K[64] = {
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+      0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+      0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+      0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+      0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+      0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+      0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+      0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+      0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+      0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+      0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+  };
+  int        t, t4;                   /* Loop counter */
+  uint32_t   temp1, temp2;            /* Temporary word value */
+  uint32_t   W[64];                   /* Word sequence */
+  uint32_t   A, B, C, D, E, F, G, H;  /* Word buffers */
+
+  /*
+   * Initialize the first 16 words in the array W
+   */
+  for (t = t4 = 0; t < 16; t++, t4 += 4)
+    W[t] = (((uint32_t)context->Message_Block[t4]) << 24) |
+           (((uint32_t)context->Message_Block[t4 + 1]) << 16) |
+           (((uint32_t)context->Message_Block[t4 + 2]) << 8) |
+           (((uint32_t)context->Message_Block[t4 + 3]));
+  for (t = 16; t < 64; t++)
+    W[t] = SHA256_sigma1(W[t-2]) + W[t-7] +
+        SHA256_sigma0(W[t-15]) + W[t-16];
+
+  A = context->Intermediate_Hash[0];
+  B = context->Intermediate_Hash[1];
+  C = context->Intermediate_Hash[2];
+  D = context->Intermediate_Hash[3];
+  E = context->Intermediate_Hash[4];
+  F = context->Intermediate_Hash[5];
+  G = context->Intermediate_Hash[6];
+  H = context->Intermediate_Hash[7];
+
+  for (t = 0; t < 64; t++) {
+    temp1 = H + SHA256_SIGMA1(E) + SHA_Ch(E,F,G) + K[t] + W[t];
+    temp2 = SHA256_SIGMA0(A) + SHA_Maj(A,B,C);
+    H = G;
+    G = F;
+    F = E;
+    E = D + temp1;
+    D = C;
+    C = B;
+    B = A;
+    A = temp1 + temp2;
+  }
+
+  context->Intermediate_Hash[0] += A;
+  context->Intermediate_Hash[1] += B;
+  context->Intermediate_Hash[2] += C;
+  context->Intermediate_Hash[3] += D;
+  context->Intermediate_Hash[4] += E;
+  context->Intermediate_Hash[5] += F;
+  context->Intermediate_Hash[6] += G;
+  context->Intermediate_Hash[7] += H;
+
+  context->Message_Block_Index = 0;
+}
+
+/*
+ * SHA224_256Finalize
+ *
+ * Description:
+ *   This helper function finishes off the digest calculations.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+static void SHA224_256Finalize(SHA256Context *context,
+    uint8_t Pad_Byte)
+{
+  int i;
+  SHA224_256PadMessage(context, Pad_Byte);
+  /* message may be sensitive, so clear it out */
+  for (i = 0; i < SHA256_Message_Block_Size; ++i)
+    context->Message_Block[i] = 0;
+  context->Length_High = 0;     /* and clear length */
+  context->Length_Low = 0;
+  context->Computed = 1;
+}
+
+/*
+ * SHA224_256PadMessage
+ *
+ * Description:
+ *   According to the standard, the message must be padded to the next
+ *   even multiple of 512 bits.  The first padding bit must be a '1'.
+ *   The last 64 bits represent the length of the original message.
+ *   All bits in between should be 0.  This helper function will pad
+ *   the message according to those rules by filling the
+ *   Message_Block array accordingly.  When it returns, it can be
+ *   assumed that the message digest has been computed.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to pad.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   Nothing.
+ */
+static void SHA224_256PadMessage(SHA256Context *context,
+    uint8_t Pad_Byte)
+{
+  /*
+   * Check to see if the current message block is too small to hold
+   * the initial padding bits and length.  If so, we will pad the
+   * block, process it, and then continue padding into a second
+   * block.
+   */
+  if (context->Message_Block_Index >= (SHA256_Message_Block_Size-8)) {
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+    while (context->Message_Block_Index < SHA256_Message_Block_Size)
+      context->Message_Block[context->Message_Block_Index++] = 0;
+    SHA224_256ProcessMessageBlock(context);
+  } else
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+
+  while (context->Message_Block_Index < (SHA256_Message_Block_Size-8))
+    context->Message_Block[context->Message_Block_Index++] = 0;
+
+  /*
+   * Store the message length as the last 8 octets
+   */
+  context->Message_Block[56] = (uint8_t)(context->Length_High >> 24);
+  context->Message_Block[57] = (uint8_t)(context->Length_High >> 16);
+  context->Message_Block[58] = (uint8_t)(context->Length_High >> 8);
+  context->Message_Block[59] = (uint8_t)(context->Length_High);
+  context->Message_Block[60] = (uint8_t)(context->Length_Low >> 24);
+  context->Message_Block[61] = (uint8_t)(context->Length_Low >> 16);
+  context->Message_Block[62] = (uint8_t)(context->Length_Low >> 8);
+  context->Message_Block[63] = (uint8_t)(context->Length_Low);
+
+  SHA224_256ProcessMessageBlock(context);
+}
+
+/*
+ * SHA224_256ResultN
+ *
+ * Description:
+ *   This helper function will return the 224-bit or 256-bit message
+ *   digest into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 27/31.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *   HashSize: [in]
+ *     The size of the hash, either 28 or 32.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+static int SHA224_256ResultN(SHA256Context *context,
+    uint8_t Message_Digest[ ], int HashSize)
+{
+  int i;
+
+  if (!context) return shaNull;
+  if (!Message_Digest) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+
+  if (!context->Computed)
+    SHA224_256Finalize(context, 0x80);
+
+  for (i = 0; i < HashSize; ++i)
+    Message_Digest[i] = (uint8_t)
+      (context->Intermediate_Hash[i>>2] >> 8 * ( 3 - ( i & 0x03 ) ));
+
+  return shaSuccess;
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/sha384-512.c
+++ b/lib/libesp32/ESP32-HomeKit/src/sha384-512.c
@@ -1,0 +1,1032 @@
+/************************* sha384-512.c ************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ * Description:
+ *   This file implements the Secure Hash Algorithms SHA-384 and
+ *   SHA-512 as defined in the U.S. National Institute of Standards
+ *   and Technology Federal Information Processing Standards
+ *   Publication (FIPS PUB) 180-3 published in October 2008
+ *   and formerly defined in its predecessors, FIPS PUB 180-1
+ *   and FIP PUB 180-2.
+ *
+ *   A combined document showing all algorithms is available at
+ *       http://csrc.nist.gov/publications/fips/
+ *              fips180-3/fips180-3_final.pdf
+ *
+ *   The SHA-384 and SHA-512 algorithms produce 384-bit and 512-bit
+ *   message digests for a given data stream.  It should take about
+ *   2**n steps to find a message with the same digest as a given
+ *   message and 2**(n/2) to find any two messages with the same
+ *   digest, when n is the digest size in bits.  Therefore, this
+ *   algorithm can serve as a means of providing a
+ *   "fingerprint" for a message.
+ *
+ * Portability Issues:
+ *   SHA-384 and SHA-512 are defined in terms of 64-bit "words",
+ *   but if USE_32BIT_ONLY is #defined, this code is implemented in
+ *   terms of 32-bit "words".  This code uses <stdint.h> (included
+ *   via "sha.h") to define the 64-, 32- and 8-bit unsigned integer
+ *   types.  If your C compiler does not support 64-bit unsigned
+ *   integers and you do not #define USE_32BIT_ONLY, this code is
+ *   not appropriate.
+ *
+ * Caveats:
+ *   SHA-384 and SHA-512 are designed to work with messages less
+ *   than 2^128 bits long.  This implementation uses SHA384/512Input()
+ *   to hash the bits that are a multiple of the size of an 8-bit
+ *   octet, and then optionally uses SHA384/256FinalBits()
+ *   to hash the final few bits of the input.
+ *
+ */
+
+#include "sha.h"
+
+#ifdef USE_32BIT_ONLY
+/*
+ * Define 64-bit arithmetic in terms of 32-bit arithmetic.
+ * Each 64-bit number is represented in a 2-word array.
+ * All macros are defined such that the result is the last parameter.
+ */
+
+/*
+ * Define shift, rotate left, and rotate right functions
+ */
+#define SHA512_SHR(bits, word, ret) (                          \
+    /* (((uint64_t)((word))) >> (bits)) */                     \
+    (ret)[0] = (((bits) < 32) && ((bits) >= 0)) ?              \
+      ((word)[0] >> (bits)) : 0,                               \
+    (ret)[1] = ((bits) > 32) ? ((word)[0] >> ((bits) - 32)) :  \
+      ((bits) == 32) ? (word)[0] :                             \
+      ((bits) >= 0) ?                                          \
+        (((word)[0] << (32 - (bits))) |                        \
+        ((word)[1] >> (bits))) : 0 )
+
+#define SHA512_SHL(bits, word, ret) (                          \
+    /* (((uint64_t)(word)) << (bits)) */                       \
+    (ret)[0] = ((bits) > 32) ? ((word)[1] << ((bits) - 32)) :  \
+         ((bits) == 32) ? (word)[1] :                          \
+         ((bits) >= 0) ?                                       \
+           (((word)[0] << (bits)) |                            \
+           ((word)[1] >> (32 - (bits)))) :                     \
+         0,                                                    \
+    (ret)[1] = (((bits) < 32) && ((bits) >= 0)) ?              \
+        ((word)[1] << (bits)) : 0 )
+
+/*
+ * Define 64-bit OR
+ */
+#define SHA512_OR(word1, word2, ret) (                         \
+    (ret)[0] = (word1)[0] | (word2)[0],                        \
+    (ret)[1] = (word1)[1] | (word2)[1] )
+
+/*
+ * Define 64-bit XOR
+ */
+#define SHA512_XOR(word1, word2, ret) (                        \
+    (ret)[0] = (word1)[0] ^ (word2)[0],                        \
+    (ret)[1] = (word1)[1] ^ (word2)[1] )
+
+/*
+ * Define 64-bit AND
+ */
+#define SHA512_AND(word1, word2, ret) (                        \
+    (ret)[0] = (word1)[0] & (word2)[0],                        \
+    (ret)[1] = (word1)[1] & (word2)[1] )
+
+/*
+ * Define 64-bit TILDA
+ */
+#define SHA512_TILDA(word, ret)                                \
+  ( (ret)[0] = ~(word)[0], (ret)[1] = ~(word)[1] )
+
+/*
+ * Define 64-bit ADD
+ */
+#define SHA512_ADD(word1, word2, ret) (                        \
+    (ret)[1] = (word1)[1], (ret)[1] += (word2)[1],             \
+    (ret)[0] = (word1)[0] + (word2)[0] + ((ret)[1] < (word1)[1]) )
+
+/*
+ * Add the 4word value in word2 to word1.
+ */
+static uint32_t ADDTO4_temp, ADDTO4_temp2;
+#define SHA512_ADDTO4(word1, word2) (                          \
+    ADDTO4_temp = (word1)[3],                                  \
+    (word1)[3] += (word2)[3],                                  \
+    ADDTO4_temp2 = (word1)[2],                                 \
+    (word1)[2] += (word2)[2] + ((word1)[3] < ADDTO4_temp),     \
+    ADDTO4_temp = (word1)[1],                                  \
+    (word1)[1] += (word2)[1] + ((word1)[2] < ADDTO4_temp2),    \
+    (word1)[0] += (word2)[0] + ((word1)[1] < ADDTO4_temp) )
+
+/*
+ * Add the 2word value in word2 to word1.
+ */
+static uint32_t ADDTO2_temp;
+#define SHA512_ADDTO2(word1, word2) (                          \
+    ADDTO2_temp = (word1)[1],                                  \
+    (word1)[1] += (word2)[1],                                  \
+    (word1)[0] += (word2)[0] + ((word1)[1] < ADDTO2_temp) )
+
+/*
+ * SHA rotate   ((word >> bits) | (word << (64-bits)))
+ */
+static uint32_t ROTR_temp1[2], ROTR_temp2[2];
+#define SHA512_ROTR(bits, word, ret) (                         \
+    SHA512_SHR((bits), (word), ROTR_temp1),                    \
+    SHA512_SHL(64-(bits), (word), ROTR_temp2),                 \
+    SHA512_OR(ROTR_temp1, ROTR_temp2, (ret)) )
+
+/*
+ * Define the SHA SIGMA and sigma macros
+ *
+ *  SHA512_ROTR(28,word) ^ SHA512_ROTR(34,word) ^ SHA512_ROTR(39,word)
+ */
+static uint32_t SIGMA0_temp1[2], SIGMA0_temp2[2],
+  SIGMA0_temp3[2], SIGMA0_temp4[2];
+#define SHA512_SIGMA0(word, ret) (                             \
+    SHA512_ROTR(28, (word), SIGMA0_temp1),                     \
+    SHA512_ROTR(34, (word), SIGMA0_temp2),                     \
+    SHA512_ROTR(39, (word), SIGMA0_temp3),                     \
+    SHA512_XOR(SIGMA0_temp2, SIGMA0_temp3, SIGMA0_temp4),      \
+    SHA512_XOR(SIGMA0_temp1, SIGMA0_temp4, (ret)) )
+
+/*
+ * SHA512_ROTR(14,word) ^ SHA512_ROTR(18,word) ^ SHA512_ROTR(41,word)
+ */
+static uint32_t SIGMA1_temp1[2], SIGMA1_temp2[2],
+  SIGMA1_temp3[2], SIGMA1_temp4[2];
+#define SHA512_SIGMA1(word, ret) (                             \
+    SHA512_ROTR(14, (word), SIGMA1_temp1),                     \
+    SHA512_ROTR(18, (word), SIGMA1_temp2),                     \
+    SHA512_ROTR(41, (word), SIGMA1_temp3),                     \
+    SHA512_XOR(SIGMA1_temp2, SIGMA1_temp3, SIGMA1_temp4),      \
+    SHA512_XOR(SIGMA1_temp1, SIGMA1_temp4, (ret)) )
+
+/*
+ * (SHA512_ROTR( 1,word) ^ SHA512_ROTR( 8,word) ^ SHA512_SHR( 7,word))
+ */
+static uint32_t sigma0_temp1[2], sigma0_temp2[2],
+  sigma0_temp3[2], sigma0_temp4[2];
+#define SHA512_sigma0(word, ret) (                             \
+    SHA512_ROTR( 1, (word), sigma0_temp1),                     \
+    SHA512_ROTR( 8, (word), sigma0_temp2),                     \
+    SHA512_SHR( 7, (word), sigma0_temp3),                      \
+    SHA512_XOR(sigma0_temp2, sigma0_temp3, sigma0_temp4),      \
+    SHA512_XOR(sigma0_temp1, sigma0_temp4, (ret)) )
+
+/*
+ * (SHA512_ROTR(19,word) ^ SHA512_ROTR(61,word) ^ SHA512_SHR( 6,word))
+ */
+static uint32_t sigma1_temp1[2], sigma1_temp2[2],
+  sigma1_temp3[2], sigma1_temp4[2];
+#define SHA512_sigma1(word, ret) (                             \
+    SHA512_ROTR(19, (word), sigma1_temp1),                     \
+    SHA512_ROTR(61, (word), sigma1_temp2),                     \
+    SHA512_SHR( 6, (word), sigma1_temp3),                      \
+    SHA512_XOR(sigma1_temp2, sigma1_temp3, sigma1_temp4),      \
+    SHA512_XOR(sigma1_temp1, sigma1_temp4, (ret)) )
+
+#ifndef USE_MODIFIED_MACROS
+/*
+ * These definitions are the ones used in FIPS 180-3, section 4.1.3
+ *  Ch(x,y,z)   ((x & y) ^ (~x & z))
+ */
+static uint32_t Ch_temp1[2], Ch_temp2[2], Ch_temp3[2];
+#define SHA_Ch(x, y, z, ret) (                                 \
+    SHA512_AND(x, y, Ch_temp1),                                \
+    SHA512_TILDA(x, Ch_temp2),                                 \
+    SHA512_AND(Ch_temp2, z, Ch_temp3),                         \
+    SHA512_XOR(Ch_temp1, Ch_temp3, (ret)) )
+
+/*
+ *  Maj(x,y,z)  (((x)&(y)) ^ ((x)&(z)) ^ ((y)&(z)))
+ */
+static uint32_t Maj_temp1[2], Maj_temp2[2],
+  Maj_temp3[2], Maj_temp4[2];
+#define SHA_Maj(x, y, z, ret) (                                \
+    SHA512_AND(x, y, Maj_temp1),                               \
+    SHA512_AND(x, z, Maj_temp2),                               \
+    SHA512_AND(y, z, Maj_temp3),                               \
+    SHA512_XOR(Maj_temp2, Maj_temp3, Maj_temp4),               \
+    SHA512_XOR(Maj_temp1, Maj_temp4, (ret)) )
+#else /* !USE_MODIFIED_MACROS */
+/*
+ * These definitions are potentially faster equivalents for the ones
+ * used in FIPS 180-3, section 4.1.3.
+ *   ((x & y) ^ (~x & z)) becomes
+ *   ((x & (y ^ z)) ^ z)
+ */
+#define SHA_Ch(x, y, z, ret) (                                 \
+   (ret)[0] = (((x)[0] & ((y)[0] ^ (z)[0])) ^ (z)[0]),         \
+   (ret)[1] = (((x)[1] & ((y)[1] ^ (z)[1])) ^ (z)[1]) )
+
+/*
+ *   ((x & y) ^ (x & z) ^ (y & z)) becomes
+ *   ((x & (y | z)) | (y & z))
+ */
+#define SHA_Maj(x, y, z, ret) (                                 \
+   ret[0] = (((x)[0] & ((y)[0] | (z)[0])) | ((y)[0] & (z)[0])), \
+   ret[1] = (((x)[1] & ((y)[1] | (z)[1])) | ((y)[1] & (z)[1])) )
+#endif /* USE_MODIFIED_MACROS */
+
+/*
+ * Add "length" to the length.
+ * Set Corrupted when overflow has occurred.
+ */
+static uint32_t addTemp[4] = { 0, 0, 0, 0 };
+#define SHA384_512AddLength(context, length) (                        \
+    addTemp[3] = (length), SHA512_ADDTO4((context)->Length, addTemp), \
+    (context)->Corrupted = (((context)->Length[3] < (length)) &&      \
+       ((context)->Length[2] == 0) && ((context)->Length[1] == 0) &&  \
+       ((context)->Length[0] == 0)) ? shaInputTooLong :               \
+                                      (context)->Corrupted )
+
+/* Local Function Prototypes */
+static int SHA384_512Reset(SHA512Context *context,
+                           uint32_t H0[SHA512HashSize/4]);
+static void SHA384_512ProcessMessageBlock(SHA512Context *context);
+static void SHA384_512Finalize(SHA512Context *context,
+  uint8_t Pad_Byte);
+static void SHA384_512PadMessage(SHA512Context *context,
+  uint8_t Pad_Byte);
+static int SHA384_512ResultN( SHA512Context *context,
+  uint8_t Message_Digest[ ], int HashSize);
+
+/* Initial Hash Values: FIPS 180-3 sections 5.3.4 and 5.3.5 */
+static uint32_t SHA384_H0[SHA512HashSize/4] = {
+    0xCBBB9D5D, 0xC1059ED8, 0x629A292A, 0x367CD507, 0x9159015A,
+    0x3070DD17, 0x152FECD8, 0xF70E5939, 0x67332667, 0xFFC00B31,
+    0x8EB44A87, 0x68581511, 0xDB0C2E0D, 0x64F98FA7, 0x47B5481D,
+    0xBEFA4FA4
+};
+static uint32_t SHA512_H0[SHA512HashSize/4] = {
+    0x6A09E667, 0xF3BCC908, 0xBB67AE85, 0x84CAA73B, 0x3C6EF372,
+    0xFE94F82B, 0xA54FF53A, 0x5F1D36F1, 0x510E527F, 0xADE682D1,
+    0x9B05688C, 0x2B3E6C1F, 0x1F83D9AB, 0xFB41BD6B, 0x5BE0CD19,
+    0x137E2179
+};
+
+#else /* !USE_32BIT_ONLY */
+
+#include "sha-private.h"
+
+/* Define the SHA shift, rotate left and rotate right macros */
+#define SHA512_SHR(bits,word)  (((uint64_t)(word)) >> (bits))
+#define SHA512_ROTR(bits,word) ((((uint64_t)(word)) >> (bits)) | \
+                                (((uint64_t)(word)) << (64-(bits))))
+
+/*
+ * Define the SHA SIGMA and sigma macros
+ *
+ *  SHA512_ROTR(28,word) ^ SHA512_ROTR(34,word) ^ SHA512_ROTR(39,word)
+ */
+#define SHA512_SIGMA0(word)   \
+ (SHA512_ROTR(28,word) ^ SHA512_ROTR(34,word) ^ SHA512_ROTR(39,word))
+#define SHA512_SIGMA1(word)   \
+ (SHA512_ROTR(14,word) ^ SHA512_ROTR(18,word) ^ SHA512_ROTR(41,word))
+#define SHA512_sigma0(word)   \
+ (SHA512_ROTR( 1,word) ^ SHA512_ROTR( 8,word) ^ SHA512_SHR( 7,word))
+#define SHA512_sigma1(word)   \
+ (SHA512_ROTR(19,word) ^ SHA512_ROTR(61,word) ^ SHA512_SHR( 6,word))
+
+/*
+ * Add "length" to the length.
+ * Set Corrupted when overflow has occurred.
+ */
+static uint64_t addTemp;
+#define SHA384_512AddLength(context, length)                   \
+   (addTemp = context->Length_Low, context->Corrupted =        \
+    ((context->Length_Low += length) < addTemp) &&             \
+    (++context->Length_High == 0) ? shaInputTooLong :          \
+                                    (context)->Corrupted)
+
+/* Local Function Prototypes */
+static int SHA384_512Reset(SHA512Context *context,
+                           uint64_t H0[SHA512HashSize/8]);
+static void SHA384_512ProcessMessageBlock(SHA512Context *context);
+static void SHA384_512Finalize(SHA512Context *context,
+  uint8_t Pad_Byte);
+static void SHA384_512PadMessage(SHA512Context *context,
+  uint8_t Pad_Byte);
+static int SHA384_512ResultN(SHA512Context *context,
+  uint8_t Message_Digest[ ], int HashSize);
+
+/* Initial Hash Values: FIPS 180-3 sections 5.3.4 and 5.3.5 */
+static uint64_t SHA384_H0[ ] = {
+    0xCBBB9D5DC1059ED8ll, 0x629A292A367CD507ll, 0x9159015A3070DD17ll,
+    0x152FECD8F70E5939ll, 0x67332667FFC00B31ll, 0x8EB44A8768581511ll,
+    0xDB0C2E0D64F98FA7ll, 0x47B5481DBEFA4FA4ll
+};
+static uint64_t SHA512_H0[ ] = {
+    0x6A09E667F3BCC908ll, 0xBB67AE8584CAA73Bll, 0x3C6EF372FE94F82Bll,
+    0xA54FF53A5F1D36F1ll, 0x510E527FADE682D1ll, 0x9B05688C2B3E6C1Fll,
+    0x1F83D9ABFB41BD6Bll, 0x5BE0CD19137E2179ll
+};
+
+#endif /* USE_32BIT_ONLY */
+
+/*
+ * SHA384Reset
+ *
+ * Description:
+ *   This function will initialize the SHA384Context in preparation
+ *   for computing a new SHA384 message digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA384Reset(SHA384Context *context)
+{
+  return SHA384_512Reset(context, SHA384_H0);
+}
+
+/*
+ * SHA384Input
+ *
+ * Description:
+ *   This function accepts an array of octets as the next portion
+ *   of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_array[ ]: [in]
+ *     An array of octets representing the next portion of
+ *     the message.
+ *   length: [in]
+ *     The length of the message in message_array.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA384Input(SHA384Context *context,
+    const uint8_t *message_array, unsigned int length)
+{
+  return SHA512Input(context, message_array, length);
+}
+
+/*
+ * SHA384FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA384FinalBits(SHA384Context *context,
+                    uint8_t message_bits, unsigned int length)
+{
+  return SHA512FinalBits(context, message_bits, length);
+}
+
+/*
+ * SHA384Result
+ *
+ * Description:
+ *   This function will return the 384-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 47.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA384Result(SHA384Context *context,
+    uint8_t Message_Digest[SHA384HashSize])
+{
+  return SHA384_512ResultN(context, Message_Digest, SHA384HashSize);
+}
+
+/*
+ * SHA512Reset
+ *
+ * Description:
+ *   This function will initialize the SHA512Context in preparation
+ *   for computing a new SHA512 message digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA512Reset(SHA512Context *context)
+{
+  return SHA384_512Reset(context, SHA512_H0);
+}
+
+/*
+ * SHA512Input
+ *
+ * Description:
+ *   This function accepts an array of octets as the next portion
+ *   of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_array[ ]: [in]
+ *     An array of octets representing the next portion of
+ *     the message.
+ *   length: [in]
+ *     The length of the message in message_array.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA512Input(SHA512Context *context,
+        const uint8_t *message_array,
+        unsigned int length)
+{
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (!message_array) return shaNull;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (context->Corrupted) return context->Corrupted;
+
+  while (length--) {
+    context->Message_Block[context->Message_Block_Index++] =
+            *message_array;
+
+    if ((SHA384_512AddLength(context, 8) == shaSuccess) &&
+      (context->Message_Block_Index == SHA512_Message_Block_Size))
+      SHA384_512ProcessMessageBlock(context);
+
+    message_array++;
+  }
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA512FinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA512FinalBits(SHA512Context *context,
+                    uint8_t message_bits, unsigned int length)
+{
+  static uint8_t masks[8] = {
+      /* 0 0b00000000 */ 0x00, /* 1 0b10000000 */ 0x80,
+      /* 2 0b11000000 */ 0xC0, /* 3 0b11100000 */ 0xE0,
+      /* 4 0b11110000 */ 0xF0, /* 5 0b11111000 */ 0xF8,
+      /* 6 0b11111100 */ 0xFC, /* 7 0b11111110 */ 0xFE
+  };
+  static uint8_t markbit[8] = {
+      /* 0 0b10000000 */ 0x80, /* 1 0b01000000 */ 0x40,
+      /* 2 0b00100000 */ 0x20, /* 3 0b00010000 */ 0x10,
+      /* 4 0b00001000 */ 0x08, /* 5 0b00000100 */ 0x04,
+      /* 6 0b00000010 */ 0x02, /* 7 0b00000001 */ 0x01
+  };
+
+  if (!context) return shaNull;
+  if (!length) return shaSuccess;
+  if (context->Corrupted) return context->Corrupted;
+  if (context->Computed) return context->Corrupted = shaStateError;
+  if (length >= 8) return context->Corrupted = shaBadParam;
+
+  SHA384_512AddLength(context, length);
+  SHA384_512Finalize(context, (uint8_t)
+    ((message_bits & masks[length]) | markbit[length]));
+
+  return context->Corrupted;
+}
+
+/*
+ * SHA512Result
+ *
+ * Description:
+ *   This function will return the 512-bit message digest
+ *   into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 63.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int SHA512Result(SHA512Context *context,
+    uint8_t Message_Digest[SHA512HashSize])
+{
+  return SHA384_512ResultN(context, Message_Digest, SHA512HashSize);
+}
+
+/*
+ * SHA384_512Reset
+ *
+ * Description:
+ *   This helper function will initialize the SHA512Context in
+ *   preparation for computing a new SHA384 or SHA512 message
+ *   digest.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to reset.
+ *   H0[ ]: [in]
+ *     The initial hash value array to use.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+#ifdef USE_32BIT_ONLY
+static int SHA384_512Reset(SHA512Context *context,
+                           uint32_t H0[SHA512HashSize/4])
+#else /* !USE_32BIT_ONLY */
+static int SHA384_512Reset(SHA512Context *context,
+                           uint64_t H0[SHA512HashSize/8])
+#endif /* USE_32BIT_ONLY */
+{
+  int i;
+  if (!context) return shaNull;
+  context->Message_Block_Index = 0;
+
+#ifdef USE_32BIT_ONLY
+  context->Length[0] = context->Length[1] =
+  context->Length[2] = context->Length[3] = 0;
+
+  for (i = 0; i < SHA512HashSize/4; i++)
+    context->Intermediate_Hash[i] = H0[i];
+#else /* !USE_32BIT_ONLY */
+  context->Length_High = context->Length_Low = 0;
+
+  for (i = 0; i < SHA512HashSize/8; i++)
+    context->Intermediate_Hash[i] = H0[i];
+#endif /* USE_32BIT_ONLY */
+
+  context->Computed = 0;
+  context->Corrupted = shaSuccess;
+
+  return shaSuccess;
+}
+
+/*
+ * SHA384_512ProcessMessageBlock
+ *
+ * Description:
+ *   This helper function will process the next 1024 bits of the
+ *   message stored in the Message_Block array.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *
+ * Returns:
+ *   Nothing.
+ *
+ * Comments:
+ *   Many of the variable names in this code, especially the
+ *   single character names, were used because those were the
+ *   names used in the Secure Hash Standard.
+ *
+ *
+ */
+static void SHA384_512ProcessMessageBlock(SHA512Context *context)
+{
+#ifdef USE_32BIT_ONLY
+  /* Constants defined in FIPS 180-3, section 4.2.3 */
+  static const uint32_t K[80*2] = {
+      0x428A2F98, 0xD728AE22, 0x71374491, 0x23EF65CD, 0xB5C0FBCF,
+      0xEC4D3B2F, 0xE9B5DBA5, 0x8189DBBC, 0x3956C25B, 0xF348B538,
+      0x59F111F1, 0xB605D019, 0x923F82A4, 0xAF194F9B, 0xAB1C5ED5,
+      0xDA6D8118, 0xD807AA98, 0xA3030242, 0x12835B01, 0x45706FBE,
+      0x243185BE, 0x4EE4B28C, 0x550C7DC3, 0xD5FFB4E2, 0x72BE5D74,
+      0xF27B896F, 0x80DEB1FE, 0x3B1696B1, 0x9BDC06A7, 0x25C71235,
+      0xC19BF174, 0xCF692694, 0xE49B69C1, 0x9EF14AD2, 0xEFBE4786,
+      0x384F25E3, 0x0FC19DC6, 0x8B8CD5B5, 0x240CA1CC, 0x77AC9C65,
+      0x2DE92C6F, 0x592B0275, 0x4A7484AA, 0x6EA6E483, 0x5CB0A9DC,
+      0xBD41FBD4, 0x76F988DA, 0x831153B5, 0x983E5152, 0xEE66DFAB,
+      0xA831C66D, 0x2DB43210, 0xB00327C8, 0x98FB213F, 0xBF597FC7,
+      0xBEEF0EE4, 0xC6E00BF3, 0x3DA88FC2, 0xD5A79147, 0x930AA725,
+      0x06CA6351, 0xE003826F, 0x14292967, 0x0A0E6E70, 0x27B70A85,
+      0x46D22FFC, 0x2E1B2138, 0x5C26C926, 0x4D2C6DFC, 0x5AC42AED,
+      0x53380D13, 0x9D95B3DF, 0x650A7354, 0x8BAF63DE, 0x766A0ABB,
+      0x3C77B2A8, 0x81C2C92E, 0x47EDAEE6, 0x92722C85, 0x1482353B,
+      0xA2BFE8A1, 0x4CF10364, 0xA81A664B, 0xBC423001, 0xC24B8B70,
+      0xD0F89791, 0xC76C51A3, 0x0654BE30, 0xD192E819, 0xD6EF5218,
+      0xD6990624, 0x5565A910, 0xF40E3585, 0x5771202A, 0x106AA070,
+      0x32BBD1B8, 0x19A4C116, 0xB8D2D0C8, 0x1E376C08, 0x5141AB53,
+      0x2748774C, 0xDF8EEB99, 0x34B0BCB5, 0xE19B48A8, 0x391C0CB3,
+      0xC5C95A63, 0x4ED8AA4A, 0xE3418ACB, 0x5B9CCA4F, 0x7763E373,
+      0x682E6FF3, 0xD6B2B8A3, 0x748F82EE, 0x5DEFB2FC, 0x78A5636F,
+      0x43172F60, 0x84C87814, 0xA1F0AB72, 0x8CC70208, 0x1A6439EC,
+      0x90BEFFFA, 0x23631E28, 0xA4506CEB, 0xDE82BDE9, 0xBEF9A3F7,
+      0xB2C67915, 0xC67178F2, 0xE372532B, 0xCA273ECE, 0xEA26619C,
+      0xD186B8C7, 0x21C0C207, 0xEADA7DD6, 0xCDE0EB1E, 0xF57D4F7F,
+      0xEE6ED178, 0x06F067AA, 0x72176FBA, 0x0A637DC5, 0xA2C898A6,
+      0x113F9804, 0xBEF90DAE, 0x1B710B35, 0x131C471B, 0x28DB77F5,
+      0x23047D84, 0x32CAAB7B, 0x40C72493, 0x3C9EBE0A, 0x15C9BEBC,
+      0x431D67C4, 0x9C100D4C, 0x4CC5D4BE, 0xCB3E42B6, 0x597F299C,
+      0xFC657E2A, 0x5FCB6FAB, 0x3AD6FAEC, 0x6C44198C, 0x4A475817
+  };
+  int     t, t2, t8;                  /* Loop counter */
+  uint32_t  temp1[2], temp2[2],       /* Temporary word values */
+        temp3[2], temp4[2], temp5[2];
+  uint32_t  W[2*80];                  /* Word sequence */
+  uint32_t  A[2], B[2], C[2], D[2],   /* Word buffers */
+        E[2], F[2], G[2], H[2];
+
+  /* Initialize the first 16 words in the array W */
+  for (t = t2 = t8 = 0; t < 16; t++, t8 += 8) {
+    W[t2++] = ((((uint32_t)context->Message_Block[t8    ])) << 24) |
+              ((((uint32_t)context->Message_Block[t8 + 1])) << 16) |
+              ((((uint32_t)context->Message_Block[t8 + 2])) << 8) |
+              ((((uint32_t)context->Message_Block[t8 + 3])));
+    W[t2++] = ((((uint32_t)context->Message_Block[t8 + 4])) << 24) |
+              ((((uint32_t)context->Message_Block[t8 + 5])) << 16) |
+              ((((uint32_t)context->Message_Block[t8 + 6])) << 8) |
+              ((((uint32_t)context->Message_Block[t8 + 7])));
+  }
+
+  for (t = 16; t < 80; t++, t2 += 2) {
+    /* W[t] = SHA512_sigma1(W[t-2]) + W[t-7] +
+      SHA512_sigma0(W[t-15]) + W[t-16]; */
+    uint32_t *Wt2 = &W[t2-2*2];
+    uint32_t *Wt7 = &W[t2-7*2];
+    uint32_t *Wt15 = &W[t2-15*2];
+    uint32_t *Wt16 = &W[t2-16*2];
+    SHA512_sigma1(Wt2, temp1);
+    SHA512_ADD(temp1, Wt7, temp2);
+    SHA512_sigma0(Wt15, temp1);
+    SHA512_ADD(temp1, Wt16, temp3);
+    SHA512_ADD(temp2, temp3, &W[t2]);
+  }
+
+  A[0] = context->Intermediate_Hash[0];
+  A[1] = context->Intermediate_Hash[1];
+  B[0] = context->Intermediate_Hash[2];
+  B[1] = context->Intermediate_Hash[3];
+  C[0] = context->Intermediate_Hash[4];
+  C[1] = context->Intermediate_Hash[5];
+  D[0] = context->Intermediate_Hash[6];
+  D[1] = context->Intermediate_Hash[7];
+  E[0] = context->Intermediate_Hash[8];
+  E[1] = context->Intermediate_Hash[9];
+  F[0] = context->Intermediate_Hash[10];
+  F[1] = context->Intermediate_Hash[11];
+  G[0] = context->Intermediate_Hash[12];
+  G[1] = context->Intermediate_Hash[13];
+  H[0] = context->Intermediate_Hash[14];
+  H[1] = context->Intermediate_Hash[15];
+
+  for (t = t2 = 0; t < 80; t++, t2 += 2) {
+    /*
+     * temp1 = H + SHA512_SIGMA1(E) + SHA_Ch(E,F,G) + K[t] + W[t];
+     */
+    SHA512_SIGMA1(E,temp1);
+    SHA512_ADD(H, temp1, temp2);
+    SHA_Ch(E,F,G,temp3);
+    SHA512_ADD(temp2, temp3, temp4);
+    SHA512_ADD(&K[t2], &W[t2], temp5);
+    SHA512_ADD(temp4, temp5, temp1);
+    /*
+     * temp2 = SHA512_SIGMA0(A) + SHA_Maj(A,B,C);
+     */
+    SHA512_SIGMA0(A,temp3);
+    SHA_Maj(A,B,C,temp4);
+    SHA512_ADD(temp3, temp4, temp2);
+    H[0] = G[0]; H[1] = G[1];
+    G[0] = F[0]; G[1] = F[1];
+    F[0] = E[0]; F[1] = E[1];
+    SHA512_ADD(D, temp1, E);
+    D[0] = C[0]; D[1] = C[1];
+    C[0] = B[0]; C[1] = B[1];
+    B[0] = A[0]; B[1] = A[1];
+    SHA512_ADD(temp1, temp2, A);
+  }
+
+  SHA512_ADDTO2(&context->Intermediate_Hash[0], A);
+  SHA512_ADDTO2(&context->Intermediate_Hash[2], B);
+  SHA512_ADDTO2(&context->Intermediate_Hash[4], C);
+  SHA512_ADDTO2(&context->Intermediate_Hash[6], D);
+  SHA512_ADDTO2(&context->Intermediate_Hash[8], E);
+  SHA512_ADDTO2(&context->Intermediate_Hash[10], F);
+  SHA512_ADDTO2(&context->Intermediate_Hash[12], G);
+  SHA512_ADDTO2(&context->Intermediate_Hash[14], H);
+
+#else /* !USE_32BIT_ONLY */
+  /* Constants defined in FIPS 180-3, section 4.2.3 */
+  static const uint64_t K[80] = {
+      0x428A2F98D728AE22ll, 0x7137449123EF65CDll, 0xB5C0FBCFEC4D3B2Fll,
+      0xE9B5DBA58189DBBCll, 0x3956C25BF348B538ll, 0x59F111F1B605D019ll,
+      0x923F82A4AF194F9Bll, 0xAB1C5ED5DA6D8118ll, 0xD807AA98A3030242ll,
+      0x12835B0145706FBEll, 0x243185BE4EE4B28Cll, 0x550C7DC3D5FFB4E2ll,
+      0x72BE5D74F27B896Fll, 0x80DEB1FE3B1696B1ll, 0x9BDC06A725C71235ll,
+      0xC19BF174CF692694ll, 0xE49B69C19EF14AD2ll, 0xEFBE4786384F25E3ll,
+      0x0FC19DC68B8CD5B5ll, 0x240CA1CC77AC9C65ll, 0x2DE92C6F592B0275ll,
+      0x4A7484AA6EA6E483ll, 0x5CB0A9DCBD41FBD4ll, 0x76F988DA831153B5ll,
+      0x983E5152EE66DFABll, 0xA831C66D2DB43210ll, 0xB00327C898FB213Fll,
+      0xBF597FC7BEEF0EE4ll, 0xC6E00BF33DA88FC2ll, 0xD5A79147930AA725ll,
+      0x06CA6351E003826Fll, 0x142929670A0E6E70ll, 0x27B70A8546D22FFCll,
+      0x2E1B21385C26C926ll, 0x4D2C6DFC5AC42AEDll, 0x53380D139D95B3DFll,
+      0x650A73548BAF63DEll, 0x766A0ABB3C77B2A8ll, 0x81C2C92E47EDAEE6ll,
+      0x92722C851482353Bll, 0xA2BFE8A14CF10364ll, 0xA81A664BBC423001ll,
+      0xC24B8B70D0F89791ll, 0xC76C51A30654BE30ll, 0xD192E819D6EF5218ll,
+      0xD69906245565A910ll, 0xF40E35855771202All, 0x106AA07032BBD1B8ll,
+      0x19A4C116B8D2D0C8ll, 0x1E376C085141AB53ll, 0x2748774CDF8EEB99ll,
+      0x34B0BCB5E19B48A8ll, 0x391C0CB3C5C95A63ll, 0x4ED8AA4AE3418ACBll,
+      0x5B9CCA4F7763E373ll, 0x682E6FF3D6B2B8A3ll, 0x748F82EE5DEFB2FCll,
+      0x78A5636F43172F60ll, 0x84C87814A1F0AB72ll, 0x8CC702081A6439ECll,
+      0x90BEFFFA23631E28ll, 0xA4506CEBDE82BDE9ll, 0xBEF9A3F7B2C67915ll,
+      0xC67178F2E372532Bll, 0xCA273ECEEA26619Cll, 0xD186B8C721C0C207ll,
+      0xEADA7DD6CDE0EB1Ell, 0xF57D4F7FEE6ED178ll, 0x06F067AA72176FBAll,
+      0x0A637DC5A2C898A6ll, 0x113F9804BEF90DAEll, 0x1B710B35131C471Bll,
+      0x28DB77F523047D84ll, 0x32CAAB7B40C72493ll, 0x3C9EBE0A15C9BEBCll,
+      0x431D67C49C100D4Cll, 0x4CC5D4BECB3E42B6ll, 0x597F299CFC657E2All,
+      0x5FCB6FAB3AD6FAECll, 0x6C44198C4A475817ll
+  };
+  int        t, t8;                   /* Loop counter */
+  uint64_t   temp1, temp2;            /* Temporary word value */
+  uint64_t   W[80];                   /* Word sequence */
+  uint64_t   A, B, C, D, E, F, G, H;  /* Word buffers */
+
+  /*
+   * Initialize the first 16 words in the array W
+   */
+  for (t = t8 = 0; t < 16; t++, t8 += 8)
+    W[t] = ((uint64_t)(context->Message_Block[t8  ]) << 56) |
+           ((uint64_t)(context->Message_Block[t8 + 1]) << 48) |
+           ((uint64_t)(context->Message_Block[t8 + 2]) << 40) |
+           ((uint64_t)(context->Message_Block[t8 + 3]) << 32) |
+           ((uint64_t)(context->Message_Block[t8 + 4]) << 24) |
+           ((uint64_t)(context->Message_Block[t8 + 5]) << 16) |
+           ((uint64_t)(context->Message_Block[t8 + 6]) << 8) |
+           ((uint64_t)(context->Message_Block[t8 + 7]));
+
+  for (t = 16; t < 80; t++)
+    W[t] = SHA512_sigma1(W[t-2]) + W[t-7] +
+        SHA512_sigma0(W[t-15]) + W[t-16];
+  A = context->Intermediate_Hash[0];
+  B = context->Intermediate_Hash[1];
+  C = context->Intermediate_Hash[2];
+  D = context->Intermediate_Hash[3];
+  E = context->Intermediate_Hash[4];
+  F = context->Intermediate_Hash[5];
+  G = context->Intermediate_Hash[6];
+  H = context->Intermediate_Hash[7];
+
+  for (t = 0; t < 80; t++) {
+    temp1 = H + SHA512_SIGMA1(E) + SHA_Ch(E,F,G) + K[t] + W[t];
+    temp2 = SHA512_SIGMA0(A) + SHA_Maj(A,B,C);
+    H = G;
+    G = F;
+    F = E;
+    E = D + temp1;
+    D = C;
+    C = B;
+    B = A;
+    A = temp1 + temp2;
+  }
+
+  context->Intermediate_Hash[0] += A;
+  context->Intermediate_Hash[1] += B;
+  context->Intermediate_Hash[2] += C;
+  context->Intermediate_Hash[3] += D;
+  context->Intermediate_Hash[4] += E;
+  context->Intermediate_Hash[5] += F;
+  context->Intermediate_Hash[6] += G;
+  context->Intermediate_Hash[7] += H;
+#endif /* USE_32BIT_ONLY */
+
+  context->Message_Block_Index = 0;
+}
+
+/*
+ * SHA384_512Finalize
+ *
+ * Description:
+ *   This helper function finishes off the digest calculations.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+static void SHA384_512Finalize(SHA512Context *context,
+    uint8_t Pad_Byte)
+{
+  int_least16_t i;
+  SHA384_512PadMessage(context, Pad_Byte);
+  /* message may be sensitive, clear it out */
+  for (i = 0; i < SHA512_Message_Block_Size; ++i)
+    context->Message_Block[i] = 0;
+#ifdef USE_32BIT_ONLY    /* and clear length */
+  context->Length[0] = context->Length[1] = 0;
+  context->Length[2] = context->Length[3] = 0;
+#else /* !USE_32BIT_ONLY */
+  context->Length_High = context->Length_Low = 0;
+#endif /* USE_32BIT_ONLY */
+  context->Computed = 1;
+}
+
+/*
+ * SHA384_512PadMessage
+ *
+ * Description:
+ *   According to the standard, the message must be padded to the next
+ *   even multiple of 1024 bits.  The first padding bit must be a '1'.
+ *   The last 128 bits represent the length of the original message.
+ *   All bits in between should be 0.  This helper function will
+ *   pad the message according to those rules by filling the
+ *   Message_Block array accordingly.  When it returns, it can be
+ *   assumed that the message digest has been computed.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to pad.
+ *   Pad_Byte: [in]
+ *     The last byte to add to the message block before the 0-padding
+ *     and length.  This will contain the last bits of the message
+ *     followed by another single bit.  If the message was an
+ *     exact multiple of 8-bits long, Pad_Byte will be 0x80.
+ *
+ * Returns:
+ *   Nothing.
+ *
+ */
+static void SHA384_512PadMessage(SHA512Context *context,
+    uint8_t Pad_Byte)
+{
+  /*
+   * Check to see if the current message block is too small to hold
+   * the initial padding bits and length.  If so, we will pad the
+   * block, process it, and then continue padding into a second
+   * block.
+   */
+  if (context->Message_Block_Index >= (SHA512_Message_Block_Size-16)) {
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+    while (context->Message_Block_Index < SHA512_Message_Block_Size)
+      context->Message_Block[context->Message_Block_Index++] = 0;
+
+    SHA384_512ProcessMessageBlock(context);
+  } else
+    context->Message_Block[context->Message_Block_Index++] = Pad_Byte;
+
+  while (context->Message_Block_Index < (SHA512_Message_Block_Size-16))
+    context->Message_Block[context->Message_Block_Index++] = 0;
+
+  /*
+   * Store the message length as the last 16 octets
+   */
+#ifdef USE_32BIT_ONLY
+  context->Message_Block[112] = (uint8_t)(context->Length[0] >> 24);
+  context->Message_Block[113] = (uint8_t)(context->Length[0] >> 16);
+  context->Message_Block[114] = (uint8_t)(context->Length[0] >> 8);
+  context->Message_Block[115] = (uint8_t)(context->Length[0]);
+  context->Message_Block[116] = (uint8_t)(context->Length[1] >> 24);
+  context->Message_Block[117] = (uint8_t)(context->Length[1] >> 16);
+  context->Message_Block[118] = (uint8_t)(context->Length[1] >> 8);
+  context->Message_Block[119] = (uint8_t)(context->Length[1]);
+
+  context->Message_Block[120] = (uint8_t)(context->Length[2] >> 24);
+  context->Message_Block[121] = (uint8_t)(context->Length[2] >> 16);
+  context->Message_Block[122] = (uint8_t)(context->Length[2] >> 8);
+  context->Message_Block[123] = (uint8_t)(context->Length[2]);
+  context->Message_Block[124] = (uint8_t)(context->Length[3] >> 24);
+  context->Message_Block[125] = (uint8_t)(context->Length[3] >> 16);
+  context->Message_Block[126] = (uint8_t)(context->Length[3] >> 8);
+  context->Message_Block[127] = (uint8_t)(context->Length[3]);
+#else /* !USE_32BIT_ONLY */
+  context->Message_Block[112] = (uint8_t)(context->Length_High >> 56);
+  context->Message_Block[113] = (uint8_t)(context->Length_High >> 48);
+  context->Message_Block[114] = (uint8_t)(context->Length_High >> 40);
+  context->Message_Block[115] = (uint8_t)(context->Length_High >> 32);
+  context->Message_Block[116] = (uint8_t)(context->Length_High >> 24);
+  context->Message_Block[117] = (uint8_t)(context->Length_High >> 16);
+  context->Message_Block[118] = (uint8_t)(context->Length_High >> 8);
+  context->Message_Block[119] = (uint8_t)(context->Length_High);
+
+  context->Message_Block[120] = (uint8_t)(context->Length_Low >> 56);
+  context->Message_Block[121] = (uint8_t)(context->Length_Low >> 48);
+  context->Message_Block[122] = (uint8_t)(context->Length_Low >> 40);
+  context->Message_Block[123] = (uint8_t)(context->Length_Low >> 32);
+  context->Message_Block[124] = (uint8_t)(context->Length_Low >> 24);
+  context->Message_Block[125] = (uint8_t)(context->Length_Low >> 16);
+  context->Message_Block[126] = (uint8_t)(context->Length_Low >> 8);
+  context->Message_Block[127] = (uint8_t)(context->Length_Low);
+#endif /* USE_32BIT_ONLY */
+
+  SHA384_512ProcessMessageBlock(context);
+}
+
+/*
+ * SHA384_512ResultN
+ *
+ * Description:
+ *   This helper function will return the 384-bit or 512-bit message
+ *   digest into the Message_Digest array provided by the caller.
+ *   NOTE:
+ *    The first octet of hash is stored in the element with index 0,
+ *    the last octet of hash in the element with index 47/63.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA hash.
+ *   Message_Digest[ ]: [out]
+ *     Where the digest is returned.
+ *   HashSize: [in]
+ *     The size of the hash, either 48 or 64.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+static int SHA384_512ResultN(SHA512Context *context,
+    uint8_t Message_Digest[ ], int HashSize)
+{
+  int i;
+#ifdef USE_32BIT_ONLY
+  int i2;
+#endif /* USE_32BIT_ONLY */
+
+  if (!context) return shaNull;
+  if (!Message_Digest) return shaNull;
+  if (context->Corrupted) return context->Corrupted;
+
+  if (!context->Computed)
+    SHA384_512Finalize(context, 0x80);
+
+#ifdef USE_32BIT_ONLY
+  for (i = i2 = 0; i < HashSize; ) {
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>24);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>16);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>8);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2++]);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>24);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>16);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2]>>8);
+    Message_Digest[i++]=(uint8_t)(context->Intermediate_Hash[i2++]);
+  }
+#else /* !USE_32BIT_ONLY */
+  for (i = 0; i < HashSize; ++i)
+    Message_Digest[i] = (uint8_t)
+      (context->Intermediate_Hash[i>>3] >> 8 * ( 7 - ( i % 8 ) ));
+#endif /* USE_32BIT_ONLY */
+
+  return shaSuccess;
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/shatest.c
+++ b/lib/libesp32/ESP32-HomeKit/src/shatest.c
@@ -1,0 +1,1530 @@
+/************************** shatest.c **************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *    This file will exercise the SHA code performing
+ *      the three tests documented in FIPS PUB 180-3
+ *        (http://csrc.nist.gov/publications/fips/
+ *         fips180-2/fips180-2withchangenotice.pdf)
+ *      one that calls SHAInput with an exact multiple of 512 bits
+ *      the seven tests documented for each algorithm in
+ *        "The Secure Hash Algorithm Validation System (SHAVS)"
+ *        (http://csrc.nist.gov/cryptval/shs/SHAVS.pdf),
+ *        three of which are bit-level tests
+ *
+ *    These tests have subsequently been moved to pages linked from
+ *      http://csrc.nist.gov/groups/ST/toolkit/examples.html
+ *
+ *    This file will exercise the HMAC SHA1 code performing
+ *      the seven tests documented in RFCs [RFC 2202] and [RFC 4231].
+ *
+ *    This file will exercise the HKDF code performing
+ *      the seven tests documented in RFC 4869.
+ *
+ *    To run the tests and just see PASSED/FAILED, use the -p option.
+ *
+ *    Other options exercise:
+ *      hashing an arbitrary string
+ *      hashing a file's contents
+ *      a few error test checks
+ *      printing the results in raw format
+ *
+ *  Portability Issues:
+ *    None.
+ *
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <unistd.h>     /* defines getopt() and optarg */
+#include "sha.h"
+
+static int scasecmp(const char *s1, const char *s2);
+
+/*
+ *  Define patterns for testing
+ */
+#define TEST1    "abc"
+#define TEST2_1  \
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+#define TEST2_2a \
+        "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+#define TEST2_2b \
+        "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+#define TEST2_2  TEST2_2a TEST2_2b
+#define TEST3    "a"                            /* times 1000000 */
+#define TEST4a   "01234567012345670123456701234567"
+#define TEST4b   "01234567012345670123456701234567"
+    /* an exact multiple of 512 bits */
+#define TEST4   TEST4a TEST4b                   /* times 10 */
+#define TEST7_1 \
+  "\x49\xb2\xae\xc2\x59\x4b\xbe\x3a\x3b\x11\x75\x42\xd9\x4a\xc8"
+#define TEST8_1 \
+  "\x9a\x7d\xfd\xf1\xec\xea\xd0\x6e\xd6\x46\xaa\x55\xfe\x75\x71\x46"
+#define TEST9_1 \
+  "\x65\xf9\x32\x99\x5b\xa4\xce\x2c\xb1\xb4\xa2\xe7\x1a\xe7\x02\x20" \
+  "\xaa\xce\xc8\x96\x2d\xd4\x49\x9c\xbd\x7c\x88\x7a\x94\xea\xaa\x10" \
+  "\x1e\xa5\xaa\xbc\x52\x9b\x4e\x7e\x43\x66\x5a\x5a\xf2\xcd\x03\xfe" \
+  "\x67\x8e\xa6\xa5\x00\x5b\xba\x3b\x08\x22\x04\xc2\x8b\x91\x09\xf4" \
+  "\x69\xda\xc9\x2a\xaa\xb3\xaa\x7c\x11\xa1\xb3\x2a"
+#define TEST10_1 \
+  "\xf7\x8f\x92\x14\x1b\xcd\x17\x0a\xe8\x9b\x4f\xba\x15\xa1\xd5\x9f" \
+  "\x3f\xd8\x4d\x22\x3c\x92\x51\xbd\xac\xbb\xae\x61\xd0\x5e\xd1\x15" \
+  "\xa0\x6a\x7c\xe1\x17\xb7\xbe\xea\xd2\x44\x21\xde\xd9\xc3\x25\x92" \
+  "\xbd\x57\xed\xea\xe3\x9c\x39\xfa\x1f\xe8\x94\x6a\x84\xd0\xcf\x1f" \
+  "\x7b\xee\xad\x17\x13\xe2\xe0\x95\x98\x97\x34\x7f\x67\xc8\x0b\x04" \
+  "\x00\xc2\x09\x81\x5d\x6b\x10\xa6\x83\x83\x6f\xd5\x56\x2a\x56\xca" \
+  "\xb1\xa2\x8e\x81\xb6\x57\x66\x54\x63\x1c\xf1\x65\x66\xb8\x6e\x3b" \
+  "\x33\xa1\x08\xb0\x53\x07\xc0\x0a\xff\x14\xa7\x68\xed\x73\x50\x60" \
+  "\x6a\x0f\x85\xe6\xa9\x1d\x39\x6f\x5b\x5c\xbe\x57\x7f\x9b\x38\x80" \
+  "\x7c\x7d\x52\x3d\x6d\x79\x2f\x6e\xbc\x24\xa4\xec\xf2\xb3\xa4\x27" \
+  "\xcd\xbb\xfb"
+#define TEST7_224 \
+  "\xf0\x70\x06\xf2\x5a\x0b\xea\x68\xcd\x76\xa2\x95\x87\xc2\x8d"
+#define TEST8_224 \
+  "\x18\x80\x40\x05\xdd\x4f\xbd\x15\x56\x29\x9d\x6f\x9d\x93\xdf\x62"
+#define TEST9_224 \
+  "\xa2\xbe\x6e\x46\x32\x81\x09\x02\x94\xd9\xce\x94\x82\x65\x69\x42" \
+  "\x3a\x3a\x30\x5e\xd5\xe2\x11\x6c\xd4\xa4\xc9\x87\xfc\x06\x57\x00" \
+  "\x64\x91\xb1\x49\xcc\xd4\xb5\x11\x30\xac\x62\xb1\x9d\xc2\x48\xc7" \
+  "\x44\x54\x3d\x20\xcd\x39\x52\xdc\xed\x1f\x06\xcc\x3b\x18\xb9\x1f" \
+  "\x3f\x55\x63\x3e\xcc\x30\x85\xf4\x90\x70\x60\xd2"
+#define TEST10_224 \
+  "\x55\xb2\x10\x07\x9c\x61\xb5\x3a\xdd\x52\x06\x22\xd1\xac\x97\xd5" \
+  "\xcd\xbe\x8c\xb3\x3a\xa0\xae\x34\x45\x17\xbe\xe4\xd7\xba\x09\xab" \
+  "\xc8\x53\x3c\x52\x50\x88\x7a\x43\xbe\xbb\xac\x90\x6c\x2e\x18\x37" \
+  "\xf2\x6b\x36\xa5\x9a\xe3\xbe\x78\x14\xd5\x06\x89\x6b\x71\x8b\x2a" \
+  "\x38\x3e\xcd\xac\x16\xb9\x61\x25\x55\x3f\x41\x6f\xf3\x2c\x66\x74" \
+  "\xc7\x45\x99\xa9\x00\x53\x86\xd9\xce\x11\x12\x24\x5f\x48\xee\x47" \
+  "\x0d\x39\x6c\x1e\xd6\x3b\x92\x67\x0c\xa5\x6e\xc8\x4d\xee\xa8\x14" \
+  "\xb6\x13\x5e\xca\x54\x39\x2b\xde\xdb\x94\x89\xbc\x9b\x87\x5a\x8b" \
+  "\xaf\x0d\xc1\xae\x78\x57\x36\x91\x4a\xb7\xda\xa2\x64\xbc\x07\x9d" \
+  "\x26\x9f\x2c\x0d\x7e\xdd\xd8\x10\xa4\x26\x14\x5a\x07\x76\xf6\x7c" \
+  "\x87\x82\x73"
+#define TEST7_256 \
+  "\xbe\x27\x46\xc6\xdb\x52\x76\x5f\xdb\x2f\x88\x70\x0f\x9a\x73"
+#define TEST8_256 \
+  "\xe3\xd7\x25\x70\xdc\xdd\x78\x7c\xe3\x88\x7a\xb2\xcd\x68\x46\x52"
+#define TEST9_256 \
+  "\x3e\x74\x03\x71\xc8\x10\xc2\xb9\x9f\xc0\x4e\x80\x49\x07\xef\x7c" \
+  "\xf2\x6b\xe2\x8b\x57\xcb\x58\xa3\xe2\xf3\xc0\x07\x16\x6e\x49\xc1" \
+  "\x2e\x9b\xa3\x4c\x01\x04\x06\x91\x29\xea\x76\x15\x64\x25\x45\x70" \
+  "\x3a\x2b\xd9\x01\xe1\x6e\xb0\xe0\x5d\xeb\xa0\x14\xeb\xff\x64\x06" \
+  "\xa0\x7d\x54\x36\x4e\xff\x74\x2d\xa7\x79\xb0\xb3"
+#define TEST10_256 \
+  "\x83\x26\x75\x4e\x22\x77\x37\x2f\x4f\xc1\x2b\x20\x52\x7a\xfe\xf0" \
+  "\x4d\x8a\x05\x69\x71\xb1\x1a\xd5\x71\x23\xa7\xc1\x37\x76\x00\x00" \
+  "\xd7\xbe\xf6\xf3\xc1\xf7\xa9\x08\x3a\xa3\x9d\x81\x0d\xb3\x10\x77" \
+  "\x7d\xab\x8b\x1e\x7f\x02\xb8\x4a\x26\xc7\x73\x32\x5f\x8b\x23\x74" \
+  "\xde\x7a\x4b\x5a\x58\xcb\x5c\x5c\xf3\x5b\xce\xe6\xfb\x94\x6e\x5b" \
+  "\xd6\x94\xfa\x59\x3a\x8b\xeb\x3f\x9d\x65\x92\xec\xed\xaa\x66\xca" \
+  "\x82\xa2\x9d\x0c\x51\xbc\xf9\x33\x62\x30\xe5\xd7\x84\xe4\xc0\xa4" \
+  "\x3f\x8d\x79\xa3\x0a\x16\x5c\xba\xbe\x45\x2b\x77\x4b\x9c\x71\x09" \
+  "\xa9\x7d\x13\x8f\x12\x92\x28\x96\x6f\x6c\x0a\xdc\x10\x6a\xad\x5a" \
+  "\x9f\xdd\x30\x82\x57\x69\xb2\xc6\x71\xaf\x67\x59\xdf\x28\xeb\x39" \
+  "\x3d\x54\xd6"
+#define TEST7_384 \
+  "\x8b\xc5\x00\xc7\x7c\xee\xd9\x87\x9d\xa9\x89\x10\x7c\xe0\xaa"
+#define TEST8_384 \
+  "\xa4\x1c\x49\x77\x79\xc0\x37\x5f\xf1\x0a\x7f\x4e\x08\x59\x17\x39"
+#define TEST9_384 \
+  "\x68\xf5\x01\x79\x2d\xea\x97\x96\x76\x70\x22\xd9\x3d\xa7\x16\x79" \
+  "\x30\x99\x20\xfa\x10\x12\xae\xa3\x57\xb2\xb1\x33\x1d\x40\xa1\xd0" \
+  "\x3c\x41\xc2\x40\xb3\xc9\xa7\x5b\x48\x92\xf4\xc0\x72\x4b\x68\xc8" \
+  "\x75\x32\x1a\xb8\xcf\xe5\x02\x3b\xd3\x75\xbc\x0f\x94\xbd\x89\xfe" \
+  "\x04\xf2\x97\x10\x5d\x7b\x82\xff\xc0\x02\x1a\xeb\x1c\xcb\x67\x4f" \
+  "\x52\x44\xea\x34\x97\xde\x26\xa4\x19\x1c\x5f\x62\xe5\xe9\xa2\xd8" \
+  "\x08\x2f\x05\x51\xf4\xa5\x30\x68\x26\xe9\x1c\xc0\x06\xce\x1b\xf6" \
+  "\x0f\xf7\x19\xd4\x2f\xa5\x21\xc8\x71\xcd\x23\x94\xd9\x6e\xf4\x46" \
+  "\x8f\x21\x96\x6b\x41\xf2\xba\x80\xc2\x6e\x83\xa9"
+#define TEST10_384 \
+  "\x39\x96\x69\xe2\x8f\x6b\x9c\x6d\xbc\xbb\x69\x12\xec\x10\xff\xcf" \
+  "\x74\x79\x03\x49\xb7\xdc\x8f\xbe\x4a\x8e\x7b\x3b\x56\x21\xdb\x0f" \
+  "\x3e\x7d\xc8\x7f\x82\x32\x64\xbb\xe4\x0d\x18\x11\xc9\xea\x20\x61" \
+  "\xe1\xc8\x4a\xd1\x0a\x23\xfa\xc1\x72\x7e\x72\x02\xfc\x3f\x50\x42" \
+  "\xe6\xbf\x58\xcb\xa8\xa2\x74\x6e\x1f\x64\xf9\xb9\xea\x35\x2c\x71" \
+  "\x15\x07\x05\x3c\xf4\xe5\x33\x9d\x52\x86\x5f\x25\xcc\x22\xb5\xe8" \
+  "\x77\x84\xa1\x2f\xc9\x61\xd6\x6c\xb6\xe8\x95\x73\x19\x9a\x2c\xe6" \
+  "\x56\x5c\xbd\xf1\x3d\xca\x40\x38\x32\xcf\xcb\x0e\x8b\x72\x11\xe8" \
+  "\x3a\xf3\x2a\x11\xac\x17\x92\x9f\xf1\xc0\x73\xa5\x1c\xc0\x27\xaa" \
+  "\xed\xef\xf8\x5a\xad\x7c\x2b\x7c\x5a\x80\x3e\x24\x04\xd9\x6d\x2a" \
+  "\x77\x35\x7b\xda\x1a\x6d\xae\xed\x17\x15\x1c\xb9\xbc\x51\x25\xa4" \
+  "\x22\xe9\x41\xde\x0c\xa0\xfc\x50\x11\xc2\x3e\xcf\xfe\xfd\xd0\x96" \
+  "\x76\x71\x1c\xf3\xdb\x0a\x34\x40\x72\x0e\x16\x15\xc1\xf2\x2f\xbc" \
+  "\x3c\x72\x1d\xe5\x21\xe1\xb9\x9b\xa1\xbd\x55\x77\x40\x86\x42\x14" \
+  "\x7e\xd0\x96"
+#define TEST7_512 \
+  "\x08\xec\xb5\x2e\xba\xe1\xf7\x42\x2d\xb6\x2b\xcd\x54\x26\x70"
+#define TEST8_512 \
+  "\x8d\x4e\x3c\x0e\x38\x89\x19\x14\x91\x81\x6e\x9d\x98\xbf\xf0\xa0"
+#define TEST9_512 \
+  "\x3a\xdd\xec\x85\x59\x32\x16\xd1\x61\x9a\xa0\x2d\x97\x56\x97\x0b" \
+  "\xfc\x70\xac\xe2\x74\x4f\x7c\x6b\x27\x88\x15\x10\x28\xf7\xb6\xa2" \
+  "\x55\x0f\xd7\x4a\x7e\x6e\x69\xc2\xc9\xb4\x5f\xc4\x54\x96\x6d\xc3" \
+  "\x1d\x2e\x10\xda\x1f\x95\xce\x02\xbe\xb4\xbf\x87\x65\x57\x4c\xbd" \
+  "\x6e\x83\x37\xef\x42\x0a\xdc\x98\xc1\x5c\xb6\xd5\xe4\xa0\x24\x1b" \
+  "\xa0\x04\x6d\x25\x0e\x51\x02\x31\xca\xc2\x04\x6c\x99\x16\x06\xab" \
+  "\x4e\xe4\x14\x5b\xee\x2f\xf4\xbb\x12\x3a\xab\x49\x8d\x9d\x44\x79" \
+  "\x4f\x99\xcc\xad\x89\xa9\xa1\x62\x12\x59\xed\xa7\x0a\x5b\x6d\xd4" \
+  "\xbd\xd8\x77\x78\xc9\x04\x3b\x93\x84\xf5\x49\x06"
+#define TEST10_512 \
+  "\xa5\x5f\x20\xc4\x11\xaa\xd1\x32\x80\x7a\x50\x2d\x65\x82\x4e\x31" \
+  "\xa2\x30\x54\x32\xaa\x3d\x06\xd3\xe2\x82\xa8\xd8\x4e\x0d\xe1\xde" \
+  "\x69\x74\xbf\x49\x54\x69\xfc\x7f\x33\x8f\x80\x54\xd5\x8c\x26\xc4" \
+  "\x93\x60\xc3\xe8\x7a\xf5\x65\x23\xac\xf6\xd8\x9d\x03\xe5\x6f\xf2" \
+  "\xf8\x68\x00\x2b\xc3\xe4\x31\xed\xc4\x4d\xf2\xf0\x22\x3d\x4b\xb3" \
+  "\xb2\x43\x58\x6e\x1a\x7d\x92\x49\x36\x69\x4f\xcb\xba\xf8\x8d\x95" \
+  "\x19\xe4\xeb\x50\xa6\x44\xf8\xe4\xf9\x5e\xb0\xea\x95\xbc\x44\x65" \
+  "\xc8\x82\x1a\xac\xd2\xfe\x15\xab\x49\x81\x16\x4b\xbb\x6d\xc3\x2f" \
+  "\x96\x90\x87\xa1\x45\xb0\xd9\xcc\x9c\x67\xc2\x2b\x76\x32\x99\x41" \
+  "\x9c\xc4\x12\x8b\xe9\xa0\x77\xb3\xac\xe6\x34\x06\x4e\x6d\x99\x28" \
+  "\x35\x13\xdc\x06\xe7\x51\x5d\x0d\x73\x13\x2e\x9a\x0d\xc6\xd3\xb1" \
+  "\xf8\xb2\x46\xf1\xa9\x8a\x3f\xc7\x29\x41\xb1\xe3\xbb\x20\x98\xe8" \
+  "\xbf\x16\xf2\x68\xd6\x4f\x0b\x0f\x47\x07\xfe\x1e\xa1\xa1\x79\x1b" \
+  "\xa2\xf3\xc0\xc7\x58\xe5\xf5\x51\x86\x3a\x96\xc9\x49\xad\x47\xd7" \
+  "\xfb\x40\xd2"
+#define SHA1_SEED "\xd0\x56\x9c\xb3\x66\x5a\x8a\x43\xeb\x6e\xa2\x3d" \
+  "\x75\xa3\xc4\xd2\x05\x4a\x0d\x7d"
+#define SHA224_SEED "\xd0\x56\x9c\xb3\x66\x5a\x8a\x43\xeb\x6e\xa2" \
+  "\x3d\x75\xa3\xc4\xd2\x05\x4a\x0d\x7d\x66\xa9\xca\x99\xc9\xce\xb0" \
+  "\x27"
+#define SHA256_SEED "\xf4\x1e\xce\x26\x13\xe4\x57\x39\x15\x69\x6b" \
+  "\x5a\xdc\xd5\x1c\xa3\x28\xbe\x3b\xf5\x66\xa9\xca\x99\xc9\xce\xb0" \
+  "\x27\x9c\x1c\xb0\xa7"
+#define SHA384_SEED "\x82\x40\xbc\x51\xe4\xec\x7e\xf7\x6d\x18\xe3" \
+  "\x52\x04\xa1\x9f\x51\xa5\x21\x3a\x73\xa8\x1d\x6f\x94\x46\x80\xd3" \
+  "\x07\x59\x48\xb7\xe4\x63\x80\x4e\xa3\xd2\x6e\x13\xea\x82\x0d\x65" \
+  "\xa4\x84\xbe\x74\x53"
+#define SHA512_SEED "\x47\x3f\xf1\xb9\xb3\xff\xdf\xa1\x26\x69\x9a" \
+  "\xc7\xef\x9e\x8e\x78\x77\x73\x09\x58\x24\xc6\x42\x55\x7c\x13\x99" \
+  "\xd9\x8e\x42\x20\x44\x8d\xc3\x5b\x99\xbf\xdd\x44\x77\x95\x43\x92" \
+  "\x4c\x1c\xe9\x3b\xc5\x94\x15\x38\x89\x5d\xb9\x88\x26\x1b\x00\x77" \
+  "\x4b\x12\x27\x20\x39"
+
+#define TESTCOUNT 10
+#define HASHCOUNT 5
+#define RANDOMCOUNT 4
+#define HMACTESTCOUNT 7
+#define HKDFTESTCOUNT 7
+
+#define PRINTNONE 0
+#define PRINTTEXT 1
+#define PRINTRAW 2
+#define PRINTHEX 3
+#define PRINTBASE64 4
+
+#define PRINTPASSFAIL 1
+#define PRINTFAIL 2
+
+#define length(x) (sizeof(x)-1)
+
+/* Test arrays for hashes. */
+struct hash {
+    const char *name;
+    SHAversion whichSha;
+    int hashsize;
+    struct {
+        const char *testarray;
+        int length;
+        long repeatcount;
+        int extrabits;
+        int numberExtrabits;
+        const char *resultarray;
+    } tests[TESTCOUNT];
+    const char *randomtest;
+    const char *randomresults[RANDOMCOUNT];
+} hashes[HASHCOUNT] = {
+  { "SHA1", SHA1, SHA1HashSize,
+    {
+      /* 1 */ { TEST1, length(TEST1), 1, 0, 0,
+        "A9993E364706816ABA3E25717850C26C9CD0D89D" },
+      /* 2 */ { TEST2_1, length(TEST2_1), 1, 0, 0,
+        "84983E441C3BD26EBAAE4AA1F95129E5E54670F1" },
+      /* 3 */ { TEST3, length(TEST3), 1000000, 0, 0,
+        "34AA973CD4C4DAA4F61EEB2BDBAD27316534016F" },
+      /* 4 */ { TEST4, length(TEST4), 10, 0, 0,
+        "DEA356A2CDDD90C7A7ECEDC5EBB563934F460452" },
+      /* 5 */ { "", 0, 0, 0x98, 5,
+        "29826B003B906E660EFF4027CE98AF3531AC75BA" },
+      /* 6 */ { "\x5e", 1, 1, 0, 0,
+        "5E6F80A34A9798CAFC6A5DB96CC57BA4C4DB59C2" },
+      /* 7 */ { TEST7_1, length(TEST7_1), 1, 0x80, 3,
+        "6239781E03729919C01955B3FFA8ACB60B988340" },
+      /* 8 */ { TEST8_1, length(TEST8_1), 1, 0, 0,
+        "82ABFF6605DBE1C17DEF12A394FA22A82B544A35" },
+      /* 9 */ { TEST9_1, length(TEST9_1), 1, 0xE0, 3,
+        "8C5B2A5DDAE5A97FC7F9D85661C672ADBF7933D4" },
+      /* 10 */ { TEST10_1, length(TEST10_1), 1, 0, 0,
+        "CB0082C8F197D260991BA6A460E76E202BAD27B3" }
+    }, SHA1_SEED, { "E216836819477C7F78E0D843FE4FF1B6D6C14CD4",
+        "A2DBC7A5B1C6C0A8BCB7AAA41252A6A7D0690DBC",
+        "DB1F9050BB863DFEF4CE37186044E2EEB17EE013",
+        "127FDEDF43D372A51D5747C48FBFFE38EF6CDF7B"
+     } },
+  { "SHA224", SHA224, SHA224HashSize,
+    {
+      /* 1 */ { TEST1, length(TEST1), 1, 0, 0,
+        "23097D223405D8228642A477BDA255B32AADBCE4BDA0B3F7E36C9DA7" },
+      /* 2 */ { TEST2_1, length(TEST2_1), 1, 0, 0,
+        "75388B16512776CC5DBA5DA1FD890150B0C6455CB4F58B1952522525" },
+      /* 3 */ { TEST3, length(TEST3), 1000000, 0, 0,
+        "20794655980C91D8BBB4C1EA97618A4BF03F42581948B2EE4EE7AD67" },
+      /* 4 */ { TEST4, length(TEST4), 10, 0, 0,
+        "567F69F168CD7844E65259CE658FE7AADFA25216E68ECA0EB7AB8262" },
+      /* 5 */ { "", 0, 0, 0x68, 5,
+        "E3B048552C3C387BCAB37F6EB06BB79B96A4AEE5FF27F51531A9551C" },
+      /* 6 */ { "\x07", 1, 1, 0, 0,
+        "00ECD5F138422B8AD74C9799FD826C531BAD2FCABC7450BEE2AA8C2A" },
+      /* 7 */ { TEST7_224, length(TEST7_224), 1, 0xA0, 3,
+        "1B01DB6CB4A9E43DED1516BEB3DB0B87B6D1EA43187462C608137150" },
+      /* 8 */ { TEST8_224, length(TEST8_224), 1, 0, 0,
+        "DF90D78AA78821C99B40BA4C966921ACCD8FFB1E98AC388E56191DB1" },
+      /* 9 */ { TEST9_224, length(TEST9_224), 1, 0xE0, 3,
+        "54BEA6EAB8195A2EB0A7906A4B4A876666300EEFBD1F3B8474F9CD57" },
+      /* 10 */ { TEST10_224, length(TEST10_224), 1, 0, 0,
+        "0B31894EC8937AD9B91BDFBCBA294D9ADEFAA18E09305E9F20D5C3A4" }
+    }, SHA224_SEED, { "100966A5B4FDE0B42E2A6C5953D4D7F41BA7CF79FD"
+        "2DF431416734BE", "1DCA396B0C417715DEFAAE9641E10A2E99D55A"
+        "BCB8A00061EB3BE8BD", "1864E627BDB2319973CD5ED7D68DA71D8B"
+        "F0F983D8D9AB32C34ADB34", "A2406481FC1BCAF24DD08E6752E844"
+        "709563FB916227FED598EB621F"
+     } },
+  { "SHA256", SHA256, SHA256HashSize,
+  {
+      /* 1 */ { TEST1, length(TEST1), 1, 0, 0, "BA7816BF8F01CFEA4141"
+        "40DE5DAE2223B00361A396177A9CB410FF61F20015AD" },
+      /* 2 */ { TEST2_1, length(TEST2_1), 1, 0, 0, "248D6A61D20638B8"
+        "E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1" },
+      /* 3 */ { TEST3, length(TEST3), 1000000, 0, 0, "CDC76E5C9914FB92"
+        "81A1C7E284D73E67F1809A48A497200E046D39CCC7112CD0" },
+      /* 4 */ { TEST4, length(TEST4), 10, 0, 0, "594847328451BDFA"
+        "85056225462CC1D867D877FB388DF0CE35F25AB5562BFBB5" },
+      /* 5 */ { "", 0, 0, 0x68, 5, "D6D3E02A31A84A8CAA9718ED6C2057BE"
+        "09DB45E7823EB5079CE7A573A3760F95" },
+      /* 6 */ { "\x19", 1, 1, 0, 0, "68AA2E2EE5DFF96E3355E6C7EE373E3D"
+        "6A4E17F75F9518D843709C0C9BC3E3D4" },
+      /* 7 */ { TEST7_256, length(TEST7_256), 1, 0x60, 3, "77EC1DC8"
+        "9C821FF2A1279089FA091B35B8CD960BCAF7DE01C6A7680756BEB972" },
+      /* 8 */ { TEST8_256, length(TEST8_256), 1, 0, 0, "175EE69B02BA"
+        "9B58E2B0A5FD13819CEA573F3940A94F825128CF4209BEABB4E8" },
+      /* 9 */ { TEST9_256, length(TEST9_256), 1, 0xA0, 3, "3E9AD646"
+        "8BBBAD2AC3C2CDC292E018BA5FD70B960CF1679777FCE708FDB066E9" },
+      /* 10 */ { TEST10_256, length(TEST10_256), 1, 0, 0, "97DBCA7D"
+        "F46D62C8A422C941DD7E835B8AD3361763F7E9B2D95F4F0DA6E1CCBC" },
+    }, SHA256_SEED, { "83D28614D49C3ADC1D6FC05DB5F48037C056F8D2A4CE44"
+        "EC6457DEA5DD797CD1", "99DBE3127EF2E93DD9322D6A07909EB33B6399"
+        "5E529B3F954B8581621BB74D39", "8D4BE295BB64661CA3C7EFD129A2F7"
+        "25B33072DBDDE32385B9A87B9AF88EA76F", "40AF5D3F9716B040DF9408"
+        "E31536B70FF906EC51B00447CA97D7DD97C12411F4"
+    } },
+  { "SHA384", SHA384, SHA384HashSize,
+    {
+      /* 1 */ { TEST1, length(TEST1), 1, 0, 0,
+        "CB00753F45A35E8BB5A03D699AC65007272C32AB0EDED163"
+        "1A8B605A43FF5BED8086072BA1E7CC2358BAECA134C825A7" },
+      /* 2 */ { TEST2_2, length(TEST2_2), 1, 0, 0,
+        "09330C33F71147E83D192FC782CD1B4753111B173B3B05D2"
+        "2FA08086E3B0F712FCC7C71A557E2DB966C3E9FA91746039" },
+      /* 3 */ { TEST3, length(TEST3), 1000000, 0, 0,
+        "9D0E1809716474CB086E834E310A4A1CED149E9C00F24852"
+        "7972CEC5704C2A5B07B8B3DC38ECC4EBAE97DDD87F3D8985" },
+      /* 4 */ { TEST4, length(TEST4), 10, 0, 0,
+        "2FC64A4F500DDB6828F6A3430B8DD72A368EB7F3A8322A70"
+        "BC84275B9C0B3AB00D27A5CC3C2D224AA6B61A0D79FB4596" },
+      /* 5 */ { "", 0, 0, 0x10, 5,
+        "8D17BE79E32B6718E07D8A603EB84BA0478F7FCFD1BB9399"
+        "5F7D1149E09143AC1FFCFC56820E469F3878D957A15A3FE4" },
+      /* 6 */ { "\xb9", 1, 1, 0, 0,
+        "BC8089A19007C0B14195F4ECC74094FEC64F01F90929282C"
+        "2FB392881578208AD466828B1C6C283D2722CF0AD1AB6938" },
+      /* 7 */ { TEST7_384, length(TEST7_384), 1, 0xA0, 3,
+        "D8C43B38E12E7C42A7C9B810299FD6A770BEF30920F17532"
+        "A898DE62C7A07E4293449C0B5FA70109F0783211CFC4BCE3" },
+      /* 8 */ { TEST8_384, length(TEST8_384), 1, 0, 0,
+        "C9A68443A005812256B8EC76B00516F0DBB74FAB26D66591"
+        "3F194B6FFB0E91EA9967566B58109CBC675CC208E4C823F7" },
+      /* 9 */ { TEST9_384, length(TEST9_384), 1, 0xE0, 3,
+        "5860E8DE91C21578BB4174D227898A98E0B45C4C760F0095"
+        "49495614DAEDC0775D92D11D9F8CE9B064EEAC8DAFC3A297" },
+      /* 10 */ { TEST10_384, length(TEST10_384), 1, 0, 0,
+        "4F440DB1E6EDD2899FA335F09515AA025EE177A79F4B4AAF"
+        "38E42B5C4DE660F5DE8FB2A5B2FBD2A3CBFFD20CFF1288C0" }
+    }, SHA384_SEED, { "CE44D7D63AE0C91482998CF662A51EC80BF6FC68661A3C"
+        "57F87566112BD635A743EA904DEB7D7A42AC808CABE697F38F", "F9C6D2"
+        "61881FEE41ACD39E67AA8D0BAD507C7363EB67E2B81F45759F9C0FD7B503"
+        "DF1A0B9E80BDE7BC333D75B804197D", "D96512D8C9F4A7A4967A366C01"
+        "C6FD97384225B58343A88264847C18E4EF8AB7AEE4765FFBC3E30BD485D3"
+        "638A01418F", "0CA76BD0813AF1509E170907A96005938BC985628290B2"
+        "5FEF73CF6FAD68DDBA0AC8920C94E0541607B0915A7B4457F7"
+    } },
+  { "SHA512", SHA512, SHA512HashSize,
+    {
+      /* 1 */ { TEST1, length(TEST1), 1, 0, 0,
+        "DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA2"
+        "0A9EEEE64B55D39A2192992A274FC1A836BA3C23A3FEEBBD"
+        "454D4423643CE80E2A9AC94FA54CA49F" },
+      /* 2 */ { TEST2_2, length(TEST2_2), 1, 0, 0,
+        "8E959B75DAE313DA8CF4F72814FC143F8F7779C6EB9F7FA1"
+        "7299AEADB6889018501D289E4900F7E4331B99DEC4B5433A"
+        "C7D329EEB6DD26545E96E55B874BE909" },
+       /* 3 */ { TEST3, length(TEST3), 1000000, 0, 0,
+        "E718483D0CE769644E2E42C7BC15B4638E1F98B13B204428"
+        "5632A803AFA973EBDE0FF244877EA60A4CB0432CE577C31B"
+        "EB009C5C2C49AA2E4EADB217AD8CC09B" },
+      /* 4 */ { TEST4, length(TEST4), 10, 0, 0,
+        "89D05BA632C699C31231DED4FFC127D5A894DAD412C0E024"
+        "DB872D1ABD2BA8141A0F85072A9BE1E2AA04CF33C765CB51"
+        "0813A39CD5A84C4ACAA64D3F3FB7BAE9" },
+      /* 5 */ { "", 0, 0, 0xB0, 5,
+        "D4EE29A9E90985446B913CF1D1376C836F4BE2C1CF3CADA0"
+        "720A6BF4857D886A7ECB3C4E4C0FA8C7F95214E41DC1B0D2"
+        "1B22A84CC03BF8CE4845F34DD5BDBAD4" },
+      /* 6 */ { "\xD0", 1, 1, 0, 0,
+        "9992202938E882E73E20F6B69E68A0A7149090423D93C81B"
+        "AB3F21678D4ACEEEE50E4E8CAFADA4C85A54EA8306826C4A"
+        "D6E74CECE9631BFA8A549B4AB3FBBA15" },
+      /* 7 */ { TEST7_512, length(TEST7_512), 1, 0x80, 3,
+        "ED8DC78E8B01B69750053DBB7A0A9EDA0FB9E9D292B1ED71"
+        "5E80A7FE290A4E16664FD913E85854400C5AF05E6DAD316B"
+        "7359B43E64F8BEC3C1F237119986BBB6" },
+      /* 8 */ { TEST8_512, length(TEST8_512), 1, 0, 0,
+        "CB0B67A4B8712CD73C9AABC0B199E9269B20844AFB75ACBD"
+        "D1C153C9828924C3DDEDAAFE669C5FDD0BC66F630F677398"
+        "8213EB1B16F517AD0DE4B2F0C95C90F8" },
+      /* 9 */ { TEST9_512, length(TEST9_512), 1, 0x80, 3,
+        "32BA76FC30EAA0208AEB50FFB5AF1864FDBF17902A4DC0A6"
+        "82C61FCEA6D92B783267B21080301837F59DE79C6B337DB2"
+        "526F8A0A510E5E53CAFED4355FE7C2F1" },
+      /* 10 */ { TEST10_512, length(TEST10_512), 1, 0, 0,
+        "C665BEFB36DA189D78822D10528CBF3B12B3EEF726039909"
+        "C1A16A270D48719377966B957A878E720584779A62825C18"
+        "DA26415E49A7176A894E7510FD1451F5" }
+    }, SHA512_SEED, { "2FBB1E7E00F746BA514FBC8C421F36792EC0E11FF5EFC3"
+        "78E1AB0C079AA5F0F66A1E3EDBAEB4F9984BE14437123038A452004A5576"
+        "8C1FD8EED49E4A21BEDCD0", "25CBE5A4F2C7B1D7EF07011705D50C62C5"
+        "000594243EAFD1241FC9F3D22B58184AE2FEE38E171CF8129E29459C9BC2"
+        "EF461AF5708887315F15419D8D17FE7949", "5B8B1F2687555CE2D7182B"
+        "92E5C3F6C36547DA1C13DBB9EA4F73EA4CBBAF89411527906D35B1B06C1B"
+        "6A8007D05EC66DF0A406066829EAB618BDE3976515AAFC", "46E36B007D"
+        "19876CDB0B29AD074FE3C08CDD174D42169D6ABE5A1414B6E79707DF5877"
+        "6A98091CF431854147BB6D3C66D43BFBC108FD715BDE6AA127C2B0E79F"
+    }
+  }
+};
+
+/* Test arrays for HMAC. */
+struct hmachash {
+    const char *keyarray[5];
+    int keylength[5];
+    const char *dataarray[5];
+    int datalength[5];
+    const char *resultarray[5];
+    int resultlength[5];
+} hmachashes[HMACTESTCOUNT] = {
+  { /* 1 */ {
+      "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b"
+      "\x0b\x0b\x0b\x0b\x0b"
+    }, { 20 }, {
+      "\x48\x69\x20\x54\x68\x65\x72\x65" /* "Hi There" */
+    }, { 8 }, {
+      /* HMAC-SHA-1 */
+      "B617318655057264E28BC0B6FB378C8EF146BE00",
+      /* HMAC-SHA-224 */
+      "896FB1128ABBDF196832107CD49DF33F47B4B1169912BA4F53684B22",
+      /* HMAC-SHA-256 */
+      "B0344C61D8DB38535CA8AFCEAF0BF12B881DC200C9833DA726E9376C2E32"
+      "CFF7",
+      /* HMAC-SHA-384 */
+      "AFD03944D84895626B0825F4AB46907F15F9DADBE4101EC682AA034C7CEB"
+      "C59CFAEA9EA9076EDE7F4AF152E8B2FA9CB6",
+      /* HMAC-SHA-512 */
+      "87AA7CDEA5EF619D4FF0B4241A1D6CB02379F4E2CE4EC2787AD0B30545E1"
+      "7CDEDAA833B7D6B8A702038B274EAEA3F4E4BE9D914EEB61F1702E696C20"
+      "3A126854"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  },
+  { /* 2 */ {
+      "\x4a\x65\x66\x65" /* "Jefe" */
+    }, { 4 }, {
+      "\x77\x68\x61\x74\x20\x64\x6f\x20\x79\x61\x20\x77\x61\x6e\x74"
+      "\x20\x66\x6f\x72\x20\x6e\x6f\x74\x68\x69\x6e\x67\x3f"
+      /* "what do ya want for nothing?" */
+    }, { 28 }, {
+      /* HMAC-SHA-1 */
+      "EFFCDF6AE5EB2FA2D27416D5F184DF9C259A7C79",
+      /* HMAC-SHA-224 */
+      "A30E01098BC6DBBF45690F3A7E9E6D0F8BBEA2A39E6148008FD05E44",
+      /* HMAC-SHA-256 */
+      "5BDCC146BF60754E6A042426089575C75A003F089D2739839DEC58B964EC"
+      "3843",
+      /* HMAC-SHA-384 */
+      "AF45D2E376484031617F78D2B58A6B1B9C7EF464F5A01B47E42EC3736322"
+      "445E8E2240CA5E69E2C78B3239ECFAB21649",
+      /* HMAC-SHA-512 */
+      "164B7A7BFCF819E2E395FBE73B56E0A387BD64222E831FD610270CD7EA25"
+      "05549758BF75C05A994A6D034F65F8F0E6FDCAEAB1A34D4A6B4B636E070A"
+      "38BCE737"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  },
+  { /* 3 */
+    {
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa"
+    }, { 20 }, {
+      "\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd"
+      "\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd"
+      "\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd\xdd"
+      "\xdd\xdd\xdd\xdd\xdd"
+    }, { 50 }, {
+      /* HMAC-SHA-1 */
+      "125D7342B9AC11CD91A39AF48AA17B4F63F175D3",
+      /* HMAC-SHA-224 */
+      "7FB3CB3588C6C1F6FFA9694D7D6AD2649365B0C1F65D69D1EC8333EA",
+      /* HMAC-SHA-256 */
+      "773EA91E36800E46854DB8EBD09181A72959098B3EF8C122D9635514CED5"
+      "65FE",
+      /* HMAC-SHA-384 */
+      "88062608D3E6AD8A0AA2ACE014C8A86F0AA635D947AC9FEBE83EF4E55966"
+      "144B2A5AB39DC13814B94E3AB6E101A34F27",
+      /* HMAC-SHA-512 */
+      "FA73B0089D56A284EFB0F0756C890BE9B1B5DBDD8EE81A3655F83E33B227"
+      "9D39BF3E848279A722C806B485A47E67C807B946A337BEE8942674278859"
+      "E13292FB"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  },
+  { /* 4 */ {
+      "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
+      "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19"
+    }, { 25 }, {
+      "\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd"
+      "\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd"
+      "\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd\xcd"
+      "\xcd\xcd\xcd\xcd\xcd"
+    }, { 50 }, {
+      /* HMAC-SHA-1 */
+      "4C9007F4026250C6BC8414F9BF50C86C2D7235DA",
+      /* HMAC-SHA-224 */
+      "6C11506874013CAC6A2ABC1BB382627CEC6A90D86EFC012DE7AFEC5A",
+      /* HMAC-SHA-256 */
+      "82558A389A443C0EA4CC819899F2083A85F0FAA3E578F8077A2E3FF46729"
+      "665B",
+      /* HMAC-SHA-384 */
+      "3E8A69B7783C25851933AB6290AF6CA77A9981480850009CC5577C6E1F57"
+      "3B4E6801DD23C4A7D679CCF8A386C674CFFB",
+      /* HMAC-SHA-512 */
+      "B0BA465637458C6990E5A8C5F61D4AF7E576D97FF94B872DE76F8050361E"
+      "E3DBA91CA5C11AA25EB4D679275CC5788063A5F19741120C4F2DE2ADEBEB"
+      "10A298DD"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  },
+  { /* 5 */ {
+      "\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c"
+      "\x0c\x0c\x0c\x0c\x0c"
+    }, { 20 }, {
+      "Test With Truncation"
+    }, { 20 }, {
+      /* HMAC-SHA-1 */
+      "4C1A03424B55E07FE7F27BE1",
+      /* HMAC-SHA-224 */
+      "0E2AEA68A90C8D37C988BCDB9FCA6FA8",
+      /* HMAC-SHA-256 */
+      "A3B6167473100EE06E0C796C2955552B",
+      /* HMAC-SHA-384 */
+      "3ABF34C3503B2A23A46EFC619BAEF897",
+      /* HMAC-SHA-512 */
+      "415FAD6271580A531D4179BC891D87A6"
+    }, { 12, 16, 16, 16, 16 }
+  },
+  { /* 6 */ {
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+    }, { 80, 131 }, {
+      "Test Using Larger Than Block-Size Key - Hash Key First"
+    }, { 54 }, {
+      /* HMAC-SHA-1 */
+      "AA4AE5E15272D00E95705637CE8A3B55ED402112",
+      /* HMAC-SHA-224 */
+      "95E9A0DB962095ADAEBE9B2D6F0DBCE2D499F112F2D2B7273FA6870E",
+      /* HMAC-SHA-256 */
+      "60E431591EE0B67F0D8A26AACBF5B77F8E0BC6213728C5140546040F0EE3"
+      "7F54",
+      /* HMAC-SHA-384 */
+      "4ECE084485813E9088D2C63A041BC5B44F9EF1012A2B588F3CD11F05033A"
+      "C4C60C2EF6AB4030FE8296248DF163F44952",
+      /* HMAC-SHA-512 */
+      "80B24263C7C1A3EBB71493C1DD7BE8B49B46D1F41B4AEEC1121B013783F8"
+      "F3526B56D037E05F2598BD0FD2215D6A1E5295E64F73F63F0AEC8B915A98"
+      "5D786598"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  },
+  { /* 7 */ {
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+      "\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa\xaa"
+    }, { 80, 131 }, {
+      "Test Using Larger Than Block-Size Key and "
+      "Larger Than One Block-Size Data",
+      "\x54\x68\x69\x73\x20\x69\x73\x20\x61\x20\x74\x65\x73\x74\x20"
+      "\x75\x73\x69\x6e\x67\x20\x61\x20\x6c\x61\x72\x67\x65\x72\x20"
+      "\x74\x68\x61\x6e\x20\x62\x6c\x6f\x63\x6b\x2d\x73\x69\x7a\x65"
+      "\x20\x6b\x65\x79\x20\x61\x6e\x64\x20\x61\x20\x6c\x61\x72\x67"
+      "\x65\x72\x20\x74\x68\x61\x6e\x20\x62\x6c\x6f\x63\x6b\x2d\x73"
+      "\x69\x7a\x65\x20\x64\x61\x74\x61\x2e\x20\x54\x68\x65\x20\x6b"
+      "\x65\x79\x20\x6e\x65\x65\x64\x73\x20\x74\x6f\x20\x62\x65\x20"
+      "\x68\x61\x73\x68\x65\x64\x20\x62\x65\x66\x6f\x72\x65\x20\x62"
+      "\x65\x69\x6e\x67\x20\x75\x73\x65\x64\x20\x62\x79\x20\x74\x68"
+      "\x65\x20\x48\x4d\x41\x43\x20\x61\x6c\x67\x6f\x72\x69\x74\x68"
+      "\x6d\x2e"
+      /* "This is a test using a larger than block-size key and a "
+          "larger than block-size data.  The key needs to be hashed "
+          "before being used by the HMAC algorithm." */
+    }, { 73, 152 }, {
+      /* HMAC-SHA-1 */
+      "E8E99D0F45237D786D6BBAA7965C7808BBFF1A91",
+      /* HMAC-SHA-224 */
+      "3A854166AC5D9F023F54D517D0B39DBD946770DB9C2B95C9F6F565D1",
+      /* HMAC-SHA-256 */
+      "9B09FFA71B942FCB27635FBCD5B0E944BFDC63644F0713938A7F51535C3A"
+      "35E2",
+      /* HMAC-SHA-384 */
+      "6617178E941F020D351E2F254E8FD32C602420FEB0B8FB9ADCCEBB82461E"
+      "99C5A678CC31E799176D3860E6110C46523E",
+      /* HMAC-SHA-512 */
+      "E37B6A775DC87DBAA4DFA9F96E5E3FFDDEBD71F8867289865DF5A32D20CD"
+      "C944B6022CAC3C4982B10D5EEB55C3E4DE15134676FB6DE0446065C97440"
+      "FA8C6A58"
+    }, { SHA1HashSize, SHA224HashSize, SHA256HashSize,
+      SHA384HashSize, SHA512HashSize }
+  }
+};
+
+/* Test arrays for HKDF. */
+struct hkdfhash {
+    SHAversion whichSha;
+    int ikmlength;
+    const char *ikmarray;
+    int saltlength;
+    const char *saltarray;
+    int infolength;
+    const char *infoarray;
+    int prklength;
+    const char *prkarray;
+    int okmlength;
+    const char *okmarray;
+} hkdfhashes[HKDFTESTCOUNT] = {
+    {   /* RFC 5869 A.1. Test Case 1 */
+        SHA256,
+        22, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b"
+            "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
+        13, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c",
+        10, "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9",
+        32, "077709362C2E32DF0DDC3F0DC47BBA6390B6C73BB50F9C3122EC844A"
+            "D7C2B3E5",
+        42, "3CB25F25FAACD57A90434F64D0362F2A2D2D0A90CF1A5A4C5DB02D56"
+            "ECC4C5BF34007208D5B887185865"
+    },
+    {   /* RFC 5869 A.2. Test Case 2 */
+        SHA256,
+        80, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d"
+            "\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b"
+            "\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29"
+            "\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33\x34\x35\x36\x37"
+            "\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f\x40\x41\x42\x43\x44\x45"
+            "\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f",
+        80, "\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6a\x6b\x6c\x6d"
+            "\x6e\x6f\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7a\x7b"
+            "\x7c\x7d\x7e\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89"
+            "\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97"
+            "\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5"
+            "\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+        80, "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd"
+            "\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb"
+            "\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9"
+            "\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7"
+            "\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5"
+            "\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff",
+        32, "06A6B88C5853361A06104C9CEB35B45C"
+            "EF760014904671014A193F40C15FC244",
+        82, "B11E398DC80327A1C8E7F78C596A4934"
+            "4F012EDA2D4EFAD8A050CC4C19AFA97C"
+            "59045A99CAC7827271CB41C65E590E09"
+            "DA3275600C2F09B8367793A9ACA3DB71"
+            "CC30C58179EC3E87C14C01D5C1F3434F"
+            "1D87"
+    },
+    {   /* RFC 5869 A.3. Test Case 3 */
+        SHA256,
+        22, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b"
+            "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
+        0, "",
+        0, "",
+        32, "19EF24A32C717B167F33A91D6F648BDF"
+            "96596776AFDB6377AC434C1C293CCB04",
+        42, "8DA4E775A563C18F715F802A063C5A31"
+            "B8A11F5C5EE1879EC3454E5F3C738D2D"
+            "9D201395FAA4B61A96C8"
+    },
+    {   /* RFC 5869 A.4. Test Case 4 */
+        SHA1,
+        11, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
+        13, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c",
+        10, "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9",
+        20, "9B6C18C432A7BF8F0E71C8EB88F4B30BAA2BA243",
+        42, "085A01EA1B10F36933068B56EFA5AD81"
+            "A4F14B822F5B091568A9CDD4F155FDA2"
+            "C22E422478D305F3F896"
+    },
+    {   /* RFC 5869 A.5. Test Case 5 */
+        SHA1,
+        80, "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d"
+            "\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b"
+            "\x1c\x1d\x1e\x1f\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29"
+            "\x2a\x2b\x2c\x2d\x2e\x2f\x30\x31\x32\x33\x34\x35\x36\x37"
+            "\x38\x39\x3a\x3b\x3c\x3d\x3e\x3f\x40\x41\x42\x43\x44\x45"
+            "\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f",
+        80, "\x60\x61\x62\x63\x64\x65\x66\x67\x68\x69\x6A\x6B\x6C\x6D"
+            "\x6E\x6F\x70\x71\x72\x73\x74\x75\x76\x77\x78\x79\x7A\x7B"
+            "\x7C\x7D\x7E\x7F\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89"
+            "\x8A\x8B\x8C\x8D\x8E\x8F\x90\x91\x92\x93\x94\x95\x96\x97"
+            "\x98\x99\x9A\x9B\x9C\x9D\x9E\x9F\xA0\xA1\xA2\xA3\xA4\xA5"
+            "\xA6\xA7\xA8\xA9\xAA\xAB\xAC\xAD\xAE\xAF",
+        80, "\xB0\xB1\xB2\xB3\xB4\xB5\xB6\xB7\xB8\xB9\xBA\xBB\xBC\xBD"
+            "\xBE\xBF\xC0\xC1\xC2\xC3\xC4\xC5\xC6\xC7\xC8\xC9\xCA\xCB"
+            "\xCC\xCD\xCE\xCF\xD0\xD1\xD2\xD3\xD4\xD5\xD6\xD7\xD8\xD9"
+            "\xDA\xDB\xDC\xDD\xDE\xDF\xE0\xE1\xE2\xE3\xE4\xE5\xE6\xE7"
+            "\xE8\xE9\xEA\xEB\xEC\xED\xEE\xEF\xF0\xF1\xF2\xF3\xF4\xF5"
+            "\xF6\xF7\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF",
+        20, "8ADAE09A2A307059478D309B26C4115A224CFAF6",
+        82, "0BD770A74D1160F7C9F12CD5912A06EB"
+            "FF6ADCAE899D92191FE4305673BA2FFE"
+            "8FA3F1A4E5AD79F3F334B3B202B2173C"
+            "486EA37CE3D397ED034C7F9DFEB15C5E"
+            "927336D0441F4C4300E2CFF0D0900B52"
+            "D3B4"
+    },
+    {   /* RFC 5869 A.6. Test Case 6 */
+        SHA1,
+        22, "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b"
+            "\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b",
+        0, "",
+        0, "",
+        20, "DA8C8A73C7FA77288EC6F5E7C297786AA0D32D01",
+        42, "0AC1AF7002B3D761D1E55298DA9D0506"
+            "B9AE52057220A306E07B6B87E8DF21D0"
+            "EA00033DE03984D34918"
+    },
+    {   /* RFC 5869 A.7. Test Case 7. */
+        SHA1,
+        22, "\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c"
+            "\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c",
+        0, 0,
+        0, "",
+        20, "2ADCCADA18779E7C2077AD2EB19D3F3E731385DD",
+        42, "2C91117204D745F3500D636A62F64F0A"
+            "B3BAE548AA53D423B0D1F27EBBA6F5E5"
+            "673A081D70CCE7ACFC48"
+    }
+};
+
+/*
+ * Check the hash value against the expected string, expressed in hex
+ */
+static const char hexdigits[ ] = "0123456789ABCDEF";
+int checkmatch(const unsigned char *hashvalue,
+  const char *hexstr, int hashsize)
+{
+  int i;
+  for (i = 0; i < hashsize; ++i) {
+    if (*hexstr++ != hexdigits[(hashvalue[i] >> 4) & 0xF])
+      return 0;
+    if (*hexstr++ != hexdigits[hashvalue[i] & 0xF]) return 0;
+  }
+  return 1;
+}
+
+/*
+ * Print the string, converting non-printable characters to "."
+ */
+void printstr(const char *str, int len)
+{
+  for ( ; len-- > 0; str++)
+    putchar(isprint((unsigned char)*str) ? *str : '.');
+}
+
+/*
+ * Print the string, converting all characters to hex "## ".
+ */
+void printxstr(const char *str, int len)
+{
+  char *sep = "";
+  for ( ; len-- > 0; str++) {
+    printf("%s%c%c", sep, hexdigits[(*str >> 4) & 0xF],
+      hexdigits[*str & 0xF]);
+    sep = " ";
+  }
+}
+
+/*
+ * Print a usage message.
+ */
+void usage(const char *argv0)
+{
+  fprintf(stderr,
+    "Usage:\n"
+    "Common options: [-h hash] [-w|-x|-6] [-H]\n"
+    "Hash a string:\n"
+      "\t%s [-S expectedresult] -s hashstr [-k key] "
+           "[-i info -L okm-len]\n"
+    "Hash a file:\n"
+      "\t%s [-S expectedresult] -f file [-k key] "
+           "[-i info -L okm-len]\n"
+    "Hash a file, ignoring whitespace:\n"
+      "\t%s [-S expectedresult] -F file [-k key] "
+           "[-i info -L okm-len]\n"
+    "Additional bits to add in: [-B bitcount -b bits]\n"
+    "(If -k,-i&-L are used, run HKDF-SHA###.\n"
+    " If -k is used, but not -i&-L, run HMAC-SHA###.\n"
+    " Otherwise, run SHA###.)\n"
+    "Standard tests:\n"
+      "\t%s [-m | -d] [-l loopcount] [-t test#] [-e]\n"
+      "\t\t[-r randomseed] [-R randomloop-count] "
+        "[-p] [-P|-X]\n"
+    "-h\thash to test: "
+      "0|SHA1, 1|SHA224, 2|SHA256, 3|SHA384, 4|SHA512\n"
+    "-m\tperform hmac standard tests\n"
+    "-k\tkey for hmac test\n"
+    "-d\tperform hkdf standard tests\n"
+    "-t\ttest case to run, 1-10\n"
+    "-l\thow many times to run the test\n"
+    "-e\ttest error returns\n"
+    "-p\tdo not print results\n"
+    "-P\tdo not print PASSED/FAILED\n"
+    "-X\tprint FAILED, but not PASSED\n"
+    "-r\tseed for random test\n"
+    "-R\thow many times to run random test\n"
+    "-s\tstring to hash\n"
+    "-S\texpected result of hashed string, in hex\n"
+    "-w\toutput hash in raw format\n"
+    "-x\toutput hash in hex format\n"
+    "-6\toutput hash in base64 format\n"
+    "-B\t# extra bits to add in after string or file input\n"
+    "-b\textra bits to add (high order bits of #, 0# or 0x#)\n"
+    "-H\tinput hashstr or randomseed is in hex\n"
+    , argv0, argv0, argv0, argv0);
+  exit(1);
+}
+
+/*
+ * Print the results and PASS/FAIL.
+ */
+void printResult(uint8_t *Message_Digest, int hashsize,
+    const char *hashname, const char *testtype, const char *testname,
+    const char *resultarray, int printResults, int printPassFail)
+{
+  int i, k;
+  if (printResults == PRINTTEXT) {
+    printf("\nhashsize=%d\n", hashsize);
+    putchar('\t');
+    for (i = 0; i < hashsize; ++i) {
+      putchar(hexdigits[(Message_Digest[i] >> 4) & 0xF]);
+      putchar(hexdigits[Message_Digest[i] & 0xF]);
+      putchar(' ');
+    }
+    putchar('\n');
+  } else if (printResults == PRINTRAW) {
+    fwrite(Message_Digest, 1, hashsize, stdout);
+  } else if (printResults == PRINTHEX) {
+    for (i = 0; i < hashsize; ++i) {
+      putchar(hexdigits[(Message_Digest[i] >> 4) & 0xF]);
+      putchar(hexdigits[Message_Digest[i] & 0xF]);
+    }
+    putchar('\n');
+  } else if (printResults == PRINTBASE64) {
+    unsigned char b;
+    char *sm = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+               "0123456789+/";
+    for (i = 0; i < hashsize; i += 3) {
+      putchar(sm[Message_Digest[i] >> 2]);
+      b = (Message_Digest[i] & 0x03) << 4;
+      if (i+1 < hashsize) b |= Message_Digest[i+1] >> 4;
+      putchar(sm[b]);
+      if (i+1 < hashsize) {
+        b = (Message_Digest[i+1] & 0x0f) << 2;
+        if (i+2 < hashsize) b |= Message_Digest[i+2] >> 6;
+        putchar(sm[b]);
+      } else putchar('=');
+      if (i+2 < hashsize) putchar(sm[Message_Digest[i+2] & 0x3f]);
+      else putchar('=');
+    }
+    putchar('\n');
+  }
+
+  if (printResults && resultarray) {
+    printf("    Should match:\n\t");
+    for (i = 0, k = 0; i < hashsize; i++, k += 2) {
+      putchar(resultarray[k]);
+      putchar(resultarray[k+1]);
+      putchar(' ');
+    }
+    putchar('\n');
+  }
+
+  if (printPassFail && resultarray) {
+    int ret = checkmatch(Message_Digest, resultarray, hashsize);
+    if ((printPassFail == PRINTPASSFAIL) || !ret)
+      printf("%s %s %s: %s\n", hashname, testtype, testname,
+        ret ? "PASSED" : "FAILED");
+  }
+}
+
+/*
+ * Exercise a hash series of functions.  The input is the testarray,
+ * repeated repeatcount times, followed by the extrabits.  If the
+ * result is known, it is in resultarray in uppercase hex.
+ */
+int hash(int testno, int loopno, int hashno,
+  const char *testarray, int length, long repeatcount,
+  int numberExtrabits, int extrabits, const unsigned char *keyarray,
+  int keylen, const unsigned char *info, int infolen, int okmlen,
+  const char *resultarray, int hashsize, int printResults,
+  int printPassFail)
+{
+  USHAContext sha;
+  HMACContext hmac;
+  HKDFContext hkdf;
+  int err, i;
+  uint8_t Message_Digest_Buf[USHAMaxHashSize];
+  uint8_t *Message_Digest = Message_Digest_Buf;
+  char buf[20];
+
+  if (printResults == PRINTTEXT) {
+    printf("\nTest %d: Iteration %d, Repeat %ld\n\t'", testno+1,
+      loopno, repeatcount);
+    printstr(testarray, length);
+    printf("'\n\t'");
+    printxstr(testarray, length);
+    printf("'\n");
+    printf("    Length=%d bytes (%d bits), ", length, length * 8);
+    printf("ExtraBits %d: %2.2x\n", numberExtrabits, extrabits);
+  }
+
+  if (info) Message_Digest = malloc(okmlen);
+  memset(&sha, '\343', sizeof(sha)); /* force bad data into struct */
+  memset(&hmac, '\343', sizeof(hmac));
+  memset(&hkdf, '\343', sizeof(hkdf));
+
+  err = info ? hkdfReset(&hkdf, hashes[hashno].whichSha,
+                             keyarray, keylen) :
+        keyarray ? hmacReset(&hmac, hashes[hashno].whichSha,
+                             keyarray, keylen) :
+                   USHAReset(&sha, hashes[hashno].whichSha);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hash(): %sReset Error %d.\n",
+            info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+    return err;
+  }
+
+  for (i = 0; i < repeatcount; ++i) {
+    err = info ? hkdfInput(&hkdf, (const uint8_t *)testarray, length) :
+          keyarray ? hmacInput(&hmac, (const uint8_t *) testarray,
+                               length) :
+                     USHAInput(&sha, (const uint8_t *) testarray,
+                               length);
+    if (err != shaSuccess) {
+      fprintf(stderr, "hash(): %sInput Error %d.\n",
+              info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+      return err;
+    }
+  }
+
+  if (numberExtrabits > 0) {
+    err = info ? hkdfFinalBits(&hkdf, extrabits, numberExtrabits) :
+          keyarray ? hmacFinalBits(&hmac, (uint8_t) extrabits,
+                                   numberExtrabits) :
+                     USHAFinalBits(&sha, (uint8_t) extrabits,
+                                   numberExtrabits);
+    if (err != shaSuccess) {
+      fprintf(stderr, "hash(): %sFinalBits Error %d.\n",
+              info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+      return err;
+    }
+  }
+
+  err = info ? hkdfResult(&hkdf, 0, info, infolen,
+                          Message_Digest, okmlen) :
+        keyarray ? hmacResult(&hmac, Message_Digest) :
+                   USHAResult(&sha, Message_Digest);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hash(): %s Result Error %d, could not compute "
+      "message digest.\n",
+      info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+    return err;
+  }
+
+  sprintf(buf, "%d", testno+1);
+  printResult(Message_Digest, info ? okmlen : hashsize,
+    hashes[hashno].name, info ? "hkdf standard test" :
+    keyarray ? "hmac standard test" : "sha standard test", buf,
+    resultarray, printResults, printPassFail);
+
+  return err;
+}
+
+/*
+ * Exercise an HKDF series.  The input is the testarray,
+ * repeated repeatcount times, followed by the extrabits.  If the
+ * result is known, it is in resultarray in uppercase hex.
+ */
+int hashHkdf(int testno, int loopno, int hashno,
+  int printResults, int printPassFail)
+{
+  int err;
+  unsigned char prk[USHAMaxHashSize+1];
+  uint8_t okm[255 * USHAMaxHashSize+1];
+  char buf[24];
+
+  if (printResults == PRINTTEXT) {
+    printf("\nTest %d: Iteration %d\n\tSALT\t'", testno+1, loopno);
+    printxstr(hkdfhashes[testno].saltarray,
+      hkdfhashes[testno].saltlength);
+    printf("'\n\tIKM\t'");
+    printxstr(hkdfhashes[testno].ikmarray,
+      hkdfhashes[testno].ikmlength);
+    printf("'\n\tINFO\t'");
+    printxstr(hkdfhashes[testno].infoarray,
+      hkdfhashes[testno].infolength);
+    printf("'\n");
+    printf("    L=%d bytes\n", hkdfhashes[testno].okmlength);
+  }
+
+  /* Run hkdf() against the test vectors */
+  err = hkdf(hkdfhashes[testno].whichSha,
+             (const uint8_t *) hkdfhashes[testno].saltarray,
+             hkdfhashes[testno].saltlength,
+             (const uint8_t *) hkdfhashes[testno].ikmarray,
+             hkdfhashes[testno].ikmlength,
+             (const uint8_t *) hkdfhashes[testno].infoarray,
+             hkdfhashes[testno].infolength, okm,
+             hkdfhashes[testno].okmlength);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashHkdf(): hkdf Error %d.\n", err);
+    return err;
+  }
+  sprintf(buf, "hkdf %d", testno+1);
+  printResult(okm, hkdfhashes[testno].okmlength,
+    USHAHashName(hkdfhashes[testno].whichSha), "hkdf standard test",
+    buf, hkdfhashes[testno].okmarray, printResults, printPassFail);
+
+  /* Now run hkdfExtract() by itself against the test vectors */
+  /* to verify the intermediate results. */
+  err = hkdfExtract(hkdfhashes[testno].whichSha,
+                    (const uint8_t *) hkdfhashes[testno].saltarray,
+                    hkdfhashes[testno].saltlength,
+                    (const uint8_t *) hkdfhashes[testno].ikmarray,
+                    hkdfhashes[testno].ikmlength, prk);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashHkdf(): hkdfExtract Error %d.\n", err);
+    return err;
+  }
+  sprintf(buf, "hkdfExtract %d", testno+1);
+  printResult(prk, USHAHashSize(hkdfhashes[testno].whichSha),
+    USHAHashName(hkdfhashes[testno].whichSha), "hkdf standard test",
+    buf, hkdfhashes[testno].prkarray, printResults, printPassFail);
+
+  /* Now run hkdfExpand() by itself against the test vectors */
+  /* using the intermediate results from hkdfExtract. */
+  err = hkdfExpand(hkdfhashes[testno].whichSha, prk,
+    USHAHashSize(hkdfhashes[testno].whichSha),
+    (const uint8_t *)hkdfhashes[testno].infoarray,
+    hkdfhashes[testno].infolength, okm, hkdfhashes[testno].okmlength);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashHkdf(): hkdfExpand Error %d.\n", err);
+    return err;
+  }
+  sprintf(buf, "hkdfExpand %d", testno+1);
+  printResult(okm, hkdfhashes[testno].okmlength,
+    USHAHashName(hkdfhashes[testno].whichSha), "hkdf standard test",
+    buf, hkdfhashes[testno].okmarray, printResults, printPassFail);
+
+  return err;
+}
+
+/*
+ * Exercise a hash series of functions.  The input is a filename.
+ * If the result is known, it is in resultarray in uppercase hex.
+ */
+int hashfile(int hashno, const char *hashfilename, int bits,
+  int bitcount, int skipSpaces, const unsigned char *keyarray,
+  int keylen, const unsigned char *info, int infolen, int okmlen,
+  const char *resultarray, int hashsize,
+  int printResults, int printPassFail)
+{
+  USHAContext sha;
+  HMACContext hmac;
+  HKDFContext hkdf;
+  int err, nread, c;
+  unsigned char buf[4096];
+  uint8_t Message_Digest_Buf[USHAMaxHashSize];
+  uint8_t *Message_Digest = Message_Digest_Buf;
+  unsigned char cc;
+  FILE *hashfp = (strcmp(hashfilename, "-") == 0) ? stdin :
+    fopen(hashfilename, "r");
+
+  if (!hashfp) {
+    fprintf(stderr, "cannot open file '%s'\n", hashfilename);
+    return shaStateError;
+  }
+
+  if (info) Message_Digest = malloc(okmlen);
+  memset(&sha, '\343', sizeof(sha)); /* force bad data into struct */
+  memset(&hmac, '\343', sizeof(hmac));
+  memset(&hkdf, '\343', sizeof(hkdf));
+  err = info ? hkdfReset(&hkdf, hashes[hashno].whichSha,
+                             keyarray, keylen) :
+        keyarray ? hmacReset(&hmac, hashes[hashno].whichSha,
+                             keyarray, keylen) :
+                   USHAReset(&sha, hashes[hashno].whichSha);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashfile(): %sReset Error %d.\n",
+            info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+    return err;
+  }
+
+  if (skipSpaces)
+    while ((c = getc(hashfp)) != EOF) {
+      if (!isspace(c)) {
+        cc = (unsigned char)c;
+        err = info ? hkdfInput(&hkdf, &cc, 1) :
+              keyarray ? hmacInput(&hmac, &cc, 1) :
+                         USHAInput(&sha, &cc, 1);
+        if (err != shaSuccess) {
+          fprintf(stderr, "hashfile(): %sInput Error %d.\n",
+                  info ? "hkdf" : keyarray ? "hmac" : "sha", err);
+          if (hashfp != stdin) fclose(hashfp);
+          return err;
+        }
+      }
+    }
+  else
+    while ((nread = fread(buf, 1, sizeof(buf), hashfp)) > 0) {
+      err = info ? hkdfInput(&hkdf, buf, nread) :
+            keyarray ? hmacInput(&hmac, buf, nread) :
+                       USHAInput(&sha, buf, nread);
+      if (err != shaSuccess) {
+        fprintf(stderr, "hashfile(): %s Error %d.\n",
+                info ? "hkdf" : keyarray ? "hmacInput" :
+                "shaInput", err);
+        if (hashfp != stdin) fclose(hashfp);
+        return err;
+      }
+    }
+
+  if (bitcount > 0)
+    err = info ? hkdfFinalBits(&hkdf, bits, bitcount) :
+          keyarray ? hmacFinalBits(&hmac, bits, bitcount) :
+                   USHAFinalBits(&sha, bits, bitcount);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashfile(): %s Error %d.\n",
+            info ? "hkdf" : keyarray ? "hmacFinalBits" :
+            "shaFinalBits", err);
+    if (hashfp != stdin) fclose(hashfp);
+    return err;
+  }
+
+  err = info ? hkdfResult(&hkdf, 0, info, infolen,
+                          Message_Digest, okmlen) :
+        keyarray ? hmacResult(&hmac, Message_Digest) :
+                   USHAResult(&sha, Message_Digest);
+  if (err != shaSuccess) {
+    fprintf(stderr, "hashfile(): %s Error %d.\n",
+            info ? "hkdf" : keyarray ? "hmacResult" :
+            "shaResult", err);
+    if (hashfp != stdin) fclose(hashfp);
+    return err;
+  }
+
+  printResult(Message_Digest, info ? okmlen : hashsize,
+    hashes[hashno].name, "file", hashfilename, resultarray,
+    printResults, printPassFail);
+
+  if (hashfp != stdin) fclose(hashfp);
+  if (info) free(Message_Digest);
+  return err;
+}
+
+/*
+ * Exercise a hash series of functions through multiple permutations.
+ * The input is an initial seed.  That seed is replicated 3 times.
+ * For 1000 rounds, the previous three results are used as the input.
+ * This result is then checked, and used to seed the next cycle.
+ * If the result is known, it is in resultarrays in uppercase hex.
+ */
+void randomtest(int hashno, const char *seed, int hashsize,
+    const char **resultarrays, int randomcount,
+    int printResults, int printPassFail)
+{
+  int i, j; char buf[20];
+  unsigned char SEED[USHAMaxHashSize], MD[1003][USHAMaxHashSize];
+
+  /* INPUT: Seed - A random seed n bits long */
+  memcpy(SEED, seed, hashsize);
+  if (printResults == PRINTTEXT) {
+    printf("%s random test seed= '", hashes[hashno].name);
+    printxstr(seed, hashsize);
+    printf("'\n");
+  }
+
+  for (j = 0; j < randomcount; j++) {
+    /* MD0 = MD1 = MD2 = Seed; */
+    memcpy(MD[0], SEED, hashsize);
+    memcpy(MD[1], SEED, hashsize);
+    memcpy(MD[2], SEED, hashsize);
+    for (i=3; i<1003; i++) {
+      /* Mi = MDi-3 || MDi-2 || MDi-1; */
+      USHAContext Mi;
+      memset(&Mi, '\343', sizeof(Mi)); /* force bad data into struct */
+      USHAReset(&Mi, hashes[hashno].whichSha);
+      USHAInput(&Mi, MD[i-3], hashsize);
+      USHAInput(&Mi, MD[i-2], hashsize);
+      USHAInput(&Mi, MD[i-1], hashsize);
+      /* MDi = SHA(Mi); */
+      USHAResult(&Mi, MD[i]);
+    }
+
+    /* MDj = Seed = MDi; */
+    memcpy(SEED, MD[i-1], hashsize);
+
+    /* OUTPUT: MDj */
+    sprintf(buf, "%d", j);
+    printResult(SEED, hashsize, hashes[hashno].name, "random test",
+      buf, resultarrays ? resultarrays[j] : 0, printResults,
+      (j < RANDOMCOUNT) ? printPassFail : 0);
+  }
+}
+
+/*
+ * Look up a hash name.
+ */
+int findhash(const char *argv0, const char *opt)
+{
+  int i;
+  const char *names[HASHCOUNT][2] = {
+    { "0", "sha1" }, { "1", "sha224" }, { "2", "sha256" },
+    { "3", "sha384" }, { "4", "sha512" }
+  };
+  for (i = 0; i < HASHCOUNT; i++)
+    if ((strcmp(opt, names[i][0]) == 0) ||
+        (scasecmp(opt, names[i][1]) == 0))
+      return i;
+
+  fprintf(stderr, "%s: Unknown hash name: '%s'\n", argv0, opt);
+  usage(argv0);
+  return 0;
+}
+
+/*
+ * Run some tests that should invoke errors.
+ */
+void testErrors(int hashnolow, int hashnohigh, int printResults,
+    int printPassFail)
+{
+  USHAContext usha;
+  uint8_t Message_Digest[USHAMaxHashSize];
+  int hashno, err;
+
+  for (hashno = hashnolow; hashno <= hashnohigh; hashno++) {
+    memset(&usha, '\343', sizeof(usha)); /* force bad data */
+    USHAReset(&usha, hashno);
+    USHAResult(&usha, Message_Digest);
+    err = USHAInput(&usha, (const unsigned char *)"foo", 3);
+    if (printResults == PRINTTEXT)
+      printf ("\nError %d. Should be %d.\n", err, shaStateError);
+    if ((printPassFail == PRINTPASSFAIL) ||
+        ((printPassFail == PRINTFAIL) && (err != shaStateError)))
+      printf("%s se: %s\n", hashes[hashno].name,
+        (err == shaStateError) ? "PASSED" : "FAILED");
+
+    err = USHAFinalBits(&usha, 0x80, 3);
+    if (printResults == PRINTTEXT)
+      printf ("\nError %d. Should be %d.\n", err, shaStateError);
+    if ((printPassFail == PRINTPASSFAIL) ||
+        ((printPassFail == PRINTFAIL) && (err != shaStateError)))
+      printf("%s se: %s\n", hashes[hashno].name,
+        (err == shaStateError) ? "PASSED" : "FAILED");
+
+    err = USHAReset(0, hashes[hashno].whichSha);
+    if (printResults == PRINTTEXT)
+       printf("\nError %d. Should be %d.\n", err, shaNull);
+    if ((printPassFail == PRINTPASSFAIL) ||
+        ((printPassFail == PRINTFAIL) && (err != shaNull)))
+       printf("%s usha null: %s\n", hashes[hashno].name,
+        (err == shaNull) ? "PASSED" : "FAILED");
+
+    switch (hashno) {
+      case SHA1: err = SHA1Reset(0); break;
+      case SHA224: err = SHA224Reset(0); break;
+      case SHA256: err = SHA256Reset(0); break;
+      case SHA384: err = SHA384Reset(0); break;
+      case SHA512: err = SHA512Reset(0); break;
+    }
+    if (printResults == PRINTTEXT)
+       printf("\nError %d. Should be %d.\n", err, shaNull);
+    if ((printPassFail == PRINTPASSFAIL) ||
+        ((printPassFail == PRINTFAIL) && (err != shaNull)))
+       printf("%s sha null: %s\n", hashes[hashno].name,
+        (err == shaNull) ? "PASSED" : "FAILED");
+  }
+}
+
+/* replace a hex string in place with its value */
+int unhexStr(char *hexstr)
+{
+  char *o = hexstr;
+  int len = 0, nibble1 = 0, nibble2 = 0;
+  if (!hexstr) return 0;
+  for ( ; *hexstr; hexstr++) {
+    if (isalpha((int)(unsigned char)(*hexstr))) {
+      nibble1 = tolower((int)(unsigned char)(*hexstr)) - 'a' + 10;
+    } else if (isdigit((int)(unsigned char)(*hexstr))) {
+      nibble1 = *hexstr - '0';
+    } else {
+      printf("\nError: bad hex character '%c'\n", *hexstr);
+    }
+    if (!*++hexstr) break;
+    if (isalpha((int)(unsigned char)(*hexstr))) {
+      nibble2 = tolower((int)(unsigned char)(*hexstr)) - 'a' + 10;
+    } else if (isdigit((int)(unsigned char)(*hexstr))) {
+      nibble2 = *hexstr - '0';
+    } else {
+      printf("\nError: bad hex character '%c'\n", *hexstr);
+    }
+    *o++ = (char)((nibble1 << 4) | nibble2);
+    len++;
+  }
+  return len;
+}
+
+int main(int argc, char **argv)
+{
+  int i, err;
+  int loopno, loopnohigh = 1;
+  int hashno, hashnolow = 0, hashnohigh = HASHCOUNT - 1;
+  int testno, testnolow = 0, testnohigh;
+  int ntestnohigh = 0;
+  int printResults = PRINTTEXT;
+  int printPassFail = 1;
+  int checkErrors = 0;
+  char *hashstr = 0;
+  int hashlen = 0;
+  const char *resultstr = 0;
+  char *randomseedstr = 0;
+  int runHmacTests = 0;
+  int runHkdfTests = 0;
+  char *hmacKey = 0;
+  int hmaclen = 0;
+  char *info = 0;
+  int infolen = 0, okmlen = 0;
+  int randomcount = RANDOMCOUNT;
+  const char *hashfilename = 0;
+  const char *hashFilename = 0;
+  int extrabits = 0, numberExtrabits = 0;
+  int strIsHex = 0;
+
+  if ('A' != 0x41) {
+    fprintf(stderr, "%s: these tests require ASCII\n", argv[0]);
+  }
+
+  while ((i = getopt(argc, argv,
+                      "6b:B:def:F:h:i:Hk:l:L:mpPr:R:s:S:t:wxX")) != -1)
+    switch (i) {
+      case 'b': extrabits = strtol(optarg, 0, 0); break;
+      case 'B': numberExtrabits = atoi(optarg); break;
+      case 'd': runHkdfTests = 1; break;
+      case 'e': checkErrors = 1; break;
+      case 'f': hashfilename = optarg; break;
+      case 'F': hashFilename = optarg; break;
+      case 'h': hashnolow = hashnohigh = findhash(argv[0], optarg);
+        break;
+      case 'H': strIsHex = 1; break;
+      case 'i': info = optarg; infolen = strlen(optarg); break;
+      case 'k': hmacKey = optarg; hmaclen = strlen(optarg); break;
+      case 'l': loopnohigh = atoi(optarg); break;
+      case 'L': okmlen = strtol(optarg, 0, 0); break;
+      case 'm': runHmacTests = 1; break;
+      case 'P': printPassFail = 0; break;
+      case 'p': printResults = PRINTNONE; break;
+      case 'R': randomcount = atoi(optarg); break;
+      case 'r': randomseedstr = optarg; break;
+      case 's': hashstr = optarg; hashlen = strlen(hashstr); break;
+      case 'S': resultstr = optarg; break;
+      case 't': testnolow = ntestnohigh = atoi(optarg) - 1; break;
+      case 'w': printResults = PRINTRAW; break;
+      case 'x': printResults = PRINTHEX; break;
+      case 'X': printPassFail = 2; break;
+      case '6': printResults = PRINTBASE64; break;
+      default: usage(argv[0]);
+      }
+
+  if (strIsHex) {
+    hashlen = unhexStr(hashstr);
+    unhexStr(randomseedstr);
+    hmaclen = unhexStr(hmacKey);
+    infolen = unhexStr(info);
+  }
+  testnohigh = (ntestnohigh != 0) ? ntestnohigh:
+               runHmacTests ? (HMACTESTCOUNT-1) :
+               runHkdfTests ? (HKDFTESTCOUNT-1) :
+               (TESTCOUNT-1);
+  if ((testnolow < 0) ||
+      (testnohigh >= (runHmacTests ? HMACTESTCOUNT : TESTCOUNT)) ||
+      (hashnolow < 0) || (hashnohigh >= HASHCOUNT) ||
+      (hashstr && (testnolow == testnohigh)) ||
+      (randomcount < 0) ||
+      (resultstr && (!hashstr && !hashfilename && !hashFilename)) ||
+      ((runHmacTests || hmacKey) && randomseedstr) ||
+      (hashfilename && hashFilename) ||
+      (info && ((infolen <= 0) || (okmlen <= 0))) ||
+      (info && !hmacKey))
+    usage(argv[0]);
+
+  /*
+   *  Perform SHA/HMAC tests
+   */
+  for (hashno = hashnolow; hashno <= hashnohigh; ++hashno) {
+    if (printResults == PRINTTEXT)
+      printf("Hash %s\n", hashes[hashno].name);
+    err = shaSuccess;
+
+    for (loopno = 1; (loopno <= loopnohigh) && (err == shaSuccess);
+         ++loopno) {
+      if (hashstr)
+        err = hash(0, loopno, hashno, hashstr, hashlen, 1,
+          numberExtrabits, extrabits, (const unsigned char *)hmacKey,
+          hmaclen, (const uint8_t *) info, infolen, okmlen, resultstr,
+          hashes[hashno].hashsize, printResults, printPassFail);
+
+      else if (randomseedstr)
+        randomtest(hashno, randomseedstr, hashes[hashno].hashsize, 0,
+          randomcount, printResults, printPassFail);
+
+      else if (hashfilename)
+        err = hashfile(hashno, hashfilename, extrabits,
+                       numberExtrabits, 0,
+                       (const unsigned char *)hmacKey, hmaclen,
+                       (const uint8_t *) info, infolen, okmlen,
+                       resultstr, hashes[hashno].hashsize,
+                       printResults, printPassFail);
+
+      else if (hashFilename)
+        err = hashfile(hashno, hashFilename, extrabits,
+                       numberExtrabits, 1,
+                       (const unsigned char *)hmacKey, hmaclen,
+                       (const uint8_t *) info, infolen, okmlen,
+                       resultstr, hashes[hashno].hashsize,
+                       printResults, printPassFail);
+
+      else /* standard tests */ {
+        for (testno = testnolow;
+             (testno <= testnohigh) && (err == shaSuccess); ++testno) {
+          if (runHmacTests) {
+            err = hash(testno, loopno, hashno,
+                       hmachashes[testno].dataarray[hashno] ?
+                       hmachashes[testno].dataarray[hashno] :
+                       hmachashes[testno].dataarray[1] ?
+                       hmachashes[testno].dataarray[1] :
+                       hmachashes[testno].dataarray[0],
+                       hmachashes[testno].datalength[hashno] ?
+                       hmachashes[testno].datalength[hashno] :
+                       hmachashes[testno].datalength[1] ?
+                       hmachashes[testno].datalength[1] :
+                       hmachashes[testno].datalength[0],
+                       1, 0, 0,
+                       (const unsigned char *)(
+                        hmachashes[testno].keyarray[hashno] ?
+                        hmachashes[testno].keyarray[hashno] :
+                        hmachashes[testno].keyarray[1] ?
+                        hmachashes[testno].keyarray[1] :
+                        hmachashes[testno].keyarray[0]),
+                       hmachashes[testno].keylength[hashno] ?
+                       hmachashes[testno].keylength[hashno] :
+                       hmachashes[testno].keylength[1] ?
+                       hmachashes[testno].keylength[1] :
+                       hmachashes[testno].keylength[0],
+                       0, 0, 0,
+                       hmachashes[testno].resultarray[hashno],
+                       hmachashes[testno].resultlength[hashno],
+                       printResults, printPassFail);
+          } else if (runHkdfTests) {
+            err = hashHkdf(testno, loopno, hashno,
+                       printResults, printPassFail);
+          } else { /* sha tests */
+            err = hash(testno, loopno, hashno,
+                       hashes[hashno].tests[testno].testarray,
+                       hashes[hashno].tests[testno].length,
+                       hashes[hashno].tests[testno].repeatcount,
+                       hashes[hashno].tests[testno].numberExtrabits,
+                       hashes[hashno].tests[testno].extrabits,
+                       0, 0, 0, 0, 0,
+                       hashes[hashno].tests[testno].resultarray,
+                       hashes[hashno].hashsize,
+                       printResults, printPassFail);
+          }
+        }
+        if (!runHmacTests && !runHkdfTests) {
+          randomtest(hashno, hashes[hashno].randomtest,
+            hashes[hashno].hashsize, hashes[hashno].randomresults,
+            RANDOMCOUNT, printResults, printPassFail);
+        }
+      }
+    }
+  }
+
+  /* Test some error returns */
+  if (checkErrors) {
+    testErrors(hashnolow, hashnohigh, printResults, printPassFail);
+  }
+
+  return 0;
+}
+
+/*
+ * Compare two strings, case independently.
+ * Equivalent to strcasecmp() found on some systems.
+ */
+int scasecmp(const char *s1, const char *s2)
+{
+  for (;;) {
+    char u1 = tolower((int)(unsigned char)(*s1++));
+    char u2 = tolower((int)(unsigned char)(*s2++));
+    if (u1 != u2)
+      return u1 - u2;
+    if (u1 == '\0')
+      return 0;
+   }
+}
+

--- a/lib/libesp32/ESP32-HomeKit/src/usha.c
+++ b/lib/libesp32/ESP32-HomeKit/src/usha.c
@@ -1,0 +1,281 @@
+/**************************** usha.c ***************************/
+/***************** See RFC 6234 for details. *******************/
+/* Copyright (c) 2011 IETF Trust and the persons identified as */
+/* authors of the code.  All rights reserved.                  */
+/* See sha.h for terms of use and redistribution.              */
+
+/*
+ *  Description:
+ *     This file implements a unified interface to the SHA algorithms.
+ */
+
+#include "sha.h"
+
+/*
+ *  USHAReset
+ *
+ *  Description:
+ *      This function will initialize the SHA Context in preparation
+ *      for computing a new SHA message digest.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The context to reset.
+ *      whichSha: [in]
+ *          Selects which SHA reset to call
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int USHAReset(USHAContext *context, enum SHAversion whichSha)
+{
+  if (!context) return shaNull;
+  context->whichSha = whichSha;
+  switch (whichSha) {
+    case SHA1:   return SHA1Reset((SHA1Context*)&context->ctx);
+    case SHA224: return SHA224Reset((SHA224Context*)&context->ctx);
+    case SHA256: return SHA256Reset((SHA256Context*)&context->ctx);
+    case SHA384: return SHA384Reset((SHA384Context*)&context->ctx);
+    case SHA512: return SHA512Reset((SHA512Context*)&context->ctx);
+    default: return shaBadParam;
+  }
+}
+
+/*
+ *  USHAInput
+ *
+ *  Description:
+ *      This function accepts an array of octets as the next portion
+ *      of the message.
+ *
+ *  Parameters:
+ *      context: [in/out]
+ *          The SHA context to update.
+ *      message_array: [in]
+ *          An array of octets representing the next portion of
+ *          the message.
+ *      length: [in]
+ *          The length of the message in message_array.
+ *
+ *  Returns:
+ *      sha Error Code.
+ *
+ */
+int USHAInput(USHAContext *context,
+              const uint8_t *bytes, unsigned int bytecount)
+{
+  if (!context) return shaNull;
+  switch (context->whichSha) {
+    case SHA1:
+      return SHA1Input((SHA1Context*)&context->ctx, bytes,
+                       bytecount);
+    case SHA224:
+      return SHA224Input((SHA224Context*)&context->ctx, bytes,
+          bytecount);
+    case SHA256:
+      return SHA256Input((SHA256Context*)&context->ctx, bytes,
+          bytecount);
+    case SHA384:
+      return SHA384Input((SHA384Context*)&context->ctx, bytes,
+          bytecount);
+    case SHA512:
+      return SHA512Input((SHA512Context*)&context->ctx, bytes,
+          bytecount);
+    default: return shaBadParam;
+  }
+}
+
+/*
+ * USHAFinalBits
+ *
+ * Description:
+ *   This function will add in any final bits of the message.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The SHA context to update.
+ *   message_bits: [in]
+ *     The final bits of the message, in the upper portion of the
+ *     byte.  (Use 0b###00000 instead of 0b00000### to input the
+ *     three bits ###.)
+ *   length: [in]
+ *     The number of bits in message_bits, between 1 and 7.
+ *
+ * Returns:
+ *   sha Error Code.
+ */
+int USHAFinalBits(USHAContext *context,
+                  uint8_t bits, unsigned int bit_count)
+{
+  if (!context) return shaNull;
+  switch (context->whichSha) {
+    case SHA1:
+      return SHA1FinalBits((SHA1Context*)&context->ctx, bits,
+                           bit_count);
+    case SHA224:
+      return SHA224FinalBits((SHA224Context*)&context->ctx, bits,
+          bit_count);
+    case SHA256:
+      return SHA256FinalBits((SHA256Context*)&context->ctx, bits,
+          bit_count);
+    case SHA384:
+      return SHA384FinalBits((SHA384Context*)&context->ctx, bits,
+          bit_count);
+    case SHA512:
+      return SHA512FinalBits((SHA512Context*)&context->ctx, bits,
+          bit_count);
+    default: return shaBadParam;
+  }
+}
+
+/*
+ * USHAResult
+ *
+ * Description:
+ *   This function will return the message digest of the appropriate
+ *   bit size, as returned by USHAHashSizeBits(whichSHA) for the
+ *   'whichSHA' value used in the preceeding call to USHAReset,
+ *   into the Message_Digest array provided by the caller.
+ *
+ * Parameters:
+ *   context: [in/out]
+ *     The context to use to calculate the SHA-1 hash.
+ *   Message_Digest: [out]
+ *     Where the digest is returned.
+ *
+ * Returns:
+ *   sha Error Code.
+ *
+ */
+int USHAResult(USHAContext *context,
+               uint8_t Message_Digest[USHAMaxHashSize])
+{
+  if (!context) return shaNull;
+  switch (context->whichSha) {
+    case SHA1:
+      return SHA1Result((SHA1Context*)&context->ctx, Message_Digest);
+    case SHA224:
+      return SHA224Result((SHA224Context*)&context->ctx,
+                          Message_Digest);
+    case SHA256:
+      return SHA256Result((SHA256Context*)&context->ctx,
+                          Message_Digest);
+    case SHA384:
+      return SHA384Result((SHA384Context*)&context->ctx,
+                          Message_Digest);
+    case SHA512:
+      return SHA512Result((SHA512Context*)&context->ctx,
+                          Message_Digest);
+    default: return shaBadParam;
+  }
+}
+
+/*
+ * USHABlockSize
+ *
+ * Description:
+ *   This function will return the blocksize for the given SHA
+ *   algorithm.
+ *
+ * Parameters:
+ *   whichSha:
+ *     which SHA algorithm to query
+ *
+ * Returns:
+ *   block size
+ *
+ */
+int USHABlockSize(enum SHAversion whichSha)
+{
+  switch (whichSha) {
+    case SHA1:   return SHA1_Message_Block_Size;
+    case SHA224: return SHA224_Message_Block_Size;
+    case SHA256: return SHA256_Message_Block_Size;
+    case SHA384: return SHA384_Message_Block_Size;
+    default:
+    case SHA512: return SHA512_Message_Block_Size;
+  }
+}
+
+/*
+ * USHAHashSize
+ *
+ * Description:
+ *   This function will return the hashsize for the given SHA
+ *   algorithm.
+ *
+ * Parameters:
+ *   whichSha:
+ *     which SHA algorithm to query
+ *
+ * Returns:
+ *   hash size
+ *
+ */
+int USHAHashSize(enum SHAversion whichSha)
+{
+  switch (whichSha) {
+    case SHA1:   return SHA1HashSize;
+    case SHA224: return SHA224HashSize;
+    case SHA256: return SHA256HashSize;
+    case SHA384: return SHA384HashSize;
+    default:
+    case SHA512: return SHA512HashSize;
+  }
+}
+
+/*
+ * USHAHashSizeBits
+ *
+ * Description:
+ *   This function will return the hashsize for the given SHA
+ *   algorithm, expressed in bits.
+ *
+ * Parameters:
+ *   whichSha:
+ *     which SHA algorithm to query
+ *
+ * Returns:
+ *   hash size in bits
+ *
+ */
+int USHAHashSizeBits(enum SHAversion whichSha)
+{
+  switch (whichSha) {
+    case SHA1:   return SHA1HashSizeBits;
+    case SHA224: return SHA224HashSizeBits;
+    case SHA256: return SHA256HashSizeBits;
+    case SHA384: return SHA384HashSizeBits;
+    default:
+    case SHA512: return SHA512HashSizeBits;
+  }
+}
+
+/*
+ * USHAHashName
+ *
+ * Description:
+ *   This function will return the name of the given SHA algorithm
+ *   as a string.
+ *
+ * Parameters:
+ *   whichSha:
+ *     which SHA algorithm to query
+ *
+ * Returns:
+ *   character string with the name in it
+ *
+ */
+const char *USHAHashName(enum SHAversion whichSha)
+{
+  switch (whichSha) {
+    case SHA1:   return "SHA1";
+    case SHA224: return "SHA224";
+    case SHA256: return "SHA256";
+    case SHA384: return "SHA384";
+    default:
+    case SHA512: return "SHA512";
+  }
+}
+

--- a/tasmota/homekit.c
+++ b/tasmota/homekit.c
@@ -1,0 +1,599 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2018 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS products only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+/* HomeKit Smart Outlet Example
+*/
+
+#ifdef ESP32
+
+#include <Arduino.h>
+#include <stdio.h>
+#include <string.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/queue.h>
+#include <esp_log.h>
+#include <driver/gpio.h>
+
+
+#include <hap.h>
+
+#include <hap_apple_servs.h>
+#include <hap_apple_chars.h>
+#include <hap_platform_keystore.h>
+
+//#include <app_wifi.h>
+//#include <app_hap_setup_payload.h>
+
+static const char *TAG = "HAP outlet";
+char *hk_desc;
+char hk_code[12];
+
+extern void Ext_Replace_Cmd_Vars(char *srcbuf, uint32_t srcsize, char *dstbuf, uint32_t dstsize);
+extern uint32_t Ext_UpdVar(char *vname, float *fvar, uint32_t mode);
+
+#define MAX_HAP_DEFS 16
+struct HAP_DESC {
+  char hap_name[16];
+  char var_name[16];
+  char var2_name[16];
+  char var3_name[16];
+  char var4_name[16];
+  uint8_t hap_cid;
+  uint8_t type;
+  hap_acc_t *accessory;
+  hap_serv_t *service;
+} hap_devs[MAX_HAP_DEFS];
+
+#define HK_SRCBSIZE 256
+
+
+#define SMART_OUTLET_TASK_PRIORITY  1
+#define SMART_OUTLET_TASK_STACKSIZE 4 * 1024
+#define SMART_OUTLET_TASK_NAME      "hap_outlet"
+
+//#define OUTLET_IN_USE_GPIO GPIO_NUM_0
+#define OUTLET_IN_USE_GPIO -1
+
+#define ESP_INTR_FLAG_DEFAULT 0
+
+static xQueueHandle s_esp_evt_queue = NULL;
+/**
+ * @brief the recover outlet in use gpio interrupt function
+ */
+static void IRAM_ATTR outlet_in_use_isr(void* arg)
+{
+    uint32_t gpio_num = (uint32_t) arg;
+    xQueueSendFromISR(s_esp_evt_queue, &gpio_num, NULL);
+}
+
+/**
+ * Enable a GPIO Pin for Outlet in Use Detection
+ */
+static void outlet_in_use_key_init(uint32_t key_gpio_pin)
+{
+    gpio_config_t io_conf;
+    /* Interrupt for both the edges  */
+    io_conf.intr_type = GPIO_INTR_ANYEDGE;
+    /* Bit mask of the pins */
+    io_conf.pin_bit_mask = 1 << key_gpio_pin;
+    /* Set as input mode */
+    io_conf.mode = GPIO_MODE_INPUT;
+    /* Enable internal pull-up */
+    io_conf.pull_up_en = 1;
+    /* Disable internal pull-down */
+    io_conf.pull_down_en = 0;
+    /* Set the GPIO configuration */
+    gpio_config(&io_conf);
+
+    /* Install gpio isr service */
+    gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT);
+    /* Hook isr handler for specified gpio pin */
+    gpio_isr_handler_add(key_gpio_pin, outlet_in_use_isr, (void*)key_gpio_pin);
+}
+
+/**
+ * Initialize the Smart Outlet Hardware.Here, we just enebale the Outlet-In-Use detection.
+ */
+void smart_outlet_hardware_init(int32_t gpio_num) {
+    s_esp_evt_queue = xQueueCreate(2, sizeof(uint32_t));
+
+    if (gpio_num < 0) return;
+
+    if (s_esp_evt_queue != NULL) {
+        outlet_in_use_key_init(gpio_num);
+    }
+}
+
+
+static int bridge_identify(hap_acc_t *ha)
+{
+    ESP_LOGI(TAG, "Bridge identified");
+    return HAP_SUCCESS;
+}
+
+static int accessory_identify(hap_acc_t *ha)
+{
+    hap_serv_t *hs = hap_acc_get_serv_by_uuid(ha, HAP_SERV_UUID_ACCESSORY_INFORMATION);
+    hap_char_t *hc = hap_serv_get_char_by_uuid(hs, HAP_CHAR_UUID_NAME);
+    const hap_val_t *val = hap_char_get_val(hc);
+    char *name = val->s;
+
+    ESP_LOGI(TAG, "Bridged Accessory %s identified", name);
+    return HAP_SUCCESS;
+}
+
+/* A dummy callback for handling a write on the "On" characteristic of Outlet.
+ * In an actual accessory, this should control the hardware
+ */
+static int sensor_write(hap_write_data_t write_data[], int count, void *serv_priv, void *write_priv, uint32_t index) {
+    int i, ret = HAP_SUCCESS;
+    hap_write_data_t *write;
+    for (i = 0; i < count; i++) {
+        write = &write_data[i];
+        const char *hcp = hap_char_get_type_uuid(write->hc);
+        if (!strcmp(hcp, HAP_CHAR_UUID_ON)) {
+            //ESP_LOGI(TAG, "Received Write. Outlet %s", write->val.b ? "On" : "Off");
+        	ESP_LOG_LEVEL(ESP_LOG_INFO, TAG, "Received Write. Outlet %s", write->val.b ? "On" : "Off");
+          hap_char_update_val(write->hc, &(write->val));
+          float fvar = write->val.b;
+          Ext_UpdVar(hap_devs[index].var_name, &fvar, 1);
+          *(write->status) = HAP_STATUS_SUCCESS;
+        } else if (!strcmp(hcp, HAP_CHAR_UUID_HUE)) {
+          hap_char_update_val(write->hc, &(write->val));
+          float fvar = write->val.f;
+          Ext_UpdVar(hap_devs[index].var2_name, &fvar, 1);
+          *(write->status) = HAP_STATUS_SUCCESS;
+        } else if (!strcmp(hcp, HAP_CHAR_UUID_SATURATION)) {
+          hap_char_update_val(write->hc, &(write->val));
+          float fvar = write->val.f;
+          Ext_UpdVar(hap_devs[index].var3_name, &fvar, 1);
+          *(write->status) = HAP_STATUS_SUCCESS;
+        } else if (!strcmp(hcp, HAP_CHAR_UUID_BRIGHTNESS)) {
+          hap_char_update_val(write->hc, &(write->val));
+          float fvar = write->val.u;
+          Ext_UpdVar(hap_devs[index].var4_name, &fvar, 1);
+          *(write->status) = HAP_STATUS_SUCCESS;
+        } else {
+          *(write->status) = HAP_STATUS_RES_ABSENT;
+        }
+    }
+    return ret;
+}
+
+
+// common read routine
+static int sensor_read(hap_char_t *hc, hap_status_t *status_code, void *serv_priv, void *read_priv, uint32_t index) {
+  hap_val_t new_val;
+  float fvar = 0;
+
+    if (hap_req_get_ctrl_id(read_priv)) {
+        ESP_LOGI(TAG, "Received read from %s", hap_req_get_ctrl_id(read_priv));
+    }
+
+    const char *hcp = hap_char_get_type_uuid(hc);
+
+    if (!strcmp(hcp, HAP_CHAR_UUID_CURRENT_TEMPERATURE)
+    || !strcmp(hcp, HAP_CHAR_UUID_CURRENT_RELATIVE_HUMIDITY)
+    || !strcmp(hcp, HAP_CHAR_UUID_CURRENT_AMBIENT_LIGHT_LEVEL)
+    ) {
+
+        Ext_UpdVar(hap_devs[index].var_name, &fvar, 0);
+        new_val.f = fvar;
+        hap_char_update_val(hc, &new_val);
+        *status_code = HAP_STATUS_SUCCESS;
+    }
+    if (!strcmp(hcp, HAP_CHAR_UUID_ON)) {
+      Ext_UpdVar(hap_devs[index].var_name, &fvar, 0);
+      new_val.b = fvar;
+      hap_char_update_val(hc, &new_val);
+      *status_code = HAP_STATUS_SUCCESS;
+    }
+    if (!strcmp(hcp, HAP_CHAR_UUID_HUE)) {
+      Ext_UpdVar(hap_devs[index].var2_name, &fvar, 0);
+      new_val.f = fvar;
+      hap_char_update_val(hc, &new_val);
+      *status_code = HAP_STATUS_SUCCESS;
+    }
+    if (!strcmp(hcp, HAP_CHAR_UUID_SATURATION)) {
+      Ext_UpdVar(hap_devs[index].var3_name, &fvar, 0);
+      new_val.f = fvar;
+      hap_char_update_val(hc, &new_val);
+      *status_code = HAP_STATUS_SUCCESS;
+    }
+    if (!strcmp(hcp, HAP_CHAR_UUID_BRIGHTNESS)) {
+      Ext_UpdVar(hap_devs[index].var4_name, &fvar, 0);
+      new_val.u = fvar;
+      hap_char_update_val(hc, &new_val);
+      *status_code = HAP_STATUS_SUCCESS;
+    }
+    return HAP_SUCCESS;
+}
+
+#define HAP_READ hap_char_t *hc, hap_status_t *status_code, void *serv_priv, void *read_priv) {  return sensor_read(hc, status_code, serv_priv, read_priv
+
+static int sensor_read1(HAP_READ, 0);}
+static int sensor_read2(HAP_READ, 1);}
+static int sensor_read3(HAP_READ, 2);}
+static int sensor_read4(HAP_READ, 3);}
+static int sensor_read5(HAP_READ, 4);}
+static int sensor_read6(HAP_READ, 5);}
+static int sensor_read7(HAP_READ, 6);}
+static int sensor_read8(HAP_READ, 7);}
+static int sensor_read9(HAP_READ, 8);}
+static int sensor_read10(HAP_READ, 9);}
+static int sensor_read11(HAP_READ, 10);}
+static int sensor_read12(HAP_READ, 11);}
+static int sensor_read13(HAP_READ, 12);}
+static int sensor_read14(HAP_READ, 13);}
+static int sensor_read15(HAP_READ, 14);}
+static int sensor_read16(HAP_READ, 15);}
+
+void hap_set_read(hap_serv_t *service, uint32_t index) {
+  switch (index) {
+    case 0: hap_serv_set_read_cb(service, sensor_read1);break;
+    case 1: hap_serv_set_read_cb(service, sensor_read2);break;
+    case 2: hap_serv_set_read_cb(service, sensor_read3);break;
+    case 3: hap_serv_set_read_cb(service, sensor_read4);break;
+    case 4: hap_serv_set_read_cb(service, sensor_read5);break;
+    case 5: hap_serv_set_read_cb(service, sensor_read6);break;
+    case 6: hap_serv_set_read_cb(service, sensor_read7);break;
+    case 7: hap_serv_set_read_cb(service, sensor_read8);break;
+    case 8: hap_serv_set_read_cb(service, sensor_read9);break;
+    case 9: hap_serv_set_read_cb(service, sensor_read10);break;
+    case 10: hap_serv_set_read_cb(service, sensor_read11);break;
+    case 11: hap_serv_set_read_cb(service, sensor_read12);break;
+    case 12: hap_serv_set_read_cb(service, sensor_read13);break;
+    case 13: hap_serv_set_read_cb(service, sensor_read14);break;
+    case 14: hap_serv_set_read_cb(service, sensor_read15);break;
+    case 15: hap_serv_set_read_cb(service, sensor_read16);break;
+  }
+}
+
+
+#define HAP_WRITE hap_write_data_t write_data[], int count, void *serv_priv, void *write_priv) {  return sensor_write(write_data, count, serv_priv, write_priv
+
+static int sensor_write1(HAP_WRITE, 0);}
+static int sensor_write2(HAP_WRITE, 1);}
+static int sensor_write3(HAP_WRITE, 2);}
+static int sensor_write4(HAP_WRITE, 3);}
+static int sensor_write5(HAP_WRITE, 4);}
+static int sensor_write6(HAP_WRITE, 5);}
+static int sensor_write7(HAP_WRITE, 6);}
+static int sensor_write8(HAP_WRITE, 7);}
+static int sensor_write9(HAP_WRITE, 8);}
+static int sensor_write10(HAP_WRITE, 9);}
+static int sensor_write11(HAP_WRITE, 10);}
+static int sensor_write12(HAP_WRITE, 11);}
+static int sensor_write13(HAP_WRITE, 12);}
+static int sensor_write14(HAP_WRITE, 13);}
+static int sensor_write15(HAP_WRITE, 14);}
+static int sensor_write16(HAP_WRITE, 15);}
+
+
+void hap_set_write(hap_serv_t *service, uint32_t index) {
+  switch (index) {
+    case 0: hap_serv_set_write_cb(service, sensor_write1);break;
+    case 1: hap_serv_set_write_cb(service, sensor_write2);break;
+    case 2: hap_serv_set_write_cb(service, sensor_write3);break;
+    case 3: hap_serv_set_write_cb(service, sensor_write4);break;
+    case 4: hap_serv_set_write_cb(service, sensor_write5);break;
+    case 5: hap_serv_set_write_cb(service, sensor_write6);break;
+    case 6: hap_serv_set_write_cb(service, sensor_write7);break;
+    case 7: hap_serv_set_write_cb(service, sensor_write8);break;
+    case 8: hap_serv_set_write_cb(service, sensor_write9);break;
+    case 9: hap_serv_set_write_cb(service, sensor_write10);break;
+    case 10: hap_serv_set_write_cb(service, sensor_write11);break;
+    case 11: hap_serv_set_write_cb(service, sensor_write12);break;
+    case 12: hap_serv_set_write_cb(service, sensor_write13);break;
+    case 13: hap_serv_set_write_cb(service, sensor_write14);break;
+    case 14: hap_serv_set_write_cb(service, sensor_write15);break;
+    case 15: hap_serv_set_write_cb(service, sensor_write16);break;
+  }
+}
+
+
+uint32_t HK_getlinelen(char *lp) {
+uint32_t cnt;
+  for (cnt=0; cnt<HK_SRCBSIZE-1; cnt++) {
+    if (lp[cnt]=='\n') {
+      break;
+    }
+  }
+  return cnt;
+}
+
+
+uint32_t str2c(char **sp, char *vp, uint32_t len) {
+    char *lp = *sp;
+    if (len) len--;
+    char *cp = strchr(lp, ',');
+    if (cp) {
+        while (1) {
+            if (*lp == ',') {
+                *vp = 0;
+                *sp = lp + 1;
+                return 0;
+            }
+            if (len) {
+                *vp++ = *lp++;
+                len--;
+            } else {
+                lp++;
+            }
+        }
+    } else {
+      if (strlen(*sp)) {
+        strlcpy(vp, *sp, len);
+        return 0;
+      }
+    }
+    return 1;
+}
+
+/*The main thread for handling the Smart Outlet Accessory */
+static void smart_outlet_thread_entry(void *p) {
+    /* Initialize the HAP core */
+    hap_init(HAP_TRANSPORT_WIFI);
+
+    hap_acc_t *accessory;
+
+    hap_acc_cfg_t cfg = {
+        .name = "Tasmota-Bridge",
+        .manufacturer = "Tasmota",
+        .model = "Bridge",
+        .serial_num = "001122334455",
+        .fw_rev = "0.9.0",
+        .hw_rev = NULL,
+        .pv = "1.1.0",
+        .identify_routine = bridge_identify,
+        .cid = HAP_CID_BRIDGE,
+    };
+    /* Create accessory object */
+    accessory = hap_acc_create(&cfg);
+
+    /* Add a dummy Product Data */
+    uint8_t product_data[] = {'E','S','P','3','2','H','A','P'};
+    hap_acc_add_product_data(accessory, product_data, sizeof(product_data));
+
+    /* Add the Accessory to the HomeKit Database */
+    hap_add_accessory(accessory);
+
+    /* Initialise the mandatory parameters for Accessory which will be added as
+     * the mandatory services internally
+     */
+     hap_char_t *outlet_in_use;
+    // get values from descriptor, line per line
+    // name, cid, var
+    char *lp = hk_desc;
+    uint8_t index = 0;
+    while (*lp) {
+      if (*lp == '#') break;
+      if (*lp == '\n') lp++;
+      if (*lp == ' ') lp++;
+      if (*lp == ';') goto nextline;
+
+      char dstbuf[HK_SRCBSIZE*2];
+      Ext_Replace_Cmd_Vars(lp, 1, dstbuf, sizeof(dstbuf));
+      lp += HK_getlinelen(lp);
+
+      char *lp1 = dstbuf;
+      if (str2c(&lp1, hap_devs[index].hap_name, sizeof(hap_devs[index].hap_name))) {
+        goto nextline;
+      }
+      hap_devs[index].hap_cid = strtol(lp1, &lp1, 10);
+      lp1++;
+      hap_devs[index].type = strtol(lp1, &lp1, 10);
+      lp1++;
+      if (str2c(&lp1, hap_devs[index].var_name, sizeof(hap_devs[index].var_name))) {
+        goto nextline;
+      }
+      if (hap_devs[index].hap_cid == HAP_CID_LIGHTING) {
+        // get 3 add vars
+        if (str2c(&lp1, hap_devs[index].var2_name, sizeof(hap_devs[index].var2_name))) {
+          goto nextline;
+        }
+        if (str2c(&lp1, hap_devs[index].var3_name, sizeof(hap_devs[index].var3_name))) {
+          goto nextline;
+        }
+        if (str2c(&lp1, hap_devs[index].var4_name, sizeof(hap_devs[index].var4_name))) {
+          goto nextline;
+        }
+      }
+
+
+      hap_acc_cfg_t hap_cfg;
+      hap_cfg.name = hap_devs[index].hap_name;
+      hap_cfg.manufacturer = "Tasmota";
+      hap_cfg.model = "Tasmota Device";
+      hap_cfg.serial_num = "001122334455";
+      hap_cfg.fw_rev = "0.9.0";
+      hap_cfg.hw_rev = NULL;
+      hap_cfg.pv = "1.1.0";
+      hap_cfg.identify_routine = accessory_identify;
+      hap_cfg.cid =  hap_devs[index].hap_cid;
+
+      /* Create accessory object */
+      hap_devs[index].accessory = hap_acc_create(&hap_cfg);
+      /* Add a dummy Product Data */
+      uint8_t product_data[] = {'E','S','P','3','2','H','A','P'};
+      hap_acc_add_product_data(hap_devs[index].accessory, product_data, sizeof(product_data));
+
+      int ret = hap_serv_add_char(hap_devs[index].service, hap_char_name_create(hap_devs[index].hap_name));
+      switch (hap_cfg.cid) {
+        case HAP_CID_LIGHTING:
+          { float fvar = 0;
+            Ext_UpdVar(hap_devs[index].var_name, &fvar, 0);
+            hap_devs[index].service = hap_serv_lightbulb_create(fvar);
+            Ext_UpdVar(hap_devs[index].var2_name, &fvar, 0);
+            ret |= hap_serv_add_char(hap_devs[index].service, hap_char_hue_create(fvar));
+            Ext_UpdVar(hap_devs[index].var3_name, &fvar, 0);
+            ret |= hap_serv_add_char(hap_devs[index].service, hap_char_saturation_create(fvar));
+            Ext_UpdVar(hap_devs[index].var4_name, &fvar, 0);
+            ret |= hap_serv_add_char(hap_devs[index].service, hap_char_brightness_create(fvar));
+          }
+          break;
+        case HAP_CID_OUTLET:
+          { float fvar = 0;
+            Ext_UpdVar(hap_devs[index].var_name, &fvar, 0);
+            hap_devs[index].service = hap_serv_outlet_create(fvar, true);
+          }
+          break;
+        case HAP_CID_SENSOR:
+          { float fvar = 22;
+            Ext_UpdVar(hap_devs[index].var_name, &fvar, 0);
+            switch (hap_devs[index].type) {
+              case 0: hap_devs[index].service = hap_serv_temperature_sensor_create(fvar); break;
+              case 1: hap_devs[index].service = hap_serv_humidity_sensor_create(fvar); break;
+              case 2: hap_devs[index].service = hap_serv_light_sensor_create(fvar); break;
+            }
+          }
+          break;
+        default:
+          hap_devs[index].service = hap_serv_outlet_create(true, true);
+      }
+
+      hap_set_read(hap_devs[index].service, index);
+      hap_set_write(hap_devs[index].service, index);
+
+      /* Get pointer to the outlet in use characteristic which we need to monitor for state changes */
+      hap_char_t *outlet_in_use = hap_serv_get_char_by_uuid(hap_devs[index].service, HAP_CHAR_UUID_OUTLET_IN_USE);
+
+      /* Add the Outlet Service to the Accessory Object */
+      hap_acc_add_serv(hap_devs[index].accessory, hap_devs[index].service);
+
+      /* Add the Accessory to the HomeKit Database */
+      hap_add_bridged_accessory(hap_devs[index].accessory, hap_get_unique_aid(hap_devs[index].hap_name));
+
+      index++;
+
+nextline:
+      if (*lp=='\n') {
+        lp++;
+      } else {
+        lp = strchr(lp, '\n');
+        if (!lp) break;
+        lp++;
+      }
+    }
+
+
+    /* Initialize the appliance specific hardware. This enables out-in-use detection */
+    smart_outlet_hardware_init(OUTLET_IN_USE_GPIO);
+
+    /* For production accessories, the setup code shouldn't be programmed on to
+     * the device. Instead, the setup info, derived from the setup code must
+     * be used. Use the factory_nvs_gen utility to generate this data and then
+     * flash it into the factory NVS partition.
+     *
+     * By default, the setup ID and setup info will be read from the factory_nvs
+     * Flash partition and so, is not required to set here explicitly.
+     *
+     * However, for testing purpose, this can be overridden by using hap_set_setup_code()
+     * and hap_set_setup_id() APIs, as has been done here.
+     */
+    hap_set_setup_code(hk_code);
+    hap_set_setup_id("ES32");
+#ifdef CONFIG_EXAMPLE_USE_HARDCODED_SETUP_CODE
+    /* Unique Setup code of the format xxx-xx-xxx. Default: 111-22-333 */
+    hap_set_setup_code(CONFIG_EXAMPLE_SETUP_CODE);
+    /* Unique four character Setup Id. Default: ES32 */
+    hap_set_setup_id(CONFIG_EXAMPLE_SETUP_ID);
+#ifdef CONFIG_APP_WIFI_USE_WAC_PROVISIONING
+    app_hap_setup_payload(CONFIG_EXAMPLE_SETUP_CODE, CONFIG_EXAMPLE_SETUP_ID, true, hap_devs[0].hap_cid);
+#else
+    app_hap_setup_payload(CONFIG_EXAMPLE_SETUP_CODE, CONFIG_EXAMPLE_SETUP_ID, false, hap_devs[0].hap_cid);
+#endif
+#endif // CONFIG_EXAMPLE_USE_HARDCODED_SETUP_CODE
+
+    /* Enable Hardware MFi authentication (applicable only for MFi variant of SDK) */
+    hap_enable_mfi_auth(HAP_MFI_AUTH_HW);
+
+    /* Initialize Wi-Fi */
+    //app_wifi_init();
+
+    /* After all the initializations are done, start the HAP core */
+    hap_start();
+    /* Start Wi-Fi */
+    //app_wifi_start(portMAX_DELAY);
+
+    uint32_t io_num = OUTLET_IN_USE_GPIO;
+    if (io_num >= 0) {
+        hap_val_t appliance_value = {
+          .b = true,
+        };
+
+        /* Listen for Outlet-In-Use state change events. Other read/write functionality will be handled
+        * by the HAP Core.
+        * When the Outlet in Use GPIO goes low, it means Outlet is not in use.
+        * When the Outlet in Use GPIO goes high, it means Outlet is in use.
+        * Applications can define own logic as per their hardware.
+        */
+        while (1) {
+          if (xQueueReceive(s_esp_evt_queue, &io_num, portMAX_DELAY) == pdFALSE) {
+            ESP_LOGI(TAG, "Outlet-In-Use trigger FAIL");
+          } else {
+            appliance_value.b = gpio_get_level(io_num);
+            /* If any state change is detected, update the Outlet In Use characteristic value */
+            hap_char_update_val(outlet_in_use, &appliance_value);
+            ESP_LOGI(TAG, "Outlet-In-Use triggered [%d]", appliance_value.b);
+          }
+        }
+    } else {
+        while (1) {
+        }
+    }
+}
+
+
+#define HK_MAXSIZE 1024
+
+void homekit_main(char *desc) {
+  if (desc) {
+    char *cp = desc;
+    cp += 2;
+    while (*cp == ' ') cp++;
+    // "111-11-111"
+    uint32_t cnt;
+    for (cnt = 0; cnt < 10; cnt++) {
+      hk_code[cnt] = *cp++;
+    }
+    hk_code[cnt] = 0;
+    if (*cp != '\n') {
+      printf("init error\n");
+      return;
+    }
+    cp++;
+    hk_desc = cp;
+  } else {
+    hap_platfrom_keystore_erase_partition("nvs");
+    return;
+  }
+
+  if (!hk_desc) return;
+
+  /* Create the application thread */
+  xTaskCreate(smart_outlet_thread_entry, SMART_OUTLET_TASK_NAME, SMART_OUTLET_TASK_STACKSIZE, NULL, SMART_OUTLET_TASK_PRIORITY, NULL);
+}
+
+#endif // ESP32


### PR DESCRIPTION
## Description:

initial support for apple HomeKit on esp32 (siri)

installs as a home kit bridge and supports up to 16 secondary devices per esp32

currently supported:
outlet, on,off
light, on,off, hue, sat,bri
and sensors (temperature, humidity, light etc)

#define USE_HOMEKIT

descriptor:

; homekit + passcode
\>h 111-11-111
; device name, hap_cid, option, var to use
Steckdose,7,0,p1
Licht,5,0,pwr,hue,sat,bri
Temperatur,10,0,s1
Feuchtigkeit,10,1,s2
Helligkeit,10,2,s3
#

also adds epoffs settable

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
