### PR TITLE
gzip map file to save disk space

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -6,10 +6,31 @@ import gzip
 platform = env.PioPlatform()
 board = env.BoardConfig()
 mcu = board.get("build.mcu", "esp32")
+
+OUTPUT_DIR = "build_output{}".format(os.path.sep)
+
+def map_gzip(source, target, env):
+    variant = str(target[0]).split(os.path.sep)[2]
+
+    # create string with location and file names based on variant
+    bin_file = "{}map{}{}.map".format(OUTPUT_DIR, os.path.sep, variant)
+    gzip_file = "{}map{}{}.map.gz".format(OUTPUT_DIR, os.path.sep, variant)
+
+    # check if new target map files exist and remove if necessary
+    if os.path.isfile(gzip_file): os.remove(gzip_file)
+
+    # write gzip map file
+    with open(bin_file,"rb") as fp:
+        with gzip.open(gzip_file, "wb", compresslevel = 9) as f:
+            shutil.copyfileobj(fp, f)
+
+    # remove map file
+    if os.path.isfile(bin_file): os.remove(bin_file)
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [map_gzip])
+
 # gzip only for ESP8266
 if env["PIOPLATFORM"] != "espressif32":
-
-    OUTPUT_DIR = "build_output{}".format(os.path.sep)
 
     def bin_gzip(source, target, env):
         variant = str(target[0]).split(os.path.sep)[2]
@@ -33,5 +54,5 @@ if env["PIOPLATFORM"] != "espressif32":
             print("\u001b[31;1m!!! Tasmota firmware size is too big with {} bytes. Max size is 995326 bytes !!! \u001b[0m".format(ORG_FIRMWARE_SIZE))
         else:
             print("Compression reduced firmware size by {:.0f}% (was {} bytes, now {} bytes)".format((GZ_FIRMWARE_SIZE / ORG_FIRMWARE_SIZE) * 100, ORG_FIRMWARE_SIZE, GZ_FIRMWARE_SIZE))
-            
+
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])


### PR DESCRIPTION
map files can get big and need a lot of space when storing uncompressed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
