### PR TITLE
Use mode `dout` for all ESP32 builds

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app1856k_spiffs320k.csv"

--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "m5stack_core2",
     "partitions": "esp32_partition_app2944k_spiffs10M.csv"

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "odroid_esp32",
     "partitions": "esp32_partition_app2944k_spiffs10M.csv"

--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_16M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app2944k_spiffs10M.csv"

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_4M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app1856k_spiffs320k.csv"

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_8M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "esp32_partition_app2944k_spiffs2M.csv"

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -6,7 +6,7 @@
     "core": "esp32",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32c3",
     "variant": "esp32c3",
     "partitions": "esp32_partition_app1856k_spiffs320k.csv"

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -6,7 +6,7 @@
     "core": "esp32",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
+    "flash_mode": "dout",
     "mcu": "esp32s2",
     "variant": "esp32s2",
     "partitions": "esp32_partition_app1856k_spiffs320k.csv"

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -55,21 +55,18 @@ build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base
 board                   = esp32-cam
-board_build.flash_mode  = qio
 build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_WEBCAM
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32_base
 board                   = esp32-odroid
-board_build.flash_mode  = qio
 build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-core2]
 extends                 = env:tasmota32_base
 board                   = esp32-m5core2
-board_build.flash_mode  = qio
 build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_M5STACK_CORE2
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 


### PR DESCRIPTION
since Platformio has a bug generating/flashing the correct flash modes.
Issue https://github.com/platformio/platform-espressif32/issues/584

Maybe fixes #12560

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
