### PR TITLE
LVGL Fix warning when sending NULL instead of an instance

### DIFF
--- a/lib/libesp32_lvgl/LVGL/library.json
+++ b/lib/libesp32_lvgl/LVGL/library.json
@@ -7,9 +7,6 @@
 		"type": "git",
 		"url": "https://github.com/lvgl/lvgl.git"
 	},
-	"build": {
-		"includeDir": "."
-	},
 	"license": "MIT",
 	"homepage": "https://lvgl.io",
 	"frameworks": "*",

--- a/tasmota/xdrv_52_2_berry_native.ino
+++ b/tasmota/xdrv_52_2_berry_native.ino
@@ -310,7 +310,12 @@ int32_t be_convert_single_elt(bvm *vm, int32_t idx, const char * arg_type = null
 
   // check if simple type was a match
   if (provided_type) {
-    if ((arg_type_len != 1) || ((arg_type[0] != provided_type) && arg_type[0] != '.') ) {
+    bool type_ok = false;
+    type_ok = (arg_type[0] == '.');                           // any type is accepted
+    type_ok = type_ok || (arg_type[0] == provided_type);      // or type is a match
+    type_ok = type_ok || (ret == 0 && arg_type_len != 1);    // or NULL is accepted for an instance
+    
+    if (!type_ok) {
       berry_log_P("Unexpected argument type '%c', expected '%s'", provided_type, arg_type);
     }
     return ret;


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
