### PR TITLE
Berry fix assertion violation when loading bytecode

### DIFF
--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -492,7 +492,7 @@ static void load_constant(bvm *vm, void *fp, bproto *proto, int version)
     }
 }
 
-static void load_proto_table(bvm *vm, void *fp, bproto *proto, int version)
+static void load_proto_table(bvm *vm, void *fp, bproto *proto, int info, int version)
 {
     int size = (int)load_long(fp); /* proto count */
     if (size) {
@@ -501,7 +501,7 @@ static void load_proto_table(bvm *vm, void *fp, bproto *proto, int version)
         proto->ptab = p;
         proto->nproto = size;
         while (size--) {
-            load_proto(vm, fp, p++, -1, version);
+            load_proto(vm, fp, p++, info, version);
         }
     }
 }
@@ -538,7 +538,7 @@ static bbool load_proto(bvm *vm, void *fp, bproto **proto, int info, int version
         }
         load_bytecode(vm, fp, *proto, info);
         load_constant(vm, fp, *proto, version);
-        load_proto_table(vm, fp, *proto, version);
+        load_proto_table(vm, fp, *proto, info, version);
         load_upvals(vm, fp, *proto);
         return btrue;
     }

--- a/lib/libesp32/berry/src/be_var.c
+++ b/lib/libesp32/berry/src/be_var.c
@@ -12,6 +12,7 @@
 #include "be_map.h"
 #include "be_gc.h"
 #include "be_class.h"
+#include <string.h>
 
 #define global(vm)      ((vm)->gbldesc.global)
 #define builtin(vm)     ((vm)->gbldesc.builtin)


### PR DESCRIPTION
## Description:

Fix assertion violation when loading pre-compiled Berry bytecode containing closures.

```
ASSERT 'be_islist(vm, info)', lib/libesp32/berry/src/be_bytecode.c - 460
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
