### PR TITLE
Berry add stack increase observability

### DIFF
--- a/lib/libesp32/Berry/src/be_exec.c
+++ b/lib/libesp32/Berry/src/be_exec.c
@@ -392,7 +392,7 @@ void be_stack_expansion(bvm *vm, int n)
     }
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size, size + n);
+        (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size * sizeof(bvalue), (size + n) * sizeof(bvalue));
 #endif
     stack_resize(vm, size + n);
 }

--- a/lib/libesp32/Berry/src/be_exec.c
+++ b/lib/libesp32/Berry/src/be_exec.c
@@ -390,6 +390,10 @@ void be_stack_expansion(bvm *vm, int n)
         stack_resize(vm, size + 1);
         be_raise(vm, "runtime_error", STACK_OVER_MSG(BE_STACK_TOTAL_MAX));
     }
+#if BE_USE_OBSERVABILITY_HOOK
+    if (vm->obshook != NULL)
+        (*vm->obshook)(vm, BE_OBS_STACK_RESIZE_START, size, size + n);
+#endif
     stack_resize(vm, size + n);
 }
 

--- a/lib/libesp32/Berry/src/berry.h
+++ b/lib/libesp32/Berry/src/berry.h
@@ -405,6 +405,7 @@ enum beobshookevents {
   BE_OBS_GC_START,        /* start of GC, arg = allocated size */
   BE_OBS_GC_END,          /* end of GC, arg = allocated size */
   BE_OBS_VM_HEARTBEAT,    /* VM heartbeat called every million instructions */
+  BE_OBS_STACK_RESIZE_START,    /* Berry stack resized */
 };
 
 /* FFI functions */

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -268,6 +268,13 @@ void BerryObservability(bvm *vm, int event...) {
         }
       }
       break;
+    case BE_OBS_STACK_RESIZE_START:
+      {
+        int32_t stack_before = va_arg(param, int32_t);
+        int32_t stack_after = va_arg(param, int32_t);
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_BERRY "Stack resized from %i to %i bytes"), stack_before, stack_after);
+      }
+      break;
     case BE_OBS_VM_HEARTBEAT:
       {
         // AddLog(LOG_LEVEL_INFO, ">>>: Heartbeat now=%i timeout=%i", millis(), berry.timeout);


### PR DESCRIPTION
## Description:

Berry add debug logs when Berry's stack is increase:

```
00:00:00.346 BRY: GC from 770 to 770 bytes (in 0 ms)
00:00:00.349 BRY: GC from 1563 to 1563 bytes (in 0 ms)
00:00:00.350 BRY: Stack resized from 160 to 328 bytes
00:00:00.370 BRY: GC from 3416 to 3216 bytes (in 1 ms)
00:00:00.494 BRY: Stack resized from 328 to 504 bytes
00:00:00.504 BRY: GC from 5281 to 4174 bytes (in 1 ms)
00:00:00.505 BRY: Berry initialized, RAM used=4174
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
