### PR TITLE
PIO tools overrides using .ini file settings

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -28,7 +28,7 @@ def map_gzip(source, target, env):
             map_file.unlink()
 
 
-if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_MAP_GZ):
+if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_MAP_GZ, env):
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [map_gzip])
 
 # gzip only for ESP8266
@@ -66,5 +66,5 @@ if env["PIOPLATFORM"] != "espressif32":
                 )
             )
 
-    if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_BIN_GZ):
+    if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_BIN_GZ, env):
         env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [bin_gzip])

--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -1,19 +1,43 @@
-"""Supporting library for pio-tools scripts"""
+"""Supporting library for pio-tools scripts
+
+This also provides functions to allow overrides of some settings, see the available
+overides below.
+
+Overrides can be set using environment variables or .ini file settings for controlling
+build output file locations and formats.
+
+To set a value using an environment variable, prefix the value with "TASMOTA_" and
+ensure the entire value is UPPER CASE, for example in bash, it would be:
+
+      export TASMOTA_DISABLE_MAP_GZ=1
+
+To set a value in your .ini file, such as in platformio_override.ini, create a
+[tasmota] section, and put the key ensuring it is all lower case, for example:
+
+[tasmota]
+disable_map_gz = 1
+map_dir = /tmp/map_files/
+
+Values in .ini files override environment variables
+
+"""
 import pathlib
 import os
 
-# Constants for environment variables that can be set to control build output file
-# locations and formats
-
+# === AVAILABLE OVERRIDES ===
 # if set to 1, will not gzip esp8266 bin files
-DISABLE_BIN_GZ = "TASMOTA_DISABLE_BIN_GZ"
-# if set, an alternative ptah to put generated .bin files
-BIN_DIR = "TASMOTA_BIN_DIR"
+DISABLE_BIN_GZ = "disable_bin_gz"
+# if set, an alternative ptah to put generated .bin files, relative to project directory
+BIN_DIR = "bin_dir"
 # if set to 1, will not gzip generated .map files
-DISABLE_MAP_GZ = "TASMOTA_DISABLE_MAP_GZ"
-# if set, an alternative path to put generated .map files
-MAP_DIR = "TASMOTA_MAP_DIR"
+DISABLE_MAP_GZ = "disable_map_gz"
+# if set, an alternative path to put generated .map files, relative to project directory
+MAP_DIR = "map_dir"
 
+# === END AVAILABLE OVERRIDES ===
+
+
+# This is the default output directory
 OUTPUT_DIR = pathlib.Path("build_output")
 
 
@@ -26,7 +50,7 @@ def get_final_bin_path(env) -> pathlib.Path:
     """Path to the final destination for the .bin
 
     If the parent directory does not exist, it will be created"""
-    firmware_dir = get_override_path(BIN_DIR)
+    firmware_dir = get_override_path(BIN_DIR, env)
     firmware_dir.mkdir(parents=True, exist_ok=True)
     return firmware_dir / "{}.bin".format(get_variant(env))
 
@@ -35,7 +59,7 @@ def get_final_map_path(env) -> pathlib.Path:
     """Path to the final destination for the .map file
 
     If the parent directory does not exist, it will be created"""
-    map_dir = get_override_path(MAP_DIR)
+    map_dir = get_override_path(MAP_DIR, env)
     map_dir.mkdir(parents=True, exist_ok=True)
     return map_dir / "{}.map".format(get_variant(env))
 
@@ -62,13 +86,23 @@ def get_source_map_path(env) -> pathlib.Path:
     raise FileNotFoundError
 
 
-def get_override_path(pathtype) -> pathlib.Path:
+def get_tasmota_override_option(name: str, env):
+    """Gets a set override option from a .ini or env variable, None if no match"""
+    config = env.GetProjectConfig()
+    override = config.get("tasmota", name.lower(), None)
+    if override is not None:
+        return override
+    # Return env if available
+    return os.environ.get("TASMOTA_" + name.upper())
+
+
+def get_override_path(pathtype: str, env) -> pathlib.Path:
     """
     Returns a path to a givens override path if set, otherwise OUTPUT_DIR is used
 
     pathtype must be either MAP_DIR or BIN_DIR.
     """
-    override = os.environ.get(pathtype)
+    override = get_tasmota_override_option(pathtype, env)
     if override:
         return pathlib.Path(override)
     if pathtype == BIN_DIR:
@@ -78,9 +112,9 @@ def get_override_path(pathtype) -> pathlib.Path:
     raise ValueError
 
 
-def is_env_set(name: str):
+def is_env_set(name: str, env):
     """True if the enviornment variable <name> is set to `1`"""
-    val = os.environ.get(name.upper())
+    val = get_tasmota_override_option(name, env)
     if val:
         val = val.strip()
         return val == "1"


### PR DESCRIPTION
## Description:

Expanding on https://github.com/arendst/Tasmota/pull/12896, this PR allows for overrides using the `platformio*.ini` files, for example, you can now add (eg: in your `platform_override.ini`):
```
[tasmota]
disable_map_gz = 1
map_dir = /tmp/map_files/
```

To change the location of the generated `.map` files, and not compress them.

I also improved the inline documentation.

Please let me know if you think it needs anything else.

Thanks!

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
