### PR TITLE
Berry fix wrong solidification of class name

### DIFF
--- a/lib/libesp32/berry/src/be_solidifylib.c
+++ b/lib/libesp32/berry/src/be_solidifylib.c
@@ -511,7 +511,7 @@ static void m_solidify_subclass(bvm *vm, bbool str_literal, bclass *cl, int buil
         size_t id_len = toidentifier_length(class_name);
         char id_buf[id_len];
         toidentifier(id_buf, class_name);
-        logfmt("    &be_const_str_%s,\n", id_buf);
+        logfmt("    (bstring*) &be_const_str_%s\n", id_buf);
     } else {
         size_t id_len = toliteral_length(class_name);
         char id_buf[id_len];


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] plus  I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
