### PR TITLE
BLEDetails2/3/4 JSON change "details" to "DetailsBLE" for more explicit Rule/Berry use

### DIFF
--- a/tasmota/xdrv_79_esp32_ble.ino
+++ b/tasmota/xdrv_79_esp32_ble.ino
@@ -1150,7 +1150,7 @@ void setDetails(ble_advertisment_t *ad){
 
   *(p++) = '{';
   maxlen--;
-  strcpy(p, "\"details\":{");
+  strcpy(p, "\"DetailsBLE\":{");
   int len = strlen(p);
   p += len;
   maxlen -= len;


### PR DESCRIPTION
## Description:

When using `BLEDetails2/3/4` the JSON published leads with "details". This changes that "details" to "DetailsBLE" for more explicit Rule processing. This makes it easier / more explicit to pull into Berry for processing of BLE advertisements to easily support new devices that may not warrant a full source level driver. An example Berry script is below.

```python
tasmota.cmd('BLEAlias AABBCCDDEEFF=ATC1')
tasmota.cmd('BLEDetails4')

import string

var ble_devices = {}
var indent = '    '

def test_print(value, trigger, msg)
  print('-----')
  var p_str = value['p']
  var p = bytes(p_str)
  var i = 0
  var adv_len = 0
  var adv_data = bytes('')
  var adv_type = 0
  var mac = value['mac']
  try
    ble_devices[mac]['p'] = p_str
  except 'key_error'
    ble_devices[mac] = {'p': p_str}
  end
  while i < size(p)
    adv_len = p.get(i,1)
    adv_type = p.get(i+1,1)
    adv_data = p[i+2..i+adv_len]
    print(adv_len, adv_type, adv_data)
    if adv_type == 0x16 # Service Data 16-bit UUID, used by pvvx and ATC advert
      if adv_data[0..1] == bytes('1A18') # little endian of 0x181A
        print(indent, 'ATC or pvvx UUID = 0x1A18, Length =', adv_len)
        if adv_len == 16
            print(indent, indent, 'ATC - 16 Length')
            print(indent, indent, indent, 'Temp', adv_data.geti(8,-2)/10.0)
            print(indent, indent, indent, 'Humi', adv_data.get(10,1))
            print(indent, indent, indent, 'Batt', adv_data.get(11,1))
            print(indent, indent, indent, 'Volt', adv_data.get(12,-2)/1000.0)
        elif adv_len == 18
            print(indent, indent, 'pvvx - 18 Length')
            print(indent, indent, indent, 'Temp', adv_data.geti(8,2)/100.0)
            print(indent, indent, indent, 'Humi', adv_data.get(10,2)/100.0)
            print(indent, indent, indent, 'Batt', adv_data.get(14,1))
            print(indent, indent, indent, 'Volt', adv_data.get(12,2)/1000.0)
        else
            print(indent, indent, 'Unhandled Length')
        end
      else
        print(indent, 'Unhandled UUID', adv_data[0..1], 'with data', adv_data[2..])
      end
    elif adv_type == 0x09 # "Complete Local Name"
      print(indent, 'Device Name',adv_data.asstring()) # present in Govee Adv
    else
      print(indent, 'Unhandled Advertisement Type', adv_type, 'with data', adv_data)
    end
    i = i + adv_len + 1
  end
  print(ble_devices)
end
tasmota.add_rule("DetailsBLE", test_print)
``` 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
