### PR TITLE
Report serial buffer overruns with LOG_LEVEL_ERROR

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1549,7 +1549,7 @@ void SerialInput(void)
       TasmotaGlobal.serial_in_buffer[TasmotaGlobal.serial_in_byte_counter] = 0;                // Serial data completed
       TasmotaGlobal.seriallog_level = (Settings.seriallog_level < LOG_LEVEL_INFO) ? (uint8_t)LOG_LEVEL_INFO : Settings.seriallog_level;
       if (serial_buffer_overrun) {
-        AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_COMMAND "Serial buffer overrun"));
+        AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_COMMAND "Serial buffer overrun, try the SerialBuffer command to fix this"));
       } else {
         AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_COMMAND "%s"), TasmotaGlobal.serial_in_buffer);
         ExecuteCommand(TasmotaGlobal.serial_in_buffer, SRC_SERIAL);
@@ -1566,7 +1566,7 @@ void SerialInput(void)
     bool assume_json = (!Settings.flag.mqtt_serial_raw && (TasmotaGlobal.serial_in_buffer[0] == '{'));
 
     if (serial_buffer_overrun) {
-      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_COMMAND "Serial buffer overrun"));
+      AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_COMMAND "Serial buffer overrun, try the SerialBuffer command to fix this"));
     }
 
     Response_P(PSTR("{\"" D_JSON_SERIALRECEIVED "\":"));


### PR DESCRIPTION
## Description:

Should a serial buffer overrun be detected, it will be logged with LOG_LEVEL_ERROR and a hint how to fix this using the SerialBuffer command is shown as well.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
