### PR TITLE
DHT support both type of negative temperature

### DIFF
--- a/tasmota/xsns_06_dht.ino
+++ b/tasmota/xsns_06_dht.ino
@@ -152,11 +152,10 @@ bool DhtRead(uint32_t sensor) {
     case GPIO_SI7021:                                   // iTead SI7021
       humidity = ((dht_data[0] << 8) | dht_data[1]) * 0.1;
       // DHT21/22 (Adafruit):
-      temperature = ((int16_t)(dht_data[2] & 0x7F) << 8 ) | dht_data[3];
-      temperature *= 0.1f;
-      if (dht_data[2] & 0x80) {
-        temperature *= -1;
-      }
+      int16_t temp16 = dht_data[2] << 8  | dht_data[3]; // case 1 : signed 16 bits
+      if ((dht_data[2] & 0xF0) == 0x80)                 // case 2 : negative when high nibble = 0x80
+        temp16 = -(0xFFF & temp16);
+      temperature = 0.1f * temp16;
       break;
   }
   if (isnan(temperature) || isnan(humidity)) {


### PR DESCRIPTION
## Description:

https://github.com/arendst/Tasmota/issues/14165
There seems to be 2 variants of DHT22: 
- one with temperature provided as signed 16 bits (2's complement)
- one with only bit 31 set to indicate a negative temperature (more standard model)

This patch seamlessly handles both case by comparing high nibble to 0x8


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
