### PR TITLE
XDRV53 - add Acer projector support

### DIFF
--- a/tasmota/xdrv_53_projector_ctrl.h
+++ b/tasmota/xdrv_53_projector_ctrl.h
@@ -68,22 +68,23 @@ static const struct projector_ctrl_command_info_s projector_ctrl_commands[] = {
 #elif defined(USE_PROJECTOR_CTRL_ACER)
 /* see the serial codes in
  * http://global-download.acer.com/GDFiles/Document/RS232%20Command%20Table/RS232%20Command%20Table_Acer_1.0_A_A.zip?acerid=636791605984811687
- * not really tested with ACER devices
+ * tested with ACER P1500
  */
 #define PROJECTOR_CTRL_LOGNAME	"DLP[ACER]"
-static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','I','R',' ','0','3','5', 0x0d }; //line50
-static const uint8_t projector_ctrl_msg_qry_pwr[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //line97
-static const uint8_t projector_ctrl_msg_pwr_on[]  = { '*',' ','0',' ','I','R',' ','0','0','1', 0x0d }; //line18
-static const uint8_t projector_ctrl_msg_pwr_off[] = { '*',' ','0',' ','I','R',' ','0','0','2', 0x0d }; //line19
+//static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','I','R',' ','0','3','5', 0x0d }; //line50 - responds *000\rModel Model P1500E\r [fails in OFF mode]
+static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //cannot query typ, so query Lamp status instead
+static const uint8_t projector_ctrl_msg_qry_pwr[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //line97 - responds *000\rLamp 0\r
+static const uint8_t projector_ctrl_msg_pwr_on[]  = { '*',' ','0',' ','I','R',' ','0','0','1', 0x0d }; //line18 - responds *000\r
+static const uint8_t projector_ctrl_msg_pwr_off[] = { '*',' ','0',' ','I','R',' ','0','0','2', 0x0d }; //line19 - responds *000\r
 static const struct projector_ctrl_command_info_s projector_ctrl_commands[] = {
 	{PROJECTOR_CTRL_S_QRY_TYPE, &projector_ctrl_msg_qry_typ[0], sizeof(projector_ctrl_msg_qry_typ),
-								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'M', 10, 6, 4, '?', 1, 0, 1},
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, '*', 12, 10, 1, '?', 1, 0, 1},
 	{PROJECTOR_CTRL_S_QRY_PWR,  &projector_ctrl_msg_qry_pwr[0], sizeof(projector_ctrl_msg_qry_pwr),
-								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'L', 7, 5, 1, '?', 1, 0, 1},
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, '*', 12, 10, 1, '?', 1, 0, 1},
 	{PROJECTOR_CTRL_S_PWR_ON,   &projector_ctrl_msg_pwr_on[0], sizeof(projector_ctrl_msg_pwr_on),
-								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'O', 2, 0, 1, '?', 1, 0, 1},
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, '*', 5, 0, 1, '?', 1, 0, 1},
 	{PROJECTOR_CTRL_S_PWR_OFF,  &projector_ctrl_msg_pwr_off[0], sizeof(projector_ctrl_msg_pwr_off),
-								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'O', 2, 0, 1, '?', 1, 0, 1}
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, '*', 5, 0, 1, '?', 1, 0, 1}
 };
 #define PROJECTOR_CTRL_QRYPWR_ON      '1'
 #define PROJECTOR_CTRL_QRYPWR_COOLING '1'  //placebo

