### PR TITLE
Esp32c3 enable `int32_t` fix in config

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -197,7 +197,9 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
                               tasmota/toolchain-riscv32
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags} -mtarget-align
-build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE
+build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE      
+                              -I$PROJECT_DIR/include
+                              -include "fix_esp32c3.h"
                               ;-DESP32_STAGE=true
 lib_extra_dirs              = lib/libesp32
 lib_ignore                  =

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -197,7 +197,7 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
                               tasmota/toolchain-riscv32
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags} -mtarget-align
-build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE      
+build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE
                               -I$PROJECT_DIR/include
                               -include "fix_esp32c3.h"
                               ;-DESP32_STAGE=true


### PR DESCRIPTION
## Description:

Follow-up of #11807 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
