### PR TITLE
LVGL increase stack size for Freetype

### DIFF
--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -84,6 +84,8 @@
 #ifdef USE_UNIVERSAL_DISPLAY
   #define USE_LVGL
   #define USE_LVGL_FREETYPE
+    #undef SET_ESP32_STACK_SIZE
+    #define SET_ESP32_STACK_SIZE (24 * 1024)
 //  #define USE_DISPLAY_LVGL_ONLY
 #else
   #define USE_DISPLAY_ILI9341                      // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
@@ -126,6 +128,8 @@
 #ifdef USE_UNIVERSAL_DISPLAY
   #define USE_LVGL
   #define USE_LVGL_FREETYPE
+    #undef SET_ESP32_STACK_SIZE
+    #define SET_ESP32_STACK_SIZE (24 * 1024)
 //  #define USE_DISPLAY_LVGL_ONLY
 #else
   #define USE_DISPLAY_ILI9341                  // [DisplayModel 4] Enable ILI9341 Tft 480x320 display (+19k code)
@@ -212,6 +216,8 @@
 #define USE_SPI
 #define USE_LVGL
 #define USE_LVGL_FREETYPE
+  #undef SET_ESP32_STACK_SIZE
+  #define SET_ESP32_STACK_SIZE (24 * 1024)
 #define USE_LVGL_PNG_DECODER
 #define USE_DISPLAY
 #define SHOW_SPLASH


### PR DESCRIPTION
## Description:

`USE_LVGL_FREETYPE` requires stack to be increased from 8KB to 24KB.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
