### PR TITLE
Berry fix wrong color in console

### DIFF
--- a/tasmota/xdrv_52_0_berry_struct.ino
+++ b/tasmota/xdrv_52_0_berry_struct.ino
@@ -96,4 +96,7 @@ public:
 };
 BerrySupport berry;
 
+// multi-purpose serial logging
+extern "C" void serial_debug(const char * berry_buf, ...);
+
 #endif  // USE_BERRY

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -24,7 +24,7 @@
 #include <Wire.h>
 
 const uint32_t BERRY_MAX_LOGS = 16;   // max number of print output recorded when outside of REPL, used to avoid infinite grow of logs
-const uint32_t BERRY_MAX_REPL_LOGS = 1024;   // max number of print output recorded when inside REPL
+const uint32_t BERRY_MAX_REPL_LOGS = 50;   // max number of print output recorded when inside REPL
 
 // /*********************************************************************************************\
 //  * Return C callback from index
@@ -601,7 +601,7 @@ void berry_log(const char * berry_buf) {
   if (berry.log.log.length() == 0) {
     pre_delimiter = BERRY_CONSOLE_CMD_DELIMITER;
   }
-  if (berry.log.log.length() >= BERRY_MAX_LOGS) {
+  if (berry.log.log.length() >= max_logs) {
     berry.log.log.remove(berry.log.log.head());
   }
   berry.log.addString(berry_buf, pre_delimiter, "\n");

--- a/tasmota/xdrv_52_9_berry.ino
+++ b/tasmota/xdrv_52_9_berry.ino
@@ -492,15 +492,15 @@ const char HTTP_SCRIPT_BERRY_CONSOLE[] PROGMEM =
       "x.onreadystatechange=function(){"
         "if(x.readyState==4&&x.status==200){"
           "var d,t1;"
-          "d=x.responseText.split(/" BERRY_CONSOLE_CMD_DELIMITER "/);"  // Field separator
-          "var d1=d.shift();"
+          "d=x.responseText.split(/" BERRY_CONSOLE_CMD_DELIMITER "/,2);"  // Field separator
+          "var d1=d.length>1?d[0]:null;"
           "if(d1){"
             "t1=document.createElement('div');"
             "t1.classList.add('br1');"
             "t1.innerText=d1;"
             "t.appendChild(t1);"
           "}"
-          "d1=d.shift();"
+          "d1=d.length>1?d[1]:d[0];"
           "if(d1){"
             "t1=document.createElement('div');"
             "t1.classList.add('br2');"


### PR DESCRIPTION
## Description:

Berry fix wrong color in console when the output is too long.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
