### PR TITLE
Minor updates to Range Extender

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -20,8 +20,8 @@ build_flags                 = ${esp82xx_defaults.build_flags}
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
                               -D FIRMWARE_RANGE_EXTENDER
-                              -D USE_WIFI_RANGE_EXTENDER
                               -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                              -D USE_WIFI_RANGE_EXTENDER
                               -D USE_WIFI_RANGE_EXTENDER_NAPT
 
 ; *** Tasmota development core version ESP32 IDF3.3.5 / Currently none, same as default
@@ -86,6 +86,13 @@ build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
                               -Wno-switch-unreachable
                               ;-DESP32_STAGE=true
+
+[env:tasmota32-rangeextender]
+extends                     = env:tasmota32idf4
+build_flags                 = ${env:tasmota32idf4.build_flags} 
+                              -D FIRMWARE_TASMOTA32
+                              -D USE_WIFI_RANGE_EXTENDER
+                              -D USE_WIFI_RANGE_EXTENDER_NAPT
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -871,6 +871,8 @@ void SettingsDefaultSet2(void) {
   SettingsUpdateText(SET_HOSTNAME, WIFI_HOSTNAME);
   SettingsUpdateText(SET_RGX_SSID, PSTR(WIFI_RGX_SSID));
   SettingsUpdateText(SET_RGX_PASSWORD, PSTR(WIFI_RGX_PASSWORD));
+  Settings->sbflag1.range_extender = WIFI_RGX_STATE;
+  Settings->sbflag1.range_extender_napt = WIFI_RGX_NAPT;
 
   // Syslog
   SettingsUpdateText(SET_SYSLOG_HOST, PSTR(SYS_LOG_HOST));
@@ -1386,6 +1388,8 @@ void SettingsDelta(void) {
       ParseIPv4(&Settings->ipv4_address[4], PSTR(WIFI_DNS2));
     }
     if (Settings->version < 0x09050005) {
+      Settings->sbflag1.range_extender = WIFI_RGX_STATE;
+      Settings->sbflag1.range_extender_napt = WIFI_RGX_NAPT;
       ParseIPv4(&Settings->ipv4_rgx_address, PSTR(WIFI_RGX_IP_ADDRESS));
       ParseIPv4(&Settings->ipv4_rgx_subnetmask, PSTR(WIFI_RGX_SUBNETMASK));
       SettingsUpdateText(SET_RGX_SSID, PSTR(WIFI_RGX_SSID));

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -344,6 +344,12 @@ String EthernetMacAddress(void);
 #define STARTING_OFFSET             30         // NOVA SDS parameter used in settings
 #endif
 
+#ifndef WIFI_RGX_STATE
+#define WIFI_RGX_STATE              0
+#endif
+#ifndef WIFI_RGX_NAPT
+#define WIFI_RGX_NAPT               0
+#endif
 #ifndef WIFI_RGX_SSID
 #define WIFI_RGX_SSID               ""
 #endif


### PR DESCRIPTION
## Description:

Continuing on from #12784

I have made the `RgxState` and `RgxNAPT` have matching compile time constants to allow the firmware to have it default to on. Please let me know if I have done this incorrectly and I can correct.

I have also put in a few more comments, and changed RgxNAPT to reboot as well when disabled and in my testing I'm finding the ESP32 does not disable NAPT most of the time. I also realized that my editor (VScode) reformatted that file, sorry about that :(  - if you have a .vscode config I can use to match yours, I'll apply and update the PR.

To get this to work, I needed to comment out 2 lines in `AudioOutputI2S*.cpp`, I'll make an issue for this and assign to the author of those changes.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings (with exception mentioned above)
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 *V.2*
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
