### PR TITLE
Use key count for SO88 default group count, minimize at 1

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -111,18 +111,18 @@ void DeviceGroupsInit(void)
   if (!device_group_count) {
 
     // If relays in separate device groups is enabled, set the device group count to highest numbered
-    // relay.
+    // button.
     if (Settings->flag4.multiple_device_groups) {  // SetOption88 - Enable relays in separate device groups
-      for (uint32_t relay_index = 0; relay_index < MAX_RELAYS; relay_index++) {
-        if (PinUsed(GPIO_REL1, relay_index)) device_group_count = relay_index + 1;
+      for (uint32_t index = 0; index < MAX_KEYS; index++) {
+        if (PinUsed(GPIO_KEY1, index)) device_group_count = index + 1;
       }
-      if (device_group_count > MAX_DEV_GROUP_NAMES) device_group_count = MAX_DEV_GROUP_NAMES;
     }
 
-    // Otherwise, set the device group count to 1.
-    else {
+    // Set up a minimum of one device group.
+    if (!device_group_count)
       device_group_count = 1;
-    }
+    else if (device_group_count > MAX_DEV_GROUP_NAMES)
+      device_group_count = MAX_DEV_GROUP_NAMES;
   }
 
   // If there are more device group names set than the number of device groups needed by the


### PR DESCRIPTION
## Description:

Use the key (button) count for the default device group count instead of the relay count. Minimize the device group count at one. Previously, if SO88 was enabled and there we no relays, the code would continuously try to allocate a 0-byte array.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
