### PR TITLE
Fix opentherm json

### DIFF
--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -237,7 +237,7 @@ void sns_opentherm_stat(bool json)
     {
         ResponseAppend_P(PSTR(",\"OPENTHERM\":{"));
         ResponseAppend_P(PSTR("\"conn\":\"%s\","), statusStr);
-        ResponseAppend_P(PSTR("\"settings\":%d,"), Settings->ot_flags);
+        ResponseAppend_P(PSTR("\"settings\":%d"), Settings->ot_flags);
         sns_opentherm_dump_telemetry();
         ResponseJsonEnd();
 #ifdef USE_WEBSERVER

--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -235,9 +235,7 @@ void sns_opentherm_stat(bool json)
 
     if (json)
     {
-        ResponseAppend_P(PSTR(",\"OPENTHERM\":{"));
-        ResponseAppend_P(PSTR("\"conn\":\"%s\","), statusStr);
-        ResponseAppend_P(PSTR("\"settings\":%d"), Settings->ot_flags);
+        ResponseAppend_P(PSTR(",\"OPENTHERM\":{\"conn\":\"%s\",\"settings\":%d"), statusStr, Settings->ot_flags);
         sns_opentherm_dump_telemetry();
         ResponseJsonEnd();
 #ifdef USE_WEBSERVER

--- a/tasmota/xsns_69_opentherm_protocol.ino
+++ b/tasmota/xsns_69_opentherm_protocol.ino
@@ -549,7 +549,6 @@ void sns_opentherm_process_success_response(struct OT_BOILER_STATUS_T *boilerSta
 
 void sns_opentherm_dump_telemetry()
 {
-    bool add_coma = false;
     for (int i = 0; i < SNS_OT_COMMANDS_COUNT; ++i)
     {
         struct OpenThermCommandT *cmd = &sns_opentherm_commands[i];
@@ -558,11 +557,8 @@ void sns_opentherm_dump_telemetry()
             continue;
         }
 
-        ResponseAppend_P(PSTR("%s\"%s\":"), add_coma ? "," : "", cmd->m_command_name);
-
+        ResponseAppend_P(PSTR(",\"%s\":"), cmd->m_command_name);
         cmd->m_ot_appent_telemetry(cmd);
-
-        add_coma = true;
     }
 }
 


### PR DESCRIPTION
## Description:

Following report from Xrus on Discord : https://discord.com/channels/479389167382691863/882284950995492864/882284955445628929
`tele / tasmota / SENSOR = {"Time": "2021-08-30T07: 45: 34", "SI7021": {"Temperature": 20.4, "Humidity": 76.9, "DewPoint"  : 16.2}, "OPENTHERM": {"conn": "FAULT", "settings": 3,}, "Global": {"Temperature": 20.4, "Humidity": 76.9, "DewPoint": 16.2}, "  TempUnit ":" C "}`
Obvious useless `,` in the OPENTHERM section after `"settings":3`

Refactored the code to avoid this when no telemetry is provided

Will be tested by the user

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
