### PR TITLE
IR update tolerance after update

### DIFF
--- a/tasmota/xdrv_05_irremote.ino
+++ b/tasmota/xdrv_05_irremote.ino
@@ -209,7 +209,7 @@ void IrReceiveInit(void)
   // an IR led is at GPIO_IRRECV
   irrecv = new IRrecv(Pin(GPIO_IRRECV), IR_RCV_BUFFER_SIZE, IR_RCV_TIMEOUT, IR_RCV_SAVE_BUFFER);
   irrecv->setUnknownThreshold(Settings->param[P_IR_UNKNOW_THRESHOLD]);
-  irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
+  IrReceiveUpdateTolerance();
   irrecv->enableIRIn();                  // Start the receiver
 
   //  AddLog(LOG_LEVEL_DEBUG, PSTR("IrReceive initialized"));

--- a/tasmota/xdrv_05_irremote_full.ino
+++ b/tasmota/xdrv_05_irremote_full.ino
@@ -207,7 +207,7 @@ void IrReceiveInit(void)
   // an IR led is at GPIO_IRRECV
   irrecv = new IRrecv(Pin(GPIO_IRRECV), IR_FULL_BUFFER_SIZE, IR__FULL_RCV_TIMEOUT, IR_FULL_RCV_SAVE_BUFFER);
   irrecv->setUnknownThreshold(Settings->param[P_IR_UNKNOW_THRESHOLD]);
-  irrecv->setTolerance(Settings->param[P_IR_TOLERANCE]);
+  IrReceiveUpdateTolerance();
   irrecv->enableIRIn();                  // Start the receiver
 }
 


### PR DESCRIPTION
## Description:

Solve https://github.com/arendst/Tasmota/pull/14555#issuecomment-1031412367

Tolerance is not updated from `0` to default value after an update.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
