### PR TITLE
Berry longer logs

### DIFF
--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -59,11 +59,11 @@ extern "C" {
 #define BERRY_LOGSZ 700
 #endif
 extern "C" {
-    extern void *lvbe_malloc(size_t size);
+    extern void *berry_malloc(size_t size);
 }
 static char * log_berry_buffer = nullptr;
 static_block {
-    log_berry_buffer = (char*) lvbe_malloc(BERRY_LOGSZ);
+    log_berry_buffer = (char*) berry_malloc(BERRY_LOGSZ);
     if (log_berry_buffer) log_berry_buffer[0] = 0;
 }
 extern void berry_log(const char * berry_buf);

--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -12,6 +12,9 @@
 #include <string.h>
 #include <Arduino.h>
 
+// from https://github.com/eyalroz/cpp-static-block
+#include "static_block.hpp"
+
 // Local pointer for file managment
 #include <FS.h>
 extern FS *ufsp;
@@ -53,13 +56,21 @@ extern "C" {
 
 // We need to create a local buffer, since we might mess up mqtt_data
 #ifndef BERRY_LOGSZ
-#define BERRY_LOGSZ 128
+#define BERRY_LOGSZ 700
 #endif
-static char log_berry_buffer[BERRY_LOGSZ] = { 0, };
+extern "C" {
+    extern void *lvbe_malloc(size_t size);
+}
+static char * log_berry_buffer = nullptr;
+static_block {
+    log_berry_buffer = (char*) lvbe_malloc(BERRY_LOGSZ);
+    if (log_berry_buffer) log_berry_buffer[0] = 0;
+}
 extern void berry_log(const char * berry_buf);
 
 BERRY_API void be_writebuffer(const char *buffer, size_t length)
 {
+    if (!log_berry_buffer) return;
     if (buffer == nullptr || length == 0) { return; }
     uint32_t idx = 0;
     while (idx < length) {
@@ -72,7 +83,7 @@ BERRY_API void be_writebuffer(const char *buffer, size_t length)
             }
         }
         uint32_t chars_to_append = (cr_pos >= 0) ? cr_pos - idx : length - idx;     // note cr_pos < length
-        snprintf(log_berry_buffer, sizeof(log_berry_buffer), "%s%.*s", log_berry_buffer, chars_to_append, &buffer[idx]);   // append at most `length` chars
+        snprintf(log_berry_buffer, BERRY_LOGSZ, "%s%.*s", log_berry_buffer, chars_to_append, &buffer[idx]);   // append at most `length` chars
         if (cr_pos >= 0) {
             // flush
             berry_log(log_berry_buffer);

--- a/lib/libesp32/Berry/default/static_block.hpp
+++ b/lib/libesp32/Berry/default/static_block.hpp
@@ -1,0 +1,80 @@
+/**
+ * static_block.hpp
+ *
+ * An implementation of a Java-style static block, in C++ (and potentially a
+ * GCC/clang extension to avoid warnings). Almost, but not quite, valid C.
+ * Partially inspired by Andrei Alexandrescu's Scope Guard and
+ * discussions on stackoverflow.com
+ *
+ * By Eyal Rozenberg <eyalroz@technion.ac.il>
+ *
+ * Licensed under the Apache License v2.0:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+#pragma once
+#ifndef STATIC_BLOCK_HPP_
+#define STATIC_BLOCK_HPP_
+
+#ifndef CONCATENATE
+#define CONCATENATE(s1, s2)     s1##s2
+#define EXPAND_THEN_CONCATENATE(s1, s2) CONCATENATE(s1, s2)
+#endif /* CONCATENATE */
+
+#ifndef UNIQUE_IDENTIFIER
+/**
+ * This macro expands into a different identifier in every expansion.
+ * Note that you _can_ clash with an invocation of UNIQUE_IDENTIFIER
+ * by manually using the same identifier elsewhere; or by carefully
+ * choosing another prefix etc.
+ */
+#ifdef __COUNTER__
+#define UNIQUE_IDENTIFIER(prefix) EXPAND_THEN_CONCATENATE(prefix, __COUNTER__)
+#else
+#define UNIQUE_IDENTIFIER(prefix) EXPAND_THEN_CONCATENATE(prefix, __LINE__)
+#endif /* COUNTER */
+#else
+#endif /* UNIQUE_IDENTIFIER */
+
+/**
+ * Following is a mechanism for executing code statically.
+ *
+ * @note Caveats:
+ * - Your static block must be surround by curly braces.
+ * - No need for a semicolon after the block (but it won't hurt).
+ * - Do not put static blocks in files, as it might get compiled multiple
+ *   times ane execute multiple times.
+ * - A static_block can only be used in file scope - not within any other block etc.
+ * - Templated static blocks will probably not work. Avoid them.
+ * - No other funny business, this is fragile.
+ * - This does not having any threading issues (AFAICT) - as it has no static
+ *   initialization order issue. Of course, you have to _keep_ it safe with
+ *   your static code.
+ * - Execution of the code is guaranteed to occur before main() executes,
+ *   but the relative order of statics being initialized is unknown/unclear. So,
+ *   do not call any method of an instance of a class which you expect to have been
+ *   constructed; it may not have been. Instead, you can use a static getInstance() method
+ *   (look this idiom up on the web, it's safe).
+ * - Variables defined within the static block are not global; they will
+ *   go out of scope as soon as its execution concludes.
+ *
+ * Usage example:
+ *
+ *   static_block {
+ *         do_stuff();
+ *         std::cout << "in the static block!\n";
+ *   }
+ *
+ */
+#define static_block STATIC_BLOCK_IMPL1(UNIQUE_IDENTIFIER(_static_block_))
+
+#define STATIC_BLOCK_IMPL1(prefix) \
+	STATIC_BLOCK_IMPL2(CONCATENATE(prefix,_fn),CONCATENATE(prefix,_var))
+
+#define STATIC_BLOCK_IMPL2(function_name,var_name) \
+static void function_name(); \
+static int var_name __attribute((unused)) = (function_name(), 0) ; \
+static void function_name()
+
+
+#endif // STATIC_BLOCK_HPP_


### PR DESCRIPTION
## Description:

Extend Berry `print()` to 700 characters to be consistent with `AddLog_P()`. Print buffer is allocated in PSRAM if possible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
