### PR TITLE
Add a Warning in UI if the web admin password is not set

### DIFF
--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Uitgewis sektor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Skakel JavaScript aan om Tasmota te gebruik"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware <br> gradeer asseblief op"
 #define D_WEBSERVER_ACTIVE_ON "Webbediener aktief op"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Изтрит сектор"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Разрешете JavaScript, за да използвате Tasmota"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Минимален фърмуер<br>моля надградете го"
 #define D_WEBSERVER_ACTIVE_ON "Уеб сървърът е активен на"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Smazaný sektor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Pro používání prostředí Tasmota povolte JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware MINIMÁLNÍ<br>prosím zaktualizujte"
 #define D_WEBSERVER_ACTIVE_ON "Aktivní Web server"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "gelöschter Sektor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "JavaScript aktivieren um Tasmota benutzen zu können"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMUM-Firmware<br>bitte upgraden"
 #define D_WEBSERVER_ACTIVE_ON "Web-Server aktiv bei"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Διαγραφή τομέα"
 
 // webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "To use Tasmota, please enable JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware<br>παρακαλώ αναβαθμίστε"
 #define D_WEBSERVER_ACTIVE_ON "Ενεργός διακομιστής Web στο"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -28,7 +28,7 @@
  * Use online command StateText to translate ON, OFF, HOLD and TOGGLE.
  * Use online command Prefix to translate cmnd, stat and tele.
  *
- * Updated until v9.4.0.1
+ * Updated until v9.5.0.3
 \*********************************************************************/
 
 //#define LANGUAGE_MODULE_NAME         // Enable to display "Module Generic" (ie Spanish), Disable to display "Generic Module" (ie English)
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Erased sector"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "To use Tasmota, please enable JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware<br>please upgrade"
 #define D_WEBSERVER_ACTIVE_ON "Web server active on"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Sector borrado"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Dispositivo Inseguro<br>Por favor, configure una clave para Web Admin"
 #define D_NOSCRIPT "Habilitar JavaScript para usar Tasmota"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware MÍNIMO<br>actualice por favor"
 #define D_WEBSERVER_ACTIVE_ON "Servidor web activo en"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Secteur effacé"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Pour utiliser Tasmota, veuillez activer JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware MINIMAL<br>merci de mettre à jour"
 #define D_WEBSERVER_ACTIVE_ON "Serveur web actif sur"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Sektor wiskje"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Aktivearje JavaScript foar Tasmota"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMALE firmware <br> upgrade"
 #define D_WEBSERVER_ACTIVE_ON "Webserver aktyf op"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "סקטור מחוק"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "JavaScript - כדי להשתמש בקושחת אסמוטה אנא הפעל"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "קושחה מינימלית<br>בבקשה אנא שדרג"
 #define D_WEBSERVER_ACTIVE_ON "שרת ווב פעיל"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Szektor törlése"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "A Tasmota használatához engedélyezd a Javascriptet!"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMÁLIS firmware<br>frissítsd!"
 #define D_WEBSERVER_ACTIVE_ON "Webszerver aktív:"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR          "Settore cancellato"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET                          "Dispositivo non Sicuro<br>Si prega di impostare una chiave admin web"
 #define D_NOSCRIPT                                 "Per usare Tasmota abilita JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE          "Firmware MINIMALE<br>Effettua aggiornamento"
 #define D_WEBSERVER_ACTIVE_ON                      "Server web attivo in"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "삭제된 섹터"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Tasmota를 사용하려면 JavaScript를 활성화 하십시오."
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware<br>업그레이드가 필요합니다"
 #define D_WEBSERVER_ACTIVE_ON "Web 서버 작동 중"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Wis sector"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Zet JavaScript aan voor Tasmota"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware<br>opwaarderen"
 #define D_WEBSERVER_ACTIVE_ON "Webserver actief op"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Sektor wymazany"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Aby korzystać z Tasmota, włącz obsługę JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Oprogramowanie MINIMAL<br>proszę uaktualnić"
 #define D_WEBSERVER_ACTIVE_ON "Aktywny serwer Web"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Apagar setores"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Dispositivo Inseguro<br>Por favor, defina uma senha de admin web"
 #define D_NOSCRIPT "Para usar o Tasmota, por favor habilite o  JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware mínimo<br>Atualizar por favor"
 #define D_WEBSERVER_ACTIVE_ON "Servidor WEB ativo em"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Apagado setor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Dispositivo Inseguro<br>Por favor, defina uma Palavra Chave<br>de admin web"
 #define D_NOSCRIPT "Para utilizar o Tasmota, por favor ative o JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware MÍNIMO<br>Por favor atualize"
 #define D_WEBSERVER_ACTIVE_ON "Servidor WEB ativo em"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Sector șters"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Pentru a folosi Tasmota, vă rugăm activați JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "firmware MINIMAL<br>vă rugăm actualizați"
 #define D_WEBSERVER_ACTIVE_ON "Server Web activ"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Стереть сектор"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "To use Tasmota, please enable JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Прошивка MINIMAL<br>пожалуйста обновите"
 #define D_WEBSERVER_ACTIVE_ON "Веб-сервер активен"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Zmazaný sektor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Pre používanie prostredia Tasmota povoľte JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Firmware MINIMÁLNY<br>prosím aktualizujte"
 #define D_WEBSERVER_ACTIVE_ON "Aktívny Web server"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Rensade sektor"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "För att använda Tasmota, aktivera JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL firmware<br>var god uppgradera"
 #define D_WEBSERVER_ACTIVE_ON "Webbserver aktiv på"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Sektör temizlendi"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "To use Tasmota, please enable JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Donanım yazılımı çok düşük<br>lütfen yükseltin"
 #define D_WEBSERVER_ACTIVE_ON "Web sunucusu aktif"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Стерто сектор"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Для використання Tasmota треба увімкнути JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Прошивка MINIMAL<br>будь-ласка оновіть"
 #define D_WEBSERVER_ACTIVE_ON "Веб-сервер активний"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "Khu vực bị xóa"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Để sử dụng Tasmota, vui lòng bật JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "Đang sử dụng bản MINIMAL <br>vui lòng nâng cấp"
 #define D_WEBSERVER_ACTIVE_ON "Máy chủ Web đã bật"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "擦除扇区"
 
 // webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "Tasmota 要求浏览器支持 JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "当前是精简版固件<br>请升级"
 #define D_WEBSERVER_ACTIVE_ON "Web 服务器地址:"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -240,6 +240,7 @@
 #define D_ERASED_SECTOR "抹除磁區"
 
 // xdrv_02_webserver.ino
