### PR TITLE
LVGL fix crash in file system

### DIFF
--- a/lib/libesp32_lvgl/LVGL/src/lv_misc/lv_fs.c
+++ b/lib/libesp32_lvgl/LVGL/src/lv_misc/lv_fs.c
@@ -148,7 +148,9 @@ lv_fs_res_t lv_fs_close(lv_fs_file_t * file_p)
 
     lv_fs_res_t res = file_p->drv->close_cb(file_p->drv, file_p->file_d);
 
-    lv_mem_free(file_p->file_d); /*Clean up*/
+    if(file_p->drv->file_size != 0) {  /*Is file_d zero size?*/
+        lv_mem_free(file_p->file_d); /*Clean up*/
+    }
     file_p->file_d = NULL;
     file_p->drv    = NULL;
 

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -219,7 +219,6 @@ static lv_fs_res_t lvbe_fs_open(lv_fs_drv_t * drv, void * file_p, const char * p
   // AddLog(LOG_LEVEL_INFO, "LVG: F=%*_H", sizeof(f), &f);
   if (f) {
     File * f_ptr = new File(f);                 // copy to dynamic object
-    *f_ptr = f;                                 // TODO is this necessary?
     *((File**)file_p) = f_ptr;
     return LV_FS_RES_OK;
   } else {


### PR DESCRIPTION
## Description:

Fix crash when LVGL uses file system. This is already fixed in upstream LVGL in latest dev version.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
