### PR TITLE
KNX: Fix Telegrams UDP Overrun

### DIFF
--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
@@ -80,6 +80,7 @@ void ESPKNXIP::send(address_t const &receiver, knx_command_type_t ct, uint8_t da
 	udp.beginPacketMulticast(MULTICAST_IP, MULTICAST_PORT, WiFi.localIP());
 	udp.write(buf, len);
  	udp.endPacket();
+	delay(1);
 
 }
 


### PR DESCRIPTION
## Description:

KNX: Fix Telegrams UDP Overrun

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/12577

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
