### PR TITLE
Expand config_version ESP32 id

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -444,11 +444,11 @@ bool SettingsConfigRestore(void) {
     valid_settings = (0 == settings_buffer[0xF36]);  // Settings->config_version
 #endif  // ESP8266
 #ifdef ESP32
-#ifdef CONFIG_IDF_TARGET_ESP32C3
+#ifdef CONFIG_IDF_TARGET_ESP32S3
     valid_settings = (2 == settings_buffer[0xF36]);  // Settings->config_version
 #else
     valid_settings = (1 == settings_buffer[0xF36]);  // Settings->config_version
-#endif  // CONFIG_IDF_TARGET_ESP32C3
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // ESP32
   }
 
@@ -828,11 +828,11 @@ void SettingsDefaultSet2(void) {
 //  Settings->config_version = 0;  // ESP8266 (Has been 0 for long time)
 #endif  // ESP8266
 #ifdef ESP32
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-  Settings->config_version = 2;  // ESP32C3
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+  Settings->config_version = 2;  // ESP32S3
 #else
   Settings->config_version = 1;  // ESP32
-#endif  // CONFIG_IDF_TARGET_ESP32C3
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // ESP32
 
   flag.stop_flash_rotate |= APP_FLASH_CYCLE;
@@ -1354,11 +1354,11 @@ void SettingsDelta(void) {
       Settings->config_version = 0;  // ESP8266 (Has been 0 for long time)
 #endif  // ESP8266
 #ifdef ESP32
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-      Settings->config_version = 2;  // ESP32C3
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+      Settings->config_version = 2;  // ESP32S3
 #else
       Settings->config_version = 1;  // ESP32
-#endif  // CONFIG_IDF_TARGET_ESP32C3
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // ESP32
     }
     if (Settings->version < 0x08020006) {

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -444,10 +444,15 @@ bool SettingsConfigRestore(void) {
     valid_settings = (0 == settings_buffer[0xF36]);  // Settings->config_version
 #endif  // ESP8266
 #ifdef ESP32
+
 #ifdef CONFIG_IDF_TARGET_ESP32S3
-    valid_settings = (2 == settings_buffer[0xF36]);  // Settings->config_version
+    valid_settings = (2 == settings_buffer[0xF36]);  // Settings->config_version ESP32S3
+#elif CONFIG_IDF_TARGET_ESP32S2
+    valid_settings = (3 == settings_buffer[0xF36]);  // Settings->config_version ESP32S2
+#elif CONFIG_IDF_TARGET_ESP32C3
+    valid_settings = (4 == settings_buffer[0xF36]);  // Settings->config_version ESP32C3
 #else
-    valid_settings = (1 == settings_buffer[0xF36]);  // Settings->config_version
+    valid_settings = (1 == settings_buffer[0xF36]);  // Settings->config_version ESP32 all other
 #endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // ESP32
   }
@@ -830,6 +835,10 @@ void SettingsDefaultSet2(void) {
 #ifdef ESP32
 #ifdef CONFIG_IDF_TARGET_ESP32S3
   Settings->config_version = 2;  // ESP32S3
+#elif CONFIG_IDF_TARGET_ESP32S2
+  Settings->config_version = 3;  // ESP32S2
+#elif CONFIG_IDF_TARGET_ESP32C3
+  Settings->config_version = 4;  // ESP32C3
 #else
   Settings->config_version = 1;  // ESP32
 #endif  // CONFIG_IDF_TARGET_ESP32S3
@@ -1356,6 +1365,10 @@ void SettingsDelta(void) {
 #ifdef ESP32
 #ifdef CONFIG_IDF_TARGET_ESP32S3
       Settings->config_version = 2;  // ESP32S3
+#elif CONFIG_IDF_TARGET_ESP32S2
+      Settings->config_version = 3;  // ESP32S2
+#elif CONFIG_IDF_TARGET_ESP32C3
+      Settings->config_version = 4;  // ESP32C3
 #else
       Settings->config_version = 1;  // ESP32
 #endif  // CONFIG_IDF_TARGET_ESP32S3


### PR DESCRIPTION
## Description:

Fix ESP32S3 id, expand other ESP32 id for setting detection


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
