### PR TITLE
make adc_ph formula more flexible

### DIFF
--- a/tasmota/xsns_02_analog.ino
+++ b/tasmota/xsns_02_analog.ino
@@ -338,13 +338,13 @@ float AdcGetPh(uint32_t idx) {
   int adc = AdcRead(Adc[idx].pin, 2);
 
 
-  float y1 = Adc[idx].param1 / ANALOG_PH_DECIMAL_MULTIPLIER;
-  uint32_t x1 = Adc[idx].param2;
-  float y2 = Adc[idx].param3 / ANALOG_PH_DECIMAL_MULTIPLIER;
-  uint32_t x2 = Adc[idx].param4;
+  float y1 = (float)Adc[idx].param1 / ANALOG_PH_DECIMAL_MULTIPLIER;
+  int32_t x1 = Adc[idx].param2;
+  float y2 = (float)Adc[idx].param3 / ANALOG_PH_DECIMAL_MULTIPLIER;
+  int32_t x2 = Adc[idx].param4;
 
-  float m = (y2 - y1) / (x2 - x1);
-  float ph = m * (adc - x1) + y1;
+  float m = (y2 - y1) / (float)(x2 - x1);
+  float ph = m * (float)(adc - x1) + y1;
 
 
   char phLow_chr[6];
@@ -417,7 +417,7 @@ void AdcEverySecond(void) {
       double Rt = (adc * Adc[idx].param1) / (ANALOG_RANGE * ANALOG_V33 - (double)adc);  // Shelly param1 = 32000 (ANALOG_NTC_BRIDGE_RESISTANCE)
 #else
       double Rt = (adc * Adc[idx].param1) / (ANALOG_RANGE - (double)adc);
-#endif      
+#endif
       double BC = (double)Adc[idx].param3 / 10000;                                      // Shelly param3 = 3350 (ANALOG_NTC_B_COEFFICIENT)
       double T = BC / (BC / ANALOG_T0 + TaylorLog(Rt / (double)Adc[idx].param2));       // Shelly param2 = 10000 (ANALOG_NTC_RESISTANCE)
       Adc[idx].temperature = ConvertTemp(TO_CELSIUS(T));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/14245

Make the formula more flexible with regards to negative ADC difference


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
