### PR TITLE
Set LEDs to max PWM value

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2000,7 +2000,14 @@ void LightApplyPower(uint8_t new_color[LST_MAX], power_t power) {
 void LightSetOutputs(const uint16_t *cur_col_10) {
   // now apply the actual PWM values, adjusted and remapped 10-bits range
   if (TasmotaGlobal.light_type < LT_PWM6) {   // only for direct PWM lights, not for Tuya, Armtronix...
+#ifdef USE_PWM_DIMMER
+    uint16_t max_col = 0;
+#endif  // USE_PWM_DIMMER
     for (uint32_t i = 0; i < (Light.subtype - Light.pwm_offset); i++) {
+      uint16_t cur_col = cur_col_10[i + Light.pwm_offset];
+#ifdef USE_PWM_DIMMER
+      if (cur_col > max_col) max_col = cur_col;
+#endif  // USE_PWM_DIMMER
       if (PinUsed(GPIO_PWM1, i)) {
         //AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_APPLICATION "Cur_Col%d 10 bits %d"), i, cur_col_10[i]);
         uint16_t cur_col = cur_col_10[i + Light.pwm_offset];
@@ -2010,12 +2017,12 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         if (!Settings->flag4.zerocross_dimmer) {
           analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
         }
-#ifdef USE_PWM_DIMMER
-        // Animate brightness LEDs to follow PWM dimmer brightness
-        if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(change10to8(cur_col));
-#endif  // USE_PWM_DIMMER
       }
     }
+#ifdef USE_PWM_DIMMER
+    // Animate brightness LEDs to follow PWM dimmer brightness
+    if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(change10to8(max_col));
+#endif  // USE_PWM_DIMMER
   }
 //  char msg[24];
 //  AddLog(LOG_LEVEL_DEBUG, PSTR("LGT: Channels %s"), ToHex_P((const unsigned char *)cur_col_10, 10, msg, sizeof(msg)));


### PR DESCRIPTION
## Description:

The PWM Dimmer brightness LEDs were being set to the value of the highest-numbered PWM pin in use. When PWMDimmerPWMs is set, we want the LEDs to be set to the highest PWM value of all the virtual PWMs even though there is only one real PWM.

**Related issue (if applicable):** fixes #12860

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
