### PR TITLE
Berry fix DAC support

### DIFF
--- a/tasmota/xdrv_52_3_berry_gpio.ino
+++ b/tasmota/xdrv_52_3_berry_gpio.ino
@@ -62,8 +62,8 @@ extern "C" {
             // DAC
 #if   defined(CONFIG_IDF_TARGET_ESP32)
             if (25 == pin || 26 == pin) {
-              uint32_t channel = pin - 25 + 1;    // 1 or 2
-              esp_err_t err = dac_output_enable((dac_channel_t) channel);
+              dac_channel_t channel = (25 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
+              esp_err_t err = dac_output_enable(channel);
               if (err) {
                 be_raisef(vm, "value_error", "Error: dac_output_enable(%i) -> %i", channel, err);
               }
@@ -72,8 +72,8 @@ extern "C" {
             }
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
             if (17 == pin || 18 == pin) {
-              uint32_t channel = pin - 17 + 1;    // 1 or 2
-              esp_err_t err = dac_output_enable((dac_channel_t) channel);
+              dac_channel_t channel = (17 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
+              esp_err_t err = dac_output_enable(channel);
               if (err) {
                 be_raisef(vm, "value_error", "Error: dac_output_enable(%i) -> %i", channel, err);
               }
@@ -133,8 +133,8 @@ extern "C" {
       uint32_t dac_value = changeUIntScale(mV, 0, 3300, 0, 255);    // convert from 0..3300 ms to 0..255
 #if   defined(CONFIG_IDF_TARGET_ESP32)
       if (25 == pin || 26 == pin) {
-        uint32_t channel = pin - 25 + 1;    // 1 or 2
-        esp_err_t err = dac_output_voltage((dac_channel_t) channel, dac_value);
+        dac_channel_t channel = (25 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
+        esp_err_t err = dac_output_voltage(channel, dac_value);
         if (err) {
           be_raisef(vm, "internal_error", "Error: esp_err_tdac_output_voltage(%i, %i) -> %i", channel, dac_value, err);
         }
@@ -143,8 +143,8 @@ extern "C" {
       }
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
       if (17 == pin || 18 == pin) {
-        uint32_t channel = pin - 17 + 1;    // 1 or 2
-        esp_err_t err = dac_output_voltage((dac_channel_t) channel, dac_value);
+        dac_channel_t channel = (17 == pin) ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
+        esp_err_t err = dac_output_voltage(channel, dac_value);
         if (err) {
           be_raisef(vm, "internal_error", "Error: esp_err_tdac_output_voltage(%i, %i) -> %i", channel, dac_value, err);
         }


### PR DESCRIPTION
## Description:

It looks like at some moment, `dac_channel_t` value changed from 1/2 to 0/1. This fix hooks back to the esp-idf headers and prevents any further bad surprise.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
