### PR TITLE
Berry fixes

### DIFF
--- a/lib/default/Ext-printf/src/ext_printf.cpp
+++ b/lib/default/Ext-printf/src/ext_printf.cpp
@@ -213,7 +213,7 @@ char * copyStr(const char * str) {
 }
 
 const char ext_invalid_mem[] PROGMEM = "<--INVALID-->";
-const uint32_t min_valid_ptr = 0x3FF00000;    // addresses below this line are invalid
+const uint32_t min_valid_ptr = 0x3F000000;    // addresses below this line are invalid
 
 int32_t ext_vsnprintf_P(char * buf, size_t buf_len, const char * fmt_P, va_list va) {
   va_list va_cpy;

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -75,6 +75,7 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top == 2 && be_isstring(vm, 2)) {  // only 1 argument of type string accepted
       const char * command = be_tostring(vm, 2);
+      be_pop(vm, 2);    // clear the stack before calling, because of re-entrant call to Berry in a Rule
       ExecuteCommand(command, SRC_BERRY);
       be_pushstring(vm, TasmotaGlobal.mqtt_data);
       be_return(vm); // Return
@@ -294,7 +295,7 @@ extern "C" {
 
         if (data_present) {
           // see ResponseLightState()
-          map_insert_bool(vm, "power", bitRead(TasmotaGlobal.power, light_num));
+          map_insert_bool(vm, "power", bitRead(TasmotaGlobal.power, light_num + Light.device - 1));
           map_insert_int(vm, "bri", bri);
 
           if (subtype >= LST_RGB) {
@@ -364,9 +365,9 @@ extern "C" {
       // power
       if (map_find(vm, "power")) {
         bool power = be_tobool(vm, -1);
-        bool current_power = bitRead(TasmotaGlobal.power, idx);
+        bool current_power = bitRead(TasmotaGlobal.power, idx + Light.device - 1);
         if (power != current_power) {   // only send command if needed
-          ExecuteCommandPower(Light.device + idx, (power) ? POWER_ON : POWER_OFF, SRC_BERRY);
+          ExecuteCommandPower(idx + Light.device, (power) ? POWER_ON : POWER_OFF, SRC_BERRY);
         }
       }
       be_pop(vm, 1);


### PR DESCRIPTION
## Description:

Fixes to Berry
- fix set\_light/get\_light when there are relays
- fix warning when using `tasmota.cmd`
- fix wrong address safeguard for ESP32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
