### PR TITLE
Berry fix crash when no attributes

### DIFF
--- a/lib/libesp32/Berry-0.1.10/src/be_debuglib.c
+++ b/lib/libesp32/Berry-0.1.10/src/be_debuglib.c
@@ -40,7 +40,9 @@ static void dump_module(bmodule *module)
 
 static void dump_class(bclass *class)
 {
-    dump_map(class->members);
+    if (class->members) {
+        dump_map(class->members);
+    }
 }
 
 static void dump_instanse(binstance *ins)


### PR DESCRIPTION
## Description:

Fix crash when `import debug debug.attrdump(obj)` if `obj` has zero attribute.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
