### PR TITLE
PWM_DIMMER: fix light fade stop, use dimmer_step

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -1818,6 +1818,7 @@ void LightAnimate(void)
         memcpy(Light.fade_start_10, cur_col_10, sizeof(Light.fade_start_10));
         // push the final values at 8 and 10 bits resolution to the PWMs
         LightSetOutputs(cur_col_10);
+        LightStopFade();
         Light.fade_initialized = true;      // it is now ok to fade
         Light.fade_once_enabled = false;    // light has been set, reset fade_once_enabled
         Light.speed_once_enabled = false;   // light has been set, reset speed_once_enabled
@@ -1842,10 +1843,6 @@ void LightAnimate(void)
         LightSetOutputs(Light.fade_cur_10);
       }
     }
-#ifdef USE_PWM_DIMMER
-    // If the power is off and the fade is done, turn the relay off.
-    if (PWM_DIMMER == TasmotaGlobal.module_type && !Light.power && !Light.fade_running) PWMDimmerSetPower();
-#endif  // USE_PWM_DIMMER
     // For WYZE bulbs we must set the CT pin (PWM2) to INPUT to fully turn it off
     if (TasmotaGlobal.gpio_optiona.pwm1_input && !Light.power && !Light.fade_running) {  // GPIO Option_A1
       if (PinUsed(GPIO_PWM1, 1)) { pinMode(Pin(GPIO_PWM1, 1), INPUT); }
@@ -1902,6 +1899,14 @@ uint8_t LightGetCurFadeBri(void) {
   return max_bri;
 }
 
+void LightStopFade(void) {
+  Light.fade_running = false;
+#ifdef USE_PWM_DIMMER
+  // If the power is off and the fade is done, turn the relay off.
+  if (PWM_DIMMER == TasmotaGlobal.module_type && !Light.power) PWMDimmerSetPower();
+#endif  // USE_PWM_DIMMER
+}
+
 bool LightApplyFade(void) {   // did the value chanegd and needs to be applied
   static uint32_t last_millis = 0;
   uint32_t now = millis();
@@ -1940,7 +1945,7 @@ bool LightApplyFade(void) {   // did the value chanegd and needs to be applied
       }
     } else {
       // no fade needed, we keep the duration at zero, it will fallback directly to end of fade
-      Light.fade_running = false;
+      LightStopFade();
     }
   }
 
@@ -1960,7 +1965,7 @@ bool LightApplyFade(void) {   // did the value chanegd and needs to be applied
   } else {
     // stop fade
 //AddLop_P2(LOG_LEVEL_DEBUG, PSTR("Stop fade"));
-    Light.fade_running = false;
+    LightStopFade();
     Light.fade_start = 0;
     Light.fade_duration = 0;
     // set light to target value
@@ -2937,7 +2942,7 @@ void CmndFade(void)
   #ifdef USE_DEVICE_GROUPS
     if (XdrvMailbox.payload >= 0 && XdrvMailbox.payload <= 2) SendDeviceGroupMessage(Light.device, DGR_MSGTYP_UPDATE, DGR_ITEM_LIGHT_FADE, Settings->light_fade);
   #endif  // USE_DEVICE_GROUPS
-    if (!Settings->light_fade) { Light.fade_running = false; }
+    if (!Settings->light_fade) { LightStopFade(); }
   }
   ResponseCmndStateText(Settings->light_fade);
 }
@@ -2951,7 +2956,7 @@ void CmndSpeed(void)
       Light.fade_once_value = (XdrvMailbox.payload > 0);
       Light.speed_once_enabled = true;
       Light.speed_once_value = XdrvMailbox.payload;
