### PR TITLE
Refactor Platformio and fix override use

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,15 +25,14 @@ extra_configs               = platformio_tasmota32.ini
                               platformio_override.ini
 
 [common]
-framework                   = arduino
-board_build.filesystem      = littlefs
-custom_unpack_dir           = unpacked_littlefs
-board                       = esp8266_1M
 platform                    = ${core.platform}
 platform_packages           = ${core.platform_packages}
+framework                   = arduino
+board                       = esp8266_1M
+board_build.filesystem      = littlefs
+custom_unpack_dir           = unpacked_littlefs
 build_unflags               = ${core.build_unflags}
 build_flags                 = ${core.build_flags}
-
 monitor_speed               = 115200
 monitor_port                = COM5
 ; *** Upload Serial reset method for Wemos and NodeMCU

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -11,33 +11,33 @@
 [platformio]
 ; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
 ;core_dir = .platformio
-extra_configs = platformio_tasmota_cenv.ini
+extra_configs           = platformio_tasmota_cenv.ini
 
 ; *** Build/upload environment
-default_envs =
+default_envs            =
 ; *** Uncomment the line(s) below to select version(s)
-                tasmota
-;                tasmota-debug
-;                tasmota-minimal
-;                tasmota-lite
-;                tasmota-knx
-;                tasmota-sensors
-;                tasmota-display
-;                tasmota-zbbridge
-;                tasmota-ir
-;                tasmota32
-;                tasmota32-bluetooth
-;                tasmota32-webcam
-;                tasmota32-knx
-;                tasmota32-sensors
-;                tasmota32-display
-;                tasmota32-ir
-;                tasmota32-ircustom
-;                tasmota32solo1
-;                tasmota32c3
-;                tasmota32s2
-;                tasmota32-odroidgo
-;                tasmota32-core2
+                          tasmota
+;                          tasmota-debug
+;                          tasmota-minimal
+;                          tasmota-lite
+;                          tasmota-knx
+;                          tasmota-sensors
+;                          tasmota-display
+;                          tasmota-zbbridge
+;                          tasmota-ir
+;                          tasmota32
+;                          tasmota32-bluetooth
+;                          tasmota32-webcam
+;                          tasmota32-knx
+;                          tasmota32-sensors
+;                          tasmota32-display
+;                          tasmota32-ir
+;                          tasmota32-ircustom
+;                          tasmota32solo1
+;                          tasmota32c3
+;                          tasmota32s2
+;                          tasmota32-odroidgo
+;                          tasmota32-core2
 
 
 [env]
@@ -61,97 +61,98 @@ build_flags             = ${common.build_flags}
 ;                         -DDEBUG_TASMOTA_SENSOR
 monitor_speed           = ${common.monitor_speed}
 ; *** Serial port used for erasing/flashing the ESP82xx
