### PR TITLE
Fix calculation of thermostat duty cycle value

### DIFF
--- a/tasmota/xdrv_39_thermostat.ino
+++ b/tasmota/xdrv_39_thermostat.ino
@@ -1334,7 +1334,7 @@ uint8_t ThermostatGetDutyCycle(uint8_t ctr_output)
   if ( (Thermostat[ctr_output].status.controller_mode == CTR_PI)
     || ((Thermostat[ctr_output].status.controller_mode == CTR_HYBRID)
       &&(Thermostat[ctr_output].status.phase_hybrid_ctr == CTR_HYBRID_PI))) {
-    value = Thermostat[ctr_output].time_total_pi / Thermostat[ctr_output].time_pi_cycle;
+    value = 100*Thermostat[ctr_output].time_total_pi / ((uint32_t)60*(uint32_t)Thermostat[ctr_output].time_pi_cycle);
   }
   else if ( (Thermostat[ctr_output].status.controller_mode == CTR_RAMP_UP)
         || ((Thermostat[ctr_output].status.controller_mode == CTR_HYBRID)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
Calculation issue in duty cycle of thermostat controller

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
