### PR TITLE
SetOption136 disable TuyaSNS immediate publish

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -165,7 +165,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t shift595_invert_outputs : 1;  // bit 19 (v10.0.0.4) - SetOption133 - (Shift595) Invert outputs of 74x595 shift registers
     uint32_t pwm_force_same_phase : 1;     // bit 20 (v10.1.0.6) - SetOption134 - (PWM) force PWM lights to start at same phase, default is to spread phases to minimze overlap (also needed for H-bridge)
     uint32_t display_no_splash : 1;        // bit 21 (v11.0.0.2) - SetOption135 - (Display & LVGL) forece disbabling default splash screen
-    uint32_t spare22 : 1;                  // bit 22
+    uint32_t tuyasns_no_immediate : 1;     // bit 22 (v11.0.0.4) - SetOption136 - (TuyaSNS) When ON disable publish single SNS value on Tuya Receive (keep Teleperiod)
     uint32_t spare23 : 1;                  // bit 23
     uint32_t spare24 : 1;                  // bit 24
     uint32_t spare25 : 1;                  // bit 25

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -830,7 +830,11 @@ void TuyaProcessStatePacket(void) {
             GetTextIndexed(sname, sizeof(sname), (fnId-71), kTuyaSensors);
             ResponseClear(); // Clear retained message
             Response_P(PSTR("{\"TuyaSNS\":{\"%s\":%s}}"), sname, dtostrfd(TuyaAdjustedTemperature(packetValue, res), res, tempval)); // sensor update is just on change
-            MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_CMND_SENSOR));
+            if (Settings->flag5.tuyasns_no_immediate) {
+              XdrvRulesProcess(0);
+            } else {
+              MqttPublishPrefixTopicRulesProcess_P(TELE, PSTR(D_CMND_SENSOR));
+            }
           }
         }
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #14842 

### Summary
`SetOption136 0` : default (legacy behavior) : publish an immediate tele/../SENSOR TuyaSNS message at each reception of individual value
`SetOption136 1`: disable this behavior while using immediate receive in Rules

Type of MQTT "spamming" with legacy configuration that is disabled with `SO136 1`
```
23:48:13.606 MQT: tele/nodemcu/SENSOR = {"TuyaSNS":{"Humidity":1.1}}
23:48:13.664 MQT: tele/nodemcu/SENSOR = {"TuyaSNS":{"CarbonDioxide":295}}
23:48:13.696 MQT: tele/nodemcu/SENSOR = {"TuyaSNS":{"TVOC":40}}
```

Non-breaking PR as the legacy behavior remains.

Tested on ESP8266 nodemcu using Tuya Simulator (cool product once you found when to switch it in english)
esp32-c3 to be tested by @loca5790


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
