### PR TITLE
Berry update to more compact representation of solidified code

### DIFF
--- a/lib/libesp32/Berry/default/be_driverlib.c
+++ b/lib/libesp32/Berry/default/be_driverlib.c
@@ -34,87 +34,85 @@
 /********************************************************************
 ** Solidified function: get_tasmota
 ********************************************************************/
-
-/********** Solidified proto: get_tasmota */
-be_define_local_const_str(get_tasmota_str_name, "get_tasmota", 334356779, 11);
-be_define_local_const_str(get_tasmota_str_source, "input", -103256197, 5);
-be_define_local_const_str(get_tasmota_str_0, "global", 503252654, 6);
-be_define_local_const_str(get_tasmota_str_1, "tasmota", 424643812, 7);
-
-static const bvalue get_tasmota_ktab[2] = {
-  { { .s=be_local_const_str(get_tasmota_str_0) }, BE_STRING},
-  { { .s=be_local_const_str(get_tasmota_str_1) }, BE_STRING},
-};
-
-static const uint32_t get_tasmota_code[3] = {
-  0xA4060000,  //  0000  IMPORT	R1	R256
-  0x88080301,  //  0001  GETMBR	R2	R1	R257
-  0x80040400,  //  0002  RET	1	R2
-};
-
-be_define_local_proto(get_tasmota, 3, 1, 1, 0, 0);
-be_define_local_closure(get_tasmota);
-
+be_local_closure(get_tasmota,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* upvals */
+      { { .s=be_nested_const_str("global", 503252654, 6) }, BE_STRING},
+      { { .s=be_nested_const_str("tasmota", 424643812, 7) }, BE_STRING},
+    }),
+    (be_nested_const_str("get_tasmota", 334356779, 11)),
+    (be_nested_const_str("stdin", -1529146723, 5)),
+    ( &(const binstruction[ 3]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	R256
+      0x88080301,  //  0001  GETMBR	R2	R1	R257
+      0x80040400,  //  0002  RET	1	R2
+    })
+  )
+);
 /*******************************************************************/
 
 /********************************************************************
 ** Solidified function: add_cmd
 ********************************************************************/
