### PR TITLE
Berry add `tasmota.global.devices_present`

### DIFF
--- a/tasmota/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota_global.ino
@@ -33,9 +33,10 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_global_struct = {
     sizeof(TasmotaGlobal),  /* size in bytes */
-    1,  /* number of elements */
+    2,  /* number of elements */
     nullptr,
     (const be_ctypes_structure_item_t[2]) {
+      { "devices_present", offsetof(TasmotaGlobal_t, devices_present), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TasmotaGlobal_t, sleep), 0, 0, ctypes_u8, 0 },
   }};
 
@@ -43,7 +44,7 @@ extern "C" {
     sizeof(TSettings),  /* size in bytes */
     1,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[2]) {
+    (const be_ctypes_structure_item_t[1]) {
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },
   }};
 

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -811,8 +811,9 @@ bool Xdrv52(uint8_t function)
     case FUNC_EVERY_SECOND:
       callBerryEventDispatcher(PSTR("every_second"), nullptr, 0, nullptr);
       break;
-    // case FUNC_SET_POWER:
-    //   break;
+    case FUNC_SET_POWER:
+      callBerryEventDispatcher(PSTR("set_power"), nullptr, XdrvMailbox.index, nullptr);
+      break;
 #ifdef USE_WEBSERVER
     case FUNC_WEB_ADD_CONSOLE_BUTTON:
       if (XdrvMailbox.index) {

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -812,7 +812,7 @@ bool Xdrv52(uint8_t function)
       callBerryEventDispatcher(PSTR("every_second"), nullptr, 0, nullptr);
       break;
     case FUNC_SET_POWER:
-      callBerryEventDispatcher(PSTR("set_power"), nullptr, XdrvMailbox.index, nullptr);
+      callBerryEventDispatcher(PSTR("set_power_handler"), nullptr, XdrvMailbox.index, nullptr);
       break;
 #ifdef USE_WEBSERVER
     case FUNC_WEB_ADD_CONSOLE_BUTTON:


### PR DESCRIPTION
## Description:

Berry add access to `tasmota.global.devices_present` in read/write mode.

Added `set_power_handler` event to respond to `FUNC_SET_POWER` events. You need to implement `set_power_handler(cmd, idx)`. `cmd` is empty for this event, `idx` contains the number of the device whose power changed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
