### PR TITLE
HTTP API to switch to and from factory partition

### DIFF
--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -299,6 +299,11 @@ bool EspSingleOtaPartition(void) {
   return (1 == esp_ota_get_app_partition_count());
 }
 
+bool EspRunningFactoryPartition(void) {
+  const esp_partition_t *cur_part = esp_ota_get_running_partition();
+  return (cur_part->type == 0 && cur_part->subtype == 0);
+}
+
 void EspPrepRestartToSafeMode(void) {
 //  esp_ota_mark_app_invalid_rollback_and_reboot();  // Doesn't work 20220501
   const esp_partition_t *otadata_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_OTA, NULL);


### PR DESCRIPTION
## Description:

Short term API to switch the active partition from `app0` to `factory` and the other way around:
- `http://<ip>/u4?u4=fct` switches to factory partition if it exists and restart. If already on factory partition, does nothing and redirects to root page
- `http://<ip>/u4?u4=ota` switches to ota `app0``  partition and restarts. If already on ota partition, does nothing and redirects to root page

These API are only effective if there is only 1 OTA partition [ESP32 only]

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
