### PR TITLE
Berry allow import from file system

### DIFF
--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -95,8 +95,15 @@ BERRY_API char* be_readstring(char *buffer, size_t size)
 void* be_fopen(const char *filename, const char *modes)
 {
     if (ufsp != nullptr && filename != nullptr && modes != nullptr) {
+        char fname2[strlen(filename) + 2];
+        if (filename[0] == '/') {
+            strcpy(fname2, filename);   // copy unchanged
+        } else {
+            fname2[0] = '/';
+            strcpy(fname2 + 1, filename);   // prepend with '/'
+        }
         // Serial.printf("be_fopen filename=%s, modes=%s\n", filename, modes);
-        File f = ufsp->open(filename, modes);       // returns an object, not a pointer
+        File f = ufsp->open(fname2, modes);       // returns an object, not a pointer
         if (f) {
             File * f_ptr = new File(f);                 // copy to dynamic object
             *f_ptr = f;                                 // TODO is this necessary?


### PR DESCRIPTION
## Description:

`be_fopen()` now automatically adds `/` prefix if not present. This allows Berry's `import` to work.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
