### PR TITLE
Fix for #14006: can't USE_TOUCH_BUTTONS without USE_UFILESYS

### DIFF
--- a/lib/lib_display/Adafruit-GFX-Library-1.5.6-gemu-1.0/Adafruit_GFX.cpp
+++ b/lib/lib_display/Adafruit-GFX-Library-1.5.6-gemu-1.0/Adafruit_GFX.cpp
@@ -1610,10 +1610,12 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
     text    = _fillcolor;
   }
 
+  #if defined USE_UFILESYS
   if (_label[0]=='/') {
     draw_picture(_label, _x1, _y1, _w, _h, outline, inverted);
     _gfx->drawRect(_x1, _y1, _w, _h, text);
   } else {
+  #endif
     uint8_t r = min(_w, _h) / 4; // Corner radius
     _gfx->fillRoundRect(_x1, _y1, _w, _h, r, fill);
     _gfx->drawRoundRect(_x1, _y1, _w, _h, r, outline);
@@ -1622,7 +1624,9 @@ void Adafruit_GFX_Button::drawButton(boolean inverted) {
     _gfx->setTextColor(text);
     _gfx->setTextSize(_textsize_x, _textsize_y);
     _gfx->print(_label);
+  #if defined USE_UFILESYS
   }
+  #endif
 }
 
 /**************************************************************************/


### PR DESCRIPTION
## Description:

Fix for: can't `USE_TOUCH_BUTTONS` without `USE_UFILESYS`
**Related issue (if applicable):** fixes discussion #14006.

Without `USE_UFILESYS` you can't draw picture buttons, so I have put `#if defined USE_UFILESYS` around the place where `draw_picture()` gets called.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
