### PR TITLE
Support for DisplayDimmer for Core2 with Berry drivers

### DIFF
--- a/tasmota/berry/drivers/i2c_axp192_M5StackCore2.be
+++ b/tasmota/berry/drivers/i2c_axp192_M5StackCore2.be
@@ -3,7 +3,7 @@
  -------------------------------------------------------------#
 class AXP192_M5Stack_Core2 : AXP192
   def init()
-    super(self, AXP192).init()
+    super(self).init()
 
     if self.wire
       # Disable vbus hold limit
@@ -116,6 +116,20 @@ class AXP192_M5Stack_Core2 : AXP192
       self.write8(0x12, self.read8(0x12) | 0x40)          # set EXTEN to enable 5v boost
     end
   end
+
+  # Dimmer in percentage
+  def set_displaydimmer(x)
+    var v = tasmota.scale_uint(x, 0, 100, 2500, 3300)
+    self.set_lcd_voltage(v)
+  end
+
+  # respond to display events
+  def display(cmd, idx, payload, raw)
+    if cmd == "dim" || cmd == "power"
+      self.set_displaydimmer(idx)
+    end
+  end
+
 end
 
 axp = AXP192_M5Stack_Core2()

--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -1861,6 +1861,10 @@ void DisplaySetPower(void)
       XdspCall(FUNC_DISPLAY_POWER);
     } else {
       renderer->DisplayOnff(disp_power);
+#ifdef USE_BERRY
+      // still call Berry virtual display in case it is not managed entirely by renderer
+      Xdsp18(FUNC_DISPLAY_POWER);
+#endif // USE_BERRY
     }
   }
 }
@@ -1961,6 +1965,10 @@ void ApplyDisplayDimmer(void) {
   }
   if (renderer) {
     renderer->dim8(dimmer8, dimmer8_gamma);   // provide 8 bits and gamma corrected dimmer in 8 bits
+#ifdef USE_BERRY
+    // still call Berry virtual display in case it is not managed entirely by renderer
+    Xdsp18(FUNC_DISPLAY_DIM);
+#endif // USE_BERRY
   } else {
     XdspCall(FUNC_DISPLAY_DIM);
   }

--- a/tasmota/xdsp_18_berry_display.ino
+++ b/tasmota/xdsp_18_berry_display.ino
@@ -32,19 +32,19 @@ bool Xdsp18(uint8_t function) {
   switch (function) {
 
     case FUNC_DISPLAY_INIT_DRIVER:
-      result = callBerryEventDispatcher(PSTR("display"), PSTR("init_driver"), function, XdrvMailbox.data);
+      result = callBerryEventDispatcher(PSTR("display"), PSTR("init_driver"), 0, nullptr);
       break;
     case FUNC_DISPLAY_INIT:
-      result = callBerryEventDispatcher(PSTR("display"), PSTR("init_driver"), function, XdrvMailbox.data);
+      result = callBerryEventDispatcher(PSTR("display"), PSTR("init_driver"), 0, nullptr);
       break;
     case FUNC_DISPLAY_MODEL:
-      result = callBerryEventDispatcher(PSTR("display"), PSTR("model"), function, XdrvMailbox.data);
+      result = callBerryEventDispatcher(PSTR("display"), PSTR("model"), 0, nullptr);
       break;
     case FUNC_DISPLAY_DIM:
-      result = callBerryEventDispatcher(PSTR("display"), PSTR("dim"), function, XdrvMailbox.data);
+      result = callBerryEventDispatcher(PSTR("display"), PSTR("dim"), GetDisplayDimmer(), nullptr);
       break;
     case FUNC_DISPLAY_POWER:
-      result = callBerryEventDispatcher(PSTR("display"), PSTR("power"), function, XdrvMailbox.data);
+      result = callBerryEventDispatcher(PSTR("display"), PSTR("power"), disp_power ? GetDisplayDimmer() : 0, nullptr);
       break;
   }
   return result;


### PR DESCRIPTION
## Description:

Full support for M5Stack Core2 `DisplayDimmer` and display on/off via Berry drivers for AXP192. This means that you don't need a specific build anymore for full M5Stack Core2 support.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
