### PR TITLE
Berry solidified constants

### DIFF
--- a/lib/libesp32/Berry/default/be_lvgl_signal_wifi_lib.c
+++ b/lib/libesp32/Berry/default/be_lvgl_signal_wifi_lib.c
@@ -20,11 +20,11 @@ be_local_closure(init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-      be_nested_string("global", 503252654, 6),
-      be_nested_string("lv_signal_bars", -780994737, 14),
-      be_nested_string("init", 380752755, 4),
-      be_nested_string("tasmota", 424643812, 7),
-      be_nested_string("add_driver", 1654458371, 10),
+      be_nested_string("global", 503252654, 6),    /* R256 - K0 */
+      be_nested_string("lv_signal_bars", -780994737, 14),    /* R257 - K1 */
+      be_nested_string("init", 380752755, 4),    /* R258 - K2 */
+      be_nested_string("tasmota", 424643812, 7),    /* R259 - K3 */
+      be_nested_string("add_driver", 1654458371, 10),    /* R260 - K4 */
     }),
     (be_nested_const_str("init", 380752755, 4)),
     (be_nested_const_str("input", -103256197, 5)),
@@ -62,12 +62,12 @@ be_local_closure(every_second,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-      be_nested_string("global", 503252654, 6),
-      be_nested_string("tasmota", 424643812, 7),
-      be_nested_string("wifi", 120087624, 4),
-      be_nested_string("find", -1108310694, 4),
-      be_nested_string("quality", -1697296346, 7),
-      be_nested_string("set_percentage", -1342944572, 14),
+      be_nested_string("global", 503252654, 6),    /* R256 - K0 */
+      be_nested_string("tasmota", 424643812, 7),    /* R257 - K1 */
+      be_nested_string("wifi", 120087624, 4),    /* R258 - K2 */
+      be_nested_string("find", -1108310694, 4),    /* R259 - K3 */
+      be_nested_string("quality", -1697296346, 7),    /* R260 - K4 */
+      be_nested_string("set_percentage", -1342944572, 14),    /* R261 - K5 */
     }),
     (be_nested_const_str("every_second", 2075451465, 12)),
     (be_nested_const_str("input", -103256197, 5)),

--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -129,7 +129,7 @@ static void m_solidify_proto(bvm *vm, bproto *pr, const char * func_name, int bu
         for (int k = 0; k < pr->nconst; k++) {
             logfmt("%*s  ", indent, "");
             m_solidify_bvalue(vm, &pr->ktab[k]);
-            logfmt(",\n");
+            logfmt(",    /* R%d - K%d */\n", 256+k, k);
         }
         logfmt("%*s}),\n", indent, "");
     } else {


### PR DESCRIPTION
## Description:

Print explicit numbers for constants in solidified Berry code (cosmetic only, but helps reading generated code).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
