### PR TITLE
fix sml obis

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -1287,7 +1287,11 @@ void sml_empty_receiver(uint32_t meters) {
 
 void sml_shift_in(uint32_t meters,uint32_t shard) {
   uint32_t count;
+#ifndef SML_OBIS_LINE
   if (meter_desc_p[meters].type!='e' && meter_desc_p[meters].type!='m' && meter_desc_p[meters].type!='M' && meter_desc_p[meters].type!='p' && meter_desc_p[meters].type!='R' && meter_desc_p[meters].type!='v') {
+#else
+  if (meter_desc_p[meters].type!='o' && meter_desc_p[meters].type!='e' && meter_desc_p[meters].type!='m' && meter_desc_p[meters].type!='M' && meter_desc_p[meters].type!='p' && meter_desc_p[meters].type!='R' && meter_desc_p[meters].type!='v') {
+#endif
     // shift in
     for (count=0; count<SML_BSIZ-1; count++) {
       smltbuf[meters][count]=smltbuf[meters][count+1];
@@ -1295,8 +1299,21 @@ void sml_shift_in(uint32_t meters,uint32_t shard) {
   }
   uint8_t iob=(uint8_t)meter_ss[meters]->read();
 
-  if (meter_desc_p[meters].type=='o') {
-    smltbuf[meters][SML_BSIZ-1]=iob&0x7f;
+  if (meter_desc_p[meters].type == 'o') {
+#ifndef SML_OBIS_LINE
+    smltbuf[meters][SML_BSIZ-1] = iob & 0x7f;
+#else
+    iob &= 0x7f;
+    smltbuf[meters][meter_spos[meters]] = iob;
+    meter_spos[meters]++;
+    if (meter_spos[meters] >= SML_BSIZ) {
+      meter_spos[meters] = 0;
+    }
+    if (iob == 0x0a) {
+      SML_Decode(meters);
+      meter_spos[meters] = 0;
+    }
+#endif
   } else if (meter_desc_p[meters].type=='s') {
     smltbuf[meters][SML_BSIZ-1]=iob;
   } else if (meter_desc_p[meters].type=='r') {
@@ -1369,7 +1386,11 @@ void sml_shift_in(uint32_t meters,uint32_t shard) {
 		}
   }
   sb_counter++;
+#ifndef SML_OBIS_LINE
   if (meter_desc_p[meters].type!='e' && meter_desc_p[meters].type!='m' && meter_desc_p[meters].type!='M' && meter_desc_p[meters].type!='p' && meter_desc_p[meters].type!='R' && meter_desc_p[meters].type!='v') SML_Decode(meters);
+#else
+  if (meter_desc_p[meters].type!='o' && meter_desc_p[meters].type!='e' && meter_desc_p[meters].type!='m' && meter_desc_p[meters].type!='M' && meter_desc_p[meters].type!='p' && meter_desc_p[meters].type!='R' && meter_desc_p[meters].type!='v') SML_Decode(meters);
+#endif
 }
 
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #13127

fixes obis decoder with rarely used short ids.
needs 

#define SML_OBIS_LINE

to do a line compare instead of a pattern compare


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
