### PR TITLE
MI32: refactoring conn task, bugfix, add response to op

### DIFF
--- a/tasmota/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/xdrv_52_3_berry_MI32.ino
@@ -118,7 +118,7 @@ extern "C" {
 ********************************************************************/ 
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
-  extern bool MI32runBerryConnection(uint8_t operation);
+  extern bool MI32runBerryConnection(uint8_t operation, bool response);
   extern bool MI32setBerryCtxSvc(const char *Svc);
   extern bool MI32setBerryCtxChr(const char *Chr);
   extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type);
@@ -193,8 +193,12 @@ extern "C" {
   int be_BLE_run(bvm *vm);
   int be_BLE_run(bvm *vm){    
     int32_t argc = be_top(vm); // Get the number of arguments
-    if ((argc == 2) && be_isint(vm, 2)) {
-      if (MI32runBerryConnection(be_toint(vm, 2))) be_return(vm);
+    if ((argc > 1) && be_isint(vm, 2)) {
+      bool response = false;
+      if(argc == 3 && be_isint(vm, 3)){
+        response = be_toint(vm,3)>0;
+      }
+      if (MI32runBerryConnection(be_toint(vm, 2),response)) be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }

--- a/tasmota/xsns_62_esp32_mi.h
+++ b/tasmota/xsns_62_esp32_mi.h
@@ -154,6 +154,7 @@ struct MI32connectionContextBerry_t{
   uint8_t addrType;
   int error;
   bool oneOp;
+  bool response;
 };
 
 struct {
@@ -180,6 +181,8 @@ struct {
       uint32_t didStartHAP:1;
       uint32_t triggerBerryAdvCB:1;
       uint32_t triggerBerryConnCB:1;
+      uint32_t triggerNextConnJob:1;
+      uint32_t readyForNextConnJob:1;
     };
     uint32_t all = 0;
   } mode;
@@ -382,7 +385,7 @@ const char * kMI32DeviceType[] PROGMEM = {kMI32DeviceType1,kMI32DeviceType2,kMI3
                                           kMI32DeviceType9,kMI32DeviceType10,kMI32DeviceType11,kMI32DeviceType12,
                                           kMI32DeviceType13,kMI32DeviceType14,kMI32DeviceType15,kMI32DeviceType16};
 
-const char kMI32_ConnErrorMsg[] PROGMEM = "no Error|could not connect|got no service|got no characteristic|can not read|can not notify|can not write|did not write|notify time out";
+const char kMI32_ConnErrorMsg[] PROGMEM = "no Error|could not connect|did disconnect|got no service|got no characteristic|can not read|can not notify|can not write|did not write|notify time out";
 
 const char kMI32_BLEInfoMsg[] PROGMEM = "Scan ended|Got Notification|Did connect|Did disconnect|Still connected|Start scanning";
 
@@ -407,6 +410,7 @@ enum MI32_TASK {
 enum MI32_ConnErrorMsg {
   MI32_CONN_NO_ERROR = 0,
   MI32_CONN_NO_CONNECT,
+  MI32_CONN_DID_DISCCONNECT,
   MI32_CONN_NO_SERVICE,
   MI32_CONN_NO_CHARACTERISTIC,
   MI32_CONN_CAN_NOT_READ,


### PR DESCRIPTION
## Description:

This PR is pretty much the result of my attempt to port the legacy bind_key generator to Berry inside Tasmota, which seems to work now.
Changes:
- the connection task stays alive for asynchronous operations
- added optional `response`-flag to the `run`-method   in Berry -> subscribe and/or write in BLE w/o response from BLE device
i.e. `ble.run(2,1)`- means write with response 
- introduced return op of 103 in the callback to report a notification, that came asynchronously
- fixed a really stupid bug for command `MI32Key`, which also correctly expands the 12-byte-legacy key to a 16-byte-key.
- less LOG_LEVEL_INFO and more LOG_LEVEL_DEBUG, there were a bit to many messages for a more complex Berry project 
- use NimBLEAttValue

Here is the very unpolished version of the legacy bind_key generator:
https://gist.github.com/Staars/8f87799cc9f4fcb5a535d7c5623d671f

Possible usage:
Have the MAC of the dimmer in the format AABBCCDDEEFF (for instance from the dashboard).
Paste the berry script into the Berry web console and run the code.
In the Tasmota console type `pair AABBCCDDEEFF`, then long press the pair button of the dimmer.
After completion copy-paste the key from the console and merge with the MAC to a key_mac_string.
Add key with `MI32key KEYMAC`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
