### PR TITLE
Tuya send raw data

### DIFF
--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -43,6 +43,7 @@
 #define TUYA_LOW_POWER_CMD_WIFI_CONFIG  0x04
 #define TUYA_LOW_POWER_CMD_STATE        0x05
 
+#define TUYA_TYPE_RAW          0x00
 #define TUYA_TYPE_BOOL         0x01
 #define TUYA_TYPE_VALUE        0x02
 #define TUYA_TYPE_STRING       0x03
@@ -147,6 +148,9 @@ TuyaSend2 11,100 -> Sends integer (Type 2) data 100 to dpId 11 (Max data length 
 TuyaSend2 11,0xAABBCCDD -> Sends 4 bytes (Type 2) data to dpId 11 (Max data length 4 bytes)
 TuyaSend3 11,ThisIsTheData -> Sends the supplied string (Type 3) to dpId 11 ( Max data length not-known)
 TuyaSend4 11,1 -> Sends enum (Type 4) data 1 to dpId 11 (Max data length 1 bytes)
+TuyaSend5 11,ABCD -> Sends an HEX string (Type 3) data to dpId 
+TuyaSend6 11,ABCD -> Sends raw (Type 0) data to dpId
+
 */
 
 void CmndTuyaSend(void) {
@@ -186,6 +190,8 @@ void CmndTuyaSend(void) {
         TuyaSendHexString(dpId, data);
       } else if (4 == XdrvMailbox.index) {
         TuyaSendEnum(dpId, strtoul(data, nullptr, 0));
+      } else if (6 == XdrvMailbox.index) {
+        TuyaSendRaw(dpId, data);
       }
     }
   }
@@ -501,6 +507,24 @@ void TuyaSendEnum(uint8_t id, uint32_t value)
   TuyaSendState(id, TUYA_TYPE_ENUM, (uint8_t*)(&value));
 }
 
+static uint16_t convertHexStringtoBytes (uint8_t * dest, char src[], uint16_t src_len){
+  if (NULL == dest || NULL == src || 0 == src_len){
+    return 0;
+  }
+  
+  char hexbyte[3];
+  hexbyte[2] = 0;
+  uint16_t i;
+
+  for (i = 0; i < src_len; i++) {
+    hexbyte[0] = src[2*i];
+    hexbyte[1] = src[2*i+1];
+    dest[i] = strtol(hexbyte, NULL, 16);
+  }
+
+  return i;
+}
+
 void TuyaSendHexString(uint8_t id, char data[]) {
 
   uint16_t len = strlen(data)/2;
@@ -511,14 +535,7 @@ void TuyaSendHexString(uint8_t id, char data[]) {
   payload_buffer[2] = len >> 8;
   payload_buffer[3] = len & 0xFF;
 
-  char hexbyte[3];
-  hexbyte[2] = 0;
-
-  for (uint16_t i = 0; i < len; i++) {
-    hexbyte[0] = data[2*i];
-    hexbyte[1] = data[2*i+1];
-    payload_buffer[4+i] = strtol(hexbyte,NULL,16);
-  }
+  (void) convertHexStringtoBytes(&payload_buffer[4], data, len);
 
   TuyaSendCmd(TUYA_CMD_SET_DP, payload_buffer, payload_len);
 }
@@ -540,6 +557,31 @@ void TuyaSendString(uint8_t id, char data[]) {
   TuyaSendCmd(TUYA_CMD_SET_DP, payload_buffer, payload_len);
 }
 
+void TuyaSendRaw(uint8_t id, char data[]) {
+  AddLog(LOG_LEVEL_ERROR, PSTR("TYA: Send Raw-Data from string: %s"), data);
+  
+  char* beginPos = strchr(data, 'x');
+  if(!beginPos) {
+    beginPos = strchr(data, 'X');
+  }
+  if(!beginPos) {
+    beginPos = data;
+  } else {
+    beginPos += 1;
+  }
+  uint16_t strSize = strlen(beginPos);
+  uint16_t len = strSize/2;
+  uint16_t payload_len = 4 + len;
+  uint8_t payload_buffer[payload_len];
+  payload_buffer[0] = id;
+  payload_buffer[1] = TUYA_TYPE_RAW;
+  payload_buffer[2] = len >> 8;
+  payload_buffer[3] = len & 0xFF;
+
+  (void) convertHexStringtoBytes(&payload_buffer[4], beginPos, len);
+
+  TuyaSendCmd(TUYA_CMD_SET_DP, payload_buffer, payload_len);
+}
 bool TuyaSetPower(void)
 {
   bool status = false;

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -558,8 +558,6 @@ void TuyaSendString(uint8_t id, char data[]) {
 }
 
 void TuyaSendRaw(uint8_t id, char data[]) {
-  AddLog(LOG_LEVEL_ERROR, PSTR("TYA: Send Raw-Data from string: %s"), data);
-  
   char* beginPos = strchr(data, 'x');
   if(!beginPos) {
     beginPos = strchr(data, 'X');


### PR DESCRIPTION
## Description:
Extend the Tuya module by a further TuyaSend6 command (TuyaSendRaw) command to send a raw payload (with type 0 = raw) to the Tuya MCU. These raw datatype and the new TuyaSend6 command are used in some complex thermostat devices to transfer the week program / time profile.  

The description of Tasmota Docs Tuya page is extended in pull request https://github.com/tasmota/docs/pull/958

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
