### PR TITLE
Berry print stack trace when exception, more detailed with line numbers if `#define USE_BERRY_DEBUG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Support for Sensirion SCD40/SCD41 CO2 sensor (#13139)
 - Support for BL0939 energy monitor as used in ESP32 based Sonoff Dual R3 V2 Pow (#13195)
 - Command ``WebQuery <url> GET|POST|PUT|PATCH [<headers>] <body>`` to extent HTTP requests (#13209)
+- Berry print stack trace when exception, more detailed with line numbers if `#define USE_BERRY_DEBUG`
 
 ### Changed
 - M5 Stack Core2 uses UNIVERSAL_DISPLAY with enabled LVGL as default now

--- a/lib/libesp32/Berry/default/berry_conf.h
+++ b/lib/libesp32/Berry/default/berry_conf.h
@@ -216,4 +216,10 @@ extern "C" {
  **/
 #define be_assert(expr)                 assert(expr)
 
+/* Tasmota debug specific */
+#ifdef USE_BERRY_DEBUG
+  #undef BE_DEBUG_RUNTIME_INFO
+  #define BE_DEBUG_RUNTIME_INFO 2 /* record line information in 16 bits */
+#endif // USE_BERRY_DEBUG
+
 #endif

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -982,6 +982,7 @@
 
 #define USE_BERRY                                // Enable Berry scripting language
   #define USE_BERRY_PSRAM                        // Allocate Berry memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
+  // #define USE_BERRY_DEBUG                        // Compile Berry bytecode with line number information, makes exceptions easier to debug. Adds +8% of memory consumption for compiled code
   #define USE_WEBCLIENT                          // Enable `webclient` to make HTTP/HTTPS requests. Can be disabled for security reasons.
     // #define USE_WEBCLIENT_HTTPS                  // Enable HTTPS outgoing requests based on BearSSL (much ligher then mbedTLS, 42KB vs 150KB) in insecure mode (no verification of server's certificate)
                                                  // Note that only one cipher is enabled: ECDHE_RSA_WITH_AES_128_GCM_SHA256 which is very commonly used and highly secure

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -27,6 +27,7 @@
 
 extern "C" {
   extern void be_load_custom_libs(bvm *vm);
+  extern void be_tracestack(bvm *vm);
 }
 
 const char kBrCommands[] PROGMEM = D_PRFX_BR "|"    // prefix
@@ -115,6 +116,8 @@ void BerryDumpErrorAndClear(bvm *vm, bool berry_console) {
   if (top >= 2 && be_isstring(vm, -1) && be_isstring(vm, -2)) {
     if (berry_console) {
       berry_log_C(PSTR(D_LOG_BERRY "Exception> '%s' - %s"), be_tostring(berry.vm, -2), be_tostring(berry.vm, -1));
+      be_tracestack(vm);
+      top = be_top(vm);   // update top after dump
     } else {
       AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_BERRY "Exception> '%s' - %s"), be_tostring(berry.vm, -2), be_tostring(berry.vm, -1));
     }


### PR DESCRIPTION
## Description:

Berry exception now prints stack trace:

Example:
```
def g()
  #- comment -#
  var a = 'a' + 1  #- will trigger an expcetion -#
end
def f()
  g()
end
f()
```

Will print:
```
BRY: Exception> 'type_error' - unsupported operand type(s) for +: 'string' and 'int'
stack traceback:
	<unknow source>: in function `g`
	<unknow source>: in function `f`
	<unknow source>: in function `main`
```

You can get more details when compiling with `#define USE_BERRY_DEBUG` at the cost of +8% of memory footpring of compiled code:
```
BRY: Exception> 'type_error' - unsupported operand type(s) for +: 'string' and 'int'
stack traceback:
	input:3: in function `g`
	input:6: in function `f`
	input:8: in function `main`
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
