### PR TITLE
Use Arduino ESP32 core 1.0.7.1

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -27,7 +27,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = espressif32 @ 3.2.0
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.1/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-esptoolpy @ ~1.30100
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}


### PR DESCRIPTION
Adding feature: PSRAM auto detect. PSRAM can be enabled even when board has no PSRAM .
No impact on the compiled binaries.

Adding `-DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround` to `build_flags` will build a binary with support for PSRAM. Tasmota will start and work normally EVEN no PSRAM is found!
(Adds 35k to flash)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
