### PR TITLE
Changed log level of NRG: EnergyTotal to Level 4 vs Level 3

### DIFF
--- a/tasmota/xdrv_03_energy.ino
+++ b/tasmota/xdrv_03_energy.ino
@@ -249,7 +249,7 @@ void EnergyUpdateTotal(void) {
   // Provide total import active energy as float Energy.import_active[phase] in kWh: 98Wh = 0.098kWh
 
   for (uint32_t i = 0; i < Energy.phase_count; i++) {
-    AddLog(LOG_LEVEL_DEBUG, PSTR("NRG: EnergyTotal[%d] %4_f kWh"), i, &Energy.import_active[i]);
+    AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("NRG: EnergyTotal[%d] %4_f kWh"), i, &Energy.import_active[i]);
 
     if (0 == Energy.start_energy[i] || (Energy.import_active[i] < Energy.start_energy[i])) {
       Energy.start_energy[i] = Energy.import_active[i];  // Init after restart and handle roll-over if any


### PR DESCRIPTION
With console log set to level 3, this function prints out the EnergyTotal every second, which makes the console pretty useless for any other debugging work. Makes more sense to me to have it output all that on Level 4.  Still accessible if people want it, but less obtrusive for normal debugging work. 

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X ] The pull request is done against the latest development branch
  - [ X] Only relevant files were touched
  - [ X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [ X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
