### PR TITLE
Copy firmware in github release section

### DIFF
--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1395,8 +1395,16 @@ jobs:
         name: firmware
         path: ./mv_firmware
     - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: ./mv_firmware
+      run: ls -R ./mv_firmware/
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      #if: startsWith(github.ref, 'refs/tags/')
+      with:
+        tag_name: ${{ github.run_number }}
+        files: ./mv_firmware/firmware/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
     - name: Move firmware files in sub-folders
       run: |
         mkdir -p ./firmware/tasmota/languages


### PR DESCRIPTION
when a push is done to branch master.

Pushing this commit to branch `master` will generate all firmwares and the will be copied in branch `release-firmware` and in release section with a version tag (github run number). The tag can be easily edited. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
