### PR TITLE
Fix Optional Compilation of ZigBee with KNX

### DIFF
--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -61,7 +61,7 @@ lib_extra_dirs          = lib/lib_basic
 [env:tasmota-zbbridge]
 build_flags             = ${env.build_flags} -DFIRMWARE_ZBBRIDGE
 board                   = esp8266_zbbridge
-lib_extra_dirs          = lib/lib_basic, lib/lib_ssl
+lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/lib_div
 
 [env:tasmota-zigbee]
 build_flags             = ${env.build_flags} -DUSE_ZIGBEE -DUSE_CCLOADER -DUSE_UFILESYS

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -503,7 +503,7 @@
   #define USE_TLS                                  // flag indicates we need to include TLS code
 #endif                                             // USE_ZBBRIDGE_TLS
 
-#undef USE_KNX                                   // Disable KNX IP Protocol Support
+//#undef USE_KNX                                   // Disable KNX IP Protocol Support
 //#undef USE_WEBSERVER                             // Disable Webserver
 #undef USE_ENHANCED_GUI_WIFI_SCAN                // Disable wifi scan output with BSSID (+0k5 code)
 //#undef USE_WEBSEND_RESPONSE                      // Disable command WebSend response message (+1k code)

--- a/tasmota/xdrv_11_knx.ino
+++ b/tasmota/xdrv_11_knx.ino
@@ -644,6 +644,7 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           knx.answer_4byte_float(msg.received_on, last_hum);
         }
       }
+#if defined(USE_ENERGY_SENSOR)      
       else if (chan->type == KNX_ENERGY_VOLTAGE) // Reply KNX_ENERGY_VOLTAGE
       {        
         knx.answer_4byte_float(msg.received_on, Energy.voltage[0]);
@@ -701,6 +702,7 @@ void KNX_CB_Action(message_t const &msg, void *arg)
           knx.answer_4byte_float(msg.received_on, Energy.total);
         }
       }
+#endif
 #ifdef USE_RULES
       else if ((chan->type >= KNX_SLOT1) && (chan->type <= KNX_SLOT5)) // KNX RX SLOTs (read command)
       {


### PR DESCRIPTION
## Description:

Fix Optional Compilation of ZigBee with KNX as users request in Discord Chat.

To add KNX to a zigbee compilation, users must add `#define USE_KNX` in _**user_config_override.h**_ file and compile the ZigBee version by themselves.

Now, with this PR, it is possible to make a KNX to ZigBee Bridge with Tasmota. All the logic and automations must be set using rules.

**Related issue (if applicable):** NA

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
