### PR TITLE
BLE_EQ3: Fix and enhance the JSON response

### DIFF
--- a/tasmota/xdrv_85_BLE_EQ3_TRV.ino
+++ b/tasmota/xdrv_85_BLE_EQ3_TRV.ino
@@ -188,7 +188,8 @@ const char *cmdnames[] = {
   "day",
   "night",
   "reqprofile",
-  "setprofile"
+  "setprofile",
+  "lock",
 };
 
 const uint8_t *macprefixes[1] = {
@@ -206,7 +207,7 @@ struct eq3_device_tag{
   int8_t RSSI;
   uint64_t timeoutTime;
   uint8_t pairing;
-  uint8_t lastStatus[10]; // last received 02 stat
+  uint8_t lastStatus[16]; // last received 02 stat
   uint8_t lastStatusLen;
   uint32_t lastStatusTime; // in utc
   uint8_t nextDiscoveryData;
@@ -433,8 +434,8 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
   if (success){
     if ((op->notifylen >= 6) && (op->dataNotify[0] == 2) && (op->dataNotify[1] == 1)){
       if (eq3){
-        memcpy(eq3->lastStatus, op->dataNotify, (op->notifylen <= 10)?op->notifylen:10);
-        eq3->lastStatusLen = (op->notifylen <= 10)?op->notifylen:10;
+        memcpy(eq3->lastStatus, op->dataNotify, (op->notifylen <= 10)?op->notifylen:16);
+        eq3->lastStatusLen = (op->notifylen <= 10)?op->notifylen:16;
         eq3->lastStatusTime = UtcTime();
       }
     }
@@ -504,6 +505,15 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
       status[6],
       hh, mm
       );
+
+    if (statlen >= 15) {
+      ResponseAppend_P(PSTR(",\"windowdur\":%d"), ((int)status[11])*5);
+      ResponseAppend_P(PSTR(",\"windowtemp\":%2.1f"), ((float)status[10])/2);
+      ResponseAppend_P(PSTR(",\"day\":%2.1f"), ((float)status[12])/2);
+      ResponseAppend_P(PSTR(",\"night\":%2.1f"), ((float)status[13])/2);
+      ResponseAppend_P(PSTR(",\"offset\":%2.1f"), ((float)status[14]-7) /2);
+    }
+
   }
 
   if (success) {
@@ -1216,7 +1226,7 @@ int EQ3Send(const uint8_t* addr, const char *cmd, char* param, char* param2, int
     if (!strcmp(cmd, "unboost"))  { 
       cmdtype = 10;
       d[0] = 0x45; d[1] = 0x00; dlen = 2; break; }
-    if (!strcmp(cmd, "lock"))     { d[0] = 0x80; d[1] = 0x01; 
+    if (!strcmp(cmd, "lock"))     { cmdtype = 23; d[0] = 0x80; d[1] = 0x01; 
       if (param && (!strcmp(param, "off") || param[0] == '0')){
         d[1] = 0x00;
       }

--- a/tasmota/xdrv_85_BLE_EQ3_TRV.ino
+++ b/tasmota/xdrv_85_BLE_EQ3_TRV.ino
@@ -79,7 +79,12 @@ stat/EQ3/001A22092C9A = {
   "dst":"set",
   "window":"closed",
   "state":"unlocked",
-  "battery":"GOOD"
+  "battery":"GOOD",
+  "windowtemp": 12.0,
+  "windowdur": 15,
+  "day": 21.0,
+  "night": 17.0,
+  "offset": 0.0
 }
 
 holiday:
@@ -507,8 +512,8 @@ int EQ3ParseOp(BLE_ESP32::generic_sensor_t *op, bool success, int retries){
       );
 
     if (statlen >= 15) {
-      ResponseAppend_P(PSTR(",\"windowdur\":%d"), ((int)status[11])*5);
       ResponseAppend_P(PSTR(",\"windowtemp\":%2.1f"), ((float)status[10])/2);
+      ResponseAppend_P(PSTR(",\"windowdur\":%d"), ((int)status[11])*5);
       ResponseAppend_P(PSTR(",\"day\":%2.1f"), ((float)status[12])/2);
       ResponseAppend_P(PSTR(",\"night\":%2.1f"), ((float)status[13])/2);
       ResponseAppend_P(PSTR(",\"offset\":%2.1f"), ((float)status[14]-7) /2);


### PR DESCRIPTION
## Description:

Fix and enhance the JSON response  after command execution.

a) Add

-   "windowdur"
-   "windowtemp"
-   "day"
-   "night"
-   "offset"

to "ResponseAppend_P" (json response)

b) Assign cmdtype = 23 to "lock" so the correct `"cmd":"lock"` will show in "ResponseAppend_P

**Info:** I have also re-worked the documentation and will create  a separate PR for it the next days

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9  (ESP8266 has no Bluetooth)
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
