### PR TITLE
additional to add DeviceName PR

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -224,6 +224,7 @@
 #define D_JSON_RESETTABLE_TOTAL_ACTIVE "ResetTotalActive"
 #define D_JSON_SIGNALSTRENGTH "SignalStrength"
 #define D_JSON_CHIPTEMPERATURE "ChipTemperature"
+#define D_JSON_DEVICENAME "DeviceName"
 
 #define D_RSLT_ENERGY "ENERGY"
 #define D_RSLT_HASS_STATE "HASS_STATE"


### PR DESCRIPTION
I am operating an android App that is heavily using Tasmota devices data. The app is made so, it creates GUI only using Tasmota retain mqtt messages. This is big advantage, because other gui apps usually needs to modify GUI config when new elemet is added. This is not necessary here. One limitation is missing DeviceName in Telemetry STATE message. IThis patch may help others who are building GUI just based on MQTT messages. to keep my app simple I want to avoid Using discovery Tasmota mqtt messages and deal with multiple topics correlating them later

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
