### PR TITLE
Berry python compat for ranges

### DIFF
--- a/lib/libesp32/Berry/src/be_parser.c
+++ b/lib/libesp32/Berry/src/be_parser.c
@@ -20,6 +20,7 @@
 #include "be_decoder.h"
 #include "be_debug.h"
 #include "be_exec.h"
+#include <limits.h>
 
 #define OP_NOT_BINARY           TokenNone
 #define OP_NOT_UNARY            TokenNone
@@ -29,6 +30,17 @@
 
 #define FUNC_METHOD             1
 #define FUNC_ANONYMOUS          2
+
+#if BE_INTGER_TYPE == 0 /* int */
+  #define M_IMAX    INT_MAX
+  #define M_IMIN    INT_MIN
+#elif BE_INTGER_TYPE == 1 /* long */
+  #define M_IMAX    LONG_MAX
+  #define M_IMIN    LONG_MIN
+#else /* int64_t (long long) */
+  #define M_IMAX    LLONG_MAX
+  #define M_IMIN    LLONG_MIN
+#endif
 
 /* get binary operator priority */
 #define binary_op_prio(op)      (binary_op_prio_tab[cast_int(op) - OptAdd])
@@ -1075,7 +1087,7 @@ static void sub_expr(bparser *parser, bexpdesc *e, int prio)
         init_exp(&e2, ETVOID, 0);
         sub_expr(parser, &e2, binary_op_prio(op));  /* parse right side */
         if ((e2.type == ETVOID) && (op == OptConnect)) {
-            init_exp(&e2, ETINT, -1);
+            init_exp(&e2, ETINT, M_IMAX);
         } else {
             check_var(parser, &e2);  /* check if valid */
         }

--- a/lib/libesp32/Berry/src/be_parser.c
+++ b/lib/libesp32/Berry/src/be_parser.c
@@ -1074,7 +1074,11 @@ static void sub_expr(bparser *parser, bexpdesc *e, int prio)
         be_code_prebinop(finfo, op, e); /* and or */
         init_exp(&e2, ETVOID, 0);
         sub_expr(parser, &e2, binary_op_prio(op));  /* parse right side */
-        check_var(parser, &e2);  /* check if valid */
+        if ((e2.type == ETVOID) && (op == OptConnect)) {
+            init_exp(&e2, ETINT, -1);
+        } else {
+            check_var(parser, &e2);  /* check if valid */
+        }
         be_code_binop(finfo, op, e, &e2, -1); /* encode binary op */
         op = get_binop(parser);  /* is there a following binop? */
     }

--- a/lib/libesp32/Berry/tests/lexer.be
+++ b/lib/libesp32/Berry/tests/lexer.be
@@ -38,7 +38,7 @@ check(45.e+2, 4500)
 
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
 test_source('x = 5; 0...x;', 'unexpected symbol near \'.\'')
-test_source('45..', 'unexpected symbol near \'EOS\'')
+# test_source('45..', 'unexpected symbol near \'EOS\'')
 test_source('0xg', 'invalid hexadecimal number')
 test_source('"\\x5g"', 'invalid hexadecimal number')
 test_source('0x5g', 'malformed number')

--- a/lib/libesp32/Berry/tests/string.be
+++ b/lib/libesp32/Berry/tests/string.be
@@ -34,3 +34,8 @@ assert(s.format("%i%%", 12) == "12%")
 assert(s.format("%i%%%i", 12, 13) == "12%13")
 assert(s.format("%s%%", "foo") == "foo%")
 assert(s.format("%.1f%%", 3.5) == "3.5%")
+
+s="azerty"
+assert(s[1..2] == "ze")
+assert(s[1..] == "zerty")
+assert(s[1..-1] == "zerty")


### PR DESCRIPTION
## Description:

Berry now accepts partial ranges like in Python

Example
```
> s = "azerty"
> s[2..-1]
'erty'
> s[2..]      # if you don't specify the end range, it defaults to MAX_INT
'erty'
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
