### PR TITLE
Allow Captive Portal to be optional

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1017,7 +1017,9 @@ void WebSliderColdWarm(void)
 
 void HandleRoot(void)
 {
+#ifndef NO_CAPTIVE_PORTAL
   if (CaptivePortal()) { return; }  // If captive portal redirect instead of displaying the page.
+#endif  // NO_CAPTIVE_PORTAL
 
   if (Webserver->hasArg(F("rst"))) {
     WebRestart(0);
@@ -2941,8 +2943,9 @@ void HandleConsoleRefresh(void)
 void HandleNotFound(void)
 {
 //  AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_HTTP "Not found (%s)"), Webserver->uri().c_str());
-
+#ifndef NO_CAPTIVE_PORTAL
   if (CaptivePortal()) { return; }  // If captive portal redirect instead of displaying the error page.
+#endif  // NO_CAPTIVE_PORTAL
 
 #ifdef USE_EMULATION
 #ifdef USE_EMULATION_HUE
@@ -2962,6 +2965,7 @@ void HandleNotFound(void)
   }
 }
 
+#ifndef NO_CAPTIVE_PORTAL
 /* Redirect to captive portal if we got a request for another domain. Return true in that case so the page handler do not try to handle the request again. */
 bool CaptivePortal(void)
 {
@@ -2976,6 +2980,7 @@ bool CaptivePortal(void)
   }
   return false;
 }
+#endif  // NO_CAPTIVE_PORTAL
 
 /*********************************************************************************************/
 


### PR DESCRIPTION
## Description:

This PR just adds a new precompiler `#define` so as to allow the captive portal feature to be included or not in the build. By default, the captive portal is enabled and Tasmota's behaviour is the same as always.

If an user adds the following line in _user_config_override.h_ file, Tasmota won't pop up the captive portal for the Initial Wi-Fi configuration. If the user opens a web browser to go to 192.168.4.1, the Initial Wi-Fi configuration page will be shown.
```cpp
#define NO_CAPTIVE_PORTAL 
```

This optional is useful if the Wi-Fi credentials are going to be entered by a third party software, like a phone app. In the case of a phone app, it just needs to connect to the Tasmota AP, and then, by HTTP API, it can send the Wi-Fi Credentials. If the captive portal feature was active, when the phone app connects to Tasmota AP, the Tasmota WebUI page will pop up difficulting the user to return to the phone app. 

This PR don't increase the FLASH, nor RAM usage.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
