### PR TITLE
Berry fix solidified sub-protos

### DIFF
--- a/lib/libesp32/Berry/default/be_driverlib.c
+++ b/lib/libesp32/Berry/default/be_driverlib.c
@@ -46,12 +46,12 @@ be_local_closure(get_tasmota,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* upvals */
-      { { .s=be_nested_const_str("global", 503252654, 6) }, BE_STRING},
-      { { .s=be_nested_const_str("tasmota", 424643812, 7) }, BE_STRING},
+    ( &(const bvalue[ 2]) {     /* constants */
+      be_nested_string("global", 503252654, 6),
+      be_nested_string("tasmota", 424643812, 7),
     }),
     (be_nested_const_str("get_tasmota", 334356779, 11)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[ 3]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	R256
       0x88080301,  //  0001  GETMBR	R2	R1	R257
@@ -71,38 +71,40 @@ be_local_closure(add_cmd,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    be_nested_proto(
-      10,                          /* nstack */
-      4,                          /* argc */
-      1,                          /* has upvals */
-      ( &(const bupvaldesc[ 2]) {  /* upvals */
-        be_local_const_upval(1, 2),
-        be_local_const_upval(1, 0),
-      }),
-      0,                          /* has sup protos */
-      NULL,                       /* no sub protos */
-      0,                          /* has constants */
-      NULL,                       /* no const */
-      (be_nested_const_str("<lambda>", 607256038, 8)),
-      (be_nested_const_str("stdin", -1529146723, 5)),
-      ( &(const binstruction[ 8]) {  /* code */
-        0x68100000,  //  0000  GETUPV	R4	U0
-        0x68140001,  //  0001  GETUPV	R5	U1
-        0x5C180000,  //  0002  MOVE	R6	R0
-        0x5C1C0200,  //  0003  MOVE	R7	R1
-        0x5C200400,  //  0004  MOVE	R8	R2
-        0x5C240600,  //  0005  MOVE	R9	R3
-        0x7C100A00,  //  0006  CALL	R4	5
-        0x80040800,  //  0007  RET	1	R4
-      })
-    ),
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 2),
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        0,                          /* has constants */
+        NULL,                       /* no const */
+        (be_nested_const_str("<lambda>", 607256038, 8)),
+        (be_nested_const_str("input", -103256197, 5)),
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x68140001,  //  0001  GETUPV	R5	U1
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80040800,  //  0007  RET	1	R4
+        })
+      ),
+    }),
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* upvals */
-      { { .s=be_nested_const_str("get_tasmota", 334356779, 11) }, BE_STRING},
-      { { .s=be_nested_const_str("add_cmd", -933336417, 7) }, BE_STRING},
+    ( &(const bvalue[ 2]) {     /* constants */
+      be_nested_string("get_tasmota", 334356779, 11),
+      be_nested_string("add_cmd", -933336417, 7),
     }),
     (be_nested_const_str("add_cmd", -933336417, 7)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[ 8]) {  /* code */
       0x8C0C0100,  //  0000  GETMET	R3	R0	R256
       0x7C0C0200,  //  0001  CALL	R3	1

--- a/lib/libesp32/Berry/default/be_lvgl_signal_bars_lib.c
+++ b/lib/libesp32/Berry/default/be_lvgl_signal_bars_lib.c
@@ -8,93 +8,45 @@
 #include "lvgl.h"
 
 /********************************************************************
-** Solidified function: get_percentage
-********************************************************************/
-be_local_closure(get_percentage,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-      be_nested_string("percentage", -1756136011, 10),
-    }),
-    (be_nested_const_str("get_percentage", -1414483304, 14)),
-    (be_nested_const_str("input", -103256197, 5)),
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	R256
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_percentage
-********************************************************************/
-be_local_closure(set_percentage,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-      be_nested_string("percentage", -1756136011, 10),
-      be_const_int(0),
-      be_nested_string("invalidate", -1645232368, 10),
-    }),
-    (be_nested_const_str("set_percentage", -1342944572, 14)),
-    (be_nested_const_str("input", -103256197, 5)),
-    ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	R256
-      0x540E0004,  //  0001  LDINT	R3	5
-      0x0C080403,  //  0002  DIV	R2	R2	R3
-      0x540E0063,  //  0003  LDINT	R3	100
-      0x240C0203,  //  0004  GT	R3	R1	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x54060063,  //  0006  LDINT	R1	100
-      0x140C0301,  //  0007  LT	R3	R1	R257
-      0x780E0000,  //  0008  JMPF	R3	#000A
-      0x58040001,  //  0009  LDCONST	R1	K1
-      0x90020001,  //  000A  SETMBR	R0	R256	R1
-      0x540E0004,  //  000B  LDINT	R3	5
-      0x0C0C0203,  //  000C  DIV	R3	R1	R3
-      0x200C0403,  //  000D  NE	R3	R2	R3
-      0x780E0001,  //  000E  JMPF	R3	#0011
-      0x8C0C0102,  //  000F  GETMET	R3	R0	R258
-      0x7C0C0200,  //  0010  CALL	R3	1
-      0x80000000,  //  0011  RET	0	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: my_design_cb
 ********************************************************************/
 be_local_closure(my_design_cb,   /* name */
   be_nested_proto(
-    22,                          /* nstack */
+    23,                          /* nstack */
     3,                          /* argc */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+          be_const_int(1),
+        }),
+        (be_nested_const_str("atleast1", 1956331672, 8)),
+        (be_nested_const_str("input", -103256197, 5)),
+        ( &(const binstruction[ 6]) {  /* code */
+          0x28040100,  //  0000  GE	R1	R0	R256
+          0x78060001,  //  0001  JMPF	R1	#0004
+          0x80040000,  //  0002  RET	1	R0
+          0x70020000,  //  0003  JMP		#0005
+          0x80060000,  //  0004  RET	1	R256
+          0x80000000,  //  0005  RET	0	R0
+        })
+      ),
+    }),
     1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
