### PR TITLE
Add Support for multiple VL53L0X I2C Laser Distance Sensors

### DIFF
--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.4
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v8.2.0.6
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -796,7 +796,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.5.0.9
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.3
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.5.0
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v8.0.0.0
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -1,5 +1,5 @@
 /*
-  es-ES.h - localization for Spanish - Spain for Tasmota
+  es-ES.h - localization for Spanish - Spain for Tasmota (translation also valid for all latinamerica)
 
   Copyright (C) 2021  Adrian Scillato
 
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.3
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Cambiando dirección a"
+#define D_OUT_OF_RANGE         "Fuera de Rango"
+#define D_SENSOR_DETECTED      "detectado"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -1,14 +1,18 @@
 /*
   fr-FR.h - localization for French - France for Tasmota
+  
   Copyright (C) 2021  Olivier Francais
+  
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
+  
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+  
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.3
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -793,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.4
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.14.0b
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.12.0e
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -1,7 +1,7 @@
 /*
   it-IT.h - localization for Italian - Italy for Tasmota
 
-  Copyright (C) 2021  Gennaro Tortone - some mods by Antonio Fragola - Updated by bovirus - rev. 03.03.2021
+  Copyright (C) 2021  Gennaro Tortone, Antonio Fragola, Bovirus and Adrian Scillato
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.0.0a
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,6 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand - D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool - TX"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool - RX"
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Cambio di indirizzo a"
+#define D_OUT_OF_RANGE         "Fuori dal limite"
+#define D_SENSOR_DETECTED      "rilevato"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -1,7 +1,7 @@
 /*
   ko-KO.h - localization for Korean - Korean for Tasmota
 
-  Copyright (C) 2021  Theo Arends (translated by NyaamZ)
+  Copyright (C) 2021  NyaamZ
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.2.1.11
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.2.0.4
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -1,7 +1,7 @@
 /*
   pl-PL-d.h - localization for Polish with diacritics - Poland for Tasmota
 
-  Copyright (C) 2021  Theo Arends (translated by roblad - Robert L., upgraded by R. Turala)
+  Copyright (C) 2021  Roblad (Robert L.) and R. Turala
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.12.0d
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -797,6 +797,7 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
 #define D_NEW_ADDRESS          "Mudança de endereço para"
 #define D_OUT_OF_RANGE         "Fora de Alcance"
 #define D_SENSOR_DETECTED      "detectou"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -1,7 +1,7 @@
 /*
   pt-BR.h - localization for Portuguese - Brazil for Tasmota
 
-  Copyright (C) 2021  Fabiano Bovo
+  Copyright (C) 2021  Fabiano Bovo and Adrian Scillato
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v7.0.0.1
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,9 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_NEW_ADDRESS          "Mudança de endereço para"
+#define D_OUT_OF_RANGE         "Fora de Alcance"
+#define D_SENSOR_DETECTED      "detectou"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -1,7 +1,7 @@
 /*
   pt-PT.h - localization for Portuguese - Portugal for Tasmota
 
-  Copyright (C) 2021  Paulo Paiva
+  Copyright (C) 2021  Paulo Paiva and Adrian Scillato
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v7.0.0.1
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 #define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Mudança de endereço para"
+#define D_OUT_OF_RANGE         "Fora de Alcance"
+#define D_SENSOR_DETECTED      "detectou"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v8.1.0.10
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -1,7 +1,7 @@
 /*
-  ru-RU.h - localization for Russian - Rissia for Tasmota
+  ru-RU.h - localization for Russian - Russia for Tasmota
 
-  Copyright (C) 2021  Theo Arends / roman-vn
+  Copyright (C) 2021  Roman-vn
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.12.0b
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.2.1.14
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.2.1.11
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v6.1.1
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -1,7 +1,7 @@
 /*
   uk-UA.h - localization for Ukrainian - Ukraine for Tasmota
 
-  Copyright (C) 2021  Theo Arends / vadym-adik
+  Copyright (C) 2021  Vadym-adik
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.14.0a
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE                    "А"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -1,7 +1,7 @@
 /*
   vi-VN.h - localization for Vietnam for Tasmota
 
-  Copyright (C) 2021  translateb by Tâm.NT
+  Copyright (C) 2021  Tâm.NT
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.0.0.1
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -1,7 +1,7 @@
 /*
   zh-CN.h - localization for Chinese (Simplified) - China for Tasmota
 
-  Copyright (C) 2021  Theo Arends (translated by killadm)
+  Copyright (C) 2021  Killadm
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.14.0b
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "安"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -1,7 +1,7 @@
 /*
   zh-TW.h - localization for Chinese (Traditional) - Taiwan for Tasmota
 
-  Copyright (C) 2021  Theo Arends (translated by dannydu)
+  Copyright (C) 2021  Dannydu
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v5.12.0d
+ * Updated until v9.3.1.1
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -797,7 +797,10 @@
 #define D_SENSOR_WIEGAND_D1    "Wiegand D1"
 #define D_SENSOR_NEOPOOL_TX    "NeoPool Tx"
 #define D_SENSOR_NEOPOOL_RX    "NeoPool Rx"
-
+#define D_SENSOR_VL53L0X_XSHUT "VL53L0X XSHUT"
+#define D_NEW_ADDRESS          "Setting address to"
+#define D_OUT_OF_RANGE         "Out of Range"
+#define D_SENSOR_DETECTED      "detected"
 
 // Units
 #define D_UNIT_AMPERE "安培"

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -83,6 +83,7 @@ const uint8_t MAX_SHUTTER_KEYS = 4;         // Max number of shutter keys or but
 const uint8_t MAX_PCF8574 = 4;              // Max number of PCF8574 devices
 const uint8_t MAX_RULE_SETS = 3;            // Max number of rule sets of size 512 characters
 const uint16_t MAX_RULE_SIZE = 512;         // Max number of characters in rules
+const uint16_t VL53L0X_MAX_SENSORS = 8;     // Max number of VL53L0X sensors
 
 #ifdef ESP32
 const uint8_t MAX_I2C = 2;                  // Max number of I2C controllers (ESP32 = 2)

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -154,6 +154,7 @@ enum UserSelectablePins {
   GPIO_SSD1351_DC,
   GPIO_XPT2046_CS,                     // XPT2046 SPI Chip Select
   GPIO_CSE7761_TX, GPIO_CSE7761_RX,    // CSE7761 Serial interface (Dual R3)
+  GPIO_VL53L0X_XSHUT1,                 // VL53L0X_XSHUT (the max number of sensors is VL53L0X_MAX_SENSORS)- Used when connecting multiple VL53L0X
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -328,6 +329,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_SSD1351_DC "|"
   D_SENSOR_XPT2046_CS "|"
   D_SENSOR_CSE7761_TX "|" D_SENSOR_CSE7761_RX "|"
+  D_SENSOR_VL53L0X_XSHUT "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -781,6 +783,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_PROJECTOR_CTRL_TX),      // LCD/DLP Projector Serial Control
   AGPIO(GPIO_PROJECTOR_CTRL_RX),      // LCD/DLP Projector Serial Control
 #endif
+#ifdef USE_VL53L0X
+  AGPIO(GPIO_VL53L0X_XSHUT1) + VL53L0X_MAX_SENSORS,  // When using multiple VL53L0X.
+#endif  
+  
 /*-------------------------------------------------------------------------------------------*\
  * ESP32 specifics
 \*-------------------------------------------------------------------------------------------*/

