### PR TITLE
Berry remove re1.5 compilation warnings

### DIFF
--- a/lib/libesp32/re1.5/main.c
+++ b/lib/libesp32/re1.5/main.c
@@ -5,7 +5,7 @@
 #include "re1.5.h"
 
 struct {
-	char *name;
+	const char *name;
 	int (*fn)(ByteProg*, Subject*, const char**, int, int);
 } tab[] = {
 	{"recursive", re1_5_recursiveprog},

--- a/lib/libesp32/re1.5/re1.5.h
+++ b/lib/libesp32/re1.5/re1.5.h
@@ -46,7 +46,7 @@ Regexp *parse(char*);
 Regexp *reg(int type, Regexp *left, Regexp *right);
 void printre(Regexp*);
 #ifndef re1_5_fatal
-void re1_5_fatal(char*);
+void re1_5_fatal(const char*);
 #endif
 #ifndef re1_5_stack_chk
 #define re1_5_stack_chk()

--- a/lib/libesp32/re1.5/util.c
+++ b/lib/libesp32/re1.5/util.c
@@ -4,10 +4,13 @@
 
 #include "re1.5.h"
 
+extern void berry_log_C(const char * berry_buf, ...);
+
 void
-re1_5_fatal(char *msg)
+re1_5_fatal(const char *msg)
 {
-	fprintf(stderr, "fatal error: %s\n", msg);
+	berry_log_C("BRY: regex fatal error: %s", msg);
+	// fprintf(stderr, "fatal error: %s\n", msg);
 	exit(2);
 }
 


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
