### PR TITLE
Delay HA discovery during PZEM sensor intialization

### DIFF
--- a/tasmota/xnrg_03_pzem004t.ino
+++ b/tasmota/xnrg_03_pzem004t.ino
@@ -30,6 +30,7 @@
 
 #define XNRG_03                  3
 
+#define PZEM_WATHCDOG            5
 const uint32_t PZEM_STABILIZE = 30;        // Number of seconds to stabilize configuration
 
 #include <TasmotaSerial.h>
@@ -227,13 +228,14 @@ void PzemEvery250ms(void)
       Pzem.read_state = 0;  // Set address
     }
 
-    Pzem.send_retry = 5;
+    Pzem.send_retry = PZEM_WATHCDOG;
     PzemSend(pzem_commands[Pzem.read_state]);
   }
   else {
     Pzem.send_retry--;
     if ((Energy.phase_count > 1) && (0 == Pzem.send_retry) && (TasmotaGlobal.uptime < PZEM_STABILIZE)) {
       Energy.phase_count--;  // Decrement phases if no response after retry within 30 seconds after restart
+      hass_init_step += PZEM_WATHCDOG/4 + 1; // Don't send Home Assistant discovery yet, delay by 5*250ms + 1s
     }
   }
 }

--- a/tasmota/xnrg_05_pzem_ac.ino
+++ b/tasmota/xnrg_05_pzem_ac.ino
@@ -111,6 +111,7 @@ void PzemAcEverySecond(void)
     PzemAc.send_retry--;
     if ((Energy.phase_count > 1) && (0 == PzemAc.send_retry) && (TasmotaGlobal.uptime < PZEM_AC_STABILIZE)) {
       Energy.phase_count--;  // Decrement phases if no response after retry within 30 seconds after restart
+      hass_init_step += ENERGY_WATCHDOG + 1; // Don't send Home Assistant discovery yet, delay by 4s + 1s
     }
   }
 }

--- a/tasmota/xnrg_06_pzem_dc.ino
+++ b/tasmota/xnrg_06_pzem_dc.ino
@@ -107,6 +107,7 @@ void PzemDcEverySecond(void)
     PzemDc.send_retry--;
     if ((Energy.phase_count > 1) && (0 == PzemDc.send_retry) && (TasmotaGlobal.uptime < PZEM_DC_STABILIZE)) {
       Energy.phase_count--;  // Decrement channels if no response after retry within 30 seconds after restart
+      hass_init_step += ENERGY_WATCHDOG + 1; // Don't send Home Assistant discovery yet, delay by 4s + 1s
     }
   }
 }


### PR DESCRIPTION
## Description:

Delay HA discovery during PZEM sensor intialization while the number of phases monitored by the sensor is not known.
**Related issue:** https://github.com/home-assistant/core/issues/50291

Note: I have no PZEM energy monitor, but I have verified the `hass_init_step` is bumped as intended by all three PZEM drivers.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
