### PR TITLE
option for 16k more heap

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -21,6 +21,8 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
+                              ; 16k extra heap https://github.com/esp8266/Arduino/pull/7060
+                              -DMMU_IRAM_SIZE=0xC000
                               -Wno-switch-unreachable
 
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -18,11 +18,8 @@ platform_packages           = framework-arduinoespressif8266 @ https://github.co
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
 build_flags                 = ${esp82xx_defaults.build_flags}
-; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM
-                              ;-DWAVEFORM_LOCKED_PHASE
-                              -DWAVEFORM_LOCKED_PWM
-                              ; 16k extra heap https://github.com/esp8266/Arduino/pull/7060
-                              -DPIO_FRAMEWORK_MMU__16KB_CACHE__48KB_IRAM
+; *** 16k extra heap https://github.com/esp8266/Arduino/pull/7060
+                              ;-DPIO_FRAMEWORK_MMU__16KB_CACHE__48KB_IRAM
                               -Wno-switch-unreachable
 
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -12,7 +12,7 @@ build_flags  = ${common.build_flags}
 
 [core_stage]
 ; *** Esp8266 core for Arduino version stage
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino/releases/download/3.0.0/esp8266-3.0.0.zip
+platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino.git#3.0.0.1
 ; *** Use Xtensa build chain 10.2. GNU23 from https://github.com/earlephilhower/esp-quick-toolchain
                               tasmota/toolchain-xtensa @ 5.100200.210303
 build_unflags               = ${esp_defaults.build_unflags}
@@ -22,7 +22,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
                               ;-DWAVEFORM_LOCKED_PHASE
                               -DWAVEFORM_LOCKED_PWM
                               ; 16k extra heap https://github.com/esp8266/Arduino/pull/7060
-                              -DMMU_IRAM_SIZE=0xC000
+                              -DPIO_FRAMEWORK_MMU__16KB_CACHE__48KB_IRAM
                               -Wno-switch-unreachable
 
 


### PR DESCRIPTION
## Description:

with Arduino Core 3.0.0 (just added changed `platformio_build.py`) to support the Pio MMU switch https://github.com/esp8266/Arduino/pull/8075

Tasmota does NOT start with Arduino Core 3.0.0 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
