### PR TITLE
Berry simplified preinit and autoexec

### DIFF
--- a/lib/libesp32/Berry/default/berry_conf.h
+++ b/lib/libesp32/Berry/default/berry_conf.h
@@ -100,6 +100,12 @@
  **/
 #define BE_STACK_FREE_MIN               20
 
+/* Macro: BE_STACK_START
+ * Set the starting size of the stack at VM creation.
+ * Default: 50
+ **/
+#define BE_STACK_START                  100
+
 /* Macro: BE_CONST_SEARCH_SIZE
  * Constants in function are limited to 255. However the compiler
  * will look for a maximum of pre-existing constants to avoid

--- a/lib/libesp32/Berry/default/embedded/autoconf.be
+++ b/lib/libesp32/Berry/default/embedded/autoconf.be
@@ -293,6 +293,7 @@ autoconf_module.init = def (m)
       self._error = nil
     end
 
+    # called by the synthetic event `preinit`
     def preinit()
       if self._archive == nil  return end
       # try to launch `preinit.be`
@@ -327,6 +328,7 @@ autoconf_module.init = def (m)
       end
     end
 
+    # called by the synthetic event `autoexec`
     def autoexec()
       if self._archive == nil  return end
       # try to launch `preinit.be`

--- a/lib/libesp32/Berry/src/be_vm.c
+++ b/lib/libesp32/Berry/src/be_vm.c
@@ -453,8 +453,8 @@ BERRY_API bvm* be_vm_new(void)
     be_stack_init(vm, &vm->refstack, sizeof(binstance*));
     be_stack_init(vm, &vm->exceptstack, sizeof(struct bexecptframe));
     be_stack_init(vm, &vm->tracestack, sizeof(bcallsnapshot));
-    vm->stack = be_malloc(vm, sizeof(bvalue) * BE_STACK_FREE_MIN);
-    vm->stacktop = vm->stack + BE_STACK_FREE_MIN;
+    vm->stack = be_malloc(vm, sizeof(bvalue) * BE_STACK_START);
+    vm->stacktop = vm->stack + BE_STACK_START;
     vm->reg = vm->stack;
     vm->top = vm->reg;
     be_globalvar_init(vm);


### PR DESCRIPTION
## Description:

Berry simplified calls during preinit and autoexec, not needing anymore a specific function.

Also, set a higher Berry stack size at startup to spare resizes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
