### PR TITLE
Fix OpenTherm conflicting symbols

### DIFF
--- a/lib/lib_div/OpenTherm-0.9.0/src/OpenTherm.h
+++ b/lib/lib_div/OpenTherm-0.9.0/src/OpenTherm.h
@@ -17,26 +17,26 @@ P MGS-TYPE SPARE DATA-ID  DATA-VALUE
 #include <Arduino.h>
 
 enum OpenThermResponseStatus {
-	NONE,
-	SUCCESS,
-	INVALID,
-	TIMEOUT
+	OPTH_NONE,
+	OPTH_SUCCESS,
+	OPTH_INVALID,
+	OPTH_TIMEOUT
 };
 
 
 enum OpenThermMessageType {
 	/*  Master to Slave */
-	READ_DATA       = B000,
-	READ            = READ_DATA, // for backwared compatibility
-	WRITE_DATA      = B001,
-	WRITE           = WRITE_DATA, // for backwared compatibility
-	INVALID_DATA    = B010,
-	RESERVED        = B011,
+	OPTH_READ_DATA       = B000,
+	OPTH_READ            = OPTH_READ_DATA, // for backwared compatibility
+	OPTH_WRITE_DATA      = B001,
+	OPTH_WRITE           = OPTH_WRITE_DATA, // for backwared compatibility
+	OPTH_INVALID_DATA    = B010,
+	OPTH_RESERVED        = B011,
 	/* Slave to Master */
-	READ_ACK        = B100,
-	WRITE_ACK       = B101,
-	DATA_INVALID    = B110,
-	UNKNOWN_DATA_ID = B111
+	OPTH_READ_ACK        = B100,
+	OPTH_WRITE_ACK       = B101,
+	OPTH_DATA_INVALID    = B110,
+	OPTH_UNKNOWN_DATA_ID = B111
 };
 
 typedef OpenThermMessageType OpenThermRequestType; // for backwared compatibility
@@ -99,15 +99,15 @@ enum OpenThermMessageID {
 };
 
 enum OpenThermStatus {
-	NOT_INITIALIZED,
-	READY,
-	DELAY,
-	REQUEST_SENDING,
-	RESPONSE_WAITING,
-	RESPONSE_START_BIT,
-	RESPONSE_RECEIVING,
-	RESPONSE_READY,
-	RESPONSE_INVALID
+	OPTH_NOT_INITIALIZED,
+	OPTH_READY,
+	OPTH_DELAY,
+	OPTH_REQUEST_SENDING,
+	OPTH_RESPONSE_WAITING,
+	OPTH_RESPONSE_START_BIT,
+	OPTH_RESPONSE_RECEIVING,
+	OPTH_RESPONSE_READY,
+	OPTH_RESPONSE_INVALID
 };
 
 class OpenTherm

