### PR TITLE
Berry take into account `bytes()` in gc size

### DIFF
--- a/lib/libesp32/Berry/generate/be_fixed_be_class_bytes.h
+++ b/lib/libesp32/Berry/generate/be_fixed_be_class_bytes.h
@@ -1,36 +1,37 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(be_class_bytes_map) {
-    { be_const_key(dot_p, -1), be_const_var(0) },
-    { be_const_key(seti, 6), be_const_func(m_set) },
-    { be_const_key(get, 7), be_const_func(m_getu) },
-    { be_const_key(size, 10), be_const_func(m_size) },
-    { be_const_key(resize, 1), be_const_func(m_resize) },
-    { be_const_key(opt_add, 22), be_const_func(m_merge) },
-    { be_const_key(getbits, -1), be_const_closure(getbits_closure) },
-    { be_const_key(geti, 16), be_const_func(m_geti) },
-    { be_const_key(setitem, -1), be_const_func(m_setitem) },
-    { be_const_key(add, -1), be_const_func(m_add) },
-    { be_const_key(fromb64, -1), be_const_func(m_fromb64) },
-    { be_const_key(opt_neq, -1), be_const_func(m_nequal) },
-    { be_const_key(set, -1), be_const_func(m_set) },
-    { be_const_key(asstring, -1), be_const_func(m_asstring) },
-    { be_const_key(copy, 3), be_const_func(m_copy) },
-    { be_const_key(opt_eq, 2), be_const_func(m_equal) },
-    { be_const_key(tob64, -1), be_const_func(m_tob64) },
-    { be_const_key(setbits, 12), be_const_closure(setbits_closure) },
-    { be_const_key(_buffer, -1), be_const_func(m_buffer) },
-    { be_const_key(fromstring, 0), be_const_func(m_fromstring) },
-    { be_const_key(tostring, 9), be_const_func(m_tostring) },
-    { be_const_key(item, 8), be_const_func(m_item) },
-    { be_const_key(init, 23), be_const_func(m_init) },
+    { be_const_key(deinit, -1), be_const_func(m_deinit) },
     { be_const_key(opt_connect, -1), be_const_func(m_connect) },
+    { be_const_key(item, 3), be_const_func(m_item) },
+    { be_const_key(seti, 22), be_const_func(m_set) },
+    { be_const_key(asstring, -1), be_const_func(m_asstring) },
+    { be_const_key(getbits, -1), be_const_closure(getbits_closure) },
+    { be_const_key(copy, -1), be_const_func(m_copy) },
+    { be_const_key(get, -1), be_const_func(m_getu) },
+    { be_const_key(_buffer, -1), be_const_func(m_buffer) },
+    { be_const_key(fromb64, -1), be_const_func(m_fromb64) },
+    { be_const_key(add, -1), be_const_func(m_add) },
+    { be_const_key(dot_p, -1), be_const_var(0) },
+    { be_const_key(size, 0), be_const_func(m_size) },
+    { be_const_key(tostring, -1), be_const_func(m_tostring) },
+    { be_const_key(opt_add, 10), be_const_func(m_merge) },
+    { be_const_key(resize, -1), be_const_func(m_resize) },
+    { be_const_key(setitem, -1), be_const_func(m_setitem) },
+    { be_const_key(set, -1), be_const_func(m_set) },
+    { be_const_key(geti, -1), be_const_func(m_geti) },
+    { be_const_key(init, -1), be_const_func(m_init) },
     { be_const_key(clear, -1), be_const_func(m_clear) },
+    { be_const_key(opt_neq, 23), be_const_func(m_nequal) },
+    { be_const_key(tob64, 24), be_const_func(m_tob64) },
+    { be_const_key(opt_eq, -1), be_const_func(m_equal) },
+    { be_const_key(fromstring, -1), be_const_func(m_fromstring) },
+    { be_const_key(setbits, -1), be_const_closure(setbits_closure) },
 };
 
 static be_define_const_map(
     be_class_bytes_map,
-    25
+    26
 );
 
 BE_EXPORT_VARIABLE be_define_const_class(

--- a/lib/libesp32/Berry/src/be_gc.c
+++ b/lib/libesp32/Berry/src/be_gc.c
@@ -461,7 +461,10 @@ static void destruct_object(bvm *vm, bgcobject *obj)
         type = be_instance_member(vm, ins, str_literal(vm, "deinit"), vm->top);
         be_incrtop(vm);
         if (basetype(type) == BE_FUNCTION) {
-            be_dofunc(vm, vm->top - 1, 1);
+            var_setinstance(vm->top, ins);  /* push instance on stack as arg 1 */
+            be_incrtop(vm);
+            be_dofunc(vm, vm->top - 2, 1);  /* warning, there shoudln't be any exception raised here, or the gc stops */
+            be_stackpop(vm, 1);
         }
         be_stackpop(vm, 1);
     }


### PR DESCRIPTION
## Description:

Now `bytes()` allocated are taken into account in the gc memory usage.
Also fixed call to `deinit()` that wouldn't pass the instance as argument.

Before:
```
> tasmota.gc()
7723

> b=bytes().resize(2000)

> tasmota.gc()
7739           # the 2KB are not taken into account
```

After
```
> tasmota.gc()
7723

> b=bytes().resize(2000)

> tasmota.gc()
8717           # increase Berry of heap size

> b=nil
> tasmota.gc()
7701           # `b` is garbage collected and buffer freed
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
