### PR TITLE
use type SemaphoreHandle_t where TasAutoMutex is used to silence new …

### DIFF
--- a/pio-tools/cxx_flags.py
+++ b/pio-tools/cxx_flags.py
@@ -1,4 +1,0 @@
-Import("env")
-
-# General options that are passed to the C++ compiler
-env.Append(CXXFLAGS=["-fpermissive"])

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -90,8 +90,6 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DUSE_BLE_ESP32
                               -DUSE_MI_ESP32
                               ;-DESP32_STAGE=true
-extra_scripts               = ${env:tasmota32_base.extra_scripts}
-                              pre:pio-tools/cxx_flags.py
 lib_extra_dirs              = lib/libesp32
                               lib/libesp32_div
                               lib/libesp32_lvgl

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -136,20 +136,20 @@ class TasAutoMutex {
   int maxWait;
   const char *name;
   public:
-    TasAutoMutex(void ** mutex, const char *name = "", int maxWait = 40, bool take=true);
+    TasAutoMutex(SemaphoreHandle_t* mutex, const char *name = "", int maxWait = 40, bool take=true);
     ~TasAutoMutex();
     void give();
     void take();
-    static void init(void ** ptr);
+    static void init(SemaphoreHandle_t* ptr);
 };
 //////////////////////////////////////////
 
-TasAutoMutex::TasAutoMutex(void **mutex, const char *name, int maxWait, bool take) {
+TasAutoMutex::TasAutoMutex(SemaphoreHandle_t*mutex, const char *name, int maxWait, bool take) {
   if (mutex) {
     if (!(*mutex)){
       TasAutoMutex::init(mutex);
     }
-    this->mutex = (SemaphoreHandle_t)*mutex;
+    this->mutex = *mutex;
     this->maxWait = maxWait;
     this->name = name;
     if (take) {
@@ -172,9 +172,9 @@ TasAutoMutex::~TasAutoMutex() {
   }
 }
 
-void TasAutoMutex::init(void ** ptr) {
+void TasAutoMutex::init(SemaphoreHandle_t* ptr) {
   SemaphoreHandle_t mutex = xSemaphoreCreateRecursiveMutex();
-  (*ptr) = (void *) mutex;
+  (*ptr) = mutex;
   // needed, else for ESP8266 as we will initialis more than once in logging
 //  (*ptr) = (void *) 1;
 }
@@ -2327,7 +2327,7 @@ bool NeedLogRefresh(uint32_t req_loglevel, uint32_t index) {
 #ifdef ESP32
   // this takes the mutex, and will be release when the class is destroyed -
   // i.e. when the functon leaves  You CAN call mutex.give() to leave early.
-  TasAutoMutex mutex(&TasmotaGlobal.log_buffer_mutex);
+  TasAutoMutex mutex((SemaphoreHandle_t *)&TasmotaGlobal.log_buffer_mutex);
 #endif  // ESP32
 
   // Skip initial buffer fill
@@ -2349,7 +2349,7 @@ bool GetLog(uint32_t req_loglevel, uint32_t* index_p, char** entry_pp, size_t* l
 #ifdef ESP32
   // this takes the mutex, and will be release when the class is destroyed -
   // i.e. when the functon leaves  You CAN call mutex.give() to leave early.
-  TasAutoMutex mutex(&TasmotaGlobal.log_buffer_mutex);
+  TasAutoMutex mutex((SemaphoreHandle_t *)&TasmotaGlobal.log_buffer_mutex);
 #endif  // ESP32
 
   if (!index) {                            // Dump all
@@ -2396,7 +2396,7 @@ void AddLogData(uint32_t loglevel, const char* log_data, const char* log_data_pa
 #ifdef ESP32
   // this takes the mutex, and will be release when the class is destroyed -
   // i.e. when the functon leaves  You CAN call mutex.give() to leave early.
-  TasAutoMutex mutex(&TasmotaGlobal.log_buffer_mutex);
+  TasAutoMutex mutex((SemaphoreHandle_t *)&TasmotaGlobal.log_buffer_mutex);
 #endif  // ESP32
 
   char mxtime[14];  // "13:45:21.999 "

--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -343,7 +343,7 @@ std::vector<mi_sensor_t> MIBLEsensors;
 std::vector<mi_bindKey_t> MIBLEbindKeys;
 std::vector<MAC_t> MIBLEBlockList;
 
-void *slotmutex = nullptr;
+SemaphoreHandle_t slotmutex = (SemaphoreHandle_t) nullptr;
 
 /*********************************************************************************************\
  * constants


### PR DESCRIPTION
…compiler warnings

## Description:
Fixes requested by jason to solve compiler errors on new esp32 c3
low risk.
untested, but builds for esp8266 & esp32c3 & esp32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