-
-/********** Solidified proto: add_cmd_0 */
-static const bupvaldesc add_cmd_0_upvals[2] = {
-  be_local_const_upval(1, 2),
-  be_local_const_upval(1, 0),
-};
-
-be_define_local_const_str(add_cmd_0_str_name, "add_cmd_0", 607256038, 8);
-be_define_local_const_str(add_cmd_0_str_source, "input", -103256197, 5);
-
-static const uint32_t add_cmd_0_code[8] = {
-  0x68100000,  //  0000  GETUPV	R4	U0
-  0x68140001,  //  0001  GETUPV	R5	U1
-  0x5C180000,  //  0002  MOVE	R6	R0
-  0x5C1C0200,  //  0003  MOVE	R7	R1
-  0x5C200400,  //  0004  MOVE	R8	R2
-  0x5C240600,  //  0005  MOVE	R9	R3
-  0x7C100A00,  //  0006  CALL	R4	5
-  0x80040800,  //  0007  RET	1	R4
-};
-
-be_define_local_proto(add_cmd_0, 10, 4, 0, 0, 1);
-
-/********** Solidified proto: add_cmd */
-static const bproto *add_cmd_subproto[1] = {
-  &add_cmd_0_proto,
-};
-
-be_define_local_const_str(add_cmd_str_name, "add_cmd", -933336417, 7);
-be_define_local_const_str(add_cmd_str_source, "input", -103256197, 5);
-be_define_local_const_str(add_cmd_str_0, "get_tasmota", 334356779, 11);
-be_define_local_const_str(add_cmd_str_1, "add_cmd", -933336417, 7);
-
-static const bvalue add_cmd_ktab[2] = {
-  { { .s=be_local_const_str(add_cmd_str_0) }, BE_STRING},
-  { { .s=be_local_const_str(add_cmd_str_1) }, BE_STRING},
-};
-
-static const uint32_t add_cmd_code[8] = {
-  0x8C0C0100,  //  0000  GETMET	R3	R0	R256
-  0x7C0C0200,  //  0001  CALL	R3	1
-  0x8C100701,  //  0002  GETMET	R4	R3	R257
-  0x5C180200,  //  0003  MOVE	R6	R1
-  0x841C0000,  //  0004  CLOSURE	R7	P0
-  0x7C100600,  //  0005  CALL	R4	3
-  0xA0000000,  //  0006  CLOSE	0
-  0x80000000,  //  0007  RET	0	R0
-};
-
-be_define_local_proto(add_cmd, 8, 3, 1, 1, 0);
-be_define_local_closure(add_cmd);
-
+be_local_closure(add_cmd,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    be_nested_proto(
+      10,                          /* nstack */
+      4,                          /* argc */
+      1,                          /* has upvals */
+      ( &(const bupvaldesc[ 2]) {  /* upvals */
+        be_local_const_upval(1, 2),
+        be_local_const_upval(1, 0),
+      }),
+      0,                          /* has sup protos */
+      NULL,                       /* no sub protos */
+      0,                          /* has constants */
+      NULL,                       /* no const */
+      (be_nested_const_str("<lambda>", 607256038, 8)),
+      (be_nested_const_str("stdin", -1529146723, 5)),
+      ( &(const binstruction[ 8]) {  /* code */
+        0x68100000,  //  0000  GETUPV	R4	U0
+        0x68140001,  //  0001  GETUPV	R5	U1
+        0x5C180000,  //  0002  MOVE	R6	R0
+        0x5C1C0200,  //  0003  MOVE	R7	R1
+        0x5C200400,  //  0004  MOVE	R8	R2
+        0x5C240600,  //  0005  MOVE	R9	R3
+        0x7C100A00,  //  0006  CALL	R4	5
+        0x80040800,  //  0007  RET	1	R4
+      })
+    ),
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* upvals */
+      { { .s=be_nested_const_str("get_tasmota", 334356779, 11) }, BE_STRING},
+      { { .s=be_nested_const_str("add_cmd", -933336417, 7) }, BE_STRING},
+    }),
+    (be_nested_const_str("add_cmd", -933336417, 7)),
+    (be_nested_const_str("stdin", -1529146723, 5)),
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	R256
+      0x7C0C0200,  //  0001  CALL	R3	1
+      0x8C100701,  //  0002  GETMET	R4	R3	R257
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x841C0000,  //  0004  CLOSURE	R7	P0
+      0x7C100600,  //  0005  CALL	R4	3
+      0xA0000000,  //  0006  CLOSE	0
+      0x80000000,  //  0007  RET	0	R0
+    })
+  )
+);
 /*******************************************************************/
-
-
 
 #if BE_USE_PRECOMPILED_OBJECT
 #include "../generate/be_fixed_be_class_tasmota_driver.h"

--- a/lib/libesp32/Berry/default/be_tasmotalib.c
+++ b/lib/libesp32/Berry/default/be_tasmotalib.c
@@ -1423,35 +1423,36 @@ static const bclosure exec_cmd_closure = {
       "return gc.allocated() "
     "end "
 ********************************************************************/
+
 /********************************************************************
 ** Solidified function: gc
 ********************************************************************/
-
-/********** Solidified proto: gc */
-be_define_local_const_str(gc_str_name, "gc", 1042313471, 2);
-be_define_local_const_str(gc_str_source, "string", 398550328, 6);
-be_define_local_const_str(gc_str_0, "gc", 1042313471, 2);
-be_define_local_const_str(gc_str_1, "collect", -1895928271, 7);
-be_define_local_const_str(gc_str_2, "allocated", 429986098, 9);
-
-static const bvalue gc_ktab[3] = {
-  { { .s=be_local_const_str(gc_str_0) }, BE_STRING},
-  { { .s=be_local_const_str(gc_str_1) }, BE_STRING},
-  { { .s=be_local_const_str(gc_str_2) }, BE_STRING},
-};
-
-static const uint32_t gc_code[6] = {
-  0xA4060000,  //  0000  IMPORT	R1	R256
-  0x8C080301,  //  0001  GETMET	R2	R1	R257
-  0x7C080200,  //  0002  CALL	R2	1
-  0x8C080302,  //  0003  GETMET	R2	R1	R258
-  0x7C080200,  //  0004  CALL	R2	1
-  0x80040400,  //  0005  RET	1	R2
-};
-
-be_define_local_proto(gc, 4, 1, 1, 0, 0);
-be_define_local_closure(gc);
-
+be_local_closure(gc,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* upvals */
+      { { .s=be_nested_const_str("gc", 1042313471, 2) }, BE_STRING},
+      { { .s=be_nested_const_str("collect", -1895928271, 7) }, BE_STRING},
+      { { .s=be_nested_const_str("allocated", 429986098, 9) }, BE_STRING},
+    }),
+    (be_nested_const_str("gc", 1042313471, 2)),
+    (be_nested_const_str("string", 398550328, 6)),
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	R256
+      0x8C080301,  //  0001  GETMET	R2	R1	R257
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	R258
+      0x7C080200,  //  0004  CALL	R2	1
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
 /*******************************************************************/
 
 /********************************************************************

--- a/lib/libesp32/Berry/default/be_wirelib.c
+++ b/lib/libesp32/Berry/default/be_wirelib.c
@@ -37,93 +37,57 @@ extern int b_wire_detect(bvm *vm);
       "return ret "
     "end "
 ********************************************************************/
