### PR TITLE
ESP32 fix leftover GPIO configuration after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [10.0.0.3]
 ### Added
 - Autoconfiguration for ESP32 and variants
+- ESP32 fix leftover GPIO configuration after restart
 
 ### Changed
 - ESP8266 Gratuitous ARP enabled and set to 60 seconds (#13623)

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -1651,6 +1651,22 @@ void ResetPwm(void)
 
 /********************************************************************************************/
 
+#ifdef ESP32
+// Since ESP-IDF 4.4, GPIO matrix or I/O is not reset during a restart
+// and GPIO configuration can get stuck because of leftovers
+//
+// This patched version of pinMode forces a full GPIO reset before setting new mode
+//
+extern "C" void ARDUINO_ISR_ATTR __pinMode(uint8_t pin, uint8_t mode);
+
+extern "C" void ARDUINO_ISR_ATTR pinMode(uint8_t pin, uint8_t mode) {
+  gpio_reset_pin((gpio_num_t)pin);
+  __pinMode(pin, mode);
+}
+#endif
+
+/********************************************************************************************/
+
 void GpioInit(void)
 {
   if (!ValidModule(Settings->module)) {


### PR DESCRIPTION
## Description:

After a restart (not reset or power cycle), some internal GPIO configuration (matrix, I/O) might interfere with Arduino's GPIO configuration. For example setting a Relay, restarting, then setting PWM fails.

This PR does a systematic GPIO reset before any new configuration.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
