### PR TITLE
Add HTTPS support to `WebQuery` and `WebGetConfig` (ESP32x only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Command ``IfxPeriod `` to overrule ``Teleperiod`` for Influx messages (#13750)
 - OTA over HTTPS (ESP32x only)
 - Berry add ``import re`` regex module
+- Add HTTPS support to ``WebQuery`` (ESP32x only)
 
 ### Changed
 - ESP8266 Gratuitous ARP enabled and set to 60 seconds (#13623)

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3117,8 +3117,12 @@ int WebQuery(char *buffer)
   // An unlimited number of headers can be sent per request, and a body can be sent for all command types
   // The body will be ignored if sending a GET command
 
+#if defined(ESP32) && defined(USE_WEBCLIENT_HTTPS)
+  HTTPClientLight http;
+#else // HTTP only
   WiFiClient http_client;
   HTTPClient http;
+#endif
 
   int status = WEBCMND_WRONG_PARAMETERS;
 
@@ -3127,7 +3131,11 @@ int WebQuery(char *buffer)
   char *method = strtok_r(temp, " ", &temp);
 
   if (url && method) {
+#if defined(ESP32) && defined(USE_WEBCLIENT_HTTPS)
+    if (http.begin(UrlEncode(url))) {
+#else // HTTP only
     if (http.begin(http_client, UrlEncode(url))) {
+#endif
       char empty_body[1] = { 0 };
       char *body = empty_body;
       if (temp) {                             // There is a body and/or header
@@ -3204,9 +3212,15 @@ int WebGetConfig(char *buffer)
 
   DEBUG_CORE_LOG(PSTR("WEB: Config Uri '%s'"), url.c_str());
 
+
+#if defined(ESP32) && defined(USE_WEBCLIENT_HTTPS)
+  HTTPClientLight http;
+  if (http.begin(UrlEncode(url))) {  // UrlEncode(url) = |http://192.168.178.86/cm?cmnd=POWER1%20ON|
+#else // HTTP only
   WiFiClient http_client;
   HTTPClient http;
   if (http.begin(http_client, UrlEncode(url))) {  // UrlEncode(url) = |http://192.168.178.86/cm?cmnd=POWER1%20ON|
+#endif
     int http_code = http.GET();             // Start connection and send HTTP header
     if (http_code > 0) {                    // http_code will be negative on error
       status = WEBCMND_DONE;


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
