### PR TITLE
Berry support for vararg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Turn HTTP API (command ``SetOption128 1``) default on for backward compatibility
 - Support for IEM3155 Wattmeter (#12940)
+- Berry support for vararg
 
 ### Fixed
 - WDT reset on shutters with stepper motors during deceleration (#12849)

--- a/lib/libesp32/Berry/tests/vararg.be
+++ b/lib/libesp32/Berry/tests/vararg.be
@@ -1,0 +1,14 @@
+#- vararg -#
+def f(a,*b) return b end
+
+assert(f() == [])
+assert(f(1) == [])
+assert(f(1,2) == [2])
+assert(f(1,2,3) == [2, 3])
+
+def g(*a) return a end
+
+assert(g() == [])
+assert(g("foo") == ["foo"])
+assert(g("foo", nil) == ["foo", nil])
+assert(g("foo", nil, 2) == ["foo", nil, 2])

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -347,7 +347,7 @@ void BrLoad(const char * script_name) {
     bool loaded = be_tobool(berry.vm, -2);  // did it succeed?
     be_pop(berry.vm, 2);
     if (loaded) {
-      AddLog(LOG_LEVEL_INFO, D_LOG_BERRY "sucessfully loaded '%s'", script_name);
+      AddLog(LOG_LEVEL_INFO, D_LOG_BERRY "successfully loaded '%s'", script_name);
     } else {
       AddLog(LOG_LEVEL_INFO, D_LOG_BERRY "no '%s'", script_name);
     }


### PR DESCRIPTION
## Description:

When declaring the last argument of a function or a method with a preceding `*`, the function is marked as vararg. This means that all parameters starting at this variable are collated in a list that the function can traverse. If no argument is present, the list is empty.

```
> def f(a, *b) return b end
> f()
[]
> f(1,2)
[2]
> f(1,2,3,4)
[2, 3, 4]
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
