### PR TITLE
Berry fix stack corruption in solidify.dump

### DIFF
--- a/lib/libesp32/Berry/src/be_solidifylib.c
+++ b/lib/libesp32/Berry/src/be_solidifylib.c
@@ -125,9 +125,7 @@ static void m_solidify_bvalue(bvm *vm, bvalue * value, const char *classname, co
             be_pushstring(vm, str(var_tostr(value)));
             be_toescape(vm, -1, 'u');
             logfmt("be_nested_str_literal(%s)", be_tostring(vm, -1));
-            // logfmt("be_nested_string(%s", be_tostring(vm, -1));
-            // be_pop(vm, 1);
-            // logfmt(", %i, %zu)", be_strhash(var_tostr(value)), len >= 255 ? 255 : len);
+            be_pop(vm, 1);
         }
         break;
     case BE_CLOSURE:


### PR DESCRIPTION
## Description:

Fix Berry stack corruption when solidifying large files.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
