### PR TITLE
remove redundant Platformio entrys

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ extra_configs               = platformio_tasmota32.ini
 framework                   = arduino
 board_build.filesystem      = littlefs
 custom_unpack_dir           = unpacked_littlefs
-board_build.flash_mode      = dout
+board                       = esp8266_1M
 platform                    = ${core.platform}
 platform_packages           = ${core.platform_packages}
 build_unflags               = ${core.build_unflags}
@@ -86,7 +86,6 @@ build_flags                 = -DCORE_DEBUG_LEVEL=0
 
 
 [esp82xx_defaults]
-board                       = esp8266_1M
 build_flags                 = ${esp_defaults.build_flags}
                               -DNDEBUG
                               -DFP_IN_IROM

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -58,8 +58,6 @@ build_flags                 = ${core.build_flags}
 ;board                       = esp8266_1M
 ; Build variant 2MB = 1MB firmware, 1MB filesystem (most Shelly devices)
 ;board                       = esp8266_2M1M
-; Build variant 4MB = 1MB firmware, 3MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
-;board                       = esp8266_4M3M
 ; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
 ;board                       = esp8266_4M2M
 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -11,7 +11,6 @@ board                       = esp32dev
 board_build.filesystem      = ${common.board_build.filesystem}
 custom_unpack_dir           = ${common.custom_unpack_dir}
 board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
-board_build.flash_mode      = ${common.board_build.flash_mode}
 board_build.f_flash         = ${common.board_build.f_flash}
 board_build.f_cpu           = ${common.board_build.f_cpu}
 monitor_speed               = 115200

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -2,9 +2,8 @@
 platform                = ${common.platform}
 platform_packages       = ${common.platform_packages}
 framework               = ${common.framework}
-board                   = ${esp82xx_defaults.board}
+board                   = ${common.board}
 board_build.filesystem  = ${common.board_build.filesystem}
-board_build.flash_mode  = ${common.board_build.flash_mode}
 board_build.f_flash     = ${common.board_build.f_flash}
 board_build.f_cpu       = ${common.board_build.f_cpu}
 build_unflags           = ${common.build_unflags}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -4,7 +4,6 @@ platform                = ${common32.platform}
 platform_packages       = ${common32.platform_packages}
 board                   = ${common32.board}
 board_build.partitions  = ${common32.board_build.partitions}
-board_build.flash_mode  = ${common32.board_build.flash_mode}
 board_build.f_flash     = ${common32.board_build.f_flash}
 board_build.f_cpu       = ${common32.board_build.f_cpu}
 monitor_speed           = ${common32.monitor_speed}


### PR DESCRIPTION
## Description:

since it is defined in `boards.json` already. Doing this avoids possible overriding errors (as before with ldscript).
More future proof. Any new board will be added via a specific `boards.json` where all needed settings for are in one place.

The usage (sketch, OTA, SPIFFS) for ESP8266 can now be seen
![image](https://user-images.githubusercontent.com/24528715/115141760-55a18f80-a03e-11eb-8e32-f3155ee1f2f8.png)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
