### PR TITLE
Add lib/libesp32_epdiy in Platformio

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -122,6 +122,8 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
                               lib/libesp32
 ; *** uncomment the following line if you want to use Bluetooth or Apple Homekit in a Tasmota32 build
 ;                              lib/libesp32_div
+; *** uncomment the following line if you want to use Epaper driver epidy in your Tasmota32 build
+;                              lib/libesp32_epdiy
 
 [core32]
 ; Activate Stage Core32 by removing ";" in next 3 lines, if you want to override the standard core32

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -66,7 +66,7 @@ lib_extra_dirs              =
 ; uncomment the following line if you need Bluetooth, Homekit or TTGO Watch libraries in your Tasmota32 build
 ;                              lib/libesp32_div
 ; uncomment the following line if you want to use Epaper driver epidy in your Tasmota32 build
-;                              libesp32_epdiy
+;                              lib/libesp32_epdiy
                               lib/lib_basic
                               lib/lib_i2c
                               lib/lib_display

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -65,6 +65,8 @@ lib_extra_dirs              =
                               lib/libesp32
 ; uncomment the following line if you need Bluetooth, Homekit or TTGO Watch libraries in your Tasmota32 build
 ;                              lib/libesp32_div
+; uncomment the following line if you want to use Epaper driver epidy in your Tasmota32 build
+;                              libesp32_epdiy
                               lib/lib_basic
                               lib/lib_i2c
                               lib/lib_display


### PR DESCRIPTION
commented for using the Epaper ESP32 driver epidy libs

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
