### PR TITLE
Berry workaround for ESP32 Rev0 bug

### DIFF
--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -596,8 +596,11 @@ newframe: /* a new call frame */
             if (var_isint(a) && var_isint(b)) {
                 var_setint(dst, ibinop(+, a, b));
             } else if (var_isnumber(a) && var_isnumber(b)) {
-                breal x = var2real(a), y = var2real(b);
-                var_setreal(dst, x + y);
+                union bvaldata x, y;        // TASMOTA workaround for ESP32 rev0 bug
+                x.i = a->v.i;
+                y.i = b->v.i;
+                // breal x = var2real(a), y = var2real(b);
+                var_setreal(dst, x.r + y.r);
             } else if (var_isstr(a) && var_isstr(b)) { /* strcat */
                 bstring *s = be_strcat(vm, var_tostr(a), var_tostr(b));
                 reg = vm->reg;


### PR DESCRIPTION
## Description:

Workaround for a bug that seems specific to ESP32 Rev0. Test case is `def f() return 0.5+0.5 end` would crash, because in some cases reading a `float` from IRAM can cause a crash using Xtensa `lsi` instruction (I suppose that the read can be partial). The workaround forces an `int` load and then a conversion to float with `float.s` instruction.

There should not be any performance impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
