### PR TITLE
Berry fix crash with GC for ctype

### DIFF
--- a/lib/libesp32/berry/src/be_gc.h
+++ b/lib/libesp32/berry/src/be_gc.h
@@ -47,7 +47,7 @@ if (!gc_isconst(o)) { \
 #define gc_exmark(o)        (((o)->marked >> 4) & 0x0F)
 #define gc_setexmark(o, k)  ((o)->marked |= (k) << 4)
 
-#define be_isgcobj(o)       (var_primetype(o) >= BE_GCOBJECT)
+#define be_isgcobj(o)       (var_primetype(o) >= BE_GCOBJECT && var_primetype(o) < BE_GCOBJECT_MAX)
 #define be_gcnew(v, t, s)   be_newgcobj((v), (t), sizeof(s))
 
 #define set_fixed(s)        bbool _was_fixed = be_gc_fix_set(vm, cast(bgcobject*, (s)), 1)

--- a/lib/libesp32/berry/src/be_object.h
+++ b/lib/libesp32/berry/src/be_object.h
@@ -21,6 +21,7 @@
 #define BE_FUNCTION     6
 
 #define BE_GCOBJECT     16      /* from this type can be gced */
+#define BE_GCOBJECT_MAX (3<<5)  /* from this type can't be gced */
 
 #define BE_STRING       16
 #define BE_CLASS        17


### PR DESCRIPTION
## Description:

Fix a rare crash when GC occurs on a ctype function.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
