### PR TITLE
Adding support for SAS Token Generation

### DIFF
--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -24,7 +24,7 @@
 #endif
 
 #ifdef USE_MQTT_AZURE_IOT
-#include <bearssl\bearssl.h>
+#include <t_bearssl.h>
 #include <base64.hpp>
 #include <JsonParser.h>
 #undef  MQTT_PORT

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -23,9 +23,9 @@
 #define MQTT_WIFI_CLIENT_TIMEOUT   200    // Wifi TCP connection timeout (default is 5000 mSec)
 #endif
 
-#ifdef USE_MQTT_AZURE_IOT
 #include <bearssl\bearssl.h>
 #include <base64.hpp>
+#ifdef USE_MQTT_AZURE_IOT
 #include <JsonParser.h>
 #undef  MQTT_PORT
 #define MQTT_PORT         8883

--- a/tasmota/xdrv_02_mqtt.ino
+++ b/tasmota/xdrv_02_mqtt.ino
@@ -23,9 +23,9 @@
 #define MQTT_WIFI_CLIENT_TIMEOUT   200    // Wifi TCP connection timeout (default is 5000 mSec)
 #endif
 
+#ifdef USE_MQTT_AZURE_IOT
 #include <bearssl\bearssl.h>
 #include <base64.hpp>
-#ifdef USE_MQTT_AZURE_IOT
 #include <JsonParser.h>
 #undef  MQTT_PORT
 #define MQTT_PORT         8883
@@ -224,6 +224,7 @@ void MqttInit(void) {
   MqttClient.setSocketTimeout(Settings.mqtt_socket_timeout);
 }
 
+#ifdef USE_MQTT_AZURE_IOT
 String azurePreSharedKeytoSASToken(char *iotHubFQDN, const char *deviceId, const char *preSharedKey, int sasTTL = 86400){
   int ttl = time(NULL) + sasTTL;
   String dataToSignString = urlEncodeBase64(String(iotHubFQDN) + "/devices/" + String(deviceId)) + "\n" + String(ttl);
@@ -268,6 +269,7 @@ String urlEncodeBase64(String stringToEncode){
   stringToEncode.replace("/", "%2F");
   return stringToEncode;
 }
+#endif  // USE_MQTT_AZURE_IOT
 
 bool MqttIsConnected(void) {
   return MqttClient.connected();


### PR DESCRIPTION
Azure IoT Hub uses a Sha256 has as opposed to a password.  This change enables the admin to add the 'Preshared Key' and lets Tasmota calculate the SAS token, vs the original changes where the end user had to calculate the SAS Token.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
