### PR TITLE
arendst#14678 added option to let direction relay execute before power on

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -28,11 +28,11 @@
 #endif
 
 #ifndef SHUTTER_RELAY_OPERATION_TIME
-  #define SHUTTER_RELAY_OPERATION_TIME = 100 // wait for direction relay 0.1sec before power up main relay
+  #define SHUTTER_RELAY_OPERATION_TIME 100 // wait for direction relay 0.1sec before power up main relay
 #endif
 
 #ifndef MOTOR_STOP_TIME
- #define MOTOR_STOP_TIME = 500 // wait 0.5 second after stop to do any other action. e.g. move in the opposite direction
+ #define MOTOR_STOP_TIME 500 // wait 0.5 second after stop to do any other action. e.g. move in the opposite direction
 #endif
 
 //#define SHUTTER_UNITTEST

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1,7 +1,7 @@
 /*
   xdrv_27_Shutter[i].ino - Shutter/Blind support for Tasmota
 
-  Copyright (C) 2022  Stefan Bode
+  Copyright (C) 2022  Stefan Bode 
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1,7 +1,7 @@
 /*
   xdrv_27_Shutter[i].ino - Shutter/Blind support for Tasmota
 
-  Copyright (C) 2021  Stefan Bode
+  Copyright (C) 2022  Stefan Bode
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -27,11 +27,19 @@
   #define SHUTTER_STEPPER
 #endif
 
+#ifndef SHUTTER_RELAY_OPERATION_TIME
+  #define SHUTTER_RELAY_OPERATION_TIME = 100 // wait for direction relay 0.1sec before power up main relay
+#endif
+
+#ifndef MOTOR_STOP_TIME
+ #define MOTOR_STOP_TIME = 500 // wait 0.5 second after stop to do any other action. e.g. move in the opposite direction
+#endif
+
 //#define SHUTTER_UNITTEST
 
 #define D_SHUTTER "SHUTTER"
 
-const uint16_t MOTOR_STOP_TIME = 500;   // in mS
+
 const uint16_t RESOLUTION = 1000;       // incresed to 1000 in 8.5 to ramp servos
 const uint8_t  STEPS_PER_SECOND = 20;   // FUNC_EVERY_50_MSECOND
 const uint16_t pwm_servo_max = 500;
@@ -474,7 +482,7 @@ void ShutterDecellerateForStop(uint8_t i)
 
 void ShutterPowerOff(uint8_t i)
 {
-  AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Stop %d. Mode %d, time:%d"), i+1,Shutter[i].switch_mode, Shutter[i].time); // fix log to indicate correct shutter number
+  AddLog(LOG_LEVEL_DEBUG, PSTR("SHT: Stop %d Mode %d time %d"), i+1,Shutter[i].switch_mode, Shutter[i].time); // fix log to indicate correct shutter number
   ShutterDecellerateForStop(i);
   uint8_t cur_relay = Settings->shutter_startrelay[i] + (Shutter[i].direction == 1 ? 0 : (uint8_t)(ShutterGlobal.position_mode == SHT_TIME)) ;
   if (Shutter[i].direction !=0) {
@@ -1177,6 +1185,8 @@ void CmndShutterPosition(void)
         }
         if (Shutter[index].direction != new_shutterdirection) {
           ShutterStartInit(index, new_shutterdirection, Shutter[index].target_position);
+          uint8_t save_direction = Shutter[i].direction;
+          Shutter[i].direction = 0; // set temporary direction = 0 to avoid RTC timer sarting. Some delay may happen before shutter starts moving
           switch (ShutterGlobal.position_mode) {
             case SHT_COUNTER:
             case SHT_PWM_TIME:
@@ -1185,6 +1195,7 @@ void CmndShutterPosition(void)
               if (!ShutterGlobal.skip_relay_change) {
                 // Code for shutters with circuit safe configuration, switch the direction Relay
                 ExecuteCommandPowerShutter(Settings->shutter_startrelay[index] +1, new_shutterdirection == 1 ? 0 : 1, SRC_SHUTTER);
+                delay(SHUTTER_RELAY_OPERATION_TIME);
                 // power on
                 ExecuteCommandPowerShutter(Settings->shutter_startrelay[index], 1, SRC_SHUTTER);
               }
@@ -1204,9 +1215,9 @@ void CmndShutterPosition(void)
                   AddLog(LOG_LEVEL_INFO, PSTR("SHT: Garage not move in this direction: %d"), Shutter[index].switch_mode == SHT_PULSE);
                   for (uint8_t k=0 ; k <= (uint8_t)(Shutter[index].switch_mode == SHT_PULSE) ; k++) {
                     ExecuteCommandPowerShutter(Settings->shutter_startrelay[index], 1, SRC_SHUTTER);
-                    delay(500);
+                    delay(MOTOR_STOP_TIME);
                     ExecuteCommandPowerShutter(Settings->shutter_startrelay[index], 0, SRC_SHUTTER);
-                    delay(500);
+                    delay(MOTOR_STOP_TIME);
                   }
                   // reset shutter time to avoid 2 seconds above count as runtime
                   Shutter[index].time = 0;
@@ -1215,6 +1226,7 @@ void CmndShutterPosition(void)
               } // if (!ShutterGlobal.skip_relay_change)
             break;
           } // switch (ShutterGlobal.position_mode)
+          Shutter[i].direction = save_direction;
           ShutterGlobal.RelayCurrentMask = 0;
         } // if (Shutter[i].direction[index] != new_shutterdirection)
       } else {
@@ -1611,6 +1623,7 @@ void CmndShutterSetTilt(void)
     }
   }
   XdrvMailbox.data[0] = '\0';
+  AddLog(LOG_LEVEL_INFO, PSTR("SHT: TiltTarget %d, payload %d"), Shutter[XdrvMailbox.index -1].tilt_target_pos,XdrvMailbox.payload);
   ResponseCmndNumber(Shutter[XdrvMailbox.index -1].tilt_target_pos);
   Shutter[XdrvMailbox.index -1].tiltmoving = 1;
   CmndShutterPosition();

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -1185,8 +1185,8 @@ void CmndShutterPosition(void)
         }
         if (Shutter[index].direction != new_shutterdirection) {
           ShutterStartInit(index, new_shutterdirection, Shutter[index].target_position);
-          uint8_t save_direction = Shutter[i].direction;
-          Shutter[i].direction = 0; // set temporary direction = 0 to avoid RTC timer sarting. Some delay may happen before shutter starts moving
+          uint8_t save_direction = Shutter[index].direction;
+          Shutter[index].direction = 0; // set temporary direction = 0 to avoid RTC timer sarting. Some delay may happen before shutter starts moving
           switch (ShutterGlobal.position_mode) {
             case SHT_COUNTER:
             case SHT_PWM_TIME:
@@ -1226,7 +1226,7 @@ void CmndShutterPosition(void)
               } // if (!ShutterGlobal.skip_relay_change)
             break;
           } // switch (ShutterGlobal.position_mode)
-          Shutter[i].direction = save_direction;
+          Shutter[index].direction = save_direction;
           ShutterGlobal.RelayCurrentMask = 0;
         } // if (Shutter[i].direction[index] != new_shutterdirection)
       } else {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#14678 
Added to new user_config.override options 
 #define SHUTTER_RELAY_OPERATION_TIME 100 // wait for direction relay 0.1sec before power up main relay
 #define MOTOR_STOP_TIME 500 // wait 0.5 second after stop to do any other action. e.g. move in the opposite direction
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
