### PR TITLE
Files starting with underscore in file system are no more hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Removed command ``EnergyReset`` as it is replaced by new commands
+- Files starting with underscore in file system are no more hidden
 
 ## [9.5.0.8] 20210927
 ### Added

--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -259,7 +259,6 @@ uint8_t UfsReject(char *name) {
   }
 
   while (*name=='/') { name++; }
-  if (*name=='_') { return 1; }
   if (*name=='.') { return 1; }
 
   if (!strncasecmp(name, "SPOTLI~1", REJCMPL)) { return 1; }


### PR DESCRIPTION
## Description:

Files starting with underscore in file system are no more hidden in Web UI.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
