### PR TITLE
Berry simplify drivers

### DIFF
--- a/tasmota/berry/drivers/AXP192_M5Stack_Core2.be
+++ b/tasmota/berry/drivers/AXP192_M5Stack_Core2.be
@@ -73,6 +73,8 @@ class AXP192_M5Stack_Core2 : AXP192
 
       # bus power mode_output
       self.set_buf_power_mode(false)
+
+      tasmota.add_driver(self)
     end
   end
 
@@ -132,5 +134,4 @@ class AXP192_M5Stack_Core2 : AXP192
 
 end
 
-axp = AXP192_M5Stack_Core2()
-tasmota.add_driver(axp)
+return AXP192_M5Stack_Core2()

--- a/tasmota/berry/drivers/AXP192_M5Stack_Tough.be
+++ b/tasmota/berry/drivers/AXP192_M5Stack_Tough.be
@@ -88,6 +88,8 @@ class AXP192_M5Stack_Tough : AXP192
       else
         self.set_buf_power_mode(false)
       end
+
+      tasmota.add_driver(self)
     end
   end
 
@@ -147,5 +149,4 @@ class AXP192_M5Stack_Tough : AXP192
 
 end
 
-axp = AXP192_M5Stack_Tough()
-tasmota.add_driver(axp)
+return AXP192_M5Stack_Tough()

--- a/tasmota/berry/drivers/AXP192_M5StickC.be
+++ b/tasmota/berry/drivers/AXP192_M5StickC.be
@@ -67,6 +67,8 @@ class AXP192_M5StickC : AXP192
       # Bit 1: APS voltage ADC enable
       # Bit 0: TS pin ADC function enable
       self.write8(0x82, 0xFF)
+
+      tasmota.add_driver(self)
     end
   end
 
@@ -103,5 +105,4 @@ class AXP192_M5StickC : AXP192
   end
 end
 
-axp = AXP192_M5StickC()
-tasmota.add_driver(axp)
+return AXP192_M5StickC()

--- a/tasmota/berry/drivers/AXP202_LilyGo_TWatch_2020V3.be
+++ b/tasmota/berry/drivers/AXP202_LilyGo_TWatch_2020V3.be
@@ -40,6 +40,8 @@ class AXP202_LilyGo_TWatch_2020V3 : AXP202
       # // No use
       # power->setPowerOutPut(AXP202_LDO3, false);
       self.set_ldo_enable(3, false)
+
+      tasmota.add_driver(self)
     end
   end
   
@@ -66,5 +68,4 @@ class AXP202_LilyGo_TWatch_2020V3 : AXP202
   end
 end
 
-axp202 = AXP202_LilyGo_TWatch_2020V3()
-tasmota.add_driver(axp202)
+return AXP202_LilyGo_TWatch_2020V3()

--- a/tasmota/berry/drivers/CHSC6540.be
+++ b/tasmota/berry/drivers/CHSC6540.be
@@ -1,0 +1,78 @@
+#-
+ - I2C driver for the Touch Screen driver CHSC6540 of the M5Stack Tough
+ -
+ - This is based on 
+ - https://github.com/m5stack/M5Tough/blob/master/src/M5Touch.cpp
+ - https://github.com/m5stack/M5Tough/blob/master/src/M5Touch.h
+ -#
+
+ class CHSC6540 : I2C_Driver
+  var tp_int    # gpio used as INT - going low when the screen is touched
+  # prevous values
+  var touched, x, y   # previous values (bool, int, int) to be repeated when not touched
+  
+  def init()
+    # set current values
+    self.x = 0
+    self.y = 0
+    self.touched = false
+
+    self.tp_int = gpio.pin(gpio.INTERRUPT, 0)
+    super(self).init("CHSC6540", 0x2E)
+
+    tasmota.add_driver(self)
+    # check that display is present
+    import introspect
+    if !introspect.module("display")
+      tasmota.log("I2C: can't start CHSC6540 without display enabled", 3)
+      self.wire = nil
+    end
+
+    if self.tp_int < 0
+      tasmota.log("I2C: can't start CHSC6540 without INTERRUPT-1 gpio configured", 3)
+      self.wire = nil
+    else
+      gpio.pin_mode(self.tp_int, gpio.INPUT_PULLUP)
+    end
+
+    # all good, configure device
+    if self.wire
+      self.write8(0x5A, 0x5A)   # INT mode change
+
+      tasmota.add_driver(self)
+    end
+  end
+
+  # is the screen pressed - i.e. TP_INT is low
+  def is_pressed()
+    if self.wire == nil   return end
+    return gpio.digital_read(self.tp_int) == 0
+  end
+
+  def every_50ms()
+    if self.wire == nil   return end
+
+    self.touched = self.is_pressed()
+    # tasmota.log("DEBUG> int="+str(self.tp_int)+" touched="+str(self.touched), 2)
+    if self.touched
+      import string
+      var raw_read = self.wire.read_bytes(self.addr, 0x02, 11)    # read a series of 11 bytes at from register 0x02
+      var pts = raw_read[0]
+      if pts <= 0 || pts > 2 return end     # wrong
+      # supports multi-touch
+      #var p0f = (raw_read[4] & 0x10) != 0   # unused for now
+      self.x = raw_read.get(1,-2) & 0x0FFF
+      self.y = raw_read.get(3,-2) & 0x0FFF
+      # tasmota.log(string.format("I2C: screen pressed x=%i y=%i", self.x, self.y), 2)
+      # var p1x = raw_read.get(7,2) & 0x0FFF
+      # var p1y = raw_read.get(9,2) & 0x0FFF
+   end
+
+    # return values
+    import display
+    display.touch_update(self.touched ? 1 : 0, self.x, self.y, 0)
+  end
+
+end
+
+return CHSC6540()

