### PR TITLE
Satisfy requirements when enabling MQTT TLS from user_config_override.h

### DIFF
--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -500,8 +500,7 @@
 // -- MQTT - TLS - AWS IoT ------------------------
 #ifdef USE_ZBBRIDGE_TLS                            // Enable TLS for ZbBridge
   #define USE_MQTT_TLS                             // Use TLS for MQTT connection (+34.5k code, +7.0k mem and +4.8k additional during connection handshake)
-    #define USE_MQTT_AWS_IOT_LIGHT                 // Enable MQTT for AWS IoT in light mode, with user/password instead of private certificate
-  #define USE_TLS                                  // flag indicates we need to include TLS code
+  #define USE_MQTT_AWS_IOT_LIGHT                   // Enable MQTT for AWS IoT in light mode, with user/password instead of private certificate
 #endif                                             // USE_ZBBRIDGE_TLS
 
 //#undef USE_KNX                                   // Disable KNX IP Protocol Support
@@ -940,7 +939,6 @@
 #undef USE_BERRY
 //#undef USE_WEBCLIENT
 //#undef USE_WEBCLIENT_HTTPS
-//#undef USE_TLS   // needed for MQTT over TLS
 
 #endif  // FIRMWARE_MINICUSTOM
 
@@ -1046,5 +1044,9 @@
 #ifdef USE_EMULATION_HUE
 #define USE_UNISHOX_COMPRESSION                // Add support for string compression
 #endif
+
+#ifdef USE_MQTT_TLS                              // If TLS for MQTT is enabled:
+  #define USE_TLS                                // flag indicates we need to include TLS code
+#endif                                           // USE_MQTT_TLS
 
 #endif  // _TASMOTA_CONFIGURATIONS_H_


### PR DESCRIPTION
## Description:

It is always needed to define `USE_TLS` if using `USE_MQTT_TLS`. The key `USE_TLS` is used inside the **_TLS_mini_** library (specifically at the top of _WiFiClientSecureLightBearSSL.h_).

**Related issue (if applicable):** fixes compiling with MQTT TLS

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