-upload_port             = ${common.upload_port}
-;upload_port             = COM5
+;upload_port             = ${common.upload_port}
+upload_port             = COM5
 upload_resetmethod      = ${common.upload_resetmethod}
 extra_scripts           = ${scripts_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py
 lib_ldf_mode            = ${common.lib_ldf_mode}
 lib_compat_mode         = ${common.lib_compat_mode}
 lib_ignore              =
-    Servo(esp8266)
-    ESP8266AVRISP
-    ESP8266LLMNR
-    ESP8266NetBIOS
-    ESP8266SSDP
-    SP8266WiFiMesh
-    Ethernet(esp8266)
-    GDBStub
-    TFT_Touch_Shield_V2
-    ESP8266HTTPUpdateServer
-    ESP8266WiFiMesh
-    EspSoftwareSerial
-    SPISlave
-    Hash
+                          Servo(esp8266)
+                          ESP8266AVRISP
+                          ESP8266LLMNR
+                          ESP8266NetBIOS
+                          ESP8266SSDP
+                          SP8266WiFiMesh
+                          Ethernet(esp8266)
+                          GDBStub
+                          TFT_Touch_Shield_V2
+                          ESP8266HTTPUpdateServer
+                          ESP8266WiFiMesh
+                          EspSoftwareSerial
+                          SPISlave
+                          Hash
 ; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
-    ArduinoOTA
+                          ArduinoOTA
 lib_extra_dirs          = ${library.lib_extra_dirs}
 
 
 [env:tasmota32_base]
 framework               = ${common.framework}
-platform                = ${common32.platform}
-platform_packages       = ${common32.platform_packages}
+platform                = ${core32.platform}
+platform_packages       = ${core32.platform_packages}
 ; Build variant ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k LITTLEFS (default)
-board                   = ${common32.board}
+board                   = esp32_4M
 ; Build variant ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k LITTLEFS
 ;board                   = esp32_8M
 ; Build variant ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M LITTLEFS
 ;board                   = esp32_16M
 ;board_build.f_cpu       = 240000000L
 ;board_build.f_flash     = 40000000L
-monitor_speed           = ${common32.monitor_speed}
-upload_resetmethod      = ${common32.upload_resetmethod}
+monitor_speed           = 115200
 ; *** Serial port used for erasing/flashing the ESP32
-upload_port             = ${common32.upload_port}
-;upload_port             = COM4
-; upload_speed           = 115200
-extra_scripts           = ${common32.extra_scripts}
-build_unflags           = ${common32.build_unflags}
-build_flags             = ${common32.build_flags}
-lib_ldf_mode            = ${common32.lib_ldf_mode}
-lib_compat_mode         = ${common32.lib_compat_mode}
+;upload_port             = ${common.upload_port}
+upload_port             = COM4
+;upload_speed            = 115200
+upload_resetmethod      = ${common.upload_resetmethod}
+extra_scripts           = ${common.extra_scripts}
+build_unflags           = ${esp32_defaults.build_unflags}
+build_flags             = ${esp32_defaults.build_flags}
+lib_ldf_mode            = ${common.lib_ldf_mode}
+lib_compat_mode         = ${common.lib_compat_mode}
 lib_ignore              =
-    ESP32 Azure IoT Arduino
-    ESP32 Async UDP
-    ESP32 BLE Arduino
-;    SimpleBLE
-    NetBIOS
-    ESP32
-    Preferences
-    BluetoothSerial
+                          ESP32 Azure IoT Arduino
+                          ESP32 Async UDP
+                          ESP32 BLE Arduino
+;                          SimpleBLE
+                          NetBIOS
+                          ESP32
+                          Preferences
+                          BluetoothSerial
 ; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
-    ArduinoOTA
+                          ArduinoOTA
 
-lib_extra_dirs              = ${library.lib_extra_dirs}
+lib_extra_dirs           = ${library.lib_extra_dirs}
 ; *** ESP32 lib. ALWAYS needed for ESP32 !!!
-                              lib/libesp32
+                          lib/libesp32
 ; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
-                              lib/libesp32_lvgl
-; *** comment the following line if you dont use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
-                              lib/libesp32_div
-; *** uncomment the following line if you dont use Epaper driver epidy in your Tasmota32 build. Reduces compile time 
-                              lib/libesp32_epdiy
+                          lib/libesp32_lvgl
+; *** uncomment the following line if you use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
+;                          lib/libesp32_div
+; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time 
+;                          lib/libesp32_epdiy
+
 
 [library]
-shared_libdeps_dir          = lib
+shared_libdeps_dir      = lib
 ; *** Library disable / enable for variant Tasmota(32). Disable reduces compile time
 ; *** !!! Disabling needed libs will generate compile errors !!!
 ; *** The resulting firmware will NOT be different if you leave all libs enabled
 ; *** Disabling by putting a ";" in front of the lib name
 ; *** If you dont know what it is all about, do not change
-lib_extra_dirs              =
+lib_extra_dirs           =
 ; *** Only disabled for Tasmota minimal and Tasmota light. For all other variants needed!
-                              lib/lib_basic
+                           lib/lib_basic
 ; **** I2C devices. Most sensors. Disable only if you dont have ANY I2C device enabled
-                              lib/lib_i2c
+                           lib/lib_i2c
 ; *** Displays. Disable if you dont have any Display activated
-                              lib/lib_display
+                           lib/lib_display
 ; *** Bear SSL and base64. Disable if you dont have SSL or TLS activated
-                              lib/lib_ssl
+                           lib/lib_ssl
 ; *** Audio needs a lot of time to compile. Mostly not used functions. Recommended to disable
-                              lib/lib_audio
+;                           lib/lib_audio
 ; *** RF 433 stuff (not RF Bridge). Recommended to disable
-                              lib/lib_rf
+                           lib/lib_rf
 ; *** Mostly not used functions. Recommended to disable
-                              lib/lib_div
+                           lib/lib_div

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -1,37 +1,6 @@
 ; ***              BETA ESP32 Tasmota version                 ***
 ; ***  expect the unexpected. Some features not working!!!    ***
 
-[common32]
-framework                   = ${common.framework}
-platform                    = ${core32.platform}
-platform_packages           = ${core32.platform_packages}
-build_unflags               = ${core32.build_unflags}
-build_flags                 = ${core32.build_flags}
-board                       = esp32_4M
-board_build.filesystem      = ${common.board_build.filesystem}
-custom_unpack_dir           = ${common.custom_unpack_dir}
-monitor_speed               = 115200
-upload_port                 = ${common.upload_port}
-upload_resetmethod          = ${common.upload_resetmethod}
-extra_scripts               = ${common.extra_scripts}
-lib_ldf_mode                = ${common.lib_ldf_mode}
-lib_compat_mode             = ${common.lib_compat_mode}
-shared_libdeps_dir          = lib
-lib_extra_dirs              =
-                              lib/libesp32
-                              lib/libesp32_lvgl
-; uncomment the following line if you need Bluetooth, Homekit or TTGO Watch libraries in your Tasmota32 build
-;                              lib/libesp32_div
-; uncomment the following line if you want to use Epaper driver epidy in your Tasmota32 build
-;                              lib/libesp32_epdiy
-                              lib/lib_basic
-                              lib/lib_i2c
-                              lib/lib_display
-                              lib/lib_ssl
-                              lib/lib_audio
-                              lib/lib_rf
-                              lib/lib_div
-
 [esp32_defaults]
 build_unflags               = ${esp_defaults.build_unflags}
                               -fexceptions

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -38,7 +38,7 @@ platform                    = https://github.com/platformio/platform-espressif32
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/307/framework-arduinoespressif32-master-1d7068e4b.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${common32.build_flags} -DFIRMWARE_LITE
+build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE
 lib_extra_dirs              = lib/libesp32
 lib_ignore                  =
     NimBLE-Arduino

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -34,110 +34,110 @@ lib_ignore              =
 [env:tasmota]
 
 [env:tasmota-minimal]
-build_flags             = ${common.build_flags} -DFIRMWARE_MINIMAL
+build_flags             = ${env.build_flags} -DFIRMWARE_MINIMAL
 lib_extra_dirs          =
 
 [env:tasmota-lite]
-build_flags             = ${common.build_flags} -DFIRMWARE_LITE
+build_flags             = ${env.build_flags} -DFIRMWARE_LITE
 lib_extra_dirs          =
 
 [env:tasmota-knx]
-build_flags             = ${common.build_flags} -DFIRMWARE_KNX_NO_EMULATION
+build_flags             = ${env.build_flags} -DFIRMWARE_KNX_NO_EMULATION
 lib_extra_dirs          = lib/lib_basic, lib/lib_div
 
 [env:tasmota-sensors]
-build_flags             = ${common.build_flags} -DFIRMWARE_SENSORS
+build_flags             = ${env.build_flags} -DFIRMWARE_SENSORS
 lib_extra_dirs          = lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div
 
 [env:tasmota-display]
-build_flags             = ${common.build_flags} -DFIRMWARE_DISPLAYS
+build_flags             = ${env.build_flags} -DFIRMWARE_DISPLAYS
 lib_extra_dirs          = lib/lib_basic, lib/lib_display
 
 [env:tasmota-ir]
-build_flags             = ${common.build_flags} -DFIRMWARE_IR
+build_flags             = ${env.build_flags} -DFIRMWARE_IR
 lib_extra_dirs          = lib/lib_basic
 
 [env:tasmota-zbbridge]
-build_flags             = ${common.build_flags} -DFIRMWARE_ZBBRIDGE
+build_flags             = ${env.build_flags} -DFIRMWARE_ZBBRIDGE
 board                   = esp8266_zbbridge
 lib_extra_dirs          = lib/lib_ssl
 
 [env:tasmota-zigbee]
-build_flags             = ${common.build_flags} -DUSE_ZIGBEE -DUSE_CCLOADER -DUSE_UFILESYS
+build_flags             = ${env.build_flags} -DUSE_ZIGBEE -DUSE_CCLOADER -DUSE_UFILESYS
 board                   = esp8266_4M2M
 board_build.f_cpu       = 160000000L
 
 [env:tasmota-AF]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=af_AF
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=af_AF
 
 [env:tasmota-BG]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=bg_BG
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=bg_BG
 
 [env:tasmota-BR]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=pt_BR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_BR
 
 [env:tasmota-CN]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=zh_CN
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_CN
 
 [env:tasmota-CZ]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=cs_CZ
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=cs_CZ
 
 [env:tasmota-DE]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=de_DE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=de_DE
 
 [env:tasmota-ES]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=es_ES
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=es_ES
 
 [env:tasmota-FR]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=fr_FR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=fr_FR
 
 [env:tasmota-FY]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=fy_NL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=fy_NL
 
 [env:tasmota-GR]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=el_GR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=el_GR
 
 [env:tasmota-HE]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=he_HE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=he_HE
 
 [env:tasmota-HU]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=hu_HU
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=hu_HU
 
 [env:tasmota-IT]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=it_IT
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=it_IT
 
 [env:tasmota-KO]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=ko_KO
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ko_KO
 
 [env:tasmota-NL]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=nl_NL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=nl_NL
 
 [env:tasmota-PL]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=pl_PL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pl_PL
 
 [env:tasmota-PT]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=pt_PT
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_PT
 
 [env:tasmota-RO]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=ro_RO
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ro_RO
 
 [env:tasmota-RU]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=ru_RU
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ru_RU
 
 [env:tasmota-SE]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=sv_SE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=sv_SE
 
 [env:tasmota-SK]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=sk_SK
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=sk_SK
 
 [env:tasmota-TR]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=tr_TR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=tr_TR
 
 [env:tasmota-TW]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=zh_TW
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_TW
 
 [env:tasmota-UK]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=uk_UA
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=uk_UA
 
 [env:tasmota-VN]
-build_flags             = ${common.build_flags} -DMY_LANGUAGE=vi_VN
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=vi_VN

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -1,35 +1,36 @@
 [env]
-platform                = ${common.platform}
-platform_packages       = ${common.platform_packages}
-framework               = ${common.framework}
-board                   = ${common.board}
-board_build.filesystem  = ${common.board_build.filesystem}
-build_unflags           = ${common.build_unflags}
-build_flags             = ${common.build_flags}
-monitor_speed           = ${common.monitor_speed}
-upload_port             = ${common.upload_port}
-upload_resetmethod      = ${common.upload_resetmethod}
-extra_scripts           = ${common.extra_scripts}
-lib_extra_dirs          = ${common.lib_extra_dirs}
-lib_ldf_mode            = ${common.lib_ldf_mode}
-lib_compat_mode         = ${common.lib_compat_mode}
-lib_ignore              =
-    Servo(esp8266)
-    ESP8266AVRISP
-    ESP8266LLMNR
-    ESP8266NetBIOS
-    ESP8266SSDP
-    SP8266WiFiMesh
-    Ethernet(esp8266)
-    GDBStub
-    TFT_Touch_Shield_V2
-    ESP8266HTTPUpdateServer
-    ESP8266WiFiMesh
-    EspSoftwareSerial
-    SPISlave
-    Hash
+platform                    = ${common.platform}
+platform_packages           = ${common.platform_packages}
+framework                   = ${common.framework}
+board                       = ${common.board}
+board_build.filesystem      = ${common.board_build.filesystem}
+build_unflags               = ${common.build_unflags}
+build_flags                 = ${common.build_flags}
+monitor_speed               = ${common.monitor_speed}
+upload_port                 = ${common.upload_port}
+upload_resetmethod          = ${common.upload_resetmethod}
+extra_scripts               = ${common.extra_scripts}
+lib_ldf_mode                = ${common.lib_ldf_mode}
+lib_compat_mode             = ${common.lib_compat_mode}
+lib_extra_dirs              = ${common.lib_extra_dirs}
+lib_ignore                  =
+                              Servo(esp8266)
+                              ESP8266AVRISP
+                              ESP8266LLMNR
+                              ESP8266NetBIOS
+                              ESP8266SSDP
+                              SP8266WiFiMesh
+                              Ethernet(esp8266)
+                              GDBStub
+                              TFT_Touch_Shield_V2
+                              ESP8266HTTPUpdateServer
+                              ESP8266WiFiMesh
+                              EspSoftwareSerial
+                              SPISlave
+                              Hash
 ; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
-    ArduinoOTA
+                              ArduinoOTA
+
 
 [env:tasmota]
 

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -26,163 +26,163 @@ lib_ignore              =
 
 [env:tasmota32]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32_8M]
 extends                 = env:tasmota32_base
 board                   = esp32_8M
