### PR TITLE
Adapt ST7789 to support ST7735 as well

### DIFF
--- a/lib/lib_display/Arduino_ST7789-gemu-1.0/Arduino_ST7789.h
+++ b/lib/lib_display/Arduino_ST7789-gemu-1.0/Arduino_ST7789.h
@@ -61,37 +61,43 @@
 #define ST7789_135x240_XSTART_R3 40
 #define ST7789_135x240_YSTART_R3 53
 
+// for 1.44 and mini
+#define ST7735_TFTWIDTH_128  128
+// for mini
+#define ST7735_TFTWIDTH_80   80
+// for 1.44" display
+#define ST7735_TFTHEIGHT_128 128
+// for 1.8" and mini display
+#define ST7735_TFTHEIGHT_160  160
+
+#define ST7735_TFTWIDTH  ST7735_TFTWIDTH_128
+#define ST7735_TFTHEIGHT ST7735_TFTHEIGHT_160
+
 #define ST_CMD_DELAY   0x80    // special signifier for command lists
 
-#define ST7789_NOP     0x00
-#define ST7789_SWRESET 0x01
-#define ST7789_RDDID   0x04
-#define ST7789_RDDST   0x09
-
-#define ST7789_SLPIN   0x10
-#define ST7789_SLPOUT  0x11
-#define ST7789_PTLON   0x12
-#define ST7789_NORON   0x13
-
-#define ST7789_INVOFF  0x20
-#define ST7789_INVON   0x21
-#define ST7789_DISPOFF 0x28
-#define ST7789_DISPON  0x29
-#define ST7789_CASET   0x2A
-#define ST7789_RASET   0x2B
-#define ST7789_RAMWR   0x2C
-#define ST7789_RAMRD   0x2E
-
-#define ST7789_PTLAR   0x30
-#define ST7789_COLMOD  0x3A
-#define ST7789_MADCTL  0x36
-
-#define ST7789_MADCTL_MY  0x80
-#define ST7789_MADCTL_MX  0x40
-#define ST7789_MADCTL_MV  0x20
-#define ST7789_MADCTL_ML  0x10
-#define ST7789_MADCTL_RGB 0x00
-
+#define ST77XX_NOP     0x00
+#define ST77XX_SWRESET 0x01
+#define ST77XX_SLPIN   0x10
+#define ST77XX_SLPOUT  0x11
+#define ST77XX_NORON   0x13
+#define ST77XX_INVOFF  0x20
+#define ST77XX_INVON   0x21
+#define ST77XX_DISPOFF 0x28
+#define ST77XX_DISPON  0x29
+#define ST77XX_CASET   0x2A
+#define ST77XX_RASET   0x2B
+#define ST77XX_RAMWR   0x2C
+#define ST77XX_MADCTL  0x36
+#define ST77XX_COLMOD  0x3A
+#define ST77XX_MADCTL_MY  0x80
+#define ST77XX_MADCTL_MX  0x40
+#define ST77XX_MADCTL_MV  0x20
+#define ST77XX_MADCTL_ML  0x10
+#ifdef USE_DISPLAY_ST7735
+#define ST77XX_MADCTL_RGB 0x08
+#else
+#define ST77XX_MADCTL_RGB 0x00
+#endif
 #define ST7789_RDID1   0xDA
 #define ST7789_RDID2   0xDB
 #define ST7789_RDID3   0xDC
@@ -112,24 +118,39 @@
 
 // Color definitions
 #define ST7789_BLACK       0x0000      /*   0,   0,   0 */
-#define ST7789_NAVY        0x000F      /*   0,   0, 128 */
 #define ST7789_DARKGREEN   0x03E0      /*   0, 128,   0 */
-#define ST7789_DARKCYAN    0x03EF      /*   0, 128, 128 */
-#define ST7789_MAROON      0x7800      /* 128,   0,   0 */
 #define ST7789_PURPLE      0x780F      /* 128,   0, 128 */
