### PR TITLE
Berry fix string.format crash

### DIFF
--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -578,7 +578,7 @@ static int str_format(bvm *vm)
                 break;
             case 's': {
                 const char *s = be_tostring(vm, index);
-                int len = be_strlen(vm, 2);
+                int len = be_strlen(vm, index);
                 if (len > 100 && strlen(mode) == 2) {
                     be_pushvalue(vm, index);
                 } else {

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -39,3 +39,44 @@ s="azerty"
 assert(s[1..2] == "ze")
 assert(s[1..] == "zerty")
 assert(s[1..-1] == "zerty")
+
+#- string ranges -#
+s="azertyuiop"
+assert(s[0] == "a")
+assert(s[0..1] == "az")
+assert(s[0..2] == "aze")
+assert(s[0..10] == s)
+assert(s[0..size(s)] == s)
+assert(s[0..50] == s)       #- upper limit is allowed to be out of range -#
+
+#- negative indices start from the end -#
+s="azertyuiop"
+assert(s[-1] == "p")
+assert(s[-2] == "o")
+assert(s[0..-2] == "azertyuio")
+assert(s[-4..-2] == "uio")
+assert(s[-2..-4] == "")  #- if range is in wrong order, returns empty string -#
+assert(s[-40..-2] == "azertyuio")  #- borders are allowed to be out of range -#
+
+# escape
+import string
+assert(string.escape("A") == '"A"')
+assert(string.escape("A", true) == "'A'")
+assert(string.escape("\"") == '"\\""')
+assert(string.escape("\"", true) == '\'"\'')
+
+var s ='"a\'b"\''
+assert(string.escape(s) == '"\\"a\'b\\"\'"')
+assert(string.escape(s, true) == '\'"a\\\'b"\\\'\'')
+
+# tr
+assert(string.tr("azer", "abcde", "ABCDE") == 'AzEr')
+assert(string.tr("azer", "", "") == 'azer')
+assert(string.tr("azer", "aaa", "ABC") == 'Azer')  # only first match works
+assert(string.tr("A_b", "_", " ") == 'A b')
+# tr used to remove characters
+assert(string.tr("qwerty", "qwe", "_") == '_rty')
+
+# the following should not crash
+var s1 = 'A string of more than 128 bytes 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
+var s2 = string.format("%i, %s", 1, s1)


### PR DESCRIPTION
## Description:

Applying patch https://github.com/berry-lang/berry/pull/226

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
