### PR TITLE
Generalise/Expand SetOption137

### DIFF
--- a/tasmota/settings.h
+++ b/tasmota/settings.h
@@ -166,7 +166,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t pwm_force_same_phase : 1;     // bit 20 (v10.1.0.6) - SetOption134 - (PWM) force PWM lights to start at same phase, default is to spread phases to minimze overlap (also needed for H-bridge)
     uint32_t display_no_splash : 1;        // bit 21 (v11.0.0.2) - SetOption135 - (Display & LVGL) forece disbabling default splash screen
     uint32_t tuyasns_no_immediate : 1;     // bit 22 (v11.0.0.4) - SetOption136 - (TuyaSNS) When ON disable publish single SNS value on Tuya Receive (keep Teleperiod)
-    uint32_t tuya_exclude_heartbeat : 1;   // bit 23 (v11.0.0.5) - SetOption137 - (Tuya) When Set, avoid the (mqtt-) publish of Tuya MCU Heartbeat response if SetOption66 is active
+    uint32_t tuya_exclude_from_mqtt : 1;   // bit 23 (v11.0.0.5) - SetOption137 - (Tuya) When Set, avoid the (MQTT-) publish of defined Tuya CMDs (see xdrv_16_tuyamcu.ino) if SetOption66 is active
     uint32_t spare24 : 1;                  // bit 24
     uint32_t spare25 : 1;                  // bit 25
     uint32_t spare26 : 1;                  // bit 26

