### PR TITLE
LVGL new widget ``lv_wifi_bars``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry ESP32 support for I2S audio mp3 playback
 - Berry add module ``introspect``
 - Berry add ``tasmota.wifi()`` and ``tasmota.eth()``
+- LVGL new widget ``lv_wifi_bars``
 
 ### Changed
 - ESP32 core library from v1.0.7.1 to v1.0.7.3

--- a/lib/libesp32/Berry/default/be_lvgl_signal_bars_lib.c
+++ b/lib/libesp32/Berry/default/be_lvgl_signal_bars_lib.c
@@ -371,7 +371,7 @@ be_local_class(lv_signal_bars,
 /*******************************************************************/
 
 void be_load_lv_signal_bars_class(bvm *vm) {
-    be_pushntvclass(vm, &be_lv_signal_bars_class);
+    be_pushntvclass(vm, &be_class_lv_signal_bars);
     be_setglobal(vm, "lv_signal_bars");
     be_pop(vm, 1);
 }

--- a/lib/libesp32/Berry/default/be_lvgl_signal_wifi_lib.c
+++ b/lib/libesp32/Berry/default/be_lvgl_signal_wifi_lib.c
@@ -1,0 +1,117 @@
+/********************************************************************
+ * Tasmota LVGL lv_signal_bars widget
+ *******************************************************************/
+#include "be_constobj.h"
+
+#ifdef USE_LVGL
+
+#include "lvgl.h"
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+      be_nested_string("global", 503252654, 6),
+      be_nested_string("lv_signal_bars", -780994737, 14),
+      be_nested_string("init", 380752755, 4),
+      be_nested_string("tasmota", 424643812, 7),
+      be_nested_string("add_driver", 1654458371, 10),
+    }),
+    (be_nested_const_str("init", 380752755, 4)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[14]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	R256
+      0x60100014,  //  0001  GETGBL	R4	G20
+      0x5C140000,  //  0002  MOVE	R5	R0
+      0x88180701,  //  0003  GETMBR	R6	R3	R257
+      0x7C100400,  //  0004  CALL	R4	2
+      0x8C100902,  //  0005  GETMET	R4	R4	R258
+      0x5C180200,  //  0006  MOVE	R6	R1
+      0x5C1C0400,  //  0007  MOVE	R7	R2
+      0x7C100600,  //  0008  CALL	R4	3
+      0x88100703,  //  0009  GETMBR	R4	R3	R259
+      0x8C100904,  //  000A  GETMET	R4	R4	R260
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x7C100400,  //  000C  CALL	R4	2
+      0x80000000,  //  000D  RET	0	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(every_second,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+      be_nested_string("global", 503252654, 6),
+      be_nested_string("tasmota", 424643812, 7),
+      be_nested_string("wifi", 120087624, 4),
+      be_nested_string("find", -1108310694, 4),
+      be_nested_string("quality", -1697296346, 7),
+      be_nested_string("set_percentage", -1342944572, 14),
+    }),
+    (be_nested_const_str("every_second", 2075451465, 12)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[14]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	R256
+      0x88080301,  //  0001  GETMBR	R2	R1	R257
+      0x8C080502,  //  0002  GETMET	R2	R2	R258
+      0x7C080200,  //  0003  CALL	R2	1
+      0x8C0C0503,  //  0004  GETMET	R3	R2	R259
+      0x58140004,  //  0005  LDCONST	R5	K4
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x4C100000,  //  0007  LDNIL	4
+      0x20100604,  //  0008  NE	R4	R3	R4
+      0x78120002,  //  0009  JMPF	R4	#000D
+      0x8C100105,  //  000A  GETMET	R4	R0	R261
+      0x5C180600,  //  000B  MOVE	R6	R3
+      0x7C100400,  //  000C  CALL	R4	2
+      0x80000000,  //  000D  RET	0	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified class: lv_wifi_bars
+********************************************************************/
+extern const bclass be_class_lv_signal_bars;
+be_local_class(lv_wifi_bars,
+    0,
+    &be_class_lv_signal_bars,
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_nested_key("init", 380752755, 4, -1), be_const_closure(init_closure) },
+        { be_nested_key("every_second", 2075451465, 12, 0), be_const_closure(every_second_closure) },
+    })),
+    (be_nested_const_str("lv_wifi_bars", 2109539196, 12))
+);
+/*******************************************************************/
+
+void be_load_lv_wifi_bars_class(bvm *vm) {
+    be_pushntvclass(vm, &be_class_lv_wifi_bars);
+    be_setglobal(vm, "lv_wifi_bars");
+    be_pop(vm, 1);
+}
+
+#endif // USE_LVGL

