### PR TITLE
Fix changeUIntScale to be stable

### DIFF
--- a/tasmota/support_float.ino
+++ b/tasmota/support_float.ino
@@ -407,8 +407,19 @@ uint16_t changeUIntScale(uint16_t inum, uint16_t ifrom_min, uint16_t ifrom_max,
     to_max = ito_min;
   }
 
-  uint32_t numerator = (num - from_min) * (to_max - to_min + 1);
-  uint32_t result = numerator / (from_max - from_min) + to_min;
+  // short-cut if limits to avoid rounding errors
+  if (num == from_min) return to_min;
+  if (num == from_max) return to_max;
+
+  uint32_t result;
+  if ((num - from_min) < 0x8000L) {   // no overflow possible
+    uint32_t numerator = ((num - from_min) * 2 + 1) * (to_max - to_min + 1);
+    result = numerator / ((from_max - from_min + 1) * 2) + to_min;
+  } else {    // no pre-rounding since it might create an overflow
+    uint32_t numerator = (num - from_min) * (to_max - to_min + 1);
+    result = numerator / (from_max - from_min) + to_min;
+  }
+
   return (uint32_t) (result > to_max ? to_max : (result < to_min ? to_min : result));
 }
 


### PR DESCRIPTION
## Description:

I redid the math and changed slightly the computation. Now instead of converting a number to another number, it converts a range bucket to another range bucket. For value `n`, its bucket if `[n,n+1[`. So now I'm taking the value of the center of the bucket which is `n+1/2`

The new algorithm is now proven to be stable when going from `0..100` to `0..255` and back to `0..100`

``` ruby
for i: 0..100
  var d = tasmota.scale_uint(i,0,100,0,255)
  var j = tasmota.scale_uint(d,0,255,0,100)
  print(string.format("i=%i d=%i j=%i", i, d, j))
  if i != j print("BLAH ----------------") end
end
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.1.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
