### PR TITLE
Use toolchains 8.4.0-2021r2 for ESP32xx

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -32,14 +32,14 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.0/Tasmota-platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.1/Tasmota-platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.0/Tasmota-platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.1/Tasmota-platform-espressif32.zip
 platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/arduino-esp32/releases/download/2.0.1.1/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

error fixes are done. Used for core 2.0.x in Arduino IDE too.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
