### PR TITLE
Fix compilation when USE_UFILESYS is not defined

### DIFF
--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -16,8 +16,10 @@
 #include "static_block.hpp"
 
 // Local pointer for file managment
-#include <FS.h>
-extern FS *ufsp;
+#ifdef USE_UFILESYS
+    #include <FS.h>
+    extern FS *ufsp;
+#endif // USE_UFILESYS
 
 /* this file contains configuration for the file system. */
 
@@ -105,6 +107,7 @@ BERRY_API char* be_readstring(char *buffer, size_t size)
 
 void* be_fopen(const char *filename, const char *modes)
 {
+#ifdef USE_UFILESYS
     if (ufsp != nullptr && filename != nullptr && modes != nullptr) {
         char fname2[strlen(filename) + 2];
         if (filename[0] == '/') {
@@ -121,12 +124,14 @@ void* be_fopen(const char *filename, const char *modes)
             return f_ptr;
         }
     }
+#endif // USE_UFILESYS
     return nullptr;
     // return fopen(filename, modes);
 }
 
 int be_fclose(void *hfile)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fclose\n");
     if (ufsp != nullptr && hfile != nullptr) {
         File * f_ptr = (File*) hfile;
@@ -134,23 +139,27 @@ int be_fclose(void *hfile)
         delete f_ptr;
         return 0;
     }
+#endif // USE_UFILESYS
     return -1;
     // return fclose(hfile);
 }
 
 size_t be_fwrite(void *hfile, const void *buffer, size_t length)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fwrite %d\n", length);
     if (ufsp != nullptr && hfile != nullptr && buffer != nullptr) {
         File * f_ptr = (File*) hfile;
         return f_ptr->write((const uint8_t*) buffer, length);
     }
+#endif // USE_UFILESYS
     return 0;
     // return fwrite(buffer, 1, length, hfile);
 }
 
 size_t be_fread(void *hfile, void *buffer, size_t length)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fread %d\n", length);
     if (ufsp != nullptr && hfile != nullptr && buffer != nullptr) {
         File * f_ptr = (File*) hfile;
@@ -160,12 +169,14 @@ size_t be_fread(void *hfile, void *buffer, size_t length)
             return ret;
         }
     }
+#endif // USE_UFILESYS
     return 0;
     // return fread(buffer, 1, length, hfile);
 }
 
 char* be_fgets(void *hfile, void *buffer, int size)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fgets %d\n", size);
     uint8_t * buf = (uint8_t*) buffer;
     if (ufsp != nullptr && hfile != nullptr && buffer != nullptr && size > 0) {
@@ -176,12 +187,14 @@ char* be_fgets(void *hfile, void *buffer, int size)
             return (char*) buffer;
         }
     }
+#endif // USE_UFILESYS
     return nullptr;
     // return fgets(buffer, size, hfile);
 }
 
 int be_fseek(void *hfile, long offset)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fseek %d\n", offset);
     if (ufsp != nullptr && hfile != nullptr) {
         File * f_ptr = (File*) hfile;
@@ -189,34 +202,40 @@ int be_fseek(void *hfile, long offset)
             return 0;       // success
         }
     }
+#endif // USE_UFILESYS
     return -1;
     // return fseek(hfile, offset, SEEK_SET);
 }
 
 long int be_ftell(void *hfile)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_ftell\n");
     if (ufsp != nullptr && hfile != nullptr) {
         File * f_ptr = (File*) hfile;
         return f_ptr->position();
     }
+#endif // USE_UFILESYS
     return 0;
     // return ftell(hfile);
 }
 
 long int be_fflush(void *hfile)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fflush\n");
     if (ufsp != nullptr && hfile != nullptr) {
         File * f_ptr = (File*) hfile;
         f_ptr->flush();
     }
+#endif // USE_UFILESYS
     return 0;
     // return fflush(hfile);
 }
 
 size_t be_fsize(void *hfile)
 {
+#ifdef USE_UFILESYS
     // Serial.printf("be_fsize\n");
     if (ufsp != nullptr && hfile != nullptr) {
         File * f_ptr = (File*) hfile;
@@ -227,6 +246,7 @@ size_t be_fsize(void *hfile)
     // size = ftell(hfile);
     // fseek(hfile, offset, SEEK_SET);
     // return size;
+#endif // USE_UFILESYS
     return 0;
 }
 

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -161,14 +161,16 @@ void SettingsErase(uint8_t type) {
   // cal_data - SDK PHY calibration data as documented in esp_phy_init.h
   // qpc      - Tasmota Quick Power Cycle state
   // main     - Tasmota Settings data
-  int32_t r1, r2, r3;
+  int32_t r1, r2, r3 = 0;
   switch (type) {
     case 0:               // Reset 2 = Erase all flash from program end to end of physical flash
     case 2:               // Reset 5, 6 = Erase all flash from program end to end of physical flash excluding filesystem
 //      nvs_flash_erase();  // Erase RTC, PHY, sta.mac, ap.sndchan, ap.mac, Tasmota etc.
       r1 = NvmErase("qpc");
       r2 = NvmErase("main");
+#ifdef USE_UFILESYS
       r3 = TfsDeleteFile(TASM_FILE_SETTINGS);
+#endif
       AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_ERASE " Tasmota data (%d,%d,%d)"), r1, r2, r3);
       break;
     case 1:               // Reset 3 = SDK parameter area
@@ -184,7 +186,9 @@ void SettingsErase(uint8_t type) {
 //      r3 = esp_phy_erase_cal_data_in_nvs();
 //      r3 = NvmErase("cal_data");
 //      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_ERASE " Tasmota (%d,%d) and PHY data (%d)"), r1, r2, r3);
+#ifdef USE_UFILESYS
       r3 = TfsDeleteFile(TASM_FILE_SETTINGS);
+#endif
       AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION D_ERASE " Tasmota data (%d,%d,%d)"), r1, r2, r3);
       break;
   }
@@ -192,15 +196,21 @@ void SettingsErase(uint8_t type) {
 
 uint32_t SettingsRead(void *data, size_t size) {
   uint32_t source = 1;
+#ifdef USE_UFILESYS
   if (!TfsLoadFile(TASM_FILE_SETTINGS, (uint8_t*)data, size)) {
+#endif
     source = 0;
     NvmLoad("main", "Settings", data, size);
+#ifdef USE_UFILESYS
   }
+#endif
   return source;
 }
 
 void SettingsWrite(const void *pSettings, unsigned nSettingsLen) {
+#ifdef USE_UFILESYS
   TfsSaveFile(TASM_FILE_SETTINGS, (const uint8_t*)pSettings, nSettingsLen);
+#endif
   NvmSave("main", "Settings", pSettings, nSettingsLen);
 }
 


### PR DESCRIPTION
## Description:

Esp32 specific

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
