### PR TITLE
Zigbee avoid erasing ZbData if zigbee is not started

### DIFF
--- a/tasmota/xdrv_23_zigbee_4b_data.ino
+++ b/tasmota/xdrv_23_zigbee_4b_data.ino
@@ -220,6 +220,7 @@ bool hydrateDevicesData(void) {
 \*********************************************************************************************/
 void hibernateAllData(void) {
   if (Rtc.utc_time < START_VALID_TIME) { return; }
+  if (zigbee_devices.devicesSize() == 0) { return; }    // safe-guard, if data is empty, don't save anything
   Univ_Write_File f;
   const char * storage_class = PSTR("");
 
@@ -242,9 +243,6 @@ void hibernateAllData(void) {
 #endif
 
   if (f.valid()) {
-    // first prefix is number of devices
-    uint8_t device_num = zigbee_devices.devicesSize();
-
     for (const auto & device : zigbee_devices.getDevices()) {
       // allocte a buffer for a single device
       SBuffer buf = hibernateDeviceData(device);

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -2177,8 +2177,10 @@ bool Xdrv23(uint8_t function)
         result = DecodeCommand(kZbCommands, ZigbeeCommand, kZbSynonyms);
         break;
       case FUNC_SAVE_BEFORE_RESTART:
-        hibernateAllData();
-        restoreDumpAllDevices();
+        if (!zigbee.init_phase) { 
+          hibernateAllData();
+          restoreDumpAllDevices();
+        }
         break;
     }
   }


### PR DESCRIPTION
## Description:

Avoid erasing ZbData if zigbee is not started.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
