### PR TITLE
Berry bytes() allow negative indices

### DIFF
--- a/lib/libesp32/Berry/src/be_byteslib.c
+++ b/lib/libesp32/Berry/src/be_byteslib.c
@@ -883,6 +883,9 @@ static int m_item(bvm *vm)
     buf_impl attr = bytes_check_data(vm, 0); /* we reserve 4 bytes anyways */
     if (argc >=2 && be_isint(vm, 2)) {  /* single byte */
         int index = be_toint(vm,2);
+        if (index < 0) {
+            index += attr.len;
+        }
         if (index >= 0 && index < attr.len) {
             be_pushint(vm, buf_get1(&attr, index));
             be_return(vm);
@@ -900,6 +903,9 @@ static int m_item(bvm *vm)
             be_getmember(vm, 2, "__upper__");
             upper = be_toint(vm, -1);
             be_pop(vm, 1);
+            /* handle negative limits */
+            if (upper < 0) { upper += attr.len; }
+            if (lower < 0) { lower += attr.len; }
             /* protection scope */
             upper = upper < size ? upper : size - 1;
             lower = lower < 0 ? 0 : lower;
@@ -1257,38 +1263,38 @@ be_local_closure(getbits,   /* name */
     (be_nested_const_str("getbits", -1200798317, 7)),
     (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[32]) {  /* code */
-      0x180C0500,  //  0000  LE	R3	R2	K0
-      0x740E0002,  //  0001  JMPT	R3	#0005
-      0x540E001F,  //  0002  LDINT	R3	32
-      0x240C0403,  //  0003  GT	R3	R2	R3
-      0x780E0000,  //  0004  JMPF	R3	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x580C0000,  //  0006  LDCONST	R3	K0
-      0x3C100303,  //  0007  SHR	R4	R1	K3
-      0x54160007,  //  0008  LDINT	R5	8
-      0x10040205,  //  0009  MOD	R1	R1	R5
-      0x58140000,  //  000A  LDCONST	R5	K0
-      0x24180500,  //  000B  GT	R6	R2	K0
-      0x781A0011,  //  000C  JMPF	R6	#001F
-      0x541A0007,  //  000D  LDINT	R6	8
-      0x04180C01,  //  000E  SUB	R6	R6	R1
-      0x241C0C02,  //  000F  GT	R7	R6	R2
-      0x781E0000,  //  0010  JMPF	R7	#0012
-      0x5C180400,  //  0011  MOVE	R6	R2
-      0x381E0806,  //  0012  SHL	R7	K4	R6
-      0x041C0F04,  //  0013  SUB	R7	R7	K4
-      0x381C0E01,  //  0014  SHL	R7	R7	R1
-      0x94200004,  //  0015  GETIDX	R8	R0	R4
-      0x2C201007,  //  0016  AND	R8	R8	R7
-      0x3C201001,  //  0017  SHR	R8	R8	R1
-      0x38201005,  //  0018  SHL	R8	R8	R5
-      0x300C0608,  //  0019  OR	R3	R3	R8
-      0x00140A06,  //  001A  ADD	R5	R5	R6
-      0x04080406,  //  001B  SUB	R2	R2	R6
-      0x58040000,  //  001C  LDCONST	R1	K0
-      0x00100904,  //  001D  ADD	R4	R4	K4
-      0x7001FFEB,  //  001E  JMP		#000B
-      0x80040600,  //  001F  RET	1	R3
+      0x180C0500,  //  0000  LE  R3  R2  K0
+      0x740E0002,  //  0001  JMPT  R3  #0005
+      0x540E001F,  //  0002  LDINT  R3  32
+      0x240C0403,  //  0003  GT  R3  R2  R3
+      0x780E0000,  //  0004  JMPF  R3  #0006
+      0xB0060302,  //  0005  RAISE  1  K1  K2
+      0x580C0000,  //  0006  LDCONST  R3  K0
+      0x3C100303,  //  0007  SHR  R4  R1  K3
+      0x54160007,  //  0008  LDINT  R5  8
+      0x10040205,  //  0009  MOD  R1  R1  R5
+      0x58140000,  //  000A  LDCONST  R5  K0
+      0x24180500,  //  000B  GT  R6  R2  K0
+      0x781A0011,  //  000C  JMPF  R6  #001F
+      0x541A0007,  //  000D  LDINT  R6  8
+      0x04180C01,  //  000E  SUB  R6  R6  R1
+      0x241C0C02,  //  000F  GT  R7  R6  R2
+      0x781E0000,  //  0010  JMPF  R7  #0012
+      0x5C180400,  //  0011  MOVE  R6  R2
+      0x381E0806,  //  0012  SHL  R7  K4  R6
+      0x041C0F04,  //  0013  SUB  R7  R7  K4
+      0x381C0E01,  //  0014  SHL  R7  R7  R1
+      0x94200004,  //  0015  GETIDX  R8  R0  R4
+      0x2C201007,  //  0016  AND  R8  R8  R7
+      0x3C201001,  //  0017  SHR  R8  R8  R1
+      0x38201005,  //  0018  SHL  R8  R8  R5
+      0x300C0608,  //  0019  OR  R3  R3  R8
+      0x00140A06,  //  001A  ADD  R5  R5  R6
+      0x04080406,  //  001B  SUB  R2  R2  R6
+      0x58040000,  //  001C  LDCONST  R1  K0
+      0x00100904,  //  001D  ADD  R4  R4  K4
+      0x7001FFEB,  //  001E  JMP    #000B
+      0x80040600,  //  001F  RET  1  R3
     })
   )
 );
