### PR TITLE
Fix tcp bridge serial config

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1841,14 +1841,16 @@ int8_t ParseSerialConfig(const char *pstr)
 }
 
 #ifdef ESP8266
-SerConfu8 ConvertSerialConfig(uint8_t serial_config) {
+SerConfu8 ConvertSerialConfigESP8286(uint8_t serial_config) {
   return (SerConfu8)pgm_read_byte(kTasmotaSerialConfig + serial_config);
 }
+#define ConvertSerialConfig(a) ConvertSerialConfigESP8286(a)
 #endif  // ESP8266
 #ifdef ESP32
-uint32_t ConvertSerialConfig(uint8_t serial_config) {
+uint32_t ConvertSerialConfigESP32(uint8_t serial_config) {
   return (uint32_t)pgm_read_dword(kTasmotaSerialConfig + serial_config);
 }
+#define ConvertSerialConfig(a) ConvertSerialConfigESP32(a)
 #endif  // ESP32
 
 // workaround disabled 05.11.2021 solved with https://github.com/espressif/arduino-esp32/pull/5549

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1840,6 +1840,16 @@ int8_t ParseSerialConfig(const char *pstr)
   return serial_config;
 }
 
+#ifdef ESP8266
+SerConfu8 ConvertSerialConfig(uint8_t serial_config) {
+  return (SerConfu8)pgm_read_byte(kTasmotaSerialConfig + serial_config);
+}
+#endif  // ESP8266
+#ifdef ESP32
+uint32_t ConvertSerialConfig(uint8_t serial_config) {
+  return (uint32_t)pgm_read_dword(kTasmotaSerialConfig + serial_config);
+}
+#endif  // ESP32
 
 // workaround disabled 05.11.2021 solved with https://github.com/espressif/arduino-esp32/pull/5549
 //#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3

--- a/tasmota/xdrv_41_tcp_bridge.ino
+++ b/tasmota/xdrv_41_tcp_bridge.ino
@@ -134,6 +134,7 @@ void TCPLoop(void)
 }
 
 /********************************************************************************************/
+
 void TCPInit(void) {
   if (PinUsed(GPIO_TCP_RX) && PinUsed(GPIO_TCP_TX)) {
     if (0 == (0x80 & Settings->tcp_config)) // !0x80 means unitialized
@@ -143,7 +144,7 @@ void TCPInit(void) {
 
     if (!Settings->tcp_baudrate)  { Settings->tcp_baudrate = 115200 / 1200; }
     TCPSerial = new TasmotaSerial(Pin(GPIO_TCP_RX), Pin(GPIO_TCP_TX), TasmotaGlobal.seriallog_level ? 1 : 2, 0, TCP_BRIDGE_BUF_SIZE);   // set a receive buffer of 256 bytes
-    TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);
+    TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));
     if (TCPSerial->hardwareSerial()) {
       ClaimSerial();
 		}
@@ -199,7 +200,7 @@ void CmndTCPBaudrate(void) {
   if ((XdrvMailbox.payload >= 1200) && (XdrvMailbox.payload <= 115200)) {
     XdrvMailbox.payload /= 1200;  // Make it a valid baudrate
     Settings->tcp_baudrate = XdrvMailbox.payload;
-    TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);  // Reinitialize serial port with new baud rate
+    TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));  // Reinitialize serial port with new baud rate
   }
   ResponseCmndNumber(Settings->tcp_baudrate * 1200);
 }
@@ -209,7 +210,7 @@ void CmndTCPConfig(void) {
     uint8_t serial_config = ParseSerialConfig(XdrvMailbox.data);
     if (serial_config >= 0) {
       Settings->tcp_config = 0x80 | serial_config; // default 0x00 should be 8N1
-      TCPSerial->begin(Settings->tcp_baudrate * 1200, 0x7F & Settings->tcp_config);  // Reinitialize serial port with new config
+      TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));  // Reinitialize serial port with new config
     }
   }
   ResponseCmndChar_P(GetSerialConfig(0x7F & Settings->tcp_config).c_str());


### PR DESCRIPTION
## Description:

Previous PR on TCPBridge TCPConfig command was missing that Tasmota's serial_config needs to be converted.
Quick patch to restore TCP Bridge functionality with new `ConvertSerialConfig()` with versions for ESP8266 and ESP32
Will be leverage at other place later

Seems ok but difficult to be fully tested

@s-hadinger can you validate with your zifbee use-case ?


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
