### PR TITLE
Update xdsp_17_universal.ino

### DIFF
--- a/tasmota/xdsp_17_universal.ino
+++ b/tasmota/xdsp_17_universal.ino
@@ -59,7 +59,7 @@ void Core2DisplayDim(uint8_t dim);
 
 /*********************************************************************************************/
 #ifdef DSP_ROM_DESC
-const char DSP_SAMPLE_DESC[] PROGMEM = DSP_ROM_DESC
+const char DSP_SAMPLE_DESC[] PROGMEM = DSP_ROM_DESC;
 #endif // DSP_ROM_DESC
 /*********************************************************************************************/
 Renderer *Init_uDisplay(const char *desc) {


### PR DESCRIPTION
Throw error when compiling with #define DSP_ROM_DESC
xdsp_17_universal.ino:65:1: error: expected ',' or ';' before 'Renderer'
 Renderer *Init_uDisplay(const char *desc) {
 ^

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
