### PR TITLE
Tuya esp32c3

### DIFF
--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -133,7 +133,7 @@ String EthernetMacAddress(void);
 #undef FIRMWARE_MINIMAL                            // Minimal is not supported as not needed
 
 // Hardware has no ESP32
-#undef USE_TUYA_DIMMER
+//#undef USE_TUYA_DIMMER
 #undef USE_PWM_DIMMER
 #undef USE_EXS_DIMMER
 #undef USE_ARMTRONIX_DIMMERS
@@ -148,7 +148,7 @@ String EthernetMacAddress(void);
 // Not ported (yet)
 
 #undef USE_MY92X1
-#undef USE_TUYA_MCU
+//#undef USE_TUYA_MCU
 #undef USE_PS_16_DZ
 
 #undef USE_HM10                     // Disable support for HM-10 as a BLE-bridge as an alternative is using the internal ESP32 BLE

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -133,7 +133,6 @@ String EthernetMacAddress(void);
 #undef FIRMWARE_MINIMAL                            // Minimal is not supported as not needed
 
 // Hardware has no ESP32
-//#undef USE_TUYA_DIMMER
 #undef USE_PWM_DIMMER
 #undef USE_EXS_DIMMER
 #undef USE_ARMTRONIX_DIMMERS
@@ -147,8 +146,14 @@ String EthernetMacAddress(void);
 
 // Not ported (yet)
 
+#ifdef CONFIG_IDF_TARGET_ESP32C3
+// tuya suported on C3 to allow brain-transplant
+#else
+#undef USE_TUYA_MCU
+#undef USE_TUYA_DIMMER
+#endif
+
 #undef USE_MY92X1
