### PR TITLE
remove S3 temp sensor from webinterface

### DIFF
--- a/tasmota/xsns_127_esp32_sensors.ino
+++ b/tasmota/xsns_127_esp32_sensors.ino
@@ -121,18 +121,24 @@ bool Xsns127(uint8_t function) {
   bool result = false;
 
   switch (function) {
+#ifndef CONFIG_IDF_TARGET_ESP32S3
     case FUNC_JSON_APPEND:
       Esp32SensorShow(1);
       break;
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #ifdef USE_WEBSERVER
+#ifndef CONFIG_IDF_TARGET_ESP32S3
     case FUNC_WEB_SENSOR:
       Esp32SensorShow(0);
       break;
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // USE_WEBSERVER
 #if CONFIG_IDF_TARGET_ESP32
+#ifndef CONFIG_IDF_TARGET_ESP32S3
     case FUNC_INIT:
       Esp32SensorInit();
       break;
+#endif  // CONFIG_IDF_TARGET_ESP32S3
 #endif  // CONFIG_IDF_TARGET_ESP32
   }
   return result;


### PR DESCRIPTION
## Description:

since there is still no support for from IDF44/Arduino 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
