### PR TITLE
Zigbee fix flash size detection

### DIFF
--- a/tasmota/xdrv_23_zigbee_4a_nano_fs.ino
+++ b/tasmota/xdrv_23_zigbee_4a_nano_fs.ino
@@ -29,7 +29,7 @@ extern FS *dfsp;
 extern "C" uint32_t _FS_end;
 // Is it ok to write to bank 0x402FF000
 bool flash_valid(void) {
-  return (_FS_end > 0x40280000) && (_FS_end < 0x402FF000);
+  return (((uint32_t)&_FS_end) > 0x40280000) && (((uint32_t)&_FS_end) < 0x402FF000);
 }
 
 void hydrateSingleDevice(const SBuffer & buf_d);


### PR DESCRIPTION
## Description:

Fix wrong flash size detection when saving Zigbee device information on ESP8266.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
