### PR TITLE
Berry renumber internal types to allow for extensions

### DIFF
--- a/lib/libesp32/Berry/src/be_gc.h
+++ b/lib/libesp32/Berry/src/be_gc.h
@@ -10,8 +10,6 @@
 
 #include "be_object.h"
 
-#define BE_GCOBJECT         BE_STRING
-
 #define gc_object(o)        cast(bgcobject*, o)
 #define gc_cast(o, t, T)    ((o) && (o)->type == (t) ? (T*)(o) : NULL)
 #define cast_proto(o)       gc_cast(o, BE_PROTO, bproto)

--- a/lib/libesp32/Berry/src/be_object.h
+++ b/lib/libesp32/Berry/src/be_object.h
@@ -19,14 +19,18 @@
 #define BE_COMPTR       5       /* common pointer */
 #define BE_INDEX        6       /* index for instance variable, previously BE_INT */
 #define BE_FUNCTION     7
-#define BE_STRING       8       /* from this type can be gced, see BE_GCOBJECT */
-#define BE_CLASS        9
-#define BE_INSTANCE     10
-#define BE_PROTO        11
-#define BE_LIST         12
-#define BE_MAP          13
-#define BE_MODULE       14
-#define BE_COMOBJ       15      /* common object */
+
+#define BE_GCOBJECT     16      /* from this type can be gced */
+
+#define BE_STRING       16
+#define BE_CLASS        17
+#define BE_INSTANCE     18
+#define BE_PROTO        19
+#define BE_LIST         20
+#define BE_MAP          21
+#define BE_MODULE       22
+#define BE_COMOBJ       23      /* common object */
+
 #define BE_NTVFUNC      ((0 << 5) | BE_FUNCTION)
 #define BE_CLOSURE      ((1 << 5) | BE_FUNCTION)
 #define BE_NTVCLOS      ((2 << 5) | BE_FUNCTION)


### PR DESCRIPTION
## Description:

Renumber internal types to separate in two distinct groups GC and non GC types, and allow for possible extensions without breaking future bytecode .bec pre-compiled code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
