### PR TITLE
Add option to specify retention policy for InfluxDB writes

### DIFF
--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -418,7 +418,7 @@ enum SettingsTextIndex { SET_OTAURL,
 #endif  // ESP32
                          SET_SHD_PARAM,
                          SET_RGX_SSID, SET_RGX_PASSWORD,
-                         SET_INFLUXDB_HOST, SET_INFLUXDB_PORT, SET_INFLUXDB_ORG, SET_INFLUXDB_TOKEN, SET_INFLUXDB_BUCKET, SET_INFLUXDB_RP
+                         SET_INFLUXDB_HOST, SET_INFLUXDB_PORT, SET_INFLUXDB_ORG, SET_INFLUXDB_TOKEN, SET_INFLUXDB_BUCKET, SET_INFLUXDB_RP,
                          SET_MAX };
 
 enum SpiInterfaces { SPI_NONE, SPI_MOSI, SPI_MISO, SPI_MOSI_MISO };

--- a/tasmota/tasmota.h
+++ b/tasmota/tasmota.h
@@ -418,7 +418,7 @@ enum SettingsTextIndex { SET_OTAURL,
 #endif  // ESP32
                          SET_SHD_PARAM,
                          SET_RGX_SSID, SET_RGX_PASSWORD,
-                         SET_INFLUXDB_HOST, SET_INFLUXDB_PORT, SET_INFLUXDB_ORG, SET_INFLUXDB_TOKEN, SET_INFLUXDB_BUCKET,
+                         SET_INFLUXDB_HOST, SET_INFLUXDB_PORT, SET_INFLUXDB_ORG, SET_INFLUXDB_TOKEN, SET_INFLUXDB_BUCKET, SET_INFLUXDB_RP
                          SET_MAX };
 
 enum SpiInterfaces { SPI_NONE, SPI_MOSI, SPI_MISO, SPI_MOSI_MISO };


### PR DESCRIPTION
## Description:

Another exercise in copy/paste to add IfxRP command to the InfluxDB driver, so users can define which retention policy they want to use, if not the default.

**Related issue (if applicable):** fixes #15257

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
