### PR TITLE
WifiManager save wificonfig from settings, do it only once

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -404,7 +404,7 @@ struct WEB {
   uint8_t wifiTest = WIFI_NOT_TESTING;
   uint8_t wifi_test_counter = 0;
   uint16_t save_data_counter = 0;
-  uint8_t old_wificonfig = WIFI_MANAGER;
+  uint8_t old_wificonfig = MAX_WIFI_OPTION; // means "nothing yet saved here"
 } Web;
 
 // Helper function to avoid code duplication (saves 4k Flash)
@@ -1798,9 +1798,13 @@ void HandleWifiConfiguration(void) {
       TasmotaGlobal.save_data_counter = 0;               // Stop auto saving data - Updating Settings
       Settings.save_data = 0;
 
-      Web.old_wificonfig = TasmotaGlobal.wifi_state_flag;
-      Settings.sta_config = WIFI_MANAGER;
-      TasmotaGlobal.wifi_state_flag = Settings.sta_config;
+      if (MAX_WIFI_OPTION == Web.old_wificonfig) {
+        Web.old_wificonfig = Settings.sta_config;
+        //AddLog(LOG_LEVEL_INFO,PSTR("WFM: save wificonfig %d and set to 2 (settings=%d)"), Web.old_wificonfig, Settings.sta_config);
+      } else {
+        //AddLog(LOG_LEVEL_INFO,PSTR("WFM: wificonfig already saved %d, set to 2 (settings=%d)"), Web.old_wificonfig, Settings.sta_config);
+      }
+      TasmotaGlobal.wifi_state_flag = Settings.sta_config = WIFI_MANAGER;;
 
       TasmotaGlobal.sleep = 0;                           // Disable sleep
       TasmotaGlobal.restart_flag = 0;                    // No restart
@@ -3295,8 +3299,12 @@ bool Xdrv01(uint8_t function)
           Web.wifiTest = WIFI_TEST_FINISHED_SUCCESSFUL;
           AddLog_P(LOG_LEVEL_INFO, PSTR(D_LOG_WIFI D_CMND_SSID "1 %s: " D_CONNECTED " - " D_IP_ADDRESS " %_I"), SettingsText(SET_STASSID1), (uint32_t)WiFi.localIP());
 //          TasmotaGlobal.blinks = 255;                    // Signal wifi connection with blinks
-          Settings.sta_config = Web.old_wificonfig;
-          TasmotaGlobal.wifi_state_flag = Settings.sta_config;
+          if (MAX_WIFI_OPTION != Web.old_wificonfig) {
+            TasmotaGlobal.wifi_state_flag = Settings.sta_config = Web.old_wificonfig;
+            //AddLog(LOG_LEVEL_INFO,PSTR("WFM: Restore wificonfig %d"), Web.old_wificonfig);
+          } else {
+            //AddLog(LOG_LEVEL_INFO,PSTR("WFM: Keep wificonfig %d"), Settings.sta_config);
+          }
           TasmotaGlobal.save_data_counter = Web.save_data_counter;
           Settings.save_data = Web.save_data_counter;
           SettingsSaveAll();


### PR DESCRIPTION
## Description:

Issue: https://github.com/arendst/Tasmota/issues/12235

Changes:
- Save wificonfig from Settings instead of TasmotaGlobal
- Do it only once at boot

@ascillato , @arendst, I'm not 100% sure of side effects, especially initializing Web.old_wificonfig with something else than WIFI_MANAGER


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
