### PR TITLE
Berry stability fix

### DIFF
--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -120,6 +120,7 @@ void BerryDumpErrorAndClear(bvm *vm, bool berry_console) {
       top = be_top(vm);   // update top after dump
     } else {
       AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_BERRY "Exception> '%s' - %s"), be_tostring(berry.vm, -2), be_tostring(berry.vm, -1));
+      be_tracestack(vm);
     }
   } else {
     be_dumpstack(vm);


### PR DESCRIPTION
## Description:

Fix in Berry that could cause rare random crashes and data corruption.

Internally, when calling a virtual member, Berry's stack could be increased and relocated. The result of the virtual member search would then be store in the old location where is stack is no more. This means that the data was lost and memory potentially corrupted.

Also increased logging in specific situations

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
