### PR TITLE
Berry stack resize debug mode

### DIFF
--- a/lib/libesp32/berry/default/berry_conf.h
+++ b/lib/libesp32/berry/default/berry_conf.h
@@ -175,6 +175,14 @@
  **/
 #define BE_USE_DEBUG_GC                  0
 
+/* Macro: BE_USE_DEBUG_STACK
+ * Enable Stack Resize debug mode. At each function call
+ * the stack is reallocated at a different memory location
+ * and the previous location is cleared with toxic data.
+ * Default: 0
+ **/
+#define BE_USE_DEBUG_STACK               0
+
 /* Macro: BE_USE_MEM_ALIGNED
  * Some embedded processors have special memory areas
  * with read/write constraints of being aligned to 32 bits boundaries.

--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -1207,11 +1207,12 @@ static void prep_closure(bvm *vm, int pos, int argc, int mode)
     for (v = vm->reg + argc; v <= end; ++v) {
         var_setnil(v);
     }
+    int v_offset = v - vm->stack;   /* offset from stack base, stack may be reallocated */
     if (proto->varg & BE_VA_VARARG) {  /* there are vararg at the last argument, build the list */
         /* code below uses mostly low-level calls for performance */
-        be_stack_require(vm, argc + 2);   /* make sure we don't overflow the stack */
-        bvalue *top_save = vm->top;  /* save original stack, we need fresh slots to create the 'list' instance */
-        vm->top = v;  /* move top of stack right after last argument */
+        be_stack_require(vm, argc + 4);   /* make sure we don't overflow the stack */
+        int top_save_offset = vm->top - vm->stack;  /* save original stack, we need fresh slots to create the 'list' instance */
+        vm->top = vm->stack + v_offset;  /* move top of stack right after last argument */
         be_newobject(vm, "list");  /* this creates 2 objects on stack: list instance, BE_LIST object */
         blist *list = var_toobj(vm->top-1);  /* get low-level BE_LIST structure */
         v = vm->reg + proto->argc - 1;  /* last argument */
@@ -1219,7 +1220,7 @@ static void prep_closure(bvm *vm, int pos, int argc, int mode)
             be_list_push(vm, list, v); /* push all varargs into list */       
         }
         *(vm->reg + proto->argc - 1) = *(vm->top-2);  /* change the vararg argument to now contain the list instance */
-        vm->top = top_save;  /* restore top of stack pointer */
+        vm->top = vm->stack + top_save_offset;  /* restore top of stack pointer */
     }
 }
 


### PR DESCRIPTION
## Description:

There is still a rare bug happening when there is a Berry stack resize. The stack has been sized for this event to never happen in normal conditions. This PR adds 2 features:
- a first bug fixed when a stack resize event occurs while calling a vararg function
- added a debug mode that relocates the stack at each function call. This is for **debug** only and is VERY slow.

@arendst There is no urgency in this PR, it can wait post-release if it makes things simpler.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
