### PR TITLE
Add littlefs partition option

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -14,7 +14,9 @@
 # -  0x1000 | ~\.platformio\packages\framework-arduinoespressif32\tools\sdk\esp32\bin\bootloader_dout_40m.bin
 # -  0x8000 | ~\Tasmota\.pio\build\<env name>\partitions.bin
 # -  0xe000 | ~\.platformio\packages\framework-arduinoespressif32\tools\partitions\boot_app0.bin
-# - 0x10000 | ~\Tasmota\.pio\build\<env name>/firmware.bin
+# - 0x10000 | ~\.platformio/packages/framework-arduinoespressif32/variants/tasmota/\<env name>-safeboot.bin
+# - 0xe0000 | ~\Tasmota\.pio\build\<env name>/firmware.bin
+# - 0x3b0000| ~\Tasmota\.pio\build\<env name>/littlefs.bin
 
 Import("env")
 
@@ -28,12 +30,26 @@ from os.path import join
 import csv
 import requests
 import shutil
+import subprocess
 
 sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
 variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
+
+def esp32_build_filesystem(fs_size):
+    files = env.GetProjectOption("custom_files_upload").splitlines()
+    filesystem_dir = join(env.subst("$BUILD_DIR"),"littlefs_data")
+    if not os.path.exists(filesystem_dir):
+        os.makedirs(filesystem_dir)
+    print("Creating filesystem with content:")
+    for file in files:
+        shutil.copy(file, filesystem_dir)
+    env.Replace( MKSPIFFSTOOL=platform.get_package_dir("tool-mklittlefs") + '/mklittlefs' )
+    tool = env.subst(env["MKSPIFFSTOOL"])
+    cmd = (tool,"-c",filesystem_dir,"-s",fs_size,join(env.subst("$BUILD_DIR"),"littlefs.bin"))
+    returncode = subprocess.call(cmd, shell=False)
 
 def esp32_fetch_safeboot_bin(chip):
     safeboot_fw_url = "https://github.com/arendst/Tasmota-firmware/raw/main/firmware/tasmota32/tasmota" + ("32solo1" if "solo1" in env.subst("$BUILD_DIR") else chip[3:]) + "-safeboot.bin"
@@ -60,7 +76,7 @@ def esp32_create_combined_bin(source, target, env):
     # This is defined in the partition .csv file
     factory_offset = -1      # error code value
     app_offset = 0x10000     # default value for "old" scheme
-    spiffs_offset = -1       # error code value
+    fs_offset = -1       # error code value
     with open(env.BoardConfig().get("build.partitions")) as csv_file:
         print("Read partitions from ",env.BoardConfig().get("build.partitions"))
         csv_reader = csv.reader(csv_file, delimiter=',')
@@ -76,8 +92,9 @@ def esp32_create_combined_bin(source, target, env):
                     app_offset = int(row[3],base=16)
                 # elif(row[0] == 'factory'):
                 #     factory_offset = int(row[3],base=16)
-                # elif(row[0] == 'spiffs'):
-                #     spiffs_offset = int(row[3],base=16)
+                elif(row[0] == 'spiffs'):
+                    fs_offset = int(row[3],base=16)
+                    esp32_build_filesystem(row[4])
 
 
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
@@ -111,10 +128,32 @@ def esp32_create_combined_bin(source, target, env):
     if("safeboot" not in firmware_name):
         print(f" - {hex(app_offset)} | {firmware_name}")
         cmd += [hex(app_offset), firmware_name]
+
     else:
         print("Upload new safeboot binary only")
 
-    #print('Using esptool.py arguments: %s' % ' '.join(cmd))
+    if(fs_offset != -1):
+        fs_bin = join(env.subst("$BUILD_DIR"),"littlefs.bin")
+        if exists(fs_bin):
+            print(f" - {hex(fs_offset)}| {fs_bin}")
+            cmd += [hex(fs_offset), fs_bin]
+            env.Replace(        
+            UPLOADERFLAGS=[
+            "--chip", chip,
+            "--port", '"$UPLOAD_PORT"',
+            "--baud", "$UPLOAD_SPEED",
+            "--before", "default_reset",
+            "--after", "hard_reset",
+            "write_flash", "-z",
+            "--flash_mode", "${__get_board_flash_mode(__env__)}",
+            "--flash_freq", "${__get_board_f_flash(__env__)}",
+            "--flash_size", flash_size
+            ],
+            UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS ' + " ".join(cmd[7:])
+            )
+            print("Will use custom upload command for flashing operation to add file system defined for this build target.")
+
+    # print('Using esptool.py arguments: %s' % ' '.join(cmd))
 
     esptool.main(cmd)
 


### PR DESCRIPTION
to factory firmware builder script. With this enhancement it is possible to add files to the Tasmota filesystem when the device is flashed (with the builded factory firmware).  

Different files can be added per build env.

Setup example:

**Global setting**  added as last entry in `[env:tasmota32_base]`:
```
;Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)                                                             ArduinoOTA
custom_files_upload = tasmota/berry/modules/Partition_Manager.tapp
```
to include in all [env] in Tasmota filesystem the Berry Partition tapp

**Too add to a specific [env]**
Setting in [env] after the usual settings there. [env:tasmota32-mi32-homebridge] as example 
```
[env:tasmota32-mi32-homebridge]
custom_files_upload = ${env:tasmota32_base.custom_files_upload} 
                                       tasmota/berry/module/mi.be
```
Syntax: Only one file per line. Separated with a newline.

Thx @Staars for the idea and doing

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
