### PR TITLE
Fix DHT12 on ESP32

### DIFF
--- a/tasmota/xsns_58_dht12.ino
+++ b/tasmota/xsns_58_dht12.ino
@@ -56,8 +56,8 @@ bool Dht12Read(void)
   uint8_t tempTenth     = Wire.read();
   uint8_t checksum      = Wire.read();
 
-  Dht12.humidity    = ConvertHumidity( (float) humidity + (float) humidityTenth/(float) 10.0 );
-  Dht12.temperature = ConvertTemp( ((float)temp + (float)(tempTenth & 0x7F) / (float) 10.0) * (tempTenth & 0x80) ? -1.0 : 1.0 );
+  Dht12.humidity    = ConvertHumidity( humidity + ((float) humidityTenth) /10 );
+  Dht12.temperature = ConvertTemp( (temp + (tempTenth & 0x7F) / 10.0f) * ((tempTenth & 0x80) ? -1 : 1) );
 
   if (isnan(Dht12.temperature) || isnan(Dht12.humidity)) { return false; }
 


### PR DESCRIPTION
## Description:

There was an issue in calculating the temperature for DHT12 on ESP32 compiler. I simplified the expression and added parenthesis to avoid any compiler confusion.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
