### PR TITLE
TLS make ALPN configurable

### DIFF
--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -204,6 +204,8 @@ void WiFiClientSecure_light::_clear() {
   _ta_P = nullptr;
   _ta_size = 0;
   _max_thunkstack_use = 0;
+  _alpn_names = nullptr;
+  _alpn_num = 0;
 }
 
 // Constructor
@@ -949,8 +951,6 @@ extern "C" {
     // we support only P256 EC curve for AWS IoT, no EC curve for Letsencrypt unless forced
     br_ssl_engine_set_ec(&cc->eng, &br_ec_p256_m15); // TODO
 #endif
-    static const char * alpn_mqtt = "mqtt";
-    br_ssl_engine_set_protocol_names(&cc->eng, &alpn_mqtt, 1);
   }
 }
 
@@ -983,6 +983,9 @@ bool WiFiClientSecure_light::_connectSSL(const char* hostName) {
     _eng = &_sc->eng; // Allocation/deallocation taken care of by the _sc shared_ptr
 
     br_ssl_client_base_init(_sc.get());
+    if (_alpn_names && _alpn_num > 0) {
+      br_ssl_engine_set_protocol_names(_eng, _alpn_names, _alpn_num);
+    }
 
     // ============================================================
     // Allocatte and initialize Decoder Context

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -93,6 +93,12 @@ class WiFiClientSecure_light : public WiFiClient {
 
     void setTrustAnchor(const br_x509_trust_anchor *ta, size_t ta_size);
 
+    void setALPN(const char **names, size_t num) {
+      // set ALPN extensions, used mostly by AWS IoT on port 443. Need to be static pointers
+      _alpn_names = names;
+      _alpn_num = num;
+    }
+
     // Sets the requested buffer size for transmit and receive
     void setBufferSizes(int recv, int xmit);
 
@@ -165,6 +171,10 @@ class WiFiClientSecure_light : public WiFiClient {
     // record the maximum use of ThunkStack for monitoring
     size_t _max_thunkstack_use;
 
+    // ALPN
+    const char ** _alpn_names;
+    size_t        _alpn_num;
+
 };
 
 #define ERR_OOM             -1000
@@ -236,6 +246,44 @@ class WiFiClientSecure_light : public WiFiClient {
 // #define BR_ERR_X509_FORBIDDEN_KEY_USAGE   59
 // #define BR_ERR_X509_WEAK_PUBLIC_KEY       60
 // #define BR_ERR_X509_NOT_TRUSTED           62
+
+// Alert types for TLSContentType.ALERT messages
+// See RFC 8466, section B.2
+
+// CLOSE_NOTIFY = 0
+// UNEXPECTED_MESSAGE = 10
+// BAD_RECORD_MAC = 20
+// DECRYPTION_FAILED = 21
+// RECORD_OVERFLOW = 22
+// DECOMPRESSION_FAILURE = 30
+// HANDSHAKE_FAILURE = 40
+// NO_CERTIFICATE = 41
+// BAD_CERTIFICATE = 42
+// UNSUPPORTED_CERTIFICATE = 43
+// CERTIFICATE_REVOKED = 44
+// CERTIFICATE_EXPIRED = 45
+// CERTIFICATE_UNKNOWN = 46
+// ILLEGAL_PARAMETER = 47
+// UNKNOWN_CA = 48
+// ACCESS_DENIED = 49
+// DECODE_ERROR = 50
+// DECRYPT_ERROR = 51
+// EXPORT_RESTRICTION = 60
+// PROTOCOL_VERSION = 70
+// INSUFFICIENT_SECURITY = 71
+// INTERNAL_ERROR = 80
+// INAPPROPRIATE_FALLBACK = 86
+// USER_CANCELED = 90
+// NO_RENEGOTIATION = 100
+// MISSING_EXTENSION = 109
+// UNSUPPORTED_EXTENSION = 110
+// CERTIFICATE_UNOBTAINABLE = 111
+// UNRECOGNIZED_NAME = 112
+// BAD_CERTIFICATE_STATUS_RESPONSE = 113
+// BAD_CERTIFICATE_HASH_VALUE = 114
+// UNKNOWN_PSK_IDENTITY = 115
+// CERTIFICATE_REQUIRED = 116
+// NO_APPLICATION_PROTOCOL = 120
 
 };
 

--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -216,6 +216,12 @@ void MqttInit(void) {
     tlsClient = new BearSSL::WiFiClientSecure_light(1024,1024);
 #endif
 
+#ifdef USE_MQTT_AWS_IOT_LIGHT
+    if (443 == Settings->mqtt_port) {
+      static const char * alpn_mqtt = "mqtt";   // needs to be static
+      tlsClient->setALPN(&alpn_mqtt, 1);         // need to set alpn to 'mqtt' for AWS IoT
+    }
+#endif
 #ifdef USE_MQTT_AWS_IOT
     loadTlsDir();   // load key and certificate data from Flash
     if ((nullptr != AWS_IoT_Private_Key) && (nullptr != AWS_IoT_Client_Certificate)) {


### PR DESCRIPTION
## Description:

Up to now, TLS ALPN was set to 'mqtt' as required by AWS IoT, and was generally ignored by other servers. Actually some servers (github) do care. It is now set only for AWS IoT and can be customized.

Also added TLS server error codes to ease future debugging.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
