### PR TITLE
Add missing & on function pointer for coherency

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -65,7 +65,7 @@ void (* const TasmotaCommand[])(void) PROGMEM = {
   &CmndTimeDst, &CmndAltitude, &CmndLedPower, &CmndLedState, &CmndLedMask, &CmndLedPwmOn, &CmndLedPwmOff, &CmndLedPwmMode,
   &CmndWifiPower, &CmndTempOffset, &CmndHumOffset, &CmndSpeedUnit, &CmndGlobalTemp, &CmndGlobalHum, &CmndSwitchText,
 #ifdef USE_I2C
-  &CmndI2cScan, CmndI2cDriver,
+  &CmndI2cScan, &CmndI2cDriver,
 #endif
 #ifdef USE_DEVICE_GROUPS
   &CmndDevGroupName,

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -59,7 +59,7 @@ void (* const ZigbeeCommand[])(void) PROGMEM = {
   &CmndZbInfo, &CmndZbForget, &CmndZbSave, &CmndZbName,
   &CmndZbBind, &CmndZbUnbind, &CmndZbPing, &CmndZbModelId,
   &CmndZbLight, &CmndZbOccupancy,
-  &CmndZbRestore, &CmndZbBindState, &CmndZbMap, CmndZbLeave,
+  &CmndZbRestore, &CmndZbBindState, &CmndZbMap, &CmndZbLeave,
   &CmndZbConfig, &CmndZbData, &CmndZbScan,
   };
 


### PR DESCRIPTION
## Description:

https://github.com/arendst/Tasmota/issues/14213

In that context using `CmndFunctionName` or `&CmndFunctionName` is equivalent (albeit non identical in theory)
However, still better for code coherency to keep a uniform syntax

Some discussions about it:
https://stackoverflow.com/questions/6893285/why-do-function-pointer-definitions-work-with-any-number-of-ampersands-or-as



## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
