### PR TITLE
Added new functionality if motor of shutter stops late

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -88,7 +88,7 @@ struct SHUTTER {
   int8_t   direction;          // 1 == UP , 0 == stop; -1 == down
   int8_t   lastdirection;      // last direction (1 == UP , -1 == down)
   uint8_t  switch_mode;        // how to switch relays: SHT_SWITCH, SHT_PULSE
-  int16_t  motordelay;         // initial motorstarttime in 0.05sec. Also uses for ramp at steppers and servos
+  int8_t   motordelay;         // initial motorstarttime in 0.05sec. Also uses for ramp at steppers and servos, negative if motor stops late
   int16_t  pwm_velocity;       // frequency of PWN for stepper motors or PWM duty cycle change for PWM servo
   uint16_t pwm_value;          // dutyload of PWM 0..1023 on ESP8266
   uint16_t close_velocity_max; // maximum of PWM change during closeing. Defines velocity on opening. Steppers and Servos only
@@ -1186,11 +1186,11 @@ void CmndShutterMotorDelay(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.shutters_present)) {
     if (XdrvMailbox.data_len > 0) {
-      Settings->shutter_motordelay[XdrvMailbox.index -1] = (uint16_t)(STEPS_PER_SECOND * CharToFloat(XdrvMailbox.data));
+      Settings->shutter_motordelay[XdrvMailbox.index -1] = (uint8_t)(STEPS_PER_SECOND * CharToFloat(XdrvMailbox.data));
       ShutterInit();
     }
     char time_chr[10];
-    dtostrfd((float)(Settings->shutter_motordelay[XdrvMailbox.index -1]) / STEPS_PER_SECOND, 2, time_chr);
+    dtostrfd((float)(Shutter[XdrvMailbox.index -1].motordelay) / STEPS_PER_SECOND, 2, time_chr);
     ResponseCmndIdxChar(time_chr);
   }
 }


### PR DESCRIPTION
I saw on my blind that if I move it in 5% steps it opens much more than it should. The reason is, that the motor runs to long. shuttermotordelay was only able to work with >0 values. Now also <0 is supported for standard shutters.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
