### PR TITLE
Berry improvements to `persist`

### DIFF
--- a/lib/libesp32/Berry/default/be_persist_lib.c
+++ b/lib/libesp32/Berry/default/be_persist_lib.c
@@ -8,6 +8,76 @@
 #include "be_constobj.h"
 
 /********************************************************************
+** Solidified function: tostring
+********************************************************************/
+be_local_closure(tostring,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_string("string", 398550328, 6),
+    /* K1   */  be_nested_string("format", -1180859054, 6),
+    /* K2   */  be_nested_string("<instance: %s(%s)>", 1553432777, 18),
+    /* K3   */  be_nested_string("_p", 1594591802, 2),
+    }),
+    (be_nested_const_str("tostring", -1995258651, 8)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[11]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x60140005,  //  0003  GETGBL	R5	G5
+      0x5C180000,  //  0004  MOVE	R6	R0
+      0x7C140200,  //  0005  CALL	R5	1
+      0x60180008,  //  0006  GETGBL	R6	G8
+      0x881C0103,  //  0007  GETMBR	R7	R0	K3
+      0x7C180200,  //  0008  CALL	R6	1
+      0x7C080800,  //  0009  CALL	R2	4
+      0x80040400,  //  000A  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: member
+********************************************************************/
+be_local_closure(member,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("find", -1108310694, 4),
+    }),
+    (be_nested_const_str("member", 719708611, 6)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: setmember
 ********************************************************************/
 be_local_closure(setmember,   /* name */
@@ -21,17 +91,49 @@ be_local_closure(setmember,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("p", -183745553, 1),
-    /* K1   */  be_nested_string("dirty", -1627386213, 5),
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("_dirty", 283846766, 6),
     }),
     (be_nested_const_str("setmember", 1432909441, 9)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[ 5]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
       0x980C0202,  //  0001  SETIDX	R3	R1	R2
       0x500C0200,  //  0002  LDBOOL	R3	1	0
       0x90020203,  //  0003  SETMBR	R0	K1	R3
       0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: zero
+********************************************************************/
+be_local_closure(zero,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("_dirty", 283846766, 6),
+    }),
+    (be_nested_const_str("zero", -1955600541, 4)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[ 6]) {  /* code */
+      0x60040013,  //  0000  GETGBL	R1	G19
+      0x7C040000,  //  0001  CALL	R1	0
+      0x90020001,  //  0002  SETMBR	R0	K0	R1
+      0x50040200,  //  0003  LDBOOL	R1	1	0
+      0x90020201,  //  0004  SETMBR	R0	K1	R1
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -53,16 +155,16 @@ be_local_closure(save,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_string("json", 916562499, 4),
-    /* K1   */  be_nested_string("filename", 1058081160, 8),
+    /* K1   */  be_nested_string("_filename", 1430813195, 9),
     /* K2   */  be_nested_string("w", -234078410, 1),
     /* K3   */  be_nested_string("write", -1104765092, 5),
     /* K4   */  be_nested_string("dump", -631966073, 4),
-    /* K5   */  be_nested_string("p", -183745553, 1),
+    /* K5   */  be_nested_string("_p", 1594591802, 2),
     /* K6   */  be_nested_string("close", 667630371, 5),
-    /* K7   */  be_nested_string("dirty", -1627386213, 5),
+    /* K7   */  be_nested_string("_dirty", 283846766, 6),
     }),
     (be_nested_const_str("save", -855671224, 4)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[30]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x4C080000,  //  0001  LDNIL	R2
@@ -101,130 +203,9 @@ be_local_closure(save,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: has
 ********************************************************************/
-be_local_closure(init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_string("filename", 1058081160, 8),
-    /* K1   */  be_nested_string("_persist.json", 2008425138, 13),
-    /* K2   */  be_nested_string("p", -183745553, 1),
-    /* K3   */  be_nested_string("copy", -446502332, 4),
-    /* K4   */  be_nested_string("load", -435725847, 4),
-    /* K5   */  be_nested_string("dirty", -1627386213, 5),
-    }),
-    (be_nested_const_str("init", 380752755, 4)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
-    ( &(const binstruction[20]) {  /* code */
-      0x90020101,  //  0000  SETMBR	R0	K0	K1
-      0x6008000F,  //  0001  GETGBL	R2	G15
-      0x5C0C0200,  //  0002  MOVE	R3	R1
-      0x60100013,  //  0003  GETGBL	R4	G19
-      0x7C080400,  //  0004  CALL	R2	2
-      0x780A0003,  //  0005  JMPF	R2	#000A
-      0x8C080303,  //  0006  GETMET	R2	R1	K3
-      0x7C080200,  //  0007  CALL	R2	1
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0x70020002,  //  0009  JMP		#000D
-      0x60080013,  //  000A  GETGBL	R2	G19
-      0x7C080000,  //  000B  CALL	R2	0
-      0x90020402,  //  000C  SETMBR	R0	K2	R2
-      0x8C080104,  //  000D  GETMET	R2	R0	K4
-      0x88100102,  //  000E  GETMBR	R4	R0	K2
-      0x88140100,  //  000F  GETMBR	R5	R0	K0
-      0x7C080600,  //  0010  CALL	R2	3
-      0x50080000,  //  0011  LDBOOL	R2	0	0
-      0x90020A02,  //  0012  SETMBR	R0	K5	R2
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: zero
-********************************************************************/
-be_local_closure(zero,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("p", -183745553, 1),
-    /* K1   */  be_nested_string("dirty", -1627386213, 5),
-    }),
-    (be_nested_const_str("zero", -1955600541, 4)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
-    ( &(const binstruction[ 6]) {  /* code */
-      0x60040013,  //  0000  GETGBL	R1	G19
-      0x7C040000,  //  0001  CALL	R1	0
-      0x90020001,  //  0002  SETMBR	R0	K0	R1
-      0x50040200,  //  0003  LDBOOL	R1	1	0
-      0x90020201,  //  0004  SETMBR	R0	K1	R1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_string("string", 398550328, 6),
-    /* K1   */  be_nested_string("format", -1180859054, 6),
-    /* K2   */  be_nested_string("<instance: %s(%s)>", 1553432777, 18),
-    /* K3   */  be_nested_string("p", -183745553, 1),
-    }),
-    (be_nested_const_str("tostring", -1995258651, 8)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
-    ( &(const binstruction[11]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x60140005,  //  0003  GETGBL	R5	G5
-      0x5C180000,  //  0004  MOVE	R6	R0
-      0x7C140200,  //  0005  CALL	R5	1
-      0x60180008,  //  0006  GETGBL	R6	G8
-      0x881C0103,  //  0007  GETMBR	R7	R0	K3
-      0x7C180200,  //  0008  CALL	R6	1
-      0x7C080800,  //  0009  CALL	R2	4
-      0x80040400,  //  000A  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: member
-********************************************************************/
-be_local_closure(member,   /* name */
+be_local_closure(has,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -235,17 +216,51 @@ be_local_closure(member,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("p", -183745553, 1),
-    /* K1   */  be_nested_string("find", -1108310694, 4),
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("has", -306245661, 3),
     }),
-    (be_nested_const_str("member", 719708611, 6)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("has", -306245661, 3)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[ 5]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x5C100200,  //  0002  MOVE	R4	R1
       0x7C080400,  //  0003  CALL	R2	2
       0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove
+********************************************************************/
+be_local_closure(remove,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("remove", -611183107, 6),
+    /* K2   */  be_nested_string("_dirty", 283846766, 6),
+    }),
+    (be_nested_const_str("remove", -611183107, 6)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x50080200,  //  0004  LDBOOL	R2	1	0
+      0x90020402,  //  0005  SETMBR	R0	K2	R2
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -269,16 +284,16 @@ be_local_closure(load,   /* name */
     /* K0   */  be_nested_string("json", 916562499, 4),
     /* K1   */  be_nested_string("path", -2071507658, 4),
     /* K2   */  be_nested_string("exists", 1002329533, 6),
-    /* K3   */  be_nested_string("filename", 1058081160, 8),
+    /* K3   */  be_nested_string("_filename", 1430813195, 9),
     /* K4   */  be_nested_string("r", -150190315, 1),
     /* K5   */  be_nested_string("load", -435725847, 4),
     /* K6   */  be_nested_string("read", -824204347, 4),
     /* K7   */  be_nested_string("close", 667630371, 5),
-    /* K8   */  be_nested_string("p", -183745553, 1),
-    /* K9   */  be_nested_string("dirty", -1627386213, 5),
+    /* K8   */  be_nested_string("_p", 1594591802, 2),
+    /* K9   */  be_nested_string("_dirty", 283846766, 6),
     }),
     (be_nested_const_str("load", -435725847, 4)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[37]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
@@ -324,23 +339,108 @@ be_local_closure(load,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(init,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_string("_filename", 1430813195, 9),
+    /* K1   */  be_nested_string("_persist.json", 2008425138, 13),
+    /* K2   */  be_nested_string("_p", 1594591802, 2),
+    /* K3   */  be_nested_string("copy", -446502332, 4),
+    /* K4   */  be_nested_string("load", -435725847, 4),
+    /* K5   */  be_nested_string("_dirty", 283846766, 6),
+    }),
+    (be_nested_const_str("init", 380752755, 4)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[20]) {  /* code */
+      0x90020101,  //  0000  SETMBR	R0	K0	K1
+      0x6008000F,  //  0001  GETGBL	R2	G15
+      0x5C0C0200,  //  0002  MOVE	R3	R1
+      0x60100013,  //  0003  GETGBL	R4	G19
+      0x7C080400,  //  0004  CALL	R2	2
+      0x780A0003,  //  0005  JMPF	R2	#000A
+      0x8C080303,  //  0006  GETMET	R2	R1	K3
+      0x7C080200,  //  0007  CALL	R2	1
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x70020002,  //  0009  JMP		#000D
+      0x60080013,  //  000A  GETGBL	R2	G19
+      0x7C080000,  //  000B  CALL	R2	0
+      0x90020402,  //  000C  SETMBR	R0	K2	R2
+      0x8C080104,  //  000D  GETMET	R2	R0	K4
+      0x88100102,  //  000E  GETMBR	R4	R0	K2
+      0x88140100,  //  000F  GETMBR	R5	R0	K0
+      0x7C080600,  //  0010  CALL	R2	3
+      0x50080000,  //  0011  LDBOOL	R2	0	0
+      0x90020A02,  //  0012  SETMBR	R0	K5	R2
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find
+********************************************************************/
+be_local_closure(find,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_string("_p", 1594591802, 2),
+    /* K1   */  be_nested_string("find", -1108310694, 4),
+    }),
+    (be_nested_const_str("find", -1108310694, 4)),
+    (be_nested_const_str("input", -103256197, 5)),
+    ( &(const binstruction[ 6]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x80040600,  //  0005  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Persist
 ********************************************************************/
 be_local_class(Persist,
     3,
     NULL,
-    be_nested_map(10,
+    be_nested_map(13,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("filename", 1058081160, 8, -1), be_const_var(0) },
-        { be_nested_key("setmember", 1432909441, 9, 7), be_const_closure(setmember_closure) },
+        { be_nested_key("tostring", -1995258651, 8, -1), be_const_closure(tostring_closure) },
+        { be_nested_key("member", 719708611, 6, 3), be_const_closure(member_closure) },
+        { be_nested_key("setmember", 1432909441, 9, 5), be_const_closure(setmember_closure) },
+        { be_nested_key("zero", -1955600541, 4, 9), be_const_closure(zero_closure) },
         { be_nested_key("save", -855671224, 4, -1), be_const_closure(save_closure) },
-        { be_nested_key("dirty", -1627386213, 5, 8), be_const_var(2) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_closure(init_closure) },
-        { be_nested_key("zero", -1955600541, 4, 6), be_const_closure(zero_closure) },
-        { be_nested_key("tostring", -1995258651, 8, 4), be_const_closure(tostring_closure) },
-        { be_nested_key("member", 719708611, 6, -1), be_const_closure(member_closure) },
-        { be_nested_key("p", -183745553, 1, -1), be_const_var(1) },
+        { be_nested_key("has", -306245661, 3, -1), be_const_closure(has_closure) },
+        { be_nested_key("_filename", 1430813195, 9, 10), be_const_var(0) },
+        { be_nested_key("remove", -611183107, 6, -1), be_const_closure(remove_closure) },
+        { be_nested_key("_dirty", 283846766, 6, -1), be_const_var(2) },
         { be_nested_key("load", -435725847, 4, -1), be_const_closure(load_closure) },
+        { be_nested_key("init", 380752755, 4, -1), be_const_closure(init_closure) },
+        { be_nested_key("_p", 1594591802, 2, 1), be_const_var(1) },
+        { be_nested_key("find", -1108310694, 4, -1), be_const_closure(find_closure) },
     })),
     (be_nested_const_str("Persist", 1456346147, 7))
 );
@@ -362,7 +462,7 @@ be_local_closure(_anonymous_,   /* name */
     /* K0   */  be_const_class(be_class_Persist),
     }),
     (be_nested_const_str("_anonymous_", 1957281476, 11)),
-    (be_nested_const_str("stdin", -1529146723, 5)),
+    (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[ 5]) {  /* code */
       0x58040000,  //  0000  LDCONST	R1	K0
       0xB4000000,  //  0001  CLASS	K0

--- a/lib/libesp32/Berry/default/embedded/persist.be
+++ b/lib/libesp32/Berry/default/embedded/persist.be
@@ -12,45 +12,58 @@ var persist_module = module("persist")
 persist_module.init = def (m)
 
   class Persist
-    var filename
-    var p
-    var dirty
+    var _filename
+    var _p
+    var _dirty
 
     #- persist can be initialized with pre-existing values. The map is not copied so any change will be reflected -#
     def init(m)
       # print("Persist init")
-      self.filename = '_persist.json'
+      self._filename = '_persist.json'
       if isinstance(m,map)
-        self.p = m.copy()   # need to copy instead?
+        self._p = m.copy()   # need to copy instead?
       else
-        self.p = {}
+        self._p = {}
       end
-      self.load(self.p, self.filename)
-      self.dirty = false
+      self.load(self._p, self._filename)
+      self._dirty = false
       # print("Persist init")
     end
 
     #- virtual member getter, if a key does not exists return `nil`-#
     def member(key)
-      return self.p.find(key)
+      return self._p.find(key)
     end
 
     #- virtual member setter -#
     def setmember(key, value)
-      self.p[key] = value
-      self.dirty = true
+      self._p[key] = value
+      self._dirty = true
     end
 
     #- clear all entries -#
     def zero()
-      self.p = {}
-      self.dirty = true
+      self._p = {}
+      self._dirty = true
     end
     
+    def remove(k)
+        self._p.remove(k)
+        self._dirty = true
+    end
+
+    def has(k)
+        return self._p.has(k)
+    end
+
+    def find(k, d)
+        return self._p.find(k, d)
+    end
+
     #- custom tostring -#
     def tostring()
       import string
-      return string.format("<instance: %s(%s)>", classname(self), str(self.p))
+      return string.format("<instance: %s(%s)>", classname(self), str(self._p))
     end
 
     def load()
@@ -59,17 +72,17 @@ persist_module.init = def (m)
       var f           # file object
       var val         # values loaded from json
 
-      if path.exists(self.filename)
+      if path.exists(self._filename)
         try
-          f = open(self.filename, "r")
+          f = open(self._filename, "r")
           val = json.load(f.read())
           f.close()
         except .. as e, m
           if f != nil f.close() end
           raise e, m
         end
-        self.p = val
-        self.dirty = false
+        self._p = val
+        self._dirty = false
       end
 
       # print("Loading")
@@ -80,14 +93,14 @@ persist_module.init = def (m)
   
       var f       # file object
       try
-        f = open(self.filename, "w")
-        f.write(json.dump(self.p))
+        f = open(self._filename, "w")
+        f.write(json.dump(self._p))
         f.close()
       except .. as e, m
         if f != nil f.close() end
         raise e, m
       end
-      self.dirty = false
+      self._dirty = false
       # print("Saving")
     end
   end

--- a/lib/libesp32/Berry/generate/be_const_strtab.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab.h
@@ -238,6 +238,7 @@ extern const bcstring be_const_str_lv_arc;
 extern const bcstring be_const_str_nil;
 extern const bcstring be_const_str_NRG_SEL_INV;
 extern const bcstring be_const_str_SYMBOL_LEFT;
+extern const bcstring be_const_str_has;
 extern const bcstring be_const_str_DDSU666_TX;
 extern const bcstring be_const_str_sin;
 extern const bcstring be_const_str_sqrt;

--- a/lib/libesp32/Berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab_def.h
@@ -237,7 +237,8 @@ be_define_const_str(bytes, "bytes", 1706151940u, 0, 5, &be_const_str_lv_arc);
 be_define_const_str(lv_arc, "lv_arc", 4170125384u, 0, 6, &be_const_str_nil);
 be_define_const_str(nil, "nil", 228849900u, 63, 3, NULL);
 be_define_const_str(NRG_SEL_INV, "NRG_SEL_INV", 3567431069u, 0, 11, &be_const_str_SYMBOL_LEFT);
-be_define_const_str(SYMBOL_LEFT, "SYMBOL_LEFT", 1563517575u, 0, 11, NULL);
+be_define_const_str(SYMBOL_LEFT, "SYMBOL_LEFT", 1563517575u, 0, 11, &be_const_str_has);
+be_define_const_str(has, "has", 3988721635u, 0, 3, NULL);
 be_define_const_str(DDSU666_TX, "DDSU666_TX", 1880604150u, 0, 10, NULL);
 be_define_const_str(sin, "sin", 3761252941u, 0, 3, &be_const_str_sqrt);
 be_define_const_str(sqrt, "sqrt", 2112764879u, 0, 4, &be_const_str_time_reached);
@@ -1028,6 +1029,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 334,
-    .count = 668,
+    .count = 669,
     .table = m_string_table
 };

--- a/lib/libesp32/Berry/generate/be_fixed_be_class_map.h
+++ b/lib/libesp32/Berry/generate/be_fixed_be_class_map.h
@@ -1,22 +1,23 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(be_class_map_map) {
-    { be_const_key(dot_p, 2), be_const_var(0) },
-    { be_const_key(insert, -1), be_const_func(m_insert) },
-    { be_const_key(remove, -1), be_const_func(m_remove) },
-    { be_const_key(tostring, -1), be_const_func(m_tostring) },
-    { be_const_key(iter, 5), be_const_func(m_iter) },
     { be_const_key(size, -1), be_const_func(m_size) },
-    { be_const_key(keys, -1), be_const_func(m_keys) },
-    { be_const_key(setitem, -1), be_const_func(m_setitem) },
-    { be_const_key(find, 0), be_const_func(m_find) },
+    { be_const_key(tostring, -1), be_const_func(m_tostring) },
+    { be_const_key(has, 11), be_const_func(m_has) },
     { be_const_key(init, -1), be_const_func(m_init) },
-    { be_const_key(item, 1), be_const_func(m_item) },
+    { be_const_key(insert, -1), be_const_func(m_insert) },
+    { be_const_key(keys, -1), be_const_func(m_keys) },
+    { be_const_key(find, -1), be_const_func(m_find) },
+    { be_const_key(dot_p, 2), be_const_var(0) },
+    { be_const_key(setitem, 4), be_const_func(m_setitem) },
+    { be_const_key(remove, -1), be_const_func(m_remove) },
+    { be_const_key(item, 6), be_const_func(m_item) },
+    { be_const_key(iter, -1), be_const_func(m_iter) },
 };
 
 static be_define_const_map(
     be_class_map_map,
-    11
+    12
 );
 
 BE_EXPORT_VARIABLE be_define_const_class(

--- a/lib/libesp32/Berry/src/be_maplib.c
+++ b/lib/libesp32/Berry/src/be_maplib.c
@@ -121,6 +121,15 @@ static int m_find(bvm *vm)
     be_return(vm);
 }
 
+static int m_has(bvm *vm)
+{
+    be_getmember(vm, 1, ".p");
+    map_check_data(vm, 2);
+    be_pushvalue(vm, 2);
+    be_pushbool(vm, be_getindex(vm, -2));
+    be_return(vm);
+}
+
 static int m_insert(bvm *vm)
 {
     bbool res;
@@ -232,6 +241,7 @@ class be_class_map (scope: global, name: map) {
     item, func(m_item)
     setitem, func(m_setitem)
     find, func(m_find)
+    has, func(m_has)
     size, func(m_size)
     insert, func(m_insert)
     iter, func(m_iter)


### PR DESCRIPTION
## Description:

Following Discord discussion, additions to `persist`:
- `persist.has("my_param")` returns true or false if the key exists
- `persist.remove("my_param")` removes a key, or ignore if the key does not exist
- `persist.find("my_param" [, "default value"])` returns the value for a key, or `nil` or the default value. Similar as `map.find`
- persist attributes have a `_` prefix to avoid collision with keys

Also:
- added `map.has(key) -> bool`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
