### PR TITLE
Zigee increase auto-bind range #10399

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -856,6 +856,8 @@
 
 
   // Auto-binding constants, see `Z_autoAttributeReporting`
+  #define USE_ZIGBEE_AUTOBIND_MAX_ENDPOINTS 8       // max number of endpoint receiving auto-bind requests
+  #define USE_ZIGBEE_AUTOBIND_MAX_CLUSTER   0x10    // max endpoint number (excluded receiving auto-bind requests)
   // Below are the threshold for attribute reporting
   #define USE_ZIGBEE_AUTOBIND_BATTVOLTAGE   0.2     // V
   #define USE_ZIGBEE_AUTOBIND_BATTPERCENT   5       // %

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -638,7 +638,7 @@ int32_t Z_ReceiveActiveEp(int32_t res, const SBuffer &buf) {
   for (uint32_t i = 0; i < activeEpCount; i++) {
     uint8_t ep = activeEpList[i];
     zigbee_devices.getShortAddr(nwkAddr).addEndpoint(ep);
-    if ((i < 4) && (ep < 0x10)) {
+    if ((i < USE_ZIGBEE_AUTOBIND_MAX_ENDPOINTS) && (ep < USE_ZIGBEE_AUTOBIND_MAX_CLUSTER)) {
       zigbee_devices.queueTimer(nwkAddr, 0 /* groupaddr */, 1500, ep /* fake cluster as ep */, ep, Z_CAT_EP_DESC, 0 /* value */, &Z_SendSimpleDescReq);
     }
   }


### PR DESCRIPTION
## Description:

Increase Zigbee auto-bind from 4 to 8 endpoints receiving requests, and moving to compile defines: `USE_ZIGBEE_AUTOBIND_MAX_ENDPOINTS` and `USE_ZIGBEE_AUTOBIND_MAX_CLUSTER`

**Related issue (if applicable):** fixes #10399

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
