### PR TITLE
May improve ESP32 UFS download reliability

### DIFF
--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -348,7 +348,7 @@ bool TfsLoadFile(const char *fname, uint8_t *buf, uint32_t len) {
     AddLog(LOG_LEVEL_INFO, PSTR("TFS: File '%s' not found"), fname +1);  // Skip leading slash
     return false;
   }
-  
+
   size_t flen = file.size();
   if (len > flen){
     len = flen;
@@ -888,7 +888,10 @@ uint8_t UfsDownloadFile(char *file) {
   UfsData.download_busy = true;
   char *path = (char*)malloc(128);
   strcpy(path,file);
-  xTaskCreatePinnedToCore(donload_task, "DT", 6000, (void*)path, 3, NULL, 1);
+  BaseType_t ret = xTaskCreatePinnedToCore(donload_task, "DT", 6000, (void*)path, 3, nullptr, 1);
+  if (ret != pdPASS)
+    AddLog(LOG_LEVEL_INFO, PSTR("UFS: Download task failed with %d"), ret);
+  yield();
 #endif // ESP32_DOWNLOAD_TASK
 
   return 0;


### PR DESCRIPTION
## Description:

Downloading a file from ESP32 File System Manager seems to be at best randomly successfull on most tasmota32 variants and very unreliable with bluetooth.

Adding a test on download task creation and `yield()` right after to insure the task is scheduled seems to make it more reliable.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
