### PR TITLE
Berry static methods

### DIFF
--- a/lib/libesp32/Berry/src/be_bytecode.c
+++ b/lib/libesp32/Berry/src/be_bytecode.c
@@ -23,7 +23,7 @@
 #define MAGIC_NUMBER1       0xBE
 #define MAGIC_NUMBER2       0xCD
 #define MAGIC_NUMBER3       0xFE
-#define BYTECODE_VERSION    2
+#define BYTECODE_VERSION    3
 
 #define USE_64BIT_INT       (BE_INTGER_TYPE == 2 \
     || BE_INTGER_TYPE == 1 && LONG_MAX == 9223372036854775807L)
@@ -425,7 +425,7 @@ static void load_class(bvm *vm, void *fp, bvalue *v, int version)
         be_incrtop(vm);
         if (load_proto(vm, fp, (bproto**)&var_toobj(value), -3, version)) {
             /* actual method */
-            be_method_bind(vm, c, name, var_toobj(value));
+            be_method_bind(vm, c, name, var_toobj(value), bfalse);
         } else {
             /* no proto, static member set to nil */
             be_member_bind(vm, c, name, bfalse);

--- a/lib/libesp32/Berry/src/be_class.c
+++ b/lib/libesp32/Berry/src/be_class.c
@@ -75,7 +75,7 @@ void be_member_bind(bvm *vm, bclass *c, bstring *name, bbool var)
     }
 }
 
-void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
+void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p, bbool is_static)
 {
     bclosure *cl;
     bvalue *attr;
@@ -87,6 +87,9 @@ void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p)
     cl = be_newclosure(vm, p->nupvals);
     cl->proto = p;
     var_setclosure(attr, cl);
+    if (is_static) {
+        func_setstatic(attr);
+    }
 }
 
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f)

--- a/lib/libesp32/Berry/src/be_class.h
+++ b/lib/libesp32/Berry/src/be_class.h
@@ -53,7 +53,7 @@ bclass* be_newclass(bvm *vm, bstring *name, bclass *super);
 void be_class_compress(bvm *vm, bclass *c);
 int be_class_attribute(bvm *vm, bclass *c, bstring *attr);
 void be_member_bind(bvm *vm, bclass *c, bstring *name, bbool var);
-void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p);
+void be_method_bind(bvm *vm, bclass *c, bstring *name, bproto *p, bbool is_static);
 void be_prim_method_bind(bvm *vm, bclass *c, bstring *name, bntvfunc f);
 void be_closure_method_bind(bvm *vm, bclass *c, bstring *name, bclosure *cl);
 int be_class_closure_count(bclass *c);

--- a/lib/libesp32/Berry/src/be_constobj.h
+++ b/lib/libesp32/Berry/src/be_constobj.h
@@ -38,6 +38,11 @@ extern "C" {
     .type = BE_FUNCTION                                         \
 }
 
+#define be_const_static_func(_func) {                           \
+    .v.nf = (_func),                                            \
+    .type = BE_FUNCTION | BE_FUNC_STATIC                        \
+}
+
 #define be_const_nil() {                                        \
     .v.i = 0,                                                   \
     .type = BE_NIL                                              \
@@ -86,6 +91,11 @@ extern "C" {
 #define be_const_closure(_closure) {                            \
     .v.c = &(_closure),                                         \
     .type = BE_CLOSURE                                          \
+}
+
+#define be_const_static_closure(_closure) {                     \
+    .v.c = &(_closure),                                         \
+    .type = BE_CLOSURE | BE_FUNC_STATIC                         \
 }
 
 #define be_const_module(_module) {                              \
@@ -251,6 +261,11 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_FUNCTION                                                 \
 }
 
+#define be_const_static_func(_func) {                           \
+    bvaldata(_func),                                            \
+    BE_FUNCTION | BE_FUNC_STATIC                                \
+}
+
 #define be_const_nil() {                                        \
     bvaldata(0),                                                \
     BE_NIL                                                      \
@@ -299,6 +314,11 @@ const bntvmodule be_native_module(_module) = {                  \
 #define be_const_closure(_closure) {                            \
     bvaldata(&(_closure)),                                      \
     BE_CLOSURE                                                  \
+}
+
+#define be_const_static_closure(_closure) {                     \
+    bvaldata(&(_closure)),                                      \
+    BE_CLOSURE | BE_FUNC_STATIC                                 \
 }
 
 #define be_const_module(_module) {                              \