@@ -1317,43 +1323,43 @@ be_local_closure(setbits,   /* name */
     (be_nested_const_str("setbits", -1532559129, 7)),
     (be_nested_const_str("input", -103256197, 5)),
     ( &(const binstruction[37]) {  /* code */
-      0x14100500,  //  0000  LT	R4	R2	K0
-      0x74120002,  //  0001  JMPT	R4	#0005
-      0x5412001F,  //  0002  LDINT	R4	32
-      0x24100404,  //  0003  GT	R4	R2	R4
-      0x78120000,  //  0004  JMPF	R4	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x60100009,  //  0006  GETGBL	R4	G9
-      0x5C140600,  //  0007  MOVE	R5	R3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x5C0C0800,  //  0009  MOVE	R3	R4
-      0x3C100303,  //  000A  SHR	R4	R1	K3
-      0x54160007,  //  000B  LDINT	R5	8
-      0x10040205,  //  000C  MOD	R1	R1	R5
-      0x24140500,  //  000D  GT	R5	R2	K0
-      0x78160014,  //  000E  JMPF	R5	#0024
-      0x54160007,  //  000F  LDINT	R5	8
-      0x04140A01,  //  0010  SUB	R5	R5	R1
-      0x24180A02,  //  0011  GT	R6	R5	R2
-      0x781A0000,  //  0012  JMPF	R6	#0014
-      0x5C140400,  //  0013  MOVE	R5	R2
-      0x381A0805,  //  0014  SHL	R6	K4	R5
-      0x04180D04,  //  0015  SUB	R6	R6	K4
-      0x541E00FE,  //  0016  LDINT	R7	255
-      0x38200C01,  //  0017  SHL	R8	R6	R1
-      0x041C0E08,  //  0018  SUB	R7	R7	R8
-      0x94200004,  //  0019  GETIDX	R8	R0	R4
-      0x2C201007,  //  001A  AND	R8	R8	R7
-      0x2C240606,  //  001B  AND	R9	R3	R6
-      0x38241201,  //  001C  SHL	R9	R9	R1
-      0x30201009,  //  001D  OR	R8	R8	R9
-      0x98000808,  //  001E  SETIDX	R0	R4	R8
-      0x3C0C0605,  //  001F  SHR	R3	R3	R5
-      0x04080405,  //  0020  SUB	R2	R2	R5
-      0x58040000,  //  0021  LDCONST	R1	K0
-      0x00100904,  //  0022  ADD	R4	R4	K4
-      0x7001FFE8,  //  0023  JMP		#000D
-      0x80040000,  //  0024  RET	1	R0
+      0x14100500,  //  0000  LT  R4  R2  K0
+      0x74120002,  //  0001  JMPT  R4  #0005
+      0x5412001F,  //  0002  LDINT  R4  32
+      0x24100404,  //  0003  GT  R4  R2  R4
+      0x78120000,  //  0004  JMPF  R4  #0006
+      0xB0060302,  //  0005  RAISE  1  K1  K2
+      0x60100009,  //  0006  GETGBL  R4  G9
+      0x5C140600,  //  0007  MOVE  R5  R3
+      0x7C100200,  //  0008  CALL  R4  1
+      0x5C0C0800,  //  0009  MOVE  R3  R4
+      0x3C100303,  //  000A  SHR  R4  R1  K3
+      0x54160007,  //  000B  LDINT  R5  8
+      0x10040205,  //  000C  MOD  R1  R1  R5
+      0x24140500,  //  000D  GT  R5  R2  K0
+      0x78160014,  //  000E  JMPF  R5  #0024
+      0x54160007,  //  000F  LDINT  R5  8
+      0x04140A01,  //  0010  SUB  R5  R5  R1
+      0x24180A02,  //  0011  GT  R6  R5  R2
+      0x781A0000,  //  0012  JMPF  R6  #0014
+      0x5C140400,  //  0013  MOVE  R5  R2
+      0x381A0805,  //  0014  SHL  R6  K4  R5
+      0x04180D04,  //  0015  SUB  R6  R6  K4
+      0x541E00FE,  //  0016  LDINT  R7  255
+      0x38200C01,  //  0017  SHL  R8  R6  R1
+      0x041C0E08,  //  0018  SUB  R7  R7  R8
+      0x94200004,  //  0019  GETIDX  R8  R0  R4
+      0x2C201007,  //  001A  AND  R8  R8  R7
+      0x2C240606,  //  001B  AND  R9  R3  R6
+      0x38241201,  //  001C  SHL  R9  R9  R1
+      0x30201009,  //  001D  OR  R8  R8  R9
+      0x98000808,  //  001E  SETIDX  R0  R4  R8
+      0x3C0C0605,  //  001F  SHR  R3  R3  R5
+      0x04080405,  //  0020  SUB  R2  R2  R5
+      0x58040000,  //  0021  LDCONST  R1  K0
+      0x00100904,  //  0022  ADD  R4  R4  K4
+      0x7001FFE8,  //  0023  JMP    #000D
+      0x80040000,  //  0024  RET  1  R0
     })
   )
 );

