### PR TITLE
Correct monitor speed for ESP8266 in VSC Terminal

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -80,7 +80,7 @@ build_flags                 = ${core.build_flags}
 
 board_build.f_cpu           = 80000000L
 board_build.f_flash         = 40000000L
-monitor_speed               = 74880
+monitor_speed               = 115200
 monitor_port                = COM5
 upload_speed                = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU


### PR DESCRIPTION
changed by accident in a other PR

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
