### PR TITLE
Add FlashWriteCount to INFO3

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -82,6 +82,7 @@
 #define D_JSON_FLASHCHIPID "FlashChipId"
 #define D_JSON_FLASHMODE "FlashMode"
 #define D_JSON_FLASHSIZE "FlashSize"
+#define D_JSON_FLASHWRITECOUNT "FlashWriteCount"
 #define D_JSON_FLOWRATE "FlowRate"
 #define D_JSON_FREEMEMORY "Free"
 #define D_JSON_FREQUENCY "Frequency"

--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -943,6 +943,7 @@ void MqttConnected(void) {
         ResponseAppend_P(PSTR("\"%s\""), GetResetReason().c_str());
       }
       ResponseAppend_P(PSTR(",\"" D_JSON_BOOTCOUNT "\":%d}}"), Settings->bootcount +1);
+      ResponseAppend_P(PSTR(",\"" D_JSON_FLASHWRITECOUNT "\":%d}}"), Settings->save_flag);
       MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_RSLT_INFO "3"), Settings->flag5.mqtt_info_retain);
     }
 


### PR DESCRIPTION
## Description:

Add FlashWriteCount to INFO3 so we could monitorize that value to log it and find abnormal working of our Tasmotas.

(related discussion: [https://github.com/arendst/Tasmota/discussions/14785](https://github.com/arendst/Tasmota/discussions/14785))

NOTE: I have re-created the PR because the old one was automatically closed. I dont know if it can be reopen again, so just in case, I have done this one. (Previous PR: [https://github.com/arendst/Tasmota/pull/14822](https://github.com/arendst/Tasmota/pull/14822))

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
