### PR TITLE
Latest Berry fixes

### DIFF
--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -650,6 +650,9 @@ buf_impl bytes_check_data(bvm *vm, size_t add_size) {
     buf_impl attr = m_read_attributes(vm, 1);
     /* check if the `size` is big enough */
     if (attr.len + (int32_t)add_size > attr.size) {
+        if (attr.fixed) {
+            be_raise(vm, BYTES_RESIZE_ERROR, BYTES_RESIZE_MESSAGE);
+        }
         /* it does not fit so we need to realocate the buffer */
         bytes_resize(vm, &attr, attr.len + add_size);
     }

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -174,7 +174,7 @@ void end_varinfo(bparser *parser, int beginpc)
     if (beginpc == -1) /* use block->beginpc by default */
         beginpc = binfo->beginpc;
     /* skip the variable of the previous blocks */
-    for (; it->beginpc < beginpc; ++it);
+    for (; (it <= end) && (it->beginpc < beginpc); ++it);
     for (; it <= end; ++it) {
         if (!it->endpc) /* write to endpc only once */
             it->endpc = finfo->pc;


### PR DESCRIPTION
## Description:

Apply latest fixes from https://github.com/berry-lang/berry/pull/204
- solves a random crash when compiling with `BE_DEBUG_VAR_INFO 1` which does not happen on Tasmota (option not enabled)
- solves a double free of memory if trying to add to a fixed sized bytes buffer

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
