### PR TITLE
Berry improve asserts and stack size

### DIFF
--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -251,6 +251,17 @@ extern "C" {
 #ifdef USE_BERRY_DEBUG
   #undef BE_DEBUG_RUNTIME_INFO
   #define BE_DEBUG_RUNTIME_INFO 1 /* record line information in 32 bits to be places in IRAM */
+  #undef BE_DEBUG
+  #define BE_DEBUG 1
+  #undef be_assert
+  #define be_assert(expr)                                                        \
+      ((expr)                                                                \
+      ? (0)                                                \
+      : serial_debug("BRY: ASSERT '%s', %s - %i\n", #expr, __FILE__, __LINE__))
+  #ifdef USE_LVGL
+    #undef BE_STACK_START
+    #define BE_STACK_START                  200
+  #endif // USE_LVGL
 #endif // USE_BERRY_DEBUG
 
 #endif

--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -1694,7 +1694,7 @@ static void statement(bparser *parser)
     case OptSemic: scan_next_token(parser); break; /* empty statement */
     default: expr_stmt(parser); break;
     }
-    be_assert(parser->finfo->freereg == be_list_count(parser->finfo->local));
+    be_assert(parser->finfo->freereg >= be_list_count(parser->finfo->local));
 }
 
 static void stmtlist(bparser *parser)


### PR DESCRIPTION
## Description:

Berry improvements in preparation to OpenHASP support:
- increase Berry stack size when LVGL is enabled, to avoid stack resize
- print asserts on serial when `#define USE_BERRY_DEBUG`
- fix assert in parser

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
