### PR TITLE
Remove `ESP.getFlashChipSize()` replaced by `ESP_getFlashChipSize()`

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -45,7 +45,6 @@ extern void analogWritePhase(uint8_t pin, uint32_t duty, uint32_t phase = 0);
 #define ETS_UART_INTR_ENABLE()
 
 #define ESPhttpUpdate httpUpdate
-#define getFlashChipRealSize() getFlashChipSize()
 
 #define os_delay_us ets_delay_us
 // Serial minimal type to hold the config


### PR DESCRIPTION
## Description:

Cleaning leftover.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
