### PR TITLE
Add libs to ignore

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -19,6 +19,9 @@ lib_extra_dirs              = ${common.lib_extra_dirs}
                               lib/libesp32_div
                               lib/libesp32_epdiy
 lib_ignore                  =
+                              ESP RainMaker
+                              WiFiProv
+                              USB
                               ESP32 Azure IoT Arduino
                               ESP32 Async UDP
                               ESP32 BLE Arduino


### PR DESCRIPTION
## Description:

Ignore libs from compiling we do not use in Tasmota32 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
