### PR TITLE
Halleffect not for ESP32-S2

### DIFF
--- a/tasmota/xsns_87_esp32_halleffect.ino
+++ b/tasmota/xsns_87_esp32_halleffect.ino
@@ -18,6 +18,7 @@
 */
 
 #ifdef ESP32
+#if CONFIG_IDF_TARGET_ESP32
 #ifdef USE_HALLEFFECT
 /*********************************************************************************************\
  * ESP32 internal Hall Effect sensor connected to both GPIO36 and GPIO39
@@ -96,4 +97,5 @@ bool Xsns87(uint8_t function) {
 }
 
 #endif  // USE_HALLEFFECT
+#endif  // CONFIG_IDF_TARGET_ESP32
 #endif  // ESP32


### PR DESCRIPTION
without compile for ESP32-S2 fails

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