-//#undef USE_TUYA_MCU
 #undef USE_PS_16_DZ
 
 #undef USE_HM10                     // Disable support for HM-10 as a BLE-bridge as an alternative is using the internal ESP32 BLE

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -2617,13 +2617,13 @@ const mytmplt kModules[] PROGMEM = {
     AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0, XTAL_32K_P
     AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1, XTAL_32K_N
     AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2, FSPIQ
-    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3
-    AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4, FSPIHD, MTMS
-    AGPIO(GPIO_USER),            // 5       IO                  GPIO5, ADC2_CH0, FSPIWP, MTDI
+    AGPIO(GPIO_LEDLNK_INV),      // 3       IO                  GPIO3, ADC1_CH3  (based on ESP-12F=>ESP32C3-12F)
+    AGPIO(GPIO_NRG_SEL_INV),     // 4       IO                  GPIO4, ADC1_CH4, FSPIHD, MTMS (based on ESP-12F=>ESP32C3-12F)
+    AGPIO(GPIO_LED1_INV),        // 5       IO                  GPIO5, ADC2_CH0, FSPIWP, MTDI (based on ESP-12F=>ESP32C3-12F)
     AGPIO(GPIO_USER),            // 6       IO                  GPIO6, FSPICLK, MTCK
     AGPIO(GPIO_USER),            // 7       IO                  GPIO7, FSPID, MTDO
-    AGPIO(GPIO_USER),            // 8       IO                  GPIO8
-    AGPIO(GPIO_USER),            // 9       IO                  GPIO9
+    AGPIO(GPIO_REL1),            // 8       IO                  GPIO8 (based on ESP-12F=>ESP32C3-12F)
+    AGPIO(GPIO_KEY1),            // 9       IO                  GPIO9 (based on ESP-12F=>ESP32C3-12F)
     AGPIO(GPIO_USER),            // 10      IO                  GPIO10
     0,                           // 11      IO                  GPIO11, output power supply for flash
     0,                           // 12      IO                  GPIO12, SPIHD
@@ -2632,8 +2632,8 @@ const mytmplt kModules[] PROGMEM = {
     0,                           // 15      IO                  GPIO15, SPICLK
     0,                           // 16      IO                  GPIO16, SPID
     0,                           // 17      IO                  GPIO17, SPIQ
-    AGPIO(GPIO_USER),            // 18      IO                  GPIO18, USB_D
-    AGPIO(GPIO_USER),            // 19      IO                  GPIO19, USB_D+
+    AGPIO(GPIO_HLW_CF),          // 18      IO                  GPIO18, USB_D  (based on ESP-12F=>ESP32C3-12F)
+    AGPIO(GPIO_NRG_CF1),         // 19      IO                  GPIO19, USB_D+ (based on ESP-12F=>ESP32C3-12F)
     AGPIO(GPIO_USER),            // 20      IO     RXD0         GPIO20, U0RXD
     AGPIO(GPIO_USER),            // 21      IO     TXD0         GPIO21, U0TXD
     0                            // Flag

--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -2546,22 +2546,74 @@ const mytmplt8285 kModules8285[TMP_MAXMODULE_8266 - TMP_WEMOS] PROGMEM = {
 
 // Supported hardware modules
 enum SupportedModules {
-  WEMOS,
+  WEMOS,TUYA_DIMMER,SK03_TUYA,
   MAXMODULE };
 
 // Default module settings
 const uint8_t kModuleNiceList[] PROGMEM = {
   WEMOS,
+  TUYA_DIMMER,         // Dimmer Devices
+  SK03_TUYA,
 };
 
 // !!! Update this list in the same order as kModuleNiceList !!!
 const char kModuleNames[] PROGMEM =
-  "ESP32C3|"
+  "ESP32C3|Tuya MCU|SK03 Outdoor|"
   ;
 
 // !!! Update this list in the same order as SupportedModules !!!
 const mytmplt kModules[] PROGMEM = {
   {                              // Generic ESP32C3 device
+    AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0, XTAL_32K_P
+    AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1, XTAL_32K_N
+    AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2, FSPIQ
+    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3
+    AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4, FSPIHD, MTMS
+    AGPIO(GPIO_USER),            // 5       IO                  GPIO5, ADC2_CH0, FSPIWP, MTDI
+    AGPIO(GPIO_USER),            // 6       IO                  GPIO6, FSPICLK, MTCK
+    AGPIO(GPIO_USER),            // 7       IO                  GPIO7, FSPID, MTDO
+    AGPIO(GPIO_USER),            // 8       IO                  GPIO8
+    AGPIO(GPIO_USER),            // 9       IO                  GPIO9
+    AGPIO(GPIO_USER),            // 10      IO                  GPIO10
+    0,                           // 11      IO                  GPIO11, output power supply for flash
+    0,                           // 12      IO                  GPIO12, SPIHD
+    0,                           // 13      IO                  GPIO13, SPIWP
+    0,                           // 14      IO                  GPIO14, SPICS0
+    0,                           // 15      IO                  GPIO15, SPICLK
+    0,                           // 16      IO                  GPIO16, SPID
+    0,                           // 17      IO                  GPIO17, SPIQ
+    AGPIO(GPIO_USER),            // 18      IO                  GPIO18, USB_D
+    AGPIO(GPIO_USER),            // 19      IO                  GPIO19, USB_D+
+    AGPIO(GPIO_USER),            // 20      IO     RXD0         GPIO20, U0RXD
+    AGPIO(GPIO_USER),            // 21      IO     TXD0         GPIO21, U0TXD
+    0                            // Flag
+  },
+  {                              // TUYA_DIMMER - Tuya MCU device
+    AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0, XTAL_32K_P
+    AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1, XTAL_32K_N
+    AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2, FSPIQ
+    AGPIO(GPIO_USER),            // 3       IO                  GPIO3, ADC1_CH3
+    AGPIO(GPIO_USER),            // 4       IO                  GPIO4, ADC1_CH4, FSPIHD, MTMS
+    AGPIO(GPIO_USER),            // 5       IO                  GPIO5, ADC2_CH0, FSPIWP, MTDI
+    AGPIO(GPIO_USER),            // 6       IO                  GPIO6, FSPICLK, MTCK
+    AGPIO(GPIO_USER),            // 7       IO                  GPIO7, FSPID, MTDO
+    AGPIO(GPIO_USER),            // 8       IO                  GPIO8
+    AGPIO(GPIO_USER),            // 9       IO                  GPIO9
+    AGPIO(GPIO_USER),            // 10      IO                  GPIO10
+    0,                           // 11      IO                  GPIO11, output power supply for flash
+    0,                           // 12      IO                  GPIO12, SPIHD
+    0,                           // 13      IO                  GPIO13, SPIWP
+    0,                           // 14      IO                  GPIO14, SPICS0
+    0,                           // 15      IO                  GPIO15, SPICLK
+    0,                           // 16      IO                  GPIO16, SPID
+    0,                           // 17      IO                  GPIO17, SPIQ
+    AGPIO(GPIO_USER),            // 18      IO                  GPIO18, USB_D
+    AGPIO(GPIO_USER),            // 19      IO                  GPIO19, USB_D+
+    AGPIO(GPIO_USER),            // 20      IO     RXD0         GPIO20, U0RXD
+    AGPIO(GPIO_USER),            // 21      IO     TXD0         GPIO21, U0TXD
+    0                            // Flag
+  },
+  {                              // SK03_TUYA - Outdoor smart plug with power monitoring HLW8012 chip - https://www.amazon.com/gp/product/B07CG7MBPV
     AGPIO(GPIO_USER),            // 0       IO                  GPIO0, ADC1_CH0, XTAL_32K_P
     AGPIO(GPIO_USER),            // 1       IO                  GPIO1, ADC1_CH1, XTAL_32K_N
     AGPIO(GPIO_USER),            // 2       IO                  GPIO2, ADC1_CH2, FSPIQ
@@ -2595,7 +2647,7 @@ const mytmplt kModules[] PROGMEM = {
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
 
 /********************************************************************************************\
- * ESP32-C3 Module templates
+ * ESP32-S2 Module templates
 \********************************************************************************************/
 
 #define USER_MODULE        255

--- a/tasmota/xdrv_12_discovery.ino
+++ b/tasmota/xdrv_12_discovery.ino
@@ -49,7 +49,9 @@ void TasDiscoverMessage(void) {
 
   bool TuyaMod = false;
   bool iFanMod = false;
+#ifdef TUYA_MCU
   if ((TUYA_DIMMER == TasmotaGlobal.module_type) || (SK03_TUYA == TasmotaGlobal.module_type)) { TuyaMod = true; };
+#endif
 #ifdef ESP8266
   if ((SONOFF_IFAN02 == TasmotaGlobal.module_type) || (SONOFF_IFAN03 == TasmotaGlobal.module_type)) { iFanMod = true; };
 #endif  // ESP8266

--- a/tasmota/xdrv_12_discovery.ino
+++ b/tasmota/xdrv_12_discovery.ino
@@ -49,8 +49,8 @@ void TasDiscoverMessage(void) {
 
   bool TuyaMod = false;
   bool iFanMod = false;
-#ifdef ESP8266
   if ((TUYA_DIMMER == TasmotaGlobal.module_type) || (SK03_TUYA == TasmotaGlobal.module_type)) { TuyaMod = true; };
+#ifdef ESP8266
   if ((SONOFF_IFAN02 == TasmotaGlobal.module_type) || (SONOFF_IFAN03 == TasmotaGlobal.module_type)) { iFanMod = true; };
 #endif  // ESP8266
 

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -216,7 +216,9 @@ void HassDiscoverMessage(void) {
 
   bool TuyaMod = false;
   bool iFanMod = false;
+#ifdef TUYA_MCU
   if ((TUYA_DIMMER == TasmotaGlobal.module_type) || (SK03_TUYA == TasmotaGlobal.module_type)) { TuyaMod = true; };
+#endif
 #ifdef ESP8266
   if ((SONOFF_IFAN02 == TasmotaGlobal.module_type) || (SONOFF_IFAN03 == TasmotaGlobal.module_type)) { iFanMod = true; };
 #endif  // ESP8266
@@ -461,8 +463,10 @@ void HAssAnnounceRelayLight(void)
         if (SONOFF_IFAN02 == TasmotaGlobal.module_type || SONOFF_IFAN03 == TasmotaGlobal.module_type) { FanMod = true; }
         if (SONOFF_DUAL == TasmotaGlobal.module_type) { valid_relay = 2; }
   #endif //ESP8266
+  #ifdef TUYA_MCU
         if (TUYA_DIMMER == TasmotaGlobal.module_type || SK03_TUYA == TasmotaGlobal.module_type) { TuyaMod = true; }
-
+  #endif
+  
 #ifdef USE_LIGHT
   // If there is a special Light to be enabled and managed with SetOption68 or SetOption37 >= 128, Discovery calculates the maximum number of entities to be generated in advance
   if (PwmMulti) { max_lights = Light.subtype; }

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -216,8 +216,8 @@ void HassDiscoverMessage(void) {
 
   bool TuyaMod = false;
   bool iFanMod = false;
-#ifdef ESP8266
   if ((TUYA_DIMMER == TasmotaGlobal.module_type) || (SK03_TUYA == TasmotaGlobal.module_type)) { TuyaMod = true; };
+#ifdef ESP8266
   if ((SONOFF_IFAN02 == TasmotaGlobal.module_type) || (SONOFF_IFAN03 == TasmotaGlobal.module_type)) { iFanMod = true; };
 #endif  // ESP8266
 
@@ -460,8 +460,8 @@ void HAssAnnounceRelayLight(void)
         if (PWM_DIMMER == TasmotaGlobal.module_type ) { PwmMod = true; } //
         if (SONOFF_IFAN02 == TasmotaGlobal.module_type || SONOFF_IFAN03 == TasmotaGlobal.module_type) { FanMod = true; }
         if (SONOFF_DUAL == TasmotaGlobal.module_type) { valid_relay = 2; }
-        if (TUYA_DIMMER == TasmotaGlobal.module_type || SK03_TUYA == TasmotaGlobal.module_type) { TuyaMod = true; }
   #endif //ESP8266
+        if (TUYA_DIMMER == TasmotaGlobal.module_type || SK03_TUYA == TasmotaGlobal.module_type) { TuyaMod = true; }
 
 #ifdef USE_LIGHT
   // If there is a special Light to be enabled and managed with SetOption68 or SetOption37 >= 128, Discovery calculates the maximum number of entities to be generated in advance


### PR DESCRIPTION
## Description:

As disccussed in https://github.com/arendst/Tasmota/discussions/14086
esp32C3 is a good alternative to esp8266 for Tuya frankesteinization
This PR brings Tuya_MCU to C3

TUYA_MCU is module 2 on C3 vs 54 on ESP8266
So templates need to be manually adapted


Note that it also brings SK03_TUYA in order to minimize code change.
Alternatively, SK03_TUYA could be excluded with #if

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
