### PR TITLE
Slower than 1Hz PWM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Support for (Yeelight) Mi Desk Pro using binary tasmota32solo1.bin
 - Initial support for influxdb using ``#define USE_INFLUXDB`` and several ``Ifx`` commands
 - Command ``SetOption128 1`` disabling web referer check default blocking HTTP web commands (#12828)
-- Initial support for PWM with slower than 1Hz periods using ``#define USE_SLOW_PWM`` and ``SlowPwmPeriod`` command
+- Initial support for PWM with slower than 1Hz periods using ``#define USE_SLOW_PWM`` and ``SlowPwmPeriod`` command (#12890)
 
 ### Changed
 - NeoPixelBus library from v2.6.3 to v2.6.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Support for (Yeelight) Mi Desk Pro using binary tasmota32solo1.bin
 - Initial support for influxdb using ``#define USE_INFLUXDB`` and several ``Ifx`` commands
 - Command ``SetOption128 1`` disabling web referer check default blocking HTTP web commands (#12828)
+- Initial support for PWM with slower than 1Hz periods using ``#define USE_SLOW_PWM`` and ``SlowPwmPeriod`` command
 
 ### Changed
 - NeoPixelBus library from v2.6.3 to v2.6.7

--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -281,6 +281,7 @@
 #define D_CMND_GPIOS "GPIOs"
 #define D_CMND_PWM "PWM"
 #define D_CMND_PWMFREQUENCY "PWMFrequency"
+#define D_CMND_SLOWPWMPERIOD "SlowPWMPeriod"
 #define D_CMND_PWMRANGE "PWMRange"
 #define D_CMND_BUTTONDEBOUNCE "ButtonDebounce"
 #define D_CMND_SWITCHDEBOUNCE "SwitchDebounce"

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -587,8 +587,9 @@ typedef struct {
 
   uint16_t      influxdb_port;             // 4CE
   power_t       interlock[MAX_INTERLOCKS_SET];  // 4D0 MAX_INTERLOCKS = MAX_RELAYS / 2
+  uint16_t      slow_pwm_period;           // 508
 
-  uint8_t       free_508[36];              // 508
+  uint8_t       free_50A[34];              // 50A
 
   uint16_t      mqtt_keepalive;            // 52C
   uint16_t      mqtt_socket_timeout;       // 52E

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1044,6 +1044,7 @@ void SettingsDefaultSet2(void) {
   flag4.virtual_ct_cw |= LIGHT_VIRTUAL_CT_CW;
 
   Settings->pwm_frequency = PWM_FREQ;
+  Settings->slow_pwm_period = SLOW_PWM_PERIOD;
   Settings->pwm_range = PWM_RANGE;
   for (uint32_t i = 0; i < MAX_PWMS; i++) {
     Settings->light_color[i] = DEFAULT_LIGHT_COMPONENT;
@@ -1394,6 +1395,7 @@ void SettingsDelta(void) {
       ParseIPv4(&Settings->ipv4_rgx_subnetmask, PSTR(WIFI_RGX_SUBNETMASK));
       SettingsUpdateText(SET_RGX_SSID, PSTR(WIFI_RGX_SSID));
       SettingsUpdateText(SET_RGX_PASSWORD, PSTR(WIFI_RGX_PASSWORD));
+      Settings->slow_pwm_period = SLOW_PWM_PERIOD;
     }
 
     Settings->version = VERSION;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1437,7 +1437,11 @@ void CmndPwm(void)
   if (TasmotaGlobal.pwm_present && (XdrvMailbox.index > 0) && (XdrvMailbox.index <= MAX_PWMS)) {
     if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= Settings->pwm_range) && PinUsed(GPIO_PWM1, XdrvMailbox.index -1)) {
       Settings->pwm_value[XdrvMailbox.index -1] = XdrvMailbox.payload;
+#ifdef USE_SLOW_PWM
+      SlowPWMAnalogWrite(Pin(GPIO_PWM1, XdrvMailbox.index -1), bitRead(TasmotaGlobal.pwm_inverted, XdrvMailbox.index -1) ? Settings->pwm_range - XdrvMailbox.payload : XdrvMailbox.payload);
+#else
       analogWrite(Pin(GPIO_PWM1, XdrvMailbox.index -1), bitRead(TasmotaGlobal.pwm_inverted, XdrvMailbox.index -1) ? Settings->pwm_range - XdrvMailbox.payload : XdrvMailbox.payload);
+#endif  // USE_SLOW_PWM
     }
     Response_P(PSTR("{"));
     MqttShowPWMState();  // Render the PWM status to MQTT
@@ -1472,6 +1476,9 @@ void CmndPwmrange(void) {
       }
     }
     if (Settings->pwm_range != old_pwm_range) {  // On ESP32 this prevents loss of duty state
+#ifdef USE_SLOW_PWM
+      SlowPWMAnalogWriteRangeChanged();
+#endif  // USE_SLOW_PWM
       analogWriteRange(Settings->pwm_range);     // Default is 1023 (Arduino.h)
     }
   }

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1634,8 +1634,12 @@ void ResetPwm(void)
 {
   for (uint32_t i = 0; i < MAX_PWMS; i++) {     // Basic PWM control only
     if (PinUsed(GPIO_PWM1, i)) {
+#ifdef USE_SLOW_PWM
+      SlowPWMAnalogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range : 0);
+#else
       analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range : 0);
 //      analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - Settings->pwm_value[i] : Settings->pwm_value[i]);
+#endif  // USE_SLOW_PWM
     }
   }
 }
