### PR TITLE
OpenTherm: Fix settings initialization

### DIFF
--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -216,8 +216,6 @@ bool sns_opentherm_Init()
         sns_ot_master = new OpenTherm(Pin(GPIO_BOILER_OT_RX), Pin(GPIO_BOILER_OT_TX));
         sns_ot_master->begin(sns_opentherm_handleInterrupt, sns_opentherm_processResponseCallback);
         sns_ot_connection_status = OpenThermConnectionStatus::OTC_CONNECTING;
-
-        sns_opentherm_init_boiler_status();
         return true;
     }
     return false;
@@ -341,7 +339,7 @@ void sns_ot_process_handshake(unsigned long response, int st)
     sns_ot_connection_status = OpenThermConnectionStatus::OTC_READY;
 }
 
-void sns_opentherm_CheckSettings(void)
+void sns_opentherm_check_settings(void)
 {
     bool settingsValid = true;
 
@@ -547,7 +545,8 @@ bool Xsns69(uint8_t function)
     {
         if (sns_opentherm_Init())
         {
-            sns_opentherm_CheckSettings();
+            sns_opentherm_check_settings();
+            sns_opentherm_init_boiler_status();
         }
     }
 


### PR DESCRIPTION
## Description:

This PR fixes an initial OpenTherm setting initialization issue. A `sns_opentherm_Init()` method  calls the `sns_opentherm_init_boiler_status()` before the `sns_opentherm_check_settings()` method. Thus `sns_ot_boiler_status` variable get initialized from zero (or random) setting values.

The PR change the order of the method calls. That way `sns_opentherm_init_boiler_status()` is always called after the `sns_opentherm_check_settings()`.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
