### PR TITLE
Fixed 2 typos in Portuguese PT language file

### DIFF
--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -449,8 +449,8 @@
 #define D_TIMER_TIME "Tempo"
 #define D_TIMER_DAYS "Dias"
 #define D_TIMER_REPEAT "Repetir"
-#define D_TIMER_OUTPUT "Aaída"
-#define D_TIMER_ACTION "Açao"
+#define D_TIMER_OUTPUT "Saída"
+#define D_TIMER_ACTION "Ação"
 
 // xdrv_10_knx.ino
 #define D_CONFIGURE_KNX "Configurar KNX"


### PR DESCRIPTION
## Description:
fixed typos "Aaída" "Açao" to "Saída" "Ação" in the portuguese language header file, pt_PT.h.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
