### PR TITLE
Add a tasmota_lib_changes.md in OpenTherm forlder

### DIFF
--- a/lib/lib_div/OpenTherm-0.9.0/tasmota_lib_changes.md
+++ b/lib/lib_div/OpenTherm-0.9.0/tasmota_lib_changes.md
@@ -1,0 +1,29 @@
+Attention when updating library. Changes in lib needed!!
+All OpenTherm constants shall be prepended with `OPTH_` to avoid conflicts with other libs.
+
+See commit https://github.com/arendst/Tasmota/commit/960291729ccc7cb4da50108e5299d44a79cb06de
+
+As of OpenTherm-0.9.0, hte list is:
+        OPTH_NONE
+        OPTH_SUCCESS
+        OPTH_INVALID
+        OPTH_TIMEOUT
+        OPTH_READ_DATA
+        OPTH_READ
+        OPTH_WRITE_DATA
+        OPTH_WRITE
+        OPTH_INVALID_DATA
+        OPTH_RESERVED
+        OPTH_READ_ACK
+        OPTH_WRITE_ACK
+        OPTH_DATA_INVALID
+        OPTH_UNKNOWN_DATA_ID
+        OPTH_NOT_INITIALIZED
+        OPTH_READY
+        OPTH_DELAY
+        OPTH_REQUEST_SENDING
+        OPTH_RESPONSE_WAITING
+        OPTH_RESPONSE_START_BIT
+        OPTH_RESPONSE_RECEIVING
+        OPTH_RESPONSE_READY
+        OPTH_RESPONSE_INVALID


### PR DESCRIPTION
## Description:

Add a warning that opentherm symbols shall be prepended by `OPTH_` in order to avoid conflicts with NimBLE.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
