### PR TITLE
Allow retaining ratio between white and color channels

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1269,8 +1269,8 @@ void LightSetBriScaled(uint8_t bri) {
     bri_rgb = bri;
     bri_ct = bri;
   } else {
-    bri_rgb = bri * bri_rgb / max_bri;
-    bri_ct = bri * bri_ct / max_bri;
+    bri_rgb = changeUIntScale(bri_rgb, 0, max_bri, 0, bri);
+    bri_ct = changeUIntScale(bri_ct, 0, max_bri, 0, bri);
   }
 #ifdef DEBUG_LIGHT
   AddLog(LOG_LEVEL_DEBUG, "LightSetBri new bri_rgb:%d, new bri_ct: %d", bri_rgb, bri_ct);


### PR DESCRIPTION
## Description:
Allow retaining brightness ratio between white and color channels when setting dimmer for linked lights.

The ratio will be retained when:
 - Command `color2` is used to set color while retaining dimmer
 - New command `dimmer4` is used to set brightness

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
