### PR TITLE
Add Partition Manager v0 in Berry

### DIFF
--- a/tasmota/berry/modules/partition.be
+++ b/tasmota/berry/modules/partition.be
@@ -110,6 +110,15 @@ class Partition_info
     
   end
 
+  # check if the parition is an OTA partition
+  # if yes, return OTA number (starting at 0)
+  # if no, return nil
+  def is_ota()
+    if self.type == 0 && (self.subtype >= 0x10 && self.subtype < 0x20)
+      return self.subtype - 0x10
+    end
+  end
+
   def tostring()
     import string
     var type_s = ""
@@ -418,14 +427,13 @@ end
 partition.Partition = Partition
 
 return partition
-#Example
-#-
+
+#- Example
 
 import partition
-Partition = partition.Partition
 
 # read
-p = Partition()
+p = partition.Partition()
 print(p)
 
 -#

--- a/tasmota/berry/modules/partition_manager.be
+++ b/tasmota/berry/modules/partition_manager.be
@@ -1,0 +1,100 @@
+#-------------------------------------------------------------
+ - Parser manager for ESP32
+ -
+ -------------------------------------------------------------#
+
+import flash
+import string
+import partition
+import webserver
+
+class Partition_manager : Driver
+
+  def init()
+  end
+
+  # create a method for adding a button to the main menu
+  # the button 'Partition Manager' redirects to '/part_mgr?'
+  def web_add_button()
+    webserver.content_send(
+      "<form id=but_part_mgr style='display: block;' action='part_mgr' method='get'><button>Partition Manager</button></form>")
+  end
+
+  #
+  # Show a single OTA Partition
+  #
+  def page_show_partition(slot, active)
+    webserver.content_send("<fieldset><legend><b>&nbsp;" + slot.label)
+    if active
+      webserver.content_send(" (active)")
+    end
+    webserver.content_send("</b></legend>")
+
+    webserver.content_send(string.format("<p><b>Start: </b>0x<b>%03x</b> 000</p>", slot.start / 0x1000))
+    webserver.content_send(string.format("<p><b>Size: </b>%i KB</p>", slot.size / 1024))
+    
+    webserver.content_send("<p></p></fieldset><p></p>")
+  end
+
+
+  #
+  # Show a single OTA Partition
+  #
+  def page_show_spiffs(slot, free_mem)
+    webserver.content_send("<fieldset><legend><b>&nbsp;" + slot.label)
+    webserver.content_send("</b></legend>")
+
+    webserver.content_send(string.format("<p><b>Start: </b>0x<b>%03x</b> 000</p>", slot.start / 0x1000))
+    webserver.content_send(string.format("<p><b>Size: </b>%i KB</p>", slot.size / 1024))
+    if free_mem != nil
+      webserver.content_send(string.format("<p><b>Unallocated: </b>%i KB</p>", free_mem / 1024))
+    end
+    
+    webserver.content_send("<p></p></fieldset><p></p>")
+  end
+
+  def page_show_partitions()
+    var p = partition.Partition()
+
+    # display ota partitions
+    for slot: p.slots
+      # is the slot app?
+      var ota_num = slot.is_ota()
+      if ota_num != nil
+        # we have an OTA partition
+        self.page_show_partition(slot, ota_num == p.otadata.active_otadata)
+      elif slot.type == 1 && slot.subtype == 130
+        var flash_size = tasmota.memory()['flash'] * 1024
+        var used_size = (slot.start + slot.size)
+        self.page_show_spiffs(slot, slot == p.slots[-1] ? flash_size - used_size : nil)
+      end
+    end
+  end
+
+  #- this method displays the web page -#
+  def page_part_mgr()
+    if !webserver.check_privileged_access() return nil end
+
+    webserver.content_start("Partition Manager")           #- title of the web page -#
+    webserver.content_send_style()                  #- send standard Tasmota styles -#
+
+    webserver.content_send("<p><b>Esp32 Partition Manager</b></p><p></p>")   #- send any html -#
+    self.page_show_partitions()
+
+    webserver.content_button(webserver.BUTTON_MANAGEMENT) #- button back to management page -#
+    webserver.content_stop()                        #- end of web page -#
+  end
+
+  #- this is called at Tasmota start-up, as soon as Wifi/Eth is up and web server running -#
+  def web_add_handler()
+    #- we need to register a closure, not just a function, that captures the current instance -#
+    webserver.on("/part_mgr", / -> self.page_part_mgr())
+  end
+
+end
+
+#- create and register driver in Tasmota -#
+partition_manager = Partition_manager()
+tasmota.add_driver(partition_manager)
+## to be removed if put in 'autoexec.bat'
+partition_manager.web_add_handler()


### PR DESCRIPTION
## Description:

First try for a partition manager in Berry. This quick and dirty version is read-only and displays partition information.

To use:
- copy `partition.be` and `partition_manager.be` in the file system on the Esp32 device
- in the Berry console, type `import partition_manager.be`
- on the main page, click on "Consoles" and "Partition Manager"

![part_mgr_v0](https://user-images.githubusercontent.com/49731213/122614895-ca696800-d087-11eb-9f9f-4a21c1072062.png)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
