### PR TITLE
Berry string range

### DIFF
--- a/lib/libesp32/Berry/src/be_strlib.c
+++ b/lib/libesp32/Berry/src/be_strlib.c
@@ -97,6 +97,9 @@ static bstring* sim2str(bvm *vm, bvalue *v)
     case BE_MODULE:
         module2str(sbuf, v);
         break;
+    case BE_COMPTR:
+        sprintf(sbuf, "<ptr: %p>", var_toobj(v));
+        break;
     default:
         strcpy(sbuf, "(unknow value)");
         break;

--- a/lib/libesp32/Berry/src/be_strlib.c
+++ b/lib/libesp32/Berry/src/be_strlib.c
@@ -97,9 +97,6 @@ static bstring* sim2str(bvm *vm, bvalue *v)
     case BE_MODULE:
         module2str(sbuf, v);
         break;
-    case BE_COMPTR:
-        sprintf(sbuf, "<ptr: %p>", var_toobj(v));
-        break;
     default:
         strcpy(sbuf, "(unknow value)");
         break;
@@ -326,15 +323,47 @@ BERRY_API const char *be_str2num(bvm *vm, const char *str)
     return sout;
 }
 
+static bstring* string_range(bvm *vm, bstring *str, binstance *range)
+{
+    bint lower, upper;
+    bint size = str_len(str);   /* size of source string */
+    // bint size = be_data_size(vm, -1); /* get source list size */
+    /* get index range */
+    bvalue temp;
+    be_instance_member(vm, range, be_newstr(vm, "__lower__"), &temp);
+    lower = var_toint(&temp);
+    be_instance_member(vm, range, be_newstr(vm, "__upper__"), &temp);
+    upper = var_toint(&temp);
+    /* protection scope */
+    if (upper < 0) { upper = size + upper; }
+    if (lower < 0) { lower = size + lower; }
+    upper = upper < size ? upper : size - 1;
+    lower = lower < 0 ? 0 : lower;
+    if (lower > upper) {
+        return be_newstrn(vm, "", 0);   /* empty string */
+    }
+    return be_newstrn(vm, str(str) + lower, upper - lower + 1);
+
+}
+
 /* string subscript operation */
 bstring* be_strindex(bvm *vm, bstring *str, bvalue *idx)
 {
     if (var_isint(idx)) {
         int pos = var_toidx(idx);
-        if (pos < str_len(str)) {
+        int size = str_len(str);
+        if (pos < 0) { pos = size + pos; }
+        if ((pos < size) && (pos >= 0)) {
             return be_newstrn(vm, str(str) + pos, 1);
         }
         be_raise(vm, "index_error", "string index out of range");
+    } else if (var_isinstance(idx)) {
+        binstance * ins = var_toobj(idx);
+        const char *cname = str(be_instance_name(ins));
+        if (!strcmp(cname, "range")) {
+            return string_range(vm, str, ins);
+        }
+        // str(be_instance_name(i))
     }
     be_raise(vm, "index_error", "string indices must be integers");
     return NULL;


### PR DESCRIPTION
## Description:

Berry ability to splice strings like `s[1..3]`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
