### PR TITLE
Berry fix warning in `tasmota.read_sensors()`

### DIFF
--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -555,6 +555,7 @@ extern "C" {
     if (top >= 2) {
       sensor_display = be_tobool(vm, 2);
     }
+    be_pop(vm, top);    // clear stack to avoid `Error be_top is non zero=1` errors
     ResponseClear();
     if (MqttShowSensor(sensor_display)) {
       // return string


### PR DESCRIPTION
## Description:

Berry fix warning in `tasmota.read_sensors()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
