### PR TITLE
Add Linkind dimmer support

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -694,6 +694,44 @@ jobs:
         path: ./build_output
 
 
+  tasmota32solo1-linkind:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota32solo1-linkind
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
+
+
+  tasmota32solo1-linkind-ble:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota32solo1-linkind-ble
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
+
+
   tasmota32-webcam:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -692,6 +692,44 @@ jobs:
         path: ./build_output
 
 
+  tasmota32solo1-linkind:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota32solo1-linkind
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
+
+
+  tasmota32solo1-linkind-ble:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        pip install -U platformio
+    - name: Run PlatformIO
+      run: |
+        platformio run -e tasmota32solo1-linkind-ble
+    - uses: actions/upload-artifact@v2
+      with:
+        name: firmware
+        path: ./build_output
+
+
   tasmota32-webcam:
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -40,6 +40,8 @@ jobs:
           - tasmota32-odroidgo
           - tasmota32c3
           - tasmota32solo1
+          - tasmota32solo1-linkind
+          - tasmota32solo1-linkind-ble
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -52,6 +52,17 @@ extends                 = env:tasmota32_base
 platform_packages       = ${core32solo1.platform_packages}
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 
+[env:tasmota32solo1-linkind]
+extends                 = env:tasmota32_base
+platform_packages       = ${core32solo1.platform_packages}
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DUSE_LINKIND
+
+[env:tasmota32solo1-linkind-ble]
+extends                 = env:tasmota32_base
+platform_packages       = ${core32solo1.platform_packages}
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DUSE_LINKIND -DUSE_BLE_ESP32 -DUSE_MI_ESP32 -DUSE_EQ3_ESP32
+lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_audio
+
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base
 board                   = esp32-cam

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1525,6 +1525,14 @@ void ModuleDefault(uint32_t module)
 void SetModuleType(void)
 {
   TasmotaGlobal.module_type = (USER_MODULE == Settings->module) ? Settings->user_template_base : Settings->module;
+
+  TasmotaGlobal.use_pwm_dimmer = false;
+#ifdef ESP8266
+  if (PWM_DIMMER == TasmotaGlobal.module_type) TasmotaGlobal.use_pwm_dimmer = true;
+#endif  // ESP8266
+#ifdef USE_LINKIND
+  if (LINKIND == TasmotaGlobal.module_type) TasmotaGlobal.use_pwm_dimmer = true;
+#endif  // USE_LINKIND
 }
 
 bool FlashPin(uint32_t pin)

--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -568,14 +568,14 @@ bool SendKey(uint32_t key, uint32_t device, uint32_t state)
     result = XdrvRulesProcess(0);
   }
 #ifdef USE_PWM_DIMMER
-  if (PWM_DIMMER != TasmotaGlobal.module_type || (!result && !Settings->flag3.mqtt_buttons)) {
+  if (!TasmotaGlobal.use_pwm_dimmer || (!result && !Settings->flag3.mqtt_buttons)) {
 #endif  // USE_PWM_DIMMER
   int32_t payload_save = XdrvMailbox.payload;
   XdrvMailbox.payload = device_save << 24 | key << 16 | state << 8 | device;
   XdrvCall(FUNC_ANY_KEY);
   XdrvMailbox.payload = payload_save;
 #ifdef USE_PWM_DIMMER
-    if (PWM_DIMMER == TasmotaGlobal.module_type) result = true;
+    if (TasmotaGlobal.use_pwm_dimmer) result = true;
   }
 #endif  // USE_PWM_DIMMER
   return result;
@@ -2036,7 +2036,7 @@ void GpioInit(void)
   }
 
 #ifdef USE_PWM_DIMMER
