### PR TITLE
remove endian-swap on major & minor for iBeacon - …

### DIFF
--- a/tasmota/xsns_52_esp32_ibeacon_ble.ino
+++ b/tasmota/xsns_52_esp32_ibeacon_ble.ino
@@ -233,8 +233,10 @@ int advertismentCallback(BLE_ESP32::ble_advertisment_t *pStruct)
       memcpy(UUID,oBeacon.getProximityUUID().getNative()->u128.value,16);
       ESP32BLE_ReverseStr(UUID,16);
 
-      uint16_t    Major = ENDIAN_CHANGE_U16(oBeacon.getMajor());
-      uint16_t    Minor = ENDIAN_CHANGE_U16(oBeacon.getMinor());
+//      uint16_t    Major = ENDIAN_CHANGE_U16(oBeacon.getMajor());
+//      uint16_t    Minor = ENDIAN_CHANGE_U16(oBeacon.getMinor());
+      uint16_t    Major = oBeacon.getMajor();
+      uint16_t    Minor = oBeacon.getMinor();
       uint8_t     PWR   = oBeacon.getSignalPower();
 
       DumpHex((const unsigned char*)&UUID,16,ib.UID);


### PR DESCRIPTION
in theory to match HM10 implementation?

## Description:
We had a report that major and minor are byte-swapped with reference to the HM10 implementation.
This REMOVES a byte swap of major and minor.
Note: Not many people have reported on iBeacon use, so this is low-impact; hopefully.
The only other person known to use iBeacon is aware of the up-coming change.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
https://github.com/arendst/Tasmota/issues/10990

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
