### PR TITLE
Board allow no 'flash_size'

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -90,7 +90,7 @@ def esp32_create_combined_bin(source, target, env):
         esp32_copy_new_safeboot_bin(chip,firmware_name)
     else:
         esp32_fetch_safeboot_bin(chip)
-    flash_size = env.BoardConfig().get("upload.flash_size")
+    flash_size = env.BoardConfig().get("upload.flash_size", "4MB")
     cmd = [
         "--chip",
         chip,


### PR DESCRIPTION
## Description:

Allow boards JSON to not have a `flash_size` field, which means auto-detect at flash time.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
