### PR TITLE
Berry add `path` module

### DIFF
--- a/lib/libesp32/Berry/default/be_modtab.c
+++ b/lib/libesp32/Berry/default/be_modtab.c
@@ -27,6 +27,7 @@ be_extern_native_module(gpio);
 be_extern_native_module(energy);
 be_extern_native_module(webserver);
 be_extern_native_module(flash);
+be_extern_native_module(path);
 #ifdef USE_LVGL
 be_extern_native_module(lvgl);
 #endif // USE_LVGL
@@ -70,6 +71,7 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #endif
     /* user-defined modules register start */
     
+    &be_native_module(path),
     &be_native_module(gpio),
 #ifdef USE_LIGHT
     &be_native_module(light),

--- a/lib/libesp32/Berry/default/be_path_tasmota_lib.c
+++ b/lib/libesp32/Berry/default/be_path_tasmota_lib.c
@@ -1,0 +1,45 @@
+/********************************************************************
+** Copyright (c) 2018-2020 Guan Wenliang
+** This file is part of the Berry default interpreter.
+** skiars@qq.com, https://github.com/Skiars/berry
+** See Copyright Notice in the LICENSE file or at
+** https://github.com/Skiars/berry/blob/master/LICENSE
+********************************************************************/
+
+/********************************************************************
+ * Berry module `path`
+ * 
+ * Minimal version of `import path`
+ * 
+ *******************************************************************/
+#include "be_object.h"
+#include "be_strlib.h"
+#include "be_mem.h"
+#include "be_sys.h"
+
+static int m_path_exists(bvm *vm)
+{
+    const char *path = NULL;
+    if (be_top(vm) >= 1 && be_isstring(vm, 1)) {
+        path = be_tostring(vm, 1);
+    }
+    be_pushbool(vm, be_isexist(path));
+    be_return(vm);
+}
+
+#if !BE_USE_PRECOMPILED_OBJECT
+be_native_module_attr_table(path) {
+    be_native_module_function("exists", m_path_exists),
+};
+
+static be_define_native_module(path, NULL);
+
+#else
+/* @const_object_info_begin
+module path (scope: global, file: tasmota_path) {
+    exists, func(m_path_exists)
+}
+@const_object_info_end */
+#include "../generate/be_fixed_tasmota_path.h"
+
+#endif

--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -250,7 +250,22 @@ size_t be_fsize(void *hfile)
     return 0;
 }
 
-
+int be_isexist(const char *filename)
+{
+#ifdef USE_UFILESYS
+    if (ufsp != nullptr) {
+        char fname2[strlen(filename) + 2];
+        if (filename[0] == '/') {
+            strcpy(fname2, filename);   // copy unchanged
+        } else {
+            fname2[0] = '/';
+            strcpy(fname2 + 1, filename);   // prepend with '/'
+        }
+        return ufsp->exists(fname2);
+    }
+#endif // USE_UFILESYS
+    return 0;
+}
 
 #if BE_USE_FILE_SYSTEM
 #if defined(USE_FATFS) /* FatFs */

--- a/lib/libesp32/Berry/generate/be_const_strtab.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab.h
@@ -446,6 +446,7 @@ extern const bcstring be_const_str_content_button;
 extern const bcstring be_const_str_HX711_DAT;
 extern const bcstring be_const_str_dot_p;
 extern const bcstring be_const_str_content_stop;
+extern const bcstring be_const_str_exists;
 extern const bcstring be_const_str_GPS_RX;
 extern const bcstring be_const_str_HX711_SCK;
 extern const bcstring be_const_str_RDM6300_RX;

--- a/lib/libesp32/Berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab_def.h
@@ -445,7 +445,8 @@ be_define_const_str(add_driver, "add_driver", 1654458371u, 0, 10, &be_const_str_
 be_define_const_str(content_button, "content_button", 1956476087u, 0, 14, NULL);
 be_define_const_str(HX711_DAT, "HX711_DAT", 2935118250u, 0, 9, NULL);
 be_define_const_str(dot_p, ".p", 1171526419u, 0, 2, &be_const_str_content_stop);
-be_define_const_str(content_stop, "content_stop", 658554751u, 0, 12, NULL);
+be_define_const_str(content_stop, "content_stop", 658554751u, 0, 12, &be_const_str_exists);
+be_define_const_str(exists, "exists", 1002329533u, 0, 6, NULL);
 be_define_const_str(GPS_RX, "GPS_RX", 1075637342u, 0, 6, &be_const_str_HX711_SCK);
 be_define_const_str(HX711_SCK, "HX711_SCK", 3785979404u, 0, 9, &be_const_str_RDM6300_RX);
 be_define_const_str(RDM6300_RX, "RDM6300_RX", 1522345628u, 0, 10, NULL);
@@ -943,6 +944,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 306,
-    .count = 612,
+    .count = 613,
     .table = m_string_table
 };

--- a/lib/libesp32/Berry/generate/be_fixed_tasmota_path.h
+++ b/lib/libesp32/Berry/generate/be_fixed_tasmota_path.h
@@ -1,0 +1,17 @@
+#include "be_constobj.h"
+
+static be_define_const_map_slots(m_libpath_map) {
+    { be_const_key(exists, -1), be_const_func(m_path_exists) },
+};
+
+static be_define_const_map(
+    m_libpath_map,
+    1
+);
+
+static be_define_const_module(
+    m_libpath,
+    "path"
+);
+
+BE_EXPORT_VARIABLE be_define_const_native_module(path, NULL);


### PR DESCRIPTION
## Description:

Add a minified version of `path` module, which currently contains only `exists()` function to test if a file exists.

Example:
```python
> import path

> path.exists("random_name")
false

> path.exists("autoexec.be")
true
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