--- a/tasmota/xsns_69_opentherm.ino
+++ b/tasmota/xsns_69_opentherm.ino
@@ -179,7 +179,7 @@ void sns_opentherm_processResponseCallback(unsigned long response, int st)
 
     switch (status)
     {
-    case OpenThermResponseStatus::SUCCESS:
+    case OpenThermResponseStatus::OPTH_SUCCESS:
         if (sns_ot_master->isValidResponse(response))
         {
             sns_opentherm_process_success_response(&sns_ot_boiler_status, response);
@@ -188,7 +188,7 @@ void sns_opentherm_processResponseCallback(unsigned long response, int st)
         sns_ot_timeout_before_disconnect = SNS_OT_MAX_TIMEOUTS_BEFORE_DISCONNECT;
         break;
 
-    case OpenThermResponseStatus::INVALID:
+    case OpenThermResponseStatus::OPTH_INVALID:
         sns_opentherm_check_retry_request();
         sns_ot_connection_status = OpenThermConnectionStatus::OTC_READY;
         sns_ot_timeout_before_disconnect = SNS_OT_MAX_TIMEOUTS_BEFORE_DISCONNECT;
@@ -198,7 +198,7 @@ void sns_opentherm_processResponseCallback(unsigned long response, int st)
     // In this case we do reconnect.
     // If this command will timeout multiple times, it will be excluded from the rotation later on
     // after couple of failed attempts. See sns_opentherm_check_retry_request logic
-    case OpenThermResponseStatus::TIMEOUT:
+    case OpenThermResponseStatus::OPTH_TIMEOUT:
         sns_opentherm_check_retry_request();
         if (--sns_ot_timeout_before_disconnect == 0)
         {
@@ -315,7 +315,7 @@ void sns_ot_start_handshake()
     sns_opentherm_protocol_reset();
 
     sns_ot_master->sendRequestAync(
-        OpenTherm::buildRequest(OpenThermMessageType::READ_DATA, OpenThermMessageID::SConfigSMemberIDcode, 0));
+        OpenTherm::buildRequest(OpenThermMessageType::OPTH_READ_DATA, OpenThermMessageID::SConfigSMemberIDcode, 0));
 
     sns_ot_connection_status = OpenThermConnectionStatus::OTC_HANDSHAKE;
 }
@@ -324,7 +324,7 @@ void sns_ot_process_handshake(unsigned long response, int st)
 {
     OpenThermResponseStatus status = (OpenThermResponseStatus)st;
 
-    if (status != OpenThermResponseStatus::SUCCESS || !sns_ot_master->isValidResponse(response))
+    if (status != OpenThermResponseStatus::OPTH_SUCCESS || !sns_ot_master->isValidResponse(response))
     {
         AddLog(LOG_LEVEL_ERROR,
                   PSTR("[OTH]: getSlaveConfiguration failed. Status=%s"),

--- a/tasmota/xsns_69_opentherm_protocol.ino
+++ b/tasmota/xsns_69_opentherm_protocol.ino
@@ -274,7 +274,7 @@ unsigned long sns_opentherm_set_slave_flags(struct OpenThermCommandT *self, stru
 
     data <<= 8;
 
-    return OpenTherm::buildRequest(OpenThermRequestType::READ, OpenThermMessageID::Status, data);
+    return OpenTherm::buildRequest(OpenThermRequestType::OPTH_READ, OpenThermMessageID::Status, data);
 }
 
 void sns_opentherm_parse_slave_flags(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
@@ -320,7 +320,7 @@ unsigned long sns_opentherm_set_boiler_temperature(struct OpenThermCommandT *sel
     self->m_results[0].m_float = status->m_boilerSetpoint;
 
     unsigned int data = OpenTherm::temperatureToData(status->m_boilerSetpoint);
-    return OpenTherm::buildRequest(OpenThermMessageType::WRITE_DATA, OpenThermMessageID::TSet, data);
+    return OpenTherm::buildRequest(OpenThermMessageType::OPTH_WRITE_DATA, OpenThermMessageID::TSet, data);
 }
 void sns_opentherm_parse_set_boiler_temperature(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
 {
@@ -360,7 +360,7 @@ unsigned long sns_opentherm_set_boiler_dhw_temperature(struct OpenThermCommandT 
     self->m_results[0].m_float = status->m_hotWaterSetpoint;
 
     unsigned int data = OpenTherm::temperatureToData(status->m_hotWaterSetpoint);
-    return OpenTherm::buildRequest(OpenThermMessageType::WRITE_DATA, OpenThermMessageID::TdhwSet, data);
+    return OpenTherm::buildRequest(OpenThermMessageType::OPTH_WRITE_DATA, OpenThermMessageID::TdhwSet, data);
 }
 void sns_opentherm_parse_boiler_dhw_temperature(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
 {
@@ -381,7 +381,7 @@ void sns_opentherm_tele_boiler_dhw_temperature(struct OpenThermCommandT *self)
 /////////////////////////////////// App Specific Fault Flags //////////////////////////////////////////////////
 unsigned long sns_opentherm_get_flags(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *)
 {
-    return OpenTherm::buildRequest(OpenThermRequestType::READ, OpenThermMessageID::ASFflags, 0);
+    return OpenTherm::buildRequest(OpenThermRequestType::OPTH_READ, OpenThermMessageID::ASFflags, 0);
 }
 
 void sns_opentherm_parse_flags(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
@@ -416,7 +416,7 @@ void sns_opentherm_tele_u16(struct OpenThermCommandT *self)
 /////////////////////////////////// OEM Diag Code //////////////////////////////////////////////////
 unsigned long sns_opentherm_get_oem_diag(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *)
 {
-    return OpenTherm::buildRequest(OpenThermRequestType::READ, OpenThermMessageID::OEMDiagnosticCode, 0);
+    return OpenTherm::buildRequest(OpenThermRequestType::OPTH_READ, OpenThermMessageID::OEMDiagnosticCode, 0);
 }
 
 void sns_opentherm_parse_oem_diag(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
@@ -434,7 +434,7 @@ void sns_opentherm_tele_oem_diag(struct OpenThermCommandT *self)
 /////////////////////////////////// Generic Single Float /////////////////////////////////////////////////
 unsigned long sns_opentherm_get_generic_float(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *)
 {
-    return OpenTherm::buildRequest(OpenThermRequestType::READ, (OpenThermMessageID)self->m_command_code, 0);
+    return OpenTherm::buildRequest(OpenThermRequestType::OPTH_READ, (OpenThermMessageID)self->m_command_code, 0);
 }
 
 void sns_opentherm_parse_generic_float(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)
@@ -452,7 +452,7 @@ void sns_opentherm_tele_generic_float(struct OpenThermCommandT *self)
 /////////////////////////////////// Generic U16 /////////////////////////////////////////////////
 unsigned long sns_opentherm_get_generic_u16(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *)
 {
-    return OpenTherm::buildRequest(OpenThermRequestType::READ, (OpenThermMessageID)self->m_command_code, 0);
+    return OpenTherm::buildRequest(OpenThermRequestType::OPTH_READ, (OpenThermMessageID)self->m_command_code, 0);
 }
 
 void sns_opentherm_parse_generic_u16(struct OpenThermCommandT *self, struct OT_BOILER_STATUS_T *boilerStatus, unsigned long response)


### PR DESCRIPTION
## Description:

Following discussion on Discord it appears that OpenTherm and NimBLE are conflicting on a few symbols like READ and WRITE
So I prepended `OPTH_` on every symbols just to be safe 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
