### PR TITLE
Ethernet IP Config

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -687,7 +687,13 @@ typedef struct {
   uint8_t       weight_change;             // E9F
   uint8_t       web_color2[2][3];          // EA0  Needs to be on integer / 3 distance from web_color
 
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32
+  uint8_t       free_ea6[10];              // EA6
+  uint32_t      eth_ipv4_address[5];       // EB0
+  uint8_t       free_ec4[2];               // EC4
+#else
   uint8_t       free_ea6[32];              // EA6
+#endif
 
   uint8_t       shift595_device_count;     // EC6
   uint8_t       sta_config;                // EC7

--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -859,8 +859,8 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint16_t http_init : 1;
     uint16_t shutter_moved : 1;
     uint16_t shutter_moving : 1;
-    uint16_t spare11 : 1;
-    uint16_t spare12 : 1;
+    uint16_t eth_connected : 1;
+    uint16_t eth_disconnected : 1;
     uint16_t spare13 : 1;
     uint16_t spare14 : 1;
     uint16_t spare15 : 1;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -581,9 +581,9 @@ void CmndStatus(void)
                           "Eth" D_JSON_MAC "\":\"%s\",\""
 #endif
                           D_CMND_WEBSERVER "\":%d,\"HTTP_API\":%d,\"" D_CMND_WIFICONFIG "\":%d,\"" D_CMND_WIFIPOWER "\":%s}}"),
-                          NetworkHostname(),
-                          (uint32_t)NetworkAddress(), Settings->ipv4_address[1], Settings->ipv4_address[2], Settings->ipv4_address[3], Settings->ipv4_address[4],
-                          NetworkMacAddress().c_str(),
+                          TasmotaGlobal.hostname,
+                          (uint32_t)WiFi.localIP(), Settings->ipv4_address[1], Settings->ipv4_address[2], Settings->ipv4_address[3], Settings->ipv4_address[4],
+                          WiFi.macAddress().c_str(),
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
                           EthernetHostname(),
                           (uint32_t)EthernetLocalIP(), Settings->eth_ipv4_address[1], Settings->eth_ipv4_address[2], Settings->eth_ipv4_address[3], Settings->eth_ipv4_address[4],
@@ -1649,7 +1649,7 @@ void CmndIpAddress(void)
 {
   if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= 5)) {
     char network_address[22];
-    ext_snprintf_P(network_address, sizeof(network_address), PSTR(" (%_I)"), (uint32_t)NetworkAddress());
+    ext_snprintf_P(network_address, sizeof(network_address), PSTR(" (%_I)"), (uint32_t)WiFi.localIP());
     if (!XdrvMailbox.usridx) {
       ResponseClear();
       for (uint32_t i = 0; i < 5; i++) {

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -570,12 +570,26 @@ void CmndStatus(void)
   }
 
   if ((0 == payload) || (5 == payload)) {
-    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%_I\",\""
-                          D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\"" D_JSON_DNSSERVER "1\":\"%_I\",\"" D_JSON_DNSSERVER "2\":\"%_I\",\""
-                          D_JSON_MAC "\":\"%s\",\"" D_CMND_WEBSERVER "\":%d,\"HTTP_API\":%d,\"" D_CMND_WIFICONFIG "\":%d,\"" D_CMND_WIFIPOWER "\":%s}}"),
-                          NetworkHostname(), (uint32_t)NetworkAddress(),
-                          Settings->ipv4_address[1], Settings->ipv4_address[2], Settings->ipv4_address[3], Settings->ipv4_address[4],
-                          NetworkMacAddress().c_str(), Settings->webserver, Settings->flag5.disable_referer_chk, Settings->sta_config, WifiGetOutputPower().c_str());
+    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
+                          D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
+                          D_JSON_DNSSERVER "1\":\"%_I\",\"" D_JSON_DNSSERVER "2\":\"%_I\",\""
+                          D_JSON_MAC "\":\"%s\",\""
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+                          "Eth" D_CMND_HOSTNAME "\":\"%s\",\""
+                          "Eth" D_CMND_IPADDRESS "\":\"%_I\",\"Eth" D_JSON_GATEWAY "\":\"%_I\",\"Eth" D_JSON_SUBNETMASK "\":\"%_I\",\""
+                          "Eth" D_JSON_DNSSERVER "1\":\"%_I\",\"Eth" D_JSON_DNSSERVER "2\":\"%_I\",\""
+                          "Eth" D_JSON_MAC "\":\"%s\",\""
+#endif
+                          D_CMND_WEBSERVER "\":%d,\"HTTP_API\":%d,\"" D_CMND_WIFICONFIG "\":%d,\"" D_CMND_WIFIPOWER "\":%s}}"),
+                          NetworkHostname(),
+                          (uint32_t)NetworkAddress(), Settings->ipv4_address[1], Settings->ipv4_address[2], Settings->ipv4_address[3], Settings->ipv4_address[4],
+                          NetworkMacAddress().c_str(),
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+                          EthernetHostname(),
+                          (uint32_t)EthernetLocalIP(), Settings->eth_ipv4_address[1], Settings->eth_ipv4_address[2], Settings->eth_ipv4_address[3], Settings->eth_ipv4_address[4],
+                          EthernetMacAddress().c_str(),
+#endif
+                          Settings->webserver, Settings->flag5.disable_referer_chk, Settings->sta_config, WifiGetOutputPower().c_str());
     CmndStatusResponse(5);
   }
 

