### PR TITLE
Allow Tasmota32 minimal setup

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -36,7 +36,9 @@
 #include <ESP8266HTTPClient.h>              // Ota
 #include <ESP8266httpUpdate.h>              // Ota
 #ifdef ESP32
+  #ifdef USE_BERRY
   #include "HTTPUpdateLight.h"              // Ota over HTTPS for ESP32
+  #endif // USE_BERRY
 #endif
 #include <StreamString.h>                   // Webserver, Updater
 #include <ext_printf.h>

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -964,14 +964,17 @@
 \*********************************************************************************************/
 
 #ifndef ESP8266_1M
-#define USE_UFILESYS
-#define GUI_TRASH_FILE
-#define GUI_EDIT_FILE
-#define USE_PING
+  #ifndef FIRMWARE_MINIMAL    // there might be a ESP32-minimal
+    #define USE_UFILESYS
+      #define GUI_TRASH_FILE
+      #define GUI_EDIT_FILE
+    #define USE_PING
+  #endif // FIRMWARE_MINIMAL
+
   #ifdef USE_RULES
-  #define USE_EXPRESSION
-  #define SUPPORT_IF_STATEMENT
-  #define SUPPORT_MQTT_EVENT
+    #define USE_EXPRESSION
+    #define SUPPORT_IF_STATEMENT
+    #define SUPPORT_MQTT_EVENT
   #endif  // USE_RULES
 #endif  // NOT ESP8266_1M
 

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -130,8 +130,6 @@ String EthernetMacAddress(void);
 #define ARDUINO_CORE_RELEASE        ARDUINO_ESP32_RELEASE
 #endif  // ARDUINO_ESP32_RELEASE
 
-#undef FIRMWARE_MINIMAL                            // Minimal is not supported as not needed
-
 // Hardware has no ESP32
 #undef USE_EXS_DIMMER
 #undef USE_ARMTRONIX_DIMMERS


### PR DESCRIPTION
## Description:

This allows to compile ESP32 with a minimal setup. Note: no firmware is pre-built for minimal setup.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
