### PR TITLE
Berry make debug easier

### DIFF
--- a/tasmota/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/xdrv_52_7_berry_embedded.ino
@@ -75,6 +75,10 @@ const char berry_prog[] =
 
   "import tapp "
 
+#ifdef USE_BERRY_DEBUG
+  "import debug "
+  "import solidify "
+#endif
   ;
 
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Make Berry debug easier, by doing automatic `import debug` and `import solidify` when `#define USE_BERRY_DEBUG` is set.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
