### PR TITLE
Remove superfluous "END":1 from telemetry in MCP230xx driver

### DIFF
--- a/tasmota/xsns_29_mcp230xx.ino
+++ b/tasmota/xsns_29_mcp230xx.ino
@@ -366,13 +366,15 @@ void MCP230xx_Show(bool json)
       uint16_t gpiototal = ((uint16_t)gpiob << 8) | gpio;
       ResponseAppend_P(PSTR(",\"MCP230_OUT\":{"));
       char stt[7];
+      bool first = true;
       for (uint32_t pinx = 0; pinx < mcp230xx_pincount; pinx++) {
         if (Settings.mcp230xx_config[pinx].pinmode >= 5) {
           sprintf(stt, ConvertNumTxt(((gpiototal>>pinx)&1), Settings.mcp230xx_config[pinx].pinmode));
-          ResponseAppend_P(PSTR("\"OUT_D%i\":\"%s\","), pinx, stt);
+          ResponseAppend_P(PSTR("%s\"OUT_D%i\":\"%s\""), (first) ? "" : ",", pinx, stt);
+          first = false;
         }
       }
-      ResponseAppend_P(PSTR("\"END\":1}"));
+      ResponseAppend_P(PSTR("}"));
     }
 #endif  // USE_MCP230xx_OUTPUT
     ResponseJsonEnd();
@@ -778,13 +780,15 @@ void MCP230xx_OutputTelemetry(void)
 
 void MCP230xx_Interrupt_Counter_Report(void) {
   ResponseTime_P(PSTR(",\"MCP230_INTTIMER\":{"));
+  bool first = true;
   for (uint32_t pinx = 0;pinx < mcp230xx_pincount;pinx++) {
     if (Settings.mcp230xx_config[pinx].int_count_en) { // Counting is enabled for this pin so we add to report
-      ResponseAppend_P(PSTR("\"INTCNT_D%i\":%i,"),pinx,mcp230xx_int_counter[pinx]);
+      ResponseAppend_P(PSTR("%s\"INTCNT_D%i\":%i,"), (first) ? "" : "?", pinx, mcp230xx_int_counter[pinx]);
+      first = false;
       mcp230xx_int_counter[pinx]=0;
     }
   }
-  ResponseAppend_P(PSTR("\"END\":1}}"));
+  ResponseAppend_P(PSTR("}}"));
   MqttPublishTeleSensor();
   mcp230xx_int_sec_counter = 0;
 }


### PR DESCRIPTION
## Description:

The telemetry messages from the MCP230xx driver contain an superfluous "END":1 to terminate lists of values. This PR removes those while still keeping comma's in the correct places.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
