### PR TITLE
Force `MQTT_MAX_PACKET_SIZE` in PubSub client

### DIFF
--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -188,6 +188,9 @@ void MqttDisableLogging(bool state) {
 PubSubClient MqttClient;
 
 void MqttInit(void) {
+  // Force buffer size since the #define may not be visible from Arduino lib
+  MqttClient.setBufferSize(MQTT_MAX_PACKET_SIZE);
+
 #ifdef USE_MQTT_AZURE_IOT
   Settings->mqtt_port = 8883;
 #endif //USE_MQTT_AZURE_IOT


### PR DESCRIPTION
## Description:

Force the change of `MQTT_MAX_PACKET_SIZE` in PubSub client, when `#define MQTT_MAX_PACKET_SIZE` was defined in user config and not in compile options CLI. Otherwise the size is increased in Tasmota but not in PubSub.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
