### PR TITLE
prometheus: add 'friendlyname' to tasmota_info

### DIFF
--- a/tasmota/xsns_75_prometheus.ino
+++ b/tasmota/xsns_75_prometheus.ino
@@ -200,6 +200,7 @@ void HandleMetrics(void) {
     PSTR("image"), TasmotaGlobal.image_name,
     PSTR("build_timestamp"), GetBuildDateAndTime().c_str(),
     PSTR("devicename"), SettingsText(SET_DEVICENAME),
+    PSTR("friendlyname"), SettingsText(SET_FRIENDLYNAME1),
     nullptr);
 
   WritePromMetricInt32(PSTR("uptime_seconds"), kPromMetricGauge, TasmotaGlobal.uptime, nullptr);


### PR DESCRIPTION
## Description:

Adding property `friendlyname` to tasmota_info metric.

`- tasmota_info{version="11.0.0",image="(tasmota)",build_timestamp="2022-02-14T16:29:35",devicename="Tasmota"} 1`
`+ tasmota_info{version="11.0.0",image="(tasmota)",build_timestamp="2022-02-14T16:29:35",devicename="Tasmota",friendlyname="Tasmota"} 1`


I found that I wanted this while using grafana to display metrics.

Meaning I can do the following:

Metrics Browser: `tasmota_sensors_current_amperes * on(instance) group_left(friendlyname) tasmota_info`
Legend: `{{friendlyname}}`



**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ x Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
