### PR TITLE
Add command to change timeout in RfReceive

### DIFF
--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -1,18 +1,18 @@
 /*
   xdrv_17_rcswitch.ino - RF transceiver using RcSwitch library for Tasmota
-  
+
   Copyright (C) 2021  Theo Arends
-  
+
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */

--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -1,18 +1,14 @@
 /*
   xdrv_17_rcswitch.ino - RF transceiver using RcSwitch library for Tasmota
-
   Copyright (C) 2021  Theo Arends
-
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -27,24 +23,26 @@
 #define D_JSON_RF_BITS "Bits"
 #define D_JSON_RF_DATA "Data"
 
-#define D_CMND_RFSEND "RFSend"
+#define D_CMND_RFSEND "RfSend"
 #define D_CMND_RFPROTOCOL "RfProtocol"
+#define D_CMND_RFTIMEOUT "RfTimeOut"
 
 #define D_JSON_RF_PULSE "Pulse"
 #define D_JSON_RF_REPEAT "Repeat"
 #define D_JSON_NONE_ENABLED "None Enabled"
 
 const char kRfCommands[] PROGMEM = "|"  // No prefix
-  D_CMND_RFSEND "|" D_CMND_RFPROTOCOL;
+  D_CMND_RFSEND "|" D_CMND_RFPROTOCOL "|" D_CMND_RFTIMEOUT;
 
 void (* const RfCommands[])(void) PROGMEM = {
-  &CmndRfSend, &CmndRfProtocol };
+  &CmndRfSend, &CmndRfProtocol, &CmndRfTimeOut};
 
 #include <RCSwitch.h>
 
 RCSwitch mySwitch = RCSwitch();
 
-#define RF_TIME_AVOID_DUPLICATE 1000  // Milliseconds
+int RF_TIME_AVOID_DUPLICATE = 3000;  // Use variable to change "RfTimeOut" to get new data from RfReceive
+//#define RF_TIME_AVOID_DUPLICATE 1000  // Milliseconds
 
 uint32_t rf_lasttime = 0;
 
@@ -211,6 +209,15 @@ void CmndRfSend(void)
   }
   if (error) {
     Response_P(PSTR("{\"" D_CMND_RFSEND "\":\"" D_JSON_NO " " D_JSON_RF_DATA ", " D_JSON_RF_BITS ", " D_JSON_RF_PROTOCOL ", " D_JSON_RF_REPEAT " " D_JSON_OR " " D_JSON_RF_PULSE "\"}"));
+  }
+}
+
+void CmndRfTimeOut(void) { // Command to change "RfTimeOut"
+  if (XdrvMailbox.data_len > 0) {
+    RF_TIME_AVOID_DUPLICATE = atoi(XdrvMailbox.data); //Change "RfTimeOut" if signal long 1000 milliseconds
+    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RF_TIME_AVOID_DUPLICATE); // Write to console changed "RfTimeOut"
+  } else {
+    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RF_TIME_AVOID_DUPLICATE); // If "RfTimeOut" command without parameters show current "RfTimeOut" look at 48 line
   }
 }
 

--- a/tasmota/xdrv_17_rcswitch.ino
+++ b/tasmota/xdrv_17_rcswitch.ino
@@ -1,14 +1,18 @@
 /*
   xdrv_17_rcswitch.ino - RF transceiver using RcSwitch library for Tasmota
+  
   Copyright (C) 2021  Theo Arends
+  
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
+  
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
+  
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -41,8 +45,7 @@ void (* const RfCommands[])(void) PROGMEM = {
 
 RCSwitch mySwitch = RCSwitch();
 
-int RF_TIME_AVOID_DUPLICATE = 3000;  // Use variable to change "RfTimeOut" to get new data from RfReceive
-//#define RF_TIME_AVOID_DUPLICATE 1000  // Milliseconds
+int RfTimeToAvoidDupplicate = 1000;  // Use variable in milliseconds to change "RfTimeOut" to get new data from RfReceive
 
 uint32_t rf_lasttime = 0;
 
@@ -57,7 +60,7 @@ void RfReceiveCheck(void) {
     AddLog(LOG_LEVEL_DEBUG, PSTR("RFR: Data 0x%lX (%u), Bits %d, Protocol %d, Delay %d"), data, data, bits, protocol, delay);
 
     uint32_t now = millis();
-    if ((now - rf_lasttime > RF_TIME_AVOID_DUPLICATE) && (data > 0)) {
+    if ((now - rf_lasttime > RfTimeToAvoidDupplicate) && (data > 0)) {
       rf_lasttime = now;
 
       char stemp[16];
@@ -214,10 +217,10 @@ void CmndRfSend(void)
 
 void CmndRfTimeOut(void) { // Command to change "RfTimeOut"
   if (XdrvMailbox.data_len > 0) {
-    RF_TIME_AVOID_DUPLICATE = atoi(XdrvMailbox.data); //Change "RfTimeOut" if signal long 1000 milliseconds
-    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RF_TIME_AVOID_DUPLICATE); // Write to console changed "RfTimeOut"
+    RfTimeToAvoidDupplicate = atoi(XdrvMailbox.data); //Change "RfTimeOut" if signal long 1000 milliseconds
+    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RfTimeToAvoidDupplicate); // Write to console changed "RfTimeOut"
   } else {
-    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RF_TIME_AVOID_DUPLICATE); // If "RfTimeOut" command without parameters show current "RfTimeOut" look at 48 line
+    Response_P(PSTR("{\"RfTimeOut\":\"%d\"}"), RfTimeToAvoidDupplicate); // If "RfTimeOut" command without parameters show current "RfTimeOut" look at 48 line
   }
 }
 


### PR DESCRIPTION
## Description:

Add command to change timeout in RfReceive
My door bell transmiter (Quhwa/1byone) sending ~70 payload (protocol 22).
I make rule to send mqtt status, but mqtt send 2-3 times payload.
To send 1 mqtt payload i was change "RF_TIME_AVOID_DUPLICATE" and add command to can change it.
But i dont know how to save timeout. After reboot timeout change to default.

I newbee in Tasmota (((
Sorry for my English

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
