### PR TITLE
Use Berry as default

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -908,6 +908,8 @@
 //#define USE_IBEACON_ESP32
 //#define USE_WEBCAM                               // Add support for webcam
 
+#define USE_BERRY                                // Enable Berry scripting language
+
 #define USE_CSE7761                              // Add support for CSE7761 Energy monitor as used in Sonoff Dual R3
 
 #endif  // ESP32

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -37,6 +37,7 @@
 #define USE_SDCARD
   #define GUI_TRASH_FILE
 #define USE_SPI
+#undef USE_BERRY                                 // Disable Berry scripting language
 #undef  USE_MI_ESP32                             // (ESP32 only) Disable support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
 #endif  // FIRMWARE_WEBCAM
 
@@ -150,6 +151,7 @@
 #define USE_SDCARD
   #define GUI_TRASH_FILE
 #define USE_ADC
+#undef USE_BERRY                                 // Disable Berry scripting language
 #define USE_BLE_ESP32                            // Enable new BLE driver
 #define USE_MI_ESP32                             // (ESP32 only) Add support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
 #endif  // FIRMWARE_BLUETOOTH

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -60,8 +60,9 @@
 #define USE_SDCARD
   #define GUI_TRASH_FILE
 
-#define USE_BERRY                                // Enable Berry scripting language
+#ifdef USE_BERRY                                 // Berry scripting language
   #define USE_BERRY_PSRAM                        // Allocate Berry memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
+#endif
 
 #define USE_ADC
 #define USE_SPI
@@ -93,8 +94,9 @@
 #define USE_SDCARD
   #define GUI_TRASH_FILE
 
-#define USE_BERRY                                // Enable Berry scripting language
+#ifdef USE_BERRY                                 // Berry scripting language
   #define USE_BERRY_PSRAM                        // Allocate Berry memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
+#endif
 
 #define USE_I2C
   #define USE_BMA423


### PR DESCRIPTION
for Tasmota32. Disable in build Webcam and Bluetooth.

@s-hadinger Big Thx for this awesome enhancement / work!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
