### PR TITLE
InfluxDB: Add command IfxPeriod

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -598,7 +598,8 @@ typedef struct {
 
   int8_t        shutter_tilt_config[5][MAX_SHUTTERS];  //508
   int8_t        shutter_tilt_pos[MAX_SHUTTERS];        //51C
-  uint8_t       free_520[12];              // 520
+  uint16_t      influxdb_period;           // 520
+  uint8_t       free_522[10];              // 522
 
   uint16_t      mqtt_keepalive;            // 52C
   uint16_t      mqtt_socket_timeout;       // 52E

--- a/tasmota/xdrv_59_influxdb.ino
+++ b/tasmota/xdrv_59_influxdb.ino
@@ -37,6 +37,7 @@
  * IfxBucket   - Set Influxdb v2 and bucket name
  * IfxOrg      - Set Influxdb v2 and organization
  * IfxToken    - Set Influxdb v2 and token
+ * IfxPeriod   - Set Influxdb period. If not set (or 0), use Teleperiod
  *
  * Set influxdb update interval with command teleperiod
  *
@@ -364,8 +365,9 @@ void InfluxDbPublishPowerState(uint32_t device) {
 void InfluxDbLoop(void) {
   if (!TasmotaGlobal.global_state.network_down) {
     IFDB.interval--;
-    if (IFDB.interval <= 0 || IFDB.interval > Settings->tele_period) {
-      IFDB.interval = Settings->tele_period;
+    uint16_t period = Settings->influxdb_period ? Settings->influxdb_period : Settings->tele_period;
+    if (IFDB.interval <= 0 || IFDB.interval > period) {
+      IFDB.interval = period;
       if (!IFDB.init) {
         if (InfluxDbParameterInit()) {
           IFDB.init = InfluxDbValidateConnection();
@@ -408,20 +410,23 @@ void InfluxDbLoop(void) {
 #define D_CMND_INFLUXDBTOKEN    "Token"
 #define D_CMND_INFLUXDBDATABASE "Database"
 #define D_CMND_INFLUXDBBUCKET   "Bucket"
+#define D_CMND_INFLUXDBPERIOD   "Period"
 
 const char kInfluxDbCommands[] PROGMEM = D_PRFX_INFLUXDB "|"  // Prefix
   "|" D_CMND_INFLUXDBLOG "|"
   D_CMND_INFLUXDBHOST "|" D_CMND_INFLUXDBPORT "|"
   D_CMND_INFLUXDBUSER "|" D_CMND_INFLUXDBORG "|"
   D_CMND_INFLUXDBPASSWORD "|" D_CMND_INFLUXDBTOKEN "|"
-  D_CMND_INFLUXDBDATABASE "|" D_CMND_INFLUXDBBUCKET;
+  D_CMND_INFLUXDBDATABASE "|" D_CMND_INFLUXDBBUCKET "|"
+  D_CMND_INFLUXDBPERIOD;
 
 void (* const InfluxCommand[])(void) PROGMEM = {
   &CmndInfluxDbState, &CmndInfluxDbLog,
   &CmndInfluxDbHost, &CmndInfluxDbPort,
   &CmndInfluxDbUser, &CmndInfluxDbUser,
   &CmndInfluxDbPassword, &CmndInfluxDbPassword,
-  &CmndInfluxDbDatabase, &CmndInfluxDbDatabase };
+  &CmndInfluxDbDatabase, &CmndInfluxDbDatabase,
+  &CmndInfluxDbPeriod };
 
 void InfluxDbReinit(void) {
   IFDB.init = false;
@@ -502,6 +507,16 @@ void CmndInfluxDbDatabase(void) {
     InfluxDbReinit();
   }
   ResponseCmndChar(SettingsText(SET_INFLUXDB_BUCKET));
+}
+
+void CmndInfluxDbPeriod(void) {
+  if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload < 3601)) {
+    Settings->influxdb_period = XdrvMailbox.payload;
+    if(Settings->influxdb_period > 0 && Settings->influxdb_period < 10) {
+      Settings->influxdb_period = 10;
+    }
+  }
+  ResponseCmndNumber(Settings->influxdb_period);
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Discussion (https://github.com/arendst/Tasmota/discussions/13745) with @pkkrusty

Implementing command `IfxPeriod <value>` which allow to specify a period for InfluxDb publication different from `Teleperiod`.
- By default or by specifiying `IfxPeriod 0`, InfluxDb period is same as Teleperiod and will be changed if Teleperiod is changed.
- If set to value 10..3600, the publication period will follow this value. If Teleperiod is changed, it won't impact IfxPeriod.
- If set to value 1..9, the value is forced to 10 (just like Teleperiod)
- Value greater than 3600 are rejected (just like Teleperiod)

Note: As before, even when the InfluxDb publication period uses the Teleperiod value, it is not synced with Teleperiod.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
