### PR TITLE
Add Rule Trigger for WebQueryResponse of WebQuery Command

### DIFF
--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3164,15 +3164,22 @@ int WebQuery(char *buffer)
           // Return received data to the user - Adds 900+ bytes to the code
           const char* read = http.getString().c_str();  // File found at server - may need lot of ram or trigger out of memory!
           ResponseClear();
-          char text[2] = { 0 };
-          text[0] = '.';
           Response_P(PSTR("{\"" D_CMND_WEBQUERY "\":"));
+          char text[2] = { 0 };
+          text[0] = *read++;
+          bool assume_json = (text[0] == '{') || (text[0] == '[');
+          if (!assume_json) { ResponseAppend_P(PSTR("\"")); }
           while (text[0] != '\0') {
-            text[0] = *read++;
             if (text[0] > 31) {               // Remove control characters like linefeed
-              if (ResponseAppend_P(text) == ResponseSize()) { break; };
+              if (assume_json) {
+                if (ResponseAppend_P(text) == ResponseSize()) { break; };
+              } else {
+                if (ResponseAppend_P(EscapeJSONString(text).c_str()) == ResponseSize()) { break; };
+              }
             }
+            text[0] = *read++;
           }
+          if (!assume_json) { ResponseAppend_P(PSTR("\"")); }
           ResponseJsonEnd();
 #ifdef USE_SCRIPT
           extern uint8_t tasm_cmd_activ;

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -3166,12 +3166,14 @@ int WebQuery(char *buffer)
           ResponseClear();
           char text[2] = { 0 };
           text[0] = '.';
+          Response_P(PSTR("{\"" D_CMND_WEBQUERY "\":"));
           while (text[0] != '\0') {
             text[0] = *read++;
             if (text[0] > 31) {               // Remove control characters like linefeed
               if (ResponseAppend_P(text) == ResponseSize()) { break; };
             }
           }
+          ResponseJsonEnd();
 #ifdef USE_SCRIPT
           extern uint8_t tasm_cmd_activ;
           // recursive call must be possible in this case


### PR DESCRIPTION
## Description:

The `WebQuery` command has the optional **WebQueryResponse feature**. This feature allows Tasmota to see in the console the response of a WebQuery. This PR adds a trigger to use this response in rules.

For example, if querying a weather API and if **WebQueryResponse** is enabled, you will see in the console:

```haskell
07:18:03.079 CMD: webquery http://goweather.herokuapp.com/weather/RiodeJaneiro GET
07:18:04.435 MQT: stat/tasmota_84B598/RESULT = {"temperature":"20 °C","wind":"4 km/h","description":"Light rain shower","forecast":[{"day":"1","temperature":"+28 °C","wind":"5 km/h"},{"day":"2","temperature":"+26 °C","wind":"11 km/h"},{"day":"3","temperature":"+26 °C","wind":"8 km/h"}]}
```

That response can't trigger any rule.

With this PR, the response is changed to:

```haskell
07:18:03.079 CMD: webquery http://goweather.herokuapp.com/weather/RiodeJaneiro GET
07:18:04.435 MQT: stat/tasmota_84B598/RESULT = {"WebQuery":{"temperature":"20 °C","wind":"4 km/h","description":"Light rain shower","forecast":[{"day":"1","temperature":"+28 °C","wind":"5 km/h"},{"day":"2","temperature":"+26 °C","wind":"11 km/h"},{"day":"3","temperature":"+26 °C","wind":"8 km/h"}]}}
```

Now, this new response can trigger rules like the following:

```JS
Rule1
  ON WebQuery#Temperature DO Var1 %value% ENDON
  ON WebQuery#Description DO Var2 %value% ENDON
  ON WebQuery#Forecast[1]#Temperature DO Var3 %value% ENDON
```

_Note:_ In order to use the **WebQueryResponse feature**, it must be added at compile time by adding `#define USE_WEBSEND_RESPONSE` to _**user_config_override.h**_ file.
_Note 2:_ If using an ESP8266, the WebQuery command can be used only with HTTP URLs. If using an ESP32, the WebQuery command can be used with HTTP and HTTPS URLs.

**Related issue (if applicable):** N/A

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
