### PR TITLE
Esp32c3: work-around for `int32_t` definition

### DIFF
--- a/include/fix_esp32c3.h
+++ b/include/fix_esp32c3.h
@@ -1,0 +1,40 @@
+/*
+  fix_esp32c3.h - webserver for Tasmota
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+ * Xtensa toolchain declares `int32_t` as `int` but RISC-V toolchain
+ * declares `int32_t` as `long int` which causes compilation errors.
+ * 
+ * See:
+ *   https://github.com/espressif/esp-idf/issues/6906
+ *   https://github.com/espressif/arduino-esp32/issues/5086
+ * 
+ * You need to add the following lines in `build_flags`:      
+ *                            -I$PROJECT_DIR/include
+ *                            -include "fix_esp32c3.h"
+ */
+#ifdef __riscv
+
+#undef __INT32_TYPE__
+#define __INT32_TYPE__      int
+
+#undef __UINT32_TYPE__
+#define __UINT32_TYPE__     unsigned int
+
+#endif // __riscv

--- a/include/fix_esp32c3.h
+++ b/include/fix_esp32c3.h
@@ -1,5 +1,5 @@
 /*
-  fix_esp32c3.h - webserver for Tasmota
+  fix_esp32c3.h - fix esp32c3 toolchain
 
   Copyright (C) 2021  Theo Arends
 


### PR DESCRIPTION
## Description:

Xtensa toolchain declares `int32_t` as `int` but RISC-V toolchain declares `int32_t` as `long int` which causes compilation errors.
 
 See:
 *   https://github.com/espressif/esp-idf/issues/6906
 *   https://github.com/espressif/arduino-esp32/issues/5086

You need to add the following lines in `build_flags`:
```
                            -I$PROJECT_DIR/include
                            -include "fix_esp32c3.h"
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
