### PR TITLE
Berry support for SD card

### DIFF
--- a/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.cpp
+++ b/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.cpp
@@ -393,8 +393,26 @@ bool ZipArchive::parse(void) {
 ** 
 ********************************************************************/
 
+/* get the FS corresponding to the prefix, typically /sd/ for sdcard */
+FS * ZipReadFSImpl::getFS(const char *path) const {
+  if (_fs == nullptr) { return nullptr; }
+  if (_alt_fs == nullptr || _alt_fs_prefix == nullptr) { return *_fs; }
+
+  /* from now neither _fs not _alt_fs are null
+  /* if however they point to the same value, then we don't have an alternative FS */
+  if (*_fs == *_alt_fs) { return *_fs; }
+
+  /* check prefix */
+  if (strncmp(_alt_fs_prefix, path, strlen(_alt_fs_prefix))) {
+    return *_alt_fs;
+  } else {
+    return *_fs;
+  }
+}
+
 FileImplPtr ZipReadFSImpl::open(const char* path, const char* mode, const bool create) {
-  if (*_fs == nullptr) { return nullptr; }
+  FS * fs = getFS(path);
+  if (fs == nullptr) { return nullptr; }
 
   if (strchr(path, '#')) {
     // we don't support any other mode than "r" and no-create
@@ -414,7 +432,7 @@ FileImplPtr ZipReadFSImpl::open(const char* path, const char* mode, const bool c
     if (*suffix == '/') { suffix++; }
     // AddLog(LOG_LEVEL_DEBUG, "ZIP: prefix=%s suffix=%s", prefix, suffix);
     // parse ZIP archive
-    File zipfile = (*_fs)->open(prefix, "r", false);
+    File zipfile = fs->open(prefix, "r", false);
     if ((bool)zipfile) {
       // we could read the file
       ZipArchive zip_archive = ZipArchive(&zipfile);
@@ -424,7 +442,7 @@ FileImplPtr ZipReadFSImpl::open(const char* path, const char* mode, const bool c
         if (entry.file_name.equals(suffix)) {
           // found
           // AddLog(LOG_LEVEL_DEBUG, "ZIP: file '%s' in archive (start=%i - len=%i - last_mod=%i)", suffix, entry.file_start, entry.file_len, entry.last_mod);
-          return ZipItemImplPtr(new ZipItemImpl((*_fs)->open(prefix, "r", false), entry.file_start, entry.file_len, entry.last_mod));
+          return ZipItemImplPtr(new ZipItemImpl(fs->open(prefix, "r", false), entry.file_start, entry.file_len, entry.last_mod));
         }
       }
       return ZipReadFileImplPtr();    // return an error
@@ -434,12 +452,13 @@ FileImplPtr ZipReadFSImpl::open(const char* path, const char* mode, const bool c
     }
   } else {
     // simple file, do nothing
-    return ZipReadFileImplPtr(new ZipReadFileImpl((*_fs)->open(path, mode, create)));
+    return ZipReadFileImplPtr(new ZipReadFileImpl(fs->open(path, mode, create)));
   }
 }
 
 bool ZipReadFSImpl::exists(const char* path) {
-  if (*_fs == nullptr) { return false; }
+  FS * fs = getFS(path);
+  if (fs == nullptr) { return false; }
 
   if (strchr(path, '#')) {
     // treat as a ZIP archive
@@ -451,7 +470,7 @@ bool ZipReadFSImpl::exists(const char* path) {
     char *prefix = strtok_r(sub_path, "#", &tok);
     char *suffix = strtok_r(NULL, "", &tok);
     // parse ZIP archive
-    File zipfile = (*_fs)->open(prefix, "r", false);
+    File zipfile = fs->open(prefix, "r", false);
     if ((bool)zipfile) {
       // we could read the file
       ZipArchive zip_archive = ZipArchive(&zipfile);
@@ -466,7 +485,7 @@ bool ZipReadFSImpl::exists(const char* path) {
     return false;
   } else {
     // simple file, do nothing
-    return (*_fs)->exists(path);
+    return fs->exists(path);
   }
 }
 

--- a/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.h
+++ b/lib/libesp32/Zip-readonly-FS/src/ZipReadFS.h
@@ -17,40 +17,32 @@ typedef std::shared_ptr<FSImpl> ZipReadFSImplPtr;
 class ZipReadFSImpl : public FSImpl {
 public:
 
-  ZipReadFSImpl(FS **fs) : _fs(fs) {};
+  ZipReadFSImpl(FS **fs) : _fs(fs), _alt_fs(nullptr), _alt_fs_prefix(nullptr) {};
+  ZipReadFSImpl(FS **fs, const char *alt_fs_prefix, FS **alt_fs) : _fs(fs), _alt_fs(alt_fs), _alt_fs_prefix(alt_fs_prefix) {};
   virtual ~ZipReadFSImpl();
+
+  /* get the FS corresponding to the prefix, typically /sd/ for sdcard */
+  FS * getFS(const char *path) const;
 
   FileImplPtr open(const char* path, const char* mode, const bool create);
 
   bool exists(const char* path);
 
   bool rename(const char* pathFrom, const char* pathTo) {
-    if (*_fs) {
-      return (*_fs)->rename(pathFrom, pathTo);
-    } else {
-      return false;
-    }
+    FS * fs = getFS(pathFrom);
+    return fs ? fs->rename(pathFrom, pathTo) : false;
   }
   bool remove(const char* path) {
-    if (*_fs) {
-      return (*_fs)->remove(path);
-    } else {
-      return false;
-    }
+    FS * fs = getFS(path);
+    return fs ? fs->remove(path) : false;
   }
   bool mkdir(const char *path) {
-    if (*_fs) {
-      return (*_fs)->mkdir(path);
-    } else {
-      return false;
-    }
+    FS * fs = getFS(path);
+    return fs ? fs->mkdir(path) : false;
   }
   bool rmdir(const char *path) {
-    if (*_fs) {
-      return (*_fs)->rmdir(path);
-    } else {
-      return false;
-    }
+    FS * fs = getFS(path);
+    return fs ? fs->rmdir(path) : false;
   }
   void mountpoint(const char *) {
   };
@@ -60,6 +52,8 @@ public:
 
 private:
     FS **_fs;
+    FS **_alt_fs;
+    const char *_alt_fs_prefix;
 };
 
 #endif // ESP32

--- a/tasmota/xdrv_50_filesystem.ino
+++ b/tasmota/xdrv_50_filesystem.ino
@@ -110,10 +110,10 @@ void UfsInitOnce(void) {
 #ifdef ESP32
   // try lfs first
   ffsp = &LittleFS;
-  if (!LittleFS.begin(true)) {
+ if (!LittleFS.begin(true, "")) {         // force empty mount point to make it the fallback FS
     // ffat is second
     ffsp = &FFat;
-    if (!FFat.begin(true)) {
+   if (!FFat.begin(true, "")) {
       ffsp = nullptr;
       return;
     }

--- a/tasmota/xdrv_54_lvgl.ino
+++ b/tasmota/xdrv_54_lvgl.ino
@@ -119,7 +119,8 @@ void lv_flush_callback(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *c
 #include <FS.h>
 #include "ZipReadFS.h"
 extern FS *ffsp;
-FS lv_zip_ufsp(ZipReadFSImplPtr(new ZipReadFSImpl(&ffsp)));
+extern FS *ufsp;
+FS lv_zip_ufsp(ZipReadFSImplPtr(new ZipReadFSImpl(&ffsp, "/sd/", &ufsp)));
 
 extern "C" {
 


### PR DESCRIPTION
## Description:

Support for SD card in Berry. Just use the prefix `/sd/<file>`.

Example:

``` berry
import path
print(path.listdir("/sd/"))
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
