### PR TITLE
add partial and full refresh

### DIFF
--- a/lib/libesp32_epdiy/src/epd4in7.cpp
+++ b/lib/libesp32_epdiy/src/epd4in7.cpp
@@ -44,9 +44,13 @@
 
 extern uint8_t *buffer;
 
-int temperature;
+int temperature = 25;
 
 EpdiyHighlevelState hl;
+
+uint16_t Epd47::GetColorFromIndex(uint8_t index) {
+  return index & 0xf;
+}
 
 Epd47::Epd47(int16_t dwidth, int16_t dheight) :  Renderer(dwidth, dheight) {
   width = dwidth;
@@ -63,10 +67,26 @@ int32_t Epd47::Init(void) {
 
 void Epd47::DisplayInit(int8_t p, int8_t size, int8_t rot, int8_t font) {
 
-  if (p ==  DISPLAY_INIT_FULL) {
+
+  if (p ==  DISPLAY_INIT_MODE) {
     epd_poweron();
     epd_clear();
     epd_poweroff();
+  }
+  if (p ==  DISPLAY_INIT_FULL) {
+    memset(hl.back_fb, 0xff, width * height / 2);
+    epd_poweron();
+    epd_clear();
+    epd_hl_update_screen(&hl, MODE_GC16, temperature);
+    epd_poweroff();
+    return;
+  }
+  if (p ==  DISPLAY_INIT_PARTIAL) {
+    memset(hl.back_fb, 0xff, width * height / 2);
+    epd_poweron();
+    epd_hl_update_screen(&hl, MODE_GL16, temperature);
+    epd_poweroff();
+    return;
   }
   setRotation(rot);
   setTextWrap(false);
@@ -94,6 +114,7 @@ void Epd47::fillScreen(uint16_t color) {
 void Epd47::drawPixel(int16_t x, int16_t y, uint16_t color) {
 uint16_t xp = x;
 uint16_t yp = y;
+uint8_t *buf_ptr;
 
   switch (getRotation()) {
     case 1:
@@ -107,14 +128,13 @@ uint16_t yp = y;
     case 3:
       _swap(xp, yp);
       yp = height - yp - 1;
+
       break;
   }
 
-    uint32_t maxsize = width * height / 2;
-    uint8_t *buf_ptr = &buffer[yp * width / 2 + xp / 2];
-    if ((uint32_t)buf_ptr >= (uint32_t)buffer + maxsize) {
-      return;
-    }
+  if (xp >= width) return;
+  if (yp >= height) return;
+  buf_ptr = &buffer[yp * width / 2 + xp / 2];
 
     if (xp % 2) {
         *buf_ptr = (*buf_ptr & 0x0F) | (color << 4);

--- a/lib/libesp32_epdiy/src/epd4in7.h
+++ b/lib/libesp32_epdiy/src/epd4in7.h
@@ -51,6 +51,7 @@ public:
     void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
     void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
     void pushColors(uint16_t *data, uint16_t len, boolean first);
+    uint16_t GetColorFromIndex(uint8_t index);
 private:
   uint16_t width;
   uint16_t height;

--- a/tasmota/xdsp_16_esp32_epaper_47.ino
+++ b/tasmota/xdsp_16_esp32_epaper_47.ino
@@ -53,7 +53,7 @@ void EpdInitDriver47(void) {
     epd47->Init();
 
     renderer = epd47;
-    renderer->DisplayInit(DISPLAY_INIT_FULL, Settings.display_size, Settings.display_rotate, Settings.display_font);
+    renderer->DisplayInit(DISPLAY_INIT_MODE, Settings.display_size, Settings.display_rotate, Settings.display_font);
     renderer->setTextColor(EPD47_BLACK, EPD47_WHITE);
 
 #ifdef SHOW_SPLASH


### PR DESCRIPTION
## Description:

add partial and full refresh to lilygo e-paper 4.7

@arendst 
announcing a universal display driver that works with descriptors and may replace
nearly all renderer display drivers (except RA8876 and LILYGO EPD)
Display is defined via a textual descriptor (<512 bytes)
it may be provided by a scripter section >d or by a "dspdesc.txt" file on file system.
(on 1 m devices without scripts may be it could reside in rule buffer 3?)
Display parameters may be edited on the fly and restarted without reboot.
a new display may be easily added by a new descriptor.
will support i2c and 3 or 4 wire spi on all displays
it will be display driver 17 and may coexist with all existing drivers.

sample descriptor
\>d
; name,xs,ys,bpp,interface, spi_nr cs, sclk,mosi,dc, bp ,reset,miso,spi_speed
:H
ILI9341,240,320,16,SPI,2,\*,\*,\*,\*,\*,\*,\*,40000000
; splash settings, font, size, fgcol, bgcol, x,y
:S
2,1,1,0,40,20
; initialyze
:I
EF,3,03,80,02
CF,3,00,C1,30
ED,4,64,03,12,81
E8,3,85,00,78
CB,5,39,2C,00,34,02
F7,1,20
EA,2,00,00
C0,1,23
C1,1,10
C5,2,3e,28
C7,1,86
36,1,48
37,1,00
3A,1,55
B1,2,00,18
B6,3,08,82,27
F2,1,00
26,1,01
E0,0F,0F,31,2B,0C,0E,08,4E,F1,37,07,10,03,0E,09,00
E1,0F,00,0E,14,03,11,07,31,C1,48,08,0F,0C,31,36,0F
11,80
29,80    
; off
:o
28
; on
:O
29
; set adress window
:A
2A,2B,2C
; rotation
:0
48
:1
28
:2
88
:3
E8






## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