--- a/tasmota/berry/drivers/MPU6886_9250.be
+++ b/tasmota/berry/drivers/MPU6886_9250.be
@@ -5,7 +5,7 @@
  - Alternative to xsns_85_mpu6886.ino 
  -#
 
-class MPU6886 : I2C_Driver
+class MPU6886_9250 : I2C_Driver
   var device
   var gres, ares
   var accel, gyro
@@ -49,6 +49,8 @@ class MPU6886 : I2C_Driver
 
       self.gres = 2000.0/32768.0
       self.ares = 8.0/32678.0
+
+      tasmota.add_driver(self)
     end
   end
 
@@ -133,5 +135,4 @@ class MPU6886 : I2C_Driver
 
 end
 
-mpu_accel = MPU6886()
-tasmota.add_driver(mpu_accel)
+return MPU6886_9250()

--- a/tasmota/berry/drivers/Shift595.be
+++ b/tasmota/berry/drivers/Shift595.be
@@ -77,4 +77,4 @@ class Shift595
 
 end
 
-return Shift595 # allow using 'import' instead of 'load()'
+return Shift595() # allow using 'import' instead of 'load()'

--- a/tasmota/berry/drivers/lv_touch_3_buttons.be
+++ b/tasmota/berry/drivers/lv_touch_3_buttons.be
@@ -24,6 +24,10 @@ class lv_touch_3_buttons
   # Pre-condition:
   #   LVGL must be already started
   def init(btn1, btn2, btn3, active_low)
+    import global
+    if !global.contains("lv") return end    # abort if LVGL is not there
+    lv.start()    # make sure LVGL is started, or things can go really wrong
+
     # set current values
     self.x = 0
     self.y = 0
@@ -44,6 +48,9 @@ class lv_touch_3_buttons
     var vres = lv.get_ver_res()       # should be 240
     self.x_coords = [ hres / 6, hres / 2, hres * 5 / 6]
     self.y_coords = [ vres - 10, vres - 10, vres - 10]
+
+    # add self to drivers
+    tasmota.add_driver(self)
   end
 
   # scan every 50ms
@@ -78,7 +85,7 @@ class lv_touch_3_buttons
   end
 end
 
-return lv_touch_3_buttons
+return lv_touch_3_buttons(gpio.pin(gpio.INPUT, 0), gpio.pin(gpio.INPUT, 1), gpio.pin(gpio.INPUT, 2), true)
 
 #-
 lv_btn3 = lv_touch_3_buttons(gpio.pin(gpio.INPUT, 0), gpio.pin(gpio.INPUT, 1), gpio.pin(gpio.INPUT, 2), lv_touch_3_buttons.ACTIVE_LOW)


### PR DESCRIPTION
## Description:

Simplify and rename drivers:
- now you only need to import the relevant module, no additional code required
- added M5Stack Tough CHSC6540 Touch Screen driver

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