--- a/tasmota/support_network.ino
+++ b/tasmota/support_network.ino
@@ -96,35 +96,35 @@ void MdnsUpdate(void) {
 \*********************************************************************************************/
 
 char* NetworkHostname(void) {
-#ifdef ESP32
+/*#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetHostname();
   }
 #endif
-#endif
+#endif*/
   return TasmotaGlobal.hostname;
 }
 
 IPAddress NetworkAddress(void) {
-#ifdef ESP32
+/*#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetLocalIP();
   }
 #endif
-#endif
+#endif*/
   return WiFi.localIP();
 }
 
 String NetworkMacAddress(void) {
-#ifdef ESP32
+/*#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetMacAddress();
   }
 #endif
-#endif
+#endif*/
   return WiFi.macAddress();
 }
 

--- a/tasmota/support_network.ino
+++ b/tasmota/support_network.ino
@@ -96,35 +96,35 @@ void MdnsUpdate(void) {
 \*********************************************************************************************/
 
 char* NetworkHostname(void) {
-/*#ifdef ESP32
+#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetHostname();
   }
 #endif
-#endif*/
+#endif
   return TasmotaGlobal.hostname;
 }
 
 IPAddress NetworkAddress(void) {
-/*#ifdef ESP32
+#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetLocalIP();
   }
 #endif
-#endif*/
+#endif
   return WiFi.localIP();
 }
 
 String NetworkMacAddress(void) {
-/*#ifdef ESP32
+#ifdef ESP32
 #ifdef USE_ETHERNET
   if (!TasmotaGlobal.global_state.eth_down) {
     return EthernetMacAddress();
   }
 #endif
-#endif*/
+#endif
   return WiFi.macAddress();
 }
 

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -685,7 +685,11 @@ bool HttpCheckPriviledgedAccess(bool autorequestauth = true)
       referer.toUpperCase();
       String hostname = NetworkHostname();
       hostname.toUpperCase();
-      if ((referer.indexOf(hostname) == 7) || (referer.indexOf(NetworkAddress().toString()) == 7)) {
+      if ((referer.indexOf(hostname) == 7) || (referer.indexOf(WiFi.localIP().toString()) == 7)
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+          || (referer.indexOf(EthernetLocalIP().toString()) == 7)
+#endif
+      ) {
         return true;
       }
     }

--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -921,8 +921,16 @@ void MqttConnected(void) {
         Response_P(PSTR("{\"Info2\":{\"" D_JSON_WEBSERVER_MODE "\":\"%s\",\"" D_CMND_HOSTNAME "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%s\",\"IPv6Address\":\"%s\"}}"),
           (2 == Settings->webserver) ? PSTR(D_ADMIN) : PSTR(D_USER), NetworkHostname(), NetworkAddress().toString().c_str(), WifiGetIPv6().c_str(), Settings->flag5.mqtt_info_retain);
 #else
-        Response_P(PSTR("{\"Info2\":{\"" D_JSON_WEBSERVER_MODE "\":\"%s\",\"" D_CMND_HOSTNAME "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%s\"}}"),
-          (2 == Settings->webserver) ? PSTR(D_ADMIN) : PSTR(D_USER), NetworkHostname(), NetworkAddress().toString().c_str(), Settings->flag5.mqtt_info_retain);
+        Response_P(PSTR("{\"Info2\":{\"" D_JSON_WEBSERVER_MODE "\":\"%s\",\"" D_CMND_HOSTNAME "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%s\""
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+          ",\"Eth" D_CMND_HOSTNAME "\":\"%s\",\"Eth" D_CMND_IPADDRESS "\":\"%s\""
+#endif
+          "}}"),
+          (2 == Settings->webserver) ? PSTR(D_ADMIN) : PSTR(D_USER), TasmotaGlobal.hostname, WiFi.localIP().toString().c_str(),
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+          EthernetHostname(), (uint32_t)EthernetLocalIP().toString().c_str(),
+#endif
+          Settings->flag5.mqtt_info_retain);
 #endif // LWIP_IPV6 = 1
         MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_RSLT_INFO "2"), Settings->flag5.mqtt_info_retain);
       }

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -979,6 +979,10 @@ void RulesEvery50ms(void)
             case 9: strncpy_P(json_event, PSTR("{\"SHUTTER\":{\"Moved\":1}}"), sizeof(json_event)); break;
             case 10: strncpy_P(json_event, PSTR("{\"SHUTTER\":{\"Moving\":1}}"), sizeof(json_event)); break;
 #endif  // USE_SHUTTER
