### PR TITLE
Refactor Platformio

### DIFF
--- a/boards/esp8266_1M.json
+++ b/boards/esp8266_1M.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.1m.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dout",
+    "mcu": "esp8266",
+    "variant": "generic"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino",
+    "esp8266-rtos-sdk",
+    "esp8266-nonos-sdk"
+  ],
+  "name": "Espressif Generic ESP8266 ESP-01 1M",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 1048576,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
+  "vendor": "Espressif"
+}

--- a/lib/default/Ext-printf/src/ext_printf.cpp
+++ b/lib/default/Ext-printf/src/ext_printf.cpp
@@ -126,7 +126,7 @@ void * __va_cur_ptr4(va_list &va) {
 // >>> Reading a_ptr=0x3FFFFD70 *a_ptr=6
 // >>> Reading a_ptr=0x3FFFFD74 *a_ptr=7
 // >>> Reading a_ptr=0x3FFFFD78 *a_ptr=8
-#elif defined(__RISC_V__)
+#elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3 RISC_V
 // #define __va_argsiz_tas(t)  	(((sizeof(t) + sizeof(int) - 1) / sizeof(int)) * sizeof(int))
 #define va_cur_ptr4(va,T) ( (T*) __va_cur_ptr4(va) )
 void * __va_cur_ptr4(va_list &va) {

--- a/lib/default/TasmotaSerial-3.3.0/src/TasmotaSerial.cpp
+++ b/lib/default/TasmotaSerial-3.3.0/src/TasmotaSerial.cpp
@@ -42,6 +42,8 @@ TasmotaSerial *tms_obj_list[16];
 static int tasmota_serial_index = 2;  // Allow UART2 and UART1 only
 #elif CONFIG_IDF_TARGET_ESP32S2       // ESP32-S2
 static int tasmota_serial_index = 1;  // Allow UART1 only
+#elif CONFIG_IDF_TARGET_ESP32C3       // ESP32-C3
+static int tasmota_serial_index = 1;  // Allow UART1 only
 #endif
 
 #endif  // ESP32

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -24,6 +24,8 @@
     #include "esp32/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32S2  // ESP32-S2
     #include "esp32s2/rom/rtc.h"
+  #elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3
+    #include "esp32c3/rom/rtc.h"
   #else
     #error Target CONFIG_IDF_TARGET is not supported
   #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,12 +26,9 @@ extra_configs               = platformio_tasmota32.ini
 
 [common]
 framework                   = arduino
-board                       = esp01_1m
 board_build.filesystem      = littlefs
 custom_unpack_dir           = unpacked_littlefs
 board_build.flash_mode      = dout
-board_build.ldscript        = eagle.flash.1m.ld
-
 platform                    = ${core.platform}
 platform_packages           = ${core.platform_packages}
 build_unflags               = ${core.build_unflags}
@@ -89,6 +86,7 @@ build_flags                 = -DCORE_DEBUG_LEVEL=0
 
 
 [esp82xx_defaults]
+board                       = esp8266_1M
 build_flags                 = ${esp_defaults.build_flags}
                               -DNDEBUG
                               -DFP_IN_IROM

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -175,24 +175,22 @@ build_flags                 = ${common32.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
-board_build.ldscript        = esp32s2_out.ld
 board_build.flash_mode      = qio
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-master-cf457d412.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
                               platformio/tool-esptoolpy @ ~1.30000.0
 build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${common32.build_flags}
+build_flags                 = ${common32.build_flags} -DFIRMWARE_LITE
+lib_extra_dirs              = lib/libesp32
 lib_ignore                  =
     NimBLE-Arduino
     Micro-RTSP
-    ESP32 Ethernet
-    ESP32-HomeKit
+
 
 ; *** EXPERIMENTAL Tasmota version for ESP32-C3
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-board_build.ldscript        = esp32c3_out.ld
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/v.2.0.0.pre/framework-arduinoespressif32-master-cf457d412.tar.gz
                               ; needed toolchain for Windows
@@ -203,8 +201,12 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
                               ;toolchain-riscv32 @ https://github.com/Jason2866/platform-espressif32/releases/download/8.4.0/riscv32-esp-elf-gcc8_4_0-crosstool-ng-1.24.0-123-g64eb9ff-macos.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags} -mtarget-align
-build_flags                 = ${esp32_defaults.build_flags}
+build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE
                               ;-DESP32_STAGE=true
+lib_extra_dirs              = lib/libesp32
+lib_ignore                  =
+    NimBLE-Arduino
+    Micro-RTSP
 
 ; *** EXPERIMENTAL Tasmota version for Arduino ESP32 IDF4.4. Linking not working.
 [env:tasmota32idf4]

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -185,6 +185,7 @@ lib_extra_dirs              = lib/libesp32
 lib_ignore                  =
     NimBLE-Arduino
     Micro-RTSP
+    ESP32-HomeKit
 
 
 ; *** EXPERIMENTAL Tasmota version for ESP32-C3

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -2,6 +2,7 @@
 ; ***  expect the unexpected. Some features not working!!!    ***
 
 [common32]
+framework                   = ${common.framework}
 platform                    = ${core32.platform}
 platform_packages           = ${core32.platform_packages}
 build_unflags               = ${core32.build_unflags}
@@ -9,7 +10,6 @@ build_flags                 = ${core32.build_flags}
 board                       = esp32dev
 board_build.filesystem      = ${common.board_build.filesystem}
 custom_unpack_dir           = ${common.custom_unpack_dir}
-board_build.ldscript        = esp32_out.ld
 board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 board_build.flash_mode      = ${common.board_build.flash_mode}
 board_build.f_flash         = ${common.board_build.f_flash}

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -2,9 +2,8 @@
 platform                = ${common.platform}
 platform_packages       = ${common.platform_packages}
 framework               = ${common.framework}
-board                   = ${common.board}
+board                   = ${esp82xx_defaults.board}
 board_build.filesystem  = ${common.board_build.filesystem}
-board_build.ldscript    = ${common.board_build.ldscript}
 board_build.flash_mode  = ${common.board_build.flash_mode}
 board_build.f_flash     = ${common.board_build.f_flash}
 board_build.f_cpu       = ${common.board_build.f_cpu}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -3,7 +3,6 @@ framework               = ${common.framework}
 platform                = ${common32.platform}
 platform_packages       = ${common32.platform_packages}
 board                   = ${common32.board}
-board_build.ldscript    = ${common32.board_build.ldscript}
 board_build.partitions  = ${common32.board_build.partitions}
 board_build.flash_mode  = ${common32.board_build.flash_mode}
 board_build.f_flash     = ${common32.board_build.f_flash}

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -117,6 +117,8 @@ String GetDeviceHardware(void) {
     #include "esp32/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32S2  // ESP32-S2
     #include "esp32s2/rom/rtc.h"
+  #elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3
+    #include "esp32c3/rom/rtc.h"
   #else
     #error Target CONFIG_IDF_TARGET is not supported
   #endif
@@ -242,6 +244,8 @@ extern "C" {
     #include "esp32/rom/spi_flash.h"
   #elif CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
     #include "esp32s2/rom/spi_flash.h"
+  #elif CONFIG_IDF_TARGET_ESP32C3   // ESP32-C3
+    #include "esp32c3/rom/spi_flash.h"
   #else
     #error Target CONFIG_IDF_TARGET is not supported
   #endif


### PR DESCRIPTION
## Description:

to fix strange Linker errors with ESP-S2 / C3. Override of setting `board_build.ldscript` is not always working.
Added #ifdefs for ESP-C3 in Tasmota to fix some compile errors.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
