### PR TITLE
Berry upgrade to latest changes

### DIFF
--- a/lib/libesp32/Berry/src/be_code.c
+++ b/lib/libesp32/Berry/src/be_code.c
@@ -251,7 +251,7 @@ static int newconst(bfuncinfo *finfo, bvalue *k)
 }
 
 /* Find constant by value and return constant number, or -1 if constant does not exist */
-/* The search is linear and lilited to 50 elements for performance reasons */
+/* The search is linear and limited to 100 elements for performance reasons */
 static int findconst(bfuncinfo *finfo, bexpdesc *e)
 {
     int i, count = be_vector_count(&finfo->kvec);
@@ -260,7 +260,7 @@ static int findconst(bfuncinfo *finfo, bexpdesc *e)
      * so only search the constant table for the
      * previous value.
      **/
-    count = count < 50 ? count : 50;
+    count = count < 100 ? count : 100;
     for (i = 0; i < count; ++i) {
         bvalue *k = be_vector_at(&finfo->kvec, i);
         switch (e->type) {
@@ -746,10 +746,12 @@ int be_code_proto(bfuncinfo *finfo, bproto *proto)
 
 void be_code_closure(bfuncinfo *finfo, bexpdesc *e, int idx)
 {
-    int reg = e->type == ETGLOBAL ? finfo->freereg: e->v.idx;
+    int reg = (e->type == ETGLOBAL || e->type == ETNGLOBAL) ? finfo->freereg: e->v.idx;
     code_closure(finfo, idx, reg);
-    if (e->type == ETGLOBAL) { /* store to grobal R(A) -> G(Bx) */
+    if (e->type == ETGLOBAL) { /* store to global R(A) -> G(Bx) */
         codeABx(finfo, OP_SETGBL, reg, e->v.idx);
+    } else if (e->type == ETNGLOBAL) { /* store R(A) -> GLOBAL[RK(B)] */
+        codeABC(finfo, OP_SETNGBL, reg, e->v.idx, 0);
     }
 }
 
@@ -841,9 +843,12 @@ void be_code_class(bfuncinfo *finfo, bexpdesc *dst, bclass *c)
     src = newconst(finfo, &var);  /* allocate a new constant and return kreg */
     if (dst->type == ETLOCAL) {  /* if target is a local variable, just assign */
         codeABx(finfo, OP_LDCONST, dst->v.idx, src);
-    } else {  /* otherwise set as global with same name as class name */
+    } else if (dst->type == ETGLOBAL) {  /* otherwise set as global with same name as class name */
         codeABx(finfo, OP_LDCONST, finfo->freereg, src);
         codeABx(finfo, OP_SETGBL, finfo->freereg, dst->v.idx);
+    } else if (dst->type == ETNGLOBAL) {
+        codeABx(finfo, OP_LDCONST, finfo->freereg, src);
+        codeABC(finfo, OP_SETNGBL, finfo->freereg, dst->v.idx, 0);
     }
     codeABx(finfo, OP_CLASS, 0, src);  /* emit CLASS opcode to register class */
 }

--- a/lib/libesp32/Berry/src/be_debug.c
+++ b/lib/libesp32/Berry/src/be_debug.c
@@ -62,7 +62,7 @@ void be_print_inst(binstruction ins, int pc)
     case OP_OR: case OP_XOR: case OP_SHL: case OP_SHR:
         logbuf("%s\tR%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),
                 isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK,
-                isKB(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
+                isKC(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
         break;
     case OP_GETNGBL: case OP_SETNGBL:
         logbuf("%s\tR%d\t%c%d", opc2str(op), IGET_RA(ins),
@@ -116,7 +116,7 @@ void be_print_inst(binstruction ins, int pc)
     case OP_RAISE:
         logbuf("%s\t%d\t%c%d\t%c%d", opc2str(op), IGET_RA(ins),
                 isKB(ins) ? 'K' : 'R', IGET_RKB(ins) & KR_MASK,
-                isKB(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
+                isKC(ins) ? 'K' : 'R', IGET_RKC(ins) & KR_MASK);
         break;
     case OP_EXBLK:
         if (IGET_RA(ins)) {

--- a/lib/libesp32/Berry/src/be_module.h
+++ b/lib/libesp32/Berry/src/be_module.h
@@ -34,8 +34,8 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
-bvalue* be_module_attr(bvm *vm, bmodule *module, bstring *attr);
-bvalue* be_module_bind(bvm *vm, bmodule *module, bstring *attr);
+int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
+bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);
 const char* be_module_name(bmodule *module);
 bbool be_module_setname(bmodule *module, bstring *name);
 

--- a/lib/libesp32/Berry/src/be_parser.c
+++ b/lib/libesp32/Berry/src/be_parser.c
@@ -461,6 +461,14 @@ static void new_var(bparser *parser, bstring *name, bexpdesc *var)
             push_error(parser,
                 "too many global variables (in '%s')", str(name));
         }
+        if (comp_is_named_gbl(parser->vm)) {
+            /* change to ETNGLBAL */
+            bexpdesc key;
+            init_exp(&key, ETSTRING, 0);
+            key.v.s = name;
+            init_exp(var, ETNGLOBAL, 0);
+            var->v.idx = be_code_nglobal(parser->finfo, &key);
+        }
     }
 }
 

--- a/lib/libesp32/Berry/src/be_string.c
+++ b/lib/libesp32/Berry/src/be_string.c
@@ -55,7 +55,6 @@ int be_eqstr(bstring *s1, bstring *s2)
         blstring *ls2 = cast(blstring*, s2);
         return ls1->llen == ls2->llen && !strcmp(lstr(ls1), lstr(ls2));
     }
-    // TODO one is long const and the other is long string
     /* const short strings */
     if (gc_isconst(s1) || gc_isconst(s2)) { /* one of the two string is short const */
         if (cast(bcstring*, s1)->hash && cast(bcstring*, s2)->hash) {

--- a/lib/libesp32/Berry/tools/grammar/berry.bytecode
+++ b/lib/libesp32/Berry/tools/grammar/berry.bytecode
@@ -4,18 +4,13 @@
 --                             description
 --
 --         a double dash ('--') start a line comment.
--- a: n    means that the size of entity 'a' is 'n' bytes.
--- 'a: .n  means that the size of entity 'a' is 'n' bits.
--- a:
---      b  means that the entity 'a' is realized by the 'b' structure.
--- a:
---      b
---      c  'b' and 'c' are arranged in a compact order (one byte alignment).
+-- a: b    means that the entity 'a' is realized by the 'b' structure.
+-- a: b c  'b' and 'c' are arranged in a compact order (one byte alignment).
 -- [a]     means that structure 'a' can be repeated 0 to any times.
 -- [a](b)  means that structure 'a' can be repeated 'b' times.
 -- a | b   means that the entity can be implemented by structure 'a' or 'b'.
--- a -> b  is equivalent to 'a:
---                               b'.
+-- N       a number indicates the byte count of the field (eg. 'a: 1').
+-- .N      means the number of bits in the field (eg. 'a: .1').
 --         only the first entity is a file entity (the root).
 -------------------------------------------------------------------------------
 
@@ -26,7 +21,7 @@ bytecode_file:  -- little endian
 
 header: 8
     magic_number: 3 -- 0xbecdfe (berry code file)
-    version: 1      -- update with file structure definition
+    version: 2      -- update with file structure definition
     integer_size: .1
     float_size: .1
     -- reserved space
@@ -35,7 +30,7 @@ main_function -> function
 
 global_desc:
     builtin_count: 4
-    global_count: 4
+    global_count: 4 -- excluding builtins
     global_name -> [
             string
         ](global_count)
@@ -48,7 +43,8 @@ function:
             string
         argc: 1   -- arguments count
         nstack: 1 -- number of stack size by this function
-        extra: 2  -- extra data
+        varg: 1
+        extra: 1  -- extra data
     bytecode:
         code_size: 4
         code_array -> [ -- bytecode array
@@ -62,7 +58,7 @@ function:
         [function](proto_count)
     upval_table:
         upval_count: 1
-        upvals -> [
+        upvals: [
                 instack: 1
                 index: 1
             ](upval_count)
@@ -82,7 +78,7 @@ class:
         string
     member_count: 4   -- number of member variables
     method_count: 4   -- number of method
-    method_table -> [
+    method_table: [
             string    -- method name
             function  -- method function body
         ](method_count)
@@ -92,5 +88,5 @@ class:
 
 nil: 1
 boolean: 1
-integer: 4 or 8
-float: 4 or 8
+integer: 4 | 8
+float: 4 | 8

--- a/tasmota/xdrv_52_3_berry_lvgl.ino
+++ b/tasmota/xdrv_52_3_berry_lvgl.ino
@@ -809,12 +809,10 @@ extern "C" {
 
           // all good
           be_return(vm);
-        } else {
-          be_return_nil(vm);
         }
       }
     }
-    be_raise(vm, "attribute_error", "module 'lvgl' has no such attribute");
+    be_return_nil(vm);
   }
 
   /*********************************************************************************************\

--- a/tasmota/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/xdrv_52_3_berry_webserver.ino
@@ -57,9 +57,12 @@ extern "C" {
         // we did have a match, low == high
         be_pushint(vm, webserver_constants[constant_idx].value);
         be_return(vm);
+      } else if (strcmp(needle, "init")) {
+        /* don't throw an exception if the 'init' function is requested */
+        be_raise(vm, "attribute_error", be_pushfstring(vm, "module 'webserver' has no such attribute '%s'", needle));
       }
     }
-    be_raise(vm, "attribute_error", "module 'webserver' has no such attribute");
+    be_return_nil(vm);
   }
 }
 


### PR DESCRIPTION
## Description:

Latest Berry improvements:
- `be_setmember()`, `be_getmember()` and `be_getmethod()` now support virtual members
- fixed bug in codedump
- max constants search raised from 50 to 100 (can happen in LVGL code)
- update in bytecode version to v2, to support vararg function in bytecode and make 'bec' files smaller

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
