### PR TITLE
Berry add global.contains()

### DIFF
--- a/lib/libesp32/berry/generate/be_fixed_global.h
+++ b/lib/libesp32/berry/generate/be_fixed_global.h
@@ -1,14 +1,15 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libglobal_map) {
-    { be_const_key(member, -1), be_const_func(m_findglobal) },
-    { be_const_key(setmember, 0), be_const_func(m_setglobal) },
+    { be_const_key(contains, -1), be_const_func(m_contains) },
+    { be_const_key(setmember, -1), be_const_func(m_setglobal) },
     { be_const_key(_X28_X29, -1), be_const_func(m_globals) },
+    { be_const_key(member, -1), be_const_func(m_findglobal) },
 };
 
 static be_define_const_map(
     m_libglobal_map,
-    3
+    4
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry/src/be_globallib.c
+++ b/lib/libesp32/berry/src/be_globallib.c
@@ -42,6 +42,18 @@ static int m_globals(bvm *vm)
     be_return(vm);
 }
 
+static int m_contains(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1 && be_isstring(vm, 1)) {
+        const char * name = be_tostring(vm, 1);
+        int idx = be_global_find(vm, be_newstr(vm, name));
+        be_pushbool(vm, idx > -1);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
 static int m_findglobal(bvm *vm)
 {
     int top = be_top(vm);
@@ -67,6 +79,7 @@ static int m_setglobal(bvm *vm)
 #if !BE_USE_PRECOMPILED_OBJECT
 be_native_module_attr_table(global) {
     be_native_module_function("()", m_globals),
+    be_native_module_function("contains", m_contains),
     be_native_module_function("member", m_findglobal),
     be_native_module_function("setmember", m_setglobal),
 };
@@ -76,6 +89,7 @@ be_define_native_module(global, NULL);
 /* @const_object_info_begin
 module global (scope: global, depend: BE_USE_GLOBAL_MODULE) {
     (), func(m_globals)
+    contains, func(m_contains)
     member, func(m_findglobal)
     setmember, func(m_setglobal)
 }


### PR DESCRIPTION
## Description:

Berry add `global.contains(name:string) -> bool` to quickly check if a global exists.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
