### PR TITLE
Lvgl cleaned berry mapping

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -832,6 +832,7 @@ extern const bcstring be_const_str_time_str;
 extern const bcstring be_const_str_timer_cb;
 extern const bcstring be_const_str_to_gamma;
 extern const bcstring be_const_str_tob64;
+extern const bcstring be_const_str_toint;
 extern const bcstring be_const_str_tolower;
 extern const bcstring be_const_str_tomap;
 extern const bcstring be_const_str_top;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -351,7 +351,7 @@ be_define_const_str(deg, "deg", 3327754271u, 0, 3, &be_const_str_lv_event);
 be_define_const_str(deinit, "deinit", 2345559592u, 0, 6, NULL);
 be_define_const_str(del, "del", 3478752842u, 0, 3, &be_const_str_out_X20of_X20range);
 be_define_const_str(delay, "delay", 1322381784u, 0, 5, &be_const_str_splash);
-be_define_const_str(delete_all_configs, "delete_all_configs", 2382067578u, 0, 18, NULL);
+be_define_const_str(delete_all_configs, "delete_all_configs", 2382067578u, 0, 18, &be_const_str_toint);
 be_define_const_str(depower, "depower", 3563819571u, 0, 7, &be_const_str_files);
 be_define_const_str(deregister_obj, "deregister_obj", 3909966993u, 0, 14, &be_const_str_set_mode_rgb);
 be_define_const_str(destructor_cb, "destructor_cb", 1930283190u, 0, 13, NULL);
@@ -824,6 +824,7 @@ be_define_const_str(time_str, "time_str", 2613827612u, 0, 8, NULL);
 be_define_const_str(timer_cb, "timer_cb", 79918026u, 0, 8, NULL);
 be_define_const_str(to_gamma, "to_gamma", 1597139862u, 0, 8, NULL);
 be_define_const_str(tob64, "tob64", 373777640u, 0, 5, &be_const_str_widget_struct_default);
+be_define_const_str(toint, "toint", 3613182909u, 0, 5, NULL);
 be_define_const_str(tolower, "tolower", 1042520049u, 0, 7, NULL);
 be_define_const_str(tomap, "tomap", 612167626u, 0, 5, NULL);
 be_define_const_str(top, "top", 2802900028u, 0, 3, NULL);
@@ -1368,6 +1369,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 447,
-    .count = 917,
+    .count = 918,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_lv.h
+++ b/lib/libesp32/berry/generate/be_fixed_lv.h
@@ -1,0 +1,18 @@
+#include "be_constobj.h"
+
+static be_define_const_map_slots(m_liblv_map) {
+    { be_const_key(init, -1), be_const_closure(lv_lv_module_init_closure) },
+    { be_const_key(member, 0), be_const_func(lv0_member) },
+};
+
+static be_define_const_map(
+    m_liblv_map,
+    2
+);
+
+static be_define_const_module(
+    m_liblv,
+    "lv"
+);
+
+BE_EXPORT_VARIABLE be_define_const_native_module(lv);

--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_module.c
@@ -851,19 +851,12 @@ be_local_closure(lv_lv_module_init,   /* name */
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified module: lv
-********************************************************************/
-be_local_module(lv,
-    "lv",
-    be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(init, -1), be_const_closure(lv_lv_module_init_closure) },
-        { be_const_key(member, 0), be_const_func(lv0_member) },
-    }))
-);
-BE_EXPORT_VARIABLE be_define_const_native_module(lv);
-/********************************************************************/
+/* @const_object_info_begin
+module lv (scope: global, file: lv) {
+    init, closure(lv_lv_module_init_closure)
+    member, func(lv0_member)
+}
+@const_object_info_end */
+#include "be_fixed_lv.h"
 
 /********************************************************************/

--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
@@ -1021,7 +1021,7 @@ be_local_class(lv_style,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv_be_style_init) },
     })),
-    (be_nested_const_str("lv_style", -143355747, 8))
+    (be_str_literal("lv_style"))
 );
 /*******************************************************************/
 

--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
@@ -1016,10 +1016,10 @@ be_local_class(lv_style,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv_be_style_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv_be_style_init) },
     })),
     (be_nested_const_str("lv_style", -143355747, 8))
 );
@@ -1033,11 +1033,11 @@ be_local_class(lv_obj,
     NULL,
     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("tostring", -1995258651, 8, 3), be_const_func(lv_x_tostring) },
