### PR TITLE
ESP32 increase TLS buffers

### DIFF
--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -183,7 +183,11 @@ void MqttInit(void) {
   }
 
   if (Mqtt.mqtt_tls) {
+#ifdef ESP32
+    tlsClient = new BearSSL::WiFiClientSecure_light(2048,2048);
+#else // ESP32 - ESP8266
     tlsClient = new BearSSL::WiFiClientSecure_light(1024,1024);
+#endif
 
 #ifdef USE_MQTT_AWS_IOT
     loadTlsDir();   // load key and certificate data from Flash


### PR DESCRIPTION
## Description:

ESP32: increase TLS buffers to 2Kb for tx and rx. This protects against TLS servers not supporting MFLN and accidentally sending more than 1Kb of data.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
