### PR TITLE
Remove home assistant discovery

### DIFF
--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -73,6 +73,8 @@
 #define USE_ODROID_GO                            // Add support for Odroid Go
 #define USE_SDCARD
 
+#undef USE_HOME_ASSISTANT
+
 #define USE_ADC
 #define USE_SPI
   #define USE_DISPLAY                            // Add SPI Display Support (+2k code)
@@ -98,6 +100,8 @@
 #define MODULE                 M5STACK_CORE2     // [Module] Select default module from tasmota_template.h
 #undef FALLBACK_MODULE
 #define FALLBACK_MODULE        M5STACK_CORE2     // [Module2] Select default module on fast reboot where USER_MODULE is user template
+
+#undef USE_HOME_ASSISTANT
 
 #define USE_M5STACK_CORE2                        // Add support for M5Stack Core2
   #define USE_I2S_SAY_TIME
@@ -159,6 +163,9 @@
 #define MODULE                 WEMOS             // [Module] Select default module from tasmota_template.h
 #undef FALLBACK_MODULE
 #define FALLBACK_MODULE        WEMOS             // [Module2] Select default module on fast reboot where USER_MODULE is user template
+
+#define USE_TASMOTA_DISCOVERY
+#undef USE_HOME_ASSISTANT
 
 #define USE_SDCARD
 


### PR DESCRIPTION
## Description:

in the env Odroid-Go, M5-Stack core2. Use Tasmota-discovery in env Bluetooth
since not needed or deprecated

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
