### PR TITLE
Store Tasmota firmware files in repo `Tasmota-firmware`

### DIFF
--- a/.github/workflows/Tasmota_build_development.yml
+++ b/.github/workflows/Tasmota_build_development.yml
@@ -1,4 +1,4 @@
-name: Build_firmware
+name: Build_firmware_development
 
 on:
   workflow_dispatch:  # Manually start a workflow
@@ -25,7 +25,6 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: 'development'
-        force: true
 
 
   tasmota:
@@ -1393,13 +1392,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: firmware
-    - name: Display files from branch firmware
-      run: ls -R
-    - name: Remove old firmware files
-      run: rm -rf ./firmware/*
     - uses: actions/download-artifact@v2
       with:
         name: firmware
@@ -1411,8 +1403,6 @@ jobs:
       run: |
         mkdir -p ./firmware/tasmota/languages
         mkdir -p ./firmware/tasmota32/languages
-        mkdir -p ./firmware/tasmota32/ESP32_needed_files/
-        mkdir -p ./firmware/tasmota32/Odroid_go_and_core2_needed_files/
         mkdir -p ./firmware/map
         [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./firmware/map/
         [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./firmware/tasmota/
@@ -1435,31 +1425,14 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
-        [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
-        [ ! -f ./tools/Esptool/Odroid_go_and_core2/*.* ] || mv ./tools/Esptool/Odroid_go_and_core2/*.* ./firmware/tasmota32/Odroid_go_and_core2_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./FIRMWARE.md ./README.md
-    - uses: actions/checkout@v2
-      with:
-        ref: release-firmware
-        path: tmp-folder
-    - name: Display files from branch release-firmware
-      run: |
-        ls -R ./tmp-folder
-        mkdir -p ./release-firmware/
-        cp -rf ./tmp-folder/firmware/* ./release-firmware/
-        rm -rf ./tmp-folder
-    - name: Display files to commit
+    - name: Display files to transfer
       run: ls -R ./*
-    - name: Commit files  # transfer the new binaries back into the repository
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git rm -r --cached .
-        git add -f ./*
-        git commit -m "Tasmota ESP Binaries http://tasmota.com"
-    - name: Push changes  # push the firmware files to branch firmware
-      uses: ad-m/github-push-action@master
+    - name: Push Firmware files to https://github.com/arendst/Tasmota-firmware
+      uses: dmnemec/copy_file_to_another_repo_action@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: 'firmware'
-        force: true
+        source_file: 'firmware'
+        destination_repo: 'arendst/Tasmota-firmware'
+        user_email: 'github-actions@github.com'
+        user_name: 'github-actions'

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -24,7 +24,6 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: 'master'
-        force: true
 
 
   tasmota:
@@ -1412,8 +1411,6 @@ jobs:
       run: |
         mkdir -p ./firmware/tasmota/languages
         mkdir -p ./firmware/tasmota32/languages
-        mkdir -p ./firmware/tasmota32/ESP32_needed_files/
-        mkdir -p ./firmware/tasmota32/Odroid_go_and_core2_needed_files/
         mkdir -p ./firmware/map
         [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./firmware/map/
         [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./firmware/tasmota/
@@ -1436,20 +1433,15 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./firmware/tasmota32/languages/
         [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
-        [ ! -f ./tools/Esptool/ESP32/*.* ] || mv ./tools/Esptool/ESP32/*.* ./firmware/tasmota32/ESP32_needed_files/
-        [ ! -f ./tools/Esptool/Odroid_go_and_core2/*.* ] || mv ./tools/Esptool/Odroid_go_and_core2/*.* ./firmware/tasmota32/Odroid_go_and_core2_needed_files/
-        [ ! -f ./FIRMWARE.md ] || mv -f ./RELEASENOTES.md ./README.md
-    - name: Commit files  # transfer the new binaries back into the repository
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git rm -r --cached .
-        git add ./README.md
-        git add -f ./firmware/*.*
-        git commit -m "Tasmota ESP Binaries http://tasmota.com"
-    - name: Push changes  # push the firmware files to branch firmware
-      uses: ad-m/github-push-action@master
+    - name: Display files
+      run: ls -R ./*
+    - name: Push Firmware files to https://github.com/arendst/Tasmota-firmware
+      uses: dmnemec/copy_file_to_another_repo_action@main
+      env:
+        API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: 'release-firmware'
-        force: true
+        source_file: 'firmware'
+        destination_repo: 'arendst/Tasmota-firmware'
+        destination_folder: 'release-firmware'
+        user_email: 'github-actions@github.com'
+        user_name: 'github-actions'

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -1409,30 +1409,30 @@ jobs:
 
     - name: Move firmware files in sub-folders
       run: |
-        mkdir -p ./firmware/tasmota/languages
-        mkdir -p ./firmware/tasmota32/languages
-        mkdir -p ./firmware/map
-        [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./firmware/map/
-        [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-sensors.* ] || mv ./mv_firmware/firmware/tasmota-sensors.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-minimal.* ] || mv ./mv_firmware/firmware/tasmota-minimal.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-lite.* ] || mv ./mv_firmware/firmware/tasmota-lite.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-ir*.* ] || mv ./mv_firmware/firmware/tasmota-ir*.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-knx.* ] || mv ./mv_firmware/firmware/tasmota-knx.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota-zigbee.* ] || mv ./mv_firmware/firmware/tasmota-zigbee.* ./firmware/tasmota/
-        [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32solo1*.* ] || mv ./mv_firmware/firmware/tasmota32solo1*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-lvgl.* ] || mv ./mv_firmware/firmware/tasmota32-lvgl.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./firmware/tasmota32/
-        [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./firmware/tasmota32/languages/
-        [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./firmware/tasmota/languages/
+        mkdir -p ./release-firmware/tasmota/languages
+        mkdir -p ./release-firmware/tasmota32/languages
+        mkdir -p ./release-firmware/map
+        [ ! -f ./mv_firmware/map/* ] || mv ./mv_firmware/map/* ./release-firmware/map/
+        [ ! -f ./mv_firmware/firmware/tasmota.* ] || mv ./mv_firmware/firmware/tasmota.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-sensors.* ] || mv ./mv_firmware/firmware/tasmota-sensors.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-minimal.* ] || mv ./mv_firmware/firmware/tasmota-minimal.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-lite.* ] || mv ./mv_firmware/firmware/tasmota-lite.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-ir*.* ] || mv ./mv_firmware/firmware/tasmota-ir*.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-display.* ] || mv ./mv_firmware/firmware/tasmota-display.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-knx.* ] || mv ./mv_firmware/firmware/tasmota-knx.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-zbbridge.* ] || mv ./mv_firmware/firmware/tasmota-zbbridge.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota-zigbee.* ] || mv ./mv_firmware/firmware/tasmota-zigbee.* ./release-firmware/tasmota/
+        [ ! -f ./mv_firmware/firmware/tasmota32.* ] || mv ./mv_firmware/firmware/tasmota32.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32solo1*.* ] || mv ./mv_firmware/firmware/tasmota32solo1*.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-ir*.* ] || mv ./mv_firmware/firmware/tasmota32-ir*.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-lvgl.* ] || mv ./mv_firmware/firmware/tasmota32-lvgl.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32* ] || mv ./mv_firmware/firmware/tasmota32* ./release-firmware/tasmota32/languages/
+        [ ! -f ./mv_firmware/firmware/* ] || mv ./mv_firmware/firmware/* ./release-firmware/tasmota/languages/
     - name: Display files
       run: ls -R ./*
     - name: Push Firmware files to https://github.com/arendst/Tasmota-firmware
@@ -1440,8 +1440,7 @@ jobs:
       env:
         API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
       with:
-        source_file: 'firmware'
+        source_file: 'release-firmware'
         destination_repo: 'arendst/Tasmota-firmware'
-        destination_folder: 'release-firmware'
         user_email: 'github-actions@github.com'
         user_name: 'github-actions'


### PR DESCRIPTION
Storing the firmware files makes the Tasmota repo big. It takes very long to clone the repo with a low bandwidth internet connection. By this PR the firmware files are stored not anymore in the `Tasmota` repo. The firmware files are stored now in the repo `Tasmota-firmware`. If a new release is done the release firmware files will be automated updated there too

@arendst 
- Before you merge you have to add a github secret token! 
- Please activate github pages in `Tasmota-firmware` to enable the Tasmota Web Flasher.

How to add a Github token:
- Go to the Github Settings (on the right hand side on the profile picture)
- On the left hand side pane click on "Developer Settings"
- Click on "Personal Access Tokens" (also available at https://github.com/settings/tokens)
- Generate a new token, choose "Repo". Copy the token.

Then make the token available to the Github Action following the steps:
- Go to the Github page for the repository that you push from, click on "Settings"
- On the left hand side pane click on "Secrets"
- Click on "Add a new secret" and name it "API_TOKEN_GITHUB"

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
