### PR TITLE
Small bugfix

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -558,6 +558,8 @@ void ShutterUpdatePosition(void)
         //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Pre: Tilt not match %d -> %d, moving: %d"),Shutter[i].tilt_real_pos,Shutter[i].tilt_target_pos,Shutter[i].tiltmoving);
         if (abs(Shutter[i].tilt_real_pos - Shutter[i].tilt_target_pos) > Shutter[i].min_TiltChange && Shutter[i].tiltmoving == 0) {
           AddLog(LOG_LEVEL_INFO, PSTR("SHT: Tilt not match %d -> %d"),Shutter[i].tilt_real_pos,Shutter[i].tilt_target_pos);
+          char databuf[1] = "";
+          XdrvMailbox.data = databuf;
           XdrvMailbox.payload = -99;
           XdrvMailbox.index = i+1;
           Shutter[i].tiltmoving = 1;
@@ -718,6 +720,9 @@ void ShutterRelayChanged(void)
       }
       switch (ShutterGlobal.position_mode) {
         // enum Shutterposition_mode {SHT_TIME, SHT_TIME_UP_DOWN, SHT_TIME_GARAGE, SHT_COUNTER, SHT_PWM_VALUE, SHT_PWM_TIME,};
+        if (powerstate_local > 0) {
+          Shutter[i].tiltmoving = 0;
+        }
         case SHT_TIME_UP_DOWN:
         case SHT_COUNTER:
         case SHT_PWM_VALUE:


### PR DESCRIPTION
Wallbuttons did not work after first use because shutter was in tilt mode.
up/down webbuttons did not stop the shutter correctly in tilt mode

## Description:
#13598 fixed wall button disfunction after first usage in tilt mode

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
