### PR TITLE
Esp32 real flash size

### DIFF
--- a/lib/libesp32/berry/generate/be_fixed_flash.h
+++ b/lib/libesp32/berry/generate/be_fixed_flash.h
@@ -1,15 +1,17 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libflash_map) {
+    { be_const_key(id, 5), be_const_ctype_func(p_flashid) },
+    { be_const_key(factory, 4), be_const_ctype_func(p_factory) },
     { be_const_key(write, -1), be_const_func(p_flash_write) },
-    { be_const_key(factory, 2), be_const_ctype_func(p_factory) },
-    { be_const_key(erase, 3), be_const_func(p_flash_erase) },
     { be_const_key(read, -1), be_const_func(p_flash_read) },
+    { be_const_key(erase, -1), be_const_func(p_flash_erase) },
+    { be_const_key(size, -1), be_const_ctype_func(p_flashsize) },
 };
 
 static be_define_const_map(
     m_libflash_map,
-    4
+    6
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry_tasmota/src/be_flash_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_flash_lib.c
@@ -9,10 +9,24 @@
 #include "be_mapping.h"
 
 #include "esp_partition.h"
+#include "bootloader_flash.h"
 
 // Forces the next restart to use the `factory` partition if any is present
 extern void p_factory(bbool force_ota);
 BE_FUNC_CTYPE_DECLARE(p_factory, "", "b");
+
+int32_t p_flashid(void) {
+    uint32_t id = bootloader_read_flash_id();
+    id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
+    return id;
+}
+BE_FUNC_CTYPE_DECLARE(p_flashid, "i", "");
+
+int32_t p_flashsize(void) {
+    uint32_t id = (p_flashid() >> 16) & 0xFF;
+    return 2 << (id - 1);
+}
+BE_FUNC_CTYPE_DECLARE(p_flashsize, "i", "");
 
 extern int p_flash_read(bvm *vm);
 extern int p_flash_write(bvm *vm);
@@ -25,6 +39,9 @@ module flash (scope: global) {
     erase, func(p_flash_erase)
 
     factory, ctype_func(p_factory)
+
+    id, ctype_func(p_flashid)
+    size, ctype_func(p_flashsize)
 }
 @const_object_info_end */
 #include "be_fixed_flash.h"

--- a/tasmota/support_command.ino
+++ b/tasmota/support_command.ino
@@ -619,18 +619,14 @@ void CmndStatus(void)
                           D_JSON_STACKLOWMARK "\":%d,\"" D_JSON_PSRMAXMEMORY "\":%d,\"" D_JSON_PSRFREEMEMORY "\":%d,\""
 #endif  // ESP32
                           D_JSON_PROGRAMFLASHSIZE "\":%d,\"" D_JSON_FLASHSIZE "\":%d"
-#ifdef ESP8266
                           ",\"" D_JSON_FLASHCHIPID "\":\"%06X\""
-#endif  // ESP8266
                           ",\"FlashFrequency\":%d,\"" D_JSON_FLASHMODE "\":%d"),
                           ESP_getSketchSize()/1024, ESP_getFreeSketchSpace()/1024, ESP_getFreeHeap1024(),
 #ifdef ESP32
                           uxTaskGetStackHighWaterMark(nullptr) / 1024, ESP.getPsramSize()/1024, ESP.getFreePsram()/1024,
 #endif  // ESP32
-                          ESP.getFlashChipSize()/1024, ESP.getFlashChipRealSize()/1024
-#ifdef ESP8266
-                          , ESP.getFlashChipId()
-#endif  // ESP8266
+                          ESP.getFlashChipSize()/1024, ESP_getFlashChipRealSize()/1024
+                          , ESP_getFlashChipId()
                           , ESP.getFlashChipSpeed()/1000000, ESP.getFlashChipMode());
     ResponseAppendFeatures();
     XsnsDriverState();

--- a/tasmota/support_esp.ino
+++ b/tasmota/support_esp.ino
@@ -57,6 +57,14 @@ uint32_t ESP_getFreeHeap(void) {
   return ESP.getFreeHeap();
 }
 
