### PR TITLE
Fix Eth DNS Server overwritten

### DIFF
--- a/tasmota/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/xdrv_82_esp32_ethernet.ino
@@ -100,8 +100,10 @@ void EthernetEvent(WiFiEvent_t event) {
         ETH.macAddress().c_str(), (uint32_t)ETH.localIP(), eth_hostname);
       Settings->eth_ipv4_address[1] = (uint32_t)ETH.gatewayIP();
       Settings->eth_ipv4_address[2] = (uint32_t)ETH.subnetMask();
-      Settings->eth_ipv4_address[3] = (uint32_t)ETH.dnsIP();
-      Settings->eth_ipv4_address[4] = (uint32_t)ETH.dnsIP(1);
+      if (0 == Settings->eth_ipv4_address[0]) {  // At this point ETH.dnsIP() are NOT correct unless DHCP
+        Settings->eth_ipv4_address[3] = (uint32_t)ETH.dnsIP();
+        Settings->eth_ipv4_address[4] = (uint32_t)ETH.dnsIP(1);
+      }
       TasmotaGlobal.rules_flag.eth_connected = 1;
       TasmotaGlobal.global_state.eth_down = 0;
       break;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** As pointed by https://github.com/arendst/Tasmota/issues/14688

What appears as a display problem is in fact that DNS Server settings where actually overwritten to 0.0.0.0
Settings should not be overwritten by ETH.dnsIP() in EVENT_GET_IP unless we are in DHCP

This little test solve it

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
