### PR TITLE
BLE EQ3 driver fix compile error

### DIFF
--- a/tasmota/xdrv_85_BLE_EQ3_TRV.ino
+++ b/tasmota/xdrv_85_BLE_EQ3_TRV.ino
@@ -128,7 +128,6 @@ print("".join(pin))
 
 // for testing of BLE_ESP32, we remove xsns_62_MI_ESP32.ino completely, and instead add this modified xsns_52_ibeacon_BLE_ESP32.ino
 #if CONFIG_IDF_TARGET_ESP32
-#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 #ifdef USE_EQ3_ESP32
 #ifdef ESP32                       // ESP32 only. Use define USE_HM10 for ESP8266 support
 #ifdef USE_BLE_ESP32
@@ -226,7 +225,7 @@ uint8_t pairing = 0;
 
 #define EQ3_NUM_DEVICESLOTS 16
 eq3_device_tag EQ3Devices[EQ3_NUM_DEVICESLOTS];
-void *EQ3mutex = nullptr;
+SemaphoreHandle_t EQ3mutex = nullptr;
 
 int EQ3Period = 300;
 uint8_t EQ3OnlyAliased = 0;
@@ -1765,5 +1764,4 @@ bool Xdrv85(uint8_t function)
 #endif  // ESP32
 
 #endif
-#endif  // ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 0, 0)
 #endif  // CONFIG_IDF_TARGET_ESP32


### PR DESCRIPTION
## Description:

fix the compile error with Core 2, just a type issue

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
