### PR TITLE
Move Post Processing Macros after user_config_override.h

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -980,9 +980,6 @@
 #define SET_ESP32_STACK_SIZE  (8 * 1024)         // Set the stack size for Tasmota. The default value is 8192 for Arduino, some builds might need to increase it
 
 //#define USE_SONOFF_SPM                           // Add support for ESP32 based Sonoff Smart Stackable Power Meter(+6k3 code)
-#ifdef USE_SONOFF_SPM
-#define USE_ETHERNET
-#endif
 
 //#define USE_ETHERNET                             // Add support for ethernet (Currently fixed for Olimex ESP32-PoE)
 //  #define USE_WT32_ETH01                         // Add support for Wireless-Tag WT32-ETH01
@@ -1095,7 +1092,15 @@
 //#define FIRMWARE_MINIMAL                         // Create tasmota-minimal as intermediate firmware for OTA-MAGIC
 
 /*********************************************************************************************\
- * No user configurable items below
+ * User configurable items override                                                          *
+\*********************************************************************************************/
+
+#ifdef USE_CONFIG_OVERRIDE
+  #include "user_config_override.h"         // Configuration overrides for my_user_config.h
+#endif
+
+/*********************************************************************************************\
+ * Mutual exclude options
 \*********************************************************************************************/
 
 #if defined(USE_DISCOVERY) && (defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT))
@@ -1107,7 +1112,7 @@
 #endif
 
 /*********************************************************************************************\
- * Post-process compile options for Autoconf
+ * Post-process compile options for Autoconf and others
 \*********************************************************************************************/
 
 #if defined(USE_AUTOCONF)
@@ -1122,16 +1127,16 @@
   #endif
 #endif // USE_AUTOCONF
 
+#ifdef USE_SONOFF_SPM
+  #define USE_ETHERNET
+#endif
+
 /*********************************************************************************************\
  * Post-process compile options for TLS
 \*********************************************************************************************/
 
 #if defined(USE_MQTT_TLS) || defined(USE_SENDMAIL) || defined(USE_TELEGRAM) || defined(USE_WEBCLIENT_HTTPS) || defined(USE_ALEXA_AVS)
   #define USE_TLS                                  // flag indicates we need to include TLS code
-#endif
-
-#ifdef USE_CONFIG_OVERRIDE
-  #include "user_config_override.h"         // Configuration overrides for my_user_config.h
 #endif
 
 /*********************************************************************************************\

--- a/tasmota/tasmota_configurations.h
+++ b/tasmota/tasmota_configurations.h
@@ -1045,8 +1045,8 @@
 #define USE_UNISHOX_COMPRESSION                // Add support for string compression
 #endif
 
-#if defined(USE_MQTT_TLS) || defined(USE_TELEGRAM)      // Enable TLS if required:
-  #define USE_TLS                                       // flag indicates we need to include TLS code
-#endif                                                  // USE_MQTT_TLS || USE_TELEGRAM
+#if defined(USE_MQTT_TLS)                      // Enable TLS if required:
+  #define USE_TLS                              // flag indicates we need to include TLS code
+#endif                                         // USE_MQTT_TLS
 
 #endif  // _TASMOTA_CONFIGURATIONS_H_


### PR DESCRIPTION
## Description:

Move Post Processing Macros after user_config_override.h
Fix compilation issue for Telegram and other features that require USE_TLS when the user enables them in user_config_override.h

**Related issue (if applicable):** fixes #14509, #14512

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
