### PR TITLE
LVGL prepare for Touch Screen calibration

### DIFF
--- a/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
+++ b/lib/libesp32_lvgl/Adafruit_LvGL_Glue-shadinger/Adafruit_LvGL_Glue.cpp
@@ -1,5 +1,6 @@
 #include "Adafruit_LvGL_Glue.h"
 #include <lvgl.h>
+#include "lv_berry.h"
 
 // ARCHITECTURE-SPECIFIC TIMER STUFF ---------------------------------------
 
@@ -12,29 +13,22 @@ static void lv_tick_handler(void) { lv_tick_inc(lv_tick_interval_ms); }
 
 // TOUCHSCREEN STUFF -------------------------------------------------------
 
-// STMPE610 calibration for raw touch data
-#define TS_MINX 100
-#define TS_MAXX 3800
-#define TS_MINY 100
-#define TS_MAXY 3750
 
-// Same, for ADC touchscreen
-#define ADC_XMIN 325
-#define ADC_XMAX 750
-#define ADC_YMIN 240
-#define ADC_YMAX 840
-
-
-
-uint32_t Touch_Status(uint32_t sel);
+uint32_t Touch_Status(int32_t sel);
 
 static void touchscreen_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data) {
-  //lv_coord_t last_x = 0, last_y = 0;
-  //static uint8_t release_count = 0;
   data->point.x = Touch_Status(1); // Last-pressed coordinates
   data->point.y = Touch_Status(2);
   data->state = Touch_Status(0) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
   data->continue_reading = false; /*No buffering now so no more data read*/
+  // keep data for TS calibration
+  lv_ts_calibration.state = data->state;
+  if (data->state == LV_INDEV_STATE_PRESSED) {    // if not pressed, the data may be invalid
+    lv_ts_calibration.x = data->point.x;
+    lv_ts_calibration.y = data->point.y;
+    lv_ts_calibration.raw_x = Touch_Status(-1);
+    lv_ts_calibration.raw_y = Touch_Status(-2);
+  }
 }
 
 // OTHER LITTLEVGL VITALS --------------------------------------------------

--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
@@ -8,10 +8,13 @@
 
 #include "lvgl.h"
 #include "be_mapping.h"
+#include "lv_berry.h"
 #include "lv_theme_openhasp.h"
 
 extern int lv0_member(bvm *vm);     // resolve virtual members
 extern int lv0_load_font(bvm *vm);
