### PR TITLE
Remove WiFiUDP32 to solve linker warnings

### DIFF
--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-send.cpp
@@ -77,7 +77,14 @@ void ESPKNXIP::send(address_t const &receiver, knx_command_type_t ct, uint8_t da
 	DEBUG_PRINTLN(F(""));
 #endif
 
+#ifdef ESP8266
 	udp.beginPacketMulticast(MULTICAST_IP, MULTICAST_PORT, WiFi.localIP());
+#else
+	if (0 == udp.beginMulticastPacket()) {
+		udp.beginMulticast(MULTICAST_IP, MULTICAST_PORT);
+		udp.beginMulticastPacket();
+	}
+#endif
 	udp.write(buf, len);
  	udp.endPacket();
 	delay(1);

--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip.cpp
@@ -95,7 +95,11 @@ void ESPKNXIP::__start()
 #endif
     server->begin();
   }
+#ifdef ESP8266
   udp.beginMulticast(WiFi.localIP(),  MULTICAST_IP, MULTICAST_PORT);
+#else
+  udp.beginMulticast(MULTICAST_IP, MULTICAST_PORT);
+#endif
 }
 
 void ESPKNXIP::save_to_eeprom()

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
@@ -53,37 +53,3 @@ void wifi_station_disconnect();
 void wifi_station_dhcpc_start();
 extern WiFiClass32 WiFi32;
 #define WiFi WiFi32
-
-class WiFiUDP32 : public WiFiUDP
-{
-    public:
-        size_t write(const char*s)
-        {
-            return WiFiUDP::write((const uint8_t *)s, strlen(s));
-        }
-        size_t write(const uint8_t *buf, size_t n)
-        {
-            return WiFiUDP::write(buf, n);
-        }
-        static void stopAll()
-        {
-
-        }
-        static void forceSleepWake()
-        {
-
-        }
-        uint8_t beginMulticast(IPAddress interfaceAddr, IPAddress multicast, uint16_t port)
-        {
-            return WiFiUDP::beginMulticast(multicast, port);
-        }
-        void beginPacketMulticast(IPAddress multicast, uint16_t port, IPAddress interfaceAddr)
-        {
-            if (0 == WiFiUDP::beginMulticastPacket()) {
-              WiFiUDP::beginMulticast(multicast, port);
-            }
-            WiFiUDP::beginMulticastPacket();
-        }
-};
-
-#define WiFiUDP WiFiUDP32

--- a/tasmota/support.ino
+++ b/tasmota/support.ino
@@ -2410,7 +2410,7 @@ void SyslogAsync(bool refresh) {
         line_start += 1460;
       }
 #else
-      PortUdp.write(header);
+      PortUdp.write((const uint8_t*)header, strlen(header));
       PortUdp.write((uint8_t*)line_start, len -mxtime -1);
       PortUdp.endPacket();
 #endif

--- a/tasmota/support_device_groups.ino
+++ b/tasmota/support_device_groups.ino
@@ -177,10 +177,17 @@ void DeviceGroupsStart()
     }
 
     // Subscribe to device groups multicasts.
+#ifdef ESP8266
     if (!device_groups_udp.beginMulticast(WiFi.localIP(), IPAddress(DEVICE_GROUPS_ADDRESS), DEVICE_GROUPS_PORT)) {
       AddLog(LOG_LEVEL_ERROR, PSTR("DGR: Error subscribing"));
       return;
     }
+#else
+    if (!device_groups_udp.beginMulticast(IPAddress(DEVICE_GROUPS_ADDRESS), DEVICE_GROUPS_PORT)) {
+      AddLog(LOG_LEVEL_ERROR, PSTR("DGR: Error subscribing"));
+      return;
+    }
+#endif
     device_groups_up = true;
 
     // The WiFi was down but now it's up and device groups is initialized. (Re-)discover devices in

--- a/tasmota/support_udp.ino
+++ b/tasmota/support_udp.ino
@@ -69,7 +69,9 @@ bool UdpDisconnect(void)
     PortUdp.stop();
 #else // USE_DEVICE_GROUPS
     // stop all
