### PR TITLE
Enable second HW SPI for ESP32

### DIFF
--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -87,8 +87,10 @@ const uint16_t VL53L0X_MAX_SENSORS = 8;     // Max number of VL53L0X sensors
 
 #ifdef ESP32
 const uint8_t MAX_I2C = 2;                  // Max number of I2C controllers (ESP32 = 2)
+const uint8_t MAX_SPI = 2;                  // Max number of Hardware SPI controllers (ESP32 = 2)
 #else
 const uint8_t MAX_I2C = 0;                  // Max number of I2C controllers (ESP8266 = 0, no choice)
+const uint8_t MAX_SPI = 0;                  // Max number of Hardware SPI controllers (ESP8266 = 0, no choice)
 #endif
 
 // Changes to the following MAX_ defines need to be in line with enum SettingsTextIndex

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -407,11 +407,11 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #endif
 
 #ifdef USE_SPI
-  AGPIO(GPIO_SPI_MISO),                 // SPI MISO
-  AGPIO(GPIO_SPI_MOSI),                 // SPI MOSI
-  AGPIO(GPIO_SPI_CLK),                  // SPI Clk
-  AGPIO(GPIO_SPI_CS),                   // SPI Chip Select
-  AGPIO(GPIO_SPI_DC),                   // SPI Data Direction
+  AGPIO(GPIO_SPI_MISO) + MAX_SPI,       // SPI MISO
+  AGPIO(GPIO_SPI_MOSI) + MAX_SPI,       // SPI MOSI
+  AGPIO(GPIO_SPI_CLK) + MAX_SPI,        // SPI Clk
+  AGPIO(GPIO_SPI_CS) + MAX_SPI,         // SPI Chip Select
+  AGPIO(GPIO_SPI_DC) + MAX_SPI,         // SPI Data Direction
 #ifdef USE_NRF24
   AGPIO(GPIO_NRF24_CS),
   AGPIO(GPIO_NRF24_DC),


### PR DESCRIPTION
## Description:

Allows to configure a second Hardware SPI in settings.
ESP32 has 4 hardware SPI (SPI 0 to 3). SPI0 and SPI1 are reserved. SPI2 is also called HSPI and supports DMA. SPI3 is called VSPI on ESP32 or OSPI on ESP32 S2, and is not capable of DMA on S2.

Arduino `SPI` object maps to VSPI or OSPI, i.e. `SPI3`.

SPI #2 in Tasmota will actually map to HSPI which is `SPI2`.

In a nutshell numbers are reversed... But you shouldn't care too much.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
