### PR TITLE
Bug fix in serial library for hardware parity applications.

### DIFF
--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -1885,15 +1885,14 @@ void SetSerialBegin(void) {
   AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_SERIAL "Set to %s %d bit/s"), GetSerialConfig().c_str(), TasmotaGlobal.baudrate);
   Serial.flush();
 #ifdef ESP8266
-  Serial.begin(TasmotaGlobal.baudrate, (SerialConfig)pgm_read_byte(kTasmotaSerialConfig + Settings->serial_config));
+  Serial.begin(TasmotaGlobal.baudrate, (SerialConfig)ConvertSerialConfig(Settings->serial_config));
   SetSerialSwap();
 #endif  // ESP8266
 #ifdef ESP32
   delay(10);  // Allow time to cleanup queues - if not used hangs ESP32
   Serial.end();
   delay(10);  // Allow time to cleanup queues - if not used hangs ESP32
-  uint32_t config = pgm_read_dword(kTasmotaSerialConfig + Settings->serial_config);
-  Serial.begin(TasmotaGlobal.baudrate, config);
+  Serial.begin(TasmotaGlobal.baudrate, ConvertSerialConfig(Settings->serial_config));
 #endif  // ESP32
 }
 

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -337,7 +337,7 @@ void setup(void) {
     Settings->baudrate = APP_BAUDRATE / 300;
     Settings->serial_config = TS_SERIAL_8N1;
   }
-  SetSerialBaudrate(Settings->baudrate * 300);  // Reset serial interface if current baudrate is different from requested baudrate
+  SetSerialBegin();                            // Reset serial interface if current serial settings are different from requested serial settings
 
   if (1 == RtcReboot.fast_reboot_count) {      // Allow setting override only when all is well
     UpdateQuickPowerCycle(true);

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -337,7 +337,7 @@ void setup(void) {
     Settings->baudrate = APP_BAUDRATE / 300;
     Settings->serial_config = TS_SERIAL_8N1;
   }
-  SetSerialBegin();                            // Reset serial interface if current serial settings are different from requested serial settings
+  SetSerialBaudrate(Settings->baudrate * 300);  // Reset serial interface if current baudrate is different from requested baudrate
 
   if (1 == RtcReboot.fast_reboot_count) {      // Allow setting override only when all is well
     UpdateQuickPowerCycle(true);

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -3620,15 +3620,7 @@ chknext:
             glob_script_mem.sp = new TasmotaSerial(rxpin, txpin, 1, 0, rxbsiz);
 
             if (glob_script_mem.sp) {
-              uint32_t config;
-#ifdef ESP8266
-              config = pgm_read_byte(kTasmotaSerialConfig + sconfig);
-#endif  // ESP8266
-
-#ifdef ESP32
-              config = pgm_read_dword(kTasmotaSerialConfig + sconfig);
-#endif // ESP32
-              fvar = glob_script_mem.sp->begin(br, config);
+              fvar = glob_script_mem.sp->begin(br, ConvertSerialConfig(sconfig));
               uint32_t savc = Settings->serial_config;
               //setRxBufferSize(TMSBSIZ);
 


### PR DESCRIPTION
TasmotaSerial.cpp
- Fixed issue where fake parity for software serial was being called on software and hardware serial, and was overwriting parity settings for hardware configurations.

tasmota.ino:
- Force the baudrate + serial config settings after boot. Previously, the baudrate would change, but any non-8N1 settings were not applied if using the debug hardware serial port.

support.ino
- Cleanup to use already present ConvertSerialConfig API.

xdrv_10_scripter.ino
- Cleanup to use already present ConvertSerialConfig API.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
