### PR TITLE
add some protection on tcpbridge

### DIFF
--- a/tasmota/xdrv_41_tcp_bridge.ino
+++ b/tasmota/xdrv_41_tcp_bridge.ino
@@ -104,7 +104,7 @@ void TCPLoop(void)
       }
     }
     if (buf_len > 0) {
-      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "from MCU: %*_H"), buf_len, tcp_buf);
+      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_TCP "from MCU: %*_H"), buf_len, tcp_buf);
 
       for (uint32_t i=0; i<nitems(client_tcp); i++) {
         WiFiClient &client = client_tcp[i];
@@ -124,7 +124,7 @@ void TCPLoop(void)
         }
       }
       if (buf_len > 0) {
-        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "to MCU/%d: %*_H"), i+1, buf_len, tcp_buf);
+        AddLog(LOG_LEVEL_DEBUG_MORE, PSTR(D_LOG_TCP "to MCU/%d: %*_H"), i+1, buf_len, tcp_buf);
         TCPSerial->write(tcp_buf, buf_len);
       }
     }
@@ -144,10 +144,16 @@ void TCPInit(void) {
 
     if (!Settings->tcp_baudrate)  { Settings->tcp_baudrate = 115200 / 1200; }
     TCPSerial = new TasmotaSerial(Pin(GPIO_TCP_RX), Pin(GPIO_TCP_TX), TasmotaGlobal.seriallog_level ? 1 : 2, 0, TCP_BRIDGE_BUF_SIZE);   // set a receive buffer of 256 bytes
-    TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));
-    if (TCPSerial->hardwareSerial()) {
-      ClaimSerial();
-		}
+    if (TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config))) {
+      if (TCPSerial->hardwareSerial()) {
+        ClaimSerial();
+      }
+#ifdef ESP32
+      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "using hardserial %d"), TCPSerial->getUart());
+#endif
+    } else {
+      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "failed init serial"));
+    }
   }
 }
 
@@ -197,20 +203,30 @@ void CmndTCPStart(void) {
 }
 
 void CmndTCPBaudrate(void) {
+  if (!TCPSerial) { return; }
+
   if ((XdrvMailbox.payload >= 1200) && (XdrvMailbox.payload <= 115200)) {
     XdrvMailbox.payload /= 1200;  // Make it a valid baudrate
-    Settings->tcp_baudrate = XdrvMailbox.payload;
-    TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));  // Reinitialize serial port with new baud rate
+    if (Settings->tcp_baudrate != XdrvMailbox.payload) {
+      Settings->tcp_baudrate = XdrvMailbox.payload;
+      if (!TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config))) {
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "failed reinit serial"));
+      }  // Reinitialize serial port with new baud rate
+    }
   }
   ResponseCmndNumber(Settings->tcp_baudrate * 1200);
 }
 
 void CmndTCPConfig(void) {
+  if (!TCPSerial) { return; }
+
   if (XdrvMailbox.data_len > 0) {
     uint8_t serial_config = ParseSerialConfig(XdrvMailbox.data);
-    if (serial_config >= 0) {
+    if ((serial_config >= 0) && (Settings->tcp_config != (0x80 | serial_config))) {
       Settings->tcp_config = 0x80 | serial_config; // default 0x00 should be 8N1
-      TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config));  // Reinitialize serial port with new config
+      if (!TCPSerial->begin(Settings->tcp_baudrate * 1200, ConvertSerialConfig(0x7F & Settings->tcp_config))) {
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_TCP "failed reinit serial"));
+      }  // Reinitialize serial port with new config
     }
   }
   ResponseCmndChar_P(GetSerialConfig(0x7F & Settings->tcp_config).c_str());
@@ -222,17 +238,19 @@ void CmndTCPConfig(void) {
 //
 void CmndTCPConnect(void) {
   int32_t tcp_port = XdrvMailbox.payload;
-  
+
+  if (!TCPSerial) { return; }
+
   if (ArgC() == 2) {
     char sub_string[XdrvMailbox.data_len];
     WiFiClient new_client;
-    AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Connecting to %s on port %d"), ArgV(sub_string, 2),tcp_port);  
+    AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Connecting to %s on port %d"), ArgV(sub_string, 2),tcp_port);
     if (new_client.connect(ArgV(sub_string, 2),tcp_port)) {
-      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "connected!"));  
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "connected!"));
     } else {
-      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "error connecting!"));  
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "error connecting!"));
     }
-    
+
     // find an empty slot
     uint32_t i;
     for (i=0; i<nitems(client_tcp); i++) {
@@ -249,9 +267,9 @@ void CmndTCPConnect(void) {
       client = new_client;
     }
   } else {
-    AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Usage: port,ip_address"));  
+    AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_TCP "Usage: port,ip_address"));
   }
-  
+
   ResponseCmndDone();
 }
 


### PR DESCRIPTION
## Description:

- add some protections against crash/restart when a TCPxxx command was sent but no TCPTx/Rx GPIO was configured 
- add a test on TCPSerial->begin() result in case something goes wrong
- move buffer dumps ("to MCU"/"fom MCU") from  LOG_LEVEL_DEBUG to LOG_LEVEL_DEBUG_MORE

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
