### PR TITLE
Berry json dump for subclasses

### DIFF
--- a/lib/libesp32/Berry/src/be_jsonlib.c
+++ b/lib/libesp32/Berry/src/be_jsonlib.c
@@ -45,8 +45,19 @@ static const char* match_char(const char *json, int ch)
 static int is_object(bvm *vm, const char *class, int idx)
 {
     if (be_isinstance(vm, idx)) {
+        be_pushvalue(vm, idx);
+        while (1) {
+            be_getsuper(vm, -1);
+            if (be_isnil(vm, -1)) {
+                be_pop(vm, 1);
+                break;
+            }
+            be_remove(vm, -2);
+        }
         const char *name = be_classname(vm, idx);
-        return !strcmp(name, class);
+        bbool ret = !strcmp(name, class);
+        be_pop(vm, 1);
+        return ret;
     }
     return  0;
 }


### PR DESCRIPTION
## Description:

Berry `json.dump()` now works for subclasses of `list` and `map.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
