### PR TITLE
Mqtt discovery fixes

### DIFF
--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -39,7 +39,7 @@ const char kHAssJsonSensorDevCla[] PROGMEM =
   "dev_cla\":\"power|dev_cla\":\"battery|dev_cla\":\"current|ic\":\"mdi:leak|ic\":\"mdi:current-ac|dev_cla\":\"humidity|dev_cla\":\"illuminance|"
   "ic\":\"mdi:cup-water|ic\":\"mdi:flask|ic\":\"mdi:flask|ic\":\"mdi:flask|ic\":\"mdi:flask|ic\":\"mdi:flask|ic\":\"mdi:flask|"
   "dev_cla\":\"pm1|dev_cla\":\"pm25|dev_cla\":\"pm10|dev_cla\":\"power_factor|dev_cla\":\"power|ic\":\"mdi:progress-clock|"
-  "dev_cla\":\"power|dev_cla\":\"energy|dev_cla\":\"energy|dev_cla\":\"voltage|ic\":\"mdi:scale|dev_cla\":\"energy|"
+  "dev_cla\":\"power|dev_cla\":\"energy|dev_cla\":\"energy\",\"stat_cla\":\"total_increasing|dev_cla\":\"voltage|ic\":\"mdi:scale|dev_cla\":\"energy|"
   "dev_cla\":\"carbon_dioxide|dev_cla\":\"carbon_dioxide|dev_class\":\"volatile_organic_compounds|"
   "ic\":\"mdi:palette|ic\":\"mdi:palette|ic\":\"mdi:palette|ic\":\"mdi:temperature-kelvin|ic\":\"mdi:ruler|dev_cla\":\"illuminance|";
 

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -1030,8 +1030,7 @@ void HAssAnnounceShutters(void)
       } else {
         snprintf_P(stemp1, sizeof(stemp1), PSTR("%s"), SettingsText(SET_FRIENDLYNAME1 + i));
       }
-      GetTopic_P(stemp2, TELE, TasmotaGlobal.mqtt_topic, D_RSLT_STATE);
-      Response_P(HASS_DISCOVER_BASE, stemp1, stemp2);
+      Response_P(PSTR("{\"name\":\"%s\""), stemp1);
 
       GetTopic_P(stemp1, TELE, TasmotaGlobal.mqtt_topic, S_LWT);
       TryResponseAppend_P(HASS_DISCOVER_SENSOR_LWT, stemp1);

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -1042,8 +1042,10 @@ void HAssAnnounceShutters(void)
       GetTopic_P(stemp2, CMND, TasmotaGlobal.mqtt_topic, PSTR("ShutterPosition"));
       TryResponseAppend_P(HASS_DISCOVER_SHUTTER_POS, stemp1, i + 1, stemp2, i + 1);
 
-      GetTopic_P(stemp1, CMND, TasmotaGlobal.mqtt_topic, PSTR("ShutterTilt"));
-      TryResponseAppend_P(HASS_DISCOVER_SHUTTER_TILT, stemp1, i + 1, Settings->shutter_tilt_config[3][i], Settings->shutter_tilt_config[4][i]);
+      if (Settings->shutter_tilt_config[3][i] != Settings->shutter_tilt_config[4][i]) {
+        GetTopic_P(stemp1, CMND, TasmotaGlobal.mqtt_topic, PSTR("ShutterTilt"));
+        TryResponseAppend_P(HASS_DISCOVER_SHUTTER_TILT, stemp1, i + 1, Settings->shutter_tilt_config[3][i], Settings->shutter_tilt_config[4][i]);
+      }
 
       TryResponseAppend_P(HASS_DISCOVER_DEVICE_INFO_SHORT, unique_id, ESP_getChipId());
       TryResponseAppend_P(PSTR("}"));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

* The `state_topic` in the cover MQTT discovery announcements is completely useless. This data will be ignored by the Home Assistant if `position_topic` is configured, and just causing parsing errors like this:
  ```
  Payload is not supported (e.g. open, closed, opening, closing, stopped):{"Time":"2022-01-12T23:08:03","Uptime":"12T15:50:07","UptimeSec":1093807,"Heap":25,"SleepMode":"Dynamic","Sleep":50,"LoadAvg":19,"MqttCount":12,"POWER1":"OFF","POWER2":"OFF","Wifi":{"AP":1,"SSId":"foo","BSSId":"11:22:33:44:55:66","Channel":7,"RSSI":32,"Signal":-84,"LinkCount":11,"Downtime":"0T00:02:28"}}
  ```
* The Shutter Tilt Discovery is unnecessary if no tilting is configured. Without this check Home Assistant shows tilting controls even for regular covers.
* Without the `state_class` property Home Assistant won't show energy totals in long term statistics.