### PR TITLE
Forgot flag in ESP32S2/C3 templates

### DIFF
--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -2559,6 +2559,7 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 19      IO                  GPIO19, USB_D+
     AGPIO(GPIO_USER),            // 20      IO     RXD0         GPIO20, U0RXD
     AGPIO(GPIO_USER),            // 21      IO     TXD0         GPIO21, U0TXD
+    0                            // Flag
   },
 };
 
@@ -2639,6 +2640,7 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 44      IO                  GPIO44, U0RXD
     AGPIO(GPIO_USER),            // 45      IO                  GPIO45, Strapping
     AGPIO(GPIO_USER),            // 46      I                   GPIO46, Input only, Strapping
+    0                            // Flag
   },
 };
 


### PR DESCRIPTION
## Description:

No change in compiled code but cleaner.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
