### PR TITLE
LVGL fix byte order for DMA and non-DMA

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -1053,6 +1053,8 @@ void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean first) {
     if (lvgl_param.use_dma) {
       pushPixelsDMA(data, len );
     } else {
+      // reversed order for DMA, so non-DMA needs to get back to normal order
+      for (uint32_t i = 0; i < len; i++) (data[i] = data[i] << 8 | data[i] >> 8);
       uspi->writePixels(data, len * 2);
     }
 #endif
@@ -1911,11 +1913,6 @@ void uDisplay::pushPixelsDMA(uint16_t* image, uint32_t len) {
   if ((len == 0) || (!DMA_Enabled)) return;
 
   dmaWait();
-
-/*
-  if(_swapBytes) {
-    for (uint32_t i = 0; i < len; i++) (image[i] = image[i] << 8 | image[i] >> 8);
-  }*/
 
   esp_err_t ret;
 

--- a/tasmota/lvgl_berry/tasmota_lv_conf.h
+++ b/tasmota/lvgl_berry/tasmota_lv_conf.h
@@ -37,7 +37,7 @@
  * Useful if the display has a 8 bit interface (e.g. SPI)*/
 //  #define LV_COLOR_16_SWAP   1
 // #if defined(ADAFRUIT_PYPORTAL)
-//  #define LV_COLOR_16_SWAP   1
+#define LV_COLOR_16_SWAP   1          // needed for DMA transfer
 // #else
 //  #define LV_COLOR_16_SWAP   0
 // #endif

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -168,7 +168,7 @@ void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *c
 
   lv_disp_flush_ready(disp);
 
-  if (pixels_len >= 10000) {
+  if (pixels_len >= 10000 && (!display->lvgl_param.use_dma)) {
     AddLog(LOG_LEVEL_DEBUG, D_LOG_LVGL "Refreshed %d pixels in %d ms (%i pix/ms)", pixels_len, chrono_time,
             chrono_time > 0 ? pixels_len / chrono_time : -1);
   }


### PR DESCRIPTION
## Description:

As DMA requires reversed byte order, this is now the norm.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
