### PR TITLE
Increase TWDT to 10s

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -348,7 +348,7 @@
 #define ZIGBEE_DISTINCT_TOPICS false             // [SetOption89] Enable unique device topic based on Zigbee device ShortAddr
 #define ZIGBEE_RMV_ZBRECEIVED  false             // [SetOption100] Remove ZbReceived form JSON message
 #define ZIGBEE_INDEX_EP        false             // [SetOption101] Add the source endpoint as suffix to attributes, ex `Power3` instead of `Power` if sent from endpoint 3
-#define WATCHDOG_TASK_SECONDS  5                 // [ESP32 only] Task Watchdog Timer (TWDT) time in seconds - detecting Tasmota running for a prolonged period of time without yielding with `esp_task_wdt_reset()`
+#define WATCHDOG_TASK_SECONDS  10                // [ESP32 only] Task Watchdog Timer (TWDT) time in seconds - detecting Tasmota running for a prolonged period of time without yielding with `esp_task_wdt_reset()`
 
 /*********************************************************************************************\
  * END OF SECTION 1


### PR DESCRIPTION
## Description:

Increase watchdog timeout to 10s since some wifi connection timeout at 5s could trigger the watchdog.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
