### PR TITLE
Use Arduino core 2..0..0.pre for S2

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -175,7 +175,7 @@ build_flags                 = ${common32.build_flags}
 extends                     = env:tasmota32_base
 board                       = esp32s2
 board_build.flash_mode      = qio
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/s2-1.0.5-rc6/esp32-s2-1.0.5-rc6.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/esp32-2.0.0-pre/esp32-2.0.0-pre.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}


### PR DESCRIPTION
it is based on IDF4.4 and Arduino branch master commit https://github.com/espressif/arduino-esp32/commit/371f382db7dd36c470bb2669b222adf0a497600d

Fixes in core for S2

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
