### PR TITLE
Allow increasing MQTT connection timeout

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -119,6 +119,7 @@
 #define MQTT_STATE_RETAIN      false             // [StateRetain] State may send retain flag (false = off, true = on)
 #define MQTT_NO_HOLD_RETAIN    false             // [SetOption62] Disable retain flag on HOLD messages
 #define MQTT_NO_RETAIN         false             // [SetOption104] No Retain - disable all MQTT retained messages, some brokers don't support it: AWS IoT, Losant
+#define MQTT_INCREASE_TIMEOUT  false             // [SetOption145] Increase connection timeout
 
 #define MQTT_STATUS_OFF        "OFF"             // [StateText1] Command or Status result when turned off (needs to be a string like "0" or "Off")
 #define MQTT_STATUS_ON         "ON"              // [StateText2] Command or Status result when turned on (needs to be a string like "1" or "On")

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -174,7 +174,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t spare28 : 1;                  // bit 28
     uint32_t spare29 : 1;                  // bit 29
     uint32_t spare30 : 1;                  // bit 30
-    uint32_t spare31 : 1;                  // bit 31
+    uint32_t mqtt_increase_timeout : 1;    // bit 31 - SetOption145 - Increase connection timeout
   };
 } SOBitfield5;
 

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -901,6 +901,7 @@ void SettingsDefaultSet2(void) {
   flag5.mqtt_info_retain |= MQTT_INFO_RETAIN;
   flag5.mqtt_state_retain |= MQTT_STATE_RETAIN;
   flag5.mqtt_switches |= MQTT_SWITCHES;
+  flag5.mqtt_increase_timeout |= MQTT_INCREASE_TIMEOUT;
 //  flag.mqtt_serial |= 0;
   flag.device_index_enable |= MQTT_POWER_FORMAT;
   flag3.time_append_timezone |= MQTT_APPEND_TIMEZONE;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1057,6 +1057,9 @@ void CmndSetoptionBase(bool indexed) {
                   TasmotaGlobal.restart_flag = 2;
                 }
                 break;
+              case 31:                     // SetOption145 - Increase MQTT connection timeout
+                TasmotaGlobal.restart_flag = 2;
+                break;
             }
           }
         } else {

--- a/tasmota/xdrv_02_mqtt_9_impl.ino
+++ b/tasmota/xdrv_02_mqtt_9_impl.ino
@@ -22,6 +22,9 @@
 #ifndef MQTT_WIFI_CLIENT_TIMEOUT
 #define MQTT_WIFI_CLIENT_TIMEOUT   200    // Wifi TCP connection timeout (default is 5000 mSec)
 #endif
+#ifndef MQTT_MAX_WIFI_CLIENT_TIMEOUT
+#define MQTT_MAX_WIFI_CLIENT_TIMEOUT   5000    // Wifi TCP connection timeout upper limit
+#endif
 
 #define USE_MQTT_NEW_PUBSUBCLIENT
 
@@ -966,7 +969,7 @@ void MqttReconnect(void) {
   Response_P(S_LWT_OFFLINE);
 
   if (MqttClient.connected()) { MqttClient.disconnect(); }
-  EspClient.setTimeout(MQTT_WIFI_CLIENT_TIMEOUT);
+  EspClient.setTimeout(Settings.flag5.mqtt_increase_timeout ? MQTT_MAX_WIFI_CLIENT_TIMEOUT : MQTT_WIFI_CLIENT_TIMEOUT);
 #ifdef USE_MQTT_TLS
   if (Mqtt.mqtt_tls) {
     tlsClient->stop();


### PR DESCRIPTION
## Description:

Version 9.1.0.2 changed MQTT Wifi connection timeout from 5000ms to 200ms (#9886).

Some MQTT brokers in the cloud (e.g. MyQttHub - free plan) appear to have a slightly longer connection time (between 400ms and 600ms).

You can compile your own build with a bigger value changing `MQTT_WIFI_CLIENT_TIMEOUT` in `user_config_override.h`
   
This PR creates a new option to allow using the previous value without the needing of rebuild the firmware.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
