### PR TITLE
Fix audio compile for ESP32 Core 2.0.0

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/libtinysoundfont/tsf.h
+++ b/lib/lib_audio/ESP8266Audio/src/libtinysoundfont/tsf.h
@@ -190,6 +190,7 @@ TSFDEF void tsf_channel_set_bank(tsf* f, int channel, int bank);
 TSFDEF int  tsf_channel_set_bank_preset(tsf* f, int channel, int bank, int preset_number);
 TSFDEF void tsf_channel_set_pan(tsf* f, int channel, float pan);
 TSFDEF void tsf_channel_set_volume(tsf* f, int channel, float volume);
+TSFDEF void tsf_channel_set_volume_to_one(tsf* f, int channel); // solves a Compiler bug!! TODO: refactor after compiler fix!!
 TSFDEF void tsf_channel_set_pitchwheel(tsf* f, int channel, int pitch_wheel);
 TSFDEF void tsf_channel_set_pitchrange(tsf* f, int channel, float pitch_range);
 TSFDEF void tsf_channel_set_tuning(tsf* f, int channel, float tuning);
@@ -2054,6 +2055,10 @@ TSFDEF void tsf_channel_sounds_off_all(tsf* f, int channel)
 			tsf_voice_endquick(v, f->outSampleRate);
 }
 
+TSFDEF void tsf_channel_set_volume_to_one(tsf* f, int channel){
+	tsf_channel_set_volume(f, channel, 1.0f);
+}
+
 TSFDEF void tsf_channel_midi_control(tsf* f, int channel, int controller, int control_value)
 {
 	struct tsf_channel* c = tsf_channel_init(f, channel);
@@ -2079,7 +2084,7 @@ TSFDEF void tsf_channel_midi_control(tsf* f, int channel, int controller, int co
 			c->midiVolume = c->midiExpression = 16383;
 			c->midiPan = 8192;
 			c->bank = 0;
-			tsf_channel_set_volume(f, channel, 1.0f);
+			tsf_channel_set_volume_to_one(f, channel);
 			tsf_channel_set_pan(f, channel, 0.5f);
 			tsf_channel_set_pitchrange(f, channel, 2.0f);
 			return;


### PR DESCRIPTION
fix done by @Staars

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