+    ( &(const bvalue[34]) {     /* constants */
       be_nested_string("global", 503252654, 6),
       be_nested_string("lv", 1529997255, 2),
       be_nested_string("get_height", -723211773, 10),
       be_nested_string("get_width", -1001549996, 9),
-      be_nested_string("atleast1", 1956331672, 8),
       be_const_int(3),
       be_const_int(2),
       be_nested_string("DESIGN_COVER_CHK", -1298406708, 16),
@@ -128,117 +80,118 @@ be_local_closure(my_design_cb,   /* name */
     }),
     (be_nested_const_str("my_design_cb", -1173588798, 12)),
     (be_nested_const_str("input", -103256197, 5)),
-    ( &(const binstruction[110]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	R256
-      0x88100701,  //  0001  GETMBR	R4	R3	R257
-      0x8C140102,  //  0002  GETMET	R5	R0	R258
-      0x7C140200,  //  0003  CALL	R5	1
-      0x8C180103,  //  0004  GETMET	R6	R0	R259
-      0x7C180200,  //  0005  CALL	R6	1
-      0x8C1C0104,  //  0006  GETMET	R7	R0	R260
-      0x5426000E,  //  0007  LDINT	R9	15
-      0x0C240C09,  //  0008  DIV	R9	R6	R9
-      0x7C1C0400,  //  0009  CALL	R7	2
-      0x8C200104,  //  000A  GETMET	R8	R0	R260
-      0x08280F05,  //  000B  MUL	R10	R7	R261
-      0x04280C0A,  //  000C  SUB	R10	R6	R10
-      0x542E0003,  //  000D  LDINT	R11	4
-      0x0C28140B,  //  000E  DIV	R10	R10	R11
-      0x7C200400,  //  000F  CALL	R8	2
-      0x0C241106,  //  0010  DIV	R9	R8	R262
-      0x88280907,  //  0011  GETMBR	R10	R4	R263
-      0x1C28040A,  //  0012  EQ	R10	R2	R10
-      0x782A0007,  //  0013  JMPF	R10	#001C
-      0x88280108,  //  0014  GETMBR	R10	R0	R264
-      0x8C281509,  //  0015  GETMET	R10	R10	R265
-      0x5C300000,  //  0016  MOVE	R12	R0
-      0x5C340200,  //  0017  MOVE	R13	R1
-      0x5C380400,  //  0018  MOVE	R14	R2
-      0x7C280800,  //  0019  CALL	R10	4
-      0x80041400,  //  001A  RET	1	R10
-      0x7002004F,  //  001B  JMP		#006C
-      0x8828090A,  //  001C  GETMBR	R10	R4	R266
-      0x1C28040A,  //  001D  EQ	R10	R2	R10
-      0x782A004C,  //  001E  JMPF	R10	#006C
-      0x8C28010B,  //  001F  GETMET	R10	R0	R267
-      0x5C300200,  //  0020  MOVE	R12	R1
-      0x7C280400,  //  0021  CALL	R10	2
-      0x8828030C,  //  0022  GETMBR	R10	R1	R268
-      0x882C030D,  //  0023  GETMBR	R11	R1	R269
-      0x8C30090E,  //  0024  GETMET	R12	R4	R270
-      0x8838010F,  //  0025  GETMBR	R14	R0	R271
-      0x7C300400,  //  0026  CALL	R12	2
-      0x8C300110,  //  0027  GETMET	R12	R0	R272
-      0x88380911,  //  0028  GETMBR	R14	R4	R273
-      0x883C010F,  //  0029  GETMBR	R15	R0	R271
-      0x7C300600,  //  002A  CALL	R12	3
-      0x8830010F,  //  002B  GETMBR	R12	R0	R271
-      0x90322513,  //  002C  SETMBR	R12	R274	R275
-      0x8830010F,  //  002D  GETMBR	R12	R0	R271
-      0x90322913,  //  002E  SETMBR	R12	R276	R275
-      0x8830010F,  //  002F  GETMBR	R12	R0	R271
-      0x90322A08,  //  0030  SETMBR	R12	R277	R8
-      0x8C300116,  //  0031  GETMET	R12	R0	R278
-      0x88380911,  //  0032  GETMBR	R14	R4	R273
-      0x883C0917,  //  0033  GETMBR	R15	R4	R279
-      0x7C300600,  //  0034  CALL	R12	3
-      0x8C340118,  //  0035  GETMET	R13	R0	R280
-      0x883C0911,  //  0036  GETMBR	R15	R4	R273
-      0x88400917,  //  0037  GETMBR	R16	R4	R279
-      0x7C340600,  //  0038  CALL	R13	3
-      0x60380000,  //  0039  GETGBL	R14	G0
-      0x403E3305,  //  003A  CONNECT	R15	R281	R261
-      0x7C380200,  //  003B  CALL	R14	1
-      0xA802002B,  //  003C  EXBLK	0	#0069
-      0x5C3C1C00,  //  003D  MOVE	R15	R14
-      0x7C3C0000,  //  003E  CALL	R15	0
-      0x8840010F,  //  003F  GETMBR	R16	R0	R271
-      0x8844011B,  //  0040  GETMBR	R17	R0	R283
-      0x00481F13,  //  0041  ADD	R18	R15	R275
-      0x544E0013,  //  0042  LDINT	R19	20
-      0x08482413,  //  0043  MUL	R18	R18	R19
-      0x28442212,  //  0044  GE	R17	R17	R18
-      0x78460001,  //  0045  JMPF	R17	#0048
-      0x5C441800,  //  0046  MOVE	R17	R12
-      0x70020000,  //  0047  JMP		#0049
-      0x5C441A00,  //  0048  MOVE	R17	R13
-      0x90423411,  //  0049  SETMBR	R16	R282	R17
-      0x8840011C,  //  004A  GETMBR	R16	R0	R284
-      0x00441605,  //  004B  ADD	R17	R11	R5
-      0x04442313,  //  004C  SUB	R17	R17	R275
-      0x04442209,  //  004D  SUB	R17	R17	R9
-      0x90423A11,  //  004E  SETMBR	R16	R285	R17
-      0x8840011C,  //  004F  GETMBR	R16	R0	R284
-      0x00441007,  //  0050  ADD	R17	R8	R7
-      0x08441E11,  //  0051  MUL	R17	R15	R17
-      0x00441411,  //  0052  ADD	R17	R10	R17
-      0x00442209,  //  0053  ADD	R17	R17	R9
-      0x90423C11,  //  0054  SETMBR	R16	R286	R17
-      0x8840011F,  //  0055  GETMBR	R16	R0	R287
-      0x04460A0F,  //  0056  SUB	R17	R261	R15
-      0x04480A08,  //  0057  SUB	R18	R5	R8
-      0x08442212,  //  0058  MUL	R17	R17	R18
-      0x544A0003,  //  0059  LDINT	R18	4
-      0x0C442212,  //  005A  DIV	R17	R17	R18
-      0x00441611,  //  005B  ADD	R17	R11	R17
-      0x00442209,  //  005C  ADD	R17	R17	R9
-      0x90423A11,  //  005D  SETMBR	R16	R285	R17
-      0x8840011F,  //  005E  GETMBR	R16	R0	R287
-      0x8844011C,  //  005F  GETMBR	R17	R0	R284
-      0x8844231E,  //  0060  GETMBR	R17	R17	R286
-      0x90423C11,  //  0061  SETMBR	R16	R286	R17
-      0x8C400920,  //  0062  GETMET	R16	R4	R288
-      0x8848011C,  //  0063  GETMBR	R18	R0	R284
-      0x884C011F,  //  0064  GETMBR	R19	R0	R287
-      0x5C500200,  //  0065  MOVE	R20	R1
-      0x8854010F,  //  0066  GETMBR	R21	R0	R271
-      0x7C400A00,  //  0067  CALL	R16	5
-      0x7001FFD3,  //  0068  JMP		#003D
-      0x58380021,  //  0069  LDCONST	R14	K33
-      0xAC380200,  //  006A  CATCH	R14	1	0
-      0xB0080000,  //  006B  RAISE	2	R0	R0
-      0x88280922,  //  006C  GETMBR	R10	R4	R290
-      0x80041400,  //  006D  RET	1	R10
+    ( &(const binstruction[111]) {  /* code */
+      0x840C0000,  //  0000  CLOSURE	R3	P0
+      0xA4120000,  //  0001  IMPORT	R4	R256
+      0x88140901,  //  0002  GETMBR	R5	R4	R257
+      0x8C180102,  //  0003  GETMET	R6	R0	R258
+      0x7C180200,  //  0004  CALL	R6	1
+      0x8C1C0103,  //  0005  GETMET	R7	R0	R259
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x5C200600,  //  0007  MOVE	R8	R3
+      0x5426000E,  //  0008  LDINT	R9	15
+      0x0C240E09,  //  0009  DIV	R9	R7	R9
+      0x7C200200,  //  000A  CALL	R8	1
+      0x5C240600,  //  000B  MOVE	R9	R3
+      0x08281104,  //  000C  MUL	R10	R8	R260
+      0x04280E0A,  //  000D  SUB	R10	R7	R10
+      0x542E0003,  //  000E  LDINT	R11	4
+      0x0C28140B,  //  000F  DIV	R10	R10	R11
+      0x7C240200,  //  0010  CALL	R9	1
+      0x0C281305,  //  0011  DIV	R10	R9	R261
+      0x882C0B06,  //  0012  GETMBR	R11	R5	R262
+      0x1C2C040B,  //  0013  EQ	R11	R2	R11
+      0x782E0007,  //  0014  JMPF	R11	#001D
+      0x882C0107,  //  0015  GETMBR	R11	R0	R263
+      0x8C2C1708,  //  0016  GETMET	R11	R11	R264
+      0x5C340000,  //  0017  MOVE	R13	R0
+      0x5C380200,  //  0018  MOVE	R14	R1
+      0x5C3C0400,  //  0019  MOVE	R15	R2
+      0x7C2C0800,  //  001A  CALL	R11	4
+      0x80041600,  //  001B  RET	1	R11
+      0x7002004F,  //  001C  JMP		#006D
+      0x882C0B09,  //  001D  GETMBR	R11	R5	R265
+      0x1C2C040B,  //  001E  EQ	R11	R2	R11
+      0x782E004C,  //  001F  JMPF	R11	#006D
+      0x8C2C010A,  //  0020  GETMET	R11	R0	R266
+      0x5C340200,  //  0021  MOVE	R13	R1
+      0x7C2C0400,  //  0022  CALL	R11	2
+      0x882C030B,  //  0023  GETMBR	R11	R1	R267
+      0x8830030C,  //  0024  GETMBR	R12	R1	R268
+      0x8C340B0D,  //  0025  GETMET	R13	R5	R269
+      0x883C010E,  //  0026  GETMBR	R15	R0	R270
+      0x7C340400,  //  0027  CALL	R13	2
+      0x8C34010F,  //  0028  GETMET	R13	R0	R271
+      0x883C0B10,  //  0029  GETMBR	R15	R5	R272
+      0x8840010E,  //  002A  GETMBR	R16	R0	R270
+      0x7C340600,  //  002B  CALL	R13	3
+      0x8834010E,  //  002C  GETMBR	R13	R0	R270
+      0x90362312,  //  002D  SETMBR	R13	R273	R274
+      0x8834010E,  //  002E  GETMBR	R13	R0	R270
+      0x90362712,  //  002F  SETMBR	R13	R275	R274
+      0x8834010E,  //  0030  GETMBR	R13	R0	R270
+      0x90362809,  //  0031  SETMBR	R13	R276	R9
+      0x8C340115,  //  0032  GETMET	R13	R0	R277
+      0x883C0B10,  //  0033  GETMBR	R15	R5	R272
+      0x88400B16,  //  0034  GETMBR	R16	R5	R278
+      0x7C340600,  //  0035  CALL	R13	3
+      0x8C380117,  //  0036  GETMET	R14	R0	R279
+      0x88400B10,  //  0037  GETMBR	R16	R5	R272
+      0x88440B16,  //  0038  GETMBR	R17	R5	R278
+      0x7C380600,  //  0039  CALL	R14	3
+      0x603C0000,  //  003A  GETGBL	R15	G0
+      0x40423104,  //  003B  CONNECT	R16	R280	R260
+      0x7C3C0200,  //  003C  CALL	R15	1
+      0xA802002B,  //  003D  EXBLK	0	#006A
+      0x5C401E00,  //  003E  MOVE	R16	R15
+      0x7C400000,  //  003F  CALL	R16	0
+      0x8844010E,  //  0040  GETMBR	R17	R0	R270
+      0x8848011A,  //  0041  GETMBR	R18	R0	R282
+      0x004C2112,  //  0042  ADD	R19	R16	R274
+      0x54520013,  //  0043  LDINT	R20	20
+      0x084C2614,  //  0044  MUL	R19	R19	R20
+      0x28482413,  //  0045  GE	R18	R18	R19
+      0x784A0001,  //  0046  JMPF	R18	#0049
+      0x5C481A00,  //  0047  MOVE	R18	R13
+      0x70020000,  //  0048  JMP		#004A
+      0x5C481C00,  //  0049  MOVE	R18	R14
+      0x90463212,  //  004A  SETMBR	R17	R281	R18
+      0x8844011B,  //  004B  GETMBR	R17	R0	R283
+      0x00481806,  //  004C  ADD	R18	R12	R6
+      0x04482512,  //  004D  SUB	R18	R18	R274
+      0x0448240A,  //  004E  SUB	R18	R18	R10
+      0x90463812,  //  004F  SETMBR	R17	R284	R18
+      0x8844011B,  //  0050  GETMBR	R17	R0	R283
+      0x00481208,  //  0051  ADD	R18	R9	R8
+      0x08482012,  //  0052  MUL	R18	R16	R18
+      0x00481612,  //  0053  ADD	R18	R11	R18
+      0x0048240A,  //  0054  ADD	R18	R18	R10
+      0x90463A12,  //  0055  SETMBR	R17	R285	R18
+      0x8844011E,  //  0056  GETMBR	R17	R0	R286
+      0x044A0810,  //  0057  SUB	R18	R260	R16
+      0x044C0C09,  //  0058  SUB	R19	R6	R9
+      0x08482413,  //  0059  MUL	R18	R18	R19
+      0x544E0003,  //  005A  LDINT	R19	4
+      0x0C482413,  //  005B  DIV	R18	R18	R19
+      0x00481812,  //  005C  ADD	R18	R12	R18
+      0x0048240A,  //  005D  ADD	R18	R18	R10
+      0x90463812,  //  005E  SETMBR	R17	R284	R18
+      0x8844011E,  //  005F  GETMBR	R17	R0	R286
+      0x8848011B,  //  0060  GETMBR	R18	R0	R283
+      0x8848251D,  //  0061  GETMBR	R18	R18	R285
+      0x90463A12,  //  0062  SETMBR	R17	R285	R18
+      0x8C440B1F,  //  0063  GETMET	R17	R5	R287
+      0x884C011B,  //  0064  GETMBR	R19	R0	R283
+      0x8850011E,  //  0065  GETMBR	R20	R0	R286
+      0x5C540200,  //  0066  MOVE	R21	R1
+      0x8858010E,  //  0067  GETMBR	R22	R0	R270
+      0x7C440A00,  //  0068  CALL	R17	5
+      0x7001FFD3,  //  0069  JMP		#003E
+      0x583C0020,  //  006A  LDCONST	R15	K32
+      0xAC3C0200,  //  006B  CATCH	R15	1	0
+      0xB0080000,  //  006C  RAISE	2	R0	R0
+      0x882C0B21,  //  006D  GETMBR	R11	R5	R289
+      0x80041600,  //  006E  RET	1	R11
     })
   )
 );
@@ -246,29 +199,25 @@ be_local_closure(my_design_cb,   /* name */
 
 
 /********************************************************************
-** Solidified function: atleast1
+** Solidified function: get_percentage
 ********************************************************************/
-be_local_closure(atleast1,   /* name */
+be_local_closure(get_percentage,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
+    2,                          /* nstack */
+    1,                          /* argc */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-      be_const_int(1),
+      be_nested_string("percentage", -1756136011, 10),
     }),
-    (be_nested_const_str("atleast1", 1956331672, 8)),
+    (be_nested_const_str("get_percentage", -1414483304, 14)),
     (be_nested_const_str("input", -103256197, 5)),
-    ( &(const binstruction[ 6]) {  /* code */
-      0x28080300,  //  0000  GE	R2	R1	R256
-      0x780A0001,  //  0001  JMPF	R2	#0004
-      0x80040200,  //  0002  RET	1	R1
-      0x70020000,  //  0003  JMP		#0005
-      0x80060000,  //  0004  RET	1	R256
-      0x80000000,  //  0005  RET	0	R0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	R256
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -346,25 +295,68 @@ be_local_closure(init,   /* name */
 
 
 /********************************************************************
+** Solidified function: set_percentage
+********************************************************************/
+be_local_closure(set_percentage,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+      be_nested_string("percentage", -1756136011, 10),
+      be_const_int(0),
+      be_nested_string("invalidate", -1645232368, 10),
+    }),
+    (be_nested_const_str("set_percentage", -1342944572, 14)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[18]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	R256
+      0x540E0004,  //  0001  LDINT	R3	5
+      0x0C080403,  //  0002  DIV	R2	R2	R3
+      0x540E0063,  //  0003  LDINT	R3	100
+      0x240C0203,  //  0004  GT	R3	R1	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x54060063,  //  0006  LDINT	R1	100
+      0x140C0301,  //  0007  LT	R3	R1	R257
+      0x780E0000,  //  0008  JMPF	R3	#000A
+      0x58040001,  //  0009  LDCONST	R1	K1
+      0x90020001,  //  000A  SETMBR	R0	R256	R1
+      0x540E0004,  //  000B  LDINT	R3	5
+      0x0C0C0203,  //  000C  DIV	R3	R1	R3
+      0x200C0403,  //  000D  NE	R3	R2	R3
+      0x780E0001,  //  000E  JMPF	R3	#0011
+      0x8C0C0102,  //  000F  GETMET	R3	R0	R258
+      0x7C0C0200,  //  0010  CALL	R3	1
+      0x80000000,  //  0011  RET	0	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: lv_signal_bars
 ********************************************************************/
 extern const bclass be_class_lv_obj;
 be_local_class(lv_signal_bars,
     6,
     &be_class_lv_obj,
-    be_nested_map(11,
+    be_nested_map(10,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_nested_key("p1", -1605446022, 2, -1), be_const_index(2) },
-        { be_nested_key("get_percentage", -1414483304, 14, 5), be_const_closure(get_percentage_closure) },
-        { be_nested_key("set_percentage", -1342944572, 14, -1), be_const_closure(set_percentage_closure) },
-        { be_nested_key("p2", -1622223641, 2, -1), be_const_index(3) },
-        { be_nested_key("ancestor_design", 421545719, 15, -1), be_const_index(0) },
-        { be_nested_key("percentage", -1756136011, 10, 4), be_const_index(1) },
-        { be_nested_key("line_dsc", -200476318, 8, -1), be_const_index(4) },
         { be_nested_key("my_design_cb", -1173588798, 12, -1), be_const_closure(my_design_cb_closure) },
-        { be_nested_key("atleast1", 1956331672, 8, -1), be_const_closure(atleast1_closure) },
-        { be_nested_key("init", 380752755, 4, 8), be_const_closure(init_closure) },
-        { be_nested_key("area", -1693507260, 4, 3), be_const_index(5) },
+        { be_nested_key("get_percentage", -1414483304, 14, -1), be_const_closure(get_percentage_closure) },
+        { be_nested_key("init", 380752755, 4, 7), be_const_closure(init_closure) },
+        { be_nested_key("set_percentage", -1342944572, 14, 0), be_const_closure(set_percentage_closure) },
+        { be_nested_key("percentage", -1756136011, 10, 3), be_const_index(1) },
+        { be_nested_key("area", -1693507260, 4, -1), be_const_index(5) },
+        { be_nested_key("p2", -1622223641, 2, -1), be_const_index(3) },
+        { be_nested_key("line_dsc", -200476318, 8, 1), be_const_index(4) },
+        { be_nested_key("ancestor_design", 421545719, 15, -1), be_const_index(0) },
     })),
     (be_nested_const_str("lv_signal_bars", -780994737, 14))
 );

--- a/lib/libesp32/Berry/default/embedded/lv_signal_bars.be
+++ b/lib/libesp32/Berry/default/embedded/lv_signal_bars.be
@@ -24,18 +24,16 @@ class lv_signal_bars : lv_obj
     self.area = global.lv_area()
   end
 
-  def atleast1(x) if x >= 1 return x else return 1 end end
-
   def my_design_cb(area, mode)
+    def atleast1(x) if x >= 1 return x else return 1 end end
     import global
     var lv = global.lv
-    #def atleast1(x) if x >= 1 return x else return 1 end end
     # the model is that we have 4 bars and inter-bar (1/4 of width)
     var height = self.get_height()
     var width = self.get_width()
 
-    var inter_bar = self.atleast1(width / 15)
-    var bar = self.atleast1((width - inter_bar * 3) / 4)
+    var inter_bar = atleast1(width / 15)
+    var bar = atleast1((width - inter_bar * 3) / 4)
     var bar_offset = bar / 2
 
     if mode == lv.DESIGN_COVER_CHK

--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -110,13 +110,15 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
 
     logfmt("%*s%d,                          /* has sup protos */\n", indent, "", (pr->nproto > 0) ? 1 : 0);
     if (pr->nproto > 0) {
+        logfmt("%*s( &(const struct bproto*[%2d]) {\n", indent, "", pr->nproto);
         for (int32_t i = 0; i < pr->nproto; i++) {
             size_t sub_len = strlen(func_name) + 10;
             char sub_name[sub_len];
             snprintf(sub_name, sizeof(sub_name), "%s_%d", func_name, i);
-            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent);
+            m_solidify_proto(vm, pr->ptab[i], sub_name, builtins, indent+2);
             logfmt(",\n");
         }
+        logfmt("%*s}),\n", indent, "");
     } else {
         logfmt("%*sNULL,                       /* no sub protos */\n", indent, "");
     }


### PR DESCRIPTION
## Description:

Berry fix in solidification of functions containing sub-protos or closures, which would yield to a crash.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
