### PR TITLE
Simple change to allow DEVICE_NAME in user_config_override

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -750,7 +750,11 @@ void SettingsDefaultSet2(void) {
   SettingsUpdateText(SET_FRIENDLYNAME2, PSTR(FRIENDLY_NAME"2"));
   SettingsUpdateText(SET_FRIENDLYNAME3, PSTR(FRIENDLY_NAME"3"));
   SettingsUpdateText(SET_FRIENDLYNAME4, PSTR(FRIENDLY_NAME"4"));
+  #ifdef DEVICE_NAME
+  SettingsUpdateText(SET_DEVICENAME, PSTR(DEVICE_NAME));
+  #else
   SettingsUpdateText(SET_DEVICENAME, SettingsText(SET_FRIENDLYNAME1));
+  #endif
   SettingsUpdateText(SET_OTAURL, PSTR(OTA_URL));
 
   // Power


### PR DESCRIPTION
## Description:

https://github.com/arendst/Tasmota/discussions/11687

Allows `#define DEVICE_NAME "some name"` in `user_config_override.h` for initializing a clean device.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
