### PR TITLE
add tasmota32idf4-solo1

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -7,6 +7,15 @@ platform_packages           = framework-arduinoespressif32 @ https://github.com/
 build_flags                 = ${env:tasmota32idf4.build_flags}
                               -D FIRMWARE_TASMOTA32
 
+[env:tasmota32idf4-solo1]
+extends                     = env:tasmota32idf4
+platform                    = ${env:tasmota32idf4.platform}
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc2/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
+                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
+                              platformio/tool-mklittlefs @ ~1.203.200522
+build_flags                 = ${env:tasmota32idf4.build_flags}
+                              -D FIRMWARE_TASMOTA32
+
 ;*** Beta Tasmota version for ESP32-S2
 ;*** Example how to override the standard core with [tasmota32-dev] core
 [env:tasmota32s2]
@@ -14,7 +23,7 @@ extends                     = env:tasmota32-dev
 platform_packages           = ${env:tasmota32-dev.platform_packages}
 board                       = esp32s2
 build_flags                 = ${env:tasmota32idf4.build_flags}
-                             -D FIRMWARE_TASMOTA32
+                              -D FIRMWARE_TASMOTA32
 lib_ignore                  =
                               ESP8266Audio
                               ESP8266SAM


### PR DESCRIPTION
to `platformio_tasmota_cenv_sample.ini` to have the possibility to build a solo1 Variant based on Arduino ESP core 2.0.1rc2-solo1

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
