### PR TITLE
Implement WebQuery Command

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -415,6 +415,7 @@
 #define D_CMND_WEBLOG "WebLog"
 #define D_CMND_WEBREFRESH "WebRefresh"
 #define D_CMND_WEBSEND "WebSend"
+#define D_CMND_WEBQUERY "WebQuery"
 #define D_CMND_WEBCOLOR "WebColor"
 #define D_CMND_WEBBUTTON "WebButton"
 #define D_CMND_WEBSENSOR "WebSensor"

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3098,14 +3098,86 @@ int WebSend(char *buffer)
       }
       url += F("cmnd=");                      // url = |http://192.168.178.86/cm?cmnd=| or |http://192.168.178.86/cm?user=admin&password=joker&cmnd=|
     }
-    url += command;                           // url = |http://192.168.178.86/cm?cmnd=POWER1 ON|
+    url += command;
+    url += F(" GET");                         // url = |http://192.168.178.86/cm?cmnd=POWER1 ON|
 
     DEBUG_CORE_LOG(PSTR("WEB: Uri |%s|"), url.c_str());
+    status = WebQuery(const_cast<char*>(url.c_str()));
+  }
+  return status;
+}
 
-    WiFiClient http_client;
-    HTTPClient http;
-    if (http.begin(http_client, UrlEncode(url))) {  // UrlEncode(url) = |http://192.168.178.86/cm?cmnd=POWER1%20ON|
-      int http_code = http.GET();             // Start connection and send HTTP header
+int WebQuery(char *buffer)
+{
+  // http://192.168.1.1/path GET                                         -> Sends HTTP GET http://192.168.1.1/path
+  // http://192.168.1.1/path POST {"some":"message"}                     -> Sends HTTP POST to http://192.168.1.1/path with body {"some":"message"}
+  // http://192.168.1.1/path PUT [Autorization: Bearer abcdxyz] potato   -> Sends HTTP PUT to http://192.168.1.1/path with authorization header and body "potato"
+  // http://192.168.1.1/path PATCH patchInfo                             -> Sends HTTP PATCH to http://192.168.1.1/path with body "potato"
+
+  // Valid HTTP Commands: GET, POST, PUT, and PATCH
+  // An unlimited number of headers can be sent per request, and a body can be sent for all command types
+  // The body will be ignored if sending a GET command
+
+  int status = WEBCMND_WRONG_PARAMETERS;
+  int http_code;
+  WiFiClient http_client;
+  HTTPClient http;
+  String methodStr;
+  String bodyStr;
+  char *url;
+  char *header;
+  char *headerBody;
+  char *body;
+  char *method;
+  char *temp;
+  bool headerFound;
+
+  url = strtok_r(buffer, " ", &temp);
+  method = strtok_r(temp, " ", &temp);
+
+  if(url && method) {
+    if (http.begin(http_client, UrlEncode(url))) {
+      if(temp) { //There is a body and/or header
+        if(temp[0] == '[') { //Header information was sent; decode it
+          temp += 1;
+          temp = strtok_r(temp, "]", &body);
+          headerFound = true;
+          while(headerFound) {
+            header = strtok_r(temp, ":", &temp);
+            if(header) {
+              headerBody = strtok_r(temp, "|", &temp);
+              if(headerBody) {
+                http.addHeader(header, headerBody);
+              }
+              else headerFound = false;
+            }
+            else headerFound = false;
+          }
+        }
+        else { //No header information was sent, but there was a body
+          body = temp;
+        }
+      }
+      
+      //No body sent; define empty string for the body
+      else {
+        body = (char*)malloc(1);
+        body[0] = 0;
+      }
+
+      //Format Strings
+      methodStr = String(method);
+      methodStr.toUpperCase();
+      bodyStr = String(body);
+      bodyStr.trim();
+
+      //Perform specified web request type
+      if(methodStr.equals("GET")) http_code = http.GET();
+      else if(methodStr.equals("POST")) http_code = http.POST(body);
+      else if(methodStr.equals("PUT")) http_code = http.PUT(body);
+      else if(methodStr.equals("PATCH")) http_code = http.PATCH(body);
+      else return status;
+
       if (http_code > 0) {                    // http_code will be negative on error
         if (http_code == HTTP_CODE_OK || http_code == HTTP_CODE_MOVED_PERMANENTLY) {
 #ifdef USE_WEBSEND_RESPONSE
@@ -3125,7 +3197,7 @@ int WebSend(char *buffer)
           // recursive call must be possible in this case
           tasm_cmd_activ = 0;
 #endif  // USE_SCRIPT
-          MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_CMND_WEBSEND));
+          MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_STAT, PSTR(D_CMND_WEBQUERY));
 #endif  // USE_WEBSEND_RESPONSE
         }
         status = WEBCMND_DONE;
@@ -3240,8 +3312,8 @@ const char kWebCommands[] PROGMEM = "|"  // No prefix
 #if defined(USE_SENDMAIL) || defined(USE_ESP32MAIL)
   D_CMND_SENDMAIL "|"
 #endif
-  D_CMND_WEBSERVER "|" D_CMND_WEBPASSWORD "|" D_CMND_WEBLOG "|" D_CMND_WEBREFRESH "|" D_CMND_WEBSEND "|" D_CMND_WEBCOLOR "|"
-  D_CMND_WEBSENSOR "|" D_CMND_WEBBUTTON
+  D_CMND_WEBSERVER "|" D_CMND_WEBPASSWORD "|" D_CMND_WEBLOG "|" D_CMND_WEBREFRESH "|" D_CMND_WEBSEND "|" D_CMND_WEBQUERY "|"
+  D_CMND_WEBCOLOR "|" D_CMND_WEBSENSOR "|" D_CMND_WEBBUTTON
 #ifdef USE_WEBGETCONFIG
   "|" D_CMND_WEBGETCONFIG
 #endif
@@ -3257,8 +3329,8 @@ void (* const WebCommand[])(void) PROGMEM = {
 #if defined(USE_SENDMAIL) || defined(USE_ESP32MAIL)
   &CmndSendmail,
 #endif
-  &CmndWebServer, &CmndWebPassword, &CmndWeblog, &CmndWebRefresh, &CmndWebSend, &CmndWebColor,
-  &CmndWebSensor, &CmndWebButton
+  &CmndWebServer, &CmndWebPassword, &CmndWeblog, &CmndWebRefresh, &CmndWebSend, &CmndWebQuery,
+  &CmndWebColor, &CmndWebSensor, &CmndWebButton
 #ifdef USE_WEBGETCONFIG
   , &CmndWebGetConfig
 #endif
@@ -3354,6 +3426,15 @@ void CmndWebSend(void)
 {
   if (XdrvMailbox.data_len > 0) {
     uint32_t result = WebSend(XdrvMailbox.data);
+    char stemp1[20];
+    ResponseCmndChar(GetTextIndexed(stemp1, sizeof(stemp1), result, kWebCmndStatus));
+  }
+}
+
+void CmndWebQuery(void)
+{
+  if (XdrvMailbox.data_len > 0) {
+    uint32_t result = WebQuery(XdrvMailbox.data);
     char stemp1[20];
     ResponseCmndChar(GetTextIndexed(stemp1, sizeof(stemp1), result, kWebCmndStatus));
   }


### PR DESCRIPTION
## Description:

Implements new WebQuery command. The command allows for GET, POST, PUT, and PATCH HTTP Queries, complete with Request Headers and request body (when applicable).

Syntax examples:
`WebQuery http://192.168.1.1/path GET`: Sends HTTP GET http://192.168.1.1/path
`WebQuery http://192.168.1.1/path POST {"some":"message"}`: Sends HTTP POST to http://192.168.1.1/path with body {"some":"message"}
`WebQuery http://192.168.1.1/path PUT [Autorization: Bearer abcdxyz|Second:Header] potato`: Sends HTTP PUT to http://192.168.1.1/path with authorization header, a second header, and body "potato"
`WebQuery http://192.168.1.1/path PATCH patchInfo`: Sends HTTP PATCH to http://192.168.1.1/path with body "patchInfo"

An unlimited number of headers can be sent per request, and a body can be sent for all command types. The body will be ignored if sending a GET command

This command enables Tasmota to send advanced web queries in addition to GET. It is my vision that this is an open-ended command that can control other SmartHome Devices, such as Philips Hue Hubs, the vacuum cleaner mentioned in #12249, and anything else that can be controlled over HTTP. It is designed to be more flexible than other Tasmota HTTP PRs I've seen

Let me know if you think anything needs changed!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
