### PR TITLE
AXP192 add `set_exten`

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -652,6 +652,7 @@ extern const bcstring be_const_str_set_channels;
 extern const bcstring be_const_str_set_chg_current;
 extern const bcstring be_const_str_set_dc_voltage;
 extern const bcstring be_const_str_set_dcdc_enable;
+extern const bcstring be_const_str_set_exten;
 extern const bcstring be_const_str_set_first_time;
 extern const bcstring be_const_str_set_gain;
 extern const bcstring be_const_str_set_height;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -262,7 +262,7 @@ be_define_const_str(check_not_method, "check_not_method", 2597324607u, 0, 16, &b
 be_define_const_str(check_privileged_access, "check_privileged_access", 3692933968u, 0, 23, NULL);
 be_define_const_str(class, "class", 2872970239u, 57, 5, NULL);
 be_define_const_str(class_init_obj, "class_init_obj", 178410604u, 0, 14, &be_const_str_set_useragent);
-be_define_const_str(classname, "classname", 1998589948u, 0, 9, NULL);
+be_define_const_str(classname, "classname", 1998589948u, 0, 9, &be_const_str_set_exten);
 be_define_const_str(classof, "classof", 1796577762u, 0, 7, &be_const_str_kv);
 be_define_const_str(clear, "clear", 1550717474u, 0, 5, &be_const_str_scale_uint);
 be_define_const_str(clear_first_time, "clear_first_time", 632769909u, 0, 16, &be_const_str_width_def);
@@ -644,6 +644,7 @@ be_define_const_str(set_channels, "set_channels", 1370190620u, 0, 12, NULL);
 be_define_const_str(set_chg_current, "set_chg_current", 336304386u, 0, 15, NULL);
 be_define_const_str(set_dc_voltage, "set_dc_voltage", 2181981936u, 0, 14, NULL);
 be_define_const_str(set_dcdc_enable, "set_dcdc_enable", 1594690786u, 0, 15, &be_const_str_widget_event);
+be_define_const_str(set_exten, "set_exten", 1721782768u, 0, 9, NULL);
 be_define_const_str(set_first_time, "set_first_time", 3111247550u, 0, 14, &be_const_str__X7D);
 be_define_const_str(set_gain, "set_gain", 3847781975u, 0, 8, &be_const_str_set_text);
 be_define_const_str(set_height, "set_height", 1080207399u, 0, 10, NULL);
@@ -1197,6 +1198,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 390,
-    .count = 803,
+    .count = 804,
     .table = m_string_table
 };

