### PR TITLE
Berry `string.tr` accepts removing chars

### DIFF
--- a/lib/libesp32/Berry/src/be_strlib.c
+++ b/lib/libesp32/Berry/src/be_strlib.c
@@ -793,9 +793,6 @@ static int str_tr(bvm *vm)
         const char *p, *s = be_tostring(vm, 1);
         const char *t1 = be_tostring(vm, 2);
         const char *t2 = be_tostring(vm, 3);
-        if (strlen(t2) < strlen(t1)) {
-            be_raise(vm, "value_error", "invalid translation pattern");
-        }
         size_t len = (size_t)be_strlen(vm, 1);
         char *buf, *q;
         buf = be_pushbuffer(vm, len);
@@ -803,11 +800,17 @@ static int str_tr(bvm *vm)
         for (p = s, q = buf; *p != '\0'; ++p, ++q) {
             const char *p1, *p2;
             *q = *p;  /* default to no change */
-            for (p1=t1, p2=t2; *p1 != '\0'; ++p1, ++p2) {
+            for (p1=t1, p2=t2; *p1 != '\0'; ++p1) {
                 if (*p == *p1) {
-                    *q = *p2;
+                    if (*p2) {
+                        *q = *p2;
+                    } else {
+                        q--;    /* remove this char */
+                        len--;
+                    }
                     break;
                 }
+                if (*p2) { p2++; }
             }
         }
         be_pushnstring(vm, buf, len); /* make escape string from buffer */


### PR DESCRIPTION
## Description:

`string.tr()` now removes any character absent from the second pattern.

Example:
```
> import string
> string.tr("qwerty", "qwe", "_")
_rty
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
