### PR TITLE
Berry flash.factory()

### DIFF
--- a/lib/libesp32/berry/generate/be_fixed_flash.h
+++ b/lib/libesp32/berry/generate/be_fixed_flash.h
@@ -2,9 +2,9 @@
 
 static be_define_const_map_slots(m_libflash_map) {
     { be_const_key(write, -1), be_const_func(p_flash_write) },
-    { be_const_key(read, 2), be_const_func(p_flash_read) },
+    { be_const_key(factory, 2), be_const_ctype_func(p_factory) },
     { be_const_key(erase, 3), be_const_func(p_flash_erase) },
-    { be_const_key(rollback, -1), be_const_ctype_func(p_rollback) },
+    { be_const_key(read, -1), be_const_func(p_flash_read) },
 };
 
 static be_define_const_map(

--- a/lib/libesp32/berry_tasmota/src/be_flash_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_flash_lib.c
@@ -8,12 +8,16 @@
 #include "be_constobj.h"
 #include "be_mapping.h"
 
-#include "esp_ota_ops.h"
+#include "esp_partition.h"
 
-void p_rollback(void) {
-    esp_ota_mark_app_invalid_rollback_and_reboot();
+// Forces the next restart to use the `factory` partition if any is present
+void p_factory(void) {
+    const esp_partition_t *otadata_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_OTA, NULL);
+    if (otadata_partition) {
+        esp_partition_erase_range(otadata_partition, 0, SPI_FLASH_SEC_SIZE * 2);
+    }
 }
-BE_FUNC_CTYPE_DECLARE(p_rollback, "", "");
+BE_FUNC_CTYPE_DECLARE(p_factory, "", "");
 
 extern int p_flash_read(bvm *vm);
 extern int p_flash_write(bvm *vm);
@@ -25,7 +29,7 @@ module flash (scope: global) {
     write, func(p_flash_write)
     erase, func(p_flash_erase)
 
-    rollback, ctype_func(p_rollback)
+    factory, ctype_func(p_factory)
 }
 @const_object_info_end */
 #include "be_fixed_flash.h"


### PR DESCRIPTION
## Description:

Berry, rename and make it more reliable:
- `flash.factory()` forces the next reboot to start on `factory` partition if any. If not, uses the first OTA partition.

This is used for internal purposes and is not meant for general use.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
