### PR TITLE
Berry fix raise counter

### DIFF
--- a/lib/libesp32/Berry/src/be_exec.c
+++ b/lib/libesp32/Berry/src/be_exec.c
@@ -74,6 +74,9 @@ struct filebuf {
 
 void be_throw(bvm *vm, int errorcode)
 {
+#if BE_USE_PERF_COUNTERS
+    vm->counter_exc++;
+#endif
     if (vm->errjmp) {
         vm->errjmp->status = errorcode;
         exec_throw(vm->errjmp);

--- a/lib/libesp32/Berry/src/be_vm.c
+++ b/lib/libesp32/Berry/src/be_vm.c
@@ -1019,9 +1019,6 @@ newframe: /* a new call frame */
             dispatch();
         }
         opcase(RAISE): {
-#if BE_USE_PERF_COUNTERS
-            vm->counter_exc++;
-#endif
             if (IGET_RA(ins) < 2) {  /* A==2 means no arguments are passed to RAISE, i.e. rethrow with current exception */
                 bvalue *top = vm->top;
                 top[0] = *RKB(); /* push the exception value to top */


### PR DESCRIPTION
## Description:

Berry fix `'raise'` counter in `debug.counters()`. It was previously stuck to zero.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
