### PR TITLE
no cache fix needed for M5Core2...

### DIFF
--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw",
+    "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",


### PR DESCRIPTION
since it is a D0WDQ6-V3
Source: https://github.com/m5stack/M5Core2

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
