### PR TITLE
solo1 as extra core variant

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -28,7 +28,18 @@ build_flags                 = ${esp_defaults.build_flags}
 [core32]
 platform                    = espressif32 @ 3.3.1
 platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.5/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
-                              platformio/tool-esptoolpy @ ~1.30100
+                              platformio/toolchain-xtensa32 @ ~2.50200.0
+                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${esp32_defaults.build_flags}
+
+
+[core32solo1]
+platform                    = espressif32 @ 3.3.1
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.5/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+                              platformio/toolchain-xtensa32 @ ~2.50200.0
+                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -63,8 +63,7 @@ build_flags             = ${env:tasmota32_base.build_flags}
 [env:tasmota32solo1-ocd]
 ;build_type              = debug
 extends                 = env:tasmota32_base
-platform_packages       = ${core32.platform_packages}
-                          framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.5/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
+platform_packages       = ${core32solo1.platform_packages}
 board                   = esp32_solo1_4M
 debug_tool              = esp-prog
 upload_protocol         = esp-prog


### PR DESCRIPTION
## Description:
since when a overriding of the core32 is done, the solo1 env. is not working anymore.
Now the solo1 core is not overriden anymore.  

Update esptool.py to release version 3.2. All ESP32-C3 variants are recognized now correctly.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
