### PR TITLE
Stabilize Platformio when overriding

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -91,8 +91,9 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 [env:tasmota32_base]
 ; *** Uncomment next lines ";" to enable Beta Tasmota Arduino version ESP32 IDF4.4
 ;platform                = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-;platform_packages       = ${core32.platform_packages}
-;                          framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc1/framework-arduinoespressif32-release_IDF4.4.tar.gz
+;platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc1/framework-arduinoespressif32-release_IDF4.4.tar.gz
+;                          platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
+;                          platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags           = ${esp32_defaults.build_unflags}
 build_flags             = ${esp32_defaults.build_flags}
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -1,24 +1,11 @@
 ; *** Tasmota32 development core version ESP32 IDF4.4
 [env:tasmota32-dev]
-extends                     = env:tasmota32idf4
-platform_packages           = ${core32.platform_packages}
-                              framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/511/framework-arduinoespressif32-release_v4.4-432c3c78c.tar.gz
+extends                     = env:tasmota32_base
+platform_packages           = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/511/framework-arduinoespressif32-release_v4.4-432c3c78c.tar.gz
+                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
 build_flags                 = ${env:tasmota32idf4.build_flags}
                               -D FIRMWARE_TASMOTA32
-
-[env:tasmota-rangeextender]
-build_flags                 = ${env.build_flags}
-                              -D FIRMWARE_RANGE_EXTENDER
-                              -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-                              -D USE_WIFI_RANGE_EXTENDER
-                              -D USE_WIFI_RANGE_EXTENDER_NAPT
-
-[env:tasmota32-rangeextender]
-extends                     = env:tasmota32idf4
-build_flags                 = ${env:tasmota32idf4.build_flags}
-                              -D FIRMWARE_TASMOTA32
-                              -D USE_WIFI_RANGE_EXTENDER
-                              -D USE_WIFI_RANGE_EXTENDER_NAPT
 
 ;*** Beta Tasmota version for ESP32-S2
 ;*** Example how to override the standard core with [tasmota32-dev] core
@@ -33,6 +20,20 @@ lib_extra_dirs              = lib/libesp32
                               lib/lib_i2c
                               lib/lib_ssl
                               lib/lib_display
+
+[env:tasmota-rangeextender]
+build_flags                 = ${env.build_flags}
+                              -D FIRMWARE_RANGE_EXTENDER
+                              -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                              -D USE_WIFI_RANGE_EXTENDER
+                              -D USE_WIFI_RANGE_EXTENDER_NAPT
+
+[env:tasmota32-rangeextender]
+extends                     = env:tasmota32idf4
+build_flags                 = ${env:tasmota32idf4.build_flags}
+                              -D FIRMWARE_TASMOTA32
+                              -D USE_WIFI_RANGE_EXTENDER
+                              -D USE_WIFI_RANGE_EXTENDER_NAPT
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -36,8 +36,9 @@ lib_ignore                  =
 [env:tasmota32idf4]
 extends                 = env:tasmota32_base
 platform                = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-platform_packages       = ${core32.platform_packages}
-                          framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc1/framework-arduinoespressif32-release_IDF4.4.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc1/framework-arduinoespressif32-release_IDF4.4.tar.gz
+                          platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
+                          platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -Wswitch-unreachable
                           -Wstringop-overflow


### PR DESCRIPTION
Nested overrides do fail now and than. It is now removed. Less elegant but always working.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_