-        { be_nested_key("member", 719708611, 6, -1), be_const_func(lv_x_member) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("init", 380752755, 4, 4), be_const_func(be_ntv_lv_obj_init) },
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_obj_class) },
+        { be_const_key(_class, 3), be_const_comptr(&lv_obj_class) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(tostring, 4), be_const_func(lv_x_tostring) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_obj_init) },
     })),
     (be_nested_const_str("lv_obj", -37134147, 6))
 );
@@ -1051,10 +1051,10 @@ be_local_class(lv_group,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_group_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(be_ntv_lv_group_init) },
     })),
     (be_nested_const_str("lv_group", -442928277, 8))
 );
@@ -1068,10 +1068,10 @@ be_local_class(lv_indev,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     (be_nested_const_str("lv_indev", 225602374, 8))
 );
@@ -1085,10 +1085,10 @@ be_local_class(lv_disp,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     (be_nested_const_str("lv_disp", 609712084, 8))
 );
@@ -1102,10 +1102,10 @@ be_local_class(lv_timer,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     be_str_literal("lv_timer")
 );
@@ -1119,10 +1119,10 @@ be_local_class(lv_anim,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv_be_anim_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv_be_anim_init) },
     })),
     be_str_literal("lv_anim")
 );
@@ -1136,9 +1136,9 @@ be_local_class(lv_font,
     NULL,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lvbe_font_create) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lvbe_font_create) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
     })),
     (be_nested_const_str("lv_font", 1550958453, 7))
 );
@@ -1152,9 +1152,9 @@ be_local_class(lv_theme,
     NULL,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lvbe_theme_create) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lvbe_theme_create) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
     })),
     (be_nested_const_str("lv_theme", 1550958453, 7))
 );
@@ -1168,10 +1168,10 @@ be_local_class(lv_color,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("toint", -681784387, 5, -1), be_const_func(lco_toint) },
-        { be_nested_key("tostring", -1995258651, 8, 0), be_const_func(lco_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lco_init) },
+        { be_const_key(toint, -1), be_const_func(lco_toint) },
+        { be_const_key(tostring, 0), be_const_func(lco_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lco_init) },
     })),
     (be_nested_const_str("lv_color", 1419148319, 8))
 );
@@ -1210,8 +1210,8 @@ be_local_class(lv_img,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_img_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_img_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_img_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_img_init) },
     })),
     (be_nested_const_str("lv_img", 1612829968, 6))
 );
@@ -1256,8 +1256,8 @@ be_local_class(lv_chart,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_chart_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_chart_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_chart_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_chart_init) },
     })),
     (be_nested_const_str("lv_chart", 1612829968, 6))
 );
@@ -1278,8 +1278,8 @@ be_local_class(lv_colorwheel,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_colorwheel_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_colorwheel_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_colorwheel_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_colorwheel_init) },
     })),
     (be_nested_const_str("lv_colorwheel", 1612829968, 6))
 );
@@ -1300,8 +1300,8 @@ be_local_class(lv_imgbtn,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_imgbtn_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_imgbtn_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_imgbtn_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_imgbtn_init) },
     })),
     (be_nested_const_str("lv_imgbtn", 1612829968, 6))
 );
@@ -1322,8 +1322,8 @@ be_local_class(lv_led,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_led_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_led_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_led_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_led_init) },
     })),
     (be_nested_const_str("lv_led", 1612829968, 6))
 );
@@ -1344,8 +1344,8 @@ be_local_class(lv_meter,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_meter_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_meter_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_meter_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_meter_init) },
     })),
     (be_nested_const_str("lv_meter", 1612829968, 6))
 );
@@ -1366,8 +1366,8 @@ be_local_class(lv_msgbox,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_msgbox_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_msgbox_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_msgbox_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_msgbox_init) },
     })),
     (be_nested_const_str("lv_msgbox", 1612829968, 6))
 );
@@ -1388,8 +1388,8 @@ be_local_class(lv_spinbox,
     &be_class_lv_textarea,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_spinbox_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_spinbox_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_spinbox_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_spinbox_init) },
     })),
     (be_nested_const_str("lv_spinbox", 1612829968, 6))
 );
