### PR TITLE
Update to iBeacon

### DIFF
--- a/tasmota/xsns_52_esp32_ibeacon_ble.ino
+++ b/tasmota/xsns_52_esp32_ibeacon_ble.ino
@@ -337,7 +337,7 @@ uint32_t ibeacon_add(struct IBEACON *ib) {
   if (!strncmp(ib->MAC,"FFFF",4) || strncmp(ib->FACID,"00000000",8)) {
     for (uint32_t cnt=0;cnt<MAX_IBEACONS;cnt++) {
       if (ibeacons[cnt].FLAGS) {
-        if (!strncmp_P(ib->UID,PSTR("00000000000000000000000000000000"),32)) {
+//        if (!strncmp_P(ib->UID,PSTR("00000000000000000000000000000000"),32)) {
           if (!strncmp(ibeacons[cnt].MAC,ib->MAC,12)) {
             // exists
             strncpy(ibeacons[cnt].NAME,ib->NAME,sizeof(ibeacons[cnt].NAME));
@@ -350,7 +350,7 @@ uint32_t ibeacon_add(struct IBEACON *ib) {
             ibeacons[cnt].count++;
             return 2;
           }
-        } else {
+/*        } else {
           if (!strncmp(ibeacons[cnt].UID,ib->UID,32)) {
             // exists
             strncpy(ibeacons[cnt].NAME,ib->NAME,sizeof(ibeacons[cnt].NAME));
@@ -363,7 +363,7 @@ uint32_t ibeacon_add(struct IBEACON *ib) {
             ibeacons[cnt].count++;
             return 2;
           }
-        }
+        }*/
       }
     }
     for (uint32_t cnt=0;cnt<MAX_IBEACONS;cnt++) {


### PR DESCRIPTION
 to use only MAC to recognise different beacons - this brings it into line with common use.

A further update would be nice to display major & minor in the web ui, not included here.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
