### PR TITLE
Add missing board linker scripts for S2 / C3

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -175,6 +175,7 @@ build_flags                 = ${common32.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
+board_build.ldscript        = esp32s2_out.ld
 board_build.flash_mode      = qio
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-master-cf457d412.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
@@ -190,6 +191,7 @@ lib_ignore                  =
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
+board_build.ldscript        = esp32c3_out.ld
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-master-cf457d412.tar.gz
                               ; needed toolchain for Windows


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
