### PR TITLE
Enable TAS_DISCO when HOME_ASS is disabled

### DIFF
--- a/tasmota/tasmota_configurations_ESP32.h
+++ b/tasmota/tasmota_configurations_ESP32.h
@@ -40,6 +40,7 @@
 
 #undef USE_I2C
 #undef USE_HOME_ASSISTANT
+#define USE_TASMOTA_DISCOVERY                    // Enable Tasmota Discovery support (+2k code)
 #undef USE_COUNTER
 #undef USE_IR_REMOTE
 #undef USE_AC_ZERO_CROSS_DIMMER
@@ -71,8 +72,8 @@
 #define FALLBACK_MODULE        WEMOS             // [Module2] Select default module on fast reboot where USER_MODULE is user template
 
 #define USE_INFLUXDB                             // Enable influxdb support (+5k code)
-#define USE_TASMOTA_DISCOVERY
 #undef USE_HOME_ASSISTANT
+#define USE_TASMOTA_DISCOVERY
 
 #define USE_SDCARD
 
@@ -108,6 +109,7 @@
 
 #undef USE_DOMOTICZ
 #undef USE_HOME_ASSISTANT
+#define USE_TASMOTA_DISCOVERY                    // Enable Tasmota Discovery support (+2k code)
 
 #define USE_WEBCLIENT_HTTPS
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/discussions/15347

Enable TAS_DISCOVERY tasmota32 variants where HOME_ASS is not already enabled


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
