### PR TITLE
Removed hard dependency on USE_LIGHT from USE_HOME_ASSISTANT

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -414,6 +414,7 @@ void TryResponseAppend_P(const char *format, ...) {
 #endif
 }
 
+#ifdef USE_LIGHT
 void HAssAnnounceRelayLight(void)
 {
   char stopic[TOPSZ];
@@ -535,7 +536,6 @@ void HAssAnnounceRelayLight(void)
           }
           TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO_SHORT, unique_id, ESP_getChipId());
 
-  #ifdef USE_LIGHT
         if (i >= Light.device) {
           if (!RelayX || PwmMod || (TuyaDim > 0 && TuyaMod)) {
             char *brightness_command_topic = stemp1;
@@ -586,7 +586,6 @@ void HAssAnnounceRelayLight(void)
           ind_light = false;
           max_lights--;
         }
-  #endif  // USE_LIGHT
         TryResponseAppend_P(PSTR("}"));
       }
     }
@@ -594,6 +593,7 @@ void HAssAnnounceRelayLight(void)
     MqttPublish(stopic, true);
   }
 }
+#endif  // USE_LIGHT
 
 void HAssAnnouncerTriggers(uint8_t device, uint8_t present, uint8_t key, uint8_t toggle, uint8_t hold, uint8_t single, uint8_t trg_start, uint8_t trg_end)
 {
@@ -1107,8 +1107,10 @@ void HAssDiscovery(void)
     // Send info about shutters
     HAssAnnounceShutters();
 
+#ifdef USE_LIGHT
     // Send info about relays and lights
     HAssAnnounceRelayLight();
+#endif // USE_LIGHT
 
     // Send info about status sensor
     HAssAnnounceDeviceInfoAndStatusSensor();


### PR DESCRIPTION
## Description:

This PR rearranges a few preprocessor directives to make `USE_HOME_ASSISTANT` not depend on `USE_LIGHT`.

Tuya is remains incompatible with undefining `USE_LIGHT` however.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
