### PR TITLE
Berry driver.add_cmd()

### DIFF
--- a/lib/libesp32/Berry-0.1.10/src/port/be_driverlib.c
+++ b/lib/libesp32/Berry-0.1.10/src/port/be_driverlib.c
@@ -5,6 +5,77 @@
  * 
  *******************************************************************/
 #include "be_object.h"
+#include "be_string.h"
+#include "be_gc.h"
+
+extern int d_getTasmotaGlob(bvm *vm);
+
+
+/********************************************************************
+  "class Driver2 : Driver "
+    "def add_cmd(c, f) "
+      "var tasmota = self.get_tasmota() "
+      "tasmota.add_cmd(c, / cmd, idx, payload, payload_json -> f(self, cmd, idx, payload, payload_json)) "
+    "end "
+  "end "
+  "Driver = Driver2 "
+********************************************************************/
+/********************************************************************
+** Solidified function: add_cmd
+********************************************************************/
+
+/********** Solidified proto: add_cmd_0 */
+static const bupvaldesc add_cmd_0_upvals[2] = {
+  be_local_const_upval(1, 2),
+  be_local_const_upval(1, 0),
+};
+
+be_define_local_const_str(add_cmd_0_str_name, "add_cmd_0", 607256038, 0, 8, 0);
+be_define_local_const_str(add_cmd_0_str_source, "input", -103256197, 0, 5, 0);
+
+static const uint32_t add_cmd_0_code[8] = {
+  0x68100000,  //  0000  GETUPV	R4	U0
+  0x68140001,  //  0001  GETUPV	R5	U1
+  0x5C180000,  //  0002  MOVE	R6	R0
+  0x5C1C0200,  //  0003  MOVE	R7	R1
+  0x5C200400,  //  0004  MOVE	R8	R2
+  0x5C240600,  //  0005  MOVE	R9	R3
+  0x7C100A00,  //  0006  CALL	R4	5
+  0x80040800,  //  0007  RET	1	R4
+};
+
+be_define_local_proto(add_cmd_0, 10, 4, 0, 0, 1);
+
+/********** Solidified proto: add_cmd */
+static const bproto *add_cmd_subproto[1] = {
+  &add_cmd_0_proto,
+};
+
+be_define_local_const_str(add_cmd_str_name, "add_cmd", -933336417, 0, 7, 0);
+be_define_local_const_str(add_cmd_str_source, "input", -103256197, 0, 5, 0);
+be_define_local_const_str(add_cmd_str_0, "get_tasmota", 334356779, 0, 11, 0);
+be_define_local_const_str(add_cmd_str_1, "add_cmd", -933336417, 0, 7, 0);
+
+static const bvalue add_cmd_ktab[2] = {
+  { { .s=be_local_const_str(add_cmd_str_0) }, BE_STRING},
+  { { .s=be_local_const_str(add_cmd_str_1) }, BE_STRING},
+};
+
+static const uint32_t add_cmd_code[8] = {
+  0x8C0C0100,  //  0000  GETMET	R3	R0	R256
+  0x7C0C0200,  //  0001  CALL	R3	1
+  0x8C100701,  //  0002  GETMET	R4	R3	R257
+  0x5C180200,  //  0003  MOVE	R6	R1
+  0x841C0000,  //  0004  CLOSURE	R7	P0
+  0x7C100600,  //  0005  CALL	R4	3
+  0xA0000000,  //  0006  CLOSE	0
+  0x80000000,  //  0007  RET	0	R0
+};
+
+be_define_local_proto(add_cmd, 8, 3, 1, 1, 0);
+be_define_local_closure(add_cmd);
+
+/*******************************************************************/
 
 // #if !BE_USE_PRECOMPILED_OBJECT
 #if 1           // TODO we will do pre-compiled later
@@ -19,6 +90,11 @@ void be_load_driverlib(bvm *vm)
         { "web_sensor", NULL },
         { "json_append", NULL },
         { "button_pressed", NULL },
+
+        { "get_tasmota", d_getTasmotaGlob },
+
+        { NULL, (bntvfunc) BE_CLOSURE }, /* mark section for berry closures */
+        { "add_cmd", (bntvfunc) &add_cmd_closure },
         
         { NULL, NULL }
     };

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -361,4 +361,21 @@ void berry_log(const char * berry_buf) {
 }
 
 
+/*********************************************************************************************\
+ * Helper function for `Driver` class
+ * 
+ * get_tasmota() -> tasmota instance from globals
+ *   allows to use solidified methods refering to the global object `tasmota`
+ * 
+\*********************************************************************************************/
+extern "C" {
+
+  int32_t d_getTasmotaGlob(struct bvm *vm);
+  int32_t d_getTasmotaGlob(struct bvm *vm) {
+    be_getglobal(berry.vm, PSTR("tasmota"));
+    be_return(vm); // Return
+  }
+
+}
+
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -352,6 +352,15 @@ const char berry_prog[] =
 
   "end "
 
+  // // Monkey patch `Driver` class - To be continued
+  // "class Driver2 : Driver "
+  //   "def add_cmd(c, f) "
+  //     "var tasmota = self.get_tasmota() "
+  //     "tasmota.add_cmd(c, / cmd, idx, payload, payload_json -> f(self, cmd, idx, payload, payload_json)) "
+  //   "end "
+  // "end "
+  // "Driver = Driver2 "
+
   // Instantiate tasmota object
   "tasmota = Tasmota() "
   "def log(m,l) tasmota.log(m,l) end "
@@ -380,12 +389,16 @@ const char berry_prog[] =
   //   "end "
   // "end "
 
+#ifdef USE_I2C
   "tasmota.wire1 = Wire(1) "
   "tasmota.wire2 = Wire(2) "
   "wire1 = tasmota.wire1 "
   "wire2 = tasmota.wire2 "
+#endif // USE_I2C
+
   // auto-import gpio
   "import gpio "
+
 #ifdef USE_LIGHT
   "import light "
 #endif // USE_LIGHT


### PR DESCRIPTION
## Description:

Added a method `add_cmd` to `Driver` class to make adding commands easier.

Before, if you wanted to add a method as command, you needed a closure:
```
class foo_cmd : Driver
  var msg
  def init()
    self.msg = "hello"
  end

  def my_cmd(idx, payload, payload_json)
    print(self.msg)
  end
end

d = Driver()
# ugly command below
tasmota.add_cmd("foo", / payload, payload_json -> d.my_cmd(cmd, idx, payload, payload_json))
```

Now you can just call:
```

class foo_cmd : Driver
  var msg
  def init()
    self.msg = "hello"
  end

  def my_cmd(idx, payload, payload_json)
    print(self.msg)
  end
end

d = Driver()
d.add_cmd("foo", d.my_cmd)
```

Of course you can still use `tasmota.add_cmd()` for a pure function.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
