### PR TITLE
Make sure PWM Dimmer night light stays updated

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -491,6 +491,9 @@ void SetLedLink(uint32_t state)
 #ifdef USE_BUZZER
   BuzzerSetStateToLed(state);
 #endif // USE_BUZZER
+#ifdef USE_PWM_DIMMER
+  if (Settings->flag4.powered_off_led) TasmotaGlobal.restore_powered_off_led_counter = 3;
+#endif  // USE_PWM_DIMMER
 }
 
 void SetPulseTimer(uint32_t index, uint32_t time)

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -184,6 +184,9 @@ struct TasmotaGlobal_t {
   uint8_t last_source;                      // Last command source
   uint8_t shutters_present;                 // Number of actual define shutters
   uint8_t discovery_counter;                // Delayed discovery counter
+#ifdef USE_PWM_DIMMER
+  uint8_t restore_powered_off_led_counter;  // Seconds before powered-off LED (LEDLink) is restored
+#endif  // USE_PWM_DIMMER
 
 #ifndef SUPPORT_IF_STATEMENT
   uint8_t backlog_index;                    // Command backlog index

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -63,7 +63,6 @@ struct remote_pwm_dimmer {
 uint32_t ignore_any_key_time = 0;
 uint32_t button_hold_time[3];
 uint8_t led_timeout_seconds = 0;
-uint8_t restore_powered_off_led_counter = 0;
 uint8_t power_button_index = 0;
 uint8_t down_button_index = 1;
 uint8_t buttons_pressed = 0;
@@ -744,16 +743,10 @@ bool Xdrv35(uint8_t function)
         PWMDimmerSetBrightnessLeds(-2);
       }
 
-      // The powered-off LED is also the LedLink LED. If we lose the WiFi or MQTT server connection,
-      // the LED will be set to a blinking state and will be turned off when the connection is
-      // restored. If the state is blinking now, set a flag so we know that we need to restore it
-      // when it stops blinking.
-      if (TasmotaGlobal.global_state.data)
-        restore_powered_off_led_counter = 5;
-      else if (restore_powered_off_led_counter) {
-        PWMDimmerSetPoweredOffLed();
-        restore_powered_off_led_counter--;
-      }
+      // The powered-off LED is also the LedLink LED. If the state of it gets changed,
+      // restore_powered_off_led_counter will get set to the number of seconds
+      // to wait before restoring it to the proper state.
+      if (TasmotaGlobal.restore_powered_off_led_counter && !--TasmotaGlobal.restore_powered_off_led_counter) PWMDimmerSetPoweredOffLed();
       break;
 
     case FUNC_BUTTON_PRESSED:


### PR DESCRIPTION
## Description:

Add logic to set a global when the PWM Dimmer powered-off LED is enabled and the LEDLink state gets changed. Decrement the global in PWM Dimmer every second and restore the powered-off LED state when it reaches 0.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
