### PR TITLE
Allow dynamic reconfiguration of TasmotaSerial

### DIFF
--- a/lib/default/TasmotaSerial-3.4.0/src/TasmotaSerial.h
+++ b/lib/default/TasmotaSerial-3.4.0/src/TasmotaSerial.h
@@ -49,6 +49,7 @@ class TasmotaSerial : public Stream {
     size_t read(char* buffer, size_t size);
     int available(void) override;
     void flush(void) override;
+    bool isValid() { return m_valid; }
 
     void rxRead(void);
 


### PR DESCRIPTION
## Description:

SerialBridge, TCPBridge, Teleinfo have commands that tries to change the serial configuration dynnamically by calling `TasmotaSerial::begin()` while the port was already allocated.
Unfortunately up to now, on ESP32, this was trying to reallocate an new UART. Which quickly comes to an end if a few are in use...

This PR bypass the UART allocation if TasmotaSerial already has an UART assigned.

@arendst Should I change the version number to 3.4.1 ?


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
