### PR TITLE
Berry add `math.atan2()` and change `list.find()`

### DIFF
--- a/lib/libesp32/Berry/generate/be_const_strtab.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab.h
@@ -550,6 +550,7 @@ extern const bcstring be_const_str_SYMBOL_NEXT;
 extern const bcstring be_const_str_strftime;
 extern const bcstring be_const_str_import;
 extern const bcstring be_const_str_REL1_INV;
+extern const bcstring be_const_str_atan2;
 extern const bcstring be_const_str_tan;
 extern const bcstring be_const_str_CHANGE;
 extern const bcstring be_const_str_range;

--- a/lib/libesp32/Berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab_def.h
@@ -550,6 +550,7 @@ be_define_const_str(SYMBOL_NEXT, "SYMBOL_NEXT", 1102844455u, 0, 11, &be_const_st
 be_define_const_str(strftime, "strftime", 187738851u, 0, 8, NULL);
 be_define_const_str(import, "import", 288002260u, 66, 6, NULL);
 be_define_const_str(REL1_INV, "REL1_INV", 3733155371u, 0, 8, NULL);
+be_define_const_str(atan2, "atan2", 3173440503u, 0, 5, &be_const_str_tan);
 be_define_const_str(tan, "tan", 2633446552u, 0, 3, NULL);
 be_define_const_str(CHANGE, "CHANGE", 4280911421u, 0, 6, &be_const_str_range);
 be_define_const_str(range, "range", 4208725202u, 0, 5, NULL);
@@ -948,7 +949,7 @@ static const bstring* const m_string_table[] = {
     (const bstring *)&be_const_str_SYMBOL_NEXT,
     (const bstring *)&be_const_str_import,
     (const bstring *)&be_const_str_REL1_INV,
-    (const bstring *)&be_const_str_tan,
+    (const bstring *)&be_const_str_atan2,
     (const bstring *)&be_const_str_CHANGE,
     (const bstring *)&be_const_str_SYMBOL_WIFI,
     NULL,
@@ -1013,6 +1014,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 329,
-    .count = 658,
+    .count = 659,
     .table = m_string_table
 };

--- a/lib/libesp32/Berry/generate/be_fixed_math.h
+++ b/lib/libesp32/Berry/generate/be_fixed_math.h
@@ -1,35 +1,36 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libmath_map) {
-    { be_const_key(tanh, 11), be_const_func(m_tanh) },
+    { be_const_key(asin, 13), be_const_func(m_asin) },
     { be_const_key(acos, -1), be_const_func(m_acos) },
-    { be_const_key(pi, -1), be_const_real(M_PI) },
-    { be_const_key(log10, -1), be_const_func(m_log10) },
-    { be_const_key(deg, 18), be_const_func(m_deg) },
-    { be_const_key(pow, -1), be_const_func(m_pow) },
-    { be_const_key(asin, -1), be_const_func(m_asin) },
-    { be_const_key(rad, -1), be_const_func(m_rad) },
-    { be_const_key(ceil, 14), be_const_func(m_ceil) },
-    { be_const_key(log, -1), be_const_func(m_log) },
-    { be_const_key(imax, -1), be_const_int(M_IMAX) },
-    { be_const_key(imin, 3), be_const_int(M_IMIN) },
-    { be_const_key(cos, -1), be_const_func(m_cos) },
-    { be_const_key(sin, -1), be_const_func(m_sin) },
-    { be_const_key(exp, -1), be_const_func(m_exp) },
-    { be_const_key(atan, 1), be_const_func(m_atan) },
-    { be_const_key(tan, 7), be_const_func(m_tan) },
+    { be_const_key(tanh, 5), be_const_func(m_tanh) },
+    { be_const_key(atan2, -1), be_const_func(m_atan2) },
+    { be_const_key(cos, 20), be_const_func(m_cos) },
+    { be_const_key(pi, 24), be_const_real(M_PI) },
+    { be_const_key(abs, 17), be_const_func(m_abs) },
+    { be_const_key(sinh, -1), be_const_func(m_sinh) },
     { be_const_key(srand, -1), be_const_func(m_srand) },
-    { be_const_key(sqrt, -1), be_const_func(m_sqrt) },
-    { be_const_key(abs, -1), be_const_func(m_abs) },
     { be_const_key(cosh, -1), be_const_func(m_cosh) },
+    { be_const_key(imax, 6), be_const_int(M_IMAX) },
     { be_const_key(floor, -1), be_const_func(m_floor) },
+    { be_const_key(log, -1), be_const_func(m_log) },
+    { be_const_key(exp, 22), be_const_func(m_exp) },
+    { be_const_key(imin, 9), be_const_int(M_IMIN) },
+    { be_const_key(ceil, 1), be_const_func(m_ceil) },
+    { be_const_key(sin, 12), be_const_func(m_sin) },
     { be_const_key(rand, -1), be_const_func(m_rand) },
-    { be_const_key(sinh, 4), be_const_func(m_sinh) },
+    { be_const_key(pow, -1), be_const_func(m_pow) },
+    { be_const_key(atan, -1), be_const_func(m_atan) },
+    { be_const_key(sqrt, -1), be_const_func(m_sqrt) },
+    { be_const_key(deg, -1), be_const_func(m_deg) },
+    { be_const_key(log10, -1), be_const_func(m_log10) },
+    { be_const_key(rad, -1), be_const_func(m_rad) },
+    { be_const_key(tan, -1), be_const_func(m_tan) },
 };
 
 static be_define_const_map(
     m_libmath_map,
-    24
+    25
 );
 
 static be_define_const_module(

--- a/lib/libesp32/Berry/src/be_listlib.c
+++ b/lib/libesp32/Berry/src/be_listlib.c
@@ -209,15 +209,31 @@ static int m_item(bvm *vm)
 
 static int m_find(bvm *vm)
 {
+    bbool found = bfalse;
+    int idx;
     be_getmember(vm, 1, ".p");
     list_check_data(vm, 2);
-    if (be_isint(vm, 2)) {
-        be_pushvalue(vm, 2);
-        if (be_getindex(vm, -2)) {
-            be_return(vm);
+    list_check_ref(vm);
+    be_refpush(vm, 1);
+    be_pushiter(vm, -1);
+    for (idx=0; be_iter_hasnext(vm, -2); idx++) {
+        be_iter_next(vm, -2);
+        be_pushvalue(vm, 2);    /* push needle to compare */
+        if (be_iseq(vm)) {
+            found = btrue;
+            be_pop(vm, 2);
+            break;
         }
+        be_pop(vm, 2);
     }
-    be_return_nil(vm);
+    be_pop(vm, 1); /* pop iterator */
+    be_refpop(vm);
+    if (found) {
+        be_pushint(vm, idx);
+        be_return(vm);
+    } else {
+        be_return_nil(vm);
+    }
 }
 
 static int m_setitem(bvm *vm)

--- a/lib/libesp32/Berry/src/be_mathlib.c
+++ b/lib/libesp32/Berry/src/be_mathlib.c
@@ -133,6 +133,18 @@ static int m_atan(bvm *vm)
     be_return(vm);
 }
 
+static int m_atan2(bvm *vm)
+{
+    if (be_top(vm) >= 2 && be_isnumber(vm, 1) && be_isnumber(vm, 2)) {
+        breal y = be_toreal(vm, 1);
+        breal x = be_toreal(vm, 2);
+        be_pushreal(vm, mathfunc(atan2)(y, x));
+    } else {
+        be_pushreal(vm, (breal)0.0);
+    }
+    be_return(vm);
+}
+
 static int m_sinh(bvm *vm)
 {
     if (be_top(vm) >= 1 && be_isnumber(vm, 1)) {
@@ -269,6 +281,7 @@ be_native_module_attr_table(math) {
     be_native_module_function("asin", m_asin),
     be_native_module_function("acos", m_acos),
     be_native_module_function("atan", m_atan),
+    be_native_module_function("atan2", m_atan2),
     be_native_module_function("sinh", m_sinh),
     be_native_module_function("cosh", m_cosh),
     be_native_module_function("tanh", m_tanh),
@@ -299,6 +312,7 @@ module math (scope: global, depend: BE_USE_MATH_MODULE) {
     asin, func(m_asin)
     acos, func(m_acos)
     atan, func(m_atan)
+    atan2, func(m_atan2)
     sinh, func(m_sinh)
     cosh, func(m_cosh)
     tanh, func(m_tanh)


### PR DESCRIPTION
## Description:

Berry improvements:

### Add `math.atan2(y, x)`

Provide a safer atan function to compute the angle of a triangle without a dangerous division.
Semantically: atan2(y, x) == atan(y/x)

```
> import math
> math.deg(math.atan2(5, 5))
45
> math.deg(math.atan2(0, 5))
0
> math.deg(math.atan2(5, 0))
90
```

### changed `list.find(item) -> index:int`

`list.find(item)` now looks for the first element equal to `item` and returns its index, or `nil` if not found.

```
> l = [ 'a', 'b', 'c' ]
> l.find('a')
0
> l.find('b')
1
> l.find('foo')

```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
