### PR TITLE
Modified to drive shutters through hue emulation (using dummy PWM outs)

### DIFF
--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -510,8 +510,18 @@ void HueLightStatus1(uint8_t device, String *response)
   if (bri < 1)    bri = 1;
 
 #ifdef USE_SHUTTER
-  if (ShutterState(device)) {
-    bri = (float)((Settings->shutter_options[device-1] & 1) ? 100 - Settings->shutter_position[device-1] : Settings->shutter_position[device-1]) / 100;
+  uint8_t shutter = ShutterId(device);
+  if (ShutterState(shutter)) {
+  //  bri = (float)((Settings->shutter_options[device-1] & 1) ? 100 - Settings->shutter_position[device-1] : Settings->shutter_position[device-1]) / 100;
+  
+  // if shutter is moving send the target position instead of the real position. 
+  // This will prevent Alexa to say the device is not working properly when shutter is still moving
+  if (ShutterIsMoving(shutter-1)) { // shutter is moving
+      bri = changeUIntScale(ShutterRealToPercentPosition(ShutterGetTargetPosition(shutter-1), shutter-1), 0, 100, 1,254);
+    }
+   else{
+      bri = changeUIntScale((Settings->shutter_options[shutter-1] & 1) ? 100 - Settings->shutter_position[shutter-1] : Settings->shutter_position[shutter-1], 0, 100, 1,254);
+    }
   }
 #endif
 
@@ -720,6 +730,10 @@ void HueLightsCommand(uint8_t device, uint32_t device_id, String &response) {
   bool change = false;  // need to change a parameter to the light
   uint8_t local_light_subtype = getLocalLightSubtype(device); // get the subtype for this device
 
+  #ifdef USE_SHUTTER
+      uint8_t shutter = ShutterId(device);
+  #endif
+
   const size_t buf_size = 100;
   char * buf = (char*) malloc(buf_size);
   UnishoxStrings msg(HUE_LIGHTS);
@@ -743,13 +757,15 @@ void HueLightsCommand(uint8_t device, uint32_t device_id, String &response) {
                  device_id, on ? PSTR("true") : PSTR("false"));
 
 #ifdef USE_SHUTTER
-      if (ShutterState(device)) {
+      if (ShutterState(shutter)) {
         if (!change) {
           bri = on ? 1.0f : 0.0f; // when bri is not part of this request then calculate it
           change = true;
           resp = true;
           response += buf;        // actually publish the state
         }
+        // turn on/off the real device anyway
+        ExecuteCommandPower(device, (on) ? POWER_ON : POWER_OFF, SRC_HUE);
       } else {
 #endif
         ExecuteCommandPower(device, (on) ? POWER_ON : POWER_OFF, SRC_HUE);
@@ -878,9 +894,10 @@ void HueLightsCommand(uint8_t device, uint32_t device_id, String &response) {
 
     if (change) {
 #ifdef USE_SHUTTER
-      if (ShutterState(device)) {
-        AddLog(LOG_LEVEL_DEBUG, PSTR("Settings->shutter_invert: %d"), Settings->shutter_options[device-1] & 1);
-        ShutterSetPosition(device, bri * 100.0f );
+      if (ShutterState(shutter)) {
+        AddLog(LOG_LEVEL_DEBUG, PSTR("Settings->shutter_invert: %d bri: %d"), Settings->shutter_options[shutter-1] & 1, bri);
+        // ShutterSetPosition(device, bri * 100.0f);
+        ShutterSetPosition(shutter, changeUIntScale(bri, 1, 254, 0, 100));
       } else
 #endif
       if (TasmotaGlobal.light_type && (local_light_subtype > LST_NONE)) {   // not relay
@@ -1075,6 +1092,34 @@ void HandleHueApi(String *path)
   else if (path->endsWith(msg[HUE_RESOURCELINKS])) HueNotImplemented(path);
   else HueGlobalConfig(path);
 }
+
+#ifdef USE_SHUTTER
+///  converts the dummy pwd id to a real shutter id
+uint8_t ShutterId(uint8_t device){
+  uint8_t shutter_num = device;
+  if( TasmotaGlobal.shutters_present>0 && Settings->flag3.shutter_mode){ // <--- should add a SetOption configuration bit? (e.g. Settings->flagXXX.use_dummy_pwm_for_shutters &&)
+    switch(Settings->shutter_mode){ 
+      case 0:
+      case 1:
+      case 2:
+      case 3:
+          if(shutter_num> (TasmotaGlobal.shutters_present * 2) + TasmotaGlobal.shutters_present) return device;
+          shutter_num = device -  TasmotaGlobal.shutters_present * 2; // subtract the used shutters relays from the device id
+          AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("HUE: Changed device id from %d to %d"),device , shutter_num);
+          break;
+      case 4:
+      case 5:
+          if(shutter_num> (TasmotaGlobal.shutters_present * 3) + TasmotaGlobal.shutters_present) return device;
+          shutter_num = device -  TasmotaGlobal.shutters_present * 3; // subtract the used shutters relays and pwm from the device id
+          AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("HUE: Changed device id from %d to %d"),device , shutter_num);
+          break;
+      default:
+        break;
+    }
+  }
+  return shutter_num;
+}
+#endif
 
 /*********************************************************************************************\
  * Interface

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -239,6 +239,14 @@ uint8_t ShutterRealToPercentPosition(int32_t realpos, uint32_t index)
   }
 }
 
+bool ShutterIsMoving(uint8_t i){
+  return ( Shutter[i].direction != 0 ) ? true : false;
+}
+
+int32_t ShutterGetTargetPosition(uint8_t i) {
+  return Shutter[i].target_position;
+}
+
 void ShutterInit(void)
 {
   TasmotaGlobal.shutters_present = 0;


### PR DESCRIPTION
## Description:
This change corrects/enable hue emulation to drive shutters in percentage using pwm.
It will be useful to make entry level users to use just a tasmota device and an Amazon echo to drive shutters  (no need to use an MQTT broker). 
You can say eg. "Alexa set FRIENDLY_NAME to 20%"...

Some code improvements have been done preventing Alexa to say "the device is not working properly": 
  original code was  sending the real positon when shutter still moving so the verify state API message failed, now the target 
  position is sent.

Please see: https://github.com/arendst/Tasmota/discussions/13509#discussioncomment-1635465

If this PR will be approved may be a SetOption configuration bit could be useful to enabe/disable this feature, see line 1100 in xdrv_20_hue.ino file

Thanks

**Related issue (if applicable):** fixes  https://github.com/arendst/Tasmota/discussions/13509#discussioncomment-1635465

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
