### PR TITLE
LVGL screenshot disk full protection

### DIFF
--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -71,11 +71,13 @@ void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *c
       uint16_t * pix = (uint16_t*) color_p;
       for (uint32_t i = 0; i < btw / 2; i++) (pix[i] = pix[i] << 8 | pix[i] >> 8);
 #endif
-      int32_t ret = glue->getScreenshotFile()->write((const uint8_t*) color_p, btw);
-      if (ret >= 0) {
-        btw -= ret;
-      } else {
-        btw = 0;  // abort
+      if (btw > 0) {    // if we had a previous error (ex disk full) don't try to write anymore
+        int32_t ret = glue->getScreenshotFile()->write((const uint8_t*) color_p, btw);
+        if (ret >= 0) {
+          btw -= ret;
+        } else {
+          btw = 0;  // abort
+        }
       }
     }
     lv_disp_flush_ready(disp);


### PR DESCRIPTION
## Description:

Handle disk full when using `lv.screenshot()`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
