### PR TITLE
Force PWM reapply after frequency change

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1450,8 +1450,10 @@ void CmndPwmfrequency(void)
   if ((1 == XdrvMailbox.payload) || ((XdrvMailbox.payload >= PWM_MIN) && (XdrvMailbox.payload <= PWM_MAX))) {
     Settings->pwm_frequency = (1 == XdrvMailbox.payload) ? PWM_FREQ : XdrvMailbox.payload;
     analogWriteFreq(Settings->pwm_frequency);   // Default is 1000 (core_esp8266_wiring_pwm.c)
+#ifdef USE_LIGHT
     LightReapplyColor();
     LightAnimate();
+#endif // USE_LIGHT
   }
   ResponseCmndNumber(Settings->pwm_frequency);
 }

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1450,6 +1450,8 @@ void CmndPwmfrequency(void)
   if ((1 == XdrvMailbox.payload) || ((XdrvMailbox.payload >= PWM_MIN) && (XdrvMailbox.payload <= PWM_MAX))) {
     Settings->pwm_frequency = (1 == XdrvMailbox.payload) ? PWM_FREQ : XdrvMailbox.payload;
     analogWriteFreq(Settings->pwm_frequency);   // Default is 1000 (core_esp8266_wiring_pwm.c)
+    LightReapplyColor();
+    LightAnimate();
   }
   ResponseCmndNumber(Settings->pwm_frequency);
 }

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1656,6 +1656,13 @@ uint8_t LightGetSpeedSetting(void) {
   return Settings->light_speed;
 }
 
+// Force to reapply color, for example when PWM Frequency changed
+void LightReapplyColor(void) {
+  for (uint32_t i = 0; i < LST_MAX; i++) {
+    Light.last_color[i] = 0;
+  }
+}
+
 // On entry Light.new_color[5] contains the color to be displayed
 // and Light.last_color[5] the color currently displayed
 // Light.power tells which lights or channels (SetOption68) are on/off


### PR DESCRIPTION
## Description:

Reapply PWM settings after a PMW Frequency change

**Related issue (if applicable):** fixes #13123

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
