### PR TITLE
Back to highest numbered relay for default count, Only send event mes…

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -113,8 +113,8 @@ void DeviceGroupsInit(void)
     // If relays in separate device groups is enabled, set the device group count to highest numbered
     // button.
     if (Settings->flag4.multiple_device_groups) {  // SetOption88 - Enable relays in separate device groups
-      for (uint32_t index = 0; index < MAX_KEYS; index++) {
-        if (PinUsed(GPIO_KEY1, index)) device_group_count = index + 1;
+      for (uint32_t relay_index = 0; relay_index < MAX_RELAYS; relay_index++) {
+        if (PinUsed(GPIO_REL1, relay_index)) device_group_count = relay_index + 1;
       }
     }
 

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -2200,7 +2200,7 @@ void CmndEvent(void)
   if (XdrvMailbox.data_len > 0) {
     strlcpy(Rules.event_data, XdrvMailbox.data, sizeof(Rules.event_data));
 #ifdef USE_DEVICE_GROUPS
-    SendDeviceGroupMessage(1, DGR_MSGTYP_UPDATE, DGR_ITEM_EVENT, XdrvMailbox.data);
+    if (!XdrvMailbox.grpflg) SendDeviceGroupMessage(1, DGR_MSGTYP_UPDATE, DGR_ITEM_EVENT, XdrvMailbox.data);
 #endif  // USE_DEVICE_GROUPS
   }
   if (XdrvMailbox.command) ResponseCmndDone();


### PR DESCRIPTION
## Description:

Go back to using the higest numbered relay for the default device group count. This is really a holdover from before device groups had their own namespace. If more device group names (DevGroupName) have been defined than the number of relays, it will use the device group name count. If there are more relays than have been defined, it will use the group topic suffixed with a number for the extra device group names.

Also only send event commands to the device group is the event command did not arrive as an MQTT message to the group topic.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
