### PR TITLE
Show the new IP after the Wi-Fi Initial Config

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -955,7 +955,7 @@ void WebRestart(uint32_t type)
     } else {
 #if (AFTER_INITIAL_WIFI_CONFIG_GO_TO_NEW_IP)
       WSContentTextCenterStart(WebColor(COL_TEXT_SUCCESS));
-      WSContentSend_P(PSTR(D_SUCCESSFUL_WIFI_CONNECTION "<br><br></div><div style='text-align:center;'>" D_REDIRECTING_TO_NEW_IP "<br><br></div>"));
+      WSContentSend_P(PSTR(D_SUCCESSFUL_WIFI_CONNECTION "<br><br></div><div style='text-align:center;'>" D_REDIRECTING_TO_NEW_IP "<br><br><a href='http://%_I'>%_I</a><br></div>"),(uint32_t)WiFi.localIP(),(uint32_t)WiFi.localIP());
 #else
       WSContentTextCenterStart(WebColor(COL_TEXT_SUCCESS));
       WSContentSend_P(PSTR(D_SUCCESSFUL_WIFI_CONNECTION "<br><br></div><div style='text-align:center;'>" D_NOW_YOU_CAN_CLOSE_THIS_WINDOW "<br><br></div>"));


### PR DESCRIPTION
## Description:

Show the new IP after the Wi-Fi Initial Config.

If using the default option keys for the Initial Wi-Fi Config:

```cpp
#define RESTART_AFTER_INITIAL_WIFI_CONFIG         true
#define AFTER_INITIAL_WIFI_CONFIG_GO_TO_NEW_IP    true
```

After configuring the Wi-Fi credentials, Tasmota tests the connection and if everything is correct, it connects to the new Wi-Fi Network and redirects the user to the new IP.
In PCs this works fine.
In Iphone/Ipad this works fine too.
In Android phones using chrome and going to 192.168.4.1, it also works fine.
But, in some Android phones, if using the captive portal, that captive portal will be closed after Tasmota shutdowns its own AP, due to successful connection to the new Network, and the redirection to the new IP is not happening (due to there isn't open any browser anymore). So, for this case, this PR shows the new IP address in the last screen that the users will see before their phones close the browser.

BEFORE:
![image](https://user-images.githubusercontent.com/35405447/118026044-c898e000-b336-11eb-958d-312b1becdd81.png)

AFTER:
![image](https://user-images.githubusercontent.com/35405447/118025882-b028c580-b336-11eb-8013-ec88c6256b8e.png)

The IP it is also an Hyperlink to the new IP.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
