### PR TITLE
LVGL support for PSRAM

### DIFF
--- a/lib/libesp32/Berry/default/berry_conf.h
+++ b/lib/libesp32/Berry/default/berry_conf.h
@@ -168,22 +168,25 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  extern void *berry_malloc(uint32_t size);
+  extern void *berry_malloc(size_t size);
+  extern void  berry_free(void *ptr);
   extern void *berry_realloc(void *ptr, size_t size);
 #ifdef __cplusplus
 }
 #endif
   #define BE_EXPLICIT_MALLOC              berry_malloc
+  #define BE_EXPLICIT_FREE                berry_free
   #define BE_EXPLICIT_REALLOC             berry_realloc
 #else
   #define BE_EXPLICIT_MALLOC              malloc
+  #define BE_EXPLICIT_FREE                free
   #define BE_EXPLICIT_REALLOC             realloc
 #endif // USE_BERRY_PSRAM
 
 #define BE_EXPLICIT_ABORT               abort
 #define BE_EXPLICIT_EXIT                exit
 // #define BE_EXPLICIT_MALLOC              malloc
-#define BE_EXPLICIT_FREE                free
+// #define BE_EXPLICIT_FREE                free
 // #define BE_EXPLICIT_REALLOC             realloc
 
 /* Macro: be_assert

--- a/tasmota/lvgl_berry/tasmota_lv_conf.h
+++ b/tasmota/lvgl_berry/tasmota_lv_conf.h
@@ -87,7 +87,7 @@ typedef int16_t lv_coord_t;
  * The graphical objects and other related data are stored here. */
 
 /* 1: use custom malloc/free, 0: use the built-in `lv_mem_alloc` and `lv_mem_free` */
-#define LV_MEM_CUSTOM      0
+#define LV_MEM_CUSTOM      1
 #if LV_MEM_CUSTOM == 0
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
 #ifdef ARDUINO_SAMD_ZERO
@@ -106,9 +106,9 @@ typedef int16_t lv_coord_t;
 /* Automatically defrag. on free. Defrag. means joining the adjacent free cells. */
 #  define LV_MEM_AUTO_DEFRAG  1
 #else       /*LV_MEM_CUSTOM*/
-#  define LV_MEM_CUSTOM_INCLUDE <stdlib.h>   /*Header for the dynamic memory function*/
-#  define LV_MEM_CUSTOM_ALLOC   malloc       /*Wrapper to malloc*/
-#  define LV_MEM_CUSTOM_FREE    free         /*Wrapper to free*/
+#  define LV_MEM_CUSTOM_INCLUDE <tasmota_lv_stdlib.h>   /*Header for the dynamic memory function*/
+#  define LV_MEM_CUSTOM_ALLOC   lvbe_malloc       /*Wrapper to malloc*/ /* PSRAM support */
+#  define LV_MEM_CUSTOM_FREE    lvbe_free         /*Wrapper to free*/
 #endif     /*LV_MEM_CUSTOM*/
 
 /* Use the standard memcpy and memset instead of LVGL's own functions.

--- a/tasmota/lvgl_berry/tasmota_lv_stdlib.h
+++ b/tasmota/lvgl_berry/tasmota_lv_stdlib.h
@@ -1,0 +1,23 @@
+/*
+  tasmota_lv_stdlib.h - internationalization for Tasmota
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// replacement for <stdlib.h> used for PSRAM malloc in LVGL
+
+extern void *lvbe_malloc(size_t size);
+extern void  lvbe_free(void *ptr);

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -922,6 +922,7 @@
 
 // -- LVGL Graphics Library ---------------------------------
 //#define USE_LVGL                                  // LVGL Engine, requires Berry, takes 440k of Flash
+  #define USE_LVGL_PSRAM                            // Allocate LVGL memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
   #define USE_LVGL_BG_DEFAULT 0x000000              // Default color for the uninitialized background screen (black)
 
 

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -78,6 +78,10 @@ void *special_realloc(void *ptr, size_t size) {
   return realloc(ptr, size);
 }
 
+void *special_calloc(size_t num, size_t size) {
+  return calloc(num, size);
+}
+
 String GetDeviceHardware(void) {
   // esptool.py get_efuses
   uint32_t efuse1 = *(uint32_t*)(0x3FF00050);
@@ -486,6 +490,13 @@ void *special_realloc(void *ptr, size_t size) {
     return heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   } else {
     return realloc(ptr, size);
+  }
+}
+void *special_calloc(size_t num, size_t size) {
+  if (psramFound()) {
+    return heap_caps_calloc(num, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  } else {
+    return calloc(num, size);
   }
 }
 

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -63,6 +63,9 @@ extern "C" {
   void *berry_realloc(void *ptr, size_t size) {
     return special_realloc(ptr, size);
   }
+  void *berry_calloc(size_t num, size_t size) {
+    return special_calloc(num, size);
+  }
 #else
   void *berry_malloc(uint32_t size) {
     return malloc(size);
@@ -70,8 +73,14 @@ extern "C" {
   void *berry_realloc(void *ptr, size_t size) {
     return realloc(ptr, size);
   }
+  void *berry_calloc(size_t num, size_t size) {
+    return calloc(num, size);
+  }
 #endif // USE_BERRY_PSRAM
 
+  void berry_free(void *ptr) {
+    free(ptr);
+  }
 }
 
 

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -296,6 +296,48 @@ static lv_fs_res_t lvbe_fs_remove(lv_fs_drv_t * drv, const char *path) {
 }
 #endif // USE_UFILESYS
 
+/*********************************************************************************************\
+ * Memory handler
+ * Use PSRAM if available
+\*********************************************************************************************/
+extern "C" {
+  /*
+  Use the following
+
+  extern void *lvbe_malloc(size_t size);
+  extern void  lvbe_free(void *ptr);
+  extern void *lvbe_realloc(void *ptr, size_t size);
+  extern void *lvbe_calloc(size_t num, size_t size);
+  */
+  void *lvbe_malloc(uint32_t size);
+  void *lvbe_realloc(void *ptr, size_t size);
+#ifdef USE_BERRY_PSRAM
+  void *lvbe_malloc(uint32_t size) {
+    return special_malloc(size);
+  }
+  void *lvbe_realloc(void *ptr, size_t size) {
+    return special_realloc(ptr, size);
+  }
+  void *lvbe_calloc(size_t num, size_t size) {
+    return special_calloc(num, size);
+  }
+#else // USE_BERRY_PSRAM
+  void *lvbe_malloc(uint32_t size) {
+    return malloc(size);
+  }
+  void *lvbe_realloc(void *ptr, size_t size) {
+    return realloc(ptr, size);
+  }
+  void *lvbe_calloc(size_t num, size_t size) {
+    return calloc(num, size);
+  }
+#endif // USE_BERRY_PSRAM
+
+  void lvbe_free(void *ptr) {
+    free(ptr);
+  }
+}
+
 /************************************************************
  * Initialize the display / touchscreen drivers then launch lvgl
  *


### PR DESCRIPTION
## Description:

LVGL will use PSRAM (if present) instead of internal RAM if `#define USE_LVGL_PSRAM` (enabled by default).

Note: frame-buffer is always allocated in internal RAM because PSRAM is not capable of DMA transfers to SPI.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
