### PR TITLE
Fix shutter-stepper driver if >1 door moving

### DIFF
--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -182,7 +182,7 @@ void ShutterRtc50mS(void)
             startWaveformClockCycles(Pin(GPIO_PWM1, i), cc/2, cc/2, 0, -1, 0, false);
   #endif  // ESP8266
   #ifdef ESP32
-            analogWriteFreq(Shutter[i].pwm_velocity)
+            analogWriteFreq(Shutter[i].pwm_velocity);
             analogWrite(Pin(GPIO_PWM1, i), 50);
   #endif  // ESP32
           }

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -175,10 +175,15 @@ void ShutterRtc50mS(void)
           if (Shutter[i].accelerator) {
             //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Accelerator i=%d -> %d"),i, Shutter[i].accelerator);
             ShutterUpdateVelocity(i);
-            digitalWrite(Pin(GPIO_PWM1, i), LOW);
+  #ifdef ESP8266
             // Convert frequency into clock cycles
             uint32_t cc = microsecondsToClockCycles(1000000UL) / Shutter[i].pwm_velocity;
             startWaveformClockCycles(Pin(GPIO_PWM1, i), cc/2, cc/2, 0, -1, 0, false);
+  #endif  // ESP8266
+  #ifdef ESP32
+            analogWriteFreq(Shutter[i].pwm_velocity)
+            analogWrite(Pin(GPIO_PWM1, i), 50);
+  #endif  // ESP32
           }
         break;
       }

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -175,8 +175,10 @@ void ShutterRtc50mS(void)
           if (Shutter[i].accelerator) {
             //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Accelerator i=%d -> %d"),i, Shutter[i].accelerator);
             ShutterUpdateVelocity(i);
-            analogWriteFreq(Shutter[i].pwm_velocity);
-            analogWrite(Pin(GPIO_PWM1, i), 50);
+            digitalWrite(Pin(GPIO_PWM1, i), LOW);
+            // Convert frequency into clock cycles
+            uint32_t cc = microsecondsToClockCycles(1000000UL) / Shutter[i].pwm_velocity;
+            startWaveformClockCycles(Pin(GPIO_PWM1, i), cc/2, cc/2, 0, -1, 0, false);
           }
         break;
       }

--- a/tasmota/xdrv_27_shutter.ino
+++ b/tasmota/xdrv_27_shutter.ino
@@ -175,6 +175,7 @@ void ShutterRtc50mS(void)
           if (Shutter[i].accelerator) {
             //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Accelerator i=%d -> %d"),i, Shutter[i].accelerator);
             ShutterUpdateVelocity(i);
+	    digitalWrite(Pin(GPIO_PWM1, i), LOW);
   #ifdef ESP8266
             // Convert frequency into clock cycles
             uint32_t cc = microsecondsToClockCycles(1000000UL) / Shutter[i].pwm_velocity;


### PR DESCRIPTION
Accelerate and decelerate did not work properly on two pins with different frequencies. Was always synced to the last send frequency without PIN awareness. If moving two doors or more frequency must work for each door independent

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
