### PR TITLE
prometheus: Fix typo in comment

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -164,7 +164,7 @@ void WritePromMetricStr(const char *name, uint8_t flags, const char *value, ...)
   va_end(labels);
 }
 
-// Sentinel value for known memory metrics, chosen to unlikely match actual
+// Sentinel value for unknown memory metrics, chosen to unlikely match actual
 // values.
 const uint32_t kPromMemoryUnknown = 0xFFFFFFFF - 1;
 


### PR DESCRIPTION
## Description:

Fix-up for a typo added in PR #12692.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
    - Comment-only change
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7
    - Comment-only change
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
