### PR TITLE
Fix millisecond comparisons

### DIFF
--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -854,7 +854,8 @@ bool Xdrv35(uint8_t function)
           }
 
           // If hold time has arrived and no rule is enabled that handles the button hold, handle it.
-          else if (button_hold_time[button_index] <= now) {
+          else if ((int32_t)(now - button_hold_time[button_index]) >= 0) {
+
 #ifdef USE_RULES
             Response_P(PSTR("{\"Button%u\":{\"State\":3}}"), button_index + 1);
             Rules.no_execute = true;
@@ -908,7 +909,8 @@ bool Xdrv35(uint8_t function)
     case FUNC_ANY_KEY:
       {
         uint32_t state = (XdrvMailbox.payload >> 8) & 0xFF;  // 0 = Off, 1 = On, 2 = Toggle, 3 = Hold, 10,11,12,13 and 14 for Button Multipress
-        if ((state == 2 || state == 10) && ignore_any_key_time < millis()) {
+        if ((state == 2 || state == 10) && (int32_t)(millis() - ignore_any_key_time) > 0) {
+
           uint32_t button_index = (XdrvMailbox.payload & 0xFF) - 1;
           button_unprocessed[button_index] = false;
           PWMDimmerHandleButton(button_index, false);


### PR DESCRIPTION
## Description:

Fix millisecond comparisons to handle wraps.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
