### PR TITLE
Prometheus: Always use prefix and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 - Make Sonoff L1 MusicSync persistent (#12008)
 - Relax NTP poll if no ntpserver can be resolved by DNS
 - Move firmware binaries to https://github.com/arendst/Tasmota-firmware/tree/main/release-firmware
+- Prometheus: All metrics are prefixed with ``tasmota_``; memory metrics have
+  been cleaned up to work consistently between ESP8266 and ESP32; the device
+  name is reported as an info metric
 
 ### Fixed
 - Neopool communication error (#12813)

--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -78,16 +78,15 @@ String FormatMetricName(const char *metric) {
 }
 
 const uint8_t
-  kPromMetricNoPrefix = _BV(1),
-  kPromMetricGauge = _BV(2),
-  kPromMetricCounter = _BV(3),
+  kPromMetricGauge = _BV(0),
+  kPromMetricCounter = _BV(1),
   kPromMetricTypeMask = kPromMetricGauge | kPromMetricCounter;
 
 // Format and send a Prometheus metric to the client. Use flags to configure
 // the type. Labels must be supplied in tuples of two character array pointers
 // and terminated by nullptr.
 void WritePromMetric(const char *name, uint8_t flags, const char *value, va_list labels) {
-  PGM_P const prefix = (flags & kPromMetricNoPrefix) ? PSTR("") : PSTR("tasmota_");
+  PGM_P const prefix = PSTR("tasmota_");
   PGM_P tmp;
   String lval;
 
@@ -258,29 +257,27 @@ void HandleMetrics(void) {
 #endif
 
 #ifdef USE_ENERGY_SENSOR
-  // TODO: Don't disable prefix on energy metrics
   WritePromMetricDec(PSTR("energy_voltage_volts"),
-    kPromMetricGauge | kPromMetricNoPrefix,
+    kPromMetricGauge,
     Energy.voltage[0], Settings->flag2.voltage_resolution, nullptr);
   WritePromMetricDec(PSTR("energy_current_amperes"),
-    kPromMetricGauge | kPromMetricNoPrefix,
+    kPromMetricGauge,
     Energy.current[0], Settings->flag2.current_resolution, nullptr);
   WritePromMetricDec(PSTR("energy_power_active_watts"),
-    kPromMetricGauge | kPromMetricNoPrefix,
+    kPromMetricGauge,
     Energy.active_power[0], Settings->flag2.wattage_resolution, nullptr);
   WritePromMetricDec(PSTR("energy_power_kilowatts_daily"),
-    kPromMetricCounter | kPromMetricNoPrefix,
+    kPromMetricCounter,
     Energy.daily, Settings->flag2.energy_resolution, nullptr);
   WritePromMetricDec(PSTR("energy_power_kilowatts_total"),
-    kPromMetricCounter | kPromMetricNoPrefix,
+    kPromMetricCounter,
     Energy.total, Settings->flag2.energy_resolution, nullptr);
 #endif
 
   for (uint32_t device = 0; device < TasmotaGlobal.devices_present; device++) {
     power_t mask = 1 << device;
-    // TODO: Don't disable prefix
     snprintf_P(namebuf, sizeof(namebuf), PSTR("relay%d_state"), device + 1);
-    WritePromMetricInt32(namebuf, kPromMetricGauge | kPromMetricNoPrefix,
+    WritePromMetricInt32(namebuf, kPromMetricGauge,
       (TasmotaGlobal.power & mask), nullptr);
   }
 


### PR DESCRIPTION
## Description:

Implement TODOs to apply the `tasmota_` prefix on all metrics and describe the changes from #12624 and #12692 in changelog.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
    - Compilation test only.
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7
    - Compilation test only.
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
