### PR TITLE
Berry fix crash when superfluous parameter is sent

### DIFF
--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -342,7 +342,7 @@ int be_check_arg_type(bvm *vm, int arg_start, int argc, const char * arg_type, i
           arg_type = NULL;   // stop iterations
           break;
       }
-      if (arg_type[arg_idx] == '[' || arg_type[arg_idx] == ']') {   // '[' is a marker that following parameters are optional and default to NULL
+      if (arg_type && (arg_type[arg_idx] == '[' || arg_type[arg_idx] == ']')) {   // '[' is a marker that following parameters are optional and default to NULL
         arg_optional = btrue;
         arg_idx++;
       }


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
