### PR TITLE
Berry add 200ms and 250ms messages

### DIFF
--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -777,6 +777,12 @@ bool Xdrv52(uint8_t function)
     case FUNC_EVERY_100_MSECOND:
       callBerryEventDispatcher(PSTR("every_100ms"), nullptr, 0, nullptr);
       break;
+    case FUNC_EVERY_200_MSECOND:
+      callBerryEventDispatcher(PSTR("every_200ms"), nullptr, 0, nullptr);
+      break;
+    case FUNC_EVERY_250_MSECOND:
+      callBerryEventDispatcher(PSTR("every_250ms"), nullptr, 0, nullptr);
+      break;
     case FUNC_EVERY_SECOND:
       callBerryEventDispatcher(PSTR("every_second"), nullptr, 0, nullptr);
       break;


### PR DESCRIPTION
## Description:

Add Berry messages for `every_200ms` and `every_250ms`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
