### PR TITLE
Fix PSRAM compilation for Esp32c3

### DIFF
--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -472,7 +472,11 @@ extern "C" {
 // `psramFound()` can return true even if no PSRAM is actually installed
 // This new version also checks `esp_spiram_is_initialized` to know if the PSRAM is initialized
 bool FoundPSRAM(void) {
+#if CONFIG_IDF_TARGET_ESP32C3
+  return psramFound();
+#else
   return psramFound() && esp_spiram_is_initialized();
+#endif
 }
 
 // new function to check whether PSRAM is present and supported (i.e. required pacthes are present)


### PR DESCRIPTION
## Description:

Fix regression of #13037 for Esp32C3.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
