### PR TITLE
[SR04] fix mode 1 detection

### DIFF
--- a/tasmota/xsns_22_sr04.ino
+++ b/tasmota/xsns_22_sr04.ino
@@ -136,6 +136,7 @@ void Sr04TModeDetect(void) {
       sonar_serial = nullptr;
     }
     sonar = new NewPing(sr04_trig_pin, sr04_echo_pin, SR04_MAX_SENSOR_DISTANCE);
+    delay(100); // give time to inizialise, preventing ping_median fails
     if (!sonar || !sonar->ping_median(5)) {
       SR04.type = SR04_MODE_NONE;
     }


### PR DESCRIPTION
## Description:

Detection of sensors running in mode 1 fixed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
