### PR TITLE
Berry add `bool()` function

### DIFF
--- a/lib/libesp32/Berry/src/be_baselib.c
+++ b/lib/libesp32/Berry/src/be_baselib.c
@@ -340,6 +340,17 @@ static int l_str(bvm *vm)
     be_return(vm);
 }
 
+static int l_bool(bvm *vm)
+{
+    if (be_top(vm)) {
+        be_pushbool(vm, be_tobool(vm, 1));
+    } else {
+        be_pushbool(vm, bfalse);
+    }
+    be_return(vm);
+}
+
+
 static int l_size(bvm *vm)
 {
     if (be_top(vm) && be_isstring(vm, 1)) {
@@ -462,9 +473,10 @@ void be_load_baselib(bvm *vm)
 }
 
 /* call must be added later to respect order of builtins */
-void be_load_baselib_call(bvm *vm)
+void be_load_baselib_next(bvm *vm)
 {
     be_regfunc(vm, "call", l_call);
+    be_regfunc(vm, "bool", l_bool);
 }
 #else
 extern const bclass be_class_list;
@@ -497,6 +509,7 @@ vartab m_builtin (scope: local) {
     range, class(be_class_range)
     bytes, class(be_class_bytes)
     call, func(l_call)
+    bool, func(l_bool)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_m_builtin.h"

--- a/lib/libesp32/Berry/src/be_libs.c
+++ b/lib/libesp32/Berry/src/be_libs.c
@@ -8,7 +8,7 @@
 #include "be_libs.h"
 
 extern void be_load_baselib(bvm *vm);
-extern void be_load_baselib_call(bvm *vm);
+extern void be_load_baselib_next(bvm *vm);
 extern void be_load_listlib(bvm *vm);
 extern void be_load_maplib(bvm *vm);
 extern void be_load_rangelib(bvm *vm);
@@ -24,6 +24,6 @@ void be_loadlibs(bvm *vm)
     be_load_rangelib(vm);
     be_load_filelib(vm);
     be_load_byteslib(vm);
-    be_load_baselib_call(vm);
+    be_load_baselib_next(vm);
 #endif
 }

--- a/lib/libesp32/Berry/tests/bool.be
+++ b/lib/libesp32/Berry/tests/bool.be
@@ -16,3 +16,24 @@ def test(a, b)
     end
 end
 test(true, true)
+
+# bug in unary 
+def f(i)
+    var j = !i       # bug if i is erroneously modified
+    return i
+end
+assert(f(1) == 1)
+
+#- addind bool() function -#
+assert(bool() == false)
+assert(bool(0) == false)
+assert(bool(0.0) == false)
+assert(bool(false) == false)
+assert(bool(nil) == false)
+
+assert(bool(-1) == true)
+assert(bool(3.5) == true)
+assert(bool('') == true)
+assert(bool('a') == true)
+assert(bool(list) == true)
+assert(bool(list()) == true)


### PR DESCRIPTION
## Description:

### add `bool()` function

Similarly to `str()`, `int()`... Adding `bool()` to convert any value to its bool value. `bool(v)` is equivalent to `!!v`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
