### PR TITLE
DisplayDimmer support for M5StickC

### DIFF
--- a/tasmota/berry/drivers/i2c_axp192_M5StickC.be
+++ b/tasmota/berry/drivers/i2c_axp192_M5StickC.be
@@ -85,6 +85,19 @@ class AXP192_M5StickC : AXP192
   def set_lcd_reset(state)
     self.set_ldo_enable(3, state)
   end
+  
+  # Dimmer in percentage
+  def set_displaydimmer(x)
+    var v = tasmota.scale_uint(x, 0, 100, 2500, 3300)
+    self.set_lcd_voltage(v)
+  end
+
+  # respond to display events
+  def display(cmd, idx, payload, raw)
+    if cmd == "dim" || cmd == "power"
+      self.set_displaydimmer(idx)
+    end
+  end
 end
 
 axp = AXP192_M5StickC()


### PR DESCRIPTION
## Description:

Updated AXP192 Berry driver to support DisplayDimmer.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
