### PR TITLE
Fix xy calculation

### DIFF
--- a/tasmota/support_float.ino
+++ b/tasmota/support_float.ino
@@ -155,7 +155,6 @@ inline float atanf(float x) { return atan_66(x); }
 inline float asinf(float x) { return asinf1(x); }
 inline float acosf(float x) { return acosf1(x); }
 inline float sqrtf(float x) { return sqrt1(x); }
-inline float powf(float x, float y) { return FastPrecisePow(x, y); }
 
 // Math constants we'll use
 double const f_pi           = 3.1415926535897932384626433;  // f_pi


### PR DESCRIPTION
## Description:

Fix calculation for XY to RGB, it is now precise enough. ESP32 uses `powf` which is more precise. No Flash size impact.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
