### PR TITLE
Make easier to disable PID_USE_TIMPROP

### DIFF
--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -160,7 +160,7 @@ String EthernetMacAddress(void);
  * Fallback parameters
 \*********************************************************************************************/
 
-#ifdef USE_PID
+#if defined(USE_PID) && (!defined(PID_USE_TIMPROP) || (PID_USE_TIMPROP > 0))
 #define USE_TIMEPROP
 #endif
                                                // See https://github.com/esp8266/Arduino/pull/4889

--- a/tasmota/xdrv_48_timeprop.ino
+++ b/tasmota/xdrv_48_timeprop.ino
@@ -93,11 +93,6 @@
 enum TimepropCommands { CMND_TIMEPROP_SETPOWER };
 const char kTimepropCommands[] PROGMEM = D_CMND_TIMEPROP_SETPOWER;
 
-static Timeprop timeprops[TIMEPROP_NUM_OUTPUTS];
-static int relayNos[TIMEPROP_NUM_OUTPUTS] = {TIMEPROP_RELAYS};
-static long currentRelayStates = 0;  // current actual relay states. Bit 0 first relay
-
-
 #ifndef TIMEPROP_NUM_OUTPUTS
 #define TIMEPROP_NUM_OUTPUTS          1       // how many outputs to control (with separate alogorithm for each)
 #endif
@@ -119,6 +114,10 @@ static long currentRelayStates = 0;  // current actual relay states. Bit 0 first
 #ifndef TIMEPROP_RELAYS
 #define TIMEPROP_RELAYS               1       // which relay to control 1:8
 #endif
+
+static Timeprop timeprops[TIMEPROP_NUM_OUTPUTS];
+static int relayNos[TIMEPROP_NUM_OUTPUTS] = {TIMEPROP_RELAYS};
+static long currentRelayStates = 0;  // current actual relay states. Bit 0 first relay
 
 struct {
   Timeprop timeprops[TIMEPROP_NUM_OUTPUTS];

--- a/tasmota/xdrv_49_pid.ino
+++ b/tasmota/xdrv_49_pid.ino
@@ -103,20 +103,21 @@
    #define PID_USE_TIMPROP               1       // To use an internal relay for a time proportioned output to drive the
                                                  // process, set this to indicate which timeprop output to use. For a device
                                                  // with just one relay then this will be 1.
-                                                 // It is then also necessary to define USE_TIMEPROP and set the output up as
-                                                 // explained in xdrv_49_timeprop.ino
-                                                 // To disable this feature leave this undefined (undefined, not defined to nothing).
+                                                 // USE_TIMEPROP will be automativally included. You must set the output as
+                                                 // explained in xdrv_48_timeprop.ino
+                                                 // To disable, override to false in user_config_override.h. If USE_TIMEPROP is 
+                                                 // not explicitly defined, then it will not be added by default.
 
    #define PID_USE_LOCAL_SENSOR                  // If defined then the local sensor will be used for pv. Leave undefined if
                                                  // this is not required.  The rate that the sensor is read is defined by TELE_PERIOD
                                                  // If not using the sensor then you can supply process values via MQTT using
                                                  // cmnd PidPv
 
-   #define PID_SHUTTER                   1     // if using the PID to control a 3-way valve, create Tasmota Shutter and define the
+   #define PID_SHUTTER                   1       // if using the PID to control a 3-way valve, create Tasmota Shutter and define the
                                                  // number of the shutter here. Otherwise leave this commented out
 
-   #define PID_REPORT_MORE_SETTINGS                   // If defined, the SENSOR output will provide more extensive json
-                                                 // output in the PID section
+   #define PID_REPORT_MORE_SETTINGS    true      // If defined to true, the SENSOR output will provide more extensive json
+                                                 // output in the PID section. Override to false to reduce json output
 
  * Help with using the PID algorithm and with loop tuning can be found at
  * http://blog.clanlaw.org.uk/2018/01/09/PID-tuning-with-node-red-contrib-pid.html
@@ -155,10 +156,14 @@
 #define PID_UPDATE_SECS               0       // [PidUpdateSecs] How often to run the pid algorithm
 #endif
 
-#define PID_USE_TIMPROP               1       // To disable this feature leave this undefined
+#ifndef PID_USE_TIMPROP
+#define PID_USE_TIMPROP               1       // To disable this feature define as false in user_config_override
+#endif
 //#define PID_USE_LOCAL_SENSOR                  // [PidPv] If defined then the local sensor will be used for pv.
 //#define PID_SHUTTER                   1       // Number of the shutter here. Otherwise leave this commented out
-#define PID_REPORT_MORE_SETTINGS              // If defined, the SENSOR output will provide more extensive json
+#ifndef PID_REPORT_MORE_SETTINGS
+#define PID_REPORT_MORE_SETTINGS     true     // Override to false if less details are required in SENSOR JSON
+#endif
 
 #include "PID.h"
 
@@ -342,7 +347,7 @@ void PIDShowValues(void) {
   dtostrfd(d_buf, 2, str_buf);
   ResponseAppend_P(PSTR("\"PidSp\":%s,"), str_buf);
 
-#ifdef PID_REPORT_MORE_SETTINGS
+#if PID_REPORT_MORE_SETTINGS
 // #define D_CMND_PID_SETPROPBAND "Pb"
   d_buf = Pid.pid.getPb();
   dtostrfd(d_buf, 2, str_buf);
@@ -403,7 +408,7 @@ void PIDRun(void) {
   ShutterSetPosition(PID_SHUTTER, pos);
 #endif //PID_SHUTTER
 
-#if defined PID_USE_TIMPROP
+#if defined(PID_USE_TIMPROP) && (PID_USE_TIMPROP > 0)
   // send power to appropriate timeprop output
   TimepropSetPower( PID_USE_TIMPROP-1, power );
 #endif // PID_USE_TIMPROP


### PR DESCRIPTION
## Description:

Discussion : https://github.com/arendst/Tasmota/discussions/11744
It was impossible to compile with `USE_PID` and not using `TIMEPROP` because USE_TIMEPROP was enforced in `tasmota_globals.h` as soon as `USE_PID` was used. The only way to compile with PID and without TIMEPROP was to modify `tasmota_globals.h` and `xdrv_49_pid.ino`.

With these little preprocessor tricks the following combinations  are now possible in `user_config_override.h`
- No change, USE_TIMEPROP will be automatically added if forgotten, PID_USE_TIMPROP still default to 1.
```
#define USE_PID
```

- USE_PID with TIMEPROP (automatically added as before), overriding the relay output to output 2
```
#define USE_PID
#define PID_USE_TIMPROP 2
```

- USE_PID but not using TIMEPROP at all
```
#define USE_PID
#define PID_USE_TIMPROP false
```

Beside, some lines have been moved in `xdrv_48_timeprop.ino` to allow correct compilation with default parameters.
(some arrays were defined before the #define macros that were defining their size)


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