+#define D_NO_PASSWORD_SET "Device Insecure<br>Please set a Web Admin Password"
 #define D_NOSCRIPT "為了要使用 Tasmota，請啟用 JavaScript"
 #define D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "MINIMAL韌體<br>請升級"
 #define D_WEBSERVER_ACTIVE_ON "網頁伺服器已經啟動，位於:"

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -234,6 +234,8 @@ const char HTTP_HEAD_STYLE3[] PROGMEM =
   "<div style='text-align:left;display:inline-block;color:#%06x;min-width:340px;'>"  // COLOR_TEXT
 #ifdef FIRMWARE_MINIMAL
   "<div style='text-align:center;color:#%06x;'><h3>" D_MINIMAL_FIRMWARE_PLEASE_UPGRADE "</h3></div>"  // COLOR_TEXT_WARNING
+#else
+  "<div style='text-align:center;color:#%06x;display:%s;'><h3>" D_NO_PASSWORD_SET "</h3></div>"  // COLOR_TEXT_WARNING
 #endif
   "<div style='text-align:center;color:#%06x;'><noscript>" D_NOSCRIPT "<br></noscript>" // COLOR_TITLE
 /*
@@ -816,12 +818,16 @@ void WSContentSendStyle_P(const char* formatP, ...) {
     _WSContentSendBuffer(false, formatP, arg);
     va_end(arg);
   }
-  WSContentSend_P(HTTP_HEAD_STYLE3, WebColor(COL_TEXT),
-#ifdef FIRMWARE_MINIMAL
-  WebColor(COL_TEXT_WARNING),
+  WSContentSend_P(HTTP_HEAD_STYLE3,
+                    WebColor(COL_TEXT),
+                    WebColor(COL_TEXT_WARNING),
+#ifndef FIRMWARE_MINIMAL
+                    ( (WifiIsInManagerMode()) || (strlen(SettingsText(SET_WEBPWD))) ) ? "none" : "initial",
 #endif
-  WebColor(COL_TITLE),
-  (Web.initial_config) ? "" : ModuleName().c_str(), SettingsText(SET_DEVICENAME));
+                    WebColor(COL_TITLE),
+                    (Web.initial_config) ? "" : ModuleName().c_str(),
+                    SettingsText(SET_DEVICENAME)
+                  );
 
   // SetOption53 - Show hostname and IP address in GUI main menu
 #if (RESTART_AFTER_INITIAL_WIFI_CONFIG)


### PR DESCRIPTION
## Description:

Add a Warning in Tasmota User Interface if the **_web admin password_** is not set.

To set the **_web admin password_**, you can go to CONFIGURATIONS -> CONFIG OTHER -> Web Admin Password.
Or
In the console by `webpassword` command.

Then, after restart, your browser will ask for Username and Password. By default the username is `admin`. The username can be changed by using the key `WEB_USERNAME` in the _user_config_override.h_ file.

As the password is for securing the HTTP API and the web interface, this warning is not published by MQTT nor Serial. Only in the web UI.

This continues the PR: https://github.com/arendst/Tasmota/pull/12827

![image](https://user-images.githubusercontent.com/35405447/128411263-71364f81-286f-4ddd-9c8d-3ca400979ed8.png)

**Related issue (if applicable):** https://github.com/arendst/Tasmota/issues/6767

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
