### PR TITLE
Change github actions for webflasher use in branch firmware

### DIFF
--- a/.github/workflows/Tasmota_build.yml
+++ b/.github/workflows/Tasmota_build.yml
@@ -1390,6 +1390,15 @@ jobs:
     continue-on-error: true
     steps:
     - uses: actions/checkout@v1
+    - name: Delete all files and folders
+      run: |
+        rm -rf *
+        git config --local user.name "Platformio BUILD"
+        git checkout firmware
+    - name: Display files from branch firmware
+      run: ls -R
+    - name: Remove old firmware files
+      run: rm -rf ./firmware/*
     - uses: actions/download-artifact@v2
       with:
         name: firmware
@@ -1410,7 +1419,7 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota-minimal.* ] || mv ./mv_firmware/firmware/tasmota-minimal.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota-lite.* ] || mv ./mv_firmware/firmware/tasmota-lite.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota-ir*.* ] || mv ./mv_firmware/firmware/tasmota-ir*.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./firmware/tasmota/ 
+        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota-knx.* ] || mv ./mv_firmware/firmware/tasmota-knx.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
         [ ! -f ./mv_firmware/firmware/tasmota-zigbee.* ] || mv ./mv_firmware/firmware/tasmota-zigbee.* ./firmware/tasmota/
@@ -1428,12 +1437,22 @@ jobs:
         [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
         [ ! -f ./tools/Esptool/Odroid_go_and_core2/*.* ] || mv ./tools/Esptool/Odroid_go_and_core2/*.* ./firmware/tasmota32/Odroid_go_and_core2_needed_files/
         [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md
+    - uses: actions/checkout@v2
+      with:
+        ref: release-firmware
+        path: tmp-folder
+    - name: Display files from branch release-firmware
+      run: |
+        ls -R ./tmp-folder
+        mkdir -p ./release-firmware/
+        cp -rf ./tmp-folder/firmware/* ./release-firmware/
+        rm -rf ./tmp-folder
+    - name: Display files to commit
+      run: ls -R ./*
     - name: Commit files  # transfer the new binaries back into the repository
       run: |
-        git config --local user.name "Platformio BUILD"
         git rm -r --cached .
-        git add ./README.md
-        git add -f ./firmware/*.*
+        git add -f ./*
         git commit -m "Tasmota ESP Binaries http://tasmota.com"
     - name: Push changes  # push the firmware files to branch firmware
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
## Description:

Changed the way how the new firmware files are placed in branch `firmware`.
It does not delete the other files in the branch anymore.
The release files from `release-firmware` branch are copied too in folder `release-firmware`.
By doing this it is possible for Webflasher (work to be done...) to provide all firmwares

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
