### PR TITLE
ESP32S3 allow NeoPixelBus to compile

### DIFF
--- a/lib/lib_basic/NeoPixelBus/src/internal/Esp32_i2s.c
+++ b/lib/lib_basic/NeoPixelBus/src/internal/Esp32_i2s.c
@@ -19,8 +19,8 @@
 
 #include "sdkconfig.h" // this sets useful config symbols, like CONFIG_IDF_TARGET_ESP32C3
 
-// ESP32C3 I2S is not supported yet due to significant changes to interface
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+// ESP32C3/S3 I2S is not supported yet due to significant changes to interface
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
 
 #include <string.h>
 #include <stdio.h>


### PR DESCRIPTION
## Description:

Anticipating https://github.com/Makuna/NeoPixelBus/pull/558
Allows RMT NeoPixelBus to work on Esp32S3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
