### PR TITLE
Fix off by one error

### DIFF
--- a/tools/decode-status.py
+++ b/tools/decode-status.py
@@ -337,7 +337,7 @@ def StartDecode():
     if "StatusMEM" in obj:
         if "Features" in obj["StatusMEM"]:
             features = []
-            maxfeatures = len(obj["StatusMEM"]["Features"])
+            maxfeatures = len(obj["StatusMEM"]["Features"]) - 1
             if maxfeatures > len(a_features):
                 print("decode-status.py too old, does not support all feature bits")
             maxfeatures = min(maxfeatures, len(a_features))


### PR DESCRIPTION
Oops, warning about too old python script came when it should not.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
