### PR TITLE
Fix display clock

### DIFF
--- a/tasmota/xdsp_15_tm1637.ino
+++ b/tasmota/xdsp_15_tm1637.ino
@@ -980,14 +980,8 @@ void TM1637ShowTime()
   uint8_t hr = RtcTime.hour;
   uint8_t mn = RtcTime.minute;
   uint8_t sc = RtcTime.second;
-  // uint8_t hr = 1;
-  // uint8_t mn = 0;
-  char z = ' ';
-  if (TM1637Data.clock_24)
-  {
-    z = '0';
-  }
-  else
+  
+  if (!TM1637Data.clock_24)
   {
     if (hr > 12)
       hr -= 12;
@@ -995,8 +989,13 @@ void TM1637ShowTime()
       hr = 12;
   }
 
-  char tm[9];
-  snprintf_P(tm, sizeof(tm), PSTR("%c%d%02d%02d"), z, hr, mn, sc);
+  char tm[7];
+  snprintf_P(tm, sizeof(tm), PSTR("%02d%02d%02d"), hr, mn, sc);
+
+  if (!TM1637Data.clock_24 && tm[0] == '0')
+  {
+    tm[0] = ' ';
+  }
   
   if (TM1637 == TM1637Data.display_type)
   {


### PR DESCRIPTION
## Description:
If the hour is larger or equal to 10 it still renders the leading character resulting in a string: `01123` for 11:23, this is displayed as `0112` on the display.

This PR fixes that behavior.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9 (it compiles and should be fine)
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).