### PR TITLE
shutter: fixed stepper wrong position #12849 follow up

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1084,7 +1084,7 @@ void CmndShutterPosition(void)
         }
         int8_t new_shutterdirection = Shutter[index].real_position < Shutter[index].target_position ? 1 : -1;
         if (Shutter[index].direction == -new_shutterdirection) {
-	  Shutter[index].start_position = Shutter[index].target_position;	
+	  Shutter[index].target_position = Shutter[index].start_position;
           ShutterPowerOff(index);
         }
         if (Shutter[index].direction != new_shutterdirection) {


### PR DESCRIPTION
Position was wrongly calculated on emergency stop

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
