### PR TITLE
Add experimental support for ESP32-C3

### DIFF
--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -1,0 +1,29 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32c3",
+    "variant": "esp32c3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Espressif ESP32-C3",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest",
+  "vendor": "Espressif"
+}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -35,6 +35,7 @@ default_envs =
 ;                tasmota32-ir
 ;                tasmota32-ircustom
 ;                tasmota32solo1
+;                tasmota32c3
 ;                tasmota32s2
 ;                tasmota32-odroidgo
 ;                tasmota32-core2
@@ -185,15 +186,32 @@ lib_ignore                  =
     Micro-RTSP
     ESP32 Ethernet
 
-; *** EXPERIMENTAL Tasmota version for Arduino ESP32-C3
+; *** EXPERIMENTAL Tasmota version for ESP32-C3
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
+board                       = esp32c3
+platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-master-a6f33a9d3.tar.gz
+                              ; needed toolchain for Windows
+                              toolchain-riscv32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/riscv32-esp-elf-gcc8_4_0-crosstool-ng-1.24.0-123-g64eb9ff-win32.zip
+                              ; needed toolchain for Linux
+                              ;toolchain-riscv32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/riscv32-esp-elf-gcc8_4_0-crosstool-ng-1.24.0-123-g64eb9ff-linux-amd64.tar.gz
+                              ; needed toolchain for MacOS
+                              ;toolchain-riscv32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/riscv32-esp-elf-gcc8_4_0-crosstool-ng-1.24.0-123-g64eb9ff-macos.tar.gz
+                              platformio/tool-mklittlefs @ ~1.203.200522
+build_unflags               = ${esp32_defaults.build_unflags} -mtarget-align
+build_flags                 = ${esp32_defaults.build_flags}
+                              ;-DESP32_STAGE=true
+
+; *** EXPERIMENTAL Tasmota version for Arduino ESP32 IDF4.4. Linking not working.
+[env:tasmota32idf4]
+extends                     = env:tasmota32_base
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-idf-v4.4
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-c3-1cb31e509.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/esp32-2.0.0-pre/esp32-2.0.0-pre.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              -DESP32_STAGE=true
+                              ;-DESP32_STAGE=true
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]
@@ -208,4 +226,3 @@ build_type                  = debug
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 ;                              -Wstack-usage=300
-

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -208,3 +208,4 @@ build_type                  = debug
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 ;                              -Wstack-usage=300
+

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -185,15 +185,15 @@ lib_ignore                  =
     Micro-RTSP
     ESP32 Ethernet
 
-; *** EXPERIMENTAL Tasmota version for Arduino ESP32 IDF4.4. Linking not working.
-[env:tasmota32idf4]
+; *** EXPERIMENTAL Tasmota version for Arduino ESP32-C3
+[env:tasmota32c3]
 extends                     = env:tasmota32_base
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-idf-v4.4
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/arduino-esp32/releases/download/esp32-2.0.0-pre/esp32-2.0.0-pre.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-c3-1cb31e509.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
-                              ;-DESP32_STAGE=true
+                              -DESP32_STAGE=true
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]


### PR DESCRIPTION
## Description:

Experimental PlatformIO support added for toolchain espressif riscv32
Experimental Arduino ESP32-C3 support

Tasmota fails to compile with build errors. Toolchain seems to work in general
To activate uncomment `tasmota32c3` 


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
