### PR TITLE
add #define USE_WEBCLIENT_HTTPS

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -81,7 +81,7 @@ lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display
 
 [env:tasmota32-lvgl]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL -DUSE_AUTOCONF
 board_build.f_cpu       = 160000000L
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -73,6 +73,8 @@
 #define USE_ODROID_GO                            // Add support for Odroid Go
 #define USE_SDCARD
 
+#define USE_WEBCLIENT_HTTPS
+
 #undef USE_HOME_ASSISTANT
 
 #define USE_I2C
@@ -112,6 +114,8 @@
   #define USE_I2S_SAY_TIME
   #define USE_I2S_WEBRADIO
 #define USE_SDCARD
+
+#define USE_WEBCLIENT_HTTPS
 
 #define USE_I2C
   #define USE_BMA423
@@ -199,6 +203,8 @@
 
 #undef USE_DOMOTICZ
 #undef USE_HOME_ASSISTANT
+
+#define USE_WEBCLIENT_HTTPS
 
 #define USE_I2S
 #define USE_SPI


### PR DESCRIPTION
- for some env (ODroid-Go M5 stack core 2 and lvgl). To make it possible to do OTA easily for own builded firmwares stored for example in github which needs https
- Enable Autoconfig for lvgl env
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
