### PR TITLE
Esp32c3 fix template command and Web UI

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1533,12 +1533,13 @@ void TemplateGpios(myio *gp)
   uint32_t j = 0;
   for (uint32_t i = 0; i < nitems(Settings->user_template.gp.io); i++) {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
+    dest[i] = src[i];
 #else
     if (6 == i) { j = 9; }
     if (8 == i) { j = 12; }
-#endif
     dest[j] = src[i];
     j++;
+#endif
   }
   // 11 85 00 85 85 00 00 00 00 00 00 00 15 38 85 00 00 81
 


### PR DESCRIPTION
## Description:

Fix template command and Web UI for Esp32c3. All GPIOs are present in template and web UI, but Flash GPIOs are hidden on the web page.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