@@ -1410,8 +1410,8 @@ be_local_class(lv_spinner,
     &be_class_lv_arc,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_spinner_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_spinner_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_spinner_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_spinner_init) },
     })),
     (be_nested_const_str("lv_spinner", 1612829968, 6))
 );
@@ -1444,8 +1444,8 @@ be_local_class(lv_arc,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_arc_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_arc_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_arc_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_arc_init) },
     })),
     (be_nested_const_str("lv_arc", 1612829968, 6))
 );
@@ -1466,8 +1466,8 @@ be_local_class(lv_bar,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_bar_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_bar_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_bar_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_bar_init) },
     })),
     (be_nested_const_str("lv_bar", 1612829968, 6))
 );
@@ -1488,8 +1488,8 @@ be_local_class(lv_btn,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_btn_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_btn_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_btn_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_btn_init) },
     })),
     (be_nested_const_str("lv_btn", 1612829968, 6))
 );
@@ -1510,8 +1510,8 @@ be_local_class(lv_btnmatrix,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_btnmatrix_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_btnmatrix_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_btnmatrix_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_btnmatrix_init) },
     })),
     (be_nested_const_str("lv_btnmatrix", 1612829968, 6))
 );
@@ -1532,8 +1532,8 @@ be_local_class(lv_canvas,
     &be_class_lv_img,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_canvas_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_canvas_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_canvas_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_canvas_init) },
     })),
     (be_nested_const_str("lv_canvas", 1612829968, 6))
 );
@@ -1554,8 +1554,8 @@ be_local_class(lv_checkbox,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_checkbox_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_checkbox_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_checkbox_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_checkbox_init) },
     })),
     (be_nested_const_str("lv_checkbox", 1612829968, 6))
 );
@@ -1576,8 +1576,8 @@ be_local_class(lv_dropdown,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_dropdown_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_dropdown_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_dropdown_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_dropdown_init) },
     })),
     (be_nested_const_str("lv_dropdown", 1612829968, 6))
 );
@@ -1598,8 +1598,8 @@ be_local_class(lv_label,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_label_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_label_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_label_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_label_init) },
     })),
     (be_nested_const_str("lv_label", 1612829968, 6))
 );
@@ -1620,8 +1620,8 @@ be_local_class(lv_line,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_line_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_line_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_line_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_line_init) },
     })),
     (be_nested_const_str("lv_line", 1612829968, 6))
 );
@@ -1642,8 +1642,8 @@ be_local_class(lv_roller,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_roller_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_roller_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_roller_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_roller_init) },
     })),
     (be_nested_const_str("lv_roller", 1612829968, 6))
 );
@@ -1664,8 +1664,8 @@ be_local_class(lv_slider,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_slider_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_slider_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_slider_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_slider_init) },
     })),
     (be_nested_const_str("lv_slider", 1612829968, 6))
 );
@@ -1686,8 +1686,8 @@ be_local_class(lv_switch,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_switch_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_switch_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_switch_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_switch_init) },
     })),
     (be_nested_const_str("lv_switch", 1612829968, 6))
 );
@@ -1708,8 +1708,8 @@ be_local_class(lv_table,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_table_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_table_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_table_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_table_init) },
     })),
     (be_nested_const_str("lv_table", 1612829968, 6))
 );
@@ -1730,8 +1730,8 @@ be_local_class(lv_textarea,
     &be_class_lv_obj,
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_textarea_class) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_textarea_init) },
+        { be_const_key(_class, -1), be_const_comptr(&lv_textarea_class) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_textarea_init) },
     })),
     (be_nested_const_str("lv_textarea", 1612829968, 6))
 );

--- a/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
+++ b/lib/libesp32_lvgl/lv_berry/generate/be_lvgl_widgets_lib.c
@@ -1039,7 +1039,7 @@ be_local_class(lv_obj,
         { be_const_key(tostring, 4), be_const_func(lv_x_tostring) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_obj_init) },
     })),
-    (be_nested_const_str("lv_obj", -37134147, 6))
+    (be_str_literal("lv_obj"))
 );
 /*******************************************************************/
 
@@ -1056,7 +1056,7 @@ be_local_class(lv_group,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(be_ntv_lv_group_init) },
     })),
-    (be_nested_const_str("lv_group", -442928277, 8))
+    (be_str_literal("lv_group"))
 );
 /*******************************************************************/
 
