### PR TITLE
Berry add `display.dimmer()`

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -333,6 +333,7 @@ extern const bcstring be_const_str_detect;
 extern const bcstring be_const_str_detected_X20on_X20bus;
 extern const bcstring be_const_str_digital_read;
 extern const bcstring be_const_str_digital_write;
+extern const bcstring be_const_str_dimmer;
 extern const bcstring be_const_str_dirty;
 extern const bcstring be_const_str_display;
 extern const bcstring be_const_str_display_X2Eini;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -1,768 +1,769 @@
-be_define_const_str(, "", 2166136261u, 0, 0, &be_const_str_display_X2Eini);
-be_define_const_str(_X0A, "\n", 252472541u, 0, 1, &be_const_str__X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E);
-be_define_const_str(_X20, " ", 621580159u, 0, 1, &be_const_str_widget_ctor_impl);
-be_define_const_str(_X21_X3D, "!=", 2428715011u, 0, 2, &be_const_str__X23autoexec_X2Ebe);
-be_define_const_str(_X21_X3D_X3D, "!==", 559817114u, 0, 3, &be_const_str_elements_X20must_X20be_X20a_X20lv_point);
-be_define_const_str(_X23, "#", 638357778u, 0, 1, &be_const_str_line_dsc);
-be_define_const_str(_X23autoexec_X2Ebat, "#autoexec.bat", 3382890497u, 0, 13, &be_const_str_pixels_buffer);
-be_define_const_str(_X23autoexec_X2Ebe, "#autoexec.be", 1181757091u, 0, 12, &be_const_str_list_handlers);
-be_define_const_str(_X23display_X2Eini, "#display.ini", 182218220u, 0, 12, &be_const_str_get_current_module_name);
-be_define_const_str(_X23init_X2Ebat, "#init.bat", 3297595077u, 0, 9, &be_const_str_MD5);
-be_define_const_str(_X23preinit_X2Ebe, "#preinit.be", 687035716u, 0, 11, &be_const_str__ptr);
-be_define_const_str(_X2502d_X25s_X2502d, "%02d%s%02d", 1587999717u, 0, 10, &be_const_str_push_path);
-be_define_const_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d, "%04d-%02d-%02dT%02d:%02d:%02d", 3425528601u, 0, 29, &be_const_str_bus);
-be_define_const_str(_X25s_X2Eautoconf, "%s.autoconf", 3560383524u, 0, 11, &be_const_str_delay);
-be_define_const_str(_X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B, "&lt;Error: apply new or remove&gt;", 2855507949u, 0, 34, &be_const_str_json);
-be_define_const_str(_X26lt_X3BNone_X26gt_X3B, "&lt;None&gt;", 2602165498u, 0, 12, &be_const_str_AudioGeneratorMP3);
-be_define_const_str(_X28_X29, "()", 685372826u, 0, 2, &be_const_str__dirty);
-be_define_const_str(_X2B, "+", 772578730u, 0, 1, &be_const_str_a);
-be_define_const_str(_X2C, ",", 688690635u, 0, 1, &be_const_str_TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27);
-be_define_const_str(_X2D_X2D_X3A_X2D_X2D, "--:--", 1370615441u, 0, 5, &be_const_str_f);
-be_define_const_str(_X2E, ".", 722245873u, 0, 1, &be_const_str_dirty);
-be_define_const_str(_X2E_X2E, "..", 2748622605u, 0, 2, &be_const_str_content_flush);
-be_define_const_str(_X2Eautoconf, ".autoconf", 2524679088u, 0, 9, &be_const_str_get_bat_voltage);
-be_define_const_str(_X2Ebe, ".be", 1325797348u, 0, 3, &be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20);
-be_define_const_str(_X2Ebec, ".bec", 3985273221u, 0, 4, &be_const_str_Animate_X20pc_X20is_X20out_X20of_X20range);
-be_define_const_str(_X2Elen, ".len", 850842136u, 0, 4, &be_const_str_super);
-be_define_const_str(_X2Ep, ".p", 1171526419u, 0, 2, &be_const_str_SERIAL_6O2);
-be_define_const_str(_X2Ep1, ".p1", 249175686u, 0, 3, &be_const_str_SERIAL_8E1);
-be_define_const_str(_X2Ep2, ".p2", 232398067u, 0, 3, NULL);
-be_define_const_str(_X2Esize, ".size", 1965188224u, 0, 5, &be_const_str_update);
-be_define_const_str(_X2Etapp, ".tapp", 1363391594u, 0, 5, &be_const_str_attrdump);
-be_define_const_str(_X2Ew, ".w", 1255414514u, 0, 2, &be_const_str__X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E);
-be_define_const_str(_X2F, "/", 705468254u, 0, 1, &be_const_str_set_style_pad_right);
-be_define_const_str(_X2F_X2Eautoconf, "/.autoconf", 2212074393u, 0, 10, &be_const_str_SERIAL_8E2);
-be_define_const_str(_X2F_X3Frst_X3D, "/?rst=", 580074707u, 0, 6, &be_const_str_elif);
-be_define_const_str(_X2Fac, "/ac", 3904651978u, 0, 3, &be_const_str_STATE_DEFAULT);
-be_define_const_str(_X3A, ":", 1057798253u, 0, 1, &be_const_str_AudioFileSourceFS);
-be_define_const_str(_X3C, "<", 957132539u, 0, 1, &be_const_str_base_class);
-be_define_const_str(_X3C_X2Fform_X3E_X3C_X2Fp_X3E, "</form></p>", 3546571739u, 0, 11, &be_const_str_BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20);
-be_define_const_str(_X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E, "</select><p></p>", 1863865923u, 0, 16, &be_const_str_CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s);
-be_define_const_str(_X3C_X3D, "<=", 2499223986u, 0, 2, &be_const_str_pc_rel);
-be_define_const_str(_X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E, "<button name='reapply' class='button bgrn'>Re-apply current configuration</button>", 3147934216u, 0, 82, &be_const_str__X3Cselect_X20name_X3D_X27zip_X27_X3E);
-be_define_const_str(_X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E, "<button name='zipapply' class='button bgrn'>Apply configuration</button>", 1205771629u, 0, 72, &be_const_str_as);
-be_define_const_str(_X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E, "<fieldset><style>.bdis{background:#888;}.bdis:hover{background:#888;}</style>", 842307168u, 0, 77, NULL);
-be_define_const_str(_X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29, "<instance: %s(%s, %s, %s)", 257363333u, 0, 25, NULL);
+be_define_const_str(, "", 2166136261u, 0, 0, &be_const_str_AudioFileSourceFS);
+be_define_const_str(_X0A, "\n", 252472541u, 0, 1, &be_const_str_True);
+be_define_const_str(_X20, " ", 621580159u, 0, 1, &be_const_str_due);
+be_define_const_str(_X21_X3D, "!=", 2428715011u, 0, 2, &be_const_str_i2c_enabled);
+be_define_const_str(_X21_X3D_X3D, "!==", 559817114u, 0, 3, &be_const_str_STATE_DEFAULT);
+be_define_const_str(_X23, "#", 638357778u, 0, 1, &be_const_str_Unknown_X20command);
+be_define_const_str(_X23autoexec_X2Ebat, "#autoexec.bat", 3382890497u, 0, 13, NULL);
+be_define_const_str(_X23autoexec_X2Ebe, "#autoexec.be", 1181757091u, 0, 12, &be_const_str_consume_mono);
+be_define_const_str(_X23display_X2Eini, "#display.ini", 182218220u, 0, 12, &be_const_str_Timer);
+be_define_const_str(_X23init_X2Ebat, "#init.bat", 3297595077u, 0, 9, &be_const_str_response_append);
+be_define_const_str(_X23preinit_X2Ebe, "#preinit.be", 687035716u, 0, 11, &be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E);
+be_define_const_str(_X2502d_X25s_X2502d, "%02d%s%02d", 1587999717u, 0, 10, &be_const_str_CFG_X3A_X20removing_X20first_X20time_X20marker);
+be_define_const_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d, "%04d-%02d-%02dT%02d:%02d:%02d", 3425528601u, 0, 29, &be_const_str_exec_cmd);
+be_define_const_str(_X25s_X2Eautoconf, "%s.autoconf", 3560383524u, 0, 11, &be_const_str___lower__);
+be_define_const_str(_X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B, "&lt;Error: apply new or remove&gt;", 2855507949u, 0, 34, &be_const_str_lv_wifi_arcs);
+be_define_const_str(_X26lt_X3BNone_X26gt_X3B, "&lt;None&gt;", 2602165498u, 0, 12, &be_const_str_I2C_Driver);
+be_define_const_str(_X28_X29, "()", 685372826u, 0, 2, NULL);
+be_define_const_str(_X2B, "+", 772578730u, 0, 1, &be_const_str_collect);
+be_define_const_str(_X2C, ",", 688690635u, 0, 1, &be_const_str_SERIAL_6N2);
+be_define_const_str(_X2D_X2D_X3A_X2D_X2D, "--:--", 1370615441u, 0, 5, &be_const_str_contains);
+be_define_const_str(_X2E, ".", 722245873u, 0, 1, &be_const_str_codedump);
+be_define_const_str(_X2E_X2E, "..", 2748622605u, 0, 2, &be_const_str_HTTP_GET);
+be_define_const_str(_X2Eautoconf, ".autoconf", 2524679088u, 0, 9, &be_const_str_TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27);
+be_define_const_str(_X2Ebe, ".be", 1325797348u, 0, 3, &be_const_str_https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson);
+be_define_const_str(_X2Ebec, ".bec", 3985273221u, 0, 4, &be_const_str_set);
+be_define_const_str(_X2Elen, ".len", 850842136u, 0, 4, &be_const_str_AudioOutputI2S);
+be_define_const_str(_X2Ep, ".p", 1171526419u, 0, 2, &be_const_str_SERIAL_5E1);
+be_define_const_str(_X2Ep1, ".p1", 249175686u, 0, 3, &be_const_str_SERIAL_7O1);
+be_define_const_str(_X2Ep2, ".p2", 232398067u, 0, 3, &be_const_str_cosh);
+be_define_const_str(_X2Esize, ".size", 1965188224u, 0, 5, &be_const_str_widget_instance_size);
+be_define_const_str(_X2Etapp, ".tapp", 1363391594u, 0, 5, &be_const_str__end_transmission);
+be_define_const_str(_X2Ew, ".w", 1255414514u, 0, 2, &be_const_str__dirty);
+be_define_const_str(_X2F, "/", 705468254u, 0, 1, &be_const_str_AudioGeneratorWAV);
+be_define_const_str(_X2F_X2Eautoconf, "/.autoconf", 2212074393u, 0, 10, NULL);
+be_define_const_str(_X2F_X3Frst_X3D, "/?rst=", 580074707u, 0, 6, &be_const_str_cb_event_closure);
+be_define_const_str(_X2Fac, "/ac", 3904651978u, 0, 3, &be_const_str_create_custom_widget);
+be_define_const_str(_X3A, ":", 1057798253u, 0, 1, &be_const_str_BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29);
+be_define_const_str(_X3C, "<", 957132539u, 0, 1, &be_const_str_lv_coord_arr);
+be_define_const_str(_X3C_X2Fform_X3E_X3C_X2Fp_X3E, "</form></p>", 3546571739u, 0, 11, NULL);
+be_define_const_str(_X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E, "</select><p></p>", 1863865923u, 0, 16, &be_const_str_set_chg_current);
+be_define_const_str(_X3C_X3D, "<=", 2499223986u, 0, 2, &be_const_str_connected);
+be_define_const_str(_X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E, "<button name='reapply' class='button bgrn'>Re-apply current configuration</button>", 3147934216u, 0, 82, &be_const_str_add_rule);
+be_define_const_str(_X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E, "<button name='zipapply' class='button bgrn'>Apply configuration</button>", 1205771629u, 0, 72, &be_const_str__archive);
+be_define_const_str(_X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E, "<fieldset><style>.bdis{background:#888;}.bdis:hover{background:#888;}</style>", 842307168u, 0, 77, &be_const_str_files);
+be_define_const_str(_X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29, "<instance: %s(%s, %s, %s)", 257363333u, 0, 25, &be_const_str_classname);
 be_define_const_str(_X3Clabel_X3EChoose_X20a_X20device_X20configuration_X3A_X3C_X2Flabel_X3E_X3Cbr_X3E, "<label>Choose a device configuration:</label><br>", 1336654704u, 0, 49, NULL);
-be_define_const_str(_X3Clambda_X3E, "<lambda>", 607256038u, 0, 8, &be_const_str_isinstance);
+be_define_const_str(_X3Clambda_X3E, "<lambda>", 607256038u, 0, 8, &be_const_str_shared_key);
 be_define_const_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27Autoconfiguration_X27_X3E_X26nbsp_X3BCurrent_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E, "<legend><b title='Autoconfiguration'>&nbsp;Current auto-configuration</b></legend>", 4212500780u, 0, 82, NULL);
-be_define_const_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E, "<legend><b title='New autoconf'>&nbsp;Select new auto-configuration</b></legend>", 1926223891u, 0, 80, &be_const_str__global_addr);
-be_define_const_str(_X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E, "<option value='%s'>%s</option>", 510303524u, 0, 30, NULL);
-be_define_const_str(_X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E, "<option value='reset'>&lt;Remove autoconf&gt;</option>", 3994619755u, 0, 54, &be_const_str_Leds);
-be_define_const_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E, "<p style='width:340px;'><b>Exception:</b><br>'%s'<br>%s</p>", 4252565082u, 0, 59, &be_const_str_AudioGenerator);
-be_define_const_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E, "<p></p></fieldset><p></p>", 2052843416u, 0, 25, NULL);
-be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E, "<p><form id=ac action='ac' style='display: block;' method='get'><button>Auto-configuration</button></form></p>", 2058443583u, 0, 110, &be_const_str_widget_height_def);
-be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20, "<p><form id=reapply style='display: block;' action='/ac' method='post' ", 546993478u, 0, 71, &be_const_str_color);
-be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20, "<p><form id=zip style='display: block;' action='/ac' method='post' ", 4033622166u, 0, 67, &be_const_str_BUTTON_CONFIGURATION);
-be_define_const_str(_X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E, "<p><small>&nbsp;(This feature requires an internet connection)</small></p>", 2719266486u, 0, 74, &be_const_str_get_style_pad_right);
-be_define_const_str(_X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E, "<p>Current configuration: </p><p><b>%s</b></p>", 4115655761u, 0, 46, &be_const_str_i2c_enabled);
-be_define_const_str(_X3Cselect_X20name_X3D_X27zip_X27_X3E, "<select name='zip'>", 4247924536u, 0, 19, &be_const_str_eth);
-be_define_const_str(_X3D, "=", 940354920u, 0, 1, &be_const_str__class);
-be_define_const_str(_X3D_X3C_X3E_X21, "=<>!", 2664470277u, 0, 4, &be_const_str__X3E);
+be_define_const_str(_X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E, "<legend><b title='New autoconf'>&nbsp;Select new auto-configuration</b></legend>", 1926223891u, 0, 80, &be_const_str__X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E);
+be_define_const_str(_X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E, "<option value='%s'>%s</option>", 510303524u, 0, 30, &be_const_str_tomap);
+be_define_const_str(_X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E, "<option value='reset'>&lt;Remove autoconf&gt;</option>", 3994619755u, 0, 54, &be_const_str_EVENT_DELETE);
+be_define_const_str(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E, "<p style='width:340px;'><b>Exception:</b><br>'%s'<br>%s</p>", 4252565082u, 0, 59, &be_const_str_list_handlers);
+be_define_const_str(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E, "<p></p></fieldset><p></p>", 2052843416u, 0, 25, &be_const_str_add_handler);
+be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E, "<p><form id=ac action='ac' style='display: block;' method='get'><button>Auto-configuration</button></form></p>", 2058443583u, 0, 110, &be_const_str_LVG_X3A_X20object_X3A);
+be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20, "<p><form id=reapply style='display: block;' action='/ac' method='post' ", 546993478u, 0, 71, &be_const_str__drivers);
+be_define_const_str(_X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20, "<p><form id=zip style='display: block;' action='/ac' method='post' ", 4033622166u, 0, 67, &be_const_str_cmd_res);
+be_define_const_str(_X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E, "<p><small>&nbsp;(This feature requires an internet connection)</small></p>", 2719266486u, 0, 74, &be_const_str_input);
+be_define_const_str(_X3Cp_X3ECurrent_X20configuration_X3A_X20_X3C_X2Fp_X3E_X3Cp_X3E_X3Cb_X3E_X25s_X3C_X2Fb_X3E_X3C_X2Fp_X3E, "<p>Current configuration: </p><p><b>%s</b></p>", 4115655761u, 0, 46, NULL);
+be_define_const_str(_X3Cselect_X20name_X3D_X27zip_X27_X3E, "<select name='zip'>", 4247924536u, 0, 19, &be_const_str_memory);
+be_define_const_str(_X3D, "=", 940354920u, 0, 1, &be_const_str_introspect);
+be_define_const_str(_X3D_X3C_X3E_X21, "=<>!", 2664470277u, 0, 4, &be_const_str_preinit);
 be_define_const_str(_X3D_X3D, "==", 2431966415u, 0, 2, NULL);
-be_define_const_str(_X3E, ">", 990687777u, 0, 1, &be_const_str_SK6812_GRBW);
-be_define_const_str(_X3E_X3D, ">=", 284975636u, 0, 2, &be_const_str_find_key_i);
-be_define_const_str(_X3F, "?", 973910158u, 0, 1, &be_const_str_WS2812);
-be_define_const_str(AES_GCM, "AES_GCM", 3832208678u, 0, 7, &be_const_str_I2C_Driver);
-be_define_const_str(AXP192, "AXP192", 757230128u, 0, 6, &be_const_str_AudioGeneratorWAV);
-be_define_const_str(Animate_X20pc_X20is_X20out_X20of_X20range, "Animate pc is out of range", 1854929421u, 0, 26, &be_const_str_argument_X20must_X20be_X20a_X20list);
-be_define_const_str(AudioFileSource, "AudioFileSource", 2959980058u, 0, 15, &be_const_str_allocated);
-be_define_const_str(AudioFileSourceFS, "AudioFileSourceFS", 1839147653u, 0, 17, &be_const_str_CFG_X3A_X20loading_X20);
-be_define_const_str(AudioGenerator, "AudioGenerator", 1839297342u, 0, 14, &be_const_str_chars_in_string);
-be_define_const_str(AudioGeneratorMP3, "AudioGeneratorMP3", 2199818488u, 0, 17, &be_const_str_consume_stereo);
-be_define_const_str(AudioGeneratorWAV, "AudioGeneratorWAV", 2746509368u, 0, 17, &be_const_str_lv_signal_arcs);
-be_define_const_str(AudioOutput, "AudioOutput", 3257792048u, 0, 11, &be_const_str_HTTP_GET);
-be_define_const_str(AudioOutputI2S, "AudioOutputI2S", 638031784u, 0, 14, &be_const_str_CFG_X3A_X20running_X20);
-be_define_const_str(Auto_X2Dconfiguration, "Auto-configuration", 1665006109u, 0, 18, &be_const_str_erase);
-be_define_const_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20, "BRY: ERROR, bad json: ", 2715135809u, 0, 22, &be_const_str_fromptr);
-be_define_const_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s, "BRY: Exception> '%s' - %s", 2246990964u, 0, 25, &be_const_str_skip);
-be_define_const_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29, "BRY: could not save compiled file %s (%s)", 736659787u, 0, 41, &be_const_str_solidified);
-be_define_const_str(BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson, "BRY: failed to load _persist.json", 2991913445u, 0, 33, NULL);
-be_define_const_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27, "BRY: method not allowed, use a closure like '/ args -> obj.func(args)'", 177121572u, 0, 70, &be_const_str_EVENT_DRAW_PART_END);
-be_define_const_str(BUTTON_CONFIGURATION, "BUTTON_CONFIGURATION", 70820856u, 0, 20, &be_const_str_before_del);
-be_define_const_str(CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting, "CFG: 'init.bat' done, restarting", 1569670677u, 0, 32, &be_const_str_decode);
-be_define_const_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s, "CFG: Exception> '%s' - %s", 1228874553u, 0, 25, &be_const_str__ccmd);
-be_define_const_str(CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found, "CFG: No '*.autoconf' file found", 755798501u, 0, 31, NULL);
-be_define_const_str(CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29, "CFG: could not run %s (%s - %s)", 1428829580u, 0, 31, &be_const_str_listdir);
-be_define_const_str(CFG_X3A_X20downloading_X20_X27_X25s_X27, "CFG: downloading '%s'", 589480701u, 0, 21, &be_const_str_SERIAL_6N1);
-be_define_const_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27, "CFG: exception '%s' - '%s'", 4095407913u, 0, 26, &be_const_str_atan2);
+be_define_const_str(_X3E, ">", 990687777u, 0, 1, &be_const_str_set_matrix_pixel_color);
+be_define_const_str(_X3E_X3D, ">=", 284975636u, 0, 2, &be_const_str_AXP192);
+be_define_const_str(_X3F, "?", 973910158u, 0, 1, &be_const_str_OpusDecoder);
+be_define_const_str(AES_GCM, "AES_GCM", 3832208678u, 0, 7, &be_const_str_init);
+be_define_const_str(AXP192, "AXP192", 757230128u, 0, 6, &be_const_str_strptime);
+be_define_const_str(Animate_X20pc_X20is_X20out_X20of_X20range, "Animate pc is out of range", 1854929421u, 0, 26, &be_const_str_state);
+be_define_const_str(AudioFileSource, "AudioFileSource", 2959980058u, 0, 15, &be_const_str_widget_group_def);
+be_define_const_str(AudioFileSourceFS, "AudioFileSourceFS", 1839147653u, 0, 17, &be_const_str_get_vbus_voltage);
+be_define_const_str(AudioGenerator, "AudioGenerator", 1839297342u, 0, 14, &be_const_str_WS2812_GRB);
+be_define_const_str(AudioGeneratorMP3, "AudioGeneratorMP3", 2199818488u, 0, 17, &be_const_str_cos);
+be_define_const_str(AudioGeneratorWAV, "AudioGeneratorWAV", 2746509368u, 0, 17, &be_const_str_CFG_X3A_X20loaded_X20_X20);
+be_define_const_str(AudioOutput, "AudioOutput", 3257792048u, 0, 11, &be_const_str_class);
+be_define_const_str(AudioOutputI2S, "AudioOutputI2S", 638031784u, 0, 14, NULL);
+be_define_const_str(Auto_X2Dconfiguration, "Auto-configuration", 1665006109u, 0, 18, &be_const_str__fl);
+be_define_const_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20, "BRY: ERROR, bad json: ", 2715135809u, 0, 22, &be_const_str_SERIAL_8O1);
+be_define_const_str(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s, "BRY: Exception> '%s' - %s", 2246990964u, 0, 25, NULL);
+be_define_const_str(BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29, "BRY: could not save compiled file %s (%s)", 736659787u, 0, 41, NULL);
+be_define_const_str(BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson, "BRY: failed to load _persist.json", 2991913445u, 0, 33, &be_const_str___upper__);
+be_define_const_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27, "BRY: method not allowed, use a closure like '/ args -> obj.func(args)'", 177121572u, 0, 70, NULL);
+be_define_const_str(BUTTON_CONFIGURATION, "BUTTON_CONFIGURATION", 70820856u, 0, 20, &be_const_str_SERIAL_6E2);
+be_define_const_str(CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting, "CFG: 'init.bat' done, restarting", 1569670677u, 0, 32, &be_const_str_clock_icon);
+be_define_const_str(CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s, "CFG: Exception> '%s' - %s", 1228874553u, 0, 25, &be_const_str_base_class);
+be_define_const_str(CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found, "CFG: No '*.autoconf' file found", 755798501u, 0, 31, &be_const_str_CFG_X3A_X20running_X20);
+be_define_const_str(CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29, "CFG: could not run %s (%s - %s)", 1428829580u, 0, 31, &be_const_str_floor);
+be_define_const_str(CFG_X3A_X20downloading_X20_X27_X25s_X27, "CFG: downloading '%s'", 589480701u, 0, 21, NULL);
+be_define_const_str(CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27, "CFG: exception '%s' - '%s'", 4095407913u, 0, 26, &be_const_str_CFG_X3A_X20loading_X20);
 be_define_const_str(CFG_X3A_X20loaded_X20_X20, "CFG: loaded  ", 3710273538u, 0, 13, NULL);
