### PR TITLE
[Solax X1] Resolve RTS-timing problem

### DIFF
--- a/tasmota/xnrg_12_solaxX1.ino
+++ b/tasmota/xnrg_12_solaxX1.ino
@@ -162,6 +162,7 @@ void solaxX1_RS485Send(uint16_t msgLen)
   solaxX1Serial->write(message, msgLen);
   solaxX1Serial->write(highByte(crc));
   solaxX1Serial->write(lowByte(crc));
+  solaxX1Serial->flush();
   if (PinUsed(GPIO_SOLAXX1_RTS)) {
     digitalWrite(Pin(GPIO_SOLAXX1_RTS), LOW);
   }


### PR DESCRIPTION
## Description:
On some devices there is a timing problem with the RTS line, when not using flush. It seems that it isn't only a send buffer flush.
flush does also wait until all data is send: https://www.arduino.cc/reference/en/language/functions/communication/serial/flush/

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