+
 /********************************************************************
 ** Solidified function: read_bytes
 ********************************************************************/
-
-be_define_local_const_str(read_bytes_str_name, "read_bytes", -718234123, 10);
-be_define_local_const_str(read_bytes_str_source, "string", 398550328, 6);
-be_define_local_const_str(read_bytes_str_0, "_begin_transmission", -1515506120, 19);
-be_define_local_const_str(read_bytes_str_1, "_write", -2079504471, 6);
-be_define_local_const_str(read_bytes_str_2, "_end_transmission", -1057486896, 17);
-be_define_local_const_str(read_bytes_str_3, "_request_from", -329818692, 13);
-be_define_local_const_str(read_bytes_str_4, "_available", 1306196581, 10);
-be_define_local_const_str(read_bytes_str_5, "_read", 346717030, 5);
-
-static const bvalue read_bytes_ktab[6] = {
-  { { .s=be_local_const_str(read_bytes_str_0) }, BE_STRING},
-  { { .s=be_local_const_str(read_bytes_str_1) }, BE_STRING},
-  { { .s=be_local_const_str(read_bytes_str_2) }, BE_STRING},
-  { { .s=be_local_const_str(read_bytes_str_3) }, BE_STRING},
-  { { .s=be_local_const_str(read_bytes_str_4) }, BE_STRING},
-  { { .s=be_local_const_str(read_bytes_str_5) }, BE_STRING},
-};
-
-static const uint32_t read_bytes_code[24] = {
-  0x8C100100,  //  0000  GETMET	R4	R0	R256
-  0x5C180200,  //  0001  MOVE	R6	R1
-  0x7C100400,  //  0002  CALL	R4	2
-  0x8C100101,  //  0003  GETMET	R4	R0	R257
-  0x5C180400,  //  0004  MOVE	R6	R2
-  0x7C100400,  //  0005  CALL	R4	2
-  0x8C100102,  //  0006  GETMET	R4	R0	R258
-  0x50180000,  //  0007  LDBOOL	R6	0	0
-  0x7C100400,  //  0008  CALL	R4	2
-  0x8C100103,  //  0009  GETMET	R4	R0	R259
-  0x5C180200,  //  000A  MOVE	R6	R1
-  0x5C1C0600,  //  000B  MOVE	R7	R3
-  0x7C100600,  //  000C  CALL	R4	3
-  0x60100002,  //  000D  GETGBL	R4	G2
-  0x5C140600,  //  000E  MOVE	R5	R3
-  0x7C100200,  //  000F  CALL	R4	1
-  0x8C140104,  //  0010  GETMET	R5	R0	R260
-  0x7C140200,  //  0011  CALL	R5	1
-  0x78160003,  //  0012  JMPF	R5	#0017
-  0x8C140105,  //  0013  GETMET	R5	R0	R261
-  0x7C140200,  //  0014  CALL	R5	1
-  0x40140805,  //  0015  CONNECT	R5	R4	R5
-  0x7001FFF8,  //  0016  JMP		#0010
-  0x80040800,  //  0017  RET	1	R4
-};
-
-static const bproto read_bytes_proto = {
-  NULL,     // bgcobject *next
-  8,       // type
-  GC_CONST,        // marked
-  8,       // nstack
-  0,       // nupvals
-  4,       // argc
-  0,       // varg
-  NULL,     // bgcobject *gray
-  NULL,     // bupvaldesc *upvals
-  (bvalue*) &read_bytes_ktab,     // ktab
-  NULL,     // bproto **ptab
-  (binstruction*) &read_bytes_code,     // code
-  be_local_const_str(read_bytes_str_name),       // name
-  24,       // codesize
-  6,       // nconst
-  0,       // nproto
-  be_local_const_str(read_bytes_str_source),     // source
-#if BE_DEBUG_RUNTIME_INFO /* debug information */
-  NULL,     // lineinfo
-  0,        // nlineinfo
-#endif
-#if BE_DEBUG_VAR_INFO
-  NULL,     // varinfo
-  0,        // nvarinfo
-#endif
-};
-
-const bclosure read_bytes_closure = {
-  NULL,     // bgcobject *next
-  36,       // type
-  GC_CONST,        // marked
-  0,       // nupvals
-  NULL,     // bgcobject *gray
-  (bproto*) &read_bytes_proto,     // proto
-  { NULL }     // upvals
-};
-
+be_local_closure(read_bytes,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    4,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* upvals */
+      { { .s=be_nested_const_str("_begin_transmission", -1515506120, 19) }, BE_STRING},
+      { { .s=be_nested_const_str("_write", -2079504471, 6) }, BE_STRING},
+      { { .s=be_nested_const_str("_end_transmission", -1057486896, 17) }, BE_STRING},
+      { { .s=be_nested_const_str("_request_from", -329818692, 13) }, BE_STRING},
+      { { .s=be_nested_const_str("_available", 1306196581, 10) }, BE_STRING},
+      { { .s=be_nested_const_str("_read", 346717030, 5) }, BE_STRING},
+    }),
+    (be_nested_const_str("read_bytes", -718234123, 10)),
+    (be_nested_const_str("string", 398550328, 6)),
+    ( &(const binstruction[24]) {  /* code */
+      0x8C100100,  //  0000  GETMET	R4	R0	R256
+      0x5C180200,  //  0001  MOVE	R6	R1
+      0x7C100400,  //  0002  CALL	R4	2
+      0x8C100101,  //  0003  GETMET	R4	R0	R257
+      0x5C180400,  //  0004  MOVE	R6	R2
+      0x7C100400,  //  0005  CALL	R4	2
+      0x8C100102,  //  0006  GETMET	R4	R0	R258
+      0x50180000,  //  0007  LDBOOL	R6	0	0
+      0x7C100400,  //  0008  CALL	R4	2
+      0x8C100103,  //  0009  GETMET	R4	R0	R259
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x5C1C0600,  //  000B  MOVE	R7	R3
+      0x7C100600,  //  000C  CALL	R4	3
+      0x60100002,  //  000D  GETGBL	R4	G2
+      0x5C140600,  //  000E  MOVE	R5	R3
+      0x7C100200,  //  000F  CALL	R4	1
+      0x8C140104,  //  0010  GETMET	R5	R0	R260
+      0x7C140200,  //  0011  CALL	R5	1
+      0x78160003,  //  0012  JMPF	R5	#0017
+      0x8C140105,  //  0013  GETMET	R5	R0	R261
+      0x7C140200,  //  0014  CALL	R5	1
+      0x40140805,  //  0015  CONNECT	R5	R4	R5
+      0x7001FFF8,  //  0016  JMP		#0010
+      0x80040800,  //  0017  RET	1	R4
+    })
+  )
+);
 /*******************************************************************/
 
 
