### PR TITLE
Fix compilation issue for Telegram

### DIFF
--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -1045,8 +1045,8 @@
 #define USE_UNISHOX_COMPRESSION                // Add support for string compression
 #endif
 
-#ifdef USE_MQTT_TLS                              // If TLS for MQTT is enabled:
-  #define USE_TLS                                // flag indicates we need to include TLS code
-#endif                                           // USE_MQTT_TLS
+#if defined(USE_MQTT_TLS) || defined(USE_TELEGRAM)      // Enable TLS if required:
+  #define USE_TLS                                       // flag indicates we need to include TLS code
+#endif                                                  // USE_MQTT_TLS || USE_TELEGRAM
 
 #endif  // _TASMOTA_CONFIGURATIONS_H_


### PR DESCRIPTION
## Description:

Fix compilation issue for Telegram.  It was missing the define USE_TLS for TELEGRAM.

**Related issue (if applicable):** fixes #14509

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
