### PR TITLE
always add teleinfo values in telemetry

### DIFF
--- a/tasmota/xnrg_15_teleinfo.ino
+++ b/tasmota/xnrg_15_teleinfo.ino
@@ -594,9 +594,7 @@ void TInfoShow(bool json)
         }
 
         // add teleinfo full frame only if no teleinfo raw data setup
-        if (!Settings.flag4.teleinfo_rawdata) {
-            ResponseAppendTInfo(',');
-        }
+        ResponseAppendTInfo(',');
 
 
 #ifdef USE_WEBSERVER

--- a/tasmota/xnrg_15_teleinfo.ino
+++ b/tasmota/xnrg_15_teleinfo.ino
@@ -593,7 +593,7 @@ void TInfoShow(bool json)
             ResponseAppend_P(PSTR(",\"Load\":%d"),(int) ((Energy.current[0]*100.0f) / isousc));
         }
 
-        // add teleinfo full frame only if no teleinfo raw data setup
+        // add teleinfo full frame 
         ResponseAppendTInfo(',');
 
 


### PR DESCRIPTION
always add teleinfo values in telemetry, whatever rawdata is selected or not

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