+#if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+            case 11: strncpy_P(json_event, PSTR("{\"ETH\":{\"Connected\":1}}"), sizeof(json_event)); break;
+            case 12: strncpy_P(json_event, PSTR("{\"ETH\":{\"Disconnected\":1}}"), sizeof(json_event)); break;
+#endif
           }
           if (json_event[0]) {
             RulesProcessEvent(json_event);

--- a/tasmota/xdrv_58_range_extender.ino
+++ b/tasmota/xdrv_58_range_extender.ino
@@ -22,14 +22,14 @@
 To use this, add the following to your user_config_override.h
 #define USE_WIFI_RANGE_EXTENDER
 
-Additionally, for the ESP8266, PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH must be 
+Additionally, for the ESP8266, PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH must be
 set in your build options.
 For example, in your platfromio_tasmota_cenv.ini, you will need an entry such as:
 [env:tasmota-rangeextender]
 build_flags = ${common.build_flags}
               -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
 
-For the ESP32, the arduino-esp32 library must be at least version 2, with 
+For the ESP32, the arduino-esp32 library must be at least version 2, with
 CONFIG_LWIP_IP_FORWARD option set, and optionally CONFIG_LWIP_IPV4_NAPT.
 
 If you want to support NAPT (removing the need for routes on a core router):

--- a/tasmota/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/xdrv_82_esp32_ethernet.ino
@@ -93,6 +93,7 @@ void EthernetEvent(WiFiEvent_t event) {
     case ARDUINO_EVENT_ETH_CONNECTED:
       AddLog(LOG_LEVEL_INFO, PSTR("ETH: " D_CONNECTED " at %dMbps%s"),
         ETH.linkSpeed(), (ETH.fullDuplex()) ? " Full Duplex" : "");
+      TasmotaGlobal.rules_flag.eth_connected = 1;
       break;
     case ARDUINO_EVENT_ETH_GOT_IP:
       AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Mac %s, IPAddress %_I, Hostname %s"),
@@ -106,6 +107,8 @@ void EthernetEvent(WiFiEvent_t event) {
     case ARDUINO_EVENT_ETH_DISCONNECTED:
       AddLog(LOG_LEVEL_INFO, PSTR("ETH: Disconnected"));
       TasmotaGlobal.global_state.eth_down = 1;
+      TasmotaGlobal.rules_flag.eth_disconnected = 1;
+
       break;
     case ARDUINO_EVENT_ETH_STOP:
       AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Stopped"));


### PR DESCRIPTION
## Description:

Following multiple discussions this PR introduces full support for Ethernet IP configuration independently of Wifi
- New commands dedicated to Ethernet
    - `EthIpAddress`
    - `EthGateway`
    - `EthSubnetmask`  (aligned to D_JSON_SUBNETMASK)
    - `EthDNSServer[1|2]`
    - Configuration saved in dedicated Setting area only for ESP32 (excluding C3/S2)
- Update Status 5 with separated details for Wifi (legacy) and Ethernet
```
{
    "StatusNET":{
        "Hostname":"myesp","IPAddress":"192.168.168.51","Gateway":"192.168.168.254","Subnetmask":"255.255.255.0",
        "DNSServer1":"192.168.168.244","DNSServer2":"1.1.1.1","Mac":"F0:08:D1:F7:B9:D0",
        "EthHostname":"myesp-eth","EthIPAddress":"192.168.100.100","EthGateway":"192.168.100.1","EthSubnetmask":"255.255.255.0",
        "EthDNSServer1":"1.1.1.1","EthDNSServer2":"8.8.8.8","EthMac":"12:34:56:78:9A:BC",
        "Webserver":2,"HTTP_API":1,"WifiConfig":5,"WifiPower":17.0
    }
}
```
- Update the INFO2 Message
```
{
    "Info2":{
        "WebServerMode":"Admin","Hostname":"myesp","IPAddress":"192.168.168.51",
        "EthHostname":"myesp-eth","EthIPAddress":"192.168.100.100"
    }
}
```
- Add rules events
    - `on Eth#Connected do`
    - `on Eth#Disconnected do`

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
