### PR TITLE
Add seconds to MAX7219 DisplayClock command

### DIFF
--- a/tasmota/xdsp_15_tm1637.ino
+++ b/tasmota/xdsp_15_tm1637.ino
@@ -995,7 +995,7 @@ void TM1637ShowTime()
       hr = 12;
   }
 
-  char tm[5];
+  char tm[9];
   if (hr < 10)
   {
     if (mn < 10)

--- a/tasmota/xdsp_15_tm1637.ino
+++ b/tasmota/xdsp_15_tm1637.ino
@@ -996,41 +996,8 @@ void TM1637ShowTime()
   }
 
   char tm[9];
-  if (hr < 10)
-  {
-    if (mn < 10)
-    {
-      if (sc < 10)
-        snprintf(tm, sizeof(tm), PSTR("%c%d0%d0%d"), z, hr, mn, sc);
-      else
-        snprintf(tm, sizeof(tm), PSTR("%c%d0%d%d"), z, hr, mn, sc);
-    }
-    else
-    {
-      if (sc < 10)
-        snprintf(tm, sizeof(tm), PSTR("%c%d%d0%d"), z, hr, mn, sc);
-      else
-        snprintf(tm, sizeof(tm), PSTR("%c%d%d%d"), z, hr, mn, sc);
-    }
-  }
-  else
-  {
-    if (mn < 10)
-    {
-      if (sc < 10)
-        snprintf(tm, sizeof(tm), PSTR("%d0%d0%d"), hr, mn, sc);
-      else
-        snprintf(tm, sizeof(tm), PSTR("%d0%d%d"), hr, mn, sc);
-    }
-    else
-    {
-      if (sc < 10)
-        snprintf(tm, sizeof(tm), PSTR("%d%d0%d"), hr, mn, sc);
-      else
-        snprintf(tm, sizeof(tm), PSTR("%d%d%d"), hr, mn, sc);
-    }
-  }
-
+  snprintf_P(tm, sizeof(tm), PSTR("%c%d%02d%02d"), z, hr, mn, sc);
+  
   if (TM1637 == TM1637Data.display_type)
   {
     uint8_t rawBytes[1];

--- a/tasmota/xdsp_15_tm1637.ino
+++ b/tasmota/xdsp_15_tm1637.ino
@@ -979,6 +979,7 @@ void TM1637ShowTime()
 {
   uint8_t hr = RtcTime.hour;
   uint8_t mn = RtcTime.minute;
+  uint8_t sc = RtcTime.second;
   // uint8_t hr = 1;
   // uint8_t mn = 0;
   char z = ' ';
@@ -998,16 +999,36 @@ void TM1637ShowTime()
   if (hr < 10)
   {
     if (mn < 10)
-      snprintf(tm, sizeof(tm), PSTR("%c%d0%d"), z, hr, mn);
+    {
+      if (sc < 10)
+        snprintf(tm, sizeof(tm), PSTR("%c%d0%d0%d"), z, hr, mn, sc);
+      else
+        snprintf(tm, sizeof(tm), PSTR("%c%d0%d%d"), z, hr, mn, sc);
+    }
     else
-      snprintf(tm, sizeof(tm), PSTR("%c%d%d"), z, hr, mn);
+    {
+      if (sc < 10)
+        snprintf(tm, sizeof(tm), PSTR("%c%d%d0%d"), z, hr, mn, sc);
+      else
+        snprintf(tm, sizeof(tm), PSTR("%c%d%d%d"), z, hr, mn, sc);
+    }
   }
   else
   {
     if (mn < 10)
-      snprintf(tm, sizeof(tm), PSTR("%d0%d"), hr, mn);
+    {
+      if (sc < 10)
+        snprintf(tm, sizeof(tm), PSTR("%d0%d0%d"), hr, mn, sc);
+      else
+        snprintf(tm, sizeof(tm), PSTR("%d0%d%d"), hr, mn, sc);
+    }
     else
-      snprintf(tm, sizeof(tm), PSTR("%d%d"), hr, mn);
+    {
+      if (sc < 10)
+        snprintf(tm, sizeof(tm), PSTR("%d%d0%d"), hr, mn, sc);
+      else
+        snprintf(tm, sizeof(tm), PSTR("%d%d%d"), hr, mn, sc);
+    }
   }
 
   if (TM1637 == TM1637Data.display_type)
@@ -1035,7 +1056,8 @@ void TM1637ShowTime()
   {
     for (uint32_t i = 0; i < 4; i++)
     {
-      if ((millis() % 1000) > 500 && (i == 1))
+      //if ((millis() % 1000) > 500 && (i == 3))
+      if ((i == 1) || (i == 3))
         displayMAX7219ASCIIwDot(i, tm[i]);
       else
         displayMAX7219ASCII(i, tm[i]);


### PR DESCRIPTION
As extra digits are available, may as well use them to allow more accuracy. Also changed the colon/dot to remain illuminated since the seconds fulfill the heartbeat function, and colon/dot serves as just a separator.

TM1637 and TM1638 code is unchanged.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
