### PR TITLE
Correct #if for compile time error notice in range_extender

### DIFF
--- a/tasmota/xdrv_58_range_extender.ino
+++ b/tasmota/xdrv_58_range_extender.ino
@@ -62,7 +62,7 @@ Backlog RgxSSID rangeextender ; RgxPassword securepassword ; RgxAddress 192.168.
 #warning **** USE_WIFI_RANGE_EXTENDER is enabled ****
 
 #ifdef ESP8266
-#ifdef LWIP_FEATURES
+#if LWIP_FEATURES
 // All good
 #else
 #error LWIP_FEATURES required, add "-D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH" to build_flags


### PR DESCRIPTION
## Description:

Very small one, apologies.

I stuffed up one of the `#if` definitions along the way when trying to tidy up the code and changed it to a `#ifdef`. This fixes that mistake to better notify the user if they are missing a compile time flag.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
