### PR TITLE
TLS ESP32, if max packet size is more than 2000, extend TLS buffers to 4K

### DIFF
--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -211,7 +211,11 @@ void MqttInit(void) {
 
   if (Mqtt.mqtt_tls) {
 #ifdef ESP32
+  #if MQTT_MAX_PACKET_SIZE > 2000
+    tlsClient = new BearSSL::WiFiClientSecure_light(4096,4096);
+  #else
     tlsClient = new BearSSL::WiFiClientSecure_light(2048,2048);
+  #endif
 #else // ESP32 - ESP8266
     tlsClient = new BearSSL::WiFiClientSecure_light(1024,1024);
 #endif


### PR DESCRIPTION
## Description:

Increase both TLS buffers to 4096 if max mqtt size is more than 2000 (compile time option).
No impact on existing code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
