### PR TITLE
OpenTherm: Reset internal state on handshake

### DIFF
--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -313,6 +313,8 @@ void sns_ot_start_handshake()
 
     AddLog(LOG_LEVEL_DEBUG, PSTR("[OTH]: perform handshake"));
 
+    sns_opentherm_protocol_reset();
+
     sns_ot_master->sendRequestAync(
         OpenTherm::buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::SConfigSMemberIDcode, 0));
 

--- a/tasmota/xsns_69_opentherm_protocol.ino
+++ b/tasmota/xsns_69_opentherm_protocol.ino
@@ -441,6 +441,7 @@ void sns_opentherm_dump_telemetry()
 
 void sns_opentherm_protocol_reset()
 {
+    sns_opentherm_current_command = SNS_OT_COMMANDS_COUNT;
     for (int i = 0; i < SNS_OT_COMMANDS_COUNT; ++i)
     {
         struct OpenThermCommandT *cmd = &sns_opentherm_commands[i];

--- a/tasmota/xsns_69_opentherm_protocol.ino
+++ b/tasmota/xsns_69_opentherm_protocol.ino
@@ -438,4 +438,15 @@ void sns_opentherm_dump_telemetry()
         add_coma = true;
     }
 }
+
+void sns_opentherm_protocol_reset()
+{
+    for (int i = 0; i < SNS_OT_COMMANDS_COUNT; ++i)
+    {
+        struct OpenThermCommandT *cmd = &sns_opentherm_commands[i];
+        cmd->m_flags.m_flags = 0;
+        memset(cmd->m_results, 0, sizeof(OpenThermCommandT::m_results));
+    }
+}
+
 #endif


### PR DESCRIPTION
## Description:

This PR fixes a pretty interesting bug with the OT internal state I observed twice.
The boiler may perform a restart. This might happen because of the power blip, internal watchdog reset, or software bug/feature. OT integration sees this as a timeout, and transitions to the `OTC_DISCONNECTED` state and reconnect.

On reconnect, OT integration does not send all parameters, such as boiler setpoint or DHW temperature. In my case, this leads to the default DHW temperature and a condition when the boiler is unable to start by the `ot_ch 1` or by the `Heat Request` signal from the mechanical thermostat.

This PR adds a reset logic of the internal state before the handshake. That way all the parameters will be queued for sending after the boiler reset.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
