### PR TITLE
Fix compilation issue when disabling `USE_LIGHT` feature

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -55,6 +55,7 @@ m = minimal, l = lite, t = tasmota, k = knx, s = sensors, i = ir, d = display
 | USE_KEELOQ            | - | - | - / - | - | - | - | - |
 | USE_SONOFF_D1         | - | - | x / - | x | - | - | - |
 | USE_SHELLY_DIMMER     | - | - | x / - | - | - | - | - |
+| USE_AC_ZERO_CROSS_DIMMER | - | - | x / x | x | x | x | x |
 |                       |   |   |       |   |   |   |   |
 | Feature or Sensor     | m | l | t     | k | s | i | d | Remarks
 | USE_LIGHT             | - | x | x / x | x | x | x | x |

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -321,6 +321,7 @@
 #define LIGHT_VIRTUAL_CT       false             // [SetOption106] Virtual CT - Creates a virtual White ColorTemp for RGBW lights
 #define LIGHT_VIRTUAL_CT_CW    false             // [SetOption107] Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
 #define LIGHT_VIRTUAL_CT_POINTS 3                // Number of reference points for Virtual CT (min 2, default 3)
+#define USE_AC_ZERO_CROSS_DIMMER                 // Requires USE_COUNTER and USE_LIGHT
 
 // -- Energy --------------------------------------
 #define ENERGY_VOLTAGE_ALWAYS  false             // [SetOption21] Enable show voltage even if powered off

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -982,6 +982,14 @@
 #define USE_EMULATION
 #endif
 
+#ifdef USE_COUNTER
+#define USE_LIGHT
+#endif
+
+#ifdef USE_PWM_DIMMER
+#define USE_LIGHT
+#endif
+
 // Convert legacy slave to client
 #ifdef USE_TASMOTA_SLAVE
 #define USE_TASMOTA_CLIENT

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -898,6 +898,7 @@
 #undef USE_PROMETHEUS                            // Disable support for https://prometheus.io/ metrics exporting over HTTP /metrics endpoint
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code
+#undef USE_AC_ZERO_CROSS_DIMMER                  // Disable support for AC_ZERO_CROSS_DIMMER
 
 #endif  // FIRMWARE_MINIMAL
 #endif  // ifndef FIRMWARE_MINICUSTOM

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -506,7 +506,6 @@
 //#undef USE_WEBSERVER                             // Disable Webserver
 #undef USE_ENHANCED_GUI_WIFI_SCAN                // Disable wifi scan output with BSSID (+0k5 code)
 //#undef USE_WEBSEND_RESPONSE                      // Disable command WebSend response message (+1k code)
-#define USE_EMULATION                            // Enable Hue emulation
 #define USE_EMULATION_HUE                        // Enable Hue Bridge emulation for Alexa (+14k code, +2k mem common)
 #undef USE_EMULATION_WEMO                        // Disable Belkin WeMo emulation for Alexa (+6k code, +2k mem common)
 #undef USE_CUSTOM                                // Disable Custom features
@@ -981,12 +980,24 @@
 #ifdef USE_EMULATION_WEMO
 #define USE_EMULATION
 #endif
+#ifdef USE_EMULATION
+#define USE_LIGHT
+#endif
 
-#ifdef USE_COUNTER
+#ifdef USE_AC_ZERO_CROSS_DIMMER
+#define USE_COUNTER
 #define USE_LIGHT
 #endif
 
 #ifdef USE_PWM_DIMMER
+#define USE_LIGHT
+#endif
+
+#ifdef USE_TUYA_MCU
+#define USE_LIGHT
+#endif
+
+#ifdef USE_ARILUX_RF
 #define USE_LIGHT
 #endif
 

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -754,6 +754,7 @@
 #undef USE_THERMOSTAT                            // Disable support for Thermostat
 #undef DEBUG_THEO                                // Disable debug code
 #undef USE_DEBUG_DRIVER                          // Disable debug code
