### PR TITLE
Display ESP Board Type on information page

### DIFF
--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS ontdekking"
 #define D_MDNS_ADVERTISE "mDNS adverteer"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Size"
 #define D_FREE_PROGRAM_SPACE "Vrye program grootte"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS откриване"
 #define D_MDNS_ADVERTISE "mDNS известяване"
 #define D_ESP_CHIP_ID "ID на ESP чипа"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID на чипа на флаш паметта"
 #define D_FLASH_CHIP_SIZE "Размер на флаш паметта"
 #define D_FREE_PROGRAM_SPACE "Свободно пространство за програми"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Získávání mDNS"
 #define D_MDNS_ADVERTISE "Rozesílání mDNS"
 #define D_ESP_CHIP_ID "ID systému ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID systému paměti flash"
 #define D_FLASH_CHIP_SIZE "Velikost flash"
 #define D_FREE_PROGRAM_SPACE "Volné místo pro program"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS-Erkennung"
 #define D_MDNS_ADVERTISE "mDNS-Freigaben"
 #define D_ESP_CHIP_ID "ESP Chip ID"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip ID"
 #define D_FLASH_CHIP_SIZE "Größe Flash-Chip"
 #define D_FREE_PROGRAM_SPACE "Flash frei"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Discovery"
 #define D_MDNS_ADVERTISE "mDNS Advertise"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Μέγεθος Flash"
 #define D_FREE_PROGRAM_SPACE "Ελεύθερος χώρος προγράμματος"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Discovery"
 #define D_MDNS_ADVERTISE "mDNS Advertise"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Size"
 #define D_FREE_PROGRAM_SPACE "Free Program Space"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Discovery"
 #define D_MDNS_ADVERTISE "mDNS Advertise"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Tamaño Flash"
 #define D_FREE_PROGRAM_SPACE "Memoria de Programa Libre"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Découverte mDNS"
 #define D_MDNS_ADVERTISE "Annonce mDNS"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Taille flash"
 #define D_FREE_PROGRAM_SPACE "Espace programme libre"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Untdekking"
 #define D_MDNS_ADVERTISE "mDNS Advertearje"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Grutte"
 #define D_FREE_PROGRAM_SPACE "Fergese programmaromte"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS זיהוי"
 #define D_MDNS_ADVERTISE "mDNS פרסום"
 #define D_ESP_CHIP_ID "ESP מס' רכיב"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "מס' רכיב פלאש"
 #define D_FLASH_CHIP_SIZE "גודל זיכרון פלאש"
 #define D_FREE_PROGRAM_SPACE "מקום פנוי - תוכנה"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS láthatóság"
 #define D_MDNS_ADVERTISE "mDNS hirdetés"
 #define D_ESP_CHIP_ID "ESP chip ID"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash chip ID"
 #define D_FLASH_CHIP_SIZE "Flash mérete"
 #define D_FREE_PROGRAM_SPACE "Szabad programhely"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY        "Ricerca mDNS"
 #define D_MDNS_ADVERTISE        "Notifica mDNS"
 #define D_ESP_CHIP_ID           "ID chip ESP"
