### PR TITLE
Fix prepending "backlog0" chain with "backlog" in rules

### DIFF
--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -772,8 +772,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       // Use Backlog with event to prevent rule event loop exception unless IF is used which uses an implicit backlog
       if ((ucommand.indexOf(F("IF ")) == -1) &&
           (ucommand.indexOf(F("EVENT ")) != -1) &&
-          (ucommand.indexOf(F("BACKLOG0 ")) == -1) &&
-          (ucommand.indexOf(F("BACKLOG ")) == -1)) {
+          (ucommand.indexOf(F("BACKLOG")) == -1)) {
         commands = String(F("backlog ")) + commands;
       }
 

--- a/tasmota/xdrv_10_rules.ino
+++ b/tasmota/xdrv_10_rules.ino
@@ -772,6 +772,7 @@ bool RuleSetProcess(uint8_t rule_set, String &event_saved)
       // Use Backlog with event to prevent rule event loop exception unless IF is used which uses an implicit backlog
       if ((ucommand.indexOf(F("IF ")) == -1) &&
           (ucommand.indexOf(F("EVENT ")) != -1) &&
+          (ucommand.indexOf(F("BACKLOG0 ")) == -1) &&
           (ucommand.indexOf(F("BACKLOG ")) == -1)) {
         commands = String(F("backlog ")) + commands;
       }


### PR DESCRIPTION
## Description:

When using the `Event` command in a rule, `Backlog` is prepended in order to avoid event loops. This is not done if the rule contains an `If` statement (has its own implicit backlog) or already contains a `Backlog` command.

Similarly it should not be prepended if the rule already contains a `Backlog0` command.

Setup:
```
rule1 on
rule1 ON event#scene_tv DO backlog0 power1 toggle; publish cmnd/mango/event scene_tv ENDON
```

Unexpected:
```
18:06:08.968 CMD: event scene_tv
18:06:08.976 MQT: stat/tasmota_2E4CA3/RESULT = {"Event":"Done"}
18:06:09.023 RUL: EVENT#SCENE_TV performs "backlog backlog0 power1 toggle; publish cmnd/mango/event scene_tv"
18:06:09.036 MQT: stat/tasmota_2E4CA3/RESULT = {"Command":"Unknown"}
18:06:09.287 MQT: cmnd/mango/event = scene_tv
```

With the proposed fix:
```
18:06:53.111 CMD: event scene_tv
18:06:53.118 MQT: stat/tasmota_2DD7FC/RESULT = {"Event":"Done"}
18:06:53.152 RUL: EVENT#SCENE_TV performs "backlog0 power1 toggle; publish cmnd/mango/event scene_tv"
18:06:53.162 MQT: stat/tasmota_2DD7FC/RESULT = {"POWER":"OFF"}
18:06:53.167 MQT: stat/tasmota_2DD7FC/POWER = OFF
18:06:53.175 MQT: cmnd/mango/event = scene_tv
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).