### PR TITLE
Reflect PVVX firmware reed switch status

### DIFF
--- a/tasmota/xsns_62_esp32_mi_ble.ino
+++ b/tasmota/xsns_62_esp32_mi_ble.ino
@@ -1586,6 +1586,10 @@ void MI32ParseATCPacket(const uint8_t * _buf, uint32_t length, const uint8_t *ad
         MIBLEsensors[_slot].bat = ppv_packet->battery_level;
         MIBLEsensors[_slot].eventType.bat  = 1;
 
+        MIBLEsensors[_slot].Btn = (ppv_packet->flags) & 0x1; // First bit is reed switch status
+        MIBLEsensors[_slot].eventType.Btn = 1;
+        MIBLEsensors[_slot].feature.Btn = 1;
+
         if(MI32.option.directBridgeMode) {
           MIBLEsensors[_slot].shallSendMQTT = 1;
           MI32.mode.shallTriggerTele = 1;


### PR DESCRIPTION
## Description:

The first bit of the flag field reflects reed switch status so this device can additionally be used to monitor the status of a door. 

See: https://github.com/pvvx/ATC_MiThermometer#reed-switch-on-gpio-pa6-label-on-the-p8-pin

Since existing door monitors seem to use the Btn field, this is what I used in this  case.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
