### PR TITLE
Lvgl update

### DIFF
--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.cpp
@@ -153,6 +153,13 @@ void Renderer::DrawStringAt(int16_t x, int16_t y, const char* text, uint16_t col
     int refcolumn = x;
     sFONT *xfont = selected_font;
 
+/*
+    if (font == 5 && !drawmode) {
+      // clear bckground
+      int16_t x1,y1;
+      uint16_t w,h;
+      Adafruit_GFX::getTextBounds(text, 0, 0, &x1, &y1, &w, &h);
+    }*/
 #ifndef USE_EPD_FONTS
     font=0;
 #endif
@@ -297,13 +304,15 @@ void Renderer::setTextFont(uint8_t f) {
 
 
 void Renderer::SetRamfont(uint8_t *font) {
+
   ramfont = (GFXfont*)font;
-  uint32_t bitmap_offset = (uint32_t)ramfont->bitmap;
-  uint32_t glyph_offset = (uint32_t)ramfont->glyph;
+  if (font) {
+    uint32_t bitmap_offset = (uint32_t)ramfont->bitmap;
+    uint32_t glyph_offset = (uint32_t)ramfont->glyph;
 
-  ramfont->bitmap = (uint8_t*)((uint32_t)font + bitmap_offset);
-  ramfont->glyph = (GFXglyph*)((uint32_t)font + glyph_offset);
-
+    ramfont->bitmap = (uint8_t*)((uint32_t)font + bitmap_offset);
+    ramfont->glyph = (GFXglyph*)((uint32_t)font + glyph_offset);
+  }
   setFont(ramfont);
 }
 
@@ -586,6 +595,33 @@ void Renderer::setScrollMargins(uint16_t top, uint16_t bottom) {
 }
 void Renderer::scrollTo(uint16_t y) {
 
+}
+
+void Renderer::SetPwrCB(pwr_cb cb) {
+
+}
+void Renderer::SetDimCB(dim_cb cb) {
+
+}
+
+uint16_t Renderer::fgcol(void) {
+  return 0;
+}
+uint16_t Renderer::bgcol(void) {
+  return 0;
+}
+int8_t Renderer::color_type(void) {
+ return 0;
+}
+
+void Renderer::Splash(void) {
+
+}
+
+const char dname[1] = {0};
+
+char *Renderer::devname(void) {
+  return (char*)dname;
 }
 
 void VButton::xdrawButton(bool inverted) {

--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -16,6 +16,8 @@
 // a. in class GFX setCursor,setTextSize => virtual
 // b. textcolor,textbgcolor => public;
 
+typedef void (*pwr_cb)(uint8_t);
+typedef void (*dim_cb)(uint8_t);
 
 class Renderer : public Adafruit_GFX {
   //Paint(unsigned char* image, int width, int height);
@@ -42,12 +44,21 @@ public:
   virtual void setScrollMargins(uint16_t top, uint16_t bottom);
   virtual void scrollTo(uint16_t y);
   virtual void TS_RotConvert(int16_t *x, int16_t *y);
+  virtual void SetPwrCB(pwr_cb cb);
+  virtual void SetDimCB(dim_cb cb);
+  virtual uint16_t fgcol(void);
+  virtual uint16_t bgcol(void);
+  virtual int8_t color_type(void);
+  virtual void Splash(void);
+  virtual char *devname(void);
 
   void setDrawMode(uint8_t mode);
   uint8_t drawmode;
   virtual void FastString(uint16_t x,uint16_t y,uint16_t tcolor, const char* str);
   void setTextSize(uint8_t s);
   virtual uint8_t *allocate_framebuffer(uint32_t size);
+  pwr_cb pwr_cbp = 0;
+  dim_cb dim_cbp = 0;
 private:
   void DrawCharAt(int16_t x, int16_t y, char ascii_char,int16_t colored);
   inline void drawFastVLineInternal(int16_t x, int16_t y, int16_t h, uint16_t color) __attribute__((always_inline));

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -31,6 +31,17 @@ uint16_t uDisplay::GetColorFromIndex(uint8_t index) {
   return udisp_colors[index];
 }
 
+uint16_t uDisplay::fgcol(void) {
+  return fg_col;
+}
+uint16_t uDisplay::bgcol(void) {
+  return bg_col;
+}
+
+int8_t uDisplay::color_type(void) {
+  return col_type;
+}
+
 
 uDisplay::~uDisplay(void) {
   if (framebuffer) {
@@ -40,6 +51,8 @@ uDisplay::~uDisplay(void) {
 
 uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
   // analyse decriptor
+  pwr_cbp = 0;
+  dim_cbp = 0;
   framebuffer = 0;
   col_mode = 16;
   sa_mode = 16;
@@ -915,8 +928,8 @@ void uDisplay::setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
     SPI_CS_HIGH
     SPI_END_TRANSACTION
   } else {
-    SPI_CS_LOW
     SPI_BEGIN_TRANSACTION
+    SPI_CS_LOW
     setAddrWindow_int(x0, y0, x1 - x0, y1 - y0 );
   }
 }
@@ -1092,7 +1105,11 @@ void uDisplay::DisplayOnff(int8_t on) {
     return;
   }
 
-  udisp_bpwr(on);
+  if (pwr_cbp) {
+    pwr_cbp(on);
+  }
+
+//  udisp_bpwr(on);
 
   if (interface == _UDSP_I2C) {
     if (on) {
@@ -1162,7 +1179,10 @@ void uDisplay::dim(uint8_t dim) {
     if (bpanel >= 0) {
       ledcWrite(ESP32_PWM_CHANNEL, dimmer);
     } else {
-      udisp_dimm(dim);
+      //udisp_dimm(dim);
+      if (dim_cbp) {
+        dim_cbp(dim);
+      }
     }
 #endif
 

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -79,9 +79,9 @@ class uDisplay : public Renderer {
   void DisplayOnff(int8_t on);
   void Splash(void);
   char *devname(void);
-  uint16_t fgcol(void) const { return fg_col; };
-  uint16_t bgcol(void) const { return bg_col; };
-  int8_t color_type(void) const { return col_type; };
+  uint16_t fgcol(void);
+  uint16_t bgcol(void);
+  int8_t color_type(void);
   void dim(uint8_t dim);
   uint16_t GetColorFromIndex(uint8_t index);
   void setRotation(uint8_t m);
@@ -90,6 +90,8 @@ class uDisplay : public Renderer {
   void pushColors(uint16_t *data, uint16_t len, boolean first);
   void TS_RotConvert(int16_t *x, int16_t *y);
   void invertDisplay(boolean i);
+  void SetPwrCB(pwr_cb cb) { pwr_cbp = cb; };
+  void SetDimCB(dim_cb cb) { dim_cbp = cb; };
 
  private:
    void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);

--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
@@ -22,107 +22,15 @@ static void lv_tick_handler(void) { lv_tick_inc(lv_tick_interval_ms); }
 #define ADC_YMIN 240
 #define ADC_YMAX 840
 
+
+uint32_t Touch_Status(uint32_t sel);
+
 static bool touchscreen_read(struct _lv_indev_drv_t *indev_drv, lv_indev_data_t *data) {
-//   static lv_coord_t last_x = 0, last_y = 0;
-//   static uint8_t release_count = 0;
-
-//   // Get pointer to glue object from indev user data
-//   Adafruit_LvGL_Glue *glue = (Adafruit_LvGL_Glue *)indev_drv->user_data;
-//   uDisplay_lvgl *disp = glue->display;
-
-//   if (glue->is_adc_touch) {
-//     TouchScreen *touch = (TouchScreen *)glue->touchscreen;
-//     TSPoint p = touch->getPoint();
-//     // Serial.printf("%d %d %d\r\n", p.x, p.y, p.z);
-//     // Having an issue with spurious z=0 results from TouchScreen lib.
-//     // Since touch is polled periodically, workaround is to watch for
-//     // several successive z=0 results, and only then regard it as
-//     // a release event (otherwise still touched).
-//     if (p.z < touch->pressureThreshhold) { // A zero-ish value
-//       release_count += (release_count < 255);
-//       if (release_count >= 4) {
-//         data->state = LV_INDEV_STATE_REL; // Is REALLY RELEASED
-//       } else {
-//         data->state = LV_INDEV_STATE_PR; // Is STILL PRESSED
-//       }
-//     } else {
-//       release_count = 0;               // Reset release counter
-//       data->state = LV_INDEV_STATE_PR; // Is PRESSED
-//       switch (glue->display->getRotation()) {
-//       case 0:
-//         last_x = map(p.x, ADC_XMIN, ADC_XMAX, 0, disp->width() - 1);
-//         last_y = map(p.y, ADC_YMAX, ADC_YMIN, 0, disp->height() - 1);
-//         break;
-//       case 1:
-//         last_x = map(p.y, ADC_YMAX, ADC_YMIN, 0, disp->width() - 1);
-//         last_y = map(p.x, ADC_XMAX, ADC_XMIN, 0, disp->height() - 1);
-//         break;
-//       case 2:
-//         last_x = map(p.x, ADC_XMAX, ADC_XMIN, 0, disp->width() - 1);
-//         last_y = map(p.y, ADC_YMIN, ADC_YMAX, 0, disp->height() - 1);
-//         break;
-//       case 3:
-//         last_x = map(p.y, ADC_YMIN, ADC_YMAX, 0, disp->width() - 1);
-//         last_y = map(p.x, ADC_XMIN, ADC_XMAX, 0, disp->height() - 1);
-//         break;
-//       }
-//     }
-//     data->point.x = last_x; // Last-pressed coordinates
-//     data->point.y = last_y;
-//     return false; // No buffering of ADC touch data
-//   } else {
-//     uint8_t fifo; // Number of points in touchscreen FIFO
-//     bool moar = false;
-//     Adafruit_STMPE610 *touch = (Adafruit_STMPE610 *)glue->touchscreen;
-//     // Before accessing SPI touchscreen, wait on any in-progress
-//     // DMA screen transfer to finish (shared bus).
-//     //disp->dmaWait();
-//     // disp->endWrite();
-//     if ((fifo = touch->bufferSize())) { // 1 or more points await
-//       data->state = LV_INDEV_STATE_PR;  // Is PRESSED
-//       TS_Point p = touch->getPoint();
-//       // Serial.printf("%d %d %d\r\n", p.x, p.y, p.z);
-//       // On big TFT FeatherWing, raw X axis is flipped??
-//       if ((glue->display->width() == 480) || (glue->display->height() == 480)) {
-//         p.x = (TS_MINX + TS_MAXX) - p.x;
-//       }
-//       switch (glue->display->getRotation()) {
-//       case 0:
-//         last_x = map(p.x, TS_MAXX, TS_MINX, 0, disp->width() - 1);
-//         last_y = map(p.y, TS_MINY, TS_MAXY, 0, disp->height() - 1);
-//         break;
-//       case 1:
-//         last_x = map(p.y, TS_MINY, TS_MAXY, 0, disp->width() - 1);
-//         last_y = map(p.x, TS_MINX, TS_MAXX, 0, disp->height() - 1);
-//         break;
-//       case 2:
-//         last_x = map(p.x, TS_MINX, TS_MAXX, 0, disp->width() - 1);
-//         last_y = map(p.y, TS_MAXY, TS_MINY, 0, disp->height() - 1);
-//         break;
-//       case 3:
-//         last_x = map(p.y, TS_MAXY, TS_MINY, 0, disp->width() - 1);
-//         last_y = map(p.x, TS_MAXX, TS_MINX, 0, disp->height() - 1);
-//         break;
-//       }
-//       moar = (fifo > 1); // true if more in FIFO, false if last point
-// #if defined(NRF52_SERIES)
-//       // Not sure what's up here, but nRF doesn't seem to always poll
-//       // the FIFO size correctly, causing false release events. If it
-//       // looks like we've read the last point from the FIFO, pause
-//       // briefly to allow any more FIFO events to pile up. This
-//       // doesn't seem to be necessary on SAMD or ESP32. ???
-//       if (!moar) {
-//         delay(50);
-//       }
-// #endif
-//     } else {                            // FIFO empty
-//       data->state = LV_INDEV_STATE_REL; // Is RELEASED
-//     }
-
-//     data->point.x = last_x; // Last-pressed coordinates
-//     data->point.y = last_y;
-//     return moar;
-//   }
+  //lv_coord_t last_x = 0, last_y = 0;
+  //static uint8_t release_count = 0;
+  data->point.x = Touch_Status(1); // Last-pressed coordinates
+  data->point.y = Touch_Status(2);
+  data->state = Touch_Status(0);
   return false; /*No buffering now so no more data read*/
 }
 

--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
@@ -165,7 +165,7 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_col
     return; // ok
   }
 
-  uDisplay_lvgl *display = glue->display;
+  Renderer *display = glue->display;
 
   if (!glue->first_frame) {
     //display->dmaWait();  // Wait for prior DMA transfer to complete
@@ -174,11 +174,9 @@ static void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_col
     glue->first_frame = false;
   }
 
-  // display->startWrite();
-  // display->setAddrWindow(area->x1, area->y1, width, height);
-  display->writePixels(area->x1, area->y1, width, height,
-                       (uint16_t *)color_p, width * height);
-  // display->pushColors((uint16_t *)color_p, width * height, false);
+  display->setAddrWindow(area->x1, area->y1, area->x1+width, area->y1+height);
+  display->pushColors((uint16_t *)color_p, width * height, true);
+  display->setAddrWindow(0,0,0,0);
 
   lv_disp_flush_ready(disp);
 }
@@ -286,11 +284,11 @@ Adafruit_LvGL_Glue::~Adafruit_LvGL_Glue(void) {
  * * LVGL_ERR_TIMER : Failure to set up timers
  * * LVGL_ERR_ALLOC : Failure to allocate memory
  */
-LvGLStatus Adafruit_LvGL_Glue::begin(uDisplay_lvgl *tft, bool debug) {
+LvGLStatus Adafruit_LvGL_Glue::begin(Renderer *tft, bool debug) {
   return begin(tft, (void *)NULL, debug);
 }
 
-LvGLStatus Adafruit_LvGL_Glue::begin(uDisplay_lvgl *tft, void *touch, bool debug) {
+LvGLStatus Adafruit_LvGL_Glue::begin(Renderer *tft, void *touch, bool debug) {
 
   lv_init();
 // #if (LV_USE_LOG)

--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.h
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.h
@@ -28,6 +28,7 @@ public:
   // LvGLStatus begin(uDisplay_lvgl *tft, TouchScreen *touch,
   //                  bool debug = false);
   LvGLStatus begin(Renderer *tft, bool debug = false);
+  LvGLStatus begin(Renderer *tft, void *touch, bool debug);
   // These items need to be public for some internal callbacks,
   // but should be avoided by user code please!
   Renderer *display; ///< Pointer to the SPITFT display instance
@@ -40,7 +41,6 @@ public:
   void stopScreenshot(void) { screenshot = nullptr; }
 
 private:
-  LvGLStatus begin(Renderer *tft, void *touch, bool debug);
   lv_disp_drv_t lv_disp_drv;
   lv_disp_buf_t lv_disp_buf;
   lv_color_t *lv_pixel_buf;

--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.h
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.h
@@ -2,7 +2,7 @@
 #define _ADAFRUIT_LVGL_GLUE_H_
 
 #include <lvgl.h>              // LittlevGL core lib
-#include <uDisplay_lvgl.h>
+#include <renderer.h>
 #include <Ticker.h> // ESP32-specific timer lib
 #include <FS.h>
 
@@ -27,10 +27,10 @@ public:
   //                  bool debug = false);
   // LvGLStatus begin(uDisplay_lvgl *tft, TouchScreen *touch,
   //                  bool debug = false);
-  LvGLStatus begin(uDisplay_lvgl *tft, bool debug = false);
+  LvGLStatus begin(Renderer *tft, bool debug = false);
   // These items need to be public for some internal callbacks,
   // but should be avoided by user code please!
-  uDisplay_lvgl *display; ///< Pointer to the SPITFT display instance
+  Renderer *display; ///< Pointer to the SPITFT display instance
   void *touchscreen;        ///< Pointer to the touchscreen object to use
   bool is_adc_touch; ///< determines if the touchscreen controlelr is ADC based
   bool first_frame;  ///< Tracks if a call to `lv_flush_callback` needs to wait
@@ -40,7 +40,7 @@ public:
   void stopScreenshot(void) { screenshot = nullptr; }
 
 private:
-  LvGLStatus begin(uDisplay_lvgl *tft, void *touch, bool debug);
+  LvGLStatus begin(Renderer *tft, void *touch, bool debug);
   lv_disp_drv_t lv_disp_drv;
   lv_disp_buf_t lv_disp_buf;
   lv_color_t *lv_pixel_buf;

--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -824,27 +824,36 @@ extern FS *ffsp;
                 char fname[32];
                 *ep = 0;
                 ep++;
-                if (*cp != '/') {
-                  fname[0] = '/';
-                  fname[1] = 0;
+                if (*cp == '-' && *(cp + 1) == 0) {
+                  if (ram_font) {
+                    free (ram_font);
+                    ram_font = 0;
+                    if (renderer) renderer->SetRamfont(0);
+                  }
+                  cp = ep;
                 } else {
-                  fname[0] = 0;
-                }
-                strlcat(fname, cp, sizeof(fname));
-                if (!strstr(cp, ".fnt")) {
-                  strlcat(fname, ".fnt", sizeof(fname));
-                }
-                if (ffsp) {
-                  File fp;
-                  fp = ffsp->open(fname, "r");
-                  if (fp > 0) {
-                    uint32_t size = fp.size();
-                    if (ram_font) free (ram_font);
-                    ram_font = (uint8_t*)special_malloc(size + 4);
-                    fp.read((uint8_t*)ram_font, size);
-                    fp.close();
-                    if (renderer) renderer->SetRamfont(ram_font);
-                    //Serial.printf("Font loaded: %s\n",fname );
+                  if (*cp != '/') {
+                    fname[0] = '/';
+                    fname[1] = 0;
+                  } else {
+                    fname[0] = 0;
+                  }
+                  strlcat(fname, cp, sizeof(fname));
+                  if (!strstr(cp, ".fnt")) {
+                    strlcat(fname, ".fnt", sizeof(fname));
+                  }
+                  if (ffsp) {
+                    File fp;
+                    fp = ffsp->open(fname, "r");
+                    if (fp > 0) {
+                      uint32_t size = fp.size();
+                      if (ram_font) free (ram_font);
+                      ram_font = (uint8_t*)special_malloc(size + 4);
+                      fp.read((uint8_t*)ram_font, size);
+                      fp.close();
+                      if (renderer) renderer->SetRamfont(ram_font);
+                      //Serial.printf("Font loaded: %s\n",fname );
+                    }
                   }
                 }
                 cp = ep;

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -243,7 +243,8 @@ static lv_fs_res_t lvbe_fs_remove(lv_fs_drv_t * drv, const char *path) {
  * display ecosystem.
  ************************************************************/
 
- Renderer *Init_uDisplay(const char *desc, int8_t cs);
+Renderer *Init_uDisplay(const char *desc, int8_t cs);
+
 
 void start_lvgl(const char * uconfig);
 void start_lvgl(const char * uconfig) {
@@ -268,7 +269,7 @@ void start_lvgl(const char * uconfig) {
   glue = new Adafruit_LvGL_Glue();
 
   // Initialize glue, passing in address of display & touchscreen
-  LvGLStatus status = glue->begin(renderer);
+  LvGLStatus status = glue->begin(renderer, (void*)1, false);
   if (status != LVGL_OK) {
     AddLog(LOG_LEVEL_ERROR, PSTR("Glue error %d"), status);
     return;

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -254,8 +254,12 @@ void start_lvgl(const char * uconfig) {
   }
 
   if (uconfig && !renderer) {
+#ifdef USE_UNIVERSAL_DISPLAY
     renderer  = Init_uDisplay((char*)uconfig, -1);
     if (!renderer) return;
+#else
+    return;
+#endif
   }
 
   // **************************************************

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -20,7 +20,7 @@
 
 #ifdef USE_LVGL
 
-#include <uDisplay_lvgl.h>
+#include <renderer.h>
 #include "lvgl.h"
 
 #define XDRV_54             54
@@ -37,7 +37,7 @@
  * you should lock on the very same semaphore! */
 
 SemaphoreHandle_t xGuiSemaphore;
-uDisplay_lvgl * udisp = nullptr;
+//uDisplay * udisp = nullptr;
 
 // necessary for compilation
 uint8_t color_type_lvgl = 0;
@@ -121,7 +121,7 @@ static void guiTask(void *pvParameter) {
 
 /************************************************************
  * Callbacks for file system access from LVGL
- * 
+ *
  * Useful to load fonts or images from file system
  ************************************************************/
 
@@ -217,7 +217,7 @@ static lv_fs_res_t lvbe_fs_seek(lv_fs_drv_t * drv, void * file_p, uint32_t pos) 
     return LV_FS_RES_OK;
   } else {
     return LV_FS_RES_UNKNOWN;
-  }  
+  }
 }
 
 static lv_fs_res_t lvbe_fs_size(lv_fs_drv_t * drv, void * file_p, uint32_t * size_p);
@@ -238,10 +238,12 @@ static lv_fs_res_t lvbe_fs_remove(lv_fs_drv_t * drv, const char *path) {
 
 /************************************************************
  * Initialize the display / touchscreen drivers then launch lvgl
- * 
+ *
  * We use Adafruit_LvGL_Glue to leverage the Adafruit
  * display ecosystem.
  ************************************************************/
+
+ Renderer *Init_uDisplay(const char *desc, int8_t cs);
 
 void start_lvgl(const char * uconfig);
 void start_lvgl(const char * uconfig) {
@@ -251,17 +253,10 @@ void start_lvgl(const char * uconfig) {
     return;
   }
 
-  if (udisp == nullptr) {
-    udisp  = new uDisplay_lvgl((char*)uconfig);
+  if (uconfig && !renderer) {
+    renderer  = Init_uDisplay((char*)uconfig, -1);
+    if (!renderer) return;
   }
-
-  udisp->Init();
-
-  // Settings.display_width = udisp->width();
-  // Settings.display_height = udisp->height();
-
-  udisp->DisplayInit(0 /* DISPLAY_INIT_MODE */, Settings.display_size, Settings.display_rotate, Settings.display_font);
-  udisp->dim(Settings.display_dimmer);
 
   // **************************************************
   // Initialize the glue between Adafruit and LVGL
@@ -269,7 +264,7 @@ void start_lvgl(const char * uconfig) {
   glue = new Adafruit_LvGL_Glue();
 
   // Initialize glue, passing in address of display & touchscreen
-  LvGLStatus status = glue->begin(udisp);
+  LvGLStatus status = glue->begin(renderer);
   if (status != LVGL_OK) {
     AddLog(LOG_LEVEL_ERROR, PSTR("Glue error %d"), status);
     return;
@@ -277,8 +272,10 @@ void start_lvgl(const char * uconfig) {
 
   // Set the default background color of the display
   // This is normally overriden by an opaque screen on top
+#ifdef USE_BERRY
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_from_uint32(USE_LVGL_BG_DEFAULT));
   lv_obj_set_style_local_bg_opa(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
+#endif
 
 #if LV_USE_LOG
   lv_log_register_print_cb(lvbe_debug);
@@ -319,6 +316,8 @@ void start_lvgl(const char * uconfig) {
     * Otherwise there can be problem such as memory corruption and so on.
     * NOTE: When not using Wi-Fi nor Bluetooth you can pin the guiTask to core 0 */
   xTaskCreatePinnedToCore(guiTask, "gui", 4096*2, NULL, 0, NULL, 1);
+
+  AddLog(LOG_LEVEL_INFO, PSTR("LVGL initialized"));
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

remove all global vars from renderer to callbacks
LVGL glue now takes renderer class. (no separate LVGL udisp needed)
this allows  concurrent action of LVGL and display text. (all renderer display drivers, not only udisp)

verified with Berry examples. however @s-hadinger  please verify commit

(touch support in preparation)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