--- a/lib/libesp32/Berry/default/be_modtab.c
+++ b/lib/libesp32/Berry/default/be_modtab.c
@@ -118,6 +118,7 @@ extern void be_load_lvgl_ctypes_lib(bvm *vm);
 extern void be_load_ctypes_definitions_lib(bvm *vm);
 // custom widgets
 extern void be_load_lv_signal_bars_class(bvm *vm);
+extern void be_load_lv_wifi_bars_class(bvm *vm);
 #endif// USE_LVGL
 
 /* this code loads the native class definitions */
@@ -151,6 +152,7 @@ BERRY_API void be_load_custom_libs(bvm *vm)
     be_load_ctypes_definitions_lib(vm);
     // custom widgets
     be_load_lv_signal_bars_class(vm);
+    be_load_lv_wifi_bars_class(vm);
 #endif // USE_LVGL
 }
 #endif

--- a/lib/libesp32/Berry/default/be_tasmotalib.c
+++ b/lib/libesp32/Berry/default/be_tasmotalib.c
@@ -1364,14 +1364,15 @@ be_local_closure(gc,   /* name */
 ********************************************************************/
 be_local_closure(event,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    18,                          /* nstack */
     5,                          /* argc */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
+      be_nested_string("introspect", 164638290, 10),
       be_nested_string("every_50ms", -1911083288, 10),
       be_nested_string("run_deferred", 371594696, 12),
       be_nested_string("cmd", -158181397, 3),
@@ -1381,19 +1382,8 @@ be_local_closure(event,   /* name */
       be_nested_string("mqtt_data", -1756753932, 9),
       be_nested_string("gc", 1042313471, 2),
       be_nested_string("_drivers", -1034638311, 8),
-      be_nested_string("every_second", 2075451465, 12),
-      be_nested_string("every_100ms", 1546407804, 11),
-      be_nested_string("web_add_button", -757092238, 14),
-      be_nested_string("web_add_main_button", -334599632, 19),
-      be_nested_string("web_add_management_button", -1556090110, 25),
-      be_nested_string("web_add_config_button", 639674325, 21),
-      be_nested_string("web_add_console_button", -813531104, 22),
-      be_nested_string("save_before_restart", 1253239338, 19),
-      be_nested_string("web_add_handler", -304792334, 15),
-      be_nested_string("web_sensor", -1394870324, 10),
-      be_nested_string("json_append", -1292948012, 11),
-      be_nested_string("button_pressed", 1694209616, 14),
-      be_nested_string("display", 1164572437, 7),
+      be_nested_string("get", 1410115415, 3),
+      be_nested_string("function", -1630125495, 8),
       be_nested_string("string", 398550328, 6),
       be_nested_string("format", -1180859054, 6),
       be_nested_string("BRY: Exception> '%s' - %s", -2047976332, 25),
@@ -1401,170 +1391,79 @@ be_local_closure(event,   /* name */
     }),
     (be_nested_const_str("event", -30355297, 5)),
     (be_nested_const_str("input", -103256197, 5)),
-    ( &(const binstruction[163]) {  /* code */
-      0x1C140300,  //  0000  EQ	R5	R1	R256
-      0x78160001,  //  0001  JMPF	R5	#0004
-      0x8C140101,  //  0002  GETMET	R5	R0	R257
-      0x7C140200,  //  0003  CALL	R5	1
-      0x1C140302,  //  0004  EQ	R5	R1	R258
-      0x78160006,  //  0005  JMPF	R5	#000D
-      0x8C140103,  //  0006  GETMET	R5	R0	R259
-      0x5C1C0400,  //  0007  MOVE	R7	R2
-      0x5C200600,  //  0008  MOVE	R8	R3
-      0x5C240800,  //  0009  MOVE	R9	R4
-      0x7C140800,  //  000A  CALL	R5	4
-      0x80040A00,  //  000B  RET	1	R5
-      0x70020094,  //  000C  JMP		#00A2
-      0x1C140304,  //  000D  EQ	R5	R1	R260
-      0x78160004,  //  000E  JMPF	R5	#0014
-      0x8C140105,  //  000F  GETMET	R5	R0	R261
-      0x5C1C0800,  //  0010  MOVE	R7	R4
-      0x7C140400,  //  0011  CALL	R5	2
-      0x80040A00,  //  0012  RET	1	R5
-      0x7002008D,  //  0013  JMP		#00A2
-      0x1C140306,  //  0014  EQ	R5	R1	R262
-      0x78160002,  //  0015  JMPF	R5	#0019
-      0x4C140000,  //  0016  LDNIL	5
-      0x80040A00,  //  0017  RET	1	R5
-      0x70020088,  //  0018  JMP		#00A2
-      0x1C140307,  //  0019  EQ	R5	R1	R263
-      0x78160003,  //  001A  JMPF	R5	#001F
-      0x8C140107,  //  001B  GETMET	R5	R0	R263
-      0x7C140200,  //  001C  CALL	R5	1
-      0x80040A00,  //  001D  RET	1	R5
-      0x70020082,  //  001E  JMP		#00A2
-      0x88140108,  //  001F  GETMBR	R5	R0	R264
-      0x78160080,  //  0020  JMPF	R5	#00A2
-      0x60140000,  //  0021  GETGBL	R5	G0
-      0x88180108,  //  0022  GETMBR	R6	R0	R264
-      0x7C140200,  //  0023  CALL	R5	1
-      0xA8020079,  //  0024  EXBLK	0	#009F
-      0x5C180A00,  //  0025  MOVE	R6	R5
-      0x7C180000,  //  0026  CALL	R6	0
-      0xA8020069,  //  0027  EXBLK	0	#0092
-      0x1C1C0309,  //  0028  EQ	R7	R1	R265
-      0x781E0004,  //  0029  JMPF	R7	#002F
-      0x881C0D09,  //  002A  GETMBR	R7	R6	R265
-      0x781E0002,  //  002B  JMPF	R7	#002F
-      0x8C1C0D09,  //  002C  GETMET	R7	R6	R265
-      0x7C1C0200,  //  002D  CALL	R7	1
-      0x70020060,  //  002E  JMP		#0090
-      0x1C1C0300,  //  002F  EQ	R7	R1	R256
-      0x781E0004,  //  0030  JMPF	R7	#0036
-      0x881C0D00,  //  0031  GETMBR	R7	R6	R256
-      0x781E0002,  //  0032  JMPF	R7	#0036
-      0x8C1C0D00,  //  0033  GETMET	R7	R6	R256
-      0x7C1C0200,  //  0034  CALL	R7	1
-      0x70020059,  //  0035  JMP		#0090
-      0x1C1C030A,  //  0036  EQ	R7	R1	R266
-      0x781E0004,  //  0037  JMPF	R7	#003D
-      0x881C0D0A,  //  0038  GETMBR	R7	R6	R266
-      0x781E0002,  //  0039  JMPF	R7	#003D
-      0x8C1C0D0A,  //  003A  GETMET	R7	R6	R266
-      0x7C1C0200,  //  003B  CALL	R7	1
-      0x70020052,  //  003C  JMP		#0090
-      0x1C1C030B,  //  003D  EQ	R7	R1	R267
-      0x781E0004,  //  003E  JMPF	R7	#0044
-      0x881C0D0B,  //  003F  GETMBR	R7	R6	R267
-      0x781E0002,  //  0040  JMPF	R7	#0044
-      0x8C1C0D0B,  //  0041  GETMET	R7	R6	R267
-      0x7C1C0200,  //  0042  CALL	R7	1
-      0x7002004B,  //  0043  JMP		#0090
-      0x1C1C030C,  //  0044  EQ	R7	R1	R268
-      0x781E0004,  //  0045  JMPF	R7	#004B
-      0x881C0D0C,  //  0046  GETMBR	R7	R6	R268
-      0x781E0002,  //  0047  JMPF	R7	#004B
-      0x8C1C0D0C,  //  0048  GETMET	R7	R6	R268
-      0x7C1C0200,  //  0049  CALL	R7	1
-      0x70020044,  //  004A  JMP		#0090
-      0x1C1C030D,  //  004B  EQ	R7	R1	R269
-      0x781E0004,  //  004C  JMPF	R7	#0052
-      0x881C0D0D,  //  004D  GETMBR	R7	R6	R269
-      0x781E0002,  //  004E  JMPF	R7	#0052
-      0x8C1C0D0D,  //  004F  GETMET	R7	R6	R269
-      0x7C1C0200,  //  0050  CALL	R7	1
-      0x7002003D,  //  0051  JMP		#0090
-      0x1C1C030E,  //  0052  EQ	R7	R1	R270
-      0x781E0004,  //  0053  JMPF	R7	#0059
-      0x881C0D0E,  //  0054  GETMBR	R7	R6	R270
-      0x781E0002,  //  0055  JMPF	R7	#0059
-      0x8C1C0D0E,  //  0056  GETMET	R7	R6	R270
-      0x7C1C0200,  //  0057  CALL	R7	1
-      0x70020036,  //  0058  JMP		#0090
-      0x1C1C030F,  //  0059  EQ	R7	R1	R271
-      0x781E0004,  //  005A  JMPF	R7	#0060
-      0x881C0D0F,  //  005B  GETMBR	R7	R6	R271
-      0x781E0002,  //  005C  JMPF	R7	#0060
-      0x8C1C0D0F,  //  005D  GETMET	R7	R6	R271
-      0x7C1C0200,  //  005E  CALL	R7	1
-      0x7002002F,  //  005F  JMP		#0090
-      0x1C1C0310,  //  0060  EQ	R7	R1	R272
-      0x781E0004,  //  0061  JMPF	R7	#0067
-      0x881C0D10,  //  0062  GETMBR	R7	R6	R272
-      0x781E0002,  //  0063  JMPF	R7	#0067
-      0x8C1C0D10,  //  0064  GETMET	R7	R6	R272
-      0x7C1C0200,  //  0065  CALL	R7	1
-      0x70020028,  //  0066  JMP		#0090
-      0x1C1C0311,  //  0067  EQ	R7	R1	R273
-      0x781E0004,  //  0068  JMPF	R7	#006E
-      0x881C0D11,  //  0069  GETMBR	R7	R6	R273
-      0x781E0002,  //  006A  JMPF	R7	#006E
-      0x8C1C0D11,  //  006B  GETMET	R7	R6	R273
-      0x7C1C0200,  //  006C  CALL	R7	1
-      0x70020021,  //  006D  JMP		#0090
-      0x1C1C0312,  //  006E  EQ	R7	R1	R274
-      0x781E0004,  //  006F  JMPF	R7	#0075
-      0x881C0D12,  //  0070  GETMBR	R7	R6	R274
-      0x781E0002,  //  0071  JMPF	R7	#0075
-      0x8C1C0D12,  //  0072  GETMET	R7	R6	R274
-      0x7C1C0200,  //  0073  CALL	R7	1
-      0x7002001A,  //  0074  JMP		#0090
-      0x1C1C0313,  //  0075  EQ	R7	R1	R275
-      0x781E0004,  //  0076  JMPF	R7	#007C
-      0x881C0D13,  //  0077  GETMBR	R7	R6	R275
-      0x781E0002,  //  0078  JMPF	R7	#007C
-      0x8C1C0D13,  //  0079  GETMET	R7	R6	R275
-      0x7C1C0200,  //  007A  CALL	R7	1
-      0x70020013,  //  007B  JMP		#0090
-      0x1C1C0314,  //  007C  EQ	R7	R1	R276
-      0x781E0004,  //  007D  JMPF	R7	#0083
-      0x881C0D14,  //  007E  GETMBR	R7	R6	R276
-      0x781E0002,  //  007F  JMPF	R7	#0083
-      0x8C1C0D14,  //  0080  GETMET	R7	R6	R276
-      0x7C1C0200,  //  0081  CALL	R7	1
-      0x7002000C,  //  0082  JMP		#0090
-      0x1C1C0311,  //  0083  EQ	R7	R1	R273
-      0x781E0004,  //  0084  JMPF	R7	#008A
-      0x881C0D15,  //  0085  GETMBR	R7	R6	R277
-      0x781E0002,  //  0086  JMPF	R7	#008A
-      0x8C1C0D15,  //  0087  GETMET	R7	R6	R277
-      0x7C1C0200,  //  0088  CALL	R7	1
-      0x70020005,  //  0089  JMP		#0090
-      0x1C1C0315,  //  008A  EQ	R7	R1	R277
-      0x781E0003,  //  008B  JMPF	R7	#0090
-      0x881C0D15,  //  008C  GETMBR	R7	R6	R277
-      0x781E0001,  //  008D  JMPF	R7	#0090
-      0x8C1C0D15,  //  008E  GETMET	R7	R6	R277
-      0x7C1C0200,  //  008F  CALL	R7	1
-      0xA8040001,  //  0090  EXBLK	1	1
-      0x7002000B,  //  0091  JMP		#009E
-      0xAC1C0002,  //  0092  CATCH	R7	0	2
-      0x70020008,  //  0093  JMP		#009D
-      0xA4262C00,  //  0094  IMPORT	R9	R278
-      0x6028000F,  //  0095  GETGBL	R10	G15
-      0x8C2C1317,  //  0096  GETMET	R11	R9	R279
-      0x58340018,  //  0097  LDCONST	R13	K24
-      0x5C380E00,  //  0098  MOVE	R14	R7
-      0x5C3C1000,  //  0099  MOVE	R15	R8
-      0x7C2C0800,  //  009A  CALL	R11	4
-      0x7C280200,  //  009B  CALL	R10	1
-      0x70020000,  //  009C  JMP		#009E
-      0xB0080000,  //  009D  RAISE	2	R0	R0
-      0x7001FF85,  //  009E  JMP		#0025
-      0x58140019,  //  009F  LDCONST	R5	K25
-      0xAC140200,  //  00A0  CATCH	R5	1	0
-      0xB0080000,  //  00A1  RAISE	2	R0	R0
-      0x80000000,  //  00A2  RET	0	R0
+    ( &(const binstruction[72]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	R256
+      0x1C180301,  //  0001  EQ	R6	R1	R257
+      0x781A0001,  //  0002  JMPF	R6	#0005
+      0x8C180102,  //  0003  GETMET	R6	R0	R258
+      0x7C180200,  //  0004  CALL	R6	1
+      0x1C180303,  //  0005  EQ	R6	R1	R259
+      0x781A0006,  //  0006  JMPF	R6	#000E
+      0x8C180104,  //  0007  GETMET	R6	R0	R260
+      0x5C200400,  //  0008  MOVE	R8	R2
+      0x5C240600,  //  0009  MOVE	R9	R3
+      0x5C280800,  //  000A  MOVE	R10	R4
+      0x7C180800,  //  000B  CALL	R6	4
+      0x80040C00,  //  000C  RET	1	R6
+      0x70020038,  //  000D  JMP		#0047
+      0x1C180305,  //  000E  EQ	R6	R1	R261
+      0x781A0004,  //  000F  JMPF	R6	#0015
+      0x8C180106,  //  0010  GETMET	R6	R0	R262
+      0x5C200800,  //  0011  MOVE	R8	R4
+      0x7C180400,  //  0012  CALL	R6	2
+      0x80040C00,  //  0013  RET	1	R6
+      0x70020031,  //  0014  JMP		#0047
+      0x1C180307,  //  0015  EQ	R6	R1	R263
+      0x781A0002,  //  0016  JMPF	R6	#001A
+      0x4C180000,  //  0017  LDNIL	6
+      0x80040C00,  //  0018  RET	1	R6
+      0x7002002C,  //  0019  JMP		#0047
+      0x1C180308,  //  001A  EQ	R6	R1	R264
+      0x781A0003,  //  001B  JMPF	R6	#0020
+      0x8C180108,  //  001C  GETMET	R6	R0	R264
+      0x7C180200,  //  001D  CALL	R6	1
+      0x80040C00,  //  001E  RET	1	R6
+      0x70020026,  //  001F  JMP		#0047
+      0x88180109,  //  0020  GETMBR	R6	R0	R265
+      0x781A0024,  //  0021  JMPF	R6	#0047
+      0x60180000,  //  0022  GETGBL	R6	G0
+      0x881C0109,  //  0023  GETMBR	R7	R0	R265
+      0x7C180200,  //  0024  CALL	R6	1
+      0xA802001D,  //  0025  EXBLK	0	#0044
+      0x5C1C0C00,  //  0026  MOVE	R7	R6
+      0x7C1C0000,  //  0027  CALL	R7	0
+      0x8C200B0A,  //  0028  GETMET	R8	R5	R266
+      0x5C280E00,  //  0029  MOVE	R10	R7
+      0x5C2C0200,  //  002A  MOVE	R11	R1
+      0x7C200600,  //  002B  CALL	R8	3
+      0x60240015,  //  002C  GETGBL	R9	G21
+      0x5C281000,  //  002D  MOVE	R10	R8
+      0x7C240200,  //  002E  CALL	R9	1
+      0x1C24130B,  //  002F  EQ	R9	R9	R267
+      0x78260011,  //  0030  JMPF	R9	#0043
+      0xA8020004,  //  0031  EXBLK	0	#0037
+      0x5C241000,  //  0032  MOVE	R9	R8
+      0x5C280E00,  //  0033  MOVE	R10	R7
+      0x7C240200,  //  0034  CALL	R9	1
+      0xA8040001,  //  0035  EXBLK	1	1
+      0x7002000B,  //  0036  JMP		#0043
+      0xAC240002,  //  0037  CATCH	R9	0	2
+      0x70020008,  //  0038  JMP		#0042
+      0xA42E1800,  //  0039  IMPORT	R11	R268
+      0x6030000F,  //  003A  GETGBL	R12	G15
+      0x8C34170D,  //  003B  GETMET	R13	R11	R269
+      0x583C000E,  //  003C  LDCONST	R15	K14
+      0x5C401200,  //  003D  MOVE	R16	R9
+      0x5C441400,  //  003E  MOVE	R17	R10
+      0x7C340800,  //  003F  CALL	R13	4
+      0x7C300200,  //  0040  CALL	R12	1
+      0x70020000,  //  0041  JMP		#0043
+      0xB0080000,  //  0042  RAISE	2	R0	R0
+      0x7001FFE1,  //  0043  JMP		#0026
+      0x5818000F,  //  0044  LDCONST	R6	K15
+      0xAC180200,  //  0045  CATCH	R6	1	0
+      0xB0080000,  //  0046  RAISE	2	R0	R0
+      0x80000000,  //  0047  RET	0	R0
     })
   )
 );

--- a/lib/libesp32/Berry/default/embedded/Tasmota.be
+++ b/lib/libesp32/Berry/default/embedded/Tasmota.be
@@ -241,7 +241,7 @@ class Tasmota2 : Tasmota
 
   end
 
-  def event(type, cmd, idx, payload)
+  def event_old(type, cmd, idx, payload)
     if type=='every_50ms' self.run_deferred() end  #- first run deferred events -#
 
     if type=='cmd' return self.exec_cmd(cmd, idx, payload)
@@ -270,6 +270,29 @@ class Tasmota2 : Tasmota
         except .. as e,m
           import string
           print(string.format("BRY: Exception> '%s' - %s", e, m))
+        end
+      end
+    end
+  end
+
+  def event(event_type, cmd, idx, payload)
+    import introspect
+    if event_type=='every_50ms' self.run_deferred() end  #- first run deferred events -#
+
+    if event_type=='cmd' return self.exec_cmd(cmd, idx, payload)
+    elif event_type=='rule' return self.exec_rules(payload)
+    elif event_type=='mqtt_data' return nil
+    elif event_type=='gc' return self.gc()
+    elif self._drivers
+      for d:self._drivers
+        var f = introspect.get(d, event_type)   # try to match a function or method with the same name
+        if type(f) == 'function'
+          try
+            f(d)
+          except .. as e,m
+            import string
+            print(string.format("BRY: Exception> '%s' - %s", e, m))
+          end
         end
       end
     end

--- a/lib/libesp32/Berry/default/embedded/Tasmota.be
+++ b/lib/libesp32/Berry/default/embedded/Tasmota.be
@@ -241,40 +241,6 @@ class Tasmota2 : Tasmota
 
   end
 
-  def event_old(type, cmd, idx, payload)
-    if type=='every_50ms' self.run_deferred() end  #- first run deferred events -#
-
-    if type=='cmd' return self.exec_cmd(cmd, idx, payload)
-    elif type=='rule' return self.exec_rules(payload)
-    elif type=='mqtt_data' return nil
-    elif type=='gc' return self.gc()
-    elif self._drivers
-      for d:self._drivers
-        try
-          if   type=='every_second' && d.every_second                           d.every_second()
-          elif type=='every_50ms' && d.every_50ms                               d.every_50ms()
-          elif type=='every_100ms' && d.every_100ms                             d.every_100ms()
-          elif type=='web_add_button' && d.web_add_button                       d.web_add_button()
-          elif type=='web_add_main_button' && d.web_add_main_button             d.web_add_main_button()
-          elif type=='web_add_management_button' && d.web_add_management_button d.web_add_management_button()
-          elif type=='web_add_config_button' && d.web_add_config_button         d.web_add_config_button()
-          elif type=='web_add_console_button' && d.web_add_console_button       d.web_add_console_button()
-          elif type=='save_before_restart' && d.save_before_restart             d.save_before_restart()
-          elif type=='web_add_handler' && d.web_add_handler                     d.web_add_handler()
-          elif type=='web_sensor' && d.web_sensor                               d.web_sensor()
-          elif type=='json_append' && d.json_append                             d.json_append()
-          elif type=='button_pressed' && d.button_pressed                       d.button_pressed()
-          elif type=='web_add_handler' && d.display                             d.display()
-          elif type=='display' && d.display                                     d.display()
-          end
-        except .. as e,m
-          import string
-          print(string.format("BRY: Exception> '%s' - %s", e, m))
-        end
-      end
-    end
-  end
-
   def event(event_type, cmd, idx, payload)
     import introspect
     if event_type=='every_50ms' self.run_deferred() end  #- first run deferred events -#

--- a/lib/libesp32/Berry/default/embedded/lv_signal_bars.be
+++ b/lib/libesp32/Berry/default/embedded/lv_signal_bars.be
@@ -1,0 +1,106 @@
+#- LVGL lv_signal_bars and lv_wifi_bars
+ -
+--#
+
+class lv_signal_bars : lv_obj
+  var ancestor_design    # previous design_cb
+  var percentage
+  var p1, p2, line_dsc, area
+
+  def init(parent, copy)
+    import global
+    var lv = global.lv
+    # init parent object
+    super(self, global.lv_obj).init(parent, copy)
+    # keep a copy of 
+    self.ancestor_design = self.get_design_cb()
+    self.set_design_cb(self.my_design_cb)
+    # own values
+    self.percentage = 100
+    # pre-allocate buffers
+    self.p1 = global.lv_point()
+    self.p2 = global.lv_point()
+    self.line_dsc = global.lv_draw_line_dsc()
+    self.area = global.lv_area()
+  end
+
+  def atleast1(x) if x >= 1 return x else return 1 end end
+
+  def my_design_cb(area, mode)
+    import global
+    var lv = global.lv
+    #def atleast1(x) if x >= 1 return x else return 1 end end
+    # the model is that we have 4 bars and inter-bar (1/4 of width)
+    var height = self.get_height()
+    var width = self.get_width()
+
+    var inter_bar = self.atleast1(width / 15)
+    var bar = self.atleast1((width - inter_bar * 3) / 4)
+    var bar_offset = bar / 2
+
+    if mode == lv.DESIGN_COVER_CHK
+      #- Return false if the object is not covers the clip_area area -#
+      return self.ancestor_design.call(self, area, mode)
+
+    elif mode == lv.DESIGN_DRAW_MAIN
+      #self.ancestor_design.call(self, area, mode)  - don't draw a background
+    
+      # get coordinates of area
+      self.get_coords(area)
+      var x_ofs = area.x1
+      var y_ofs = area.y1
+
+      lv.draw_line_dsc_init(self.line_dsc)
+      self.init_draw_line_dsc(lv.OBJ_PART_MAIN, self.line_dsc)
+
+      self.line_dsc.round_start = 1
+      self.line_dsc.round_end = 1
+      self.line_dsc.width = bar
+      var on_color = self.get_style_line_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT)
+      var off_color = self.get_style_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT)
+
+      for i:0..3
+        self.line_dsc.color = self.percentage >= (i+1)*20 ? on_color : off_color
+        self.p1.y = y_ofs + height - 1 - bar_offset
+        self.p1.x = x_ofs + i * (bar + inter_bar) + bar_offset
+        self.p2.y = y_ofs + ((3 - i) * (height - bar)) / 4 + bar_offset
+        self.p2.x = self.p1.x
+        lv.draw_line(self.p1, self.p2, area, self.line_dsc)
+      end
+    #elif mode == lv.DESIGN_DRAW_POST    # we don't want a frame around this object
+      #self.ancestor_design.call(self, area, mode)
+    end
+    return lv.DESIGN_RES_OK
+  end
+
+  def set_percentage(v)
+    var old_bars = self.percentage / 5
+    if v > 100 v = 100 end
+    if v < 0   v = 0 end
+    self.percentage = v
+    if old_bars != v / 5
+      self.invalidate()    # be frugal and avoid updating the widget if it's not needed
+    end
+  end
+
+  def get_percentage()
+    return self.percentage
+  end
+end
+
+class lv_wifi_bars: lv_signal_bars
+  def init(parent, copy)
+    import global
+    super(self, global.lv_signal_bars).init(parent, copy)
+    global.tasmota.add_driver(self)
+  end
+
+  def every_second()
+    import global
+    var wifi = global.tasmota.wifi()
+    var quality = wifi.find("quality")
+    if quality != nil
+      self.set_percentage(quality)
+    end
+  end
+end

