### PR TITLE
Berry fix MD5 compilation for idf4

### DIFF
--- a/tasmota/xdrv_52_3_berry_md5.ino
+++ b/tasmota/xdrv_52_3_berry_md5.ino
@@ -21,7 +21,7 @@
 #ifdef USE_BERRY
 
 #include <berry.h>
-#include "mbedtls/md5.h"
+#include "MD5Builder.h"
 #include "be_mem.h"
 
 /*********************************************************************************************\
@@ -33,7 +33,7 @@ extern "C" {
   int free_ctx(bvm* vm) {
     int argc = be_top(vm);
     if (argc > 0) {
-      mbedtls_md5_context * ctx = (mbedtls_md5_context*) be_tocomptr(vm, 1);
+      struct MD5Context * ctx = (struct MD5Context *) be_tocomptr(vm, 1);
       if (ctx != NULL) {
         be_os_free(ctx);
       }
@@ -45,12 +45,11 @@ extern "C" {
   int32_t m_md5_init(struct bvm *vm);
   int32_t m_md5_init(struct bvm *vm) {
 
-    mbedtls_md5_context * ctx = (mbedtls_md5_context*) be_os_malloc(sizeof(mbedtls_md5_context));
+    struct MD5Context * ctx = (struct MD5Context *) be_os_malloc(sizeof(struct MD5Context));
     if (!ctx) {
       be_throw(vm, BE_MALLOC_FAIL);
     }
-    mbedtls_md5_init(ctx);
-    mbedtls_md5_starts_ret(ctx);
+    MD5Init(ctx);
 
     be_newcomobj(vm, ctx, &free_ctx);
     be_setmember(vm, 1, ".p");
@@ -72,12 +71,12 @@ extern "C" {
         if (!bytes) break;
 
         be_getmember(vm, 1, ".p");
-        mbedtls_md5_context * ctx;
-        ctx = (mbedtls_md5_context*) be_tocomptr(vm, -1);
+        struct MD5Context * ctx;
+        ctx = (struct MD5Context *) be_tocomptr(vm, -1);
         if (!ctx) break;
 
         if (length > 0) {
-          mbedtls_md5_update_ret(ctx, (const uint8_t*) bytes, length);
+          MD5Update(ctx, (const uint8_t*) bytes, length);
         }
         be_return_nil(vm);
         // success
@@ -92,11 +91,11 @@ extern "C" {
   int32_t m_md5_finish(struct bvm *vm);
   int32_t m_md5_finish(struct bvm *vm) {
     be_getmember(vm, 1, ".p");
-    mbedtls_md5_context * ctx;
-    ctx = (mbedtls_md5_context*) be_tocomptr(vm, -1);
+    struct MD5Context * ctx;
+    ctx = (struct MD5Context *) be_tocomptr(vm, -1);
 
     uint8_t output[16];
-    mbedtls_md5_finish_ret(ctx, output);
+    MD5Final(output, ctx);
     be_pushbytes(vm, output, sizeof(output));
     be_return(vm);
   }

--- a/tasmota/xdrv_56_BM8563_RTC.ino
+++ b/tasmota/xdrv_56_BM8563_RTC.ino
@@ -114,7 +114,7 @@ void InitTimeFromRTC(void) {
 
 void BM8563EverySecond(void) {
   if (bm8563_driver.rtc_ready) {
-    if (!bm8563_driver.ntp_time_ok && Rtc.utc_time > START_VALID_TIME && abs(Rtc.utc_time - BM8563GetUtc()) > 3) {
+    if (!bm8563_driver.ntp_time_ok && Rtc.utc_time > START_VALID_TIME && abs((int32_t)Rtc.utc_time - (int32_t)BM8563GetUtc()) > 3) {
       BM8563SetUtc(Rtc.utc_time);
       AddLog(LOG_LEVEL_INFO, PSTR("I2C: Write Time TO BM8563 from NTP (" D_UTC_TIME ") %s, (" D_DST_TIME ") %s, (" D_STD_TIME ") %s"),
                   GetDateAndTime(DT_UTC).c_str(), GetDateAndTime(DT_DST).c_str(), GetDateAndTime(DT_STD).c_str());


### PR DESCRIPTION
## Description:

Fix compilation of MD5 for idf4. Uses Arduino's include instead of esp-idf, which will avoid conflicts.

Edit: added fix for BM8563 too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
