### PR TITLE
Support Tuya powermeter >6500W 

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -985,7 +985,12 @@ void EnergyShow(bool json)
           if ((Energy.current[i] > 0.005) && ((difference > 15) || (difference > (uint32_t)(apparent_power * 100 / 1000)))) {
             // calculating reactive power only if current is greater than 0.005A and
             // difference between active and apparent power is greater than 1.5W or 1%
-            reactive_power = (float)(RoundSqrtInt((uint32_t)(apparent_power * apparent_power * 100) - (uint32_t)(Energy.active_power[i] * Energy.active_power[i] * 100))) / 10;
+            //reactive_power = (float)(RoundSqrtInt((uint64_t)(apparent_power * apparent_power * 100) - (uint64_t)(Energy.active_power[i] * Energy.active_power[i] * 100))) / 10;
+            float power_diff = apparent_power * apparent_power - Energy.active_power[i] * Energy.active_power[i];
+            if (power_diff < 10737418) // 2^30 / 100 (RoundSqrtInt is limited to 2^30-1)
+              reactive_power = (float)(RoundSqrtInt((uint32_t)(power_diff * 100.0))) / 10.0;
+            else
+              reactive_power = (float)(SqrtInt((uint32_t)(power_diff)));
           }
         }
 

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -729,7 +729,7 @@ void TuyaProcessStatePacket(void) {
 
           if (RtcTime.valid) {
             if (Tuya.lastPowerCheckTime != 0 && Energy.active_power[0] > 0) {
-              Energy.kWhtoday += (float)Energy.active_power[0] * (Rtc.utc_time - Tuya.lastPowerCheckTime) / 36;
+              Energy.kWhtoday += Energy.active_power[0] * (float)(Rtc.utc_time - Tuya.lastPowerCheckTime) / 36.0;
               EnergyUpdateToday();
             }
             Tuya.lastPowerCheckTime = Rtc.utc_time;
@@ -856,12 +856,13 @@ void TuyaProcessStatePacket(void) {
           Energy.current[0] = (float)packetValue / 1000;
           AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: Rx ID=%d Current=%d"), Tuya.buffer[dpidStart], packetValue);
         } else if (tuya_energy_enabled && fnId == TUYA_MCU_FUNC_POWER) {
+          uint32_t packetValue = Tuya.buffer[dpidStart + 5] << 16 |Tuya.buffer[dpidStart + 6] << 8 | Tuya.buffer[dpidStart + 7];
           Energy.active_power[0] = (float)packetValue / 10;
           AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: Rx ID=%d Active_Power=%d"), Tuya.buffer[dpidStart], packetValue);
 
           if (RtcTime.valid) {
             if (Tuya.lastPowerCheckTime != 0 && Energy.active_power[0] > 0) {
-              Energy.kWhtoday += (float)Energy.active_power[0] * (Rtc.utc_time - Tuya.lastPowerCheckTime) / 36;
+              Energy.kWhtoday += Energy.active_power[0] * (float)(Rtc.utc_time - Tuya.lastPowerCheckTime) / 36.0;
               EnergyUpdateToday();
             }
             Tuya.lastPowerCheckTime = Rtc.utc_time;


### PR DESCRIPTION
## Description:

Discussion here : https://github.com/arendst/Tasmota/discussions/12114 with @tesnaa and @arendst 

This PR provides:
1) tuyamcu : Extend extracting power for Tuya device up to 3 bytes (instead of 2) to support power > 6553.5 W
2) energy: Avoid uint32 overflow in reactive power calculation
   (the final implementation is slighly different than the one discussed as overflow where still occuring in some cases)

This has been tested  with dummy energy meter with various triplet (V, I, P) up to (250V, 250A)
High power may still create overflows in other calculation like per day totalization (not tested/not checked).

Impact on flash size : none
before change
RAM:   [======    ]  55.4% (used 45392 bytes from 81920 bytes)
Flash: [======    ]  59.9% (used 613184 bytes from 1023984 bytes)

after change
RAM:   [======    ]  55.4% (used 45392 bytes from 81920 bytes)
Flash: [======    ]  59.9% (used 613184 bytes from 1023984 bytes)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
