### PR TITLE
When compiling with LVGL and Universal Display but NOT berry compile error.

### DIFF
--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -363,6 +363,8 @@ extern "C" {
  * We use Adafruit_LvGL_Glue to leverage the Adafruit
  * display ecosystem.
  ************************************************************/
+extern Renderer *Init_uDisplay(const char *desc);
+
 
 void start_lvgl(const char * uconfig);
 void start_lvgl(const char * uconfig) {


### PR DESCRIPTION
If using lvgl and universal display and NOT berry then Init_uDisplay declaration needed.

## Description:

When compiling with LVGL and Universal Display but NOT berry compile error.

C:/Users/mike/Documents/GitHub/Tasmota/tasmota/xdrv_54_lvgl.ino:379:16: error: 'Init_uDisplay' was not declared in this scope
     renderer  = Init_uDisplay((char*)uconfig);

If you want to recreate this compile error, compile for tasmota32-lvgl  and add "#undef USE_BERRY" to #ifdef FIRMWARE_LVGL section in file tasmota_configurations_ESP32.h




**Related issue (if applicable):** fixes #<Tasmota issue number goes here>


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