--- a/lib/libesp32/Berry/tests/bytes.be
+++ b/lib/libesp32/Berry/tests/bytes.be
@@ -8,8 +8,8 @@ assert(str(b) == "bytes('')")
 b=bytes(1)
 assert(str(b) == "bytes('')")
 b=bytes(-1)
-assert(str(b) == "bytes('')")
-assert(b.size() == 0)
+assert(str(b) == "bytes(\'00\')")
+assert(b.size() == 1)
 
 b=bytes("a")
 assert(str(b) == "bytes('')")
@@ -120,7 +120,7 @@ assert(b[2] == 0x55)
 #- item range -#
 b = bytes("00112233445566778899AABBCCDDEEFF")
 assert(str(b[1..1]) =="bytes('11')")
-assert(str(b[-11..1]) =="bytes('0011')")
+assert(str(b[-1..1]) =="bytes('')")
 assert(str(b[0..40]) =="bytes('00112233445566778899AABBCCDDEEFF')")
 assert(str(b[1..0]) =="bytes('')")
 
@@ -168,3 +168,18 @@ assert(str(b) =="bytes('4C6F72656D20697073756D20646F6C6F722073697420616D65742C20
 assert(b.tostring(0) =="bytes('4C6F72656D20697073756D20646F6C6F722073697420616D65742C20636F6E73656374657475722061646970697363696E6720656C69742C2073656420646F20656975736D6F642074656D706F7220696E6369646964756E74207574206C61626F726520657420646F6C6F7265206D61676E6120616C697175612E')")
 
 assert(size(bytes('4C6F72656D20697073756D20646F6C6F722073697420616D65742C20636F6E73656374657475722061646970697363696E6720656C69742C2073656420646F20656975736D6F642074656D706F7220696E6369646964756E74207574206C61626F726520657420646F6C6F7265206D61676E6120616C697175612E')) == 123)
+
+#- negative index -#
+b=bytes("112233")
+assert(b[0] == 0x11)
+assert(b[-1] == 0x33)   #- last element -#
+assert(b[-3] == 0x11)
+
+#- ranges with negative indices -#
+b = bytes("00112233445566778899AABBCCDDEEFF")
+assert(b[0..-1] == b)
+assert(b[1..-2] == bytes("112233445566778899AABBCCDDEE"))
+assert(b[5..10] == bytes("5566778899AA"))
+assert(b[-10..-5] == bytes("66778899AABB"))
+assert(b[5..-10] == bytes("5566"))
+assert(b[7..-12] == bytes())


### PR DESCRIPTION
## Description:

Adds ability to do index and ranges with negative values (from the end).

```
> b = bytes("11223344")
> b[1..-2]
bytes('2233')
> b[-1]
68     # 0x44
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
