### PR TITLE
Fix Berry I2C driver lib with latest changes

### DIFF
--- a/lib/libesp32/berry/default/be_driverlib.c
+++ b/lib/libesp32/berry/default/be_driverlib.c
@@ -7,57 +7,6 @@
 #include "be_constobj.h"
 
 /********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Driver_init,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_tasmota
-********************************************************************/
-be_local_closure(Driver_get_tasmota,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota),
-    }),
-    &be_const_str_get_tasmota,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: add_cmd
 ********************************************************************/
 be_local_closure(Driver_add_cmd,   /* name */
@@ -123,24 +72,22 @@ be_local_closure(Driver_add_cmd,   /* name */
 be_local_class(Driver,
     13,
     NULL,
-    be_nested_map(16,
+    be_nested_map(14,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(web_add_main_button, 14), be_const_var(4) },
-        { be_const_key(web_add_console_button, -1), be_const_var(7) },
-        { be_const_key(web_add_management_button, 8), be_const_var(5) },
-        { be_const_key(init, -1), be_const_closure(Driver_init_closure) },
-        { be_const_key(json_append, -1), be_const_var(10) },
-        { be_const_key(web_add_config_button, 7), be_const_var(6) },
-        { be_const_key(every_100ms, -1), be_const_var(1) },
-        { be_const_key(display, -1), be_const_var(12) },
-        { be_const_key(web_add_button, 13), be_const_var(3) },
-        { be_const_key(every_second, -1), be_const_var(0) },
-        { be_const_key(save_before_restart, -1), be_const_var(8) },
-        { be_const_key(get_tasmota, -1), be_const_closure(Driver_get_tasmota_closure) },
-        { be_const_key(web_sensor, 6), be_const_var(9) },
-        { be_const_key(web_add_handler, -1), be_const_var(2) },
-        { be_const_key(button_pressed, 1), be_const_var(11) },
+        { be_const_key(web_add_console_button, 6), be_const_var(7) },
+        { be_const_key(web_add_config_button, -1), be_const_var(6) },
+        { be_const_key(button_pressed, 9), be_const_var(11) },
+        { be_const_key(every_second, 1), be_const_var(0) },
+        { be_const_key(web_add_handler, 11), be_const_var(2) },
         { be_const_key(add_cmd, -1), be_const_closure(Driver_add_cmd_closure) },
+        { be_const_key(web_sensor, -1), be_const_var(9) },
+        { be_const_key(display, -1), be_const_var(12) },
+        { be_const_key(web_add_main_button, 2), be_const_var(4) },
+        { be_const_key(save_before_restart, -1), be_const_var(8) },
+        { be_const_key(web_add_management_button, 0), be_const_var(5) },
+        { be_const_key(every_100ms, 13), be_const_var(1) },
+        { be_const_key(json_append, -1), be_const_var(10) },
+        { be_const_key(web_add_button, -1), be_const_var(3) },
     })),
     be_str_literal("Driver")
 );

