### PR TITLE
Fix NEO_RGBW

### DIFF
--- a/tasmota/xlgt_01_ws2812.ino
+++ b/tasmota/xlgt_01_ws2812.ino
@@ -69,7 +69,7 @@ void (* const Ws2812Command[])(void) PROGMEM = {
 #elif (USE_WS2812_CTYPE == NEO_RBG)
   #define NEO_FEATURE_TYPE  Rbg
 #elif (USE_WS2812_CTYPE == NEO_RGBW)
-  #define NEO_FEATURE_TYPE  Rbgw
+  #define NEO_FEATURE_TYPE  Rgbw
 #elif (USE_WS2812_CTYPE == NEO_GRBW)
   #define NEO_FEATURE_TYPE  Grbw
 #else


### PR DESCRIPTION
## Description:

Fix typo that prevented using NEO_RGBW

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
