### PR TITLE
Fix berry compiler bug #101

### DIFF
--- a/lib/libesp32/Berry/src/be_code.c
+++ b/lib/libesp32/Berry/src/be_code.c
@@ -317,7 +317,7 @@ static void free_suffix(bfuncinfo *finfo, bexpdesc *e)
         be_code_freeregs(finfo, 1);
     }
     /* release object register */
-    if (e->v.ss.tt == ETREG && (int)e->v.ss.obj >= nlocal) {
+    if (e->v.ss.tt == ETREG && (int)e->v.ss.obj >= nlocal && (e->v.ss.obj + 1 >= finfo->freereg)) {
         be_code_freeregs(finfo, 1);
     }
 }

--- a/lib/libesp32/Berry/tests/suffix.be
+++ b/lib/libesp32/Berry/tests/suffix.be
@@ -9,3 +9,20 @@ var pairs = {
 for i : 0 .. keys.size() - 1
     assert(pairs[keys[i]] == 'value' .. i + 1)
 end
+
+#- test cases related to #101 -#
+class C var l end
+c=C()
+c.l=[0,1,2]
+
+def t_101_nok_1() return c.l[0..1] end
+def t_101_ok_1() var l2 = c.l return l2[0..1] end
+
+t_i = 0
+def t_101_nok_2() return c.l[t_i] end
+def t_101_ok_2() return c.l[0] end
+
+assert(t_101_nok_1() == [0, 1])
+assert(t_101_ok_1() == [0, 1])
+assert(t_101_nok_2() == 0)
+assert(t_101_ok_2() == 0)


### PR DESCRIPTION
## Description:

Fix Berry compiler bug: https://github.com/Skiars/berry/pull/102

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