-be_define_const_str(CFG_X3A_X20loaded_X20_X27_X25s_X27, "CFG: loaded '%s'", 1699028828u, 0, 16, &be_const_str_c);
-be_define_const_str(CFG_X3A_X20loading_X20, "CFG: loading ", 4010361503u, 0, 13, &be_const_str_due);
-be_define_const_str(CFG_X3A_X20loading_X20_X27_X25s_X27, "CFG: loading '%s'", 2285306097u, 0, 17, &be_const_str_arg_size);
-be_define_const_str(CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29, "CFG: multiple autoconf files found, aborting ('%s' + '%s')", 197663371u, 0, 58, &be_const_str_POST);
-be_define_const_str(CFG_X3A_X20ran_X20_X20, "CFG: ran  ", 3579570472u, 0, 10, NULL);
-be_define_const_str(CFG_X3A_X20removed_X20file_X20_X27_X25s_X27, "CFG: removed file '%s'", 2048602473u, 0, 22, NULL);
-be_define_const_str(CFG_X3A_X20removing_X20autoconf_X20files, "CFG: removing autoconf files", 4014704970u, 0, 28, &be_const_str_begin);
-be_define_const_str(CFG_X3A_X20removing_X20first_X20time_X20marker, "CFG: removing first time marker", 2125556683u, 0, 31, &be_const_str_byte);
-be_define_const_str(CFG_X3A_X20return_code_X3D_X25i, "CFG: return_code=%i", 2059897320u, 0, 19, &be_const_str_OPTION_A);
-be_define_const_str(CFG_X3A_X20running_X20, "CFG: running ", 2478334534u, 0, 13, NULL);
-be_define_const_str(CFG_X3A_X20skipping_X20_X27display_X2Eini_X27_X20because_X20already_X20present_X20in_X20file_X2Dsystem, "CFG: skipping 'display.ini' because already present in file-system", 3965549264u, 0, 66, &be_const_str__archive);
-be_define_const_str(COLOR_BLACK, "COLOR_BLACK", 264427940u, 0, 11, &be_const_str_pin_mode);
+be_define_const_str(CFG_X3A_X20loaded_X20_X27_X25s_X27, "CFG: loaded '%s'", 1699028828u, 0, 16, &be_const_str_char);
+be_define_const_str(CFG_X3A_X20loading_X20, "CFG: loading ", 4010361503u, 0, 13, &be_const_str__buffer);
+be_define_const_str(CFG_X3A_X20loading_X20_X27_X25s_X27, "CFG: loading '%s'", 2285306097u, 0, 17, &be_const_str_exec_rules);
+be_define_const_str(CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29, "CFG: multiple autoconf files found, aborting ('%s' + '%s')", 197663371u, 0, 58, &be_const_str_a);
+be_define_const_str(CFG_X3A_X20ran_X20_X20, "CFG: ran  ", 3579570472u, 0, 10, &be_const_str_lv_extra);
+be_define_const_str(CFG_X3A_X20removed_X20file_X20_X27_X25s_X27, "CFG: removed file '%s'", 2048602473u, 0, 22, &be_const_str_strftime);
+be_define_const_str(CFG_X3A_X20removing_X20autoconf_X20files, "CFG: removing autoconf files", 4014704970u, 0, 28, &be_const_str_instance);
+be_define_const_str(CFG_X3A_X20removing_X20first_X20time_X20marker, "CFG: removing first time marker", 2125556683u, 0, 31, &be_const_str_clear_to);
+be_define_const_str(CFG_X3A_X20return_code_X3D_X25i, "CFG: return_code=%i", 2059897320u, 0, 19, &be_const_str_v);
+be_define_const_str(CFG_X3A_X20running_X20, "CFG: running ", 2478334534u, 0, 13, &be_const_str_bri);
+be_define_const_str(CFG_X3A_X20skipping_X20_X27display_X2Eini_X27_X20because_X20already_X20present_X20in_X20file_X2Dsystem, "CFG: skipping 'display.ini' because already present in file-system", 3965549264u, 0, 66, &be_const_str_None);
+be_define_const_str(COLOR_BLACK, "COLOR_BLACK", 264427940u, 0, 11, &be_const_str_add);
 be_define_const_str(COLOR_WHITE, "COLOR_WHITE", 2536871270u, 0, 11, NULL);
-be_define_const_str(EC_C25519, "EC_C25519", 95492591u, 0, 9, &be_const_str_I2C_X3A);
-be_define_const_str(EVENT_DELETE, "EVENT_DELETE", 282828603u, 0, 12, &be_const_str_bool);
-be_define_const_str(EVENT_DRAW_MAIN, "EVENT_DRAW_MAIN", 1955620614u, 0, 15, &be_const_str_OpusDecoder);
-be_define_const_str(EVENT_DRAW_PART_BEGIN, "EVENT_DRAW_PART_BEGIN", 3391865024u, 0, 21, &be_const_str_fromstring);
-be_define_const_str(EVENT_DRAW_PART_END, "EVENT_DRAW_PART_END", 3301625292u, 0, 19, &be_const_str_enabled);
-be_define_const_str(False, "False", 2541049336u, 0, 5, NULL);
-be_define_const_str(GET, "GET", 2531704439u, 0, 3, &be_const_str_https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf);
-be_define_const_str(HTTP_GET, "HTTP_GET", 1722467738u, 0, 8, &be_const_str_lv_extra);
-be_define_const_str(HTTP_POST, "HTTP_POST", 1999554144u, 0, 9, &be_const_str_matrix);
-be_define_const_str(I2C_X3A, "I2C:", 813483371u, 0, 4, &be_const_str_exec_tele);
-be_define_const_str(I2C_Driver, "I2C_Driver", 1714501658u, 0, 10, &be_const_str_battery_present);
-be_define_const_str(LVG_X3A_X20call_X20to_X20unsupported_X20callback, "LVG: call to unsupported callback", 504176819u, 0, 33, &be_const_str_argument_X20must_X20be_X20a_X20function);
-be_define_const_str(LVG_X3A_X20object_X3A, "LVG: object:", 3824079937u, 0, 12, &be_const_str_connect);
-be_define_const_str(Leds, "Leds", 2709245275u, 0, 4, &be_const_str_valuer_error);
-be_define_const_str(MD5, "MD5", 1935726387u, 0, 3, NULL);
-be_define_const_str(None, "None", 810547195u, 0, 4, &be_const_str_font_seg7);
-be_define_const_str(OPTION_A, "OPTION_A", 1133299440u, 0, 8, NULL);
-be_define_const_str(OneWire, "OneWire", 2298990722u, 0, 7, &be_const_str__fl);
-be_define_const_str(OpusDecoder, "OpusDecoder", 3618742074u, 0, 11, &be_const_str_size);
-be_define_const_str(PART_MAIN, "PART_MAIN", 2473491508u, 0, 9, &be_const_str_string);
-be_define_const_str(POST, "POST", 1929554311u, 0, 4, &be_const_str_unknown_X20instruction);
-be_define_const_str(Parameter_X20error, "Parameter error", 3840042038u, 0, 15, &be_const_str_addr);
-be_define_const_str(RES_OK, "RES_OK", 1233817284u, 0, 6, &be_const_str_lv_obj_class);
-be_define_const_str(Restart_X201, "Restart 1", 3504455855u, 0, 9, &be_const_str_widget_destructor);
-be_define_const_str(SERIAL_5E1, "SERIAL_5E1", 1163775235u, 0, 10, &be_const_str_cb_event_closure);
-be_define_const_str(SERIAL_5E2, "SERIAL_5E2", 1180552854u, 0, 10, &be_const_str_count);
-be_define_const_str(SERIAL_5N1, "SERIAL_5N1", 3313031680u, 0, 10, &be_const_str__read);
-be_define_const_str(SERIAL_5N2, "SERIAL_5N2", 3363364537u, 0, 10, &be_const_str_readline);
-be_define_const_str(SERIAL_5O1, "SERIAL_5O1", 3782657917u, 0, 10, &be_const_str__settings_def);
-be_define_const_str(SERIAL_5O2, "SERIAL_5O2", 3732325060u, 0, 10, &be_const_str_decompress);
-be_define_const_str(SERIAL_6E1, "SERIAL_6E1", 334249486u, 0, 10, &be_const_str_widget_editable);
+be_define_const_str(EC_C25519, "EC_C25519", 95492591u, 0, 9, &be_const_str__X7Bs_X7DVBus_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D);
+be_define_const_str(EVENT_DELETE, "EVENT_DELETE", 282828603u, 0, 12, &be_const_str_atleast1);
+be_define_const_str(EVENT_DRAW_MAIN, "EVENT_DRAW_MAIN", 1955620614u, 0, 15, &be_const_str_module);
+be_define_const_str(EVENT_DRAW_PART_BEGIN, "EVENT_DRAW_PART_BEGIN", 3391865024u, 0, 21, &be_const_str_last_modified);
+be_define_const_str(EVENT_DRAW_PART_END, "EVENT_DRAW_PART_END", 3301625292u, 0, 19, NULL);
+be_define_const_str(False, "False", 2541049336u, 0, 5, &be_const_str_asin);
+be_define_const_str(GET, "GET", 2531704439u, 0, 3, NULL);
+be_define_const_str(HTTP_GET, "HTTP_GET", 1722467738u, 0, 8, &be_const_str__write);
+be_define_const_str(HTTP_POST, "HTTP_POST", 1999554144u, 0, 9, &be_const_str_SERIAL_7N1);
+be_define_const_str(I2C_X3A, "I2C:", 813483371u, 0, 4, &be_const_str_autorun);
+be_define_const_str(I2C_Driver, "I2C_Driver", 1714501658u, 0, 10, &be_const_str_escape);
+be_define_const_str(LVG_X3A_X20call_X20to_X20unsupported_X20callback, "LVG: call to unsupported callback", 504176819u, 0, 33, &be_const_str__X5D);
+be_define_const_str(LVG_X3A_X20object_X3A, "LVG: object:", 3824079937u, 0, 12, &be_const_str_WS2812);
+be_define_const_str(Leds, "Leds", 2709245275u, 0, 4, &be_const_str_page_autoconf_mgr);
+be_define_const_str(MD5, "MD5", 1935726387u, 0, 3, &be_const_str_consume_stereo);
+be_define_const_str(None, "None", 810547195u, 0, 4, &be_const_str_on);
+be_define_const_str(OPTION_A, "OPTION_A", 1133299440u, 0, 8, &be_const_str_ins_ramp);
+be_define_const_str(OneWire, "OneWire", 2298990722u, 0, 7, NULL);
+be_define_const_str(OpusDecoder, "OpusDecoder", 3618742074u, 0, 11, &be_const_str__global_def);
+be_define_const_str(PART_MAIN, "PART_MAIN", 2473491508u, 0, 9, &be_const_str_toupper);
+be_define_const_str(POST, "POST", 1929554311u, 0, 4, NULL);
+be_define_const_str(Parameter_X20error, "Parameter error", 3840042038u, 0, 15, &be_const_str_widget_editable);
+be_define_const_str(RES_OK, "RES_OK", 1233817284u, 0, 6, &be_const_str_cb);
+be_define_const_str(Restart_X201, "Restart 1", 3504455855u, 0, 9, &be_const_str_offseta);
+be_define_const_str(SERIAL_5E1, "SERIAL_5E1", 1163775235u, 0, 10, &be_const_str_content_stop);
+be_define_const_str(SERIAL_5E2, "SERIAL_5E2", 1180552854u, 0, 10, &be_const_str_add_fast_loop);
+be_define_const_str(SERIAL_5N1, "SERIAL_5N1", 3313031680u, 0, 10, &be_const_str__);
+be_define_const_str(SERIAL_5N2, "SERIAL_5N2", 3363364537u, 0, 10, NULL);
+be_define_const_str(SERIAL_5O1, "SERIAL_5O1", 3782657917u, 0, 10, &be_const_str_nan);
+be_define_const_str(SERIAL_5O2, "SERIAL_5O2", 3732325060u, 0, 10, &be_const_str_ins_time);
+be_define_const_str(SERIAL_6E1, "SERIAL_6E1", 334249486u, 0, 10, &be_const_str_pi);
 be_define_const_str(SERIAL_6E2, "SERIAL_6E2", 317471867u, 0, 10, NULL);
-be_define_const_str(SERIAL_6N1, "SERIAL_6N1", 198895701u, 0, 10, &be_const_str_arg);
-be_define_const_str(SERIAL_6N2, "SERIAL_6N2", 148562844u, 0, 10, &be_const_str_gamma);
-be_define_const_str(SERIAL_6O1, "SERIAL_6O1", 266153272u, 0, 10, &be_const_str_WS2812_GRB);
-be_define_const_str(SERIAL_6O2, "SERIAL_6O2", 316486129u, 0, 10, &be_const_str_load);
-be_define_const_str(SERIAL_7E1, "SERIAL_7E1", 147718061u, 0, 10, &be_const_str_deg);
-be_define_const_str(SERIAL_7E2, "SERIAL_7E2", 97385204u, 0, 10, &be_const_str_SERIAL_7O2);
-be_define_const_str(SERIAL_7N1, "SERIAL_7N1", 1891060246u, 0, 10, &be_const_str__timers);
-be_define_const_str(SERIAL_7N2, "SERIAL_7N2", 1874282627u, 0, 10, NULL);
-be_define_const_str(SERIAL_7O1, "SERIAL_7O1", 1823802675u, 0, 10, &be_const_str_SERIAL_8N1);
-be_define_const_str(SERIAL_7O2, "SERIAL_7O2", 1840580294u, 0, 10, &be_const_str_SERIAL_8N2);
-be_define_const_str(SERIAL_8E1, "SERIAL_8E1", 2371121616u, 0, 10, &be_const_str_files);
-be_define_const_str(SERIAL_8E2, "SERIAL_8E2", 2421454473u, 0, 10, &be_const_str_consume_mono);
-be_define_const_str(SERIAL_8N1, "SERIAL_8N1", 2369297235u, 0, 10, &be_const_str_collect);
-be_define_const_str(SERIAL_8N2, "SERIAL_8N2", 2386074854u, 0, 10, &be_const_str_clear);
-be_define_const_str(SERIAL_8O1, "SERIAL_8O1", 289122742u, 0, 10, &be_const_str_deinit);
-be_define_const_str(SERIAL_8O2, "SERIAL_8O2", 272345123u, 0, 10, &be_const_str_dump);
-be_define_const_str(SK6812_GRBW, "SK6812_GRBW", 81157857u, 0, 11, &be_const_str_arch);
-be_define_const_str(STATE_DEFAULT, "STATE_DEFAULT", 712406428u, 0, 13, &be_const_str_finish);
-be_define_const_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27, "TAP: Loaded Tasmota App '%s'", 926477145u, 0, 28, &be_const_str__debug_present);
-be_define_const_str(Tasmota, "Tasmota", 4047617668u, 0, 7, &be_const_str_instance);
-be_define_const_str(Tele, "Tele", 1329980653u, 0, 4, NULL);
-be_define_const_str(Timer, "Timer", 3948127682u, 0, 5, &be_const_str_Unknown_X20command);
-be_define_const_str(True, "True", 3453902341u, 0, 4, &be_const_str_clock_icon);
-be_define_const_str(Unknown_X20command, "Unknown command", 1830905432u, 0, 15, &be_const_str_calldepth);
-be_define_const_str(WS2812, "WS2812", 3539741218u, 0, 6, &be_const_str_has_arg);
-be_define_const_str(WS2812_GRB, "WS2812_GRB", 1736405692u, 0, 10, &be_const_str_debug);
+be_define_const_str(SERIAL_6N1, "SERIAL_6N1", 198895701u, 0, 10, &be_const_str_SERIAL_8E1);
+be_define_const_str(SERIAL_6N2, "SERIAL_6N2", 148562844u, 0, 10, &be_const_str_begin_multicast);
+be_define_const_str(SERIAL_6O1, "SERIAL_6O1", 266153272u, 0, 10, &be_const_str_animators);
+be_define_const_str(SERIAL_6O2, "SERIAL_6O2", 316486129u, 0, 10, NULL);
+be_define_const_str(SERIAL_7E1, "SERIAL_7E1", 147718061u, 0, 10, &be_const_str_widget_dtor_cb);
+be_define_const_str(SERIAL_7E2, "SERIAL_7E2", 97385204u, 0, 10, NULL);
+be_define_const_str(SERIAL_7N1, "SERIAL_7N1", 1891060246u, 0, 10, &be_const_str__available);
+be_define_const_str(SERIAL_7N2, "SERIAL_7N2", 1874282627u, 0, 10, &be_const_str_x);
+be_define_const_str(SERIAL_7O1, "SERIAL_7O1", 1823802675u, 0, 10, &be_const_str_name);
+be_define_const_str(SERIAL_7O2, "SERIAL_7O2", 1840580294u, 0, 10, NULL);
+be_define_const_str(SERIAL_8E1, "SERIAL_8E1", 2371121616u, 0, 10, &be_const_str_animate);
+be_define_const_str(SERIAL_8E2, "SERIAL_8E2", 2421454473u, 0, 10, &be_const_str_gamma);
+be_define_const_str(SERIAL_8N1, "SERIAL_8N1", 2369297235u, 0, 10, &be_const_str_load_freetype_font);
+be_define_const_str(SERIAL_8N2, "SERIAL_8N2", 2386074854u, 0, 10, NULL);
+be_define_const_str(SERIAL_8O1, "SERIAL_8O1", 289122742u, 0, 10, &be_const_str__debug_present);
+be_define_const_str(SERIAL_8O2, "SERIAL_8O2", 272345123u, 0, 10, &be_const_str_arg);
+be_define_const_str(SK6812_GRBW, "SK6812_GRBW", 81157857u, 0, 11, &be_const_str_autoexec);
+be_define_const_str(STATE_DEFAULT, "STATE_DEFAULT", 712406428u, 0, 13, NULL);
+be_define_const_str(TAP_X3A_X20Loaded_X20Tasmota_X20App_X20_X27_X25s_X27, "TAP: Loaded Tasmota App '%s'", 926477145u, 0, 28, &be_const_str_loop);
+be_define_const_str(Tasmota, "Tasmota", 4047617668u, 0, 7, &be_const_str_clear);
+be_define_const_str(Tele, "Tele", 1329980653u, 0, 4, &be_const_str_every_50ms);
+be_define_const_str(Timer, "Timer", 3948127682u, 0, 5, NULL);
+be_define_const_str(True, "True", 3453902341u, 0, 4, &be_const_str_counters);
+be_define_const_str(Unknown_X20command, "Unknown command", 1830905432u, 0, 15, NULL);
+be_define_const_str(WS2812, "WS2812", 3539741218u, 0, 6, NULL);
+be_define_const_str(WS2812_GRB, "WS2812_GRB", 1736405692u, 0, 10, &be_const_str_create_segment);
 be_define_const_str(Wire, "Wire", 1938276536u, 0, 4, NULL);
-be_define_const_str(_X5B, "[", 3725336506u, 0, 1, NULL);
-be_define_const_str(_X5D, "]", 3624670792u, 0, 1, &be_const_str_connected);
-be_define_const_str(_, "_", 3658226030u, 0, 1, &be_const_str_get_width);
-be_define_const_str(__iterator__, "__iterator__", 3884039703u, 0, 12, &be_const_str_animators);
-be_define_const_str(__lower__, "__lower__", 123855590u, 0, 9, &be_const_str_detect);
-be_define_const_str(__upper__, "__upper__", 3612202883u, 0, 9, &be_const_str_draw_line_dsc);
-be_define_const_str(_anonymous_, "_anonymous_", 1957281476u, 0, 11, &be_const_str_pc);
-be_define_const_str(_archive, "_archive", 4004559404u, 0, 8, &be_const_str_set_percentage);
-be_define_const_str(_available, "_available", 1306196581u, 0, 10, &be_const_str_autoexec);
+be_define_const_str(_X5B, "[", 3725336506u, 0, 1, &be_const_str_content_flush);
+be_define_const_str(_X5D, "]", 3624670792u, 0, 1, &be_const_str_seti);
+be_define_const_str(_, "_", 3658226030u, 0, 1, &be_const_str_pc_rel);
+be_define_const_str(__iterator__, "__iterator__", 3884039703u, 0, 12, &be_const_str_widget_constructor);
+be_define_const_str(__lower__, "__lower__", 123855590u, 0, 9, &be_const_str_imax);
+be_define_const_str(__upper__, "__upper__", 3612202883u, 0, 9, &be_const_str_acos);
+be_define_const_str(_anonymous_, "_anonymous_", 1957281476u, 0, 11, &be_const_str_elements_X20must_X20be_X20a_X20lv_point);
+be_define_const_str(_archive, "_archive", 4004559404u, 0, 8, &be_const_str_check_privileged_access);
+be_define_const_str(_available, "_available", 1306196581u, 0, 10, &be_const_str__X7B);
 be_define_const_str(_begin_transmission, "_begin_transmission", 2779461176u, 0, 19, NULL);
-be_define_const_str(_buffer, "_buffer", 2044888568u, 0, 7, &be_const_str_decrypt);
-be_define_const_str(_ccmd, "_ccmd", 2163421413u, 0, 5, &be_const_str_deregister_obj);
-be_define_const_str(_class, "_class", 2732146350u, 0, 6, &be_const_str_get_bat_charge_current);
-be_define_const_str(_cmd, "_cmd", 3419822142u, 0, 4, &be_const_str_dac_voltage);
-be_define_const_str(_debug_present, "_debug_present", 4063411725u, 0, 14, &be_const_str_call_native);
-be_define_const_str(_def, "_def", 1985022181u, 0, 4, &be_const_str_point);
-be_define_const_str(_dirty, "_dirty", 283846766u, 0, 6, &be_const_str_button_pressed);
-be_define_const_str(_drivers, "_drivers", 3260328985u, 0, 8, &be_const_str__write);
-be_define_const_str(_end_transmission, "_end_transmission", 3237480400u, 0, 17, NULL);
-be_define_const_str(_energy, "_energy", 535372070u, 0, 7, &be_const_str_animate);
-be_define_const_str(_error, "_error", 1132109656u, 0, 6, &be_const_str_closure);
-be_define_const_str(_filename, "_filename", 1430813195u, 0, 9, &be_const_str_reset_search);
-be_define_const_str(_fl, "_fl", 4042564892u, 0, 3, &be_const_str_fast_loop);
+be_define_const_str(_buffer, "_buffer", 2044888568u, 0, 7, &be_const_str_add_header);
+be_define_const_str(_ccmd, "_ccmd", 2163421413u, 0, 5, NULL);
+be_define_const_str(_class, "_class", 2732146350u, 0, 6, &be_const_str_dump);
+be_define_const_str(_cmd, "_cmd", 3419822142u, 0, 4, &be_const_str__lvgl);
+be_define_const_str(_debug_present, "_debug_present", 4063411725u, 0, 14, &be_const_str_back_forth);
+be_define_const_str(_def, "_def", 1985022181u, 0, 4, &be_const_str__settings_ptr);
+be_define_const_str(_dirty, "_dirty", 283846766u, 0, 6, &be_const_str_compile);
+be_define_const_str(_drivers, "_drivers", 3260328985u, 0, 8, &be_const_str_remote_ip);
+be_define_const_str(_end_transmission, "_end_transmission", 3237480400u, 0, 17, &be_const_str__request_from);
+be_define_const_str(_energy, "_energy", 535372070u, 0, 7, &be_const_str_rtc);
+be_define_const_str(_error, "_error", 1132109656u, 0, 6, NULL);
+be_define_const_str(_filename, "_filename", 1430813195u, 0, 9, &be_const_str_screenshot);
+be_define_const_str(_fl, "_fl", 4042564892u, 0, 3, &be_const_str_pixel_size);
 be_define_const_str(_global_addr, "_global_addr", 533766721u, 0, 12, NULL);
