### PR TITLE
Fixes for esp32c3

### DIFF
--- a/lib/lib_ssl/bearssl-esp8266/src/pgmspace_bearssl.h
+++ b/lib/lib_ssl/bearssl-esp8266/src/pgmspace_bearssl.h
@@ -44,6 +44,7 @@ extern "C" {
   #define PSTR(s)            (__extension__({static const char __c[] __attribute__((__aligned__(4))) PROGMEM = (s); &__c[0];}))
 #endif
 
+#ifdef ESP8266
 // Flash memory must be read using 32 bit aligned addresses else a processor
 // exception will be triggered.
 // The order within the 32 bit values are:
@@ -86,6 +87,26 @@ static inline uint16_t pgm_read_word_inlined(const void* addr) {
     #define pgm_read_float(addr)            (*(const float*)(addr))
     #define pgm_read_ptr(addr)              (*(const void* const*)(addr))
 #endif
+
+#else // ESP8266
+
+
+#ifdef __cplusplus
+    #define pgm_read_byte(addr)             (*reinterpret_cast<const uint8_t*>(addr))
+    #define pgm_read_word(addr)             (*reinterpret_cast<const uint16_t*>(addr))
+    #define pgm_read_dword(addr)            (*reinterpret_cast<const uint32_t*>(addr))
+    #define pgm_read_float(addr)            (*reinterpret_cast<const float>(addr))
+    #define pgm_read_ptr(addr)              (*reinterpret_cast<const void* const *>(addr))
+#else
+    #define pgm_read_byte(addr)             (*(const uint8_t*)(addr))
+    #define pgm_read_word(addr)             (*(const uint16_t*)(addr))
+    #define pgm_read_dword(addr)            (*(const uint32_t*)(addr))
+    #define pgm_read_float(addr)            (*(const float)(addr))
+    #define pgm_read_ptr(addr)              (*(const void* const *)(addr))
+#endif
+
+
+#endif // ESP8266
 
 #define pgm_read_byte_near(addr)        pgm_read_byte(addr)
 #define pgm_read_word_near(addr)        pgm_read_word(addr)

--- a/tasmota/WiFiClientSecureLightBearSSL.cpp
+++ b/tasmota/WiFiClientSecureLightBearSSL.cpp
@@ -33,11 +33,6 @@
 #include <errno.h>
 #include <algorithm>
 
-extern "C" {
-#include "osapi.h"
-#include "ets_sys.h"
-}
-#include "debug.h"
 #include "WiFiClientSecureLightBearSSL.h"	// needs to be before "ESP8266WiFi.h" to avoid conflict with Arduino headers
 #include "ESP8266WiFi.h"
 #include "WiFiClient.h"

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -196,8 +196,8 @@ int32_t callBerryEventDispatcher(const char *type, const char *cmd, int32_t idx,
 /*********************************************************************************************\
  * VM Observability
 \*********************************************************************************************/
-void BerryObservability(bvm *vm, int32_t event...);
-void BerryObservability(bvm *vm, int32_t event...) {
+void BerryObservability(bvm *vm, int event...);
+void BerryObservability(bvm *vm, int event...) {
   va_list param;
   va_start(param, event);
   static int32_t vm_usage = 0;


### PR DESCRIPTION
## Description:

Fixes to make BearSSL and Berry compile for Esp32c3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
