### PR TITLE
Demo of PWM 100% problem on ESP32 (for discussion)

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -89,6 +89,7 @@ inline void analogAttach(uint32_t pin, uint32_t channel) {
 inline void analogWrite(uint8_t pin, int val)
 {
   uint32_t channel = _analog_pin2chan(pin);
+  if ( val >> (_pwm_bit_num-1) ) ++val;
   ledcWrite(channel + PWM_CHANNEL_OFFSET, val);
 //  Serial.printf("write %d - %d\n",channel,val);
 }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1967,12 +1967,7 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
           cur_col = cur_col > 0 ? changeUIntScale(cur_col, 0, Settings.pwm_range, Light.pwm_min, Light.pwm_max) : 0;   // shrink to the range of pwm_min..pwm_max
         }
         if (!Settings.flag4.zerocross_dimmer) {
-          uint16_t pwm = bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col;
-          #ifdef ESP32
-          if (pwm = Settings.pwm_range) pwm = Settings.pwm_range+1; // ESP32 full PWM is 1024 (1023 on ESP8266)
-          #endif
-          //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("LIT: PWM%d = %d"), i, pwm);
-          analogWrite(Pin(GPIO_PWM1, i), pwm);
+          analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col);
         }
 #ifdef USE_PWM_DIMMER
         // Animate brightness LEDs to follow PWM dimmer brightness

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -122,7 +122,7 @@
 \*********************************************************************************************/
 
 #define XDRV_04              4
-// #define DEBUG_LIGHT
+ #define DEBUG_LIGHT
 
 enum LightSchemes { LS_POWER, LS_WAKEUP, LS_CYCLEUP, LS_CYCLEDN, LS_RANDOM, LS_MAX };
 
@@ -1967,7 +1967,12 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
           cur_col = cur_col > 0 ? changeUIntScale(cur_col, 0, Settings.pwm_range, Light.pwm_min, Light.pwm_max) : 0;   // shrink to the range of pwm_min..pwm_max
         }
         if (!Settings.flag4.zerocross_dimmer) {
-          analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col);
+          uint16_t pwm = bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings.pwm_range - cur_col : cur_col;
+          #ifdef ESP32
+          if (pwm = Settings.pwm_range) pwm = Settings.pwm_range+1; // ESP32 full PWM is 1024 (1023 on ESP8266)
+          #endif
+          //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("LIT: PWM%d = %d"), i, pwm);
+          analogWrite(Pin(GPIO_PWM1, i), pwm);
         }
 #ifdef USE_PWM_DIMMER
         // Animate brightness LEDs to follow PWM dimmer brightness

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -122,7 +122,7 @@
 \*********************************************************************************************/
 
 #define XDRV_04              4
- #define DEBUG_LIGHT
+// #define DEBUG_LIGHT
 
 enum LightSchemes { LS_POWER, LS_WAKEUP, LS_CYCLEUP, LS_CYCLEDN, LS_RANDOM, LS_MAX };
 


### PR DESCRIPTION
## Description:

This is to demo and track a problem with ESP32's PWM not able to reach 100% duty cycle
The most annoying problem is not able to reach 0% on PWM_i inverted outputs which prevent powering off the output.

How to see the problem : 
- connect a LED to a GPIO with a 150..220 ohms resistor toward 3V3
- set the GPIO as PWM_i
- Try to power off the led
- Without this patch, the led will remain slighly on

Looking with a scope the GPIO signal shows that while we would expect the signal to be a continuous HI to reach 0% duty cycle for a PWM_i, a 1us pulse to LOW remains every cycle (1/1023th) but that is enough to slighly lite the LED.

The sample patch I provide force the pwm value to 1024 if the calculated value is 1023 which is enough to do the trick.

While this seems to fix the problem for ligthts (using color or channel), the same problem can be seen everywhere analogWrite() is used : PWM command, LedPWM, ....

I'm not sure to understand all the intrinsic around PWMrange and what impact modifying the whole PWMrange logic would have on Tuya dimmers for example

I can't tell this is a bug of the ESP32 HAL has I haven't found a definite description of what the ESP32 LedControl module should do. But this is clearly for now a difference with the ESP8266 that do not show this behavior.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
