### PR TITLE
EVENT support JSON payload

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -913,7 +913,10 @@ void RulesEvery50ms(void)
         } else {
           parameter = event + strlen(event);  // '\0'
         }
-        snprintf_P(json_event, sizeof(json_event), PSTR("{\"Event\":{\"%s\":\"%s\"}}"), event, parameter);
+        if (parameter[0]=='{')
+          snprintf_P(json_event, sizeof(json_event), PSTR("{\"Event\":{\"%s\":%s}}"), event, parameter);
+        else
+          snprintf_P(json_event, sizeof(json_event), PSTR("{\"Event\":{\"%s\":\"%s\"}}"), event, parameter);
         Rules.event_data[0] ='\0';
         RulesProcessEvent(json_event);
       } else {


### PR DESCRIPTION
## Description:

If the EVENT payload is a JSON (starts with `'{'`), do not insert in into quotes i the `json_event` for rule processing.
This allows Rules triggers to parse the JSON such as `ON event#test#key1#key2=value DO...`

Useful with `Subscribe` events
From discussion https://github.com/arendst/Tasmota/discussions/12472

Note that the JSON payload is still limited to slightly below 100 chars because `Rules.event_data` is limited to 100 chars and `json_event` is limited too.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
