### PR TITLE
Berry list.keys()

### DIFF
--- a/lib/libesp32/Berry/generate/be_fixed_be_class_list.h
+++ b/lib/libesp32/Berry/generate/be_fixed_be_class_list.h
@@ -1,32 +1,33 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(be_class_list_map) {
-    { be_const_key(concat, -1), be_const_func(m_concat) },
-    { be_const_key(push, -1), be_const_func(m_push) },
-    { be_const_key(insert, 1), be_const_func(m_insert) },
-    { be_const_key(find, -1), be_const_func(m_find) },
-    { be_const_key(remove, 9), be_const_func(m_remove) },
-    { be_const_key(clear, -1), be_const_func(m_clear) },
-    { be_const_key(size, -1), be_const_func(m_size) },
-    { be_const_key(resize, 13), be_const_func(m_resize) },
-    { be_const_key(copy, -1), be_const_func(m_copy) },
-    { be_const_key(pop, -1), be_const_func(m_pop) },
-    { be_const_key(tostring, 3), be_const_func(m_tostring) },
-    { be_const_key(opt_eq, -1), be_const_func(m_equal) },
+    { be_const_key(opt_add, -1), be_const_func(m_merge) },
     { be_const_key(init, -1), be_const_func(m_init) },
-    { be_const_key(dot_p, 17), be_const_var(0) },
+    { be_const_key(opt_connect, 11), be_const_func(m_connect) },
+    { be_const_key(tostring, 2), be_const_func(m_tostring) },
+    { be_const_key(pop, 6), be_const_func(m_pop) },
+    { be_const_key(insert, -1), be_const_func(m_insert) },
+    { be_const_key(size, -1), be_const_func(m_size) },
+    { be_const_key(remove, 12), be_const_func(m_remove) },
+    { be_const_key(find, -1), be_const_func(m_find) },
+    { be_const_key(push, 1), be_const_func(m_push) },
+    { be_const_key(item, 5), be_const_func(m_item) },
+    { be_const_key(concat, -1), be_const_func(m_concat) },
+    { be_const_key(dot_p, -1), be_const_var(0) },
+    { be_const_key(iter, -1), be_const_func(m_iter) },
+    { be_const_key(copy, -1), be_const_func(m_copy) },
+    { be_const_key(reverse, 13), be_const_func(m_reverse) },
+    { be_const_key(keys, -1), be_const_func(m_keys) },
+    { be_const_key(resize, 16), be_const_func(m_resize) },
     { be_const_key(setitem, -1), be_const_func(m_setitem) },
-    { be_const_key(opt_connect, 4), be_const_func(m_connect) },
-    { be_const_key(opt_neq, -1), be_const_func(m_nequal) },
-    { be_const_key(opt_add, 18), be_const_func(m_merge) },
-    { be_const_key(iter, 20), be_const_func(m_iter) },
-    { be_const_key(item, -1), be_const_func(m_item) },
-    { be_const_key(reverse, -1), be_const_func(m_reverse) },
+    { be_const_key(opt_neq, 7), be_const_func(m_nequal) },
+    { be_const_key(clear, -1), be_const_func(m_clear) },
+    { be_const_key(opt_eq, -1), be_const_func(m_equal) },
 };
 
 static be_define_const_map(
     be_class_list_map,
-    21
+    22
 );
 
 BE_EXPORT_VARIABLE be_define_const_class(

--- a/lib/libesp32/Berry/src/be_listlib.c
+++ b/lib/libesp32/Berry/src/be_listlib.c
@@ -432,6 +432,19 @@ static int list_equal(bvm *vm, bbool iseq)
     be_return(vm);
 }
 
+static int m_keys(bvm *vm)
+{
+    be_getmember(vm, 1, ".p");
+    list_check_data(vm, 1);
+    int size = be_data_size(vm, -1);
+    be_getbuiltin(vm, "range");
+    be_pushint(vm, 0);
+    be_pushint(vm, size - 1);
+    be_call(vm, 2);
+    be_pop(vm, 2);
+    be_return(vm);
+}
+
 static int m_equal(bvm *vm)
 {
     return list_equal(vm, btrue);
@@ -463,6 +476,7 @@ void be_load_listlib(bvm *vm)
         { "concat", m_concat },
         { "reverse", m_reverse },
         { "copy", m_copy },
+        { "keys", m_keys },
         { "..", m_connect },
         { "+", m_merge },
         { "==", m_equal },
@@ -491,6 +505,7 @@ class be_class_list (scope: global, name: list) {
     concat, func(m_concat)
     reverse, func(m_reverse)
     copy, func(m_copy)
+    keys, func(m_keys)
     .., func(m_connect)
     +, func(m_merge)
     ==, func(m_equal)


### PR DESCRIPTION
## Description:

Add `list.keys()` returning a `range` object from a list. This mirror the `keys()` method of a map.
In effect, the range is `(0 .. size(<list>)-1)`

Example:
```
> l1 = ["a", nil, "b"]
> size(l1)
3

> l1.keys()
(0..2)

> for i:l1.keys()  print(l1[i]) end
a
nil
b

> [].keys()    # empty list
(0..-1)     # empty range

> # don't forget that the simplest way to iterate through a list is:
> for e:l1 print(e) end
a
nil
b
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
