### PR TITLE
Core 1.0.7.3 code base for all ESP32 builds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.2
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -27,7 +27,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = espressif32 @ 3.3.0
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.2/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

Build solo1 has changes in Arduino ESP.cpp and updater.cpp. This changes are compatible to the ESP32.
To keep the same code base these changes are used for the ESP32 builds too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