-be_define_const_str(_global_def, "_global_def", 646007001u, 0, 11, NULL);
-be_define_const_str(_lvgl, "_lvgl", 2689219483u, 0, 5, &be_const_str_create_matrix);
-be_define_const_str(_p, "_p", 1594591802u, 0, 2, &be_const_str_format);
-be_define_const_str(_persist_X2Ejson, "_persist.json", 2008425138u, 0, 13, &be_const_str_instance_size);
-be_define_const_str(_ptr, "_ptr", 306235816u, 0, 4, &be_const_str_fast_loop_enabled);
-be_define_const_str(_read, "_read", 346717030u, 0, 5, &be_const_str_signal_bars);
-be_define_const_str(_request_from, "_request_from", 3965148604u, 0, 13, &be_const_str_is_first_time);
-be_define_const_str(_rules, "_rules", 4266217105u, 0, 6, NULL);
-be_define_const_str(_settings_def, "_settings_def", 3775560307u, 0, 13, &be_const_str_setbits);
-be_define_const_str(_settings_ptr, "_settings_ptr", 1825772182u, 0, 13, &be_const_str_str);
-be_define_const_str(_t, "_t", 1527481326u, 0, 2, &be_const_str_page_autoconf_ctl);
-be_define_const_str(_timers, "_timers", 2600100916u, 0, 7, &be_const_str_find_op);
-be_define_const_str(_write, "_write", 2215462825u, 0, 6, NULL);
-be_define_const_str(a, "a", 3826002220u, 0, 1, &be_const_str_add);
-be_define_const_str(abs, "abs", 709362235u, 0, 3, &be_const_str_remove_timer);
-be_define_const_str(acos, "acos", 1006755615u, 0, 4, &be_const_str_leds);
-be_define_const_str(add, "add", 993596020u, 0, 3, &be_const_str_ins_ramp);
-be_define_const_str(add_anim, "add_anim", 3980662668u, 0, 8, &be_const_str_compile);
-be_define_const_str(add_cmd, "add_cmd", 3361630879u, 0, 7, &be_const_str_class);
-be_define_const_str(add_driver, "add_driver", 1654458371u, 0, 10, &be_const_str_keys);
-be_define_const_str(add_event_cb, "add_event_cb", 633097693u, 0, 12, &be_const_str_ctor);
-be_define_const_str(add_fast_loop, "add_fast_loop", 3025842946u, 0, 13, &be_const_str_draw_line);
-be_define_const_str(add_handler, "add_handler", 2055124119u, 0, 11, &be_const_str_atan);
-be_define_const_str(add_header, "add_header", 927130612u, 0, 10, NULL);
-be_define_const_str(add_rule, "add_rule", 596540743u, 0, 8, &be_const_str_ins_goto);
-be_define_const_str(addr, "addr", 1087856498u, 0, 4, &be_const_str_cb);
-be_define_const_str(allocated, "allocated", 429986098u, 0, 9, &be_const_str_check_privileged_access);
-be_define_const_str(alternate, "alternate", 1140253277u, 0, 9, &be_const_str_content_button);
-be_define_const_str(animate, "animate", 3885786800u, 0, 7, NULL);
-be_define_const_str(animators, "animators", 279858213u, 0, 9, &be_const_str_set_power);
-be_define_const_str(arch, "arch", 2952804297u, 0, 4, &be_const_str_open);
-be_define_const_str(area, "area", 2601460036u, 0, 4, &be_const_str_param);
-be_define_const_str(arg, "arg", 1047474471u, 0, 3, NULL);
-be_define_const_str(arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj, "arg must be a subclass of lv_obj", 1641882079u, 0, 32, &be_const_str_lv_signal_bars);
-be_define_const_str(arg_name, "arg_name", 1345046155u, 0, 8, &be_const_str_zero);
-be_define_const_str(arg_size, "arg_size", 3310243257u, 0, 8, NULL);
-be_define_const_str(argument_X20must_X20be_X20a_X20function, "argument must be a function", 527172389u, 0, 27, NULL);
-be_define_const_str(argument_X20must_X20be_X20a_X20list, "argument must be a list", 3056915661u, 0, 23, &be_const_str_gen_cb);
+be_define_const_str(_global_def, "_global_def", 646007001u, 0, 11, &be_const_str_else);
+be_define_const_str(_lvgl, "_lvgl", 2689219483u, 0, 5, &be_const_str__rules);
+be_define_const_str(_p, "_p", 1594591802u, 0, 2, &be_const_str_arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj);
+be_define_const_str(_persist_X2Ejson, "_persist.json", 2008425138u, 0, 13, &be_const_str_can_show);
+be_define_const_str(_ptr, "_ptr", 306235816u, 0, 4, &be_const_str_group_def);
+be_define_const_str(_read, "_read", 346717030u, 0, 5, &be_const_str_round_start);
+be_define_const_str(_request_from, "_request_from", 3965148604u, 0, 13, NULL);
+be_define_const_str(_rules, "_rules", 4266217105u, 0, 6, &be_const_str_hour);
+be_define_const_str(_settings_def, "_settings_def", 3775560307u, 0, 13, NULL);
+be_define_const_str(_settings_ptr, "_settings_ptr", 1825772182u, 0, 13, NULL);
+be_define_const_str(_t, "_t", 1527481326u, 0, 2, &be_const_str_isinstance);
+be_define_const_str(_timers, "_timers", 2600100916u, 0, 7, &be_const_str_begin);
+be_define_const_str(_write, "_write", 2215462825u, 0, 6, &be_const_str_add_driver);
+be_define_const_str(a, "a", 3826002220u, 0, 1, &be_const_str_content_start);
+be_define_const_str(abs, "abs", 709362235u, 0, 3, &be_const_str_geti);
+be_define_const_str(acos, "acos", 1006755615u, 0, 4, &be_const_str_param);
+be_define_const_str(add, "add", 993596020u, 0, 3, &be_const_str_eth);
+be_define_const_str(add_anim, "add_anim", 3980662668u, 0, 8, &be_const_str_obj_class_create_obj);
+be_define_const_str(add_cmd, "add_cmd", 3361630879u, 0, 7, NULL);
+be_define_const_str(add_driver, "add_driver", 1654458371u, 0, 10, &be_const_str_fromb64);
+be_define_const_str(add_event_cb, "add_event_cb", 633097693u, 0, 12, &be_const_str_skip);
+be_define_const_str(add_fast_loop, "add_fast_loop", 3025842946u, 0, 13, &be_const_str_get_current_module_path);
+be_define_const_str(add_handler, "add_handler", 2055124119u, 0, 11, &be_const_str_readline);
+be_define_const_str(add_header, "add_header", 927130612u, 0, 10, &be_const_str_classof);
+be_define_const_str(add_rule, "add_rule", 596540743u, 0, 8, &be_const_str_getbits);
+be_define_const_str(addr, "addr", 1087856498u, 0, 4, &be_const_str_log10);
+be_define_const_str(allocated, "allocated", 429986098u, 0, 9, &be_const_str_reverse_gamma10);
+be_define_const_str(alternate, "alternate", 1140253277u, 0, 9, NULL);
+be_define_const_str(animate, "animate", 3885786800u, 0, 7, &be_const_str_get_cb_list);
+be_define_const_str(animators, "animators", 279858213u, 0, 9, &be_const_str_chars_in_string);
+be_define_const_str(arch, "arch", 2952804297u, 0, 4, &be_const_str_get_width);
+be_define_const_str(area, "area", 2601460036u, 0, 4, &be_const_str_ceil);
+be_define_const_str(arg, "arg", 1047474471u, 0, 3, &be_const_str_solidified);
+be_define_const_str(arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj, "arg must be a subclass of lv_obj", 1641882079u, 0, 32, &be_const_str_get_pixel_color);
+be_define_const_str(arg_name, "arg_name", 1345046155u, 0, 8, NULL);
+be_define_const_str(arg_size, "arg_size", 3310243257u, 0, 8, &be_const_str_get);
+be_define_const_str(argument_X20must_X20be_X20a_X20function, "argument must be a function", 527172389u, 0, 27, &be_const_str_atan);
+be_define_const_str(argument_X20must_X20be_X20a_X20list, "argument must be a list", 3056915661u, 0, 23, &be_const_str_assert);
 be_define_const_str(as, "as", 1579491469u, 67, 2, NULL);
-be_define_const_str(asin, "asin", 4272848550u, 0, 4, NULL);
-be_define_const_str(assert, "assert", 2774883451u, 0, 6, &be_const_str_is_running);
-be_define_const_str(asstring, "asstring", 1298225088u, 0, 8, &be_const_str_number);
-be_define_const_str(atan, "atan", 108579519u, 0, 4, &be_const_str_fromb64);
-be_define_const_str(atan2, "atan2", 3173440503u, 0, 5, NULL);
-be_define_const_str(atleast1, "atleast1", 1956331672u, 0, 8, &be_const_str_cmd_res);
-be_define_const_str(attrdump, "attrdump", 1521571304u, 0, 8, &be_const_str_available);
-be_define_const_str(autoexec, "autoexec", 3676861891u, 0, 8, &be_const_str_send);
-be_define_const_str(autorun, "autorun", 1447527407u, 0, 7, &be_const_str_minute);
-be_define_const_str(available, "available", 1727918744u, 0, 9, &be_const_str_copy);
-be_define_const_str(b, "b", 3876335077u, 0, 1, &be_const_str_set);
-be_define_const_str(back_forth, "back_forth", 2665042062u, 0, 10, &be_const_str_write_bytes);
-be_define_const_str(base_class, "base_class", 1107737279u, 0, 10, NULL);
-be_define_const_str(battery_present, "battery_present", 3588397058u, 0, 15, &be_const_str_every_50ms);
-be_define_const_str(before_del, "before_del", 815924436u, 0, 10, &be_const_str_set_chg_current);
-be_define_const_str(begin, "begin", 1748273790u, 0, 5, &be_const_str_clear_to);
+be_define_const_str(asin, "asin", 4272848550u, 0, 4, &be_const_str_f);
+be_define_const_str(assert, "assert", 2774883451u, 0, 6, &be_const_str_ctor);
+be_define_const_str(asstring, "asstring", 1298225088u, 0, 8, &be_const_str_internal_error);
+be_define_const_str(atan, "atan", 108579519u, 0, 4, &be_const_str_point);
+be_define_const_str(atan2, "atan2", 3173440503u, 0, 5, &be_const_str_resp_cmnd_str);
+be_define_const_str(atleast1, "atleast1", 1956331672u, 0, 8, &be_const_str_get_style_bg_color);
+be_define_const_str(attrdump, "attrdump", 1521571304u, 0, 8, &be_const_str_digital_write);
+be_define_const_str(autoexec, "autoexec", 3676861891u, 0, 8, &be_const_str_pop);
+be_define_const_str(autorun, "autorun", 1447527407u, 0, 7, &be_const_str_display);
+be_define_const_str(available, "available", 1727918744u, 0, 9, &be_const_str_register_obj);
+be_define_const_str(b, "b", 3876335077u, 0, 1, &be_const_str_dimmer);
+be_define_const_str(back_forth, "back_forth", 2665042062u, 0, 10, &be_const_str_gc);
+be_define_const_str(base_class, "base_class", 1107737279u, 0, 10, &be_const_str_init_draw_line_dsc);
+be_define_const_str(battery_present, "battery_present", 3588397058u, 0, 15, &be_const_str_lv_point_arr);
+be_define_const_str(before_del, "before_del", 815924436u, 0, 10, NULL);
+be_define_const_str(begin, "begin", 1748273790u, 0, 5, NULL);
 be_define_const_str(begin_multicast, "begin_multicast", 57647915u, 0, 15, NULL);
-be_define_const_str(bool, "bool", 3365180733u, 0, 4, &be_const_str_strip);
+be_define_const_str(bool, "bool", 3365180733u, 0, 4, &be_const_str_search);
 be_define_const_str(break, "break", 3378807160u, 58, 5, NULL);
-be_define_const_str(bri, "bri", 2112284244u, 0, 3, NULL);
-be_define_const_str(bus, "bus", 1607822841u, 0, 3, &be_const_str_read_sensors);
-be_define_const_str(button_pressed, "button_pressed", 1694209616u, 0, 14, &be_const_str_zip);
-be_define_const_str(byte, "byte", 1683620383u, 0, 4, &be_const_str_json_fdump_list);
-be_define_const_str(bytes, "bytes", 1706151940u, 0, 5, &be_const_str_set_timeouts);
-be_define_const_str(c, "c", 3859557458u, 0, 1, NULL);
-be_define_const_str(call, "call", 3018949801u, 0, 4, &be_const_str_content_stop);
-be_define_const_str(call_native, "call_native", 1389147405u, 0, 11, &be_const_str_every_second);
-be_define_const_str(calldepth, "calldepth", 3122364302u, 0, 9, &be_const_str_set_alternate);
-be_define_const_str(can_show, "can_show", 960091187u, 0, 8, &be_const_str_constructor_cb);
-be_define_const_str(cb, "cb", 1428787088u, 0, 2, NULL);
-be_define_const_str(cb_do_nothing, "cb_do_nothing", 1488730702u, 0, 13, NULL);
-be_define_const_str(cb_event_closure, "cb_event_closure", 3828267325u, 0, 16, &be_const_str_round_end);
-be_define_const_str(cb_obj, "cb_obj", 1195696482u, 0, 6, &be_const_str_to_gamma);
-be_define_const_str(ceil, "ceil", 1659167240u, 0, 4, NULL);
-be_define_const_str(char, "char", 2823553821u, 0, 4, NULL);
-be_define_const_str(chars_in_string, "chars_in_string", 3148785132u, 0, 15, &be_const_str_get_cb_list);
-be_define_const_str(check_not_method, "check_not_method", 2597324607u, 0, 16, &be_const_str_point_arr);
+be_define_const_str(bri, "bri", 2112284244u, 0, 3, &be_const_str_unknown_X20instruction);
+be_define_const_str(bus, "bus", 1607822841u, 0, 3, NULL);
+be_define_const_str(button_pressed, "button_pressed", 1694209616u, 0, 14, &be_const_str_font_seg7);
+be_define_const_str(byte, "byte", 1683620383u, 0, 4, &be_const_str_setrange);
+be_define_const_str(bytes, "bytes", 1706151940u, 0, 5, &be_const_str_target);
+be_define_const_str(c, "c", 3859557458u, 0, 1, &be_const_str_size);
+be_define_const_str(call, "call", 3018949801u, 0, 4, NULL);
+be_define_const_str(call_native, "call_native", 1389147405u, 0, 11, NULL);
+be_define_const_str(calldepth, "calldepth", 3122364302u, 0, 9, &be_const_str_json_fdump_list);
+be_define_const_str(can_show, "can_show", 960091187u, 0, 8, &be_const_str_read8);
+be_define_const_str(cb, "cb", 1428787088u, 0, 2, &be_const_str_set_pwm);
+be_define_const_str(cb_do_nothing, "cb_do_nothing", 1488730702u, 0, 13, &be_const_str_wifi_arcs);
+be_define_const_str(cb_event_closure, "cb_event_closure", 3828267325u, 0, 16, &be_const_str_reset_search);
+be_define_const_str(cb_obj, "cb_obj", 1195696482u, 0, 6, NULL);
+be_define_const_str(ceil, "ceil", 1659167240u, 0, 4, &be_const_str_reapply);
+be_define_const_str(char, "char", 2823553821u, 0, 4, &be_const_str_get_battery_chargin_status);
+be_define_const_str(chars_in_string, "chars_in_string", 3148785132u, 0, 15, &be_const_str_exec_tele);
+be_define_const_str(check_not_method, "check_not_method", 2597324607u, 0, 16, &be_const_str_remove_cmd);
 be_define_const_str(check_privileged_access, "check_privileged_access", 3692933968u, 0, 23, NULL);
 be_define_const_str(class, "class", 2872970239u, 57, 5, NULL);
-be_define_const_str(class_init_obj, "class_init_obj", 178410604u, 0, 14, &be_const_str_set_useragent);
-be_define_const_str(classname, "classname", 1998589948u, 0, 9, &be_const_str_set_exten);
-be_define_const_str(classof, "classof", 1796577762u, 0, 7, &be_const_str_kv);
-be_define_const_str(clear, "clear", 1550717474u, 0, 5, &be_const_str_scale_uint);
-be_define_const_str(clear_first_time, "clear_first_time", 632769909u, 0, 16, &be_const_str_width_def);
-be_define_const_str(clear_to, "clear_to", 3528002130u, 0, 8, &be_const_str_connection_error);
-be_define_const_str(clock_icon, "clock_icon", 544669651u, 0, 10, &be_const_str_value_error);
-be_define_const_str(close, "close", 667630371u, 0, 5, &be_const_str_get_object_from_ptr);
-be_define_const_str(closure, "closure", 1548407746u, 0, 7, &be_const_str_item);
-be_define_const_str(cmd, "cmd", 4136785899u, 0, 3, &be_const_str_tolower);
-be_define_const_str(cmd_res, "cmd_res", 921166762u, 0, 7, &be_const_str_tan);
-be_define_const_str(code, "code", 4180765940u, 0, 4, &be_const_str_detected_X20on_X20bus);
-be_define_const_str(codedump, "codedump", 1786337906u, 0, 8, &be_const_str_w);
-be_define_const_str(collect, "collect", 2399039025u, 0, 7, &be_const_str_init);
+be_define_const_str(class_init_obj, "class_init_obj", 178410604u, 0, 14, &be_const_str_has);
+be_define_const_str(classname, "classname", 1998589948u, 0, 9, &be_const_str_editable);
+be_define_const_str(classof, "classof", 1796577762u, 0, 7, &be_const_str_font_montserrat);
+be_define_const_str(clear, "clear", 1550717474u, 0, 5, NULL);
+be_define_const_str(clear_first_time, "clear_first_time", 632769909u, 0, 16, &be_const_str_get_coords);
+be_define_const_str(clear_to, "clear_to", 3528002130u, 0, 8, NULL);
+be_define_const_str(clock_icon, "clock_icon", 544669651u, 0, 10, &be_const_str_code);
+be_define_const_str(close, "close", 667630371u, 0, 5, &be_const_str_tasmota);
+be_define_const_str(closure, "closure", 1548407746u, 0, 7, NULL);
+be_define_const_str(cmd, "cmd", 4136785899u, 0, 3, &be_const_str_pop_path);
+be_define_const_str(cmd_res, "cmd_res", 921166762u, 0, 7, NULL);
+be_define_const_str(code, "code", 4180765940u, 0, 4, &be_const_str_set_style_text_font);
+be_define_const_str(codedump, "codedump", 1786337906u, 0, 8, &be_const_str_draw_line);
+be_define_const_str(collect, "collect", 2399039025u, 0, 7, &be_const_str_json_append);
 be_define_const_str(color, "color", 1031692888u, 0, 5, NULL);
 be_define_const_str(compile, "compile", 1000265118u, 0, 7, NULL);
-be_define_const_str(compress, "compress", 2818084237u, 0, 8, &be_const_str_from_to);
-be_define_const_str(concat, "concat", 4124019837u, 0, 6, NULL);
-be_define_const_str(connect, "connect", 2866859257u, 0, 7, &be_const_str_display);
-be_define_const_str(connected, "connected", 1424938192u, 0, 9, NULL);
-be_define_const_str(connection_error, "connection_error", 1358926260u, 0, 16, NULL);
-be_define_const_str(constructor_cb, "constructor_cb", 2489105297u, 0, 14, &be_const_str_ctypes_bytes_dyn);
-be_define_const_str(consume_mono, "consume_mono", 3577563453u, 0, 12, &be_const_str_get_option);
-be_define_const_str(consume_silence, "consume_silence", 1445390925u, 0, 15, &be_const_str_https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson);
-be_define_const_str(consume_stereo, "consume_stereo", 1834661098u, 0, 14, &be_const_str_height_def);
+be_define_const_str(compress, "compress", 2818084237u, 0, 8, NULL);
+be_define_const_str(concat, "concat", 4124019837u, 0, 6, &be_const_str_get_aps_voltage);
+be_define_const_str(connect, "connect", 2866859257u, 0, 7, &be_const_str_get_bat_current);
+be_define_const_str(connected, "connected", 1424938192u, 0, 9, &be_const_str_constructor_cb);
+be_define_const_str(connection_error, "connection_error", 1358926260u, 0, 16, &be_const_str_get_percentage);
+be_define_const_str(constructor_cb, "constructor_cb", 2489105297u, 0, 14, &be_const_str_from_to);
+be_define_const_str(consume_mono, "consume_mono", 3577563453u, 0, 12, &be_const_str_destructor_cb);
+be_define_const_str(consume_silence, "consume_silence", 1445390925u, 0, 15, &be_const_str_event_send);
+be_define_const_str(consume_stereo, "consume_stereo", 1834661098u, 0, 14, NULL);
 be_define_const_str(contains, "contains", 1825239352u, 0, 8, NULL);
-be_define_const_str(content_button, "content_button", 1956476087u, 0, 14, &be_const_str_push);
-be_define_const_str(content_flush, "content_flush", 214922475u, 0, 13, NULL);
-be_define_const_str(content_send, "content_send", 1673733649u, 0, 12, &be_const_str_iter);
-be_define_const_str(content_send_style, "content_send_style", 1087907647u, 0, 18, NULL);
-be_define_const_str(content_start, "content_start", 2937509069u, 0, 13, &be_const_str_digital_write);
-be_define_const_str(content_stop, "content_stop", 658554751u, 0, 12, &be_const_str_h);
+be_define_const_str(content_button, "content_button", 1956476087u, 0, 14, NULL);
+be_define_const_str(content_flush, "content_flush", 214922475u, 0, 13, &be_const_str_lower);
+be_define_const_str(content_send, "content_send", 1673733649u, 0, 12, &be_const_str_keys);
+be_define_const_str(content_send_style, "content_send_style", 1087907647u, 0, 18, &be_const_str_isnan);
+be_define_const_str(content_start, "content_start", 2937509069u, 0, 13, &be_const_str_count);
+be_define_const_str(content_stop, "content_stop", 658554751u, 0, 12, &be_const_str_get_input_power_status);
 be_define_const_str(continue, "continue", 2977070660u, 59, 8, NULL);
-be_define_const_str(coord_arr, "coord_arr", 4189963658u, 0, 9, &be_const_str_path);
-be_define_const_str(copy, "copy", 3848464964u, 0, 4, &be_const_str_web_add_main_button);
-be_define_const_str(cos, "cos", 4220379804u, 0, 3, NULL);
-be_define_const_str(cosh, "cosh", 4099687964u, 0, 4, &be_const_str_global);
-be_define_const_str(couldn_X27t_X20not_X20initialize_X20noepixelbus, "couldn't not initialize noepixelbus", 2536490812u, 0, 35, NULL);
-be_define_const_str(count, "count", 967958004u, 0, 5, &be_const_str_isnan);
-be_define_const_str(counters, "counters", 4095866864u, 0, 8, &be_const_str_yield);
-be_define_const_str(create_custom_widget, "create_custom_widget", 1140594778u, 0, 20, NULL);
-be_define_const_str(create_matrix, "create_matrix", 3528185923u, 0, 13, &be_const_str_select);
-be_define_const_str(create_segment, "create_segment", 3863522719u, 0, 14, &be_const_str_hour);
-be_define_const_str(ctor, "ctor", 375399343u, 0, 4, &be_const_str_json_fdump_map);
-be_define_const_str(ctypes_bytes, "ctypes_bytes", 3879019703u, 0, 12, &be_const_str_widget_struct_default);
+be_define_const_str(coord_arr, "coord_arr", 4189963658u, 0, 9, &be_const_str_read_sensors);
+be_define_const_str(copy, "copy", 3848464964u, 0, 4, &be_const_str_reset);
+be_define_const_str(cos, "cos", 4220379804u, 0, 3, &be_const_str_lv_clock_icon);
+be_define_const_str(cosh, "cosh", 4099687964u, 0, 4, &be_const_str_get_temp);
+be_define_const_str(couldn_X27t_X20not_X20initialize_X20noepixelbus, "couldn't not initialize noepixelbus", 2536490812u, 0, 35, &be_const_str_year);
+be_define_const_str(count, "count", 967958004u, 0, 5, &be_const_str_read32);
+be_define_const_str(counters, "counters", 4095866864u, 0, 8, &be_const_str_flush);
+be_define_const_str(create_custom_widget, "create_custom_widget", 1140594778u, 0, 20, &be_const_str_lv_module_init);
+be_define_const_str(create_matrix, "create_matrix", 3528185923u, 0, 13, &be_const_str_month);
+be_define_const_str(create_segment, "create_segment", 3863522719u, 0, 14, NULL);
+be_define_const_str(ctor, "ctor", 375399343u, 0, 4, &be_const_str_wire_scan);
+be_define_const_str(ctypes_bytes, "ctypes_bytes", 3879019703u, 0, 12, &be_const_str_set_ldo_enable);
 be_define_const_str(ctypes_bytes_dyn, "ctypes_bytes_dyn", 915205307u, 0, 16, NULL);
-be_define_const_str(dac_voltage, "dac_voltage", 1552257222u, 0, 11, &be_const_str_font_montserrat);
-be_define_const_str(day, "day", 3830391293u, 0, 3, &be_const_str_wifi_bars);
-be_define_const_str(debug, "debug", 1483009432u, 0, 5, &be_const_str_tasmota);
-be_define_const_str(decode, "decode", 3007678287u, 0, 6, &be_const_str_event_cb);
-be_define_const_str(decompress, "decompress", 2887031650u, 0, 10, &be_const_str_lower);
-be_define_const_str(decrypt, "decrypt", 2886974618u, 0, 7, &be_const_str_get_switch);
+be_define_const_str(dac_voltage, "dac_voltage", 1552257222u, 0, 11, NULL);
+be_define_const_str(day, "day", 3830391293u, 0, 3, &be_const_str_json_fdump_map);
+be_define_const_str(debug, "debug", 1483009432u, 0, 5, &be_const_str_tele);
+be_define_const_str(decode, "decode", 3007678287u, 0, 6, &be_const_str_sinh);
+be_define_const_str(decompress, "decompress", 2887031650u, 0, 10, &be_const_str_item);
+be_define_const_str(decrypt, "decrypt", 2886974618u, 0, 7, NULL);
 be_define_const_str(def, "def", 3310976652u, 55, 3, NULL);
-be_define_const_str(deg, "deg", 3327754271u, 0, 3, NULL);
-be_define_const_str(deinit, "deinit", 2345559592u, 0, 6, &be_const_str_find);
-be_define_const_str(delay, "delay", 1322381784u, 0, 5, &be_const_str_target);
-be_define_const_str(delete_all_configs, "delete_all_configs", 2382067578u, 0, 18, NULL);
-be_define_const_str(depower, "depower", 3563819571u, 0, 7, &be_const_str_floor);
-be_define_const_str(deregister_obj, "deregister_obj", 3909966993u, 0, 14, &be_const_str_pixel_count);
-be_define_const_str(destructor_cb, "destructor_cb", 1930283190u, 0, 13, &be_const_str_json_fdump);
-be_define_const_str(detect, "detect", 8884370u, 0, 6, &be_const_str_lv_clock_icon);
-be_define_const_str(detected_X20on_X20bus, "detected on bus", 1432002650u, 0, 15, NULL);
+be_define_const_str(deg, "deg", 3327754271u, 0, 3, &be_const_str_draw_arc);
+be_define_const_str(deinit, "deinit", 2345559592u, 0, 6, &be_const_str_lv_point);
+be_define_const_str(delay, "delay", 1322381784u, 0, 5, &be_const_str_update);
+be_define_const_str(delete_all_configs, "delete_all_configs", 2382067578u, 0, 18, &be_const_str_kv);
+be_define_const_str(depower, "depower", 3563819571u, 0, 7, &be_const_str_event);
+be_define_const_str(deregister_obj, "deregister_obj", 3909966993u, 0, 14, &be_const_str_read);
+be_define_const_str(destructor_cb, "destructor_cb", 1930283190u, 0, 13, NULL);
+be_define_const_str(detect, "detect", 8884370u, 0, 6, &be_const_str_pc_abs);
+be_define_const_str(detected_X20on_X20bus, "detected on bus", 1432002650u, 0, 15, &be_const_str_digital_read);
 be_define_const_str(digital_read, "digital_read", 3585496928u, 0, 12, NULL);
