### PR TITLE
fix ambiguous error in knx

### DIFF
--- a/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-webserver.cpp
+++ b/lib/lib_div/esp-knx-ip-0.5.2/src/esp-knx-ip-webserver.cpp
@@ -42,7 +42,7 @@ void ESPKNXIP::__handle_root()
         case FEEDBACK_TYPE_FLOAT:
           m += F("<span class='input-group-text'>");
           m += feedbacks[i].options.float_options.prefix;
-          m += String(*(float *)feedbacks[i].data, feedbacks[i].options.float_options.precision);
+          m += String(*(float *)feedbacks[i].data, (unsigned int)feedbacks[i].options.float_options.precision);
           m += feedbacks[i].options.float_options.suffix;
           m += F("</span>");
           break;


### PR DESCRIPTION
## Description:

when compile with upstream Arduino core ESP32
Thx @Staars 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
