### PR TITLE
Fix wrong gc count for instances

### DIFF
--- a/lib/libesp32/Berry/src/be_gc.c
+++ b/lib/libesp32/Berry/src/be_gc.c
@@ -339,12 +339,19 @@ static void free_lstring(bvm *vm, bgcobject *obj)
     }
 }
 
+static void free_instance(bvm *vm, bgcobject *obj)
+{
+    binstance *o = cast_instance(obj);
+    int nvar = be_instance_member_count(o);
+    be_free(vm, obj, sizeof(binstance) + sizeof(bvalue) * (nvar - 1));
+}
+
 static void free_object(bvm *vm, bgcobject *obj)
 {
     switch (obj->type) {
     case BE_STRING: free_lstring(vm, obj); break; /* long string */
     case BE_CLASS: be_free(vm, obj, sizeof(bclass)); break;
-    case BE_INSTANCE: be_free(vm, obj, sizeof(binstance)); break;
+    case BE_INSTANCE: free_instance(vm, obj); break;
     case BE_MAP: be_map_delete(vm, cast_map(obj)); break;
     case BE_LIST: be_list_delete(vm, cast_list(obj)); break;
     case BE_CLOSURE: free_closure(vm, obj); break;


### PR DESCRIPTION
## Description:

Fix Berry wrong gc free space calculation, update from https://github.com/Skiars/berry/pull/114

**Related issue (if applicable):** fixes #12678

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
