### PR TITLE
Enhance embedding of local root certificate

### DIFF
--- a/tasmota/local_ca_data_sample.h
+++ b/tasmota/local_ca_data_sample.h
@@ -1,0 +1,51 @@
+/*
+  local_ca_sample.h - sample file for embedding a local CA certificate
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+To generate a version of this file containing data for your root certificate, 
+run the following command from a Linux or Cygwin bash shell, assuming that a 
+copy of brssl (or brssl.exe) is in the directory where the EasyRSA shell script
+is located. 
+
+./brssl ta pki/ca.crt | sed -e '/br_x509/,+999 d' >local_ca_data.h
+
+Then copy local_ca_data.h into the same directory as user_config_override.
+
+Add this line to user_config_override.h:
+
+#define INCLUDE_LOCAL_CERT
+
+Be sure to generate both files: local_ca_data.h, and local_ca_descriptor.h
+*/
+
+//
+// this is what the result will look like, except there will be
+// a lot of data bytes defined in the first three arrays 
+//
+static const unsigned char PROGMEM TA0_DN[] = {
+	// variable number of bytes go here (typically 100-140 or so) for the DN
+};
+
+static const unsigned char PROGMEM TA0_RSA_N[] = {
+	// 256 bytes go here for the public key modulus
+};
+
+static const unsigned char PROGMEM TA0_RSA_E[] = {
+	// 3 bytes go here for the public key exponent
+};

--- a/tasmota/local_ca_descriptor_sample.h
+++ b/tasmota/local_ca_descriptor_sample.h
@@ -1,0 +1,50 @@
+/*
+  local-ca-sample.h - sample file for embedding a local CA certificate
+
+  Copyright (C) 2021  Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/*
+To generate a version of this file containing data for your root certificate, 
+run the following command from a Linux or Cygwin bash shell, assuming that a 
+copy of brssl (or brssl.exe) is in the directory where the EasyRSA shell script
+is located. 
+
+./brssl ta pki/ca.crt | sed -e '1,/br_x509/ d' -e '/};/,+999 d' >local_ca_descriptor.h
+
+Then copy local_ca_descriptor.h into the same directory as user_config_override.
+
+Add this line to user_config_override.h:
+
+#define INCLUDE_LOCAL_CERT
+
+Be sure to generate both files: local_ca_data.h, and local_ca_descriptor.h
+*/
+
+//
+// this is what the result will look like
+//
+	{
+		{ (unsigned char *)TA0_DN, sizeof TA0_DN },
+		BR_X509_TA_CA,
+		{
+			BR_KEYTYPE_RSA,
+			{ .rsa = {
+				(unsigned char *)TA0_RSA_N, sizeof TA0_RSA_N,
+				(unsigned char *)TA0_RSA_E, sizeof TA0_RSA_E,
+			} }
+		}
+	}


### PR DESCRIPTION
Embedding a local root certificate for MQTT TLS currently requires modifying the source distribution (tasmota_ca.ino). This change eliminates the need to do this, providing the option through user_config_override.h. Some un-referenced data structures in tasmota_ca.ino have also been removed.  A pull request has also been made on Tasmota/docs to update docs/Self-signed-Mosquitto.md to include a description of the new process for embedding a root certificate.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
