### PR TITLE
include DeviceName in retained telemetry mqtt message

### DIFF
--- a/tasmota/support_tasmota.ino
+++ b/tasmota/support_tasmota.ino
@@ -762,9 +762,9 @@ void MqttShowState(void)
 #endif  // USE_ADC_VCC
 #endif  // ESP8266
 
-  ResponseAppend_P(PSTR(",\"" D_JSON_HEAPSIZE "\":%d,\"SleepMode\":\"%s\",\"Sleep\":%u,\"LoadAvg\":%u,\"MqttCount\":%u"),
+  ResponseAppend_P(PSTR(",\"" D_JSON_HEAPSIZE "\":%d,\"SleepMode\":\"%s\",\"Sleep\":%u,\"LoadAvg\":%u,\"MqttCount\":%u,\"" D_JSON_DEVICENAME "\":\"%s\"" ),
     ESP_getFreeHeap1024(), GetTextIndexed(stemp1, sizeof(stemp1), Settings->flag3.sleep_normal, kSleepMode),  // SetOption60 - Enable normal sleep instead of dynamic sleep
-    TasmotaGlobal.sleep, TasmotaGlobal.loop_load_avg, MqttConnectCount());
+    TasmotaGlobal.sleep, TasmotaGlobal.loop_load_avg, MqttConnectCount(),SettingsText(SET_DEVICENAME));
 
 #ifdef USE_BERRY
     extern void BrShowState(void);


### PR DESCRIPTION
I have build an android App that is heavily using Tasmota devices mqtt data. The app is made so, it creates GUI only using Tasmota retain mqtt messages. This is big advantage, because other gui apps usually needs to modify GUI config when new element is added. This is not necessary here. One limitation is missing DeviceName in Telemetry STATE message. IThis patch may help others who are building GUI just based on MQTT messages. to keep my app simple I want to avoid Using discovery Tasmota mqtt messages and deal with multiple topics correlating them later

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
