### PR TITLE
remove c3 serial workaround

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1841,19 +1841,20 @@ int8_t ParseSerialConfig(const char *pstr)
 }
 
 
-#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
+// workaround disabled 05.11.2021 solved with https://github.com/espressif/arduino-esp32/pull/5549
+//#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
 // temporary workaround, see https://github.com/espressif/arduino-esp32/issues/5287
-#include <driver/uart.h>
-uint32_t GetSerialBaudrate(void) {
-  uint32_t br;
-  uart_get_baudrate(0, &br);
-  return (br / 300) * 300;  // Fix ESP32 strange results like 115201
-}
-#else
+//#include <driver/uart.h>
+//uint32_t GetSerialBaudrate(void) {
+//  uint32_t br;
+//  uart_get_baudrate(0, &br);
+//  return (br / 300) * 300;  // Fix ESP32 strange results like 115201
+//}
+//#else
 uint32_t GetSerialBaudrate(void) {
   return (Serial.baudRate() / 300) * 300;  // Fix ESP32 strange results like 115201
 }
-#endif
+//#endif
 
 #ifdef ESP8266
 void SetSerialSwap(void) {


### PR DESCRIPTION
## Description:

not needed anymore. Fixed with https://github.com/espressif/arduino-esp32/pull/5549
The PR is included in Tasmota 2.0.1.rc1

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
