### PR TITLE
Ds18x20 arithm mean

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 [build_envs]
 default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
-                tasmota
+;                tasmota
 ;                tasmota-ircustom
 ;                tasmota-minimal
 ;                tasmota-lite
@@ -81,11 +81,11 @@ build_flags                 = ${core.build_flags}
 board_build.f_cpu           = 80000000L
 board_build.f_flash         = 40000000L
 monitor_speed               = 115200
-monitor_port                = COM3
+monitor_port                = COM5
 upload_speed                = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_resetmethod          = nodemcu
-upload_port                 = COM3
+upload_port                 = COM5
 extra_scripts               = ${scripts_defaults.extra_scripts}
 lib_ldf_mode                = chain
 lib_compat_mode             = strict

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 [build_envs]
 default_envs =
 ; *** Uncomment by deleting ";" in the line(s) below to select version(s)
-;                tasmota
+                tasmota
 ;                tasmota-ircustom
 ;                tasmota-minimal
 ;                tasmota-lite
@@ -81,11 +81,11 @@ build_flags                 = ${core.build_flags}
 board_build.f_cpu           = 80000000L
 board_build.f_flash         = 40000000L
 monitor_speed               = 115200
-monitor_port                = COM5
+monitor_port                = COM3
 upload_speed                = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_resetmethod          = nodemcu
-upload_port                 = COM5
+upload_port                 = COM3
 extra_scripts               = ${scripts_defaults.extra_scripts}
 lib_ldf_mode                = chain
 lib_compat_mode             = strict

--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -26,12 +26,11 @@
 #define XSNS_05              5
 
 //#define USE_DS18x20_RECONFIGURE    // When sensor is lost keep retrying or re-configure
-//#define DS18x20_USE_ID_AS_NAME     // Use last 3 bytes for naming of sensors
+//#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
 //#define W1_PARASITE_POWER          // Use only 2 wires to connect sensor (no VCC)
 #ifndef W1_PARASITE_POWER
 #define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
 #endif
-#define DS18x20_ADD_DS2413         // add code for 1wire DS2312 2 bit IOport
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
 #define DS1822_CHIPID        0x22  // +/-2C 12-bit
@@ -60,7 +59,7 @@ struct DS18X20STRUCT {
   uint8_t numread;
   float   temp_sum;
 #endif
-  float   temperature;
+  float temperature;
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
 struct {
@@ -361,7 +360,7 @@ void Ds18x20Convert(void) {
 
 bool Ds18x20Read(uint8_t sensor) {
   uint8_t data[9];
-  int8_t  sign = 1;
+  int8_t sign = 1;
   float   temp;
 
   uint8_t index = ds18x20_sensor[sensor].index;

--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -29,7 +29,7 @@
 //#define DS18x20_USE_ID_AS_NAME     // Use last 3 bytes for naming of sensors
 //#define W1_PARASITE_POWER          // Use only 2 wires to connect sensor (no VCC)
 #ifndef W1_PARASITE_POWER
-//#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
+#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
 #endif
 #define DS18x20_ADD_DS2413         // add code for 1wire DS2312 2 bit IOport
 

--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -29,7 +29,7 @@
 //#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
 //#define W1_PARASITE_POWER          // Use only 2 wires to connect sensor (no VCC)
 #ifndef W1_PARASITE_POWER
-#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
+//#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
 #endif
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
@@ -56,7 +56,7 @@ struct DS18X20STRUCT {
   uint8_t index;
   uint8_t valid;
 #ifdef DS18x20_ARITH_MEAN
-  uint8_t numread;
+  uint16_t numread;
   float   temp_sum;
 #endif
   float temperature;

--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -29,7 +29,7 @@
 //#define DS18x20_USE_ID_AS_NAME     // Use last 3 bytes for naming of sensors
 //#define W1_PARASITE_POWER          // Use only 2 wires to connect sensor (no VCC)
 #ifndef W1_PARASITE_POWER
-#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
+//#define DS18x20_ARITH_MEAN         // non parasite power: compute arithmetic mean
 #endif
 #define DS18x20_ADD_DS2413         // add code for 1wire DS2312 2 bit IOport
 


### PR DESCRIPTION
## Description:

if DSx20 sensors are powered by VCC, the temperature is read every 2 seconds and updated mostly in the WEB_SERVER. MQTT gets only a new value every telemetry period. An arithmetic mean can be used reduce noise variations and increase the resolution.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

Please ignore my changes to platformio.ini

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
