### PR TITLE
ZigBee serial: always initialize RST pins (for TCP serial server)

### DIFF
--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -282,6 +282,17 @@ void ZigbeeInputLoop(void) {
 void ZigbeeInitSerial(void)
 {
   zigbee.active = false;
+
+  // always initialize reset pins for TCP serial server
+  if (PinUsed(GPIO_ZIGBEE_RST)) {
+    pinMode(Pin(GPIO_ZIGBEE_RST), OUTPUT);
+    digitalWrite(Pin(GPIO_ZIGBEE_RST), 1);
+  }
+  if (PinUsed(GPIO_ZIGBEE_RST, 1)) {
+    pinMode(Pin(GPIO_ZIGBEE_RST, 1), OUTPUT);
+    digitalWrite(Pin(GPIO_ZIGBEE_RST, 1), 1);
+  }
+
   if (PinUsed(GPIO_ZIGBEE_RX) && PinUsed(GPIO_ZIGBEE_TX)) {
 		AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_ZIGBEE "GPIOs Rx:%d Tx:%d"), Pin(GPIO_ZIGBEE_RX), Pin(GPIO_ZIGBEE_TX));
     // if TasmotaGlobal.seriallog_level is 0, we allow GPIO 13/15 to switch to Hardware Serial
@@ -294,15 +305,6 @@ void ZigbeeInitSerial(void)
 		} else {
 			zigbee_buffer = new SBuffer(ZIGBEE_BUFFER_SIZE);
 		}
-
-    if (PinUsed(GPIO_ZIGBEE_RST)) {
-      pinMode(Pin(GPIO_ZIGBEE_RST), OUTPUT);
-      digitalWrite(Pin(GPIO_ZIGBEE_RST), 1);
-    }
-    if (PinUsed(GPIO_ZIGBEE_RST, 1)) {
-      pinMode(Pin(GPIO_ZIGBEE_RST, 1), OUTPUT);
-      digitalWrite(Pin(GPIO_ZIGBEE_RST, 1), 1);
-    }
 
     zigbee.active = true;
 		zigbee.init_phase = true;			// start the state machine


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #13350

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
