### PR TITLE
enable PSRAM if found

### DIFF
--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_16M",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DESP32_16M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_4M",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DESP32_4M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DESP32_8M",
+    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DESP32_8M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
     "flash_mode": "dout",


### PR DESCRIPTION
## Description:

when check from Tasmota side is positive to use. Not done for the solo1 since no variant is known to have PSRAM 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
