### PR TITLE
Adds the AT42QT1070 touch sensor

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -98,3 +98,4 @@ Index | Define              | Driver  | Device   | Address(es) | Description
   62  | USE_SCD40           | xsns_92 | SCD40    | 0x62        | CO2 sensor Sensirion SCD40/SCD41
   63  | USE_HM330X          | xsns_93 | HM330X   | 0x40        | Particule sensor
   64  | USE_HDC2010         | xsns_94 | HDC2010  | 0x40        | Temperature and Humidity sensor  
+  66  | USE_AT42QT1070      | xsns_96 |AT42QT1070| 0x1B        | Touch Button Sensor

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -659,6 +659,7 @@
 //  #define USE_T67XX                              // [I2cDriver61] Enable Telaire T67XX CO2 sensor (I2C address 0x15) (+1k3 code)
 //  #define USE_HM330X                             // [I2cDriver63] Enable support for SeedStudio Grove Particule sensor (I2C address 0x40) (+1k5 code)
 //  #define USE_HDC2010                            // [I2cDriver64] Enable HDC2010 temperature/humidity sensor (I2C address 0x40) (+1k5 code)
+//  #define USE_AT42QT1070                         // [I2cDriver66] Enable AT42QT1070 Touch Button Sensor (I2C address 0x1B) (+1k5 code)
 //    #define HM330X_DEFAULT_ADDRESS    0x40       // Option: change default I2C address for HM330X used in SeedSTudio Particucle Sensor
 //    #define HM330X_WARMUP_DELAY       30         // Option: change warmup delay during which data are not read from sensor after a power up
 //    #define HM330X_HIDE_OUT_OF_DATE   false      // Option: change to true to hide data from web GUI and SENSOR while sensor is asleep

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -149,6 +149,7 @@
 //#define USE_AM2320                             // [I2cDriver60] Enable AM2320 temperature and humidity Sensor (I2C address 0x5C) (+1k code)
 //#define USE_T67XX                              // [I2cDriver61] Enable Telaire T67XX CO2 sensor (I2C address 0x15) (+1k3 code)
 //#define USE_HDC2010                            // [I2cDriver64] Enable HDC2010 temperature/humidity sensor (I2C address 0x40) (+1k5 code)
+//#define USE_AT42QT1070                         // [I2cDriver66] Enable AT42QT1070 Touch Button sensor (I2C address 0x1B) (+1k5 code)
 
 //#define USE_SPI                                // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
 //#define USE_RC522                              // Add support for MFRC522 13.56Mhz Rfid reader (+6k code)

