### PR TITLE
uDisplay remove byte swap

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -1046,13 +1046,6 @@ void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean not_inverted) {
 
   //Serial.printf("push %x - %d\n", (uint32_t)data, len);
 
-#ifdef ESP32
-// reversed order for DMA, so non-DMA needs to get back to normal order
-  if (!not_inverted && !lvgl_param.use_dma) {
-    for (uint32_t i = 0; i < len; i++) (data[i] = data[i] << 8 | data[i] >> 8);
-  }
-#endif
-
   if (bpp != 16) {
     // stupid monchrome version
     for (uint32_t y = seta_yp1; y < seta_yp2; y++) {
@@ -1076,7 +1069,7 @@ void uDisplay::pushColors(uint16_t *data, uint16_t len, boolean not_inverted) {
     if (lvgl_param.use_dma) {
       pushPixelsDMA(data, len );
     } else {
-      uspi->writePixels(data, len * 2);
+      uspi->writeBytes((uint8_t*)data, len * 2);
     }
 #endif
   } else {


### PR DESCRIPTION
## Description:

@gemu2015 
Actually `writePixels()` was doing byte swapping under the hood, which made a double swapping. Using `writeBytes()` removes the need to byte swap.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
