### PR TITLE
Berry system events for rules

### DIFF
--- a/lib/libesp32/Berry/default/embedded/Tasmota.be
+++ b/lib/libesp32/Berry/default/embedded/Tasmota.be
@@ -15,6 +15,7 @@ class Timer
   end
 end
 
+tasmota = nil
 class Tasmota
 
   # add `chars_in_string(s:string,c:string) -> int``

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -801,6 +801,11 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
 
 bool RulesProcessEvent(const char *json_event)
 {
+#ifdef USE_BERRY
+  // events are passed to Berry before Rules engine
+  callBerryRule(json_event);
+#endif
+
   if (Rules.busy) { return false; }
 
   Rules.busy = true;
@@ -858,7 +863,11 @@ void RulesInit(void)
 
 void RulesEvery50ms(void)
 {
+#ifdef USE_BERRY
+  if (!Rules.busy) {  // Emitting Rules events is always enabled with Berry
+#else
   if (Settings->rule_enabled && !Rules.busy) {  // Any rule enabled
+#endif
     char json_event[120];
 
     if (-1 == Rules.new_power) { Rules.new_power = TasmotaGlobal.power; }

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -93,12 +93,13 @@ extern "C" {
 \*********************************************************************************************/
 // // call a function (if exists) of type void -> void
 
-bool callBerryRule(void) {
+// If event == nullptr, then take XdrvMailbox.data
+bool callBerryRule(const char *event) {
   if (berry.rules_busy) { return false; }
   berry.rules_busy = true;
   char * json_event = XdrvMailbox.data;
   bool serviced = false;
-  serviced = callBerryEventDispatcher(PSTR("rule"), nullptr, 0, XdrvMailbox.data);
+  serviced = callBerryEventDispatcher(PSTR("rule"), nullptr, 0, event ? event : XdrvMailbox.data);
   berry.rules_busy = false;
   return serviced;     // TODO event not handled
 }
@@ -732,7 +733,7 @@ bool Xdrv52(uint8_t function)
 
     // Berry wide commands and events
     case FUNC_RULES_PROCESS:
-      result = callBerryRule();
+      result = callBerryRule(nullptr);
       break;
     case FUNC_MQTT_DATA:
       result = callBerryEventDispatcher(PSTR("mqtt_data"), XdrvMailbox.topic, 0, XdrvMailbox.data, XdrvMailbox.data_len);

--- a/tasmota/xdrv_interface.ino
+++ b/tasmota/xdrv_interface.ino
@@ -1083,8 +1083,8 @@ bool XdrvRulesProcess(bool teleperiod, const char* event) {
   char* data_save = XdrvMailbox.data;
   XdrvMailbox.data = (char*)event;
   bool rule_handled = XdrvCallDriver(10, (teleperiod) ? FUNC_TELEPERIOD_RULES_PROCESS : FUNC_RULES_PROCESS);
-#ifdef USE_BERRY
-  // events are passed to both Rules engine AND Berry engine
+#if defined(USE_BERRY) && !defined(USE_RULES)
+  // events are sent to Berry in Rules driver, or here if USE_RULES is not defined (only on a subset)
   bool berry_handled = XdrvCallDriver(52, FUNC_RULES_PROCESS);
   rule_handled |= berry_handled;
 #endif


### PR DESCRIPTION
## Description:

Enable most system events from Rules to be caught by Berry. However if Rules are not enabled, only MQTT published messages are sent to Berry.

Example, enabling this code in `autoexec.be` to show all incoming messages:
```python
def dump_rule(value, trigger, msg)
  print(">>>>> Rule_fires",msg)
end
tasmota.add_rule("?", dump_rule)
```

This is the logs of a Tasmota boot:
```
00:00:00.002 HDW: ESP32-D0WD
00:00:00.007 UFS: FlashFS mounted with 296 kB free
00:00:00.019 CFG: Loaded from File, Count 240
00:00:00.026 QPC: Count 1
00:00:00.053 BRY: Berry initialized, RAM used=5246
00:00:00.058 BRY: no 'preinit.be'
00:00:00.063 Project tasmota - Tasmota Version 9.5.0.6(tasmota)-1_0_7_3(2021-08-19T12:23:58)
00:00:00.164 BRY: sucessfully loaded 'autoexec.be'
00:00:00.227 >>>>> Rule_fires {'Dimmer': {'Boot': 10}}
00:00:00.696 WIF: Connecting to AP1 XXX Channel 1 BSSId...
00:00:00.944 >>>>> Rule_fires {'System': {'Init': 1}}
00:00:04.472 WIF: Connected
00:00:04.531 >>>>> Rule_fires {'WIFI': {'Connected': 1}}
00:00:04.729 HTP: Web server active on tasmota-XXXX with IP address XXXX
00:00:04.732 RSL: INFO1 = {"Info1":{"Module":"ESP32-DevKit","Version":"9.5.0.6(tasmota)","FallbackTopic":"cmnd/Tasmota-XXX/","GroupTopic":"cmnd/tasmotas/"}}
00:00:04.752 >>>>> Rule_fires {'Info1': {'GroupTopic': 'cmnd/tasmotas/', 'Module': 'ESP32-DevKit', 'FallbackTopic': 'cmnd/Tasmota-XXX/', 'Version': '9.5.0.6(tasmota)'}}
00:00:04.759 RSL: INFO2 = {"Info2":{"WebServerMode":"Admin","Hostname":"tasmota-XXX","IPAddress":"XXX"}}
00:00:04.777 >>>>> Rule_fires {'Info2': {'Hostname': 'tasmota-XXX', 'WebServerMode': 'Admin', 'IPAddress': 'XXX'}}
00:00:04.781 RSL: INFO3 = {"Info3":{"RestartReason":"Software reset CPU"}}
00:00:04.796 >>>>> Rule_fires {'Info3': {'RestartReason': 'Software reset CPU'}}
00:00:04.811 >>>>> Rule_fires {'System': {'Boot': 1}}
00:00:04.862 >>>>> Rule_fires {'HTTP': {'Initialized': 1}}
11:39:56.080 >>>>> Rule_fires {'Time': {'Initialized': 699}}
11:39:57.978 QPC: Reset
11:39:59.979 RSL: STATE = {"Time":"2021-08-19T11:39:59","Uptime":"0T00:00:10","UptimeSec":10,"Heap":179,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":19,"MqttCount":0,"Wifi":{"AP":1,"SSId":"XXX","BSSId":"XXX","Channel":1,"Mode":"11n","RSSI":86,"Signal":-57,"LinkCount":1,"Downtime":"0T00:00:05"}}
11:40:00.022 >>>>> Rule_fires {'Sleep': 50, 'MqttCount': 0, 'Wifi': {'Mode': '11n', 'LinkCount': 1, 'Signal': -57, 'SSId': 'XXX', 'Downtime': '0T00:00:05', 'Channel': 1, 'RSSI': 86, 'BSSId': 'XXX', 'AP': 1}, 'Heap': 179, 'Uptime': '0T00:00:10', 'UptimeSec': 10, 'SleepMode': 'Dynamic', 'Time': '2021-08-19T11:39:59', 'LoadAvg': 19}
11:40:00.047 RSL: SENSOR = {"Time":"2021-08-19T11:40:00","ESP32":{"Temperature":31.1},"Global":{"Temperature":31.1},"TempUnit":"C"}
11:40:00.065 >>>>> Rule_fires {'Time': '2021-08-19T11:40:00', 'TempUnit': 'C', 'ESP32': {'Temperature': 31.1}, 'Global': {'Temperature': 31.1}}
```

Note: time related events are not generated.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
