### PR TITLE
fix lvgl pushcolors

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -163,8 +163,8 @@ class uDisplay : public Renderer {
    uint8_t dsp_on;
    uint8_t dsp_off;
    uint8_t allcmd_mode;
-   uint16_t splash_font;
-   uint16_t splash_size;
+   int8_t splash_font;
+   uint8_t splash_size;
    uint16_t splash_xp;
    uint16_t splash_yp;
    uint16_t fg_col;

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -162,7 +162,7 @@ void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *c
   uint32_t pixels_len = width * height;
   uint32_t chrono_start = millis();
   display->setAddrWindow(area->x1, area->y1, area->x1+width, area->y1+height);
-  display->pushColors((uint16_t *)color_p, pixels_len, true);
+  display->pushColors((uint16_t *)color_p, pixels_len, false);
   display->setAddrWindow(0,0,0,0);
   uint32_t chrono_time = millis() - chrono_start;
 


### PR DESCRIPTION
## Description:

fix udisp pushcolors to work also for displaytext.
if section :S in displaydescriptor is not present display is not cleared initially 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
