### PR TITLE
Berry allow bytes() mapped region to hold a null pointer

### DIFF
--- a/lib/libesp32/berry/src/be_globallib.c
+++ b/lib/libesp32/berry/src/be_globallib.c
@@ -13,6 +13,7 @@
 #include "be_debug.h"
 #include "be_map.h"
 #include "be_vm.h"
+#include "be_var.h"
 #include <string.h>
 
 #if BE_USE_GLOBAL_MODULE

--- a/lib/libesp32/berry/src/be_mem.c
+++ b/lib/libesp32/berry/src/be_mem.c
@@ -121,6 +121,8 @@ BERRY_API void* be_realloc(bvm *vm, void *ptr, size_t old_size, size_t new_size)
 }
 
 BERRY_API void* be_move_to_aligned(bvm *vm, void *ptr, size_t size) {
+    (void)vm;
+    (void)size;
 #if BE_USE_MEM_ALIGNED
     if (size <= POOL32_SIZE) {
         return ptr;     /* if in memory pool, don't move it so be_free() will continue to work */
@@ -303,7 +305,6 @@ BERRY_API void be_gc_free_memory_pools(bvm *vm) {
         gc16_t* pool_to_freed = pool16;
         pool16 = pool16->next;
         be_os_free(pool_to_freed);
-        pool16 = pool16->next;
     }
     vm->gc.pool16 = NULL;
 
@@ -312,12 +313,12 @@ BERRY_API void be_gc_free_memory_pools(bvm *vm) {
         gc32_t* pool_to_freed = pool32;
         pool32 = pool32->next;
         be_os_free(pool_to_freed);
-        pool32 = pool32->next;
     }
     vm->gc.pool32 = NULL;
 }
 
 /* https://github.com/hcs0/Hackers-Delight/blob/master/pop.c.txt - count number of 1-bits */
+static int pop0(uint32_t n) __attribute__((unused));
 static int pop0(uint32_t n) {
     n = (n & 0x55555555u) + ((n >> 1) & 0x55555555u);
     n = (n & 0x33333333u) + ((n >> 2) & 0x33333333u);

--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -172,7 +172,7 @@ static void m_solidify_bvalue(bvm *vm, bvalue * value, const char *classname, co
         break;
     case BE_REAL:
 #if BE_USE_SINGLE_FLOAT
-        logfmt("be_const_real_hex(0x%08X)", (uint32_t) var_toobj(value));
+        logfmt("be_const_real_hex(%08" PRIX32 ")", (uint32_t)(uintptr_t)var_toobj(value));
 #else
         logfmt("be_const_real_hex(0x%016" PRIx64 ")", (uint64_t)var_toobj(value));
 #endif


### PR DESCRIPTION
## Description:

Allow `bytes()` object mapped to a memory region to hold a null pointer, and avoid crash when this happens. This allows to reuse `bytes()` object in certain cases and reduce GC pressure.

Also removed some compilation warnings, and a potential crash when freeing the VM.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
