### PR TITLE
have Fade and Speed generate STATE messages with So59 enabled too

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2865,9 +2865,15 @@ void CmndFade(void)
       Settings.light_fade ^= 1;
       break;
     }
+    if (XdrvMailbox.payload >= 0 && XdrvMailbox.payload <= 2) {
   #ifdef USE_DEVICE_GROUPS
-    if (XdrvMailbox.payload >= 0 && XdrvMailbox.payload <= 2) SendDeviceGroupMessage(Light.device, DGR_MSGTYP_UPDATE, DGR_ITEM_LIGHT_FADE, Settings.light_fade);
+      SendDeviceGroupMessage(Light.device, DGR_MSGTYP_UPDATE, DGR_ITEM_LIGHT_FADE, Settings.light_fade);
   #endif  // USE_DEVICE_GROUPS
+      // Publish state message for Hass
+      if (Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
+        MqttPublishTeleState();
+      }
+    }
     if (!Settings.light_fade) { Light.fade_running = false; }
   }
   ResponseCmndStateText(Settings.light_fade);
@@ -2903,6 +2909,10 @@ void CmndSpeed(void)
 #ifdef USE_DEVICE_GROUPS
       SendDeviceGroupMessage(Light.device, DGR_MSGTYP_UPDATE, DGR_ITEM_LIGHT_SPEED, Settings.light_speed);
 #endif  // USE_DEVICE_GROUPS
+      // Publish state message for Hass
+      if (Settings.flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
+        MqttPublishTeleState();
+      }
     }
     ResponseCmndNumber(Settings.light_speed);
   }


### PR DESCRIPTION

## Description:

This makes changing the fade or speed consistent with other commands that change the light config/state, ie, if `SetOption59` is enabled, changes will generate STATE messages. The values of these fields are already part of the STATE information, so this change just makes the STATE messages appear when the values are set.

This allows me to easily add clicky-clicky things in HA to control these parameters. Here's an example of a simple light set up in HA with a switch entity to control whether fade is enabled or not:

```yaml
light test:
  - platform: mqtt
    name: "Test Light"
    command_topic: "cmnd/twinkle_D41199/POWER"
    state_topic: "tele/twinkle_D41199/STATE"
    state_value_template: "{{value_json.POWER}}"
    payload_on: "ON"
    payload_off: "OFF"
    availability_topic: "tele/twinkle_D41199/LWT"
    payload_available: "Online"
    payload_not_available: "Offline"
    brightness_state_topic: "tele/twinkle_D41199/STATE"
    brightness_command_topic: "cmnd/twinkle_D41199/Dimmer"
    brightness_scale: 100
    brightness_value_template: "{{ value_json.Dimmer }}"

switch test_fade:
  - platform: mqtt
    name: "Test Light Fade"
    availability_topic: "tele/twinkle_D41199/LWT"
    payload_available: "Online"
    payload_not_available: "Offline"
    state_topic: "tele/twinkle_D41199/STATE"
    value_template: "{{ value_json.Fade }}"
    state_on: "ON"
    state_off: "OFF"
    command_topic: "cmnd/twinkle_D41199/FADE"
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
