### PR TITLE
Berry introspect.module

### DIFF
--- a/lib/libesp32/berry/generate/be_fixed_introspect.h
+++ b/lib/libesp32/berry/generate/be_fixed_introspect.h
@@ -1,17 +1,18 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libintrospect_map) {
-    { be_const_key(members, 3), be_const_func(m_attrlist) },
-    { be_const_key(set, -1), be_const_func(m_setmember) },
-    { be_const_key(get, -1), be_const_func(m_findmember) },
-    { be_const_key(toptr, -1), be_const_func(m_toptr) },
     { be_const_key(ismethod, -1), be_const_func(m_ismethod) },
-    { be_const_key(fromptr, 2), be_const_func(m_fromptr) },
+    { be_const_key(toptr, -1), be_const_func(m_toptr) },
+    { be_const_key(get, -1), be_const_func(m_findmember) },
+    { be_const_key(module, 5), be_const_func(m_getmodule) },
+    { be_const_key(fromptr, 1), be_const_func(m_fromptr) },
+    { be_const_key(members, -1), be_const_func(m_attrlist) },
+    { be_const_key(set, 3), be_const_func(m_setmember) },
 };
 
 static be_define_const_map(
     m_libintrospect_map,
-    6
+    7
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry/src/be_introspectlib.c
+++ b/lib/libesp32/berry/src/be_introspectlib.c
@@ -127,6 +127,22 @@ static int m_fromptr(bvm *vm)
     be_return_nil(vm);
 }
 
+/* load module by name, like `import` would do. But don't create a global variable from it. */
+static int m_getmodule(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 1) {
+        bvalue *v = be_indexof(vm, 1);
+        if (var_isstr(v)) {
+            int ret = be_module_load(vm, var_tostr(v));
+            if (ret == BE_OK) {
+                be_return(vm);
+            }
+        }
+    }
+    be_return_nil(vm);
+}
+
 /* checks if the function (berry bytecode bproto only) is hinted as a method */
 static int m_ismethod(bvm *vm)
 {
@@ -150,6 +166,8 @@ be_native_module_attr_table(introspect) {
     be_native_module_function("get", m_findmember),
     be_native_module_function("set", m_setmember),
 
+    be_native_module_function("module", m_getmodule),
+
     be_native_module_function("toptr", m_toptr),
     be_native_module_function("fromptr", m_fromptr),
 
@@ -164,6 +182,8 @@ module introspect (scope: global, depend: BE_USE_INTROSPECT_MODULE) {
 
     get, func(m_findmember)
     set, func(m_setmember)
+
+    module, func(m_getmodule)
 
     toptr, func(m_toptr)
     fromptr, func(m_fromptr)

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -128,8 +128,11 @@ static char* fixpath(bvm *vm, bstring *path, size_t *size)
     const char *split, *base;
     bvalue *func = vm->cf->func;
     bclosure *cl = var_toobj(func);
-    be_assert(var_isclosure(func));
-    base = str(cl->proto->source); /* get the source file path */
+    if (var_isclosure(func)) {
+        base = str(cl->proto->source); /* get the source file path */
+    } else {
+        base = "/";
+    }
     split = be_splitpath(base);
     *size = split - base + (size_t)str_len(path) + SUFFIX_LEN;
     buffer = be_malloc(vm, *size);


### PR DESCRIPTION
## Description:

Berry add ability to dynamically load a module by its name:
- `introspect.module(name:string) -> module or nil` load a module by name or return `nil` if not found. The `import` command works only for static predefined names, this addition makes it dynamic. Contrary to `import` command, this function does not create an entry in the current scope (i.e. does not either create a global variable with the module's name).

Also fixed a bug that would cause a crash when calling `be_module_load()` from a native C function.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.2.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