-    WiFiUDP::stopAll();
+#ifdef ESP8266
+    WiFiUDP::stopAll();   // only for ESP8266
+#endif // ESP8266
 #endif  // !USE_DEVICE_GROUPS
     AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPNP D_MULTICAST_DISABLED));
     udp_connected = false;
@@ -92,7 +94,7 @@ bool UdpConnect(void)
       }
 #endif  // ESP8266
 #ifdef ESP32
-    if (PortUdp.beginMulticast(WiFi.localIP(), IPAddress(239,255,255,250), 1900)) {
+    if (PortUdp.beginMulticast(IPAddress(239,255,255,250), 1900)) {
       AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_UPNP D_MULTICAST_REJOINED));
       udp_connected = true;
 #endif  // ESP32

--- a/tasmota/xdrv_10_scripter.ino
+++ b/tasmota/xdrv_10_scripter.ino
@@ -1020,7 +1020,11 @@ void Script_Init_UDP() {
   if (!glob_script_mem.udp_flags.udp_used) return;
   if (glob_script_mem.udp_flags.udp_connected) return;
 
+#ifdef ESP8266
   if (glob_script_mem.Script_PortUdp.beginMulticast(WiFi.localIP(), IPAddress(239,255,255,250), SCRIPT_UDP_PORT)) {
+#else
+  if (glob_script_mem.Script_PortUdp.beginMulticast(IPAddress(239,255,255,250), SCRIPT_UDP_PORT)) {
+#endif
 #ifdef SCRIPT_DEBUG_UDP
     AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_UPNP "SCRIPT UDP started"));
 #endif

--- a/tasmota/xdrv_20_hue.ino
+++ b/tasmota/xdrv_20_hue.ino
@@ -205,17 +205,17 @@ void HueRespondToMSearch(void)
     String uuid = HueUuid();
 
     snprintf_P(response + len, sizeof(response) - len, msg[HUE_RESP_ST1], uuid.c_str());
-    PortUdp.write(response);
+    PortUdp.write((const uint8_t*)response, strlen(response));
     PortUdp.endPacket();
     // AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_UPNP "UDP resp=%s"), response);
 
     snprintf_P(response + len, sizeof(response) - len, msg[HUE_RESP_ST2], uuid.c_str(), uuid.c_str());
-    PortUdp.write(response);
+    PortUdp.write((const uint8_t*)response, strlen(response));
     PortUdp.endPacket();
     // AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_UPNP "UDP resp=%s"), response);
 
     snprintf_P(response + len, sizeof(response) - len, msg[HUE_RESP_ST3], uuid.c_str());
-    PortUdp.write(response);
+    PortUdp.write((const uint8_t*)response, strlen(response));
     PortUdp.endPacket();
     // AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_UPNP "UDP resp=%s"), response);
 

--- a/tasmota/xdrv_21_wemo.ino
+++ b/tasmota/xdrv_21_wemo.ino
@@ -67,7 +67,7 @@ void WemoRespondToMSearch(int echo_type)
     }
     char response[400];
     snprintf_P(response, sizeof(response), WEMO_MSEARCH, WiFi.localIP().toString().c_str(), type, WemoUuid().c_str(), type);
-    PortUdp.write(response);
+    PortUdp.write((uint8_t*)response, strlen(response));
     PortUdp.endPacket();
     snprintf_P(message, sizeof(message), PSTR(D_RESPONSE_SENT));
   } else {

--- a/tasmota/xdrv_21_wemo_multi.ino
+++ b/tasmota/xdrv_21_wemo_multi.ino
@@ -291,7 +291,7 @@ public:
       }
       char response[400];
       snprintf_P(response, sizeof(response), WEMO_MSEARCH, WiFi.localIP().toString().c_str(), _localPort, type, WemoUuid().c_str(), type);
-      PortUdp.write(response);
+      PortUdp.write((const uint8_t*)response, strlen(response));
       PortUdp.endPacket();
 
 //      AddLog(LOG_LEVEL_DEBUG, PSTR("WMO: Sending packet device %d: %s"), _deviceId, response);


### PR DESCRIPTION
## Description:

Removed WiFiUDP32 and patched code to use native ESP32 WiFiUDP instead. This also solves linker warnings.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
