### PR TITLE
Add command TCPConfig to TCPBridge

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -733,8 +733,9 @@ typedef struct {
   uint8_t       shd_leading_edge;          // F5B
   uint16_t      shd_warmup_brightness;     // F5C
   uint8_t       shd_warmup_time;           // F5E
+  uint8_t       tcp_config;                // F5F
 
-  uint8_t       free_f5f[61];              // F5F - Decrement if adding new Setting variables just above and below
+  uint8_t       free_f60[60];              // F60 - Decrement if adding new Setting variables just above and below
 
   // Only 32 bit boundary variables below
 

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -1525,28 +1525,8 @@ void CmndSerialConfig(void)
       }
     }
     else if ((XdrvMailbox.payload >= 5) && (XdrvMailbox.payload <= 8)) {
-      uint8_t serial_config = XdrvMailbox.payload -5;  // Data bits 5, 6, 7 or 8, No parity and 1 stop bit
-
-      bool valid = true;
-      char parity = (XdrvMailbox.data[1] & 0xdf);
-      if ('E' == parity) {
-        serial_config += 0x08;                         // Even parity
-      }
-      else if ('O' == parity) {
-        serial_config += 0x10;                         // Odd parity
-      }
-      else if ('N' != parity) {
-        valid = false;
-      }
-
-      if ('2' == XdrvMailbox.data[2]) {
-        serial_config += 0x04;                         // Stop bits 2
-      }
-      else if ('1' != XdrvMailbox.data[2]) {
-        valid = false;
-      }
-
-      if (valid) {
+      int8_t serial_config = ParseSerialConfig(XdrvMailbox.data);
+      if (serial_config >= 0) {
         SetSerialConfig(serial_config);
       }
     }

--- a/tasmota/xdrv_41_tcp_bridge.ino
+++ b/tasmota/xdrv_41_tcp_bridge.ino
@@ -41,11 +41,11 @@ IPAddress    ip_filter;
 TasmotaSerial *TCPSerial = nullptr;
 
 const char kTCPCommands[] PROGMEM = "TCP" "|"    // prefix
-  "Start" "|" "Baudrate"
+  "Start" "|" "Baudrate" "|" "Config"
   ;
 
 void (* const TCPCommand[])(void) PROGMEM = {
-  &CmndTCPStart, &CmndTCPBaudrate
+  &CmndTCPStart, &CmndTCPBaudrate, &CmndTCPConfig
   };
 
 //
@@ -136,12 +136,14 @@ void TCPLoop(void)
 /********************************************************************************************/
 void TCPInit(void) {
   if (PinUsed(GPIO_TCP_RX) && PinUsed(GPIO_TCP_TX)) {
+    if (0 == (0x80 & Settings->tcp_config)) // !0x80 means unitialized
+      Settings->tcp_config = 0x80 | ParseSerialConfig("8N1"); // default as 8N1 for backward compatibility
     tcp_buf = (uint8_t*) malloc(TCP_BRIDGE_BUF_SIZE);
     if (!tcp_buf) { AddLog(LOG_LEVEL_ERROR, PSTR(D_LOG_TCP "could not allocate buffer")); return; }
 
     if (!Settings->tcp_baudrate)  { Settings->tcp_baudrate = 115200 / 1200; }
     TCPSerial = new TasmotaSerial(Pin(GPIO_TCP_RX), Pin(GPIO_TCP_TX), TasmotaGlobal.seriallog_level ? 1 : 2, 0, TCP_BRIDGE_BUF_SIZE);   // set a receive buffer of 256 bytes
-    TCPSerial->begin(Settings->tcp_baudrate * 1200);
+    TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);
     if (TCPSerial->hardwareSerial()) {
       ClaimSerial();
 		}
@@ -197,9 +199,20 @@ void CmndTCPBaudrate(void) {
   if ((XdrvMailbox.payload >= 1200) && (XdrvMailbox.payload <= 115200)) {
     XdrvMailbox.payload /= 1200;  // Make it a valid baudrate
     Settings->tcp_baudrate = XdrvMailbox.payload;
-    TCPSerial->begin(Settings->tcp_baudrate * 1200);  // Reinitialize serial port with new baud rate
+    TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);  // Reinitialize serial port with new baud rate
   }
   ResponseCmndNumber(Settings->tcp_baudrate * 1200);
+}
+
+void CmndTCPConfig(void) {
+  if (XdrvMailbox.data_len > 0) {
+    uint8_t serial_config = ParseSerialConfig(XdrvMailbox.data);
+    if (serial_config >= 0) {
+      Settings->tcp_config = 0x80 | serial_config; // default 0x00 should be 8N1
+      TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);  // Reinitialize serial port with new config
+    }
+  }
+  ResponseCmndChar_P(GetSerialConfig(0x7F & Settings->tcp_config).c_str());
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Adding Command `TCPConfig <configstring>` to change the mode from the default 8N1
The `<configstring>` is the standard 3 characters mode such as `8N1`, `7E1` etc ...
Supports:
- 5 to 8 bits
- N, E, O parity
- 1 or 2 stop bits

I haven't added the support for a numeric parameter (0..23) like `SerialConfig`...

To limit code size, I moved the parsing from `CmndSerialConfig()` into a new `ParseSerialConfig()` function in order to make it re-usable.
Also I changed `GetSerialConfig()` to support an optional parameter inn order to use it with other config than `Settings->serial_config`

In order to preserve backward compatibility with flash settings where the `tcp_config` field was not present (defaults to 0), I set the MSBit to 1 to state the value is valid. A value without this bit set is interpreted as default `8N1`.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
