### PR TITLE
Silence compiler warning from lib ESP8266Audio

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.cpp
+++ b/lib/lib_audio/ESP8266Audio/src/AudioFileSourceICYStream.cpp
@@ -20,7 +20,9 @@
 
 #if defined(ESP32) || defined(ESP8266)
 
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+  #define _GNU_SOURCE
+#endif
 
 #include "AudioFileSourceICYStream.h"
 #include <string.h>

--- a/lib/lib_audio/ESP8266Audio/src/libflac/config.h
+++ b/lib/lib_audio/ESP8266Audio/src/libflac/config.h
@@ -3,7 +3,9 @@
 #ifdef DEBUG
   #undef NDEBUG
 #else
-  #define NDEBUG
+  #ifndef NDEBUG
+    #define NDEBUG
+  #endif
 #endif
 
 /* config.h.  Generated from config.h.in by configure.  */


### PR DESCRIPTION
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
