### PR TITLE
Fix Hue emulation for Alexa

### DIFF
--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -936,6 +936,15 @@ public:
     calcLevels();
   }
 
+  /* special version for Alexa Hue maintaining a 16 bits Hue value */
+  void changeH16SB(uint16_t hue, uint8_t sat, uint8_t briRGB) {
+    _state->setH16S(hue, sat);
+    _state->setBriRGB(briRGB);
+    if (_ct_rgb_linked) { _state->setColorMode(LCM_RGB); }   // try to force RGB
+    saveSettings();
+    calcLevels();
+  }
+
   // save the current light state to Settings
   void saveSettings() {
     if (Light.pwm_multi_channels) {


### PR DESCRIPTION
## Description:

Uses the new `_hue16` variable to store the high resolution (16 bits) hue set by Alexa and according to Philips Hue API.

**Related issue (if applicable):** fixes #15019 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