-build_flags             = ${common32.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32_16M]
 extends                 = env:tasmota32_base
 board                   = esp32_16M
-build_flags             = ${common32.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32solo1]
 extends                 = env:tasmota32_base
 platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
                           platformio/tool-esptoolpy @ ~1.30100
                           platformio/tool-mklittlefs @ ~1.203.200522
-build_flags             = ${common32.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base
 board                   = esp32-cam
 board_build.flash_mode  = qio
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_WEBCAM
+build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_WEBCAM
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32_base
 board                   = esp32-odroid
 board_build.flash_mode  = qio
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_ODROID_GO
+build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-core2]
 extends                 = env:tasmota32_base
 board                   = esp32-m5core2
 board_build.flash_mode  = qio
-build_flags             = ${common32.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_M5STACK_CORE2
+build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_M5STACK_CORE2
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32-bluetooth]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DFIRMWARE_BLUETOOTH
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_BLUETOOTH
 lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
 
 [env:tasmota32-display]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DFIRMWARE_DISPLAYS
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_DISPLAYS
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display
 
 [env:tasmota32-lvgl]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DFIRMWARE_LVGL
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL
 board_build.f_cpu       = 160000000L
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-ir]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DUSE_IR_REMOTE_FULL -DFIRMWARE_IR
+build_flags             = ${env:tasmota32_base.build_flags} -DUSE_IR_REMOTE_FULL -DFIRMWARE_IR
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-AF]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=af_AF -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=af_AF -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-BG]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=bg_BG -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=bg_BG -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-BR]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pt_BR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_BR -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-CN]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=zh_CN -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_CN -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-CZ]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=cs_CZ -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=cs_CZ -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-DE]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=de_DE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=de_DE -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-ES]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=es_ES -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=es_ES -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-FR]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=fr_FR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fr_FR -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-FY]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=fy_NL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fy_NL -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-GR]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=el_GR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=el_GR -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-HE]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=he_HE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=he_HE -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-HU]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=hu_HU -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=hu_HU -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-IT]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=it_IT -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=it_IT -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-KO]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ko_KO -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ko_KO -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-NL]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=nl_NL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=nl_NL -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-PL]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pl_PL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pl_PL -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-PT]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=pt_PT -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_PT -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-RO]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ro_RO -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ro_RO -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-RU]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=ru_RU -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ru_RU -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-SE]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=sv_SE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sv_SE -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-SK]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=sk_SK -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sk_SK -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-TR]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=tr_TR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=tr_TR -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-TW]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=zh_TW -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_TW -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-UK]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=uk_UA -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=uk_UA -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-VN]
 extends                 = env:tasmota32_base
