### PR TITLE
WS2812 RMT work-around

### DIFF
--- a/tasmota/xlgt_01_ws2812.ino
+++ b/tasmota/xlgt_01_ws2812.ino
@@ -224,6 +224,9 @@ void Ws2812StripShow(void)
     }
   }
   strip->Show();
+#ifdef ESP32    // workaround for SPI conflict
+  rmt_wait_tx_done((rmt_channel_t) USE_WS2812_RMT, 50/portTICK_PERIOD_MS);
+#endif
 }
 
 int mod(int a, int b)
@@ -497,6 +500,9 @@ void Ws2812Clear(void)
   strip->ClearTo(0);
   strip->Show();
   Ws2812.show_next = 1;
+#ifdef ESP32    // workaround for SPI conflict
+  rmt_wait_tx_done((rmt_channel_t) USE_WS2812_RMT, 50/portTICK_PERIOD_MS);
+#endif
 }
 
 void Ws2812SetColor(uint32_t led, uint8_t red, uint8_t green, uint8_t blue, uint8_t white)
@@ -523,6 +529,9 @@ void Ws2812SetColor(uint32_t led, uint8_t red, uint8_t green, uint8_t blue, uint
   if (!Ws2812.suspend_update) {
     strip->Show();
     Ws2812.show_next = 1;
+#ifdef ESP32    // workaround for SPI conflict
+  rmt_wait_tx_done((rmt_channel_t) USE_WS2812_RMT, 50/portTICK_PERIOD_MS);
+#endif
   }
 }
 
@@ -564,6 +573,9 @@ void Ws2812ForceUpdate (void)
   Ws2812.suspend_update = false;
   strip->Show();
   Ws2812.show_next = 1;
+#ifdef ESP32    // workaround for SPI conflict
+  rmt_wait_tx_done((rmt_channel_t) USE_WS2812_RMT, 50/portTICK_PERIOD_MS);
+#endif
 }
 
 /********************************************************************************************/


### PR DESCRIPTION
## Description:

It seems that WS2812 can create a crash if a RMT transmission is on-going when a SPI flash read occurs.

This fix waits for the RMT transmission to proceed before continuing. The timeout is max 50ms which is very large for WS2812

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
