### PR TITLE
fix edit file gui for sd card

### DIFF
--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -978,15 +978,15 @@ void UfsEditor(void) {
   char fname[UFS_FILENAME_SIZE];
   UfsFilename(fname, fname_input);                  // Trim spaces and add slash
 
-  AddLog(LOG_LEVEL_DEBUG, PSTR("UFS: UfsEditor: file=%s, ffs_type=%d, TfsFileExist=%d"), fname, ffs_type, TfsFileExists(fname));
+  AddLog(LOG_LEVEL_DEBUG, PSTR("UFS: UfsEditor: file=%s, ffs_type=%d, TfsFileExist=%d"), fname, ffs_type, dfsp->exists(fname));
 
   WSContentStart_P(PSTR(D_EDIT_FILE));
   WSContentSendStyle();
   char *bfname = fname +1;
   WSContentSend_P(HTTP_EDITOR_FORM_START, bfname);  // Skip leading slash
 
-  if (ffs_type && TfsFileExists(fname)) {
-    File fp = ffsp->open(fname, "r");
+  if (ffs_type && dfsp->exists(fname)) {
+    File fp = dfsp->open(fname, "r");
     if (!fp) {
       AddLog(LOG_LEVEL_DEBUG, PSTR("UFS: UfsEditor: file open failed"));
       WSContentSend_P(D_NEW_FILE);
@@ -1039,14 +1039,14 @@ void UfsEditorUpload(void) {
   }
   String content = Webserver->arg("content");
 
-  if (!ffsp) {
+  if (!dfsp) {
     Web.upload_error = 1;
     AddLog(LOG_LEVEL_ERROR, PSTR("UFS: UfsEditor: 507: no storage available"));
     WSSend(507, CT_PLAIN, F("507: no storage available"));
     return;
   }
 
-  File fp = ffsp->open(fname, "w");
+  File fp = dfsp->open(fname, "w");
   if (!fp) {
     Web.upload_error = 1;
     AddLog(LOG_LEVEL_ERROR, PSTR("UFS: UfsEditor: 400: invalid file name '%s'"), fname);


### PR DESCRIPTION
## Description:

fixes gui edit file for sdcard files

btw SDCARD is not working properly with current tasmota esp32 core 2.02
had to revert to a previous version
this is a known issue:
https://github.com/espressif/arduino-esp32/issues/6078

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
