### PR TITLE
Berry improve flash.write for faster writes

### DIFF
--- a/tasmota/xdrv_52_3_berry_flash.ino
+++ b/tasmota/xdrv_52_3_berry_flash.ino
@@ -39,7 +39,7 @@ size_t FlashWriteSubSector(uint32_t address_start, const uint8_t *data, size_t s
         size_in_page = SPI_FLASH_SEC_SIZE - addr_in_page;
       }
 
-      AddLog(LOG_LEVEL_DEBUG, ">>>: flash_write addr=%p size=%i -- page_addr=%p addr_in_page=%p size_in_page=%i size_left=%i", address_start, size, page_addr, addr_in_page, size_in_page, size_left);
+      // AddLog(LOG_LEVEL_DEBUG, ">>>: flash_write addr=%p size=%i -- page_addr=%p addr_in_page=%p size_in_page=%i size_left=%i", address_start, size, page_addr, addr_in_page, size_in_page, size_left);
       // check if whole page?
       if (addr_in_page == 0 && size_in_page == SPI_FLASH_SEC_SIZE) {
         memcpy(buffer, data + current_offset, SPI_FLASH_SEC_SIZE);
@@ -94,9 +94,8 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
-  // Berry: `flash.write(address:int, content:bytes()) -> nil`
-  //
-  // If length is not specified, it is full block 4KB
+  // Berry: `flash.write(address:int, content:bytes() [, no_erase:bool]) -> nil`
+  // if `no_erase` is true, just call spi_flash_write
   int32_t p_flash_write(struct bvm *vm);
   int32_t p_flash_write(struct bvm *vm) {
     int32_t argc = be_top(vm); // Get the number of arguments


### PR DESCRIPTION
## Description:

`webclient.write_flash()` is much faster. Internally it first earse the whole region and does simple writes.

`flash.write()` as a new option to not erase the region first. This makes it faster, but only if you have already erased the region first.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