@@ -1073,7 +1073,7 @@ be_local_class(lv_indev,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
-    (be_nested_const_str("lv_indev", 225602374, 8))
+    (be_str_literal("lv_indev"))
 );
 /*******************************************************************/
 
@@ -1090,7 +1090,7 @@ be_local_class(lv_disp,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
-    (be_nested_const_str("lv_disp", 609712084, 8))
+    (be_str_literal("lv_disp"))
 );
 /*******************************************************************/
 
@@ -1140,7 +1140,7 @@ be_local_class(lv_font,
         { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
         { be_const_key(_p, -1), be_const_var(0) },
     })),
-    (be_nested_const_str("lv_font", 1550958453, 7))
+    (be_str_literal("lv_font"))
 );
 /*******************************************************************/
 
@@ -1156,7 +1156,7 @@ be_local_class(lv_theme,
         { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
         { be_const_key(_p, -1), be_const_var(0) },
     })),
-    (be_nested_const_str("lv_theme", 1550958453, 7))
+    (be_str_literal("lv_theme"))
 );
 /*******************************************************************/
 
@@ -1173,7 +1173,7 @@ be_local_class(lv_color,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, -1), be_const_func(lco_init) },
     })),
-    (be_nested_const_str("lv_color", 1419148319, 8))
+    (be_str_literal("lv_color"))
 );
 /*******************************************************************/
 
@@ -1213,7 +1213,7 @@ be_local_class(lv_img,
         { be_const_key(_class, -1), be_const_comptr(&lv_img_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_img_init) },
     })),
-    (be_nested_const_str("lv_img", 1612829968, 6))
+    (be_str_literal("lv_img"))
 );
 /*******************************************************************/
 
@@ -1259,7 +1259,7 @@ be_local_class(lv_chart,
         { be_const_key(_class, -1), be_const_comptr(&lv_chart_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_chart_init) },
     })),
-    (be_nested_const_str("lv_chart", 1612829968, 6))
+    (be_str_literal("lv_chart"))
 );
 /*******************************************************************/
 
@@ -1281,7 +1281,7 @@ be_local_class(lv_colorwheel,
         { be_const_key(_class, -1), be_const_comptr(&lv_colorwheel_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_colorwheel_init) },
     })),
-    (be_nested_const_str("lv_colorwheel", 1612829968, 6))
+    (be_str_literal("lv_colorwheel"))
 );
 /*******************************************************************/
 
@@ -1303,7 +1303,7 @@ be_local_class(lv_imgbtn,
         { be_const_key(_class, -1), be_const_comptr(&lv_imgbtn_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_imgbtn_init) },
     })),
-    (be_nested_const_str("lv_imgbtn", 1612829968, 6))
+    (be_str_literal("lv_imgbtn"))
 );
 /*******************************************************************/
 
@@ -1325,7 +1325,7 @@ be_local_class(lv_led,
         { be_const_key(_class, -1), be_const_comptr(&lv_led_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_led_init) },
     })),
-    (be_nested_const_str("lv_led", 1612829968, 6))
+    (be_str_literal("lv_led"))
 );
 /*******************************************************************/
 
@@ -1347,7 +1347,7 @@ be_local_class(lv_meter,
         { be_const_key(_class, -1), be_const_comptr(&lv_meter_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_meter_init) },
     })),
-    (be_nested_const_str("lv_meter", 1612829968, 6))
+    (be_str_literal("lv_meter"))
 );
 /*******************************************************************/
 
@@ -1369,7 +1369,7 @@ be_local_class(lv_msgbox,
         { be_const_key(_class, -1), be_const_comptr(&lv_msgbox_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_msgbox_init) },
     })),
-    (be_nested_const_str("lv_msgbox", 1612829968, 6))
+    (be_str_literal("lv_msgbox"))
 );
 /*******************************************************************/
 
@@ -1391,7 +1391,7 @@ be_local_class(lv_spinbox,
         { be_const_key(_class, -1), be_const_comptr(&lv_spinbox_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_spinbox_init) },
     })),
-    (be_nested_const_str("lv_spinbox", 1612829968, 6))
+    (be_str_literal("lv_spinbox"))
 );
 /*******************************************************************/
 
@@ -1413,7 +1413,7 @@ be_local_class(lv_spinner,
         { be_const_key(_class, -1), be_const_comptr(&lv_spinner_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_spinner_init) },
     })),
