### PR TITLE
Changed Memory display on ESP32 to not include IRAM (i.e. less by 40-50KB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking Changed
 - ESP32 LVGL updated to v8.0.2
+- Changed Memory display on ESP32 to not include IRAM (i.e. less by 40-50KB)
 
 ### Changed
 - Removed command ``EnergyReset`` as it is replaced by new commands

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -387,12 +387,13 @@ uint32_t ESP_getSketchSize(void) {
 }
 
 uint32_t ESP_getFreeHeap(void) {
-  return ESP.getFreeHeap();
+  // ESP_getFreeHeap() returns also IRAM which we don't use
+  return heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 }
 
 uint32_t ESP_getMaxAllocHeap(void) {
-  // largest block of heap that can be allocated at once
-  uint32_t free_block_size = ESP.getMaxAllocHeap();
+  // arduino returns IRAM but we want only DRAM
+  uint32_t free_block_size = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
   if (free_block_size > 100) { free_block_size -= 100; }
   return free_block_size;
 }


### PR DESCRIPTION
## Description:

Free Memory would include IRAM, although this memory has some restricted access pattern (32 bits alined) and is therefore not currently used in Tasmota.
Now the Free Memory does not include IRAM but only usable RAM. The metrics goes down by 40-50KB - which is normal.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
