### PR TITLE
Add IP filter to TCPStart command

### DIFF
--- a/tasmota/xdrv_41_tcp_bridge.ino
+++ b/tasmota/xdrv_41_tcp_bridge.ino
@@ -35,6 +35,7 @@ WiFiServer   *server_tcp = nullptr;
 WiFiClient   client_tcp[TCP_BRIDGE_CONNECTIONS];
 uint8_t      client_next = 0;
 uint8_t     *tcp_buf = nullptr;     // data transfer buffer
+IPAddress    ip_filter = 0;
 
 #include <TasmotaSerial.h>
 TasmotaSerial *TCPSerial = nullptr;
@@ -60,12 +61,25 @@ void TCPLoop(void)
 
   // check for a new client connection
   if ((server_tcp) && (server_tcp->hasClient())) {
+    WiFiClient new_client = server_tcp->available();
+    
+    AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Got connection from %s"), new_client.remoteIP().toString().c_str());
+    // Check for IP filtering if it's enabled.
+    if (ip_filter) {
+      if (ip_filter != new_client.remoteIP()) {
+        AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Rejected due to filtering"));
+        new_client.stop();
+      } else {
+        AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Allowed through filter"));
+      }
+    }
+
     // find an empty slot
     uint32_t i;
     for (i=0; i<nitems(client_tcp); i++) {
       WiFiClient &client = client_tcp[i];
       if (!client) {
-        client = server_tcp->available();
+        client = new_client;
         break;
       }
     }
@@ -73,7 +87,7 @@ void TCPLoop(void)
       i = client_next++ % nitems(client_tcp);
       WiFiClient &client = client_tcp[i];
       client.stop();
-      client = server_tcp->available();
+      client = new_client;
     }
   }
 
@@ -139,12 +153,21 @@ void TCPInit(void) {
 \*********************************************************************************************/
 
 //
-// Command `ZbConfig`
+// Command `TCPStart`
+// Params: port,<IPv4 allow>
 //
 void CmndTCPStart(void) {
 
   if (!TCPSerial) { return; }
+
   int32_t tcp_port = XdrvMailbox.payload;
+  if (ArgC() == 2) {
+    char sub_string[XdrvMailbox.data_len];
+    ip_filter.fromString(ArgV(sub_string, 2));
+  } else {
+    // Disable whitelist if previously set
+    ip_filter = (uint32_t)0;
+  }
 
   if (server_tcp) {
     AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Stopping TCP server"));
@@ -159,6 +182,9 @@ void CmndTCPStart(void) {
   }
   if (tcp_port > 0) {
     AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Starting TCP server on port %d"), tcp_port);
+    if (ip_filter) {
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Filtering %s"), ip_filter.toString().c_str());
+    }
     server_tcp = new WiFiServer(tcp_port);
     server_tcp->begin(); // start TCP server
     server_tcp->setNoDelay(true);


### PR DESCRIPTION
## Description:

This is an optional second parameter to enable some *very basic* security around the `TCPStart` command. I run Home Assistant with the ZHA integration using the TCP Serial feature. The HTTP interface can be protected with a password and MQTT uses authentication, but there's no security measures on the TCP Serial bits. Of course there's no protocol to add authentication as such, but old NFS relied upon host-based security and it seems harmless to implement.

I'll update the docs as well, but I thought it best to see your thoughts as well beforehand.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3 *(I don't have ESP32 hardware)*
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
