### PR TITLE
gcc add -Wnonnull-compare

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -43,6 +43,7 @@ build_unflags           = ${env:tasmota32_base.build_unflags}
                           -Wswitch-unreachable
                           -Wstringop-overflow
                           -Wincompatible-pointer-types
+                          -Wnonnull-compare
 build_flags             = ${env:tasmota32_base.build_flags}
                           -Wno-switch-unreachable
                           -Wno-stringop-overflow


### PR DESCRIPTION
## Description:

Add compile option `-Wnonnull-compare` to IDF4.4 compiles, since the behavior of gcc changed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
