### PR TITLE
LVGL add lv.pct

### DIFF
--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
@@ -27,6 +27,16 @@ static int lv_get_ver_res(void) {
 /* `lv` methods */
 const be_ntv_func_def_t lv_func[] = {
 
+  { "area_align", { (const void*) &lv_area_align, "", "(lv.lv_area)(lv.lv_area)iii" } },
+  { "area_copy", { (const void*) &lv_area_copy, "", "(lv.lv_area)(lv.lv_area)" } },
+  { "area_get_height", { (const void*) &lv_area_get_height, "i", "(lv.lv_area)" } },
+  { "area_get_size", { (const void*) &lv_area_get_size, "i", "(lv.lv_area)" } },
+  { "area_get_width", { (const void*) &lv_area_get_width, "i", "(lv.lv_area)" } },
+  { "area_increase", { (const void*) &lv_area_increase, "", "(lv.lv_area)ii" } },
+  { "area_move", { (const void*) &lv_area_move, "", "(lv.lv_area)ii" } },
+  { "area_set", { (const void*) &lv_area_set, "", "(lv.lv_area)iiii" } },
+  { "area_set_height", { (const void*) &lv_area_set_height, "", "(lv.lv_area)i" } },
+  { "area_set_width", { (const void*) &lv_area_set_width, "", "(lv.lv_area)i" } },
   { "atan2", { (const void*) &lv_atan2, "i", "ii" } },
   { "bezier3", { (const void*) &lv_bezier3, "i", "iiiii" } },
   { "clamp_height", { (const void*) &lv_clamp_height, "i", "iiii" } },
@@ -121,6 +131,7 @@ const be_ntv_func_def_t lv_func[] = {
   { "palette_darken", { (const void*) &lv_palette_darken, "lv.lv_color", "ii" } },
   { "palette_lighten", { (const void*) &lv_palette_lighten, "lv.lv_color", "ii" } },
   { "palette_main", { (const void*) &lv_palette_main, "lv.lv_color", "i" } },
+  { "pct", { (const void*) &lv_pct, "i", "i" } },
   { "qrcode_create", { (const void*) &lv_qrcode_create, "lv.lv_obj", "(lv.lv_obj)i(lv.lv_color)(lv.lv_color)" } },
   { "qrcode_delete", { (const void*) &lv_qrcode_delete, "", "(lv.lv_obj)" } },
   { "qrcode_update", { (const void*) &lv_qrcode_update, "i", "(lv.lv_obj).i" } },

--- a/lib/libesp32_lvgl/lv_berry/mapping/lv_funcs.h
+++ b/lib/libesp32_lvgl/lv_berry/mapping/lv_funcs.h
@@ -708,6 +708,19 @@ static inline void lv_obj_move_foreground(lv_obj_t * obj)
 static inline void lv_obj_move_background(lv_obj_t * obj)
 static inline uint32_t lv_obj_get_child_id(const struct _lv_obj_t * obj)
 
+// ../../lvgl/src/misc/lv_area.h
+void lv_area_set(lv_area_t * area_p, lv_coord_t x1, lv_coord_t y1, lv_coord_t x2, lv_coord_t y2)
+inline static void lv_area_copy(lv_area_t * dest, const lv_area_t * src)
+static inline lv_coord_t lv_area_get_width(const lv_area_t * area_p)
+static inline lv_coord_t lv_area_get_height(const lv_area_t * area_p)
+void lv_area_set_width(lv_area_t * area_p, lv_coord_t w)
+void lv_area_set_height(lv_area_t * area_p, lv_coord_t h)
+uint32_t lv_area_get_size(const lv_area_t * area_p)
+void lv_area_increase(lv_area_t * area, lv_coord_t w_extra, lv_coord_t h_extra)
+void lv_area_move(lv_area_t * area, lv_coord_t x_ofs, lv_coord_t y_ofs)
+void lv_area_align(const lv_area_t * base, lv_area_t * to_align, lv_align_t align, lv_coord_t ofs_x, lv_coord_t ofs_y)
+static inline lv_coord_t lv_pct(lv_coord_t x)
+
 // ../../lvgl/src/misc/lv_color.h
 static inline uint8_t lv_color_to1(lv_color_t color)
 static inline uint8_t lv_color_to8(lv_color_t color)

--- a/lib/libesp32_lvgl/lv_berry/tools/preprocessor.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/preprocessor.py
@@ -70,8 +70,8 @@ lv_fun_globs = [
                   "misc/lv_style_gen.h",
                   "misc/lv_color.h",
                   "misc/lv_style.h",
-                  "misc/lv_math.h"
-                  #"misc/lv_area.h",
+                  "misc/lv_math.h",
+                  "misc/lv_area.h",
                   #"**/*.h",
               ]
 headers_names = list_files(lv_src_prefix, lv_fun_globs)


### PR DESCRIPTION
## Description:

Add `lv_area.h` header into Berry mapping, which adds `lv.pct()` for percentage sizes.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
