### PR TITLE
Added WIFI check to avoid extensive battery usage

### DIFF
--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -32,7 +32,9 @@
 
 #define D_PRFX_DEEPSLEEP "DeepSleep"
 #define D_CMND_DEEPSLEEP_TIME "Time"
-#define DEEPSLEEP_NETWORK_TIMEOUT 15
+#ifndef DEEPSLEEP_NETWORK_TIMEOUT
+  #define DEEPSLEEP_NETWORK_TIMEOUT 15
+#endif
 
 const uint32_t DEEPSLEEP_MAX = 10 * 366 * 24 * 60 * 60;  // Allow max 10 years sleep
 const uint32_t DEEPSLEEP_MAX_CYCLE = 60 * 60;            // Maximum time for a deepsleep as defined by chip hardware
@@ -154,13 +156,11 @@ void DeepSleepStart(void)
 
 void DeepSleepEverySecond(void)
 {
-#ifdef DEEPSLEEP_NETWORK_TIMEOUT
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
   if (DEEPSLEEP_NETWORK_TIMEOUT && TasmotaGlobal.uptime > DEEPSLEEP_NETWORK_TIMEOUT && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
     AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect 15 seconds. Deepsleep") );
     deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
   }
-#endif // DEEPSLEEP_NETWORK_TIMEOUT
 
   if (!deepsleep_flag) { return; }
 

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -32,6 +32,7 @@
 
 #define D_PRFX_DEEPSLEEP "DeepSleep"
 #define D_CMND_DEEPSLEEP_TIME "Time"
+#define DEEPSLEEP_NETWORK_TIMEOUT 15
 
 const uint32_t DEEPSLEEP_MAX = 10 * 366 * 24 * 60 * 60;  // Allow max 10 years sleep
 const uint32_t DEEPSLEEP_MAX_CYCLE = 60 * 60;            // Maximum time for a deepsleep as defined by chip hardware
@@ -137,8 +138,6 @@ void DeepSleepPrepare(void)
 
 void DeepSleepStart(void)
 {
-  AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_APPLICATION "Sleeping"));  // Won't show in GUI
-
   WifiShutdown();
   RtcSettings.ultradeepsleep = RtcSettings.nextwakeup - LocalTime();
   RtcSettingsSave();
@@ -154,13 +153,14 @@ void DeepSleepStart(void)
 }
 
 void DeepSleepEverySecond(void)
-{  
+{
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
-  if (TasmotaGlobal.uptime > 15 && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
+  if (DEEPSLEEP_NETWORK_TIMEOUT && TasmotaGlobal.uptime > DEEPSLEEP_NETWORK_TIMEOUT && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
     AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect 15 seconds. Deepsleep") );
     deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
   }
   if (!deepsleep_flag) { return; }
+
   if (DeepSleepEnabled()) {
     if (DEEPSLEEP_START_COUNTDOWN == deepsleep_flag) {  // Allow 4 seconds to update web console before deepsleep
       SettingsSaveAll();

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -154,9 +154,13 @@ void DeepSleepStart(void)
 }
 
 void DeepSleepEverySecond(void)
-{
+{  
+  //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
+  if (TasmotaGlobal.uptime > 15 && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
+    AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect 15 seconds. Deepsleep") );
+    deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
+  }
   if (!deepsleep_flag) { return; }
-
   if (DeepSleepEnabled()) {
     if (DEEPSLEEP_START_COUNTDOWN == deepsleep_flag) {  // Allow 4 seconds to update web console before deepsleep
       SettingsSaveAll();

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -158,7 +158,7 @@ void DeepSleepEverySecond(void)
 {
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
   if (DEEPSLEEP_NETWORK_TIMEOUT && TasmotaGlobal.uptime > DEEPSLEEP_NETWORK_TIMEOUT && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
-    AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect 15 seconds. Deepsleep") );
+    AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect %s seconds. Deepsleep"), DEEPSLEEP_NETWORK_TIMEOUT);
     deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
   }
 

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -158,7 +158,7 @@ void DeepSleepEverySecond(void)
 {
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
   if (DEEPSLEEP_NETWORK_TIMEOUT && TasmotaGlobal.uptime > DEEPSLEEP_NETWORK_TIMEOUT && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
-    AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect %s seconds. Deepsleep"), DEEPSLEEP_NETWORK_TIMEOUT);
+    AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect %d seconds. Deepsleep"), DEEPSLEEP_NETWORK_TIMEOUT);
     deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
   }
 

--- a/tasmota/xdrv_29_deepsleep.ino
+++ b/tasmota/xdrv_29_deepsleep.ino
@@ -1,7 +1,7 @@
 /*
   xdrv_29_deepsleep.ino - DeepSleep support for Tasmota
 
-  Copyright (C) 2021  Stefan Bode
+  Copyright (C) 2022  Stefan Bode
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -154,11 +154,14 @@ void DeepSleepStart(void)
 
 void DeepSleepEverySecond(void)
 {
+#ifdef DEEPSLEEP_NETWORK_TIMEOUT
   //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("Wifi Info: up %d, wifidown %d, wifistatus %d, flag %d"),TasmotaGlobal.uptime, TasmotaGlobal.global_state.wifi_down, Wifi.status , deepsleep_flag);
   if (DEEPSLEEP_NETWORK_TIMEOUT && TasmotaGlobal.uptime > DEEPSLEEP_NETWORK_TIMEOUT && Wifi.status != WL_CONNECTED && !deepsleep_flag && DeepSleepEnabled()) {
     AddLog(LOG_LEVEL_ERROR, PSTR("Error Wifi could not connect 15 seconds. Deepsleep") );
     deepsleep_flag = DEEPSLEEP_START_COUNTDOWN;  // Start deepsleep in 4 seconds
   }
+#endif // DEEPSLEEP_NETWORK_TIMEOUT
+
   if (!deepsleep_flag) { return; }
 
   if (DeepSleepEnabled()) {


### PR DESCRIPTION
The device is sent to an additional deepsleep cycle if there could not establish a WIFI connection with IP in the first 15 seconds after startup. The normal connection time is 6-7 seconds. Address #14483

## Description:
#14483 send the device back into deepsleep if WIFI does not work for whatever reason
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
