### PR TITLE
Add setting for IRremoteESP8266 tolerance

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -858,6 +858,7 @@
     #define IR_RCV_TIMEOUT          15           // Number of milli-Seconds of no-more-data before we consider a message ended (default 15)
     #define IR_RCV_MIN_UNKNOWN_SIZE 6            // Set the smallest sized "UNKNOWN" message packets we actually care about (default 6, max 255)
     #define IR_RCV_WHILE_SENDING    0            // Turns on receiver while sending messages, i.e. receive your own. This is unreliable and can cause IR timing issues
+    #define IR_RCV_TOLERANCE        25           // Base tolerance percentage for matching incoming IR messages (default 25, max 100)
 
 // -- Zigbee interface ----------------------------
 //#define USE_ZIGBEE                                // Enable serial communication with Zigbee CC2530/CC2652 flashed with ZNP or EFR32 flashed with EZSP (+49k code, +3k mem)

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1032,6 +1032,7 @@ void SettingsDefaultSet2(void) {
   flag.ir_receive_decimal |= IR_DATA_RADIX;
   flag3.receive_raw |= IR_ADD_RAW_DATA;
   Settings->param[P_IR_UNKNOW_THRESHOLD] = IR_RCV_MIN_UNKNOWN_SIZE;
+  Settings->param[P_IR_TOLERANCE] = IR_RCV_TOLERANCE;
 
   // RF Bridge
   flag.rf_receive_decimal |= RF_DATA_RADIX;

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -992,6 +992,9 @@ void CmndSetoptionBase(bool indexed) {
           if (P_IR_UNKNOW_THRESHOLD == pindex) {
             IrReceiveUpdateThreshold();    // SetOption38
           }
+          if (P_IR_TOLERANCE == pindex) {
+            IrReceiveUpdateTolerance();    // SetOption44
+          }
 #endif
 #ifdef ROTARY_V1
           if (P_ROTARY_MAX_STEP == pindex) {

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -320,7 +320,7 @@ enum Shortcuts { SC_CLEAR, SC_DEFAULT, SC_USER };
 
 enum SettingsParamIndex { P_HOLD_TIME, P_MAX_POWER_RETRY, P_BACKLOG_DELAY, P_MDNS_DELAYED_START, P_BOOT_LOOP_OFFSET, P_RGB_REMAP, P_IR_UNKNOW_THRESHOLD,  // SetOption32 .. SetOption38
                           P_CSE7766_INVALID_POWER, P_HOLD_IGNORE, P_ARP_GRATUITOUS, P_OVER_TEMP,  // SetOption39 .. SetOption42
-                          P_ROTARY_MAX_STEP, P_ex_TUYA_VOLTAGE_ID, P_ex_TUYA_CURRENT_ID, P_ex_TUYA_POWER_ID,  // SetOption43 .. SetOption46
+                          P_ROTARY_MAX_STEP, P_IR_TOLERANCE, P_ex_TUYA_CURRENT_ID, P_ex_TUYA_POWER_ID,  // SetOption43 .. SetOption46
                           P_ex_ENERGY_TARIFF1, P_ex_ENERGY_TARIFF2,  // SetOption47 .. SetOption48
                           P_MAX_PARAM8 };  // Max is PARAM8_SIZE (18) - SetOption32 until SetOption49
 

--- a/tasmota/tasmota_globals.h
+++ b/tasmota/tasmota_globals.h
@@ -306,6 +306,10 @@ String EthernetMacAddress(void);
 #define IR_RCV_MIN_UNKNOWN_SIZE     6          // Set the smallest sized "UNKNOWN" message packets we actually care about (default 6, max 255)
 #endif
 
+#ifndef IR_RCV_TOLERANCE
+#define IR_RCV_TOLERANCE            25         // Base tolerance percentage for matching incoming IR messages (default 25, max 100)
+#endif
+
 #ifndef ENERGY_OVERTEMP
 #define ENERGY_OVERTEMP             90         // Overtemp in Celsius
 #endif

--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -195,11 +195,20 @@ void IrReceiveUpdateThreshold(void)
   }
 }
 
+void IrReceiveUpdateTolerance(void)
+{
+  if (irrecv != nullptr) {
+    if (Settings->param[P_IR_TOLERANCE] > 100) { Settings->param[P_IR_TOLERANCE] = 100; }
+    irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
+  }
+}
+
 void IrReceiveInit(void)
 {
   // an IR led is at GPIO_IRRECV
   irrecv = new IRrecv(Pin(GPIO_IRRECV), IR_RCV_BUFFER_SIZE, IR_RCV_TIMEOUT, IR_RCV_SAVE_BUFFER);
   irrecv->setUnknownThreshold(Settings->param[P_IR_UNKNOW_THRESHOLD]);
+  irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
   irrecv->enableIRIn();                  // Start the receiver
 
   //  AddLog(LOG_LEVEL_DEBUG, PSTR("IrReceive initialized"));

--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -198,6 +198,7 @@ void IrReceiveUpdateThreshold(void)
 void IrReceiveUpdateTolerance(void)
 {
   if (irrecv != nullptr) {
+    if (Settings->param[P_IR_TOLERANCE] == 0) { Settings->param[P_IR_TOLERANCE] = IR_RCV_TOLERANCE; }
     if (Settings->param[P_IR_TOLERANCE] > 100) { Settings->param[P_IR_TOLERANCE] = 100; }
     irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
   }

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -193,11 +193,20 @@ void IrReceiveUpdateThreshold(void)
   }
 }
 
+void IrReceiveUpdateTolerance(void)
+{
+  if (irrecv != nullptr) {
+    if (Settings->param[P_IR_TOLERANCE] > 100) { Settings->param[P_IR_TOLERANCE] = 100; }
+    irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
+  }
+}
+
 void IrReceiveInit(void)
 {
   // an IR led is at GPIO_IRRECV
   irrecv = new IRrecv(Pin(GPIO_IRRECV), IR_FULL_BUFFER_SIZE, IR__FULL_RCV_TIMEOUT, IR_FULL_RCV_SAVE_BUFFER);
   irrecv->setUnknownThreshold(Settings->param[P_IR_UNKNOW_THRESHOLD]);
+  irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
   irrecv->enableIRIn();                  // Start the receiver
 }
 

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -196,6 +196,7 @@ void IrReceiveUpdateThreshold(void)
 void IrReceiveUpdateTolerance(void)
 {
   if (irrecv != nullptr) {
+    if (Settings->param[P_IR_TOLERANCE] == 0) { Settings->param[P_IR_TOLERANCE] = IR_RCV_TOLERANCE; }
     if (Settings->param[P_IR_TOLERANCE] > 100) { Settings->param[P_IR_TOLERANCE] = 100; }
     irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
   }


### PR DESCRIPTION
## Description:
Add setting that allow changing IRremoteESP8266 tolerance.
Discussion as ref: https://github.com/arendst/Tasmota/discussions/14435

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
