### PR TITLE
Berry module gpio for OptionA

### DIFF
--- a/tasmota/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/xdrv_52_3_berry_gpio.ino
@@ -173,7 +173,12 @@ extern "C" {
       if (argc == 2 && be_isint(vm, 2)) {
         index = be_toint(vm, 2);
       }
-      bool ret = PinUsed(pin, index);
+      bool ret;
+      if (pin == GPIO_OPTION_A) {
+        ret = bitRead(TasmotaGlobal.gpio_optiona.data, index);
+      } else  {
+        ret = PinUsed(pin, index);
+      }
       be_pushbool(vm, ret);
       be_return(vm);
     }


### PR DESCRIPTION
## Description:

Allow `gpio.pin_used` to test for `OptionA`. Warning: it does not work with `gpio.pin` since the gpio is virtual.

```python
gpio.pin_used(gpio.OPTION_A, 2)   # test for OptionA=3 (0 based so you need to substract 1)
```

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
