### PR TITLE
Teleinfo, send as object TIC in telemetry frame

### DIFF
--- a/tasmota/xnrg_15_teleinfo.ino
+++ b/tasmota/xnrg_15_teleinfo.ino
@@ -912,8 +912,9 @@ void TInfoShow(bool json)
             ResponseAppend_P(PSTR(",\"Load\":%d"),(int) ((Energy.current[0]*100.0f) / isousc));
         }
 
-        // add teleinfo full frame 
-        ResponseAppendTInfo(',', true);
+        // add teleinfo TIC object
+        ResponseAppend_P(PSTR("},\"TIC\":{"));
+        ResponseAppendTInfo(' ', true);
 
 #ifdef USE_WEBSERVER
     }


### PR DESCRIPTION
## Description:

TIC data is now send as object in telemetry frame (like in raw frames)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