--- a/tasmota/xsns_96_at42qt1070.ino
+++ b/tasmota/xsns_96_at42qt1070.ino
@@ -1,0 +1,167 @@
+/*
+  xsns_96_at42qt1070.ino - AT42QT1070 touch sensor support for Tasmota
+
+  Copyright (C) 2021  Luc Boudreau
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_AT42QT1070
+
+/*********************************************************************************************\
+ * AT42QT1070 - Touch Controller
+ *
+ * Source:        Luc Boudreau
+ *
+ * I2C Address: 0x1B
+\*********************************************************************************************/
+
+#define XSNS_96             96
+#define XI2C_66             66      // See I2CDEVICES.md
+
+#define AT42QT1070_ADDR              0x1B
+#define AT42QT1070_CHIPID            0x2E
+#define AT42QT1070_REG_CHIPID        0x00
+#define AT42QT1070_REG_KEYSTATUS     0x03
+#define AT42QT1070_REG_RESET         0x39
+#define AT42QT1070_REG_CALIBRATE     0x3801
+
+const char* AT42QT1070_NAME PROGMEM = "AT42QT1070";
+const char at42qt1070_json[] PROGMEM = "\"AT42QT1070\":{\"KEYS\":\"";
+
+struct AT42QT1070 {
+  // Bits 0 to 6 are buttons 0 to 6
+  uint8_t buttonStatusCurrent;
+  uint8_t buttonStatusPrevious;
+};
+
+struct AT42QT1070 *AT42QT1070data = nullptr;
+
+/**
+ * The various initialization steps for this sensor.
+ */
+void AT42QT1070Init(void)  {
+  AT42QT1070data = (AT42QT1070*)calloc(1,sizeof(AT42QT1070));
+  if (!AT42QT1070data) {
+    AddLog(LOG_LEVEL_DEBUG, PSTR("AT42QT1070: out of memory"));
+    return;
+  }
+  // reset
+  Wire.beginTransmission(AT42QT1070_ADDR);
+  Wire.write(AT42QT1070_REG_RESET);
+  Wire.endTransmission();
+  delay(50);
+  //calibrate
+  AT42QT1070Calibrate();
+}
+
+void AT42QT1070Calibrate(void) {
+  Wire.beginTransmission(AT42QT1070_ADDR);
+  Wire.write(AT42QT1070_REG_CALIBRATE);
+  Wire.endTransmission();
+}
+
+/**
+ * Performs a read of all buttons
+ */
+void AT42QT1070Read(void) {
+  AT42QT1070data->buttonStatusCurrent = I2cRead8(AT42QT1070_ADDR, AT42QT1070_REG_KEYSTATUS);
+  for (uint8_t i = 0; i < 7; i++) {
+    bool currentBit = 0 != (AT42QT1070data->buttonStatusCurrent & (1 << i));
+    bool previousBit = 0 != (AT42QT1070data->buttonStatusPrevious & (1 << i));
+    if (currentBit != previousBit) {
+      Response_P(PSTR("{\"%s\":{\"Button%i\":%i}}"), AT42QT1070_NAME, i, currentBit);
+      MqttPublishTeleSensor();
+    }
+  }
+  AT42QT1070data->buttonStatusPrevious = AT42QT1070data->buttonStatusCurrent;
+}
+
+/**
+ * Detects the sensor
+ */
+bool AT42QT1070Detect(void) {
+  if (!I2cSetDevice(AT42QT1070_ADDR)) {
+    return false;
+  }
+  uint8_t chipid = I2cRead8(AT42QT1070_ADDR, AT42QT1070_REG_CHIPID);
+  //AddLog(LOG_LEVEL_DEBUG, PSTR("AT42QT1070Detect: device at address = 0x%02x; chip id 0x%02x"), AT42QT1070_ADDR, chipid);
+  if (chipid = AT42QT1070_CHIPID) {
+    AT42QT1070Init();
+    I2cSetActiveFound(AT42QT1070_ADDR, AT42QT1070_NAME);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Shows the sensor in the ui
+ */
+void AT42QT1070Show(bool json) {
+  if (json) {
+    ResponseAppend_P(PSTR(",\"AT42QT1070\":{"));
+
+    for (uint8_t i = 0; i < 7; i++) {
+      bool currentBit = 0 != (AT42QT1070data->buttonStatusCurrent & (1 << i));
+      if (i > 0) {
+        ResponseAppend_P(PSTR(","));
+      }
+      ResponseAppend_P(PSTR("\"Button%i\":%i"), i, currentBit);
+    }
+    ResponseAppend_P(PSTR("}"));
+  }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns96(uint8_t function)
+{
+  bool result = false;
+  if (!I2cEnabled(XI2C_66)) {
+    return result;
+  }
+
+  if (FUNC_INIT == function) {
+    result = AT42QT1070Detect();
+  }
+  else {
+    if (AT42QT1070data) {
+      switch (function) {
+        //case FUNC_EVERY_SECOND:
+          //AddLog(LOG_LEVEL_DEBUG, PSTR("AT42QT1070 button status: %d"), AT42QT1070data->buttonStatusCurrent);
+          //break;
+        case FUNC_EVERY_100_MSECOND:
+          // Update button status 10/s. Works nice as a baseline.
+          AT42QT1070Read();
+          result = true;
+          break;
+        case FUNC_JSON_APPEND:
+          AT42QT1070Show(1);
+          result = true;
+          break;
+        case FUNC_SAVE_AT_MIDNIGHT:
+          // Recalibrate daily at midnight
+          AT42QT1070Calibrate();
+          break;
+      }
+    }
+  }
+  return result;
+}
+
+#endif  // USE_AT42QT1070
+#endif  // USE_I2C


### PR DESCRIPTION
## Description:

Adds the AT42QT1070 touch sensor

```
00:17:32.500 RSL: STATE = {"Time":"2021-11-12T00:17:32","Uptime":"0T00:00:12","UptimeSec":12,"Heap":121,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":198,"MqttCount":0,"POWER":"OFF","Wifi":{"AP":1,"SSId":"ff","BSSId":"ff:ff","Channel":6,"Mode":"11n","RSSI":96,"Signal":-52,"LinkCount":1,"Downtime":"0T00:00:06"}}
00:17:32.528 RSL: SENSOR = {"Time":"2021-11-12T00:17:32","HDC2010":{"Temperature":24.3,"Humidity":38.3,"DewPoint":9.2},"AT42QT1070":{"Button0":0,"Button1":0,"Button2":0,"Button3":0,"Button4":0,"Button5":0,"Button6":0},"ESP32":{"Temperature":62.2},"TempUnit":"C"}
00:17:32.553 RSL: BLE = {"Time":"2021-11-12T00:17:32","BLEDevices":{"total":0}}
00:17:32.556 RSL: BLE = {"Time":"2021-11-12T00:17:32","BLE":{"scans":0,"adverts":0,"devices":0,"resets":0}}
00:19:27.440 RSL: SENSOR = {"AT42QT1070":{"Button0":1}}
00:19:27.739 RSL: SENSOR = {"AT42QT1070":{"Button0":0}}
00:19:27.839 RSL: SENSOR = {"AT42QT1070":{"Button0":1}}
00:19:28.139 RSL: SENSOR = {"AT42QT1070":{"Button0":0}}
00:19:28.239 RSL: SENSOR = {"AT42QT1070":{"Button0":1}}
00:19:28.538 RSL: SENSOR = {"AT42QT1070":{"Button0":0}}
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_