### PR TITLE
Berry allow instance functions

### DIFF
--- a/lib/libesp32/Berry/src/be_vm.c
+++ b/lib/libesp32/Berry/src/be_vm.c
@@ -853,9 +853,9 @@ newframe: /* a new call frame */
                 reg = vm->reg;
                 bvalue *a = RA();
                 *a = a_temp;
-                if (basetype(type) == BE_FUNCTION) {
-                    if (func_isstatic(a)) {
-                        /* static method, don't bother with the instance */
+                if (var_basetype(a) == BE_FUNCTION) {
+                    if (func_isstatic(a) || (type == BE_INDEX)) {    /* if instance variable then we consider it's non-method */
+                       /* static method, don't bother with the instance */
                         a[1] = a_temp;
                         var_settype(a, NOT_METHOD);
                     } else {

--- a/lib/libesp32/Berry/tests/class_const.be
+++ b/lib/libesp32/Berry/tests/class_const.be
@@ -64,7 +64,7 @@ A.h = def (x, y) return type(x) end
 assert(type(a.g) == 'function')
 assert(type(a.h) == 'function')
 
-assert_attribute_error("a.g(1,2)")
+assert(a.g(1) == 'int')
 assert(a.h(1) == 'int')
 assert(A.h(1) == 'int')
 
@@ -85,6 +85,9 @@ assert(a.g(1,2) == [1,2])
 assert(a.h(1,2) == [1,2])
 assert(A.g(1,2) == [1,2])
 assert(A.h(1,2) == [1,2])
+a.a = def (x,y) return [x,y] end
+assert(a.a(1,2) == [1,2])
+
 
 #- test static initializers -#
 class A


### PR DESCRIPTION
## Description:

Sync with latest change in Berry. Now instance variables set to function can be called with a method like syntax, but treated as static functions.

Example:
```
> class A var f end
> a = A()
> a.f = def (x) print(x) end
> a.f(1)
1              # the first argument is not set to `self` as it would for a method
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
