### PR TITLE
Fix regression for zbbridge build

### DIFF
--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.2m256.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dout",
+    "mcu": "esp8266",
+    "variant": "generic"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino",
+    "esp8266-rtos-sdk",
+    "esp8266-nonos-sdk"
+  ],
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 772k OTA 256k SPIFFS",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 995326,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
+  "vendor": "Espressif"
+}

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -65,7 +65,7 @@ build_flags             = ${common.build_flags} ${irremoteesp_full.build_flags} 
 
 [env:tasmota-zbbridge]
 build_flags             = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
-board_build.ldscript    = eagle.flash.2m256.ld
+board                   = esp8266_2M256
 board_build.f_cpu       = 160000000L
 lib_extra_dirs          = lib/lib_ssl
 


### PR DESCRIPTION
overseen to change from linker script to board definition with last platformio refactoring

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
