### PR TITLE
Use latest xtensa toolchain for esp8266 stage

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -101,7 +101,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 [core_stage]
 ; *** Esp8266 core for Arduino version stage
 platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-; *** Use Xtensa build chain 10.2. GNU13 from https://github.com/earlephilhower/esp-quick-toolchain
+; *** Use Xtensa build chain 10.2. GNU23 from https://github.com/earlephilhower/esp-quick-toolchain
                               tasmota/toolchain-xtensa @ 5.100200.210303
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -84,10 +84,9 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 ;build_unflags               = ${tasmota_stage.build_unflags}
 ;build_flags                 = ${tasmota_stage.build_flags}
 
-;
-platform_packages           = ${core_stage.platform_packages}
-build_unflags               = ${core_stage.build_unflags}
-build_flags                 = ${core_stage.build_flags}
+;platform_packages           = ${core_stage.platform_packages}
+;build_unflags               = ${core_stage.build_unflags}
+;build_flags                 = ${core_stage.build_flags}
 
 
 [tasmota_stage]

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -84,9 +84,10 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 ;build_unflags               = ${tasmota_stage.build_unflags}
 ;build_flags                 = ${tasmota_stage.build_flags}
 
-;platform_packages           = ${core_stage.platform_packages}
-;build_unflags               = ${core_stage.build_unflags}
-;build_flags                 = ${core_stage.build_flags}
+;
+platform_packages           = ${core_stage.platform_packages}
+build_unflags               = ${core_stage.build_unflags}
+build_flags                 = ${core_stage.build_flags}
 
 
 [tasmota_stage]
@@ -102,7 +103,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Esp8266 core for Arduino version stage
 platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 ; *** Use Xtensa build chain 10.2. GNU13 from https://github.com/earlephilhower/esp-quick-toolchain
-                              mcspr/toolchain-xtensa @ 5.100200.201223
+                              tasmota/toolchain-xtensa @ 5.100200.210303
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
 build_flags                 = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:

Fixes and updates in toolchain. For latest Arduino ESP8266 feature stage.
Btw. Tasmota does not compile successful with latest Arduino ESP8266 feature stage 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
