### PR TITLE
Improve behavior of color2 for unlinked RGBW and RGBWW lights

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2497,11 +2497,18 @@ void CmndSupportColor(void)
         else {
 #endif  // USE_LIGHT_PALETTE
           uint32_t old_bri = light_state.getBri();
+          uint32_t old_bri_rgb = light_state.getBriRGB();
           // change all channels to specified values
           light_controller.changeChannels(Light.entry_color);
           if (2 == XdrvMailbox.index) {
             // If Color2, set back old brightness
-            LightSetBriScaled(old_bri);
+            if (light_controller.isCTRGBLinked()) {
+              // RGB and white are linked, adjust brightness of all channels
+              LightSetBriScaled(old_bri);
+            } else {
+              // RGB and white are unlinked, adjust brightness only of RGB channels
+              LightSetBri(Light.device, old_bri_rgb);
+            }
           }
 #ifdef USE_LIGHT_PALETTE
         }


### PR DESCRIPTION
## Description:

Improve behavior of `color2` for unlinked RGBW and RGBWW lights

This makes sure the white channels are not rescaled when changing color via `color2` for an unlinked RGBW or RGBWW light.
Note that the white channels will not be rescaled even if they're explicitly set. Do we need to support that case?


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
