### PR TITLE
Make light commands support json

### DIFF
--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -471,23 +471,27 @@ void CmndDelay(void)
 
 void CmndPower(void)
 {
-  if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.devices_present)) {
-    if ((XdrvMailbox.payload < POWER_OFF) || (XdrvMailbox.payload > POWER_BLINK_STOP)) {
-      XdrvMailbox.payload = POWER_SHOW_STATE;
+  if ('{' == XdrvMailbox.data[0]) {
+    CmndJson();
+  } else {
+    if ((XdrvMailbox.index > 0) && (XdrvMailbox.index <= TasmotaGlobal.devices_present)) {
+      if ((XdrvMailbox.payload < POWER_OFF) || (XdrvMailbox.payload > POWER_BLINK_STOP)) {
+        XdrvMailbox.payload = POWER_SHOW_STATE;
+      }
+  //      Settings->flag.device_index_enable = XdrvMailbox.usridx;  // SetOption26 - Switch between POWER or POWER1
+      ExecuteCommandPower(XdrvMailbox.index, XdrvMailbox.payload, SRC_IGNORE);
+      ResponseClear();
     }
-//      Settings->flag.device_index_enable = XdrvMailbox.usridx;  // SetOption26 - Switch between POWER or POWER1
-    ExecuteCommandPower(XdrvMailbox.index, XdrvMailbox.payload, SRC_IGNORE);
-    ResponseClear();
-  }
-  else if (0 == XdrvMailbox.index) {
-    if ((XdrvMailbox.payload < POWER_OFF) || (XdrvMailbox.payload > POWER_TOGGLE)) {
-      XdrvMailbox.payload = POWER_SHOW_STATE;
+    else if (0 == XdrvMailbox.index) {
+      if ((XdrvMailbox.payload < POWER_OFF) || (XdrvMailbox.payload > POWER_TOGGLE)) {
+        XdrvMailbox.payload = POWER_SHOW_STATE;
+      }
+      SetAllPower(XdrvMailbox.payload, SRC_IGNORE);
+      if (Settings->flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
+        MqttPublishTeleState();
+      }
+      ResponseClear();
     }
-    SetAllPower(XdrvMailbox.payload, SRC_IGNORE);
-    if (Settings->flag3.hass_tele_on_power) {  // SetOption59 - Send tele/%topic%/STATE in addition to stat/%topic%/RESULT
-      MqttPublishTeleState();
-    }
-    ResponseClear();
   }
 }
 


### PR DESCRIPTION
## Description:

**Related issue: https://github.com/arendst/Tasmota/issues/14568

Make all light commands to respond to json payload by using CmndJason()

```
HSBColor  {"HSBColor": "hhh, sss, bbb"}
Scheme {"Scheme": "sss"}
CT {"CT": "ccc"}
Power {"Power<x>": "ppp"}
Dimmer {"Dimmer": "ddd"}
```

The effective changes are much lighter than what the diff highlights.
It's just encapsulating each existing command code between:
```c
void CmndXxxxx(void)
{
  if ('{' == XdrvMailbox.data[0]) {
    CmndJson();
  } else {
  .... original code ....
  }
}
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
