### PR TITLE
LOG: Increase readability of project name and device name

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -1,5 +1,5 @@
 /*
-  tasmota.ino - Tasmota firmware for iTead Sonoff, Wemos and NodeMCU hardware
+  tasmota.ino - Tasmota firmware for iTead Sonoff, Wemos, NodeMCU, ESP8266 and ESP32 hardwares
 
   Copyright (C) 2021  Theo Arends
 
@@ -398,7 +398,7 @@ void setup(void) {
   SetPowerOnState();
   WifiConnect();
 
-  AddLog(LOG_LEVEL_INFO, PSTR(D_PROJECT " %s %s " D_VERSION " %s%s-" ARDUINO_CORE_RELEASE "(%s)"),
+  AddLog(LOG_LEVEL_INFO, PSTR(D_PROJECT " %s - %s " D_VERSION " %s%s-" ARDUINO_CORE_RELEASE "(%s)"),
     PSTR(PROJECT), SettingsText(SET_DEVICENAME), TasmotaGlobal.version, TasmotaGlobal.image_name, GetBuildDateAndTime().c_str());
 #ifdef FIRMWARE_MINIMAL
   AddLog(LOG_LEVEL_INFO, PSTR(D_WARNING_MINIMAL_VERSION));


### PR DESCRIPTION
## Description:

LOG: Increase readability of project name and device name

Now it shows `Project tasmota Tasmota` that may confuse some people. The first tasmota is the project name and the second is the device name.

```lua
00:00:00.001 HDW: ESP8266EX
00:00:00.027 CFG: Loaded from flash at FA, Count 2
00:00:00.032 QPC: Count 1
00:00:00.040 Project tasmota Tasmota Version 9.5.0.3(tasmota)-2_7_4_9(2021-07-18T17:15:53)
00:00:00.180 WIF: WifiManager active for 3 minutes
00:00:00.688 HTP: Web server active on tasmota_C658CC-6348 with IP address 192.168.4.1
00:00:06.964 QPC: Reset
```

With this minimal fix, it is shown now as:

```lua
00:00:00.001 HDW: ESP8266EX
00:00:00.027 CFG: Loaded from flash at FA, Count 2
00:00:00.032 QPC: Count 1
00:00:00.040 Project tasmota - Tasmota Version 9.5.0.3(tasmota)-2_7_4_9(2021-07-18T17:15:53)
00:00:00.180 WIF: WifiManager active for 3 minutes
00:00:00.688 HTP: Web server active on tasmota_C658CC-6348 with IP address 192.168.4.1
00:00:06.964 QPC: Reset
```

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
