### PR TITLE
Updated Arduino ESP32/IDF4.4 framework, LITTLEFS -> LittleFS

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.2
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/lib/lib_div/lib_mail/src/ESP_Mail_FS.h
+++ b/lib/lib_div/lib_mail/src/ESP_Mail_FS.h
@@ -19,15 +19,8 @@
 */
 // #define ESP_Mail_DEFAULT_FLASH_FS SPIFFS
 
-#ifdef ESP8266
- #include <LittleFS.h>
- #define ESP_Mail_DEFAULT_FLASH_FS LittleFS
-#endif
-
-#ifdef ESP32
- #include <LITTLEFS.h>
-  #define ESP_Mail_DEFAULT_FLASH_FS LITTLEFS
-#endif
+#include <LittleFS.h>
+#define ESP_Mail_DEFAULT_FLASH_FS LittleFS
 
 /**
  * To use SD card file systems with different hardware interface

--- a/lib/libesp32_div/ESP32-HomeKit/src/hap_platform_keystore.cpp
+++ b/lib/libesp32_div/ESP32-HomeKit/src/hap_platform_keystore.cpp
@@ -47,7 +47,7 @@ const char * hap_platform_keystore_get_factory_nvs_partition_name() {
 
 #ifdef HAP_USE_LITTLEFS
 
-#include <LITTLEFS.h>
+#include <LittleFS.h>
 
 extern FS *ffsp;
 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -27,7 +27,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = espressif32 @ 3.3.0
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.1/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.2/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -8,7 +8,7 @@
 [core_dev]
 ; *** Esp8266 core for Arduino 3.0.1
 platform                    = espressif8266 @ 3.1.0
-platform_packages           = 
+platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
                               -Wswitch-unreachable
 build_flags                 = ${esp82xx_defaults.build_flags}
@@ -31,8 +31,8 @@ build_flags                 = ${esp32_defaults.build_flags}
 [env:tasmota32s2]
 extends                     = env:tasmota32_base
 board                       = esp32s2
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/331/framework-arduinoespressif32-master-209a0d389.tar.gz
+platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/340/framework-arduinoespressif32-master-caf43f7e9.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags} -DFIRMWARE_LITE
@@ -47,8 +47,8 @@ lib_ignore                  =
 [env:tasmota32c3]
 extends                     = env:tasmota32_base
 board                       = esp32c3
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/331/framework-arduinoespressif32-master-209a0d389.tar.gz
+platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/340/framework-arduinoespressif32-master-caf43f7e9.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
                               -Wswitch-unreachable
@@ -70,8 +70,8 @@ lib_ignore                  =
 ; *** EXPERIMENTAL Tasmota version for ESP32 IDF4.4.
 [env:tasmota32idf4]
 extends                     = env:tasmota32_base
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/idf-master
-platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/331/framework-arduinoespressif32-master-209a0d389.tar.gz
+platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/340/framework-arduinoespressif32-master-caf43f7e9.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
                               -Wswitch-unreachable

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -50,7 +50,7 @@ build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32solo1]
 extends                 = env:tasmota32_base
-platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.2/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
                           platformio/tool-esptoolpy @ ~1.30100
                           platformio/tool-mklittlefs @ ~1.203.200522
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -66,7 +66,7 @@
 #endif  // USE_SDCARD
 #endif  // ESP8266
 #ifdef ESP32
-#include <LITTLEFS.h>
+#include <LittleFS.h>
 #ifdef USE_SDCARD
 #include <SD.h>
 #endif  // USE_SDCARD

--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -109,8 +109,8 @@ void UfsInitOnce(void) {
 
 #ifdef ESP32
   // try lfs first
-  ffsp = &LITTLEFS;
-  if (!LITTLEFS.begin(true)) {
+  ffsp = &LittleFS;
+  if (!LittleFS.begin(true)) {
     // ffat is second
     ffsp = &FFat;
     if (!FFat.begin(true)) {
@@ -223,9 +223,9 @@ uint32_t UfsInfo(uint32_t sel, uint32_t type) {
 #endif  // ESP8266
 #ifdef ESP32
       if (sel == 0) {
-        result = LITTLEFS.totalBytes();
+        result = LittleFS.totalBytes();
       } else {
-        result = LITTLEFS.totalBytes() - LITTLEFS.usedBytes();
+        result = LittleFS.totalBytes() - LittleFS.usedBytes();
       }
 #endif  // ESP32
       break;


### PR DESCRIPTION
## Description:

Use Arduino ESP32 main branch with Tasmota changes in IDF4.4 for ESP32-C3 and ESP32-S2.
Since actual IDF 4.4 changed from LITTLEFS to LittleFS (now align with ESP8266) code of Tasmota has to be adopted and stable Tasmota Core32 (IDF3.5.x) LittleFS has to be changed too.
**All** Tasmota32 variants now have to use core 1.0.7.2.
Tasmota32 solo1 core has been updated too.

The compiled firmware with core 1.0.7.2 has been tested with a M5 Core2 and a Yeelight (solo1).
The Arduino IDF4.4 is tested with a ESP32-C3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
