### PR TITLE
Fix compilaion for Esp32c3

### DIFF
--- a/tasmota/xdrv_38_ping.ino
+++ b/tasmota/xdrv_38_ping.ino
@@ -125,7 +125,7 @@ extern "C" {
     struct pbuf *p;
     uint16_t ping_size = sizeof(struct icmp_echo_hdr) + Ping_data_size;
 
-    ping->ping_time_sent = system_get_time();
+    ping->ping_time_sent = micros();
     p = pbuf_alloc(PBUF_IP, ping_size, PBUF_RAM);
     if (!p) { return; }
     if ((p->len == p->tot_len) && (p->next == nullptr)) {
@@ -191,7 +191,7 @@ extern "C" {
         if (iecho->seqno != ping->seqno){   // debounce already received packet
           /* do some ping result processing */
           sys_untimeout(t_ping_timeout, ping);      // remove time-out handler
-          uint32_t delay = system_relative_time(ping->ping_time_sent);
+          uint32_t delay = micros() - ping->ping_time_sent;
           delay /= 1000;
 
           ping->sum_time += delay;


### PR DESCRIPTION
## Description:

Fix compilation for Esp32c3 and use the better supported `micros()`
Note: since we measure only short periods, converting from `uint64_t` to `uint32_t` is not an issue

Note: Ping still does not work on Esp32c3 - it times out every time.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
