### PR TITLE
ESP32-S3 support first step (of many needed)

### DIFF
--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dout",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "espidf",
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}

--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32s3_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -52,6 +52,13 @@
 #define HSPI_HOST   SPI3_HOST
 #define VSPI_HOST   SPI3_HOST
 
+#elif CONFIG_IDF_TARGET_ESP32S3
+// SPI_HOST (SPI1_HOST) is not supported by the SPI Master and SPI Slave driver on ESP32-S2 and later
+#define SPI_HOST    SPI1_HOST
+#define FSPI_HOST   SPI2_HOST
+#define HSPI_HOST   SPI3_HOST
+#define VSPI_HOST   SPI3_HOST
+
 #elif CONFIG_IDF_TARGET_ESP32C3
 #define SPI_HOST    SPI1_HOST
 #define HSPI_HOST   SPI2_HOST

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -52,3 +52,16 @@ debug_init_break        = tbreak setup
 build_unflags           = ${core32solo1.build_unflags}
 build_flags             = ${core32solo1.build_flags}
 monitor_filters         = esp32_exception_decoder
+
+; *** pre alpha S3 Version
+[env:tasmota32s3]
+extends                 = env:tasmota32_base
+platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/602/framework-arduinoespressif32-S3-v4.4.tar.gz
+board                   = esp32s3
+build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
+lib_ignore              =
+                          TTGO TWatch Library
+                          NimBLE-Arduino
+                          Micro-RTSP
+                          epdiy

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -57,7 +57,7 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/602/framework-arduinoespressif32-S3-v4.4.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/604/framework-arduinoespressif32-S3-v4.4.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore              =

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -57,7 +57,7 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/604/framework-arduinoespressif32-S3-v4.4.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/607/framework-arduinoespressif32-release_v4.4-077f93b411.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore              =

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -59,7 +59,12 @@ extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
 platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/606/framework-arduinoespressif32-release_v4.4-077f93b411.tar.gz
 board                   = esp32s3
-build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags}
+lib_extra_dirs          =
+                          lib/lib_basic
+                          lib/lib_i2c
+                          lib/lib_ssl
+                          lib/libesp32
 lib_ignore              =
                           TTGO TWatch Library
                           NimBLE-Arduino

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -57,7 +57,7 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/607/framework-arduinoespressif32-release_v4.4-077f93b411.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/606/framework-arduinoespressif32-release_v4.4-077f93b411.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_ignore              =

--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -144,7 +144,7 @@ void CrashDumpClear(void)
   }
 }
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 /**
  * Save crash information in RTC memory
  * This function is called automatically if ESP8266 suffers an exception

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -126,6 +126,8 @@ String GetDeviceHardware(void) {
     #include "esp32/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32S2  // ESP32-S2
     #include "esp32s2/rom/rtc.h"
+  #elif CONFIG_IDF_TARGET_ESP32S3  // ESP32-S3
+    #include "esp32s3/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3
     #include "esp32c3/rom/rtc.h"
   #else
@@ -277,6 +279,8 @@ extern "C" {
     #include "esp32/rom/spi_flash.h"
   #elif CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
     #include "esp32s2/rom/spi_flash.h"
+  #elif CONFIG_IDF_TARGET_ESP32S3   // ESP32-S3
+    #include "esp32s3/rom/spi_flash.h"
   #elif CONFIG_IDF_TARGET_ESP32C3   // ESP32-C3
     #include "esp32c3/rom/spi_flash.h"
   #else


### PR DESCRIPTION
Providing a early alpha Tasmota arduino framework for the ESP32-S3
Tasmota does NOT compile successfully. A lot of work to do.

**Maybe Tasmota will never be adopted to the S3!**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
