### PR TITLE
Ignore compilation artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 ## OS specific ########
 .DS_Store
 .fuse_hidden*
+
+## Compilation artefacts ########
 *.pyc
+*.d
+*.o
+*.gcno
+*.gcda
 
 ## Project files ######
 .platformio


### PR DESCRIPTION
## Description:

Add file extensions to `.gitignore` that are temporarily generated by Berry static sollidifier.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