+#undef USE_AC_ZERO_CROSS_DIMMER                  // Disable support for AC_ZERO_CROSS_DIMMER
 #endif  // FIRMWARE_LITE
 
 

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -422,7 +422,9 @@ void HAssAnnounceRelayLight(void)
   char stemp3[TOPSZ];
   char unique_id[30];
 
+#ifdef USE_LIGHT
   bool LightControl = light_controller.isCTRGBLinked(); // SetOption37 - Color remapping for led channels, also provides an option for allowing independent handling of RGB and white channels
+#endif //USE_LIGHT
   bool PwmMulti = Settings->flag3.pwm_multi_channels;    // SetOption68 - Multi-channel PWM instead of a single light
   bool is_topic_light = false;                          // Switch HAss domain between Lights and Relays
   bool ind_light = false;                               // Controls Separated Lights when SetOption37 is >= 128
@@ -448,14 +450,15 @@ void HAssAnnounceRelayLight(void)
         if (TUYA_DIMMER == TasmotaGlobal.module_type || SK03_TUYA == TasmotaGlobal.module_type) { TuyaMod = true; }
   #endif //ESP8266
 
+#ifdef USE_LIGHT
   // If there is a special Light to be enabled and managed with SetOption68 or SetOption37 >= 128, Discovery calculates the maximum number of entities to be generated in advance
-
   if (PwmMulti) { max_lights = Light.subtype; }
 
   if (!LightControl) {
     ind_light = true;
     if (!PwmMulti) { max_lights = 2;}
   }
