### PR TITLE
fix wstring issue in framework(s)

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -39,8 +39,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
 
 [core32]
 platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.2/platform-tasmota-espressif32-2.0.2.zip
-platform_packages           = framework-espressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/600/framework-arduinoespressif32-IDF44.tar.gz
-;platform_packages           =
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -57,7 +57,7 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/621/framework-arduinoespressif32-v4.4_dev-a829191c37.tar.gz
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/622/framework-arduinoespressif32-v4.4_dev-a829191c37.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
 lib_extra_dirs          =
@@ -77,4 +77,3 @@ lib_ignore              =
                           NimBLE-Arduino
                           Micro-RTSP
                           epdiy
-                          NeoPixelBus


### PR DESCRIPTION
* Fix core wstring issue in frameworks
To pull latest platform and framework delete in (hidden) folder `.platformio` the folder `platforms`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
