### PR TITLE
Fix typo in Berry with no USE_LIGHT

### DIFF
--- a/tasmota/xdrv_52_3_berry_light.ino
+++ b/tasmota/xdrv_52_3_berry_light.ino
@@ -24,8 +24,8 @@
 #include <Wire.h>
 
 /*********************************************************************************************\
- * 
- * 
+ *
+ *
 \*********************************************************************************************/
 extern "C" {
 
@@ -43,7 +43,7 @@ extern "C" {
 
     if (Light.device > 0) {
       // we have a light
-      
+
       uint8_t channels[LST_MAX];
       char s_rgb[8] = {0};         // RGB raw levels
       light_controller.calcLevels(channels);
@@ -207,7 +207,7 @@ extern "C" {
       // channels
       if (map_find(vm, "channels")) {
         if (be_isinstance(vm, -1)) {
-          be_getbuiltin(vm, "list");    // add "list" class 
+          be_getbuiltin(vm, "list");    // add "list" class
           if (be_isderived(vm, -2)) {
             be_pop(vm, 1);      // remove "list" class from top
             int32_t list_size = get_list_size(vm);
@@ -303,9 +303,9 @@ extern "C" {
   }
   int32_t l_getlight(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
   int32_t l_setlight(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t gamma8(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t reverse_gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
+  int32_t l_gamma8(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
+  int32_t l_gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
+  int32_t l_rev_gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
 #endif // #ifdef USE_LIGHT
 }
 


### PR DESCRIPTION
## Description:

Fix little typo that prevent to build Berry when no USE_LIGHT

(and a few trailing spaces)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
