### PR TITLE
Use linker Option `lto` for ESP32

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -7,11 +7,13 @@ build_unflags               = ${esp_defaults.build_unflags}
                               -Wincompatible-pointer-types
                               -Wnonnull-compare
                               -fexceptions
+                              -fno-lto
                               -Wpointer-arith
 build_flags                 = ${esp_defaults.build_flags}
                               -Wno-switch-unreachable
                               -Wno-stringop-overflow
                               -fno-exceptions
+                              -flto
                               -DBUFFER_LENGTH=128
                               -DHTTP_UPLOAD_BUFLEN=2048
                               -DMQTT_MAX_PACKET_SIZE=1200


### PR DESCRIPTION
to save flash space between 20k and 60k depending on build.
Big Thx to @s-hadinger for fixing the linker warnings!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
