### PR TITLE
Serial.swap if TXD/RXD on GPIO13/15 (ESP8266)

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1017,6 +1017,11 @@ void SetSerialBegin(void) {
   Serial.flush();
 #ifdef ESP8266
   Serial.begin(TasmotaGlobal.baudrate, (SerialConfig)pgm_read_byte(kTasmotaSerialConfig + Settings->serial_config));
+  if (15==Pin(GPIO_TXD,0) && 13==Pin(GPIO_RXD,0)) {
+    Serial.flush();
+    Serial.swap();
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_SERIAL "Serial pins swapped to alternate"));
+  }
 #endif  // ESP8266
 #ifdef ESP32
   delay(10);  // Allow time to cleanup queues - if not used hangs ESP32

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -408,6 +408,14 @@ void setup(void) {
   BerryInit();
 #endif // USE_BERRY
 
+#ifdef ESP8266
+  if (15==Pin(GPIO_TXD,0) && 13==Pin(GPIO_RXD,0)) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_SERIAL "Swapping Serial pins to alternate"));
+    Serial.flush();
+    Serial.swap();
+  }
+#endif
+
   XdrvCall(FUNC_PRE_INIT);
   XsnsCall(FUNC_PRE_INIT);
 


### PR DESCRIPTION
## Description:

Following a conversation on Discord #lounge with Phillippe who has a need for moving Tasmota serial console to alternate UART pins (15&13) instead of default (1&3).
Assigning `SerialTX` & `SerialRX` to GPIOs had no effect.

This PR allows to perform a `Serial.swap()` at startup if `SerialTX` is assigned to GPIO 15 and `SerialRX` is assigned to GPIO 13.
Same is done right after a `Serial.begin()` in case of changing serial parameters (baudrate, config...)

Only for ESP8266

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
