### PR TITLE
Berry int() converts comptr

### DIFF
--- a/lib/libesp32/berry/src/be_baselib.c
+++ b/lib/libesp32/berry/src/be_baselib.c
@@ -233,6 +233,9 @@ static int l_int(bvm *vm)
             be_pushvalue(vm, 1);
         } else if (be_isbool(vm, 1)) {
             be_pushint(vm, be_tobool(vm, 1) ? 1 : 0);
+        } else if (be_iscomptr(vm, 1)) {
+            intptr_t p = (intptr_t) be_tocomptr(vm, 1);
+            be_pushint(vm, (int) p);
         } else {
             be_return_nil(vm);
         }


### PR DESCRIPTION
## Description:

Putting back ability for Berry `int()` to convert a `comptr` to an int. Because LVGL needs it to convert `user_data` to int.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
