### PR TITLE
remove non working speed settings

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -62,14 +62,6 @@ build_flags                 = ${core.build_flags}
 ; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
 ;board                       = esp8266_4M2M
 
-; set CPU frequency to 80MHz (default) or 160MHz
-;board_build.f_cpu           = 160000000L
-
-; set Flash chip frequency to 40MHz (default), 20MHz, 26Mhz, 80Mhz
-;board_build.f_flash         = 20000000L
-;board_build.f_flash         = 26000000L
-;board_build.f_flash         = 80000000L
-
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_port                 = COM5
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable): #12390
Not fixed, removing the non working entrys.

Going back to the old setup is not the way, since this setting is global for ALL boards and variants!
Will provide a PR when i have found a user friendly solution

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works on Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with core ESP32 V.1.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
