### PR TITLE
decode Units in DT_VARS

### DIFF
--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -695,6 +695,7 @@ void DisplayText(void)
               cp = get_string(bbuff, sizeof(bbuff), cp);
               char unit[4];
               cp = get_string(unit, sizeof(unit), cp);
+	      decode_te(unit);
               define_dt_var(num, gxp, gyp, textbcol, textfcol, font, textsize, txlen, time, dp, bbuff, unit);
             }
           }


### PR DESCRIPTION
## Description:
Adds decoding of special characters from GFX e.g. (e.g. degree (~f8) Celsius) when USE_DT_VARS is defined. 
Known limitation: "~f8" takes 3 chars out of max 4 :-( , but still good for degree Celsius to display as "°C"

I have tested the change only with the two displays I have, SSD1306 (0.96") and ILI9341 (LoLin 2.4") both do work well. 

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
