### PR TITLE
LVGL increase image cache when PSRAM is present

### DIFF
--- a/tasmota/lvgl_berry/tasmota_lv_conf.h
+++ b/tasmota/lvgl_berry/tasmota_lv_conf.h
@@ -259,6 +259,7 @@ typedef void * lv_fs_drv_user_data_t;
  * However the opened images might consume additional RAM.
  * Set it to 0 to disable caching */
 #define LV_IMG_CACHE_DEF_SIZE       1
+#define LV_IMG_CACHE_DEF_SIZE_PSRAM 20    // special Tasmota setting when PSRAM is used
 
 /*Declare the type of the user data of image decoder (can be e.g. `void *`, `int`, `struct`)*/
 typedef void * lv_img_decoder_user_data_t;

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -445,6 +445,10 @@ void start_lvgl(const char * uconfig) {
   lv_png_init();
 #endif // USE_LVGL_PNG_DECODER
 
+  if (psramFound()) {
+    lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE_PSRAM);
+  }
+
   AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_LVGL "LVGL initialized"));
 }
 


### PR DESCRIPTION
## Description:

When PSRAM is present, extend image cache from 1 to 20.
Can be customized with `#define LV_IMG_CACHE_DEF_SIZE_PSRAM`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
