### PR TITLE
Fix empty D_START breaks GetStateNumber()

### DIFF
--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -161,7 +161,7 @@
 #define D_SAVE "Mentés"
 #define D_SENSOR "Szenzor"
 #define D_SSID "SSID"
-#define D_START ""
+#define D_START "Start"
 #define D_STD_TIME "STD"
 #define D_STOP "Leállítás"
 #define D_SUBNET_MASK "Alhálózati maszk"
@@ -855,8 +855,8 @@
 #define D_GPIO_SHIFT595_RCLK   "74x595 RCLK"
 #define D_GPIO_SHIFT595_OE     "74x595 OE"
 #define D_GPIO_SHIFT595_SER    "74x595 SER"
-#define D_SENSOR_CM11_TX       "CM110x TX" 
-#define D_SENSOR_CM11_RX       "CM110x RX" 
+#define D_SENSOR_CM11_TX       "CM110x TX"
+#define D_SENSOR_CM11_RX       "CM110x RX"
 
 // Units
 #define D_UNIT_AMPERE "A"


### PR DESCRIPTION
## Description:

Reported at TDM here : https://github.com/jziolkowski/tdm/issues/187

In tasmota-HU variant, empty `D_START` cause `GetSTateNumber()` to return 1
So commands `Module` and `Template` issued by TDM were interpreting as `Module 1` or `Template 1` forcing restart and breaking configuration

@vampywiz17 said that "Start" will be good for Hungarian people 


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
