### PR TITLE
Display update

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -76,6 +76,9 @@ uDisplay::uDisplay(char *lp) : Renderer(800, 600) {
   uint8_t section = 0;
   dsp_ncmds = 0;
   lut_num = 0;
+  lvgl_param.data = 0;
+  lvgl_param.fluslines = 40;
+
   for (uint32_t cnt = 0; cnt < 5; cnt++) {
     lut_cnt[cnt] = 0;
     lut_cmd[cnt] = 0xff;

--- a/tasmota/xdrv_13_display.ino
+++ b/tasmota/xdrv_13_display.ino
@@ -96,6 +96,11 @@ void Get_display(uint8_t index) {
 }
 #endif // USE_MULTI_DISPLAY
 
+#ifndef TXT_MAX_SFAC
+#define TXT_MAX_SFAC 4
+#endif // TXT_MAX_SFAC
+
+
 const uint8_t DISPLAY_MAX_DRIVERS = 32;        // Max number of display drivers/models supported by xdsp_interface.ino
 const uint8_t DISPLAY_MAX_COLS = 64;           // Max number of columns allowed with command DisplayCols
 const uint8_t DISPLAY_MAX_ROWS = 64;           // Max number of lines allowed with command DisplayRows
@@ -875,9 +880,11 @@ void DisplayText(void)
             break;
           case 's':
             // size sx
-            if (renderer) renderer->setTextSize(*cp&7);
+            var = atoiv(cp, &temp);
+            if (temp > TXT_MAX_SFAC) temp = TXT_MAX_SFAC;
+            if (renderer) renderer->setTextSize(temp);
             //else DisplaySetSize(*cp&3);
-            cp += 1;
+            cp+=var;
             break;
           case 'f':
             // font sx
@@ -2011,7 +2018,7 @@ void CmndDisplayDimmer(void) {
 }
 
 void CmndDisplaySize(void) {
-  if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= 4)) {
+  if ((XdrvMailbox.payload > 0) && (XdrvMailbox.payload <= TXT_MAX_SFAC)) {
     Settings->display_size = XdrvMailbox.payload;
     if (renderer) renderer->setTextSize(Settings->display_size);
     //else DisplaySetSize(Settings->display_size);

--- a/tasmota/xdsp_17_universal.ino
+++ b/tasmota/xdsp_17_universal.ino
@@ -55,7 +55,7 @@ void Core2DisplayDim(uint8_t dim);
 #ifndef DISP_DESC_FILE
 //#define DISP_DESC_FILE "/dispdesc.txt"
 #define DISP_DESC_FILE "/display.ini"
-#endif
+#endif // DISP_DESC_FILE
 
 /*********************************************************************************************/
 #ifdef DSP_ROM_DESC
@@ -95,7 +95,7 @@ int8_t cs;
         AddLog(LOG_LEVEL_INFO, PSTR("DSP: File descriptor used"));
       }
     }
-#endif
+#endif // USE_UFILESYS
 
 
 #ifdef USE_SCRIPT
@@ -212,8 +212,8 @@ int8_t cs;
         replacepin(&cp, Pin(GPIO_SPI_CLK, 1));
         replacepin(&cp, Pin(GPIO_SPI_MOSI, 1));
         replacepin(&cp, Pin(GPIO_SPI_DC, 1));
-        replacepin(&cp, Pin(GPIO_BACKLIGHT, 1));
-        replacepin(&cp, Pin(GPIO_OLED_RESET, 1));
+        replacepin(&cp, Pin(GPIO_BACKLIGHT));
+        replacepin(&cp, Pin(GPIO_OLED_RESET));
         replacepin(&cp, Pin(GPIO_SPI_MISO, 1));
       } else {
         // soft spi pins
@@ -280,9 +280,9 @@ int8_t cs;
       else FT5206_Touch_Init(Wire1);
 #else
       if (!wire_n) FT5206_Touch_Init(Wire);
-#endif
+#endif // ESP32
     }
-#endif
+#endif // USE_FT5206
 
 #ifdef USE_XPT2046
     cp = strstr(ddesc, ":TS,");
@@ -291,7 +291,7 @@ int8_t cs;
       uint8_t touch_cs = replacepin(&cp, Pin(GPIO_XPT2046_CS));
 	    XPT2046_Touch_Init(touch_cs);
     }
-#endif
+#endif // USE_XPT2046
 
     uint8_t inirot = Settings->display_rotate;
 
@@ -314,18 +314,18 @@ int8_t cs;
 #ifdef USE_M5STACK_CORE2
     renderer->SetPwrCB(Core2DisplayPower);
     renderer->SetDimCB(Core2DisplayDim);
-#endif
+#endif // USE_M5STACK_CORE2
 
     renderer->DisplayInit(DISPLAY_INIT_MODE, Settings->display_size, inirot, Settings->display_font);
 
     Settings->display_width = renderer->width();
     Settings->display_height = renderer->height();
-    
+
     ApplyDisplayDimmer();
 
 #ifdef SHOW_SPLASH
     renderer->Splash();
-#endif
+#endif // SHOW_SPLASH
 
     udisp_init_done = true;
     AddLog(LOG_LEVEL_INFO, PSTR("DSP: %s!"), renderer->devname());


### PR DESCRIPTION
## Description:

displaytext: make max text stretch factor configurable
fix spi2 configuration in display driver
dpa default off

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
