### PR TITLE
Allows Berry to build without USE_LIGHT

### DIFF
--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -243,6 +243,7 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+#ifdef USE_LIGHT
   // push the light status object on the vm stack
   void push_getlight(bvm *vm, uint32_t light_num) {
     bool data_present = false;      // do we have relevant data
@@ -466,6 +467,10 @@ extern "C" {
     }
     be_raise(vm, kTypeError, nullptr);
   }  // TODO
+#else // #ifdef USE_LIGHT
+  int32_t l_getlight(bvm *vm) { be_raise(vm, "feature_error", "LIGHT is not enabled, use '#define USE_LIGHT'"); }
+  int32_t l_setlight(struct bvm *vm) __attribute__ ((weak, alias ("l_getlight")));
+#endif // #ifdef USE_LIGHT
 
   // get power
   int32_t l_getpower(bvm *vm);


### PR DESCRIPTION
## Description:

Allows Berry to build even if USE_LIGHT is not enabled
If using a light function in that case, it would then raise a Berry exception "feature error"

@s-hadinger 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
