### PR TITLE
set SerialDelimiter=254 to post HEX string over the serial bridge

### DIFF
--- a/tasmota/xdrv_08_serial_bridge.ino
+++ b/tasmota/xdrv_08_serial_bridge.ino
@@ -65,7 +65,7 @@ void SerialBridgeInput(void) {
   while (SerialBridgeSerial->available()) {
     yield();
     uint8_t serial_in_byte = SerialBridgeSerial->read();
-    serial_bridge_raw = Settings->serial_delimiter == 255;
+    serial_bridge_raw = Settings->serial_delimiter == 254;
     if ((serial_in_byte > 127) && !serial_bridge_raw) {                        // Discard binary data above 127 if no raw reception allowed
       serial_bridge_in_byte_counter = 0;
       SerialBridgeSerial->flush();

--- a/tasmota/xdrv_08_serial_bridge.ino
+++ b/tasmota/xdrv_08_serial_bridge.ino
@@ -65,7 +65,7 @@ void SerialBridgeInput(void) {
   while (SerialBridgeSerial->available()) {
     yield();
     uint8_t serial_in_byte = SerialBridgeSerial->read();
-
+    serial_bridge_raw = Settings->serial_delimiter == 255;
     if ((serial_in_byte > 127) && !serial_bridge_raw) {                        // Discard binary data above 127 if no raw reception allowed
       serial_bridge_in_byte_counter = 0;
       SerialBridgeSerial->flush();


### PR DESCRIPTION
## Description:
set SerialDelimiter=254 to post HEX string over the serial bridge


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
