### PR TITLE
Fix ping on Esp32

### DIFF
--- a/tasmota/xdrv_38_ping.ino
+++ b/tasmota/xdrv_38_ping.ino
@@ -99,7 +99,7 @@ extern "C" {
   // ================================================================================
   // Prepare a echo ICMP request
   //
-  void ICACHE_FLASH_ATTR t_ping_prepare_echo(struct icmp_echo_hdr *iecho, uint16_t len, Ping_t *ping) {
+  void t_ping_prepare_echo(struct icmp_echo_hdr *iecho, uint16_t len, Ping_t *ping) {
     size_t data_len = len - sizeof(struct icmp_echo_hdr);
 
     ICMPH_TYPE_SET(iecho, ICMP_ECHO);
@@ -125,7 +125,7 @@ extern "C" {
     struct pbuf *p;
     uint16_t ping_size = sizeof(struct icmp_echo_hdr) + Ping_data_size;
 
-    ping->ping_time_sent = micros();
+    ping->ping_time_sent = millis();
     p = pbuf_alloc(PBUF_IP, ping_size, PBUF_RAM);
     if (!p) { return; }
     if ((p->len == p->tot_len) && (p->next == nullptr)) {
@@ -135,7 +135,7 @@ extern "C" {
       ping_target.addr = ping->ip;
 #endif  // ESP8266
 #ifdef ESP32
-      ping_target.u_addr.ip4.addr = ping->ip;
+      ip_addr_set_ip4_u32(&ping_target, ping->ip);
 #endif  // ESP32
       iecho = (struct icmp_echo_hdr *) p->payload;
 
@@ -191,8 +191,7 @@ extern "C" {
         if (iecho->seqno != ping->seqno){   // debounce already received packet
           /* do some ping result processing */
           sys_untimeout(t_ping_timeout, ping);      // remove time-out handler
-          uint32_t delay = micros() - ping->ping_time_sent;
-          delay /= 1000;
+          uint32_t delay = millis() - ping->ping_time_sent;
 
           ping->sum_time += delay;
           if (delay < ping->min_time) { ping->min_time = delay; }


### PR DESCRIPTION
## Description:

Fix ping on Esp32c3 (and possibly on other Esp32).
Also moved from `micros()` to `millis()` to increase portability.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
