### PR TITLE
ESP32 restore GPIO16/17 if no PSRAM was found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Berry add module ``import persist``
 - Support for BL0942 energy monitor (#13259)
 - Support for HM330X SeedStudio Grove Particule sensor (#13250)
+- ESP32 restore GPIO16/17 if no PSRAM was found
 
 ### Breaking Changed
 - ESP32 LVGL updated to v8.0.2

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -222,6 +222,13 @@ void setup(void) {
 #endif
 #endif
 
+#ifdef CONFIG_IDF_TARGET_ESP32
+  // restore GPIO16/17 if no PSRAM is found
+  if (!FoundPSRAM()) {
+    gpio_reset_pin(GPIO_NUM_16);
+    gpio_reset_pin(GPIO_NUM_17);
+  }
+#endif
   RtcPreInit();
   SettingsInit();
 


### PR DESCRIPTION
## Description:

On ESP32, by default esp-idf will probe using GPIO16/17 to see if a PSRAM is attached. Currently when no PSRAM is attached, GPIO16/17 remain connected to SPI1 (cs/clk).

With this change, if no PSRAM was found, GPIO16/17 are reset to normal GPIOs and can be used as general purpose GPIOs. Keep in mind though that they will be briefly configured as outputs and will burst SPI signals.

Note: if PSRAM is present but disabled because of missing patches (ESP32 rev1 only), GPIO16/17 are not freed and can't be used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
