### PR TITLE
LVGL add theme mono

### DIFF
--- a/lib/libesp32/Berry/default/be_lvgl_module.c
+++ b/lib/libesp32/Berry/default/be_lvgl_module.c
@@ -99,6 +99,7 @@ const lvbe_call_c_t lv_func[] = {
   { "theme_get_font_normal", (void*) &lv_theme_get_font_normal, "lv.lv_font", "(lv.lv_obj)" },
   { "theme_get_font_small", (void*) &lv_theme_get_font_small, "lv.lv_font", "(lv.lv_obj)" },
   { "theme_get_from_obj", (void*) &lv_theme_get_from_obj, "lv.lv_theme", "(lv.lv_obj)" },
+  { "theme_mono_init", (void*) &lv_theme_mono_init, "lv.lv_theme", "(lv.lv_disp)b(lv.lv_font)" },
   { "theme_openhasp_init", (void*) &lv_theme_openhasp_init, "lv.lv_theme", "(lv.lv_disp)(lv.lv_color)(lv.lv_color)b(lv.lv_font)" },
   { "theme_openhasp_is_inited", (void*) &lv_theme_openhasp_is_inited, "b", "" },
   { "theme_set_apply_cb", (void*) &lv_theme_set_apply_cb, "", "(lv.lv_theme)^lv_theme_apply_cb^" },

--- a/tools/lv_berry/lv_funcs.h
+++ b/tools/lv_berry/lv_funcs.h
@@ -501,6 +501,9 @@ void lv_draw_polygon(const lv_point_t points[], uint16_t point_cnt, const lv_are
 lv_theme_t * lv_theme_default_init(lv_disp_t * disp, lv_color_t color_primary, lv_color_t color_secondary, bool dark, const lv_font_t * font)
 bool lv_theme_default_is_inited(void)
 
+// ../../lib/libesp32_lvgl/LVGL8/src/extra/themes/mono/lv_theme_mono.h
+lv_theme_t * lv_theme_mono_init(lv_disp_t * disp, bool dark_bg, const lv_font_t * font)
+
 // ../../lib/libesp32_lvgl/LVGL8/src/extra/widgets/chart/lv_chart.h
 lv_obj_t * lv_chart_create(lv_obj_t * parent)
 void lv_chart_set_type(lv_obj_t * obj, lv_chart_type_t type)

--- a/tools/lv_berry/preprocessor.py
+++ b/tools/lv_berry/preprocessor.py
@@ -61,6 +61,7 @@ lv_fun_globs = [
                   "extra/widgets/spinbox/*.h",
                   "extra/widgets/spinner/*.h",
                   "extra/themes/default/*.h",
+                  "extra/themes/mono/*.h",
                   "core/*.h",
                   "draw/*.h",
                   "misc/lv_style_gen.h",


### PR DESCRIPTION
## Description:

LVGL add Theme mono for monochrome displays.

```
lv.start()

scr = lv.scr_act()            # default screean object
f20 = lv.montserrat_font(20)  # load embedded Montserrat 20

mono = lv.theme_mono_init(0, true, f20)  # true is dark background 
scr.get_disp().set_theme(mono)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
