### PR TITLE
AP Mode: Allow buttons to work as in Normal Mode

### DIFF
--- a/tasmota/support_button.ino
+++ b/tasmota/support_button.ino
@@ -320,9 +320,9 @@ void ButtonHandler(void) {
                   // Success
                 } else {
                   if (Button.press_counter[button_index] < 6) { // Single to Penta press
-                    if (WifiState() > WIFI_RESTART) {           // Wifimanager active
-                      TasmotaGlobal.restart_flag = 1;
-                    }
+//                    if (WifiState() > WIFI_RESTART) {           // Wifimanager active
+//                      TasmotaGlobal.restart_flag = 1;
+//                    }
                     if (!Settings->flag3.mqtt_buttons) {         // SetOption73 - Detach buttons from relays and enable MQTT action state for multipress
                       if (Button.press_counter[button_index] == 1) {  // By default first press always send a TOGGLE (2)
                         ExecuteCommandPower(button_index + Button.press_counter[button_index], POWER_TOGGLE, SRC_BUTTON);


### PR DESCRIPTION
## Description:

In AP mode, if an user push any configured button, Tasmota restarts. This PR changes that, allowing buttons to be used as configured, also in AP mode.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
