### PR TITLE
SGP30 fix garbage on web gui when abs_num not available

### DIFF
--- a/tasmota/xsns_21_sgp30.ino
+++ b/tasmota/xsns_21_sgp30.ino
@@ -114,14 +114,14 @@ void Sgp30Show(bool json)
 {
   if (sgp30_ready) {
     char abs_hum[33];
-
-    if (TasmotaGlobal.global_update && (TasmotaGlobal.humidity > 0) && !isnan(TasmotaGlobal.temperature_celsius)) {
+    bool ahum_available = TasmotaGlobal.global_update && (TasmotaGlobal.humidity > 0) && !isnan(TasmotaGlobal.temperature_celsius);
+    if (ahum_available) {
         // has humidity + temperature
         dtostrfd(sgp30_abshum,4,abs_hum);
     }
     if (json) {
       ResponseAppend_P(PSTR(",\"SGP30\":{\"" D_JSON_ECO2 "\":%d,\"" D_JSON_TVOC "\":%d"), sgp.eCO2, sgp.TVOC);
-      if (TasmotaGlobal.global_update && TasmotaGlobal.humidity>0 && !isnan(TasmotaGlobal.temperature_celsius)) {
+      if (ahum_available) {
         ResponseAppend_P(PSTR(",\"" D_JSON_AHUM "\":%s"),abs_hum);
       }
       ResponseJsonEnd();
@@ -131,7 +131,7 @@ void Sgp30Show(bool json)
 #ifdef USE_WEBSERVER
     } else {
       WSContentSend_PD(HTTP_SNS_SGP30, sgp.eCO2, sgp.TVOC);
-      if (TasmotaGlobal.global_update) {
+      if (ahum_available) {
         WSContentSend_PD(HTTP_SNS_AHUM, abs_hum);
       }
 #endif


### PR DESCRIPTION
## Description:

https://github.com/arendst/Tasmota/discussions/13621

Incomplete test leave garbage on web gui due to unitialized string


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