@@ -1935,14 +1939,26 @@ void GpioInit(void)
       pinMode(Pin(GPIO_PWM1, i), OUTPUT);
 #endif  // ESP8266
 #ifdef ESP32
+#ifdef USE_SLOW_PWM
+      pinMode(Pin(GPIO_PWM1, i), OUTPUT);
+#else
       analogAttach(Pin(GPIO_PWM1, i), i);
+#endif  // USE_SLOW_PWM
 #endif  // ESP32
       if (TasmotaGlobal.light_type) {
         // force PWM GPIOs to low or high mode, see #7165
+#ifdef USE_SLOW_PWM
+        SlowPWMAnalogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range : 0);
+#else
         analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range : 0);
+#endif  // USE_SLOW_PWM
       } else {
         TasmotaGlobal.pwm_present = true;
+#ifdef USE_SLOW_PWM
+        SlowPWMAnalogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - Settings->pwm_value[i] : Settings->pwm_value[i]);
+#else
         analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - Settings->pwm_value[i] : Settings->pwm_value[i]);
+#endif  // USE_SLOW_PWM
       }
     }
   }

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -144,6 +144,10 @@ const uint16_t PWM_MIN = 40;                // [PWM_MIN] Minimum frequency - Def
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
                                             //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
 
+const uint16_t SLOW_PWM_PERIOD = 10;        // 1..600 slow PWM period in second - Default: 10 seconds
+const uint16_t SLOW_PWM_MAX = 600;          // Maximum slow PWM period in second - Default: 10 minutes
+const uint16_t SLOW_PWM_MIN = 1;            // Minimum slow PWM period in second - Default: 1 second
+
 const uint16_t MAX_POWER_HOLD = 10;         // Time in SECONDS to allow max agreed power
 const uint16_t MAX_POWER_WINDOW = 30;       // Time in SECONDS to disable allow max agreed power
 const uint16_t SAFE_POWER_HOLD = 10;        // Time in SECONDS to allow max unit safe power

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1158,7 +1158,11 @@ void LightInit(void)
         pinMode(Pin(GPIO_PWM1, i), OUTPUT);
 #endif  // ESP8266
 #ifdef ESP32
+#ifdef USE_SLOW_PWM
+        pinMode(Pin(GPIO_PWM1, i), OUTPUT);
+#else
         analogAttach(Pin(GPIO_PWM1, i), i);
+#endif  // USE_SLOW_PWM
 #endif  // ESP32
       }
     }
@@ -2015,7 +2019,11 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
           cur_col = cur_col > 0 ? changeUIntScale(cur_col, 0, Settings->pwm_range, Light.pwm_min, Light.pwm_max) : 0;   // shrink to the range of pwm_min..pwm_max
         }
         if (!Settings->flag4.zerocross_dimmer) {
+#ifdef USE_SLOW_PWM
+          SlowPWMAnalogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+#else
           analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+#endif  // USE_SLOW_PWM
         }
       }
     }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1670,6 +1670,9 @@ void LightAnimate(void)
   // make sure we update CT range in case SetOption82 was changed
   Light.strip_timer_counter++;
 