--- a/lib/libesp32/berry/default/be_i2c_driverlib.c
+++ b/lib/libesp32/berry/default/be_i2c_driverlib.c
@@ -279,7 +279,7 @@ be_local_closure(I2C_Driver_read8,   /* name */
 ********************************************************************/
 be_local_closure(I2C_Driver_init,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    9,                          /* nstack */
     4,                          /* argc */
     0,                          /* varg */
     0,                          /* has upvals */
@@ -288,7 +288,7 @@ be_local_closure(I2C_Driver_init,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(get_tasmota),
+    /* K0   */  be_nested_str(tasmota),
     /* K1   */  be_nested_str(i2c_enabled),
     /* K2   */  be_nested_str(addr),
     /* K3   */  be_nested_str(wire),
@@ -302,49 +302,49 @@ be_local_closure(I2C_Driver_init,   /* name */
     &be_const_str_init,
     &be_const_str_solidified,
     ( &(const binstruction[44]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
-      0x7C100200,  //  0001  CALL	R4	1
-      0x4C140000,  //  0002  LDNIL	R5
-      0x20140605,  //  0003  NE	R5	R3	R5
-      0x78160004,  //  0004  JMPF	R5	#000A
-      0x8C140901,  //  0005  GETMET	R5	R4	K1
-      0x5C1C0600,  //  0006  MOVE	R7	R3
-      0x7C140400,  //  0007  CALL	R5	2
-      0x74160000,  //  0008  JMPT	R5	#000A
-      0x80000A00,  //  0009  RET	0
-      0x90020402,  //  000A  SETMBR	R0	K2	R2
-      0x8C140904,  //  000B  GETMET	R5	R4	K4
-      0x881C0102,  //  000C  GETMBR	R7	R0	K2
-      0x7C140400,  //  000D  CALL	R5	2
-      0x90020605,  //  000E  SETMBR	R0	K3	R5
-      0x88140103,  //  000F  GETMBR	R5	R0	K3
-      0x78160019,  //  0010  JMPF	R5	#002B
-      0x60140004,  //  0011  GETGBL	R5	G4
-      0x5C180200,  //  0012  MOVE	R6	R1
-      0x7C140200,  //  0013  CALL	R5	1
-      0x1C140B05,  //  0014  EQ	R5	R5	K5
-      0x78160004,  //  0015  JMPF	R5	#001B
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5C180000,  //  0017  MOVE	R6	R0
-      0x7C140200,  //  0018  CALL	R5	1
-      0x90020C05,  //  0019  SETMBR	R0	K6	R5
+      0x4C100000,  //  0000  LDNIL	R4
+      0x20100604,  //  0001  NE	R4	R3	R4
+      0x78120005,  //  0002  JMPF	R4	#0009
+      0xB8120000,  //  0003  GETNGBL	R4	K0
+      0x8C100901,  //  0004  GETMET	R4	R4	K1
+      0x5C180600,  //  0005  MOVE	R6	R3
+      0x7C100400,  //  0006  CALL	R4	2
+      0x74120000,  //  0007  JMPT	R4	#0009
+      0x80000800,  //  0008  RET	0
+      0x90020402,  //  0009  SETMBR	R0	K2	R2
+      0xB8120000,  //  000A  GETNGBL	R4	K0
+      0x8C100904,  //  000B  GETMET	R4	R4	K4
+      0x88180102,  //  000C  GETMBR	R6	R0	K2
+      0x7C100400,  //  000D  CALL	R4	2
+      0x90020604,  //  000E  SETMBR	R0	K3	R4
+      0x88100103,  //  000F  GETMBR	R4	R0	K3
+      0x78120019,  //  0010  JMPF	R4	#002B
+      0x60100004,  //  0011  GETGBL	R4	G4
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C100200,  //  0013  CALL	R4	1
+      0x1C100905,  //  0014  EQ	R4	R4	K5
+      0x78120004,  //  0015  JMPF	R4	#001B
+      0x5C100200,  //  0016  MOVE	R4	R1
+      0x5C140000,  //  0017  MOVE	R5	R0
+      0x7C100200,  //  0018  CALL	R4	1
+      0x90020C04,  //  0019  SETMBR	R0	K6	R4
       0x70020000,  //  001A  JMP		#001C
       0x90020C01,  //  001B  SETMBR	R0	K6	R1
-      0x88140106,  //  001C  GETMBR	R5	R0	K6
-      0x4C180000,  //  001D  LDNIL	R6
-      0x1C140A06,  //  001E  EQ	R5	R5	R6
-      0x78160001,  //  001F  JMPF	R5	#0022
-      0x4C140000,  //  0020  LDNIL	R5
-      0x90020605,  //  0021  SETMBR	R0	K3	R5
-      0x88140103,  //  0022  GETMBR	R5	R0	K3
-      0x78160006,  //  0023  JMPF	R5	#002B
-      0x60140001,  //  0024  GETGBL	R5	G1
-      0x58180007,  //  0025  LDCONST	R6	K7
-      0x881C0106,  //  0026  GETMBR	R7	R0	K6
-      0x58200008,  //  0027  LDCONST	R8	K8
-      0x88240103,  //  0028  GETMBR	R9	R0	K3
-      0x88241309,  //  0029  GETMBR	R9	R9	K9
-      0x7C140800,  //  002A  CALL	R5	4
+      0x88100106,  //  001C  GETMBR	R4	R0	K6
+      0x4C140000,  //  001D  LDNIL	R5
+      0x1C100805,  //  001E  EQ	R4	R4	R5
+      0x78120001,  //  001F  JMPF	R4	#0022
+      0x4C100000,  //  0020  LDNIL	R4
+      0x90020604,  //  0021  SETMBR	R0	K3	R4
+      0x88100103,  //  0022  GETMBR	R4	R0	K3
+      0x78120006,  //  0023  JMPF	R4	#002B
+      0x60100001,  //  0024  GETGBL	R4	G1
+      0x58140007,  //  0025  LDCONST	R5	K7
+      0x88180106,  //  0026  GETMBR	R6	R0	K6
+      0x581C0008,  //  0027  LDCONST	R7	K8
+      0x88200103,  //  0028  GETMBR	R8	R0	K3
+      0x88201109,  //  0029  GETMBR	R8	R8	K9
+      0x7C100800,  //  002A  CALL	R4	4
       0x80000000,  //  002B  RET	0
     })
   )

--- a/lib/libesp32/berry/default/embedded/Driver.be
+++ b/lib/libesp32/berry/default/embedded/Driver.be
@@ -16,13 +16,6 @@ class Driver
   var button_pressed
   var display
 
-  def init()
-  end
-
-  def get_tasmota()
-    return tasmota
-  end
-
   def add_cmd(c, f)
     tasmota.add_cmd(c, / cmd, idx, payload, payload_json -> f(self, cmd, idx, payload, payload_json))
   end

--- a/lib/libesp32/berry/default/embedded/i2c_driver.be
+++ b/lib/libesp32/berry/default/embedded/i2c_driver.be
@@ -29,8 +29,6 @@ class I2C_Driver
    -   i2c_index : Tasmota I2C index, see `I2CDEVICES.md` (int)
    --#
   def init(name_or_detect, addr, i2c_index)
-    var tasmota = self.get_tasmota()            #- retrieve the 'tasmota' singleton -#
-
     #- check if the i2c index is disabled by Tasmota configuration -#
     if i2c_index != nil && !tasmota.i2c_enabled(i2c_index) return end
 

--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -400,7 +400,6 @@ extern const bcstring be_const_str_get_style_bg_color;
 extern const bcstring be_const_str_get_style_line_color;
 extern const bcstring be_const_str_get_style_pad_right;
 extern const bcstring be_const_str_get_switch;
-extern const bcstring be_const_str_get_tasmota;
 extern const bcstring be_const_str_get_temp;
 extern const bcstring be_const_str_get_vbus_current;
 extern const bcstring be_const_str_get_vbus_voltage;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -264,7 +264,7 @@ be_define_const_str(collect, "collect", 2399039025u, 0, 7, &be_const_str_json_fd
 be_define_const_str(color, "color", 1031692888u, 0, 5, &be_const_str_del);
 be_define_const_str(compile, "compile", 1000265118u, 0, 7, &be_const_str_skip);
 be_define_const_str(compress, "compress", 2818084237u, 0, 8, &be_const_str_width_def);
-be_define_const_str(concat, "concat", 4124019837u, 0, 6, &be_const_str_get_tasmota);
+be_define_const_str(concat, "concat", 4124019837u, 0, 6, NULL);
 be_define_const_str(connect, "connect", 2866859257u, 0, 7, &be_const_str_resolvecmnd);
 be_define_const_str(connected, "connected", 1424938192u, 0, 9, &be_const_str_exp);
 be_define_const_str(connection_error, "connection_error", 1358926260u, 0, 16, &be_const_str_tanh);
@@ -392,7 +392,6 @@ be_define_const_str(get_style_bg_color, "get_style_bg_color", 964794381u, 0, 18,
 be_define_const_str(get_style_line_color, "get_style_line_color", 805371932u, 0, 20, &be_const_str_ip);
 be_define_const_str(get_style_pad_right, "get_style_pad_right", 3150287466u, 0, 19, NULL);
 be_define_const_str(get_switch, "get_switch", 164821028u, 0, 10, &be_const_str_init_draw_line_dsc);
-be_define_const_str(get_tasmota, "get_tasmota", 334356779u, 0, 11, NULL);
 be_define_const_str(get_temp, "get_temp", 3370919486u, 0, 8, NULL);
 be_define_const_str(get_vbus_current, "get_vbus_current", 1205347942u, 0, 16, &be_const_str_rotate);
 be_define_const_str(get_vbus_voltage, "get_vbus_voltage", 2398210401u, 0, 16, NULL);
@@ -1102,6 +1101,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 358,
-    .count = 740,
+    .count = 739,
     .table = m_string_table
 };

--- a/tasmota/berry/drivers/i2c_axp192_M5StackCore2.be
+++ b/tasmota/berry/drivers/i2c_axp192_M5StackCore2.be
@@ -67,9 +67,9 @@ class AXP192_M5Stack_Core2 : AXP192
   
       # Reset LCD Controller
       self.set_lcd_reset(false)
-      self.get_tasmota().delay(100)   # wait for 100ms
+      tasmota.delay(100)   # wait for 100ms
       self.set_lcd_reset(true)
-      self.get_tasmota().delay(100)   # wait for 100ms
+      tasmota.delay(100)   # wait for 100ms
 
       # bus power mode_output
       self.set_buf_power_mode(false)


### PR DESCRIPTION
## Description:

Autoconf for M5Stack Core2 needs to be reloaded on devices.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
