### PR TITLE
Add period char replacement for prometheus

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -57,6 +57,7 @@ String FormatMetricName(const char *metric) {  // cleanup spaces and uppercases 
   String formatted = metric;
   formatted.toLowerCase();
   formatted.replace(" ", "_");
+  formatted.replace(".", "_");
   return formatted;
 }
 


### PR DESCRIPTION
This was a problem for me when trying to get output from an SDS011 Nova
PM sensor. When parsed by the pometheus code it returns labels / metrics
like:

```
# TYPE tasmota_sensors_pm2.5_ gauge
tasmota_sensors_pm2.5_{sensor="sds0x1"} 2.2
```

 The error from prometheus was:
 ``` "append failed" err="invalid metric type \\"5_ gauge\\" ```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