@@ -135,75 +99,42 @@ const bclosure read_bytes_closure = {
       "self._end_transmission() "
     "end "
 ********************************************************************/
+
 /********************************************************************
 ** Solidified function: write_bytes
 ********************************************************************/
-
-be_define_local_const_str(write_bytes_str_name, "write_bytes", 1227543792, 11);
-be_define_local_const_str(write_bytes_str_source, "string", 398550328, 6);
-be_define_local_const_str(write_bytes_str_0, "_begin_transmission", -1515506120, 19);
-be_define_local_const_str(write_bytes_str_1, "_write", -2079504471, 6);
-be_define_local_const_str(write_bytes_str_2, "_end_transmission", -1057486896, 17);
-
-static const bvalue write_bytes_ktab[3] = {
-  { { .s=be_local_const_str(write_bytes_str_0) }, BE_STRING},
-  { { .s=be_local_const_str(write_bytes_str_1) }, BE_STRING},
-  { { .s=be_local_const_str(write_bytes_str_2) }, BE_STRING},
-};
-
-static const uint32_t write_bytes_code[12] = {
-  0x8C100100,  //  0000  GETMET	R4	R0	R256
-  0x5C180200,  //  0001  MOVE	R6	R1
-  0x7C100400,  //  0002  CALL	R4	2
-  0x8C100101,  //  0003  GETMET	R4	R0	R257
-  0x5C180400,  //  0004  MOVE	R6	R2
-  0x7C100400,  //  0005  CALL	R4	2
-  0x8C100101,  //  0006  GETMET	R4	R0	R257
-  0x5C180600,  //  0007  MOVE	R6	R3
-  0x7C100400,  //  0008  CALL	R4	2
-  0x8C100102,  //  0009  GETMET	R4	R0	R258
-  0x7C100200,  //  000A  CALL	R4	1
-  0x80000000,  //  000B  RET	0	R0
-};
-
-static const bproto write_bytes_proto = {
-  NULL,     // bgcobject *next
-  8,       // type
-  GC_CONST,        // marked
-  7,       // nstack
-  0,       // nupvals
-  4,       // argc
-  0,       // varg
-  NULL,     // bgcobject *gray
-  NULL,     // bupvaldesc *upvals
-  (bvalue*) &write_bytes_ktab,     // ktab
-  NULL,     // bproto **ptab
-  (binstruction*) &write_bytes_code,     // code
-  be_local_const_str(write_bytes_str_name),       // name
-  12,       // codesize
-  3,       // nconst
-  0,       // nproto
-  be_local_const_str(write_bytes_str_source),     // source
-#if BE_DEBUG_RUNTIME_INFO /* debug information */
-  NULL,     // lineinfo
-  0,        // nlineinfo
-#endif
-#if BE_DEBUG_VAR_INFO
-  NULL,     // varinfo
-  0,        // nvarinfo
-#endif
-};
-
-const bclosure write_bytes_closure = {
-  NULL,     // bgcobject *next
-  36,       // type
-  GC_CONST,        // marked
-  0,       // nupvals
-  NULL,     // bgcobject *gray
-  (bproto*) &write_bytes_proto,     // proto
-  { NULL }     // upvals
-};
-
+be_local_closure(write_bytes,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    4,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* upvals */
+      { { .s=be_nested_const_str("_begin_transmission", -1515506120, 19) }, BE_STRING},
+      { { .s=be_nested_const_str("_write", -2079504471, 6) }, BE_STRING},
+      { { .s=be_nested_const_str("_end_transmission", -1057486896, 17) }, BE_STRING},
+    }),
+    (be_nested_const_str("write_bytes", 1227543792, 11)),
+    (be_nested_const_str("string", 398550328, 6)),
+    ( &(const binstruction[12]) {  /* code */
+      0x8C100100,  //  0000  GETMET	R4	R0	R256
+      0x5C180200,  //  0001  MOVE	R6	R1
+      0x7C100400,  //  0002  CALL	R4	2
+      0x8C100101,  //  0003  GETMET	R4	R0	R257
+      0x5C180400,  //  0004  MOVE	R6	R2
+      0x7C100400,  //  0005  CALL	R4	2
+      0x8C100101,  //  0006  GETMET	R4	R0	R257
+      0x5C180600,  //  0007  MOVE	R6	R3
+      0x7C100400,  //  0008  CALL	R4	2
+      0x8C100102,  //  0009  GETMET	R4	R0	R258
+      0x7C100200,  //  000A  CALL	R4	1
+      0x80000000,  //  000B  RET	0	R0
+    })
+  )
+);
 /*******************************************************************/
 
 #if BE_USE_PRECOMPILED_OBJECT