--- a/tasmota/xsns_45_vl53l0x.ino
+++ b/tasmota/xsns_45_vl53l0x.ino
@@ -1,7 +1,7 @@
 /*
-  xsns_45_vl53l0x.ino - VL53L0X time of flight sensor support for Tasmota
+  xsns_45_vl53l0x.ino - VL53L0X time of flight multiple sensors support for Tasmota
 
-  Copyright (C) 2021  Theo Arends and Gerhard Mutz
+  Copyright (C) 2021  Theo Arends, Gerhard Mutz and Adrian Scillato
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -23,105 +23,216 @@
  * VL53L0x time of flight sensor
  *
  * I2C Addres: 0x29
+ *********************************************************************************************
+ *  
+ * Note: When using multiple VL53L0X, it is required to also wire the XSHUT pin of all those sensors
+ * in order to let Tasmota change by software the I2C address of those and give them an unique address
+ * for operation. The sensor don't save its address, so this procedure of changing its address is needed
+ * to be performed every restart. The Addresses used for this are 120 (0x78) to 127 (0x7F). In the I2c
+ * Standard (https://i2cdevices.org/addresses) those addresses are used by the PCA9685, so take into
+ * account they won't work together.
+ * 
+ * The default value of VL53L0X_MAX_SENSORS is set in the file tasmota.h
+ * Changing that is backwards incompatible - Max supported devices by this driver are 8
+ * 
+ **********************************************************************************************
+ *
+ * How to install this sensor: https://www.st.com/resource/en/datasheet/vl53l0x.pdf
+ * 
+ * If you are going to use long I2C wires read this:
+ * https://hackaday.com/2017/02/08/taking-the-leap-off-board-an-introduction-to-i2c-over-long-wires/
+ * 
 \*********************************************************************************************/
 
 #define XSNS_45            45
 #define XI2C_31            31  // See I2CDEVICES.md
