### PR TITLE
Fix %timerx% variables for negative values

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -477,7 +477,11 @@ bool RulesRuleMatch(uint8_t rule_set, String &event, String &rule, bool stop_all
       if ((index > 0) && (index <= MAX_TIMERS)) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), index);
         if (rule_param.startsWith(stemp)) {
-          rule_param = String(Settings->timer[index -1].time);
+          int32_t timer = Settings->timer[index -1].time;
+          if (Settings->timer[index -1].mode && (timer >= 12*60)) {
+            timer = -(timer - (12*60));
+          }
+          rule_param = String(timer);
         }
       }
     }
@@ -796,7 +800,11 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
 #if defined(USE_TIMERS)
       for (uint32_t i = 0; i < MAX_TIMERS; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), i +1);
-        RulesVarReplace(commands, stemp, String(Settings->timer[i].time));
+        int32_t timer = Settings->timer[i].time;
+        if (Settings->timer[i].mode && (timer >= 12*60)) {
+          timer = -(timer - 12*60);
+        }
+        RulesVarReplace(commands, stemp, String(timer));
       }
 #if defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/15205 from @rapi3

When timer uses mode 1 (relative to sunrise) or mode 2 (relative to sunset), the "negative" value stored in settings is "encoded" as > 12:00. This was not taken into account in previous PR https://github.com/arendst/Tasmota/pull/14619 by @alexasf

I've chosen to return the value as negative offset.

## Possible alternative 
Instead of returning the offset, for mode 1 and 2, it could return the absolute time %sunset%+offset or %sunrise%+offset 
This would return a value that is valid at this instant and not the value of the setting.

Let me know if you prefer this way, I will change the PR.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
