### PR TITLE
LDF Platformio compile fix

### DIFF
--- a/lib/libesp32_div/ESP32-HomeKit/library.json
+++ b/lib/libesp32_div/ESP32-HomeKit/library.json
@@ -1,0 +1,12 @@
+{
+  "name":"HomeKit",
+  "version": "1.0.0",
+  "description":"Apple HomeKit for ESP32",
+  "keywords":"HomeKit",
+  "repository": {
+    "type": "git",
+    "url": ""
+	},
+  "frameworks": "arduino",
+  "platforms": "espressif32"
+}

--- a/lib/libesp32_div/ESP32-HomeKit/library.json
+++ b/lib/libesp32_div/ESP32-HomeKit/library.json
@@ -1,5 +1,5 @@
 {
-  "name":"HomeKit",
+  "name":"ESP32-HomeKit",
   "version": "1.0.0",
   "description":"Apple HomeKit for ESP32",
   "keywords":"HomeKit",


### PR DESCRIPTION
## Description:

sometimes the Platformio LDF Scanner does fail without a valid library.json or library.properties file

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
