### PR TITLE
Fixed PWM5 on ESP32C3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Berry now compiling in ``strict`` mode to catch more bugs
 
+### Fixed
+- Fixed PWM5 on ESP32C3
+
 ## [9.5.0.5] 20210815
 ### Added
 - Inital support for Wi-Fi extender (#12784)

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -32,12 +32,21 @@
  * ESP32 analogWrite emulation support
 \*********************************************************************************************/
 
-#define PWM_SUPPORTED_CHANNELS 8
-#define PWM_CHANNEL_OFFSET     2   // Webcam uses channel 0, so we offset standard PWM
+#if CONFIG_IDF_TARGET_ESP32C3
+  #define PWM_SUPPORTED_CHANNELS 6
+  #define PWM_CHANNEL_OFFSET     1   // Webcam uses channel 0, so we offset standard PWM
 
-uint8_t _pwm_channel[PWM_SUPPORTED_CHANNELS] = { 99, 99, 99, 99, 99, 99, 99, 99 };
-uint32_t _pwm_frequency = 977;     // Default 977Hz
-uint8_t _pwm_bit_num = 10;         // Default 1023
+  uint8_t _pwm_channel[PWM_SUPPORTED_CHANNELS] = { 99, 99, 99, 99, 99, 99 };
+  uint32_t _pwm_frequency = 977;     // Default 977Hz
+  uint8_t _pwm_bit_num = 10;         // Default 1023
+#else // other ESP32
+  #define PWM_SUPPORTED_CHANNELS 8
+  #define PWM_CHANNEL_OFFSET     2   // Webcam uses channel 0, so we offset standard PWM
+
+  uint8_t _pwm_channel[PWM_SUPPORTED_CHANNELS] = { 99, 99, 99, 99, 99, 99, 99, 99 };
+  uint32_t _pwm_frequency = 977;     // Default 977Hz
+  uint8_t _pwm_bit_num = 10;         // Default 1023
+#endif // CONFIG_IDF_TARGET_ESP32C3 vs ESP32
 
 inline uint32_t _analog_pin2chan(uint32_t pin) {
   for (uint32_t channel = 0; channel < PWM_SUPPORTED_CHANNELS; channel++) {


### PR DESCRIPTION
## Description:

PWM5 is broken on ESP32C3 because it has only 6 PWM channels instead of 8+8 on ESP32. No change on ESP32

Now ldec0 is still reserved for other uses, and PWM1-5 are mapped to ledc1..5.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
