### PR TITLE
Move special core versions 

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -127,19 +127,6 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 ; *** uncomment the following line if you dont use Epaper driver epidy in your Tasmota32 build. Reduces compile time 
                               lib/libesp32_epdiy
 
-[core32]
-; Activate Stage Core32 by removing ";" in next 3 lines, if you want to override the standard core32
-;platform_packages           = ${core32_stage.platform_packages}
-;build_unflags               = ${core32_stage.build_unflags}
-;build_flags                 = ${core32_stage.build_flags}
-
-[core32_stage]
-platform_packages           = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
-                              platformio/tool-mklittlefs @ ~1.203.200522
-build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${esp32_defaults.build_flags}
-                              -DESP32_STAGE=true
-
 [library]
 shared_libdeps_dir          = lib
 ; *** Library disable / enable for variant Tasmota(32). Disable reduces compile time

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -78,39 +78,6 @@ extra_scripts               = ${scripts_defaults.extra_scripts}
 
 lib_extra_dirs              = ${library.lib_extra_dirs}
 
-[core]
-; Activate only (one set) if you want to override the standard core defined in platformio.ini !!!
-
-;platform_packages           = ${tasmota_stage.platform_packages}
-;build_unflags               = ${tasmota_stage.build_unflags}
-;build_flags                 = ${tasmota_stage.build_flags}
-
-;platform_packages           = ${core_stage.platform_packages}
-;build_unflags               = ${core_stage.build_unflags}
-;build_flags                 = ${core_stage.build_flags}
-
-
-[tasmota_stage]
-; *** Esp8266 core for Arduino version Tasmota stage. Backport for PWM selection
-platform_packages           = tasmota/framework-arduinoespressif8266 @ ~2.7.4
-build_unflags               = ${esp_defaults.build_unflags}
-build_flags                 = ${esp82xx_defaults.build_flags}
-; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
-                              ;-DWAVEFORM_LOCKED_PHASE
-                              -DWAVEFORM_LOCKED_PWM
-
-[core_stage]
-; *** Esp8266 core for Arduino version stage
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-; *** Use Xtensa build chain 10.2. GNU23 from https://github.com/earlephilhower/esp-quick-toolchain
-                              tasmota/toolchain-xtensa @ 5.100200.210303
-build_unflags               = ${esp_defaults.build_unflags}
-                              -Wswitch-unreachable
-build_flags                 = ${esp82xx_defaults.build_flags}
-; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
-                              ;-DWAVEFORM_LOCKED_PHASE
-                              -DWAVEFORM_LOCKED_PWM
-                              -Wno-switch-unreachable
 
 [common32]
 platform_packages           = ${core32.platform_packages}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -4,7 +4,27 @@ build_flags  = ${common.build_flags}
                           -DUSE_ZIGBEE
                           -DUSE_UFILESYS
 
-; *** EXPERIMENTAL Tasmota version for ESP32-S2
+[core]
+; Activate (by removing the ";" in the next lines) if you want to override the standard core defined in platformio.ini !!!
+;platform_packages           = ${core_stage.platform_packages}
+;build_unflags               = ${core_stage.build_unflags}
+;build_flags                 = ${core_stage.build_flags}
+
+[core_stage]
+; *** Esp8266 core for Arduino version stage
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+; *** Use Xtensa build chain 10.2. GNU23 from https://github.com/earlephilhower/esp-quick-toolchain
+                              tasmota/toolchain-xtensa @ 5.100200.210303
+build_unflags               = ${esp_defaults.build_unflags}
+                              -Wswitch-unreachable
+build_flags                 = ${esp82xx_defaults.build_flags}
+; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
+                              ;-DWAVEFORM_LOCKED_PHASE
+                              -DWAVEFORM_LOCKED_PWM
+                              -Wno-switch-unreachable
+
+
+;*** EXPERIMENTAL Tasmota version for ESP32-S2
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2


### PR DESCRIPTION
## Description:

to `platformio_tasmota_cenv_sample.ini` since `platformio_override.ini` should be used to override build settings from the default cores.

Tasmota stage esp8266 core removed completly since latest version became standard for Tasmota since a while... 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
