### PR TITLE
Added support for Hydreon RG-15 Rain Sensor

### DIFF
--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -835,6 +835,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT             "Effetto hall"
 #define D_SENSOR_EPD_DATA               "EPD - Dati"
 #define D_SENSOR_MCP2515_CS             "MCP2515 - CS"
+#define D_SENSOR_HRG15_RX               "HRG15 RX"
+#define D_SENSOR_HRG15_TX               "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE                     "A"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "Efekt Halla"
 #define D_SENSOR_EPD_DATA      "EPD Dane"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "Efeito Hall"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "Efeito Hall"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE                    "А"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -836,6 +836,8 @@
 #define D_SENSOR_HALLEFFECT    "HallEffect"
 #define D_SENSOR_EPD_DATA      "EPD Data"
 #define D_SENSOR_MCP2515_CS    "MCP2515 CS"
+#define D_SENSOR_HRG15_RX      "HRG15 RX"
+#define D_SENSOR_HRG15_TX      "HRG15 TX"
 
 // Units
 #define D_UNIT_AMPERE "安培"

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -170,6 +170,7 @@ enum UserSelectablePins {
   GPIO_I2S_IN_DATA,  GPIO_I2S_IN_CLK,  GPIO_I2S_IN_SLCT,
   GPIO_INTERRUPT,
   GPIO_MCP2515_CS,                     // MCP2515 Chip Select
+  GPIO_HRG15_RX, GPIO_HRG15_TX,        // Hydreon RG-15 rain sensor serial interface
   GPIO_SENSOR_END };
 
 enum ProgramSelectablePins {
@@ -360,6 +361,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_I2S_IN_DATA  "|" D_SENSOR_I2S_IN_CLK  "|" D_SENSOR_I2S_IN_SLCT  "|"
   D_SENSOR_INTERRUPT "|"
   D_SENSOR_MCP2515_CS "|"
+  D_SENSOR_HRG15_RX "|" D_SENSOR_HRG15_TX
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -790,6 +792,10 @@ const uint16_t kGpioNiceList[] PROGMEM = {
 #ifdef USE_AS608
   AGPIO(GPIO_AS608_TX),
   AGPIO(GPIO_AS608_RX),
+#endif
+#ifdef USE_HRG15
+  AGPIO(GPIO_HRG15_RX),
+  AGPIO(GPIO_HRG15_TX),
 #endif
 
 /*-------------------------------------------------------------------------------------------*\

--- a/tasmota/xsns_90_hrg15.ino
+++ b/tasmota/xsns_90_hrg15.ino
@@ -1,0 +1,233 @@
+/*
+  xsns_90-hrg15.ino - Hydreon RG-15 support for Tasmota
+
+  Copyright (c) 2021 Wouter Breukink
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_HRG15
+/*********************************************************************************************\
+ * Hydreon RG-15
+ * See https://rainsensors.com/products/rg-15/
+\*********************************************************************************************/
+
+#define XSNS_90 90
+
+#define RG15_NAME          "RG-15"
+#define RG15_BAUDRATE      9600
+#define RG15_READ_TIMEOUT  500
+#define RG15_EVENT_TIMEOUT 60
+
+#include <TasmotaSerial.h>
+
+#ifdef USE_WEBSERVER
+const char HTTP_RG15[] PROGMEM =
+  // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+   "{s}" RG15_NAME " " D_JSON_ACTIVE "{m}%2_f " D_UNIT_MILLIMETER "{e}"
+   "{s}" RG15_NAME " " D_JSON_EVENT "{m}%2_f " D_UNIT_MILLIMETER "{e}"
+   "{s}" RG15_NAME " " D_JSON_TOTAL "{m}%2_f " D_UNIT_MILLIMETER "{e}"
+   "{s}" RG15_NAME " " D_JSON_FLOWRATE "{m}%2_f " D_UNIT_MILLIMETER "/" D_UNIT_HOUR "{e}";
+#endif  // USE_WEBSERVER
+
+TasmotaSerial *HydreonSerial;
+
+struct RG15 {
+  uint16_t time = RG15_EVENT_TIMEOUT;
+  uint8_t ready = 1;
+  uint8_t received = 0;
+  float acc = 0.0f;
+  float event = 0.0f;
+  float total = 0.0f;
+  float rate = 0.0f;
+} Rg15;
+
+void Rg15Init(void)
+{
+  Rg15.ready = 0;
+  if (PinUsed(GPIO_HRG15_RX) && PinUsed(GPIO_HRG15_TX)) {
+    HydreonSerial = new TasmotaSerial(Pin(GPIO_HRG15_RX), Pin(GPIO_HRG15_TX));
+    if (HydreonSerial->begin(RG15_BAUDRATE)) {
+      if (HydreonSerial->hardwareSerial()) { ClaimSerial(); }
+
+      HydreonSerial->println('R');
+
+      Rg15.ready = 1;
+    }
+  }
+}
+
+bool Rg15Poll(void) {
+
+  // Trigger the first update
+  if (! Rg15.received) {
+    HydreonSerial->println('R');
+  }
+
+  if (! HydreonSerial->available()) {
+
+    // Check if the rain event has timed out, reset rate to 0
+    if (++Rg15.time == RG15_EVENT_TIMEOUT) {
+      Rg15.acc = 0;
+      Rg15.rate = 0;
+      MqttPublishSensor();
+    }
+
+    return false;
+  }
+
+  // Now read what's available
+  char rg15_buffer[255];
+
+  while (HydreonSerial->available()) {
+    Rg15ReadLine(rg15_buffer);
+    AddLog(LOG_LEVEL_DEBUG_MORE,PSTR("%s:" D_JSON_SERIALRECEIVED " = %s"),"HRG", rg15_buffer);
+    
+    Rg15Process(rg15_buffer);
+  }
+
+  MqttPublishSensor();
+
+  return true;
+}
+
+bool Rg15ReadLine(char* buffer)
+{
+  char c;
+  uint8_t i = 0;
+  uint32_t cmillis = millis();
+
+  while (1) {
+      if (HydreonSerial->available()) {
+        c = HydreonSerial->read();
+        buffer[i++] = c;
+
+        if (c == 10) { break; } // New line ends the message
+        if (i == 254) { break; } // Overflow
+      }
+
+      if ((millis() - cmillis) > RG15_READ_TIMEOUT) {
+        return false;
+      }
+  }
+
+  buffer[i-2] = '\0';
+  return true;
+}
+
+void Rg15Process(char* buffer) {
+  
+  // Process payload, example: Acc  0.01 mm, EventAcc  2.07 mm, TotalAcc 54.85 mm, RInt  2.89 mmph
+  Rg15.received = 1;
+  Rg15.acc = Rg15Parse(buffer, "Acc");
+  Rg15.event = Rg15Parse(buffer, "EventAcc");
+  Rg15.total = Rg15Parse(buffer, "TotalAcc");
+  Rg15.rate = Rg15Parse(buffer, "RInt");
+
+  if (Rg15.acc > 0.0f) {
+    Rg15.time = 0; // We have some data, so the rain event is on-going
+  }
+}
+
+float Rg15Parse(char* buffer, const char* item) {
+    char* start = strstr(buffer, item);
+    if (start != nullptr) {
+      char* end = strstr(start, " mm");
+      char tmp = end[0];
+      end[0] = '\0';
+      float result = CharToFloat (start + strlen(item));
+      end[0] = tmp;
+      return result;
+    } else {
+      return 0.0f;
+    }
+}
+
+bool Rg15Command(void) {
+  bool serviced = true;
+
+  if (XdrvMailbox.data_len == 1) {
+    char *send = XdrvMailbox.data;
+    HydreonSerial->println(send);
+    HydreonSerial->flush();
+
+    if (send[0] == 'k' || send[0] == 'K' || send[0] == 'o' || send[0] == 'O') {
+        ResponseCmndDone();
+        return serviced;
+    }
+
+    char rg15_buffer[255];
+    if (Rg15ReadLine(rg15_buffer)) {
+        Response_P(PSTR("{\"" D_JSON_SERIALRECEIVED "\":%s\"}"), rg15_buffer);
+        Rg15Process(rg15_buffer);
+    }
+  }
+
+  return serviced;
+}
+
+void Rg15Show(bool json)
+{
+    if (!Rg15.received) {
+        return;
+    }
+
+    if (json) {
+      ResponseAppend_P(PSTR(",\"" RG15_NAME "\":{\"" D_JSON_ACTIVE "\":%2_f, \"" D_JSON_EVENT "\":%2_f, \"" D_JSON_TOTAL "\":%2_f, \"" D_JSON_FLOWRATE "\":%2_f}"), &Rg15.acc, &Rg15.event, &Rg15.total, &Rg15.rate);
+#ifdef USE_WEBSERVER
+    } else {
+      WSContentSend_PD(HTTP_RG15, &Rg15.acc, &Rg15.event, &Rg15.total, &Rg15.rate);
+#endif  // USE_WEBSERVER
+    }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns90(uint8_t function)
+{
+
+  bool result = false;
+
+  if (Rg15.ready)
+  {
+    switch (function)
+    {
+    case FUNC_INIT:
+      Rg15Init();
+      break;
+    case FUNC_COMMAND_SENSOR:
+      if (XSNS_90 == XdrvMailbox.index) {
+          Rg15Command();
+      }
+      break;
+    case FUNC_EVERY_SECOND:
+      Rg15Poll();
+      break;
+    case FUNC_JSON_APPEND:
+      Rg15Show(1);
+      break;
+#ifdef USE_WEBSERVER
+    case FUNC_WEB_SENSOR:
+      Rg15Show(0);
+      break;
+#endif // USE_WEBSERVER
+    }
+  }
+
+  return result;
+}
+
+#endif // USE_HRG15


### PR DESCRIPTION
## Description:

Added support for Hydreon's [RG-15 Rain Sensor](https://rainsensors.com/products/rg-15/).

Details of the RS232 communications protocol can be found [here](https://rainsensors.com/wp-content/uploads/sites/3/2020/07/rg-15_instructions_sw_1.000.pdf#page=2).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).