### PR TITLE
EZSP32 prevent crash on IDF4.4

### DIFF
--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -108,11 +108,13 @@ void ZigbeeInit(void)
 
 #ifdef USE_ZIGBEE_EZSP
     // Check the I2C EEprom
-    Wire.beginTransmission(USE_ZIGBEE_ZBBRIDGE_EEPROM);
-    uint8_t error = Wire.endTransmission();
-    if (0 == error) {
-      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE D_ZIGBEE_EEPROM_FOUND_AT_ADDRESS " 0x%02X"), USE_ZIGBEE_ZBBRIDGE_EEPROM);
-      zigbee.eeprom_present = true;
+    if (TasmotaGlobal.i2c_enabled) {
+      Wire.beginTransmission(USE_ZIGBEE_ZBBRIDGE_EEPROM);
+      uint8_t error = Wire.endTransmission();
+      if (0 == error) {
+        AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE D_ZIGBEE_EEPROM_FOUND_AT_ADDRESS " 0x%02X"), USE_ZIGBEE_ZBBRIDGE_EEPROM);
+        zigbee.eeprom_present = true;
+      }
     }
 #endif
   }


### PR DESCRIPTION
## Description:

Avoid crash of EZSP32 using IDF4.4 when I2C is not configured.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
