### PR TITLE
Revert "ESP32 restore GPIO16/17 if no PSRAM was found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project will be documented in this file.
 - Berry add module ``import persist``
 - Support for BL0942 energy monitor (#13259)
 - Support for HM330X SeedStudio Grove Particule sensor (#13250)
-- ESP32 restore GPIO16/17 if no PSRAM was found
 
 ### Breaking Changed
 - ESP32 LVGL updated to v8.0.2

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -222,13 +222,6 @@ void setup(void) {
 #endif
 #endif
 
-#ifdef CONFIG_IDF_TARGET_ESP32
-  // restore GPIO16/17 if no PSRAM is found
-  if (!FoundPSRAM()) {
-    gpio_reset_pin(GPIO_NUM_16);
-    gpio_reset_pin(GPIO_NUM_17);
-  }
-#endif
   RtcPreInit();
   SettingsInit();
 


### PR DESCRIPTION
Reverts arendst/Tasmota#13335

Reverting because of bootloop being reported 