### PR TITLE
Fix WS2812 crash

### DIFF
--- a/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod.h
+++ b/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod.h
@@ -554,7 +554,7 @@ public:
         config.clk_div = T_SPEED::RmtClockDivider;
 
         ESP_ERROR_CHECK(rmt_config(&config));
-        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL1));
+        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, 0));
         ESP_ERROR_CHECK(rmt_translator_init(_channel.RmtChannelNumber, T_SPEED::Translate));
     }
 


### PR DESCRIPTION
## Description:

Fix WS2812 crash when RMT Tx is ongoing and a flash operation is done at the same time. Reverting to default parameters when calling `rmt_driver_install()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
