### PR TITLE
Command ``SetOption127 1`` to force Wifi in no-sleep mode even if ``Sleep 0`` is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Initial support for Tasmota Mesh (TasMesh) providing node/broker communication using ESP-NOW (#11939)
 - MQTT minimum password length restriction in GUI (#12553)
+- Command ``SetOption127 1`` to force Wifi in no-sleep mode even if ``Sleep 0`` is not enabled
 
 ### Changed
 - ESP32 core library from v1.0.7 to v1.0.7.1

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -355,6 +355,8 @@
 #define D_CMND_GLOBAL_TEMP "GlobalTemp"
 #define D_CMND_GLOBAL_HUM "GlobalHum"
 
+#define D_SO_WIFINOSLEEP "WifiNoSleep"
+
 #ifdef ESP32
 #define D_CMND_TOUCH_CAL "TouchCal"
 #define D_CMND_TOUCH_THRES "TouchThres"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -156,7 +156,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t wiegand_keypad_to_tag : 1;    // bit 10 (v9.3.1.1)  - SetOption124 - (Wiegand) send key pad stroke as single char (0) or one tag (ending char #) (1)
     uint32_t zigbee_hide_bridge_topic : 1; // bit 11 (v9.3.1.1)  - SetOption125 - (Zigbee) Hide bridge topic from zigbee topic (use with SetOption89) (1)
     uint32_t ds18x20_mean : 1;             // bit 12 (v9.3.1.2)  - SetOption126 - (DS18x20) Enable arithmetic mean over teleperiod for JSON temperature (1)
-    uint32_t spare13 : 1;                  // bit 13
+    uint32_t wifi_no_sleep : 1;            // bit 13 (v9.5.0.2)  - SetOption127 - (Wifi) keep wifi in no-sleep mode, prevents some occasional unresponsiveness
     uint32_t spare14 : 1;                  // bit 14
     uint32_t spare15 : 1;                  // bit 15
     uint32_t spare16 : 1;                  // bit 16

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -18,6 +18,9 @@
 */
 
 const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
+  // SetOptions synonyms
+  D_SO_WIFINOSLEEP "|"
+  // Other commands
   D_CMND_BACKLOG "|" D_CMND_DELAY "|" D_CMND_POWER "|" D_CMND_STATUS "|" D_CMND_STATE "|" D_CMND_SLEEP "|" D_CMND_UPGRADE "|" D_CMND_UPLOAD "|" D_CMND_OTAURL "|"
   D_CMND_SERIALLOG "|" D_CMND_RESTART "|" D_CMND_POWERONSTATE "|" D_CMND_PULSETIME "|" D_CMND_BLINKTIME "|" D_CMND_BLINKCOUNT "|" D_CMND_SAVEDATA "|"
   D_CMND_SO "|" D_CMND_SETOPTION "|" D_CMND_TEMPERATURE_RESOLUTION "|" D_CMND_HUMIDITY_RESOLUTION "|" D_CMND_PRESSURE_RESOLUTION "|" D_CMND_POWER_RESOLUTION "|"
@@ -44,6 +47,10 @@ const char kTasmotaCommands[] PROGMEM = "|"  // No prefix
    "|Info|" D_CMND_TOUCH_CAL "|" D_CMND_TOUCH_THRES "|" D_CMND_TOUCH_NUM "|" D_CMND_CPU_FREQUENCY
 #endif  // ESP32
   ;
+
+SO_SYNONYMS(kTasmotaSynonyms,
+  127,
+);
 
 void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndBacklog, &CmndDelay, &CmndPower, &CmndStatus, &CmndState, &CmndSleep, &CmndUpgrade, &CmndUpgrade, &CmndOtaUrl,
@@ -281,7 +288,7 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len)
 #ifdef USE_SCRIPT_SUB_COMMAND
   // allow overwrite tasmota cmds
     if (!Script_SubCmd()) {
-      if (!DecodeCommand(kTasmotaCommands, TasmotaCommand)) {
+      if (!DecodeCommand(kTasmotaCommands, TasmotaCommand, kTasmotaSynonyms)) {
         if (!XdrvCall(FUNC_COMMAND)) {
           if (!XsnsCall(FUNC_COMMAND)) {
             type = nullptr;  // Unknown command
@@ -290,7 +297,7 @@ void CommandHandler(char* topicBuf, char* dataBuf, uint32_t data_len)
       }
     }
 #else  // USE_SCRIPT_SUB_COMMAND
-    if (!DecodeCommand(kTasmotaCommands, TasmotaCommand)) {
+    if (!DecodeCommand(kTasmotaCommands, TasmotaCommand, kTasmotaSynonyms)) {
       if (!XdrvCall(FUNC_COMMAND)) {
         if (!XsnsCall(FUNC_COMMAND)) {
           type = nullptr;  // Unknown command

--- a/tasmota/support_wifi.ino
+++ b/tasmota/support_wifi.ino
@@ -159,16 +159,15 @@ void WiFiSetSleepMode(void)
     WiFi.setSleepMode(WIFI_MODEM_SLEEP);        // Disable sleep (Esp8288/Arduino core and sdk default)
   }
 */
-  if (0 == TasmotaGlobal.sleep) {
+  bool wifi_no_sleep = Settings->flag5.wifi_no_sleep;
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+  wifi_no_sleep = true;             // temporary patch for IDF4.4, wifi sleeping may cause wifi drops
+#endif
+  if (0 == TasmotaGlobal.sleep || wifi_no_sleep) {
     if (!TasmotaGlobal.wifi_stay_asleep) {
       WiFi.setSleepMode(WIFI_NONE_SLEEP);       // Disable sleep
     }
   } else {
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-    if (!TasmotaGlobal.wifi_stay_asleep) {
-      WiFi.setSleepMode(WIFI_NONE_SLEEP);       // Disable sleep
-    } else
-#endif
     if (Settings->flag3.sleep_normal) {         // SetOption60 - Enable normal sleep instead of dynamic sleep
       WiFi.setSleepMode(WIFI_LIGHT_SLEEP);      // Allow light sleep during idle times
     } else {


### PR DESCRIPTION
## Description:

Add `SetOption127 1` or `SO127 1` or `WifiNoSleep 1` to force Wifi in no-sleep mode. Currently wifi is set to sleep mode unless `Sleep 0` is set.

Forcing no-sleep solves some Web UI slowness or some wifi drops.

Note: no-sleep is currently forced on Esp32C3 (idf4.4) to avoid disconnects

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
