### PR TITLE
Zigbee Fix loading previous file

### DIFF
--- a/tasmota/xdrv_23_zigbee_4c_devices.ino
+++ b/tasmota/xdrv_23_zigbee_4c_devices.ino
@@ -290,6 +290,14 @@ bool loadZigbeeDevices(void) {
   if (!f.valid() && dfsp) {
     file = dfsp->open(TASM_FILE_ZIGBEE, "r");
     if (file) {
+      uint32_t signature = 0x0000;
+      file.read((uint8_t*)&signature, 4);
+      if (signature == ZIGB_NAME2) {
+        // skip another 4 bytes
+        file.read((uint8_t*)&signature, 4);
+      } else {
+        file.seek(0);  // seek back to beginning of file
+      }
       f.init(&file);
       storage_class = PSTR("File System");
     }


### PR DESCRIPTION
## Description:

Zigbee fix loading previous Device file from ESP32 file system.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