--- a/tasmota/xdrv_53_projector_ctrl.h
+++ b/tasmota/xdrv_53_projector_ctrl.h
@@ -65,6 +65,32 @@ static const struct projector_ctrl_command_info_s projector_ctrl_commands[] = {
 #define PROJECTOR_CTRL_QRYPWR_WARMING 0x31 //placebo
 
 
+#elif defined(USE_PROJECTOR_CTRL_ACER)
+/* see the serial codes in
+ * http://global-download.acer.com/GDFiles/Document/RS232%20Command%20Table/RS232%20Command%20Table_Acer_1.0_A_A.zip?acerid=636791605984811687
+ * not really tested with ACER devices
+ */
+#define PROJECTOR_CTRL_LOGNAME	"DLP[ACER]"
+static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','I','R',' ','0','3','5', 0x0d }; //line50
+static const uint8_t projector_ctrl_msg_qry_pwr[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //line97
+static const uint8_t projector_ctrl_msg_pwr_on[]  = { '*',' ','0',' ','I','R',' ','0','0','1', 0x0d }; //line18
+static const uint8_t projector_ctrl_msg_pwr_off[] = { '*',' ','0',' ','I','R',' ','0','0','2', 0x0d }; //line19
+static const struct projector_ctrl_command_info_s projector_ctrl_commands[] = {
+	{PROJECTOR_CTRL_S_QRY_TYPE, &projector_ctrl_msg_qry_typ[0], sizeof(projector_ctrl_msg_qry_typ),
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'M', 10, 6, 4, '?', 1, 0, 1},
+	{PROJECTOR_CTRL_S_QRY_PWR,  &projector_ctrl_msg_qry_pwr[0], sizeof(projector_ctrl_msg_qry_pwr),
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'L', 7, 5, 1, '?', 1, 0, 1},
+	{PROJECTOR_CTRL_S_PWR_ON,   &projector_ctrl_msg_pwr_on[0], sizeof(projector_ctrl_msg_pwr_on),
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'O', 2, 0, 1, '?', 1, 0, 1},
+	{PROJECTOR_CTRL_S_PWR_OFF,  &projector_ctrl_msg_pwr_off[0], sizeof(projector_ctrl_msg_pwr_off),
+								PROJECTOR_CTRL_SERIAL_TIMEOUT, 'O', 2, 0, 1, '?', 1, 0, 1}
+};
+#define PROJECTOR_CTRL_QRYPWR_ON      '1'
+#define PROJECTOR_CTRL_QRYPWR_COOLING '1'  //placebo
+#define PROJECTOR_CTRL_QRYPWR_STARTING '1' //placebo
+#define PROJECTOR_CTRL_QRYPWR_WARMING '1'  //placebo
+
+
 #else
 #error USE_PROJECTOR_CTRL: No projector type defined
 #endif

--- a/tasmota/xdrv_53_projector_ctrl.h
+++ b/tasmota/xdrv_53_projector_ctrl.h
@@ -69,10 +69,12 @@ static const struct projector_ctrl_command_info_s projector_ctrl_commands[] = {
 /* see the serial codes in
  * http://global-download.acer.com/GDFiles/Document/RS232%20Command%20Table/RS232%20Command%20Table_Acer_1.0_A_A.zip?acerid=636791605984811687
  * tested with ACER P1500
+ * every command is first acknowledged by "*000\r" (success) or "*001\r" (failure) followed by an optional response
+ * most commands fail in stand-by mode
  */
 #define PROJECTOR_CTRL_LOGNAME	"DLP[ACER]"
-//static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','I','R',' ','0','3','5', 0x0d }; //line50 - responds *000\rModel Model P1500E\r [fails in OFF mode]
-static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //cannot query typ, so query Lamp status instead
+//static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','I','R',' ','0','3','5', 0x0d }; //line50 - responds *000\rModel Model P1500E\r [fails in stand-by mode]
+static const uint8_t projector_ctrl_msg_qry_typ[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //cannot query type, so query Lamp status instead
 static const uint8_t projector_ctrl_msg_qry_pwr[] = { '*',' ','0',' ','L','a','m','p',' ','?', 0x0d }; //line97 - responds *000\rLamp 0\r
 static const uint8_t projector_ctrl_msg_pwr_on[]  = { '*',' ','0',' ','I','R',' ','0','0','1', 0x0d }; //line18 - responds *000\r
 static const uint8_t projector_ctrl_msg_pwr_off[] = { '*',' ','0',' ','I','R',' ','0','0','2', 0x0d }; //line19 - responds *000\r

--- a/tasmota/xdrv_53_projector_ctrl.ino
+++ b/tasmota/xdrv_53_projector_ctrl.ino
@@ -154,12 +154,18 @@ projector_ctrl_write(struct projector_ctrl_softc_s *sc, const uint8_t *bytes, co
 	}
 #ifdef USE_PROJECTOR_CTRL_NEC
 	serial->write(cksum);
-#endif
 #ifdef DEBUG_PROJECTOR_CTRL
 	char hex_b[(len + 1) * 2];
 	AddLog_P(LOG_LEVEL_DEBUG,PSTR(PROJECTOR_CTRL_LOGNAME ": RAW bytes %s %02x"),
 	    ToHex_P((uint8_t *)bytes, len, hex_b, sizeof(hex_b)), cksum);
 #endif //DEBUG_PROJECTOR_CTRL
+#else  //!USE_PROJECTOR_CTRL_NEC
+#ifdef DEBUG_PROJECTOR_CTRL
+	char hex_b[(len + 1) * 2];
+	AddLog_P(LOG_LEVEL_DEBUG,PSTR(PROJECTOR_CTRL_LOGNAME ": RAW bytes %s"),
+	    ToHex_P((uint8_t *)bytes, len, hex_b, sizeof(hex_b)));
+#endif //DEBUG_PROJECTOR_CTRL
+#endif //!USE_PROJECTOR_CTRL_NEC
 
 	serial->flush();
 	return;

--- a/tasmota/xdrv_53_projector_ctrl.ino
+++ b/tasmota/xdrv_53_projector_ctrl.ino
@@ -23,11 +23,12 @@
  * LCD/DLP Projector Control via serial interface
  * https://www.sharpnecdisplays.eu/p/download/v/5e14a015e26cacae3ae64a422f7f8af4/cp/Products/Projectors/Shared/CommandLists/PDF-ExternalControlManual-english.pdf#page=5
  * https://www.optoma.co.uk/uploads/manuals/hd36-m-en-gb.pdf#page=56
+ * http://global-download.acer.com/GDFiles/Document/RS232%20Command%20Table/RS232%20Command%20Table_Acer_1.0_A_A.zip?acerid=636791605984811687
 \*********************************************************************************************/
 
 #define XDRV_53			53
 
-#if !defined(USE_PROJECTOR_CTRL_NEC) && !defined(USE_PROJECTOR_CTRL_OPTOMA)
+#if !defined(USE_PROJECTOR_CTRL_NEC) && !defined(USE_PROJECTOR_CTRL_OPTOMA) && !defined(USE_PROJECTOR_CTRL_ACER)
 #define USE_PROJECTOR_CTRL_NEC                 // Use at least one projector
 #endif
 


### PR DESCRIPTION
## Description:

**adds control codes for DLP projectors from Acer, tested on P1500**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
