### PR TITLE
Minimum PWM Frequency lowered to 2Hz on ESP32 (#13123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - M5 Stack Core2 uses UNIVERSAL_DISPLAY with enabled LVGL as default now
 - ``DisplayDimmer`` has now range 0..100 instead of 0..15
+- Minimum PWM Frequency lowered to 2Hz on ESP32 (#13123)
 
 ### Fixed
 - OpenTherm invalid JSON (#13028)

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -137,10 +137,11 @@ const uint32_t PWM_RANGE = 1023;            // 255..1023 needs to be devisible b
 const uint16_t PWM_FREQ = 977;              // 100..4000 Hz led refresh
 #ifdef ESP32
 const uint16_t PWM_MAX = 50000;             // [PWM_MAX] Maximum frequency for ESP32 - Default: 50000
+const uint16_t PWM_MIN = 2;                 // [PWM_MIN] Minimum frequency for ESP32 - Default: 2
 #else
 const uint16_t PWM_MAX = 4000;              // [PWM_MAX] Maximum frequency - Default: 4000
-#endif
 const uint16_t PWM_MIN = 40;                // [PWM_MIN] Minimum frequency - Default: 40
+#endif
                                             //    For Dimmers use double of your mains AC frequecy (100 for 50Hz and 120 for 60Hz)
                                             //    For Controlling Servos use 50 and also set PWM_FREQ as 50 (DO NOT USE THESE VALUES FOR DIMMERS)
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #13123 (partially)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
