### PR TITLE
Turns off the relay once when the thermostat is switched off to preve…

### DIFF
--- a/tasmota/xdrv_39_thermostat.ino
+++ b/tasmota/xdrv_39_thermostat.ino
@@ -1400,6 +1400,12 @@ void CmndThermostatModeSet(void)
         Thermostat[ctr_output].status.thermostat_mode = value;
         Thermostat[ctr_output].timestamp_input_on = 0;     // Reset last manual switch timer if command set externally
       }
+      if ((value == THERMOSTAT_OFF) && (Thermostat[ctr_output].status.enable_output == IFACE_ON)) {
+        // Make sure the relay is switched to off once if the thermostat is being disabled,
+        // or it will get stuck on (danger!)
+        Thermostat[ctr_output].status.command_output = IFACE_OFF;
+        ThermostatOutputRelay(ctr_output, Thermostat[ctr_output].status.command_output);
+      }
     }
     ResponseCmndIdxNumber((int)Thermostat[ctr_output].status.thermostat_mode);
   }


### PR DESCRIPTION
…nt it from being kept on forever, as a safety precaution.

## Description:

Without this code, the relay stays on forever when the thermostat driver mode is set to off while the relay was on. Better flip it off to be sure.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
