### PR TITLE
LVGL fix calibration not applied when not touched

### DIFF
--- a/tasmota/xdrv_55_touch.ino
+++ b/tasmota/xdrv_55_touch.ino
@@ -190,6 +190,7 @@ void Touch_Check(void(*rotconvert)(int16_t *x, int16_t *y)) {
     }
 #endif  // USE_M5STACK_CORE2
 
+    rotconvert(&touch_xp, &touch_yp);   // still do rot convert if not touched
 #ifdef USE_TOUCH_BUTTONS
     CheckTouchButtons(touched, touch_xp, touch_yp);
 #endif // USE_TOUCH_BUTTONS


### PR DESCRIPTION
## Description:

Bug on resistive touch screens only.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
