### PR TITLE
Berry fix pointer warning

### DIFF
--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -214,8 +214,10 @@ static void save_proto_table(bvm *vm, void *fp, bproto *proto)
 {
     bproto **p = proto->ptab, **end;
     save_long(fp, proto->nproto); /* proto count */
-    for (end = p + proto->nproto; p < end; ++p) {
-        save_proto(vm, fp, *p);
+    if (p) {
+        for (end = p + proto->nproto; p < end; ++p) {
+            save_proto(vm, fp, *p);
+        }
     }
 }
 
@@ -223,9 +225,11 @@ static void save_upvals(void *fp, bproto *proto)
 {
     bupvaldesc *uv = proto->upvals, *end;
     save_byte(fp, proto->nupvals); /* upvals count */
-    for (end = uv + proto->nupvals; uv < end; ++uv) {
-        save_byte(fp, uv->instack);
-        save_byte(fp, uv->idx);
+    if (uv) {
+        for (end = uv + proto->nupvals; uv < end; ++uv) {
+            save_byte(fp, uv->instack);
+            save_byte(fp, uv->idx);
+        }
     }
 }
 


### PR DESCRIPTION
## Description:

Minor fix against the following pointer arithmetic warning:

```
/Users/xxx/berry/src/be_bytecode.c:217:18: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/xxx/berry/src/be_bytecode.c:217:18 in
/Users/xxx/berry/src/be_bytecode.c:226:19: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/xxx/berry/src/be_bytecode.c:226:19 in
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
