### PR TITLE
Fix crash on Risc-V ESP32 C3

### DIFF
--- a/lib/default/Ext-printf/src/ext_printf.cpp
+++ b/lib/default/Ext-printf/src/ext_printf.cpp
@@ -126,18 +126,19 @@ void * __va_cur_ptr4(va_list &va) {
 // >>> Reading a_ptr=0x3FFFFD70 *a_ptr=6
 // >>> Reading a_ptr=0x3FFFFD74 *a_ptr=7
 // >>> Reading a_ptr=0x3FFFFD78 *a_ptr=8
-#elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3 RISC_V
+
+#elif defined(__riscv)
 // #define __va_argsiz_tas(t)  	(((sizeof(t) + sizeof(int) - 1) / sizeof(int)) * sizeof(int))
 #define va_cur_ptr4(va,T) ( (T*) __va_cur_ptr4(va) )
 void * __va_cur_ptr4(va_list &va) {
   uintptr_t * va_ptr = (uintptr_t*) &va;
-  void * cur_ptr = (void*) *va_ptr;
-  *va_ptr += 4;
-  return cur_ptr;
+  int32_t * cur_ptr = (int32_t*) *va_ptr;
+  return (void*) (cur_ptr - 1);
 }
-#else   // __XTENSA__, __RISCV__
+
+#else   // __XTENSA__, __riscv
   #error "ext_printf is not suppoerted on this platform"
-#endif  // __XTENSA__, __RISCV__
+#endif  // __XTENSA__, __riscv
 
 /*********************************************************************************************\
  * Genral function to convert u64 to hex


### PR DESCRIPTION
## Description:

Fix crash of ext_snprintf on ESP32 C3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
