### PR TITLE
DDP Schemes for Light (5) and WS2812 (15) with USE_NETWORK_LIGHT_SCHEMES

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -124,7 +124,11 @@
 #define XDRV_04              4
 // #define DEBUG_LIGHT
 
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+enum LightSchemes { LS_POWER, LS_WAKEUP, LS_CYCLEUP, LS_CYCLEDN, LS_RANDOM, LS_DDP, LS_MAX };
+#else
 enum LightSchemes { LS_POWER, LS_WAKEUP, LS_CYCLEUP, LS_CYCLEDN, LS_RANDOM, LS_MAX };
+#endif
 
 const uint8_t LIGHT_COLOR_SIZE = 25;   // Char array scolor size
 
@@ -279,6 +283,11 @@ uint8_t LightDevice(void)
 static uint32_t min3(uint32_t a, uint32_t b, uint32_t c) {
   return (a < b && a < c) ? a : (b < c) ? b : c;
 }
+
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+WiFiUDP ddp_udp;
+uint8_t ddp_udp_up = 0;
+#endif
 
 //
 // LightStateClass
@@ -1615,6 +1624,51 @@ void LightCycleColor(int8_t direction)
   light_controller.calcLevels(Light.new_color);
 }
 
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+void LightListenDDP()
+{
+  // Light channels gets completely controlled over DDP. So, we don't really check other settings.
+  // To enter this scheme, we are already assured the light is at least RGB
+  static uint8_t ddp_color[5] = { 0, 0, 0, 0, 0 };
+
+  // Can't be trying to initialize UDP too early.
+  if (TasmotaGlobal.restart_flag || TasmotaGlobal.global_state.network_down) {
+    light_state.setChannels(ddp_color);
+    light_controller.calcLevels(Light.new_color);
+    return;
+  }
+
+  // Start DDP listener, if fail, just set last ddp_color
+  if (!ddp_udp_up) {
+    if (!ddp_udp.begin(4048)) {
+      light_state.setChannels(ddp_color);
+      light_controller.calcLevels(Light.new_color);
+      return;
+    }
+    ddp_udp_up = 1;
+    AddLog(LOG_LEVEL_DEBUG_MORE, "DDP: UDP Listener Started: Normal Scheme");
+  }
+
+  // Get the DDP payload over UDP
+  std::vector<uint8_t> payload;
+  while (uint16_t packet_size = ddp_udp.parsePacket()) {
+    payload.resize(packet_size);
+    if (!ddp_udp.read(&payload[0], payload.size())) {
+      continue;
+    }
+  }
+
+  // No verification checks performed against packet besides length
+  if (payload.size() > 12) {
+    ddp_color[0] = payload[10];
+    ddp_color[1] = payload[11];
+    ddp_color[2] = payload[12];
+  }
+  light_state.setChannels(ddp_color);
+  light_controller.calcLevels(Light.new_color);
+}
+#endif
+
 void LightSetPower(void)
 {
 //  Light.power = XdrvMailbox.index;
@@ -1690,7 +1744,21 @@ void LightAnimate(void)
     if (Settings->light_scheme >= LS_MAX) {
       power_off = true;
     }
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+    if (ddp_udp_up) {
+      ddp_udp.stop();
+      ddp_udp_up = 0;
+      AddLog(LOG_LEVEL_DEBUG_MORE, "DDP: UDP Stopped: Power Off");
+    }
+#endif
   } else {
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+    if ((Settings->light_scheme < LS_MAX) && (Settings->light_scheme != LS_DDP) && (ddp_udp_up)) {
+      ddp_udp.stop();
+      ddp_udp_up = 0;
+      AddLog(LOG_LEVEL_DEBUG_MORE, "DDP: UDP Stopped: Normal Scheme not DDP");
+    }
+#endif
     switch (Settings->light_scheme) {
       case LS_POWER:
         light_controller.calcLevels(Light.new_color);
@@ -1743,6 +1811,11 @@ void LightAnimate(void)
           Light.new_color[2] = changeUIntScale(Light.new_color[2], 0, 255, 0, Settings->light_color[2]);
         }
         break;
+#ifdef USE_NETWORK_LIGHT_SCHEMES
+      case LS_DDP:
+        LightListenDDP();
+        break;
+#endif
       default:
         XlgtCall(FUNC_SET_SCHEME);
     }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

This PR adds new Schemes that has the Light or WS2812 strip listen to a DDP stream (UDP on port 4048). This allows the light to be controlled by external sources like xLights, LEDFx, WLED, etc. In my testing (8x8 matrix attached to ESP32C3 12F devkit) this implementation works for, as expected, ~20 FPS effects smoothly. Folks wanting higher frame rates should obviously use a dedicated firmware as has been suggested in prior feature requests related to DMX/E131, but I am able to achieve quite satisfying effects with this on bulbs (which I prefer to keep on Tasmota due to recovery features) as well as addressable panels to add to existing setups.

To prevent the breaking change in scheme numbering and reduce space use in general, the entire change is wrapped in requiring `USE_NETWORK_LIGHT_SCHEMES` which when enabled added 1100 bytes to tasmota.bin

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