-    (be_nested_const_str("lv_spinner", 1612829968, 6))
+    (be_str_literal("lv_spinner"))
 );
 /*******************************************************************/
 
@@ -1447,7 +1447,7 @@ be_local_class(lv_arc,
         { be_const_key(_class, -1), be_const_comptr(&lv_arc_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_arc_init) },
     })),
-    (be_nested_const_str("lv_arc", 1612829968, 6))
+    (be_str_literal("lv_arc"))
 );
 /*******************************************************************/
 
@@ -1469,7 +1469,7 @@ be_local_class(lv_bar,
         { be_const_key(_class, -1), be_const_comptr(&lv_bar_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_bar_init) },
     })),
-    (be_nested_const_str("lv_bar", 1612829968, 6))
+    (be_str_literal("lv_bar"))
 );
 /*******************************************************************/
 
@@ -1491,7 +1491,7 @@ be_local_class(lv_btn,
         { be_const_key(_class, -1), be_const_comptr(&lv_btn_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_btn_init) },
     })),
-    (be_nested_const_str("lv_btn", 1612829968, 6))
+    (be_str_literal("lv_btn"))
 );
 /*******************************************************************/
 
@@ -1513,7 +1513,7 @@ be_local_class(lv_btnmatrix,
         { be_const_key(_class, -1), be_const_comptr(&lv_btnmatrix_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_btnmatrix_init) },
     })),
-    (be_nested_const_str("lv_btnmatrix", 1612829968, 6))
+    (be_str_literal("lv_btnmatrix"))
 );
 /*******************************************************************/
 
@@ -1535,7 +1535,7 @@ be_local_class(lv_canvas,
         { be_const_key(_class, -1), be_const_comptr(&lv_canvas_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_canvas_init) },
     })),
-    (be_nested_const_str("lv_canvas", 1612829968, 6))
+    (be_str_literal("lv_canvas"))
 );
 /*******************************************************************/
 
@@ -1557,7 +1557,7 @@ be_local_class(lv_checkbox,
         { be_const_key(_class, -1), be_const_comptr(&lv_checkbox_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_checkbox_init) },
     })),
-    (be_nested_const_str("lv_checkbox", 1612829968, 6))
+    (be_str_literal("lv_checkbox"))
 );
 /*******************************************************************/
 
@@ -1579,7 +1579,7 @@ be_local_class(lv_dropdown,
         { be_const_key(_class, -1), be_const_comptr(&lv_dropdown_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_dropdown_init) },
     })),
-    (be_nested_const_str("lv_dropdown", 1612829968, 6))
+    (be_str_literal("lv_dropdown"))
 );
 /*******************************************************************/
 
@@ -1601,7 +1601,7 @@ be_local_class(lv_label,
         { be_const_key(_class, -1), be_const_comptr(&lv_label_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_label_init) },
     })),
-    (be_nested_const_str("lv_label", 1612829968, 6))
+    (be_str_literal("lv_label"))
 );
 /*******************************************************************/
 
@@ -1623,7 +1623,7 @@ be_local_class(lv_line,
         { be_const_key(_class, -1), be_const_comptr(&lv_line_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_line_init) },
     })),
-    (be_nested_const_str("lv_line", 1612829968, 6))
+    (be_str_literal("lv_line"))
 );
 /*******************************************************************/
 
@@ -1645,7 +1645,7 @@ be_local_class(lv_roller,
         { be_const_key(_class, -1), be_const_comptr(&lv_roller_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_roller_init) },
     })),
-    (be_nested_const_str("lv_roller", 1612829968, 6))
+    (be_str_literal("lv_roller"))
 );
 /*******************************************************************/
 
@@ -1667,7 +1667,7 @@ be_local_class(lv_slider,
         { be_const_key(_class, -1), be_const_comptr(&lv_slider_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_slider_init) },
     })),
-    (be_nested_const_str("lv_slider", 1612829968, 6))
+    (be_str_literal("lv_slider"))
 );
 /*******************************************************************/
 
@@ -1689,7 +1689,7 @@ be_local_class(lv_switch,
         { be_const_key(_class, -1), be_const_comptr(&lv_switch_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_switch_init) },
     })),
-    (be_nested_const_str("lv_switch", 1612829968, 6))
+    (be_str_literal("lv_switch"))
 );
 /*******************************************************************/
 
