### PR TITLE
Berry: add content_response() to webserver

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -370,6 +370,7 @@ extern const bcstring be_const_str_consume_stereo;
 extern const bcstring be_const_str_contains;
 extern const bcstring be_const_str_content_button;
 extern const bcstring be_const_str_content_flush;
+extern const bcstring be_const_str_content_response;
 extern const bcstring be_const_str_content_send;
 extern const bcstring be_const_str_content_send_style;
 extern const bcstring be_const_str_content_start;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -362,6 +362,7 @@ be_define_const_str(consume_stereo, "consume_stereo", 1834661098u, 0, 14, &be_co
 be_define_const_str(contains, "contains", 1825239352u, 0, 8, &be_const_str_power_off);
 be_define_const_str(content_button, "content_button", 1956476087u, 0, 14, &be_const_str_fast_loop);
 be_define_const_str(content_flush, "content_flush", 214922475u, 0, 13, &be_const_str_min);
+be_define_const_str(content_response, "content_response", 3881475860u, 0, 16, &be_const_str_detect);
 be_define_const_str(content_send, "content_send", 1673733649u, 0, 12, &be_const_str_members);
 be_define_const_str(content_send_style, "content_send_style", 1087907647u, 0, 18, NULL);
 be_define_const_str(content_start, "content_start", 2937509069u, 0, 13, &be_const_str_json_append);
@@ -1443,7 +1444,7 @@ static const bstring* const m_string_table[] = {
     (const bstring *)&be_const_str_cb_obj,
     (const bstring *)&be_const_str__X23,
     (const bstring *)&be_const_str_add_cmd,
-    (const bstring *)&be_const_str_detect,
+    (const bstring *)&be_const_str_content_response,
     (const bstring *)&be_const_str_content_stop,
     (const bstring *)&be_const_str__X22,
     (const bstring *)&be_const_str_gpio,
@@ -1542,6 +1543,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 505,
-    .count = 1033,
+    .count = 1034,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_webserver.h
+++ b/lib/libesp32/berry/generate/be_fixed_webserver.h
@@ -1,26 +1,27 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libwebserver_map) {
-    { be_const_key(state, 5), be_const_func(w_webserver_state) },
-    { be_const_key(member, 9), be_const_func(w_webserver_member) },
-    { be_const_key(content_button, -1), be_const_func(w_webserver_content_button) },
-    { be_const_key(content_start, -1), be_const_func(w_webserver_content_start) },
-    { be_const_key(content_send, -1), be_const_func(w_webserver_content_send) },
-    { be_const_key(content_flush, -1), be_const_func(w_webserver_content_flush) },
-    { be_const_key(redirect, 8), be_const_func(w_webserver_redirect) },
+    { be_const_key(check_privileged_access, 8), be_const_func(w_webserver_check_privileged_access) },
+    { be_const_key(content_send, 14), be_const_func(w_webserver_content_send) },
     { be_const_key(content_send_style, -1), be_const_func(w_webserver_content_send_style) },
+    { be_const_key(member, -1), be_const_func(w_webserver_member) },
+    { be_const_key(content_response, -1), be_const_func(w_webserver_content_response) },
     { be_const_key(arg, -1), be_const_func(w_webserver_arg) },
-    { be_const_key(content_stop, -1), be_const_func(w_webserver_content_stop) },
-    { be_const_key(arg_name, -1), be_const_func(w_webserver_arg_name) },
-    { be_const_key(has_arg, -1), be_const_func(w_webserver_has_arg) },
+    { be_const_key(state, -1), be_const_func(w_webserver_state) },
+    { be_const_key(content_button, 5), be_const_func(w_webserver_content_button) },
+    { be_const_key(has_arg, 12), be_const_func(w_webserver_has_arg) },
     { be_const_key(arg_size, -1), be_const_func(w_webserver_argsize) },
-    { be_const_key(check_privileged_access, 11), be_const_func(w_webserver_check_privileged_access) },
-    { be_const_key(on, 3), be_const_func(w_webserver_on) },
+    { be_const_key(content_flush, -1), be_const_func(w_webserver_content_flush) },
+    { be_const_key(arg_name, 10), be_const_func(w_webserver_arg_name) },
+    { be_const_key(on, -1), be_const_func(w_webserver_on) },
+    { be_const_key(content_start, -1), be_const_func(w_webserver_content_start) },
+    { be_const_key(redirect, -1), be_const_func(w_webserver_redirect) },
+    { be_const_key(content_stop, 2), be_const_func(w_webserver_content_stop) },
 };
 
 static be_define_const_map(
     m_libwebserver_map,
-    15
+    16
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -17,6 +17,7 @@ extern int w_webserver_check_privileged_access(bvm *vm);
 extern int w_webserver_redirect(bvm *vm);
 extern int w_webserver_content_start(bvm *vm);
 extern int w_webserver_content_send(bvm *vm);
+extern int w_webserver_content_response(bvm *vm);
 extern int w_webserver_content_send_style(bvm *vm);
 extern int w_webserver_content_flush(bvm *vm);
 extern int w_webserver_content_stop(bvm *vm);
@@ -38,6 +39,7 @@ module webserver (scope: global) {
     check_privileged_access, func(w_webserver_check_privileged_access)
     redirect, func(w_webserver_redirect)
     content_send, func(w_webserver_content_send)
+    content_response, func(w_webserver_content_response)
     content_send_style, func(w_webserver_content_send_style)
     content_flush, func(w_webserver_content_flush)
     content_start, func(w_webserver_content_start)

--- a/tasmota/xdrv_52_3_berry_webserver.ino
+++ b/tasmota/xdrv_52_3_berry_webserver.ino
@@ -172,6 +172,19 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: `webserver.content_response(string) -> nil`
+  //
+  int32_t w_webserver_content_response(struct bvm *vm);
+  int32_t w_webserver_content_response(struct bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isstring(vm, 1)) {
+      const char * response = be_tostring(vm, 1);
+      WSReturnSimpleString(response);
+      be_return_nil(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
   // Berry: `webserver.content_send_style() -> nil`
   //
   int32_t w_webserver_content_send_style(struct bvm *vm);


### PR DESCRIPTION
## Description:

Adds the possibility to simply respond to XMLHttpRequest allowing AJAX based web pages.
For now only strings are supported, but that should be fine for a lot of use cases.

Code snippet for illustration:
```
  #######################################################################
  # Display the complete page
  #######################################################################
  def page_ble_scan()
    import webserver
    import string

    if !webserver.check_privileged_access() return nil end
    
    # AJAX response
    if webserver.has_arg("loop")      # reacting to something like 'xr.open('GET','/ble_scan?loop=1',true)' from the JS side
      webserver.content_response("Hello") # there may be better things to send
      return
    end

    # regular web page
    webserver.content_start("BLE scan")           #- title of the web page -#
    webserver.content_send_style()                #- send standard Tasmota styles -#
```



## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
