### PR TITLE
boards.json scanning faulty with Arduino/IDF4.4

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -75,6 +75,7 @@ lib_ignore                  =
 ; *** EXPERIMENTAL Tasmota version for ESP32 IDF4.4.
 [env:tasmota32idf4]
 extends                     = env:tasmota32_base
+board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
                               toolchain-xtensa32 @ ~2.80400.0


### PR DESCRIPTION
so adding `board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv` to [env] which are based on IDF44 are necessary.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
