### PR TITLE
Esp32c3 fix OneWire compilation

### DIFF
--- a/lib/lib_basic/OneWire-Stickbreaker-20190506-1.1/OneWire.h
+++ b/lib/lib_basic/OneWire-Stickbreaker-20190506-1.1/OneWire.h
@@ -156,10 +156,14 @@
 static inline __attribute__((always_inline))
 IO_REG_TYPE directRead(IO_REG_TYPE pin)
 {
+#if CONFIG_IDF_TARGET_ESP32C3
+    return (GPIO.in.val >> pin) & 0x1;
+#else // plain ESP32
     if ( pin < 32 )
         return (GPIO.in >> pin) & 0x1;
     else if ( pin < 40 )
         return (GPIO.in1.val >> (pin - 32)) & 0x1;
+#endif
 
     return 0;
 }
@@ -167,19 +171,27 @@ IO_REG_TYPE directRead(IO_REG_TYPE pin)
 static inline __attribute__((always_inline))
 void directWriteLow(IO_REG_TYPE pin)
 {
+#if CONFIG_IDF_TARGET_ESP32C3
+    GPIO.out_w1tc.val = ((uint32_t)1 << pin);
+#else // plain ESP32
     if ( pin < 32 )
         GPIO.out_w1tc = ((uint32_t)1 << pin);
     else if ( pin < 34 )
         GPIO.out1_w1tc.val = ((uint32_t)1 << (pin - 32));
+#endif
 }
 
 static inline __attribute__((always_inline))
 void directWriteHigh(IO_REG_TYPE pin)
 {
+#if CONFIG_IDF_TARGET_ESP32C3
+    GPIO.out_w1ts.val = ((uint32_t)1 << pin);
+#else // plain ESP32
     if ( pin < 32 )
         GPIO.out_w1ts = ((uint32_t)1 << pin);
     else if ( pin < 34 )
         GPIO.out1_w1ts.val = ((uint32_t)1 << (pin - 32));
+#endif
 }
 
 static inline __attribute__((always_inline))
@@ -196,6 +208,9 @@ void directModeInput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
         }
 #elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
+#if CONFIG_IDF_TARGET_ESP32C3
+    // Esp32c3 has no full RTC IO subsystem, so GPIO is 100% "independent" of RTC
+#else // plain ESP32
         uint32_t rtc_reg(rtc_io_desc[pin].reg);
 
         if ( rtc_reg ) // RTC pins PULL settings
@@ -204,11 +219,16 @@ void directModeInput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[pin].pullup | rtc_io_desc[pin].pulldown);
         }
 #endif
+#endif
 
+#if CONFIG_IDF_TARGET_ESP32C3
+    GPIO.enable_w1tc.val = ((uint32_t)1 << (pin - 32));
+#else // plain ESP32
         if ( pin < 32 )
             GPIO.enable_w1tc = ((uint32_t)1 << pin);
         else
             GPIO.enable1_w1tc.val = ((uint32_t)1 << (pin - 32));
+#endif
 
         uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
         pinFunction |= FUN_IE; // input enable but required for output as well?
@@ -234,6 +254,9 @@ void directModeOutput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
         }
 #elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
+#if CONFIG_IDF_TARGET_ESP32C3
+    // Esp32c3 has no full RTC IO subsystem, so GPIO is 100% "independent" of RTC
+#else // plain ESP32
         uint32_t rtc_reg(rtc_io_desc[pin].reg);
 
         if ( rtc_reg ) // RTC pins PULL settings
@@ -242,11 +265,16 @@ void directModeOutput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[pin].pullup | rtc_io_desc[pin].pulldown);
         }
 #endif
+#endif
 
+#if CONFIG_IDF_TARGET_ESP32C3
+        GPIO.enable_w1ts.val = ((uint32_t)1 << (pin - 32));
+#else // plain ESP32
         if ( pin < 32 )
             GPIO.enable_w1ts = ((uint32_t)1 << pin);
         else // already validated to pins <= 33
             GPIO.enable1_w1ts.val = ((uint32_t)1 << (pin - 32));
+#endif
 
         uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
         pinFunction |= FUN_IE; // input enable but required for output as well?

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -75,8 +75,6 @@ lib_extra_dirs              = lib/libesp32
                               lib/lib_ssl
                               lib/lib_display
 lib_ignore                  =
-                              rc-switch
-                              OneWire
                               NimBLE-Arduino
                               Micro-RTSP
                               ILI9488

--- a/tasmota/xsns_05_ds18x20_esp32.ino
+++ b/tasmota/xsns_05_ds18x20_esp32.ino
@@ -17,8 +17,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-// ESP32C3 I2S is not supported yet
-#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
+
+#ifdef ESP32
 #ifdef USE_DS18x20
 /*********************************************************************************************\
  * DS18B20 - Temperature - Multiple sensors


### PR DESCRIPTION
## Description:

Fix required because the number of GPIOs if below 32, whereas ESP32 has more than 32 GPIOs.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
