### PR TITLE
Fix ESP32-Homekit for IDF>4

### DIFF
--- a/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
+++ b/lib/libesp32_div/ESP32-HomeKit/src/port/esp_bignum.c
@@ -151,7 +151,7 @@ cleanup:
 
 
 
-
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 /* Z = (X * Y) mod M
 
    Not an mbedTLS function
@@ -192,6 +192,8 @@ cleanup:
 
     return ret;
 }
+
+#endif // ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 
 #if defined(MBEDTLS_MPI_EXP_MOD_ALT)
 
@@ -374,6 +376,7 @@ cleanup:
 static int mpi_mult_mpi_failover_mod_mult( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t z_words);
 static int mpi_mult_mpi_overlong(mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y, size_t y_words, size_t z_words);
 
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 /* Z = X * Y */
 int mbedtls_mpi_mul_mpi( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi *Y )
 {
@@ -447,6 +450,7 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *Z, const mbedtls_mpi *X, const mbedtls_mpi
 cleanup:
     return ret;
 }
+#endif //ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 
 
 


### PR DESCRIPTION
## Description:

Tested for 2 weeks now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
