### PR TITLE
Auto copy platformio_override_sample.ini

### DIFF
--- a/pio-tools/override_copy.py
+++ b/pio-tools/override_copy.py
@@ -7,3 +7,9 @@ if os.path.isfile("tasmota/user_config_override.h"):
     print ("*** use provided user_config_override.h as planned ***")
 else: 
     shutil.copy("tasmota/user_config_override_sample.h", "tasmota/user_config_override.h")
+
+# copy platformio_override_sample.ini to platformio_override.ini
+if os.path.isfile("platformio_override.ini"):
+    print ("*** use provided platformio_override.ini as planned ***")
+else: 
+    shutil.copy("platformio_override_sample.ini", "platformio_override.ini")


### PR DESCRIPTION
## Description:

to `platformio_override.ini` when Tasmota compile build is started (same way as for `user_config_override.h`) and no `platformio_override.ini` is already there.

By doing this no user rename of any file is needed anymore.
**All user changes for a self compiled build should be done only in the override files.**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
