### PR TITLE
Change representation of uptime to ISO 8601 duration format

### DIFF
--- a/tasmota/support_rtc.ino
+++ b/tasmota/support_rtc.ino
@@ -140,13 +140,9 @@ String GetDuration(uint32_t time)
   BreakTime(time, ut);
 
   // "P128DT14H35M44S" - ISO8601:2004 - https://en.wikipedia.org/wiki/ISO_8601 Durations
-//  snprintf_P(dt, sizeof(dt), PSTR("P%dDT%02dH%02dM%02dS"), ut.days, ut.hour, ut.minute, ut.second);
+  snprintf_P(dt, sizeof(dt), PSTR("P%dDT%02dH%02dM%02dS"), ut.days, ut.hour, ut.minute, ut.second);
 
-  // "128 14:35:44" - OpenVMS
-  // "128T14:35:44" - Tasmota
-  snprintf_P(dt, sizeof(dt), PSTR("%dT%02d:%02d:%02d"), ut.days, ut.hour, ut.minute, ut.second);
-
-  return String(dt);  // 128T14:35:44
+  return String(dt);
 }
 
 String GetDT(uint32_t time)


### PR DESCRIPTION
This PR changes the uptime format from the custom `128T14:35:44` to the ISO 8601 duration format `P128DT14H35M44S`.

The code was there already, but for some unknown reason it was commented out and a custom format was used instead.

I propose the use of the ISO 8601 duration format because if there is a standard it should be used. It is well-supported (e.g. for JSON) and is different enough from a timestamp to not be confused with it.

Affected by this change of format are:

- callers of `GetUptime()`
- `tasmota/support_wifi.ino` (for `Wifi.downtime`)
- `tasmota/xsns_83_neopool.ino` (for `D_NEOPOOL_JSON_CELL_RUNTIME`)
- `tasmota/xdrv_12_home_assistant.ino` (for `WifiDowntime` in `D_RSLT_HASS_STATE`)