### PR TITLE
Automatic adjustment of file size in xdrv_50_filesystem.ino

### DIFF
--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -325,6 +325,11 @@ bool TfsLoadFile(const char *fname, uint8_t *buf, uint32_t len) {
     return false;
   }
 
+  size_t flen = file.size();
+  if (len > flen){
+    len = flen;
+  }
+
   file.read(buf, len);
   file.close();
   return true;


### PR DESCRIPTION
Makes it easier to load a file of unknown size into a buffer.

## Description:

Example use case:
Using a JSON-file to store a config, where the resulting file size will be unknown, when it will be loaded into memory again. Only important thing now is, that the load memory buffer is big enough, otherwise the JSON would be incomplete/invalid, which will be seen at parse time, but will not lead to a crash in the load function.

So for unknown file sizes call `TfsLoadFile(fname, buf, sizeof(buf))`, which will work for known file sizes too. 
It is still possible to call `TfsLoadFile(fname, buf, fileSize)` as before, so no breaking change.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
