### PR TITLE
Berry conditional compile for modules

### DIFF
--- a/lib/libesp32/Berry/default/be_energylib.c
+++ b/lib/libesp32/Berry/default/be_energylib.c
@@ -7,6 +7,8 @@
  *******************************************************************/
 #include "be_object.h"
 
+#ifdef USE_ENERGY_SENSOR
+
 extern int b_nrg_read(bvm *vm);
 
 // #if !BE_USE_PRECOMPILED_OBJECT
@@ -24,3 +26,5 @@ module tasmota (scope: global, depend: 1) {
 @const_object_info_end */
 #include "../generate/be_fixed_tasmota.h"
 #endif
+
+#endif // USE_ENERGY_SENSOR

--- a/lib/libesp32/Berry/default/be_gpio_lib.c
+++ b/lib/libesp32/Berry/default/be_gpio_lib.c
@@ -290,7 +290,7 @@ be_native_module_attr_table(gpio) {
 be_define_native_module(gpio, NULL);
 #else
 /* @const_object_info_begin
-module gpio (scope: global, depend: BE_USE_TASMOTA) {
+module gpio (scope: global) {
     LOW, int(0)
     HIGH, int(1)
     

--- a/lib/libesp32/Berry/default/be_light_lib.c
+++ b/lib/libesp32/Berry/default/be_light_lib.c
@@ -7,7 +7,7 @@
 #include "be_string.h"
 #include "be_gc.h"
 
-
+#ifdef USE_LIGHT
 extern int l_getlight(bvm *vm);
 extern int l_setlight(bvm *vm);
 
@@ -39,3 +39,5 @@ module tasmota (scope: global, depend: 1) {
 @const_object_info_end */
 #include "../generate/be_fixed_tasmota.h"
 #endif
+
+#endif // USE_LIGHT

--- a/lib/libesp32/Berry/default/be_modtab.c
+++ b/lib/libesp32/Berry/default/be_modtab.c
@@ -63,15 +63,19 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
     &be_native_module(solidify),
 #endif
     /* user-defined modules register start */
-#if BE_USE_TASMOTA
+    
     &be_native_module(gpio),
+#ifdef USE_LIGHT
     &be_native_module(light),
+#endif
 
 #ifdef USE_LVGL
     &be_native_module(lvgl),
 #endif // USE_LVGL
+#ifdef USE_ENERGY_SENSOR
     &be_native_module(energy),
-#endif
+#endif // USE_ENERGY_SENSOR
+
 
     /* user-defined modules register end */
     NULL /* do not remove */
@@ -98,7 +102,9 @@ BERRY_API void be_load_custom_libs(bvm *vm)
     /* be_load_xxxlib(vm); */
 #endif
     be_load_tasmota_ntvlib(vm);
+#ifdef USE_I2C
     be_load_wirelib(vm);
+#endif // USE_I2C
     be_load_driverlib(vm);
 #ifdef USE_LVGL
     // LVGL

--- a/lib/libesp32/Berry/default/be_wirelib.c
+++ b/lib/libesp32/Berry/default/be_wirelib.c
@@ -9,6 +9,8 @@
 #include "be_string.h"
 #include "be_gc.h"
 
+#ifdef USE_I2C
+
 extern int b_wire_init(bvm *vm);
 
 extern int b_wire_begintransmission(bvm *vm);
@@ -241,3 +243,5 @@ module tasmota (scope: global, depend: 1) {
 @const_object_info_end */
 #include "../generate/be_fixed_tasmota.h"
 #endif
+
+#endif // USE_I2C

--- a/lib/libesp32/Berry/default/berry_conf.h
+++ b/lib/libesp32/Berry/default/berry_conf.h
@@ -158,12 +158,6 @@
 #define BE_USE_GC_MODULE                1
 #define BE_USE_SOLIDIFY_MODULE          1
 
-// #ifdef ESP32
-#define BE_USE_TASMOTA                  1
-// #else
-// #define BE_USE_TASMOTA                     0
-// #endif
-
 /* Macro: BE_EXPLICIT_XXX
  * If these macros are defined, the corresponding function will
  * use the version defined by these macros. These macro definitions

--- a/tasmota/xdrv_52_3_berry_energy.ino
+++ b/tasmota/xdrv_52_3_berry_energy.ino
@@ -20,6 +20,8 @@
 
 #ifdef USE_BERRY
 
+#ifdef USE_ENERGY_SENSOR
+
 #include <berry.h>
 
 
@@ -32,7 +34,6 @@
  * 
 \*********************************************************************************************/
 extern "C" {
-#ifdef USE_ENERGY_SENSOR
   // Berry: `begintransmission(address:int) -> nil`
   int32_t b_nrg_read(struct bvm *vm);
   int32_t b_nrg_read(struct bvm *vm) {
@@ -53,18 +54,17 @@ extern "C" {
     be_pop(vm, 1);
     be_return(vm); // Return
   }
-#else // USE_ENERGY_SENSOR
+}
+
+#endif // USE_ENERGY_SENSOR
+
+extern "C" {
   // 
   int32_t b_wire_energymissing(struct bvm *vm);
   int32_t b_wire_energymissing(struct bvm *vm) {
     be_raise(vm, "feature_error", "Energy sensor is not enabled, use '#define USE_ENERGY_SENSOR'");
   }
 
-  // define weak aliases
-  int32_t b_nrg_read(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_energymissing")));
-#endif // USE_ENERGY_SENSOR
 }
-
-
 
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_3_berry_light.ino
+++ b/tasmota/xdrv_52_3_berry_light.ino
@@ -20,6 +20,8 @@
 
 #ifdef USE_BERRY
 
+#ifdef USE_LIGHT
+
 #include <berry.h>
 #include <Wire.h>
 
@@ -29,7 +31,6 @@
 \*********************************************************************************************/
 extern "C" {
 
-#ifdef USE_LIGHT
   // push the light status object on the vm stack
   void push_getlight(bvm *vm, uint32_t light_num) {
     bool data_present = false;      // do we have relevant data
@@ -295,18 +296,15 @@ extern "C" {
     }
     be_raise(vm, kTypeError, nullptr);
   }
+}
 
-#else // #ifdef USE_LIGHT
+#endif // USE_LIGHT
 
+extern "C" {
   int32_t b_light_missing(struct bvm *vm) {
     be_raise(vm, "feature_error", "LIGHT is not enabled, use '#define USE_LIGHT'");
   }
-  int32_t l_getlight(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t l_setlight(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t l_gamma8(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t l_gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-  int32_t l_rev_gamma10(struct bvm *vm) __attribute__ ((weak, alias ("b_light_missing")));
-#endif // #ifdef USE_LIGHT
+
 }
 
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_3_berry_wire.ino
+++ b/tasmota/xdrv_52_3_berry_wire.ino
@@ -20,6 +20,8 @@
 
 #ifdef USE_BERRY
 
+#ifdef USE_I2C
+
 #include <berry.h>
 #include <Wire.h>
 
@@ -52,7 +54,6 @@ int32_t getBus(bvm *vm) {
  * 
 \*********************************************************************************************/
 extern "C" {
-#ifdef USE_I2C
   // Berry: `init([bus:int = 0]) -> nil
   int32_t b_wire_init(struct bvm *vm);
   int32_t b_wire_init(struct bvm *vm) {
@@ -241,28 +242,16 @@ extern "C" {
     }
     be_raise(vm, kTypeError, nullptr);
   }
-#else // USE_I2C
-  // 
+}
+
+#endif // USE_I2C
+
+extern "C" {
+  // Handle methods that require I2C to be enabled
   int32_t b_wire_i2cmissing(struct bvm *vm);
   int32_t b_wire_i2cmissing(struct bvm *vm) {
     be_raise(vm, "feature_error", "I2C is not enabled, use '#define USE_I2C'");
   }
-
-  // define weak aliases
-  int32_t b_wire_init(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_begintransmission(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_endtransmission(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_requestfrom(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_available(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_write(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_read(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_scan(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_validwrite(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_validread(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_readbytes(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_writebytes(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-  int32_t b_wire_detect(struct bvm *vm) __attribute__ ((weak, alias ("b_wire_i2cmissing")));
-#endif // USE_I2C
 }
 
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -32,7 +32,9 @@ const char berry_prog[] =
 
   // auto-import modules
   // // import alias
+#ifdef USE_ENERGY_SENSOR
   "import energy "
+#endif
 
   // Phase 1
   "class Tasmota: Tasmota_ntv "


### PR DESCRIPTION
## Description:

Add Berry conditional compiles driven via regular Tasmota defines. This saves code space when some options are not enabled (I2C, LIGHT, ENERGY_SENSOR..)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
