### PR TITLE
Disable PSRAM on unsupported hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Command ``SetSensor1..127 0|1`` to globally disable individual sensor driver
 - Support for CAN bus and Freedom Won Battery Management System by Marius Bezuidenhout (#12651)
+- Disable PSRAM on unsupported hardware
 
 ## [9.5.0.2] 20210714
 ### Added

--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -380,6 +380,7 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
 
 
 Renderer *uDisplay::Init(void) {
+  extern bool UsePSRAM(void);
 
   // for any bpp below native 16 bits, we allocate a local framebuffer to copy into
   if (ep_mode || bpp < 16) {
@@ -387,7 +388,7 @@ Renderer *uDisplay::Init(void) {
 #ifdef ESP8266
     framebuffer = (uint8_t*)calloc((gxs * gys * bpp) / 8, 1);
 #else
-    if (psramFound()) {
+    if (UsePSRAM()) {
       framebuffer = (uint8_t*)heap_caps_malloc((gxs * gys * bpp) / 8, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     } else {
       framebuffer = (uint8_t*)calloc((gxs * gys * bpp) / 8, 1);

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -276,6 +276,12 @@ void setup(void) {
 
 //  AddLog(LOG_LEVEL_INFO, PSTR("ADR: Settings %p, Log %p"), Settings, TasmotaGlobal.log_buffer);
   AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s"), GetDeviceHardware().c_str());
+  AddLog(LOG_LEVEL_DEBUG, PSTR("HDW: psramFound=%i CanUsePSRAM=%i"), psramFound(), CanUsePSRAM());
+#if defined(ESP32) && !defined(HAS_PSRAM_FIX)
+  if (psramFound() && !CanUsePSRAM()) {
+    AddLog(LOG_LEVEL_INFO, PSTR("HDW: PSRAM is disabled, requires specific compilation on this hardware (see doc)"));
+  }
+#endif // ESP32
 
 #ifdef USE_UFILESYS
   UfsInit();  // xdrv_50_filesystem.ino

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -276,7 +276,9 @@ void setup(void) {
 
 //  AddLog(LOG_LEVEL_INFO, PSTR("ADR: Settings %p, Log %p"), Settings, TasmotaGlobal.log_buffer);
   AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s"), GetDeviceHardware().c_str());
+#ifdef ESP32
   AddLog(LOG_LEVEL_DEBUG, PSTR("HDW: psramFound=%i CanUsePSRAM=%i"), psramFound(), CanUsePSRAM());
+#endif // ESP32
 #if defined(ESP32) && !defined(HAS_PSRAM_FIX)
   if (psramFound() && !CanUsePSRAM()) {
     AddLog(LOG_LEVEL_INFO, PSTR("HDW: PSRAM is disabled, requires specific compilation on this hardware (see doc)"));

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2372,7 +2372,7 @@ void HandleInformation(void)
 #ifdef ESP32
   int32_t freeMaxMem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
   WSContentSend_PD(PSTR("}1" D_FREE_MEMORY "}2%1_f kB (" D_FRAGMENTATION " %d%%)"), &freemem, freeMaxMem);
-  if (psramFound()) {
+  if (UsePSRAM()) {
     WSContentSend_P(PSTR("}1" D_PSR_MAX_MEMORY "}2%d kB"), ESP.getPsramSize() / 1024);
     WSContentSend_P(PSTR("}1" D_PSR_FREE_MEMORY "}2%d kB"), ESP.getFreePsram() / 1024);
   }

--- a/tasmota/xdrv_42_i2s_audio.ino
+++ b/tasmota/xdrv_42_i2s_audio.ino
@@ -280,12 +280,12 @@ void I2S_Init(void) {
   mp3ram = nullptr;
 
 #ifdef ESP32
-  if (psramFound()) {
+  if (UsePSRAM()) {
     mp3ram = heap_caps_malloc(preallocateCodecSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   }
 
 #ifdef USE_I2S_WEBRADIO
-  if (psramFound()) {
+  if (UsePSRAM()) {
     preallocateBuffer = heap_caps_malloc(preallocateBufferSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
     preallocateCodec = heap_caps_malloc(preallocateCodecSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   } else {

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -181,7 +181,7 @@ extern "C" {
       map_insert_int(vm, "heap_free", ESP_getFreeHeap() / 1024);
       int32_t freeMaxMem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
       map_insert_int(vm, "frag", freeMaxMem);
-      if (psramFound()) {
+      if (UsePSRAM()) {
         map_insert_int(vm, "psram", ESP.getPsramSize() / 1024);
         map_insert_int(vm, "psram_free", ESP.getFreePsram() / 1024);
       }

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -442,13 +442,13 @@ void start_lvgl(const char * uconfig) {
   // initialize the FreeType renderer
   lv_freetype_init(USE_LVGL_FREETYPE_MAX_FACES,
                    USE_LVGL_FREETYPE_MAX_SIZES,
-                   psramFound() ? USE_LVGL_FREETYPE_MAX_BYTES_PSRAM : USE_LVGL_FREETYPE_MAX_BYTES);
+                   UsePSRAM() ? USE_LVGL_FREETYPE_MAX_BYTES_PSRAM : USE_LVGL_FREETYPE_MAX_BYTES);
 #endif
 #ifdef USE_LVGL_PNG_DECODER
   lv_png_init();
 #endif // USE_LVGL_PNG_DECODER
 
-  if (psramFound()) {
+  if (UsePSRAM()) {
     lv_img_cache_set_size(LV_IMG_CACHE_DEF_SIZE_PSRAM);
   }
 

--- a/tasmota/xdrv_81_esp32_webcam.ino
+++ b/tasmota/xdrv_81_esp32_webcam.ino
@@ -252,7 +252,7 @@ uint32_t WcSetup(int32_t fsiz) {
   // if PSRAM IC present, init with UXGA resolution and higher JPEG quality
   //                      for larger pre-allocated frame buffer.
 
-  bool psram = psramFound();
+  bool psram = UsePSRAM();
   if (psram) {
     config.frame_size = FRAMESIZE_UXGA;
     config.jpeg_quality = 10;

--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -125,7 +125,7 @@ void HandleMetrics(void) {
     int32_t freeMaxMem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
     WSContentSend_PD(PSTR("# TYPE tasmota_memory_bytes gauge\ntasmota_memory_bytes{memory=\"Ram\"} %d\n"), ESP_getFreeHeap());
     WSContentSend_PD(PSTR("# TYPE tasmota_memory_ratio gauge\ntasmota_memory_ratio{memory=\"Fragmentation\"} %d)"), freeMaxMem / 100);
-    if (psramFound()) {
+    if (UsePSRAM()) {
       WSContentSend_P(PSTR("# TYPE tasmota_memory_bytes gauge\ntasmota_memory_bytes{memory=\"Psram\"} %d\n"), ESP.getFreePsram() );
     }
   #else // ESP32


### PR DESCRIPTION
## Description:

Disables PSRAM on hardware that need specific patches or versions, even if PSRAM code seem to start succesfully:
- ESP32 rev 1/2, they require specific patches that are not included by default in Tasmota32: `-DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -lc-psram-workaround -lm-psram-workaround`
- ESP32-PICO-V3-02 with embedded PSRAM, that requires esp-idf v4.4

Disabling PSRAM avoids crashes and bootloops.

Note: developers must now use `UsePSRAM()` instead of `psramFound()`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
