### PR TITLE
Berry add gc objects metrics

### DIFF
--- a/lib/libesp32/Berry/src/be_debuglib.c
+++ b/lib/libesp32/Berry/src/be_debuglib.c
@@ -169,6 +169,7 @@ static int m_counters(bvm *vm)
     map_insert(vm, "set", vm->counter_set);
     map_insert(vm, "try", vm->counter_try);
     map_insert(vm, "raise", vm->counter_exc);
+    map_insert(vm, "objects", vm->counter_gc_scanned);
     be_pop(vm, 1);
     be_return(vm);
 }

--- a/lib/libesp32/Berry/src/be_gc.c
+++ b/lib/libesp32/Berry/src/be_gc.c
@@ -497,6 +497,9 @@ static void delete_white(bvm *vm)
                 prev->next = next;
             }
             free_object(vm, node);
+#if BE_USE_PERF_COUNTERS
+            vm->counter_gc_freed++;
+#endif
         } else {
             gc_setwhite(node);
             prev = node;
@@ -537,6 +540,10 @@ void be_gc_collect(bvm *vm)
     if (vm->gc.status & GC_HALT) {
         return; /* the GC cannot run for some reason */
     }
+#if BE_USE_PERF_COUNTERS
+    vm->counter_gc_scanned = 0;
+    vm->counter_gc_freed = 0;
+#endif
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
         (*vm->obshook)(vm, BE_OBS_GC_START, vm->gc.usage);
@@ -559,6 +566,6 @@ void be_gc_collect(bvm *vm)
     vm->gc.threshold = next_threshold(vm->gc);
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage);
+        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_scanned, vm->counter_gc_freed);
 #endif
 }

--- a/lib/libesp32/Berry/src/be_gc.h
+++ b/lib/libesp32/Berry/src/be_gc.h
@@ -37,7 +37,11 @@ if (!gc_isconst(o)) { \
 
 #define gc_setwhite(o)      gc_setmark((o), GC_WHITE)
 #define gc_setgray(o)       gc_setmark((o), GC_GRAY)
-#define gc_setdark(o)       gc_setmark((o), GC_DARK)
+#if BE_USE_PERF_COUNTERS
+    #define gc_setdark(o)       { vm->counter_gc_scanned++; gc_setmark((o), GC_DARK); }
+#else
+    #define gc_setdark(o)       gc_setmark((o), GC_DARK)
+#endif
 #define gc_isfixed(o)       (((o)->marked & GC_FIXED) != 0)
 #define gc_setfixed(o)      ((o)->marked |= GC_FIXED)
 #define gc_clearfixed(o)    ((o)->marked &= ~GC_FIXED)

--- a/lib/libesp32/Berry/src/be_vm.c
+++ b/lib/libesp32/Berry/src/be_vm.c
@@ -472,6 +472,8 @@ BERRY_API bvm* be_vm_new(void)
     vm->counter_set = 0;
     vm->counter_try = 0;
     vm->counter_exc = 0;
+    vm->counter_gc_scanned = 0;
+    vm->counter_gc_freed = 0;
 #endif
     return vm;
 }

--- a/lib/libesp32/Berry/src/be_vm.h
+++ b/lib/libesp32/Berry/src/be_vm.h
@@ -112,6 +112,8 @@ struct bvm {
     uint32_t counter_set; /* counter for SETMBR */
     uint32_t counter_try; /* counter for `try` statement */
     uint32_t counter_exc; /* counter for raised exceptions */
+    uint32_t counter_gc_scanned; /* counter for objects scanned by last gc */
+    uint32_t counter_gc_freed; /* counter for objects freed by last gc */
 #endif
 #if BE_USE_DEBUG_HOOK
     bvalue hook;

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -262,7 +262,10 @@ void BerryObservability(bvm *vm, int event...) {
       {
         int32_t vm_usage2 = va_arg(param, int32_t);
         uint32_t gc_elapsed = millis() - gc_time;
-        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_BERRY "GC from %i to %i bytes (in %d ms)"), vm_usage, vm_usage2, gc_elapsed);
+        uint32_t vm_scanned = va_arg(param, uint32_t);
+        uint32_t vm_freed = va_arg(param, uint32_t);
+        AddLog(LOG_LEVEL_DEBUG, D_LOG_BERRY "GC from %i to %i bytes, objects freed %i/%i (in %d ms)",
+                                vm_usage, vm_usage2, vm_freed, vm_scanned, gc_elapsed);
         // make new threshold tighter when we reach high memory usage
         if (!UsePSRAM() && vm->gc.threshold > 20*1024) {
           vm->gc.threshold = vm->gc.usage + 10*1024;    // increase by only 10 KB


### PR DESCRIPTION
## Description:

Berry add metrics about total number of objects scanned and freed during last GC (garbage collection):

```
(when using Weblog 3)
00:00:00.194 BRY: GC from 6298 to 4892 bytes, objects freed 11/72 (in 1 ms)
```

Total objects scanned also added to `debug.counters()` as `objects` (only available with `#define USE_BERRY_DEBUG`) 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
