### PR TITLE
Berry fix compiler bug in complex compound assignments

### DIFF
--- a/lib/libesp32/Berry/src/be_parser.c
+++ b/lib/libesp32/Berry/src/be_parser.c
@@ -900,10 +900,12 @@ static void suffix_expr(bparser *parser, bexpdesc *e)
 static void suffix_alloc_reg(bparser *parser, bexpdesc *l)
 {
     bfuncinfo *finfo = parser->finfo;
-    bbool suffix = l->type == ETINDEX || l->type == ETMEMBER;
+    bbool is_suffix = l->type == ETINDEX || l->type == ETMEMBER;   /* is suffix */
+    bbool is_suffix_reg = l->v.ss.tt == ETREG || l->v.ss.tt == ETLOCAL || l->v.ss.tt == ETGLOBAL || l->v.ss.tt == ETNGLOBAL;   /* if suffix, does it need a register */
+    bbool is_global = l->type == ETGLOBAL || l->type == ETNGLOBAL;
     /* in the suffix expression, if the object is a temporary
      * variable (l->v.ss.tt == ETREG), it needs to be cached. */
-    if (suffix && l->v.ss.tt == ETREG) {
+    if (is_global || (is_suffix && is_suffix_reg)) {
         be_code_allocregs(finfo, 1);
     }
 }

--- a/lib/libesp32/Berry/tests/compound.be
+++ b/lib/libesp32/Berry/tests/compound.be
@@ -1,0 +1,19 @@
+# test bug in compound statements
+
+a = 0
+assert(a == 0)
+a += 1
+assert(a == 1)
+a += 10/2
+assert(a == 6)
+
+class A var a def init() self.a = 1 end def f(x) self.a+=x/2 end def g(x) self.a = self.a + x/2 end end
+
+a = A()
+assert(a.a == 1)
+a.f(10)
+assert(a.a == 6)
+b=A()
+assert(b.a == 1)
+b.g(10)
+assert(b.a == 6)


### PR DESCRIPTION
## Description:

https://github.com/berry-lang/berry/pull/146

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
