### PR TITLE
Move LList to its own library

### DIFF
--- a/lib/default/TasmotaLList/library.json
+++ b/lib/default/TasmotaLList/library.json
@@ -1,0 +1,14 @@
+{
+    "name": "TasmotaLList",
+    "version": "1.0",
+    "description": "Simple yet powerful linked-list",
+    "license": "MIT",
+    "homepage": "https://github.com/arendst/Tasmota",
+    "frameworks": "*",
+    "platforms": "*",
+    "authors":
+    {
+      "name": "Stephan Hadinger",
+      "maintainer": true
+    }
+  }

--- a/lib/default/TasmotaLList/src/LList.h
+++ b/lib/default/TasmotaLList/src/LList.h
@@ -1,5 +1,5 @@
 /*
-  support_light_list.ino - Lightweight Linked List for simple objects - optimized for low code size and low memory
+  LList.h - Lightweight Linked List for simple objects - optimized for low code size and low memory
 
   Copyright (C) 2021  Theo Arends and Stephan Hadinger
 
@@ -16,6 +16,11 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#ifndef __LLIST__
+#define __LLIST__
+
+#include <cstddef>
 
 /*********************************************************************************************\
  *
@@ -206,3 +211,5 @@ T & LList<T>::addToLast(LList_elt<T> * elt) {
   elt->_next = nullptr;
   return elt->_val;
 }
+
+#endif // __LLIST__

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -38,6 +38,7 @@
 #include <StreamString.h>                   // Webserver, Updater
 #include <ext_printf.h>
 #include <SBuffer.hpp>
+#include <LList.h>
 #include <JsonParser.h>
 #include <JsonGenerator.h>
 #ifdef USE_ARDUINO_OTA

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -68,10 +68,6 @@ void (* const ZigbeeCommand[])(void) PROGMEM = {
 // Initialize internal structures
 void ZigbeeInit(void)
 {
-// #pragma GCC diagnostic push
-// #pragma GCC diagnostic ignored "-Winvalid-offsetof"
-// Serial.printf(">>> offset %d %d %d\n", Z_offset(Z_Data_Light, dimmer), Z_offset(Z_Data_Light, x), Z_offset(Z_Data_Thermo, temperature));
-// #pragma GCC diagnostic pop
   // Check if settings in Flash are set
   if (PinUsed(GPIO_ZIGBEE_RX) && PinUsed(GPIO_ZIGBEE_TX)) {
     if (0 == Settings->zb_channel) {


### PR DESCRIPTION
## Description:

Move LList library (lightweight Linked List) to its own library to be used by future ZIP read-only file-system.

No impact on code nor code size.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
