### PR TITLE
OpenHASP memory optimization

### DIFF
--- a/lib/libesp32/berry_mapping/src/be_class_wrapper.c
+++ b/lib/libesp32/berry_mapping/src/be_class_wrapper.c
@@ -195,6 +195,9 @@ intptr_t be_convert_single_elt(bvm *vm, int idx, const char * arg_type, int *buf
       } else {
         be_raisef(vm, "type_error", "Can't find callback generator: 'cb.make_cb'");
       }
+    } else if (be_iscomptr(vm, idx)) {
+      // if it's a pointer, just pass it without any change
+      return (int32_t) be_tocomptr(vm, idx);;
     } else {
       be_raise(vm, "type_error", "Closure expected for callback type");
     }

--- a/lib/libesp32/berry_tasmota/src/be_lv_openhasp.c
+++ b/lib/libesp32/berry_tasmota/src/be_lv_openhasp.c
@@ -2004,72 +2004,44 @@ be_local_closure(lvh_obj_check_label,   /* name */
 ********************************************************************/
 be_local_closure(lvh_obj_register_event_cb,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        6,                          /* nstack */
-        2,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_literal("event_cb"),
-        }),
-        be_str_literal("<lambda>"),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 6]) {  /* code */
-          0x68080000,  //  0000  GETUPV	R2	U0
-          0x8C080500,  //  0001  GETMET	R2	R2	K0
-          0x5C100000,  //  0002  MOVE	R4	R0
-          0x5C140200,  //  0003  MOVE	R5	R1
-          0x7C080600,  //  0004  CALL	R2	3
-          0x80040400,  //  0005  RET	1	R2
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_literal("_event_map"),
-    /* K1   */  be_nested_str_literal("keys"),
-    /* K2   */  be_nested_str_literal("_lv_obj"),
-    /* K3   */  be_nested_str_literal("add_event_cb"),
-    /* K4   */  be_const_int(0),
+    /* K0   */  be_nested_str_literal("_page"),
+    /* K1   */  be_nested_str_literal("_oh"),
+    /* K2   */  be_nested_str_literal("_event_map"),
+    /* K3   */  be_nested_str_literal("keys"),
+    /* K4   */  be_nested_str_literal("register_event"),
     /* K5   */  be_nested_str_literal("stop_iteration"),
     }),
     be_str_literal("register_event_cb"),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x84040000,  //  0000  CLOSURE	R1	P0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0003  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x7C080200,  //  0005  CALL	R2	1
