### PR TITLE
BLE MAC address can now include type, add BLEDetails4 for aliased only.

### DIFF
--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -336,7 +336,7 @@ struct mi_sensor_t{
 };
 
 struct MAC_t {
-  uint8_t buf[6];
+  uint8_t buf[7];
 };
 
 std::vector<mi_sensor_t> MIBLEsensors;
@@ -2082,7 +2082,7 @@ void CmndMi32Period(void) {
 }
 
 int findSlot(char *addrOrAlias){
-  uint8_t mac[6];
+  uint8_t mac[7];
   int res = BLE_ESP32::getAddr(mac, addrOrAlias);
   if (!res) return -1;
 
@@ -2330,7 +2330,7 @@ void CmndMi32Keys(void){
           break;
         }
 
-        uint8_t addr[6];
+        uint8_t addr[7];
         char *mac = p;
         int addrres = BLE_ESP32::getAddr(addr, p);
         if (!addrres){


### PR DESCRIPTION

## Description:
BLE_ESP32 + iBeacon
A minor PR based on various requests over the last month or so.

1/ Extends MAC address storage to 7 bytes, last byte now type.MAC may now be 112233445566 or 112233445566/n n=0..3 indicating type.
To CONNECT to a random address, you must specify the address type.
2/ Adds BLEDetails4 - details for aliased macs only.
3/ Adds more command explanation in the top.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
