### PR TITLE
MI32: active BLE connections can remain

### DIFF
--- a/tasmota/xsns_62_esp32_mi.h
+++ b/tasmota/xsns_62_esp32_mi.h
@@ -150,7 +150,8 @@ struct ATCPacket_t{ //and PVVX
 struct MI32connectionContextBerry_t{
   NimBLEUUID serviceUUID;
   NimBLEUUID charUUID;
-  uint8_t * MAC;
+  uint16_t returnCharUUID;
+  uint8_t MAC[6];
   uint8_t * buffer;
   uint8_t operation;
   uint8_t addrType;
@@ -177,7 +178,6 @@ struct {
 
       uint32_t shallTriggerTele:1;
       uint32_t triggeredTele:1;
-      uint32_t shallClearResults:1;   // BLE scan results
       uint32_t shallShowStatusInfo:1; // react to amount of found sensors via RULES
       uint32_t didGetConfig:1;
       uint32_t didStartHAP:1;
@@ -386,7 +386,7 @@ const char * kMI32DeviceType[] PROGMEM = {kMI32DeviceType1,kMI32DeviceType2,kMI3
 
 const char kMI32_ConnErrorMsg[] PROGMEM = "no Error|could not connect|got no service|got no characteristic|can not read|can not notify|can not write|did not write|notify time out";
 
-const char kMI32_BLEInfoMsg[] PROGMEM = "Scan ended|Got Notification|Did connect|Did disconnect|Start scanning";
+const char kMI32_BLEInfoMsg[] PROGMEM = "Scan ended|Got Notification|Did connect|Did disconnect|Still connected|Start scanning";
 
 const char kMI32_HKInfoMsg[] PROGMEM = "HAP core started|HAP core did not start!!|HAP controller disconnected|HAP controller connected|HAP outlet added";
 
@@ -402,36 +402,37 @@ enum MI32_Commands {          // commands useable in console or rules
   };
 
 enum MI32_TASK {
-       MI32_TASK_SCAN = 0,
-       MI32_TASK_CONN = 1,
+  MI32_TASK_SCAN = 0,
+  MI32_TASK_CONN = 1,
 };
 
 enum MI32_ConnErrorMsg {
-       MI32_CONN_NO_ERROR = 0,
-       MI32_CONN_NO_CONNECT,
-       MI32_CONN_NO_SERVICE,
-       MI32_CONN_NO_CHARACTERISTIC,
-       MI32_CONN_CAN_NOT_READ,
-       MI32_CONN_CAN_NOT_NOTIFY,
-       MI32_CONN_CAN_NOT_WRITE,
-       MI32_CONN_DID_NOT_WRITE,
-       MI32_CONN_NOTIFY_TIMEOUT
+  MI32_CONN_NO_ERROR = 0,
+  MI32_CONN_NO_CONNECT,
+  MI32_CONN_NO_SERVICE,
+  MI32_CONN_NO_CHARACTERISTIC,
+  MI32_CONN_CAN_NOT_READ,
+  MI32_CONN_CAN_NOT_NOTIFY,
+  MI32_CONN_CAN_NOT_WRITE,
+  MI32_CONN_DID_NOT_WRITE,
+  MI32_CONN_NOTIFY_TIMEOUT
 };
 
 enum MI32_BLEInfoMsg {
-       MI32_SCAN_ENDED = 1,
-       MI32_GOT_NOTIFICATION,
-       MI32_DID_CONNECT,
-       MI32_DID_DISCONNECT,
-       MI32_START_SCANNING
+  MI32_SCAN_ENDED = 1,
+  MI32_GOT_NOTIFICATION,
+  MI32_DID_CONNECT,
+  MI32_DID_DISCONNECT,
+  MI32_STILL_CONNECTED,
+  MI32_START_SCANNING
 };
 
 enum MI32_HKInfoMsg {
-       MI32_HAP_DID_START = 1,
-       MI32_HAP_DID_NOT_START,
-       MI32_HAP_CONTROLLER_DISCONNECTED,
-       MI32_HAP_CONTROLLER_CONNECTED,
-       MI32_HAP_OUTLET_ADDED
+  MI32_HAP_DID_START = 1,
+  MI32_HAP_DID_NOT_START,
+  MI32_HAP_CONTROLLER_DISCONNECTED,
+  MI32_HAP_CONTROLLER_CONNECTED,
+  MI32_HAP_OUTLET_ADDED
 };
 
 /*********************************************************************************************\

--- a/tasmota/xsns_62_esp32_mi.ino
+++ b/tasmota/xsns_62_esp32_mi.ino
@@ -182,9 +182,11 @@ void MI32scanEndedCB(NimBLEScanResults results){
 }
 
 void MI32notifyCB(NimBLERemoteCharacteristic* pRemoteCharacteristic, uint8_t* pData, size_t length, bool isNotify){
+    if(MI32.mode.triggerBerryConnCB) return; //discard data, if we did not pass the old to Berry yet
     MI32.infoMsg = MI32_GOT_NOTIFICATION;
     MI32.conCtx->buffer[0] = (uint8_t)length;
     memcpy(MI32.conCtx->buffer + 1, pData, length);
+    MI32.conCtx->returnCharUUID = pRemoteCharacteristic->getUUID().getNative()->u32.value;
     MI32.mode.triggerBerryConnCB = 1;
     MI32.mode.readingDone = 1;
 }
@@ -647,10 +649,11 @@ void MI32Init(void) {
   }
   
   if (!MI32.mode.init) {
-    NimBLEDevice::init("MI32");
+    NimBLEDevice::init("");
     AddLog(LOG_LEVEL_INFO,PSTR("M32: Init BLE device"));
     MI32.mode.init = 1;
-
+    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM); //seems to be important for i.e. xbox controller, hopefully not breaking other things
+    NimBLEDevice::setSecurityAuth(true, true, true);
     MI32StartScanTask(); // Let's get started !!
   }
 #ifdef USE_MI_EXT_GUI
@@ -668,8 +671,9 @@ extern "C" {
 
   bool MI32runBerryConnection(uint8_t operation){
     if(MI32.conCtx != nullptr){
-      MI32.conCtx->operation = operation%100;
-      AddLog(LOG_LEVEL_DEBUG,PSTR("M32: Berry connection op: %d, addrType: %d"),MI32.conCtx->operation, MI32.conCtx->addrType);
+      MI32.conCtx->oneOp = (operation > 9);
+      MI32.conCtx->operation = operation%10;
+      AddLog(LOG_LEVEL_INFO,PSTR("M32: Berry connection op: %d, addrType: %d, oneOp: %u"),MI32.conCtx->operation, MI32.conCtx->addrType, MI32.conCtx->oneOp);
       MI32StartConnectionTask();
       return true;
     }
@@ -689,7 +693,6 @@ extern "C" {
     if(MI32.conCtx != nullptr){
       MI32.conCtx->serviceUUID = NimBLEUUID(Svc);
       AddLog(LOG_LEVEL_INFO,PSTR("M32: SVC: %s"),MI32.conCtx->serviceUUID.toString().c_str());
-      // AddLog(LOG_LEVEL_INFO,PSTR("M32: SVC: %s"),Svc);
       return true;
     }
     return false;
@@ -699,7 +702,9 @@ extern "C" {
     if(MI32.conCtx != nullptr){
       MI32.conCtx->charUUID = NimBLEUUID(Chr);
       AddLog(LOG_LEVEL_INFO,PSTR("M32: CHR: %s"),MI32.conCtx->charUUID.toString().c_str());
-      // AddLog(LOG_LEVEL_INFO,PSTR("M32: CHR: %s"),Chr);
+      uint16_t _uuid = MI32.conCtx->charUUID.getNative()->u16.value; //if not "notify op" -> present requested characteristic as return UUID
+      MI32.conCtx->returnCharUUID = _uuid;
+      AddLog(LOG_LEVEL_INFO,PSTR("M32: return UUID: %04x"),MI32.conCtx->returnCharUUID);
       return true;
     }
     return false;
@@ -707,7 +712,7 @@ extern "C" {
 
   bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type){
     if(MI32.conCtx != nullptr){
-      MI32.conCtx->MAC = MAC;
+      memcpy(MI32.conCtx->MAC,MAC,6);
       if(type<4) MI32.conCtx->addrType = type;
       else MI32.conCtx->addrType = 0;
       return true;
@@ -1005,25 +1010,6 @@ void MI32StartTask(uint32_t task){
   }
 }
 
-bool MI32ConnectActiveSensor(){ // only use inside a task !!
-    NimBLEAddress _address = NimBLEAddress(MI32.conCtx->MAC, MI32.conCtx->addrType);
-    MI32Client = nullptr;
-    if(NimBLEDevice::getClientListSize()) {
-      MI32Client = NimBLEDevice::getClientByPeerAddress(_address);
-    }
-    if (!MI32Client){
-      MI32Client = NimBLEDevice::createClient(_address);
-      MI32Client->setClientCallbacks(&MI32SensorCB , false);
-    }
-    if (!MI32Client->connect(false)) {
-        MI32.mode.willConnect = 0;
-        NimBLEDevice::deleteClient(MI32Client);
-        // AddLog(LOG_LEVEL_ERROR,PSTR("M32: did not connect client"));
-        return false;
-    }
-    return true;
-}
-
 void MI32StartScanTask(){
     if (MI32.mode.connected) return;
     if(MI32.ScanTask!=nullptr) vTaskDelete(MI32.ScanTask);
@@ -1059,6 +1045,41 @@ void MI32ScanTask(void *pvParameters){
   vTaskDelete( NULL );
 }
 
+bool MI32ConnectActiveSensor(){ // only use inside a task !!
+  NimBLEAddress _address = NimBLEAddress(MI32.conCtx->MAC, MI32.conCtx->addrType);
+  if(MI32Client != nullptr){
+    if(MI32Client->isConnected() && MI32.mode.connected == 1){ //we only accept a "clean" state without obvious packet losses
+      if(MI32.conCtx->operation == 5){ //5 is the disconnect operation
+        NimBLEDevice::deleteClient(MI32Client); // disconnect the old
+        return false; // request disconnect
+      }
+      if(MI32Client->getPeerAddress() == _address){
+        MI32.infoMsg = MI32_STILL_CONNECTED;
+        return true; // still connected -> keep it
+      }
+      else{
+        // AddLog(LOG_LEVEL_ERROR,PSTR("M32: disconnect %s"),MI32Client->getPeerAddress().toString().c_str());
+        NimBLEDevice::deleteClient(MI32Client); // disconnect the old and connect the new
+      }
+    }
+  }
+
+  MI32Client = nullptr;
+  if(NimBLEDevice::getClientListSize()) {
+    MI32Client = NimBLEDevice::getClientByPeerAddress(_address);
+  }
+  if (!MI32Client){
+    MI32Client = NimBLEDevice::createClient(_address);
+    MI32Client->setClientCallbacks(&MI32SensorCB , false);
+  }
+  if (!MI32Client->connect(false)) {
+      MI32.mode.willConnect = 0;
+      NimBLEDevice::deleteClient(MI32Client);
+      // AddLog(LOG_LEVEL_ERROR,PSTR("M32: did not connect client"));
+      return false;
+  }
+  return true;
+}
 
 bool MI32StartConnectionTask(){
     if(MI32.conCtx == nullptr) return false;
@@ -1078,7 +1099,6 @@ bool MI32StartConnectionTask(){
 }
 
 void MI32ConnectionTask(void *pvParameters){
-    MI32.mode.connected = 0;
     MI32.conCtx->error = MI32_CONN_NO_ERROR;
     if (MI32ConnectActiveSensor()){
       MI32.mode.readingDone = 0;
@@ -1109,7 +1129,7 @@ void MI32ConnectionTask(void *pvParameters){
       }
       if (pChr){
         switch(MI32.conCtx->operation){
-          case 11:
+          case 1:
             if(pChr->canRead()) {
             std::string _val = pChr->readValue();
             MI32.conCtx->buffer[0] = (uint8_t)_val.size();
@@ -1120,15 +1140,7 @@ void MI32ConnectionTask(void *pvParameters){
             MI32.conCtx->error = MI32_CONN_CAN_NOT_READ;
             }
             break;
-          case 13:
-            if(pChr->canNotify()) {
-              if(pChr->subscribe(true,MI32notifyCB,false)) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: subscribe"));
-            }
-            else{
-              MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
-            }
-            break;
-          case 12:
+          case 2:
             if(pChr->canWrite()) {
               uint8_t len = MI32.conCtx->buffer[0];
               if(pChr->writeValue(MI32.conCtx->buffer + 1,len,true)) { // true is important !
@@ -1143,6 +1155,14 @@ void MI32ConnectionTask(void *pvParameters){
             }
             MI32.mode.readingDone = 1;
             break;
+          case 3:
+            if(pChr->canNotify()) {
+              if(pChr->subscribe(true,MI32notifyCB,false)) AddLog(LOG_LEVEL_DEBUG,PSTR("M32: subscribe"));
+            }
+            else{
+              MI32.conCtx->error = MI32_CONN_CAN_NOT_NOTIFY;
+            }
+            break;
         default:
             break;
         }
@@ -1152,24 +1172,31 @@ void MI32ConnectionTask(void *pvParameters){
       }
       timer = 0;
 
-      while (timer<150){
-        if (MI32.mode.readingDone){
-          break;
+    while (timer<150){
+      if (MI32.mode.readingDone){
+        break;
+      }
+      else{
+        if (MI32.conCtx->operation==3 && MI32.conCtx->oneOp) {
+          MI32.conCtx->error = MI32_CONN_NOTIFY_TIMEOUT; //did not read on notify - timeout only for one-shot op
         }
-        else{
-          MI32.conCtx->error = MI32_CONN_NOTIFY_TIMEOUT; //did not read on notify - timeout
-        }
-        timer++;
-        vTaskDelay(100/ portTICK_PERIOD_MS);
-
+      }
+      timer++;
+      vTaskDelay(100/ portTICK_PERIOD_MS);
     }
-  MI32Client->disconnect();
-  DEBUG_SENSOR_LOG(PSTR("M32: requested disconnect"));
+    MI32.mode.readingDone = 0;
+    if(MI32.conCtx->oneOp){
+      MI32Client->disconnect();
+      MI32.mode.connected = 0;
+      DEBUG_SENSOR_LOG(PSTR("M32: requested disconnect"));
+      MI32StartTask(MI32_TASK_SCAN);
+    }
   }
   else{
     MI32.conCtx->error = MI32_CONN_NO_CONNECT; // not connected
+    MI32.mode.connected = 0;
+    MI32StartTask(MI32_TASK_SCAN);
   }
-  MI32.mode.connected = 0;
   MI32.mode.triggerBerryConnCB = 1;
   MI32StartTask(MI32_TASK_SCAN);
   vTaskDelete( NULL );
@@ -1546,11 +1573,11 @@ void MI32Every50mSecond(){
   }
   if(MI32.mode.triggerBerryConnCB == 1){
     if(MI32.beConnCB != nullptr){
-    void (*func_ptr)(int) = (void (*)(int))MI32.beConnCB;
+    void (*func_ptr)(int, int, int) = (void (*)(int, int, int))MI32.beConnCB;
     char _message[32];
     GetTextIndexed(_message, sizeof(_message), MI32.conCtx->error, kMI32_ConnErrorMsg);
     AddLog(LOG_LEVEL_DEBUG,PSTR("M32: %s"),_message);
-    func_ptr(MI32.conCtx->error);
+    func_ptr(MI32.conCtx->error, MI32.conCtx->operation , MI32.conCtx->returnCharUUID);
     } 
     MI32.mode.triggerBerryConnCB = 0;
   }
@@ -1785,7 +1812,7 @@ void MI32sendWidget(uint32_t slot){
       else {
         WSContentSend_P(PSTR("<p>Dimmer Steps pressed: %d</p>"),_sensor.dimmer);
       }
-      WSContentSend_P(PSTR("<p>Long: %u</p>"),_sensor.longpress);
+      WSContentSend_P(PSTR("<p>Hold: %u</p>"),_sensor.longpress);
   }
   if(_sensor.feature.Btn){
       char _message[16];
@@ -1889,7 +1916,6 @@ void MI32Show(bool json)
 #endif //USE_HOME_ASSISTANT
 
     if(!MI32.mode.triggeredTele){
-      // MI32.mode.shallClearResults=1;
       if(MI32.option.noSummary) return; // no message at TELEPERIOD
       }
     MI32suspendScanTask();


### PR DESCRIPTION
## Description:

This allows subscribing to notifications for a longer period of time and does not disconnect after every operation. No breaking changes but some additions to the API:

New operations:  
(<10 does not disconnect)
1 - read
2 - write
3- subscribe
5- disconnect
(the old 11 - read, 12 - write, 13 - subscribe_once are still there and will disconnect after completion)

Additions to the Berry connection callback function in the form of
```
    def cb(error,op,uuid)
      # error - code number
      # op - number 1 -3
      # uuid - 16-bit characteristic UUID (from read or notification)
    end
```

I tested this with an LYWSD03 (reading the history data from flash), a Govee desk lamp and a Xbox-S controller. It seems to work, but of course it will not be perfect. For IOT I still prefer passive sensor readings. But it is fun to play with Berry and BLE!

  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
