### PR TITLE
Berry setlight fix

### DIFF
--- a/tasmota/xdrv_52_3_berry_light.ino
+++ b/tasmota/xdrv_52_3_berry_light.ino
@@ -216,6 +216,7 @@ extern "C" {
 
             uint8_t channels[LST_MAX] = {};     // initialized with all zeroes
             if (list_size > LST_MAX) { list_size = LST_MAX; }   // no more than 5 channels, no need to test for positive, any negative will be discarded by loop
+            bool on = false;    // if all are zero, then only set power off
             for (uint32_t i = 0; i < list_size; i++) {
               // be_dumpstack(vm);
               get_list_item(vm, i);
@@ -223,16 +224,12 @@ extern "C" {
               int32_t val = be_toint(vm, -1);
               be_pop(vm, 1);      // remove result from stack
               channels[i] = to_u8(val);
-
-              bool on = false;    // if all are zero, then only set power off
-              for (uint32_t i = 0; i < LST_MAX; i++) {
-                if (channels[i] != 0) { on = true; }
-              }
-              if (on) {
-                light_controller.changeChannels(channels);
-              } else {
-                ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
-              }
+              if (channels[i]) { on = true; }
+            }
+            if (on) {
+              light_controller.changeChannels(channels);
+            } else {
+              ExecuteCommandPower(idx + 1, POWER_OFF, SRC_BERRY);
             }
           } else {
             be_pop(vm, 1);      // remove "list" class from top


### PR DESCRIPTION
## Description:

Fix wrong setting of Power with `light.set()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
