### PR TITLE
provide proper OTA_URL for tasmota32solo1

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,4 +42,4 @@ build_flags                 = ${esp32_defaults.build_flags}
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2solo1/platform-tasmota-espressif32-2.0.2-solo1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${esp32_defaults.build_flags}
+build_flags                 = ${esp32_defaults.build_flags} -DCORE32SOLO1

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -51,7 +51,7 @@ build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 extends                 = env:tasmota32_base
 platform                = ${core32solo1.platform}
 platform_packages       = ${core32solo1.platform_packages}
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${core32solo1.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -98,7 +98,9 @@
 #ifdef ESP32
 #ifdef CONFIG_IDF_TARGET_ESP32C3
 #define OTA_URL                "http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"  // [OtaUrl]
-#else   // No CONFIG_IDF_TARGET_ESP32C3
+#elif defined(CORE32SOLO1)
+#define OTA_URL                "http://ota.tasmota.com/tasmota32/release/tasmota32solo1.bin"  // [OtaUrl]
+#else
 #define OTA_URL                "http://ota.tasmota.com/tasmota32/release/tasmota32.bin"  // [OtaUrl]
 #endif  //  CONFIG_IDF_TARGET_ESP32C3
 #endif  // ESP32


### PR DESCRIPTION
## Description:

@Jason2866 This allows detection of CORE32SOLO1 build in my_user_config

```shell
~/Documents/_perso/repos/Tasmota/build_output/firmware$ strings -f *.bin | grep "ota.tasmota.com"
tasmota32.bin: http://ota.tasmota.com/tasmota32/release/tasmota32.bin
tasmota32solo1.bin: http://ota.tasmota.com/tasmota32/release/tasmota32solo1.bin
```


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
