### PR TITLE
Fix PING race condition breaks JSON

### DIFF
--- a/tasmota/xdrv_38_ping.ino
+++ b/tasmota/xdrv_38_ping.ino
@@ -246,14 +246,13 @@ extern "C" {
   int32_t t_ping_start(const char *hostname, uint32_t count) {
     IPAddress ipfull;
     if (!WiFi.hostByName(hostname, ipfull)) {
-      return -2;
+      ipfull = 0xFFFFFFFF;
     }
 
     uint32_t ip = ipfull;
-    if (0xFFFFFFFF == ip) { return -2; }    // invalid address
 
     // check if pings are already ongoing for this IP
-    if (t_ping_find(ip)) {
+    if (0xFFFFFFFF != ip && t_ping_find(ip)) {
       return -1;
     }
 
@@ -271,6 +270,12 @@ extern "C" {
     ping->next = ping_head;
     ping_head = ping;         // insert at head
 
+    if (0xFFFFFFFF == ip) { // If invalid address, set as completed
+      ping->done = true;
+      return -2;
+    }
+
+    // send
     t_ping_register_pcb();
     t_ping_send(t_ping_pcb, ping);
 
@@ -293,24 +298,34 @@ void PingResponsePoll(void) {
       uint32_t success = ping->success_count;
       uint32_t ip = ping->ip;
 
-      Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
-                      "\"Reachable\":%s"
-                      ",\"IP\":\"%d.%d.%d.%d\""
-                      ",\"Success\":%d"
-                      ",\"Timeout\":%d"
-                      ",\"MinTime\":%d"
-                      ",\"MaxTime\":%d"
-                      ",\"AvgTime\":%d"
-                      "}}}"),
-                      ping->hostname.c_str(),
-                      success ? PSTR("true") : PSTR("false"),
-                      ip & 0xFF, (ip >> 8) & 0xFF, (ip >> 16) & 0xFF, ip >> 24,
-                      success,
-                      ping->timeout_count,
-                      success ? ping->min_time : 0,
-                      ping->max_time,
-                      success ? ping->sum_time / success : 0
-                      );
+      if (0xFFFFFFFF == ip) {
+        Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
+                        "\"Reachable\":false"
+                        ",\"IP\":\"\""
+                        ",\"Success\":false"
+                        "}}}"),
+                        ping->hostname.c_str()
+                        );
+      } else {
+        Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
+                        "\"Reachable\":%s"
+                        ",\"IP\":\"%d.%d.%d.%d\""
+                        ",\"Success\":%d"
+                        ",\"Timeout\":%d"
+                        ",\"MinTime\":%d"
+                        ",\"MaxTime\":%d"
+                        ",\"AvgTime\":%d"
+                        "}}}"),
+                        ping->hostname.c_str(),
+                        success ? PSTR("true") : PSTR("false"),
+                        ip & 0xFF, (ip >> 8) & 0xFF, (ip >> 16) & 0xFF, ip >> 24,
+                        success,
+                        ping->timeout_count,
+                        success ? ping->min_time : 0,
+                        ping->max_time,
+                        success ? ping->sum_time / success : 0
+                        );
+      }
       MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_PING));
 
       // remove from linked list
@@ -342,6 +357,7 @@ void CmndPing(void) {
   } else if (-1 == res) {
     ResponseCmndChar_P(PSTR("Ping already ongoing for this IP"));
   } else {
+    /*
     Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
                     "\"Reachable\":false"
                     ",\"IP\":\"\""
@@ -350,6 +366,7 @@ void CmndPing(void) {
                     XdrvMailbox.data
                     );
     MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_PING));
+    */
     ResponseCmndChar_P(PSTR("Unable to resolve IP address"));
   }
 }

--- a/tasmota/xdrv_38_ping.ino
+++ b/tasmota/xdrv_38_ping.ino
@@ -357,16 +357,6 @@ void CmndPing(void) {
   } else if (-1 == res) {
     ResponseCmndChar_P(PSTR("Ping already ongoing for this IP"));
   } else {
-    /*
-    Response_P(PSTR("{\"" D_JSON_PING "\":{\"%s\":{"
-                    "\"Reachable\":false"
-                    ",\"IP\":\"\""
-                    ",\"Success\":false"
-                    "}}}"),
-                    XdrvMailbox.data
-                    );
-    MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_PING));
-    */
     ResponseCmndChar_P(PSTR("Unable to resolve IP address"));
   }
 }


### PR DESCRIPTION
## Description:

Related to https://discord.com/channels/479389167382691863/490244847568158751/843077860004593664

When command error message and PING "dummy" result JSON is published from `CmndPing()`, and there is a rule on PING result, JSON gets broken as per the example below.
This PR makes the result response asynchronous by inserting a _done_ `Ping_t` element in the list and move publishing the result JSON to the polling loop.

tagging @sfromis @s-hadinger 

Exemple of broken results:
```
2:43:12.446 CMD: ping bad.domain
12:43:12.474 MQT: xxxxxxxx/tele/PING = {"Ping":{"bad.domain":{"Reachable":false,"IP":"","Success":false}}}
12:43:12.485 RUL: PING#BAD.DOMAIN#REACHABLE performs "var1 FALSE"
12:43:12.494 MQT: xxxxxxxx/stat/VAR = {"Var1":"FALSE"}
12:43:12.499 MQT: xxxxxxxx/stat/PING = {"
```
or
```
16:12:00.890 CMD: ping bad.domain
16:12:00.931 MQT: tele/nodemcu/PING = {"Ping":{"bad.domain":{"Reachable":false,"IP":"","Success":false}}}
16:12:00.944 RUL: PING#BAD.DOMAIN#REACHABLE performs "var1 FALSE"
16:12:00.956 MQT: stat/nodemcu/VAR = {"Var1":"FALSE"}
16:12:00.961 MQT: stat/nodemcu/PING = {"s 0":"Unable to resolve IP address"}
```


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
