### PR TITLE
Alternative syslog dns fix

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -2137,8 +2137,11 @@ void SyslogAsync(bool refresh) {
     if (mxtime > 0) {
       uint32_t current_hash = GetHash(SettingsText(SET_SYSLOG_HOST), strlen(SettingsText(SET_SYSLOG_HOST)));
       if (syslog_host_hash != current_hash) {
+        IPAddress temp_syslog_host_addr;
+        int ret = WiFi.hostByName(SettingsText(SET_SYSLOG_HOST), temp_syslog_host_addr);  // If sleep enabled this might result in exception so try to do it once using hash
+        if (!ret) return;
         syslog_host_hash = current_hash;
-        WiFi.hostByName(SettingsText(SET_SYSLOG_HOST), syslog_host_addr);  // If sleep enabled this might result in exception so try to do it once using hash
+        syslog_host_addr = temp_syslog_host_addr;
       }
       if (!PortUdp.beginPacket(syslog_host_addr, Settings.syslog_port)) {
         TasmotaGlobal.syslog_level = 0;


### PR DESCRIPTION
## Description:

### Problem
Discord user "eddieb" reported strange behavior of syslog in his use case.
https://discord.com/channels/479389167382691863/490244847568158751/821275083342741535

When using a name for loghost instead of an IP, right after a restart, Tasmota start to broadcast syslog to 255.255.255.255 instead of the correct server's IP. Moreover his logs never starts on the expect 1st line of log  `CFG: Loaded from flash at...` but on `ESP-WIF: Connected`.

### Analysis
As I was unable to reproduce on my mini-D1 I investigated with teh help of eddieb. He seems to be in a race-condition case where `SyslogAsync()` is called before Wifi is fully initialized (late Wifi connection). That leads to a failing Wifi.getHostByName() and Tasmota start using the default returned 0xFFFFFFFF as the syslog destination which is a broadcast address.
 1st lines of logs are lost for the same reason as Tasmota tries to send them while Wifi is not yet ready.
Similar problem occurs if one define a loghost to a name that cannot be resolved to an IP (like DNS is down or typo in the name - you can try `loghost dummy`). The name resolution is done once. If it fails, Tasmota register 255.255.255.255 as the destination address and broadcast the logs until the loghost hash change.

More tests lead me to the following conclusions:
1) There seems to be a root problem visible only at eddieb's due to Wifi unusual settle time. In that case SyslogAsync() is called before Wifi is fully enabled (and MqttLogAsync() too).

2) In SyslogAsync(), if the call to Wifi.hostByName() fails, Tasmota doesn't check the error code and starts to broadcast on 255.255.255.255 which is the default value return by Wifi.hostByName() in case of failure.

3) The return code of Wifi.hostByName() is not reliable as there is one code path where it will return OK (1) without a successfull resolution, letting Tasmota use 255.255.255.255 as the loghost IP address.
I falled into this code paths during my tests.
For some reasons, loghost resolution it's the only case where I've that. I didn't faced it with MqttHost, NtpServer or Ping.
Maybe because loghost resolution is most probably the 1st name resolution performed by Tasmota in a bootup sequence.


### Proposed fix

This PR address point 2) only by implementing a processing identical to the code a few lines below in the same function which disable the syslog for 10 minutes in case of loghost un-reachability. I have tested that with 2 use-cases:
- temporarily disabling my local DNS at Tasmota restart. After re-enabling the DNS, when the timer reaches 0, Tasmota request again name resolution. If that works, syslog is restored.
- entering a dummy loghost name which always fails. Same, after entering a correct loghost, when the timer reaches 0, Tasmota request again name resolution. If that works, syslog is restored.

For now, as the returned status from WIfi.hostByName() is not fully reliable I have implemented both a test on the return value and a comparison of the address with 255.255.255.255. This will prevent anyone to willingly specifying 255.255.255.255 as syslog broadcast destination. Allowing that would required point 3 to be solved.

I haven't (yet) addressed point 1) as  I'm not enough aware of Tasmota startup sequence to analyse this part.
But Happy to do so with some guidance.
I believe this is the major problem.

Point 3) should be escalated to Arduino Core team as an issue or PR. I would appreciate some guidance with that.

### Drawback

For now, this PR limited to point 2) will solve major cases of exceptional DNS unavailability at start or badly configured loghost.
For eddieb's case, it has the drawback of losing 10 minutes of syslog after a restart.
I feel that point 1) should be solved to reach completeness.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
