### PR TITLE
Enable RTSP SERVER as default in Webcam build

### DIFF
--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -33,6 +33,7 @@
 #define CODE_IMAGE_STR "webcam"
 
 #define USE_WEBCAM
+#define ENABLE_RTSPSERVER
 #define USE_UFILESYS
 #define USE_SDCARD
   #define GUI_TRASH_FILE


### PR DESCRIPTION
since it can be controlled with `WcRtsp  0=disable, 1=enable`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