-be_define_const_str(digital_write, "digital_write", 3435877979u, 0, 13, &be_const_str_get_string);
-be_define_const_str(dirty, "dirty", 2667581083u, 0, 5, &be_const_str_get_height);
+be_define_const_str(digital_write, "digital_write", 3435877979u, 0, 13, &be_const_str_tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29);
+be_define_const_str(dimmer, "dimmer", 794270539u, 0, 6, &be_const_str_min);
+be_define_const_str(dirty, "dirty", 2667581083u, 0, 5, &be_const_str_every_second);
 be_define_const_str(display, "display", 1164572437u, 0, 7, NULL);
 be_define_const_str(display_X2Eini, "display.ini", 2646174001u, 0, 11, NULL);
 be_define_const_str(do, "do", 1646057492u, 65, 2, NULL);
-be_define_const_str(draw_arc, "draw_arc", 1828251676u, 0, 8, &be_const_str_ip);
-be_define_const_str(draw_line, "draw_line", 1634465686u, 0, 9, &be_const_str_io_error);
-be_define_const_str(draw_line_dsc, "draw_line_dsc", 4220676203u, 0, 13, &be_const_str_energy_struct);
-be_define_const_str(draw_line_dsc_init, "draw_line_dsc_init", 3866693646u, 0, 18, &be_const_str_id);
-be_define_const_str(due, "due", 3895530293u, 0, 3, NULL);
+be_define_const_str(draw_arc, "draw_arc", 1828251676u, 0, 8, &be_const_str_imin);
+be_define_const_str(draw_line, "draw_line", 1634465686u, 0, 9, &be_const_str_point_arr);
+be_define_const_str(draw_line_dsc, "draw_line_dsc", 4220676203u, 0, 13, NULL);
+be_define_const_str(draw_line_dsc_init, "draw_line_dsc_init", 3866693646u, 0, 18, NULL);
+be_define_const_str(due, "due", 3895530293u, 0, 3, &be_const_str_issubclass);
 be_define_const_str(dump, "dump", 3663001223u, 0, 4, NULL);
-be_define_const_str(duration, "duration", 799079693u, 0, 8, NULL);
-be_define_const_str(editable, "editable", 60532369u, 0, 8, NULL);
-be_define_const_str(elements_X20must_X20be_X20a_X20lv_point, "elements must be a lv_point", 1415796524u, 0, 27, &be_const_str_get_alternate);
+be_define_const_str(duration, "duration", 799079693u, 0, 8, &be_const_str_w);
+be_define_const_str(editable, "editable", 60532369u, 0, 8, &be_const_str_set_timer);
+be_define_const_str(elements_X20must_X20be_X20a_X20lv_point, "elements must be a lv_point", 1415796524u, 0, 27, &be_const_str_get_bat_charge_current);
 be_define_const_str(elif, "elif", 3232090307u, 51, 4, NULL);
 be_define_const_str(else, "else", 3183434736u, 52, 4, NULL);
-be_define_const_str(enabled, "enabled", 49525662u, 0, 7, &be_const_str_save);
-be_define_const_str(encrypt, "encrypt", 2194327650u, 0, 7, NULL);
-be_define_const_str(end, "end", 1787721130u, 56, 3, &be_const_str_import);
-be_define_const_str(energy_struct, "energy_struct", 1655792843u, 0, 13, &be_const_str_gamma10);
+be_define_const_str(enabled, "enabled", 49525662u, 0, 7, NULL);
+be_define_const_str(encrypt, "encrypt", 2194327650u, 0, 7, &be_const_str_function);
+be_define_const_str(end, "end", 1787721130u, 56, 3, NULL);
+be_define_const_str(energy_struct, "energy_struct", 1655792843u, 0, 13, NULL);
 be_define_const_str(engine, "engine", 3993360443u, 0, 6, NULL);
-be_define_const_str(erase, "erase", 1010949589u, 0, 5, &be_const_str_exec_cmd);
-be_define_const_str(escape, "escape", 2652972038u, 0, 6, NULL);
-be_define_const_str(eth, "eth", 2191266556u, 0, 3, &be_const_str_try);
-be_define_const_str(event, "event", 4264611999u, 0, 5, &be_const_str_persist);
+be_define_const_str(erase, "erase", 1010949589u, 0, 5, &be_const_str_wire1);
+be_define_const_str(escape, "escape", 2652972038u, 0, 6, &be_const_str_find_key_i);
+be_define_const_str(eth, "eth", 2191266556u, 0, 3, NULL);
+be_define_const_str(event, "event", 4264611999u, 0, 5, &be_const_str_set_dcdc_enable);
 be_define_const_str(event_cb, "event_cb", 3128698017u, 0, 8, NULL);
-be_define_const_str(event_send, "event_send", 598925582u, 0, 10, NULL);
-be_define_const_str(every_100ms, "every_100ms", 1546407804u, 0, 11, &be_const_str_imin);
-be_define_const_str(every_50ms, "every_50ms", 2383884008u, 0, 10, &be_const_str_get_pixel_color);
-be_define_const_str(every_second, "every_second", 2075451465u, 0, 12, &be_const_str_list);
+be_define_const_str(event_send, "event_send", 598925582u, 0, 10, &be_const_str_page_autoconf_ctl);
+be_define_const_str(every_100ms, "every_100ms", 1546407804u, 0, 11, NULL);
+be_define_const_str(every_50ms, "every_50ms", 2383884008u, 0, 10, &be_const_str_find_op);
+be_define_const_str(every_second, "every_second", 2075451465u, 0, 12, NULL);
 be_define_const_str(except, "except", 950914032u, 69, 6, NULL);
-be_define_const_str(exec_cmd, "exec_cmd", 493567399u, 0, 8, NULL);
-be_define_const_str(exec_rules, "exec_rules", 1445221092u, 0, 10, &be_const_str_publish_result);
-be_define_const_str(exec_tele, "exec_tele", 1020751601u, 0, 9, &be_const_str_set_y);
-be_define_const_str(exists, "exists", 1002329533u, 0, 6, &be_const_str_get_bat_power);
-be_define_const_str(exp, "exp", 1923516200u, 0, 3, &be_const_str_lv_wifi_bars_icon);
-be_define_const_str(f, "f", 3809224601u, 0, 1, &be_const_str_lv_coord_arr);
+be_define_const_str(exec_cmd, "exec_cmd", 493567399u, 0, 8, &be_const_str_pin_used);
+be_define_const_str(exec_rules, "exec_rules", 1445221092u, 0, 10, NULL);
+be_define_const_str(exec_tele, "exec_tele", 1020751601u, 0, 9, &be_const_str_file);
+be_define_const_str(exists, "exists", 1002329533u, 0, 6, &be_const_str_percentage);
+be_define_const_str(exp, "exp", 1923516200u, 0, 3, &be_const_str_type);
+be_define_const_str(f, "f", 3809224601u, 0, 1, &be_const_str_get_current_module_name);
 be_define_const_str(false, "false", 184981848u, 62, 5, NULL);
-be_define_const_str(fast_loop, "fast_loop", 3414422702u, 0, 9, &be_const_str_set_light);
+be_define_const_str(fast_loop, "fast_loop", 3414422702u, 0, 9, &be_const_str_get_free_heap);
 be_define_const_str(fast_loop_enabled, "fast_loop_enabled", 2567964376u, 0, 17, NULL);
 be_define_const_str(file, "file", 2867484483u, 0, 4, NULL);
-be_define_const_str(file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20or_X20_X27_X2Ebec_X27, "file extension is not '.be' or '.bec'", 3095719639u, 0, 37, &be_const_str_has_X20already_X20an_X20event_X20callback);
-be_define_const_str(files, "files", 1055342736u, 0, 5, &be_const_str_web_add_management_button);
+be_define_const_str(file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20or_X20_X27_X2Ebec_X27, "file extension is not '.be' or '.bec'", 3095719639u, 0, 37, &be_const_str_offset);
+be_define_const_str(files, "files", 1055342736u, 0, 5, &be_const_str_push);
 be_define_const_str(find, "find", 3186656602u, 0, 4, NULL);
-be_define_const_str(find_key_i, "find_key_i", 850136726u, 0, 10, &be_const_str_insert);
+be_define_const_str(find_key_i, "find_key_i", 850136726u, 0, 10, &be_const_str_rule);
 be_define_const_str(find_op, "find_op", 3766713376u, 0, 7, NULL);
-be_define_const_str(finish, "finish", 1494643858u, 0, 6, &be_const_str_top);
+be_define_const_str(finish, "finish", 1494643858u, 0, 6, &be_const_str_get_object_from_ptr);
 be_define_const_str(floor, "floor", 3102149661u, 0, 5, NULL);
-be_define_const_str(flush, "flush", 3002334877u, 0, 5, NULL);
-be_define_const_str(font_montserrat, "font_montserrat", 3790091262u, 0, 15, &be_const_str_write8);
-be_define_const_str(font_seg7, "font_seg7", 1551771835u, 0, 9, &be_const_str_v);
+be_define_const_str(flush, "flush", 3002334877u, 0, 5, &be_const_str_lv_wifi_bars_icon);
+be_define_const_str(font_montserrat, "font_montserrat", 3790091262u, 0, 15, &be_const_str_lv_event);
+be_define_const_str(font_seg7, "font_seg7", 1551771835u, 0, 9, &be_const_str_set_bits_per_sample);
 be_define_const_str(for, "for", 2901640080u, 54, 3, NULL);
-be_define_const_str(format, "format", 3114108242u, 0, 6, &be_const_str_setrange);
+be_define_const_str(format, "format", 3114108242u, 0, 6, &be_const_str_tcpclient);
 be_define_const_str(from_to, "from_to", 21625507u, 0, 7, NULL);
-be_define_const_str(fromb64, "fromb64", 2717019639u, 0, 7, NULL);
-be_define_const_str(fromptr, "fromptr", 666189689u, 0, 7, NULL);
-be_define_const_str(fromstring, "fromstring", 610302344u, 0, 10, NULL);
-be_define_const_str(function, "function", 2664841801u, 0, 8, &be_const_str_member);
-be_define_const_str(gamma, "gamma", 3492353034u, 0, 5, NULL);
+be_define_const_str(fromb64, "fromb64", 2717019639u, 0, 7, &be_const_str_wire2);
+be_define_const_str(fromptr, "fromptr", 666189689u, 0, 7, &be_const_str_is_dirty);
+be_define_const_str(fromstring, "fromstring", 610302344u, 0, 10, &be_const_str_url_encode);
+be_define_const_str(function, "function", 2664841801u, 0, 8, NULL);
+be_define_const_str(gamma, "gamma", 3492353034u, 0, 5, &be_const_str_get_bri);
 be_define_const_str(gamma10, "gamma10", 3472052483u, 0, 7, NULL);
-be_define_const_str(gamma8, "gamma8", 3802843830u, 0, 6, &be_const_str_nil);
-be_define_const_str(gc, "gc", 1042313471u, 0, 2, &be_const_str_stop_iteration);
-be_define_const_str(gen_cb, "gen_cb", 3245227551u, 0, 6, &be_const_str_page_autoconf_mgr);
-be_define_const_str(get, "get", 1410115415u, 0, 3, NULL);
-be_define_const_str(get_alternate, "get_alternate", 1450148894u, 0, 13, &be_const_str_wifi_arcs);
+be_define_const_str(gamma8, "gamma8", 3802843830u, 0, 6, NULL);
+be_define_const_str(gc, "gc", 1042313471u, 0, 2, &be_const_str_widget_cb);
+be_define_const_str(gen_cb, "gen_cb", 3245227551u, 0, 6, &be_const_str_isrunning);
+be_define_const_str(get, "get", 1410115415u, 0, 3, &be_const_str_get_light);
+be_define_const_str(get_alternate, "get_alternate", 1450148894u, 0, 13, &be_const_str_tr);
 be_define_const_str(get_aps_voltage, "get_aps_voltage", 2293036435u, 0, 15, NULL);
-be_define_const_str(get_bat_charge_current, "get_bat_charge_current", 1385293050u, 0, 22, &be_const_str_introspect);
-be_define_const_str(get_bat_current, "get_bat_current", 1912106073u, 0, 15, &be_const_str_rule);
-be_define_const_str(get_bat_power, "get_bat_power", 3067374853u, 0, 13, &be_const_str_tcpclient);
-be_define_const_str(get_bat_voltage, "get_bat_voltage", 706676538u, 0, 15, &be_const_str_invalidate);
-be_define_const_str(get_battery_chargin_status, "get_battery_chargin_status", 2233241571u, 0, 26, &be_const_str_get_vbus_voltage);
-be_define_const_str(get_bri, "get_bri", 2041809895u, 0, 7, &be_const_str_math);
-be_define_const_str(get_cb_list, "get_cb_list", 1605319182u, 0, 11, &be_const_str_reapply);
-be_define_const_str(get_coords, "get_coords", 1044089006u, 0, 10, &be_const_str_get_temp);
-be_define_const_str(get_current_module_name, "get_current_module_name", 2379270740u, 0, 23, &be_const_str_public_key);
-be_define_const_str(get_current_module_path, "get_current_module_path", 3206673408u, 0, 23, &be_const_str_web_add_button);
-be_define_const_str(get_free_heap, "get_free_heap", 625069757u, 0, 13, &be_const_str_tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29);
-be_define_const_str(get_height, "get_height", 3571755523u, 0, 10, NULL);
+be_define_const_str(get_bat_charge_current, "get_bat_charge_current", 1385293050u, 0, 22, &be_const_str_super);
+be_define_const_str(get_bat_current, "get_bat_current", 1912106073u, 0, 15, &be_const_str_nil);
+be_define_const_str(get_bat_power, "get_bat_power", 3067374853u, 0, 13, &be_const_str_wifi);
+be_define_const_str(get_bat_voltage, "get_bat_voltage", 706676538u, 0, 15, NULL);
+be_define_const_str(get_battery_chargin_status, "get_battery_chargin_status", 2233241571u, 0, 26, &be_const_str_top);
+be_define_const_str(get_bri, "get_bri", 2041809895u, 0, 7, &be_const_str_get_style_pad_right);
+be_define_const_str(get_cb_list, "get_cb_list", 1605319182u, 0, 11, &be_const_str_matrix);
+be_define_const_str(get_coords, "get_coords", 1044089006u, 0, 10, &be_const_str_get_warning_level);
+be_define_const_str(get_current_module_name, "get_current_module_name", 2379270740u, 0, 23, &be_const_str_read12);
+be_define_const_str(get_current_module_path, "get_current_module_path", 3206673408u, 0, 23, &be_const_str_get_style_line_color);
+be_define_const_str(get_free_heap, "get_free_heap", 625069757u, 0, 13, &be_const_str_ip);
+be_define_const_str(get_height, "get_height", 3571755523u, 0, 10, &be_const_str_get_option);
 be_define_const_str(get_input_power_status, "get_input_power_status", 4102829177u, 0, 22, NULL);
-be_define_const_str(get_light, "get_light", 381930476u, 0, 9, &be_const_str_run_deferred);
-be_define_const_str(get_object_from_ptr, "get_object_from_ptr", 2345019201u, 0, 19, &be_const_str_get_style_bg_color);
-be_define_const_str(get_option, "get_option", 2123730033u, 0, 10, NULL);
-be_define_const_str(get_percentage, "get_percentage", 2880483992u, 0, 14, &be_const_str_int);
-be_define_const_str(get_pixel_color, "get_pixel_color", 337490048u, 0, 15, &be_const_str_pop_path);
-be_define_const_str(get_power, "get_power", 3009799377u, 0, 9, NULL);
-be_define_const_str(get_size, "get_size", 2803644713u, 0, 8, &be_const_str_obj_event_base);
-be_define_const_str(get_string, "get_string", 4195847969u, 0, 10, &be_const_str_the_X20second_X20argument_X20is_X20not_X20a_X20function);
-be_define_const_str(get_style_bg_color, "get_style_bg_color", 964794381u, 0, 18, &be_const_str_get_warning_level);
-be_define_const_str(get_style_line_color, "get_style_line_color", 805371932u, 0, 20, &be_const_str_pi);
-be_define_const_str(get_style_pad_right, "get_style_pad_right", 3150287466u, 0, 19, &be_const_str_else);
+be_define_const_str(get_light, "get_light", 381930476u, 0, 9, NULL);
+be_define_const_str(get_object_from_ptr, "get_object_from_ptr", 2345019201u, 0, 19, NULL);
+be_define_const_str(get_option, "get_option", 2123730033u, 0, 10, &be_const_str_write8);
+be_define_const_str(get_percentage, "get_percentage", 2880483992u, 0, 14, &be_const_str_json_fdump);
+be_define_const_str(get_pixel_color, "get_pixel_color", 337490048u, 0, 15, NULL);
+be_define_const_str(get_power, "get_power", 3009799377u, 0, 9, &be_const_str_set_gain);
+be_define_const_str(get_size, "get_size", 2803644713u, 0, 8, &be_const_str_set_channels);
+be_define_const_str(get_string, "get_string", 4195847969u, 0, 10, NULL);
+be_define_const_str(get_style_bg_color, "get_style_bg_color", 964794381u, 0, 18, NULL);
+be_define_const_str(get_style_line_color, "get_style_line_color", 805371932u, 0, 20, NULL);
+be_define_const_str(get_style_pad_right, "get_style_pad_right", 3150287466u, 0, 19, NULL);
 be_define_const_str(get_switch, "get_switch", 164821028u, 0, 10, NULL);
-be_define_const_str(get_temp, "get_temp", 3370919486u, 0, 8, NULL);
+be_define_const_str(get_temp, "get_temp", 3370919486u, 0, 8, &be_const_str_lv);
 be_define_const_str(get_vbus_current, "get_vbus_current", 1205347942u, 0, 16, NULL);
-be_define_const_str(get_vbus_voltage, "get_vbus_voltage", 2398210401u, 0, 16, NULL);
-be_define_const_str(get_warning_level, "get_warning_level", 1737834441u, 0, 17, &be_const_str_true);
-be_define_const_str(get_width, "get_width", 3293417300u, 0, 9, &be_const_str_quality);
-be_define_const_str(getbits, "getbits", 3094168979u, 0, 7, &be_const_str_set_bri);
-be_define_const_str(geti, "geti", 2381006490u, 0, 4, &be_const_str_log10);
-be_define_const_str(global, "global", 503252654u, 0, 6, &be_const_str_udp);
-be_define_const_str(gpio, "gpio", 2638155258u, 0, 4, &be_const_str_no_X20GPIO_X20specified_X20for_X20neopixelbus);
-be_define_const_str(group_def, "group_def", 1524213328u, 0, 9, NULL);
-be_define_const_str(h, "h", 3977000791u, 0, 1, NULL);
-be_define_const_str(has, "has", 3988721635u, 0, 3, &be_const_str_lv_module_init);
-be_define_const_str(has_X20already_X20an_X20event_X20callback, "has already an event callback", 2421565249u, 0, 29, NULL);
-be_define_const_str(has_arg, "has_arg", 424878688u, 0, 7, &be_const_str_rad);
+be_define_const_str(get_vbus_voltage, "get_vbus_voltage", 2398210401u, 0, 16, &be_const_str_zip);
+be_define_const_str(get_warning_level, "get_warning_level", 1737834441u, 0, 17, NULL);
+be_define_const_str(get_width, "get_width", 3293417300u, 0, 9, &be_const_str_gpio);
+be_define_const_str(getbits, "getbits", 3094168979u, 0, 7, &be_const_str_id);
+be_define_const_str(geti, "geti", 2381006490u, 0, 4, &be_const_str_width_def);
+be_define_const_str(global, "global", 503252654u, 0, 6, &be_const_str_ismethod);
+be_define_const_str(gpio, "gpio", 2638155258u, 0, 4, &be_const_str_insert);
+be_define_const_str(group_def, "group_def", 1524213328u, 0, 9, &be_const_str_web_add_button);
+be_define_const_str(h, "h", 3977000791u, 0, 1, &be_const_str_p2);
+be_define_const_str(has, "has", 3988721635u, 0, 3, &be_const_str_math);
+be_define_const_str(has_X20already_X20an_X20event_X20callback, "has already an event callback", 2421565249u, 0, 29, &be_const_str_yield);
+be_define_const_str(has_arg, "has_arg", 424878688u, 0, 7, &be_const_str_try_rule);
 be_define_const_str(height_def, "height_def", 2348238838u, 0, 10, NULL);
-be_define_const_str(hex, "hex", 4273249610u, 0, 3, &be_const_str_lv_solidified);
-be_define_const_str(hour, "hour", 3053661199u, 0, 4, &be_const_str_traceback);
+be_define_const_str(hex, "hex", 4273249610u, 0, 3, &be_const_str_load_templates);
+be_define_const_str(hour, "hour", 3053661199u, 0, 4, &be_const_str_write_bytes);
 be_define_const_str(hs2rgb, "hs2rgb", 1040816349u, 0, 6, NULL);
-be_define_const_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf, "https://raw.githubusercontent.com/tasmota/autoconf/main/%s/%s.autoconf", 2743526309u, 0, 70, &be_const_str_lv_wifi_arcs_icon);
-be_define_const_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson, "https://raw.githubusercontent.com/tasmota/autoconf/main/%s_manifest.json", 3657552045u, 0, 72, &be_const_str_web_add_config_button);
-be_define_const_str(i2c_enabled, "i2c_enabled", 218388101u, 0, 11, NULL);
+be_define_const_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf, "https://raw.githubusercontent.com/tasmota/autoconf/main/%s/%s.autoconf", 2743526309u, 0, 70, NULL);
+be_define_const_str(https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_manifest_X2Ejson, "https://raw.githubusercontent.com/tasmota/autoconf/main/%s_manifest.json", 3657552045u, 0, 72, NULL);
+be_define_const_str(i2c_enabled, "i2c_enabled", 218388101u, 0, 11, &be_const_str_set_style_bg_color);
 be_define_const_str(id, "id", 926444256u, 0, 2, NULL);
 be_define_const_str(if, "if", 959999494u, 50, 2, NULL);
-be_define_const_str(imax, "imax", 3084515410u, 0, 4, &be_const_str_read32);
-be_define_const_str(imin, "imin", 2714127864u, 0, 4, &be_const_str_members);
+be_define_const_str(imax, "imax", 3084515410u, 0, 4, &be_const_str_minute);
+be_define_const_str(imin, "imin", 2714127864u, 0, 4, NULL);
 be_define_const_str(import, "import", 288002260u, 66, 6, NULL);
-be_define_const_str(init, "init", 380752755u, 0, 4, &be_const_str_raise);
-be_define_const_str(init_draw_line_dsc, "init_draw_line_dsc", 2507936040u, 0, 18, &be_const_str_widget_ctor_cb);
-be_define_const_str(input, "input", 4191711099u, 0, 5, &be_const_str_read);
-be_define_const_str(ins_goto, "ins_goto", 1342843963u, 0, 8, NULL);
-be_define_const_str(ins_ramp, "ins_ramp", 1068049360u, 0, 8, &be_const_str_break);
-be_define_const_str(ins_time, "ins_time", 2980245553u, 0, 8, NULL);
-be_define_const_str(insert, "insert", 3332609576u, 0, 6, &be_const_str_lv_event_cb);
+be_define_const_str(init, "init", 380752755u, 0, 4, &be_const_str_push_path);
+be_define_const_str(init_draw_line_dsc, "init_draw_line_dsc", 2507936040u, 0, 18, &be_const_str_import);
+be_define_const_str(input, "input", 4191711099u, 0, 5, NULL);
+be_define_const_str(ins_goto, "ins_goto", 1342843963u, 0, 8, &be_const_str_is_running);
+be_define_const_str(ins_ramp, "ins_ramp", 1068049360u, 0, 8, NULL);
+be_define_const_str(ins_time, "ins_time", 2980245553u, 0, 8, &be_const_str_montserrat_font);
+be_define_const_str(insert, "insert", 3332609576u, 0, 6, &be_const_str__X7D);
 be_define_const_str(instance, "instance", 193386898u, 0, 8, NULL);
-be_define_const_str(instance_X20required, "instance required", 381192159u, 0, 17, NULL);
-be_define_const_str(instance_size, "instance_size", 4280269518u, 0, 13, &be_const_str_value);
+be_define_const_str(instance_X20required, "instance required", 381192159u, 0, 17, &be_const_str_pixels_buffer);
+be_define_const_str(instance_size, "instance_size", 4280269518u, 0, 13, NULL);
 be_define_const_str(int, "int", 2515107422u, 0, 3, NULL);