--- a/lib/libesp32/Berry/src/be_constobj.h
+++ b/lib/libesp32/Berry/src/be_constobj.h
@@ -144,7 +144,7 @@ const bntvmodule be_native_module(_module) = {                  \
 
 /* defines needed for solidified classes */
 #define be_local_class(_name, _nvar, _super, _map, _cname)      \
-  const bclass be_##_name##_class = {                                \
+  const bclass be_class_##_name = {                             \
     be_const_header(BE_CLASS),                                  \
     .nvar = _nvar,                                              \
     .super = (bclass*)_super,                                   \

--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -250,7 +250,7 @@ static void m_solidify_class(bvm *vm, bclass *cl, int builtins)
     logfmt("/*******************************************************************/\n\n");
 
     logfmt("void be_load_%s_class(bvm *vm) {\n", class_name);
-    logfmt("    be_pushntvclass(vm, &be_%s_class);\n", class_name);
+    logfmt("    be_pushntvclass(vm, &be_class_%s);\n", class_name);
     logfmt("    be_setglobal(vm, \"%s\");\n", class_name);
     logfmt("    be_pop(vm, 1);\n");
     logfmt("}\n");

--- a/tasmota/berry/lvgl_examples/lvgl_demo.be
+++ b/tasmota/berry/lvgl_examples/lvgl_demo.be
@@ -57,13 +57,10 @@ log_height = log.get_height()
 # log.get_style_pad_right(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT)
 log.set_style_local_pad_right(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, log_height+1)
 
-bars = lv_signal_bars(log)
+bars = lv_wifi_bars(log)
 
 bars.set_style_local_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(lv.BLACK))
 
 bars.set_height(log_height)
 bars.set_width(log_height)
 bars.set_x(log.get_width() - log_height)
