### PR TITLE
Remove dependency on USE_LIGHT for cron class

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_cron_class.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_cron_class.cpp
@@ -5,7 +5,6 @@
  * Can be eventually subclassed to handle a physical light.
  * 
  *******************************************************************/
-#ifdef USE_LIGHT
 
 #include "be_constobj.h"
 #include "be_mapping.h"
@@ -79,5 +78,3 @@ class be_class_ccronexpr (scope: global, name: ccronexpr) {
   now, static_ctype_func(ccronexpr_now)
 }
 @const_object_info_end */
-
-#endif // USE_LIGHT


### PR DESCRIPTION
## Description:

As discussed with @s-hadinger , there is no need for cron class to depend on USE_LIGHT
(was preventing my "lite" variant to compile)

## Checklist:
  - [X ] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
