### PR TITLE
Teleinfo : Show GPIO config on EnergyConfig command

### DIFF
--- a/tasmota/xnrg_15_teleinfo.ino
+++ b/tasmota/xnrg_15_teleinfo.ino
@@ -45,7 +45,7 @@
 // Json Command
 //const char S_JSON_TELEINFO_COMMAND_STRING[] PROGMEM = "{\"" D_NAME_TELEINFO "\":{\"%s\":%s}}";
 //const char S_JSON_TELEINFO_COMMAND_NVALUE[] PROGMEM = "{\"" D_NAME_TELEINFO "\":{\"%s\":%d}}";
-const char TELEINFO_COMMAND_SETTINGS[] PROGMEM = "TIC: Settings Mode:%s, Raw:%s, Skip:%d, Limit:%d";
+const char TELEINFO_COMMAND_SETTINGS[] PROGMEM = "TIC: Settings Mode:%s, RX:%s, EN:%s, Raw:%s, Skip:%d, Limit:%d";
 
 #define MAX_TINFO_COMMAND_NAME 16+1 // Change this if one of the following kTInfo_Commands is higher then 16 char
 const char kTInfo_Commands[] PROGMEM  = "historique|standard|noraw|full|changed|skip|limit";
@@ -672,9 +672,10 @@ bool TInfoCmd(void) {
         // Just "EnergyConfig" no more parameter
         // Show Teleinfo configuration
         if (XdrvMailbox.data_len == 0) {
-
             char mode_name[MAX_TINFO_COMMAND_NAME];
             char raw_name[MAX_TINFO_COMMAND_NAME];
+            char rx_pin[8] = "None";
+            char en_pin[8] = "None" ;
             int index_mode = Settings->teleinfo.mode_standard ? CMND_TELEINFO_STANDARD : CMND_TELEINFO_HISTORIQUE;
             int index_raw = Settings->teleinfo.raw_send ? CMND_TELEINFO_RAW_FULL : CMND_TELEINFO_RAW_DISABLE;
             if (Settings->teleinfo.raw_send && Settings->teleinfo.raw_report_changed) {
@@ -684,7 +685,14 @@ bool TInfoCmd(void) {
             GetTextIndexed(mode_name, MAX_TINFO_COMMAND_NAME, index_mode, kTInfo_Commands);
             GetTextIndexed(raw_name, MAX_TINFO_COMMAND_NAME, index_raw, kTInfo_Commands);
 
-            AddLog(LOG_LEVEL_INFO, TELEINFO_COMMAND_SETTINGS, mode_name, raw_name, Settings->teleinfo.raw_skip, Settings->teleinfo.raw_limit);
+            if (PinUsed(GPIO_TELEINFO_RX)) {
+                sprintf_P(rx_pin, PSTR("GPIO%d"), tic_rx_pin);
+            }
+            if (PinUsed(GPIO_TELEINFO_ENABLE)) {
+                sprintf_P(en_pin, PSTR("GPIO%d"), Pin(GPIO_TELEINFO_ENABLE));
+            }
+
+            AddLog(LOG_LEVEL_INFO, TELEINFO_COMMAND_SETTINGS, mode_name, rx_pin, en_pin, raw_name, Settings->teleinfo.raw_skip, Settings->teleinfo.raw_limit);
 
             serviced = true;
 


### PR DESCRIPTION
## Description:

Added display of GPIO config on teleinfo  `EnergyConfig` command

```
12:53:02.683 CMD: EnergyConfig
12:53:02.688 TIC: Settings Mode:historique, RX:GPIO23, EN:None, Raw:noraw, Skip:0, Limit:0
12:53:02.699 MQT: emoncms/ticshield32_E96814/stat/RESULT = {"EnergyConfig":"Done"}
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