@@ -1711,7 +1711,7 @@ be_local_class(lv_table,
         { be_const_key(_class, -1), be_const_comptr(&lv_table_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_table_init) },
     })),
-    (be_nested_const_str("lv_table", 1612829968, 6))
+    (be_str_literal("lv_table"))
 );
 /*******************************************************************/
 
@@ -1733,7 +1733,7 @@ be_local_class(lv_textarea,
         { be_const_key(_class, -1), be_const_comptr(&lv_textarea_class) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_textarea_init) },
     })),
-    (be_nested_const_str("lv_textarea", 1612829968, 6))
+    (be_str_literal("lv_textarea"))
 );
 /*******************************************************************/
 

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -533,10 +533,10 @@ be_local_class(lv_style,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv_be_style_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv_be_style_init) },
     })),
     (be_nested_const_str("lv_style", -143355747, 8))
 );
@@ -550,11 +550,11 @@ be_local_class(lv_obj,
     NULL,
     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("tostring", -1995258651, 8, 3), be_const_func(lv_x_tostring) },
-        { be_nested_key("member", 719708611, 6, -1), be_const_func(lv_x_member) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("init", 380752755, 4, 4), be_const_func(be_ntv_lv_obj_init) },
-        { be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_obj_class) },
+        { be_const_key(_class, 3), be_const_comptr(&lv_obj_class) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(tostring, 4), be_const_func(lv_x_tostring) },
+        { be_const_key(init, -1), be_const_func(be_ntv_lv_obj_init) },
     })),
     (be_nested_const_str("lv_obj", -37134147, 6))
 );
@@ -568,10 +568,10 @@ be_local_class(lv_group,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_group_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(be_ntv_lv_group_init) },
     })),
     (be_nested_const_str("lv_group", -442928277, 8))
 );
@@ -585,10 +585,10 @@ be_local_class(lv_indev,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     (be_nested_const_str("lv_indev", 225602374, 8))
 );
@@ -602,10 +602,10 @@ be_local_class(lv_disp,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     (be_nested_const_str("lv_disp", 609712084, 8))
 );
@@ -619,10 +619,10 @@ be_local_class(lv_timer,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv0_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
     be_str_literal("lv_timer")
 );
@@ -636,10 +636,10 @@ be_local_class(lv_anim,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lv_be_anim_init) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("member", 719708611, 6, 0), be_const_func(lv_x_member) },
+        { be_const_key(member, -1), be_const_func(lv_x_member) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, 0), be_const_func(lv_be_anim_init) },
     })),
     be_str_literal("lv_anim")
 );
@@ -653,9 +653,9 @@ be_local_class(lv_font,
     NULL,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lvbe_font_create) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lvbe_font_create) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
     })),
     (be_nested_const_str("lv_font", 1550958453, 7))
 );
@@ -669,9 +669,9 @@ be_local_class(lv_theme,
     NULL,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lvbe_theme_create) },
-        { be_nested_key("tostring", -1995258651, 8, -1), be_const_func(lv_x_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lvbe_theme_create) },
+        { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
     })),
     (be_nested_const_str("lv_theme", 1550958453, 7))
 );
@@ -685,10 +685,10 @@ be_local_class(lv_color,
     NULL,
     be_nested_map(4,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_nested_key("toint", -681784387, 5, -1), be_const_func(lco_toint) },
-        { be_nested_key("tostring", -1995258651, 8, 0), be_const_func(lco_tostring) },
-        { be_nested_key("_p", 1594591802, 2, -1), be_const_var(0) },
-        { be_nested_key("init", 380752755, 4, -1), be_const_func(lco_init) },
+        { be_const_key(toint, -1), be_const_func(lco_toint) },
+        { be_const_key(tostring, 0), be_const_func(lco_tostring) },
+        { be_const_key(_p, -1), be_const_var(0) },
+        { be_const_key(init, -1), be_const_func(lco_init) },
     })),
     (be_nested_const_str("lv_color", 1419148319, 8))
 );
