### PR TITLE
Reduce difference between NTP and DS3231 before re-sync

### DIFF
--- a/tasmota/xsns_33_ds3231.ino
+++ b/tasmota/xsns_33_ds3231.ino
@@ -150,7 +150,7 @@ void DS3231EverySecond(void)
       TasmotaGlobal.rules_flag.time_set = 1;
     }
   }
-  else if (!ds3231WriteStatus && Rtc.utc_time > START_VALID_TIME && abs((int32_t)(Rtc.utc_time - ReadFromDS3231())) > 60) {  // If time is valid and is drift from RTC in more that 60 second
+  else if (!ds3231WriteStatus && Rtc.utc_time > START_VALID_TIME && abs((int32_t)(Rtc.utc_time - ReadFromDS3231())) > 10) {  // If time is valid and has drifted from RTC more than 10 seconds
     AddLog(LOG_LEVEL_INFO, PSTR("Write Time TO DS3231 from NTP (" D_UTC_TIME ") %s, (" D_DST_TIME ") %s, (" D_STD_TIME ") %s"),
                 GetDateAndTime(DT_UTC).c_str(), GetDateAndTime(DT_DST).c_str(), GetDateAndTime(DT_STD).c_str());
     SetDS3231Time (Rtc.utc_time); //update the DS3231 time


### PR DESCRIPTION
Changed a re-write of DS3231 time from a 60 second difference (compared to NTP server) to a 10 second difference.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