-be_define_const_str(internal_error, "internal_error", 2519158169u, 0, 14, NULL);
-be_define_const_str(introspect, "introspect", 164638290u, 0, 10, &be_const_str_k);
-be_define_const_str(invalidate, "invalidate", 2649734928u, 0, 10, NULL);
-be_define_const_str(io_error, "io_error", 1970281036u, 0, 8, &be_const_str_rtc);
-be_define_const_str(ip, "ip", 1261996636u, 0, 2, &be_const_str_readbytes);
-be_define_const_str(is_dirty, "is_dirty", 418034110u, 0, 8, &be_const_str_wire_scan);
-be_define_const_str(is_first_time, "is_first_time", 275242384u, 0, 13, NULL);
-be_define_const_str(is_running, "is_running", 2226847261u, 0, 10, &be_const_str_reverse);
-be_define_const_str(isinstance, "isinstance", 3669352738u, 0, 10, &be_const_str_wire2);
-be_define_const_str(ismethod, "ismethod", 3513438880u, 0, 8, NULL);
-be_define_const_str(isnan, "isnan", 2981347434u, 0, 5, &be_const_str_wifi_arcs_icon);
-be_define_const_str(isrunning, "isrunning", 1688182268u, 0, 9, &be_const_str_length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032);
-be_define_const_str(issubclass, "issubclass", 4078395519u, 0, 10, &be_const_str_loop);
-be_define_const_str(item, "item", 2671260646u, 0, 4, &be_const_str_settings);
+be_define_const_str(internal_error, "internal_error", 2519158169u, 0, 14, &be_const_str_leds);
+be_define_const_str(introspect, "introspect", 164638290u, 0, 10, &be_const_str_set_ldo_voltage);
+be_define_const_str(invalidate, "invalidate", 2649734928u, 0, 10, &be_const_str_if);
+be_define_const_str(io_error, "io_error", 1970281036u, 0, 8, &be_const_str_line_dsc);
+be_define_const_str(ip, "ip", 1261996636u, 0, 2, &be_const_str_signal_bars);
+be_define_const_str(is_dirty, "is_dirty", 418034110u, 0, 8, &be_const_str_remote_port);
+be_define_const_str(is_first_time, "is_first_time", 275242384u, 0, 13, &be_const_str_web_add_config_button);
+be_define_const_str(is_running, "is_running", 2226847261u, 0, 10, &be_const_str__X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D);
+be_define_const_str(isinstance, "isinstance", 3669352738u, 0, 10, &be_const_str_onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E);
+be_define_const_str(ismethod, "ismethod", 3513438880u, 0, 8, &be_const_str_make_cb);
+be_define_const_str(isnan, "isnan", 2981347434u, 0, 5, &be_const_str_send);
+be_define_const_str(isrunning, "isrunning", 1688182268u, 0, 9, &be_const_str_resp_cmnd_failed);
+be_define_const_str(issubclass, "issubclass", 4078395519u, 0, 10, NULL);
+be_define_const_str(item, "item", 2671260646u, 0, 4, &be_const_str_widget_event_impl);
 be_define_const_str(iter, "iter", 3124256359u, 0, 4, NULL);
 be_define_const_str(json, "json", 916562499u, 0, 4, NULL);
-be_define_const_str(json_append, "json_append", 3002019284u, 0, 11, NULL);
+be_define_const_str(json_append, "json_append", 3002019284u, 0, 11, &be_const_str_to_gamma);
 be_define_const_str(json_fdump, "json_fdump", 1694216580u, 0, 10, NULL);
 be_define_const_str(json_fdump_any, "json_fdump_any", 3348629385u, 0, 14, NULL);
-be_define_const_str(json_fdump_list, "json_fdump_list", 3903879853u, 0, 15, &be_const_str_lv_wifi_arcs);
-be_define_const_str(json_fdump_map, "json_fdump_map", 4091954653u, 0, 14, &be_const_str_load_templates);
-be_define_const_str(k, "k", 3993778410u, 0, 1, &be_const_str_read12);
-be_define_const_str(keys, "keys", 4182378701u, 0, 4, NULL);
-be_define_const_str(kv, "kv", 1497177492u, 0, 2, &be_const_str_reverse_gamma10);
-be_define_const_str(last_modified, "last_modified", 772177145u, 0, 13, &be_const_str_min);
-be_define_const_str(leds, "leds", 558858555u, 0, 4, &be_const_str_url_encode);
-be_define_const_str(length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032, "length in bits must be between 0 and 32", 2584509128u, 0, 39, &be_const_str_lv_point_arr);
-be_define_const_str(light, "light", 3801947695u, 0, 5, &be_const_str_tostring);
-be_define_const_str(line_dsc, "line_dsc", 4094490978u, 0, 8, &be_const_str_sec);
+be_define_const_str(json_fdump_list, "json_fdump_list", 3903879853u, 0, 15, NULL);
+be_define_const_str(json_fdump_map, "json_fdump_map", 4091954653u, 0, 14, &be_const_str_redirect);
+be_define_const_str(k, "k", 3993778410u, 0, 1, &be_const_str_lv_solidified);
+be_define_const_str(keys, "keys", 4182378701u, 0, 4, &be_const_str_no_X20GPIO_X20specified_X20for_X20neopixelbus);
+be_define_const_str(kv, "kv", 1497177492u, 0, 2, &be_const_str_resp_cmnd_done);
+be_define_const_str(last_modified, "last_modified", 772177145u, 0, 13, NULL);
+be_define_const_str(leds, "leds", 558858555u, 0, 4, NULL);
+be_define_const_str(length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032, "length in bits must be between 0 and 32", 2584509128u, 0, 39, &be_const_str_members);
+be_define_const_str(light, "light", 3801947695u, 0, 5, NULL);
+be_define_const_str(line_dsc, "line_dsc", 4094490978u, 0, 8, &be_const_str_set_style_pad_right);
 be_define_const_str(list, "list", 217798785u, 0, 4, NULL);
-be_define_const_str(list_handlers, "list_handlers", 593774371u, 0, 13, &be_const_str_widget_event_impl);
-be_define_const_str(listdir, "listdir", 2005220720u, 0, 7, NULL);
-be_define_const_str(load, "load", 3859241449u, 0, 4, &be_const_str_lv_obj);
+be_define_const_str(list_handlers, "list_handlers", 593774371u, 0, 13, &be_const_str_number);
+be_define_const_str(listdir, "listdir", 2005220720u, 0, 7, &be_const_str_sin);
+be_define_const_str(load, "load", 3859241449u, 0, 4, &be_const_str_round_end);
 be_define_const_str(load_freetype_font, "load_freetype_font", 2368447592u, 0, 18, NULL);
-be_define_const_str(load_templates, "load_templates", 3513870133u, 0, 14, &be_const_str_resp_cmnd_error);
+be_define_const_str(load_templates, "load_templates", 3513870133u, 0, 14, &be_const_str_rad);
 be_define_const_str(local, "local", 2621662984u, 0, 5, NULL);
-be_define_const_str(log, "log", 1062293841u, 0, 3, &be_const_str_set_ldo_enable);
-be_define_const_str(log10, "log10", 2346846000u, 0, 5, &be_const_str__X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D);
-be_define_const_str(loop, "loop", 3723446379u, 0, 4, &be_const_str_seg7_font);
-be_define_const_str(lower, "lower", 3038577850u, 0, 5, &be_const_str_lv_point);
-be_define_const_str(lv, "lv", 1529997255u, 0, 2, NULL);
+be_define_const_str(log, "log", 1062293841u, 0, 3, &be_const_str_pixel_count);
+be_define_const_str(log10, "log10", 2346846000u, 0, 5, NULL);
+be_define_const_str(loop, "loop", 3723446379u, 0, 4, NULL);
+be_define_const_str(lower, "lower", 3038577850u, 0, 5, &be_const_str_return_X20code_X3D_X25i);
+be_define_const_str(lv, "lv", 1529997255u, 0, 2, &be_const_str_resolvecmnd);
 be_define_const_str(lv_, "lv_", 663721032u, 0, 3, NULL);
-be_define_const_str(lv_clock_icon, "lv_clock_icon", 3257216210u, 0, 13, &be_const_str_nan);
-be_define_const_str(lv_coord_arr, "lv_coord_arr", 1197238601u, 0, 12, NULL);
-be_define_const_str(lv_event, "lv_event", 2434089968u, 0, 8, &be_const_str_remove_rule);
-be_define_const_str(lv_event_cb, "lv_event_cb", 2480731016u, 0, 11, NULL);
+be_define_const_str(lv_clock_icon, "lv_clock_icon", 3257216210u, 0, 13, &be_const_str_set_percentage);
+be_define_const_str(lv_coord_arr, "lv_coord_arr", 1197238601u, 0, 12, &be_const_str_publish);
+be_define_const_str(lv_event, "lv_event", 2434089968u, 0, 8, &be_const_str_start);
+be_define_const_str(lv_event_cb, "lv_event_cb", 2480731016u, 0, 11, &be_const_str_onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E);
 be_define_const_str(lv_extra, "lv_extra", 399561998u, 0, 8, NULL);
-be_define_const_str(lv_module_init, "lv_module_init", 1133027755u, 0, 14, NULL);
+be_define_const_str(lv_module_init, "lv_module_init", 1133027755u, 0, 14, &be_const_str_y);
 be_define_const_str(lv_obj, "lv_obj", 4257833149u, 0, 6, NULL);
-be_define_const_str(lv_obj_class, "lv_obj_class", 4039656294u, 0, 12, NULL);
-be_define_const_str(lv_point, "lv_point", 4120221790u, 0, 8, NULL);
-be_define_const_str(lv_point_arr, "lv_point_arr", 3959768858u, 0, 12, NULL);
-be_define_const_str(lv_signal_arcs, "lv_signal_arcs", 2839156988u, 0, 14, NULL);
-be_define_const_str(lv_signal_bars, "lv_signal_bars", 3513972559u, 0, 14, NULL);
-be_define_const_str(lv_solidified, "lv_solidified", 2274121310u, 0, 13, &be_const_str_set_channels);
-be_define_const_str(lv_wifi_arcs, "lv_wifi_arcs", 2082091963u, 0, 12, &be_const_str_read13);
-be_define_const_str(lv_wifi_arcs_icon, "lv_wifi_arcs_icon", 1507982909u, 0, 17, &be_const_str_offseta);
-be_define_const_str(lv_wifi_bars, "lv_wifi_bars", 2109539196u, 0, 12, &be_const_str_webclient);
-be_define_const_str(lv_wifi_bars_icon, "lv_wifi_bars_icon", 2805815540u, 0, 17, &be_const_str_null_cb);
-be_define_const_str(lvgl_event_dispatch, "lvgl_event_dispatch", 2104396622u, 0, 19, NULL);
+be_define_const_str(lv_obj_class, "lv_obj_class", 4039656294u, 0, 12, &be_const_str_widget_event);
+be_define_const_str(lv_point, "lv_point", 4120221790u, 0, 8, &be_const_str_r);
+be_define_const_str(lv_point_arr, "lv_point_arr", 3959768858u, 0, 12, &be_const_str_persist);
+be_define_const_str(lv_signal_arcs, "lv_signal_arcs", 2839156988u, 0, 14, &be_const_str_millis);
+be_define_const_str(lv_signal_bars, "lv_signal_bars", 3513972559u, 0, 14, &be_const_str_widget_width_def);
+be_define_const_str(lv_solidified, "lv_solidified", 2274121310u, 0, 13, &be_const_str_p1);
+be_define_const_str(lv_wifi_arcs, "lv_wifi_arcs", 2082091963u, 0, 12, NULL);
+be_define_const_str(lv_wifi_arcs_icon, "lv_wifi_arcs_icon", 1507982909u, 0, 17, NULL);
+be_define_const_str(lv_wifi_bars, "lv_wifi_bars", 2109539196u, 0, 12, &be_const_str_set_light);
+be_define_const_str(lv_wifi_bars_icon, "lv_wifi_bars_icon", 2805815540u, 0, 17, &be_const_str_resize);
+be_define_const_str(lvgl_event_dispatch, "lvgl_event_dispatch", 2104396622u, 0, 19, &be_const_str_remove_driver);
 be_define_const_str(make_cb, "make_cb", 71252785u, 0, 7, NULL);
-be_define_const_str(map, "map", 3751997361u, 0, 3, NULL);
-be_define_const_str(math, "math", 4001929615u, 0, 4, NULL);
+be_define_const_str(map, "map", 3751997361u, 0, 3, &be_const_str_zero);
+be_define_const_str(math, "math", 4001929615u, 0, 4, &be_const_str_time_str);
 be_define_const_str(matrix, "matrix", 365099244u, 0, 6, NULL);
 be_define_const_str(member, "member", 719708611u, 0, 6, NULL);
-be_define_const_str(members, "members", 937576464u, 0, 7, NULL);
-be_define_const_str(memory, "memory", 2229924270u, 0, 6, &be_const_str_running);
-be_define_const_str(millis, "millis", 1214679063u, 0, 6, &be_const_str_read_bytes);
-be_define_const_str(min, "min", 3381609815u, 0, 3, &be_const_str_widget_cb);
-be_define_const_str(minute, "minute", 954666857u, 0, 6, &be_const_str_time_dump);
-be_define_const_str(module, "module", 3617558685u, 0, 6, &be_const_str_x);
-be_define_const_str(month, "month", 3598321157u, 0, 5, &be_const_str_out_X20of_X20range);
-be_define_const_str(montserrat_font, "montserrat_font", 1819065874u, 0, 15, &be_const_str_round_start);
-be_define_const_str(name, "name", 2369371622u, 0, 4, &be_const_str_web_add_handler);
-be_define_const_str(nan, "nan", 797905850u, 0, 3, NULL);
+be_define_const_str(members, "members", 937576464u, 0, 7, &be_const_str_public_key);
+be_define_const_str(memory, "memory", 2229924270u, 0, 6, &be_const_str_as);
+be_define_const_str(millis, "millis", 1214679063u, 0, 6, &be_const_str_setitem);
+be_define_const_str(min, "min", 3381609815u, 0, 3, NULL);
+be_define_const_str(minute, "minute", 954666857u, 0, 6, NULL);
+be_define_const_str(module, "module", 3617558685u, 0, 6, &be_const_str_set_timeouts);
+be_define_const_str(month, "month", 3598321157u, 0, 5, &be_const_str_pin);
+be_define_const_str(montserrat_font, "montserrat_font", 1819065874u, 0, 15, NULL);
+be_define_const_str(name, "name", 2369371622u, 0, 4, &be_const_str_set_auth);
+be_define_const_str(nan, "nan", 797905850u, 0, 3, &be_const_str_wifi_bars_icon);
 be_define_const_str(nil, "nil", 228849900u, 63, 3, NULL);
-be_define_const_str(no_X20GPIO_X20specified_X20for_X20neopixelbus, "no GPIO specified for neopixelbus", 42078528u, 0, 33, NULL);
-be_define_const_str(null_cb, "null_cb", 2333536460u, 0, 7, &be_const_str_set_first_time);
-be_define_const_str(number, "number", 467038368u, 0, 6, &be_const_str_offset);
-be_define_const_str(obj_class_create_obj, "obj_class_create_obj", 3304390632u, 0, 20, &be_const_str_tanh);
+be_define_const_str(no_X20GPIO_X20specified_X20for_X20neopixelbus, "no GPIO specified for neopixelbus", 42078528u, 0, 33, &be_const_str_quality);
+be_define_const_str(null_cb, "null_cb", 2333536460u, 0, 7, &be_const_str_publish_result);
+be_define_const_str(number, "number", 467038368u, 0, 6, NULL);
+be_define_const_str(obj_class_create_obj, "obj_class_create_obj", 3304390632u, 0, 20, NULL);
 be_define_const_str(obj_event_base, "obj_event_base", 1624064363u, 0, 14, NULL);
 be_define_const_str(offset, "offset", 348705738u, 0, 6, NULL);
-be_define_const_str(offseta, "offseta", 1663383089u, 0, 7, &be_const_str_set_style_bg_color);
-be_define_const_str(on, "on", 1630810064u, 0, 2, NULL);
-be_define_const_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E, "onsubmit='return confirm(\"This will cause a restart.\");'>", 232646018u, 0, 57, &be_const_str_refr_size);
-be_define_const_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E, "onsubmit='return confirm(\"This will change the current configuration and cause a restart.\");'>", 3792412559u, 0, 94, NULL);
+be_define_const_str(offseta, "offseta", 1663383089u, 0, 7, &be_const_str_save_before_restart);
+be_define_const_str(on, "on", 1630810064u, 0, 2, &be_const_str_run_bat);
+be_define_const_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E, "onsubmit='return confirm(\"This will cause a restart.\");'>", 232646018u, 0, 57, NULL);
+be_define_const_str(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E, "onsubmit='return confirm(\"This will change the current configuration and cause a restart.\");'>", 3792412559u, 0, 94, &be_const_str_value);
 be_define_const_str(open, "open", 3546203337u, 0, 4, NULL);
 be_define_const_str(out_X20of_X20range, "out of range", 2236631477u, 0, 12, NULL);
 be_define_const_str(p1, "p1", 2689521274u, 0, 2, NULL);
-be_define_const_str(p2, "p2", 2672743655u, 0, 2, &be_const_str_widget_group_def);
-be_define_const_str(page_autoconf_ctl, "page_autoconf_ctl", 2453381496u, 0, 17, &be_const_str_resp_cmnd);
-be_define_const_str(page_autoconf_mgr, "page_autoconf_mgr", 3643937031u, 0, 17, &be_const_str_r);
-be_define_const_str(param, "param", 1309554226u, 0, 5, &be_const_str_show);
-be_define_const_str(path, "path", 2223459638u, 0, 4, NULL);
+be_define_const_str(p2, "p2", 2672743655u, 0, 2, NULL);
+be_define_const_str(page_autoconf_ctl, "page_autoconf_ctl", 2453381496u, 0, 17, NULL);
+be_define_const_str(page_autoconf_mgr, "page_autoconf_mgr", 3643937031u, 0, 17, NULL);
+be_define_const_str(param, "param", 1309554226u, 0, 5, &be_const_str_time_dump);
+be_define_const_str(path, "path", 2223459638u, 0, 4, &be_const_str_register_button_encoder);
 be_define_const_str(pc, "pc", 1313756516u, 0, 2, NULL);
-be_define_const_str(pc_abs, "pc_abs", 920256495u, 0, 6, &be_const_str_resp_cmnd_done);
-be_define_const_str(pc_rel, "pc_rel", 991921176u, 0, 6, NULL);
+be_define_const_str(pc_abs, "pc_abs", 920256495u, 0, 6, &be_const_str_read_bytes);
+be_define_const_str(pc_rel, "pc_rel", 991921176u, 0, 6, &be_const_str_end);
 be_define_const_str(percentage, "percentage", 2538831285u, 0, 10, NULL);
-be_define_const_str(persist, "persist", 3917083779u, 0, 7, &be_const_str_set_height);
+be_define_const_str(persist, "persist", 3917083779u, 0, 7, NULL);
 be_define_const_str(persist_X2E_p_X20is_X20not_X20a_X20map, "persist._p is not a map", 1176528732u, 0, 23, NULL);
-be_define_const_str(pi, "pi", 1213090802u, 0, 2, &be_const_str_run);
-be_define_const_str(pin, "pin", 1866532500u, 0, 3, &be_const_str_resp_cmnd_str);
+be_define_const_str(pi, "pi", 1213090802u, 0, 2, NULL);
+be_define_const_str(pin, "pin", 1866532500u, 0, 3, &be_const_str_widget_ctor_impl);
 be_define_const_str(pin_mode, "pin_mode", 3258314030u, 0, 8, NULL);
-be_define_const_str(pin_used, "pin_used", 4033854612u, 0, 8, NULL);
-be_define_const_str(pixel_count, "pixel_count", 2439130743u, 0, 11, NULL);
-be_define_const_str(pixel_size, "pixel_size", 2209135785u, 0, 10, &be_const_str_resolvecmnd);
-be_define_const_str(pixels_buffer, "pixels_buffer", 1229555807u, 0, 13, &be_const_str_return);
-be_define_const_str(point, "point", 414084241u, 0, 5, &be_const_str_real);
+be_define_const_str(pin_used, "pin_used", 4033854612u, 0, 8, &be_const_str_send_multicast);
+be_define_const_str(pixel_count, "pixel_count", 2439130743u, 0, 11, &be_const_str_tob64);
+be_define_const_str(pixel_size, "pixel_size", 2209135785u, 0, 10, &be_const_str_running);
+be_define_const_str(pixels_buffer, "pixels_buffer", 1229555807u, 0, 13, &be_const_str_readbytes);
+be_define_const_str(point, "point", 414084241u, 0, 5, NULL);
 be_define_const_str(point_arr, "point_arr", 1140859857u, 0, 9, NULL);
-be_define_const_str(pop, "pop", 1362321360u, 0, 3, &be_const_str_set_auth);
-be_define_const_str(pop_path, "pop_path", 2403243998u, 0, 8, NULL);
+be_define_const_str(pop, "pop", 1362321360u, 0, 3, NULL);
+be_define_const_str(pop_path, "pop_path", 2403243998u, 0, 8, &be_const_str_run);
 be_define_const_str(pow, "pow", 1479764693u, 0, 3, NULL);
-be_define_const_str(preinit, "preinit", 2722007100u, 0, 7, NULL);
-be_define_const_str(print, "print", 372738696u, 0, 5, NULL);
-be_define_const_str(public_key, "public_key", 4169142980u, 0, 10, &be_const_str_tob64);
+be_define_const_str(preinit, "preinit", 2722007100u, 0, 7, &be_const_str_web_add_management_button);
+be_define_const_str(print, "print", 372738696u, 0, 5, &be_const_str_set_time);
+be_define_const_str(public_key, "public_key", 4169142980u, 0, 10, &be_const_str_set_height);
 be_define_const_str(publish, "publish", 264247304u, 0, 7, NULL);
-be_define_const_str(publish_result, "publish_result", 2013351252u, 0, 14, &be_const_str_except);
+be_define_const_str(publish_result, "publish_result", 2013351252u, 0, 14, &be_const_str_remove);
 be_define_const_str(push, "push", 2272264157u, 0, 4, NULL);
 be_define_const_str(push_path, "push_path", 1155254157u, 0, 9, NULL);
-be_define_const_str(quality, "quality", 2597670950u, 0, 7, &be_const_str_register_obj);
-be_define_const_str(r, "r", 4144776981u, 0, 1, &be_const_str_response_append);
-be_define_const_str(rad, "rad", 1358899048u, 0, 3, &be_const_str_set_rate);
+be_define_const_str(quality, "quality", 2597670950u, 0, 7, NULL);
+be_define_const_str(r, "r", 4144776981u, 0, 1, &be_const_str_save);
+be_define_const_str(rad, "rad", 1358899048u, 0, 3, &be_const_str_serial);
 be_define_const_str(raise, "raise", 1593437475u, 70, 5, NULL);
 be_define_const_str(rand, "rand", 2711325910u, 0, 4, NULL);
-be_define_const_str(range, "range", 4208725202u, 0, 5, &be_const_str_time_str);
+be_define_const_str(range, "range", 4208725202u, 0, 5, &be_const_str_web_send);
 be_define_const_str(read, "read", 3470762949u, 0, 4, NULL);
-be_define_const_str(read12, "read12", 4291076970u, 0, 6, &be_const_str_widget_dtor_impl);
-be_define_const_str(read13, "read13", 12887293u, 0, 6, &be_const_str_target_search);
+be_define_const_str(read12, "read12", 4291076970u, 0, 6, NULL);
+be_define_const_str(read13, "read13", 12887293u, 0, 6, NULL);
 be_define_const_str(read24, "read24", 1808533811u, 0, 6, NULL);
-be_define_const_str(read32, "read32", 1741276240u, 0, 6, &be_const_str_send_multicast);
-be_define_const_str(read8, "read8", 2802788167u, 0, 5, &be_const_str_remote_port);
-be_define_const_str(read_bytes, "read_bytes", 3576733173u, 0, 10, &be_const_str_type);
-be_define_const_str(read_sensors, "read_sensors", 892689201u, 0, 12, &be_const_str_strftime);
+be_define_const_str(read32, "read32", 1741276240u, 0, 6, NULL);
+be_define_const_str(read8, "read8", 2802788167u, 0, 5, NULL);
+be_define_const_str(read_bytes, "read_bytes", 3576733173u, 0, 10, &be_const_str_time_reached);
+be_define_const_str(read_sensors, "read_sensors", 892689201u, 0, 12, NULL);
 be_define_const_str(readbytes, "readbytes", 2716426756u, 0, 9, NULL);
 be_define_const_str(readline, "readline", 1212709927u, 0, 8, NULL);
 be_define_const_str(real, "real", 3604983901u, 0, 4, NULL);
-be_define_const_str(reapply, "reapply", 3778939332u, 0, 7, &be_const_str_resp_cmnd_failed);
+be_define_const_str(reapply, "reapply", 3778939332u, 0, 7, NULL);
 be_define_const_str(redirect, "redirect", 389758641u, 0, 8, NULL);
-be_define_const_str(refr_size, "refr_size", 1958144468u, 0, 9, &be_const_str_run_bat);
-be_define_const_str(register_button_encoder, "register_button_encoder", 2811301550u, 0, 23, &be_const_str_set_ldo_voltage);
-be_define_const_str(register_obj, "register_obj", 3982614770u, 0, 12, NULL);
-be_define_const_str(remote_ip, "remote_ip", 2953154693u, 0, 9, &be_const_str_srand);
-be_define_const_str(remote_port, "remote_port", 2163585967u, 0, 11, &be_const_str_wifi_bars_icon);
+be_define_const_str(refr_size, "refr_size", 1958144468u, 0, 9, NULL);
+be_define_const_str(register_button_encoder, "register_button_encoder", 2811301550u, 0, 23, NULL);
+be_define_const_str(register_obj, "register_obj", 3982614770u, 0, 12, &be_const_str_setbits);
+be_define_const_str(remote_ip, "remote_ip", 2953154693u, 0, 9, &be_const_str_string);
+be_define_const_str(remote_port, "remote_port", 2163585967u, 0, 11, NULL);
 be_define_const_str(remove, "remove", 3683784189u, 0, 6, NULL);
 be_define_const_str(remove_cmd, "remove_cmd", 3832315702u, 0, 10, NULL);
 be_define_const_str(remove_driver, "remove_driver", 1030243768u, 0, 13, NULL);
