### PR TITLE
LVGL fix conflict between SPI DMA and SD card

### DIFF
--- a/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
+++ b/lib/lib_display/Display_Renderer-gemu-1.0/src/renderer.h
@@ -34,7 +34,7 @@ typedef struct LVGL_PARAMS {
     struct {
       uint8_t use_dma : 1;
       uint8_t swap_color : 1;
-      uint8_t resvd_0 : 1;
+      uint8_t async_dma : 1;   // force DMA completion before returning, avoid conflict with other devices on same bus. If set you should make sure the display is the only device on the bus
       uint8_t resvd_1 : 1;
       uint8_t resvd_2 : 1;
       uint8_t resvd_3 : 1;

--- a/lib/lib_display/UDisplay/uDisplay.h
+++ b/lib/lib_display/UDisplay/uDisplay.h
@@ -233,7 +233,7 @@ class uDisplay : public Renderer {
    spi_device_handle_t dmaHAL;
    spi_host_device_t spi_host = VSPI_HOST;
    // spi_host_device_t spi_host = VSPI_HOST;
-   bool initDMA(bool ctrl_cs);
+   bool initDMA(int32_t ctrl_cs);
    void deInitDMA(void);
    bool dmaBusy(void);
    void dmaWait(void);


### PR DESCRIPTION
## Description:

Fix conflict on M5Stack between ILI9341 and SD Card. Both SPI devices share the same bus, but use different CS lines.

When enabling SPI DMA, the CS line of ILI9341 is blocked at level LOW (enabled) probably because it is owned by the esp-idf api and digitalWrite does not work anymore. This fix forces the DMA transfer to complete before returning, and doesn't let esp-idf manage the CS line.

Changes:
- Added bit 2 for `:B` flag. The default behavior (bit 2 set to `0`) is to wait for DMA transfer to complete before returning, avoiding any conflict. Setting bit 2 to `1` enables async mode; this allows LVGL to start calculating the next screen section before the DMA transfer completes. Use this mode only if the display does not share the SPI bus with any other device. In this mode CS is always enabled.
- Change `uDisplay::initDMA()` to take the cs GPIO as argument

@gemu2015 I hope these changes are ok with you.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
