### PR TITLE
Add command EnergyConfig

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -43,7 +43,7 @@
 
 enum EnergyCommands {
   CMND_POWERCAL, CMND_VOLTAGECAL, CMND_CURRENTCAL, CMND_FREQUENCYCAL,
-  CMND_POWERSET, CMND_VOLTAGESET, CMND_CURRENTSET, CMND_FREQUENCYSET, CMND_MODULEADDRESS };
+  CMND_POWERSET, CMND_VOLTAGESET, CMND_CURRENTSET, CMND_FREQUENCYSET, CMND_MODULEADDRESS, CMND_NRGCONFIG };
 
 const char kEnergyCommands[] PROGMEM = "|"  // No prefix
   D_CMND_POWERCAL "|" D_CMND_VOLTAGECAL "|" D_CMND_CURRENTCAL "|" D_CMND_FREQUENCYCAL "|"
@@ -56,7 +56,7 @@ const char kEnergyCommands[] PROGMEM = "|"  // No prefix
   D_CMND_SAFEPOWER "|" D_CMND_SAFEPOWERHOLD "|"  D_CMND_SAFEPOWERWINDOW "|"
 #endif  // USE_ENERGY_POWER_LIMIT
 #endif  // USE_ENERGY_MARGIN_DETECTION
-  D_CMND_ENERGYRESET "|" D_CMND_TARIFF ;
+  D_CMND_ENERGYRESET "|" D_CMND_TARIFF "|EnergyConfig";
 
 void (* const EnergyCommand[])(void) PROGMEM = {
   &CmndPowerCal, &CmndVoltageCal, &CmndCurrentCal, &CmndFrequencyCal,
@@ -69,7 +69,7 @@ void (* const EnergyCommand[])(void) PROGMEM = {
   &CmndSafePower, &CmndSafePowerHold, &CmndSafePowerWindow,
 #endif  // USE_ENERGY_POWER_LIMIT
 #endif  // USE_ENERGY_MARGIN_DETECTION
-  &CmndEnergyReset, &CmndTariff };
+  &CmndEnergyReset, &CmndTariff, &CmndEnergyConfig };
 
 const char kEnergyPhases[] PROGMEM = "|%s / %s|%s / %s / %s||[%s,%s]|[%s,%s,%s]";
 
@@ -758,6 +758,14 @@ void CmndModuleAddress(void) {
     if (XnrgCall(FUNC_COMMAND)) {  // Module address
       ResponseCmndDone();
     }
+  }
+}
+
+void CmndEnergyConfig(void) {
+  AddLog_P(LOG_LEVEL_DEBUG, PSTR("NRG: xdrv_03 index:%d"), XdrvMailbox.index);
+  Energy.command_code = CMND_NRGCONFIG;
+  if (XnrgCall(FUNC_COMMAND)) {
+    ResponseCmndDone();
   }
 }
 

--- a/tasmota/xnrg_20_dummy.ino
+++ b/tasmota/xnrg_20_dummy.ino
@@ -99,6 +99,9 @@ bool NrgDummyCommand(void) {
       }
     }
   }
+  else if (CMND_NRGCONFIG == Energy.command_code) {
+    AddLog_P(LOG_LEVEL_DEBUG, PSTR("NRG: Config payload:%d, data:'%s'"), XdrvMailbox.payload, XdrvMailbox.data ? XdrvMailbox.data : "null" );
+  }
   else serviced = false;  // Unknown command
 
   return serviced;


### PR DESCRIPTION
## Description:

Proposal to add command `EnergyConfig` which allows xdrv_03 to pass the command to the lower level xnrg_xx driver
This is a proposal regarding the discussion I have with Charles Hallard regarding xdrv_15_teleinfo.
I tried to add the index in a similar way to `SensorXX` but didn't find a simple way.

Tested with xnrg_20_dummy

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