@@ -709,8 +709,8 @@ be_local_class(lv_{subtype},
     &be_class_lv_{super_class},
     be_nested_map(2,
     ( (struct bmapnode*) &(const bmapnode[]) {{
-        {{ be_nested_key("_class", -1562820946, 6, -1), be_const_comptr(&lv_{subtype}_class) }},
-        {{ be_nested_key("init", 380752755, 4, -1), be_const_func(be_ntv_lv_{subtype}_init) }},
+        {{ be_const_key(_class, -1), be_const_comptr(&lv_{subtype}_class) }},
+        {{ be_const_key(init, -1), be_const_func(be_ntv_lv_{subtype}_init) }},
     }})),
     (be_nested_const_str("lv_{subtype}", 1612829968, 6))
 );

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -556,7 +556,7 @@ be_local_class(lv_obj,
         { be_const_key(tostring, 4), be_const_func(lv_x_tostring) },
         { be_const_key(init, -1), be_const_func(be_ntv_lv_obj_init) },
     })),
-    (be_nested_const_str("lv_obj", -37134147, 6))
+    (be_str_literal("lv_obj"))
 );
 /*******************************************************************/
 
@@ -573,7 +573,7 @@ be_local_class(lv_group,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(be_ntv_lv_group_init) },
     })),
-    (be_nested_const_str("lv_group", -442928277, 8))
+    (be_str_literal("lv_group"))
 );
 /*******************************************************************/
 
@@ -590,7 +590,7 @@ be_local_class(lv_indev,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
-    (be_nested_const_str("lv_indev", 225602374, 8))
+    (be_str_literal("lv_indev"))
 );
 /*******************************************************************/
 
@@ -607,7 +607,7 @@ be_local_class(lv_disp,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv0_init) },
     })),
-    (be_nested_const_str("lv_disp", 609712084, 8))
+    (be_str_literal("lv_disp"))
 );
 /*******************************************************************/
 
@@ -657,7 +657,7 @@ be_local_class(lv_font,
         { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
         { be_const_key(_p, -1), be_const_var(0) },
     })),
-    (be_nested_const_str("lv_font", 1550958453, 7))
+    (be_str_literal("lv_font"))
 );
 /*******************************************************************/
 
@@ -673,7 +673,7 @@ be_local_class(lv_theme,
         { be_const_key(tostring, -1), be_const_func(lv_x_tostring) },
         { be_const_key(_p, -1), be_const_var(0) },
     })),
-    (be_nested_const_str("lv_theme", 1550958453, 7))
+    (be_str_literal("lv_theme"))
 );
 /*******************************************************************/
 
@@ -690,7 +690,7 @@ be_local_class(lv_color,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, -1), be_const_func(lco_init) },
     })),
-    (be_nested_const_str("lv_color", 1419148319, 8))
+    (be_str_literal("lv_color"))
 );
 /*******************************************************************/
 """)
@@ -712,7 +712,7 @@ be_local_class(lv_{subtype},
         {{ be_const_key(_class, -1), be_const_comptr(&lv_{subtype}_class) }},
         {{ be_const_key(init, -1), be_const_func(be_ntv_lv_{subtype}_init) }},
     }})),
-    (be_nested_const_str("lv_{subtype}", 1612829968, 6))
+    (be_str_literal("lv_{subtype}"))
 );
 /*******************************************************************/
 """)

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -538,7 +538,7 @@ be_local_class(lv_style,
         { be_const_key(_p, -1), be_const_var(0) },
         { be_const_key(init, 0), be_const_func(lv_be_style_init) },
     })),
-    (be_nested_const_str("lv_style", -143355747, 8))
+    (be_str_literal("lv_style"))
 );
 /*******************************************************************/
 

--- a/lib/libesp32_lvgl/lv_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_berry/tools/convert.py
@@ -873,20 +873,13 @@ be_local_closure(lv_lv_module_init,   /* name */
 );
 /*******************************************************************/
 
-
-/********************************************************************
-** Solidified module: lv
-********************************************************************/
-be_local_module(lv,
-    "lv",
-    be_nested_map(2,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(init, -1), be_const_closure(lv_lv_module_init_closure) },
-        { be_const_key(member, 0), be_const_func(lv0_member) },
-    }))
-);
-BE_EXPORT_VARIABLE be_define_const_native_module(lv);
-/********************************************************************/
+/* @const_object_info_begin
+module lv (scope: global, file: lv) {
+    init, closure(lv_lv_module_init_closure)
+    member, func(lv0_member)
+}
+@const_object_info_end */
+#include "be_fixed_lv.h"
 """)
 
 print("/********************************************************************/")


### PR DESCRIPTION
## Description:

Minor simplification of LVGL Berry mapping. Saves 1.3KB of Flash by reusing string literals.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
