### PR TITLE
Fix ESP32C3 compile error

### DIFF
--- a/lib/libesp32/LITTLEFS/src/esp_littlefs.c
+++ b/lib/libesp32/LITTLEFS/src/esp_littlefs.c
@@ -63,12 +63,16 @@
 #include <sys/lock.h>
 #include <sys/param.h>
 
-#if __has_include("esp32/rom/spi_flash.h")
+#if CONFIG_IDF_TARGET_ESP32C3
+#include "esp32c3/rom/spi_flash.h"
+#elif CONFIG_IDF_TARGET_ESP32S2
+#include "esp32s2/rom/spi_flash.h"
+#elif __has_include("esp32/rom/spi_flash.h")
 //#warning("LITTLEFS: IDF 4, spi_flash.h file location different from IDF 3")
-#include "esp32/rom/spi_flash.h"
+#include "esp32/rom/spi_flash.h" //IDF 4
 #else
 //#warning("LITTLEFS: IDF 3")
-#include "rom/spi_flash.h"
+#include "rom/spi_flash.h" //IDF 3
 #endif
 
 #include "esp_system.h"


### PR DESCRIPTION
Fix ESP32C3 compile error, maybe work in eps32s2 to.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
