### PR TITLE
Initial Wi-Fi Config: Fix Bug with SAVEDATA

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -1792,16 +1792,17 @@ void HandleWifiConfiguration(void) {
     if ( WifiIsInManagerMode() ) {
       // Test WIFI Connection to Router
       // As Tasmota is in this case in AP mode, a STA connection can be established too at the same time
+
+      if (WIFI_NOT_TESTING == Web.wifiTest) {
+        if (MAX_WIFI_OPTION == Web.old_wificonfig) { Web.old_wificonfig = Settings->sta_config; }
+        TasmotaGlobal.wifi_state_flag = Settings->sta_config = WIFI_MANAGER;
+        Web.save_data_counter = TasmotaGlobal.save_data_counter;
+      }
+
       Web.wifi_test_counter = 9;   // seconds to test user's proposed AP
       Web.wifiTest = WIFI_TESTING;
-
-      Web.save_data_counter = TasmotaGlobal.save_data_counter;
       TasmotaGlobal.save_data_counter = 0;               // Stop auto saving data - Updating Settings
       Settings->save_data = 0;
-
-      if (MAX_WIFI_OPTION == Web.old_wificonfig) { Web.old_wificonfig = Settings->sta_config; }
-      TasmotaGlobal.wifi_state_flag = Settings->sta_config = WIFI_MANAGER;
-
       TasmotaGlobal.sleep = 0;                           // Disable sleep
       TasmotaGlobal.restart_flag = 0;                    // No restart
       TasmotaGlobal.ota_state_flag = 0;                  // No OTA


### PR DESCRIPTION
## Description:

In some conditions, if the save button was pressed more than once, or the page was refreshed several times, the Wi-Fi credentials checking routine was disabling SAVEDATA in flash. This PR Fixes that condition.

**Related issue (if applicable):** fixes https://discord.com/channels/479389167382691863/479389167382691865/863076491109597235

Thanks to @gavlar6559 and @auguzanellato for reporting and testing ! 👍 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
