### PR TITLE
Berry support for int keys in map in solidification

### DIFF
--- a/lib/libesp32/berry/src/be_constobj.h
+++ b/lib/libesp32/berry/src/be_constobj.h
@@ -33,6 +33,12 @@ extern "C" {
     .next = (uint32_t)(_next) & 0xFFFFFF                        \
 }
 
+#define be_const_key_int(_i, _next) {                           \
+    .v.i = _i,                                                  \
+    .type = BE_INT,                                             \
+    .next = (uint32_t)(_next) & 0xFFFFFF                        \
+}
+
 #define be_const_func(_func) {                                  \
     .v.nf = (_func),                                            \
     .type = BE_NTVFUNC                                          \
@@ -246,6 +252,12 @@ const bntvmodule be_native_module(_module) = {                  \
 #define be_const_key(_str, _next) {                             \
     bvaldata(&be_const_str_##_str),                             \
         BE_STRING,                                              \
+        uint32_t((_next)&0xFFFFFF)                              \
+}
+
+#define be_const_key_int(_i, _next) {                           \
+    bvaldata(i),                                                \
+        BE_INT,                                                 \
         uint32_t((_next)&0xFFFFFF)                              \
 }
 

--- a/lib/libesp32/berry/src/be_string.c
+++ b/lib/libesp32/berry/src/be_string.c
@@ -113,7 +113,7 @@ static void free_sstring(bvm *vm, bstring *str)
 static uint32_t str_hash(const char *str, size_t len)
 {
     uint32_t hash = 2166136261u;
-    be_assert(str || len);
+    be_assert(str || !len);
     while (len--) {
         hash = (hash ^ (unsigned char)*str++) * 16777619u;
     }

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -92,6 +92,7 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top >= 2 && be_isstring(vm, 2)) {  // 1 mandatory string argument
       const char * payload = be_tostring(vm, 2);
+      be_pop(vm, top);    // clear the stack before calling, because of re-entrant call to Berry in a Rule
       bool handled = XdrvRulesProcess(0, payload);
       be_pushbool(vm, handled);
       be_return(vm); // Return


### PR DESCRIPTION
## Description:

Berry add support for integer keys in maps while solidifying code.
Also remove warning in `tasmota.publish_rule()`
Fix an assertion

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