+
+extern lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 
 static int lv_get_hor_res(void) {
@@ -62,6 +65,7 @@ const be_ntv_func_def_t lv_func[] = {
   { "event_set_ext_draw_size", (void*) &lv_event_set_ext_draw_size, "", "(lv.lv_event)i" },
   { "flex_init", (void*) &lv_flex_init, "", "" },
   { "get_hor_res", (void*) &lv_get_hor_res, "i", "" },
+  { "get_ts_calibration", (void*) &lv_get_ts_calibration, "lv.lv_ts_calibration", "" },
   { "get_ver_res", (void*) &lv_get_ver_res, "i", "" },
   { "grid_fr", (void*) &lv_grid_fr, "i", "i" },
   { "grid_init", (void*) &lv_grid_init, "", "" },

--- a/lib/libesp32_lvgl/lv_berry/mapping/lv_funcs.h
+++ b/lib/libesp32_lvgl/lv_berry/mapping/lv_funcs.h
@@ -4,6 +4,7 @@
 
 // Custom Tasmota functions
 void lv_img_set_tasmota_logo(lv_obj_t * img);
+lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 // ======================================================================
 // Artificial

--- a/lib/libesp32_lvgl/lv_berry/src/be_lvgl_ctypes_definitions.c
+++ b/lib/libesp32_lvgl/lv_berry/src/be_lvgl_ctypes_definitions.c
@@ -463,6 +463,18 @@ const be_ctypes_structure_t be_lv_event = {
     { "user_data", 12, 0, 0, ctypes_ptr32, 0 },
 }};
 
+const be_ctypes_structure_t be_lv_ts_calibration = {
+  12,  /* size in bytes */
+  5,  /* number of elements */
+  be_ctypes_instance_mappings,
+  (const be_ctypes_structure_item_t[5]) {
+    { "raw_x", 0, 0, 0, ctypes_i16, 0 },
+    { "raw_y", 2, 0, 0, ctypes_i16, 0 },
+    { "state", 8, 0, 0, ctypes_i32, 0 },
+    { "x", 4, 0, 0, ctypes_i16, 0 },
+    { "y", 6, 0, 0, ctypes_i16, 0 },
+}};
+
 static const char * be_ctypes_instance_mappings[] = {
   "lv_color",
   NULL
@@ -496,6 +508,7 @@ static be_define_ctypes_class(lv_meter_scale, &be_lv_meter_scale, &be_class_ctyp
 static be_define_ctypes_class(lv_obj_class, &be_lv_obj_class, &be_class_ctypes, "lv_obj_class");
 static be_define_ctypes_class(lv_point, &be_lv_point, &be_class_ctypes, "lv_point");
 static be_define_ctypes_class(lv_sqrt_res, &be_lv_sqrt_res, &be_class_ctypes, "lv_sqrt_res");
+static be_define_ctypes_class(lv_ts_calibration, &be_lv_ts_calibration, &be_class_ctypes, "lv_ts_calibration");
 
 void be_load_ctypes_lvgl_definitions_lib(bvm *vm) {
   ctypes_register_class(vm, &be_class_lv_area, &be_lv_area);
@@ -526,6 +539,7 @@ void be_load_ctypes_lvgl_definitions_lib(bvm *vm) {
   ctypes_register_class(vm, &be_class_lv_obj_class, &be_lv_obj_class);
   ctypes_register_class(vm, &be_class_lv_point, &be_lv_point);
   ctypes_register_class(vm, &be_class_lv_sqrt_res, &be_lv_sqrt_res);
+  ctypes_register_class(vm, &be_class_lv_ts_calibration, &be_lv_ts_calibration);
 }
 
 be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {
@@ -557,6 +571,7 @@ be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {
   { "lv_obj_class", &be_class_lv_obj_class },
   { "lv_point", &be_class_lv_point },
   { "lv_sqrt_res", &be_class_lv_sqrt_res },
+  { "lv_ts_calibration", &be_class_lv_ts_calibration },
 };
 const size_t be_ctypes_lvgl_classes_size = sizeof(be_ctypes_lvgl_classes)/sizeof(be_ctypes_lvgl_classes[0]);
 

--- a/lib/libesp32_lvgl/lv_berry/src/embedded/lvgl_ctypes.be
+++ b/lib/libesp32_lvgl/lv_berry/src/embedded/lvgl_ctypes.be
@@ -393,6 +393,18 @@ lv_event = [            # valid LVGL8
 ]
 lv_event = ctypes.structure(lv_event, "lv_event")
 
+#######################################################################
+# Special structure used to calibrate resistive touchscreens
+#######################################################################
+lv_ts_calibration = [            # valid LVGL8
+    [lv_coord, "raw_x"],
+    [lv_coord, "raw_y"],
+    [lv_coord, "x"],
+    [lv_coord, "y"],
+    [int32_t, "state"],
+]
+lv_ts_calibration = ctypes.structure(lv_ts_calibration, "lv_ts_calibration")
+
 #
 ctypes.print_classes("lvgl")
 

--- a/lib/libesp32_lvgl/lv_berry/src/lv_berry.c
+++ b/lib/libesp32_lvgl/lv_berry/src/lv_berry.c
@@ -229,6 +229,19 @@ int lv0_load_font(bvm *vm) {
 }
 
 /*********************************************************************************************\
+ * Get Touch Screen calibration information
+\*********************************************************************************************/
+lv_ts_calibration_t lv_ts_calibration = {
+  0, 0,
+  0, 0,
+  LV_INDEV_STATE_RELEASED
+};
+
+lv_ts_calibration_t * lv_get_ts_calibration(void) {
+  return &lv_ts_calibration;
+}
+
+/*********************************************************************************************\
  * LVGL top level virtual members
  * 
  * Responds to virtual constants

--- a/lib/libesp32_lvgl/lv_berry/src/lv_berry.h
+++ b/lib/libesp32_lvgl/lv_berry/src/lv_berry.h
@@ -27,6 +27,17 @@ extern void be_load_lvgl_classes(bvm *vm);
 // TODO temporary fix
 extern void lv_img_set_tasmota_logo(lv_obj_t * img);
 
+// used for ToushScreen calibration
+typedef struct lv_ts_calibration_t {
+  lv_coord_t        raw_x;
+  lv_coord_t        raw_y;
+  lv_coord_t        x;
+  lv_coord_t        y;
+  lv_indev_state_t  state;
+} lv_ts_calibration_t;
+extern lv_ts_calibration_t lv_ts_calibration;
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -134,6 +134,7 @@ return_types = {
   "lv_theme_t *": "lv_theme",
   "lv_disp_t *": "lv_disp",
   "lv_indev_t *": "lv_indev",
+  "lv_ts_calibration_t *": "lv_ts_calibration",
   #"lv_disp_t*": "lv_disp",
   #"lv_style_list_t*": "",
 
@@ -671,10 +672,13 @@ print("""/********************************************************************
 
 #include "lvgl.h"
 #include "be_mapping.h"
+#include "lv_berry.h"
 #include "lv_theme_openhasp.h"
 
 extern int lv0_member(bvm *vm);     // resolve virtual members
 extern int lv0_load_font(bvm *vm);
+
+extern lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 
 static int lv_get_hor_res(void) {

--- a/lib/libesp32_lvgl/lv_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/preprocessor.py
@@ -86,6 +86,7 @@ print("""
 
 // Custom Tasmota functions
 void lv_img_set_tasmota_logo(lv_obj_t * img);
+lv_ts_calibration_t * lv_get_ts_calibration(void);
 
 // ======================================================================
 // Artificial

--- a/tasmota/xdrv_55_touch.ino
+++ b/tasmota/xdrv_55_touch.ino
@@ -31,6 +31,8 @@
 
 bool FT5206_found = false;
 bool XPT2046_found = false;
+int16_t raw_touch_xp;
+int16_t raw_touch_yp;
 int16_t touch_xp;
 int16_t touch_yp;
 bool touched;
@@ -43,7 +45,7 @@ bool touched;
 VButton *buttons[MAX_TOUCH_BUTTONS];
 #endif
 
-uint32_t Touch_Status(uint32_t sel) {
+uint32_t Touch_Status(int32_t sel) {
   if (FT5206_found || XPT2046_found) {
     switch (sel) {
       case 0:
@@ -52,6 +54,10 @@ uint32_t Touch_Status(uint32_t sel) {
         return touch_xp;
       case 2:
         return touch_yp;
+      case -1:                  // before calibration
+        return raw_touch_xp;
+      case -2:
+        return raw_touch_yp;
     }
     return 0;
   } else {
@@ -141,8 +147,9 @@ void Touch_Check(void(*rotconvert)(int16_t *x, int16_t *y)) {
   }
 #endif // USE_XPT2046
 
+  raw_touch_xp = touch_xp;
+  raw_touch_yp = touch_yp;
   if (touched) {
-    AddLog(LOG_LEVEL_DEBUG_MORE, "TS : touched x=%i y=%i", touch_xp, touch_yp);
 #ifdef USE_TOUCH_BUTTONS
 #ifdef USE_M5STACK_CORE2
     // handle  3 built in touch buttons
@@ -165,6 +172,7 @@ void Touch_Check(void(*rotconvert)(int16_t *x, int16_t *y)) {
 #endif // USE_TOUCH_BUTTONS
 
     rotconvert(&touch_xp, &touch_yp);
+    AddLog(LOG_LEVEL_DEBUG_MORE, "TS : touched x=%i y=%i (raw x=%i y=%i)", touch_xp, touch_yp, raw_touch_xp, raw_touch_yp);
 
 #ifdef USE_TOUCH_BUTTONS
     CheckTouchButtons(touched, touch_xp, touch_yp);
@@ -290,8 +298,8 @@ void CheckTouchButtons(bool touched, int16_t touch_x, int16_t touch_y) {
         }
       }
     }
-    touch_xp = 0;
-    touch_yp = 0;
+    raw_touch_xp = touch_xp = 0;
+    raw_touch_yp = touch_yp = 0;
   }
 }
 #endif // USE_TOUCH_BUTTONS
@@ -321,7 +329,7 @@ bool Xdrv55(uint8_t function) {
 #else  // #if defined(USE_FT5206) || defined(USE_XPT2046) || defined(USE_LILYGO47) || defined(USE_TOUCH_BUTTONS)
 
 // dummy for LVGL without a touch controller
-uint32_t Touch_Status(uint32_t sel) {
+uint32_t Touch_Status(int32_t sel) {
   return 0;
 }
 


### PR DESCRIPTION
## Description:

Prepare LVGL and Touch Screen to enable calibration of resistive touch screens.

Slight modification of `Touch_Status()` to also return raw readings from Touch Screen before the conversion to screen coordinates.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
