### PR TITLE
add board sizes and names in boards.json

### DIFF
--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_16M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_4M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_8M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",

--- a/boards/esp8266_1M.json
+++ b/boards/esp8266_1M.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.1m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_1M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.2m1m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_2M -DESP8266_2M1M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.2m256.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_2M -DESP8266_2M256",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp8266_4M2M.json
+++ b/boards/esp8266_4M2M.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.4m2m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M2M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -4,7 +4,7 @@
       "ldscript": "eagle.flash.4m3m.ld"
     },
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M3M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",


### PR DESCRIPTION
makes it possible to do custom compiles for boards with different flash memory variants,
 include more drivers for boards with greater flash space, disable features (example Ufilesystem for boards with 1M)

## Description:
The 1M Esp8266 standard build is identified as `ESP8266_1M` (the others can be found in the boards json under `extra_flags` )and can be used in `user_config_override.h `
Example:
```
#ifdef ESP8266_1M
#warning "ESP8266 1M variant"
#endif
```
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
