### PR TITLE
Mark GPIOs 16 and 17 as red on ESP32, as they are used for PSRAM

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1632,7 +1632,13 @@ bool RedPin(uint32_t pin) // pin may be dangerous to change, display in RED in t
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
   return false;     // no red pin on ESP32C3
 #else // ESP32 and ESP8266
+
+#ifdef CONFIG_IDF_TARGET_ESP32
+  return (16==pin)||(17==pin)||(9==pin)||(10==pin);
+#else
   return (9==pin)||(10==pin);
+#endif
+
 #endif
 }
 


### PR DESCRIPTION
## Description:


Mark also GPIO 16/17 as red on ESP32. They are used by PSRAM and are probed at boot. If you don't have a PSRAM, you can you those GPIOs but please expect them to be used as outputs for a short period of time at start-up.

**Related issue (if applicable):** fixes #12635

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
