### PR TITLE
Enable all ESP32 libs in platformio_override_sample.ini

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -119,12 +119,12 @@ upload_port                 = COM4
 lib_extra_dirs              = ${library.lib_extra_dirs}
 ; *** ESP32 lib. ALWAYS needed for ESP32 !!!
                               lib/libesp32
-; *** uncomment the following line if you want to use LVGL in a Tasmota32 build
-;                              lib/libesp32_lvgl
-; *** uncomment the following line if you want to use Bluetooth or Apple Homekit in a Tasmota32 build
-;                              lib/libesp32_div
-; *** uncomment the following line if you want to use Epaper driver epidy in your Tasmota32 build
-;                              lib/libesp32_epdiy
+; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
+                              lib/libesp32_lvgl
+; *** comment the following line if you dont use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
+                              lib/libesp32_div
+; *** uncomment the following line if you dont use Epaper driver epidy in your Tasmota32 build. Reduces compile time 
+                              lib/libesp32_epdiy
 
 [core32]
 ; Activate Stage Core32 by removing ";" in next 3 lines, if you want to override the standard core32


### PR DESCRIPTION
more user friendly. Avoids compile errors by forgetting to enable needed libs. This does not raise the compile time for the automated builds since at this time no platformio_override.ini exists.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