--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -45,63 +45,44 @@ static const char * m_type_ktab(int type)
     }
 }
 
-static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int builtins)
+static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int builtins, int indent)
 {
     // const char * func_name = str(pr->name);
     const char * func_source = str(pr->source);
 
+    logfmt("%*sbe_nested_proto(\n", indent, "");
+    indent += 2;
+
+    logfmt("%*s%d,                          /* nstack */\n", indent, "", pr->nstack);
+    logfmt("%*s%d,                          /* argc */\n", indent, "", pr->argc);
+    logfmt("%*s%d,                          /* has upvals */\n", indent, "", (pr->nupvals > 0) ? 1 : 0);
+
+    if (pr->nupvals > 0) {
+        logfmt("%*s( &(const bupvaldesc[%2d]) {  /* upvals */\n", indent, "", pr->nupvals);
+        for (int32_t i = 0; i < pr->nupvals; i++) {
+            logfmt("%*s  be_local_const_upval(%i, %i),\n", indent, "", pr->upvals[i].instack, pr->upvals[i].idx);
+        }
+        logfmt("%*s}),\n", indent, "");
+    } else {
+        logfmt("%*sNULL,                       /* no upvals */\n", indent, "");
+    }
+
+    logfmt("%*s%d,                          /* has sup protos */\n", indent, "", (pr->nproto > 0) ? 1 : 0);
     if (pr->nproto > 0) {
         for (int32_t i = 0; i < pr->nproto; i++) {
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%d", func_name, i);
-            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins);
+            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent);
+            logfmt(",\n");
         }
