### PR TITLE
Enable use of Rules for Core2

### DIFF
--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -115,10 +115,9 @@
 #define USE_SENDMAIL
 #define USE_ESP32MAIL
 
-#define USE_SCRIPT                               // Add support for script (+17k code)
+#ifndef USE_RULES
+  #define USE_SCRIPT                             // Add support for script (+17k code)
 // Script related defines
-#ifdef USE_SCRIPT
-  #undef USE_RULES
   #define MAXVARS 75
   #define MAXSVARS 15
   #define MAXFILT 10
@@ -133,7 +132,7 @@
   #define SCRIPT_FULL_WEBPAGE
   #define SCRIPT_GET_HTTPS_JP
   #define USE_GOOGLE_CHARTS
-#endif  // USE_SCRIPT
+#endif  // USE_RULES
 #endif  // FIRMWARE_M5STACK_CORE2
 
 /*********************************************************************************************\


### PR DESCRIPTION
was not possible, fixed defined use_script

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
