### PR TITLE
Berry fix add for int+float

### DIFF
--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -598,7 +598,9 @@ newframe: /* a new call frame */
             } else if (var_isnumber(a) && var_isnumber(b)) {
                 union bvaldata x, y;        // TASMOTA workaround for ESP32 rev0 bug
                 x.i = a->v.i;
+                if (var_isint(a)) { x.r = (breal) x.i; }
                 y.i = b->v.i;
+                if (var_isint(b)) { y.r = (breal) y.i; }
                 // breal x = var2real(a), y = var2real(b);
                 var_setreal(dst, x.r + y.r);
             } else if (var_isstr(a) && var_isstr(b)) { /* strcat */


### PR DESCRIPTION
## Description:

Fix a bug introduced by #14376 when adding an int and a float.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
