### PR TITLE
enable autoconf for all esp32 builds

### DIFF
--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -63,12 +63,12 @@ lib_extra_dirs          = lib/libesp32
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32_base
 board                   = esp32-odroid
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_ODROID_GO -DUSE_UNIVERSAL_DISPLAY -DUSE_AUTOCONF
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_ODROID_GO -DUSE_UNIVERSAL_DISPLAY
 
 [env:tasmota32-core2]
 extends                 = env:tasmota32_base
 board                   = esp32-m5core2
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_M5STACK_CORE2 -DUSE_UNIVERSAL_DISPLAY -DUSE_AUTOCONF
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_M5STACK_CORE2 -DUSE_UNIVERSAL_DISPLAY
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32-bluetooth]
@@ -83,7 +83,7 @@ lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display
 
 [env:tasmota32-lvgl]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL -DUSE_AUTOCONF
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL
 board_build.f_cpu       = 160000000L
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
@@ -97,7 +97,7 @@ extends                 = env:tasmota32_base
 board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DUSE_AUTOCONF
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
 lib_ignore              =
                           TTGO TWatch Library
                           Micro-RTSP
@@ -106,7 +106,7 @@ lib_ignore              =
 [env:tasmota32s2]
 extends                 = env:tasmota32_base
 board                   = esp32s2
-build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32 -DUSE_AUTOCONF
+build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore              =
                           TTGO TWatch Library
                           NimBLE-Arduino

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -58,7 +58,7 @@ build_flags             = ${core32solo1.build_flags} -DFIRMWARE_TASMOTA32
 extends                 = env:tasmota32_base
 board                   = esp32-cam
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_WEBCAM
-lib_extra_dirs          = lib/libesp32
+lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32_base
@@ -79,7 +79,7 @@ lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib
 [env:tasmota32-display]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_DISPLAYS
-lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display
+lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display, lib/lib_ssl
 
 [env:tasmota32-lvgl]
 extends                 = env:tasmota32_base
@@ -90,7 +90,7 @@ lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/li
 [env:tasmota32-ir]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags} -DUSE_IR_REMOTE_FULL -DFIRMWARE_IR
-lib_extra_dirs          = lib/libesp32, lib/lib_basic
+lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_ssl
 
 [env:tasmota32c3]
 extends                 = env:tasmota32_base

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1004,7 +1004,7 @@
 //#define USE_IBEACON_ESP32
 //#define USE_WEBCAM                               // Add support for webcam
 
-// #define USE_AUTOCONF                             // Enable Esp32 autoconf feature, requires USE_BERRY and USE_WEBCLIENT_HTTPS (12KB Flash)
+#define USE_AUTOCONF                             // Enable Esp32 autoconf feature, requires USE_BERRY and USE_WEBCLIENT_HTTPS (12KB Flash)
 #define USE_BERRY                                // Enable Berry scripting language
   #define USE_BERRY_PYTHON_COMPAT                // Enable by default `import python_compat`
   #define USE_BERRY_TIMEOUT             4000     // Timeout in ms, will raise an exception if running time exceeds this timeout

--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -51,7 +51,7 @@
 #undef USE_DS18x20
 #undef USE_WS2812
 #undef USE_ENERGY_SENSOR
-#undef USE_BERRY                                 // Disable Berry scripting language
+//#undef USE_BERRY                                 // Disable Berry scripting language
 #undef USE_MI_ESP32                             // (ESP32 only) Disable support for ESP32 as a BLE-bridge (+9k2 mem, +292k flash)
 #endif  // FIRMWARE_WEBCAM
 


### PR DESCRIPTION
## Description:
to make it possible to config easily all ESP32 variants.

@arendst @s-hadinger  Let's see if webcam is still stable with now enabled Berry.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