+    } else {
+        logfmt("%*sNULL,                       /* no sub protos */\n", indent, "");
     }
 
-    logfmt("\n/********** Solidified proto: %s */\n", func_name);
-
-    if (pr->nproto > 0) {
-        logfmt("static const bproto *%s_subproto[%i] = {\n", func_name, pr->nproto);
-        for (int32_t i = 0; i < pr->nproto; i++) {
-            logfmt("  &%s_%d_proto,\n", func_name, i);
-            // logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx); TODO
-        }
-        logfmt("};\n\n");
-    }
-
-    if (pr->nupvals > 0) {
-        logfmt("static const bupvaldesc %s_upvals[%i] = {\n", func_name, pr->nupvals);
-        for (int32_t i = 0; i < pr->nupvals; i++) {
-            logfmt("  be_local_const_upval(%i, %i),\n", pr->upvals[i].instack, pr->upvals[i].idx);
-            // logfmt("// upval[%d] = { .instack = %i, .idx = %i }\n", i, pr->upvals[i].instack, pr->upvals[i].idx);
-        }
-        logfmt("};\n\n");
-    }
-
-    /* create static strings for name and source */
-    logfmt("be_define_local_const_str(%s_str_name, \"%s\", %i, %u);\n",
-            func_name, str(pr->name), be_strhash(pr->name), str_len(pr->name));
-    logfmt("be_define_local_const_str(%s_str_source, \"%s\", %i, %u);\n",
-            func_name, func_source, be_strhash(pr->source), str_len(pr->source));
-    
-    /* create static strings first */
-    for (int i = 0; i < pr->nconst; i++) {
-        if (pr->ktab[i].type == BE_STRING) {
-            logfmt("be_define_local_const_str(%s_str_%i, \"",
-                    func_name, i);
-            be_writestring(str(pr->ktab[i].v.s));
-            size_t len = strlen(str(pr->ktab[i].v.s));
-            if (len >= 255) {
-                be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
-            }
-            logfmt("\", %i, %zu);\n", be_strhash(pr->ktab[i].v.s), len >= 255 ? 255 : len);
-        }
-    }
-    logfmt("\n");
-
+    logfmt("%*s%d,                          /* has constants */\n", indent, "", (pr->nconst > 0) ? 1 : 0);
     if (pr->nconst > 0) {
-        logfmt("static const bvalue %s_ktab[%i] = {\n", func_name, pr->nconst);
+        logfmt("%*s( &(const bvalue[%2d]) {     /* upvals */\n", indent, "", pr->nconst);
         for (int k = 0; k < pr->nconst; k++) {
             int type = pr->ktab[k].type;
             const char *type_name = m_type_ktab(type);
@@ -111,26 +92,37 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
                 be_raise(vm, "internal_error", error);
             }
             if (type == BE_STRING) {
-                logfmt("  { { .s=be_local_const_str(%s_str_%i) }, %s},\n", func_name, k, type_name);
+                logfmt("%*s  { { .s=be_nested_const_str(\"", indent, "");
+                be_writestring(str(pr->ktab[k].v.s));
+                size_t len = strlen(str(pr->ktab[k].v.s));
+                if (len >= 255) {
+                    be_raise(vm, "internal_error", "Strings greater than 255 chars not supported yet");
+                }
+                logfmt("\", %i, %zu) }, %s},\n", be_strhash(pr->ktab[k].v.s), len >= 255 ? 255 : len, type_name);
             } else if (type == BE_INT) {
-                logfmt("  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", pr->ktab[k].v.i, type_name);
+                logfmt("%*s  { { .i=%" BE_INT_FMTLEN "i }, %s},\n", indent, "", pr->ktab[k].v.i, type_name);
             } else if (type == BE_REAL) {
     #if BE_USE_SINGLE_FLOAT
-                logfmt("  { { .p=(void*)0x%08X }, %s},\n", (uint32_t) pr->ktab[k].v.p, type_name);
+                logfmt("%*s  { { .p=(void*)0x%08X }, %s},\n", indent, "", (uint32_t) pr->ktab[k].v.p, type_name);
     #else
-                logfmt("  { { .p=(void*)0x%016llX }, %s},\n", (uint64_t) pr->ktab[k].v.p, type_name);
+                logfmt("%*s  { { .p=(void*)0x%016llX }, %s},\n", indent, "", (uint64_t) pr->ktab[k].v.p, type_name);
     #endif
             } else if (type == BE_BOOL) {
-                logfmt("  { { .b=%i }, %s},\n", pr->ktab[k].v.b, type_name);
+                logfmt("%*s  { { .b=%i }, %s},\n", indent, "", pr->ktab[k].v.b, type_name);
             }
         }
