### PR TITLE
LVGL small fix

### DIFF
--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -305,7 +305,7 @@ int be_check_arg_type(bvm *vm, int arg_start, int argc, const char * arg_type, i
   // special case when first parameter is '@', pass pointer to VM
   if (NULL != arg_type && arg_type[arg_idx] == '@') {
     arg_idx++;
-    p[p_idx] = vm;
+    p[p_idx] = (intptr_t) vm;
     p_idx++;
   }
 

--- a/lib/libesp32_lvgl/lvgl/README_Tasmota.md
+++ b/lib/libesp32_lvgl/lvgl/README_Tasmota.md
@@ -1,0 +1,20 @@
+# Tasmota patches
+
+Following patches need to be applied when updating LVGL:
+
+`src/extra/libs/lv_extra.c`
+
+Comment the `lv_freetype_init()` portion. The actual initializatio is done in Tasmota code
+because parameters depend on Tasmota defines and presence of PSRAM.
+
+``` C
+// TASMOTA Specific, the initialization is done in Tasmota code to adjust with PSRAM
+// #if LV_USE_FREETYPE
+//     /*Init freetype library*/
+// #  if LV_FREETYPE_CACHE_SIZE >= 0
+//     lv_freetype_init(LV_FREETYPE_CACHE_FT_FACES, LV_FREETYPE_CACHE_FT_SIZES, LV_FREETYPE_CACHE_SIZE);
+// #  else
+//     lv_freetype_init(0, 0, 0);
+// #  endif
+// #endif
+```

--- a/lib/libesp32_lvgl/lvgl/src/extra/lv_extra.c
+++ b/lib/libesp32_lvgl/lvgl/src/extra/lv_extra.c
@@ -70,14 +70,15 @@ void lv_extra_init(void)
     lv_bmp_init();
 #endif
 
-#if LV_USE_FREETYPE
-    /*Init freetype library*/
-#  if LV_FREETYPE_CACHE_SIZE >= 0
-    lv_freetype_init(LV_FREETYPE_CACHE_FT_FACES, LV_FREETYPE_CACHE_FT_SIZES, LV_FREETYPE_CACHE_SIZE);
-#  else
-    lv_freetype_init(0, 0, 0);
-#  endif
-#endif
+// TASMOTA Specific, the initialization is done in Tasmota code to adjust with PSRAM
+// #if LV_USE_FREETYPE
+//     /*Init freetype library*/
+// #  if LV_FREETYPE_CACHE_SIZE >= 0
+//     lv_freetype_init(LV_FREETYPE_CACHE_FT_FACES, LV_FREETYPE_CACHE_FT_SIZES, LV_FREETYPE_CACHE_SIZE);
+// #  else
+//     lv_freetype_init(0, 0, 0);
+// #  endif
+// #endif
 
 #if LV_USE_FFMPEG
     lv_ffmpeg_init();


### PR DESCRIPTION
## Description:

Fix a bug that would always include Freetype code in LVGL builds, even if Freetype was not selected.
Fixed a compilation warning in Berry C mapping

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
