### PR TITLE
fix my fix on autoexec.be

### DIFF
--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -423,10 +423,15 @@ const char berry_prog[] =
 
 const char berry_autoexec[] =
   // load "autoexec.be" using import, which loads either .be or .bec file
+  "import string "
   "try "
-    "load('autoexec.be') "
+  "  load('autoexec.be') "
   "except .. as e,m "
-    "log(\"BRY: exception in autoexec '\",e,\"':\",m) "
+  "  if e=='io_error' && string.find(m, \"autoexec.be\")>0 "
+  "    log(\"BRY: no autoexec.be\") "
+  "  else "
+  "    log(\"BRY: exception in autoexec.be: \"+e+\": \"+m) "
+  "  end "
   "end "
   ;
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -425,13 +425,13 @@ const char berry_autoexec[] =
   // load "autoexec.be" using import, which loads either .be or .bec file
   "import string "
   "try "
-  "  load('autoexec.be') "
+    "load('autoexec.be') "
   "except .. as e,m "
-  "  if e=='io_error' && string.find(m, \"autoexec.be\")>0 "
-  "    log(\"BRY: no autoexec.be\") "
-  "  else "
-  "    log(\"BRY: exception in autoexec.be: \"+e+\": \"+m) "
-  "  end "
+    "if e=='io_error' && string.find(m, \"autoexec.be\")>0 "
+      "log(\"BRY: no autoexec.be\") "
+    "else "
+      "log(\"BRY: exception in autoexec.be: \"+e+\": \"+m) "
+    "end "
   "end "
   ;
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

My previous PR  (https://github.com/arendst/Tasmota/pull/11669) display an ambiguous message when no `autoexec.be` is present
This allows to distinguish between an exception because there is no `autoexec.be` and a real exception during the execution of `autoexec.be`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
