### PR TITLE
Fix compilation

### DIFF
--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -36,6 +36,10 @@
   #include "lv_png.h"
 #endif // USE_LVGL_PNG_DECODER
 
+#ifdef USE_LVGL_FREETYPE
+  #include "lv_freetype.h"
+#endif // USE_LVGL_FREETYPE
+
 Adafruit_LvGL_Glue * glue;
 
 // **************************************************


### PR DESCRIPTION
## Description:

Fix compilation of FreeType when Berry is not enabled.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
