### PR TITLE
Tasmota Core32 v.1.0.7.4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.3
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -29,7 +29,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = espressif32 @ 3.3.1
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.4/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -38,7 +38,7 @@ build_flags                 = ${env.build_flags}
 [env:tasmota32idf3]
 extends                     = env:tasmota32_base
 platform                    = espressif32 @ 3.3.0
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.4/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${env:tasmota32_base.build_unflags}
 build_flags                 = ${env:tasmota32_base.build_flags}
@@ -149,6 +149,7 @@ build_flags                 = ${env:tasmota32_base.build_flags}
 ;                              -Wstack-usage=300
 
 ; *** JTAG Debug version, needs esp-prog or FT2232H or FT232H
+; *** Install howto for Windows https://community.platformio.org/t/esp32-pio-unified-debugger/4541/20
 [env:tasmota32-ocd]
 ;build_type              = debug
 extends                 = env:tasmota32_base
@@ -162,7 +163,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
 [env:tasmota32solo1-ocd]
 ;build_type              = debug
 extends                 = env:tasmota32_base
-platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.4/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
                           platformio/tool-esptoolpy @ ~1.30100
                           platformio/tool-mklittlefs @ ~1.203.200522
 board                   = esp32_solo1_4M

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -50,7 +50,7 @@ build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32solo1]
 extends                 = env:tasmota32_base
-platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.3/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.4/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
                           platformio/tool-esptoolpy @ ~1.30100
                           platformio/tool-mklittlefs @ ~1.203.200522
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32


### PR DESCRIPTION
## Description:

- CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=y -> WDT_CHECK_IDLE was not enabled for running Arduino code
- BrakTooth espressif/esp-idf@35bbd1b see https://www.espressif.com/sites/default/files/advisory_downloads/AR2021-004%20Bluetooth%20Security%20Advisory.pdf
commit included
- Saving 5k of flash (Tasmota32)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