--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1208,7 +1208,7 @@ void SettingsDefaultSet2(void) {
   // Tuya
   flag3.tuya_apply_o20 |= TUYA_SETOPTION_20;
   flag5.tuya_allow_dimmer_0 |= TUYA_ALLOW_DIMMER_0;
-  flag5.tuya_exclude_heartbeat |= TUYA_SETOPTION_137;
+  flag5.tuya_exclude_from_mqtt |= TUYA_SETOPTION_137;
   flag3.tuya_serial_mqtt_publish |= MQTT_TUYA_RECEIVED;
   mbflag2.temperature_set_res |= TUYA_TEMP_SET_RES;
 

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -112,8 +112,9 @@ void (* const TuyaCommand[])(void) PROGMEM = {
   &CmndTuyaMcu, &CmndTuyaSend, &CmndTuyaRgb, &CmndTuyaEnum, &CmndTuyaEnumList, &CmndTuyaTempSetRes
 };
 
-const uint8_t TuyaExcludeCMDsFromMQTT[] PROGMEM = // don't publish this received commands via MQTT if SetOption66 and SetOption137 is active (can be expanded in the future)
-  TUYA_CMD_HEARTBEAT, TUYA_CMD_SET_TIME, TUYA_CMD_UPGRADE_PACKAGE;
+const uint8_t TuyaExcludeCMDsFromMQTT[] PROGMEM = { // don't publish this received commands via MQTT if SetOption66 and SetOption137 is active (can be expanded in the future)
+  TUYA_CMD_HEARTBEAT, TUYA_CMD_WIFI_STATE, TUYA_CMD_SET_TIME, TUYA_CMD_UPGRADE_PACKAGE
+};
 
 /*********************************************************************************************\
  * Web Interface
@@ -1304,7 +1305,9 @@ void TuyaSerialInput(void)
         }
         if (!(isCmdToSuppress && Settings->flag5.tuya_exclude_from_mqtt)) {  // SetOption137 - (Tuya) When Set, avoid the (MQTT-) publish of defined Tuya CMDs (see TuyaExcludeCMDsFromMQTT) if SetOption66 is active
           MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_TUYA_MCU_RECEIVED));
-        }        
+        } else {
+          AddLog(LOG_LEVEL_DEBUG, ResponseData());
+        }      
       } else {
         AddLog(LOG_LEVEL_DEBUG, ResponseData());
       }

--- a/tasmota/xdrv_16_tuyamcu.ino
+++ b/tasmota/xdrv_16_tuyamcu.ino
@@ -27,16 +27,18 @@
 #define TUYA_DIMMER_ID         0
 #endif
 
-#define TUYA_CMD_HEARTBEAT     0x00
-#define TUYA_CMD_QUERY_PRODUCT 0x01
-#define TUYA_CMD_MCU_CONF      0x02
-#define TUYA_CMD_WIFI_STATE    0x03
-#define TUYA_CMD_WIFI_RESET    0x04
-#define TUYA_CMD_WIFI_SELECT   0x05
-#define TUYA_CMD_SET_DP        0x06
-#define TUYA_CMD_STATE         0x07
-#define TUYA_CMD_QUERY_STATE   0x08
-#define TUYA_CMD_SET_TIME      0x1C
+#define TUYA_CMD_HEARTBEAT          0x00
+#define TUYA_CMD_QUERY_PRODUCT      0x01
+#define TUYA_CMD_MCU_CONF           0x02
+#define TUYA_CMD_WIFI_STATE         0x03
+#define TUYA_CMD_WIFI_RESET         0x04
+#define TUYA_CMD_WIFI_SELECT        0x05
+#define TUYA_CMD_SET_DP             0x06
+#define TUYA_CMD_STATE              0x07
+#define TUYA_CMD_QUERY_STATE        0x08
+#define TUYA_CMD_INITIATING_UPGRADE 0x0A
+#define TUYA_CMD_UPGRADE_PACKAGE    0x0B
+#define TUYA_CMD_SET_TIME           0x1C
 
 #define TUYA_LOW_POWER_CMD_WIFI_STATE   0x02
 #define TUYA_LOW_POWER_CMD_WIFI_RESET   0x03
@@ -109,6 +111,9 @@ const char kTuyaCommand[] PROGMEM = D_PRFX_TUYA "|"  // Prefix
 void (* const TuyaCommand[])(void) PROGMEM = {
   &CmndTuyaMcu, &CmndTuyaSend, &CmndTuyaRgb, &CmndTuyaEnum, &CmndTuyaEnumList, &CmndTuyaTempSetRes
 };
+
+const uint8_t TuyaExcludeCMDsFromMQTT[] PROGMEM = // don't publish this received commands via MQTT if SetOption66 and SetOption137 is active (can be expanded in the future)
+  TUYA_CMD_HEARTBEAT, TUYA_CMD_SET_TIME, TUYA_CMD_UPGRADE_PACKAGE;
 
 /*********************************************************************************************\
  * Web Interface
@@ -1243,7 +1248,7 @@ void TuyaSerialInput(void)
       uint8_t dpId = 0;
       uint8_t dpDataType = 0;
       char DataStr[15];
-      bool isHeartbeat = false;
+      bool isCmdToSuppress = false;
 
       if (len > 0) {
         ResponseAppend_P(PSTR(",\"CmndData\":\"%s\""), ToHex_P((unsigned char*)&Tuya.buffer[6], len, hex_char, sizeof(hex_char)));
@@ -1287,14 +1292,17 @@ void TuyaSerialInput(void)
             dpidStart += dpDataLen + 4;
           }
         }
-        else if (TUYA_CMD_HEARTBEAT == Tuya.buffer[3]) {
-          isHeartbeat = true;
-        }
       }
       ResponseAppend_P(PSTR("}}"));
 
       if (Settings->flag3.tuya_serial_mqtt_publish) {  // SetOption66 - Enable TuyaMcuReceived messages over Mqtt
-        if (!(isHeartbeat && Settings->flag5.tuya_exclude_heartbeat)) {  // SetOption137 - (Tuya) When Set, avoid the (mqtt-) publish of Tuya MCU Heartbeat response if SetOption66 is active
+        for (uint8_t cmdsID = 0; sizeof(TuyaExcludeCMDsFromMQTT) > cmdsID; cmdsID++){
+          if (TuyaExcludeCMDsFromMQTT[cmdsID] == Tuya.buffer[3]) {
+            isCmdToSuppress = true;
+            break;
+          }  
+        }
+        if (!(isCmdToSuppress && Settings->flag5.tuya_exclude_from_mqtt)) {  // SetOption137 - (Tuya) When Set, avoid the (MQTT-) publish of defined Tuya CMDs (see TuyaExcludeCMDsFromMQTT) if SetOption66 is active
           MqttPublishPrefixTopic_P(RESULT_OR_TELE, PSTR(D_JSON_TUYA_MCU_RECEIVED));
         }        
       } else {


### PR DESCRIPTION
## Description:

To reduce the messages send via MQTT further Tuya received CMDs are filtered out.

The following Tuya receptions will be suppressed if SetOption137 are set:
- TUYA_CMD_HEARTBEAT
- TUYA_CMD_WIFI_STATE
- TUYA_CMD_SET_TIME
- TUYA_CMD_UPGRADE_PACKAGE (prepared for future)

This pull-request expands the first pull-request #15256.

Now it's easy to set new commands to suppress publishing via MQTT. 

I'll update the docs pull-request https://github.com/tasmota/docs/pull/959

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
