### PR TITLE
Move "includes"" from c3 env to esp32 default settings

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -53,8 +53,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               ;for TLS we can afford compiling for 4K RSA keys
                               -DUSE_4K_RSA
                               -I$PROJECT_DIR/include
-                              -include "fix_esp32c3.h"
                               -include "sdkconfig.h"
+                              -include "fix_esp32c3.h"
 
 
 [core32]

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -52,6 +52,9 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Dmemcmp_P=memcmp
                               ;for TLS we can afford compiling for 4K RSA keys
                               -DUSE_4K_RSA
+                              -I$PROJECT_DIR/include
+                              -include "fix_esp32c3.h"
+                              -include "sdkconfig.h"
 
 
 [core32]

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -64,9 +64,6 @@ build_unflags               = ${esp32_defaults.build_unflags}
                               -mtarget-align
 build_flags                 = ${esp32_defaults.build_flags}
                               -Wno-switch-unreachable
-                              -I$PROJECT_DIR/include
-                              -include "fix_esp32c3.h"
-                              -include "sdkconfig.h"
                               ;-DESP32_STAGE=true
 lib_extra_dirs              = lib/libesp32
                               lib/libesp32_lvgl


### PR DESCRIPTION
`sdkconfig.h` is included for all ESP32 builds. Avoiding strange errors when compiling. `fix_esp32c3.h` is only activated when riscv flag is set, so it is okay here too.

Doing this cleans the env and reduces the chance to overlook needed compile flags for user generated env

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
