### PR TITLE
Tasmota core 2.0.2.3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.1
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -38,14 +38,14 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.2/platform-tasmota-espressif32-2.0.2.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.2solo1/platform-tasmota-espressif32-2.0.2solo1.zip
+platform                    = https://github.com/tasmota/arduino-esp32/releases/download/2.0.2.3/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -45,7 +45,7 @@ build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/arduino-esp32/releases/download/2.0.2.3/framework-arduinoespressif32-solo1-release_IDF4.4.tar.gz
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3solo1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -53,11 +53,9 @@ build_unflags           = ${core32solo1.build_unflags}
 build_flags             = ${core32solo1.build_flags}
 monitor_filters         = esp32_exception_decoder
 
-; *** pre alpha S3 Version
+; *** alpha S3 Version
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
-platform                = https://github.com/Jason2866/platform-espressif32.git#IDF44/ESP32-S3
-platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/644/framework-arduinoespressif32-v4.4_dev-33b5ac5075.tar.gz
 board                   = esp32s3
 build_flags             = ${env:tasmota32_base.build_flags} -D FIRMWARE_BLUETOOTH
 lib_extra_dirs          =


### PR DESCRIPTION
fixes in core. The upcoming core 2.0.3. will be very close to this build.
New, support for ESP32-S3

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [xw] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
