### PR TITLE
Phase 1 of new Tasmota32 build variants

### DIFF
--- a/.github/workflows/CI_github_ESP32.yml
+++ b/.github/workflows/CI_github_ESP32.yml
@@ -104,26 +104,6 @@ jobs:
         name: firmware
         path: ./build_output
 
-  tasmota32-lite:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U platformio
-        platformio upgrade --dev
-        platformio update
-    - name: Run PlatformIO
-      run: |
-        platformio run -e tasmota32-lite
-    - uses: actions/upload-artifact@v2
-      with:
-        name: firmware
-        path: ./build_output
-
   tasmota32-knx:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -1435,7 +1435,6 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-sensors.* ] || mv ./mv_firmware/firmware/tasmota32-sensors.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-lite.* ] || mv ./mv_firmware/firmware/tasmota32-lite.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/

--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -724,26 +724,6 @@ jobs:
         path: ./build_output
 
 
-  tasmota32-lite:
-    needs: tasmota_pull
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        pip install -U platformio
-    - name: Run PlatformIO
-      run: |
-        platformio run -e tasmota32-lite
-    - uses: actions/upload-artifact@v2
-      with:
-        name: firmware
-        path: ./build_output
-
-
   tasmota32-webcam:
     needs: tasmota_pull
     runs-on: ubuntu-latest

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1435,7 +1435,6 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-sensors.* ] || mv ./mv_firmware/firmware/tasmota32-sensors.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-lite.* ] || mv ./mv_firmware/firmware/tasmota32-lite.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -724,26 +724,6 @@ jobs:
         path: ./build_output
 
 
-  tasmota32-lite:
-    needs: tasmota_pull
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        pip install -U platformio
-    - name: Run PlatformIO
-      run: |
-        platformio run -e tasmota32-lite
-    - uses: actions/upload-artifact@v2
-      with:
-        name: firmware
-        path: ./build_output
-
-
   tasmota32-webcam:
     needs: tasmota_pull
     runs-on: ubuntu-latest

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -29,7 +29,6 @@ default_envs =
 ;                tasmota32
 ;                tasmota32-bluetooth
 ;                tasmota32-webcam
-;                tasmota32-lite
 ;                tasmota32-knx
 ;                tasmota32-sensors
 ;                tasmota32-display

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -11,7 +11,6 @@ default_envs                =  ${build_envs.default_envs}
 ;                tasmota32-webcam
 ;                tasmota32-odroidgo
 ;                tasmota32-core2
-;                tasmota32-lite
 ;                tasmota32-knx
 ;                tasmota32-sensors
 ;                tasmota32-display

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -66,11 +66,6 @@ extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_BLUETOOTH
 lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
 
-[env:tasmota32-lite]
-extends                 = env:tasmota32
-build_flags             = ${common32.build_flags} -DFIRMWARE_LITE
-lib_extra_dirs          = lib/libesp32
-
 [env:tasmota32-knx]
 extends                 = env:tasmota32
 build_flags             = ${common32.build_flags} -DFIRMWARE_KNX_NO_EMULATION


### PR DESCRIPTION
## Description:

remove Tasmota32-lite. It is not needed for ESP32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
