### PR TITLE
ESP32-S3 support first step (of many needed)

### DIFF
--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -1,0 +1,35 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld"
+    },
+    "core": "esp32",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dout",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "partitions": "esp32_partition_app1856k_spiffs320k.csv"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "espidf",
+    "arduino"
+  ],
+  "name": "Espressif Generic ESP32-S3 4M Flash, Tasmota 1856k Code/OTA, 320k FS",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/",
+  "vendor": "Espressif"
+}

--- a/include/esp32x_fixes.h
+++ b/include/esp32x_fixes.h
@@ -52,6 +52,13 @@
 #define HSPI_HOST   SPI3_HOST
 #define VSPI_HOST   SPI3_HOST
 
+#elif CONFIG_IDF_TARGET_ESP32S3
+// SPI_HOST (SPI1_HOST) is not supported by the SPI Master and SPI Slave driver on ESP32-S2 and later
+#define SPI_HOST    SPI1_HOST
+#define FSPI_HOST   SPI2_HOST
+#define HSPI_HOST   SPI3_HOST
+#define VSPI_HOST   SPI3_HOST
+
 #elif CONFIG_IDF_TARGET_ESP32C3
 #define SPI_HOST    SPI1_HOST
 #define HSPI_HOST   SPI2_HOST

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -31,6 +31,8 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
   const uint8_t MAX_PWMS = 16;            // ESP32: 16 ledc PWM channels in total - TODO for now
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
   const uint8_t MAX_PWMS = 8;             // ESP32S2: 8 ledc PWM channels in total
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+  const uint8_t MAX_PWMS = 8;             // ESP32S2: 8 ledc PWM channels in total
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
   const uint8_t MAX_PWMS = 6;             // ESP32C3: 6 ledc PWM channels in total
 #else

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -52,3 +52,23 @@ debug_init_break        = tbreak setup
 build_unflags           = ${core32solo1.build_unflags}
 build_flags             = ${core32solo1.build_flags}
 monitor_filters         = esp32_exception_decoder
+
+; *** pre alpha S3 Version
+[env:tasmota32s3]
+extends                 = env:tasmota32_base
+platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/614/framework-arduinoespressif32-release_v4.4-077f93b411.tar.gz
+board                   = esp32s3
+build_flags             = ${env:tasmota32_base.build_flags}
+lib_extra_dirs          =
+                          lib/lib_basic
+                          lib/lib_ssl
+                          lib/libesp32
+lib_ignore              =
+                          TTGO TWatch Library
+                          NimBLE-Arduino
+                          Micro-RTSP
+                          epdiy
+                          NeoPixelBus
+                          SPI
+                          SD

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -22,6 +22,7 @@ lib_ignore                  =
                               ESP RainMaker
                               WiFiProv
                               USB
+                              SD_MMC
                               ESP32 Azure IoT Arduino
                               ESP32 Async UDP
                               ESP32 BLE Arduino

--- a/tasmota/support_crash_recorder.ino
+++ b/tasmota/support_crash_recorder.ino
@@ -144,7 +144,7 @@ void CrashDumpClear(void)
   }
 }
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 /**
  * Save crash information in RTC memory
  * This function is called automatically if ESP8266 suffers an exception

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -126,6 +126,8 @@ String GetDeviceHardware(void) {
     #include "esp32/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32S2  // ESP32-S2
     #include "esp32s2/rom/rtc.h"
+  #elif CONFIG_IDF_TARGET_ESP32S3  // ESP32-S3
+    #include "esp32s3/rom/rtc.h"
   #elif CONFIG_IDF_TARGET_ESP32C3  // ESP32-C3
     #include "esp32c3/rom/rtc.h"
   #else
@@ -277,6 +279,8 @@ extern "C" {
     #include "esp32/rom/spi_flash.h"
   #elif CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
     #include "esp32s2/rom/spi_flash.h"
+  #elif CONFIG_IDF_TARGET_ESP32S3   // ESP32-S3
+    #include "esp32s3/rom/spi_flash.h"
   #elif CONFIG_IDF_TARGET_ESP32C3   // ESP32-C3
     #include "esp32c3/rom/spi_flash.h"
   #else
@@ -524,12 +528,14 @@ float CpuTemperature(void) {
   return t;
 */
 #else
-  // Currently (20210801) repeated calls to temperatureRead() on ESP32C3 and ESP32S2 result in IDF error messages
-  static float t = NAN;
-  if (isnan(t)) {
-    t = (float)temperatureRead();  // In Celsius
-  }
-  return t;
+  #ifndef CONFIG_IDF_TARGET_ESP32S3
+    // Currently (20210801) repeated calls to temperatureRead() on ESP32C3 and ESP32S2 result in IDF error messages
+    static float t = NAN;
+    if (isnan(t)) {
+      t = (float)temperatureRead();  // In Celsius
+    }
+    return t;
+  #endif
 #endif
 }
 

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -67,6 +67,8 @@ const uint8_t MAX_PWMS_LEGACY = 5;          // Max number of PWM channels in fir
     const uint8_t MAX_PWMS = 16;            // ESP32: 16 ledc PWM channels in total - TODO for now
   #elif defined(CONFIG_IDF_TARGET_ESP32S2)
     const uint8_t MAX_PWMS = 8;             // ESP32S2: 8 ledc PWM channels in total
+  #elif defined(CONFIG_IDF_TARGET_ESP32S3)
+    const uint8_t MAX_PWMS = 8;             // ESP32S3: 8 ledc PWM channels in total
   #elif defined(CONFIG_IDF_TARGET_ESP32C3)
     const uint8_t MAX_PWMS = 6;             // ESP32C3: 6 ledc PWM channels in total
   #else
@@ -102,6 +104,8 @@ const uint8_t MAX_I2S = 2;                  // Max number of Hardware I2S contro
 const uint8_t MAX_RMT = 8;                  // Max number or RMT channels (ESP32 only)
 #elif CONFIG_IDF_TARGET_ESP32S2
 const uint8_t MAX_RMT = 4;                  // Max number or RMT channels (ESP32S2 only)
+#elif CONFIG_IDF_TARGET_ESP32S3
+const uint8_t MAX_RMT = 1;                  // Max number or RMT channels (ESP32S3 only)
 #elif CONFIG_IDF_TARGET_ESP32C3
 const uint8_t MAX_RMT = 2;                  // Max number or RMT channels (ESP32C3 only)
 #else


### PR DESCRIPTION
Providing a early alpha Tasmota arduino framework for the ESP32-S3.
SPI is not yet working in Arduino framework for S3

Tasmota does compile successfully (most driver disabled needs `#undef USE_WS2812`).
Not tested if it boots (no device to test).

A lot of work to do...

**Maybe Tasmota will never be adopted to the S3!**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
