### PR TITLE
Berry fix bool()

### DIFF
--- a/lib/libesp32/Berry/generate/be_const_strtab.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab.h
@@ -246,6 +246,7 @@ extern const bcstring be_const_str_event;
 extern const bcstring be_const_str_resp_cmnd_done;
 extern const bcstring be_const_str_AudioOutputI2S;
 extern const bcstring be_const_str_has_arg;
+extern const bcstring be_const_str_bool;
 extern const bcstring be_const_str_floor;
 extern const bcstring be_const_str_read;
 extern const bcstring be_const_str_remove;

--- a/lib/libesp32/Berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/Berry/generate/be_const_strtab_def.h
@@ -246,6 +246,7 @@ be_define_const_str(event, "event", 4264611999u, 0, 5, &be_const_str_resp_cmnd_d
 be_define_const_str(resp_cmnd_done, "resp_cmnd_done", 2601874875u, 0, 14, NULL);
 be_define_const_str(AudioOutputI2S, "AudioOutputI2S", 638031784u, 0, 14, &be_const_str_has_arg);
 be_define_const_str(has_arg, "has_arg", 424878688u, 0, 7, NULL);
+be_define_const_str(bool, "bool", 3365180733u, 0, 4, &be_const_str_floor);
 be_define_const_str(floor, "floor", 3102149661u, 0, 5, &be_const_str_read);
 be_define_const_str(read, "read", 3470762949u, 0, 4, &be_const_str_remove);
 be_define_const_str(remove, "remove", 3683784189u, 0, 6, NULL);
@@ -467,7 +468,7 @@ static const bstring* const m_string_table[] = {
     (const bstring *)&be_const_str_AudioGenerator,
     (const bstring *)&be_const_str_event,
     (const bstring *)&be_const_str_AudioOutputI2S,
-    (const bstring *)&be_const_str_floor,
+    (const bstring *)&be_const_str_bool,
     (const bstring *)&be_const_str_calldepth,
     (const bstring *)&be_const_str_gamma10,
     (const bstring *)&be_const_str__buffer,
@@ -518,6 +519,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 164,
-    .count = 328,
+    .count = 329,
     .table = m_string_table
 };

--- a/lib/libesp32/Berry/generate/be_fixed_m_builtin.h
+++ b/lib/libesp32/Berry/generate/be_fixed_m_builtin.h
@@ -1,34 +1,35 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_builtin_map) {
-    { be_const_key(number, 16), be_const_int(7) },
-    { be_const_key(map, -1), be_const_int(19) },
-    { be_const_key(classname, 22), be_const_int(5) },
-    { be_const_key(bytes, 2), be_const_int(21) },
-    { be_const_key(int, 12), be_const_int(9) },
-    { be_const_key(module, -1), be_const_int(11) },
-    { be_const_key(print, 20), be_const_int(1) },
-    { be_const_key(issubclass, -1), be_const_int(14) },
-    { be_const_key(assert, -1), be_const_int(0) },
-    { be_const_key(list, -1), be_const_int(18) },
-    { be_const_key(__iterator__, -1), be_const_int(16) },
-    { be_const_key(real, -1), be_const_int(10) },
-    { be_const_key(super, 21), be_const_int(3) },
-    { be_const_key(isinstance, 8), be_const_int(15) },
-    { be_const_key(classof, 4), be_const_int(6) },
-    { be_const_key(input, -1), be_const_int(2) },
-    { be_const_key(call, 19), be_const_int(22) },
-    { be_const_key(compile, -1), be_const_int(13) },
-    { be_const_key(open, -1), be_const_int(17) },
-    { be_const_key(size, -1), be_const_int(12) },
+    { be_const_key(number, 23), be_const_int(7) },
+    { be_const_key(call, -1), be_const_int(22) },
     { be_const_key(range, -1), be_const_int(20) },
+    { be_const_key(input, -1), be_const_int(2) },
+    { be_const_key(bytes, 11), be_const_int(21) },
+    { be_const_key(issubclass, -1), be_const_int(14) },
+    { be_const_key(compile, -1), be_const_int(13) },
+    { be_const_key(open, 22), be_const_int(17) },
+    { be_const_key(module, 17), be_const_int(11) },
+    { be_const_key(list, 7), be_const_int(18) },
+    { be_const_key(isinstance, -1), be_const_int(15) },
+    { be_const_key(classname, 20), be_const_int(5) },
+    { be_const_key(size, -1), be_const_int(12) },
+    { be_const_key(real, -1), be_const_int(10) },
+    { be_const_key(int, -1), be_const_int(9) },
+    { be_const_key(__iterator__, 5), be_const_int(16) },
     { be_const_key(str, -1), be_const_int(8) },
-    { be_const_key(type, -1), be_const_int(4) },
+    { be_const_key(bool, -1), be_const_int(23) },
+    { be_const_key(classof, -1), be_const_int(6) },
+    { be_const_key(assert, -1), be_const_int(0) },
+    { be_const_key(super, -1), be_const_int(3) },
+    { be_const_key(type, 8), be_const_int(4) },
+    { be_const_key(map, -1), be_const_int(19) },
+    { be_const_key(print, -1), be_const_int(1) },
 };
 
 static be_define_const_map(
     m_builtin_map,
-    23
+    24
 );
 
 static const bvalue __vlist_array[] = {
@@ -55,10 +56,11 @@ static const bvalue __vlist_array[] = {
     be_const_class(be_class_range),
     be_const_class(be_class_bytes),
     be_const_func(l_call),
+    be_const_func(l_bool),
 };
 
 static be_define_const_vector(
     m_builtin_vector,
     __vlist_array,
-    23
+    24
 );


### PR DESCRIPTION
## Description:

Enable Berry `bool()` (forgot to regenerate the pre-compiled headers)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
