### PR TITLE
S3 SPI enabled

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -57,7 +57,7 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/617/framework-arduinoespressif32-v4.4_dev-3cfa267e25.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/621/framework-arduinoespressif32-v4.4_dev-a829191c37.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags}
 lib_extra_dirs          =

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -70,5 +70,3 @@ lib_ignore              =
                           Micro-RTSP
                           epdiy
                           NeoPixelBus
-                          SPI
-                          SD


### PR DESCRIPTION
## Description:

latest Arduino changes added support for SPI for S3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
