### PR TITLE
support AHT20 without enabling AHT1x

### DIFF
--- a/tasmota/xsns_63_aht1x.ino
+++ b/tasmota/xsns_63_aht1x.ino
@@ -19,7 +19,7 @@
 */
 
 #ifdef USE_I2C
-#ifdef USE_AHT1x
+#if defined(USE_AHT1x) || defined(USE_AHT2x)
 
 /*********************************************************************************************\
  * AHT10/15/20 - Temperature and Humidity
@@ -38,6 +38,7 @@
  *
  * 27.08.2020 support for AHT20 added. Now, the AHT20 should support standard I2C Protokoll
  *            and allows other I2C Devices on the bus but have only one I2C Address (0x38)
+ * 14.09.2021 support AHT20 without enabling AHT1x 
  *
  * AHT20 I2C Address: 0x38
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:
Fix support AHT20 without enabling AHT1x
**Related issue (if applicable):** not applicable

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
