### PR TITLE
LVGL fixed events and callbacks

### DIFF
--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
@@ -6,7 +6,7 @@
 extern void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p);
 
 // Tick interval for LittlevGL internal timekeeping; 1 to 10 ms recommended
-static const int lv_tick_interval_ms = 10;
+static const int lv_tick_interval_ms = 5;
 
 static void lv_tick_handler(void) { lv_tick_inc(lv_tick_interval_ms); }
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -923,6 +923,7 @@
 // -- LVGL Graphics Library ---------------------------------
 //#define USE_LVGL                                  // LVGL Engine, requires Berry, takes 440k of Flash
   #define USE_LVGL_PSRAM                            // Allocate LVGL memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
+  #define USE_LVGL_MAX_SLEEP  10                    // max sleep in ms when LVGL is enabled, more than 10ms will make display less responsive
   #define USE_LVGL_BG_DEFAULT 0x000000              // Default color for the uninitialized background screen (black)
 
 

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -8365,11 +8365,6 @@ bool Xdrv10(uint8_t function)
     case FUNC_EVERY_100_MSECOND:
       ScripterEvery100ms();
       break;
-#ifdef USE_LVGL
-    case FUNC_EVERY_50_MSECOND:
-      lv_task_handler();
-      break;
-#endif // USE_LVGL
 
     case FUNC_EVERY_SECOND:
       ScriptEverySecond();

