### PR TITLE
Refactor platformio_override

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -68,21 +68,41 @@ extra_scripts               = ${scripts_defaults.extra_scripts}
 ;                              pio-tools/obj-dump.py
 lib_extra_dirs              = ${library.lib_extra_dirs}
 
-
-[common32]
-platform_packages           = ${core32.platform_packages}
-build_unflags               = ${core32.build_unflags}
-build_flags                 = ${core32.build_flags}
-
+[env:tasmota32_base]
+framework               = ${common.framework}
+platform                = ${common32.platform}
+platform_packages       = ${common32.platform_packages}
 ; Build variant ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k LITTLEFS (default)
-;board                       = esp32_4M
+board                   = ${common32.board}
 ; Build variant ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k LITTLEFS
-;board                       = esp32_8M
+;board                   = esp32_8M
 ; Build variant ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M LITTLEFS
-;board                       = esp32_16M
-
+;board                   = esp32_16M
+monitor_speed           = ${common32.monitor_speed}
+upload_resetmethod      = ${common32.upload_resetmethod}
 ; *** Serial port used for erasing/flashing the ESP32
-upload_port                 = COM4
+;upload_port             = ${common32.upload_port}
+upload_port             = COM4
+; upload_speed           = 115200
+board_build.f_cpu       = 240000000L
+board_build.f_flash     = 40000000L
+extra_scripts           = ${common32.extra_scripts}
+build_unflags           = ${common32.build_unflags}
+build_flags             = ${common32.build_flags}
+lib_extra_dirs          = ${common32.lib_extra_dirs}
+lib_ldf_mode            = ${common32.lib_ldf_mode}
+lib_compat_mode         = ${common32.lib_compat_mode}
+lib_ignore              =
+    ESP32 Azure IoT Arduino
+    ESP32 Async UDP
+    ESP32 BLE Arduino
+;    SimpleBLE
+    NetBIOS
+    ESP32
+    Preferences
+    BluetoothSerial
+; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
+    ArduinoOTA
 
 lib_extra_dirs              = ${library.lib_extra_dirs}
 ; *** ESP32 lib. ALWAYS needed for ESP32 !!!

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,7 +89,6 @@ board_build.f_flash     = 40000000L
 extra_scripts           = ${common32.extra_scripts}
 build_unflags           = ${common32.build_unflags}
 build_flags             = ${common32.build_flags}
-lib_extra_dirs          = ${common32.lib_extra_dirs}
 lib_ldf_mode            = ${common32.lib_ldf_mode}
 lib_compat_mode         = ${common32.lib_compat_mode}
 lib_ignore              =

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -42,31 +42,53 @@ default_envs =
 ;                tasmota32-core2
 
 
-[common]
-platform_packages           = ${core.platform_packages}
-build_unflags               = ${core.build_unflags}
-build_flags                 = ${core.build_flags}
-; *** Optional Debug messages
-;                            -DDEBUG_TASMOTA_CORE
-;                            -DDEBUG_TASMOTA_DRIVER
-;                            -DDEBUG_TASMOTA_SENSOR
-
-; *** CAUTION *** This setting is ONLY possible since 12.01.2021 with development version !!!
-; *** Enable only if you exactly know what are you doing
-; *** If you try with earlier builds a serial erase and flash is probably needed
-;
+[env]
+framework               = ${common.framework}
+platform                = ${common.platform}
+platform_packages       = ${common.platform_packages}
 ; Build variant 1MB = 1MB firmware no filesystem (default)
-;board                       = esp8266_1M
+board                   = ${common.board}
 ; Build variant 2MB = 1MB firmware, 1MB filesystem (most Shelly devices)
-;board                       = esp8266_2M1M
+;board                   = esp8266_2M1M
 ; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
-;board                       = esp8266_4M2M
-
+;board                   = esp8266_4M2M
+;board_build.f_cpu       = 160000000L
+;board_build.f_flash     = 40000000L
+board_build.filesystem  = ${common.board_build.filesystem}
+build_unflags           = ${common.build_unflags}
+build_flags             = ${common.build_flags}
+; *** Optional Debug messages
+;                         -DDEBUG_TASMOTA_CORE
+;                         -DDEBUG_TASMOTA_DRIVER
+;                         -DDEBUG_TASMOTA_SENSOR
+monitor_speed           = ${common.monitor_speed}
 ; *** Serial port used for erasing/flashing the ESP82xx
-upload_port                 = COM5
-extra_scripts               = ${scripts_defaults.extra_scripts}
-;                              pio-tools/obj-dump.py
-lib_extra_dirs              = ${library.lib_extra_dirs}
+upload_port             = ${common.upload_port}
+;upload_port             = COM5
+upload_resetmethod      = ${common.upload_resetmethod}
+extra_scripts           = ${scripts_defaults.extra_scripts}
+;                          pio-tools/obj-dump.py
+lib_ldf_mode            = ${common.lib_ldf_mode}
+lib_compat_mode         = ${common.lib_compat_mode}
+lib_ignore              =
+    Servo(esp8266)
+    ESP8266AVRISP
+    ESP8266LLMNR
+    ESP8266NetBIOS
+    ESP8266SSDP
+    SP8266WiFiMesh
+    Ethernet(esp8266)
+    GDBStub
+    TFT_Touch_Shield_V2
+    ESP8266HTTPUpdateServer
+    ESP8266WiFiMesh
+    EspSoftwareSerial
+    SPISlave
+    Hash
+; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
+    ArduinoOTA
+lib_extra_dirs          = ${library.lib_extra_dirs}
+
 
 [env:tasmota32_base]
 framework               = ${common.framework}
@@ -78,14 +100,14 @@ board                   = ${common32.board}
 ;board                   = esp32_8M
 ; Build variant ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M LITTLEFS
 ;board                   = esp32_16M
+;board_build.f_cpu       = 240000000L
+;board_build.f_flash     = 40000000L
 monitor_speed           = ${common32.monitor_speed}
 upload_resetmethod      = ${common32.upload_resetmethod}
 ; *** Serial port used for erasing/flashing the ESP32
-;upload_port             = ${common32.upload_port}
-upload_port             = COM4
+upload_port             = ${common32.upload_port}
+;upload_port             = COM4
 ; upload_speed           = 115200
-board_build.f_cpu       = 240000000L
-board_build.f_flash     = 40000000L
 extra_scripts           = ${common32.extra_scripts}
 build_unflags           = ${common32.build_unflags}
 build_flags             = ${common32.build_flags}

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -11,7 +11,6 @@
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
 ;core_dir = .platformio
-; Custom config Zigbee [env] -> platformio_tasmota_cenv_example.ini
 extra_configs = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment


### PR DESCRIPTION
## Description:
now override is split for ESP8266 and ESP32. No more global for both MCUs.
It is possible to override any standard esp8266 and esp32 environment setting.
Just (un)comment the setting you want. Every setting has to appear only one time! 
Separated for ESP8266 /  ESP32

Solves #12390

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
