### PR TITLE
Prevent crash on start with >100Hz on counter input

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -230,7 +230,9 @@ void UpdateQuickPowerCycle(bool update) {
 
   const uint32_t QPC_COUNT = 7;  // Number of Power Cycles before Settings erase
   const uint32_t QPC_SIGNATURE = 0xFFA55AFF;
-
+#ifdef USE_COUNTER
+  CounterInterruptDisable(true);
+#endif
 #ifdef ESP8266
   const uint32_t qpc_sector = SETTINGS_LOCATION - CFG_ROTATES;
   const uint32_t qpc_location = qpc_sector * SPI_FLASH_SEC_SIZE;
@@ -280,10 +282,11 @@ void UpdateQuickPowerCycle(bool update) {
     AddLog(LOG_LEVEL_INFO, PSTR("QPC: Reset"));
   }
 #endif  // ESP32
-
+#ifdef USE_COUNTER
+  CounterInterruptDisable(false);
+#endif
 #endif  // FIRMWARE_MINIMAL
 }
-
 #ifdef USE_EMERGENCY_RESET
 /*********************************************************************************************\
  * Emergency reset if Rx and Tx are tied together


### PR DESCRIPTION
Same procedure. setoption65 1 is a working workaround to avoid a crash on starting the device when there is a frequency of 100Hz or higher on one counter. The change temporarily disables the counter during the access to the flash. I', currently not sure if this is an ESP8266 only problem or also an ESP32 problem that the interrupt of the counter and flash access could cause a crash.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
