### PR TITLE
Fix AXP192 lcd voltage for M5Stack Core2

### DIFF
--- a/tasmota/berry/drivers/axp192.be
+++ b/tasmota/berry/drivers/axp192.be
@@ -1,4 +1,3 @@
-
 #-------------------------------------------------------------
  - Generic driver for AXP192
  -------------------------------------------------------------#
@@ -265,7 +264,7 @@ class AXP192_M5Stack_Core2 : AXP192
   def set_lcd_voltage(voltage)
     if voltage < 2500  voltage = 2500 end
     if voltage > 3300  voltage = 3300 end
-    self.set_ldo_voltage(2, voltage)
+    self.set_dc_voltage(3, voltage)
   end
 
   # set state of the green led, GPIO 1


### PR DESCRIPTION
## Description:

Fix Berry AXP192 driver for M5Stack Core2. Backlight brightness was not working.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
