### PR TITLE
Disable NDEBUG for Esp32C3

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -52,6 +52,7 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
 build_unflags               = ${esp32_defaults.build_unflags}
                               -Wswitch-unreachable
                               -mtarget-align
+                              -DNDEBUG
 build_flags                 = ${esp32_defaults.build_flags}
                               -Wno-switch-unreachable
                               ;-DESP32_STAGE=true


### PR DESCRIPTION
## Description:

Esp32C3 is still not stable enough, I propose to disable `NDEBUG` that is enabled by default in Arduino framework. For example this masks any error in NeoPixelBus.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