--- a/tasmota/xdrv_52_2_berry_native.ino
+++ b/tasmota/xdrv_52_2_berry_native.ino
@@ -227,7 +227,8 @@ const lvbe_callback lvbe_callbacks[LVBE_MAX_CALLBACK] = {
 };
 
 int32_t lvbe_callback_x(uint32_t n, struct _lv_obj_t * obj, int32_t v1, int32_t v2, int32_t v3, int32_t v4) {
-  be_getglobal(berry.vm, LVBE_LVGL_CB_OBJ);
+  // berry_log_P(">>>: Callback called n=%i obj=0x%08X v1=%i v2=%i", n, obj, v1, v2);
+  be_getglobal(berry.vm, LVBE_LVGL_CB_DISPATCH); // stack: List
   be_pushint(berry.vm, n);
   be_pushint(berry.vm, (int32_t) obj);
   be_pushint(berry.vm, v1);
@@ -237,7 +238,7 @@ int32_t lvbe_callback_x(uint32_t n, struct _lv_obj_t * obj, int32_t v1, int32_t 
   be_pcall(berry.vm, 6);
   int32_t ret = be_toint(berry.vm, -7);
   be_pop(berry.vm, 7);
-  berry_log_P(">>>: Callback called%d", n);
+  // berry_log_P(">>>: Callback called out %d ret=%i", n, ret);
   return ret;
 }
 

--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -377,6 +377,7 @@ const char berry_prog[] =
   "_lvgl_cb = [ {}, {}, {}, {}, {}, {} ] "
   "_lvgl_cb_obj = [ {}, {}, {}, {}, {}, {} ] "
   "def _lvgl_cb_dispatch(idx, obj, v1, v2, v3, v4) "
+    // "import string print(string.format('>>> idx=%i obj=0x%08X v1=%i', idx, obj, v1)) "
     "var func = _lvgl_cb[idx].find(obj) "
     "var inst = _lvgl_cb_obj[idx].find(obj) "
     "if func != nil "

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -32,52 +32,7 @@
 
 #include "Adafruit_LvGL_Glue.h"
 
-
-/* Creates a semaphore to handle concurrent call to lvgl stuff
- * If you wish to call *any* lvgl function from other threads/tasks
- * you should lock on the very same semaphore! */
-
-SemaphoreHandle_t xGuiSemaphore;
-//uDisplay * udisp = nullptr;
-
-// necessary for compilation
-uint8_t color_type_lvgl = 0;
-uint8_t * buffer_lvgl = nullptr;
-void udisp_dimm_lvgl(uint8_t dim) {}
-void udisp_bpwr_lvgl(uint8_t on) {}
-
-extern "C" {
-
-  const char task_name[] = "periodic_gui";
-    /* Create and start a periodic timer interrupt to call lv_tick_inc */
-    const esp_timer_create_args_t periodic_timer_args = {
-      &lv_tick_task,
-      nullptr,
-      ESP_TIMER_TASK,
-      task_name
-    };
-}
-
 Adafruit_LvGL_Glue * glue;
-
-/**********************
- *  STATIC PROTOTYPES
- **********************/
-
-static void guiTask(void *pvParameter);
-
-/************************************************************
- * Provide a regular tick to lvgl, every ms
- ************************************************************/
-
-#ifndef LV_TICK_PERIOD_MS
-#define LV_TICK_PERIOD_MS   1   // default to tick every 1 ms
-#endif
-
-static void lv_tick_task(void *arg) {
-  (void) arg;
-  lv_tick_inc(LV_TICK_PERIOD_MS);
-}
 
 // **************************************************
 // Logging
@@ -92,34 +47,6 @@ static void lvbe_debug(lv_log_level_t level, const char *file, uint32_t line, co
   be_writebuffer("\n", sizeof("\n"));
 }
 #endif
-
-/************************************************************
- * Maint FreeRTOS task used in a separate thread
- ************************************************************/
-static void guiTask(void *pvParameter) {
-  (void) pvParameter;
-  xGuiSemaphore = xSemaphoreCreateMutex();
-
-  /* Create and start a periodic timer interrupt to call lv_tick_inc */
-  esp_timer_handle_t periodic_timer;
-  ESP_ERROR_CHECK(esp_timer_create(&periodic_timer_args, &periodic_timer));
-  ESP_ERROR_CHECK(esp_timer_start_periodic(periodic_timer, LV_TICK_PERIOD_MS * 1000));
-
-  while (1) {
-      /* Delay 1 tick (assumes FreeRTOS tick is 10ms */
-      vTaskDelay(pdMS_TO_TICKS(10));
-
-      /* Try to take the semaphore, call lvgl related function on success */
-      if (pdTRUE == xSemaphoreTake(xGuiSemaphore, portMAX_DELAY)) {
-          lv_task_handler();
-          xSemaphoreGive(xGuiSemaphore);
-      }
-  }
-
-  /* A task should NEVER return */
-  vTaskDelete(NULL);
-}
-
 
 /************************************************************
  * Main screen refresh function
@@ -421,11 +348,6 @@ void start_lvgl(const char * uconfig) {
 
 #endif // USE_UFILESYS
 
-  /* If you want to use a task to create the graphic, you NEED to create a Pinned task
-    * Otherwise there can be problem such as memory corruption and so on.
-    * NOTE: When not using Wi-Fi nor Bluetooth you can pin the guiTask to core 0 */
-  xTaskCreatePinnedToCore(guiTask, "gui", 4096*2, NULL, 0, NULL, 1);
-
   AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_LVGL "LVGL initialized"));
 }
 
@@ -440,6 +362,12 @@ bool Xdrv54(uint8_t function)
     case FUNC_INIT:
       break;
     case FUNC_LOOP:
+      if (glue) {
+        if (TasmotaGlobal.sleep > USE_LVGL_MAX_SLEEP) {
+          TasmotaGlobal.sleep = USE_LVGL_MAX_SLEEP;   // sleep is max 10ms
+        }
+        lv_task_handler();
+      }
       break;
     case FUNC_EVERY_50_MSECOND:
       break;


### PR DESCRIPTION
## Description:

Fixed events and callbacks from LVGL. The problem was due to multi-threading between the Tasmota thread and the LVGL refresh thread. Now both run in the same thread, which means slightly less smooth animations when Tasmota is busy, but much simpler code.

Cleaned code, `lv_task_handler()` and `lv_tick_inc()` where called too often.

Note: the tick is called every 5 ms and task handler every 10ms. For this, Tasmota Sleep is lowered to 10ms when LGVL is active.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
