### PR TITLE
Expand decode-status to support all feature bits

### DIFF
--- a/tools/decode-status.py
+++ b/tools/decode-status.py
@@ -337,7 +337,11 @@ def StartDecode():
     if "StatusMEM" in obj:
         if "Features" in obj["StatusMEM"]:
             features = []
-            for f in range(7):
+            maxfeatures = len(obj["StatusMEM"]["Features"])
+            if maxfeatures > len(a_features):
+                print("decode-status.py too old, does not support all feature bits")
+            maxfeatures = min(maxfeatures, len(a_features))
+            for f in range(maxfeatures + 1):
                 feature = obj["StatusMEM"]["Features"][f]
                 i_feature = int(feature,16)
                 if f == 0:


### PR DESCRIPTION
Output of decode-status.py lacks information about the latest two new sets of feature bits, due to the constant for array size not being updated when the array was expanded. Code changed to avoid this magical number, but instead check size of array with texts, and array with features from the JSON format in Status 4, using the lowest number to provide as many bits as both Tasmota version and Python code supports. A warning is printed if the number of feature bits from Tasmota is higher than supported in the current iteration of Python code.

Based on history, I'm assuming that updates are first done in arendst/Tasmota development, later replicated to tasmota/Tasmota-decode-status. If wrong, I can move the change there.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