+uint32_t ESP_getFlashChipId(void) {
+  return ESP.getFlashChipId();
+}
+
+uint32_t ESP_getFlashChipRealSize(void) {
+  return ESP.getFlashChipRealSize();
+}
+
 void ESP_Restart(void) {
 //  ESP.restart();            // This results in exception 3 on restarts on core 2.3.0
   ESP.reset();
@@ -112,6 +120,7 @@ String GetDeviceHardwareRevision(void) {
 
 #ifdef ESP32
 
+#include "bootloader_flash.h"
 // ESP32_ARCH contains the name of the architecture (used by autoconf)
 #if CONFIG_IDF_TARGET_ESP32
   #define ESP32_ARCH              "esp32"
@@ -497,6 +506,19 @@ int32_t ESP_getHeapFragmentation(void) {
   int32_t free_maxmem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
   if (free_maxmem < 0) { free_maxmem = 0; }
   return free_maxmem;
+}
+
+uint32_t ESP_getFlashChipId(void)
+{
+  uint32_t id = bootloader_read_flash_id();
+  id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
+  return id;
+}
+
+uint32_t ESP_getFlashChipRealSize(void)
+{
+  uint32_t id = (ESP_getFlashChipId() >> 16) & 0xFF;
+  return 2 << (id - 1);
 }
 
 void ESP_Restart(void) {

--- a/tasmota/xdrv_01_webserver.ino
+++ b/tasmota/xdrv_01_webserver.ino
@@ -2452,13 +2452,9 @@ void HandleInformation(void)
 
   WSContentSend_P(PSTR("}1}2&nbsp;"));  // Empty line
   WSContentSend_P(PSTR("}1" D_ESP_CHIP_ID "}2%d (%s)"), ESP_getChipId(), GetDeviceHardwareRevision().c_str());
-#ifdef ESP8266
-  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X"), ESP.getFlashChipId());
-#endif
-  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d kB"), ESP.getFlashChipRealSize() / 1024);
-#ifdef ESP8266
+  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X"), ESP_getFlashChipId());
+  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d kB"), ESP_getFlashChipRealSize() / 1024);
   WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d kB"), ESP.getFlashChipSize() / 1024);
-#endif
   WSContentSend_P(PSTR("}1" D_PROGRAM_SIZE "}2%d kB"), ESP_getSketchSize() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_PROGRAM_SPACE "}2%d kB"), ESP_getFreeSketchSpace() / 1024);
 #ifdef ESP32
@@ -2780,7 +2776,11 @@ void HandleUploadLoop(void) {
         }
         if (0xE9 == upload.buf[0]) {
           uint32_t bin_flash_size = ESP.magicFlashChipSize((upload.buf[3] & 0xf0) >> 4);
+#ifdef ESP8266
           if (bin_flash_size > ESP.getFlashChipRealSize()) {
+#else
+          if (bin_flash_size > ESP.getFlashChipSize()) {   // TODO revisit this test
+#endif
             Web.upload_error = 4;  // Program flash size is larger than real flash size
             return;
           }

--- a/tasmota/xdrv_52_3_berry_flash.ino
+++ b/tasmota/xdrv_52_3_berry_flash.ino
@@ -86,7 +86,7 @@ extern "C" {
       auto buf = std::unique_ptr<uint8_t[]>(new uint8_t[length]);
       esp_err_t ret = spi_flash_read(address, buf.get(), length);
       if (ret)  {
-        be_raise(vm, "internal_error", "Error calling spi_flash_read()");
+        be_raisef(vm, "internal_error", "Error calling spi_flash_read(0x%X, %i)", address, length);
       }
       be_pushbytes(vm, buf.get(), length);
       be_return(vm);

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -182,7 +182,7 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top == 1) {  // no argument (instance only)
       be_newobject(vm, "map");
-      be_map_insert_int(vm, "flash", ESP.getFlashChipSize() / 1024);
+      be_map_insert_int(vm, "flash", ESP_getFlashChipRealSize() / 1024);
       be_map_insert_int(vm, "program", ESP_getSketchSize() / 1024);
       be_map_insert_int(vm, "program_free", ESP_getFreeSketchSpace() / 1024);
       be_map_insert_int(vm, "heap_free", ESP_getFreeHeap() / 1024);

--- a/tasmota/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/xdrv_52_3_berry_tasmota.ino
@@ -182,7 +182,8 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top == 1) {  // no argument (instance only)
       be_newobject(vm, "map");
-      be_map_insert_int(vm, "flash", ESP_getFlashChipRealSize() / 1024);
+      be_map_insert_int(vm, "flash", ESP.getFlashChipSize() / 1024);
+      be_map_insert_int(vm, "flash_real", ESP_getFlashChipRealSize() / 1024);
       be_map_insert_int(vm, "program", ESP_getSketchSize() / 1024);
       be_map_insert_int(vm, "program_free", ESP_getFreeSketchSpace() / 1024);
       be_map_insert_int(vm, "heap_free", ESP_getFreeHeap() / 1024);


### PR DESCRIPTION
## Description:

Restore on ESP32 information we used to have on ESP8266:
- flash chip id
- real flash size from flash chip id, which may be larger than the partition layout (often default to 4MB)

<img width="442" alt="Esp32_info" src="https://user-images.githubusercontent.com/49731213/167495765-5f8ad097-f13e-4ad1-86b3-76e6ca69d69a.png">

`Status 4` and Web Information page changed accordingly.

Berry:
- `tasmota.memory()` now returns the real flash size in `flash_real` field
- `flash.id()` returns the chip id
- `flash.size()` returns the real flash size in bytes

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
