### PR TITLE
feature: apply/execute rules after firmware flash

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -738,6 +738,8 @@
 #define D_LOG_TCP "TCP: "          // TCP bridge
 #define D_LOG_BERRY "BRY: "        // Berry scripting language
 #define D_LOG_LVGL "LVG: "         // LVGL graphics engine
+#define D_LOG_RULES "RUL:"
+
 
 /********************************************************************************************/
 

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -157,6 +157,7 @@
 #define D_RESTORE "restore"
 #define D_RETAINED "retained"
 #define D_RULE "Rule"
+#define D_RULE_SETUP_AFTER_FLASHING "Rules setup after flashing firmware"
 #define D_SAVE "Save"
 #define D_SENSOR "Sensor"
 #define D_SSID "SSId"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -738,8 +738,10 @@ struct {
   uint8_t       shd_leading_edge;          // F5B
   uint16_t      shd_warmup_brightness;     // F5C
   uint8_t       shd_warmup_time;           // F5E
+  uint8_t       rulesAfterFlash;           // F5F - flag for running rules only once after firmare flash
 
-  uint8_t       free_f5f[65];              // F5F - Decrement if adding new Setting variables just above and below
+  uint8_t       free_f5e[64];              // F60 - Decrement if adding new Setting variables just above and below
+
 
   // Only 32 bit boundary variables below
 
@@ -762,6 +764,8 @@ struct {
   uint32_t      i2c_drivers[3];            // FEC  I2cDriver
   uint32_t      cfg_timestamp;             // FF8
   uint32_t      cfg_crc32;                 // FFC
+
+
 } Settings;
 
 typedef struct {

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -391,6 +391,43 @@ void setup(void) {
 #endif
 
   TasmotaGlobal.rules_flag.system_init = 1;
+  Serial.println("rulesAfterFlash status:"+Settings.rulesAfterFlash);
+  if (!Settings.rulesAfterFlash){
+      // commands to execute at startup
+      #ifdef defaultSetting_01 
+        ExecuteCommand(defaultSetting_01, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_02 
+        ExecuteCommand(defaultSetting_02, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_03 
+        ExecuteCommand(defaultSetting_03, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_04 
+        ExecuteCommand(defaultSetting_04, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_05 
+        ExecuteCommand(defaultSetting_05, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_06 
+        ExecuteCommand(defaultSetting_06, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_07 
+        ExecuteCommand(defaultSetting_07, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_08 
+        ExecuteCommand(defaultSetting_08, SRC_IGNORE);
+      #endif
+      #ifdef defaultSetting_09 
+        ExecuteCommand(defaultSetting_09, SRC_IGNORE);
+      #endif
+      Settings.rulesAfterFlash=true;
+      SettingsSave(0);
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_RULES " " D_RULE_SETUP_AFTER_FLASHING));
+  }else{
+      Serial.println("\nskipping - Rules setup after flashing firmware\n");
+  }
+
 }
 
 void BacklogLoop(void) {


### PR DESCRIPTION
## Description:

After flashing a firmware i alwyas had to reapply the rules and activate them manually. When you have a lot of devices this can take some time and you have to remember the rules to be applied.
Whit this pull request you can apply the rules in an automatic manner after flashing the firmware.

Rules are implemented within the file user_config_override.h as last statement. Up to 9 rules can be configured using the statement  **_#define defaultSetting_01_** up to **_#define defaultSetting_09_**.

Here below a sample:

>   #ifdef APPLY_DEVICE_GARAGE
>     #define PROJECT "DRAGON"
>     #define FIRMWARE_BASIC
>     #define MODULE USER_MODULE
>     #define USER_TEMPLATE "{\"NAME\":\"CustomDragon\",\"GPIO\":[0,0,0,0,22,23,0,0,0,21,9,0,0],\"FLAG\":0,\"BASE\":18}"
>     #define defaultSetting_01 "Rule1 \
>     ON Power2#state=1 DO RuleTimer2 2 ENDON ON Rules#Timer=2 DO Power2 off ENDON  \
>     ON Power3#state=1 DO RuleTimer3 2 ENDON ON Rules#Timer=3 DO Power3 off ENDON"
>     #define defaultSetting_02 "Rule1 ON"
>  #endif

Then in you platform.ini file you define the usage like this:

> [env:DRAGON_PorteGarage]
> board = esp01_1m
> build_flags = ${common.build_flags} 
>   -DAPPLY_DEVICE_GARAGE

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
