### PR TITLE
Add standard USB modes in boards.json

### DIFF
--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32c3_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3",
+    "extra_flags": "-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3",
     "f_cpu": "160000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32s2_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S2",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dout",

--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -5,7 +5,7 @@
       "memory_type": "qspi_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_4M -DESP32S3",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32s3_8M.json
+++ b/boards/esp32s3_8M.json
@@ -5,7 +5,7 @@
       "memory_type": "qspi_qspi"
     },
     "core": "esp32",
-    "extra_flags": "-DBOARD_HAS_PSRAM -DESP32_8M -DESP32S3",
+    "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_8M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -382,6 +382,10 @@ String ESP32GetResetReason(uint32_t cpu_no) {
     case 17 : return F("Time Group1 reset CPU");                            // 17  -                 TG1WDT_CPU_RESET
     case 18 : return F("Super watchdog reset digital core and rtc module"); // 18  -                 SUPER_WDT_RESET
     case 19 : return F("Glitch reset digital core and rtc module");         // 19  -                 GLITCH_RTC_RESET
+    case 20 : return F("Efuse reset digital core");                         // 20                    EFUSE_RESET
+    case 21 : return F("Usb uart reset digital core");                      // 21                    USB_UART_CHIP_RESET
+    case 22 : return F("Usb jtag reset digital core");                      // 22                    USB_JTAG_CHIP_RESET
+    case 23 : return F("Power glitch reset digital core and rtc module");   // 23                    POWER_GLITCH_RESET
   }
 
   return F("No meaning");                                                   // 0 and undefined


### PR DESCRIPTION
## Description:

and add reset reasons from newer MCUs
(now `Usb uart reset digital core` is correctly shown when flasing via inbuilt USB-serial

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
