### PR TITLE
Berry Leds support for serpentine matrix

### DIFF
--- a/lib/libesp32/Berry/default/be_leds_lib.c
+++ b/lib/libesp32/Berry/default/be_leds_lib.c
@@ -9,7 +9,7 @@
 /********************************************************************
 ** Solidified function: get_pixel_color
 ********************************************************************/
-be_local_closure(get_pixel_color,   /* name */
+be_local_closure(Leds_get_pixel_color,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
@@ -20,7 +20,7 @@ be_local_closure(get_pixel_color,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("get_pixel_color", 337490048, 15)),
     ((bstring*) &be_const_str_input),
@@ -39,7 +39,7 @@ be_local_closure(get_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: pixels_buffer
 ********************************************************************/
-be_local_closure(pixels_buffer,   /* name */
+be_local_closure(Leds_pixels_buffer,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -50,7 +50,7 @@ be_local_closure(pixels_buffer,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("pixels_buffer", 1229555807, 13)),
     ((bstring*) &be_const_str_input),
@@ -68,7 +68,7 @@ be_local_closure(pixels_buffer,   /* name */
 /********************************************************************
 ** Solidified function: clear
 ********************************************************************/
-be_local_closure(clear,   /* name */
+be_local_closure(Leds_clear,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -79,9 +79,9 @@ be_local_closure(clear,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_string("clear_to", -766965166, 8),
+    /* K0   */  be_nested_str_literal("clear_to"),
     /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_string("show", -1454906820, 4),
+    /* K2   */  be_nested_str_literal("show"),
     }),
     (be_nested_const_str("clear", 1550717474, 5)),
     ((bstring*) &be_const_str_input),
@@ -101,10 +101,10 @@ be_local_closure(clear,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-be_local_closure(init,   /* name */
+be_local_closure(Leds_init,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
+    11,                          /* nstack */
+    5,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -112,52 +112,53 @@ be_local_closure(init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_string("gamma", -802614262, 5),
-    /* K1   */  be_nested_string("pin", 1866532500, 3),
-    /* K2   */  be_nested_string("WS2812", -755226078, 6),
+    /* K0   */  be_nested_str_literal("gamma"),
+    /* K1   */  be_nested_str_literal("pin"),
+    /* K2   */  be_nested_str_literal("WS2812"),
     /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_string("valuer_error", -1727020191, 12),
-    /* K5   */  be_nested_string("no GPIO specified for neopixelbus", 42078528, 33),
-    /* K6   */  be_nested_string("ctor", 375399343, 4),
-    /* K7   */  be_nested_string("_p", 1594591802, 2),
-    /* K8   */  be_nested_string("internal_error", -1775809127, 14),
-    /* K9   */  be_nested_string("couldn't not initialize noepixelbus", -1758476484, 35),
-    /* K10  */  be_nested_string("begin", 1748273790, 5),
+    /* K4   */  be_nested_str_literal("valuer_error"),
+    /* K5   */  be_nested_str_literal("no GPIO specified for neopixelbus"),
+    /* K6   */  be_nested_str_literal("ctor"),
+    /* K7   */  be_nested_str_literal("_p"),
+    /* K8   */  be_nested_str_literal("internal_error"),
+    /* K9   */  be_nested_str_literal("couldn't not initialize noepixelbus"),
+    /* K10  */  be_nested_str_literal("begin"),
     }),
     (be_nested_const_str("init", 380752755, 4)),
     ((bstring*) &be_const_str_input),
-    ( &(const binstruction[31]) {  /* code */
-      0x50100200,  //  0000  LDBOOL	R4	1	0
-      0x90020004,  //  0001  SETMBR	R0	K0	R4
-      0x4C100000,  //  0002  LDNIL	R4
-      0x1C100404,  //  0003  EQ	R4	R2	R4
-      0x78120008,  //  0004  JMPF	R4	#000E
-      0x8C100501,  //  0005  GETMET	R4	R2	K1
-      0x88180502,  //  0006  GETMBR	R6	R2	K2
-      0x7C100400,  //  0007  CALL	R4	2
-      0x28100903,  //  0008  GE	R4	R4	K3
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x8C100501,  //  000A  GETMET	R4	R2	K1
-      0x88180502,  //  000B  GETMBR	R6	R2	K2
-      0x7C100400,  //  000C  CALL	R4	2
-      0x5C080800,  //  000D  MOVE	R2	R4
-      0x4C100000,  //  000E  LDNIL	R4
-      0x1C100404,  //  000F  EQ	R4	R2	R4
-      0x78120000,  //  0010  JMPF	R4	#0012
+    ( &(const binstruction[32]) {  /* code */
+      0x50140200,  //  0000  LDBOOL	R5	1	0
+      0x90020005,  //  0001  SETMBR	R0	K0	R5
+      0x4C140000,  //  0002  LDNIL	R5
+      0x1C140405,  //  0003  EQ	R5	R2	R5
+      0x78160008,  //  0004  JMPF	R5	#000E
+      0x8C140501,  //  0005  GETMET	R5	R2	K1
+      0x881C0502,  //  0006  GETMBR	R7	R2	K2
+      0x7C140400,  //  0007  CALL	R5	2
+      0x28140B03,  //  0008  GE	R5	R5	K3
+      0x78160003,  //  0009  JMPF	R5	#000E
+      0x8C140501,  //  000A  GETMET	R5	R2	K1
+      0x881C0502,  //  000B  GETMBR	R7	R2	K2
+      0x7C140400,  //  000C  CALL	R5	2
+      0x5C080A00,  //  000D  MOVE	R2	R5
+      0x4C140000,  //  000E  LDNIL	R5
+      0x1C140405,  //  000F  EQ	R5	R2	R5
+      0x78160000,  //  0010  JMPF	R5	#0012
       0xB0060905,  //  0011  RAISE	1	K4	K5
-      0x8C100106,  //  0012  GETMET	R4	R0	K6
-      0x5C180200,  //  0013  MOVE	R6	R1
-      0x5C1C0400,  //  0014  MOVE	R7	R2
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x7C100800,  //  0016  CALL	R4	4
-      0x88100107,  //  0017  GETMBR	R4	R0	K7
-      0x4C140000,  //  0018  LDNIL	R5
-      0x1C100805,  //  0019  EQ	R4	R4	R5
-      0x78120000,  //  001A  JMPF	R4	#001C
-      0xB0061109,  //  001B  RAISE	1	K8	K9
-      0x8C10010A,  //  001C  GETMET	R4	R0	K10
-      0x7C100200,  //  001D  CALL	R4	1
-      0x80000000,  //  001E  RET	0
+      0x8C140106,  //  0012  GETMET	R5	R0	K6
+      0x5C1C0200,  //  0013  MOVE	R7	R1
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C140A00,  //  0017  CALL	R5	5
+      0x88140107,  //  0018  GETMBR	R5	R0	K7
+      0x4C180000,  //  0019  LDNIL	R6
+      0x1C140A06,  //  001A  EQ	R5	R5	R6
+      0x78160000,  //  001B  JMPF	R5	#001D
+      0xB0061109,  //  001C  RAISE	1	K8	K9
+      0x8C14010A,  //  001D  GETMET	R5	R0	K10
+      0x7C140200,  //  001E  CALL	R5	1
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -167,7 +168,7 @@ be_local_closure(init,   /* name */
 /********************************************************************
 ** Solidified function: set_pixel_color
 ********************************************************************/
-be_local_closure(set_pixel_color,   /* name */
+be_local_closure(Leds_set_pixel_color,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     4,                          /* argc */
@@ -178,8 +179,8 @@ be_local_closure(set_pixel_color,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
-    /* K1   */  be_nested_string("to_gamma", 1597139862, 8),
+    /* K0   */  be_nested_str_literal("call_native"),
+    /* K1   */  be_nested_str_literal("to_gamma"),
     }),
     (be_nested_const_str("set_pixel_color", 1275248356, 15)),
     ((bstring*) &be_const_str_input),
@@ -202,7 +203,7 @@ be_local_closure(set_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: begin
 ********************************************************************/
-be_local_closure(begin,   /* name */
+be_local_closure(Leds_begin,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -213,7 +214,7 @@ be_local_closure(begin,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     /* K1   */  be_const_int(1),
     }),
     (be_nested_const_str("begin", 1748273790, 5)),
@@ -232,7 +233,7 @@ be_local_closure(begin,   /* name */
 /********************************************************************
 ** Solidified function: to_gamma
 ********************************************************************/
-be_local_closure(to_gamma,   /* name */
+be_local_closure(Leds_to_gamma,   /* name */
   be_nested_proto(
     12,                          /* nstack */
     3,                          /* argc */
@@ -243,13 +244,13 @@ be_local_closure(to_gamma,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_string("tasmota", 424643812, 7),
-    /* K1   */  be_nested_string("scale_uint", -1204156202, 10),
+    /* K0   */  be_nested_str_literal("tasmota"),
+    /* K1   */  be_nested_str_literal("scale_uint"),
     /* K2   */  be_const_int(0),
     /* K3   */  be_const_int(16711680),
-    /* K4   */  be_nested_string("gamma", -802614262, 5),
-    /* K5   */  be_nested_string("light", -493019601, 5),
-    /* K6   */  be_nested_string("gamma8", -492123466, 6),
+    /* K4   */  be_nested_str_literal("gamma"),
+    /* K5   */  be_nested_str_literal("light"),
+    /* K6   */  be_nested_str_literal("gamma8"),
     }),
     (be_nested_const_str("to_gamma", 1597139862, 8)),
     ((bstring*) &be_const_str_input),
@@ -330,7 +331,7 @@ be_local_closure(to_gamma,   /* name */
 /********************************************************************
 ** Solidified function: pixel_count
 ********************************************************************/
-be_local_closure(pixel_count,   /* name */
+be_local_closure(Leds_pixel_count,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -341,7 +342,7 @@ be_local_closure(pixel_count,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("pixel_count", -1855836553, 11)),
     ((bstring*) &be_const_str_input),
@@ -359,7 +360,7 @@ be_local_closure(pixel_count,   /* name */
 /********************************************************************
 ** Solidified function: can_show
 ********************************************************************/
-be_local_closure(can_show,   /* name */
+be_local_closure(Leds_can_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -370,7 +371,7 @@ be_local_closure(can_show,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     /* K1   */  be_const_int(3),
     }),
     (be_nested_const_str("can_show", 960091187, 8)),
@@ -389,7 +390,7 @@ be_local_closure(can_show,   /* name */
 /********************************************************************
 ** Solidified function: pixel_size
 ********************************************************************/
-be_local_closure(pixel_size,   /* name */
+be_local_closure(Leds_pixel_size,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -400,7 +401,7 @@ be_local_closure(pixel_size,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("pixel_size", -2085831511, 10)),
     ((bstring*) &be_const_str_input),
@@ -418,7 +419,7 @@ be_local_closure(pixel_size,   /* name */
 /********************************************************************
 ** Solidified function: dirty
 ********************************************************************/
-be_local_closure(dirty,   /* name */
+be_local_closure(Leds_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -429,7 +430,7 @@ be_local_closure(dirty,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("dirty", -1627386213, 5)),
     ((bstring*) &be_const_str_input),
@@ -447,7 +448,7 @@ be_local_closure(dirty,   /* name */
 /********************************************************************
 ** Solidified function: show
 ********************************************************************/
-be_local_closure(show,   /* name */
+be_local_closure(Leds_show,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -458,7 +459,7 @@ be_local_closure(show,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     /* K1   */  be_const_int(2),
     }),
     (be_nested_const_str("show", -1454906820, 4)),
@@ -477,7 +478,7 @@ be_local_closure(show,   /* name */
 /********************************************************************
 ** Solidified function: clear_to
 ********************************************************************/
-be_local_closure(clear_to,   /* name */
+be_local_closure(Leds_clear_to,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     3,                          /* argc */
@@ -488,8 +489,8 @@ be_local_closure(clear_to,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
-    /* K1   */  be_nested_string("to_gamma", 1597139862, 8),
+    /* K0   */  be_nested_str_literal("call_native"),
+    /* K1   */  be_nested_str_literal("to_gamma"),
     }),
     (be_nested_const_str("clear_to", -766965166, 8)),
     ((bstring*) &be_const_str_input),
@@ -511,7 +512,7 @@ be_local_closure(clear_to,   /* name */
 /********************************************************************
 ** Solidified function: is_dirty
 ********************************************************************/
-be_local_closure(is_dirty,   /* name */
+be_local_closure(Leds_is_dirty,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -522,7 +523,7 @@ be_local_closure(is_dirty,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     }),
     (be_nested_const_str("is_dirty", 418034110, 8)),
     ((bstring*) &be_const_str_input),
@@ -540,7 +541,7 @@ be_local_closure(is_dirty,   /* name */
 /********************************************************************
 ** Solidified function: ctor
 ********************************************************************/
-be_local_closure(ctor,   /* name */
+be_local_closure(Leds_ctor,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     4,                          /* argc */
@@ -551,7 +552,7 @@ be_local_closure(ctor,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("call_native", 1389147405, 11),
+    /* K0   */  be_nested_str_literal("call_native"),
     /* K1   */  be_const_int(0),
     }),
     (be_nested_const_str("ctor", 375399343, 4)),
@@ -588,24 +589,24 @@ be_local_class(Leds,
     &be_class_Leds_ntv,
     be_nested_map(16,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("get_pixel_color", 337490048, 15, -1), be_const_closure(get_pixel_color_closure) },
-        { be_nested_key("pixels_buffer", 1229555807, 13, -1), be_const_closure(pixels_buffer_closure) },
-        { be_nested_key("clear", 1550717474, 5, 13), be_const_closure(clear_closure) },
-        { be_nested_key("init", 380752755, 4, 8), be_const_closure(init_closure) },
-        { be_nested_key("set_pixel_color", 1275248356, 15, -1), be_const_closure(set_pixel_color_closure) },
-        { be_nested_key("begin", 1748273790, 5, -1), be_const_closure(begin_closure) },
-        { be_nested_key("to_gamma", 1597139862, 8, -1), be_const_closure(to_gamma_closure) },
-        { be_nested_key("pixel_count", -1855836553, 11, -1), be_const_closure(pixel_count_closure) },
-        { be_nested_key("can_show", 960091187, 8, -1), be_const_closure(can_show_closure) },
-        { be_nested_key("pixel_size", -2085831511, 10, -1), be_const_closure(pixel_size_closure) },
+        { be_nested_key("get_pixel_color", 337490048, 15, -1), be_const_closure(Leds_get_pixel_color_closure) },
+        { be_nested_key("ctor", 375399343, 4, -1), be_const_closure(Leds_ctor_closure) },
+        { be_nested_key("clear", 1550717474, 5, 8), be_const_closure(Leds_clear_closure) },
+        { be_nested_key("init", 380752755, 4, 13), be_const_closure(Leds_init_closure) },
+        { be_nested_key("set_pixel_color", 1275248356, 15, -1), be_const_closure(Leds_set_pixel_color_closure) },
+        { be_nested_key("is_dirty", 418034110, 8, -1), be_const_closure(Leds_is_dirty_closure) },
+        { be_nested_key("to_gamma", 1597139862, 8, -1), be_const_closure(Leds_to_gamma_closure) },
+        { be_nested_key("pixel_count", -1855836553, 11, -1), be_const_closure(Leds_pixel_count_closure) },
+        { be_nested_key("clear_to", -766965166, 8, -1), be_const_closure(Leds_clear_to_closure) },
+        { be_nested_key("pixel_size", -2085831511, 10, -1), be_const_closure(Leds_pixel_size_closure) },
         { be_nested_key("gamma", -802614262, 5, -1), be_const_var(0) },
-        { be_nested_key("dirty", -1627386213, 5, -1), be_const_closure(dirty_closure) },
-        { be_nested_key("show", -1454906820, 4, -1), be_const_closure(show_closure) },
-        { be_nested_key("clear_to", -766965166, 8, -1), be_const_closure(clear_to_closure) },
-        { be_nested_key("is_dirty", 418034110, 8, 5), be_const_closure(is_dirty_closure) },
-        { be_nested_key("ctor", 375399343, 4, 1), be_const_closure(ctor_closure) },
+        { be_nested_key("dirty", -1627386213, 5, -1), be_const_closure(Leds_dirty_closure) },
+        { be_nested_key("show", -1454906820, 4, -1), be_const_closure(Leds_show_closure) },
+        { be_nested_key("can_show", 960091187, 8, -1), be_const_closure(Leds_can_show_closure) },
+        { be_nested_key("begin", 1748273790, 5, 5), be_const_closure(Leds_begin_closure) },
+        { be_nested_key("pixels_buffer", 1229555807, 13, 1), be_const_closure(Leds_pixels_buffer_closure) },
     })),
-    (be_nested_const_str("Leds", -1585722021, 4))
+    be_str_literal("Leds")
 );
 /*******************************************************************/
 

--- a/lib/libesp32/Berry/default/be_leds_matrix_lib.c
+++ b/lib/libesp32/Berry/default/be_leds_matrix_lib.c
@@ -7,9 +7,63 @@
 #ifdef USE_WS2812
 
 /********************************************************************
+** Solidified function: get_alternate
+********************************************************************/
+be_local_closure(Leds_matrix_get_alternate,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_literal("alternate"),
+    }),
+    (be_nested_const_str("get_alternate", 1450148894, 13)),
+    ((bstring*) &be_const_str_input),
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_alternate
+********************************************************************/
+be_local_closure(Leds_matrix_set_alternate,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_literal("alternate"),
+    }),
+    (be_nested_const_str("set_alternate", 1709680562, 13)),
+    ((bstring*) &be_const_str_input),
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: set_matrix_pixel_color
 ********************************************************************/
-be_local_closure(set_matrix_pixel_color,   /* name */
+be_local_closure(Leds_matrix_set_matrix_pixel_color,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
@@ -19,21 +73,40 @@ be_local_closure(set_matrix_pixel_color,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_string("set_pixel_color", 1275248356, 15),
-    /* K1   */  be_nested_string("w", -234078410, 1),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_literal("alternate"),
+    /* K1   */  be_const_int(2),
+    /* K2   */  be_nested_str_literal("set_pixel_color"),
+    /* K3   */  be_nested_str_literal("w"),
+    /* K4   */  be_nested_str_literal("h"),
+    /* K5   */  be_const_int(1),
     }),
     (be_nested_const_str("set_matrix_pixel_color", 1197149462, 22)),
     ((bstring*) &be_const_str_input),
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8C140100,  //  0000  GETMET	R5	R0	K0
-      0x881C0101,  //  0001  GETMBR	R7	R0	K1
-      0x081C0207,  //  0002  MUL	R7	R1	R7
-      0x001C0E02,  //  0003  ADD	R7	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x5C240800,  //  0005  MOVE	R9	R4
-      0x7C140800,  //  0006  CALL	R5	4
-      0x80000000,  //  0007  RET	0
+    ( &(const binstruction[23]) {  /* code */
+      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x7816000C,  //  0001  JMPF	R5	#000F
+      0x10140301,  //  0002  MOD	R5	R1	K1
+      0x7816000A,  //  0003  JMPF	R5	#000F
+      0x8C140102,  //  0004  GETMET	R5	R0	K2
+      0x881C0103,  //  0005  GETMBR	R7	R0	K3
+      0x081C0207,  //  0006  MUL	R7	R1	R7
+      0x88200104,  //  0007  GETMBR	R8	R0	K4
+      0x001C0E08,  //  0008  ADD	R7	R7	R8
+      0x041C0E02,  //  0009  SUB	R7	R7	R2
+      0x041C0F05,  //  000A  SUB	R7	R7	K5
+      0x5C200600,  //  000B  MOVE	R8	R3
+      0x5C240800,  //  000C  MOVE	R9	R4
+      0x7C140800,  //  000D  CALL	R5	4
+      0x70020006,  //  000E  JMP		#0016
+      0x8C140102,  //  000F  GETMET	R5	R0	K2
+      0x881C0103,  //  0010  GETMBR	R7	R0	K3
+      0x081C0207,  //  0011  MUL	R7	R1	R7
+      0x001C0E02,  //  0012  ADD	R7	R7	R2
+      0x5C200600,  //  0013  MOVE	R8	R3
+      0x5C240800,  //  0014  MOVE	R9	R4
+      0x7C140800,  //  0015  CALL	R5	4
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -43,7 +116,7 @@ be_local_closure(set_matrix_pixel_color,   /* name */
 /********************************************************************
 ** Solidified function: init
 ********************************************************************/
-be_local_closure(init,   /* name */
+be_local_closure(Leds_matrix_init,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     5,                          /* argc */
@@ -53,25 +126,28 @@ be_local_closure(init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_string("w", -234078410, 1),
-    /* K1   */  be_nested_string("h", -317966505, 1),
-    /* K2   */  be_nested_string("init", 380752755, 4),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_literal("w"),
+    /* K1   */  be_nested_str_literal("h"),
+    /* K2   */  be_nested_str_literal("alternate"),
+    /* K3   */  be_nested_str_literal("init"),
     }),
     (be_nested_const_str("init", 380752755, 4)),
     ((bstring*) &be_const_str_input),
-    ( &(const binstruction[11]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
       0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x60140003,  //  0002  GETGBL	R5	G3
-      0x5C180000,  //  0003  MOVE	R6	R0
-      0x7C140200,  //  0004  CALL	R5	1
-      0x8C140B02,  //  0005  GETMET	R5	R5	K2
-      0x081C0202,  //  0006  MUL	R7	R1	R2
-      0x5C200600,  //  0007  MOVE	R8	R3
-      0x5C240800,  //  0008  MOVE	R9	R4
-      0x7C140800,  //  0009  CALL	R5	4
-      0x80000000,  //  000A  RET	0
+      0x50140000,  //  0002  LDBOOL	R5	0	0
+      0x90020405,  //  0003  SETMBR	R0	K2	R5
+      0x60140003,  //  0004  GETGBL	R5	G3
+      0x5C180000,  //  0005  MOVE	R6	R0
+      0x7C140200,  //  0006  CALL	R5	1
+      0x8C140B03,  //  0007  GETMET	R5	R5	K3
+      0x081C0202,  //  0008  MUL	R7	R1	R2
+      0x5C200600,  //  0009  MOVE	R8	R3
+      0x5C240800,  //  000A  MOVE	R9	R4
+      0x7C140800,  //  000B  CALL	R5	4
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -83,16 +159,19 @@ be_local_closure(init,   /* name */
 ********************************************************************/
 extern const bclass be_class_Leds;
 be_local_class(Leds_matrix,
-    2,
+    3,
     &be_class_Leds,
-    be_nested_map(4,
+    be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_nested_key("init", 380752755, 4, 3), be_const_closure(Leds_matrix_init_closure) },
         { be_nested_key("h", -317966505, 1, -1), be_const_var(0) },
+        { be_nested_key("set_alternate", 1709680562, 13, 6), be_const_closure(Leds_matrix_set_alternate_closure) },
+        { be_nested_key("set_matrix_pixel_color", 1197149462, 22, 4), be_const_closure(Leds_matrix_set_matrix_pixel_color_closure) },
         { be_nested_key("w", -234078410, 1, -1), be_const_var(1) },
-        { be_nested_key("set_matrix_pixel_color", 1197149462, 22, 1), be_const_closure(set_matrix_pixel_color_closure) },
-        { be_nested_key("init", 380752755, 4, 0), be_const_closure(init_closure) },
+        { be_nested_key("get_alternate", 1450148894, 13, 0), be_const_closure(Leds_matrix_get_alternate_closure) },
+        { be_nested_key("alternate", 1140253277, 9, -1), be_const_var(2) },
     })),
-    (be_nested_const_str("Leds_matrix", -1450073227, 11))
+    be_str_literal("Leds_matrix")
 );
 /*******************************************************************/
 

--- a/lib/libesp32/Berry/default/be_leds_ntv_lib.c
+++ b/lib/libesp32/Berry/default/be_leds_ntv_lib.c
@@ -23,29 +23,6 @@ end
 
 extern int be_neopixelbus_call_native(bvm *vm);
 
-/********************************************************************
-** Solidified function: call_native
-********************************************************************/
-be_local_closure(call_native,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    (be_nested_const_str("call_native", 1389147405, 11)),
-    ((bstring*) &be_const_str_input),
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
 
 /********************************************************************
 ** Solidified class: Leds_ntv
@@ -55,15 +32,15 @@ be_local_class(Leds_ntv,
     NULL,
     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("WS2812_GRB", 1736405692, 10, 3), be_const_int(1) },
-        { be_nested_key("WS2812_GRBW", -660477967, 11, -1), be_const_int(2) },
-        { be_nested_key("call_native", 1389147405, 11, 1), be_const_func(be_neopixelbus_call_native) },
-        { be_nested_key("_t", 1527481326, 2, -1), be_const_var(1) },
+        { be_nested_key("WS2812_GRB", 1736405692, 10, 5), be_const_int(1) },
+        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
+        { be_nested_key("WS2812_GRBW", -660477967, 11, 3), be_const_int(2) },
+        { be_nested_key("call_native", 1389147405, 11, -1), be_const_func(be_neopixelbus_call_native) },
         { be_nested_key("SK6812_GRBW", 81157857, 11, -1), be_const_int(4) },
-        { be_nested_key("SK6812_GRB", 1159411308, 10, -1), be_const_int(3) },
-        { be_nested_key("_p", 1594591802, 2, 5), be_const_var(0) },
+        { be_nested_key("_t", 1527481326, 2, -1), be_const_var(1) },
+        { be_nested_key("SK6812_GRB", 1159411308, 10, 1), be_const_int(3) },
     })),
-    (be_nested_const_str("Leds_ntv", -292677248, 8))
+    be_str_literal("Leds_ntv")
 );
 /*******************************************************************/
 

--- a/lib/libesp32/Berry/default/embedded/leds.be
+++ b/lib/libesp32/Berry/default/embedded/leds.be
@@ -126,16 +126,71 @@ class Leds : Leds_ntv
   end
 end
 
+#-
+
+var s = Leds(25, gpio.pin(gpio.WS2812, 1))
+s.clear_to(0x300000)
+s.show()
+i = 0
+
+def anim()
+  s.clear_to(0x300000)
+  s.set_pixel_color(i, 0x004000)
+  s.show()
+  i = (i + 1) % 25
+  tasmota.set_timer(200, anim)
+end
+anim()
+
+-#
+
 class Leds_matrix : Leds
   var h, w
+  var alternate     # are rows in alternate mode (even/odd are reversed)
 
   def init(w, h, gpio, rmt)
     self.w = w
     self.h = h
+    self.alternate = false
     super(self).init(w * h, gpio, rmt)
   end
 
+  def set_alternate(alt)
+    self.alternate = alt
+  end
+  def get_alternate()
+    return self.alternate
+  end
+
   def set_matrix_pixel_color(x, y, col, bri)
-    self.set_pixel_color(x * self.w + y, col, bri)
+    if self.alternate && x % 2
+      # reversed line
+      self.set_pixel_color(x * self.w + self.h - y - 1, col, bri)
+    else
+      self.set_pixel_color(x * self.w + y, col, bri)
+    end
   end
 end
+
+#-
+
+var s = Leds_matrix(5, 5, gpio.pin(gpio.WS2812, 1))
+s.set_alternate(true)
+s.clear_to(0x300000)
+s.show()
+x = 0
+y = 0
+
+def anim()
+  s.clear_to(0x300000)
+  s.set_matrix_pixel_color(x, y, 0x004000)
+  s.show()
+  y = (y + 1) % 5
+  if y == 0
+    x = (x + 1) % 5
+  end
+  tasmota.set_timer(200, anim)
+end
+anim()
+
+-#

--- a/lib/libesp32/Berry/src/be_constobj.h
+++ b/lib/libesp32/Berry/src/be_constobj.h
@@ -234,6 +234,9 @@ const bntvmodule be_native_module(_module) = {                  \
     BE_STRING                                                   \
   }
 
+#define be_str_literal(_str)                                    \
+  be_nested_const_str(_str, 0, sizeof(_str)-1 )
+
 #define be_nested_string(_str, _hash, _len)                     \
   {                                                             \
     { .s=(be_nested_const_str(_str, _hash, _len ))              \

--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -351,7 +351,7 @@ static void m_solidify_subclass(bvm *vm, bclass *cl, int builtins)
         logfmt("    NULL,\n");
     }
 
-    logfmt("    (be_nested_str_literal(\"%s\"))\n", class_name);
+    logfmt("    be_str_literal(\"%s\")\n", class_name);
     logfmt(");\n");
 
 }

--- a/tasmota/berry/leds/rainbow.be
+++ b/tasmota/berry/leds/rainbow.be
@@ -79,7 +79,7 @@ r.start()
 
 -#
 
-class Rainbow_Matrix : Leds_animator
+class Rainbow_stripes : Leds_animator
   var cur_offset     # current offset in the palette
   static palette = [ 0xFF0000, #- red -#
                      0xFFA500, #- orange -#
@@ -111,8 +111,8 @@ class Rainbow_Matrix : Leds_animator
     var y = 0
     while y < h
       var x = 0
+      var col = palette[(cur_offset + y) % modulus]
       while x < w
-        var col = palette[(cur_offset + y) % modulus]
         set_matrix_pixel_color(strip, x, y, col, bri)   # simulate the method call without GETMET
         x += 1
       end


### PR DESCRIPTION
## Description:

Extension to `Leds_matrix` to support "serpentine" matrix.

```
var s = Leds_matrix(8, 8, gpio.pin(gpio.WS2812, 1))
s.set_alternate(true)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
