### PR TITLE
Berry add metrics to teleperiod

### DIFF
--- a/lib/libesp32/Berry/src/be_debuglib.c
+++ b/lib/libesp32/Berry/src/be_debuglib.c
@@ -169,7 +169,7 @@ static int m_counters(bvm *vm)
     map_insert(vm, "set", vm->counter_set);
     map_insert(vm, "try", vm->counter_try);
     map_insert(vm, "raise", vm->counter_exc);
-    map_insert(vm, "objects", vm->counter_gc_scanned);
+    map_insert(vm, "objects", vm->counter_gc_kept);
     be_pop(vm, 1);
     be_return(vm);
 }

--- a/lib/libesp32/Berry/src/be_gc.c
+++ b/lib/libesp32/Berry/src/be_gc.c
@@ -541,7 +541,7 @@ void be_gc_collect(bvm *vm)
         return; /* the GC cannot run for some reason */
     }
 #if BE_USE_PERF_COUNTERS
-    vm->counter_gc_scanned = 0;
+    vm->counter_gc_kept = 0;
     vm->counter_gc_freed = 0;
 #endif
 #if BE_USE_OBSERVABILITY_HOOK
@@ -566,6 +566,6 @@ void be_gc_collect(bvm *vm)
     vm->gc.threshold = next_threshold(vm->gc);
 #if BE_USE_OBSERVABILITY_HOOK
     if (vm->obshook != NULL)
-        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_scanned, vm->counter_gc_freed);
+        (*vm->obshook)(vm, BE_OBS_GC_END, vm->gc.usage, vm->counter_gc_kept, vm->counter_gc_freed);
 #endif
 }

--- a/lib/libesp32/Berry/src/be_gc.h
+++ b/lib/libesp32/Berry/src/be_gc.h
@@ -38,7 +38,7 @@ if (!gc_isconst(o)) { \
 #define gc_setwhite(o)      gc_setmark((o), GC_WHITE)
 #define gc_setgray(o)       gc_setmark((o), GC_GRAY)
 #if BE_USE_PERF_COUNTERS
-    #define gc_setdark(o)       { vm->counter_gc_scanned++; gc_setmark((o), GC_DARK); }
+    #define gc_setdark(o)       { vm->counter_gc_kept++; gc_setmark((o), GC_DARK); }
 #else
     #define gc_setdark(o)       gc_setmark((o), GC_DARK)
 #endif

--- a/lib/libesp32/Berry/src/be_vm.c
+++ b/lib/libesp32/Berry/src/be_vm.c
@@ -472,7 +472,7 @@ BERRY_API bvm* be_vm_new(void)
     vm->counter_set = 0;
     vm->counter_try = 0;
     vm->counter_exc = 0;
-    vm->counter_gc_scanned = 0;
+    vm->counter_gc_kept = 0;
     vm->counter_gc_freed = 0;
 #endif
     return vm;

--- a/lib/libesp32/Berry/src/be_vm.h
+++ b/lib/libesp32/Berry/src/be_vm.h
@@ -112,7 +112,7 @@ struct bvm {
     uint32_t counter_set; /* counter for SETMBR */
     uint32_t counter_try; /* counter for `try` statement */
     uint32_t counter_exc; /* counter for raised exceptions */
-    uint32_t counter_gc_scanned; /* counter for objects scanned by last gc */
+    uint32_t counter_gc_kept; /* counter for objects scanned by last gc */
     uint32_t counter_gc_freed; /* counter for objects freed by last gc */
 #endif
 #if BE_USE_DEBUG_HOOK

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -756,6 +756,11 @@ void MqttShowState(void)
     ESP_getFreeHeap1024(), GetTextIndexed(stemp1, sizeof(stemp1), Settings->flag3.sleep_normal, kSleepMode),  // SetOption60 - Enable normal sleep instead of dynamic sleep
     TasmotaGlobal.sleep, TasmotaGlobal.loop_load_avg, MqttConnectCount());
 
+#ifdef USE_BERRY
+    extern void BrShowState(void);
+    BrShowState();
+#endif // USE_BERRY
+
   for (uint32_t i = 1; i <= TasmotaGlobal.devices_present; i++) {
 #ifdef USE_LIGHT
     if ((LightDevice()) && (i >= LightDevice())) {

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -296,6 +296,17 @@ void BerryObservability(bvm *vm, int event...) {
 }
 
 /*********************************************************************************************\
+ * Adde Berry metrics to teleperiod
+\*********************************************************************************************/
+void BrShowState(void);
+void BrShowState(void) {
+  // trigger a gc first
+  be_gc_collect(berry.vm);
+  ResponseAppend_P(PSTR(",\"Berry\":{\"HeapUsed\":%u,\"Objects\":%u}"),
+    berry.vm->gc.usage / 1024, berry.vm->counter_gc_kept);
+}
+
+/*********************************************************************************************\
  * VM Init
 \*********************************************************************************************/
 void BerryInit(void) {


### PR DESCRIPTION
## Description:

At each teleperiod, a new section is added to JSON:
```
[...] "Berry":{"HeapUsed":13,"Objects":246} [...]
```

- `HeapUsed` (in KB) how many memory is allocated by Berry on the heap
- `Objects` how many individual objects are allocated and used

Prior to sending the JSON, a Berry gc is triggered in order to have consistent and up-to-date metrics.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
