### PR TITLE
Berry fix list.concat

### DIFF
--- a/lib/libesp32/Berry/tests/list.be
+++ b/lib/libesp32/Berry/tests/list.be
@@ -72,3 +72,58 @@ assert(l2 == [2, 3])
 assert(l1+[2] == [0, 1, 2])
 assert([-1]+l1 == [-1, 0, 1])
 assert(l1 == [0, 1])
+
+#- find -#
+#- if no argument return nil -#
+assert([].find() == nil)
+assert([1,2].find() == nil)
+assert([1,1,nil,2].find() == nil)
+
+#- nil if not found -#
+assert([1,2].find(3) == nil)
+assert([1,2].find(true) == nil)
+assert([1,2].find('foo') == nil)
+
+#- if found -#
+assert([1,2,3,4].find(1) == 0)
+assert([1,2,3,4].find(2) == 1)
+assert([1,2,3,4].find(3) == 2)
+assert([1,2,3,4].find(4) == 3)
+assert([1,2,"foo",4].find('foo') == 2)
+
+#- if multiple occurrences -#
+assert([1,1,2,2].find(1) == 0)
+assert([1,1,2,2].find(2) == 2)
+
+#- look for nil -#
+assert([1,1,nil,2].find(nil) == 2)
+
+#- sub-structure -#
+assert([1,[1,nil,2],3,[3]].find(3) == 2)
+assert([1,[1,nil,2],3,[3]].find([3]) == 3)
+assert([1,[1,nil,2],3,[3]].find([1,nil,2]) == 1)
+
+#- keys() -#
+assert(str(["a",'b',0].keys()) == "(0..2)")
+assert(str([nil].keys()) == "(0..0)")
+assert(str([].keys()) == "(0..-1)")
+
+#- concat with delimiter -#
+assert(["foo","bar",0].concat() == "foobar0")
+assert([1,2,3].concat() == "123")
+assert(["foo","bar",0].concat('') == "foobar0")
+assert([1,2,3].concat('') == "123")
+
+assert(["foo","bar",0].concat('-') == "foo-bar-0")
+assert([].concat('<->') == "")
+assert(["foo"].concat('<->') == "foo")
+assert(["foo","bar",0].concat('<->') == "foo<->bar<->0")
+
+assert(["","foo","bar",0].concat('<->') == "<->foo<->bar<->0")
+assert(["","",1,"bar",0].concat('<->') == "<-><->1<->bar<->0")
+assert(["","",1,"bar",0].concat('') == "1bar0")
+
+assert([1,2,3].concat('-') == "1-2-3")
+assert([1,"2",3].concat('-') == "1-2-3")
+
+assert(["",2,3].concat('-') == "-2-3")


### PR DESCRIPTION
## Description:

Berry fix `list.concat(<delimiter>)` and add test cases.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
