### PR TITLE
Support for ESP32S2 GPIOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Command ``WebGetConfig <url>`` if ``#define USE_WEBGETCONFIG`` is enabled to restore/init configuration from external webserver (#13034)
 - Berry class ``webclient`` for HTTP/HTTPS requests
+- Support for ESP32S2 GPIOs
 
 ### Fixed
 - OpenTherm invalid JSON (#13028)

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1565,6 +1565,10 @@ void TemplateGpios(myio *gp)
   for (uint32_t i = 0; i < nitems(Settings->user_template.gp.io); i++) {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
     dest[i] = src[i];
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    if (22 == i) { j = 33; }    // skip 22-32
+    dest[j] = src[i];
+    j++;
 #else
     if (6 == i) { j = 9; }
     if (8 == i) { j = 12; }
@@ -1623,6 +1627,8 @@ bool FlashPin(uint32_t pin)
 {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
   return (pin > 10) && (pin < 18);        // ESP32C3 has GPIOs 11-17 reserved for Flash
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+  return (pin > 21) && (pin < 33);        // ESP32S2 skip 22-32
 #else // ESP32 and ESP8266
   return (((pin > 5) && (pin < 9)) || (11 == pin));
 #endif
@@ -1632,6 +1638,8 @@ bool RedPin(uint32_t pin) // pin may be dangerous to change, display in RED in t
 {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
   return false;     // no red pin on ESP32C3
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+  return false;     // no red pin on ESP32S3
 #else // ESP32 and ESP8266
 
 #ifdef CONFIG_IDF_TARGET_ESP32
@@ -1648,13 +1656,17 @@ uint32_t ValidPin(uint32_t pin, uint32_t gpio) {
     return GPIO_NONE;    // Disable flash pins GPIO6, GPIO7, GPIO8 and GPIO11
   }
 
-#ifndef CONFIG_IDF_TARGET_ESP32C3
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+// ignore
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+// ignore
+#else // not ESP32C3 and not ESP32S2
   if ((WEMOS == Settings->module) && !Settings->flag3.user_esp8285_enable) {  // SetOption51 - Enable ESP8285 user GPIO's
     if ((9 == pin) || (10 == pin)) {
       return GPIO_NONE;  // Disable possible flash GPIO9 and GPIO10
     }
   }
-#endif  // not ESP32C3
+#endif
 
   return gpio;
 }

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -1005,7 +1005,17 @@ typedef struct MYTMPLT8266 {
 //                                  0 1 2 3 4 5 6 7 8 9101112131415161718192021
 const char PINS_WEMOS[] PROGMEM = "AOAOAOAOAOAOIOIOIOIOIOFLFLFLFLFLFLFLIOIORXTX";
 
-#else  // not CONFIG_IDF_TARGET_ESP32C3
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+
+#define MAX_GPIO_PIN       47   // Number of supported GPIO
+#define MIN_FLASH_PINS     11   // Number of flash chip pins unusable for configuration (22-25 don't exist, 26-32 for SPI)
+#define MAX_USER_PINS      36   // MAX_GPIO_PIN - MIN_FLASH_PINS
+#define WEMOS_MODULE       0    // Wemos module
+
+//                                  0 1 2 3 4 5 6 7 8 910111213141516171819202122232425262728293031323334353637383940414243444546
+const char PINS_WEMOS[] PROGMEM = "IOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOAOIO--------FLFLFLFLFLFLFLIOIOIOIOIOIOIOIOIOIOIOIOIOI ";
+
+#else  // not CONFIG_IDF_TARGET_ESP32C3 nor CONFIG_IDF_TARGET_ESP32S2 - ESP32
 
 #define MAX_GPIO_PIN       40   // Number of supported GPIO
 #define MIN_FLASH_PINS     4    // Number of flash chip pins unusable for configuration (GPIO6, 7, 8 and 11)
@@ -1015,7 +1025,7 @@ const char PINS_WEMOS[] PROGMEM = "AOAOAOAOAOAOIOIOIOIOIOFLFLFLFLFLFLFLIOIORXTX"
 //                                  0 1 2 3 4 5 6 7 8 9101112131415161718192021222324252627282930313233343536373839
 const char PINS_WEMOS[] PROGMEM = "IOTXIORXIOIOflashcFLFLolIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOIOAOAOIAIAIAIAIAIA";
 
-#endif  // not CONFIG_IDF_TARGET_ESP32C3
+#endif  // ESP32/S2/C3 selection
 #endif  // ESP32
 
 /********************************************************************************************\
@@ -2527,11 +2537,89 @@ const mytmplt kModules[] PROGMEM = {
 
 /*********************************************************************************************\
  Known templates
-
-
 \*********************************************************************************************/
 
-#else  // not CONFIG_IDF_TARGET_ESP32C3 - now ESP32
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+
+/********************************************************************************************\
+ * ESP32-C3 Module templates
+\********************************************************************************************/
+
+#define USER_MODULE        255
+
+// Supported hardware modules
+enum SupportedModules {
+  WEMOS,
+  MAXMODULE };
+
+// Default module settings
+const uint8_t kModuleNiceList[] PROGMEM = {
+  WEMOS,
+};
+
+// !!! Update this list in the same order as kModuleNiceList !!!
+const char kModuleNames[] PROGMEM =
+  "ESP32S2|"
+  ;
+
+// !!! Update this list in the same order as SupportedModules !!!
+const mytmplt kModules[] PROGMEM = {
+  {                              // Generic ESP32C3 device
+    AGPIO(GPIO_USER),            // 0       IO                  GPIO0, RTC_GPIO0, Strapping
+    AGPIO(GPIO_USER),            // 1       AO                  GPIO1, ADC1_CH0, RTC_GPIO1
+    AGPIO(GPIO_USER),            // 2       AO                  GPIO2, ADC1_CH1, RTC_GPIO2
+    AGPIO(GPIO_USER),            // 3       AO                  GPIO3, ADC1_CH2, RTC_GPIO3
+    AGPIO(GPIO_USER),            // 4       AO                  GPIO4, ADC1_CH3, RTC_GPIO4
+    AGPIO(GPIO_USER),            // 5       AO                  GPIO5, ADC1_CH4, RTC_GPIO5
+    AGPIO(GPIO_USER),            // 6       AO                  GPIO6, ADC1_CH5, RTC_GPIO6
+    AGPIO(GPIO_USER),            // 7       AO                  GPIO7, ADC1_CH6, RTC_GPIO7
+    AGPIO(GPIO_USER),            // 8       AO                  GPIO8, ADC1_CH7, RTC_GPIO8
+    AGPIO(GPIO_USER),            // 9       AO                  GPIO9, ADC1_CH8, RTC_GPIO9
+    AGPIO(GPIO_USER),            // 10      AO                  GPIO10, ADC1_CH9, RTC_GPIO10
+    AGPIO(GPIO_USER),            // 11      AO                  GPIO11, ADC2_CH0, RTC_GPIO11
+    AGPIO(GPIO_USER),            // 12      AO                  GPIO12, ADC2_CH1, RTC_GPIO12
+    AGPIO(GPIO_USER),            // 13      AO                  GPIO13, ADC2_CH2, RTC_GPIO13
+    AGPIO(GPIO_USER),            // 14      AO                  GPIO14, ADC2_CH3, RTC_GPIO14
+    AGPIO(GPIO_USER),            // 15      AO                  GPIO15, ADC2_CH4, RTC_GPIO15, XTAL_32K_P
+    AGPIO(GPIO_USER),            // 16      AO                  GPIO16, ADC2_CH5, RTC_GPIO16, XTAL_32K_N
+    AGPIO(GPIO_USER),            // 17      AO                  GPIO17, ADC2_CH6, RTC_GPIO17, DAC_1
+    AGPIO(GPIO_USER),            // 18      AO                  GPIO18, ADC2_CH7, RTC_GPIO18, DAC_2
+    AGPIO(GPIO_USER),            // 19      AO                  GPIO19, ADC2_CH8, RTC_GPIO19
+    AGPIO(GPIO_USER),            // 20      AO                  GPIO20, ADC2_CH9, RTC_GPIO20
+    AGPIO(GPIO_USER),            // 21      IO                  GPIO21, RTC_GPIO21
+                                 // 22      --                  Unused
+                                 // 23      --                  Unused
+                                 // 24      --                  Unused
+                                 // 25      --                  Unused
+                                 // 26      FL                  SPICS1, PSRAM
+                                 // 27      FL                  SPIHD
+                                 // 28      FL                  SPIWP
+                                 // 29      FL                  SPICS0
+                                 // 30      FL                  SPICLK
+                                 // 31      FL                  SPIQ
+                                 // 32      FL                  SPID
+    AGPIO(GPIO_USER),            // 33      IO                  GPIO33
+    AGPIO(GPIO_USER),            // 34      IO                  GPIO34
+    AGPIO(GPIO_USER),            // 35      IO                  GPIO35
+    AGPIO(GPIO_USER),            // 36      IO                  GPIO36
+    AGPIO(GPIO_USER),            // 37      IO                  GPIO37
+    AGPIO(GPIO_USER),            // 38      IO                  GPIO38
+    AGPIO(GPIO_USER),            // 39      IO                  GPIO39, JTAG MTCK
+    AGPIO(GPIO_USER),            // 40      IO                  GPIO40, JTAG MTDO
+    AGPIO(GPIO_USER),            // 41      IO                  GPIO41, JTAG MTDI
+    AGPIO(GPIO_USER),            // 42      IO                  GPIO42, JTAG MTMS
+    AGPIO(GPIO_USER),            // 43      IO                  GPIO43, U0TXD
+    AGPIO(GPIO_USER),            // 44      IO                  GPIO44, U0RXD
+    AGPIO(GPIO_USER),            // 45      IO                  GPIO45, Strapping
+    AGPIO(GPIO_USER),            // 46      I                   GPIO46, Input only, Strapping
+  },
+};
+
+/*********************************************************************************************\
+ Known templates
+\*********************************************************************************************/
+
+#else  // not CONFIG_IDF_TARGET_ESP32C3 nor CONFIG_IDF_TARGET_ESP32S2 - ESP32
 /********************************************************************************************\
  * ESP32 Module templates
 \********************************************************************************************/
@@ -2846,7 +2934,7 @@ const mytmplt kModules[] PROGMEM = {
 
 \*********************************************************************************************/
 
-#endif  // Not CONFIG_IDF_TARGET_ESP32C3
+#endif  // ESP32/S2/C3 selection
 #endif  // ESP32
 
 #endif  // _TASMOTA_TEMPLATE_H_


### PR DESCRIPTION
## Description:

Support for ESP32S2 specific GPIOs:
- GPIO0-21 and GPIO33-46 are configurable
  - GPIO1-20 are capable of Analog input
  - GPIO39-42 can be used for JTAG debugging (require special build)
  - GPIO43-44 are U0 TX/RX
  - GPIO46 is input only
- GPIO22-25 are not configurable
- GPIO26-32 are reserved for SPI Flash and PSRAM

![esp32s2gpios](https://user-images.githubusercontent.com/49731213/132094443-392ae8a0-ab02-4a38-a6c8-483a8075be6c.png)

Note: templates for ESP32 cannot be used for ESP32S2, GPIOs are different.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