-be_define_const_str(remove_rule, "remove_rule", 3456211328u, 0, 11, NULL);
+be_define_const_str(remove_rule, "remove_rule", 3456211328u, 0, 11, &be_const_str_static);
 be_define_const_str(remove_timer, "remove_timer", 4141472215u, 0, 12, NULL);
-be_define_const_str(reset, "reset", 1695364032u, 0, 5, &be_const_str_set_x);
-be_define_const_str(reset_search, "reset_search", 1350414305u, 0, 12, &be_const_str_widget_dtor_cb);
+be_define_const_str(reset, "reset", 1695364032u, 0, 5, NULL);
+be_define_const_str(reset_search, "reset_search", 1350414305u, 0, 12, NULL);
 be_define_const_str(resize, "resize", 3514612129u, 0, 6, NULL);
-be_define_const_str(resolvecmnd, "resolvecmnd", 993361485u, 0, 11, NULL);
-be_define_const_str(resp_cmnd, "resp_cmnd", 2869459626u, 0, 9, NULL);
+be_define_const_str(resolvecmnd, "resolvecmnd", 993361485u, 0, 11, &be_const_str_continue);
+be_define_const_str(resp_cmnd, "resp_cmnd", 2869459626u, 0, 9, &be_const_str_tan);
 be_define_const_str(resp_cmnd_done, "resp_cmnd_done", 2601874875u, 0, 14, NULL);
 be_define_const_str(resp_cmnd_error, "resp_cmnd_error", 2404088863u, 0, 15, NULL);
-be_define_const_str(resp_cmnd_failed, "resp_cmnd_failed", 2136281562u, 0, 16, &be_const_str_rotate);
-be_define_const_str(resp_cmnd_str, "resp_cmnd_str", 737845590u, 0, 13, &be_const_str_state);
-be_define_const_str(response_append, "response_append", 450346371u, 0, 15, &be_const_str_return_X20code_X3D_X25i);
+be_define_const_str(resp_cmnd_failed, "resp_cmnd_failed", 2136281562u, 0, 16, &be_const_str_scale_uint);
+be_define_const_str(resp_cmnd_str, "resp_cmnd_str", 737845590u, 0, 13, NULL);
+be_define_const_str(response_append, "response_append", 450346371u, 0, 15, NULL);
 be_define_const_str(return, "return", 2246981567u, 60, 6, NULL);
 be_define_const_str(return_X20code_X3D_X25i, "return code=%i", 2127454401u, 0, 14, NULL);
-be_define_const_str(reverse, "reverse", 558918661u, 0, 7, &be_const_str_screenshot);
-be_define_const_str(reverse_gamma10, "reverse_gamma10", 739112262u, 0, 15, NULL);
-be_define_const_str(rotate, "rotate", 2784296202u, 0, 6, &be_const_str_widget_width_def);
+be_define_const_str(reverse, "reverse", 558918661u, 0, 7, &be_const_str_set_exten);
+be_define_const_str(reverse_gamma10, "reverse_gamma10", 739112262u, 0, 15, &be_const_str__X7B_X7D);
+be_define_const_str(rotate, "rotate", 2784296202u, 0, 6, &be_const_str_set_useragent);
 be_define_const_str(round_end, "round_end", 985288225u, 0, 9, NULL);
-be_define_const_str(round_start, "round_start", 2949484384u, 0, 11, &be_const_str_widget_event_cb);
-be_define_const_str(rtc, "rtc", 1070575216u, 0, 3, &be_const_str_set_style_line_color);
-be_define_const_str(rule, "rule", 4230889683u, 0, 4, NULL);
-be_define_const_str(run, "run", 718098122u, 0, 3, &be_const_str_do);
+be_define_const_str(round_start, "round_start", 2949484384u, 0, 11, NULL);
+be_define_const_str(rtc, "rtc", 1070575216u, 0, 3, NULL);
+be_define_const_str(rule, "rule", 4230889683u, 0, 4, &be_const_str_set_style_line_color);
+be_define_const_str(run, "run", 718098122u, 0, 3, NULL);
 be_define_const_str(run_bat, "run_bat", 2536903298u, 0, 7, NULL);
 be_define_const_str(run_deferred, "run_deferred", 371594696u, 0, 12, NULL);
 be_define_const_str(running, "running", 343848780u, 0, 7, NULL);
 be_define_const_str(save, "save", 3439296072u, 0, 4, NULL);
-be_define_const_str(save_before_restart, "save_before_restart", 1253239338u, 0, 19, NULL);
-be_define_const_str(scale_uint, "scale_uint", 3090811094u, 0, 10, &be_const_str_write);
-be_define_const_str(scan, "scan", 3974641896u, 0, 4, &be_const_str_set_dc_voltage);
-be_define_const_str(screenshot, "screenshot", 3894592561u, 0, 10, &be_const_str_setmember);
+be_define_const_str(save_before_restart, "save_before_restart", 1253239338u, 0, 19, &be_const_str_var);
+be_define_const_str(scale_uint, "scale_uint", 3090811094u, 0, 10, &be_const_str_stop_iteration);
+be_define_const_str(scan, "scan", 3974641896u, 0, 4, &be_const_str_set_power);
+be_define_const_str(screenshot, "screenshot", 3894592561u, 0, 10, NULL);
 be_define_const_str(search, "search", 2150836393u, 0, 6, NULL);
 be_define_const_str(sec, "sec", 3139892658u, 0, 3, NULL);
 be_define_const_str(seg7_font, "seg7_font", 4099690689u, 0, 9, NULL);
-be_define_const_str(select, "select", 297952813u, 0, 6, NULL);
-be_define_const_str(send, "send", 1919010991u, 0, 4, NULL);
-be_define_const_str(send_multicast, "send_multicast", 812185870u, 0, 14, NULL);
-be_define_const_str(serial, "serial", 3687697785u, 0, 6, NULL);
+be_define_const_str(select, "select", 297952813u, 0, 6, &be_const_str_valuer_error);
+be_define_const_str(send, "send", 1919010991u, 0, 4, &be_const_str_signal_arcs);
+be_define_const_str(send_multicast, "send_multicast", 812185870u, 0, 14, &be_const_str_set_rate);
+be_define_const_str(serial, "serial", 3687697785u, 0, 6, &be_const_str_toptr);
 be_define_const_str(set, "set", 3324446467u, 0, 3, NULL);
-be_define_const_str(set_alternate, "set_alternate", 1709680562u, 0, 13, &be_const_str_set_pwm);
+be_define_const_str(set_alternate, "set_alternate", 1709680562u, 0, 13, NULL);
 be_define_const_str(set_auth, "set_auth", 1057170930u, 0, 8, NULL);
-be_define_const_str(set_bits_per_sample, "set_bits_per_sample", 3747657551u, 0, 19, NULL);
+be_define_const_str(set_bits_per_sample, "set_bits_per_sample", 3747657551u, 0, 19, &be_const_str_write);
 be_define_const_str(set_bri, "set_bri", 2789118779u, 0, 7, NULL);
 be_define_const_str(set_channels, "set_channels", 1370190620u, 0, 12, NULL);
 be_define_const_str(set_chg_current, "set_chg_current", 336304386u, 0, 15, NULL);
 be_define_const_str(set_dc_voltage, "set_dc_voltage", 2181981936u, 0, 14, NULL);
-be_define_const_str(set_dcdc_enable, "set_dcdc_enable", 1594690786u, 0, 15, &be_const_str_widget_event);
+be_define_const_str(set_dcdc_enable, "set_dcdc_enable", 1594690786u, 0, 15, NULL);
 be_define_const_str(set_exten, "set_exten", 1721782768u, 0, 9, NULL);
-be_define_const_str(set_first_time, "set_first_time", 3111247550u, 0, 14, &be_const_str__X7D);
-be_define_const_str(set_gain, "set_gain", 3847781975u, 0, 8, &be_const_str_set_text);
-be_define_const_str(set_height, "set_height", 1080207399u, 0, 10, NULL);
+be_define_const_str(set_first_time, "set_first_time", 3111247550u, 0, 14, NULL);
+be_define_const_str(set_gain, "set_gain", 3847781975u, 0, 8, NULL);
+be_define_const_str(set_height, "set_height", 1080207399u, 0, 10, &be_const_str_udp);
 be_define_const_str(set_ldo_enable, "set_ldo_enable", 2916502041u, 0, 14, NULL);
-be_define_const_str(set_ldo_voltage, "set_ldo_voltage", 4090501160u, 0, 15, &be_const_str_set_width);
-be_define_const_str(set_light, "set_light", 3176076152u, 0, 9, &be_const_str_set_matrix_pixel_color);
-be_define_const_str(set_matrix_pixel_color, "set_matrix_pixel_color", 1197149462u, 0, 22, NULL);
-be_define_const_str(set_percentage, "set_percentage", 2952022724u, 0, 14, &be_const_str_sys);
-be_define_const_str(set_pixel_color, "set_pixel_color", 1275248356u, 0, 15, &be_const_str_tomap);
-be_define_const_str(set_power, "set_power", 549820893u, 0, 9, NULL);
-be_define_const_str(set_pwm, "set_pwm", 3781811012u, 0, 7, NULL);
-be_define_const_str(set_rate, "set_rate", 1154016838u, 0, 8, &be_const_str_web_send);
-be_define_const_str(set_style_bg_color, "set_style_bg_color", 1689513089u, 0, 18, &be_const_str_sqrt);
+be_define_const_str(set_ldo_voltage, "set_ldo_voltage", 4090501160u, 0, 15, NULL);
+be_define_const_str(set_light, "set_light", 3176076152u, 0, 9, &be_const_str_write_gpio);
+be_define_const_str(set_matrix_pixel_color, "set_matrix_pixel_color", 1197149462u, 0, 22, &be_const_str_str);
+be_define_const_str(set_percentage, "set_percentage", 2952022724u, 0, 14, NULL);
+be_define_const_str(set_pixel_color, "set_pixel_color", 1275248356u, 0, 15, NULL);
+be_define_const_str(set_power, "set_power", 549820893u, 0, 9, &be_const_str_widget_ctor_cb);
+be_define_const_str(set_pwm, "set_pwm", 3781811012u, 0, 7, &be_const_str_return);
+be_define_const_str(set_rate, "set_rate", 1154016838u, 0, 8, NULL);
+be_define_const_str(set_style_bg_color, "set_style_bg_color", 1689513089u, 0, 18, NULL);
 be_define_const_str(set_style_line_color, "set_style_line_color", 3665238976u, 0, 20, NULL);
 be_define_const_str(set_style_pad_right, "set_style_pad_right", 3314069054u, 0, 19, NULL);
-be_define_const_str(set_style_text_font, "set_style_text_font", 1028590019u, 0, 19, &be_const_str_tag);
+be_define_const_str(set_style_text_font, "set_style_text_font", 1028590019u, 0, 19, NULL);
 be_define_const_str(set_text, "set_text", 1849641155u, 0, 8, NULL);
 be_define_const_str(set_time, "set_time", 900236405u, 0, 8, NULL);
-be_define_const_str(set_timeouts, "set_timeouts", 3732850900u, 0, 12, NULL);
+be_define_const_str(set_timeouts, "set_timeouts", 3732850900u, 0, 12, &be_const_str_set_x);
 be_define_const_str(set_timer, "set_timer", 2135414533u, 0, 9, NULL);
 be_define_const_str(set_useragent, "set_useragent", 612237244u, 0, 13, NULL);
-be_define_const_str(set_width, "set_width", 484671920u, 0, 9, &be_const_str_continue);
+be_define_const_str(set_width, "set_width", 484671920u, 0, 9, NULL);
 be_define_const_str(set_x, "set_x", 1849400772u, 0, 5, NULL);
 be_define_const_str(set_y, "set_y", 1866178391u, 0, 5, NULL);
 be_define_const_str(setbits, "setbits", 2762408167u, 0, 7, NULL);
-be_define_const_str(seti, "seti", 1500556254u, 0, 4, &be_const_str_shared_key);
+be_define_const_str(seti, "seti", 1500556254u, 0, 4, &be_const_str_show);
 be_define_const_str(setitem, "setitem", 1554834596u, 0, 7, NULL);
 be_define_const_str(setmember, "setmember", 1432909441u, 0, 9, NULL);
-be_define_const_str(setrange, "setrange", 3794019032u, 0, 8, &be_const_str_widget_struct_by_class);
-be_define_const_str(settings, "settings", 1745255176u, 0, 8, &be_const_str_year);
+be_define_const_str(setrange, "setrange", 3794019032u, 0, 8, NULL);
+be_define_const_str(settings, "settings", 1745255176u, 0, 8, NULL);
 be_define_const_str(shared_key, "shared_key", 2200833624u, 0, 10, NULL);
 be_define_const_str(show, "show", 2840060476u, 0, 4, NULL);
-be_define_const_str(signal_arcs, "signal_arcs", 1505996127u, 0, 11, &be_const_str_upper);
-be_define_const_str(signal_bars, "signal_bars", 3181573600u, 0, 11, NULL);
-be_define_const_str(sin, "sin", 3761252941u, 0, 3, NULL);
-be_define_const_str(sinh, "sinh", 282220607u, 0, 4, &be_const_str_stop);
+be_define_const_str(signal_arcs, "signal_arcs", 1505996127u, 0, 11, NULL);
+be_define_const_str(signal_bars, "signal_bars", 3181573600u, 0, 11, &be_const_str_web_add_console_button);
+be_define_const_str(sin, "sin", 3761252941u, 0, 3, &be_const_str_sqrt);
+be_define_const_str(sinh, "sinh", 282220607u, 0, 4, NULL);
 be_define_const_str(size, "size", 597743964u, 0, 4, NULL);
-be_define_const_str(skip, "skip", 1097563074u, 0, 4, &be_const_str_web_send_decimal);
-be_define_const_str(solidified, "solidified", 3257553487u, 0, 10, NULL);
-be_define_const_str(split, "split", 2276994531u, 0, 5, NULL);
-be_define_const_str(sqrt, "sqrt", 2112764879u, 0, 4, NULL);
-be_define_const_str(srand, "srand", 465518633u, 0, 5, &be_const_str_time_reached);
+be_define_const_str(skip, "skip", 1097563074u, 0, 4, &be_const_str_tolower);
+be_define_const_str(solidified, "solidified", 3257553487u, 0, 10, &be_const_str_tag);
+be_define_const_str(split, "split", 2276994531u, 0, 5, &be_const_str_stop);
+be_define_const_str(sqrt, "sqrt", 2112764879u, 0, 4, &be_const_str_srand);
+be_define_const_str(srand, "srand", 465518633u, 0, 5, &be_const_str_target_search);
 be_define_const_str(start, "start", 1697318111u, 0, 5, NULL);
-be_define_const_str(state, "state", 2016490230u, 0, 5, &be_const_str_for);
+be_define_const_str(state, "state", 2016490230u, 0, 5, NULL);
 be_define_const_str(static, "static", 3532702267u, 71, 6, NULL);
 be_define_const_str(stop, "stop", 3411225317u, 0, 4, NULL);
-be_define_const_str(stop_iteration, "stop_iteration", 4173793901u, 0, 14, &be_const_str_tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29);
+be_define_const_str(stop_iteration, "stop_iteration", 4173793901u, 0, 14, &be_const_str_sys);
 be_define_const_str(str, "str", 3259748752u, 0, 3, NULL);
 be_define_const_str(strftime, "strftime", 187738851u, 0, 8, NULL);
-be_define_const_str(string, "string", 398550328u, 0, 6, &be_const_str_wd);
+be_define_const_str(string, "string", 398550328u, 0, 6, &be_const_str_widget_struct_default);
 be_define_const_str(strip, "strip", 4246411473u, 0, 5, NULL);
-be_define_const_str(strptime, "strptime", 1277910361u, 0, 8, &be_const_str__X7B_X7D);
-be_define_const_str(super, "super", 4152230356u, 0, 5, NULL);
-be_define_const_str(sys, "sys", 3277365014u, 0, 3, &be_const_str_widget_constructor);
+be_define_const_str(strptime, "strptime", 1277910361u, 0, 8, &be_const_str_wire);
+be_define_const_str(super, "super", 4152230356u, 0, 5, &be_const_str_def);
+be_define_const_str(sys, "sys", 3277365014u, 0, 3, &be_const_str_do);
 be_define_const_str(tag, "tag", 2516003219u, 0, 3, NULL);
 be_define_const_str(tan, "tan", 2633446552u, 0, 3, NULL);
-be_define_const_str(tanh, "tanh", 153638352u, 0, 4, NULL);
-be_define_const_str(target, "target", 845187144u, 0, 6, &be_const_str_toptr);
-be_define_const_str(target_search, "target_search", 1947846553u, 0, 13, NULL);
-be_define_const_str(tasmota, "tasmota", 424643812u, 0, 7, NULL);
+be_define_const_str(tanh, "tanh", 153638352u, 0, 4, &be_const_str_wifi_bars);
+be_define_const_str(target, "target", 845187144u, 0, 6, NULL);
+be_define_const_str(target_search, "target_search", 1947846553u, 0, 13, &be_const_str__X7Bs_X7DBatt_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D);
+be_define_const_str(tasmota, "tasmota", 424643812u, 0, 7, &be_const_str_web_add_main_button);
 be_define_const_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29, "tasmota.get_light() is deprecated, use light.get()", 3525753647u, 0, 50, NULL);
-be_define_const_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29, "tasmota.set_light() is deprecated, use light.set()", 2124937871u, 0, 50, NULL);
+be_define_const_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29, "tasmota.set_light() is deprecated, use light.set()", 2124937871u, 0, 50, &be_const_str_value_error);
 be_define_const_str(tcpclient, "tcpclient", 3828797983u, 0, 9, NULL);
 be_define_const_str(tele, "tele", 3474458061u, 0, 4, NULL);
 be_define_const_str(the_X20second_X20argument_X20is_X20not_X20a_X20function, "the second argument is not a function", 3954574469u, 0, 37, NULL);
 be_define_const_str(time_dump, "time_dump", 3330410747u, 0, 9, NULL);
 be_define_const_str(time_reached, "time_reached", 2075136773u, 0, 12, NULL);
-be_define_const_str(time_str, "time_str", 2613827612u, 0, 8, &be_const_str_web_sensor);
+be_define_const_str(time_str, "time_str", 2613827612u, 0, 8, NULL);
 be_define_const_str(to_gamma, "to_gamma", 1597139862u, 0, 8, NULL);
 be_define_const_str(tob64, "tob64", 373777640u, 0, 5, NULL);
 be_define_const_str(tolower, "tolower", 1042520049u, 0, 7, NULL);
 be_define_const_str(tomap, "tomap", 612167626u, 0, 5, NULL);
 be_define_const_str(top, "top", 2802900028u, 0, 3, NULL);
-be_define_const_str(toptr, "toptr", 3379847454u, 0, 5, &be_const_str_type_error);
+be_define_const_str(toptr, "toptr", 3379847454u, 0, 5, NULL);
 be_define_const_str(tostring, "tostring", 2299708645u, 0, 8, NULL);
-be_define_const_str(toupper, "toupper", 3691983576u, 0, 7, NULL);
+be_define_const_str(toupper, "toupper", 3691983576u, 0, 7, &be_const_str_widget_event_cb);
 be_define_const_str(tr, "tr", 1195724803u, 0, 2, NULL);
 be_define_const_str(traceback, "traceback", 3385188109u, 0, 9, NULL);
 be_define_const_str(true, "true", 1303515621u, 61, 4, NULL);
 be_define_const_str(try, "try", 2887626766u, 68, 3, NULL);
-be_define_const_str(try_rule, "try_rule", 1986449405u, 0, 8, NULL);
+be_define_const_str(try_rule, "try_rule", 1986449405u, 0, 8, &be_const_str_width);
 be_define_const_str(type, "type", 1361572173u, 0, 4, NULL);
-be_define_const_str(type_error, "type_error", 3789613824u, 0, 10, NULL);
+be_define_const_str(type_error, "type_error", 3789613824u, 0, 10, &be_const_str_upper);
 be_define_const_str(udp, "udp", 1253872004u, 0, 3, NULL);
 be_define_const_str(unknown_X20instruction, "unknown instruction", 1093911841u, 0, 19, NULL);
-be_define_const_str(update, "update", 672109684u, 0, 6, &be_const_str_if);
+be_define_const_str(update, "update", 672109684u, 0, 6, NULL);
 be_define_const_str(upper, "upper", 176974407u, 0, 5, NULL);
-be_define_const_str(url_encode, "url_encode", 528392145u, 0, 10, NULL);
+be_define_const_str(url_encode, "url_encode", 528392145u, 0, 10, &be_const_str__X7Bs_X7DBatt_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D);
 be_define_const_str(v, "v", 4077666505u, 0, 1, NULL);
 be_define_const_str(value, "value", 1113510858u, 0, 5, NULL);
 be_define_const_str(value_error, "value_error", 773297791u, 0, 11, NULL);
 be_define_const_str(valuer_error, "valuer_error", 2567947105u, 0, 12, NULL);
 be_define_const_str(var, "var", 2317739966u, 64, 3, NULL);
-be_define_const_str(w, "w", 4060888886u, 0, 1, NULL);
+be_define_const_str(w, "w", 4060888886u, 0, 1, &be_const_str_web_send_decimal);
 be_define_const_str(wd, "wd", 1531424278u, 0, 2, NULL);
-be_define_const_str(web_add_button, "web_add_button", 3537875058u, 0, 14, NULL);
+be_define_const_str(web_add_button, "web_add_button", 3537875058u, 0, 14, &be_const_str_web_sensor);
 be_define_const_str(web_add_config_button, "web_add_config_button", 639674325u, 0, 21, NULL);
 be_define_const_str(web_add_console_button, "web_add_console_button", 3481436192u, 0, 22, NULL);
 be_define_const_str(web_add_handler, "web_add_handler", 3990174962u, 0, 15, NULL);
 be_define_const_str(web_add_main_button, "web_add_main_button", 3960367664u, 0, 19, NULL);
 be_define_const_str(web_add_management_button, "web_add_management_button", 2738877186u, 0, 25, NULL);
-be_define_const_str(web_send, "web_send", 2989941448u, 0, 8, NULL);
+be_define_const_str(web_send, "web_send", 2989941448u, 0, 8, &be_const_str_y1);
 be_define_const_str(web_send_decimal, "web_send_decimal", 1407210204u, 0, 16, NULL);
-be_define_const_str(web_sensor, "web_sensor", 2900096972u, 0, 10, NULL);
+be_define_const_str(web_sensor, "web_sensor", 2900096972u, 0, 10, &be_const_str_write_file);
 be_define_const_str(webclient, "webclient", 4076389146u, 0, 9, NULL);
-be_define_const_str(webserver, "webserver", 1572454038u, 0, 9, &be_const_str_false);
+be_define_const_str(webserver, "webserver", 1572454038u, 0, 9, &be_const_str__X7Bs_X7DTemp_X20AXP_X7Bm_X7D_X25_X2E1f_X20_X26deg_X3BC_X7Be_X7D);
 be_define_const_str(while, "while", 231090382u, 53, 5, NULL);
 be_define_const_str(widget_cb, "widget_cb", 2763583055u, 0, 9, NULL);
-be_define_const_str(widget_constructor, "widget_constructor", 2543785934u, 0, 18, &be_const_str__X7B);
-be_define_const_str(widget_ctor_cb, "widget_ctor_cb", 876007560u, 0, 14, NULL);
-be_define_const_str(widget_ctor_impl, "widget_ctor_impl", 194252479u, 0, 16, &be_const_str_write_file);
+be_define_const_str(widget_constructor, "widget_constructor", 2543785934u, 0, 18, NULL);
+be_define_const_str(widget_ctor_cb, "widget_ctor_cb", 876007560u, 0, 14, &be_const_str_true);
+be_define_const_str(widget_ctor_impl, "widget_ctor_impl", 194252479u, 0, 16, NULL);
 be_define_const_str(widget_destructor, "widget_destructor", 4207388345u, 0, 17, NULL);
 be_define_const_str(widget_dtor_cb, "widget_dtor_cb", 3151545845u, 0, 14, NULL);
-be_define_const_str(widget_dtor_impl, "widget_dtor_impl", 520430610u, 0, 16, NULL);
-be_define_const_str(widget_editable, "widget_editable", 3821793286u, 0, 15, &be_const_str_y);
+be_define_const_str(widget_dtor_impl, "widget_dtor_impl", 520430610u, 0, 16, &be_const_str_wifi_arcs_icon);
+be_define_const_str(widget_editable, "widget_editable", 3821793286u, 0, 15, NULL);
 be_define_const_str(widget_event, "widget_event", 1951408186u, 0, 12, NULL);
 be_define_const_str(widget_event_cb, "widget_event_cb", 1508466754u, 0, 15, NULL);
-be_define_const_str(widget_event_impl, "widget_event_impl", 2178430561u, 0, 17, NULL);
+be_define_const_str(widget_event_impl, "widget_event_impl", 2178430561u, 0, 17, &be_const_str_raise);
 be_define_const_str(widget_group_def, "widget_group_def", 1246968785u, 0, 16, NULL);
 be_define_const_str(widget_height_def, "widget_height_def", 3131667813u, 0, 17, NULL);
 be_define_const_str(widget_instance_size, "widget_instance_size", 2055354779u, 0, 20, NULL);
