### PR TITLE
Zigbee raise max devices to 48 on ESP32

### DIFF
--- a/tasmota/xdrv_23_zigbee_4_persistence.ino
+++ b/tasmota/xdrv_23_zigbee_4_persistence.ino
@@ -182,7 +182,11 @@ SBuffer hibernateDevices(void) {
   SBuffer buf(2048);
 
   size_t devices_size = zigbee_devices.devicesSize();
+#ifdef ESP32
+  if (devices_size > 48) { devices_size = 48; }         // arbitrarily limit to 48 devices on ESP32, we will go beyond when we remove the limit of 2kb buffer
+#else
   if (devices_size > 32) { devices_size = 32; }         // arbitrarily limit to 32 devices, for now
+#endif
   buf.add8(devices_size);    // number of devices
 
   for (uint32_t i = 0; i < devices_size; i++) {


### PR DESCRIPTION
## Description:

Raise to 48 devices on ESP32, it will be raised again when the 2kb buffer limit is removed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