-        logfmt("};\n\n");
+        logfmt("%*s}),\n", indent, "");
+    } else {
+        logfmt("%*sNULL,                       /* no const */\n", indent, "");
     }
 
-    logfmt("static const uint32_t %s_code[%i] = {\n", func_name, pr->codesize);
+    logfmt("%*s(be_nested_const_str(\"%s\", %i, %i)),\n", indent, "", str(pr->name), be_strhash(pr->name), str_len(pr->name));
+    logfmt("%*s(be_nested_const_str(\"%s\", %i, %i)),\n", indent, "", func_source, be_strhash(pr->source), str_len(pr->source));
+
+    logfmt("%*s( &(const binstruction[%2d]) {  /* code */\n", indent, "", pr->codesize);
     for (int pc = 0; pc < pr->codesize; pc++) {
         uint32_t ins = pr->code[pc];
-        logfmt("  0x%04X,  //", ins);
+        logfmt("%*s  0x%04X,  //", indent, "", ins);
         be_print_inst(ins, pc);
         bopcode op = IGET_OP(ins);
         if (op == OP_GETGBL || op == OP_SETGBL) {
@@ -143,10 +135,10 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
             }
         }
     }
-    logfmt("};\n\n");
+    logfmt("%*s})\n", indent, "");
+    indent -= 2;
+    logfmt("%*s)", indent, "");
 
-    logfmt("be_define_local_proto(%s, %d, %d, %d, %d, %d);\n",
-          func_name, pr->nstack, pr->argc, (pr->nconst > 0) ? 1 : 0, (pr->nproto > 0) ? 1 : 0, (pr->nupvals > 0) ? 1 : 0);
 }
 
 static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
@@ -163,11 +155,14 @@ static void m_solidify_closure(bvm *vm, bclosure *cl, int builtins)
     logfmt("** Solidified function: %s\n", func_name);
     logfmt("********************************************************************/\n");
 
