### PR TITLE
Fix homekit compile with IDF4 

### DIFF
--- a/lib/libesp32_div/ESP32-HomeKit/src/port/bignum.c
+++ b/lib/libesp32_div/ESP32-HomeKit/src/port/bignum.c
@@ -21,7 +21,14 @@
  *
  */
 
-//#include "soc/hwcrypto_periph.h"
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#warning("IDF is 4 or later")
+#include "soc/hwcrypto_periph.h"
+#endif
+#endif
+
 #include "soc/hwcrypto_reg.h"
 #include "driver/periph_ctrl.h"
 #include <mbedtls/bignum.h>

--- a/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
+++ b/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
@@ -20,6 +20,14 @@
  *  limitations under the License.
  *
  */
+#if __has_include("esp_idf_version.h")
+#include "esp_idf_version.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#warning("IDF is 4 or later")
+#include "soc/hwcrypto_periph.h"
+#endif
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <malloc.h>
@@ -27,7 +35,6 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <sys/param.h>
-//#include "soc/hwcrypto_periph.h"
 #include "esp_system.h"
 #include "esp_log.h"
 #include "esp_attr.h"


### PR DESCRIPTION
* Fix compile error with Arduino/IDF44 -> missing include file

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