-  if (PWM_DIMMER == TasmotaGlobal.module_type && PinUsed(GPIO_REL1)) { TasmotaGlobal.devices_present--; }
+  if (TasmotaGlobal.use_pwm_dimmer && PinUsed(GPIO_REL1)) { TasmotaGlobal.devices_present--; }
 #endif  // USE_PWM_DIMMER
 
   SetLedPower(Settings->ledstate &8);

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -150,6 +150,7 @@ struct TasmotaGlobal_t {
   bool wifi_stay_asleep;                    // Allow sleep only incase of ESP32 BLE
   bool no_autoexec;                         // Disable autoexec
   bool enable_logging;                      // Enable logging
+  bool use_pwm_dimmer;                      // Use PWM dimmer logic
 
   StateBitfield global_state;               // Global states (currently Wifi and Mqtt) (8 bits)
   uint8_t init_state;                       // Tasmota init state

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -391,7 +391,7 @@
 #undef USE_EXS_DIMMER                           // Disable support for EX-Store WiFi Dimmer
 //#define USE_HOTPLUG                              // Add support for sensor HotPlug
 //#undef USE_DEVICE_GROUPS                        // Disable support for device groups (+5k6 code)
-#undef USE_PWM_DIMMER                           // Disable support for MJ-SD01/acenx/NTONPOWER PWM dimmers (+4k5 code)
+//#undef USE_PWM_DIMMER                           // Disable support for MJ-SD01/acenx/NTONPOWER PWM dimmers (+4k5 code)
 #undef USE_KEELOQ                               // Disable support for Jarolift rollers by Keeloq algorithm (+4k5 code)
 #undef USE_SONOFF_D1                            // Disable support for Sonoff D1 Dimmer (+0k7 code)
 #undef USE_SHELLY_DIMMER                        // Disable support for Shelly Dimmer (+3k code)

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -134,7 +134,7 @@ String EthernetMacAddress(void);
 
 // Hardware has no ESP32
 #undef USE_TUYA_DIMMER
-#undef USE_PWM_DIMMER
+//#undef USE_PWM_DIMMER
 #undef USE_EXS_DIMMER
 #undef USE_ARMTRONIX_DIMMERS
 #undef USE_SONOFF_RF

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -2686,6 +2686,7 @@ enum SupportedModules {
   ESP32_CAM_AITHINKER,
   ODROID_GO,
   ESP32_SOLO,
+  LINKIND,
   WT32_ETH01,
   TTGO_WATCH,
   M5STACK_CORE2,
@@ -2703,6 +2704,9 @@ const uint8_t kModuleNiceList[] PROGMEM = {
 #ifdef USE_ESP32_SOLO
 //  ESP32_SOLO,                // To be defined
 #endif  // USE_ESP32_SOLO
+#ifdef USE_LINKIND
+  LINKIND,
+#endif  // USE_LINKIND
 #ifdef USE_WT32_ETH01
   WT32_ETH01,
 #endif  // USE_WT32_ETH01
@@ -2726,6 +2730,9 @@ const char kModuleNames[] PROGMEM =
 #ifdef USE_ESP32_SOLO
 //  "ESP32-Solo|"              // To be defined
 #endif  // USE_ESP32_SOLO
+#ifdef USE_LINKIND
+  "Linkind|"
+#endif  // USE_LINKIND
 #ifdef USE_WT32_ETH01
   "WT32-Eth01|"
 #endif  // USE_WT32_ETH01
@@ -2879,6 +2886,52 @@ const mytmplt kModules[] PROGMEM = {
 //  {                              // ESP32 Solo (ESP32) - To be defined
 //  },
 #endif  // USE_ESP32_SOLO
+
+#ifdef USE_LINKIND
+  {                              // LINKIND - (ESP32)
+    0,                           // 0       (I)O                GPIO0
+    0,                           // 1                           GPIO1
+    0,                           // 2                           GPIO2
+    0,                           // 3                           GPIO3
+    AGPIO(GPIO_I2C_SDA),         // 4       IO                  GPIO4, I2C_SDA
+    0,                           // 5                           GPIO5
+                                 // 6       IO                  Remapped to 28
+                                 // 7       IO                  Remapped to 29
+                                 // 8       IO                  Remapped to 30
+    0,                           // 9                           GPIO9
+    0,                           // 10                          GPIO10
+                                 // 11      IO                  Remapped to 31
+    0,                           // 12                          GPIO12
+    0,                           // 13                          GPIO13
+    AGPIO(GPIO_LED1),            // 14      IO                  GPIO14, LED1 (green)
+    0,                           // 15                          GPIO15
+    0,                           // 16                          GPIO16
+    0,                           // 17                          GPIO17
+    0,                           // 18                          GPIO18
+    0,                           // 19                          GPIO19
+    0,                           // 20                          GPIO20
+    0,                           // 21                          GPIO21
+    AGPIO(GPIO_I2C_SCL),         // 22      IO                  GPIO22, I2C_SCL
+    0,                           // 23                          GPIO23
+    0,                           // 24                          GPIO24
+    0,                           // 25                          GPIO25
+    AGPIO(GPIO_LEDLNK),          // 26      IO                  GPIO26, LEDLNK (red)
+    0,                           // 27                          GPIO27
+    0,                           // 6       IO                  GPIO6
+    0,                           // 7       IO                  GPIO7
+    0,                           // 8       IO                  GPIO8
+    0,                           // 11      IO                  GPIO11
+    AGPIO(GPIO_KEY1) +1,         // 32      IO                  GPIO32, BUTTON2
+    AGPIO(GPIO_KEY1),            // 33      IO                  GPIO33, BUTTON1
+    0,                           // 34      I   NO PULLUP       GPIO34
+    0,                           // 35      I   NO PULLUP       GPIO35
+    0,                           // 36      I   NO PULLUP       GPIO36
+    0,                           // 37          NO PULLUP       GPIO37
+    0,                           // 38          NO PULLUP       GPIO39
+    0,                           // 39      I   NO PULLUP       GPIO39
+    0                            // Flag
+  },
+#endif  // USE_LINKIND
 
 #ifdef USE_WT32_ETH01
   {                              // WT32_ETH01 - (ESP32)

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -457,7 +457,7 @@ void HAssAnnounceRelayLight(void)
   power_t shutter_mask = 0;
 
   #ifdef ESP8266
-        if (PWM_DIMMER == TasmotaGlobal.module_type ) { PwmMod = true; } //
+        if (TasmotaGlobal.use_pwm_dimmer) { PwmMod = true; } //
         if (SONOFF_IFAN02 == TasmotaGlobal.module_type || SONOFF_IFAN03 == TasmotaGlobal.module_type) { FanMod = true; }
         if (SONOFF_DUAL == TasmotaGlobal.module_type) { valid_relay = 2; }
         if (TUYA_DIMMER == TasmotaGlobal.module_type || SK03_TUYA == TasmotaGlobal.module_type) { TuyaMod = true; }


### PR DESCRIPTION
## Description:

This PR adds support for Linkind (https://www.amazon.com/dp/B08DRF58T1) ESP32-based dimmer that uses I2C to communicate with the dimmer hardware.

Please check the changes to the build and template files and let me know if anything was not done the way you want them implemented.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
