### PR TITLE
Use SO32 for power button hold time

### DIFF
--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -755,21 +755,8 @@ bool Xdrv35(uint8_t function)
         // If the button is pressed, ...
         if (!XdrvMailbox.payload) {
 
-          // If the button was just pressed, flag the button as pressed, set the hold time and
-          // increment the buttons pressed count.
+          // If the button was just pressed, ...
           if (!button_pressed[button_index]) {
-            button_pressed[button_index] = true;
-            uint32_t hold_delay = 250;
-            if (button_index == power_button_index) {
-#ifdef USE_PWM_DIMMER_REMOTE
-              if (!(active_remote_pwm_dimmer ? active_remote_pwm_dimmer->power_on : TasmotaGlobal.power)) hold_delay = 500;
-#else // USE_PWM_DIMMER_REMOTE
-              if (!TasmotaGlobal.power) hold_delay = 500;
-#endif  // USE_PWM_DIMMER_REMOTE
-            }
-            button_hold_time[button_index] = now + hold_delay;
-            buttons_pressed++;
-            if (buttons_pressed > 1) multibutton_in_progress = true;
 
 #ifdef USE_PWM_DIMMER_REMOTE
             // If there are no other buttons pressed right now and remote mode is enabled, make the
@@ -785,7 +772,7 @@ bool Xdrv35(uint8_t function)
             // Top          0          1     1     0
             // Middle       1          2    15     0
             // Bottom      15          3    15     1
-            if (buttons_pressed == 1 && Settings.flag4.multiple_device_groups) {
+            if (!buttons_pressed && Settings.flag4.multiple_device_groups) {
               power_button_index = button_index;
               down_button_index = (Pin(GPIO_KEY1, power_button_index) == 15 ? TasmotaGlobal.gpio_pin[1] : TasmotaGlobal.gpio_pin[15]) - 32;
               active_remote_pwm_dimmer = nullptr;
@@ -793,9 +780,17 @@ bool Xdrv35(uint8_t function)
                 active_remote_pwm_dimmer = &remote_pwm_dimmers[power_button_index];
             }
 #endif  // USE_PWM_DIMMER_REMOTE
+
+            // Flag the button as pressed, increment the buttons pressed count and set the hold time.
+            button_pressed[button_index] = true;
+            buttons_pressed++;
+            if (buttons_pressed > 1) multibutton_in_progress = true;
+            uint32_t hold_delay = 250;
+            if (button_index == power_button_index) hold_delay = Settings.param[P_HOLD_TIME] * 10;
+            button_hold_time[button_index] = now + hold_delay;
           }
 
-          // If hold time has arrived and a rule is enabled that handles the button hold, handle it.
+          // If hold time has arrived and no rule is enabled that handles the button hold, handle it.
           else if (button_hold_time[button_index] <= now) {
 #ifdef USE_RULES
             sprintf(TasmotaGlobal.mqtt_data, PSTR("{\"Button%u\":{\"State\":3}}"), button_index + 1);


### PR DESCRIPTION
## Description:

Use SO32 for power button hold time.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
