### PR TITLE
remove not needed OneWire code

### DIFF
--- a/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
+++ b/lib/lib_basic/OneWire-Stickbreaker/OneWire.h
@@ -210,14 +210,14 @@ void directModeInput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
         }
-#elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
-        int8_t rtc_io = esp32_gpioMux[pin].rtc;
-        uint32_t rtc_reg = (rtc_io != -1)?rtc_io_desc[rtc_io].reg:0;
-        if ( rtc_reg ) // RTC pins PULL settings
-        {
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].mux);
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].pullup | rtc_io_desc[rtc_io].pulldown);
-        }
+//#elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
+//        int8_t rtc_io = esp32_gpioMux[pin].rtc;
+//        uint32_t rtc_reg = (rtc_io != -1)?rtc_io_desc[rtc_io].reg:0;
+//        if ( rtc_reg ) // RTC pins PULL settings
+//        {
+//            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].mux);
+//            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].pullup | rtc_io_desc[rtc_io].pulldown);
+//        }
 #endif
         // Input
         if ( pin < 32 )
@@ -225,13 +225,13 @@ void directModeInput(IO_REG_TYPE pin)
         else
             GPIO.enable1_w1tc.val = ((uint32_t)1 << (pin - 32));
 
-        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
-        pinFunction |= FUN_IE; // input enable but required for output as well?
-        pinFunction |= ((uint32_t)PIN_FUNC_GPIO << MCU_SEL_S);
+//        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
+//        pinFunction |= FUN_IE; // input enable but required for output as well?
+//        pinFunction |= ((uint32_t)PIN_FUNC_GPIO << MCU_SEL_S);
 
-        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
+//        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
 
-        GPIO.pin[pin].val = 0;
+//        GPIO.pin[pin].val = 0;
     }
 #endif
 }
@@ -252,14 +252,14 @@ void directModeOutput(IO_REG_TYPE pin)
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].mux);
             ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_gpio_desc[pin].pullup | rtc_gpio_desc[pin].pulldown);
         }
-#elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
-        int8_t rtc_io = esp32_gpioMux[pin].rtc;
-        uint32_t rtc_reg = (rtc_io != -1)?rtc_io_desc[rtc_io].reg:0;
-        if ( rtc_reg ) // RTC pins PULL settings
-        {
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].mux);
-            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].pullup | rtc_io_desc[rtc_io].pulldown);
-        }
+//#elif ESP_IDF_VERSION_MAJOR > 3  // ESP32-S2 needs IDF 4.2 or later
+//        int8_t rtc_io = esp32_gpioMux[pin].rtc;
+//        uint32_t rtc_reg = (rtc_io != -1)?rtc_io_desc[rtc_io].reg:0;
+//        if ( rtc_reg ) // RTC pins PULL settings
+//        {
+//            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].mux);
+//            ESP_REG(rtc_reg) = ESP_REG(rtc_reg) & ~(rtc_io_desc[rtc_io].pullup | rtc_io_desc[rtc_io].pulldown);
+//        }
 #endif
         // Output
         if ( pin < 32 )
@@ -267,13 +267,13 @@ void directModeOutput(IO_REG_TYPE pin)
         else // already validated to pins <= 33
             GPIO.enable1_w1ts.val = ((uint32_t)1 << (pin - 32));
 
-        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
-        pinFunction |= FUN_IE; // input enable but required for output as well?
-        pinFunction |= ((uint32_t)PIN_FUNC_GPIO << MCU_SEL_S);
+//        uint32_t pinFunction((uint32_t)2 << FUN_DRV_S); // what are the drivers?
+//        pinFunction |= FUN_IE; // input enable but required for output as well?
+//        pinFunction |= ((uint32_t)PIN_FUNC_GPIO << MCU_SEL_S);
 
-        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
+//        ESP_REG(DR_REG_IO_MUX_BASE + esp32_gpioMux[pin].reg) = pinFunction;
 
-        GPIO.pin[pin].val = 0;
+//        GPIO.pin[pin].val = 0;
     }
 #endif
 }


### PR DESCRIPTION
which will conflict with next Arduino core build.
Changes are working with actual core.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
