### PR TITLE
Fix EZOO2 sensor message format

### DIFF
--- a/tasmota/xsns_78_ezoo2.ino
+++ b/tasmota/xsns_78_ezoo2.ino
@@ -39,7 +39,7 @@ struct EZOO2 : public EZOStruct {
     dtostrfd(O2, 2, str);
 
     if (json) {
-      ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_O2 "\":%d}" ), name, str);
+      ResponseAppend_P(PSTR(",\"%s\":{\"" D_JSON_O2 "\":%s}" ), name, str);
 #ifdef USE_WEBSERVER
     }else {
       WSContentSend_PD(HTTP_SNS_O2, name, str);


### PR DESCRIPTION
## Description:

[#13998](https://github.com/arendst/Tasmota/issues/13998)

Fix wrong format in `ResponseAppend_P`: `%d` => `%s`


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
