### PR TITLE
S2 compile fix

### DIFF
--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -39,12 +39,12 @@
 
 #endif // __riscv
 
+#if CONFIG_IDF_TARGET_ESP32C3
 // fix a bug in esp-idf 4.4 for esp32c3
 #ifndef REG_SPI_BASE
 #define REG_SPI_BASE(i)     (DR_REG_SPI1_BASE + (((i)>1) ? (((i)* 0x1000) + 0x20000) : (((~(i)) & 1)* 0x1000 )))
 #endif
 
-#if CONFIG_IDF_TARGET_ESP32C3
 // SPI_MOSI_DLEN_REG is not defined anymore in esp32c3, instead use SPI_MS_DLEN_REG
 #define SPI_MOSI_DLEN_REG(x) SPI_MS_DLEN_REG(x)
 //alias for different chips, deprecated for the chips after esp32s2


### PR DESCRIPTION
## Description:

Fix for C3 was used for S2 too

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
