### PR TITLE
Add support for Fitop 10W RGBCCT Bulb's (BA60H-W0080-RCBW-E7) SM2135 protocol

### DIFF
--- a/tasmota/tasmota_template.h
+++ b/tasmota/tasmota_template.h
@@ -418,7 +418,7 @@ const char kSensorNamesFixed[] PROGMEM =
 #define MAX_A4988_MSS    3
 #define MAX_WEBCAM_DATA  8
 #define MAX_WEBCAM_HSD   3
-#define MAX_SM2135_DAT   6
+#define MAX_SM2135_DAT   7
 
 const uint16_t kGpioNiceList[] PROGMEM = {
   GPIO_NONE,                            // Not used


### PR DESCRIPTION
## Description:
Fitop's 10W RGBCCT Bulb (BA60H-W0080-RCBW-E7) is not fully compatible with Tasmota's SM2135 implementation. This PR:
* Adds the option to set RGB and CCT channels simultaneously, fixing the bulb maintaining incorrect state
* Adds correct current settings

With this PR, Tasmota's behaviour matches I2C dumps of the lightbulb with the original chip/firmware.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