+#endif //USE_LIGHT
 
 #ifdef USE_SHUTTER
   if (Settings->flag3.shutter_mode) {
@@ -500,9 +503,11 @@ void HAssAnnounceRelayLight(void)
 
     if (bitRead(shutter_mask, i-1)) {
       // suppress shutter relays
+#ifdef USE_LIGHT      
     } else if ((i < Light.device) && !RelayX) {
       err_flag = true;
       AddLog(LOG_LEVEL_ERROR, PSTR("%s"), kHAssError2);
+#endif //USE_LIGHT
     } else {
       if (Settings->flag.hass_discovery && (RelayX || (Light.device > 0) && (max_lights > 0)) && !err_flag )
       {                    // SetOption19 - Control Home Assistant automatic discovery (See SetOption59)

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -507,9 +507,12 @@ void HAssAnnounceRelayLight(void)
     } else if ((i < Light.device) && !RelayX) {
       err_flag = true;
       AddLog(LOG_LEVEL_ERROR, PSTR("%s"), kHAssError2);
-#endif //USE_LIGHT
     } else {
       if (Settings->flag.hass_discovery && (RelayX || (Light.device > 0) && (max_lights > 0)) && !err_flag )
+#else
+    } else {
+      if (Settings->flag.hass_discovery && RelayX )
+#endif //USE_LIGHT
       {                    // SetOption19 - Control Home Assistant automatic discovery (See SetOption59)
           char name[TOPSZ]; // friendlyname(33) + " " + index
           char value_template[33];

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -18,6 +18,7 @@
 */
 
 #ifdef USE_PWM_DIMMER
+#ifdef USE_LIGHT
 
 /*********************************************************************************************\
 * Support for Martin Jerry/acenx/Tessan/NTONPOWER SD0x PWM dimmer switches. The brightness of
@@ -886,4 +887,5 @@ bool Xdrv35(uint8_t function)
   return result;
 }
 
+#endif  // USE_LIGHT
 #endif  // USE_PWM_DIMMER

--- a/tasmota/xsns_01_counter.ino
+++ b/tasmota/xsns_01_counter.ino
@@ -24,8 +24,6 @@
 
 #define XSNS_01             1
 
-#define USE_AC_ZERO_CROSS_DIMMER 1
-
 #define D_PRFX_COUNTER "Counter"
 #define D_CMND_COUNTERTYPE "Type"
 #define D_CMND_COUNTERDEBOUNCE "Debounce"
@@ -59,7 +57,7 @@ struct AC_ZERO_CROSS_DIMMER {
   uint32_t lastCycleCount = 0;
   uint32_t currentSteps = 100;
 } ac_zero_cross_dimmer;
-#endif
+#endif //USE_AC_ZERO_CROSS_DIMMER
 
 void IRAM_ATTR CounterIsrArg(void *arg) {
   uint32_t index = *static_cast<uint8_t*>(arg);
@@ -101,7 +99,7 @@ void IRAM_ATTR CounterIsrArg(void *arg) {
         }
         ac_zero_cross_dimmer.lastCycleCount = ac_zero_cross_dimmer.currentCycleCount;
       }
-#endif
+#endif //USE_AC_ZERO_CROSS_DIMMER
       return;
     }
   }
@@ -152,7 +150,7 @@ void CounterInit(void)
     if (PinUsed(GPIO_CNTR1, i)) {
 #ifdef USE_AC_ZERO_CROSS_DIMMER
       ac_zero_cross_dimmer.tobe_cycle_timeClockCycles = microsecondsToClockCycles(1000000 / Settings->pwm_frequency);
-#endif
+#endif //USE_AC_ZERO_CROSS_DIMMER
       Counter.any_counter = true;
       pinMode(Pin(GPIO_CNTR1, i), bitRead(Counter.no_pullup, i) ? INPUT : INPUT_PULLUP);
       if ((0 == Settings->pulse_counter_debounce_low) && (0 == Settings->pulse_counter_debounce_high) && !Settings->flag4.zerocross_dimmer) {
@@ -269,7 +267,7 @@ void SyncACDimmer(void)
     }
   }
 }
-#endif
+#endif //USE_AC_ZERO_CROSS_DIMMER
 
 /*********************************************************************************************\
  * Commands
@@ -349,7 +347,7 @@ bool Xsns01(uint8_t function)
       case FUNC_LOOP:
         SyncACDimmer();
       break;
-#endif
+#endif //USE_AC_ZERO_CROSS_DIMMER
 #ifdef USE_WEBSERVER
       case FUNC_WEB_SENSOR:
         CounterShow(0);


### PR DESCRIPTION
## Description:

This PR fixes a compilation issue when undefining `USE_LIGHT` in **_user_config_override.h_**.
Also with this, the requirements of several features that depend on `USE_LIGHT` are now satisfied.

Compiling standard Tasmota uses:
```lua
RAM:   [=====     ]  49.3% (used 40424 bytes from 81920 bytes)
Flash: [======    ]  60.6% (used 620520 bytes from 1023984 bytes)
```
So, if an user wants to disable the feature `USE_LIGHT`, the following features must be disabled too, due to they depend on `USE_LIGHT` to work. If any of those are included, `USE_LIGHT` will be automatically included too.

Example of disabling `USE_LIGHT`:
```cpp
#undef USE_LIGHT

#undef USE_AC_ZERO_CROSS_DIMMER
#undef USE_PWM_DIMMER
#undef USE_TUYA_MCU
#undef USE_EMULATION_HUE
#undef USE_EMULATION_WEMO
#undef USE_ARILUX_RF
```

So, standard Tasmota without `USE_LIGHT` _(and without `USE_LIGHT` dependent features)_ now compiles and uses:
```lua
RAM:   [=====     ]  47.5% (used 38904 bytes from 81920 bytes)       -1.5 Kbytes
Flash: [=====     ]  53.2% (used 545168 bytes from 1023984 bytes)   -75.3 Kbytes
```

### Just for comparison

Standard Tasmota-minimal.bin:
```lua
RAM:   [====      ]  42.8% (used 35100 bytes from 81920 bytes)
Flash: [====      ]  38.8% (used 397472 bytes from 1023984 bytes)
```

Standard Tasmota-lite.bin:
```lua
RAM:   [=====     ]  45.6% (used 37384 bytes from 81920 bytes)
Flash: [=====     ]  49.4% (used 505656 bytes from 1023984 bytes)
```

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/pull/12966

Thanks @Avamander for pointing this out.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
