### PR TITLE
copy ESP32 factory firmware to `build_output`

### DIFF
--- a/pio-tools/name-firmware.py
+++ b/pio-tools/name-firmware.py
@@ -14,6 +14,12 @@ def bin_map_copy(source, target, env):
     map_file = tasmotapiolib.get_final_map_path(env)
     bin_file = tasmotapiolib.get_final_bin_path(env)
 
+    if env["PIOPLATFORM"] == "espressif32":
+        factory_tmp = pathlib.Path(firsttarget).with_suffix("")
+        factory = factory_tmp.with_suffix(factory_tmp.suffix + ".factory.bin")
+        one_bin_tmp = pathlib.Path(bin_file).with_suffix("")
+        one_bin_file = one_bin_tmp.with_suffix(one_bin_tmp.suffix + ".factory.bin")
+
     # check if new target files exist and remove if necessary
     for f in [map_file, bin_file]:
         if f.is_file():
@@ -22,6 +28,7 @@ def bin_map_copy(source, target, env):
     # copy firmware.bin and map to final destination
     shutil.copy(firsttarget, bin_file)
     shutil.move(tasmotapiolib.get_source_map_path(env), map_file)
-
+    if env["PIOPLATFORM"] == "espressif32":
+        shutil.copy(factory, one_bin_file)
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", bin_map_copy)

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -37,7 +37,7 @@ def esp32_create_factory_bin(source, target, env):
     # -  0xe000 | ~\.platformio\packages\framework-arduinoespressif32\tools\partitions\boot_app0.bin
     # - 0x10000 | ~\Tasmota\.pio\build\<env name>/firmware.bin
 
-    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
     sections = env.subst(env.get('FLASH_EXTRA_IMAGES'))
     new_file = open(new_file_name,"wb")
     new_file.truncate() # Make sure no left over data is present from a previous build


### PR DESCRIPTION
enables easy initial flashing with `esptool.py --chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z 0x0 <buildname>.factory.bin`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