--- a/lib/libesp32/berry_tasmota/src/be_i2c_axp192_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_i2c_axp192_lib.c
@@ -4,13 +4,43 @@
 #include "be_constobj.h"
 
 /********************************************************************
+** Solidified function: json_append
+********************************************************************/
+be_local_closure(AXP192_json_append,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str(wire),
+    }),
+    &be_const_str_json_append,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x74060001,  //  0001  JMPT	R1	#0004
+      0x4C040000,  //  0002  LDNIL	R1
+      0x80040200,  //  0003  RET	1	R1
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_warning_level
 ********************************************************************/
 be_local_closure(AXP192_get_warning_level,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -35,543 +65,13 @@ be_local_closure(AXP192_get_warning_level,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_vbus_current
-********************************************************************/
-be_local_closure(AXP192_get_vbus_current,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3EC00000),
-    }),
-    &be_const_str_get_vbus_current,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E005B,  //  0001  LDINT	R3	92
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_chg_current
-********************************************************************/
-be_local_closure(AXP192_set_chg_current,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(write8),
-    /* K1   */  be_nested_str(read8),
-    }),
-    &be_const_str_set_chg_current,
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x54120032,  //  0001  LDINT	R4	51
-      0x8C140101,  //  0002  GETMET	R5	R0	K1
-      0x541E0032,  //  0003  LDINT	R7	51
-      0x7C140400,  //  0004  CALL	R5	2
-      0x541A00EF,  //  0005  LDINT	R6	240
-      0x2C140A06,  //  0006  AND	R5	R5	R6
-      0x541A000E,  //  0007  LDINT	R6	15
-      0x2C180206,  //  0008  AND	R6	R1	R6
-      0x30140A06,  //  0009  OR	R5	R5	R6
-      0x7C080600,  //  000A  CALL	R2	3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bat_current
-********************************************************************/
-be_local_closure(AXP192_get_bat_current,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
-    }),
-    &be_const_str_get_bat_current,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0079,  //  0001  LDINT	R3	122
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C080100,  //  0003  GETMET	R2	R0	K0
-      0x5412007B,  //  0004  LDINT	R4	124
-      0x7C080400,  //  0005  CALL	R2	2
-      0x04040202,  //  0006  SUB	R1	R1	R2
-      0x08040301,  //  0007  MUL	R1	R1	K1
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bat_power
-********************************************************************/
-be_local_closure(AXP192_get_bat_power,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read24),
-    /* K1   */  be_const_real_hex(0x3A102DE1),
-    }),
-    &be_const_str_get_bat_power,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E006F,  //  0001  LDINT	R3	112
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: json_append
-********************************************************************/
-be_local_closure(AXP192_json_append,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    }),
-    &be_const_str_json_append,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x74060001,  //  0001  JMPT	R1	#0004
-      0x4C040000,  //  0002  LDNIL	R1
-      0x80040200,  //  0003  RET	1	R1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_vbus_voltage
-********************************************************************/
-be_local_closure(AXP192_get_vbus_voltage,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3ADED28A),
-    }),
-    &be_const_str_get_vbus_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0059,  //  0001  LDINT	R3	90
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_temp
-********************************************************************/
-be_local_closure(AXP192_get_temp,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3DCCCCCD),
-    /* K2   */  be_const_real_hex(0x4310B333),
-    }),
-    &be_const_str_get_temp,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E005D,  //  0001  LDINT	R3	94
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x04040302,  //  0004  SUB	R1	R1	K2
-      0x80040200,  //  0005  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: battery_present
-********************************************************************/
-be_local_closure(AXP192_battery_present,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
-    }),
-    &be_const_str_battery_present,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
-      0x7C040800,  //  0005  CALL	R1	4
-      0x540A001F,  //  0006  LDINT	R2	32
-      0x2C040202,  //  0007  AND	R1	R1	R2
-      0x78060002,  //  0008  JMPF	R1	#000C
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
-      0x70020001,  //  000B  JMP		#000E
-      0x50040000,  //  000C  LDBOOL	R1	0	0
-      0x80040200,  //  000D  RET	1	R1
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_aps_voltage
-********************************************************************/
-be_local_closure(AXP192_get_aps_voltage,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3AB78035),
-    }),
-    &be_const_str_get_aps_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E007D,  //  0001  LDINT	R3	126
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_dcdc_enable
-********************************************************************/
-be_local_closure(AXP192_set_dcdc_enable,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(1),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_const_int(3),
-    }),
-    &be_const_str_set_dcdc_enable,
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
-      0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
-      0x54160011,  //  0003  LDINT	R5	18
-      0x58180002,  //  0004  LDCONST	R6	K2
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0303,  //  0007  EQ	R3	R1	K3
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
-      0x54160011,  //  000A  LDINT	R5	18
-      0x541A0003,  //  000B  LDINT	R6	4
-      0x5C1C0400,  //  000C  MOVE	R7	R2
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x1C0C0304,  //  000E  EQ	R3	R1	K4
-      0x780E0004,  //  000F  JMPF	R3	#0015
-      0x8C0C0101,  //  0010  GETMET	R3	R0	K1
-      0x54160011,  //  0011  LDINT	R5	18
-      0x58180000,  //  0012  LDCONST	R6	K0
-      0x5C1C0400,  //  0013  MOVE	R7	R2
-      0x7C0C0800,  //  0014  CALL	R3	4
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ldo_voltage
-********************************************************************/
-be_local_closure(AXP192_set_ldo_voltage,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write8),
-    /* K2   */  be_nested_str(read8),
-    /* K3   */  be_const_int(3),
-    }),
-    &be_const_str_set_ldo_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0x540E0CE3,  //  0000  LDINT	R3	3300
-      0x240C0403,  //  0001  GT	R3	R2	R3
-      0x780E0001,  //  0002  JMPF	R3	#0005
-      0x540A000E,  //  0003  LDINT	R2	15
-      0x70020004,  //  0004  JMP		#000A
-      0x540E0063,  //  0005  LDINT	R3	100
-      0x0C0C0403,  //  0006  DIV	R3	R2	R3
-      0x54120011,  //  0007  LDINT	R4	18
-      0x040C0604,  //  0008  SUB	R3	R3	R4
-      0x5C080600,  //  0009  MOVE	R2	R3
-      0x1C0C0300,  //  000A  EQ	R3	R1	K0
-      0x780E000C,  //  000B  JMPF	R3	#0019
-      0x8C0C0101,  //  000C  GETMET	R3	R0	K1
-      0x54160027,  //  000D  LDINT	R5	40
-      0x8C180102,  //  000E  GETMET	R6	R0	K2
-      0x54220027,  //  000F  LDINT	R8	40
-      0x7C180400,  //  0010  CALL	R6	2
-      0x541E000E,  //  0011  LDINT	R7	15
-      0x2C180C07,  //  0012  AND	R6	R6	R7
-      0x541E000E,  //  0013  LDINT	R7	15
-      0x2C1C0407,  //  0014  AND	R7	R2	R7
-      0x54220003,  //  0015  LDINT	R8	4
-      0x381C0E08,  //  0016  SHL	R7	R7	R8
-      0x30180C07,  //  0017  OR	R6	R6	R7
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x1C0C0303,  //  0019  EQ	R3	R1	K3
-      0x780E000A,  //  001A  JMPF	R3	#0026
-      0x8C0C0101,  //  001B  GETMET	R3	R0	K1
-      0x54160027,  //  001C  LDINT	R5	40
-      0x8C180102,  //  001D  GETMET	R6	R0	K2
-      0x54220027,  //  001E  LDINT	R8	40
-      0x7C180400,  //  001F  CALL	R6	2
-      0x541E00EF,  //  0020  LDINT	R7	240
-      0x2C180C07,  //  0021  AND	R6	R6	R7
-      0x541E000E,  //  0022  LDINT	R7	15
-      0x2C1C0407,  //  0023  AND	R7	R2	R7
-      0x30180C07,  //  0024  OR	R6	R6	R7
-      0x7C0C0600,  //  0025  CALL	R3	3
-      0x80000000,  //  0026  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(AXP192_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(I2C_Driver),
-    /* K1   */  be_nested_str(init),
-    /* K2   */  be_nested_str(AXP192),
-    }),
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x60040003,  //  0000  GETGBL	R1	G3
-      0x5C080000,  //  0001  MOVE	R2	R0
-      0xB80E0000,  //  0002  GETNGBL	R3	K0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x580C0002,  //  0005  LDCONST	R3	K2
-      0x54120033,  //  0006  LDINT	R4	52
-      0x7C040600,  //  0007  CALL	R1	3
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_bat_voltage
-********************************************************************/
-be_local_closure(AXP192_get_bat_voltage,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read12),
-    /* K1   */  be_const_real_hex(0x3A902DE0),
-    }),
-    &be_const_str_get_bat_voltage,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0077,  //  0001  LDINT	R3	120
-      0x7C040400,  //  0002  CALL	R1	2
-      0x08040301,  //  0003  MUL	R1	R1	K1
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ldo_enable
-********************************************************************/
-be_local_closure(AXP192_set_ldo_enable,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(2),
-    /* K1   */  be_nested_str(write_bit),
-    /* K2   */  be_const_int(3),
-    }),
-    &be_const_str_set_ldo_enable,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x1C0C0300,  //  0000  EQ	R3	R1	K0
-      0x780E0004,  //  0001  JMPF	R3	#0007
-      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
-      0x54160011,  //  0003  LDINT	R5	18
-      0x58180000,  //  0004  LDCONST	R6	K0
-      0x5C1C0400,  //  0005  MOVE	R7	R2
-      0x7C0C0800,  //  0006  CALL	R3	4
-      0x1C0C0302,  //  0007  EQ	R3	R1	K2
-      0x780E0004,  //  0008  JMPF	R3	#000E
-      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
-      0x54160011,  //  000A  LDINT	R5	18
-      0x58180002,  //  000B  LDCONST	R6	K2
-      0x5C1C0400,  //  000C  MOVE	R7	R2
-      0x7C0C0800,  //  000D  CALL	R3	4
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: set_dc_voltage
 ********************************************************************/
 be_local_closure(AXP192_set_dc_voltage,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     3,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -643,13 +143,118 @@ be_local_closure(AXP192_set_dc_voltage,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_vbus_current
+********************************************************************/
+be_local_closure(AXP192_get_vbus_current,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read12),
+    /* K1   */  be_const_real_hex(0x3EC00000),
+    }),
+    &be_const_str_get_vbus_current,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E005B,  //  0001  LDINT	R3	92
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: battery_present
+********************************************************************/
+be_local_closure(AXP192_battery_present,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str(wire),
+    /* K1   */  be_nested_str(read),
+    /* K2   */  be_nested_str(addr),
+    /* K3   */  be_const_int(1),
+    }),
+    &be_const_str_battery_present,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x7C040800,  //  0005  CALL	R1	4
+      0x540A001F,  //  0006  LDINT	R2	32
+      0x2C040202,  //  0007  AND	R1	R1	R2
+      0x78060002,  //  0008  JMPF	R1	#000C
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+      0x70020001,  //  000B  JMP		#000E
+      0x50040000,  //  000C  LDBOOL	R1	0	0
+      0x80040200,  //  000D  RET	1	R1
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bat_voltage
+********************************************************************/
+be_local_closure(AXP192_get_bat_voltage,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read12),
+    /* K1   */  be_const_real_hex(0x3A902DE0),
+    }),
+    &be_const_str_get_bat_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0077,  //  0001  LDINT	R3	120
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: write_gpio
 ********************************************************************/
 be_local_closure(AXP192_write_gpio,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     3,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -692,13 +297,262 @@ be_local_closure(AXP192_write_gpio,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_input_power_status
+********************************************************************/
+be_local_closure(AXP192_get_input_power_status,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(wire),
+    /* K1   */  be_nested_str(read),
+    /* K2   */  be_nested_str(addr),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(1),
+    }),
+    &be_const_str_get_input_power_status,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x58140004,  //  0004  LDCONST	R5	K4
+      0x7C040800,  //  0005  CALL	R1	4
+      0x80040200,  //  0006  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bat_charge_current
+********************************************************************/
+be_local_closure(AXP192_get_bat_charge_current,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read13),
+    /* K1   */  be_const_real_hex(0x3F000000),
+    }),
+    &be_const_str_get_bat_charge_current,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0079,  //  0001  LDINT	R3	122
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(AXP192_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(I2C_Driver),
+    /* K1   */  be_nested_str(init),
+    /* K2   */  be_nested_str(AXP192),
+    }),
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x60040003,  //  0000  GETGBL	R1	G3
+      0x5C080000,  //  0001  MOVE	R2	R0
+      0xB80E0000,  //  0002  GETNGBL	R3	K0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x580C0002,  //  0005  LDCONST	R3	K2
+      0x54120033,  //  0006  LDINT	R4	52
+      0x7C040600,  //  0007  CALL	R1	3
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_chg_current
+********************************************************************/
+be_local_closure(AXP192_set_chg_current,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(write8),
+    /* K1   */  be_nested_str(read8),
+    }),
+    &be_const_str_set_chg_current,
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x54120032,  //  0001  LDINT	R4	51
+      0x8C140101,  //  0002  GETMET	R5	R0	K1
+      0x541E0032,  //  0003  LDINT	R7	51
+      0x7C140400,  //  0004  CALL	R5	2
+      0x541A00EF,  //  0005  LDINT	R6	240
+      0x2C140A06,  //  0006  AND	R5	R5	R6
+      0x541A000E,  //  0007  LDINT	R6	15
+      0x2C180206,  //  0008  AND	R6	R1	R6
+      0x30140A06,  //  0009  OR	R5	R5	R6
+      0x7C080600,  //  000A  CALL	R2	3
+      0x80000000,  //  000B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_battery_chargin_status
+********************************************************************/
+be_local_closure(AXP192_get_battery_chargin_status,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str(wire),
+    /* K1   */  be_nested_str(read),
+    /* K2   */  be_nested_str(addr),
+    /* K3   */  be_const_int(1),
+    }),
+    &be_const_str_get_battery_chargin_status,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x58100003,  //  0003  LDCONST	R4	K3
+      0x58140003,  //  0004  LDCONST	R5	K3
+      0x7C040800,  //  0005  CALL	R1	4
+      0x80040200,  //  0006  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_exten
+********************************************************************/
+be_local_closure(AXP192_set_exten,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str(write_bit),
+    }),
+    &be_const_str_set_exten,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x54120011,  //  0001  LDINT	R4	18
+      0x54160005,  //  0002  LDINT	R5	6
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C080800,  //  0004  CALL	R2	4
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ldo_enable
+********************************************************************/
+be_local_closure(AXP192_set_ldo_enable,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_int(2),
+    /* K1   */  be_nested_str(write_bit),
+    /* K2   */  be_const_int(3),
+    }),
+    &be_const_str_set_ldo_enable,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x780E0004,  //  0001  JMPF	R3	#0007
+      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
+      0x54160011,  //  0003  LDINT	R5	18
+      0x58180000,  //  0004  LDCONST	R6	K0
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x7C0C0800,  //  0006  CALL	R3	4
+      0x1C0C0302,  //  0007  EQ	R3	R1	K2
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
+      0x54160011,  //  000A  LDINT	R5	18
+      0x58180002,  //  000B  LDCONST	R6	K2
+      0x5C1C0400,  //  000C  MOVE	R7	R2
+      0x7C0C0800,  //  000D  CALL	R3	4
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: web_sensor
 ********************************************************************/
 be_local_closure(AXP192_web_sensor,   /* name */
   be_nested_proto(
     11,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
@@ -756,27 +610,27 @@ be_local_closure(AXP192_web_sensor,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_bat_charge_current
+** Solidified function: get_vbus_voltage
 ********************************************************************/
-be_local_closure(AXP192_get_bat_charge_current,   /* name */
+be_local_closure(AXP192_get_vbus_voltage,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(read13),
-    /* K1   */  be_const_real_hex(0x3F000000),
+    /* K0   */  be_nested_str(read12),
+    /* K1   */  be_const_real_hex(0x3ADED28A),
     }),
-    &be_const_str_get_bat_charge_current,
+    &be_const_str_get_vbus_voltage,
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0079,  //  0001  LDINT	R3	122
+      0x540E0059,  //  0001  LDINT	R3	90
       0x7C040400,  //  0002  CALL	R1	2
       0x08040301,  //  0003  MUL	R1	R1	K1
       0x80040200,  //  0004  RET	1	R1
@@ -787,34 +641,32 @@ be_local_closure(AXP192_get_bat_charge_current,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_battery_chargin_status
+** Solidified function: get_temp
 ********************************************************************/
-be_local_closure(AXP192_get_battery_chargin_status,   /* name */
+be_local_closure(AXP192_get_temp,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(1),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(read12),
+    /* K1   */  be_const_real_hex(0x3DCCCCCD),
+    /* K2   */  be_const_real_hex(0x4310B333),
     }),
-    &be_const_str_get_battery_chargin_status,
+    &be_const_str_get_temp,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140003,  //  0004  LDCONST	R5	K3
-      0x7C040800,  //  0005  CALL	R1	4
-      0x80040200,  //  0006  RET	1	R1
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E005D,  //  0001  LDINT	R3	94
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x04040302,  //  0004  SUB	R1	R1	K2
+      0x80040200,  //  0005  RET	1	R1
     })
   )
 );