@@ -779,14 +780,14 @@ be_define_const_str(wifi_bars_icon, "wifi_bars_icon", 3641522557u, 0, 14, NULL);
 be_define_const_str(wire, "wire", 4082753944u, 0, 4, NULL);
 be_define_const_str(wire1, "wire1", 3212721419u, 0, 5, NULL);
 be_define_const_str(wire2, "wire2", 3229499038u, 0, 5, NULL);
-be_define_const_str(wire_scan, "wire_scan", 2671275880u, 0, 9, &be_const_str_end);
+be_define_const_str(wire_scan, "wire_scan", 2671275880u, 0, 9, NULL);
 be_define_const_str(write, "write", 3190202204u, 0, 5, NULL);
-be_define_const_str(write8, "write8", 3133991532u, 0, 6, &be_const_str_def);
+be_define_const_str(write8, "write8", 3133991532u, 0, 6, NULL);
 be_define_const_str(write_bit, "write_bit", 2660990436u, 0, 9, NULL);
 be_define_const_str(write_bytes, "write_bytes", 1227543792u, 0, 11, NULL);
 be_define_const_str(write_file, "write_file", 3177658879u, 0, 10, NULL);
-be_define_const_str(write_gpio, "write_gpio", 2267940334u, 0, 10, &be_const_str_x1);
-be_define_const_str(x, "x", 4245442695u, 0, 1, NULL);
+be_define_const_str(write_gpio, "write_gpio", 2267940334u, 0, 10, NULL);
+be_define_const_str(x, "x", 4245442695u, 0, 1, &be_const_str_x1);
 be_define_const_str(x1, "x1", 274927234u, 0, 2, NULL);
 be_define_const_str(y, "y", 4228665076u, 0, 1, NULL);
 be_define_const_str(y1, "y1", 2355101727u, 0, 2, NULL);
@@ -799,405 +800,406 @@ be_define_const_str(_X7Bs_X7DBatt_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D, 
 be_define_const_str(_X7Bs_X7DBatt_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D, "{s}Batt Voltage{m}%.3f V{e}", 3184308199u, 0, 27, NULL);
 be_define_const_str(_X7Bs_X7DTemp_X20AXP_X7Bm_X7D_X25_X2E1f_X20_X26deg_X3BC_X7Be_X7D, "{s}Temp AXP{m}%.1f &deg;C{e}", 2622904081u, 0, 28, NULL);
 be_define_const_str(_X7Bs_X7DVBus_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D, "{s}VBus Current{m}%.1f mA{e}", 1032721155u, 0, 28, NULL);
-be_define_const_str(_X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D, "{s}VBus Voltage{m}%.3f V{e}", 165651270u, 0, 27, NULL);
+be_define_const_str(_X7Bs_X7DVBus_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D, "{s}VBus Voltage{m}%.3f V{e}", 165651270u, 0, 27, &be_const_str_break);
 be_define_const_str(_X7B_X7D, "{}", 1415952421u, 0, 2, NULL);
 be_define_const_str(_X7D, "}", 4161554600u, 0, 1, NULL);
 
 static const bstring* const m_string_table[] = {
-    (const bstring *)&be_const_str_CFG_X3A_X20return_code_X3D_X25i,
-    (const bstring *)&be_const_str__available,
-    (const bstring *)&be_const_str_OneWire,
-    NULL,
-    NULL,
-    (const bstring *)&be_const_str_try_rule,
-    (const bstring *)&be_const_str__X2Ep1,
-    (const bstring *)&be_const_str_compress,
-    (const bstring *)&be_const_str__buffer,
-    (const bstring *)&be_const_str_add_handler,
-    (const bstring *)&be_const_str_SERIAL_5N1,
-    NULL,
-    (const bstring *)&be_const_str__X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str_tr,
-    (const bstring *)&be_const_str_CFG_X3A_X20skipping_X20_X27display_X2Eini_X27_X20because_X20already_X20present_X20in_X20file_X2Dsystem,
-    (const bstring *)&be_const_str_pc_abs,
-    (const bstring *)&be_const_str__X23preinit_X2Ebe,
+    (const bstring *)&be_const_str__X23init_X2Ebat,
+    (const bstring *)&be_const_str_widget_destructor,
+    (const bstring *)&be_const_str_sec,
+    (const bstring *)&be_const_str_instance_X20required,
+    (const bstring *)&be_const_str_CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting,
+    (const bstring *)&be_const_str_dirty,
+    (const bstring *)&be_const_str_Animate_X20pc_X20is_X20out_X20of_X20range,
+    (const bstring *)&be_const_str_SERIAL_7E2,
+    (const bstring *)&be_const_str_SERIAL_6E1,
+    (const bstring *)&be_const_str__X2Etapp,
     (const bstring *)&be_const_str__X2F_X3Frst_X3D,
-    (const bstring *)&be_const_str__persist_X2Ejson,
-    (const bstring *)&be_const_str_arg_X20must_X20be_X20a_X20subclass_X20of_X20lv_obj,
-    (const bstring *)&be_const_str__X3Clegend_X3E_X3Cb_X20title_X3D_X27Autoconfiguration_X27_X3E_X26nbsp_X3BCurrent_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E,
-    (const bstring *)&be_const_str_map,
-    (const bstring *)&be_const_str_atleast1,
+    (const bstring *)&be_const_str_setmember,
+    (const bstring *)&be_const_str__energy,
+    (const bstring *)&be_const_str_k,
+    (const bstring *)&be_const_str_CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27,
+    (const bstring *)&be_const_str_set_text,
+    (const bstring *)&be_const_str_OPTION_A,
+    (const bstring *)&be_const_str_log,
+    (const bstring *)&be_const_str_Tele,
+    (const bstring *)&be_const_str_Leds,
     NULL,
-    (const bstring *)&be_const_str_RES_OK,
-    (const bstring *)&be_const_str_SERIAL_5E1,
-    (const bstring *)&be_const_str__X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str__X3D_X3C_X3E_X21,
-    NULL,
-    (const bstring *)&be_const_str_LVG_X3A_X20call_X20to_X20unsupported_X20callback,
-    (const bstring *)&be_const_str_destructor_cb,
-    (const bstring *)&be_const_str__X7Bs_X7DTemp_X20AXP_X7Bm_X7D_X25_X2E1f_X20_X26deg_X3BC_X7Be_X7D,
-    (const bstring *)&be_const_str_range,
-    (const bstring *)&be_const_str_get_bat_current,
-    (const bstring *)&be_const_str_class_init_obj,
-    NULL,
+    (const bstring *)&be_const_str_web_add_handler,
+    (const bstring *)&be_const_str__X2Ebe,
+    (const bstring *)&be_const_str_depower,
     (const bstring *)&be_const_str_draw_line_dsc_init,
+    (const bstring *)&be_const_str_engine,
+    (const bstring *)&be_const_str_run_deferred,
+    (const bstring *)&be_const_str_lv_signal_arcs,
+    (const bstring *)&be_const_str__def,
+    (const bstring *)&be_const_str_range,
+    (const bstring *)&be_const_str__X20,
+    (const bstring *)&be_const_str_duration,
+    (const bstring *)&be_const_str_battery_present,
     NULL,
-    (const bstring *)&be_const_str_AES_GCM,
+    (const bstring *)&be_const_str_cmd,
+    (const bstring *)&be_const_str_pc,
+    (const bstring *)&be_const_str__ccmd,
+    (const bstring *)&be_const_str_lv_signal_bars,
+    (const bstring *)&be_const_str_enabled,
+    (const bstring *)&be_const_str_traceback,
+    (const bstring *)&be_const_str__X3Coption_X20value_X3D_X27_X25s_X27_X3E_X25s_X3C_X2Foption_X3E,
+    (const bstring *)&be_const_str_class_init_obj,
+    (const bstring *)&be_const_str_out_X20of_X20range,
+    (const bstring *)&be_const_str_set_bri,
+    (const bstring *)&be_const_str_closure,
+    (const bstring *)&be_const_str__error,
+    (const bstring *)&be_const_str_refr_size,
+    (const bstring *)&be_const_str_atan2,
+    (const bstring *)&be_const_str__X2C,
+    (const bstring *)&be_const_str__X3Cselect_X20name_X3D_X27zip_X27_X3E,
+    (const bstring *)&be_const_str_set_width,
+    (const bstring *)&be_const_str_I2C_X3A,
+    (const bstring *)&be_const_str_wd,
+    (const bstring *)&be_const_str_hex,
+    (const bstring *)&be_const_str_write_bit,
+    (const bstring *)&be_const_str_list,
     NULL,
-    (const bstring *)&be_const_str__X2B,
+    (const bstring *)&be_const_str__X2E,
+    (const bstring *)&be_const_str_arch,
     NULL,
-    (const bstring *)&be_const_str_exec_rules,
-    (const bstring *)&be_const_str_search,
-    NULL,
-    (const bstring *)&be_const_str_SERIAL_7O1,
-    (const bstring *)&be_const_str_False,
-    NULL,
-    (const bstring *)&be_const_str__X2Eautoconf,
-    (const bstring *)&be_const_str__X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E,
-    (const bstring *)&be_const_str_COLOR_WHITE,
-    (const bstring *)&be_const_str_redirect,
-    (const bstring *)&be_const_str__settings_ptr,
-    (const bstring *)&be_const_str_day,
-    (const bstring *)&be_const_str_seti,
-    (const bstring *)&be_const_str_None,
-    (const bstring *)&be_const_str__X7Bs_X7DBatt_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D,
-    (const bstring *)&be_const_str__X2502d_X25s_X2502d,
-    (const bstring *)&be_const_str__X2Fac,
-    NULL,
-    (const bstring *)&be_const_str_encrypt,
-    (const bstring *)&be_const_str_CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29,
-    NULL,
-    (const bstring *)&be_const_str___iterator__,
-    (const bstring *)&be_const_str__X2Esize,
-    (const bstring *)&be_const_str_begin_multicast,
-    (const bstring *)&be_const_str__X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str_LVG_X3A_X20object_X3A,
-    (const bstring *)&be_const_str_CFG_X3A_X20loaded_X20_X27_X25s_X27,
-    (const bstring *)&be_const_str_input,
+    (const bstring *)&be_const_str_rotate,
+    (const bstring *)&be_const_str_get_switch,
+    (const bstring *)&be_const_str_content_button,
+    (const bstring *)&be_const_str_remove_rule,
     NULL,
     (const bstring *)&be_const_str_read24,
-    (const bstring *)&be_const_str_back_forth,
-    NULL,
-    (const bstring *)&be_const_str_publish,
-    (const bstring *)&be_const_str_json_fdump_any,
-    (const bstring *)&be_const_str__X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E,
-    (const bstring *)&be_const_str__X23autoexec_X2Ebat,
-    (const bstring *)&be_const_str_save_before_restart,
-    (const bstring *)&be_const_str_editable,
-    (const bstring *)&be_const_str__X23display_X2Eini,
-    (const bstring *)&be_const_str__global_def,
-    (const bstring *)&be_const_str_cb_do_nothing,
-    (const bstring *)&be_const_str__X3A,
+    (const bstring *)&be_const_str_day,
     (const bstring *)&be_const_str_every_100ms,
-    (const bstring *)&be_const_str__rules,
-    (const bstring *)&be_const_str__X28_X29,
-    (const bstring *)&be_const_str_CFG_X3A_X20loading_X20_X27_X25s_X27,
-    (const bstring *)&be_const_str__X26lt_X3BNone_X26gt_X3B,
-    (const bstring *)&be_const_str_wire1,
-    (const bstring *)&be_const_str_init_draw_line_dsc,
-    (const bstring *)&be_const_str_strptime,
-    (const bstring *)&be_const_str_get_style_line_color,
+    (const bstring *)&be_const_str_detect,
+    (const bstring *)&be_const_str_encrypt,
+    (const bstring *)&be_const_str_map,
+    (const bstring *)&be_const_str__persist_X2Ejson,
     NULL,
-    NULL,
-    (const bstring *)&be_const_str_Restart_X201,
-    (const bstring *)&be_const_str_print,
-    (const bstring *)&be_const_str_BRY_X3A_X20could_X20not_X20save_X20compiled_X20file_X20_X25s_X20_X28_X25s_X29,
-    (const bstring *)&be_const_str_onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E,
-    (const bstring *)&be_const_str__X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B,
-    (const bstring *)&be_const_str_SERIAL_5O2,
-    (const bstring *)&be_const_str_SERIAL_7E1,
-    (const bstring *)&be_const_str_reset,
-    (const bstring *)&be_const_str_ins_time,
-    (const bstring *)&be_const_str_on,
-    (const bstring *)&be_const_str__X2E_X2E,
-    (const bstring *)&be_const_str__error,
-    (const bstring *)&be_const_str_can_show,
-    (const bstring *)&be_const_str_asstring,
-    (const bstring *)&be_const_str__X20,
-    (const bstring *)&be_const_str_hex,
-    (const bstring *)&be_const_str__X2Ebec,
-    (const bstring *)&be_const_str_SERIAL_6O1,
-    (const bstring *)&be_const_str_duration,
-    (const bstring *)&be_const_str_BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s,
-    (const bstring *)&be_const_str_arg_name,
-    (const bstring *)&be_const_str_get_coords,
-    (const bstring *)&be_const_str_get_power,
-    (const bstring *)&be_const_str_group_def,
-    (const bstring *)&be_const_str_set_style_text_font,
-    (const bstring *)&be_const_str_CFG_X3A_X20removing_X20autoconf_X20files,
-    (const bstring *)&be_const_str_sin,
-    (const bstring *)&be_const_str_Timer,
-    (const bstring *)&be_const_str_file,
-    NULL,
-    (const bstring *)&be_const_str__X3D_X3D,
-    NULL,
-    (const bstring *)&be_const_str_read8,
-    (const bstring *)&be_const_str_lv_event,
-    (const bstring *)&be_const_str_cmd,
-    (const bstring *)&be_const_str_is_dirty,
-    (const bstring *)&be_const_str_set_bits_per_sample,
-    (const bstring *)&be_const_str_persist_X2E_p_X20is_X20not_X20a_X20map,
-    (const bstring *)&be_const_str_CFG_X3A_X20removing_X20first_X20time_X20marker,
-    (const bstring *)&be_const_str_json_append,
-    (const bstring *)&be_const_str_serial,
-    (const bstring *)&be_const_str_area,
-    (const bstring *)&be_const_str_alternate,
-    (const bstring *)&be_const_str_add_anim,
-    (const bstring *)&be_const_str_add_cmd,
-    (const bstring *)&be_const_str_COLOR_BLACK,
-    (const bstring *)&be_const_str_log,
-    (const bstring *)&be_const_str_SERIAL_8O1,
-    (const bstring *)&be_const_str_ctypes_bytes,
-    (const bstring *)&be_const_str_SERIAL_6N2,
-    (const bstring *)&be_const_str_has,
-    (const bstring *)&be_const_str_setitem,
-    (const bstring *)&be_const_str_y1,
-    (const bstring *)&be_const_str__X2Ebe,
-    NULL,
-    (const bstring *)&be_const_str_preinit,
-    (const bstring *)&be_const_str__X21_X3D,
-    (const bstring *)&be_const_str_get_percentage,
-    (const bstring *)&be_const_str__X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str_p1,
-    (const bstring *)&be_const_str_last_modified,
-    (const bstring *)&be_const_str_write_bit,
-    NULL,
-    (const bstring *)&be_const_str_escape,
-    (const bstring *)&be_const_str_issubclass,
-    NULL,
-    NULL,
-    (const bstring *)&be_const_str_cb_obj,
-    (const bstring *)&be_const_str_add_event_cb,
-    (const bstring *)&be_const_str_cosh,
-    (const bstring *)&be_const_str__X2C,
-    (const bstring *)&be_const_str_SERIAL_7N1,
-    (const bstring *)&be_const_str_SERIAL_6E2,
-    (const bstring *)&be_const_str_webserver,
-    (const bstring *)&be_const_str_Auto_X2Dconfiguration,
-    (const bstring *)&be_const_str___lower__,
-    (const bstring *)&be_const_str_get_battery_chargin_status,
-    (const bstring *)&be_const_str_while,
-    (const bstring *)&be_const_str_pow,
-    (const bstring *)&be_const_str_bri,
-    (const bstring *)&be_const_str_make_cb,
-    (const bstring *)&be_const_str__anonymous_,
-    NULL,
-    (const bstring *)&be_const_str_AudioFileSource,
-    (const bstring *)&be_const_str_widget_instance_size,
-    (const bstring *)&be_const_str__X3D,
-    (const bstring *)&be_const_str__def,
-    (const bstring *)&be_const_str_web_add_console_button,
-    (const bstring *)&be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dac_X20action_X3D_X27ac_X27_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20method_X3D_X27get_X27_X3E_X3Cbutton_X3EAuto_X2Dconfiguration_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str_montserrat_font,
-    (const bstring *)&be_const_str_set_time,
-    (const bstring *)&be_const_str_scan,
-    (const bstring *)&be_const_str__X2Ep2,
-    (const bstring *)&be_const_str_isrunning,
-    (const bstring *)&be_const_str_remove,
-    NULL,
-    (const bstring *)&be_const_str__X0A,
-    (const bstring *)&be_const_str_obj_class_create_obj,
-    (const bstring *)&be_const_str__X2E,
-    (const bstring *)&be_const_str__X21_X3D_X3D,
-    (const bstring *)&be_const_str_module,
-    (const bstring *)&be_const_str__X2Elen,
-    (const bstring *)&be_const_str_month,
-    (const bstring *)&be_const_str_get_current_module_path,
-    (const bstring *)&be_const_str_create_segment,
-    (const bstring *)&be_const_str_register_button_encoder,
-    (const bstring *)&be_const_str_split,
-    (const bstring *)&be_const_str_remove_cmd,
-    (const bstring *)&be_const_str_remote_ip,
-    (const bstring *)&be_const_str__X25s_X2Eautoconf,
-    (const bstring *)&be_const_str_abs,
-    (const bstring *)&be_const_str__begin_transmission,
-    (const bstring *)&be_const_str_signal_arcs,
-    (const bstring *)&be_const_str__X3F,
-    (const bstring *)&be_const_str_content_start,
-    (const bstring *)&be_const_str_memory,
-    (const bstring *)&be_const_str_,
-    (const bstring *)&be_const_str_load_freetype_font,
-    (const bstring *)&be_const_str_EVENT_DELETE,
-    NULL,
-    (const bstring *)&be_const_str_get,
-    (const bstring *)&be_const_str_toupper,
-    (const bstring *)&be_const_str_flush,
-    (const bstring *)&be_const_str_coord_arr,
-    (const bstring *)&be_const_str_event,
-    (const bstring *)&be_const_str_bytes,
-    (const bstring *)&be_const_str__X2D_X2D_X3A_X2D_X2D,
-    NULL,
-    (const bstring *)&be_const_str__lvgl,
-    (const bstring *)&be_const_str__X2Ew,
-    (const bstring *)&be_const_str_consume_silence,
-    (const bstring *)&be_const_str_set_pixel_color,
-    (const bstring *)&be_const_str_sinh,
-    (const bstring *)&be_const_str_delete_all_configs,
-    NULL,
-    (const bstring *)&be_const_str_CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29,
-    (const bstring *)&be_const_str_char,
-    (const bstring *)&be_const_str_couldn_X27t_X20not_X20initialize_X20noepixelbus,
-    (const bstring *)&be_const_str_get_size,
-    (const bstring *)&be_const_str_SERIAL_5E2,
-    (const bstring *)&be_const_str_get_aps_voltage,
-    (const bstring *)&be_const_str_codedump,
-    (const bstring *)&be_const_str_CFG_X3A_X20_X27init_X2Ebat_X27_X20done_X2C_X20restarting,
-    (const bstring *)&be_const_str_classname,
-    (const bstring *)&be_const_str_getbits,
-    (const bstring *)&be_const_str_gamma8,
-    (const bstring *)&be_const_str__X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E,
-    (const bstring *)&be_const_str_event_send,
-    (const bstring *)&be_const_str__X2F_X2Eautoconf,
-    (const bstring *)&be_const_str_write_gpio,
-    (const bstring *)&be_const_str_set_gain,
-    (const bstring *)&be_const_str__X3C_X3D,
-    (const bstring *)&be_const_str_SERIAL_5N2,
-    (const bstring *)&be_const_str_Parameter_X20error,
-    NULL,
-    (const bstring *)&be_const_str_ismethod,
-    (const bstring *)&be_const_str_gc,
-    (const bstring *)&be_const_str_classof,
-    (const bstring *)&be_const_str_add_rule,
-    (const bstring *)&be_const_str_SERIAL_7E2,
-    (const bstring *)&be_const_str_acos,
-    (const bstring *)&be_const_str_add_fast_loop,
-    NULL,
-    (const bstring *)&be_const_str_gpio,
-    (const bstring *)&be_const_str_file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20or_X20_X27_X2Ebec_X27,
-    (const bstring *)&be_const_str_code,
-    (const bstring *)&be_const_str__X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d,
-    (const bstring *)&be_const_str__X5D,
-    (const bstring *)&be_const_str___upper__,
-    (const bstring *)&be_const_str_cos,
-    NULL,
-    NULL,
-    (const bstring *)&be_const_str_check_not_method,
-    (const bstring *)&be_const_str_remove_driver,
-    (const bstring *)&be_const_str__X3C_X2Fform_X3E_X3C_X2Fp_X3E,
-    (const bstring *)&be_const_str_pop,
-    (const bstring *)&be_const_str_function,
-    NULL,
-    (const bstring *)&be_const_str_millis,
-    (const bstring *)&be_const_str__request_from,
-    (const bstring *)&be_const_str_width,
-    NULL,
-    (const bstring *)&be_const_str_b,
-    (const bstring *)&be_const_str_AXP192,
-    NULL,
-    (const bstring *)&be_const_str_rand,
-    (const bstring *)&be_const_str_start,
+    (const bstring *)&be_const_str_global,
     (const bstring *)&be_const_str__cmd,
-    (const bstring *)&be_const_str_exists,
-    (const bstring *)&be_const_str_counters,
-    (const bstring *)&be_const_str_pixel_size,
-    (const bstring *)&be_const_str_set_dcdc_enable,
-    (const bstring *)&be_const_str_autorun,
+    (const bstring *)&be_const_str_SERIAL_8E2,
+    (const bstring *)&be_const_str__X2Fac,
+    (const bstring *)&be_const_str_except,
+    (const bstring *)&be_const_str_the_X20second_X20argument_X20is_X20not_X20a_X20function,
+    (const bstring *)&be_const_str__X3C_X3D,
     NULL,
-    (const bstring *)&be_const_str_content_send,
-    (const bstring *)&be_const_str__,
-    (const bstring *)&be_const_str_close,
-    (const bstring *)&be_const_str_get_vbus_current,
-    (const bstring *)&be_const_str_engine,
+    (const bstring *)&be_const_str_format,
+    (const bstring *)&be_const_str_event_cb,
+    (const bstring *)&be_const_str_AES_GCM,
+    (const bstring *)&be_const_str__X25s_X2Eautoconf,
+    (const bstring *)&be_const_str_HTTP_POST,
+    NULL,
+    (const bstring *)&be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20,
+    (const bstring *)&be_const_str_settings,
+    NULL,
     (const bstring *)&be_const_str__X3Clabel_X3EChoose_X20a_X20device_X20configuration_X3A_X3C_X2Flabel_X3E_X3Cbr_X3E,
-    (const bstring *)&be_const_str__X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E,
-    (const bstring *)&be_const_str__X3E_X3D,
+    (const bstring *)&be_const_str_SERIAL_8N2,
+    (const bstring *)&be_const_str_call,
+    (const bstring *)&be_const_str_PART_MAIN,
+    (const bstring *)&be_const_str_AudioGeneratorMP3,
+    (const bstring *)&be_const_str__X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29,
+    (const bstring *)&be_const_str_lv_,
+    (const bstring *)&be_const_str_EVENT_DRAW_MAIN,
+    (const bstring *)&be_const_str__X2Ep,
+    (const bstring *)&be_const_str__X23display_X2Eini,
     NULL,
-    (const bstring *)&be_const_str__X3Clambda_X3E,
-    (const bstring *)&be_const_str_onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20change_X20the_X20current_X20configuration_X20and_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E,
-    (const bstring *)&be_const_str_pin,
-    (const bstring *)&be_const_str_assert,
-    (const bstring *)&be_const_str_lvgl_event_dispatch,
+    NULL,
+    (const bstring *)&be_const_str_has_arg,
+    (const bstring *)&be_const_str_before_del,
+    (const bstring *)&be_const_str__X2F_X2Eautoconf,
+    (const bstring *)&be_const_str_cb_obj,
+    (const bstring *)&be_const_str_CFG_X3A_X20loaded_X20_X27_X25s_X27,
+    (const bstring *)&be_const_str_AudioGenerator,
+    (const bstring *)&be_const_str_CFG_X3A_X20downloading_X20_X27_X25s_X27,
+    (const bstring *)&be_const_str__global_addr,
+    (const bstring *)&be_const_str__X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E,
+    (const bstring *)&be_const_str__X3Clegend_X3E_X3Cb_X20title_X3D_X27Autoconfiguration_X27_X3E_X26nbsp_X3BCurrent_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E,
+    (const bstring *)&be_const_str_arg_size,
+    NULL,
+    (const bstring *)&be_const_str_COLOR_BLACK,
+    (const bstring *)&be_const_str_draw_line_dsc,
+    (const bstring *)&be_const_str_obj_event_base,
+    (const bstring *)&be_const_str_gamma8,
+    (const bstring *)&be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dreapply_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20,
+    (const bstring *)&be_const_str_energy_struct,
+    (const bstring *)&be_const_str__X3C,
+    (const bstring *)&be_const_str_get_vbus_current,
+    (const bstring *)&be_const_str_concat,
+    NULL,
+    NULL,
+    (const bstring *)&be_const_str_dac_voltage,
+    (const bstring *)&be_const_str__read,
+    (const bstring *)&be_const_str__X21_X3D_X3D,
+    (const bstring *)&be_const_str_https_X3A_X2F_X2Fraw_X2Egithubusercontent_X2Ecom_X2Ftasmota_X2Fautoconf_X2Fmain_X2F_X25s_X2F_X25s_X2Eautoconf,
+    (const bstring *)&be_const_str__X3E,
+    (const bstring *)&be_const_str__X2E_X2E,
+    (const bstring *)&be_const_str__X2D_X2D_X3A_X2D_X2D,
+    (const bstring *)&be_const_str_SERIAL_5N2,
+    (const bstring *)&be_const_str_bool,
+    (const bstring *)&be_const_str__X21_X3D,
+    (const bstring *)&be_const_str_Tasmota,
+    (const bstring *)&be_const_str_BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27,
+    (const bstring *)&be_const_str__X2502d_X25s_X2502d,
+    (const bstring *)&be_const_str_BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20,
+    (const bstring *)&be_const_str_false,
+    (const bstring *)&be_const_str__begin_transmission,
+    NULL,
+    (const bstring *)&be_const_str_clear_first_time,
+    (const bstring *)&be_const_str_rand,
+    NULL,
+    NULL,
+    (const bstring *)&be_const_str_for,
+    (const bstring *)&be_const_str__X3A,
+    (const bstring *)&be_const_str___iterator__,
+    (const bstring *)&be_const_str_Parameter_X20error,
+    (const bstring *)&be_const_str__X26lt_X3BError_X3A_X20apply_X20new_X20or_X20remove_X26gt_X3B,
+    NULL,
+    (const bstring *)&be_const_str_SERIAL_5O2,
+    (const bstring *)&be_const_str_copy,
+    (const bstring *)&be_const_str_light,
+    (const bstring *)&be_const_str_hs2rgb,
+    (const bstring *)&be_const_str_strip,
+    (const bstring *)&be_const_str_cb_do_nothing,
+    NULL,
+    (const bstring *)&be_const_str_False,
+    (const bstring *)&be_const_str_create_matrix,
+    NULL,
+    (const bstring *)&be_const_str_GET,
     NULL,
     (const bstring *)&be_const_str_local,
-    (const bstring *)&be_const_str__filename,
-    (const bstring *)&be_const_str__t,
+    (const bstring *)&be_const_str_resp_cmnd,
+    (const bstring *)&be_const_str_split,
+    (const bstring *)&be_const_str_seg7_font,
+    (const bstring *)&be_const_str_add_cmd,
+    (const bstring *)&be_const_str_pow,
+    NULL,
+    (const bstring *)&be_const_str_,
+    (const bstring *)&be_const_str_SERIAL_6O2,
+    (const bstring *)&be_const_str_display_X2Eini,
+    (const bstring *)&be_const_str_delete_all_configs,
+    NULL,
+    (const bstring *)&be_const_str_calldepth,
+    (const bstring *)&be_const_str_b,
+    (const bstring *)&be_const_str_EVENT_DRAW_PART_END,
+    (const bstring *)&be_const_str__X2Ep2,
+    (const bstring *)&be_const_str_set_dc_voltage,
+    (const bstring *)&be_const_str_widget_struct_by_class,
+    (const bstring *)&be_const_str__timers,
+    (const bstring *)&be_const_str__settings_def,
+    (const bstring *)&be_const_str_iter,
+    (const bstring *)&be_const_str_get_bat_power,
+    (const bstring *)&be_const_str_area,
+    (const bstring *)&be_const_str_AudioFileSource,
+    (const bstring *)&be_const_str_SERIAL_7O2,
+    (const bstring *)&be_const_str_byte,
+    NULL,
+    (const bstring *)&be_const_str_deg,
+    (const bstring *)&be_const_str_reverse,
+    (const bstring *)&be_const_str_CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found,
+    (const bstring *)&be_const_str__X3Clambda_X3E,
     (const bstring *)&be_const_str_content_send_style,
     NULL,
-    (const bstring *)&be_const_str_instance_X20required,
-    (const bstring *)&be_const_str__end_transmission,
-    (const bstring *)&be_const_str_EC_C25519,
-    (const bstring *)&be_const_str_lv_,
-    (const bstring *)&be_const_str_Tele,
-    (const bstring *)&be_const_str_EVENT_DRAW_PART_BEGIN,
-    (const bstring *)&be_const_str_percentage,
-    (const bstring *)&be_const_str_draw_arc,
-    (const bstring *)&be_const_str_get_input_power_status,
-    (const bstring *)&be_const_str__X23,
-    (const bstring *)&be_const_str__X7Bs_X7DBatt_X20Voltage_X7Bm_X7D_X25_X2E3f_X20V_X7Be_X7D,
-    (const bstring *)&be_const_str_exp,
-    (const bstring *)&be_const_str_tele,
-    (const bstring *)&be_const_str_CFG_X3A_X20ran_X20_X20,
-    (const bstring *)&be_const_str_SERIAL_8O2,
-    (const bstring *)&be_const_str_EVENT_DRAW_MAIN,
-    (const bstring *)&be_const_str_light,
-    (const bstring *)&be_const_str_Wire,
-    (const bstring *)&be_const_str_concat,
-    (const bstring *)&be_const_str_Tasmota,
-    (const bstring *)&be_const_str_GET,
-    (const bstring *)&be_const_str_geti,
-    (const bstring *)&be_const_str_True,
-    (const bstring *)&be_const_str_name,
+    (const bstring *)&be_const_str_ctypes_bytes,
+    (const bstring *)&be_const_str_has_X20already_X20an_X20event_X20callback,
+    (const bstring *)&be_const_str_BUTTON_CONFIGURATION,
+    (const bstring *)&be_const_str_POST,
     (const bstring *)&be_const_str_CFG_X3A_X20removed_X20file_X20_X27_X25s_X27,
-    (const bstring *)&be_const_str_wire,
-    (const bstring *)&be_const_str_p2,
-    (const bstring *)&be_const_str_lv_wifi_bars,
-    (const bstring *)&be_const_str_SERIAL_5O1,
-    (const bstring *)&be_const_str_digital_read,
-    (const bstring *)&be_const_str_hs2rgb,
-    (const bstring *)&be_const_str_imax,
-    (const bstring *)&be_const_str_CFG_X3A_X20No_X20_X27_X2A_X2Eautoconf_X27_X20file_X20found,
-    (const bstring *)&be_const_str_BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27,
-    (const bstring *)&be_const_str_set_timer,
-    (const bstring *)&be_const_str__X2Etapp,
-    (const bstring *)&be_const_str_lv,
-    (const bstring *)&be_const_str__X5B,
-    (const bstring *)&be_const_str_SERIAL_7N2,
-    (const bstring *)&be_const_str_CFG_X3A_X20loaded_X20_X20,
-    (const bstring *)&be_const_str__X2Ep,
-    (const bstring *)&be_const_str__energy,
-    (const bstring *)&be_const_str_depower,
-    (const bstring *)&be_const_str_contains,
     NULL,
-    (const bstring *)&be_const_str_HTTP_POST,
-    (const bstring *)&be_const_str__drivers,
-    (const bstring *)&be_const_str_get_light,
-    NULL,
-    (const bstring *)&be_const_str_PART_MAIN,
-    (const bstring *)&be_const_str_internal_error,
-    (const bstring *)&be_const_str_asin,
-    (const bstring *)&be_const_str_call,
-    (const bstring *)&be_const_str__p,
-    (const bstring *)&be_const_str_CFG_X3A_X20exception_X20_X27_X25s_X27_X20_X2D_X20_X27_X25s_X27,
-    (const bstring *)&be_const_str_AudioOutputI2S,
+    (const bstring *)&be_const_str__X3C_X2Fselect_X3E_X3Cp_X3E_X3C_X2Fp_X3E,
+    (const bstring *)&be_const_str_h,
+    (const bstring *)&be_const_str_available,
+    (const bstring *)&be_const_str_json_fdump_any,
+    (const bstring *)&be_const_str__X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E,
+    (const bstring *)&be_const_str_file_X20extension_X20is_X20not_X20_X27_X2Ebe_X27_X20or_X20_X27_X2Ebec_X27,
+    (const bstring *)&be_const_str_ctypes_bytes_dyn,
+    (const bstring *)&be_const_str_ins_goto,
+    (const bstring *)&be_const_str_path,
+    (const bstring *)&be_const_str_scan,
     (const bstring *)&be_const_str_BRY_X3A_X20failed_X20to_X20load_X20_persist_X2Ejson,
-    (const bstring *)&be_const_str__X3Cp_X3E_X3Cform_X20id_X3Dzip_X20style_X3D_X27display_X3A_X20block_X3B_X27_X20action_X3D_X27_X2Fac_X27_X20method_X3D_X27post_X27_X20,
-    (const bstring *)&be_const_str_static,
-    (const bstring *)&be_const_str_AudioOutput,
-    (const bstring *)&be_const_str_clear_first_time,
+    (const bstring *)&be_const_str_lvgl_event_dispatch,
+    (const bstring *)&be_const_str_remove_timer,
+    (const bstring *)&be_const_str_SERIAL_7E1,
+    (const bstring *)&be_const_str_close,
+    (const bstring *)&be_const_str_set_alternate,
+    (const bstring *)&be_const_str_fromstring,
+    (const bstring *)&be_const_str_finish,
+    (const bstring *)&be_const_str_compress,
     NULL,
-    (const bstring *)&be_const_str_add_driver,
-    (const bstring *)&be_const_str_pin_used,
     NULL,
+    (const bstring *)&be_const_str__class,
+    (const bstring *)&be_const_str_EC_C25519,
+    (const bstring *)&be_const_str_widget_dtor_impl,
+    (const bstring *)&be_const_str_webserver,
+    (const bstring *)&be_const_str_deregister_obj,
+    (const bstring *)&be_const_str_coord_arr,
+    (const bstring *)&be_const_str__X23,
+    (const bstring *)&be_const_str_CFG_X3A_X20return_code_X3D_X25i,
+    (const bstring *)&be_const_str__X23preinit_X2Ebe,
+    (const bstring *)&be_const_str_widget_height_def,
+    (const bstring *)&be_const_str_delay,
+    (const bstring *)&be_const_str_CFG_X3A_X20could_X20not_X20run_X20_X25s_X20_X28_X25s_X20_X2D_X20_X25s_X29,
+    (const bstring *)&be_const_str_lv_event_cb,
+    NULL,
+    (const bstring *)&be_const_str_EVENT_DRAW_PART_BEGIN,
+    (const bstring *)&be_const_str_get_height,
+    (const bstring *)&be_const_str_json,
+    (const bstring *)&be_const_str_get_power,
+    (const bstring *)&be_const_str_elif,
+    (const bstring *)&be_const_str_argument_X20must_X20be_X20a_X20list,
+    (const bstring *)&be_const_str_gamma10,
+    (const bstring *)&be_const_str_CFG_X3A_X20loading_X20_X27_X25s_X27,
+    NULL,
+    (const bstring *)&be_const_str__X2Ebec,
     (const bstring *)&be_const_str__X2F,
-    (const bstring *)&be_const_str__X7Bs_X7DVBus_X20Current_X7Bm_X7D_X25_X2E1f_X20mA_X7Be_X7D,
-    (const bstring *)&be_const_str_SERIAL_6E1,
-    (const bstring *)&be_const_str_get_free_heap,
-    (const bstring *)&be_const_str__X3Cfieldset_X3E_X3Cstyle_X3E_X2Ebdis_X7Bbackground_X3A_X23888_X3B_X7D_X2Ebdis_X3Ahover_X7Bbackground_X3A_X23888_X3B_X7D_X3C_X2Fstyle_X3E,
-    (const bstring *)&be_const_str_resize,
-    (const bstring *)&be_const_str_ceil,
-    (const bstring *)&be_const_str_CFG_X3A_X20downloading_X20_X27_X25s_X27,
-    (const bstring *)&be_const_str_add_header,
-    (const bstring *)&be_const_str__X3Cinstance_X3A_X20_X25s_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29,
-    (const bstring *)&be_const_str_wifi,
-    (const bstring *)&be_const_str_get_bri,
-    (const bstring *)&be_const_str_var,
-    (const bstring *)&be_const_str__X23init_X2Ebat,
-    (const bstring *)&be_const_str_create_custom_widget,
-    (const bstring *)&be_const_str__X3C
+    (const bstring *)&be_const_str_deinit,
+    NULL,
+    (const bstring *)&be_const_str_exists,
+    (const bstring *)&be_const_str_Auto_X2Dconfiguration,
+    (const bstring *)&be_const_str_CFG_X3A_X20removing_X20autoconf_X20files,
+    (const bstring *)&be_const_str__X3Cbutton_X20name_X3D_X27reapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3ERe_X2Dapply_X20current_X20configuration_X3C_X2Fbutton_X3E,
+    (const bstring *)&be_const_str__X23autoexec_X2Ebe,
+    (const bstring *)&be_const_str_select,
+    (const bstring *)&be_const_str_SERIAL_6N1,
+    (const bstring *)&be_const_str_decompress,
+    (const bstring *)&be_const_str_call_native,
+    (const bstring *)&be_const_str_abs,
+    (const bstring *)&be_const_str_OneWire,
+    (const bstring *)&be_const_str_CFG_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s,
+    (const bstring *)&be_const_str_invalidate,
+    (const bstring *)&be_const_str_real,
+    (const bstring *)&be_const_str__X28_X29,
+    (const bstring *)&be_const_str__X2B,
+    (const bstring *)&be_const_str_addr,
+    (const bstring *)&be_const_str_add_event_cb,
+    (const bstring *)&be_const_str_webclient,
+    (const bstring *)&be_const_str_allocated,
+    (const bstring *)&be_const_str_CFG_X3A_X20ran_X20_X20,
+    (const bstring *)&be_const_str_try,
+    (const bstring *)&be_const_str_Restart_X201,
+    (const bstring *)&be_const_str_get_alternate,
+    NULL,
+    (const bstring *)&be_const_str_SERIAL_7N2,
+    (const bstring *)&be_const_str_gen_cb,
+    (const bstring *)&be_const_str_attrdump,
+    (const bstring *)&be_const_str__X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d,
+    (const bstring *)&be_const_str_is_first_time,
+    (const bstring *)&be_const_str_content_send,
+    (const bstring *)&be_const_str_SERIAL_8N1,
+    NULL,
+    (const bstring *)&be_const_str__X26lt_X3BNone_X26gt_X3B,
+    (const bstring *)&be_const_str_CFG_X3A_X20skipping_X20_X27display_X2Eini_X27_X20because_X20already_X20present_X20in_X20file_X2Dsystem,
+    (const bstring *)&be_const_str_connection_error,
+    (const bstring *)&be_const_str_load,
+    (const bstring *)&be_const_str_color,
+    (const bstring *)&be_const_str_listdir,
+    (const bstring *)&be_const_str_arg_name,
+    (const bstring *)&be_const_str__X3Cp_X3E_X3Csmall_X3E_X26nbsp_X3B_X28This_X20feature_X20requires_X20an_X20internet_X20connection_X29_X3C_X2Fsmall_X3E_X3C_X2Fp_X3E,
+    (const bstring *)&be_const_str_set_pixel_color,
+    NULL,
+    (const bstring *)&be_const_str_open,
+    (const bstring *)&be_const_str_tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29,
+    NULL,
+    (const bstring *)&be_const_str_set_y,
+    (const bstring *)&be_const_str_SERIAL_5E2,
+    (const bstring *)&be_const_str__X2Eautoconf,
+    (const bstring *)&be_const_str_asstring,
+    (const bstring *)&be_const_str_length_X20in_X20bits_X20must_X20be_X20between_X200_X20and_X2032,
+    (const bstring *)&be_const_str_exp,
+    (const bstring *)&be_const_str_lv_obj_class,
+    (const bstring *)&be_const_str_couldn_X27t_X20not_X20initialize_X20noepixelbus,
+    (const bstring *)&be_const_str_LVG_X3A_X20call_X20to_X20unsupported_X20callback,
+    (const bstring *)&be_const_str_lv_wifi_arcs_icon,
+    (const bstring *)&be_const_str__filename,
+    (const bstring *)&be_const_str_tostring,
+    (const bstring *)&be_const_str_alternate,
+    NULL,
+    (const bstring *)&be_const_str__X3D,
+    (const bstring *)&be_const_str_decrypt,
+    (const bstring *)&be_const_str_int,
+    (const bstring *)&be_const_str_SERIAL_5N1,
+    (const bstring *)&be_const_str__ptr,
+    (const bstring *)&be_const_str__X2Ew,
+    (const bstring *)&be_const_str__X3Coption_X20value_X3D_X27reset_X27_X3E_X26lt_X3BRemove_X20autoconf_X26gt_X3B_X3C_X2Foption_X3E,
+    (const bstring *)&be_const_str__X3Clegend_X3E_X3Cb_X20title_X3D_X27New_X20autoconf_X27_X3E_X26nbsp_X3BSelect_X20new_X20auto_X2Dconfiguration_X3C_X2Fb_X3E_X3C_X2Flegend_X3E,
+    (const bstring *)&be_const_str_COLOR_WHITE,
+    (const bstring *)&be_const_str__X3F,
+    (const bstring *)&be_const_str_erase,
+    (const bstring *)&be_const_str__X0A,
+    (const bstring *)&be_const_str_fast_loop_enabled,
+    (const bstring *)&be_const_str_read13,
+    NULL,
+    (const bstring *)&be_const_str_decode,
+    (const bstring *)&be_const_str_get_size,
+    (const bstring *)&be_const_str__X2Esize,
+    (const bstring *)&be_const_str_SERIAL_8O2,
+    (const bstring *)&be_const_str__X2Elen,
+    (const bstring *)&be_const_str_lv_obj,
+    (const bstring *)&be_const_str__X5B,
+    (const bstring *)&be_const_str_SK6812_GRBW,
+    (const bstring *)&be_const_str__X23autoexec_X2Ebat,
+    (const bstring *)&be_const_str__t,
+    (const bstring *)&be_const_str_set_first_time,
+    (const bstring *)&be_const_str_connect,
+    (const bstring *)&be_const_str_instance_size,
+    (const bstring *)&be_const_str_resp_cmnd_error,
+    (const bstring *)&be_const_str_detected_X20on_X20bus,
+    (const bstring *)&be_const_str_MD5,
+    (const bstring *)&be_const_str_get_bat_voltage,
+    (const bstring *)&be_const_str_bus,
+    (const bstring *)&be_const_str_fast_loop,
+    NULL,
+    (const bstring *)&be_const_str_find,
+    NULL,
+    (const bstring *)&be_const_str_persist_X2E_p_X20is_X20not_X20a_X20map,
+    NULL,
+    NULL,
+    (const bstring *)&be_const_str_print,
+    NULL,
+    (const bstring *)&be_const_str__p,
+    (const bstring *)&be_const_str_SERIAL_6O1,
+    (const bstring *)&be_const_str__X3Cbutton_X20name_X3D_X27zipapply_X27_X20class_X3D_X27button_X20bgrn_X27_X3EApply_X20configuration_X3C_X2Fbutton_X3E,
+    (const bstring *)&be_const_str_lv_wifi_bars,
+    NULL,
+    (const bstring *)&be_const_str__X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E,
+    (const bstring *)&be_const_str_CFG_X3A_X20multiple_X20autoconf_X20files_X20found_X2C_X20aborting_X20_X28_X27_X25s_X27_X20_X2B_X20_X27_X25s_X27_X29,
+    (const bstring *)&be_const_str_button_pressed,
+    (const bstring *)&be_const_str_SERIAL_5O1,
+    (const bstring *)&be_const_str_RES_OK,
+    (const bstring *)&be_const_str_height_def,
+    (const bstring *)&be_const_str_check_not_method,
+    (const bstring *)&be_const_str_io_error,
+    (const bstring *)&be_const_str_add_anim,
+    (const bstring *)&be_const_str_null_cb,
+    (const bstring *)&be_const_str_c,
+    (const bstring *)&be_const_str__X3E_X3D,
+    (const bstring *)&be_const_str_fromptr,
+    (const bstring *)&be_const_str_bytes,
+    NULL,
+    (const bstring *)&be_const_str__X3D_X3D,
+    (const bstring *)&be_const_str__X3C_X2Fform_X3E_X3C_X2Fp_X3E,
+    (const bstring *)&be_const_str_BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s,
+    (const bstring *)&be_const_str_tanh,
+    (const bstring *)&be_const_str_pin_mode,
+    (const bstring *)&be_const_str_type_error,
+    (const bstring *)&be_const_str__X2Ep1,
+    (const bstring *)&be_const_str_AudioOutput,
+    (const bstring *)&be_const_str_get_string,
+    (const bstring *)&be_const_str__anonymous_,
+    (const bstring *)&be_const_str_argument_X20must_X20be_X20a_X20function,
+    (const bstring *)&be_const_str_consume_silence,
+    (const bstring *)&be_const_str_member,
+    (const bstring *)&be_const_str__X3D_X3C_X3E_X21,
+    NULL,
+    (const bstring *)&be_const_str_Wire,
+    (const bstring *)&be_const_str_while,
+    (const bstring *)&be_const_str_debug
 };
 
 static const struct bconststrtab m_const_string_table = {
-    .size = 390,
-    .count = 804,
+    .size = 391,
+    .count = 805,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_display.h
+++ b/lib/libesp32/berry/generate/be_fixed_display.h
@@ -1,0 +1,18 @@
+#include "be_constobj.h"
+
+static be_define_const_map_slots(m_libdisplay_map) {
+    { be_const_key(dimmer, -1), be_const_func(be_ntv_display_dimmer) },
+    { be_const_key(start, 0), be_const_func(be_ntv_display_start) },
+};
+
+static be_define_const_map(
+    m_libdisplay_map,
+    2
+);
+
+static be_define_const_module(
+    m_libdisplay,
+    "display"
+);
+
+BE_EXPORT_VARIABLE be_define_const_native_module(display);

--- a/lib/libesp32/berry_tasmota/src/be_display_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_display_lib.c
@@ -9,21 +9,15 @@
 
 #ifdef USE_DISPLAY
 
-// Tasmota specific
-
 extern int be_ntv_display_start(bvm *vm);
+extern int be_ntv_display_dimmer(bvm *vm);
 
-/********************************************************************
-** Solidified module: display
-********************************************************************/
-be_local_module(display,
-    "display",
-    be_nested_map(1,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(start, -1), be_const_func(be_ntv_display_start) },
-    }))
-);
-BE_EXPORT_VARIABLE be_define_const_native_module(display);
-/********************************************************************/
+/* @const_object_info_begin
+module display (scope: global) {
+    start, func(be_ntv_display_start)
+    dimmer, func(be_ntv_display_dimmer)
+}
+@const_object_info_end */
+#include "be_fixed_display.h"
 
 #endif // USE_DISPLAY

