### PR TITLE
initialize dvalues and set dvalid only after first valid delta calculculation

### DIFF
--- a/tasmota/xsns_53_sml.ino
+++ b/tasmota/xsns_53_sml.ino
@@ -1553,6 +1553,9 @@ void SML_Decode(uint8_t index) {
             // calc difference
             dtimes[dindex] = millis();
             double vdiff = meter_vars[ind - 1] - dvalues[dindex];
+            if(dvalues[dindex] > 0) {
+              dvalid[vindex] = 1;
+            }
             dvalues[dindex] = meter_vars[ind - 1];
             double dres = (double)360000.0 * vdiff / ((double)dtime / 10000.0);
 #ifdef USE_SML_MEDIAN_FILTER
@@ -1573,7 +1576,6 @@ void SML_Decode(uint8_t index) {
               SML_Immediate_MQTT((const char*)mp, vindex, mindex);
             }
           }
-          dvalid[vindex] = 1;
           dindex++;
         }
       } else if (*mp == 'h') {
@@ -2271,6 +2273,10 @@ void SML_Init(void) {
   for (uint32_t cnt=0;cnt<SML_MAX_VARS;cnt++) {
     meter_vars[cnt]=0;
     dvalid[cnt]=0;
+  }
+
+  for (uint32_t cnt=0;cnt<MAX_DVARS;cnt++) {
+    dvalues[cnt]=0;
   }
 
   for (uint32_t cnt=0;cnt<MAX_METERS;cnt++) {


### PR DESCRIPTION

## Description:

**Related issue (if applicable):** fixes #13924 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
