### PR TITLE
Fix Github actions build

### DIFF
--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -884,26 +884,6 @@ jobs:
         path: ./build_output
 
 
-  tasmota32-ircustom:
-    needs: tasmota_pull
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        pip install -U platformio
-    - name: Run PlatformIO
-      run: |
-        platformio run -e tasmota32-ircustom
-    - uses: actions/upload-artifact@v2
-      with:
-        name: firmware
-        path: ./build_output
-
-
   tasmota32-AF:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1405,7 +1385,7 @@ jobs:
 
 
   Upload:
-    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]
+    needs: [tasmota-VN, tasmota32-VN, tasmota32-TW, tasmota32-TR]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -884,26 +884,6 @@ jobs:
         path: ./build_output
 
 
-  tasmota32-ircustom:
-    needs: tasmota_pull
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        pip install -U platformio
-    - name: Run PlatformIO
-      run: |
-        platformio run -e tasmota32-ircustom
-    - uses: actions/upload-artifact@v2
-      with:
-        name: firmware
-        path: ./build_output
-
-
   tasmota32-AF:
     needs: tasmota_pull
     runs-on: ubuntu-latest
@@ -1405,7 +1385,7 @@ jobs:
 
 
   Upload:
-    needs: [tasmota-VN, tasmota32-ircustom, tasmota32-VN, tasmota32-TW, tasmota32-TR]
+    needs: [tasmota-VN, tasmota32-VN, tasmota32-TW, tasmota32-TR]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
Remove the non existing ircustom32 from github actions

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
