### PR TITLE
SwitchMode11 & 12: New SetOption129 for delaying single press event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Turn HTTP API (command ``SetOption128 1``) default on for backward compatibility
 - Support for IEM3155 Wattmeter (#12940)
 - Berry support for vararg
+- Switchmode11 and 12: ``SetOption129 1`` delays single press events from pressing to release switch (#12712 / #12713)
 
 ### Changed
 - Shelly EM template needs to use GPIO ADE7953_IRQ_2

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -158,7 +158,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t ds18x20_mean : 1;             // bit 12 (v9.3.1.2)  - SetOption126 - (DS18x20) Enable arithmetic mean over teleperiod for JSON temperature (1)
     uint32_t wifi_no_sleep : 1;            // bit 13 (v9.5.0.2)  - SetOption127 - (Wifi) Keep wifi in no-sleep mode, prevents some occasional unresponsiveness
     uint32_t disable_referer_chk : 1;      // bit 14 (v9.5.0.5)  - SetOption128 - (Web) Allow access without referer check
-    uint32_t spare15 : 1;                  // bit 15
+    uint32_t switch_dimmer_act_at_rls : 1; // bit 15 (v9.5.0.7) - SetOption129 - (Switch) With Switchmode11 & 12, State#2 is tiggered at push (0, default) or release (1) 
     uint32_t spare16 : 1;                  // bit 16
     uint32_t spare17 : 1;                  // bit 17
     uint32_t spare18 : 1;                  // bit 18


### PR DESCRIPTION
## Description:
Adds a new SetOption129 which can be used with SwitchMod11 & 12 to delay the reaction to single press events so that double press events are not triggering single press events too.

**Related issue (if applicable):** fixes #12712  (and discussion #12713)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
