### PR TITLE
Fixed crash when PSRAM is absent and ``BOARD_HAS_PSRAM`` set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [9.5.0.8]
 
+### Fixed
+- Fixed crash when PSRAM is absent and ``BOARD_HAS_PSRAM`` set
 
 ## [9.5.0.7] 20210901
 ### Added

--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -60,12 +60,10 @@ extern "C" {
 #ifndef BERRY_LOGSZ
 #define BERRY_LOGSZ 700
 #endif
-extern "C" {
-    extern void *berry_malloc(size_t size);
-}
+
 static char * log_berry_buffer = nullptr;
 static_block {
-    log_berry_buffer = (char*) berry_malloc(BERRY_LOGSZ);
+    log_berry_buffer = (char*) malloc(BERRY_LOGSZ);
     if (log_berry_buffer) log_berry_buffer[0] = 0;
 }
 extern void berry_log(const char * berry_buf);

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -464,10 +464,21 @@ uint8_t* FlashDirectAccess(void) {
   return data;
 }
 
+extern "C" {
+  bool esp_spiram_is_initialized(void);
+}
+
+// this function is a replacement for `psramFound()`.
+// `psramFound()` can return true even if no PSRAM is actually installed
+// This new version also checks `esp_spiram_is_initialized` to know if the PSRAM is initialized
+bool FoundPSRAM(void) {
+  return psramFound() && esp_spiram_is_initialized();
+}
+
 // new function to check whether PSRAM is present and supported (i.e. required pacthes are present)
 bool UsePSRAM(void) {
   static bool can_use_psram = CanUsePSRAM();
-  return psramFound() && can_use_psram;
+  return FoundPSRAM() && can_use_psram;
 }
 
 void *special_malloc(uint32_t size) {
@@ -690,6 +701,7 @@ typedef struct {
  * patches are present.
  */
 bool CanUsePSRAM(void) {
+  if (!FoundPSRAM()) return false;
 #ifdef HAS_PSRAM_FIX
   return true;
 #endif

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -275,12 +275,13 @@ void setup(void) {
   }
 
 //  AddLog(LOG_LEVEL_INFO, PSTR("ADR: Settings %p, Log %p"), Settings, TasmotaGlobal.log_buffer);
-  AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s"), GetDeviceHardware().c_str());
+  AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s %s"), GetDeviceHardware().c_str(),
+            FoundPSRAM() ? (CanUsePSRAM() ? "(PSRAM)" : "(PSRAM disabled)") : "" );
 #ifdef ESP32
-  AddLog(LOG_LEVEL_DEBUG, PSTR("HDW: psramFound=%i CanUsePSRAM=%i"), psramFound(), CanUsePSRAM());
+  AddLog(LOG_LEVEL_DEBUG, PSTR("HDW: FoundPSRAM=%i CanUsePSRAM=%i"), FoundPSRAM(), CanUsePSRAM());
 #endif // ESP32
 #if defined(ESP32) && !defined(HAS_PSRAM_FIX)
-  if (psramFound() && !CanUsePSRAM()) {
+  if (FoundPSRAM() && !CanUsePSRAM()) {
     AddLog(LOG_LEVEL_INFO, PSTR("HDW: PSRAM is disabled, requires specific compilation on this hardware (see doc)"));
   }
 #endif // ESP32

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -275,15 +275,17 @@ void setup(void) {
   }
 
 //  AddLog(LOG_LEVEL_INFO, PSTR("ADR: Settings %p, Log %p"), Settings, TasmotaGlobal.log_buffer);
+#ifdef ESP32
   AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s %s"), GetDeviceHardware().c_str(),
             FoundPSRAM() ? (CanUsePSRAM() ? "(PSRAM)" : "(PSRAM disabled)") : "" );
-#ifdef ESP32
   AddLog(LOG_LEVEL_DEBUG, PSTR("HDW: FoundPSRAM=%i CanUsePSRAM=%i"), FoundPSRAM(), CanUsePSRAM());
-#endif // ESP32
-#if defined(ESP32) && !defined(HAS_PSRAM_FIX)
+  #if !defined(HAS_PSRAM_FIX)
   if (FoundPSRAM() && !CanUsePSRAM()) {
     AddLog(LOG_LEVEL_INFO, PSTR("HDW: PSRAM is disabled, requires specific compilation on this hardware (see doc)"));
   }
+  #endif
+#else // ESP32
+  AddLog(LOG_LEVEL_INFO, PSTR("HDW: %s"), GetDeviceHardware().c_str());
 #endif // ESP32
 
 #ifdef USE_UFILESYS


### PR DESCRIPTION
## Description:

Found that `psramFound()` could return true even if no PSRAM is present. The new logic adds `esp_spiram_is_initialized()` test.

Boot log now adds basic PSRAM information: either "PSRAM", "PSRAM disabled" or <empty>.

Example with M5Stack Fire (with PSRAM):
```
00:00:00.002 HDW: ESP32-D0WDQ6 (PSRAM)
```

Minor fix: Berry log buffer is in main ram instead of SPRAM, to avoid early call to PSRAM malloc.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
