### PR TITLE
LVGL allow null pointer for lv_disp and lv_indev

### DIFF
--- a/lib/libesp32_lvgl/lv_berry/src/lv_berry.c
+++ b/lib/libesp32_lvgl/lv_berry/src/lv_berry.c
@@ -43,7 +43,7 @@ int lv0_init(bvm *vm);
 int lv0_init(bvm *vm) {
   // "+_p" indicates that there must be an non NULL argument, either passed as comptr or returned by the function
   // Here, there is no function, so calling the constructor without a non-null comptr argument is rejected
-  return be_call_c_func(vm, NULL, "+_p", NULL);
+  return be_call_c_func(vm, NULL, "=_p", NULL);
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Allow `lv.disp().get_inactive_time()` to work. I.e. allow `lv_disp()` to contain a NULL pointer, which means default display for LVGL.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
