### PR TITLE
Add `USE_VL53L1X`

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -129,6 +129,7 @@ Note: `minimal` variant is not listed as it shouldn't be used outside of the [up
 | USE_SPS30             | - | - / - | - | - | - | - |
 | USE_ADE7953           | - | x / x | x | x | - | x |
 | USE_VL53L0X           | - | - / x | - | x | - | - |
+| USE_VL53L1X           | - | - / - | - | - | - | - |
 | USE_MLX90614          | - | - / - | - | - | - | - |
 | USE_CHIRP             | - | - / - | - | - | - | - |
 | USE_PAJ7620           | - | - / - | - | - | - | - |


### PR DESCRIPTION
## Description:
Adds a `USE_VL53L1X` column to `BUILDS.md`
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
