### PR TITLE
Berry add a watchdog

### DIFF
--- a/lib/libesp32/Berry/default/berry_conf.h
+++ b/lib/libesp32/Berry/default/berry_conf.h
@@ -71,6 +71,21 @@
  **/
 #define BE_USE_OBSERVABILITY_HOOK       1
 
+/* Macro: BE_USE_OBSERVABILITY_HOOK
+ * Use the obshook function to report low-level actions.
+ * Default: 0
+ **/
+#define BE_USE_PERF_COUNTERS            1
+
+/* Macro: BE_VM_OBSERVABILITY_SAMPLING
+ * If BE_USE_OBSERVABILITY_HOOK == 1 and BE_USE_PERF_COUNTERS == 1
+ * then the observability hook is called regularly in the VM loop
+ * allowing to stop infinite loops or too-long running code.
+ * The value is a power of 2.
+ * Default: 20 - which translates to 2^20 or ~1 million instructions
+ **/
+#define BE_VM_OBSERVABILITY_SAMPLING    20
+
 /* Macro: BE_STACK_TOTAL_MAX
  * Set the maximum total stack size.
  * Default: 20000

--- a/lib/libesp32/Berry/generate/be_const_strtab.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab.h
@@ -73,6 +73,7 @@ extern const bcstring be_const_str_select;
 extern const bcstring be_const_str_BOILER_OT_TX;
 extern const bcstring be_const_str_INPUT_PULLDOWN;
 extern const bcstring be_const_str_WEBCAM_SIOC;
+extern const bcstring be_const_str_counters;
 extern const bcstring be_const_str_resp_cmnd_done;
 extern const bcstring be_const_str_tob64;
 extern const bcstring be_const_str_response_append;

--- a/lib/libesp32/Berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab_def.h
@@ -72,7 +72,8 @@ be_define_const_str(cos, "cos", 4220379804u, 0, 3, &be_const_str_select);
 be_define_const_str(select, "select", 297952813u, 0, 6, NULL);
 be_define_const_str(BOILER_OT_TX, "BOILER_OT_TX", 671743623u, 0, 12, &be_const_str_INPUT_PULLDOWN);
 be_define_const_str(INPUT_PULLDOWN, "INPUT_PULLDOWN", 1172232591u, 0, 14, &be_const_str_WEBCAM_SIOC);
-be_define_const_str(WEBCAM_SIOC, "WEBCAM_SIOC", 218815147u, 0, 11, &be_const_str_resp_cmnd_done);
+be_define_const_str(WEBCAM_SIOC, "WEBCAM_SIOC", 218815147u, 0, 11, &be_const_str_counters);
+be_define_const_str(counters, "counters", 4095866864u, 0, 8, &be_const_str_resp_cmnd_done);
 be_define_const_str(resp_cmnd_done, "resp_cmnd_done", 2601874875u, 0, 14, &be_const_str_tob64);
 be_define_const_str(tob64, "tob64", 373777640u, 0, 5, NULL);
 be_define_const_str(response_append, "response_append", 450346371u, 0, 15, NULL);
@@ -887,6 +888,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 287,
-    .count = 574,
+    .count = 575,
     .table = m_string_table
 };

--- a/lib/libesp32/Berry/generate/be_fixed_debug.h
+++ b/lib/libesp32/Berry/generate/be_fixed_debug.h
@@ -1,16 +1,17 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libdebug_map) {
+    { be_const_key(counters, 3), be_const_func(m_counters) },
     { be_const_key(traceback, -1), be_const_func(m_traceback) },
-    { be_const_key(codedump, -1), be_const_func(m_codedump) },
-    { be_const_key(calldepth, -1), be_const_func(m_calldepth) },
-    { be_const_key(top, -1), be_const_func(m_top) },
     { be_const_key(attrdump, 0), be_const_func(m_attrdump) },
+    { be_const_key(calldepth, 5), be_const_func(m_calldepth) },
+    { be_const_key(top, -1), be_const_func(m_top) },
+    { be_const_key(codedump, -1), be_const_func(m_codedump) },
 };
 
 static be_define_const_map(
     m_libdebug_map,
-    5
+    6
 );
 
 static be_define_const_module(

--- a/lib/libesp32/Berry/src/be_debuglib.c
+++ b/lib/libesp32/Berry/src/be_debuglib.c
@@ -149,6 +149,31 @@ static int m_upvname(bvm *vm)
 }
 #endif
 
+
+#if BE_USE_PERF_COUNTERS
+static void map_insert(bvm *vm, const char *key, int value)
+{
+    be_pushstring(vm, key);
+    be_pushint(vm, value);
+    be_data_insert(vm, -3);
+    be_pop(vm, 2);
+}
+
+static int m_counters(bvm *vm)
+{
+    be_newobject(vm, "map");
+    map_insert(vm, "instruction", vm->counter_ins);
+    map_insert(vm, "vmenter", vm->counter_enter);
+    map_insert(vm, "call", vm->counter_call);
+    map_insert(vm, "get", vm->counter_get);
+    map_insert(vm, "set", vm->counter_set);
+    map_insert(vm, "try", vm->counter_try);
+    map_insert(vm, "raise", vm->counter_exc);
+    be_pop(vm, 1);
+    be_return(vm);
+}
+#endif
+
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(debug) {
     be_native_module_function("attrdump", m_attrdump),
@@ -156,6 +181,9 @@ be_native_module_attr_table(debug) {
     be_native_module_function("traceback", m_traceback),
 #if BE_USE_DEBUG_HOOK
     be_native_module_function("sethook", m_sethook),
+#endif
+#if BE_USE_PERF_COUNTERS
+    be_native_module_function("counters", m_counters),
 #endif
     be_native_module_function("calldepth", m_calldepth),
     be_native_module_function("top", m_top),
@@ -173,6 +201,7 @@ module debug (scope: global, depend: BE_USE_DEBUG_MODULE) {
     codedump, func(m_codedump)
     traceback, func(m_traceback)
     sethook, func(m_sethook), BE_USE_DEBUG_HOOK
+    counters, func(m_counters), BE_USE_PERF_COUNTERS
     calldepth, func(m_calldepth)
     top, func(m_top)
     varname, func(m_varname), BE_DEBUG_VAR_INFO

--- a/lib/libesp32/Berry/src/be_vm.h
+++ b/lib/libesp32/Berry/src/be_vm.h
@@ -104,6 +104,15 @@ struct bvm {
 #if BE_USE_OBSERVABILITY_HOOK
     bobshook obshook;
 #endif
+#if BE_USE_PERF_COUNTERS
+    uint32_t counter_ins; /* instructions counter */
+    uint32_t counter_enter; /* counter for times the VM was entered */
+    uint32_t counter_call; /* counter for calls, VM or native */
+    uint32_t counter_get; /* counter for GETMBR or GETMET */
+    uint32_t counter_set; /* counter for SETMBR */
+    uint32_t counter_try; /* counter for `try` statement */
+    uint32_t counter_exc; /* counter for raised exceptions */
+#endif
 #if BE_USE_DEBUG_HOOK
     bvalue hook;
     bbyte hookmask;

