### PR TITLE
Berry support for unishox compression

### DIFF
--- a/lib/libesp32/Berry/default/be_modtab.c
+++ b/lib/libesp32/Berry/default/be_modtab.c
@@ -32,6 +32,7 @@ be_extern_native_module(energy);
 be_extern_native_module(webserver);
 be_extern_native_module(flash);
 be_extern_native_module(path);
+be_extern_native_module(unishox);
 #ifdef USE_LVGL
 be_extern_native_module(lv);
 #endif // USE_LVGL
@@ -88,6 +89,10 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #ifdef USE_LIGHT
     &be_native_module(light),
 #endif
+
+#ifdef USE_UNISHOX_COMPRESSION
+    &be_native_module(unishox),
+#endif // USE_UNISHOX_COMPRESSION
 
 #ifdef USE_LVGL
     &be_native_module(lv),

--- a/lib/libesp32/Berry/default/be_unishox_lib.c
+++ b/lib/libesp32/Berry/default/be_unishox_lib.c
@@ -1,0 +1,28 @@
+/********************************************************************
+ * Berry module `unishox`
+ * 
+ * To use: `import unishox`
+ * 
+ * Allows to respond to HTTP request
+ *******************************************************************/
+#include "be_constobj.h"
+
+#ifdef USE_UNISHOX_COMPRESSION
+
+extern int be_unishox_compress(bvm *vm);
+extern int be_unishox_decompress(bvm *vm);
+
+/********************************************************************
+** Solidified module: unishox
+********************************************************************/
+be_local_module(unishox,
+    "unishox",
+    be_nested_map(2,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_nested_key("decompress", -1407935646, 10, -1), be_const_func(be_unishox_decompress) },
+        { be_nested_key("compress", -1476883059, 8, -1), be_const_func(be_unishox_compress) },
+    }))
+);
+BE_EXPORT_VARIABLE be_define_const_native_module(unishox);
+
+#endif // USE_UNISHOX_COMPRESSION

--- a/tasmota/xdrv_52_3_berry_unishox.ino
+++ b/tasmota/xdrv_52_3_berry_unishox.ino
@@ -1,0 +1,94 @@
+/*
+  xdrv_52_3_berry_unishox.ino - Berry scripting language, native fucnctions
+
+  Copyright (C) 2021 Stephan Hadinger, Berry language by Guan Wenliang https://github.com/Skiars/berry
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifdef USE_BERRY
+
+#include <berry.h>
+
+#ifdef USE_UNISHOX_COMPRESSION
+
+extern Unishox compressor;
+
+/*********************************************************************************************\
+ * Native functions mapped to Berry functions
+ * 
+ * import unishox
+ * 
+ * 
+\*********************************************************************************************/
+extern "C" {
+
+  int be_unishox_compress(bvm *vm);
+  int be_unishox_compress(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc == 1 && be_isstring(vm, 1)) {
+      const char * s = be_tostring(vm, 1);
+      // do a dry-run to know the compressed size
+      int32_t compressed_size = compressor.unishox_compress(s, strlen(s), (char*) nullptr, 0);
+      if (compressed_size < 0) {
+        be_raise(vm, "internal_error", nullptr);
+      }
+      void * buf = be_pushbytes(vm, NULL, compressed_size);
+      if (compressed_size > 0) {
+        int32_t ret = compressor.unishox_compress(s, strlen(s), (char*) buf, compressed_size+5);  // We expand by 4 the buffer size to avoid an error, but we are sure it will not overflow (see unishox implementation)
+        if (ret < 0 || ret != compressed_size) {
+          be_raisef(vm, "internal_error", "unishox size=%i ret=%i", compressed_size, ret);
+        }
+      }
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
+  int be_unishox_decompress(bvm *vm);
+  int be_unishox_decompress(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc == 1 && be_isbytes(vm, 1)) {
+      size_t len;
+      const void * buf = be_tobytes(vm, 1, &len);
+      if (len == 0) {
+        be_pushstring(vm, "");
+      } else {
+        int32_t decomp_size = compressor.unishox_decompress((const char*)buf, len, (char*) nullptr, 0);
+        if (decomp_size < 0) {
+          be_raise(vm, "internal_error", nullptr);
+        }
+        if (decomp_size == 0) {
+          be_pushstring(vm, "");
+        } else {
+          void * buf_out = be_pushbuffer(vm, decomp_size);
+          int32_t ret = compressor.unishox_decompress((const char*)buf, len, (char*) buf_out, decomp_size);
+          if (ret < 0 || ret != decomp_size) {
+            be_raisef(vm, "internal_error", "unishox size=%i ret=%i", decomp_size, ret);
+          }
+          be_pushnstring(vm, (const char*) buf_out, decomp_size);
+        }
+      }
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
+}
+
+
+#endif // USE_UNISHOX_COMPRESSION
+
+#endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Support for unishox compression in Berry. Unishox is useful for text only and when you need to store binary format (in Flash for example):
- `unishox.compress(text:string) -> bytes()`
- `unishox.decompress(bytes) -> string`

Example:

``` python
> import unishox
> s = "Hello Tasmota"

> b = unishox.compress(s)

> print(b,"size",size(b),"orig_size",size(s))
bytes('214C20B1155F86E559') size 9 orig_size 13

> s2 = unishox.decompress(b)

> print(s2)
Hello Tasmota
```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
