### PR TITLE
Range extender [env] for esp8266

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -23,10 +23,6 @@ build_flags                 = ${esp82xx_defaults.build_flags}
                               -D USE_WIFI_RANGE_EXTENDER
                               -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
                               -D USE_WIFI_RANGE_EXTENDER_NAPT
-                              ;-D WIFI_RGX_SSID "rangeextender"
-                              ;-D WIFI_RGX_PASSWORD "securepassword"
-                              ;-D WIFI_RGX_IP_ADDRESS "10.99.1.1"
-                              ;-D WIFI_RGX_SUBNETMASK "255.255.255.0"
 
 ; *** Tasmota development core version ESP32 IDF3.3.5 / Currently none, same as default
 [env:tasmota32idf3]

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -18,7 +18,7 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 
 [env:tasmota-rangeextender]
 build_unflags               = ${esp_defaults.build_unflags}
-build_flags                 = ${esp_default.build_flags}
+build_flags                 = ${esp82xx_defaults.build_flags}
                               -D FIRMWARE_RANGE_EXTENDER
                               -D USE_WIFI_RANGE_EXTENDER
                               -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -16,6 +16,17 @@ build_flags                 = ${esp82xx_defaults.build_flags}
                               -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
                               -Wno-switch-unreachable
 
+[env:tasmota-rangeextender]
+build_unflags               = ${esp_defaults.build_unflags}
+build_flags                 = ${esp_default.build_flags}
+                              -D FIRMWARE_RANGE_EXTENDER
+                              -D USE_WIFI_RANGE_EXTENDER
+                              -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                              -D USE_WIFI_RANGE_EXTENDER_NAPT
+                              ;-D WIFI_RGX_SSID "rangeextender"
+                              ;-D WIFI_RGX_PASSWORD "securepassword"
+                              ;-D WIFI_RGX_IP_ADDRESS "10.99.1.1"
+                              ;-D WIFI_RGX_SUBNETMASK "255.255.255.0"
 
 ; *** Tasmota development core version ESP32 IDF3.3.5 / Currently none, same as default
 [env:tasmota32idf3]


### PR DESCRIPTION
in `platformio_tasmota_cenv.ini` to compile the variant tasmota-rangeextender

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
