### PR TITLE
Correct Info message from SPIFFS to FS

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "AI Thinker ESP32-CAM, 4M Flash 4MB PSRAM, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "name": "AI Thinker ESP32-CAM, 4M Flash 4MB PSRAM, Tasmota 1856k Code/OTA, 320k FS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "M5Stack Core2 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M SPIFFS",
+  "name": "M5Stack Core2 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M FS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "ESP32 ODROID-GO 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M SPIFFS",
+  "name": "ESP32 ODROID-GO 16M Flash, 4MB PSRAM, Tasmota 2944k Code/OTA, 10M FS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M SPIFFS",
+  "name": "Espressif Generic ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M FS",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k SPIFFS",
+  "name": "Espressif Generic ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k FS",
   "upload": {
     "flash_size": "8MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32_solo1_4M.json
+++ b/boards/esp32_solo1_4M.json
@@ -25,7 +25,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "name": "Espressif Generic ESP32 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -22,7 +22,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Espressif Generic ESP32-C3 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "name": "Espressif Generic ESP32-C3 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -22,7 +22,7 @@
     "espidf",
     "arduino"
   ],
-  "name": "Espressif Generic ESP32-S2 4M Flash, Tasmota 1856k Code/OTA, 320k SPIFFS",
+  "name": "Espressif Generic ESP32-S2 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
   "upload": {
     "flash_size": "4MB",
     "maximum_ram_size": 327680,

--- a/boards/esp8266_1M.json
+++ b/boards/esp8266_1M.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 Tasmota 1M sketch NO SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch NO FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,

--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 772k OTA 256k SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 772k OTA 256k FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,

--- a/boards/esp8266_4M2M.json
+++ b/boards/esp8266_4M2M.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M OTA 2M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 1M OTA 2M FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 3M SPIFFS",
+  "name": "Espressif Generic ESP8266 Tasmota 1M sketch 3M FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,

--- a/boards/esp8266_zbbridge.json
+++ b/boards/esp8266_zbbridge.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Sonoff ZbBridge Tasmota 1M sketch 772k OTA 256k SPIFFS",
+  "name": "Sonoff ZbBridge Tasmota 1M sketch 772k OTA 256k FS",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 995326,


### PR DESCRIPTION
just optical issue. Tasmota does no use SPIFFS as Filesystem. Changed in *FS*

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
