### PR TITLE
Add Wi-Fi Modes Control Command

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -200,6 +200,7 @@
 #define D_JSON_VOLUME "Volume"
 #define D_JSON_WEIGHT "Weight"
 #define D_JSON_WIFI "Wifi"
+#define D_JSON_WIFI_MODE "Mode"
 #define D_JSON_WRONG "Wrong"
 #define D_JSON_WRONG_PARAMETERS "Wrong parameters"
 #define D_JSON_YESTERDAY "Yesterday"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -2142,8 +2142,12 @@ void CmndWifi(void)
   if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 1)) {
     Settings.flag4.network_wifi = XdrvMailbox.payload;
     if (Settings.flag4.network_wifi) { WifiEnable(); }
+#ifdef ESP8266
+  } else if ((XdrvMailbox.payload >= 2) && (XdrvMailbox.payload <= 4)) {
+    WiFi.setPhyMode(WiFiPhyMode_t(XdrvMailbox.payload - 1));  // 1-B/2-BG/3-BGN
+#endif
   }
-  ResponseCmndStateText(Settings.flag4.network_wifi);
+  Response_P(PSTR("{\"" D_JSON_WIFI "\":\"%s\",\"" D_JSON_WIFI_MODE "\":\"11%c\"}"), GetStateText(Settings.flag4.network_wifi), pgm_read_byte(&kWifiPhyMode[WiFi.getPhyMode() & 0x3]) );
 }
 
 #ifdef USE_I2C

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -767,9 +767,10 @@ void MqttShowState(void)
 
   if (!TasmotaGlobal.global_state.wifi_down) {
     int32_t rssi = WiFi.RSSI();
-    ResponseAppend_P(PSTR(",\"" D_JSON_WIFI "\":{\"" D_JSON_AP "\":%d,\"" D_JSON_SSID "\":\"%s\",\"" D_JSON_BSSID "\":\"%s\",\"" D_JSON_CHANNEL "\":%d,\"" D_JSON_RSSI "\":%d,\"" D_JSON_SIGNAL "\":%d,\"" D_JSON_LINK_COUNT "\":%d,\"" D_JSON_DOWNTIME "\":\"%s\"}"),
+    ResponseAppend_P(PSTR(",\"" D_JSON_WIFI "\":{\"" D_JSON_AP "\":%d,\"" D_JSON_SSID "\":\"%s\",\"" D_JSON_BSSID "\":\"%s\",\"" D_JSON_CHANNEL "\":%d,\"" D_JSON_WIFI_MODE "\":\"11%c\",\"" D_JSON_RSSI "\":%d,\"" D_JSON_SIGNAL "\":%d,\"" D_JSON_LINK_COUNT "\":%d,\"" D_JSON_DOWNTIME "\":\"%s\"}"),
       Settings.sta_active +1, EscapeJSONString(SettingsText(SET_STASSID1 + Settings.sta_active)).c_str(), WiFi.BSSIDstr().c_str(), WiFi.channel(),
-      WifiGetRssiAsQuality(rssi), rssi, WifiLinkCount(), WifiDowntime().c_str());
+      pgm_read_byte(&kWifiPhyMode[WiFi.getPhyMode() & 0x3]), WifiGetRssiAsQuality(rssi), rssi,
+      WifiLinkCount(), WifiDowntime().c_str());
   }
 
   ResponseJsonEnd();

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -175,8 +175,6 @@ void WiFiSetSleepMode(void)
 
 void WifiBegin(uint8_t flag, uint8_t channel)
 {
-  const static char kWifiPhyMode[] PROGMEM = " bgnl";
-
 #ifdef USE_EMULATION
   UdpDisconnect();
 #endif  // USE_EMULATION

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -105,6 +105,9 @@ const uint8_t MAX_FRIENDLYNAMES = 8;        // Max number of Friendly names
 const uint8_t MAX_BUTTON_TEXT = 16;         // Max number of GUI button labels
 const uint8_t MAX_GROUP_TOPICS = 4;         // Max number of Group Topics
 const uint8_t MAX_DEV_GROUP_NAMES = 4;      // Max number of Device Group names
+
+const static char kWifiPhyMode[] PROGMEM = " bgnl"; // Wi-Fi Modes
+
 #ifdef ESP8266
 const uint8_t MAX_ADCS = 1;                 // Max number of ESP8266 ADC pins
 const uint8_t MAX_SWITCHES_TXT = 8;         // Max number of switches user text

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1782,13 +1782,8 @@ void HandleWifiConfiguration(void) {
       TasmotaGlobal.save_data_counter = 0;               // Stop auto saving data - Updating Settings
       Settings.save_data = 0;
 
-      if (MAX_WIFI_OPTION == Web.old_wificonfig) {
-        Web.old_wificonfig = Settings.sta_config;
-        //AddLog(LOG_LEVEL_INFO,PSTR("WFM: save wificonfig %d and set to 2 (settings=%d)"), Web.old_wificonfig, Settings.sta_config);
-      } else {
-        //AddLog(LOG_LEVEL_INFO,PSTR("WFM: wificonfig already saved %d, set to 2 (settings=%d)"), Web.old_wificonfig, Settings.sta_config);
-      }
-      TasmotaGlobal.wifi_state_flag = Settings.sta_config = WIFI_MANAGER;;
+      if (MAX_WIFI_OPTION == Web.old_wificonfig) { Web.old_wificonfig = Settings.sta_config; }
+      TasmotaGlobal.wifi_state_flag = Settings.sta_config = WIFI_MANAGER;
 
       TasmotaGlobal.sleep = 0;                           // Disable sleep
       TasmotaGlobal.restart_flag = 0;                    // No restart
@@ -2271,7 +2266,7 @@ void HandleInformation(void)
 #endif
   if (Settings.flag4.network_wifi) {
     int32_t rssi = WiFi.RSSI();
-    WSContentSend_P(PSTR("}1" D_AP "%d " D_SSID " (" D_RSSI ")}2%s (%d%%, %d dBm)"), Settings.sta_active +1, HtmlEscape(SettingsText(SET_STASSID1 + Settings.sta_active)).c_str(), WifiGetRssiAsQuality(rssi), rssi);
+    WSContentSend_P(PSTR("}1" D_AP "%d " D_SSID " (" D_RSSI ")}2%s (%d%%, %d dBm) 11%c"), Settings.sta_active +1, HtmlEscape(SettingsText(SET_STASSID1 + Settings.sta_active)).c_str(), WifiGetRssiAsQuality(rssi), rssi, pgm_read_byte(&kWifiPhyMode[WiFi.getPhyMode() & 0x3]) );
     WSContentSend_P(PSTR("}1" D_HOSTNAME "}2%s%s"), TasmotaGlobal.hostname, (Mdns.begun) ? PSTR(".local") : "");
 #if LWIP_IPV6
     String ipv6_addr = WifiGetIPv6();
@@ -3268,9 +3263,6 @@ bool Xdrv01(uint8_t function)
 //          TasmotaGlobal.blinks = 255;                    // Signal wifi connection with blinks
           if (MAX_WIFI_OPTION != Web.old_wificonfig) {
             TasmotaGlobal.wifi_state_flag = Settings.sta_config = Web.old_wificonfig;
-            //AddLog(LOG_LEVEL_INFO,PSTR("WFM: Restore wificonfig %d"), Web.old_wificonfig);
-          } else {
-            //AddLog(LOG_LEVEL_INFO,PSTR("WFM: Keep wificonfig %d"), Settings.sta_config);
           }
           TasmotaGlobal.save_data_counter = Web.save_data_counter;
           Settings.save_data = Web.save_data_counter;


### PR DESCRIPTION
## Description:

Tasmota in a BLANK device, supports by default all the Wi-Fi modes available in the ESP8266 that are IEEE 802.11b/g/n.
But, if the device is not blank or comes from another firmware, sometimes the supported modes are restricted like having only 11b or 11b/g. Tasmota don't force the full support. That is why, this PR adds new options for the command `WIFI` to FORCE which modes are going to be used.

The `WIFI` command now have the following options with this PR:

0 - Turn Off Wi-Fi
1 - Turn On Wi-Fi
**2 - Force the device to ONLY connects as a 11b device
3 - Force the device to ONLY connects as a 11b/g device
4 - Force the device to connects as a 11b/g/n device**

When changing modes, the device disconnects and reconnects to the router without restarting. Because of that, sometimes you need to refresh your browser.

![image](https://user-images.githubusercontent.com/35405447/120810966-e286a680-c521-11eb-8ed0-5a5661377c1d.png)

**_(REMEMBER that if your router don't support 11b, or is configured to not support 11b and you force 11b, your device won't connect. In the serial console you see AP TIMEOUT no matter if the SSId and Password are Ok)_**

Besides that, with this PR, it has been added to show the actual mode in `STATUS 11`, in the response of the `WIFI` command and in the INFORMATION menu of the WebUI, for user troubleshooting. Also this PR have some code cleaning.

![image](https://user-images.githubusercontent.com/35405447/120811349-49a45b00-c522-11eb-960e-bceca6a79751.png)

Forcing modes is useful to troubleshoot and solve issues like:
+ A device that had another firmware before,
+ A device that is far from a router (sometimes forcing 11b gives more range <- this depends on the router due to new routers have wide and better range on 11n),
+ If in the users' network, there is a very old device that only supports 11b, sometimes old or cheap routers can't manage correctly different devices in different modes and put the entire network on 11b. With this, you can force to use 11n in Tasmota and find which device is lowering the performance in the network,
+ If a new device can't connect and from the serial interface it is being showed AP TIMEOUT, it can be checked now which modes are supported in the Tasmotized device to match the Router's.

In the AP mode, the ESP8266 supports only b/g modes.

These code changes were tested too on ESP32 and works fine. The ESP32 have all mode enabled by default, so this PR don't provide the new options of the `WIFI` command for ESP32. It just provide showing the actual mode.

The ESP32 supports b/g/n/LR on both AP and STA modes. The LR mode (Long Range-Low Rate of 1km) is not supported in Tasmota ATM and can not be used.

**Related issue (if applicable):** NA

**Proposed changes to the docs:** https://github.com/tasmota/docs/pull/751

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
