### PR TITLE
xsns_82_wiegand - fix for zero key if keypad is used in the single ke…

### DIFF
--- a/tasmota/xsns_82_wiegand.ino
+++ b/tasmota/xsns_82_wiegand.ino
@@ -396,7 +396,7 @@ void Wiegand::ScanForTag() {
 
     for (int i= 0; i < WIEGAND_RFID_ARRAY_SIZE; i++)
     {
-      if (rfid_found[i].RFID != 0) {
+	  if (rfid_found[i].RFID != 0 || (rfid_found[i].RFID == 0 && i == 0)) {
         uint64_t oldTag = rfid;
         bool validKey =  WiegandConversion(rfid_found[i].RFID, rfid_found[i].bitCount);
         #if (DEV_WIEGAND_TEST_MODE)>0


### PR DESCRIPTION
fix for zero key if keypad is used in the single keyy mode (SetOption124 1)

## Description:
Tasmota ignore the zero key press on keypad when the keypad is used in single key mode ( SetOption124 1). 

**Related issue (if applicable):** fixes #12959

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
