### PR TITLE
Disable auto-TLS for port 8883

### DIFF
--- a/tasmota/settings.ino
+++ b/tasmota/settings.ino
@@ -1487,6 +1487,10 @@ void SettingsDelta(void) {
       ParseIPv4(&Settings->ipv4_rgx_subnetmask, PSTR(WIFI_RGX_SUBNETMASK));
       SettingsUpdateText(SET_RGX_SSID, PSTR(WIFI_RGX_SSID));
       SettingsUpdateText(SET_RGX_PASSWORD, PSTR(WIFI_RGX_PASSWORD));
+      if ((8883 == Settings->mqtt_port) || (8884 == Settings->mqtt_port) || (443 == Settings->mqtt_port)) {
+        // Turn on TLS for port 8883 (TLS), 8884 (TLS, client certificate), 443 (TLS, user/password)
+        Settings->flag4.mqtt_tls = true;
+      }
     }
     if (Settings->version < 0x09050007) {
 #ifdef DISABLE_REFERER_CHK

--- a/tasmota/xdrv_02_9_mqtt.ino
+++ b/tasmota/xdrv_02_9_mqtt.ino
@@ -202,10 +202,6 @@ void MqttInit(void) {
 #endif //USE_MQTT_AZURE_IOT
 #ifdef USE_MQTT_TLS
   bool aws_iot_host = false;
-  if ((8883 == Settings->mqtt_port) || (8884 == Settings->mqtt_port) || (443 == Settings->mqtt_port)) {
-    // Turn on TLS for port 8883 (TLS), 8884 (TLS, client certificate), 443 (TLS, user/password)
-    Settings->flag4.mqtt_tls = true;
-  }
   Mqtt.mqtt_tls = Settings->flag4.mqtt_tls;   // this flag should not change even if we change the SetOption (until reboot)
 
   // Detect AWS IoT and set default parameters


### PR DESCRIPTION
## Description:

Disable automatically setting TLS on for port 8883 or 8884. This behavior now only happens when upgrading from a version previous to v9.5.0.5.

**Related issue (if applicable):** fixes #15559

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
