### PR TITLE
Add ZigBee CIE Registration and Zones Enrollment Commands

### DIFF
--- a/tasmota/i18n.h
+++ b/tasmota/i18n.h
@@ -659,6 +659,8 @@
 #define D_CMND_ZIGBEE_DATA "Data"
 #define D_CMND_ZIGBEE_SCAN "Scan"
   #define D_JSON_ZIGBEE_SCAN "ZbScan"
+#define D_CMND_ZIGBEE_CIE "CIE"
+#define D_CMND_ZIGBEE_ENROLL "Enroll"
 
 // Commands xdrv_25_A4988_Stepper.ino
 #define D_CMND_MOTOR "MOTOR"

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -1412,6 +1412,7 @@ void Z_SendSingleAttributeRead(uint16_t shortaddr, uint16_t groupaddr, uint16_t 
 // Write CIE address
 //
 void Z_WriteCIEAddress(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Sending CIE Address for Cluster %d in Endpoint %d of Device 0x%04X"), cluster, endpoint, shortaddr);
   ZCLMessage zcl(12);   // message is 12 bytes
   zcl.shortaddr = shortaddr;
   zcl.cluster = 0x0500;
@@ -1428,15 +1429,15 @@ void Z_WriteCIEAddress(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster,
 
 
 //
-// Write CIE address
+// Send CIE Zone Enroll Response
 //
 void Z_SendCIEZoneEnrollResponse(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
-  AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Sending Enroll Zone %d"), Z_B0(value));
+  AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ZIGBEE "Sending Enroll Zone %d for Cluster %d in Endpoint %d of Device 0x%04X"), Z_B0(value), cluster, endpoint, shortaddr);
   ZCLMessage zcl(2);   // message is 2 bytes
   zcl.shortaddr = shortaddr;
   zcl.cluster = 0x0500;
   zcl.endpoint = endpoint;
-  zcl.cmd = 0x00,   // Zone Enroll Response
+  zcl.cmd = 0x00;   // Zone Enroll Response
   zcl.clusterSpecific = true;
   zcl.needResponse = true;
   zcl.direct = false;   // discover route


### PR DESCRIPTION
## Background:

The ZigBee specification have the IAS clusters (500, 501 and 502) which are related to security and safety devices, panels and warning devices. These devices requires to "Enroll" to a CIE (Control and Indicating Equipment) and that CIE will act as the central of an Alarm System. Enroll is a different concept than ZigBee Binding. A device that have security sensors or it is a panel, requires to first enroll to a CIE in order to send its sensors information or keypad codes and will send that only to that registered CIE.

In order for a security sensor or a panel to be able to enroll to a CIE, it first requires that the device acting as a CIE to send its IEEE address to the device we want to use. Then, the device can be enrolled to the CIE and after that the device will be able to send data. The Tasmotized ZigBee Bridge Coordinator can be used as a CIE (typically known as ZC-CIE: ZigBee Coordinator, Control and Indicating Equipment).

## Description:

This PR adds the commands `ZbCIE` and `ZbEnroll` that can be used to manually register the IEEE address of the Tasmotized ZigBee Bridge Coordinator as the CIE address in the device we want to Enroll and then Enrolling it.

The actual ZigBee Drivers have the automatic CIE registration and Enroll, but as occurs with **auto-binding**, it doesn't work in some devices and we have to manually set a **bind**. That is why, `ZbCIE` and `ZbEnroll` commands are added as a complement to the **auto-enroll** like `ZbBind` does to the **auto-binding**.

_(Note: if the endpoint is 1 in your device, it is more likely that the automatic registration will kick-in right after the device have paired)_

**More Information in the related issue:** https://github.com/arendst/Tasmota/discussions/15356

## Usage:

`ZbCIE DEVICE,ENDPOINT`

`ZbEnroll DEVICE,ENDPOINT`

    `DEVICE` can be the ZigBee Short Address of the device or the device name if set.
    `ENDPOINT` is the endpoint on which the device has the IAS Clusters

_Examples:_

`ZbCIE 0x9F87,44`
`ZbEnroll 0x9F87,44`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
