### PR TITLE
OTA follows redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Preliminary support for Tasmota Apps (.tapp extesions)
 - Berry support for neopixel (WS2812, SK6812)
 - Command ``IfxPeriod `` to overrule ``Teleperiod`` for Influx messages (#13750)
-- OTA over HTTPS
+- OTA over HTTPS (ESP32x only)
 
 ### Changed
 - ESP8266 Gratuitous ARP enabled and set to 60 seconds (#13623)

--- a/lib/libesp32/Berry-HttpClientLight/src/HTTPUpdateLight.cpp
+++ b/lib/libesp32/Berry-HttpClientLight/src/HTTPUpdateLight.cpp
@@ -39,13 +39,13 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
 HTTPUpdateLight::HTTPUpdateLight(void)
         : _httpClientTimeout(8000), _ledPin(-1)
 {
-    _followRedirects = HTTPC_DISABLE_FOLLOW_REDIRECTS;
+    _followRedirects = HTTPC_STRICT_FOLLOW_REDIRECTS;
 }
 
 HTTPUpdateLight::HTTPUpdateLight(int httpClientTimeout)
         : _httpClientTimeout(httpClientTimeout), _ledPin(-1)
 {
-    _followRedirects = HTTPC_DISABLE_FOLLOW_REDIRECTS;
+    _followRedirects = HTTPC_STRICT_FOLLOW_REDIRECTS;
 }
 
 HTTPUpdateLight::~HTTPUpdateLight(void)


### PR DESCRIPTION
## Description:

OTA now follows redirects which makes it easier to flash directly from Github.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
