### PR TITLE
BLEOp only request response if char supports it

### DIFF
--- a/tasmota/xdrv_79_esp32_ble.ino
+++ b/tasmota/xdrv_79_esp32_ble.ino
@@ -1990,7 +1990,7 @@ static void BLETaskRunCurrentOperation(BLE_ESP32::generic_sensor_t** pCurrentOpe
             }
             if (op->writelen){
               if(pCharacteristic->canWrite() || pCharacteristic->canWriteNoResponse() ) {
-                if (!pCharacteristic->writeValue(op->dataToWrite, op->writelen, true)){
+                if (!pCharacteristic->writeValue(op->dataToWrite, op->writelen, !pCharacteristic->canWriteNoResponse())){ // request response, unless we can't
                   newstate = GEN_STATE_FAILED_WRITE;
 #ifdef BLE_ESP32_DEBUG
                   AddLog(LOG_LEVEL_DEBUG,PSTR("BLE: characteristic write fail"));
@@ -3720,5 +3720,3 @@ void sendExample(){
 #endif
 #endif  // CONFIG_IDF_TARGET_ESP32 or CONFIG_IDF_TARGET_ESP32C3
 #endif  // ESP32
-
-


### PR DESCRIPTION
## Description:

Fixes `BLEOp` with write when the characteristic `canWriteNoResponse`. Prior code always requests the response which causes the write to be rejected by the receiving BLE device.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
