### PR TITLE
Tasmota repo as source for esp8266 framwork

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -106,9 +106,8 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = espressif8266 @ 2.6.3
-platform_packages           = tasmota/framework-arduinoespressif8266 @ ~2.7.4
-                              platformio/tool-esptoolpy @ ~1.30100
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/v2.7.4.9/platform-espressif8266-2.7.4.9.zip
+platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}
 ; *** Use ONE of the two PWM variants. Tasmota default is Locked PWM

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -42,8 +42,9 @@ default_envs            =
 [env]
 ; Activate Development core by removing ";" the next lines
 ;platform                = https://github.com/platformio/platform-espressif8266.git
-;platform_packages       = ${common.platform_packages}
-;                          framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+;platform_packages       = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+;                          mcspr/toolchain-xtensa @ ~5.100300.211127
+;                          platformio/tool-esptoolpy @ ~1.30100
 ;build_unflags           = ${common.build_unflags}
 ;                          -Wswitch-unreachable
 ;build_flags             = ${common.build_flags}
@@ -90,7 +91,7 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 [env:tasmota32_base]
 ; *** Uncomment next line ";" to enable development Tasmota Arduino version ESP32
-;platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/555/framework-arduinoespressif32-release_v4.4-831152548.tar.gz
+;platform                = https://github.com/Jason2866/platform-espressif32/releases/download/v2.0.2.1/platform-espressif32-2.0.2.1.zip
 build_unflags           = ${esp32_defaults.build_unflags}
 build_flags             = ${esp32_defaults.build_flags}
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -42,13 +42,13 @@ monitor_filters         = esp32_exception_decoder
 ; *** JTAG Debug version, needs esp-prog or FT2232H or FT232H
 [env:tasmota32solo1-ocd]
 build_type              = debug
-extends                 = env:tasmota32_base
+extends                 = env:tasmota32solo1
 platform                = ${core32solo1.platform}
 platform_packages       = ${core32solo1.platform_packages}
 board                   = esp32_solo1_4M
 debug_tool              = esp-prog
 upload_protocol         = esp-prog
 debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32_base.build_unflags}
-build_flags             = ${env:tasmota32_base.build_flags}
+build_unflags           = ${core32solo1.build_unflags}
+build_flags             = ${core32solo1.build_flags}
 monitor_filters         = esp32_exception_decoder


### PR DESCRIPTION
## Description:

- do esp8266 framework setup the same way as for esp32
- some minor optimizations/fixes in env and override settings

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