-      if (!Light.fade_once_value) { Light.fade_running = false; }
+      if (!Light.fade_once_value) { LightStopFade(); }
     }
     ResponseCmndIdxNumber(Light.speed_once_value);
   } else {

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -271,7 +271,8 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
 {
   bool handle_tap = false;
   bool state_updated = false;
-  int32_t bri_offset = 0;
+  int8_t bri_hold = 0;
+  int8_t bri_tap = 0;
   uint8_t power_on_bri = 0;
   uint8_t dgr_item = 0;
   uint8_t dgr_value = 0;
@@ -294,7 +295,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
     uint32_t now = millis();
 
     // If the button was pressed and released but was not processed by support_button because the
-    // button interval had not elapsed,
+    // button interval had not elapsed, publish an MQTT message.
     if (button_unprocessed[button_index]) {
       mqtt_trigger = 5;
 #ifdef USE_PWM_DIMMER_REMOTE
@@ -314,9 +315,9 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
         // The new brightness will be calculated below.
         if (power_is_on) {
 #ifdef USE_PWM_DIMMER_REMOTE
-          bri_offset = (active_remote_pwm_dimmer ? (active_remote_pwm_dimmer->power_button_increases_bri ? 1 : -1) : (power_button_increases_bri ? 1 : -1));
+          bri_hold = (active_remote_pwm_dimmer ? (active_remote_pwm_dimmer->power_button_increases_bri ? 1 : -1) : (power_button_increases_bri ? 1 : -1));
 #else // USE_PWM_DIMMER_REMOTE
-          bri_offset = (power_button_increases_bri ? 1 : -1);
+          bri_hold = (power_button_increases_bri ? 1 : -1);
 #endif  // USE_PWM_DIMMER_REMOTE
           invert_power_button_bri_direction = true;
         }
@@ -351,7 +352,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
         // Otherwise, if the power is on and remote mode is enabled, adjust the brightness. Set the
         // direction based on which button is pressed. The new brightness will be calculated below.
         else if (power_is_on && Settings->flag4.multiple_device_groups) {
-          bri_offset = (is_down_button ? -1 : 1);
+          bri_hold = (is_down_button ? -1 : 1);
         }
 
         // Otherwise, publish MQTT Event Trigger#.
@@ -365,7 +366,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
       // Otherwise, if the power is on, adjust the brightness. Set the direction based on which
       // button is pressed. The new brightness will be calculated below.
       else if (power_is_on && !button_tapped) {
-        bri_offset = (is_down_button ? -1 : 1);
+        bri_hold = (is_down_button ? -1 : 1);
       }
     }
   }
@@ -465,7 +466,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
           // If the button was not held, adjust the brightness. Set the direction based on which
           // button is pressed. The new brightness will be calculated below.
           if (!button_was_held) {
-            bri_offset = (is_down_button ? -5 : 5);
+            bri_tap = (is_down_button ? -1 : 1);
             dgr_more_to_come = false;
             state_updated = true;
           }
@@ -494,7 +495,7 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
 
   // If we need to adjust the brightness, do it.
   int32_t negated_device_group_index = -power_button_index;
-  if (bri_offset) {
+  if (bri_hold || bri_tap) {
     int32_t bri;
 #ifdef USE_PWM_DIMMER_REMOTE
     if (active_remote_pwm_dimmer)
@@ -502,8 +503,16 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
     else
 #endif  // USE_PWM_DIMMER_REMOTE
       bri = light_state.getBri();
-    int32_t new_bri = bri + bri_offset * (Settings->light_correction ? 4 : bri / 16 + 1);
-
+    int32_t bri_offset = Settings->dimmer_step;
+    if (bri_tap)
+      bri_offset *= bri_tap;
+    else {
+      bri_offset /= 5;
+      if (!Settings->light_correction) bri_offset *= bri / 32;
+      if (bri_offset < 1) bri_offset = 1;
+      bri_offset *= bri_hold;
+    }
+    int32_t new_bri = bri + bri_offset;
     if (bri_offset > 0) {
       if (new_bri > 255) new_bri = 255;
     }


### PR DESCRIPTION
## Description:

PWMDimmerSetPower was being called every light Animate pass when the light was off and no fading was in progress. It was intended to only be called once when fading is complete. This PR fixes that.

This PR modifies PWM Dimmer to use DimmerStep when adjusting the light brightness allowing users to customize the brightness change rate.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
