### PR TITLE
I2C extended MPU6886 to also support MPU9250 (found in Legacy M5Stack Fire)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Command ``Timers`` layout of JSON message changed to single line
 - Command ``Gpio`` layout of JSON message changed to single line
 - Command ``Modules`` layout of JSON message changed to single line
+- I2C extended MPU6886 to also support MPU9250 (found in Legacy M5Stack Fire)
 
 ## [9.4.0.4]
 ### Added

--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -91,5 +91,5 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   55  | USE_EZOPMP          | xsns_78 | EZOPMP   | 0x61 - 0x70 | Peristaltic Pump
   56  | USE_SEESAW_SOIL     | xsns_81 | SEESOIL  | 0x36 - 0x39 | Adafruit seesaw soil moisture sensor
   57  | USE_TOF10120        | xsns_84 | TOF10120 | 0x52        | Time-of-flight (ToF) distance sensor
-  58  | USE_MPU6886         | xsns_85 | MPU6886  | 0x68        | MPU6886 M5Stack
+  58  | USE_MPU_ACCEL       | xsns_85 | MPU_ACCEL| 0x68        | MPU6886/MPU9250 6-axis MotionTracking sensor from M5Stack
   59  | USE_BM8563          | xdrv_56 | BM8563   | 0x51        | BM8563 RTC from M5Stack

--- a/lib/lib_i2c/MPU_accel/library.properties
+++ b/lib/lib_i2c/MPU_accel/library.properties
@@ -1,9 +1,9 @@
-name=MPU6886
+name=MPU_accel
 version=
 author=M5StickC
 maintainer=Stephan Hadinger
-sentence=Support for MPU6886
-paragraph=Support for MPU6886
+sentence=Support for MPU6886, MPU9250
+paragraph=Support for MPU6886, MPU9250
 category=
 url=https://github.com/m5stack/M5StickC/blob/master/src/utility/
-architectures=esp32,esp8266
+architectures=*

--- a/lib/lib_i2c/MPU_accel/src/MPU_accel.h
+++ b/lib/lib_i2c/MPU_accel/src/MPU_accel.h
@@ -5,6 +5,9 @@
  library in the Wire.h/twi.c utility file. We are also using the 400 kHz fast
  I2C mode by setting the TWI_FREQ  to 400000L /twi.h utility file.
  */
+
+// Extended to support MPU9250 and other variants
+
 #ifndef _MPU6886_H_
 #define _MPU6886_H_
 
@@ -48,7 +51,7 @@
 #define AtR    	0.0174533	
 #define Gyro_Gr	0.0010653
 
-class MPU6886 {
+class MPU_accel {
     public:
       enum Ascale {
         AFS_2G = 0,
@@ -68,14 +71,16 @@ class MPU6886 {
       Ascale Acscale = AFS_8G;
       int16_t acRange = 8000;   // 1/1000 of g
       int16_t gyRange = 2000;   // dps - degree per second
+      uint32_t model = 6886;    // MPU model number
     public:
-      MPU6886(void) {};
+      MPU_accel(void) {};
   #ifdef ESP32
       void setBus(uint32_t _bus) { myWire = _bus ? &Wire1 : &Wire; };
   #else
       void setBus(uint32_t _bus) { myWire = &Wire; };
   #endif
       int Init(void);
+      uint32_t getModel(void) const { return model; }
       void getAccelAdc(int16_t* ax, int16_t* ay, int16_t* az);
       void getGyroAdc(int16_t* gx, int16_t* gy, int16_t* gz);
       void getTempAdc(int16_t *t);

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -628,8 +628,8 @@
 //  #define USE_EZORGB                             // [I2cDriver55] Enable support for EZO's RGB sensor (+0k5 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_EZOPMP                             // [I2cDriver55] Enable support for EZO's PMP sensor (+0k3 code) - Shared EZO code required for any EZO device (+1k2 code)
 //  #define USE_SEESAW_SOIL                        // [I2cDriver56] Enable Capacitice Soil Moisture & Temperature Sensor (I2C addresses 0x36 - 0x39) (+1k3 code)
-//  #define USE_MPU6886                            // [I2cDriver58] Enable MPU6886 - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x68) (+2k code)
-//  #define USE_BM8563                             // [I2cDriver58] Enable BM8563 RTC - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)
+//  #define USE_MPU_ACCEL                          // [I2cDriver58] Enable MPU6886/MPU9250 - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x68) (+2k code)
+//  #define USE_BM8563                             // [I2cDriver59] Enable BM8563 RTC - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)
 
 //  #define USE_DISPLAY                            // Add I2C Display Support (+2k code)
     #define USE_DISPLAY_MODES1TO5                // Enable display mode 1 to 5 in addition to mode 0

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -106,7 +106,7 @@
 
 #define USE_I2C
   #define USE_BMA423
-  #define USE_MPU6886
+  #define USE_MPU_ACCEL
 #define USE_SPI
   #define USE_DISPLAY
 #ifdef USE_UNIVERSAL_DISPLAY
@@ -233,7 +233,7 @@
 //#define USE_MPR121                             // [I2cDriver23] Enable MPR121 controller (I2C addresses 0x5A, 0x5B, 0x5C and 0x5D) in input mode for touch buttons (+1k3 code)
 //#define USE_CCS811                             // [I2cDriver24] Enable CCS811 sensor (I2C address 0x5A) (+2k2 code)
 #define USE_CCS811_V2                          // [I2cDriver24] Enable CCS811 sensor (I2C addresses 0x5A and 0x5B) (+2k8 code)
-#define USE_MPU6886                              // [I2cDriver??] Enable MPU6886 6-axis MotionTracking sensor (I2C address 0x68)
+#define USE_MPU_ACCEL                          // [I2cDriver58] Enable MPU6886, MPU9250 6-axis MotionTracking sensor (I2C address 0x68)
 //#define USE_MPU6050                            // [I2cDriver25] Enable MPU6050 sensor (I2C address 0x68 AD0 low or 0x69 AD0 high) (+3K3 of code and 188 Bytes of RAM)
 //#define USE_DS3231                             // [I2cDriver26] Enable DS3231 external RTC in case no Wifi is avaliable. See docs in the source file (+1k2 code)
 //#define USE_MGC3130                            // [I2cDriver27] Enable MGC3130 Electric Field Effect Sensor (I2C address 0x42) (+2k7 code, 0k3 mem)


### PR DESCRIPTION
## Description:

Also updated the Berry version of the driver

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