@@ -822,35 +674,214 @@ be_local_closure(AXP192_get_battery_chargin_status,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_input_power_status
+** Solidified function: get_bat_power
 ********************************************************************/
-be_local_closure(AXP192_get_input_power_status,   /* name */
+be_local_closure(AXP192_get_bat_power,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
-    0,                          /* varg */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read24),
+    /* K1   */  be_const_real_hex(0x3A102DE1),
+    }),
+    &be_const_str_get_bat_power,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E006F,  //  0001  LDINT	R3	112
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_dcdc_enable
+********************************************************************/
+be_local_closure(AXP192_set_dcdc_enable,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(wire),
-    /* K1   */  be_nested_str(read),
-    /* K2   */  be_nested_str(addr),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_const_int(1),
+    /* K0   */  be_const_int(1),
+    /* K1   */  be_nested_str(write_bit),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_const_int(3),
     }),
-    &be_const_str_get_input_power_status,
+    &be_const_str_set_dcdc_enable,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x58100003,  //  0003  LDCONST	R4	K3
-      0x58140004,  //  0004  LDCONST	R5	K4
-      0x7C040800,  //  0005  CALL	R1	4
-      0x80040200,  //  0006  RET	1	R1
+    ( &(const binstruction[22]) {  /* code */
+      0x1C0C0300,  //  0000  EQ	R3	R1	K0
+      0x780E0004,  //  0001  JMPF	R3	#0007
+      0x8C0C0101,  //  0002  GETMET	R3	R0	K1
+      0x54160011,  //  0003  LDINT	R5	18
+      0x58180002,  //  0004  LDCONST	R6	K2
+      0x5C1C0400,  //  0005  MOVE	R7	R2
+      0x7C0C0800,  //  0006  CALL	R3	4
+      0x1C0C0303,  //  0007  EQ	R3	R1	K3
+      0x780E0004,  //  0008  JMPF	R3	#000E
+      0x8C0C0101,  //  0009  GETMET	R3	R0	K1
+      0x54160011,  //  000A  LDINT	R5	18
+      0x541A0003,  //  000B  LDINT	R6	4
+      0x5C1C0400,  //  000C  MOVE	R7	R2
+      0x7C0C0800,  //  000D  CALL	R3	4
+      0x1C0C0304,  //  000E  EQ	R3	R1	K4
+      0x780E0004,  //  000F  JMPF	R3	#0015
+      0x8C0C0101,  //  0010  GETMET	R3	R0	K1
+      0x54160011,  //  0011  LDINT	R5	18
+      0x58180000,  //  0012  LDCONST	R6	K0
+      0x5C1C0400,  //  0013  MOVE	R7	R2
+      0x7C0C0800,  //  0014  CALL	R3	4
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_aps_voltage
+********************************************************************/
+be_local_closure(AXP192_get_aps_voltage,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read12),
+    /* K1   */  be_const_real_hex(0x3AB78035),
+    }),
+    &be_const_str_get_aps_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E007D,  //  0001  LDINT	R3	126
+      0x7C040400,  //  0002  CALL	R1	2
+      0x08040301,  //  0003  MUL	R1	R1	K1
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ldo_voltage
+********************************************************************/
+be_local_closure(AXP192_set_ldo_voltage,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(2),
+    /* K1   */  be_nested_str(write8),
+    /* K2   */  be_nested_str(read8),
+    /* K3   */  be_const_int(3),
+    }),
+    &be_const_str_set_ldo_voltage,
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0x540E0CE3,  //  0000  LDINT	R3	3300
+      0x240C0403,  //  0001  GT	R3	R2	R3
+      0x780E0001,  //  0002  JMPF	R3	#0005
+      0x540A000E,  //  0003  LDINT	R2	15
+      0x70020004,  //  0004  JMP		#000A
+      0x540E0063,  //  0005  LDINT	R3	100
+      0x0C0C0403,  //  0006  DIV	R3	R2	R3
+      0x54120011,  //  0007  LDINT	R4	18
+      0x040C0604,  //  0008  SUB	R3	R3	R4
+      0x5C080600,  //  0009  MOVE	R2	R3
+      0x1C0C0300,  //  000A  EQ	R3	R1	K0
+      0x780E000C,  //  000B  JMPF	R3	#0019
+      0x8C0C0101,  //  000C  GETMET	R3	R0	K1
+      0x54160027,  //  000D  LDINT	R5	40
+      0x8C180102,  //  000E  GETMET	R6	R0	K2
+      0x54220027,  //  000F  LDINT	R8	40
+      0x7C180400,  //  0010  CALL	R6	2
+      0x541E000E,  //  0011  LDINT	R7	15
+      0x2C180C07,  //  0012  AND	R6	R6	R7
+      0x541E000E,  //  0013  LDINT	R7	15
+      0x2C1C0407,  //  0014  AND	R7	R2	R7
+      0x54220003,  //  0015  LDINT	R8	4
+      0x381C0E08,  //  0016  SHL	R7	R7	R8
+      0x30180C07,  //  0017  OR	R6	R6	R7
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x1C0C0303,  //  0019  EQ	R3	R1	K3
+      0x780E000A,  //  001A  JMPF	R3	#0026
+      0x8C0C0101,  //  001B  GETMET	R3	R0	K1
+      0x54160027,  //  001C  LDINT	R5	40
+      0x8C180102,  //  001D  GETMET	R6	R0	K2
+      0x54220027,  //  001E  LDINT	R8	40
+      0x7C180400,  //  001F  CALL	R6	2
+      0x541E00EF,  //  0020  LDINT	R7	240
+      0x2C180C07,  //  0021  AND	R6	R6	R7
+      0x541E000E,  //  0022  LDINT	R7	15
+      0x2C1C0407,  //  0023  AND	R7	R2	R7
+      0x30180C07,  //  0024  OR	R6	R6	R7
+      0x7C0C0600,  //  0025  CALL	R3	3
+      0x80000000,  //  0026  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_bat_current
+********************************************************************/
+be_local_closure(AXP192_get_bat_current,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(read13),
+    /* K1   */  be_const_real_hex(0x3F000000),
+    }),
+    &be_const_str_get_bat_current,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x540E0079,  //  0001  LDINT	R3	122
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C080100,  //  0003  GETMET	R2	R0	K0
+      0x5412007B,  //  0004  LDINT	R4	124
+      0x7C080400,  //  0005  CALL	R2	2
+      0x04040202,  //  0006  SUB	R1	R1	R2
+      0x08040301,  //  0007  MUL	R1	R1	K1
+      0x80040200,  //  0008  RET	1	R1
     })
   )
 );
