### PR TITLE
Final ESP32 partitions scheme fix

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
@@ -10,7 +9,8 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "esp32"
+    "variant": "esp32",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
   },
   "connectivity": [
     "wifi",
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "AI Thinker ESP32-CAM, 4M Flash 4MB PSRAM, 1856k Code/OTA, 320k SPIFFS",
+  "name": "AI Thinker ESP32-CAM, 4M Flash 4MB PSRAM, Tasmota 1856k Code/OTA, 320k SPIFFS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app2944k_spiffs10M.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
@@ -10,7 +9,8 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "m5stack_core2"
+    "variant": "m5stack_core2",
+    "partitions": "esp32_partition_app2944k_spiffs10M.csv"
   },
   "connectivity": [
     "wifi",
@@ -22,7 +22,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "M5Stack Core2 16M Flash, 4MB PSRAM, 2944k Code/OTA, 10M SPIFFS",
+  "name": "M5Stack Core2 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M SPIFFS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app2944k_spiffs10M.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
@@ -10,7 +9,8 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "odroid_esp32"
+    "variant": "odroid_esp32",
+    "partitions": "esp32_partition_app2944k_spiffs10M.csv"
   },
   "connectivity": [
     "wifi",
@@ -22,7 +22,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "ESP32 ODROID-GO 16M Flash, 4MB PSRAM, 2944k Code/OTA, 10M SPIFFS",
+  "name": "ESP32 ODROID-GO 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M SPIFFS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app2944k_spiffs10M.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV",
@@ -10,7 +9,8 @@
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "esp32"
+    "variant": "esp32",
+    "partitions": "esp32_partition_app2944k_spiffs10M.csv"
   },
   "connectivity": [
     "wifi",
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 16M Flash, 2944k Code/OTA, 10M SPIFFS",
+  "name": "Espressif Generic ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M SPIFFS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV",
@@ -10,7 +9,8 @@
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "esp32"
+    "variant": "esp32",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
   },
   "connectivity": [
     "wifi",
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 4M Flash, 1856k Code/OTA, 320k SPIFFS",
+  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32_out.ld",
-      "partitions": "esp32_partition_app2944k_spiffs2M.csv"
+      "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV",
@@ -10,7 +9,8 @@
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",
-    "variant": "esp32"
+    "variant": "esp32",
+    "partitions": "esp32_partition_app2944k_spiffs2M.csv"
   },
   "connectivity": [
     "wifi",
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 8M Flash, 2944k Code/OTA, 2112k SPIFFS",
+  "name": "Espressif Generic ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k SPIFFS",
   "upload": {
     "flash_size": "8MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -8,7 +8,8 @@
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32c3",
-    "variant": "esp32c3"
+    "variant": "esp32c3",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
   },
   "connectivity": [
     "wifi"
@@ -16,7 +17,7 @@
   "frameworks": [
     "arduino"
   ],
-  "name": "Espressif ESP32-C3",
+  "name": "Espressif Generic ESP32-C3 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -1,15 +1,15 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s2_out.ld",
-      "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+      "ldscript": "esp32s2_out.ld"
     },
     "core": "esp32",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",
     "mcu": "esp32s2",
-    "variant": "esp32s2"
+    "variant": "esp32s2",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
   },
   "connectivity": [
     "wifi"
@@ -21,7 +21,7 @@
     "espidf",
     "arduino"
   ],
-  "name": "Espressif ESP32-S2-Saola-1",
+  "name": "Espressif Generic ESP32-S2 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp8266_1M.json
+++ b/boards/esp8266_1M.json
@@ -19,10 +19,10 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 1M sketch NO SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch NO SPIFFS",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 1048576,
+    "maximum_size": 995326,
     "require_upload_port": true,
     "resetmethod": "ck",
     "speed": 115200

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -19,10 +19,10 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 1M sketch 1M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M SPIFFS",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 1048576,
+    "maximum_size": 995326,
     "require_upload_port": true,
     "resetmethod": "ck",
     "speed": 115200

--- a/boards/esp8266_4M2M.json
+++ b/boards/esp8266_4M2M.json
@@ -19,10 +19,10 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 1M sketch 1M OTA 2M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M OTA 2M SPIFFS",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 1048576,
+    "maximum_size": 995326,
     "require_upload_port": true,
     "resetmethod": "ck",
     "speed": 115200

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -19,10 +19,10 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 1M sketch 3M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 3M SPIFFS",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 1048576,
+    "maximum_size": 995326,
     "require_upload_port": true,
     "resetmethod": "ck",
     "speed": 115200

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -40,8 +40,6 @@ build_flags             = ${esp32_defaults.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
-board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
-board_build.flash_mode      = qio
 platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
@@ -57,7 +55,6 @@ lib_ignore                  =
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 platform                    = https://github.com/Jason2866/platform-espressif32.git#feature/arduino-c3
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
                               tasmota/toolchain-riscv32
@@ -75,7 +72,6 @@ lib_ignore                  =
 ; *** EXPERIMENTAL Tasmota version for ESP32 IDF4.4.
 [env:tasmota32idf4]
 extends                     = env:tasmota32_base
-board_build.partitions      = esp32_partition_app1856k_spiffs320k.csv
 platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/259/framework-arduinoespressif32-master-c13afea63.tar.gz
                               toolchain-xtensa32 @ ~2.80400.0


### PR DESCRIPTION
moving to a different place in boards.json does work for Arduino / IDF33 and Arduino / IDF44
No more workarounds needed.
Reduced flash size definition for ESP8266 to max size of Tasmota firmware. By doing this linking will fail if Tasmota firmware is too big.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