-    m_solidify_proto(vm, pr, func_name, builtins);
+    int indent = 2;
+    logfmt("be_local_closure(%s,   /* name */\n", func_name);
+
+    m_solidify_proto(vm, pr, func_name, builtins, indent);
+    logfmt("\n");
 
     // closure
-    logfmt("be_define_local_closure(%s);\n\n", func_name);
-
+    logfmt(");\n");
     logfmt("/*******************************************************************/\n\n");
 }
 

--- a/lib/libesp32/Berry/src/berry.h
+++ b/lib/libesp32/Berry/src/berry.h
@@ -263,6 +263,18 @@ typedef struct bntvmodule {
         .s = _s                                           \
     }
 
+/* new version for more compact literals */
+#define be_nested_const_str(_s, _hash, _len)  \
+    (bstring*) &(const bcstring) {            \
+        .next = (bgcobject *)NULL,            \
+        .type = BE_STRING,                    \
+        .marked = GC_CONST,                   \
+        .extra = 0,                           \
+        .slen = _len,                         \
+        .hash = 0,                            \
+        .s = _s                               \
+    }
+
 #define be_local_const_str(_name) (bstring*) &be_local_const_str_##_name
 
 /* conditional macro see  https://stackoverflow.com/questions/11632219/c-preprocessor-macro-specialisation-based-on-an-argument */
@@ -316,6 +328,30 @@ typedef struct bntvmodule {
     PROTO_VAR_INFO_BLOCK                                                          \
   }
 
+/* new version for more compact literals */
+#define be_nested_proto(_nstack, _argc, _has_upval, _upvals, _has_subproto, _protos, _has_const, _ktab, _fname, _source, _code)     \
+  & (const bproto) {                                                              \
+    NULL,                       /* bgcobject *next */                             \
+    BE_PROTO,                   /* type BE_PROTO */                               \
+    0x08,                       /* marked outside of GC */                        \
+    (_nstack),                  /* nstack */                                      \
+    BE_IIF(_has_upval)(sizeof(*_upvals)/sizeof(bupvaldesc),0),  /* nupvals */     \
+    (_argc),                    /* argc */                                        \
+    0,                          /* varg */                                        \
+    NULL,                       /* bgcobject *gray */                             \
+    (bupvaldesc*) _upvals,      /* bupvaldesc *upvals */                          \
+    (bvalue*) _ktab,            /* ktab */                                        \
+    (struct bproto**) _protos,  /* bproto **ptab */                               \
+    (binstruction*) _code,      /* code */                                        \
+    _fname,                     /* name */                                        \
+    sizeof(*_code)/sizeof(binstruction),                        /* codesize */    \
+    BE_IIF(_has_const)(sizeof(*_ktab)/sizeof(bvalue),0),        /* nconst */      \
+    BE_IIF(_has_subproto)(sizeof(*_protos)/sizeof(bproto*),0),  /* proto */       \
+    _source,                    /* source */                                      \
+    PROTO_RUNTIME_BLOCK                                                           \
+    PROTO_VAR_INFO_BLOCK                                                          \
+  }
+
 #define be_define_local_closure(_name)        \
   const bclosure _name##_closure = {          \
     NULL,           /* bgcobject *next */     \
@@ -327,6 +363,17 @@ typedef struct bntvmodule {
     { NULL }        /* upvals */              \
   }
 
+/* new version for more compact literals */
+#define be_local_closure(_name, _proto)       \
+  const bclosure _name##_closure = {          \
+    NULL,           /* bgcobject *next */     \
+    BE_CLOSURE,     /* type BE_CLOSURE */     \
+    GC_CONST,       /* marked GC_CONST */     \
+    0,              /* nupvals */             \
+    NULL,           /* bgcobject *gray */     \
+    (bproto*) _proto, /* proto */             \
+    { NULL }        /* upvals */              \
+  }
 
 /* debug hook typedefs */
 #define BE_HOOK_LINE    1


### PR DESCRIPTION
## Description:

Update to berry `solidify` module to make solidified code representation mode compact. No impact on actual code nor memory.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