-#define ST7789_OLIVE       0x7BE0      /* 128, 128,   0 */
 #define ST7789_LIGHTGREY   0xC618      /* 192, 192, 192 */
 #define ST7789_DARKGREY    0x7BEF      /* 128, 128, 128 */
-#define ST7789_BLUE        0x001F      /*   0,   0, 255 */
+#define ST7789_MAGENTA     0xF81F      /* 255,   0, 255 */
 #define ST7789_GREEN       0x07E0      /*   0, 255,   0 */
+#define ST7789_WHITE       0xFFFF      /* 255, 255, 255 */
+#define ST7789_PINK        0xF81F
+
+#ifdef USE_DISPLAY_ST7735
+/* color = blue * 2048 + green * 64 + red */
+#define ST7789_NAVY        0x7800      /*   0,   0, 128 */
+#define ST7789_DARKCYAN    0x7BE0      /*   0, 128, 128 */
+#define ST7789_MAROON      0x000F      /* 128,   0,   0 */
+#define ST7789_OLIVE       0x03EF      /* 128, 128,   0 */
+#define ST7789_BLUE        0xF800
+#define ST7789_CYAN        0xFFE0
+#define ST7789_RED         0x001F
+#define ST7789_YELLOW      0x07FF
+#define ST7789_ORANGE      0x03FF
+#define ST7789_GREENYELLOW 0x2FF5      /* 173, 255,  47  */
+#else
+#define ST7789_NAVY        0x000F      /*   0,   0, 128 */
+#define ST7789_DARKCYAN    0x03EF      /*   0, 128, 128 */
+#define ST7789_MAROON      0x7800      /* 128,   0,   0 */
+#define ST7789_OLIVE       0x7BE0      /* 128, 128,   0 */
+#define ST7789_BLUE        0x001F      /*   0,   0, 255 */
 #define ST7789_CYAN        0x07FF      /*   0, 255, 255 */
 #define ST7789_RED         0xF800      /* 255,   0,   0 */
-#define ST7789_MAGENTA     0xF81F      /* 255,   0, 255 */
 #define ST7789_YELLOW      0xFFE0      /* 255, 255,   0 */
-#define ST7789_WHITE       0xFFFF      /* 255, 255, 255 */
 #define ST7789_ORANGE      0xFD20      /* 255, 165,   0 */
 #define ST7789_GREENYELLOW 0xAFE5      /* 173, 255,  47 */
-#define ST7789_PINK        0xF81F
+#endif
 
 
 class Arduino_ST7789 : public Renderer {

--- a/tasmota/xdsp_12_ST7789.ino
+++ b/tasmota/xdsp_12_ST7789.ino
@@ -20,6 +20,9 @@
 //#ifdef USE_SPI
 #ifdef USE_SPI
 #ifdef USE_DISPLAY
+#ifdef USE_DISPLAY_ST7735
+#define USE_DISPLAY_ST7789
+#endif
 #ifdef USE_DISPLAY_ST7789
 
 #define XDSP_12                12
@@ -67,12 +70,19 @@ void ST7789_InitDriver(void) {
     Settings->display_model = XDSP_12;
 
     if (!Settings->display_width) {
+#ifdef USE_DISPLAY_ST7735
+      Settings->display_width = ST7735_TFTWIDTH;
+#else
       Settings->display_width = 240;
+#endif
     }
     if (!Settings->display_height) {
+#ifdef USE_DISPLAY_ST7735
+      Settings->display_height = ST7735_TFTHEIGHT;
+#else
       Settings->display_height = 240;
+#endif
     }
-
     // default colors
     fg_color = ST7789_WHITE;
     bg_color = ST7789_BLACK;


### PR DESCRIPTION
## Description:

Adapt display width and height for ST7735
Adapt color codes (BGR instead of RGB)
Rename the register defines to indicate common registers
Remove unused register defines
The define USE_DISPLAY_ST7735 also selects USE_DISPLAY_ST7789

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
