### PR TITLE
Fix setmember

### DIFF
--- a/lib/libesp32/Berry/src/be_class.c
+++ b/lib/libesp32/Berry/src/be_class.c
@@ -336,7 +336,7 @@ bbool be_instance_setmember(bvm *vm, binstance *o, bstring *name, bvalue *src)
             vm->top += 4;   /* prevent collection results */
             be_dofunc(vm, top, 3); /* call method 'member' */
             vm->top -= 4;
-            return var_tobool(top);
+            return btrue;
         }
     }
     return bfalse;


### PR DESCRIPTION
## Description:

Fix Berry setmember. Now the return value of `setmember()` is ignored, any failure to store the member should raise an exception.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
