### PR TITLE
Correction of tasmota/xsns_05_ds18x20.ino Ds18x20Name() search.

### DIFF
--- a/tasmota/xsns_05_ds18x20.ino
+++ b/tasmota/xsns_05_ds18x20.ino
@@ -420,11 +420,10 @@ bool Ds18x20Read(uint8_t sensor) {
 
 void Ds18x20Name(uint8_t sensor) {
   uint8_t index = sizeof(ds18x20_chipids);
-  while (index) {
+  while (--index) {
     if (ds18x20_sensor[ds18x20_sensor[sensor].index].address[0] == ds18x20_chipids[index]) {
       break;
     }
-    index--;
   }
   GetTextIndexed(DS18X20Data.name, sizeof(DS18X20Data.name), index, kDs18x20Types);
   if (DS18X20Data.sensors > 1) {


### PR DESCRIPTION
sizeof(ds18x20_chipids) calculates number of chipids, e.g. 4 chipids + 0
entry it will return 5. So the 1st checked chipid must start at
ds18x20_chipids[4], not at ds18x20_chipids[5].

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
