### PR TITLE
Remove platformio global upload speed setting

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,6 @@ build_flags                 = ${core.build_flags}
 
 monitor_speed               = 115200
 monitor_port                = COM5
-upload_speed                = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_resetmethod          = nodemcu
 upload_port                 = COM5

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -62,12 +62,10 @@ build_flags                 = ${core.build_flags}
 ; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
 ;board                       = esp8266_4M2M
 
-; *** Upload Serial reset method for Wemos and NodeMCU
+; *** Serial port used for erasing/flashing the ESP82xx
 upload_port                 = COM5
-
 extra_scripts               = ${scripts_defaults.extra_scripts}
 ;                              pio-tools/obj-dump.py
-
 lib_extra_dirs              = ${library.lib_extra_dirs}
 
 
@@ -75,7 +73,17 @@ lib_extra_dirs              = ${library.lib_extra_dirs}
 platform_packages           = ${core32.platform_packages}
 build_unflags               = ${core32.build_unflags}
 build_flags                 = ${core32.build_flags}
+
+; Build variant ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k LITTLEFS (default)
+;board                       = esp32_4M
+; Build variant ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k LITTLEFS
+;board                       = esp32_8M
+; Build variant ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M LITTLEFS
+;board                       = esp32_16M
+
+; *** Serial port used for erasing/flashing the ESP32
 upload_port                 = COM4
+
 lib_extra_dirs              = ${library.lib_extra_dirs}
 ; *** ESP32 lib. ALWAYS needed for ESP32 !!!
                               lib/libesp32

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -13,7 +13,6 @@ custom_unpack_dir           = ${common.custom_unpack_dir}
 monitor_speed               = 115200
 upload_port                 = ${common.upload_port}
 upload_resetmethod          = ${common.upload_resetmethod}
-upload_speed                = 921600
 extra_scripts               = ${common.extra_scripts}
 lib_ldf_mode                = ${common.lib_ldf_mode}
 lib_compat_mode             = ${common.lib_compat_mode}

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -9,7 +9,6 @@ build_flags             = ${common.build_flags}
 monitor_speed           = ${common.monitor_speed}
 upload_port             = ${common.upload_port}
 upload_resetmethod      = ${common.upload_resetmethod}
-upload_speed            = ${common.upload_speed}
 extra_scripts           = ${common.extra_scripts}
 lib_extra_dirs          = ${common.lib_extra_dirs}
 lib_ldf_mode            = ${common.lib_ldf_mode}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -6,7 +6,6 @@ board                   = ${common32.board}
 monitor_speed           = ${common32.monitor_speed}
 upload_port             = ${common32.upload_port}
 upload_resetmethod      = ${common32.upload_resetmethod}
-upload_speed            = ${common32.upload_speed}
 extra_scripts           = ${common32.extra_scripts}
 build_unflags           = ${common32.build_unflags}
 build_flags             = ${common32.build_flags}


### PR DESCRIPTION
## Description:
since the correct/optimal value is defined in boards.json for every board/variant

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