-      0xA8020008,  //  0006  EXBLK	0	#0010
-      0x5C0C0400,  //  0007  MOVE	R3	R2
-      0x7C0C0000,  //  0008  CALL	R3	0
-      0x88100102,  //  0009  GETMBR	R4	R0	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
-      0x5C180200,  //  000B  MOVE	R6	R1
+    ( &(const binstruction[19]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x60080010,  //  0002  GETGBL	R2	G16
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0004  GETMET	R3	R3	K3
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x7C080200,  //  0006  CALL	R2	1
+      0xA8020006,  //  0007  EXBLK	0	#000F
+      0x5C0C0400,  //  0008  MOVE	R3	R2
+      0x7C0C0000,  //  0009  CALL	R3	0
+      0x8C100304,  //  000A  GETMET	R4	R1	K4
+      0x5C180000,  //  000B  MOVE	R6	R0
       0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x58200004,  //  000D  LDCONST	R8	K4
-      0x7C100800,  //  000E  CALL	R4	4
-      0x7001FFF6,  //  000F  JMP		#0007
-      0x58080005,  //  0010  LDCONST	R2	K5
-      0xAC080200,  //  0011  CATCH	R2	1	0
-      0xB0080000,  //  0012  RAISE	2	R0	R0
-      0xA0000000,  //  0013  CLOSE	R0
-      0x80000000,  //  0014  RET	0
+      0x7C100600,  //  000D  CALL	R4	3
+      0x7001FFF8,  //  000E  JMP		#0008
+      0x58080005,  //  000F  LDCONST	R2	K5
+      0xAC080200,  //  0010  CATCH	R2	1	0
+      0xB0080000,  //  0011  RAISE	2	R0	R0
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -3326,8 +3298,8 @@ be_local_closure(lvh_obj_get_text_color,   /* name */
 ********************************************************************/
 be_local_closure(lvh_obj_event_cb,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
+    12,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -3339,9 +3311,9 @@ be_local_closure(lvh_obj_event_cb,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 3]) {  /* upvals */
-          be_local_const_upval(1, 3),
+          be_local_const_upval(1, 2),
           be_local_const_upval(1, 0),
-          be_local_const_upval(1, 4),
+          be_local_const_upval(1, 3),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -3366,7 +3338,7 @@ be_local_closure(lvh_obj_event_cb,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 7),
+          be_local_const_upval(1, 6),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
@@ -3408,43 +3380,43 @@ be_local_closure(lvh_obj_event_cb,   /* name */
     be_str_literal("event_cb"),
     &be_const_str_solidified,
     ( &(const binstruction[39]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x880C0701,  //  0001  GETMBR	R3	R3	K1
-      0x88100502,  //  0002  GETMBR	R4	R2	K2
-      0x88140103,  //  0003  GETMBR	R5	R0	K3
-      0x4C180000,  //  0004  LDNIL	R6
-      0x20140A06,  //  0005  NE	R5	R5	R6
-      0x78160008,  //  0006  JMPF	R5	#0010
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x88140B05,  //  0008  GETMBR	R5	R5	K5
-      0x1C140805,  //  0009  EQ	R5	R4	R5
-      0x78160004,  //  000A  JMPF	R5	#0010
-      0xB8160C00,  //  000B  GETNGBL	R5	K6
-      0x8C140B07,  //  000C  GETMET	R5	R5	K7
-      0x581C0008,  //  000D  LDCONST	R7	K8
-      0x84200000,  //  000E  CLOSURE	R8	P0
-      0x7C140600,  //  000F  CALL	R5	3
-      0x88140109,  //  0010  GETMBR	R5	R0	K9
-      0x8C140B0A,  //  0011  GETMET	R5	R5	K10
-      0x5C1C0800,  //  0012  MOVE	R7	R4
-      0x7C140400,  //  0013  CALL	R5	2
-      0x4C180000,  //  0014  LDNIL	R6
-      0x20180A06,  //  0015  NE	R6	R5	R6
-      0x781A000D,  //  0016  JMPF	R6	#0025
-      0xA41A1600,  //  0017  IMPORT	R6	K11
-      0x8C1C0D0C,  //  0018  GETMET	R7	R6	K12
-      0x5824000D,  //  0019  LDCONST	R9	K13
-      0x88280100,  //  001A  GETMBR	R10	R0	K0
-      0x8828150E,  //  001B  GETMBR	R10	R10	K14
-      0x882C010F,  //  001C  GETMBR	R11	R0	K15
-      0x5C300A00,  //  001D  MOVE	R12	R5
-      0x7C1C0A00,  //  001E  CALL	R7	5
-      0xB8220C00,  //  001F  GETNGBL	R8	K6
-      0x8C201107,  //  0020  GETMET	R8	R8	K7
-      0x58280008,  //  0021  LDCONST	R10	K8
-      0x842C0001,  //  0022  CLOSURE	R11	P1
-      0x7C200600,  //  0023  CALL	R8	3
-      0xA0180000,  //  0024  CLOSE	R6
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x880C0302,  //  0002  GETMBR	R3	R1	K2
+      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0x4C140000,  //  0004  LDNIL	R5
+      0x20100805,  //  0005  NE	R4	R4	R5
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0xB8120800,  //  0007  GETNGBL	R4	K4
+      0x88100905,  //  0008  GETMBR	R4	R4	K5
+      0x1C100604,  //  0009  EQ	R4	R3	R4
+      0x78120004,  //  000A  JMPF	R4	#0010
+      0xB8120C00,  //  000B  GETNGBL	R4	K6
+      0x8C100907,  //  000C  GETMET	R4	R4	K7
+      0x58180008,  //  000D  LDCONST	R6	K8
+      0x841C0000,  //  000E  CLOSURE	R7	P0
+      0x7C100600,  //  000F  CALL	R4	3
+      0x88100109,  //  0010  GETMBR	R4	R0	K9
+      0x8C10090A,  //  0011  GETMET	R4	R4	K10
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x4C140000,  //  0014  LDNIL	R5
+      0x20140805,  //  0015  NE	R5	R4	R5
+      0x7816000D,  //  0016  JMPF	R5	#0025
+      0xA4161600,  //  0017  IMPORT	R5	K11
+      0x8C180B0C,  //  0018  GETMET	R6	R5	K12
+      0x5820000D,  //  0019  LDCONST	R8	K13
+      0x88240100,  //  001A  GETMBR	R9	R0	K0
+      0x8824130E,  //  001B  GETMBR	R9	R9	K14
+      0x8828010F,  //  001C  GETMBR	R10	R0	K15
+      0x5C2C0800,  //  001D  MOVE	R11	R4
+      0x7C180A00,  //  001E  CALL	R6	5
+      0xB81E0C00,  //  001F  GETNGBL	R7	K6
+      0x8C1C0F07,  //  0020  GETMET	R7	R7	K7
+      0x58240008,  //  0021  LDCONST	R9	K8
+      0x84280001,  //  0022  CLOSURE	R10	P1
+      0x7C1C0600,  //  0023  CALL	R7	3
+      0xA0140000,  //  0024  CLOSE	R5
       0xA0000000,  //  0025  CLOSE	R0
       0x80000000,  //  0026  RET	0
     })
@@ -4693,198 +4665,6 @@ be_local_closure(openhasp__anonymous_,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_page_cur
-********************************************************************/
-be_local_closure(OpenHASP_get_page_cur,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_literal("lvh_pages"),
-    /* K1   */  be_nested_str_literal("lvh_page_cur_idx"),
-    }),
-    be_str_literal("get_page_cur"),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x94040401,  //  0002  GETIDX	R1	R2	R1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start
-********************************************************************/
-be_local_closure(OpenHASP_start,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[33]) {     /* constants */
-    /* K0   */  be_nested_str_literal("path"),
-    /* K1   */  be_nested_str_literal("def_templ_name"),
-    /* K2   */  be_nested_str_literal("exists"),
-    /* K3   */  be_nested_str_literal("file '"),
-    /* K4   */  be_nested_str_literal("' not found"),
-    /* K5   */  be_nested_str_literal("io_erorr"),
-    /* K6   */  be_nested_str_literal("lv"),
-    /* K7   */  be_nested_str_literal("start"),
-    /* K8   */  be_nested_str_literal("dark"),
-    /* K9   */  be_nested_str_literal("hres"),
-    /* K10  */  be_nested_str_literal("get_hor_res"),
-    /* K11  */  be_nested_str_literal("vres"),
-    /* K12  */  be_nested_str_literal("get_ver_res"),
-    /* K13  */  be_nested_str_literal("scr"),
-    /* K14  */  be_nested_str_literal("scr_act"),
-    /* K15  */  be_nested_str_literal("r16"),
-    /* K16  */  be_nested_str_literal("font_embedded"),
-    /* K17  */  be_nested_str_literal("robotocondensed"),
-    /* K18  */  be_nested_str_literal("montserrat"),
-    /* K19  */  be_nested_str_literal("theme_openhasp_init"),
-    /* K20  */  be_const_int(0),
-    /* K21  */  be_nested_str_literal("color"),
-    /* K22  */  be_const_int(16711935),
-    /* K23  */  be_const_int(3158064),
-    /* K24  */  be_nested_str_literal("get_disp"),
-    /* K25  */  be_nested_str_literal("set_theme"),
-    /* K26  */  be_nested_str_literal("set_style_bg_color"),
-    /* K27  */  be_const_int(16777215),
-    /* K28  */  be_nested_str_literal("theme_apply"),
-    /* K29  */  be_nested_str_literal("layer_top"),
-    /* K30  */  be_nested_str_literal("set_style_bg_opa"),
-    /* K31  */  be_nested_str_literal("lvh_pages"),
-    /* K32  */  be_nested_str_literal("_load"),
-    }),
-    be_str_literal("start"),
-    &be_const_str_solidified,
-    ( &(const binstruction[105]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x4C100000,  //  0001  LDNIL	R4
-      0x1C100404,  //  0002  EQ	R4	R2	R4
-      0x78120000,  //  0003  JMPF	R4	#0005
-      0x88080101,  //  0004  GETMBR	R2	R0	K1
-      0x8C100702,  //  0005  GETMET	R4	R3	K2
-      0x5C180400,  //  0006  MOVE	R6	R2
-      0x7C100400,  //  0007  CALL	R4	2
-      0x74120002,  //  0008  JMPT	R4	#000C
-      0x00120602,  //  0009  ADD	R4	K3	R2
-      0x00100904,  //  000A  ADD	R4	R4	K4
-      0xB0060A04,  //  000B  RAISE	1	K5	R4
-      0xB8120C00,  //  000C  GETNGBL	R4	K6
-      0x8C100907,  //  000D  GETMET	R4	R4	K7
-      0x7C100200,  //  000E  CALL	R4	1
-      0x60100017,  //  000F  GETGBL	R4	G23
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C100200,  //  0011  CALL	R4	1
-      0x90021004,  //  0012  SETMBR	R0	K8	R4
-      0xB8120C00,  //  0013  GETNGBL	R4	K6
-      0x8C10090A,  //  0014  GETMET	R4	R4	K10
-      0x7C100200,  //  0015  CALL	R4	1
-      0x90021204,  //  0016  SETMBR	R0	K9	R4
-      0xB8120C00,  //  0017  GETNGBL	R4	K6
-      0x8C10090C,  //  0018  GETMET	R4	R4	K12
-      0x7C100200,  //  0019  CALL	R4	1
-      0x90021604,  //  001A  SETMBR	R0	K11	R4
-      0xB8120C00,  //  001B  GETNGBL	R4	K6
-      0x8C10090E,  //  001C  GETMET	R4	R4	K14
-      0x7C100200,  //  001D  CALL	R4	1
-      0x90021A04,  //  001E  SETMBR	R0	K13	R4
-      0xA8020007,  //  001F  EXBLK	0	#0028
-      0xB8120C00,  //  0020  GETNGBL	R4	K6
-      0x8C100910,  //  0021  GETMET	R4	R4	K16
-      0x58180011,  //  0022  LDCONST	R6	K17
-      0x541E000F,  //  0023  LDINT	R7	16
-      0x7C100600,  //  0024  CALL	R4	3
-      0x90021E04,  //  0025  SETMBR	R0	K15	R4
-      0xA8040001,  //  0026  EXBLK	1	1
-      0x70020009,  //  0027  JMP		#0032
-      0xAC100000,  //  0028  CATCH	R4	0	0
-      0x70020006,  //  0029  JMP		#0031
-      0xB8120C00,  //  002A  GETNGBL	R4	K6
-      0x8C100910,  //  002B  GETMET	R4	R4	K16
-      0x58180012,  //  002C  LDCONST	R6	K18
-      0x541E000D,  //  002D  LDINT	R7	14
-      0x7C100600,  //  002E  CALL	R4	3
-      0x90021E04,  //  002F  SETMBR	R0	K15	R4
-      0x70020000,  //  0030  JMP		#0032
-      0xB0080000,  //  0031  RAISE	2	R0	R0
-      0xB8120C00,  //  0032  GETNGBL	R4	K6
-      0x8C100913,  //  0033  GETMET	R4	R4	K19
-      0x58180014,  //  0034  LDCONST	R6	K20
-      0xB81E0C00,  //  0035  GETNGBL	R7	K6
-      0x8C1C0F15,  //  0036  GETMET	R7	R7	K21
-      0x58240016,  //  0037  LDCONST	R9	K22
-      0x7C1C0400,  //  0038  CALL	R7	2
-      0xB8220C00,  //  0039  GETNGBL	R8	K6
-      0x8C201115,  //  003A  GETMET	R8	R8	K21
-      0x58280017,  //  003B  LDCONST	R10	K23
-      0x7C200400,  //  003C  CALL	R8	2
-      0x88240108,  //  003D  GETMBR	R9	R0	K8
-      0x8828010F,  //  003E  GETMBR	R10	R0	K15
-      0x7C100C00,  //  003F  CALL	R4	6
-      0x8814010D,  //  0040  GETMBR	R5	R0	K13
-      0x8C140B18,  //  0041  GETMET	R5	R5	K24
-      0x7C140200,  //  0042  CALL	R5	1
-      0x8C140B19,  //  0043  GETMET	R5	R5	K25
-      0x5C1C0800,  //  0044  MOVE	R7	R4
-      0x7C140400,  //  0045  CALL	R5	2
-      0x8814010D,  //  0046  GETMBR	R5	R0	K13
-      0x8C140B1A,  //  0047  GETMET	R5	R5	K26
-      0x881C0108,  //  0048  GETMBR	R7	R0	K8
-      0x781E0004,  //  0049  JMPF	R7	#004F
-      0xB81E0C00,  //  004A  GETNGBL	R7	K6
-      0x8C1C0F15,  //  004B  GETMET	R7	R7	K21
-      0x58240014,  //  004C  LDCONST	R9	K20
-      0x7C1C0400,  //  004D  CALL	R7	2
-      0x70020003,  //  004E  JMP		#0053
-      0xB81E0C00,  //  004F  GETNGBL	R7	K6
-      0x8C1C0F15,  //  0050  GETMET	R7	R7	K21
-      0x5824001B,  //  0051  LDCONST	R9	K27
-      0x7C1C0400,  //  0052  CALL	R7	2
-      0x58200014,  //  0053  LDCONST	R8	K20
-      0x7C140600,  //  0054  CALL	R5	3
-      0xB8160C00,  //  0055  GETNGBL	R5	K6
-      0x8C140B1C,  //  0056  GETMET	R5	R5	K28
-      0xB81E0C00,  //  0057  GETNGBL	R7	K6
-      0x8C1C0F1D,  //  0058  GETMET	R7	R7	K29
-      0x7C1C0200,  //  0059  CALL	R7	1
-      0x7C140400,  //  005A  CALL	R5	2
-      0xB8160C00,  //  005B  GETNGBL	R5	K6
-      0x8C140B1D,  //  005C  GETMET	R5	R5	K29
-      0x7C140200,  //  005D  CALL	R5	1
-      0x8C140B1E,  //  005E  GETMET	R5	R5	K30
-      0x581C0014,  //  005F  LDCONST	R7	K20
-      0x58200014,  //  0060  LDCONST	R8	K20
-      0x7C140600,  //  0061  CALL	R5	3
-      0x60140013,  //  0062  GETGBL	R5	G19
-      0x7C140000,  //  0063  CALL	R5	0
-      0x90023E05,  //  0064  SETMBR	R0	K31	R5
-      0x8C140120,  //  0065  GETMET	R5	R0	K32
-      0x5C1C0400,  //  0066  MOVE	R7	R2
-      0x7C140400,  //  0067  CALL	R5	2
-      0x80000000,  //  0068  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: pages_list_sorted
 ********************************************************************/
 be_local_closure(OpenHASP_pages_list_sorted,   /* name */
@@ -4958,60 +4738,6 @@ be_local_closure(OpenHASP_pages_list_sorted,   /* name */
       0x40140805,  //  002C  CONNECT	R5	R4	R5
       0x94080405,  //  002D  GETIDX	R2	R2	R5
       0x80040400,  //  002E  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse
-********************************************************************/
-be_local_closure(OpenHASP_parse,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_literal("json"),
-    /* K1   */  be_nested_str_literal("load"),
-    /* K2   */  be_nested_str_literal("instance"),
-    /* K3   */  be_nested_str_literal("parse_page"),
-    /* K4   */  be_nested_str_literal("parse_obj"),
-    /* K5   */  be_nested_str_literal("lvh_pages"),
-    /* K6   */  be_nested_str_literal("lvh_page_cur_idx"),
-    /* K7   */  be_nested_str_literal("value_error"),
-    /* K8   */  be_nested_str_literal("unable to parse JSON line"),
-    }),
-    be_str_literal("parse"),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x60100004,  //  0004  GETGBL	R4	G4
-      0x5C140600,  //  0005  MOVE	R5	R3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x1C100902,  //  0007  EQ	R4	R4	K2
-      0x78120009,  //  0008  JMPF	R4	#0013
-      0x8C100103,  //  0009  GETMET	R4	R0	K3
-      0x5C180600,  //  000A  MOVE	R6	R3
-      0x7C100400,  //  000B  CALL	R4	2
-      0x8C100104,  //  000C  GETMET	R4	R0	K4
-      0x5C180600,  //  000D  MOVE	R6	R3
-      0x881C0106,  //  000E  GETMBR	R7	R0	K6
-      0x88200105,  //  000F  GETMBR	R8	R0	K5
-      0x941C1007,  //  0010  GETIDX	R7	R8	R7
-      0x7C100600,  //  0011  CALL	R4	3
-      0x70020000,  //  0012  JMP		#0014
-      0xB0060F08,  //  0013  RAISE	1	K7	K8
-      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -5263,33 +4989,130 @@ be_local_closure(OpenHASP_parse_obj,   /* name */
 
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: event_dispatch
 ********************************************************************/
-be_local_closure(OpenHASP_init,   /* name */
+be_local_closure(OpenHASP_event_dispatch,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
+    9,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_literal("re"),
-    /* K1   */  be_nested_str_literal("re_page_target"),
-    /* K2   */  be_nested_str_literal("compile"),
-    /* K3   */  be_nested_str_literal("p\\d+"),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_literal("introspect"),
+    /* K1   */  be_nested_str_literal("toptr"),
+    /* K2   */  be_nested_str_literal("event"),
+    /* K3   */  be_nested_str_literal("_change_buffer"),
+    /* K4   */  be_nested_str_literal("lv"),
+    /* K5   */  be_nested_str_literal("lv_event"),
+    /* K6   */  be_nested_str_literal("user_data"),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str_literal("fromptr"),
+    /* K9   */  be_nested_str_literal("instance"),
+    /* K10  */  be_nested_str_literal("event_cb"),
     }),
-    be_str_literal("init"),
+    be_str_literal("event_dispatch"),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080302,  //  0001  GETMET	R2	R1	K2
-      0x58100003,  //  0002  LDCONST	R4	K3
-      0x7C080400,  //  0003  CALL	R2	2
-      0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0x80000000,  //  0005  RET	0
+    ( &(const binstruction[35]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x78120004,  //  0005  JMPF	R4	#000B
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x5C180600,  //  0008  MOVE	R6	R3
+      0x7C100400,  //  0009  CALL	R4	2
+      0x70020004,  //  000A  JMP		#0010
+      0xB8120800,  //  000B  GETNGBL	R4	K4
+      0x8C100905,  //  000C  GETMET	R4	R4	K5
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x7C100400,  //  000E  CALL	R4	2
+      0x90020404,  //  000F  SETMBR	R0	K2	R4
+      0x88100102,  //  0010  GETMBR	R4	R0	K2
+      0x88100906,  //  0011  GETMBR	R4	R4	K6
+      0x60140009,  //  0012  GETGBL	R5	G9
+      0x5C180800,  //  0013  MOVE	R6	R4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x20140B07,  //  0015  NE	R5	R5	K7
+      0x7816000A,  //  0016  JMPF	R5	#0022
+      0x8C140508,  //  0017  GETMET	R5	R2	K8
+      0x5C1C0800,  //  0018  MOVE	R7	R4
+      0x7C140400,  //  0019  CALL	R5	2
+      0x60180004,  //  001A  GETGBL	R6	G4
+      0x5C1C0A00,  //  001B  MOVE	R7	R5
+      0x7C180200,  //  001C  CALL	R6	1
+      0x1C180D09,  //  001D  EQ	R6	R6	K9
+      0x781A0002,  //  001E  JMPF	R6	#0022
+      0x8C180B0A,  //  001F  GETMET	R6	R5	K10
+      0x88200102,  //  0020  GETMBR	R8	R0	K2
+      0x7C180400,  //  0021  CALL	R6	2
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: page_dir_to
+********************************************************************/
+be_local_closure(OpenHASP_page_dir_to,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_literal("pages_list_sorted"),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_const_int(1),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_literal("find"),
+    }),
+    be_str_literal("page_dir_to"),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0403,  //  0004  EQ	R3	R2	R3
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0x80060200,  //  0006  RET	1	K1
+      0x600C000C,  //  0007  GETGBL	R3	G12
+      0x5C100400,  //  0008  MOVE	R4	R2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x18100702,  //  000A  LE	R4	R3	K2
+      0x78120000,  //  000B  JMPF	R4	#000D
+      0x80060200,  //  000C  RET	1	K1
+      0x1C100703,  //  000D  EQ	R4	R3	K3
+      0x78120000,  //  000E  JMPF	R4	#0010
+      0x80060400,  //  000F  RET	1	K2
+      0x8C100504,  //  0010  GETMET	R4	R2	K4
+      0x5C180200,  //  0011  MOVE	R6	R1
+      0x7C100400,  //  0012  CALL	R4	2
+      0x4C140000,  //  0013  LDNIL	R5
+      0x1C140805,  //  0014  EQ	R5	R4	R5
+      0x78160000,  //  0015  JMPF	R5	#0017
+      0x80060200,  //  0016  RET	1	K1
+      0x00140702,  //  0017  ADD	R5	R3	K2
+      0x0C140B03,  //  0018  DIV	R5	R5	K3
+      0x18140805,  //  0019  LE	R5	R4	R5
+      0x78160001,  //  001A  JMPF	R5	#001D
+      0x80060400,  //  001B  RET	1	K2
+      0x70020001,  //  001C  JMP		#001F
+      0x5415FFFE,  //  001D  LDINT	R5	-1
+      0x80040A00,  //  001E  RET	1	R5
+      0x80000000,  //  001F  RET	0
     })
   )
 );
@@ -5337,6 +5160,294 @@ be_local_closure(OpenHASP_deinit,   /* name */
       0x5C100000,  //  0010  MOVE	R4	R0
       0x7C040600,  //  0011  CALL	R1	3
       0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: parse_page
+********************************************************************/
+be_local_closure(OpenHASP_parse_page,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_literal("has"),
+    /* K1   */  be_nested_str_literal("page"),
+    /* K2   */  be_nested_str_literal("int"),
+    /* K3   */  be_nested_str_literal("lvh_page_cur_idx"),
+    /* K4   */  be_nested_str_literal("lvh_pages"),
+    /* K5   */  be_nested_str_literal("contains"),
+    /* K6   */  be_nested_str_literal("lvh_page"),
+    /* K7   */  be_nested_str_literal("find"),
+    /* K8   */  be_nested_str_literal("id"),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_literal("get_page_cur"),
+    /* K11  */  be_nested_str_literal("prev"),
+    /* K12  */  be_nested_str_literal("next"),
+    /* K13  */  be_nested_str_literal("back"),
+    }),
+    be_str_literal("parse_page"),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0x8C080300,  //  0000  GETMET	R2	R1	K0
+      0x58100001,  //  0001  LDCONST	R4	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x780A0030,  //  0003  JMPF	R2	#0035
+      0x60080004,  //  0004  GETGBL	R2	G4
+      0x940C0301,  //  0005  GETIDX	R3	R1	K1
+      0x7C080200,  //  0006  CALL	R2	1
+      0x1C080502,  //  0007  EQ	R2	R2	K2
+      0x780A002B,  //  0008  JMPF	R2	#0035
+      0x60080009,  //  0009  GETGBL	R2	G9
+      0x940C0301,  //  000A  GETIDX	R3	R1	K1
+      0x7C080200,  //  000B  CALL	R2	1
+      0x90020602,  //  000C  SETMBR	R0	K3	R2
+      0x880C0104,  //  000D  GETMBR	R3	R0	K4
+      0x8C0C0705,  //  000E  GETMET	R3	R3	K5
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x740E0006,  //  0011  JMPT	R3	#0019
+      0x880C0106,  //  0012  GETMBR	R3	R0	K6
+      0x88100104,  //  0013  GETMBR	R4	R0	K4
+      0x5C140600,  //  0014  MOVE	R5	R3
+      0x5C180400,  //  0015  MOVE	R6	R2
+      0x5C1C0000,  //  0016  MOVE	R7	R0
+      0x7C140400,  //  0017  CALL	R5	2
+      0x98100405,  //  0018  SETIDX	R4	R2	R5
+      0x8C0C0307,  //  0019  GETMET	R3	R1	K7
+      0x58140008,  //  001A  LDCONST	R5	K8
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x1C0C0709,  //  001C  EQ	R3	R3	K9
+      0x780E0016,  //  001D  JMPF	R3	#0035
+      0x8C0C010A,  //  001E  GETMET	R3	R0	K10
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x60100009,  //  0020  GETGBL	R4	G9
+      0x8C140307,  //  0021  GETMET	R5	R1	K7
+      0x581C000B,  //  0022  LDCONST	R7	K11
+      0x4C200000,  //  0023  LDNIL	R8
+      0x7C140600,  //  0024  CALL	R5	3
+      0x7C100200,  //  0025  CALL	R4	1
+      0x900E1604,  //  0026  SETMBR	R3	K11	R4
+      0x60100009,  //  0027  GETGBL	R4	G9
+      0x8C140307,  //  0028  GETMET	R5	R1	K7
+      0x581C000C,  //  0029  LDCONST	R7	K12
+      0x4C200000,  //  002A  LDNIL	R8
+      0x7C140600,  //  002B  CALL	R5	3
+      0x7C100200,  //  002C  CALL	R4	1
+      0x900E1804,  //  002D  SETMBR	R3	K12	R4
+      0x60100009,  //  002E  GETGBL	R4	G9
+      0x8C140307,  //  002F  GETMET	R5	R1	K7
+      0x581C000D,  //  0030  LDCONST	R7	K13
+      0x4C200000,  //  0031  LDNIL	R8
+      0x7C140600,  //  0032  CALL	R5	3
+      0x7C100200,  //  0033  CALL	R4	1
+      0x900E1A04,  //  0034  SETMBR	R3	K13	R4
+      0x80000000,  //  0035  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: register_event
+********************************************************************/
+be_local_closure(OpenHASP_register_event,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        1,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_literal("event_dispatch"),
+        }),
+        be_str_literal("<lambda>"),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68040000,  //  0000  GETUPV	R1	U0
+          0x8C040300,  //  0001  GETMET	R1	R1	K0
+          0x5C0C0000,  //  0002  MOVE	R3	R0
+          0x7C040400,  //  0003  CALL	R1	2
+          0x80040200,  //  0004  RET	1	R1
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_literal("cb"),
+    /* K1   */  be_nested_str_literal("introspect"),
+    /* K2   */  be_nested_str_literal("event_cb"),
+    /* K3   */  be_nested_str_literal("gen_cb"),
+    /* K4   */  be_nested_str_literal("_lv_obj"),
+    /* K5   */  be_nested_str_literal("add_event_cb"),
+    /* K6   */  be_nested_str_literal("toptr"),
+    }),
+    be_str_literal("register_event"),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0x88140102,  //  0002  GETMBR	R5	R0	K2
+      0x4C180000,  //  0003  LDNIL	R6
+      0x1C140A06,  //  0004  EQ	R5	R5	R6
+      0x78160003,  //  0005  JMPF	R5	#000A
+      0x8C140703,  //  0006  GETMET	R5	R3	K3
+      0x841C0000,  //  0007  CLOSURE	R7	P0
+      0x7C140400,  //  0008  CALL	R5	2
+      0x90020405,  //  0009  SETMBR	R0	K2	R5
+      0x88140304,  //  000A  GETMBR	R5	R1	K4
+      0x8C180B05,  //  000B  GETMET	R6	R5	K5
+      0x88200102,  //  000C  GETMBR	R8	R0	K2
+      0x5C240400,  //  000D  MOVE	R9	R2
+      0x8C280906,  //  000E  GETMET	R10	R4	K6
+      0x5C300200,  //  000F  MOVE	R12	R1
+      0x7C280400,  //  0010  CALL	R10	2
+      0x7C180800,  //  0011  CALL	R6	4
+      0xA0000000,  //  0012  CLOSE	R0
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: sort
+********************************************************************/
+be_local_closure(OpenHASP_sort,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    0,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_int(1),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_literal("stop_iteration"),
+    }),
+    be_str_literal("sort"),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C080200,  //  0003  CALL	R2	1
+      0x04080500,  //  0004  SUB	R2	R2	K0
+      0x400A0002,  //  0005  CONNECT	R2	K0	R2
+      0x7C040200,  //  0006  CALL	R1	1
+      0xA8020010,  //  0007  EXBLK	0	#0019
+      0x5C080200,  //  0008  MOVE	R2	R1
+      0x7C080000,  //  0009  CALL	R2	0
+      0x940C0002,  //  000A  GETIDX	R3	R0	R2
+      0x5C100400,  //  000B  MOVE	R4	R2
+      0x24140901,  //  000C  GT	R5	R4	K1
+      0x78160008,  //  000D  JMPF	R5	#0017
+      0x04140900,  //  000E  SUB	R5	R4	K0
+      0x94140005,  //  000F  GETIDX	R5	R0	R5
+      0x24140A03,  //  0010  GT	R5	R5	R3
+      0x78160004,  //  0011  JMPF	R5	#0017
+      0x04140900,  //  0012  SUB	R5	R4	K0
+      0x94140005,  //  0013  GETIDX	R5	R0	R5
+      0x98000805,  //  0014  SETIDX	R0	R4	R5
+      0x04100900,  //  0015  SUB	R4	R4	K0
+      0x7001FFF4,  //  0016  JMP		#000C
+      0x98000803,  //  0017  SETIDX	R0	R4	R3
+      0x7001FFEE,  //  0018  JMP		#0008
+      0x58040002,  //  0019  LDCONST	R1	K2
+      0xAC040200,  //  001A  CATCH	R1	1	0
+      0xB0080000,  //  001B  RAISE	2	R0	R0
+      0x80040000,  //  001C  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_page_cur
+********************************************************************/
+be_local_closure(OpenHASP_get_page_cur,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_literal("lvh_pages"),
+    /* K1   */  be_nested_str_literal("lvh_page_cur_idx"),
+    }),
+    be_str_literal("get_page_cur"),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x94040401,  //  0002  GETIDX	R1	R2	R1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(OpenHASP_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_literal("re"),
+    /* K1   */  be_nested_str_literal("re_page_target"),
+    /* K2   */  be_nested_str_literal("compile"),
+    /* K3   */  be_nested_str_literal("p\\d+"),
+    }),
+    be_str_literal("init"),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080302,  //  0001  GETMET	R2	R1	K2
+      0x58100003,  //  0002  LDCONST	R4	K3
+      0x7C080400,  //  0003  CALL	R2	2
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -5460,7 +5571,7 @@ be_local_closure(OpenHASP_do_action,   /* name */
 ********************************************************************/
 be_local_closure(OpenHASP__load,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    14,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -5468,7 +5579,7 @@ be_local_closure(OpenHASP__load,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
+    ( &(const bvalue[17]) {     /* constants */
     /* K0   */  be_nested_str_literal("string"),
     /* K1   */  be_nested_str_literal("json"),
     /* K2   */  be_nested_str_literal("lvh_page_cur_idx"),
@@ -5476,19 +5587,20 @@ be_local_closure(OpenHASP__load,   /* name */
     /* K4   */  be_nested_str_literal("lvh_page"),
     /* K5   */  be_nested_str_literal("lvh_pages"),
     /* K6   */  be_nested_str_literal("r"),
-    /* K7   */  be_nested_str_literal("split"),
-    /* K8   */  be_nested_str_literal("read"),
-    /* K9   */  be_nested_str_literal("\n"),
-    /* K10  */  be_nested_str_literal("close"),
-    /* K11  */  be_nested_str_literal("load"),
-    /* K12  */  be_nested_str_literal("instance"),
-    /* K13  */  be_nested_str_literal("parse_page"),
-    /* K14  */  be_nested_str_literal("parse_obj"),
-    /* K15  */  be_nested_str_literal("stop_iteration"),
+    /* K7   */  be_nested_str_literal("read"),
+    /* K8   */  be_nested_str_literal("close"),
+    /* K9   */  be_nested_str_literal("split"),
+    /* K10  */  be_nested_str_literal("\n"),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_literal("load"),
+    /* K13  */  be_nested_str_literal("instance"),
+    /* K14  */  be_nested_str_literal("parse_page"),
+    /* K15  */  be_nested_str_literal("parse_obj"),
+    /* K16  */  be_nested_str_literal("remove"),
     }),
     be_str_literal("_load"),
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
+    ( &(const binstruction[54]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x90020503,  //  0002  SETMBR	R0	K2	K3
@@ -5503,42 +5615,46 @@ be_local_closure(OpenHASP__load,   /* name */
       0x5C180200,  //  000B  MOVE	R6	R1
       0x581C0006,  //  000C  LDCONST	R7	K6
       0x7C140400,  //  000D  CALL	R5	2
-      0x8C180507,  //  000E  GETMET	R6	R2	K7
-      0x8C200B08,  //  000F  GETMET	R8	R5	K8
-      0x7C200200,  //  0010  CALL	R8	1
-      0x58240009,  //  0011  LDCONST	R9	K9
-      0x7C180600,  //  0012  CALL	R6	3
-      0x8C1C0B0A,  //  0013  GETMET	R7	R5	K10
-      0x7C1C0200,  //  0014  CALL	R7	1
-      0x601C0010,  //  0015  GETGBL	R7	G16
-      0x5C200C00,  //  0016  MOVE	R8	R6
-      0x7C1C0200,  //  0017  CALL	R7	1
-      0xA8020013,  //  0018  EXBLK	0	#002D
-      0x5C200E00,  //  0019  MOVE	R8	R7
-      0x7C200000,  //  001A  CALL	R8	0
-      0x8C24070B,  //  001B  GETMET	R9	R3	K11
-      0x5C2C1000,  //  001C  MOVE	R11	R8
-      0x7C240400,  //  001D  CALL	R9	2
-      0x60280004,  //  001E  GETGBL	R10	G4
-      0x5C2C1200,  //  001F  MOVE	R11	R9
-      0x7C280200,  //  0020  CALL	R10	1
-      0x1C28150C,  //  0021  EQ	R10	R10	K12
-      0x782A0008,  //  0022  JMPF	R10	#002C
-      0x8C28010D,  //  0023  GETMET	R10	R0	K13
-      0x5C301200,  //  0024  MOVE	R12	R9
-      0x7C280400,  //  0025  CALL	R10	2
-      0x8C28010E,  //  0026  GETMET	R10	R0	K14
-      0x5C301200,  //  0027  MOVE	R12	R9
-      0x88340102,  //  0028  GETMBR	R13	R0	K2
-      0x88380105,  //  0029  GETMBR	R14	R0	K5
-      0x94341C0D,  //  002A  GETIDX	R13	R14	R13
-      0x7C280600,  //  002B  CALL	R10	3
-      0x7001FFEB,  //  002C  JMP		#0019
-      0x581C000F,  //  002D  LDCONST	R7	K15
-      0xAC1C0200,  //  002E  CATCH	R7	1	0
-      0xB0080000,  //  002F  RAISE	2	R0	R0
-      0x90020503,  //  0030  SETMBR	R0	K2	K3
-      0x80000000,  //  0031  RET	0
+      0x8C180B07,  //  000E  GETMET	R6	R5	K7
+      0x7C180200,  //  000F  CALL	R6	1
+      0x8C1C0B08,  //  0010  GETMET	R7	R5	K8
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x8C1C0509,  //  0012  GETMET	R7	R2	K9
+      0x5C240C00,  //  0013  MOVE	R9	R6
+      0x5828000A,  //  0014  LDCONST	R10	K10
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0x4C140000,  //  0016  LDNIL	R5
+      0x4C180000,  //  0017  LDNIL	R6
+      0x6020000C,  //  0018  GETGBL	R8	G12
+      0x5C240E00,  //  0019  MOVE	R9	R7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x2420110B,  //  001B  GT	R8	R8	K11
+      0x78220015,  //  001C  JMPF	R8	#0033
+      0x8C20070C,  //  001D  GETMET	R8	R3	K12
+      0x94280F0B,  //  001E  GETIDX	R10	R7	K11
+      0x7C200400,  //  001F  CALL	R8	2
+      0x60240004,  //  0020  GETGBL	R9	G4
+      0x5C281000,  //  0021  MOVE	R10	R8
+      0x7C240200,  //  0022  CALL	R9	1
+      0x1C24130D,  //  0023  EQ	R9	R9	K13
+      0x78260008,  //  0024  JMPF	R9	#002E
+      0x8C24010E,  //  0025  GETMET	R9	R0	K14
+      0x5C2C1000,  //  0026  MOVE	R11	R8
+      0x7C240400,  //  0027  CALL	R9	2
+      0x8C24010F,  //  0028  GETMET	R9	R0	K15
+      0x5C2C1000,  //  0029  MOVE	R11	R8
+      0x88300102,  //  002A  GETMBR	R12	R0	K2
+      0x88340105,  //  002B  GETMBR	R13	R0	K5
+      0x94301A0C,  //  002C  GETIDX	R12	R13	R12
+      0x7C240600,  //  002D  CALL	R9	3
+      0x4C200000,  //  002E  LDNIL	R8
+      0x8C240F10,  //  002F  GETMET	R9	R7	K16
+      0x582C000B,  //  0030  LDCONST	R11	K11
+      0x7C240400,  //  0031  CALL	R9	2
+      0x7001FFE4,  //  0032  JMP		#0018
+      0x4C1C0000,  //  0033  LDNIL	R7
+      0x90020503,  //  0034  SETMBR	R0	K2	K3
+      0x80000000,  //  0035  RET	0
     })
   )
 );
@@ -5546,65 +5662,9 @@ be_local_closure(OpenHASP__load,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort
+** Solidified function: parse
 ********************************************************************/
-be_local_closure(OpenHASP_sort,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    0,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_const_int(1),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_literal("stop_iteration"),
-    }),
-    be_str_literal("sort"),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x04080500,  //  0004  SUB	R2	R2	K0
-      0x400A0002,  //  0005  CONNECT	R2	K0	R2
-      0x7C040200,  //  0006  CALL	R1	1
-      0xA8020010,  //  0007  EXBLK	0	#0019
-      0x5C080200,  //  0008  MOVE	R2	R1
-      0x7C080000,  //  0009  CALL	R2	0
-      0x940C0002,  //  000A  GETIDX	R3	R0	R2
-      0x5C100400,  //  000B  MOVE	R4	R2
-      0x24140901,  //  000C  GT	R5	R4	K1
-      0x78160008,  //  000D  JMPF	R5	#0017
-      0x04140900,  //  000E  SUB	R5	R4	K0
-      0x94140005,  //  000F  GETIDX	R5	R0	R5
-      0x24140A03,  //  0010  GT	R5	R5	R3
-      0x78160004,  //  0011  JMPF	R5	#0017
-      0x04140900,  //  0012  SUB	R5	R4	K0
-      0x94140005,  //  0013  GETIDX	R5	R0	R5
-      0x98000805,  //  0014  SETIDX	R0	R4	R5
-      0x04100900,  //  0015  SUB	R4	R4	K0
-      0x7001FFF4,  //  0016  JMP		#000C
-      0x98000803,  //  0017  SETIDX	R0	R4	R3
-      0x7001FFEE,  //  0018  JMP		#0008
-      0x58040002,  //  0019  LDCONST	R1	K2
-      0xAC040200,  //  001A  CATCH	R1	1	0
-      0xB0080000,  //  001B  RAISE	2	R0	R0
-      0x80040000,  //  001C  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: parse_page
-********************************************************************/
-be_local_closure(OpenHASP_parse_page,   /* name */
+be_local_closure(OpenHASP_parse,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -5614,79 +5674,41 @@ be_local_closure(OpenHASP_parse_page,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_literal("has"),
-    /* K1   */  be_nested_str_literal("page"),
-    /* K2   */  be_nested_str_literal("int"),
-    /* K3   */  be_nested_str_literal("lvh_page_cur_idx"),
-    /* K4   */  be_nested_str_literal("lvh_pages"),
-    /* K5   */  be_nested_str_literal("contains"),
-    /* K6   */  be_nested_str_literal("lvh_page"),
-    /* K7   */  be_nested_str_literal("find"),
-    /* K8   */  be_nested_str_literal("id"),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_literal("get_page_cur"),
-    /* K11  */  be_nested_str_literal("prev"),
-    /* K12  */  be_nested_str_literal("next"),
-    /* K13  */  be_nested_str_literal("back"),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_literal("json"),
+    /* K1   */  be_nested_str_literal("load"),
+    /* K2   */  be_nested_str_literal("instance"),
+    /* K3   */  be_nested_str_literal("parse_page"),
+    /* K4   */  be_nested_str_literal("parse_obj"),
+    /* K5   */  be_nested_str_literal("lvh_pages"),
+    /* K6   */  be_nested_str_literal("lvh_page_cur_idx"),
+    /* K7   */  be_nested_str_literal("value_error"),
+    /* K8   */  be_nested_str_literal("unable to parse JSON line"),
     }),
-    be_str_literal("parse_page"),
+    be_str_literal("parse"),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x8C080300,  //  0000  GETMET	R2	R1	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x780A0030,  //  0003  JMPF	R2	#0035
-      0x60080004,  //  0004  GETGBL	R2	G4
-      0x940C0301,  //  0005  GETIDX	R3	R1	K1
-      0x7C080200,  //  0006  CALL	R2	1
-      0x1C080502,  //  0007  EQ	R2	R2	K2
-      0x780A002B,  //  0008  JMPF	R2	#0035
-      0x60080009,  //  0009  GETGBL	R2	G9
-      0x940C0301,  //  000A  GETIDX	R3	R1	K1
-      0x7C080200,  //  000B  CALL	R2	1
-      0x90020602,  //  000C  SETMBR	R0	K3	R2
-      0x880C0104,  //  000D  GETMBR	R3	R0	K4
-      0x8C0C0705,  //  000E  GETMET	R3	R3	K5
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x740E0006,  //  0011  JMPT	R3	#0019
-      0x880C0106,  //  0012  GETMBR	R3	R0	K6
-      0x88100104,  //  0013  GETMBR	R4	R0	K4
-      0x5C140600,  //  0014  MOVE	R5	R3
-      0x5C180400,  //  0015  MOVE	R6	R2
-      0x5C1C0000,  //  0016  MOVE	R7	R0
-      0x7C140400,  //  0017  CALL	R5	2
-      0x98100405,  //  0018  SETIDX	R4	R2	R5
-      0x8C0C0307,  //  0019  GETMET	R3	R1	K7
-      0x58140008,  //  001A  LDCONST	R5	K8
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x1C0C0709,  //  001C  EQ	R3	R3	K9
-      0x780E0016,  //  001D  JMPF	R3	#0035
-      0x8C0C010A,  //  001E  GETMET	R3	R0	K10
-      0x7C0C0200,  //  001F  CALL	R3	1
-      0x60100009,  //  0020  GETGBL	R4	G9
-      0x8C140307,  //  0021  GETMET	R5	R1	K7
-      0x581C000B,  //  0022  LDCONST	R7	K11
-      0x4C200000,  //  0023  LDNIL	R8
-      0x7C140600,  //  0024  CALL	R5	3
-      0x7C100200,  //  0025  CALL	R4	1
-      0x900E1604,  //  0026  SETMBR	R3	K11	R4
-      0x60100009,  //  0027  GETGBL	R4	G9
-      0x8C140307,  //  0028  GETMET	R5	R1	K7
-      0x581C000C,  //  0029  LDCONST	R7	K12
-      0x4C200000,  //  002A  LDNIL	R8
-      0x7C140600,  //  002B  CALL	R5	3
-      0x7C100200,  //  002C  CALL	R4	1
-      0x900E1804,  //  002D  SETMBR	R3	K12	R4
-      0x60100009,  //  002E  GETGBL	R4	G9
-      0x8C140307,  //  002F  GETMET	R5	R1	K7
-      0x581C000D,  //  0030  LDCONST	R7	K13
-      0x4C200000,  //  0031  LDNIL	R8
-      0x7C140600,  //  0032  CALL	R5	3
-      0x7C100200,  //  0033  CALL	R4	1
-      0x900E1A04,  //  0034  SETMBR	R3	K13	R4
-      0x80000000,  //  0035  RET	0
+    ( &(const binstruction[21]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x60100004,  //  0004  GETGBL	R4	G4
+      0x5C140600,  //  0005  MOVE	R5	R3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x1C100902,  //  0007  EQ	R4	R4	K2
+      0x78120009,  //  0008  JMPF	R4	#0013
+      0x8C100103,  //  0009  GETMET	R4	R0	K3
+      0x5C180600,  //  000A  MOVE	R6	R3
+      0x7C100400,  //  000B  CALL	R4	2
+      0x8C100104,  //  000C  GETMET	R4	R0	K4
+      0x5C180600,  //  000D  MOVE	R6	R3
+      0x881C0106,  //  000E  GETMBR	R7	R0	K6
+      0x88200105,  //  000F  GETMBR	R8	R0	K5
+      0x941C1007,  //  0010  GETIDX	R7	R8	R7
+      0x7C100600,  //  0011  CALL	R4	3
+      0x70020000,  //  0012  JMP		#0014
+      0xB0060F08,  //  0013  RAISE	1	K7	K8
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -5694,60 +5716,161 @@ be_local_closure(OpenHASP_parse_page,   /* name */
 
 
 /********************************************************************
-** Solidified function: page_dir_to
+** Solidified function: start
 ********************************************************************/
-be_local_closure(OpenHASP_page_dir_to,   /* name */
+be_local_closure(OpenHASP_start,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
+    11,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_literal("pages_list_sorted"),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_const_int(1),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_literal("find"),
+    ( &(const bvalue[33]) {     /* constants */
+    /* K0   */  be_nested_str_literal("path"),
+    /* K1   */  be_nested_str_literal("def_templ_name"),
+    /* K2   */  be_nested_str_literal("exists"),
+    /* K3   */  be_nested_str_literal("file '"),
+    /* K4   */  be_nested_str_literal("' not found"),
+    /* K5   */  be_nested_str_literal("io_erorr"),
+    /* K6   */  be_nested_str_literal("lv"),
+    /* K7   */  be_nested_str_literal("start"),
+    /* K8   */  be_nested_str_literal("dark"),
+    /* K9   */  be_nested_str_literal("hres"),
+    /* K10  */  be_nested_str_literal("get_hor_res"),
+    /* K11  */  be_nested_str_literal("vres"),
+    /* K12  */  be_nested_str_literal("get_ver_res"),
+    /* K13  */  be_nested_str_literal("scr"),
+    /* K14  */  be_nested_str_literal("scr_act"),
+    /* K15  */  be_nested_str_literal("r16"),
+    /* K16  */  be_nested_str_literal("font_embedded"),
+    /* K17  */  be_nested_str_literal("robotocondensed"),
+    /* K18  */  be_nested_str_literal("montserrat"),
+    /* K19  */  be_nested_str_literal("theme_openhasp_init"),
+    /* K20  */  be_const_int(0),
+    /* K21  */  be_nested_str_literal("color"),
+    /* K22  */  be_const_int(16711935),
+    /* K23  */  be_const_int(3158064),
+    /* K24  */  be_nested_str_literal("get_disp"),
+    /* K25  */  be_nested_str_literal("set_theme"),
+    /* K26  */  be_nested_str_literal("set_style_bg_color"),
+    /* K27  */  be_const_int(16777215),
+    /* K28  */  be_nested_str_literal("theme_apply"),
+    /* K29  */  be_nested_str_literal("layer_top"),
+    /* K30  */  be_nested_str_literal("set_style_bg_opa"),
+    /* K31  */  be_nested_str_literal("lvh_pages"),
+    /* K32  */  be_nested_str_literal("_load"),
     }),
-    be_str_literal("page_dir_to"),
+    be_str_literal("start"),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x58100001,  //  0001  LDCONST	R4	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x4C0C0000,  //  0003  LDNIL	R3
-      0x1C0C0403,  //  0004  EQ	R3	R2	R3
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0x80060200,  //  0006  RET	1	K1
-      0x600C000C,  //  0007  GETGBL	R3	G12
-      0x5C100400,  //  0008  MOVE	R4	R2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x18100702,  //  000A  LE	R4	R3	K2
-      0x78120000,  //  000B  JMPF	R4	#000D
-      0x80060200,  //  000C  RET	1	K1
-      0x1C100703,  //  000D  EQ	R4	R3	K3
-      0x78120000,  //  000E  JMPF	R4	#0010
-      0x80060400,  //  000F  RET	1	K2
-      0x8C100504,  //  0010  GETMET	R4	R2	K4
-      0x5C180200,  //  0011  MOVE	R6	R1
-      0x7C100400,  //  0012  CALL	R4	2
-      0x4C140000,  //  0013  LDNIL	R5
-      0x1C140805,  //  0014  EQ	R5	R4	R5
-      0x78160000,  //  0015  JMPF	R5	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x00140702,  //  0017  ADD	R5	R3	K2
-      0x0C140B03,  //  0018  DIV	R5	R5	K3
-      0x18140805,  //  0019  LE	R5	R4	R5
-      0x78160001,  //  001A  JMPF	R5	#001D
-      0x80060400,  //  001B  RET	1	K2
-      0x70020001,  //  001C  JMP		#001F
-      0x5415FFFE,  //  001D  LDINT	R5	-1
-      0x80040A00,  //  001E  RET	1	R5
-      0x80000000,  //  001F  RET	0
+    ( &(const binstruction[105]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0x4C100000,  //  0001  LDNIL	R4
+      0x1C100404,  //  0002  EQ	R4	R2	R4
+      0x78120000,  //  0003  JMPF	R4	#0005
+      0x88080101,  //  0004  GETMBR	R2	R0	K1
+      0x8C100702,  //  0005  GETMET	R4	R3	K2
+      0x5C180400,  //  0006  MOVE	R6	R2
+      0x7C100400,  //  0007  CALL	R4	2
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x00120602,  //  0009  ADD	R4	K3	R2
+      0x00100904,  //  000A  ADD	R4	R4	K4
+      0xB0060A04,  //  000B  RAISE	1	K5	R4
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
+      0x7C100200,  //  000E  CALL	R4	1
+      0x60100017,  //  000F  GETGBL	R4	G23
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C100200,  //  0011  CALL	R4	1
+      0x90021004,  //  0012  SETMBR	R0	K8	R4
+      0xB8120C00,  //  0013  GETNGBL	R4	K6
+      0x8C10090A,  //  0014  GETMET	R4	R4	K10
+      0x7C100200,  //  0015  CALL	R4	1
+      0x90021204,  //  0016  SETMBR	R0	K9	R4
+      0xB8120C00,  //  0017  GETNGBL	R4	K6
+      0x8C10090C,  //  0018  GETMET	R4	R4	K12
+      0x7C100200,  //  0019  CALL	R4	1
+      0x90021604,  //  001A  SETMBR	R0	K11	R4
+      0xB8120C00,  //  001B  GETNGBL	R4	K6
+      0x8C10090E,  //  001C  GETMET	R4	R4	K14
+      0x7C100200,  //  001D  CALL	R4	1
+      0x90021A04,  //  001E  SETMBR	R0	K13	R4
+      0xA8020007,  //  001F  EXBLK	0	#0028
+      0xB8120C00,  //  0020  GETNGBL	R4	K6
+      0x8C100910,  //  0021  GETMET	R4	R4	K16
+      0x58180011,  //  0022  LDCONST	R6	K17
+      0x541E000F,  //  0023  LDINT	R7	16
+      0x7C100600,  //  0024  CALL	R4	3
+      0x90021E04,  //  0025  SETMBR	R0	K15	R4
+      0xA8040001,  //  0026  EXBLK	1	1
+      0x70020009,  //  0027  JMP		#0032
+      0xAC100000,  //  0028  CATCH	R4	0	0
+      0x70020006,  //  0029  JMP		#0031
+      0xB8120C00,  //  002A  GETNGBL	R4	K6
+      0x8C100910,  //  002B  GETMET	R4	R4	K16
+      0x58180012,  //  002C  LDCONST	R6	K18
+      0x541E000D,  //  002D  LDINT	R7	14
+      0x7C100600,  //  002E  CALL	R4	3
+      0x90021E04,  //  002F  SETMBR	R0	K15	R4
+      0x70020000,  //  0030  JMP		#0032
+      0xB0080000,  //  0031  RAISE	2	R0	R0
+      0xB8120C00,  //  0032  GETNGBL	R4	K6
+      0x8C100913,  //  0033  GETMET	R4	R4	K19
+      0x58180014,  //  0034  LDCONST	R6	K20
+      0xB81E0C00,  //  0035  GETNGBL	R7	K6
+      0x8C1C0F15,  //  0036  GETMET	R7	R7	K21
+      0x58240016,  //  0037  LDCONST	R9	K22
+      0x7C1C0400,  //  0038  CALL	R7	2
+      0xB8220C00,  //  0039  GETNGBL	R8	K6
+      0x8C201115,  //  003A  GETMET	R8	R8	K21
+      0x58280017,  //  003B  LDCONST	R10	K23
+      0x7C200400,  //  003C  CALL	R8	2
+      0x88240108,  //  003D  GETMBR	R9	R0	K8
+      0x8828010F,  //  003E  GETMBR	R10	R0	K15
+      0x7C100C00,  //  003F  CALL	R4	6
+      0x8814010D,  //  0040  GETMBR	R5	R0	K13
+      0x8C140B18,  //  0041  GETMET	R5	R5	K24
+      0x7C140200,  //  0042  CALL	R5	1
+      0x8C140B19,  //  0043  GETMET	R5	R5	K25
+      0x5C1C0800,  //  0044  MOVE	R7	R4
+      0x7C140400,  //  0045  CALL	R5	2
+      0x8814010D,  //  0046  GETMBR	R5	R0	K13
+      0x8C140B1A,  //  0047  GETMET	R5	R5	K26
+      0x881C0108,  //  0048  GETMBR	R7	R0	K8
+      0x781E0004,  //  0049  JMPF	R7	#004F
+      0xB81E0C00,  //  004A  GETNGBL	R7	K6
+      0x8C1C0F15,  //  004B  GETMET	R7	R7	K21
+      0x58240014,  //  004C  LDCONST	R9	K20
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x70020003,  //  004E  JMP		#0053
+      0xB81E0C00,  //  004F  GETNGBL	R7	K6
+      0x8C1C0F15,  //  0050  GETMET	R7	R7	K21
+      0x5824001B,  //  0051  LDCONST	R9	K27
+      0x7C1C0400,  //  0052  CALL	R7	2
+      0x58200014,  //  0053  LDCONST	R8	K20
+      0x7C140600,  //  0054  CALL	R5	3
+      0xB8160C00,  //  0055  GETNGBL	R5	K6
+      0x8C140B1C,  //  0056  GETMET	R5	R5	K28
+      0xB81E0C00,  //  0057  GETNGBL	R7	K6
+      0x8C1C0F1D,  //  0058  GETMET	R7	R7	K29
+      0x7C1C0200,  //  0059  CALL	R7	1
+      0x7C140400,  //  005A  CALL	R5	2
+      0xB8160C00,  //  005B  GETNGBL	R5	K6
+      0x8C140B1D,  //  005C  GETMET	R5	R5	K29
+      0x7C140200,  //  005D  CALL	R5	1
+      0x8C140B1E,  //  005E  GETMET	R5	R5	K30
+      0x581C0014,  //  005F  LDCONST	R7	K20
+      0x58200014,  //  0060  LDCONST	R8	K20
+      0x7C140600,  //  0061  CALL	R5	3
+      0x60140013,  //  0062  GETGBL	R5	G19
+      0x7C140000,  //  0063  CALL	R5	0
+      0x90023E05,  //  0064  SETMBR	R0	K31	R5
+      0x8C140120,  //  0065  GETMET	R5	R0	K32
+      0x5C1C0400,  //  0066  MOVE	R7	R2
+      0x7C140400,  //  0067  CALL	R5	2
+      0x80000000,  //  0068  RET	0
     })
   )
 );
@@ -5758,48 +5881,52 @@ be_local_closure(OpenHASP_page_dir_to,   /* name */
 ** Solidified class: OpenHASP
 ********************************************************************/
 be_local_class(OpenHASP,
-    8,
+    10,
     NULL,
-    be_nested_map(38,
+    be_nested_map(42,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_literal("re_page_target", -1), be_const_var(7) },
-        { be_const_key_literal("lvh_slider", -1), be_const_class(be_class_lvh_slider) },
-        { be_const_key_literal("lvh_checkbox", -1), be_const_class(be_class_lvh_checkbox) },
-        { be_const_key_literal("start", -1), be_const_closure(OpenHASP_start_closure) },
-        { be_const_key_literal("pages_list_sorted", 8), be_const_closure(OpenHASP_pages_list_sorted_closure) },
-        { be_const_key_literal("page_dir_to", -1), be_const_closure(OpenHASP_page_dir_to_closure) },
-        { be_const_key_literal("lvh_scr", -1), be_const_class(be_class_lvh_scr) },
-        { be_const_key_literal("lvh_btnmatrix", -1), be_const_class(be_class_lvh_btnmatrix) },
-        { be_const_key_literal("parse_page", -1), be_const_closure(OpenHASP_parse_page_closure) },
-        { be_const_key_literal("dark", 7), be_const_var(0) },
-        { be_const_key_literal("parse", 17), be_const_closure(OpenHASP_parse_closure) },
-        { be_const_key_literal("scr", -1), be_const_var(3) },
-        { be_const_key_literal("parse_obj", -1), be_const_closure(OpenHASP_parse_obj_closure) },
-        { be_const_key_literal("init", -1), be_const_closure(OpenHASP_init_closure) },
-        { be_const_key_literal("lvh_img", 21), be_const_class(be_class_lvh_img) },
-        { be_const_key_literal("hres", -1), be_const_var(1) },
-        { be_const_key_literal("deinit", -1), be_const_closure(OpenHASP_deinit_closure) },
-        { be_const_key_literal("lvh_pages", -1), be_const_var(5) },
-        { be_const_key_literal("r16", 34), be_const_var(4) },
-        { be_const_key_literal("lvh_dropdown", -1), be_const_class(be_class_lvh_dropdown) },
-        { be_const_key_literal("get_page_cur", 35), be_const_closure(OpenHASP_get_page_cur_closure) },
-        { be_const_key_literal("vres", 2), be_const_var(2) },
-        { be_const_key_literal("sort", -1), be_const_static_closure(OpenHASP_sort_closure) },
-        { be_const_key_literal("lvh_roller", -1), be_const_class(be_class_lvh_roller) },
-        { be_const_key_literal("lvh_label", 18), be_const_class(be_class_lvh_label) },
-        { be_const_key_literal("lvh_spinner", -1), be_const_class(be_class_lvh_spinner) },
-        { be_const_key_literal("lvh_btn", 30), be_const_class(be_class_lvh_btn) },
-        { be_const_key_literal("lvh_bar", -1), be_const_class(be_class_lvh_bar) },
-        { be_const_key_literal("lvh_switch", 23), be_const_class(be_class_lvh_switch) },
-        { be_const_key_literal("do_action", 22), be_const_closure(OpenHASP_do_action_closure) },
-        { be_const_key_literal("_load", -1), be_const_closure(OpenHASP__load_closure) },
-        { be_const_key_literal("lvh_obj", -1), be_const_class(be_class_lvh_obj) },
-        { be_const_key_literal("lvh_textarea", -1), be_const_class(be_class_lvh_textarea) },
-        { be_const_key_literal("lvh_page", 14), be_const_class(be_class_lvh_page) },
-        { be_const_key_literal("lvh_page_cur_idx", -1), be_const_var(6) },
-        { be_const_key_literal("lvh_line", -1), be_const_class(be_class_lvh_line) },
-        { be_const_key_literal("lvh_arc", 5), be_const_class(be_class_lvh_arc) },
+        { be_const_key_literal("pages_list_sorted", -1), be_const_closure(OpenHASP_pages_list_sorted_closure) },
         { be_const_key_literal("def_templ_name", -1), be_nested_str_literal("pages.jsonl") },
+        { be_const_key_literal("parse_obj", 16), be_const_closure(OpenHASP_parse_obj_closure) },
+        { be_const_key_literal("lvh_slider", 37), be_const_class(be_class_lvh_slider) },
+        { be_const_key_literal("event_dispatch", 25), be_const_closure(OpenHASP_event_dispatch_closure) },
+        { be_const_key_literal("lvh_obj", 29), be_const_class(be_class_lvh_obj) },
+        { be_const_key_literal("page_dir_to", -1), be_const_closure(OpenHASP_page_dir_to_closure) },
+        { be_const_key_literal("vres", -1), be_const_var(2) },
+        { be_const_key_literal("lvh_textarea", -1), be_const_class(be_class_lvh_textarea) },
+        { be_const_key_literal("parse", -1), be_const_closure(OpenHASP_parse_closure) },
+        { be_const_key_literal("lvh_switch", 8), be_const_class(be_class_lvh_switch) },
+        { be_const_key_literal("dark", 13), be_const_var(0) },
+        { be_const_key_literal("event", -1), be_const_var(8) },
+        { be_const_key_literal("lvh_checkbox", -1), be_const_class(be_class_lvh_checkbox) },
+        { be_const_key_literal("lvh_scr", -1), be_const_class(be_class_lvh_scr) },
+        { be_const_key_literal("lvh_spinner", -1), be_const_class(be_class_lvh_spinner) },
+        { be_const_key_literal("lvh_page_cur_idx", 24), be_const_var(6) },
+        { be_const_key_literal("sort", -1), be_const_static_closure(OpenHASP_sort_closure) },
+        { be_const_key_literal("r16", -1), be_const_var(4) },
+        { be_const_key_literal("do_action", -1), be_const_closure(OpenHASP_do_action_closure) },
+        { be_const_key_literal("parse_page", -1), be_const_closure(OpenHASP_parse_page_closure) },
+        { be_const_key_literal("register_event", 17), be_const_closure(OpenHASP_register_event_closure) },
+        { be_const_key_literal("lvh_dropdown", -1), be_const_class(be_class_lvh_dropdown) },
+        { be_const_key_literal("init", -1), be_const_closure(OpenHASP_init_closure) },
+        { be_const_key_literal("lvh_roller", 38), be_const_class(be_class_lvh_roller) },
+        { be_const_key_literal("lvh_line", -1), be_const_class(be_class_lvh_line) },
+        { be_const_key_literal("get_page_cur", -1), be_const_closure(OpenHASP_get_page_cur_closure) },
+        { be_const_key_literal("lvh_page", 31), be_const_class(be_class_lvh_page) },
+        { be_const_key_literal("lvh_arc", -1), be_const_class(be_class_lvh_arc) },
+        { be_const_key_literal("scr", -1), be_const_var(3) },
+        { be_const_key_literal("re_page_target", -1), be_const_var(7) },
+        { be_const_key_literal("lvh_img", 22), be_const_class(be_class_lvh_img) },
+        { be_const_key_literal("lvh_btn", -1), be_const_class(be_class_lvh_btn) },
+        { be_const_key_literal("lvh_bar", 23), be_const_class(be_class_lvh_bar) },
+        { be_const_key_literal("lvh_pages", -1), be_const_var(5) },
+        { be_const_key_literal("lvh_btnmatrix", 19), be_const_class(be_class_lvh_btnmatrix) },
+        { be_const_key_literal("_load", -1), be_const_closure(OpenHASP__load_closure) },
+        { be_const_key_literal("hres", -1), be_const_var(1) },
+        { be_const_key_literal("lvh_label", -1), be_const_class(be_class_lvh_label) },
+        { be_const_key_literal("event_cb", 12), be_const_var(9) },
+        { be_const_key_literal("deinit", 9), be_const_closure(OpenHASP_deinit_closure) },
+        { be_const_key_literal("start", -1), be_const_closure(OpenHASP_start_closure) },
     })),
     be_str_literal("OpenHASP")
 );

--- a/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
+++ b/lib/libesp32_lvgl/lv_binding_berry/generate/be_lv_c_mapping.h
@@ -186,7 +186,7 @@ const be_ntv_func_def_t lv_disp_func[] = {
 
 /* `lv_obj` methods */
 const be_ntv_func_def_t lv_obj_func[] = {
-  { "add_event_cb", { (const void*) &lv_obj_add_event_cb, "i", "(lv.lv_obj)^lv_event_cb^i." } },
+  { "add_event_cb", { (const void*) &lv_obj_add_event_cb, "c", "(lv.lv_obj)^lv_event_cb^i." } },
   { "add_flag", { (const void*) &lv_obj_add_flag, "", "(lv.lv_obj)i" } },
   { "add_state", { (const void*) &lv_obj_add_state, "", "(lv.lv_obj)i" } },
   { "add_style", { (const void*) &lv_obj_add_style, "", "(lv.lv_obj)(lv.lv_style)i" } },
@@ -387,7 +387,7 @@ const be_ntv_func_def_t lv_obj_func[] = {
   { "refresh_style", { (const void*) &lv_obj_refresh_style, "", "(lv.lv_obj)ii" } },
   { "remove_event_cb", { (const void*) &lv_obj_remove_event_cb, "b", "(lv.lv_obj)." } },
   { "remove_event_cb_with_user_data", { (const void*) &lv_obj_remove_event_cb_with_user_data, "b", "(lv.lv_obj).." } },
-  { "remove_event_dsc", { (const void*) &lv_obj_remove_event_dsc, "b", "(lv.lv_obj)i" } },
+  { "remove_event_dsc", { (const void*) &lv_obj_remove_event_dsc, "b", "(lv.lv_obj)c" } },
   { "remove_local_style_prop", { (const void*) &lv_obj_remove_local_style_prop, "b", "(lv.lv_obj)ii" } },
   { "remove_style", { (const void*) &lv_obj_remove_style, "", "(lv.lv_obj)(lv.lv_style)i" } },
   { "remove_style_all", { (const void*) &lv_obj_remove_style_all, "", "(lv.lv_obj)" } },

--- a/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
+++ b/lib/libesp32_lvgl/lv_binding_berry/tools/convert.py
@@ -110,7 +110,7 @@ return_types = {
   "lv_flex_flow_t": "i",
   "lv_grid_align_t": "i",
 
-  "_lv_event_dsc_t *": "i",
+  "_lv_event_dsc_t *": "c",
   # lv_anim
   "lv_anim_t *": "lv_anim",
   "lv_anim_enable_t": "i",


### PR DESCRIPTION
## Description:

OpenHASP memory optimization. Simplification of LVGL event callback. This makes OpenHASP usable even on non-PSRAM devices.

Previously, it required 1 closure and 7 callbacks per OpenHASP object. Now, there is only one generic callback created and the actual Berry object is stored in `user_data` as a pointer.

Also when passing a callback, the automatic mapping is disabled if the argument is already a `comptr` and passed untouched in such case.

Memory impact for standard Tasmota example: from 17kB to 9.5kB of memory consumed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
