### PR TITLE
Remove warning in crashrecorder

### DIFF
--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -160,7 +160,11 @@ void CrashDumpClear(void)
 // esp_err_t IRAM_ATTR esp_backtrace_print(int depth)
 
 #include "freertos/xtensa_api.h"
-#include "esp_panic.h"
+#if ESP_IDF_VERSION_MAJOR >= 4
+  #include "esp_debug_helpers.h"
+#else  // IDF 3.x
+  #include "esp_panic.h"
+#endif
 extern "C" {
   // esp-idf 3.x
   void __real_panicHandler(XtExcFrame *frame);


### PR DESCRIPTION
## Description:

Remove compile warning when compiling crash_recorder with IDF 4.X

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
