### PR TITLE
restore USE_SCRIPT_STATUS

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -642,10 +642,6 @@ void CmndStatus(void)
   }
 #endif
 
-#ifdef USE_SCRIPT_STATUS
-  if (bitRead(Settings.rule_enabled, 0)) { Run_Scripter(">U", 2, TasmotaGlobal.mqtt_data); }
-#endif
-
   ResponseClear();
 }
 

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -8410,7 +8410,15 @@ bool Xdrv10(uint8_t function)
       break;
     case FUNC_RULES_PROCESS:
       if (bitRead(Settings.rule_enabled, 0)) {
+#ifdef USE_SCRIPT_STATUS
+        if (!strncmp_P(TasmotaGlobal.mqtt_data, PSTR("{\"Status"), 8)) {
+          Run_Scripter(">U", 2, TasmotaGlobal.mqtt_data);
+        } else {
+          Run_Scripter(">E", 2, TasmotaGlobal.mqtt_data);
+        }
+#else
         Run_Scripter(">E", 2, TasmotaGlobal.mqtt_data);
+#endif
         result = glob_script_mem.event_handeled;
       }
       break;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #12118

restores USE_SCRIPT_STATUS cmd to section >U

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
