### PR TITLE
Core 2.0.1 for all Tasmota32 env

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.5
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,6 +64,7 @@ lib_extra_dirs              =
 
 [scripts_defaults]
 extra_scripts               = pio-tools/strip-floats.py
+                              pio-tools/add_c_flags.py
                               pio-tools/name-firmware.py
                               pio-tools/gzip-firmware.py
                               pio-tools/override_copy.py

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,9 +89,9 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 
 [env:tasmota32_base]
-; *** Uncomment next lines ";" to enable Beta Tasmota Arduino version ESP32 IDF4.4
+; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
 ;platform                = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-;platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc2/framework-arduinoespressif32-release_IDF4.4.tar.gz
+;platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1/framework-arduinoespressif32-release_IDF4.4.tar.gz
 ;                          platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
 ;                          platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags           = ${esp32_defaults.build_unflags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -2,9 +2,15 @@
 
 [esp32_defaults]
 build_unflags               = ${esp_defaults.build_unflags}
+                              -Wswitch-unreachable
+                              -Wstringop-overflow
+                              -Wincompatible-pointer-types
+                              -Wnonnull-compare
                               -fexceptions
                               -Wpointer-arith
 build_flags                 = ${esp_defaults.build_flags}
+                              -Wno-switch-unreachable
+                              -Wno-stringop-overflow
                               -fno-exceptions
                               -DBUFFER_LENGTH=128
                               -DHTTP_UPLOAD_BUFLEN=2048
@@ -26,9 +32,8 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
 
 [core32]
-platform                    = espressif32 @ 3.3.1
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.5/tasmota-arduinoespressif32-release_v3.3.5.tar.gz
-                              platformio/toolchain-xtensa32 @ ~2.50200.0
+platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1/framework-arduinoespressif32-release_IDF4.4.tar.gz
                               platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
@@ -36,9 +41,8 @@ build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = espressif32 @ 3.3.1
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/1.0.7.5/tasmota-arduinoespressif32-solo1-release_v3.3.5.tar.gz
-                              platformio/toolchain-xtensa32 @ ~2.50200.0
+platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
                               platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
                               platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -1,33 +1,13 @@
-; *** Tasmota32 development core version ESP32 IDF4.4
-[env:tasmota32-dev]
-extends                     = env:tasmota32idf4
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc2/framework-arduinoespressif32-release_IDF4.4.tar.gz
-                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-                              platformio/tool-mklittlefs @ ~1.203.200522
-build_flags                 = ${env:tasmota32idf4.build_flags}
-                              -D FIRMWARE_TASMOTA32
-
-[env:tasmota32idf4-solo1]
-extends                     = env:tasmota32idf4
-platform                    = ${env:tasmota32idf4.platform}
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc2/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
-                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-                              platformio/tool-mklittlefs @ ~1.203.200522
-build_flags                 = ${env:tasmota32idf4.build_flags}
-                              -D FIRMWARE_TASMOTA32
-
 ;*** Beta Tasmota version for ESP32-S2
-;*** Example how to override the standard core with [tasmota32-dev] core
 [env:tasmota32s2]
-extends                     = env:tasmota32-dev
-platform_packages           = ${env:tasmota32-dev.platform_packages}
 board                       = esp32s2
-build_flags                 = ${env:tasmota32idf4.build_flags}
-                              -D FIRMWARE_TASMOTA32
+build_flags                 = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore                  =
                               ESP8266Audio
                               ESP8266SAM
                               TTGO TWatch Library
+                              NimBLE-Arduino
+                              epdiy
 
 [env:tasmota-rangeextender]
 build_flags                 = ${env.build_flags}
@@ -37,8 +17,8 @@ build_flags                 = ${env.build_flags}
                               -D USE_WIFI_RANGE_EXTENDER_NAPT
 
 [env:tasmota32-rangeextender]
-extends                     = env:tasmota32idf4
-build_flags                 = ${env:tasmota32idf4.build_flags}
+extends                     = env:tasmota32_base
+build_flags                 = ${env:tasmota32_base.build_flags}
                               -D FIRMWARE_TASMOTA32
                               -D USE_WIFI_RANGE_EXTENDER
                               -D USE_WIFI_RANGE_EXTENDER_NAPT

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -1,5 +1,6 @@
 ;*** Beta Tasmota version for ESP32-S2
 [env:tasmota32s2]
+extends                     = env:tasmota32_base
 board                       = esp32s2
 build_flags                 = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore                  =

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -33,23 +33,6 @@ lib_ignore                  =
 ; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
                               ArduinoOTA
 
-[env:tasmota32idf4]
-extends                 = env:tasmota32_base
-platform                = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-platform_packages       = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1rc2/framework-arduinoespressif32-release_IDF4.4.tar.gz
-                          platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-                          platformio/tool-mklittlefs @ ~1.203.200522
-build_unflags           = ${env:tasmota32_base.build_unflags}
-                          -Wswitch-unreachable
-                          -Wstringop-overflow
-                          -Wincompatible-pointer-types
-                          -Wnonnull-compare
-build_flags             = ${env:tasmota32_base.build_flags}
-                          -Wno-switch-unreachable
-                          -Wno-stringop-overflow
-extra_scripts           = ${env:tasmota32_base.extra_scripts}
-                          pio-tools/add_c_flags.py
-
 [env:tasmota32]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
@@ -109,19 +92,12 @@ build_flags             = ${env:tasmota32_base.build_flags} -DUSE_IR_REMOTE_FULL
 lib_extra_dirs          = lib/libesp32, lib/lib_basic
 
 [env:tasmota32c3]
-extends                 = env:tasmota32idf4
+extends                 = env:tasmota32_base
 board                   = esp32c3
-platform                = ${env:tasmota32idf4.platform}
-platform_packages       = ${env:tasmota32idf4.platform_packages}
-build_unflags           = ${env:tasmota32idf4.build_unflags}
+build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
                           -DNDEBUG
-build_flags             = ${env:tasmota32idf4.build_flags}
-; *** Comment next two lines to disable BLE
-;                          -DUSE_BLE_ESP32
-;                          -DUSE_MI_ESP32
-                           ;-DESP32_STAGE=true
-                           -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 lib_ignore              =
                           ESP8266Audio
                           ESP8266SAM


### PR DESCRIPTION
## Description:

use latest Tasmota Arduino Core32 2.0.1 (based on Arduino32 2.0.1) for all Tasmota32 env and MCUs
Tested with ESP32, ESP32-solo1, ESP32-C3 and ESP32-S2

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
