### PR TITLE
Fix last linker error in Tasmota32c3 build

### DIFF
--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32c3_out.ld",
-      "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+      "ldscript": "esp32c3_out.ld"
     },
     "core": "esp32",
     "f_cpu": "160000000L",

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -6,20 +6,22 @@ build_flags  = ${common.build_flags}
 
 [core]
 ; Activate (by removing the ";" in the next lines) if you want to override the standard core defined in platformio.ini !!!
+;platform                    = ${core_stage.platform}
 ;platform_packages           = ${core_stage.platform_packages}
 ;build_unflags               = ${core_stage.build_unflags}
 ;build_flags                 = ${core_stage.build_flags}
 
 [core_stage]
 ; *** Esp8266 core for Arduino version stage
-platform_packages           = framework-arduinoespressif8266 @ https://github.com/tasmota/Arduino.git#3.0.0.1
+platform                    = espressif8266 @ 3.0.0
+platform_packages           =
 ; *** Use Xtensa build chain 10.2. GNU23 from https://github.com/earlephilhower/esp-quick-toolchain
                               tasmota/toolchain-xtensa @ 5.100200.210303
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** 16k extra heap https://github.com/esp8266/Arduino/pull/7060
-                              ;-DPIO_FRAMEWORK_MMU__16KB_CACHE__48KB_IRAM
+                              -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
                               -Wno-switch-unreachable
 
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -38,6 +38,7 @@ build_flags             = ${esp32_defaults.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
+board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 board_build.flash_mode      = qio
 platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
@@ -54,6 +55,7 @@ lib_ignore                  =
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
+board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
                               tasmota/toolchain-riscv32

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -23,6 +23,17 @@ build_flags                 = ${esp82xx_defaults.build_flags}
                               -Wno-switch-unreachable
 
 
+; *** Tasmota version Stage ESP32 IDF3.3.5
+[env:tasmota32idf3]
+extends                 = env:tasmota32_base
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-6aaddf972.tar.gz
+                          ;framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#release/v1.0
+                          platformio/tool-esptoolpy @ ~1.30100
+                          platformio/tool-mklittlefs @ ~1.203.200522
+build_unflags           = ${esp32_defaults.build_unflags}
+build_flags             = ${esp32_defaults.build_flags}
+                          ;-DESP32_STAGE=true
+
 ;*** EXPERIMENTAL Tasmota version for ESP32-S2
 [env:tasmota32s2]
 extends                     = env:tasmota32_base

--- a/tasmota/support_button.ino
+++ b/tasmota/support_button.ino
@@ -167,6 +167,7 @@ void ButtonHandler(void) {
     if (PinUsed(GPIO_KEY1, button_index)) {
       button_present = 1;
 #ifdef ESP32
+#ifndef CONFIG_IDF_TARGET_ESP32C3      
       if (bitRead(Button.touch_mask, button_index)) {          // Touch
         uint32_t _value = touchRead(Pin(GPIO_KEY1, button_index));
         button = NOT_PRESSED;
@@ -187,6 +188,7 @@ void ButtonHandler(void) {
           AddLog(LOG_LEVEL_INFO, PSTR("PLOT: %u, %u, %u,"), button_index+1, _value, Button.touch_hits[button_index]);  // Button number (1..4), value, continuous hits under threshold
         }
       } else
+#endif  // not ESP32C3
 #endif  // ESP32
       {                                                 // Normal button
         button = (digitalRead(Pin(GPIO_KEY1, button_index)) != bitRead(Button.inverted_mask, button_index));


### PR DESCRIPTION
and add Tasmota Arduino stage 32 IDF3.3.5 environment in `platformio_tasmota_cenv_sample.ini`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
