### PR TITLE
feat: added units of mi flora sensors like shown in the ui 

### DIFF
--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -2822,17 +2822,17 @@ const char *classes[] = {
   // 7
   "", //- empty device class
   "Moisture",
-  "",
+  "%",
 
   // 8
   "", //- empty device class
   "Illuminance",
-  "",
+  "lx",
 
   // 9
   "", //- empty device class
   "Fertility",
-  "",
+  "µS/cm",
 
   // 10
   "", //- empty device class


### PR DESCRIPTION


## Description:
The units of the mi flora devices are shown in the Tasmota WebUI, but are not sent in the mqtt autodiscovery config messages.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
