### PR TITLE
Berry add wire read/write_bytes

### DIFF
--- a/lib/libesp32/Berry-0.1.10/src/port/be_wirelib.c
+++ b/lib/libesp32/Berry-0.1.10/src/port/be_wirelib.c
@@ -20,8 +20,6 @@ extern int b_wire_scan(bvm *vm);
 
 extern int b_wire_validwrite(bvm *vm);
 extern int b_wire_validread(bvm *vm);
-extern int b_wire_readbytes(bvm *vm);
-extern int b_wire_writebytes(bvm *vm);
 extern int b_wire_detect(bvm *vm);
 
 // #if !BE_USE_PRECOMPILED_OBJECT
@@ -40,13 +38,11 @@ void be_load_wirelib(bvm *vm)
         { "scan", b_wire_scan },
         { "write", b_wire_validwrite },
         { "read", b_wire_validread },
-        { "read_bytes", b_wire_validread },
-        { "write_bytes", b_wire_validread },
         { "detect", b_wire_detect },
         
         { NULL, NULL }
     };
-    be_regclass(vm, "Wire", members);
+    be_regclass(vm, "Wire_ntv", members);
 }
 #else
 /* @const_object_info_begin

--- a/tasmota/xdrv_52_3_berry_wire.ino
+++ b/tasmota/xdrv_52_3_berry_wire.ino
@@ -138,7 +138,7 @@ extern "C" {
     const void * buf;
     size_t len;
     TwoWire & myWire = getWire(vm);
-    if (top == 2 && (be_isint(vm, 2) || be_isstring(vm, 2))) {
+    if (top == 2 && (be_isint(vm, 2) || be_isstring(vm, 2) || be_isinstance(vm, 2))) {
       if (be_isint(vm, 2)) {
         int32_t value = be_toint(vm, 2);
         myWire.write(value);
@@ -223,46 +223,6 @@ extern "C" {
       }
       be_return(vm); // Return
     }
-    be_raise(vm, kTypeError, nullptr);
-  }
-
-  // Berry: `read_bytes(address:int, reg:int, size:int) -> bytes() or nil`
-  int32_t b_wire_readbytes(struct bvm *vm);
-  int32_t b_wire_readbytes(struct bvm *vm) {
-  //   int32_t top = be_top(vm); // Get the number of arguments
-  //   int32_t bus = getBus(vm);
-  //   if (top == 4 && be_isint(vm, 2) && be_isint(vm, 3) && be_isint(vm, 4)) {
-  //     uint8_t addr = be_toint(vm, 2);
-  //     uint8_t reg = be_toint(vm, 3);
-  //     uint8_t size = be_toint(vm, 4);
-  //     bool ok = I2cValidRead(addr, reg, size, bus);  // TODO
-  //     if (ok) {
-  //       be_pushint(vm, i2c_buffer);
-  //     } else {
-  //       be_pushnil(vm);
-  //     }
-  //     be_return(vm); // Return
-  //   }
-    be_raise(vm, kTypeError, nullptr);
-  }
-
-  // Berry: `write_bytes(address:int, reg:int, val:bytes()) -> bool or nil`
-  int32_t b_wire_writebytes(struct bvm *vm);
-  int32_t b_wire_writebytes(struct bvm *vm) {
-  //   int32_t top = be_top(vm); // Get the number of arguments
-  //   int32_t bus = getBus(vm);
-  //   if (top == 4 && be_isint(vm, 2) && be_isint(vm, 3) && be_isint(vm, 4)) {
-  //     uint8_t addr = be_toint(vm, 2);
-  //     uint8_t reg = be_toint(vm, 3);
-  //     uint8_t size = be_toint(vm, 4);
-  //     bool ok = I2cValidRead(addr, reg, size, bus);  // TODO
-  //     if (ok) {
-  //       be_pushint(vm, i2c_buffer);
-  //     } else {
-  //       be_pushnil(vm);
-  //     }
-  //     be_return(vm); // Return
-  //   }
     be_raise(vm, kTypeError, nullptr);
   }
 

--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -256,6 +256,30 @@ const char berry_prog[] =
 
   // Instantiate tasmota object
   "tasmota = Tasmota() "
+
+  // Wire class
+  "class Wire : Wire_ntv "
+    // read bytes as `bytes()` object
+    "def read_bytes(addr,reg,size) "
+      "self._begin_transmission(addr) "
+      "self._write(reg) "
+      "self._end_transmission(false) "
+      "self._request_from(addr,size) "
+      "var ret=bytes(size) "
+      "while (self._available()) "
+        "ret..self._read() "
+      "end "
+      "return ret "
+    "end "
+    // write bytes from `bytes` object
+    "def write_bytes(addr,reg,b) "
+      "self._begin_transmission(addr) "
+      "self._write(reg) "
+      "self._write(b) "
+      "self._end_transmission() "
+    "end "
+  "end "
+
   "wire = Wire(0) "
   "wire1 = wire "
   "wire2 = Wire(1) "


### PR DESCRIPTION
## Description:

Add `read_bytes` and `write_bytes` method to I2C `Wire` class

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