@@ -864,29 +895,30 @@ extern const bclass be_class_I2C_Driver;
 be_local_class(AXP192,
     0,
     &be_class_I2C_Driver,
-    be_nested_map(21,
+    be_nested_map(22,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(get_warning_level, -1), be_const_closure(AXP192_get_warning_level_closure) },
-        { be_const_key(get_vbus_current, -1), be_const_closure(AXP192_get_vbus_current_closure) },
-        { be_const_key(get_aps_voltage, -1), be_const_closure(AXP192_get_aps_voltage_closure) },
+        { be_const_key(json_append, 10), be_const_closure(AXP192_json_append_closure) },
         { be_const_key(get_bat_current, -1), be_const_closure(AXP192_get_bat_current_closure) },
-        { be_const_key(get_bat_power, 2), be_const_closure(AXP192_get_bat_power_closure) },
-        { be_const_key(json_append, -1), be_const_closure(AXP192_json_append_closure) },
-        { be_const_key(get_vbus_voltage, -1), be_const_closure(AXP192_get_vbus_voltage_closure) },
-        { be_const_key(get_battery_chargin_status, 9), be_const_closure(AXP192_get_battery_chargin_status_closure) },
-        { be_const_key(battery_present, -1), be_const_closure(AXP192_battery_present_closure) },
-        { be_const_key(get_bat_charge_current, 14), be_const_closure(AXP192_get_bat_charge_current_closure) },
-        { be_const_key(set_dcdc_enable, -1), be_const_closure(AXP192_set_dcdc_enable_closure) },
-        { be_const_key(get_temp, 19), be_const_closure(AXP192_get_temp_closure) },
-        { be_const_key(set_chg_current, 13), be_const_closure(AXP192_set_chg_current_closure) },
-        { be_const_key(set_ldo_enable, 18), be_const_closure(AXP192_set_ldo_enable_closure) },
-        { be_const_key(set_dc_voltage, -1), be_const_closure(AXP192_set_dc_voltage_closure) },
-        { be_const_key(get_bat_voltage, 7), be_const_closure(AXP192_get_bat_voltage_closure) },
-        { be_const_key(write_gpio, -1), be_const_closure(AXP192_write_gpio_closure) },
-        { be_const_key(web_sensor, -1), be_const_closure(AXP192_web_sensor_closure) },
-        { be_const_key(init, -1), be_const_closure(AXP192_init_closure) },
+        { be_const_key(set_dc_voltage, 16), be_const_closure(AXP192_set_dc_voltage_closure) },
         { be_const_key(set_ldo_voltage, -1), be_const_closure(AXP192_set_ldo_voltage_closure) },
+        { be_const_key(battery_present, -1), be_const_closure(AXP192_battery_present_closure) },
+        { be_const_key(write_gpio, -1), be_const_closure(AXP192_write_gpio_closure) },
+        { be_const_key(set_dcdc_enable, 21), be_const_closure(AXP192_set_dcdc_enable_closure) },
         { be_const_key(get_input_power_status, -1), be_const_closure(AXP192_get_input_power_status_closure) },
+        { be_const_key(get_bat_power, -1), be_const_closure(AXP192_get_bat_power_closure) },
+        { be_const_key(init, 1), be_const_closure(AXP192_init_closure) },
+        { be_const_key(get_temp, 17), be_const_closure(AXP192_get_temp_closure) },
+        { be_const_key(get_battery_chargin_status, -1), be_const_closure(AXP192_get_battery_chargin_status_closure) },
+        { be_const_key(set_ldo_enable, -1), be_const_closure(AXP192_set_ldo_enable_closure) },
+        { be_const_key(get_warning_level, 12), be_const_closure(AXP192_get_warning_level_closure) },
+        { be_const_key(web_sensor, -1), be_const_closure(AXP192_web_sensor_closure) },
+        { be_const_key(get_vbus_voltage, 8), be_const_closure(AXP192_get_vbus_voltage_closure) },
+        { be_const_key(set_exten, -1), be_const_closure(AXP192_set_exten_closure) },
+        { be_const_key(set_chg_current, 5), be_const_closure(AXP192_set_chg_current_closure) },
+        { be_const_key(get_vbus_current, 6), be_const_closure(AXP192_get_vbus_current_closure) },
+        { be_const_key(get_aps_voltage, -1), be_const_closure(AXP192_get_aps_voltage_closure) },
+        { be_const_key(get_bat_charge_current, 3), be_const_closure(AXP192_get_bat_charge_current_closure) },
+        { be_const_key(get_bat_voltage, -1), be_const_closure(AXP192_get_bat_voltage_closure) },
     })),
     be_str_literal("AXP192")
 );

--- a/lib/libesp32/berry_tasmota/src/embedded/i2c_axp192.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/i2c_axp192.be
@@ -67,6 +67,11 @@ class AXP192 : I2C_Driver
     end
   end
 
+  # set EXTEN which enables external power on M5Stack, powering Hat with 5V
+  def set_exten(state)
+    self.write_bit(0x12, 6, state)
+  end
+
   # set DCDC enable, 1/2/3
   def set_dcdc_enable(dcdc, state)
     if dcdc == 1  self.write_bit(0x12, 0, state) end

--- a/tasmota/berry/drivers/i2c_axp192_M5StickC.be
+++ b/tasmota/berry/drivers/i2c_axp192_M5StickC.be
@@ -41,6 +41,9 @@ class AXP192_M5StickC : AXP192
       self.set_dcdc_enable(1, true)
       self.set_dcdc_enable(3, true)
 
+      # enable external power on HAT connector (5V)
+      self.set_exten(true)
+
       # Set temperature protection
       self.write8(0x39, 0xFC)
 


### PR DESCRIPTION
## Description:

Added `axp.set_exten(bool)` to AXP192 driver, and changed M5StickC to enable it.

This enables the 5V output on M5StickC to power a Hat.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