-
-#bars.get_style_transform_width(lv.OBJ_PART_MAIN)
-#bars.get_style_transform_height(lv.OBJ_PART_MAIN)


### PR DESCRIPTION
## Description:

LVGL has now 2 new custom widgets for presenting radio signal strength (4 bars).
- `lv_signal_bars` is a general purpose signal bars widget. It adapts automatically the size of the bar to the bounding rectangle. Parameters are:
  - `bars.get_style_local_line_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(<color>))`: color of lines for enabled bars (good reception)
  - `bars.get_style_local_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(<color>))`: color of lines for disabled bars (bad reception)
- `lv_wifi_bars` is a subclass of the former, that updates the signal every second according to Tasmota Wifi signal strength

Example:
![lv_wifi_bars](https://user-images.githubusercontent.com/49731213/126906592-c57b2249-5ebe-4d49-b56e-6ce7ad273629.png)

From full example below:
```python
lv.start()

hres = lv.get_hor_res()
vres = lv.get_ver_res()

scr = lv.scr_act()
f20 = lv.montserrat_font(20)

scr.set_style_local_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(0x0000A0))
scr.set_style_local_bg_grad_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(0x000000))
scr.set_style_local_bg_grad_dir(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv.GRAD_DIR_VER)

log = lv_label(scr)
if f20 != nil log.set_style_local_text_font(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, f20) end
log.set_long_mode(lv.LABEL_LONG_SROLL)
log.set_width(hres)
log.set_align(lv.LABEL_ALIGN_LEFT)
log.set_style_local_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(0xD00000))
log.set_style_local_bg_opa(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv.OPA_COVER)
log.set_style_local_text_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(0xFFFFFF))
log.set_text("Welcome to Tasmota")

tastyle = lv_style()
tastyle.set_bg_color(lv.STATE_DEFAULT, lv_color(0x1fa3ec))
tastyle.set_border_color(lv.STATE_DEFAULT, lv_color(0x0000FF))
tastyle.set_bg_color(lv.STATE_FOCUSED, lv_color(0x0000FF))
tastyle.set_border_color(lv.STATE_FOCUSED, lv_color(0xFFFFFF))
tastyle.set_text_color(lv.STATE_DEFAULT, lv_color(0xFFFFFF))
tastyle.set_radius(lv.STATE_DEFAULT, 10)
tastyle.set_bg_opa(lv.STATE_DEFAULT, lv.OPA_COVER)
if f20 != nil tastyle.set_text_font(lv.STATE_DEFAULT, f20) end

prev_btn = lv_btn(scr)
prev_btn.set_pos(20,vres-40)
prev_btn.set_size(80, 30)
prev_btn.add_style(lv.OBJ_PART_MAIN, tastyle)
prev_label = lv_label(prev_btn)
prev_label.set_text("<")

next_btn = lv_btn(scr)
next_btn.set_pos(220,vres-40)
next_btn.set_size(80, 30)
next_btn.add_style(lv.OBJ_PART_MAIN, tastyle)
next_label = lv_label(next_btn)
next_label.set_text(">")

home_btn = lv_btn(scr)
home_btn.set_pos(120,vres-40)
home_btn.set_size(80, 30)
home_btn.add_style(lv.OBJ_PART_MAIN, tastyle)
home_label = lv_label(home_btn)
home_label.set_text(lv.SYMBOL_OK)

log_height = log.get_height()

# log.get_style_pad_right(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT)
log.set_style_local_pad_right(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, log_height+1)

bars = lv_wifi_bars(log)
bars.set_style_local_bg_color(lv.OBJ_PART_MAIN, lv.STATE_DEFAULT, lv_color(lv.BLACK))
bars.set_height(log_height)
bars.set_width(log_height)
bars.set_x(log.get_width() - log_height)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
