### PR TITLE
Update touchscreen x/y only when touched

### DIFF
--- a/tasmota/xdrv_55_touch.ino
+++ b/tasmota/xdrv_55_touch.ino
@@ -133,17 +133,21 @@ void Touch_Check(void(*rotconvert)(int16_t *x, int16_t *y)) {
 
 #ifdef USE_FT5206
   if (FT5206_found) {
-    touch_xp = FT5206_x();
-    touch_yp = FT5206_y();
     touched = FT5206_touched();
+    if (touched) {
+      touch_xp = FT5206_x();
+      touch_yp = FT5206_y();
+    }
   }
 #endif // USE_FT5206
 
 #ifdef USE_XPT2046
   if (XPT2046_found) {
-    touch_xp = XPT2046_x();
-    touch_yp = XPT2046_y();
     touched = XPT2046_touched();
+    if (touched) {
+      touch_xp = XPT2046_x();
+      touch_yp = XPT2046_y();
+    }
   }
 #endif // USE_XPT2046
 


### PR DESCRIPTION
## Description:

LVGL has somme issues if the x/y goes to zero after the touch being released. This PR will freeze any x/y from changing if the screen is not touched.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
