### PR TITLE
Align IR_TIME_AVOID_DUPLICATE across irremote_full.ino and irremote.ino and convert to #define

### DIFF
--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -176,7 +176,10 @@ void IrSendInit(void)
 \*********************************************************************************************/
 
 const bool IR_RCV_SAVE_BUFFER = false;         // false = do not use buffer, true = use buffer for decoding
-const uint32_t IR_TIME_AVOID_DUPLICATE = 500;  // Milliseconds
+
+#ifndef IR_TIME_AVOID_DUPLICATE
+#define IR_TIME_AVOID_DUPLICATE = 50           // Milliseconds
+#endif  // IR_TIME_AVOID_DUPLICATE
 
 #include <IRrecv.h>
 

--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -178,7 +178,7 @@ void IrSendInit(void)
 const bool IR_RCV_SAVE_BUFFER = false;         // false = do not use buffer, true = use buffer for decoding
 
 #ifndef IR_TIME_AVOID_DUPLICATE
-#define IR_TIME_AVOID_DUPLICATE = 50           // Milliseconds
+#define IR_TIME_AVOID_DUPLICATE 50           // Milliseconds
 #endif  // IR_TIME_AVOID_DUPLICATE
 
 #include <IRrecv.h>

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -167,7 +167,10 @@ uint64_t reverseBitsInBytes64(uint64_t b) {
 \*********************************************************************************************/
 
 const bool IR_FULL_RCV_SAVE_BUFFER = false;         // false = do not use buffer, true = use buffer for decoding
-const uint32_t IR_TIME_AVOID_DUPLICATE = 50;  // Milliseconds
+
+#ifndef IR_TIME_AVOID_DUPLICATE
+#define IR_TIME_AVOID_DUPLICATE = 50           // Milliseconds
+#endif  // IR_TIME_AVOID_DUPLICATE
 
 // Below is from IRrecvDumpV2.ino
 // As this program is a special purpose capture/decoder, let us use a larger

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -169,7 +169,7 @@ uint64_t reverseBitsInBytes64(uint64_t b) {
 const bool IR_FULL_RCV_SAVE_BUFFER = false;         // false = do not use buffer, true = use buffer for decoding
 
 #ifndef IR_TIME_AVOID_DUPLICATE
-#define IR_TIME_AVOID_DUPLICATE = 50           // Milliseconds
+#define IR_TIME_AVOID_DUPLICATE 50           // Milliseconds
 #endif  // IR_TIME_AVOID_DUPLICATE
 
 // Below is from IRrecvDumpV2.ino


### PR DESCRIPTION
## Description:
Reduced IR_TIME_AVOID_DUPLICATE to 50ms in xdrv_05_irremote_full.ino, matching xdrv_05_irremote_full.ino which was fixed in PR #9969 but not here.
Converted IR_TIME_AVOID_DUPLICATE from const to #define to enable override in the config override file.

**Related issue (if applicable):** #9969

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
