### PR TITLE
Rename fix_esp32c3.h to esp32x_fixes.h

### DIFF
--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -1,5 +1,5 @@
 /*
-  fix_esp32c3.h - fix esp32c3 toolchain
+  esp32x_fixes.h - fix esp32x toolchain
 
   Copyright (C) 2021  Theo Arends
 
@@ -27,7 +27,7 @@
  * 
  * You need to add the following lines in `build_flags`:      
  *                            -I$PROJECT_DIR/include
- *                            -include "fix_esp32c3.h"
+ *                            -include "esp32x_fixes.h"
  */
 #ifdef __riscv
 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -52,7 +52,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               -DUSE_4K_RSA
                               -I$PROJECT_DIR/include
                               -include "sdkconfig.h"
-                              -include "fix_esp32c3.h"
+                              -include "esp32x_fixes.h"
 
 
 [core32]


### PR DESCRIPTION
## Description:

`esp32x_fixes.h` no contains some fixes for new esp32 chips or newer esp-idf version.
This file is auto-included at the beginning of all compiled files, including libraries.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
