### PR TITLE
LVGL add display.driver_name

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -370,6 +370,7 @@ extern const bcstring be_const_str_draw_ctx;
 extern const bcstring be_const_str_draw_line;
 extern const bcstring be_const_str_draw_line_dsc;
 extern const bcstring be_const_str_draw_line_dsc_init;
+extern const bcstring be_const_str_driver_name;
 extern const bcstring be_const_str_dump;
 extern const bcstring be_const_str_duration;
 extern const bcstring be_const_str_editable;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -152,7 +152,7 @@ be_define_const_str(SERIAL_6E2, "SERIAL_6E2", 317471867u, 0, 10, &be_const_str_i
 be_define_const_str(SERIAL_6N1, "SERIAL_6N1", 198895701u, 0, 10, NULL);
 be_define_const_str(SERIAL_6N2, "SERIAL_6N2", 148562844u, 0, 10, &be_const_str_offset);
 be_define_const_str(SERIAL_6O1, "SERIAL_6O1", 266153272u, 0, 10, &be_const_str_add_header);
-be_define_const_str(SERIAL_6O2, "SERIAL_6O2", 316486129u, 0, 10, &be_const_str_function);
+be_define_const_str(SERIAL_6O2, "SERIAL_6O2", 316486129u, 0, 10, &be_const_str_driver_name);
 be_define_const_str(SERIAL_7E1, "SERIAL_7E1", 147718061u, 0, 10, &be_const_str_minute);
 be_define_const_str(SERIAL_7E2, "SERIAL_7E2", 97385204u, 0, 10, &be_const_str_fast_loop);
 be_define_const_str(SERIAL_7N1, "SERIAL_7N1", 1891060246u, 0, 10, &be_const_str_STATE_DEFAULT);
@@ -362,6 +362,7 @@ be_define_const_str(draw_ctx, "draw_ctx", 953366593u, 0, 8, &be_const_str_select
 be_define_const_str(draw_line, "draw_line", 1634465686u, 0, 9, &be_const_str_read32);
 be_define_const_str(draw_line_dsc, "draw_line_dsc", 4220676203u, 0, 13, &be_const_str_get_size);
 be_define_const_str(draw_line_dsc_init, "draw_line_dsc_init", 3866693646u, 0, 18, &be_const_str_publish_result);
+be_define_const_str(driver_name, "driver_name", 862681603u, 0, 11, &be_const_str_function);
 be_define_const_str(dump, "dump", 3663001223u, 0, 4, &be_const_str_push);
 be_define_const_str(duration, "duration", 799079693u, 0, 8, NULL);
 be_define_const_str(editable, "editable", 60532369u, 0, 8, &be_const_str_remove_timer);
@@ -1305,6 +1306,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 426,
-    .count = 875,
+    .count = 876,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_display.h
+++ b/lib/libesp32/berry/generate/be_fixed_display.h
@@ -2,13 +2,14 @@
 
 static be_define_const_map_slots(m_libdisplay_map) {
     { be_const_key(touch_update, -1), be_const_ctype_func(be_ntv_display_touch_update) },
+    { be_const_key(driver_name, 2), be_const_ctype_func(be_ntv_display_driver_name) },
     { be_const_key(dimmer, -1), be_const_func(be_ntv_display_dimmer) },
-    { be_const_key(start, -1), be_const_func(be_ntv_display_start) },
+    { be_const_key(start, 1), be_const_func(be_ntv_display_start) },
 };
 
 static be_define_const_map(
     m_libdisplay_map,
-    3
+    4
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry_tasmota/src/be_display_lib.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_display_lib.cpp
@@ -14,12 +14,15 @@ extern int be_ntv_display_start(bvm *vm);
 extern int be_ntv_display_dimmer(bvm *vm);
 extern void be_ntv_display_touch_update(int32_t touches, int32_t raw_x, int32_t raw_y, int32_t gesture);
             BE_FUNC_CTYPE_DECLARE(be_ntv_display_touch_update, "", "iiii")
+extern const char* be_ntv_display_driver_name(void);
+            BE_FUNC_CTYPE_DECLARE(be_ntv_display_driver_name, "s", "")
 
 /* @const_object_info_begin
 module display (scope: global) {
     start, func(be_ntv_display_start)
     dimmer, func(be_ntv_display_dimmer)
     touch_update, ctype_func(be_ntv_display_touch_update)
+    driver_name, ctype_func(be_ntv_display_driver_name)
 }
 @const_object_info_end */
 #include "be_fixed_display.h"

--- a/tasmota/xdrv_52_3_berry_display.ino
+++ b/tasmota/xdrv_52_3_berry_display.ino
@@ -25,6 +25,7 @@
 
 #ifdef USE_UNIVERSAL_DISPLAY
 Renderer *Init_uDisplay(const char *desc);
+extern Renderer *renderer;
 #endif //  USE_UNIVERSAL_DISPLAY
 
 /*********************************************************************************************\
@@ -76,6 +77,17 @@ void be_ntv_display_touch_update(int32_t touches, int32_t raw_x, int32_t raw_y, 
   Touch_SetStatus(touches, raw_x, raw_y, gesture);
 #endif
 }
+
+const char* be_ntv_display_driver_name(void) {
+  if (renderer) {
+    char* devname = renderer->devname();
+    if (devname) {
+      return devname;
+    }
+  }
+  return "";
+}
+
 
 #endif // USE_DISPLAY
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Add Berry `display.driver_name() -> string` to get the name of the driver from the Universal Display Driver template.

This will be used for the splash screen.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