+#ifdef USE_SLOW_PWM
+  TasmotaGlobal.sleep = Settings->sleep;
+#else
   // set sleep parameter: either settings,
   // or set a maximum of PWM_MAX_SLEEP if light is on or Fade is running
   if (Light.power || Light.fade_running) {
@@ -1681,6 +1684,7 @@ void LightAnimate(void)
   } else {
     TasmotaGlobal.sleep = Settings->sleep;
   }
+#endif  // USE_SLOW_PWM
 
   if (!Light.power) {                   // All channels powered off
     Light.strip_timer_counter = 0;

--- a/tasmota/xdrv_128_slow_pwm.ino
+++ b/tasmota/xdrv_128_slow_pwm.ino
@@ -53,6 +53,8 @@
  * - use Generic(18) or ESP32-DevKit(1) module type
  * - set GPIO pins as PWM<x> or PWM_i<x>
  * - use SlowPwmPeriod <x> command to set slow PWM cycle time
+ *   Note: Slow PWM's time resolution is 50ms, setting period times lower than 5s will decrase
+ *   even Dimmer 1..100 resolution. Use low values only for test purposes.
  * - from now on, there are 3 scenarios:
  *   - as plain PWM output:
  *     - execute: SetOption15 0
@@ -239,7 +241,7 @@ bool Xdrv128(uint8_t function) {
     case FUNC_MODULE_INIT:
       slow_pwm.PwmInit();
       break;
-    case FUNC_LOOP:
+    case FUNC_EVERY_50_MSECOND:
       slow_pwm.PwmLoop();
       break;
     case FUNC_COMMAND:

--- a/tasmota/xdrv_128_slow_pwm.ino
+++ b/tasmota/xdrv_128_slow_pwm.ino
@@ -61,7 +61,7 @@
  *   - as Light, only with 1 PWM pin (this has built in HA support also, as normal Light entity)
  *     see: https://tasmota.github.io/docs/Lights/#1-channel-dimmable-light
  *     - execute: LedTable 0  - or recompile with Settings->light_correction = 0;
- *     - use Power<x>, Dimmer<x>, Channel<x> commands to set duty cycle
+ *     - use Power<x>, Dimmer<x> commands to set duty cycle
  *     - use PwmRange <x>, SlowPwmPeriod <x> commands to change parameters
  *       Note: restart device when PwmRange changed, Light updates range only when reinitialized
  *   - as Light, but 1..5 PWM pins (this has built in HA support also, as normal Light entity)

--- a/tasmota/xdrv_128_slow_pwm.ino
+++ b/tasmota/xdrv_128_slow_pwm.ino
@@ -1,0 +1,254 @@
+
+/*
+  xdrv_128_slow_pwm.ino - Slow PWM
+
+  Copyright (C) 2021  Laszlo Magyar
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_SLOW_PWM
+#ifndef FIRMWARE_MINIMAL
+
+/*********************************************************************************************\
+ * PWM with slower than 1Hz periods
+ *
+ * Slow PWM is good for eg. heating elements, thermoelectric valve actuators that are connected
+ * to mains AC voltage, where you don't need to use phase angle dimmers, where you can use
+ * simple SSRs (Solid State Relays), or even regular relays.
+ *
+ * Slow PWM works as plain PWM and also as brightness only Light (SetOption15 0 and
+ * SetOption15 1), as Light it has built in HA support by default.
+ *
+ * Current implementation:
+ * - can be turned on only by build flag in user_config_override.h: #define USE_SLOW_PWM
+ * - adds new command SlowPwmPeriod, and adds new setting slow_pwm_period
+ * - replaces Pwm<x> command functionality, extends PwmRange command functionality
+ * - replaces Pwm<x> pin behaviour (normal Pwm and Light, SetOption15 0 or 1)
+ * - does not modify other PWM related behavior (eg. status led, buzzer, shutter, pwm dimmer,
+ *   backlight, etc.) - only pwm status led is tested on ESP8266
+ *
+ * Tested with:
+ * - ESP8266 - NodeMcu v2: D1, D2, D5, D6, D7 pins (GPIO 5, 4, 14, 12, 13)
+ * - ESP32 - Wemos D1 Mini ESP32: D1, D2, D5, D6, D7 pins (GPIO 22, 21, 18, 19, 23)
+ *
+ * How to use it:
+ * - rebuild with #define USE_SLOW_PWM in user_config_override.h
+ * - upload new firmware
+ * - Important: in case of ESP32, if PWM was set up on any pin before new firmware is uploaded,
+ *   power cycle the board, because ESP32 has hardware PWM, and power cycling the device will
+ *   detach pins from hardware PWM (that were previously attached to hardware PWM by previous
+ *   firmware), and Slow PWM can use them as digital IO pins
+ * - use Generic(18) or ESP32-DevKit(1) module type
+ * - set GPIO pins as PWM<x> or PWM_i<x>
+ * - use SlowPwmPeriod <x> command to set slow PWM cycle time
+ * - from now on, there are 3 scenarios:
+ *   - as plain PWM output:
+ *     - execute: SetOption15 0
+ *     - use PWM<x> commands to set duty cycle
+ *     - use PwmRange <x>, SlowPwmPeriod <x> commands to change parameters
+ *   - as Light, only with 1 PWM pin (this has built in HA support also, as normal Light entity)
+ *     see: https://tasmota.github.io/docs/Lights/#1-channel-dimmable-light
+ *     - execute: LedTable 0  - or recompile with Settings->light_correction = 0;
+ *     - use Power<x>, Dimmer<x>, Channel<x> commands to set duty cycle
+ *     - use PwmRange <x>, SlowPwmPeriod <x> commands to change parameters
+ *       Note: restart device when PwmRange changed, Light updates range only when reinitialized
+ *   - as Light, but 1..5 PWM pins (this has built in HA support also, as normal Light entity)
+ *     see: https://tasmota.github.io/docs/Lights/#independent-pwm-channels
+ *     - execute: LedTable 0  - or recompile with Settings->light_correction = 0;
+ *     - execute: MultiPwm 1 (previously SetOption68 1)  - or recompile with #define LIGHT_CHANNEL_MODE true
+ *     - use Power<x>, Channel<x> commands to set duty cycle
+ *     - use PwmRange <x>, SlowPwmPeriod <x> commands to change parameters
+ *       Note: restart device when PwmRange changed, Light updates range only when reinitialized
+ *
+ * I'm aware of https://tasmota.github.io/docs/Time-Proportioned-Output-support/
+ * - Timeprop has more features but no user interface. Slow PWM has less functions but has user
+ *   interface and built in HA support as Light entity.
+ * - main Timeprop features that are missing in Slow PWM:
+ *   - safety mechanism to revert to a specified fallback value when MQTT communication is lost:
+ *     - can be implemented with Tasmota rules
+ *   - actuator dead time:
+ *     - with other control specific features I think it has better place in the main control
+ *       logic in HA or other controller software
+ *   - different cycle times per pin:
+ *     - that could be useful
+ *
+ * Further development:
+ * - v0: as is now, it remains a build option, only hard core users will use it
+ *   (though we should rename it as xdrv_57 instead of xdrv_128)
+ * - v1: enable it with a new SetOption, still all PWM pin behavior will be changed when turned on
+ * - v2: create new pin config, like "SPWM<x>", where only pins defined as Slow PWM will be
+ *   affected with this behavior
+ * - v3: extend scripting (Berry?) with the implemented v1/v2 solution
+ *
+\*********************************************************************************************/
+
+#define XDRV_128             128
+
+const char kSlowPwmCommands[] PROGMEM = "|"  // No prefix
+  D_CMND_SLOWPWMPERIOD
+  ;
+
+void (* const SlowPwmCommand[])(void) PROGMEM = {
+  &CmndSlowPwmPeriod
+  };
+
+/*********************************************************************************************\
+ * Implementation
+\*********************************************************************************************/
+
+class SlowPWM {
+  private:
+
+    uint32_t period_time;
+    uint32_t period_start_time;
+
+    struct {
+      uint8_t pin_number;
+      uint8_t current_digital_value;
+      uint16_t pwm_value;
+      uint32_t duty_time;
+    } pins[MAX_PWMS];
+
+    uint8_t pinCount;
+
+    uint32_t SettingsSlowPwmPeriodTime(void) {
+      return (((Settings->slow_pwm_period >= SLOW_PWM_MIN) && (Settings->slow_pwm_period <= SLOW_PWM_MAX)) ? Settings->slow_pwm_period : SLOW_PWM_PERIOD) * 1000;
+    }
+
+    uint16_t SettingsPwmRange(void) {
+      return Settings->pwm_range;
+    }
+
+  public:
+
+    void AnalogWrite(uint8_t pin_number, uint16_t pwm_value) {
+      int i;
+      // search pin in pins
+      for (i = 0; i < pinCount && pins[i].pin_number != pin_number; i++);
+      // if new pin
+      if (i == pinCount) {
+        // if no more place
+        if (pinCount == sizeof(pins) / sizeof(pins[0])) return;
+        // if first pin used, start time calculation in the loop
+        if (pinCount == 0) {
+          period_time = SettingsSlowPwmPeriodTime();
+          period_start_time = millis();
+        }
+        // add new pin
+        pinCount++;
+        pins[i].pin_number = pin_number;
+      }
+      // set pin pwm parameters
+      pins[i].current_digital_value = -1;
+      pins[i].pwm_value = pwm_value;
+      pins[i].duty_time = period_time * pwm_value / SettingsPwmRange();
+    }
+
+    void PeriodChanged(void) {
+      period_time = SettingsSlowPwmPeriodTime();
+      period_start_time = millis();
+      for (int i = 0; i < pinCount; i++) {
+        pins[i].duty_time = period_time * pins[i].pwm_value / SettingsPwmRange();
+      }
+    }
+
+    void RangeChanged(void) {
+      for (int i = 0; i < pinCount; i++) {
+        if (pins[i].pwm_value > SettingsPwmRange()) {
+          pins[i].pwm_value = SettingsPwmRange();
+          pins[i].duty_time = period_time;
+        } else {
+          pins[i].duty_time = period_time * pins[i].pwm_value / SettingsPwmRange();
+        }
+      }
+    }
+
+    void PwmInit(void) {
+      pinCount = 0;
+    }
+
+    void PwmLoop(void) {
+      if (pinCount > 0) {
+        uint32_t period_time_passed = millis() - period_start_time;
+        if (period_time_passed >= period_time) {
+          period_start_time += period_time;
+          period_time_passed -= period_time;
+        }
+        for (int i = 0; i < pinCount; i++) {
+          if (period_time_passed < pins[i].duty_time) {
+            if (pins[i].current_digital_value != 1) {
+              digitalWrite(pins[i].pin_number, 1);
+              pins[i].current_digital_value = 1;
+            }
+          } else {
+            if (pins[i].current_digital_value != 0) {
+              digitalWrite(pins[i].pin_number, 0);
+              pins[i].current_digital_value = 0;
+            }
+          }
+        }
+      }
+    }
+} slow_pwm;
+
+void SlowPWMAnalogWrite(uint8_t pin, uint16_t value) {
+  slow_pwm.AnalogWrite(pin, value);
+}
+
+void SlowPWMAnalogWritePeriodChanged(void) {
+  slow_pwm.PeriodChanged();
+}
+
+void SlowPWMAnalogWriteRangeChanged(void) {
+  slow_pwm.RangeChanged();
+}
+
+/*********************************************************************************************\
+ * Commands
+\*********************************************************************************************/
+
+void CmndSlowPwmPeriod(void)
+{
+  if ((0 == XdrvMailbox.payload) || ((XdrvMailbox.payload >= SLOW_PWM_MIN) && (XdrvMailbox.payload <= SLOW_PWM_MAX))) {
+    Settings->slow_pwm_period = (0 == XdrvMailbox.payload) ? SLOW_PWM_PERIOD : XdrvMailbox.payload;
+    SlowPWMAnalogWritePeriodChanged();
+  }
+  ResponseCmndNumber(Settings->slow_pwm_period);
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdrv128(uint8_t function) {
+  bool result = false;
+
+  switch (function) {
+    case FUNC_MODULE_INIT:
+      slow_pwm.PwmInit();
+      break;
+    case FUNC_LOOP:
+      slow_pwm.PwmLoop();
+      break;
+    case FUNC_COMMAND:
+      result = DecodeCommand(kSlowPwmCommands, SlowPwmCommand);
+      break;
+  }
+
+  return result;
+}
+
+#endif  // FIRMWARE_MINIMAL
+#endif  // USE_SLOW_PWM


### PR DESCRIPTION
## Description:

**Related issue (if applicable):**

See detailed description below (from driver file).

I think **v0 than v2 in Further development chapter below** should be done before it can be part of an official release without #define USE_SLOW_PWM In that case I can modify the tasmota/docs documentation also.

**Add #define USE_SLOW_PWM to user_config_override.h to use this feature!** Itt adds 608 bytes to firmware.bin.

> PWM with slower than 1Hz periods
>
> Slow PWM is good for eg. heating elements, thermoelectric valve actuators that are connected
> to mains AC voltage, where you don't need to use phase angle dimmers, where you can use
> simple SSRs (Solid State Relays), or even regular relays.
>
> Slow PWM works as plain PWM and also as brightness only Light (SetOption15 0 and
> SetOption15 1), as Light it has built in HA support by default.
>
> Current implementation:
> - can be turned on only by build flag in user_config_override.h: #define USE_SLOW_PWM
> - adds new command SlowPwmPeriod, and adds new setting slow_pwm_period
> - replaces Pwm\<x> command functionality, extends PwmRange command functionality
> - replaces Pwm\<x> pin behaviour (normal Pwm and Light, SetOption15 0 or 1)
> - does not modify other PWM related behavior (eg. status led, buzzer, shutter, pwm dimmer,
>   backlight, etc.) - only pwm status led is tested on ESP8266
>
> Tested with:
> - ESP8266 - NodeMcu v2: D1, D2, D5, D6, D7 pins (GPIO 5, 4, 14, 12, 13)
> - ESP32 - Wemos D1 Mini ESP32: D1, D2, D5, D6, D7 pins (GPIO 22, 21, 18, 19, 23)
>
> How to use it:
> - rebuild with #define USE_SLOW_PWM in user_config_override.h
> - upload new firmware
> - Important: in case of ESP32, if PWM was set up on any pin before new firmware is uploaded,
>   power cycle the board, because ESP32 has hardware PWM, and power cycling the device will
>   detach pins from hardware PWM (that were previously attached to hardware PWM by previous
>   firmware), and Slow PWM can use them as digital IO pins
> - use Generic(18) or ESP32-DevKit(1) module type
> - set GPIO pins as PWM\<x> or PWM_i\<x>
> - use SlowPwmPeriod \<x> command to set slow PWM cycle time
>   Note: Slow PWM's time resolution is 50ms, setting period times lower than 5s will decrase
>   even Dimmer 1..100 resolution. Use low values only for test purposes.
> - from now on, there are 3 scenarios:
>   - as plain PWM output:
>     - execute: SetOption15 0
>     - use PWM\<x> commands to set duty cycle
>     - use PwmRange \<x>, SlowPwmPeriod \<x> commands to change parameters
>   - as Light, only with 1 PWM pin (this has built in HA support also, as normal Light entity)
>     see: https://tasmota.github.io/docs/Lights/#1-channel-dimmable-light
>     - execute: LedTable 0  - or recompile with Settings->light_correction = 0;
>     - use Power\<x>, Dimmer\<x> commands to set duty cycle
>     - use PwmRange \<x>, SlowPwmPeriod \<x> commands to change parameters
>       Note: restart device when PwmRange changed, Light updates range only when reinitialized
>   - as Light, but 1..5 PWM pins (this has built in HA support also, as normal Light entity)
>     see: https://tasmota.github.io/docs/Lights/#independent-pwm-channels
>     - execute: LedTable 0  - or recompile with Settings->light_correction = 0;
>     - execute: MultiPwm 1 (previously SetOption68 1)  - or recompile with #define LIGHT_CHANNEL_MODE true
>     - use Power\<x>, Channel\<x> commands to set duty cycle
>     - use PwmRange \<x>, SlowPwmPeriod \<x> commands to change parameters
>       Note: restart device when PwmRange changed, Light updates range only when reinitialized
>
> I'm aware of https://tasmota.github.io/docs/Time-Proportioned-Output-support/
> - Timeprop has more features but no user interface. Slow PWM has less functions but has user
>   interface and built in HA support as Light entity.
> - main Timeprop features that are missing in Slow PWM:
>   - safety mechanism to revert to a specified fallback value when MQTT communication is lost:
>     - can be implemented with Tasmota rules
>   - actuator dead time:
>     - with other control specific features I think it has better place in the main control
>       logic in HA or other controller software
>   - different cycle times per pin:
>     - that could be useful
>
> Further development:
> - v0: as is now, it remains a build option, only hard core users will use it
>   (though we should rename it as xdrv_57 instead of xdrv_128)
> - v1: enable it with a new SetOption, still all PWM pin behavior will be changed when turned on
> - v2: create new pin config, like "SPWM\<x>", where only pins defined as Slow PWM will be
>   affected with this behavior
> - v3: extend scripting (Berry?) with the implemented v1/v2 solution


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
