### PR TITLE
OpenTherm: Send boiler temperature setpoint when Central Heating flag is set.

### DIFF
--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -108,6 +108,9 @@ typedef struct OT_BOILER_STATUS_T
     // Boiler desired values
     float m_boilerSetpoint;
     float m_hotWaterSetpoint;
+    // This flag is set when Master require a CH to be on
+    // and forces the OpenThermMessageID::TSet to be sent to the boiler
+    bool m_forceSetpointSet;
 
 } OT_BOILER_STATUS;
 
@@ -594,6 +597,9 @@ bool Xsns69(uint8_t function)
         break;
     case FUNC_JSON_APPEND:
         sns_opentherm_stat(1);
+        break;
+    case FUNC_SAVE_AT_MIDNIGHT:
+        sns_opentherm_protocol_reset();
         break;
 #ifdef USE_WEBSERVER
     case FUNC_WEB_SENSOR:


### PR DESCRIPTION
## Description:

When the CH flag is set, the boiler may not start the operation. After investigating the issue a little bit I found that in order to start the burner I have to send the temperature setpoint. Since temperature may not change for a while, it seems, the boiler may "forget" it, although it reporting back a proper setpoint value.
This might look like a software bug with my particular boiler. However, it seems, always sending a temperature setpoint after the CH flag set should not hurt.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