+#define D_ESP_BOARD             "ESP Board"
 #define D_FLASH_CHIP_ID         "ID chip flash"
 #define D_FLASH_CHIP_SIZE       "Dimensione flash"
 #define D_FREE_PROGRAM_SPACE    "Memoria libera programma"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Discovery"
 #define D_MDNS_ADVERTISE "mDNS Advertise"
 #define D_ESP_CHIP_ID "ESP 칩 Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "플래시 칩 Id"
 #define D_FLASH_CHIP_SIZE "플래시 용량"
 #define D_FREE_PROGRAM_SPACE "여유 프로그램 공간"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Discovery"
 #define D_MDNS_ADVERTISE "mDNS Advertise"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Grootte"
 #define D_FREE_PROGRAM_SPACE "Programma ruimte over"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Wykrywanie mDNS"
 #define D_MDNS_ADVERTISE "Rozgłaszanie mDNS"
 #define D_ESP_CHIP_ID "ID ukladu ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID pamięci flash"
 #define D_FLASH_CHIP_SIZE "Rozmiar pamięci flash"
 #define D_FREE_PROGRAM_SPACE "Wolna pamięć programu"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Descobrir mDNS"
 #define D_MDNS_ADVERTISE "Anunciar mDNS"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Size"
 #define D_FREE_PROGRAM_SPACE "Espaço Livre Programa"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Descobrir mDNS"
 #define D_MDNS_ADVERTISE "Anunciar mDNS"
 #define D_ESP_CHIP_ID "ID do chip ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID do chip da Flash"
 #define D_FLASH_CHIP_SIZE "Tamanho da Flash"
 #define D_FREE_PROGRAM_SPACE "Espaço de Programa Livre"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Descoperă mDNS"
 #define D_MDNS_ADVERTISE "Publică mDNS"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Mărime Flash"
 #define D_FREE_PROGRAM_SPACE "Spațiu Disponibil Program"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Обнаружение"
 #define D_MDNS_ADVERTISE "mDNS Транcляция"
 #define D_ESP_CHIP_ID "ID чипа ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID чипа Flash памяти"
 #define D_FLASH_CHIP_SIZE "Размер Flash памяти"
 #define D_FREE_PROGRAM_SPACE "Свободное пространство программ"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Získavanie mDNS"
 #define D_MDNS_ADVERTISE "Rozosielanie mDNS"
 #define D_ESP_CHIP_ID "ID systému ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID systému flash pamäte"
 #define D_FLASH_CHIP_SIZE "Veľkosť flash"
 #define D_FREE_PROGRAM_SPACE "Voľné místo pre program"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS upptäckning"
 #define D_MDNS_ADVERTISE "mDNS annonsering"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash-storlek"
 #define D_FREE_PROGRAM_SPACE "Ledigt programutrymme"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Keşfi"
 #define D_MDNS_ADVERTISE "mDNS Yayını"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Flash Boyutu"
 #define D_FREE_PROGRAM_SPACE "Boşta Yazılım Alanı Boyutu"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS Виявлення"
 #define D_MDNS_ADVERTISE "mDNS Анонс"
 #define D_ESP_CHIP_ID "ID чипу ESP"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "ID чипу Flash пам'яті"
 #define D_FLASH_CHIP_SIZE "Розмір Flash пам'яті"
 #define D_FREE_PROGRAM_SPACE "Вільний простір для програм"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "Khám phá mDNS"
 #define D_MDNS_ADVERTISE "Thông báo mDNS"
 #define D_ESP_CHIP_ID "ESP Chip Id"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash Chip Id"
 #define D_FLASH_CHIP_SIZE "Kích thước bộ nhớ Flash"
 #define D_FREE_PROGRAM_SPACE "Bộ nhớ chưa sử dụng"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS 发现"
 #define D_MDNS_ADVERTISE "mDNS 广播"
 #define D_ESP_CHIP_ID "ESP 芯片 ID"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "Flash 芯片 ID"
 #define D_FLASH_CHIP_SIZE "Flash 大小"
 #define D_FREE_PROGRAM_SPACE "空闲程序空间"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -358,6 +358,7 @@
 #define D_MDNS_DISCOVERY "mDNS 探索"
 #define D_MDNS_ADVERTISE "mDNS 廣播"
 #define D_ESP_CHIP_ID "ESP晶片ID"
+#define D_ESP_BOARD "ESP Board"
 #define D_FLASH_CHIP_ID "快閃記憶體ID"
 #define D_FLASH_CHIP_SIZE "快閃記憶體大小"
 #define D_FREE_PROGRAM_SPACE "可用的程式空間"

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2358,8 +2358,11 @@ void HandleInformation(void)
   }
 #endif  // USE_DISCOVERY
 
+
+
   WSContentSend_P(PSTR("}1}2&nbsp;"));  // Empty line
   WSContentSend_P(PSTR("}1" D_ESP_CHIP_ID "}2%d"), ESP_getChipId());
+  WSContentSend_P(PSTR("}1" D_ESP_BOARD "}2%s"), ARDUINO_BOARD);
 #ifdef ESP8266
   WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X"), ESP.getFlashChipId());
 #endif


### PR DESCRIPTION
## Description:

Show ESP Board type used on compilation on Information web page

![image](https://user-images.githubusercontent.com/2471931/115091067-cb124080-9f16-11eb-8982-66c1711423fa.png)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
