### PR TITLE
Add %color% variable to rules

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -471,6 +471,12 @@ bool RulesRuleMatch(uint8_t rule_set, String &event, String &rule, bool stop_all
       rule_param = String(SunMinutes(1));
     }
 #endif  // USE_TIMERS and USE_SUNRISE
+#if defined(USE_LIGHT)
+    char scolor[LIGHT_COLOR_SIZE];
+    if (rule_param.startsWith(F("%COLOR%"))) {
+      rule_param = LightGetColor(scolor);
+    }
+#endif
 // #ifdef USE_ZIGBEE
 //     if (rule_param.startsWith(F("%ZBDEVICE%"))) {
 //       snprintf_P(stemp, sizeof(stemp), PSTR("0x%04X"), Z_GetLastDevice());
@@ -772,6 +778,10 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));
       RulesVarReplace(commands, F("%SUNSET%"), String(SunMinutes(1)));
 #endif  // USE_TIMERS and USE_SUNRISE
+#if defined(USE_LIGHT)
+      char scolor[LIGHT_COLOR_SIZE];
+      RulesVarReplace(commands, F("%COLOR%"), LightGetColor(scolor));
+#endif
 #ifdef USE_ZIGBEE
       snprintf_P(stemp, sizeof(stemp), PSTR("0x%04X"), Z_GetLastDevice());
       RulesVarReplace(commands, F("%ZBDEVICE%"), String(stemp));


### PR DESCRIPTION
## Description:

Add `%color%` variable to rules.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/14556

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
