### PR TITLE
Force Berry and Autoconf to use internal Flash file-system

### DIFF
--- a/lib/libesp32/Berry/default/be_port.cpp
+++ b/lib/libesp32/Berry/default/be_port.cpp
@@ -19,8 +19,8 @@
 #ifdef USE_UFILESYS
     #include <FS.h>
     #include "ZipReadFS.h"
-    extern FS *ufsp;
-    FS zip_ufsp(ZipReadFSImplPtr(new ZipReadFSImpl(&ufsp)));
+    extern FS *ffsp;
+    FS zip_ufsp(ZipReadFSImplPtr(new ZipReadFSImpl(&ffsp)));
 #endif // USE_UFILESYS
 
 /* this file contains configuration for the file system. */
@@ -105,7 +105,7 @@ extern "C" {
             const char *path = be_tostring(vm, 1);
             be_newobject(vm, "list");
 
-            File dir = ufsp->open(path, "r");
+            File dir = ffsp->open(path, "r");
             if (dir) {
                 dir.rewindDirectory();
                 while (1) {


### PR DESCRIPTION
## Description:

Autoconf should always run from internal file-system, even if a SD card is present.

This means that Berry can't access SD_card for now. A specific prefix will be added, probably `/SD`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