--- a/tasmota/xdrv_52_3_berry_display.ino
+++ b/tasmota/xdrv_52_3_berry_display.ino
@@ -35,10 +35,8 @@ Renderer *Init_uDisplay(const char *desc);
  * 
 \*********************************************************************************************/
 extern "C" {
-
-  int be_ntv_display_start(bvm *vm);
   int be_ntv_display_start(bvm *vm) {
-#ifdef USE_UNIVERSAL_DISPLAY
+  #ifdef USE_UNIVERSAL_DISPLAY
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 1 && be_isstring(vm, 1)) {
       const char * desc = be_tostring(vm, 1);
@@ -53,9 +51,25 @@ extern "C" {
       be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
-#else // USE_UNIVERSAL_DISPLAY
+  #else // USE_UNIVERSAL_DISPLAY
     be_raise(vm, "internal_error", "universal display driver not present");
-#endif // USE_UNIVERSAL_DISPLAY
+  #endif // USE_UNIVERSAL_DISPLAY
+  }
+
+  // `display.dimmer([dim:int]) -> int` sets the dimmer of display, value 0..100. If `0` then turn off display. If no arg, read the current value.
+  int be_ntv_display_dimmer(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    int32_t dimmer;
+    if (argc >= 1) {
+      if (!be_isint(vm, 1)) { be_raise(vm, "type_error", "arg must be int"); }
+      dimmer = be_toint(vm, 1);
+      if ((dimmer < 0) || (dimmer > 100)) { be_raise(vm, "value_error", "value must be in range 0..100"); }
+      be_pop(vm, argc);   // clear stack to avoid ripple errors in code called later
+      SetDisplayDimmer(dimmer);
+      ApplyDisplayDimmer();
+    }
+    be_pushint(vm, GetDisplayDimmer());
+    be_return(vm);
   }
 }
 


### PR DESCRIPTION
## Description:

Add Berry `display.dimmer()` which is the equivalent to `DisplayDimmer` command.

Dimmer value is in range 0..100 (percentage). Setting to `0` also turns off the screen electronics and prevents from dead pixels.

The function always returns the value of dimmer; call without argument to read it.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
