### PR TITLE
Update ESP32 platform to latest release

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -26,9 +26,8 @@ build_flags                 = ${esp_defaults.build_flags}
 
 
 [core32]
-platform                    = espressif32 @ 3.2.0
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
-                              platformio/tool-esptoolpy @ ~1.30100
+platform                    = espressif32 @ 3.3.0
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.1/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -32,7 +32,7 @@ build_flags                 = ${esp32_defaults.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
+platform                    = espressif32 @ 3.3.0
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/307/framework-arduinoespressif32-master-1d7068e4b.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
@@ -47,9 +47,8 @@ lib_ignore                  =
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-platform                    = https://github.com/platformio/platform-espressif32
+platform                    = espressif32 @ 3.3.0
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/307/framework-arduinoespressif32-master-1d7068e4b.tar.gz
-                              platformio/tool-esptoolpy @ ~1.30100
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
                               -Wswitch-unreachable
@@ -70,12 +69,15 @@ lib_ignore                  =
 ; *** EXPERIMENTAL Tasmota version for ESP32 IDF4.4.
 [env:tasmota32idf4]
 extends                     = env:tasmota32_base
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
+platform                    = espressif32 @ 3.3.0
 platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/307/framework-arduinoespressif32-master-1d7068e4b.tar.gz
                               toolchain-xtensa32 @ ~2.80400.0
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
+                              -Wswitch-unreachable
+                              -Wincompatible-pointer-types
 build_flags                 = ${esp32_defaults.build_flags}
+                              -Wno-switch-unreachable
                               ;-DESP32_STAGE=true
 
 ; *** Debug version used for PlatformIO Home Project Inspection


### PR DESCRIPTION
Stage not needed anymore. Using release for ESP32 builds

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
