### PR TITLE
Fix %TIMERx% variables for negative values

### DIFF
--- a/tasmota/xdrv_09_timers.ino
+++ b/tasmota/xdrv_09_timers.ino
@@ -235,6 +235,22 @@ uint16_t SunMinutes(uint32_t dawn)
 
 #endif  // USE_SUNRISE
 
+uint16_t TimerGetTimeOfDay(uint8_t index)
+{
+  Timer xtimer = Settings->timer[index];
+  int16_t xtime = xtimer.time;
+#ifdef USE_SUNRISE
+  if (xtimer.mode) {
+  if (xtime >= 12*60) xtime = 12*60 - xtime;
+  xtime += (int16_t)SunMinutes(xtimer.mode-1);
+  if (xtime <      0) xtime += 24*60;
+  if (xtime >= 24*60) xtime -= 24*60;
+  }
+#endif
+return xtime;
+}
+
+
 /*******************************************************************************************/
 
 void TimerSetRandomWindow(uint32_t index)

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -477,11 +477,7 @@ bool RulesRuleMatch(uint8_t rule_set, String &event, String &rule, bool stop_all
       if ((index > 0) && (index <= MAX_TIMERS)) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), index);
         if (rule_param.startsWith(stemp)) {
-          int32_t timer = Settings->timer[index -1].time;
-          if (Settings->timer[index -1].mode && (timer >= 12*60)) {
-            timer = -(timer - (12*60));
-          }
-          rule_param = String(timer);
+          rule_param = String(TimerGetTimeOfDay(index -1));
         }
       }
     }
@@ -800,11 +796,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
 #if defined(USE_TIMERS)
       for (uint32_t i = 0; i < MAX_TIMERS; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), i +1);
-        int32_t timer = Settings->timer[i].time;
-        if (Settings->timer[i].mode && (timer >= 12*60)) {
-          timer = -(timer - 12*60);
-        }
-        RulesVarReplace(commands, stemp, String(timer));
+        RulesVarReplace(commands, stemp, String(TimerGetTimeOfDay(i)));
       }
 #if defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -477,7 +477,11 @@ bool RulesRuleMatch(uint8_t rule_set, String &event, String &rule, bool stop_all
       if ((index > 0) && (index <= MAX_TIMERS)) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), index);
         if (rule_param.startsWith(stemp)) {
-          rule_param = String(Settings->timer[index -1].time);
+          int32_t timer = Settings->timer[index -1].time;
+          if (Settings->timer[index -1].mode && (timer >= 12*60)) {
+            timer = -(timer - (12*60));
+          }
+          rule_param = String(timer);
         }
       }
     }
@@ -796,7 +800,11 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
 #if defined(USE_TIMERS)
       for (uint32_t i = 0; i < MAX_TIMERS; i++) {
         snprintf_P(stemp, sizeof(stemp), PSTR("%%TIMER%d%%"), i +1);
-        RulesVarReplace(commands, stemp, String(Settings->timer[i].time));
+        int32_t timer = Settings->timer[i].time;
+        if (Settings->timer[i].mode && (timer >= 12*60)) {
+          timer = -(timer - 12*60);
+        }
+        RulesVarReplace(commands, stemp, String(timer));
       }
 #if defined(USE_SUNRISE)
       RulesVarReplace(commands, F("%SUNRISE%"), String(SunMinutes(0)));


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/15205 from @rapi3

When timer uses mode 1 (relative to sunrise) or mode 2 (relative to sunset), the "negative" offset stored in settings is "encoded" as > 12:00. This was not taken into account in previous PR https://github.com/arendst/Tasmota/pull/14619 by @alexasf

This PR provides a coherent value with mode 0, where `%TIMERx%` is the time of day at which the event has/will happen so it can be compared to `%time%` in rules.

Example with `%sunrise%` as 06:10 (400) and `%sunset%` as 19:11 (1151):
```
14:13:56.914 CMD: backlog rule3;timers;event test
14:13:56.992 MQT: stat/nodemcu/RULE = {"Rule3":{"State":"ON","Once":"OFF","StopOnError":"OFF","Length":204,"Free":307,"Rules":"ON event#test DO backlog var1 %timer1%;var2 %timer2%; var3 %timer3%;var4 %timer4%;var5 %timer5%;var6 %timer6%;var7 %timer7%;var8 %timer8%;var9 %timer9%;var10 %timer10%;var11 %sunrise%;var12 %sunset% endon"}}
14:13:57.219 MQT: stat/nodemcu/TIMERS = {"Timers":"ON",
  "Timer1":{"Enable":1,"Mode":1,"Time":"00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer2":{"Enable":1,"Mode":1,"Time":"-00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer3":{"Enable":1,"Mode":1,"Time":"11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer4":{"Enable":1,"Mode":1,"Time":"-11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer5":{"Enable":1,"Mode":2,"Time":"00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer6":{"Enable":1,"Mode":2,"Time":"-00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer7":{"Enable":1,"Mode":2,"Time":"11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer8":{"Enable":1,"Mode":2,"Time":"-11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer9":{"Enable":1,"Mode":1,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Action":3},
  "Timer10":{"Enable":1,"Mode":2,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Action":3},
...
}

14:13:57.508 MQT: stat/nodemcu/VAR = {"Var1":"410"}       => 06:40 + 00:10 => 06:50 = 410
14:13:57.758 MQT: stat/nodemcu/VAR = {"Var2":"390"}       => 06:40 - 00:10 => 06:30 = 390
14:13:58.009 MQT: stat/nodemcu/VAR = {"Var3":"1119"}      => 06:40 + 11:59 => 18:39 = 1119
14:13:58.259 MQT: stat/nodemcu/VAR = {"Var4":"1121"}      => 06:40 - 11:59 => 18:41 = 1121
14:13:58.510 MQT: stat/nodemcu/VAR = {"Var5":"1161"}      => 19:11 + 00:10 => 19:21 = 1161
14:13:58.760 MQT: stat/nodemcu/VAR = {"Var6":"1141"}      => 19:11 - 00:10 => 19:01 = 1141
14:13:59.010 MQT: stat/nodemcu/VAR = {"Var7":"430"}       => 19:11 + 11:59 => 07:10 = 430
14:13:59.259 MQT: stat/nodemcu/VAR = {"Var8":"432"}       => 19:11 - 11:59 => 07:12 = 432
14:13:59.460 MQT: stat/nodemcu/VAR = {"Var9":"400"}       => 06:40 + 00:00 => 06:40 = 400
14:13:59.710 MQT: stat/nodemcu/VAR = {"Var10":"1151"}     => 19:11 + 00:00 => 19:11 = 1151
14:13:59.961 MQT: stat/nodemcu/VAR = {"Var11":"400"}      => sunrise
14:14:00.211 MQT: stat/nodemcu/VAR = {"Var12":"1151"}     => sunset
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_