### PR TITLE
Final fix for ESP32 WS2812

### DIFF
--- a/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod.h
+++ b/lib/lib_basic/NeoPixelBus/src/internal/NeoEsp32RmtMethod.h
@@ -50,6 +50,12 @@ extern "C"
 #include <driver/rmt.h>
 }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 3, 0)
+#define NEOPIXELBUS_RMT_INT_FLAGS (ESP_INTR_FLAG_LOWMED)
+#else
+#define NEOPIXELBUS_RMT_INT_FLAGS (ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL1)
+#endif
+
 class NeoEsp32RmtSpeed
 {
 public:
@@ -554,7 +560,7 @@ public:
         config.clk_div = T_SPEED::RmtClockDivider;
 
         ESP_ERROR_CHECK(rmt_config(&config));
-        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, 0));
+        ESP_ERROR_CHECK(rmt_driver_install(_channel.RmtChannelNumber, 0, NEOPIXELBUS_RMT_INT_FLAGS));
         ESP_ERROR_CHECK(rmt_translator_init(_channel.RmtChannelNumber, T_SPEED::Translate));
     }
 


### PR DESCRIPTION
## Description:

Final fix for WS2812 crash when using flash - esp-idf 4.4 specific.

Report of https://github.com/Makuna/NeoPixelBus/pull/534

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
