### PR TITLE
Berry prevent crash when setting static variable for solidified class

### DIFF
--- a/lib/libesp32/Berry/src/be_class.c
+++ b/lib/libesp32/Berry/src/be_class.c
@@ -346,10 +346,12 @@ bbool be_class_setmember(bvm *vm, bclass *o, bstring *name, bvalue *src)
 {
     bvalue v;
     be_assert(name != NULL);
-    bclass * obj = class_member(vm, o, name, &v);
-    if (obj && !var_istype(&v, MT_VARIABLE)) {
-        be_map_insertstr(vm, obj->members, name, src);
-        return btrue;
+    if (!gc_isconst(o)) {
+        bclass * obj = class_member(vm, o, name, &v);
+        if (obj && !var_istype(&v, MT_VARIABLE)) {
+            be_map_insertstr(vm, obj->members, name, src);
+            return btrue;
+        }
     }
     return bfalse;
 }


### PR DESCRIPTION
## Description:

Prevent from crashing when trying to set a static member for a read-only solidified class. It now returns an exception.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
