### PR TITLE
Increase min stack thunk to 3800 #12031

### DIFF
--- a/lib/lib_ssl/tls_mini/src/StackThunk_light.cpp
+++ b/lib/lib_ssl/tls_mini/src/StackThunk_light.cpp
@@ -46,7 +46,7 @@ uint32_t stack_thunk_light_refcnt = 0;
 #elif defined(USE_MQTT_TLS_FORCE_EC_CIPHER) || defined(USE_4K_RSA)
   #define _stackSize (4800/4)   // no private key, we can reduce a little, max observed 4300
 #else
-  #define _stackSize (3600/4)   // using a light version of bearssl we can save 2k
+  #define _stackSize (3800/4)   // using a light version of bearssl we can save 2k
 #endif
 #define _stackPaint 0xdeadbeef
 


### PR DESCRIPTION
## Description:

Increase minimum stack thunk to 3800 bytes.

**Related issue (if applicable):** fixes #12031

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
