### PR TITLE
Update xsns_29_mcp230xx.ino

### DIFF
--- a/tasmota/xsns_29_mcp230xx.ino
+++ b/tasmota/xsns_29_mcp230xx.ino
@@ -394,7 +394,7 @@ void MCP230xx_Show(bool json)
     }
     if (outputcount) {
       uint16_t gpiototal = ((uint16_t)gpiob << 8) | gpio;
-      ResponseAppend_P(PSTR(",\"MCP230_OUT\":{"));
+      ResponseAppend_P(PSTR(",\"OUT\":{"));
       char stt[7];
       bool first = true;
       for (uint32_t pinx = 0; pinx < mcp230xx_pincount; pinx++) {


### PR DESCRIPTION
when more than single out pin is configured this prevents non unique key (for how assistant auto configuration) due too long string being ignored.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