--- a/lib/libesp32/Berry/src/be_gc.c
+++ b/lib/libesp32/Berry/src/be_gc.c
@@ -348,7 +348,7 @@ static void free_instance(bvm *vm, bgcobject *obj)
 
 static void free_object(bvm *vm, bgcobject *obj)
 {
-    switch (obj->type) {
+    switch (var_type(obj)) {
     case BE_STRING: free_lstring(vm, obj); break; /* long string */
     case BE_CLASS: be_free(vm, obj, sizeof(bclass)); break;
     case BE_INSTANCE: free_instance(vm, obj); break;

--- a/lib/libesp32/Berry/src/be_map.c
+++ b/lib/libesp32/Berry/src/be_map.c
@@ -346,5 +346,7 @@ bmapnode* be_map_val2node(bvalue *value)
 void be_map_release(bvm *vm, bmap *map)
 {
     (void)vm;
-    resize(vm, map, map->count ? map->count : 1);
+    if (!gc_isconst(map)) {
+        resize(vm, map, map->count ? map->count : 1);
+    }
 }

--- a/lib/libesp32/Berry/src/be_object.h
+++ b/lib/libesp32/Berry/src/be_object.h
@@ -11,25 +11,30 @@
 #include "berry.h"
 
 /* basic types, do not change value */
-#define BE_NONE         (-1)    /* unknown type */
-#define BE_COMPTR       (-2)    /* common pointer */
-#define BE_INDEX        (-3)    /* index for instance variable, previously BE_INT */
 #define BE_NIL          0
 #define BE_INT          1
 #define BE_REAL         2
 #define BE_BOOL         3
-#define BE_FUNCTION     4
-#define BE_STRING       5       /* from this type can be gced, see BE_GCOBJECT */
-#define BE_CLASS        6
-#define BE_INSTANCE     7
-#define BE_PROTO        8
-#define BE_LIST         9
-#define BE_MAP          10
-#define BE_MODULE       11
-#define BE_COMOBJ       12      /* common object */
+#define BE_NONE         4       /* unknown type */
+#define BE_COMPTR       5       /* common pointer */
+#define BE_INDEX        6       /* index for instance variable, previously BE_INT */
+#define BE_FUNCTION     7
+#define BE_STRING       8       /* from this type can be gced, see BE_GCOBJECT */
+#define BE_CLASS        9
+#define BE_INSTANCE     10
+#define BE_PROTO        11
+#define BE_LIST         12
+#define BE_MAP          13
+#define BE_MODULE       14
+#define BE_COMOBJ       15      /* common object */
 #define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)
 #define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)
 #define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)
+#define BE_FUNC_STATIC  (1 << 7)
+
+#define func_isstatic(o)       (((o)->type & BE_FUNC_STATIC) != 0)
+#define func_setstatic(o)      ((o)->type |= BE_FUNC_STATIC)
+#define func_clearstatic(o)    ((o)->type &= ~BE_FUNC_STATIC)
 
 #define array_count(a)   (sizeof(a) / sizeof((a)[0]))
 
@@ -187,7 +192,7 @@ typedef const char* (*breader)(void*, size_t*);
 #define cast_bool(_v)           cast(bbool, _v)
 #define basetype(_t)            ((_t) & 0x1F)
 
-#define var_type(_v)            ((_v)->type)
+#define var_type(_v)            ((_v)->type & 0x7F)
 #define var_basetype(_v)        basetype((_v)->type)
 #define var_istype(_v, _t)      (var_type(_v) == _t)
 #define var_settype(_v, _t)     ((_v)->type = _t)

--- a/lib/libesp32/Berry/src/be_string.c
+++ b/lib/libesp32/Berry/src/be_string.c
@@ -57,12 +57,18 @@ int be_eqstr(bstring *s1, bstring *s2)
     }
     /* const short strings */
     if (gc_isconst(s1) || gc_isconst(s2)) { /* one of the two string is short const */
-        if (cast(bcstring*, s1)->hash && cast(bcstring*, s2)->hash) {
-            return 0; /* if they both have a hash, then we know they are different */
+        uint32_t hash1 = cast(bcstring*, s1)->hash;
+        uint32_t hash2 = cast(bcstring*, s2)->hash;
+        if (hash1 && hash2 && hash1 != hash2) {
+            return 0; /* if hash differ, since we know both are non-null */
         }
+        /* if hash are equals, there might be a chance that they are different */
+        /* This can happen with solidified code that a same string is present more than once */
+        /* so just considering that two strings with the same hash must be same pointer, this is no more true */
         return !strcmp(str(s1), str(s2));
     }
 
+    /* if both strings are in-memory, they can't be equal without having the same pointer */
     return 0;
 }
 


### PR DESCRIPTION
## Description:

Berry static methods

Staring from now, if members of classes or instances are functions, they are never considered as a method. So any call will no longer add an implicit `self` depending on the calling syntax.

Before:
```
> class A static f = def(x) return x end end
> a = A()
> a.f(1)
<instance: A()>      # argument x is actually `self`
```

After
```
> class A static f = def(x) return x end end
> a = A()
> a.f(1)
1
```

## New syntax

There is now a new simplified syntax for static methods:

```
class <class_name>
    static def <name>(<args>)
        <body>
   end
end
```

This syntax is more or less equivalent to:

```
class <class_name>
    static <name> = def (<args>)
        <body>
    end
end
```


## Call static methods through classes

If a static class method is declared, you can now call it via the class object. This is useful when you don't have any instance of the class.

```
> class A static f = def(x) return x end end
> A.f(1)
1
```

## Bytecode breaking change

This update required to change internal structure. As a consequence, pre-compiled bytecode (.bec files) are not compatible anymore and need to be compiled again.

Module `solidify` has been updated to support this new function type. Any former solidified code that used a function/closure as a static class member needs to be re-solidified.



## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
