### PR TITLE
Fixed Max/Min Voltage incorrect symbol

### DIFF
--- a/tasmota/xsns_87_mcp2515.ino
+++ b/tasmota/xsns_87_mcp2515.ino
@@ -370,12 +370,12 @@ void MCP2515_Show(bool Json) {
       if (bms.setFields & BMS_CHARGE_VOLT_MAX) {
         char voltStr[6];
         dtostrf((float(bms.chargeVoltLimit) / 10), 5, 1, voltStr);
-        WSContentSend_PD(PSTR("{s}%s Max Voltage{m}%s " D_UNIT_AMPERE "{e}"), bms.manuf, voltStr);
+        WSContentSend_PD(PSTR("{s}%s Max Voltage{m}%s " D_UNIT_VOLT "{e}"), bms.manuf, voltStr);
       }
       if (bms.setFields & BMS_CHARGE_VOLT_MIN) {
         char voltStr[6];
         dtostrf((float(bms.dischargeVolt) / 10), 5, 1, voltStr);
-        WSContentSend_PD(PSTR("{s}%s Min Voltage{m}%s " D_UNIT_AMPERE "{e}"), bms.manuf, voltStr);
+        WSContentSend_PD(PSTR("{s}%s Min Voltage{m}%s " D_UNIT_VOLT "{e}"), bms.manuf, voltStr);
       }
       if (bms.setFields & BMS_CHARGE_AMP_MAX) {
         char ampStr[6];


### PR DESCRIPTION
## Description:

Fixed Min/Max Voltage showing A instead of V for Voltage on web service

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
