### PR TITLE
Add DevGroupSend full status item

### DIFF
--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -591,8 +591,7 @@ bool _SendDeviceGroupMessage(int32_t device, DevGroupMessageType message_type, .
       value_ptr = (uint8_t *)XdrvMailbox.data;
       while ((item = strtoul((char *)value_ptr, (char **)&value_ptr, 0))) {
         item_ptr->item = item;
-        if (*value_ptr != '=') return 1;
-        value_ptr++;
+        if (*value_ptr == '=') value_ptr++;
 
         // If flags were specified for this item, save them.
         item_ptr->flags = 0;
@@ -613,6 +612,12 @@ bool _SendDeviceGroupMessage(int32_t device, DevGroupMessageType message_type, .
             value = (oper == '+' ? old_value + value : oper == '-' ? old_value - value : oper == '^' ? old_value ^ value : oper == '|' ? old_value | value : old_value == '&' ? old_value & value : old_value);
           }
           item_ptr->value = value;
+
+          if (item == DGR_ITEM_STATUS) {
+            if (!(item_ptr->flags & DGR_ITEM_FLAG_NO_SHARE)) device_group->no_status_share = 0;
+            _SendDeviceGroupMessage(-device_group_index, DGR_MSGTYP_FULL_STATUS);
+            item_ptr--;
+          }
         }
         else {
           item_ptr->value_ptr = out_ptr;


### PR DESCRIPTION
## Description:

Add support for DevGroupSend item code 1 to send a full status update, optionally clearing all non-shared items. When items on devices in a group have intentionally been set to different values (such as different colors on lights in a group), DevGroupSend 1 will bring all the devices in sync with the device it is executed on.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
