### PR TITLE
LVGL optimizations

### DIFF
--- a/lib/libesp32_lvgl/lv_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lv_c_mapping.h
@@ -615,7 +615,7 @@ const be_ntv_func_def_t lv_chart_func[] = {
   { "set_range", { (const void*) &lv_chart_set_range, "", "(lv.lv_obj)iii" } },
   { "set_series_color", { (const void*) &lv_chart_set_series_color, "", "(lv.lv_obj)(lv.lv_chart_series)(lv.lv_color)" } },
   { "set_type", { (const void*) &lv_chart_set_type, "", "(lv.lv_obj)i" } },
-  { "set_update_mode", { (const void*) &lv_chart_set_update_mode, "", "(lv.lv_obj)(lv.lv_chart_update_mode)" } },
+  { "set_update_mode", { (const void*) &lv_chart_set_update_mode, "", "(lv.lv_obj)i" } },
   { "set_value_by_id", { (const void*) &lv_chart_set_value_by_id, "", "(lv.lv_obj)(lv.lv_chart_series)ii" } },
   { "set_value_by_id2", { (const void*) &lv_chart_set_value_by_id2, "", "(lv.lv_obj)(lv.lv_chart_series)iii" } },
   { "set_x_start_point", { (const void*) &lv_chart_set_x_start_point, "", "(lv.lv_obj)(lv.lv_chart_series)i" } },

--- a/lib/libesp32_lvgl/lv_berry/src/be_lvgl_ctypes_definitions.c
+++ b/lib/libesp32_lvgl/lv_berry/src/be_lvgl_ctypes_definitions.c
@@ -33,7 +33,7 @@ const be_ctypes_structure_t be_lv_area = {
 }};
 
 const be_ctypes_structure_t be_lv_gradient_stop = {
-  3,  /* size in bytes */
+  4,  /* size in bytes */
   2,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[2]) {
@@ -42,7 +42,7 @@ const be_ctypes_structure_t be_lv_gradient_stop = {
 }};
 
 const be_ctypes_structure_t be_lv_grad_dsc = {
-  9,  /* size in bytes */
+  12,  /* size in bytes */
   7,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[7]) {
@@ -56,7 +56,7 @@ const be_ctypes_structure_t be_lv_grad_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_rect_dsc = {
-  59,  /* size in bytes */
+  60,  /* size in bytes */
   32,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[32]) {
@@ -95,7 +95,7 @@ const be_ctypes_structure_t be_lv_draw_rect_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_line_dsc = {
-  10,  /* size in bytes */
+  12,  /* size in bytes */
   9,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[9]) {
@@ -111,7 +111,7 @@ const be_ctypes_structure_t be_lv_draw_line_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_arc_dsc = {
-  14,  /* size in bytes */
+  16,  /* size in bytes */
   8,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[8]) {
@@ -126,7 +126,7 @@ const be_ctypes_structure_t be_lv_draw_arc_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_img_dsc = {
-  21,  /* size in bytes */
+  24,  /* size in bytes */
   10,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[10]) {
@@ -142,8 +142,33 @@ const be_ctypes_structure_t be_lv_draw_img_dsc = {
     { "zoom", 2, 0, 0, ctypes_u16, 0 },
 }};
 
+const be_ctypes_structure_t be_lv_obj_draw_part_dsc = {
+  72,  /* size in bytes */
+  18,  /* number of elements */
+  be_ctypes_instance_mappings,
+  (const be_ctypes_structure_item_t[18]) {
+    { "arc_dsc", 32, 0, 0, ctypes_ptr32, 0 },
+    { "class_p", 4, 0, 0, ctypes_ptr32, 0 },
+    { "draw_area", 12, 0, 0, ctypes_ptr32, 0 },
+    { "draw_ctx", 0, 0, 0, ctypes_ptr32, 0 },
+    { "id", 56, 0, 0, ctypes_u32, 0 },
+    { "img_dsc", 28, 0, 0, ctypes_ptr32, 0 },
+    { "label_dsc", 20, 0, 0, ctypes_ptr32, 0 },
+    { "line_dsc", 24, 0, 0, ctypes_ptr32, 0 },
+    { "p1", 36, 0, 0, ctypes_ptr32, 0 },
+    { "p2", 40, 0, 0, ctypes_ptr32, 0 },
+    { "part", 52, 0, 0, ctypes_u32, 0 },
+    { "radius", 60, 0, 0, ctypes_i16, 0 },
+    { "rect_dsc", 16, 0, 0, ctypes_ptr32, 0 },
+    { "sub_part_ptr", 68, 0, 0, ctypes_ptr32, 0 },
+    { "text", 44, 0, 0, ctypes_ptr32, 0 },
+    { "text_length", 48, 0, 0, ctypes_u32, 0 },
+    { "type", 8, 0, 0, ctypes_u32, 0 },
+    { "value", 64, 0, 0, ctypes_i32, 0 },
+}};
+
 const be_ctypes_structure_t be_lv_draw_mask_common_dsc = {
-  5,  /* size in bytes */
+  8,  /* size in bytes */
   2,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[2]) {
@@ -152,7 +177,7 @@ const be_ctypes_structure_t be_lv_draw_mask_common_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_line_param_cfg = {
-  9,  /* size in bytes */
+  12,  /* size in bytes */
   5,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[5]) {
@@ -164,7 +189,7 @@ const be_ctypes_structure_t be_lv_draw_mask_line_param_cfg = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_line_param = {
-  41,  /* size in bytes */
+  44,  /* size in bytes */
   15,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[15]) {
@@ -241,7 +266,7 @@ const be_ctypes_structure_t be_lv_draw_mask_angle_param = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_radius_param_cfg = {
-  11,  /* size in bytes */
+  12,  /* size in bytes */
   6,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[6]) {
@@ -254,7 +279,7 @@ const be_ctypes_structure_t be_lv_draw_mask_radius_param_cfg = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_radius_circle_dsc = {
-  26,  /* size in bytes */
+  28,  /* size in bytes */
   7,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[7]) {
@@ -268,7 +293,7 @@ const be_ctypes_structure_t be_lv_draw_mask_radius_circle_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_radius_param = {
-  46,  /* size in bytes */
+  48,  /* size in bytes */
   15,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[15]) {
@@ -290,7 +315,7 @@ const be_ctypes_structure_t be_lv_draw_mask_radius_param = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_fade_param_cfg = {
-  14,  /* size in bytes */
+  16,  /* size in bytes */
   8,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[8]) {
@@ -305,7 +330,7 @@ const be_ctypes_structure_t be_lv_draw_mask_fade_param_cfg = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_fade_param = {
-  22,  /* size in bytes */
+  24,  /* size in bytes */
   10,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[10]) {
@@ -348,7 +373,7 @@ const be_ctypes_structure_t be_lv_draw_mask_map_param = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_polygon_param_cfg = {
-  6,  /* size in bytes */
+  8,  /* size in bytes */
   2,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[2]) {
@@ -357,7 +382,7 @@ const be_ctypes_structure_t be_lv_draw_mask_polygon_param_cfg = {
 }};
 
 const be_ctypes_structure_t be_lv_draw_mask_polygon_param = {
-  14,  /* size in bytes */
+  16,  /* size in bytes */
   4,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[4]) {
@@ -377,7 +402,7 @@ const be_ctypes_structure_t be_lv_draw_mask_saved = {
 }};
 
 const be_ctypes_structure_t be_lv_meter_scale = {
-  34,  /* size in bytes */
+  36,  /* size in bytes */
   15,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[15]) {
@@ -429,7 +454,7 @@ const be_ctypes_structure_t be_lv_meter_indicator_needle_img = {
 }};
 
 const be_ctypes_structure_t be_lv_meter_indicator_needle_line = {
-  22,  /* size in bytes */
+  24,  /* size in bytes */
   8,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[8]) {
@@ -460,7 +485,7 @@ const be_ctypes_structure_t be_lv_meter_indicator_arc = {
 }};
 
 const be_ctypes_structure_t be_lv_meter_indicator_scale_lines = {
-  23,  /* size in bytes */
+  24,  /* size in bytes */
   9,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[9]) {
@@ -476,7 +501,7 @@ const be_ctypes_structure_t be_lv_meter_indicator_scale_lines = {
 }};
 
 const be_ctypes_structure_t be_lv_chart_series = {
-  13,  /* size in bytes */
+  16,  /* size in bytes */
   9,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[9]) {
@@ -492,7 +517,7 @@ const be_ctypes_structure_t be_lv_chart_series = {
 }};
 
 const be_ctypes_structure_t be_lv_chart_cursor = {
-  14,  /* size in bytes */
+  16,  /* size in bytes */
   7,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[7]) {
@@ -506,7 +531,7 @@ const be_ctypes_structure_t be_lv_chart_cursor = {
 }};
 
 const be_ctypes_structure_t be_lv_chart_tick_dsc = {
-  10,  /* size in bytes */
+  12,  /* size in bytes */
   6,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[6]) {
@@ -519,7 +544,7 @@ const be_ctypes_structure_t be_lv_chart_tick_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_obj_class = {
-  27,  /* size in bytes */
+  28,  /* size in bytes */
   10,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[10]) {
@@ -536,7 +561,7 @@ const be_ctypes_structure_t be_lv_obj_class = {
 }};
 
 const be_ctypes_structure_t be_lv_event = {
-  25,  /* size in bytes */
+  28,  /* size in bytes */
   9,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[9]) {
@@ -608,7 +633,7 @@ const be_ctypes_structure_t be_lv_color_filter_dsc = {
 }};
 
 const be_ctypes_structure_t be_lv_timer = {
-  21,  /* size in bytes */
+  24,  /* size in bytes */
   6,  /* number of elements */
   be_ctypes_instance_mappings,
   (const be_ctypes_structure_item_t[6]) {
@@ -700,6 +725,7 @@ static be_define_ctypes_class(lv_meter_indicator_needle_line, &be_lv_meter_indic
 static be_define_ctypes_class(lv_meter_indicator_scale_lines, &be_lv_meter_indicator_scale_lines, &be_class_ctypes, "lv_meter_indicator_scale_lines");
 static be_define_ctypes_class(lv_meter_scale, &be_lv_meter_scale, &be_class_ctypes, "lv_meter_scale");
 static be_define_ctypes_class(lv_obj_class, &be_lv_obj_class, &be_class_ctypes, "lv_obj_class");
+static be_define_ctypes_class(lv_obj_draw_part_dsc, &be_lv_obj_draw_part_dsc, &be_class_ctypes, "lv_obj_draw_part_dsc");
 static be_define_ctypes_class(lv_point, &be_lv_point, &be_class_ctypes, "lv_point");
 static be_define_ctypes_class(lv_sqrt_res, &be_lv_sqrt_res, &be_class_ctypes, "lv_sqrt_res");
 static be_define_ctypes_class(lv_style_transition_dsc, &be_lv_style_transition_dsc, &be_class_ctypes, "lv_style_transition_dsc");
@@ -744,6 +770,7 @@ void be_load_ctypes_lvgl_definitions_lib(bvm *vm) {
   ctypes_register_class(vm, &be_class_lv_meter_indicator_scale_lines, &be_lv_meter_indicator_scale_lines);
   ctypes_register_class(vm, &be_class_lv_meter_scale, &be_lv_meter_scale);
   ctypes_register_class(vm, &be_class_lv_obj_class, &be_lv_obj_class);
+  ctypes_register_class(vm, &be_class_lv_obj_draw_part_dsc, &be_lv_obj_draw_part_dsc);
   ctypes_register_class(vm, &be_class_lv_point, &be_lv_point);
   ctypes_register_class(vm, &be_class_lv_sqrt_res, &be_lv_sqrt_res);
   ctypes_register_class(vm, &be_class_lv_style_transition_dsc, &be_lv_style_transition_dsc);
@@ -789,6 +816,7 @@ be_ctypes_class_by_name_t be_ctypes_lvgl_classes[] = {
   { "lv_meter_indicator_scale_lines", &be_class_lv_meter_indicator_scale_lines },
   { "lv_meter_scale", &be_class_lv_meter_scale },
   { "lv_obj_class", &be_class_lv_obj_class },
+  { "lv_obj_draw_part_dsc", &be_class_lv_obj_draw_part_dsc },
   { "lv_point", &be_class_lv_point },
   { "lv_sqrt_res", &be_class_lv_sqrt_res },
   { "lv_style_transition_dsc", &be_class_lv_style_transition_dsc },

--- a/lib/libesp32_lvgl/lv_berry/src/be_lvgl_glob_lib.c
+++ b/lib/libesp32_lvgl/lv_berry/src/be_lvgl_glob_lib.c
@@ -4,204 +4,6 @@
 #include "be_constobj.h"
 
 /********************************************************************
-** Solidified function: widget_cb
-********************************************************************/
-be_local_closure(LVGL_glob_widget_cb,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
-      be_nested_proto(
-        6,                          /* nstack */
-        2,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str(widget_ctor_impl),
-        }),
-        &be_const_str__X3Clambda_X3E,
-        &be_const_str_solidified,
-        ( &(const binstruction[ 6]) {  /* code */
-          0x68080000,  //  0000  GETUPV	R2	U0
-          0x8C080500,  //  0001  GETMET	R2	R2	K0
-          0x5C100000,  //  0002  MOVE	R4	R0
-          0x5C140200,  //  0003  MOVE	R5	R1
-          0x7C080600,  //  0004  CALL	R2	3
-          0x80040400,  //  0005  RET	1	R2
-        })
-      ),
-      be_nested_proto(
-        6,                          /* nstack */
-        2,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str(widget_dtor_impl),
-        }),
-        &be_const_str__X3Clambda_X3E,
-        &be_const_str_solidified,
-        ( &(const binstruction[ 6]) {  /* code */
-          0x68080000,  //  0000  GETUPV	R2	U0
-          0x8C080500,  //  0001  GETMET	R2	R2	K0
-          0x5C100000,  //  0002  MOVE	R4	R0
-          0x5C140200,  //  0003  MOVE	R5	R1
-          0x7C080600,  //  0004  CALL	R2	3
-          0x80040400,  //  0005  RET	1	R2
-        })
-      ),
-      be_nested_proto(
-        6,                          /* nstack */
-        2,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str(widget_event_impl),
-        }),
-        &be_const_str__X3Clambda_X3E,
-        &be_const_str_solidified,
-        ( &(const binstruction[ 6]) {  /* code */
-          0x68080000,  //  0000  GETUPV	R2	U0
-          0x8C080500,  //  0001  GETMET	R2	R2	K0
-          0x5C100000,  //  0002  MOVE	R4	R0
-          0x5C140200,  //  0003  MOVE	R5	R1
-          0x7C080600,  //  0004  CALL	R2	3
-          0x80040400,  //  0005  RET	1	R2
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str(cb),
-    /* K1   */  be_nested_str(widget_ctor_cb),
-    /* K2   */  be_nested_str(gen_cb),
-    /* K3   */  be_nested_str(widget_dtor_cb),
-    /* K4   */  be_nested_str(widget_event_cb),
-    /* K5   */  be_nested_str(widget_struct_default),
-    /* K6   */  be_nested_str(lv),
-    /* K7   */  be_nested_str(lv_obj_class),
-    /* K8   */  be_nested_str(lv_obj),
-    /* K9   */  be_nested_str(_class),
-    /* K10  */  be_nested_str(copy),
-    /* K11  */  be_nested_str(base_class),
-    /* K12  */  be_nested_str(constructor_cb),
-    /* K13  */  be_nested_str(destructor_cb),
-    /* K14  */  be_nested_str(event_cb),
-    }),
-    &be_const_str_widget_cb,
-    &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x4C0C0000,  //  0002  LDNIL	R3
-      0x1C080403,  //  0003  EQ	R2	R2	R3
-      0x780A0003,  //  0004  JMPF	R2	#0009
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
-      0x84100000,  //  0006  CLOSURE	R4	P0
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x88080103,  //  0009  GETMBR	R2	R0	K3
-      0x4C0C0000,  //  000A  LDNIL	R3
-      0x1C080403,  //  000B  EQ	R2	R2	R3
-      0x780A0003,  //  000C  JMPF	R2	#0011
-      0x8C080302,  //  000D  GETMET	R2	R1	K2
-      0x84100001,  //  000E  CLOSURE	R4	P1
-      0x7C080400,  //  000F  CALL	R2	2
-      0x90020602,  //  0010  SETMBR	R0	K3	R2
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0x4C0C0000,  //  0012  LDNIL	R3
-      0x1C080403,  //  0013  EQ	R2	R2	R3
-      0x780A0003,  //  0014  JMPF	R2	#0019
-      0x8C080302,  //  0015  GETMET	R2	R1	K2
-      0x84100002,  //  0016  CLOSURE	R4	P2
-      0x7C080400,  //  0017  CALL	R2	2
-      0x90020802,  //  0018  SETMBR	R0	K4	R2
-      0x88080105,  //  0019  GETMBR	R2	R0	K5
-      0x4C0C0000,  //  001A  LDNIL	R3
-      0x1C080403,  //  001B  EQ	R2	R2	R3
-      0x780A0016,  //  001C  JMPF	R2	#0034
-      0xB80A0C00,  //  001D  GETNGBL	R2	K6
-      0x8C080507,  //  001E  GETMET	R2	R2	K7
-      0xB8120C00,  //  001F  GETNGBL	R4	K6
-      0x88100908,  //  0020  GETMBR	R4	R4	K8
-      0x88100909,  //  0021  GETMBR	R4	R4	K9
-      0x7C080400,  //  0022  CALL	R2	2
-      0x8C08050A,  //  0023  GETMET	R2	R2	K10
-      0x7C080200,  //  0024  CALL	R2	1
-      0x90020A02,  //  0025  SETMBR	R0	K5	R2
-      0x88080105,  //  0026  GETMBR	R2	R0	K5
-      0xB80E0C00,  //  0027  GETNGBL	R3	K6
-      0x880C0708,  //  0028  GETMBR	R3	R3	K8
-      0x880C0709,  //  0029  GETMBR	R3	R3	K9
-      0x900A1603,  //  002A  SETMBR	R2	K11	R3
-      0x88080105,  //  002B  GETMBR	R2	R0	K5
-      0x880C0101,  //  002C  GETMBR	R3	R0	K1
-      0x900A1803,  //  002D  SETMBR	R2	K12	R3
-      0x88080105,  //  002E  GETMBR	R2	R0	K5
-      0x880C0103,  //  002F  GETMBR	R3	R0	K3
-      0x900A1A03,  //  0030  SETMBR	R2	K13	R3
-      0x88080105,  //  0031  GETMBR	R2	R0	K5
-      0x880C0104,  //  0032  GETMBR	R3	R0	K4
-      0x900A1C03,  //  0033  SETMBR	R2	K14	R3
-      0xA0000000,  //  0034  CLOSE	R0
-      0x80000000,  //  0035  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _anonymous_
-********************************************************************/
-be_local_closure(LVGL_glob__anonymous_,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    0,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(LVG_X3A_X20call_X20to_X20unsupported_X20callback),
-    }),
-    &be_const_str__anonymous_,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x60000001,  //  0000  GETGBL	R0	G1
-      0x58040000,  //  0001  LDCONST	R1	K0
-      0x7C000200,  //  0002  CALL	R0	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: make_cb
 ********************************************************************/
 be_local_closure(LVGL_glob_make_cb,   /* name */
@@ -395,6 +197,165 @@ be_local_closure(LVGL_glob_make_cb,   /* name */
 
 
 /********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(LVGL_glob_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str(make_cb),
+        }),
+        &be_const_str__X3Clambda_X3E,
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(cb),
+    /* K1   */  be_nested_str(add_handler),
+    /* K2   */  be_nested_str(lv_extra),
+    }),
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x84100000,  //  0002  CLOSURE	R4	P0
+      0x7C080400,  //  0003  CALL	R2	2
+      0xA40A0400,  //  0004  IMPORT	R2	K2
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_object_from_ptr
+********************************************************************/
+be_local_closure(LVGL_glob_get_object_from_ptr,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(cb_obj),
+    /* K1   */  be_nested_str(find),
+    }),
+    &be_const_str_get_object_from_ptr,
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0004,  //  0003  JMPF	R2	#0009
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80040400,  //  0008  RET	1	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: widget_ctor_impl
+********************************************************************/
+be_local_closure(LVGL_glob_widget_ctor_impl,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str(introspect),
+    /* K1   */  be_nested_str(lv),
+    /* K2   */  be_nested_str(lv_obj_class),
+    /* K3   */  be_nested_str(get_object_from_ptr),
+    /* K4   */  be_nested_str(cb_obj),
+    /* K5   */  be_nested_str(find),
+    /* K6   */  be_nested_str(instance),
+    /* K7   */  be_nested_str(get),
+    /* K8   */  be_nested_str(widget_constructor),
+    }),
+    &be_const_str_widget_ctor_impl,
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C100400,  //  0004  CALL	R4	2
+      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x5C1C0400,  //  0006  MOVE	R7	R2
+      0x7C140400,  //  0007  CALL	R5	2
+      0x88180104,  //  0008  GETMBR	R6	R0	K4
+      0x8C180D05,  //  0009  GETMET	R6	R6	K5
+      0x5C200A00,  //  000A  MOVE	R8	R5
+      0x7C180400,  //  000B  CALL	R6	2
+      0x781A0001,  //  000C  JMPF	R6	#000F
+      0x88180104,  //  000D  GETMBR	R6	R0	K4
+      0x94140C05,  //  000E  GETIDX	R5	R6	R5
+      0x60180004,  //  000F  GETGBL	R6	G4
+      0x5C1C0A00,  //  0010  MOVE	R7	R5
+      0x7C180200,  //  0011  CALL	R6	1
+      0x1C180D06,  //  0012  EQ	R6	R6	K6
+      0x781A0007,  //  0013  JMPF	R6	#001C
+      0x8C180707,  //  0014  GETMET	R6	R3	K7
+      0x5C200A00,  //  0015  MOVE	R8	R5
+      0x58240008,  //  0016  LDCONST	R9	K8
+      0x7C180600,  //  0017  CALL	R6	3
+      0x781A0002,  //  0018  JMPF	R6	#001C
+      0x8C180B08,  //  0019  GETMET	R6	R5	K8
+      0x5C200800,  //  001A  MOVE	R8	R4
+      0x7C180400,  //  001B  CALL	R6	2
+      0x80000000,  //  001C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: register_obj
 ********************************************************************/
 be_local_closure(LVGL_glob_register_obj,   /* name */
@@ -425,6 +386,50 @@ be_local_closure(LVGL_glob_register_obj,   /* name */
       0x880C0100,  //  0008  GETMBR	R3	R0	K0
       0x980C0401,  //  0009  SETIDX	R3	R2	R1
       0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: deregister_obj
+********************************************************************/
+be_local_closure(LVGL_glob_deregister_obj,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(cb_obj),
+    /* K1   */  be_nested_str(remove),
+    /* K2   */  be_nested_str(cb_event_closure),
+    }),
+    &be_const_str_deregister_obj,
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0003,  //  0003  JMPF	R2	#0008
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x4C0C0000,  //  0009  LDNIL	R3
+      0x20080403,  //  000A  NE	R2	R2	R3
+      0x780A0003,  //  000B  JMPF	R2	#0010
+      0x88080102,  //  000C  GETMBR	R2	R0	K2
+      0x8C080501,  //  000D  GETMET	R2	R2	K1
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x7C080400,  //  000F  CALL	R2	2
+      0x80000000,  //  0010  RET	0
     })
   )
 );
@@ -606,6 +611,120 @@ be_local_closure(LVGL_glob_lvgl_timer_dispatch,   /* name */
 
 
 /********************************************************************
+** Solidified function: lvgl_event_dispatch
+********************************************************************/
+be_local_closure(LVGL_glob_lvgl_event_dispatch,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str(introspect),
+    /* K1   */  be_nested_str(toptr),
+    /* K2   */  be_nested_str(event),
+    /* K3   */  be_nested_str(_change_buffer),
+    /* K4   */  be_nested_str(lv),
+    /* K5   */  be_nested_str(lv_event),
+    /* K6   */  be_nested_str(target),
+    /* K7   */  be_nested_str(cb_event_closure),
+    /* K8   */  be_nested_str(get_object_from_ptr),
+    }),
+    &be_const_str_lvgl_event_dispatch,
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x78120004,  //  0005  JMPF	R4	#000B
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x5C180600,  //  0008  MOVE	R6	R3
+      0x7C100400,  //  0009  CALL	R4	2
+      0x70020004,  //  000A  JMP		#0010
+      0xB8120800,  //  000B  GETNGBL	R4	K4
+      0x8C100905,  //  000C  GETMET	R4	R4	K5
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x7C100400,  //  000E  CALL	R4	2
+      0x90020404,  //  000F  SETMBR	R0	K2	R4
+      0x88100102,  //  0010  GETMBR	R4	R0	K2
+      0x88100906,  //  0011  GETMBR	R4	R4	K6
+      0x88140107,  //  0012  GETMBR	R5	R0	K7
+      0x94140A04,  //  0013  GETIDX	R5	R5	R4
+      0x8C180108,  //  0014  GETMET	R6	R0	K8
+      0x5C200800,  //  0015  MOVE	R8	R4
+      0x7C180400,  //  0016  CALL	R6	2
+      0x5C1C0A00,  //  0017  MOVE	R7	R5
+      0x5C200C00,  //  0018  MOVE	R8	R6
+      0x88240102,  //  0019  GETMBR	R9	R0	K2
+      0x7C1C0400,  //  001A  CALL	R7	2
+      0x80000000,  //  001B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: widget_dtor_impl
+********************************************************************/
+be_local_closure(LVGL_glob_widget_dtor_impl,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str(introspect),
+    /* K1   */  be_nested_str(lv),
+    /* K2   */  be_nested_str(lv_obj_class),
+    /* K3   */  be_nested_str(get_object_from_ptr),
+    /* K4   */  be_nested_str(instance),
+    /* K5   */  be_nested_str(get),
+    /* K6   */  be_nested_str(widget_destructor),
+    }),
+    &be_const_str_widget_dtor_impl,
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x7C100400,  //  0004  CALL	R4	2
+      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x5C1C0400,  //  0006  MOVE	R7	R2
+      0x7C140400,  //  0007  CALL	R5	2
+      0x60180004,  //  0008  GETGBL	R6	G4
+      0x5C1C0A00,  //  0009  MOVE	R7	R5
+      0x7C180200,  //  000A  CALL	R6	1
+      0x1C180D04,  //  000B  EQ	R6	R6	K4
+      0x781A0007,  //  000C  JMPF	R6	#0015
+      0x8C180705,  //  000D  GETMET	R6	R3	K5
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x58240006,  //  000F  LDCONST	R9	K6
+      0x7C180600,  //  0010  CALL	R6	3
+      0x781A0002,  //  0011  JMPF	R6	#0015
+      0x8C180B06,  //  0012  GETMET	R6	R5	K6
+      0x5C200800,  //  0013  MOVE	R8	R4
+      0x7C180400,  //  0014  CALL	R6	2
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: widget_event_impl
 ********************************************************************/
 be_local_closure(LVGL_glob_widget_event_impl,   /* name */
@@ -685,35 +804,28 @@ be_local_closure(LVGL_glob_widget_event_impl,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_object_from_ptr
+** Solidified function: _anonymous_
 ********************************************************************/
-be_local_closure(LVGL_glob_get_object_from_ptr,   /* name */
+be_local_closure(LVGL_glob__anonymous_,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
+    2,                          /* nstack */
+    0,                          /* argc */
+    0,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(cb_obj),
-    /* K1   */  be_nested_str(find),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str(LVG_X3A_X20call_X20to_X20unsupported_X20callback),
     }),
-    &be_const_str_get_object_from_ptr,
+    &be_const_str__anonymous_,
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0004,  //  0003  JMPF	R2	#0009
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x80040400,  //  0008  RET	1	R2
-      0x80000000,  //  0009  RET	0
+    ( &(const binstruction[ 4]) {  /* code */
+      0x60000001,  //  0000  GETGBL	R0	G1
+      0x58040000,  //  0001  LDCONST	R1	K0
+      0x7C000200,  //  0002  CALL	R0	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -721,9 +833,9 @@ be_local_closure(LVGL_glob_get_object_from_ptr,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: widget_cb
 ********************************************************************/
-be_local_closure(LVGL_glob_init,   /* name */
+be_local_closure(LVGL_glob_widget_cb,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     1,                          /* argc */
@@ -731,10 +843,10 @@ be_local_closure(LVGL_glob_init,   /* name */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
+    ( &(const struct bproto*[ 3]) {
       be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
+        6,                          /* nstack */
+        2,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 1]) {  /* upvals */
@@ -744,245 +856,145 @@ be_local_closure(LVGL_glob_init,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str(make_cb),
+        /* K0   */  be_nested_str(widget_ctor_impl),
         }),
         &be_const_str__X3Clambda_X3E,
         &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
+        ( &(const binstruction[ 6]) {  /* code */
+          0x68080000,  //  0000  GETUPV	R2	U0
+          0x8C080500,  //  0001  GETMET	R2	R2	K0
+          0x5C100000,  //  0002  MOVE	R4	R0
+          0x5C140200,  //  0003  MOVE	R5	R1
+          0x7C080600,  //  0004  CALL	R2	3
+          0x80040400,  //  0005  RET	1	R2
+        })
+      ),
+      be_nested_proto(
+        6,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str(widget_dtor_impl),
+        }),
+        &be_const_str__X3Clambda_X3E,
+        &be_const_str_solidified,
+        ( &(const binstruction[ 6]) {  /* code */
+          0x68080000,  //  0000  GETUPV	R2	U0
+          0x8C080500,  //  0001  GETMET	R2	R2	K0
+          0x5C100000,  //  0002  MOVE	R4	R0
+          0x5C140200,  //  0003  MOVE	R5	R1
+          0x7C080600,  //  0004  CALL	R2	3
+          0x80040400,  //  0005  RET	1	R2
+        })
+      ),
+      be_nested_proto(
+        6,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str(widget_event_impl),
+        }),
+        &be_const_str__X3Clambda_X3E,
+        &be_const_str_solidified,
+        ( &(const binstruction[ 6]) {  /* code */
+          0x68080000,  //  0000  GETUPV	R2	U0
+          0x8C080500,  //  0001  GETMET	R2	R2	K0
+          0x5C100000,  //  0002  MOVE	R4	R0
+          0x5C140200,  //  0003  MOVE	R5	R1
+          0x7C080600,  //  0004  CALL	R2	3
+          0x80040400,  //  0005  RET	1	R2
         })
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str(cb),
-    /* K1   */  be_nested_str(add_handler),
-    /* K2   */  be_nested_str(lv_extra),
+    /* K1   */  be_nested_str(widget_ctor_cb),
+    /* K2   */  be_nested_str(gen_cb),
+    /* K3   */  be_nested_str(widget_dtor_cb),
+    /* K4   */  be_nested_str(widget_event_cb),
+    /* K5   */  be_nested_str(widget_struct_default),
+    /* K6   */  be_nested_str(lv),
+    /* K7   */  be_nested_str(lv_obj_class),
+    /* K8   */  be_nested_str(lv_obj),
+    /* K9   */  be_nested_str(_class),
+    /* K10  */  be_nested_str(copy),
+    /* K11  */  be_nested_str(base_class),
+    /* K12  */  be_nested_str(constructor_cb),
+    /* K13  */  be_nested_str(destructor_cb),
+    /* K14  */  be_nested_str(event_cb),
     }),
-    &be_const_str_init,
+    &be_const_str_widget_cb,
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
+    ( &(const binstruction[54]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x84100000,  //  0002  CLOSURE	R4	P0
-      0x7C080400,  //  0003  CALL	R2	2
-      0xA40A0400,  //  0004  IMPORT	R2	K2
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: lvgl_event_dispatch
-********************************************************************/
-be_local_closure(LVGL_glob_lvgl_event_dispatch,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(lv),
-    /* K2   */  be_nested_str(lv_event),
-    /* K3   */  be_nested_str(toptr),
-    /* K4   */  be_nested_str(target),
-    /* K5   */  be_nested_str(cb_event_closure),
-    /* K6   */  be_nested_str(get_object_from_ptr),
-    }),
-    &be_const_str_lvgl_event_dispatch,
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xB80E0200,  //  0001  GETNGBL	R3	K1
-      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
-      0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x7C140400,  //  0005  CALL	R5	2
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x88100704,  //  0007  GETMBR	R4	R3	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
-      0x94140A04,  //  0009  GETIDX	R5	R5	R4
-      0x8C180106,  //  000A  GETMET	R6	R0	K6
-      0x5C200800,  //  000B  MOVE	R8	R4
-      0x7C180400,  //  000C  CALL	R6	2
-      0x5C1C0A00,  //  000D  MOVE	R7	R5
-      0x5C200C00,  //  000E  MOVE	R8	R6
-      0x5C240600,  //  000F  MOVE	R9	R3
-      0x7C1C0400,  //  0010  CALL	R7	2
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: widget_dtor_impl
-********************************************************************/
-be_local_closure(LVGL_glob_widget_dtor_impl,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(lv),
-    /* K2   */  be_nested_str(lv_obj_class),
-    /* K3   */  be_nested_str(get_object_from_ptr),
-    /* K4   */  be_nested_str(instance),
-    /* K5   */  be_nested_str(get),
-    /* K6   */  be_nested_str(widget_destructor),
-    }),
-    &be_const_str_widget_dtor_impl,
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
-      0x5C1C0400,  //  0006  MOVE	R7	R2
-      0x7C140400,  //  0007  CALL	R5	2
-      0x60180004,  //  0008  GETGBL	R6	G4
-      0x5C1C0A00,  //  0009  MOVE	R7	R5
-      0x7C180200,  //  000A  CALL	R6	1
-      0x1C180D04,  //  000B  EQ	R6	R6	K4
-      0x781A0007,  //  000C  JMPF	R6	#0015
-      0x8C180705,  //  000D  GETMET	R6	R3	K5
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x58240006,  //  000F  LDCONST	R9	K6
-      0x7C180600,  //  0010  CALL	R6	3
-      0x781A0002,  //  0011  JMPF	R6	#0015
-      0x8C180B06,  //  0012  GETMET	R6	R5	K6
-      0x5C200800,  //  0013  MOVE	R8	R4
-      0x7C180400,  //  0014  CALL	R6	2
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: deregister_obj
-********************************************************************/
-be_local_closure(LVGL_glob_deregister_obj,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(cb_obj),
-    /* K1   */  be_nested_str(remove),
-    /* K2   */  be_nested_str(cb_event_closure),
-    }),
-    &be_const_str_deregister_obj,
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0003,  //  0003  JMPF	R2	#0008
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
-      0x5C100200,  //  0006  MOVE	R4	R1
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x4C0C0000,  //  0002  LDNIL	R3
+      0x1C080403,  //  0003  EQ	R2	R2	R3
+      0x780A0003,  //  0004  JMPF	R2	#0009
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x84100000,  //  0006  CLOSURE	R4	P0
       0x7C080400,  //  0007  CALL	R2	2
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0009  LDNIL	R3
-      0x20080403,  //  000A  NE	R2	R2	R3
-      0x780A0003,  //  000B  JMPF	R2	#0010
-      0x88080102,  //  000C  GETMBR	R2	R0	K2
-      0x8C080501,  //  000D  GETMET	R2	R2	K1
-      0x5C100200,  //  000E  MOVE	R4	R1
+      0x90020202,  //  0008  SETMBR	R0	K1	R2
+      0x88080103,  //  0009  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  000A  LDNIL	R3
+      0x1C080403,  //  000B  EQ	R2	R2	R3
+      0x780A0003,  //  000C  JMPF	R2	#0011
+      0x8C080302,  //  000D  GETMET	R2	R1	K2
+      0x84100001,  //  000E  CLOSURE	R4	P1
       0x7C080400,  //  000F  CALL	R2	2
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: widget_ctor_impl
-********************************************************************/
-be_local_closure(LVGL_glob_widget_ctor_impl,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(lv),
-    /* K2   */  be_nested_str(lv_obj_class),
-    /* K3   */  be_nested_str(get_object_from_ptr),
-    /* K4   */  be_nested_str(cb_obj),
-    /* K5   */  be_nested_str(find),
-    /* K6   */  be_nested_str(instance),
-    /* K7   */  be_nested_str(get),
-    /* K8   */  be_nested_str(widget_constructor),
-    }),
-    &be_const_str_widget_ctor_impl,
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x7C100400,  //  0004  CALL	R4	2
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
-      0x5C1C0400,  //  0006  MOVE	R7	R2
-      0x7C140400,  //  0007  CALL	R5	2
-      0x88180104,  //  0008  GETMBR	R6	R0	K4
-      0x8C180D05,  //  0009  GETMET	R6	R6	K5
-      0x5C200A00,  //  000A  MOVE	R8	R5
-      0x7C180400,  //  000B  CALL	R6	2
-      0x781A0001,  //  000C  JMPF	R6	#000F
-      0x88180104,  //  000D  GETMBR	R6	R0	K4
-      0x94140C05,  //  000E  GETIDX	R5	R6	R5
-      0x60180004,  //  000F  GETGBL	R6	G4
-      0x5C1C0A00,  //  0010  MOVE	R7	R5
-      0x7C180200,  //  0011  CALL	R6	1
-      0x1C180D06,  //  0012  EQ	R6	R6	K6
-      0x781A0007,  //  0013  JMPF	R6	#001C
-      0x8C180707,  //  0014  GETMET	R6	R3	K7
-      0x5C200A00,  //  0015  MOVE	R8	R5
-      0x58240008,  //  0016  LDCONST	R9	K8
-      0x7C180600,  //  0017  CALL	R6	3
-      0x781A0002,  //  0018  JMPF	R6	#001C
-      0x8C180B08,  //  0019  GETMET	R6	R5	K8
-      0x5C200800,  //  001A  MOVE	R8	R4
-      0x7C180400,  //  001B  CALL	R6	2
-      0x80000000,  //  001C  RET	0
+      0x90020602,  //  0010  SETMBR	R0	K3	R2
+      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x4C0C0000,  //  0012  LDNIL	R3
+      0x1C080403,  //  0013  EQ	R2	R2	R3
+      0x780A0003,  //  0014  JMPF	R2	#0019
+      0x8C080302,  //  0015  GETMET	R2	R1	K2
+      0x84100002,  //  0016  CLOSURE	R4	P2
+      0x7C080400,  //  0017  CALL	R2	2
+      0x90020802,  //  0018  SETMBR	R0	K4	R2
+      0x88080105,  //  0019  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  001A  LDNIL	R3
+      0x1C080403,  //  001B  EQ	R2	R2	R3
+      0x780A0016,  //  001C  JMPF	R2	#0034
+      0xB80A0C00,  //  001D  GETNGBL	R2	K6
+      0x8C080507,  //  001E  GETMET	R2	R2	K7
+      0xB8120C00,  //  001F  GETNGBL	R4	K6
+      0x88100908,  //  0020  GETMBR	R4	R4	K8
+      0x88100909,  //  0021  GETMBR	R4	R4	K9
+      0x7C080400,  //  0022  CALL	R2	2
+      0x8C08050A,  //  0023  GETMET	R2	R2	K10
+      0x7C080200,  //  0024  CALL	R2	1
+      0x90020A02,  //  0025  SETMBR	R0	K5	R2
+      0x88080105,  //  0026  GETMBR	R2	R0	K5
+      0xB80E0C00,  //  0027  GETNGBL	R3	K6
+      0x880C0708,  //  0028  GETMBR	R3	R3	K8
+      0x880C0709,  //  0029  GETMBR	R3	R3	K9
+      0x900A1603,  //  002A  SETMBR	R2	K11	R3
+      0x88080105,  //  002B  GETMBR	R2	R0	K5
+      0x880C0101,  //  002C  GETMBR	R3	R0	K1
+      0x900A1803,  //  002D  SETMBR	R2	K12	R3
+      0x88080105,  //  002E  GETMBR	R2	R0	K5
+      0x880C0103,  //  002F  GETMBR	R3	R0	K3
+      0x900A1A03,  //  0030  SETMBR	R2	K13	R3
+      0x88080105,  //  0031  GETMBR	R2	R0	K5
+      0x880C0104,  //  0032  GETMBR	R3	R0	K4
+      0x900A1C03,  //  0033  SETMBR	R2	K14	R3
+      0xA0000000,  //  0034  CLOSE	R0
+      0x80000000,  //  0035  RET	0
     })
   )
 );
@@ -993,33 +1005,34 @@ be_local_closure(LVGL_glob_widget_ctor_impl,   /* name */
 ** Solidified class: LVGL_glob
 ********************************************************************/
 be_local_class(LVGL_glob,
-    10,
+    11,
     NULL,
-    be_nested_map(23,
+    be_nested_map(24,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(widget_cb, -1), be_const_closure(LVGL_glob_widget_cb_closure) },
-        { be_const_key(widget_event_cb, -1), be_const_var(7) },
-        { be_const_key(widget_ctor_impl, -1), be_const_closure(LVGL_glob_widget_ctor_impl_closure) },
-        { be_const_key(widget_struct_default, -1), be_const_var(8) },
-        { be_const_key(make_cb, -1), be_const_closure(LVGL_glob_make_cb_closure) },
-        { be_const_key(widget_ctor_cb, 8), be_const_var(5) },
-        { be_const_key(deregister_obj, -1), be_const_closure(LVGL_glob_deregister_obj_closure) },
-        { be_const_key(create_custom_widget, 16), be_const_closure(LVGL_glob_create_custom_widget_closure) },
-        { be_const_key(widget_event_impl, -1), be_const_closure(LVGL_glob_widget_event_impl_closure) },
-        { be_const_key(widget_dtor_cb, -1), be_const_var(6) },
-        { be_const_key(cb_event_closure, -1), be_const_var(1) },
-        { be_const_key(lvgl_timer_dispatch, -1), be_const_closure(LVGL_glob_lvgl_timer_dispatch_closure) },
-        { be_const_key(widget_dtor_impl, -1), be_const_closure(LVGL_glob_widget_dtor_impl_closure) },
-        { be_const_key(get_object_from_ptr, 17), be_const_closure(LVGL_glob_get_object_from_ptr_closure) },
+        { be_const_key(widget_ctor_cb, -1), be_const_var(6) },
+        { be_const_key(make_cb, 8), be_const_closure(LVGL_glob_make_cb_closure) },
+        { be_const_key(widget_struct_by_class, 4), be_const_var(10) },
         { be_const_key(init, -1), be_const_closure(LVGL_glob_init_closure) },
-        { be_const_key(cb_obj, -1), be_const_var(0) },
+        { be_const_key(register_obj, -1), be_const_closure(LVGL_glob_register_obj_closure) },
+        { be_const_key(widget_dtor_cb, -1), be_const_var(7) },
+        { be_const_key(deregister_obj, -1), be_const_closure(LVGL_glob_deregister_obj_closure) },
+        { be_const_key(widget_ctor_impl, -1), be_const_closure(LVGL_glob_widget_ctor_impl_closure) },
+        { be_const_key(widget_event_impl, 11), be_const_closure(LVGL_glob_widget_event_impl_closure) },
+        { be_const_key(get_object_from_ptr, 12), be_const_closure(LVGL_glob_get_object_from_ptr_closure) },
+        { be_const_key(widget_event_cb, 21), be_const_var(8) },
+        { be_const_key(lvgl_timer_dispatch, -1), be_const_closure(LVGL_glob_lvgl_timer_dispatch_closure) },
+        { be_const_key(event_cb, 6), be_const_var(2) },
+        { be_const_key(cb_event_closure, -1), be_const_var(1) },
         { be_const_key(lvgl_event_dispatch, -1), be_const_closure(LVGL_glob_lvgl_event_dispatch_closure) },
-        { be_const_key(event_cb, 15), be_const_var(2) },
-        { be_const_key(timer_cb, -1), be_const_var(3) },
-        { be_const_key(cb_do_nothing, 12), be_const_static_closure(LVGL_glob__anonymous__closure) },
-        { be_const_key(widget_struct_by_class, -1), be_const_var(9) },
-        { be_const_key(register_obj, 6), be_const_closure(LVGL_glob_register_obj_closure) },
-        { be_const_key(null_cb, 2), be_const_var(4) },
+        { be_const_key(event, -1), be_const_var(4) },
+        { be_const_key(timer_cb, 19), be_const_var(3) },
+        { be_const_key(widget_struct_default, -1), be_const_var(9) },
+        { be_const_key(cb_obj, 16), be_const_var(0) },
+        { be_const_key(widget_dtor_impl, -1), be_const_closure(LVGL_glob_widget_dtor_impl_closure) },
+        { be_const_key(null_cb, -1), be_const_var(5) },
+        { be_const_key(create_custom_widget, -1), be_const_closure(LVGL_glob_create_custom_widget_closure) },
+        { be_const_key(cb_do_nothing, -1), be_const_static_closure(LVGL_glob__anonymous__closure) },
+        { be_const_key(widget_cb, -1), be_const_closure(LVGL_glob_widget_cb_closure) },
     })),
     be_str_literal("LVGL_glob")
 );

--- a/lib/libesp32_lvgl/lv_berry/src/embedded/ctypes.be
+++ b/lib/libesp32_lvgl/lv_berry/src/embedded/ctypes.be
@@ -289,8 +289,14 @@ class structure
     self.size_bytes = self.cur_offset
 
     if name != nil
+      var size_aligned =  self.size_bytes
+      # as a final structure, we align to 2/4 bytes boundaries
+      if size_aligned >= 3
+        size_aligned = ((size_aligned + 3)/4)*4
+      end
+
       print(string.format("const be_ctypes_structure_t be_%s = {", name))
-      print(string.format("  %i,  /* size in bytes */", self.size_bytes))
+      print(string.format("  %i,  /* size in bytes */", size_aligned))
       print(string.format("  %i,  /* number of elements */", size(self.mapping)))
       print(string.format("  be_ctypes_instance_mappings,"))
       print(string.format("  (const be_ctypes_structure_item_t[%i]) {", size(self.mapping)))

--- a/lib/libesp32_lvgl/lv_berry/src/embedded/lvgl_ctypes.be
+++ b/lib/libesp32_lvgl/lv_berry/src/embedded/lvgl_ctypes.be
@@ -152,6 +152,28 @@ lv_draw_img_dsc = [            # valid LVGL8.2
 ]
 lv_draw_img_dsc = ctypes.structure(lv_draw_img_dsc, "lv_draw_img_dsc")
 
+lv_obj_draw_part_dsc = [            # valid LVGL8.2
+    [ptr, "draw_ctx"],
+    [ptr, "class_p"],
+    [uint32_t, "type"],
+    [ptr, "draw_area"],
+    [ptr, "rect_dsc"],
+    [ptr, "label_dsc"],
+    [ptr, "line_dsc"],
+    [ptr, "img_dsc"],
+    [ptr, "arc_dsc"],
+    [ptr, "p1"],
+    [ptr, "p2"],
+    [ptr, "text"],
+    [uint32_t, "text_length"],
+    [uint32_t, "part"],
+    [uint32_t, "id"],
+    [lv_coord, "radius"],
+    [int32_t, "value"],
+    [ptr, "sub_part_ptr"],
+]
+lv_obj_draw_part_dsc = ctypes.structure(lv_obj_draw_part_dsc, "lv_obj_draw_part_dsc")
+
 #- --------- lv_mask --------- -#
 lv_draw_mask_xcb = ptr    # callback
 lv_draw_mask_type = ctypes.u8
@@ -548,7 +570,7 @@ lv_timer = ctypes.structure(lv_timer, "lv_timer")
 # lv_anim = ctypes.structure(lv_anim, "lv_anim")
 
 #######################################################################
-# lv_draw_ctc
+# lv_draw_ctx
 lv_draw_ctx = [            # valid LVGL8.2
     [ptr, "buf"],
     [lv_area, "buf_area"],

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -104,6 +104,7 @@ return_types = {
   "lv_palette_t": "i",
   "lv_style_prop_t": "i",
   "lv_dither_mode_t": "i",
+  "lv_chart_update_mode_t": "i",
   # layouts
   "lv_flex_align_t": "i",
   "lv_flex_flow_t": "i",

--- a/tasmota/berry/modules/ctypes.be
+++ b/tasmota/berry/modules/ctypes.be
@@ -289,8 +289,14 @@ class structure
     self.size_bytes = self.cur_offset
 
     if name != nil
+      var size_aligned =  self.size_bytes
+      # as a final structure, we align to 2/4 bytesboundaries
+      if size_aligned >= 3
+        size_aligned = ((size_aligned + 3)/4)*4
+      end
+
       print(string.format("const be_ctypes_structure_t be_%s = {", name))
-      print(string.format("  %i,  /* size in bytes */", self.size_bytes))
+      print(string.format("  %i,  /* size in bytes */", size_aligned))
       print(string.format("  %i,  /* number of elements */", size(self.mapping)))
       print(string.format("  be_ctypes_instance_mappings,"))
       print(string.format("  (const be_ctypes_structure_item_t[%i]) {", size(self.mapping)))


### PR DESCRIPTION
## Description:

Various optimizations to LVGL:
- fix `lv_chart_update_mode` is actually `int`
- fix sizes to be rounded to next 4 bytes for LVGL structures
- added `lv.obj_draw_part_dsc`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