--- a/lib/libesp32/Berry/src/berry.h
+++ b/lib/libesp32/Berry/src/berry.h
@@ -403,8 +403,9 @@ typedef void(*bntvhook)(bvm *vm, bhookinfo *info);
 
 typedef void(*bobshook)(bvm *vm, int event, ...);
 enum beobshookevents {
-  BE_OBS_GC_START,        // start of GC, arg = allocated size
-  BE_OBS_GC_END,          // end of GC, arg = allocated size
+  BE_OBS_GC_START,        /* start of GC, arg = allocated size */
+  BE_OBS_GC_END,          /* end of GC, arg = allocated size */
+  BE_OBS_VM_HEARTBEAT,    /* VM heartbeat called every million instructions */
 };
 
 /* FFI functions */

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -990,6 +990,7 @@
 //#define USE_WEBCAM                               // Add support for webcam
 
 #define USE_BERRY                                // Enable Berry scripting language
+  #define USE_BERRY_TIMEOUT             4000     // Timeout in ms, will raise an exception if running time exceeds this timeout
   #define USE_BERRY_PSRAM                        // Allocate Berry memory in PSRAM if PSRAM is connected - this might be slightly slower but leaves main memory intact
   // #define USE_BERRY_DEBUG                        // Compile Berry bytecode with line number information, makes exceptions easier to debug. Adds +8% of memory consumption for compiled code
   #define USE_WEBCLIENT                          // Enable `webclient` to make HTTP/HTTPS requests. Can be disabled for security reasons.

--- a/tasmota/xdrv_52_0_berry_struct.ino
+++ b/tasmota/xdrv_52_0_berry_struct.ino
@@ -51,6 +51,7 @@ public:
 class BerrySupport {
 public:
   bvm *vm = nullptr;                    // berry vm
+  int32_t timeout = 0;                  // Berry heartbeat timeout, preventing code to run for too long. `0` means not enabled
   bool rules_busy = false;              // are we already processing rules, avoid infinite loop
   bool autoexec_done = false;           // do we still need to load 'autoexec.be'
   bool repl_active = false;             // is REPL running (activates log recording)

--- a/tasmota/xdrv_52_2_berry_native.ino
+++ b/tasmota/xdrv_52_2_berry_native.ino
@@ -492,5 +492,26 @@ int32_t be_convert_single_elt(bvm *vm, int32_t idx, const char * arg_type = null
   return ret;
 }
 
+/*********************************************************************************************\
+ * Manage timeout for Berry code
+ *
+\*********************************************************************************************/
+void BrTimeoutStart(void)  {
+  berry.timeout = millis() + USE_BERRY_TIMEOUT;
+  if (0 == berry.timeout) {
+    berry.timeout = 1;    // rare case when value accidentally computes to zero
+  }
+
+}
+
+void BrTimeoutYield(void) {
+  if (0 != berry.timeout) {
+    BrTimeoutStart();
+  }
+}
+
+void BrTimeoutReset(void)  {
+  berry.timeout = 0;      // remove timer
+}
 
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -308,7 +308,7 @@ extern "C" {
   // ESP object
   int32_t l_yield(bvm *vm);
   int32_t l_yield(bvm *vm) {
-    optimistic_yield(10);
+    BrTimeoutYield();   // reset timeout
     be_return_nil(vm);
   }
 


### PR DESCRIPTION
## Description:

Add a watchdog to Berry language. The default timeout is 4 seconds.
If Berry code runs for more than 4 seconds, it is interrupted with an exception.
This allows to prevent from infinite loops or too-long running code.

If you need to run code longer, you need to call `tasmota.yield()` (although it does not reset yet the ESP32 watchdog - this will come soon).

Example:

```python
> i = 0
> while i < 2 i=0 end # infinite loop
BRY: Exception> 'timeout_error' - Berry code running for too long
stack traceback:
	input:1: in function `main`
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
