### PR TITLE
Serial buffer size fix

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -256,7 +256,7 @@ void setup(void) {
   }
   Serial.begin(TasmotaGlobal.baudrate);
   Serial.println();
-//  Serial.setRxBufferSize(INPUT_BUFFER_SIZE);  // Default is 256 chars
+  Serial.setRxBufferSize(INPUT_BUFFER_SIZE);  // Default is 256 chars
   TasmotaGlobal.seriallog_level = LOG_LEVEL_INFO;  // Allow specific serial messages until config loaded
 
 #ifdef USE_UFILESYS


### PR DESCRIPTION
## Description:

This PR fixes an issue I have with v9.3.1 when I try to get data from my P1 smart meter and report them via MQTT. The smart meter sends datagrams via the serial line (a chunk of about 600-700 bytes once a second) and sometimes the data sent via MQTT looks like there are some bytes missing. I assumed that this is caused by a too small RX buffer of the serial line and when the buffer is full, data from the smart meter is dropped. The single like change here fixes that, at least on my system.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
