### PR TITLE
use own Platformio framework-espressif32 repo

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -89,11 +89,8 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 
 [env:tasmota32_base]
-; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
-;platform                = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+; *** Uncomment next line ";" to enable development Tasmota Arduino version ESP32
 ;platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/525/framework-arduinoespressif32-release_v4.4-7cac8278e.tar.gz
-;                          platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-;                          platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags           = ${esp32_defaults.build_unflags}
 build_flags             = ${esp32_defaults.build_flags}
 

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -32,18 +32,13 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
 
 [core32]
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1.1/framework-arduinoespressif32-release_IDF4.4.tar.gz
-                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-                              platformio/tool-mklittlefs @ ~1.203.200522
+platform                    = https://github.com/tasmota/platform-espressif32.git#feature/arduino-idf-v4.4
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform                    = https://github.com/tasmota/platform-espressif32.git#feature/arduino-idf-v4.4
 platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1.1/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
-                              platformio/tool-esptoolpy @ https://github.com/tasmota/esptool/releases/download/v3.2/esptool-v3.2.zip
-                              platformio/tool-mklittlefs @ ~1.203.200522
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -33,6 +33,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core32]
 platform                    = https://github.com/tasmota/platform-espressif32.git#feature/arduino-idf-v4.4
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 


### PR DESCRIPTION
## Description:
easier providing the customized Tasmota Arduino Core 32 with the needed dependencies.
Updating the Tasmota Core 32 does not need any changes in Tasmota Platformio setup anymore
**Tasmota is now independent from changes in upstream Platformio framework repo.**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
