### PR TITLE
LVGL fix init display desctriptor

### DIFF
--- a/tasmota/xdrv_52_3_berry_lvgl.ino
+++ b/tasmota/xdrv_52_3_berry_lvgl.ino
@@ -716,7 +716,7 @@ extern "C" {
     if (argc == 0 || (argc == 1 && be_isstring(vm, 1))) {
       const char * uconfig = nullptr;
       if (argc == 1) {
-        be_tostring(vm, 1);
+        uconfig = be_tostring(vm, 1);
       }
       start_lvgl(uconfig);
       be_return_nil(vm);


### PR DESCRIPTION
## Description:

Fix a bug that prevented the display descriptor from being passed as argument to `lv.start()` instead of `display.ini`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
