### PR TITLE
Esp32c3 fix wrong baudrate

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -984,10 +984,19 @@ String GetSerialConfig(void) {
   return String(config);
 }
 
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
+// temporary workaround, see https://github.com/espressif/arduino-esp32/issues/5287
+#include <driver/uart.h>
 uint32_t GetSerialBaudrate(void) {
-  // Serial.printf(">> GetSerialBaudrate baudrate = %d\n", Serial.baudRate());
+  uint32_t br;
+  uart_get_baudrate(0, &br);
+  return (br / 300) * 300;  // Fix ESP32 strange results like 115201
+}
+#else
+uint32_t GetSerialBaudrate(void) {
   return (Serial.baudRate() / 300) * 300;  // Fix ESP32 strange results like 115201
 }
+#endif
 
 void SetSerialBegin(void) {
   TasmotaGlobal.baudrate = Settings->baudrate * 300;
@@ -1019,9 +1028,7 @@ void SetSerialBaudrate(uint32_t baudrate) {
   TasmotaGlobal.baudrate = baudrate;
   Settings->baudrate = TasmotaGlobal.baudrate / 300;
   if (GetSerialBaudrate() != TasmotaGlobal.baudrate) {
-#if defined(CONFIG_IDF_TARGET_ESP32C3) && !CONFIG_IDF_TARGET_ESP32C3    // crashes on ESP32C3 - TODO
     SetSerialBegin();
-#endif
   }
 }
 


### PR DESCRIPTION
## Description:

Work-around for wrong baudrate on esp32c3, see https://github.com/espressif/arduino-esp32/issues/5287

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