-build_flags             = ${common32.build_flags} -DMY_LANGUAGE=vi_VN -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=vi_VN -DFIRMWARE_TASMOTA32

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -1,7 +1,7 @@
 [env:tasmota32_base]
 framework                   = ${common.framework}
-platform                    = ${esp32_defaults.platform}
-platform_packages           = ${esp32_defaults.platform_packages}
+platform                    = ${core32.platform}
+platform_packages           = ${core32.platform_packages}
 board_build.filesystem      = ${common.board_build.filesystem}
 custom_unpack_dir           = ${common.custom_unpack_dir}
 board                       = esp32_4M

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -1,28 +1,35 @@
 [env:tasmota32_base]
-framework               = ${common.framework}
-platform                = ${common32.platform}
-platform_packages       = ${common32.platform_packages}
-board                   = ${common32.board}
-monitor_speed           = ${common32.monitor_speed}
-upload_port             = ${common32.upload_port}
-upload_resetmethod      = ${common32.upload_resetmethod}
-extra_scripts           = ${common32.extra_scripts}
-build_unflags           = ${common32.build_unflags}
-build_flags             = ${common32.build_flags}
-lib_extra_dirs          = ${common32.lib_extra_dirs}
-lib_ldf_mode            = ${common32.lib_ldf_mode}
-lib_compat_mode         = ${common32.lib_compat_mode}
-lib_ignore              =
-    ESP32 Azure IoT Arduino
-    ESP32 Async UDP
-    ESP32 BLE Arduino
-;    SimpleBLE
-    NetBIOS
-    ESP32
-    Preferences
-    BluetoothSerial
+framework                   = ${common.framework}
+platform                    = ${esp32_defaults.platform}
+platform_packages           = ${esp32_defaults.platform_packages}
+board_build.filesystem      = ${common.board_build.filesystem}
+custom_unpack_dir           = ${common.custom_unpack_dir}
+board                       = esp32_4M
+monitor_speed               = 115200
+upload_port                 = ${common.upload_port}
+upload_resetmethod          = ${common.upload_resetmethod}
+extra_scripts               = ${common.extra_scripts}
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${esp32_defaults.build_flags}
+lib_ldf_mode                = ${common.lib_ldf_mode}
+lib_compat_mode             = ${common.lib_compat_mode}
+lib_extra_dirs              = ${common.lib_extra_dirs}
+                              lib/libesp32
+                              lib/libesp32_lvgl
+                              lib/libesp32_div
+                              lib/libesp32_epdiy
+lib_ignore                  =
+                              ESP32 Azure IoT Arduino
+                              ESP32 Async UDP
+                              ESP32 BLE Arduino
+;                              SimpleBLE
+                              NetBIOS
+                              ESP32
+                              Preferences
+                              BluetoothSerial
 ; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
-    ArduinoOTA
+                              ArduinoOTA
+
 
 [env:tasmota32]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

with the change how override is done now, some redundant can be removed. No need for entry [common32] anymore
Regression fixed in override that build_flags changes where not used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
