### PR TITLE
prep one file firmware for esp32

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -1,0 +1,30 @@
+# From: https://github.com/letscontrolit/ESPEasy/blob/mega/tools/pio/post_esp32.py
+# Thanks TD-er :)
+
+Import("env")
+
+def esp32_create_factory_bin(source, target, env):
+    #print("Generating one file initial flash firmware for esp32 units")
+    offset = 0x0
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
+    sections = env.subst(env.get('FLASH_EXTRA_IMAGES'))
+    new_file = open(new_file_name,"wb")
+    print("    {} | {}".format("Offset", "File"))
+    for section in sections:
+      sect_adr,sect_file = section.split(" ",1)
+      print(" -  {} | {}".format(sect_adr,sect_file))
+      source = open(sect_file,"rb")
+      new_file.seek(int(sect_adr,0)-offset)
+      new_file.write(source.read());
+      source.close()
+
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    firmware_start = 0x10000-offset
+    firmware = open(firmware_name,"rb")
+    print(" - {} | {}".format(hex(firmware_start),firmware_name))
+    new_file.seek(firmware_start)
+    new_file.write(firmware.read())
+    new_file.close()
+    firmware.close()
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_factory_bin)

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -31,6 +31,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               ; wrappers for the crash-recorder
                               -Wl,--wrap=panicHandler -Wl,--wrap=xt_unhandled_exception
 extra_scripts               = pre:pio-tools/add_c_flags.py
+                              post:pio-tools/post_esp32.py
                               ${esp_defaults.extra_scripts}
 
 [core32]


### PR DESCRIPTION
For easy initial flashing. Flashing at address 0x0 with esptool.py
Generated in folder `.pio..../firmware-factory.bin` (Not used at the moment!)
`esptool.py --chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_size detect 0x0 firmware-factory.bin`
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
