### PR TITLE
Always set ignore_any_key_time on button release

### DIFF
--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -893,6 +893,7 @@ bool Xdrv35(uint8_t function)
           }
           else {
             button_unprocessed[button_index] = true;
+            ignore_any_key_time = now - 1;
           }
 
           // If the power button was just released, clear the flags associated with it.


### PR DESCRIPTION
## Description:

For devices using the PWM Dimmer module, all buttons presses would be ignored about 50 days after a multi-button or button hold operation was performed. This PR sets the ignore time on every button release.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
