### PR TITLE
Move PSRAM cache fix definitions in boards.json

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue",
+    "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -55,19 +55,19 @@ build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base
 board                   = esp32-cam
-build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_WEBCAM
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_WEBCAM
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32_base
 board                   = esp32-odroid
-build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_ODROID_GO
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_ODROID_GO
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-core2]
 extends                 = env:tasmota32_base
 board                   = esp32-m5core2
-build_flags             = ${env:tasmota32_base.build_flags} -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround -DFIRMWARE_M5STACK_CORE2
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_M5STACK_CORE2
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32-bluetooth]


### PR DESCRIPTION
Description:
since this is the place where it should be.
By adding `-mfix-esp32-psram-cache-strategy=memw` which is the default strategy (see Arduino32 `boards.txt`) the one needed lib is choosen. This avoids linking a unneeded lib. Like it was before.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