+
+// Uncomment this line to use long range mode. This
+// increases the sensitivity of the sensor and extends its
+// potential range, but increases the likelihood of getting
+// an inaccurate reading because of reflections from objects
+// other than the intended target. It works best in dark
+// conditions.
+
+//#define VL53L0X_LONG_RANGE
+
+// Uncomment ONE of these two lines to get
+// - higher speed at the cost of lower accuracy OR
+// - higher accuracy at the cost of lower speed
+
+//#define VL53L0X_HIGH_SPEED
+//#define VL53L0X_HIGH_ACCURACY
 
 #define USE_VL_MEDIAN
 #define USE_VL_MEDIAN_SIZE 5   // Odd number of samples median detection
 
 #include <Wire.h>
 #include "VL53L0X.h"
-VL53L0X sensor;
 
+VL53L0X sensor[VL53L0X_MAX_SENSORS];
 struct {
   uint16_t distance;
   uint16_t distance_prev;
   uint16_t buffer[5];
   uint8_t ready = 0;
   uint8_t index;
-} Vl53l0x;
+} Vl53l0x[VL53L0X_MAX_SENSORS];
+
+bool xshut = false;
+bool VL53L0X_detected = false;
 
 /********************************************************************************************/
 
 void Vl53l0Detect(void) {
-  if (!I2cSetDevice(0x29)) { return; }
-  if (!sensor.init()) { return; }
 
-  I2cSetActiveFound(sensor.getAddress(), "VL53L0X");
+  for (uint32_t i = 0; i < VL53L0X_MAX_SENSORS; i++) {
+    if (PinUsed(GPIO_VL53L0X_XSHUT1, i)) {
+      pinMode(Pin(GPIO_VL53L0X_XSHUT1, i), OUTPUT);
+      digitalWrite(Pin(GPIO_VL53L0X_XSHUT1, i), i==0 ? 1 : 0);
+      xshut = true;
+    }
+  }
 
-  sensor.setTimeout(500);
+  for (uint32_t i = 0; i < VL53L0X_MAX_SENSORS; i++) {
+    if (PinUsed(GPIO_VL53L0X_XSHUT1, i) || (!xshut)) {   
+        if (xshut) { pinMode(Pin(GPIO_VL53L0X_XSHUT1, i), INPUT); delay(1); }       
+        if (!I2cSetDevice(0x29) && !I2cSetDevice((uint8_t)(120+i))) { return; } // Detection for unconfigured OR configured sensor    
+        if (sensor[i].init()) {         
+            if (xshut) { sensor[i].setAddress((uint8_t)(120+i)); }         
+            uint8_t addr = sensor[i].getAddress();
+            if (xshut) {
+                I2cSetActive(addr);
+                AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_I2C D_SENSOR " VL53L0X %d " D_SENSOR_DETECTED " - " D_NEW_ADDRESS " 0x%02X"), i+1, addr);
+            } else {
+                I2cSetActiveFound(addr, "VL53L0X");
+            }
+            sensor[i].setTimeout(500);
 
-  // Start continuous back-to-back mode (take readings as
-  // fast as possible).  To use continuous timed mode
-  // instead, provide a desired inter-measurement period in
-  // ms (e.g. sensor.startContinuous(100)).
-  sensor.startContinuous();
-  Vl53l0x.ready = 1;
+#if defined VL53L0X_LONG_RANGE
+            // lower the return signal rate limit (default is 0.25 MCPS)
+            sensor[i].setSignalRateLimit(0.1);
+            // increase laser pulse periods (defaults are 14 and 10 PCLKs)
+            sensor[i].setVcselPulsePeriod(VL53L0X::VcselPeriodPreRange, 18);
+            sensor[i].setVcselPulsePeriod(VL53L0X::VcselPeriodFinalRange, 14);
+#endif
+#if defined VL53L0X_HIGH_SPEED
+            // reduce timing budget to 20 ms (default is about 33 ms)
+            sensor[i].setMeasurementTimingBudget(20000);
+#elif defined VL53L0X_HIGH_ACCURACY
+            // increase timing budget to 200 ms
+            sensor[i].setMeasurementTimingBudget(200000);
+#endif
+            // Start continuous back-to-back mode (take readings as
+            // fast as possible).  To use continuous timed mode
+            // instead, provide a desired inter-measurement period in
+            // ms (e.g. sensor.startContinuous(100)).
+            sensor[i].startContinuous();
 
-  Vl53l0x.index = 0;
+            Vl53l0x[i].ready = 1;
+            Vl53l0x[i].index = 0;
+            VL53L0X_detected = true;
+            if (!xshut) { break; }
+        } else {
+            AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_I2C D_SENSOR " VL53L0X %d - " D_FAILED_TO_START), i+1);
+        }
+    }
+  }
 }
 
 void Vl53l0Every_250MSecond(void) {
-  uint16_t dist = sensor.readRangeContinuousMillimeters();
-  if ((0 == dist) || (dist > 2000)) {
-    dist = 9999;
-  }
+  for (uint32_t i = 0; i < VL53L0X_MAX_SENSORS; i++) {
+    if (PinUsed(GPIO_VL53L0X_XSHUT1, i) || (!xshut)) {
+        uint16_t dist = sensor[i].readRangeContinuousMillimeters();
+        if ((0 == dist) || (dist > 2200)) {
+            dist = 9999;
+        }
 
 #ifdef USE_VL_MEDIAN
-  // store in ring buffer
-  Vl53l0x.buffer[Vl53l0x.index] = dist;
-  Vl53l0x.index++;
-  if (Vl53l0x.index >= USE_VL_MEDIAN_SIZE) {
-    Vl53l0x.index = 0;
-  }
+        // store in ring buffer
+        Vl53l0x[i].buffer[Vl53l0x[i].index] = dist;
+        Vl53l0x[i].index++;
+        if (Vl53l0x[i].index >= USE_VL_MEDIAN_SIZE) {
+            Vl53l0x[i].index = 0;
+        }
 
-  // sort list and take median
-  uint16_t tbuff[USE_VL_MEDIAN_SIZE];
-  memmove(tbuff, Vl53l0x.buffer, sizeof(tbuff));
-  uint16_t tmp;
-  uint8_t flag;
-  for (uint32_t ocnt = 0; ocnt < USE_VL_MEDIAN_SIZE; ocnt++) {
-    flag = 0;
-    for (uint32_t count = 0; count < USE_VL_MEDIAN_SIZE -1; count++) {
-      if (tbuff[count] > tbuff[count +1]) {
-        tmp = tbuff[count];
-        tbuff[count] = tbuff[count +1];
-        tbuff[count +1] = tmp;
-        flag = 1;
-      }
-    }
-    if (!flag) { break; }
-  }
-  Vl53l0x.distance = tbuff[(USE_VL_MEDIAN_SIZE -1) / 2];
+        // sort list and take median
+        uint16_t tbuff[USE_VL_MEDIAN_SIZE];
+        memmove(tbuff, Vl53l0x[i].buffer, sizeof(tbuff));
+        uint16_t tmp;
+        uint8_t flag;
+        for (uint32_t ocnt = 0; ocnt < USE_VL_MEDIAN_SIZE; ocnt++) {
+            flag = 0;
+            for (uint32_t count = 0; count < USE_VL_MEDIAN_SIZE -1; count++) {
+            if (tbuff[count] > tbuff[count +1]) {
+                tmp = tbuff[count];
+                tbuff[count] = tbuff[count +1];
+                tbuff[count +1] = tmp;
+                flag = 1;
+            }
+            }
+            if (!flag) { break; }
+        }
+        Vl53l0x[i].distance = tbuff[(USE_VL_MEDIAN_SIZE -1) / 2];
 #else
-  Vl53l0x.distance = dist;
+        Vl53l0x[i].distance = dist;
 #endif
+    }
+    if (!xshut) { break; }
+  }
 }
 
 #ifdef USE_DOMOTICZ
 void Vl53l0Every_Second(void) {
-  if (abs(Vl53l0x.distance - Vl53l0x.distance_prev) > 8) {
-    Vl53l0x.distance_prev = Vl53l0x.distance;
-    DomoticzSensor(DZ_ILLUMINANCE, Vl53l0x.distance);
+  if (abs(Vl53l0x[0].distance - Vl53l0x[0].distance_prev) > 8) {
+    Vl53l0x[0].distance_prev = Vl53l0x[0].distance;
+    DomoticzSensor(DZ_ILLUMINANCE, Vl53l0x[0].distance);
   }
 }
 #endif  // USE_DOMOTICZ
 
 void Vl53l0Show(boolean json) {
-  if (json) {
-    ResponseAppend_P(PSTR(",\"VL53L0X\":{\"" D_JSON_DISTANCE "\":%d}"), Vl53l0x.distance);
+  for (uint32_t i = 0; i < VL53L0X_MAX_SENSORS; i++) {
+    if (PinUsed(GPIO_VL53L0X_XSHUT1, i) || (!xshut)) {    
+        if (json) {
+            if (Vl53l0x[i].distance == 9999) {
+                if (xshut) {
+                    ResponseAppend_P(PSTR(",\"VL53L0X_%d\":{\"" D_JSON_DISTANCE "\":null}"), i+1);
+                } else {
+                    ResponseAppend_P(PSTR(",\"VL53L0X\":{\"" D_JSON_DISTANCE "\":null}")); // For backwards compatibility when not using XSHUT GPIOs
+                }
+            } else {
+                if (xshut) {
+                    ResponseAppend_P(PSTR(",\"VL53L0X_%d\":{\"" D_JSON_DISTANCE "\":%d}"), i+1, Vl53l0x[i].distance);
+                } else {
+                    ResponseAppend_P(PSTR(",\"VL53L0X\":{\"" D_JSON_DISTANCE "\":%d}"), Vl53l0x[i].distance); // For backwards compatibility when not using XSHUT GPIOs
+                }
+            }
+#ifdef USE_WEBSERVER
+        } else {
+            if (Vl53l0x[i].distance == 9999) {
+                if (xshut) {
+                    WSContentSend_PD("{s}%s_%d " D_DISTANCE "{m}%s {e}", PSTR("VL53L0X"), i+1, PSTR(D_OUT_OF_RANGE));
+                } else {
+                    WSContentSend_PD("{s}%s " D_DISTANCE "{m}%s {e}", PSTR("VL53L0X"), PSTR(D_OUT_OF_RANGE)); // For backwards compatibility when not using XSHUT GPIOs
+                }
+            } else {
+                if (xshut) {
+                    WSContentSend_PD("{s}%s_%d " D_DISTANCE "{m}%d " D_UNIT_MILLIMETER "{e}", PSTR("VL53L0X"), i+1, Vl53l0x[i].distance);
+                } else {
+                    WSContentSend_PD(HTTP_SNS_DISTANCE, PSTR("VL53L0X"), Vl53l0x[i].distance); // For backwards compatibility when not using XSHUT GPIOs
+                }
+            }
+#endif
+        }
+    }
+    if (sensor[i].timeoutOccurred()) { AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_I2C D_TIMEOUT_WAITING_FOR D_SENSOR " VL53L0X %d"), i+1); }
+    if (!xshut) { break; }
+  }
 #ifdef USE_DOMOTICZ
-    if (0 == TasmotaGlobal.tele_period) {
-      DomoticzSensor(DZ_ILLUMINANCE, Vl53l0x.distance);
+    if ((json) && (0 == TasmotaGlobal.tele_period)){
+        DomoticzSensor(DZ_ILLUMINANCE, Vl53l0x[0].distance);
     }
 #endif  // USE_DOMOTICZ
-#ifdef USE_WEBSERVER
-  } else {
-    WSContentSend_PD(HTTP_SNS_DISTANCE, PSTR("VL53L0X"), Vl53l0x.distance);
-#endif
-  }
 }
 
 /*********************************************************************************************\
@@ -136,7 +247,7 @@ bool Xsns45(byte function) {
   if (FUNC_INIT == function) {
     Vl53l0Detect();
   }
-  else if (Vl53l0x.ready) {
+  else if (VL53L0X_detected) {
     switch (function) {
       case FUNC_EVERY_250_MSECOND:
         Vl53l0Every_250MSecond();


### PR DESCRIPTION
## Description:

Add Support for multiple VL53L0X - I2C ToF (Time of Flight) Laser Distance Sensors

The actual driver that Tasmota has, supports just one sensor and uses an extra of 48 Bytes of RAM and 3756 Bytes of Flash when is added into a compilation.

The proposed modifications add support up to 8 sensors and uses an extra of 360 Bytes of RAM and 4816 Bytes of Flash when is added into a compilation. It is backwards compatible. If using only one sensor, the driver behaves the same as before. If multiple sensors are going to be used, it is required to also wire the XSHUT pin of all those sensors and assign them to GPIOs of the ESP as VL53L0X XSHUT 1 to 8, in order to let Tasmota change by software the I2C address of those at start, and give them an unique address for operation. This sensor don't save its address, so this procedure of changing its address is needed to be performed every restart. The Addresses used for this are 120 (0x78) to 127 (0x7F). In the I2c Standard (https://i2cdevices.org/addresses) those addresses are used by the PCA9685, so take into account they won't work together.

About how to install this sensor and how to adapt the laser operation for several use-cases, please check: https://www.st.com/resource/en/datasheet/vl53l0x.pdf

If you are going to use long I2C wires read this:
https://hackaday.com/2017/02/08/taking-the-leap-off-board-an-introduction-to-i2c-over-long-wires/

![image](https://user-images.githubusercontent.com/35405447/111362860-144c4780-866e-11eb-84f1-461d2857ede7.png)

![image](https://user-images.githubusercontent.com/35405447/111363016-465da980-866e-11eb-9074-eb4f4c9f5237.png)

![image](https://user-images.githubusercontent.com/35405447/111363173-7907a200-866e-11eb-83e1-93cfefc45315.png)


**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
