### PR TITLE
BearSSL: support connect() without timeout on ESP32

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -303,7 +303,7 @@ int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port, int32_t timeout
   }
   return _connectSSL(nullptr);
 }
-#else // ESP32
+#endif // ESP32
 int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port) {
   DEBUG_BSSL("connect(%s,%d)", ip.toString().c_str(), port);
   clearLastError();
@@ -313,7 +313,6 @@ int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port) {
   }
   return _connectSSL(nullptr);
 }
-#endif
 
 #ifdef ESP32
 int WiFiClientSecure_light::connect(const char* name, uint16_t port, int32_t timeout) {
@@ -334,7 +333,7 @@ int WiFiClientSecure_light::connect(const char* name, uint16_t port, int32_t tim
   LOG_HEAP_SIZE("Before calling _connectSSL");
   return _connectSSL(name);
 }
-#else // ESP32
+#endif // ESP32
 int WiFiClientSecure_light::connect(const char* name, uint16_t port) {
   DEBUG_BSSL("connect(%s,%d)\n", name, port);
   IPAddress remote_addr;
@@ -353,7 +352,6 @@ int WiFiClientSecure_light::connect(const char* name, uint16_t port) {
   LOG_HEAP_SIZE("Before calling _connectSSL");
   return _connectSSL(name);
 }
-#endif
 
 void WiFiClientSecure_light::_freeSSL() {
   _ctx_present = false;

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -41,10 +41,9 @@ class WiFiClientSecure_light : public WiFiClient {
   #ifdef ESP32  // the method to override in ESP32 has timeout argument
     int connect(IPAddress ip, uint16_t port, int32_t timeout) override;
     int connect(const char* name, uint16_t port, int32_t timeout) override;
-  #else
+  #endif
     int connect(IPAddress ip, uint16_t port) override;
     int connect(const char* name, uint16_t port) override;
-  #endif
 
     uint8_t connected() override;
     size_t write(const uint8_t *buf, size_t size) override;


### PR DESCRIPTION
## Description:

Arduino-ESP32 supports both versions of 'connect' method, with and
without timeout argument. Since most users of
WiFiClientSecure_light class use version without this argument -
for example, Telegram, export both on ESP32 to fix build failure
with USE_TELEGRAM enabled on ESP32.

Fixes: 3d5c68b8505a ("Berry class ``webclient`` for HTTP/HTTPS requests")
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).