### PR TITLE
Disable Face Detection for Webcam with Core 2.0.x

### DIFF
--- a/tasmota/xdrv_81_esp32_webcam.ino
+++ b/tasmota/xdrv_81_esp32_webcam.ino
@@ -81,8 +81,17 @@
 #include "esp_camera.h"
 #include "sensor.h"
 #include "fb_gfx.h"
-#include "fd_forward.h"
-#include "fr_forward.h"
+
+#ifdef USE_FACE_DETECT
+  #if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
+    #include "fd_forward.h"
+    #include "fr_forward.h"
+//    #pragma message("Face detection enabled")
+  #else
+    #pragma message("Face detection not supported from Tasmota with Arduino Core 2.0.x. Disabling")
+    #undef USE_FACE_DETECT
+  #endif
+#endif
 
 bool HttpCheckPriviledgedAccess(bool);
 extern ESP8266WebServer *Webserver;


### PR DESCRIPTION
since the underlying functions have changed. It is not yet supported in the Tasmota webcam driver

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
