### PR TITLE
Berry add `path.format(true)`

### DIFF
--- a/lib/libesp32/berry/generate/be_fixed_tasmota_path.h
+++ b/lib/libesp32/berry/generate/be_fixed_tasmota_path.h
@@ -1,15 +1,16 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libpath_map) {
-    { be_const_key(listdir, -1), be_const_func(m_path_listdir) },
-    { be_const_key(last_modified, 2), be_const_func(m_path_last_modified) },
-    { be_const_key(exists, 3), be_const_func(m_path_exists) },
+    { be_const_key(listdir, 1), be_const_func(m_path_listdir) },
+    { be_const_key(last_modified, -1), be_const_func(m_path_last_modified) },
+    { be_const_key(format, -1), be_const_func(m_path_format) },
+    { be_const_key(exists, -1), be_const_func(m_path_exists) },
     { be_const_key(remove, -1), be_const_func(m_path_remove) },
 };
 
 static be_define_const_map(
     m_libpath_map,
-    4
+    5
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
@@ -59,12 +59,27 @@ static int m_path_remove(bvm *vm)
     be_return(vm);
 }
 
+extern int be_format_fs(void);
+static int m_path_format(bvm *vm)
+{
+    const char *path = NULL;
+    if (be_top(vm) >= 1 && be_isbool(vm, 1)) {
+        if (be_tobool(vm, 1)) {
+            be_pushbool(vm, be_format_fs());
+            be_return(vm);
+        }
+    }
+    be_pushbool(vm, bfalse);
+    be_return(vm);
+}
+
 /* @const_object_info_begin
 module path (scope: global, file: tasmota_path) {
     exists, func(m_path_exists)
     last_modified, func(m_path_last_modified)
     listdir, func(m_path_listdir)
     remove, func(m_path_remove)
+    format, func(m_path_format)
 }
 @const_object_info_end */
 #include "be_fixed_tasmota_path.h"

--- a/lib/libesp32/berry_tasmota/src/be_port.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_port.cpp
@@ -18,6 +18,7 @@
 // Local pointer for file managment
 #ifdef USE_UFILESYS
     #include <FS.h>
+    #include <LittleFS.h>
     #include "ZipReadFS.h"
     extern FS *ffsp;
     FS zip_ufsp(ZipReadFSImplPtr(new ZipReadFSImpl(&ffsp)));
@@ -340,6 +341,15 @@ int be_unlink(const char *filename)
         strcpy(fname2 + 1, filename);   // prepend with '/'
     }
     return zip_ufsp.remove(fname2);
+#endif // USE_UFILESYS
+    return 0;
+}
+
+/* format file system - erase everything */
+extern "C" int be_format_fs(void)
+{
+#ifdef USE_UFILESYS
+    return LittleFS.format();
 #endif // USE_UFILESYS
     return 0;
 }


### PR DESCRIPTION
## Description:

Sometimes, after multiple re-partitioning, the file system can get instable and corrupt. This function allows to do a clean format of Flash file-system (LitteFS). Warning: this erases the entire file system.

- `path.format(true) -> bool`: formats the LittleFS file system (internal ESP32 flash). The parameter needs to be `true` as to avoid unwanted calls. Returns `true` if reformatting was successful.

``` ruby
> import path
> path.format(true)
true
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
