### PR TITLE
Mcp230xx output mode 2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,9 @@
 [build_envs]
 default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
-                tasmota
+;                tasmota
 ;                tasmota-ircustom
-                tasmota-minimal
+;                tasmota-minimal
 ;                tasmota-lite
 ;                tasmota-knx
 ;                tasmota-sensors

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,9 +12,9 @@
 [build_envs]
 default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
-;                tasmota
+                tasmota
 ;                tasmota-ircustom
-;                tasmota-minimal
+                tasmota-minimal
 ;                tasmota-lite
 ;                tasmota-knx
 ;                tasmota-sensors

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -553,9 +553,9 @@
     #define USE_APDS9960_PROXIMITY                 // Enable APDS9960 Proximity feature (>50 code)
     #define USE_APDS9960_COLOR                     // Enable APDS9960 Color feature (+0.8k code)
     #define USE_APDS9960_STARTMODE  0              // Default to enable Gesture mode
-//  #define USE_MCP230xx                           // [I2cDriver22] Enable MCP23008/MCP23017 - Must define I2C Address in #define USE_MCP230xx_ADDR below - range 0x20 - 0x27 (+4k7 code)
+//  #define USE_MCP230xx                           // [I2cDriver22] Enable MCP23008/MCP23017 - Must define I2C Address in #define USE_MCP230xx_ADDR below - range 0x20 - 0x27 (+5k1 code)
 //    #define USE_MCP230xx_ADDR 0x20               // Enable MCP23008/MCP23017 I2C Address to use (Must be within range 0x20 through 0x26 - set according to your wired setup)
-//    #define USE_MCP230xx_OUTPUT                  // Enable MCP23008/MCP23017 OUTPUT support through sensor29 commands (+1k5 code)
+//    #define USE_MCP230xx_OUTPUT                  // Enable MCP23008/MCP23017 OUTPUT support through sensor29 commands (+2k2 code)
 //    #define USE_MCP230xx_DISPLAYOUTPUT           // Enable MCP23008/MCP23017 to display state of OUTPUT pins on Web UI (+0k2 code)
 //  #define USE_PCA9685                            // [I2cDriver1] Enable PCA9685 I2C HW PWM Driver - Must define I2C Address in #define USE_PCA9685_ADDR below - range 0x40 - 0x47 (+1k4 code)
 //    #define USE_PCA9685_ADDR 0x40                // Enable PCA9685 I2C Address to use (Must be within range 0x40 through 0x47 - set according to your wired setup)

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -259,7 +259,7 @@ typedef union {
     uint16_t int_report_defer : 4;          // Number of interrupts to ignore until reporting (default 0, max 15)
     uint16_t int_count_en : 1;              // Enable interrupt counter for this pin
     uint16_t int_retain_flag : 1;           // Report if interrupt occured for pin in next teleperiod
-    uint16_t spare13 : 1;
+    uint16_t keep_output : 1;               // For output modes, preserve the value currently in the MCP230xx
     uint16_t spare14 : 1;
     uint16_t spare15 : 1;
   };


### PR DESCRIPTION
## Description:
This adds an additional mode when setoption0 is 0.
```sensor29 pin,5|6,2```
on a restart the current value is read from the MCP230xx ic and synced internally. 
The display of the sensor pin,? command when the pin is configured as an output has also been updated to display properly. Before it displayed values as if the pin was an input which made no sense.
Updated the code sizes in the comments of the config file.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
