### PR TITLE
Berry fix unary not

### DIFF
--- a/lib/libesp32/Berry/src/be_code.c
+++ b/lib/libesp32/Berry/src/be_code.c
@@ -569,7 +569,7 @@ static void unaryexp(bfuncinfo *finfo, bopcode op, bexpdesc *e)
 /* Apply not to conditional expression */
 /* If literal compute the value */
 /* Or invert t/f subexpressions */
-static void code_not(bexpdesc *e)
+static void code_not(bfuncinfo *finfo, bexpdesc *e)
 {
     switch (e->type) {
     case ETINT: e->v.i = e->v.i == 0; break;
@@ -578,6 +578,7 @@ static void code_not(bexpdesc *e)
     case ETBOOL: e->v.i = !e->v.i; break;
     case ETSTRING: e->v.i = 0; break;
     default: {
+        unaryexp(finfo, OP_MOVE, e);
         int temp = e->t;
         e->t = e->f;
         e->f = temp;
@@ -620,7 +621,7 @@ int be_code_unop(bfuncinfo *finfo, int op, bexpdesc *e)
 {
     switch (op) {
     case OptNot:
-        code_not(e); break;
+        code_not(finfo, e); break;
     case OptFlip: /* do nothing */
         return code_flip(finfo, e);
     case OptSub:


### PR DESCRIPTION
## Description:

Fix unary not. The following code would fail because the not operator would change the value of `i`.
```
def f(i) print(!i, i) end
```

This fix forces the compiler to allocate a new register if needed. The code is not always optimal and a move could be avoided, but it will do it for now.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
