### PR TITLE
Added support for another variant of the 6-digit TM1637 display module

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -332,7 +332,7 @@ typedef union {
   struct {
   uint8_t ilimode : 3;
   uint8_t Invert : 1;
-  uint8_t spare2 : 1;
+  uint8_t tm1637_variant : 1;
   uint8_t spare3 : 1;
   uint8_t spare4 : 1;
   uint8_t spare5 : 1;

--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -80,6 +80,7 @@ const uint8_t DISPLAY_LOG_ROWS = 32;           // Number of lines in display log
 #define D_CMND_DISP_SCROLLTEXT "ScrollText"
 #define D_CMND_DISP_ILIMODE "ILIMode"
 #define D_CMND_DISP_ILIINVERT "Invert"
+#define D_CMND_DISP_TMVARIANT "TMVariant"             // `DisplayTMVariant 0` = 6 digit, standard model; `DisplayTMVariant 1` = 6 digit, "jumbled" model
 
 
 enum XdspFunctions { FUNC_DISPLAY_INIT_DRIVER, FUNC_DISPLAY_INIT, FUNC_DISPLAY_EVERY_50_MSECOND, FUNC_DISPLAY_EVERY_SECOND,
@@ -110,7 +111,7 @@ const char kDisplayCommands[] PROGMEM = D_PRFX_DISPLAY "|"  // Prefix
   D_CMND_DISP_CLEAR "|" D_CMND_DISP_NUMBER "|" D_CMND_DISP_FLOAT "|" D_CMND_DISP_NUMBERNC "|" D_CMND_DISP_FLOATNC "|"
   D_CMND_DISP_RAW "|" D_CMND_DISP_LEVEL "|" D_CMND_DISP_SEVENSEG_TEXT "|" D_CMND_DISP_SEVENSEG_TEXTNC "|"
   D_CMND_DISP_SCROLLDELAY "|" D_CMND_DISP_CLOCK "|" D_CMND_DISP_TEXTNC "|"
-  D_CMND_DISP_SCROLLTEXT "|" D_CMND_DISP_ILIMODE "|" D_CMND_DISP_ILIINVERT
+  D_CMND_DISP_SCROLLTEXT "|" D_CMND_DISP_ILIMODE "|" D_CMND_DISP_ILIINVERT "|" D_CMND_DISP_TMVARIANT
   ;
 
 void (* const DisplayCommand[])(void) PROGMEM = {
@@ -123,7 +124,7 @@ void (* const DisplayCommand[])(void) PROGMEM = {
   &CmndDisplayClear, &CmndDisplayNumber, &CmndDisplayFloat, &CmndDisplayNumberNC, &CmndDisplayFloatNC,
   &CmndDisplayRaw, &CmndDisplayLevel, &CmndDisplaySevensegText, &CmndDisplaySevensegTextNC,
   &CmndDisplayScrollDelay, &CmndDisplayClock, &CmndDisplayTextNC,
-  &CmndDisplayScrollText, &CmndDisplayILIMOde ,  &CmndDisplayILIInvert
+  &CmndDisplayScrollText, &CmndDisplayILIMOde ,  &CmndDisplayILIInvert, &CmndDisplayTMVariant
 };
 
 char *dsp_str;
@@ -1891,6 +1892,17 @@ void CmndDisplayILIMOde(void)
   }
   ResponseCmndNumber(Settings.display_options.ilimode);
 }
+
+
+void CmndDisplayTMVariant(void)
+{
+  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 2)) {
+    Settings.display_options.tm1637_variant = XdrvMailbox.payload;
+    TasmotaGlobal.restart_flag = 2;
+  }
+  ResponseCmndNumber(Settings.display_options.tm1637_variant);
+}
+
 
 void CmndDisplayILIInvert(void)
 {


### PR DESCRIPTION
## Description:

This adds support for another variant of the 6-digit TM1637 display module, where the digit order is different in hardware.
Also, this fixes the issue reported here https://github.com/arendst/Tasmota/issues/11358#issuecomment-803649954


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
