### PR TITLE
JTAG debug env

### DIFF
--- a/boards/esp32_solo1_4M.json
+++ b/boards/esp32_solo1_4M.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_4M",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dout",
+    "mcu": "esp32",
+    "variant": "esp32",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet",
+    "can"
+  ],
+  "debug": {
+    "openocd_target": "esp32-solo-1.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://en.wikipedia.org/wiki/ESP32",
+  "vendor": "Espressif"
+}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -93,3 +93,27 @@ build_type                  = debug
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 ;                              -Wstack-usage=300
+
+; *** JTAG Debug version, needs esp-prog or FT2232H or FT232H
+[env:tasmota32-ocd]
+;build_type              = debug
+extends                 = env:tasmota32_base
+debug_tool              = esp-prog
+upload_protocol         = esp-prog
+debug_init_break        = tbreak setup
+build_unflags           = ${esp32_defaults.build_unflags}
+build_flags             = ${env:tasmota32_base.build_flags}
+
+; *** JTAG Debug version, needs esp-prog or FT2232H or FT232H
+[env:tasmota32solo1-ocd]
+;build_type              = debug
+extends                 = env:tasmota32_base
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+                          platformio/tool-esptoolpy @ ~1.30100
+                          platformio/tool-mklittlefs @ ~1.203.200522
+board                   = esp32_solo1_4M
+debug_tool              = esp-prog
+upload_protocol         = esp-prog
+debug_init_break        = tbreak setup
+build_unflags           = ${esp32_defaults.build_unflags}
+build_flags             = ${env:tasmota32_base.build_flags}


### PR DESCRIPTION
## Description:

which are needed for JTAG upload and debug via esp-prog or FT2232H/FT232H.
No Tasmota code change.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
