### PR TITLE
Esp32 upload file checked done against OTA partitionsize

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -36,6 +36,7 @@ default_envs            =
 ;                          tasmota32solo1
 ;                          tasmota32c3
 ;                          tasmota32s2
+;                          tasmota32s3
 ;                          tasmota32-odroidgo
 ;                          tasmota32-core2
 
@@ -90,8 +91,8 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 
 [env:tasmota32_base]
 ; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
-;platform                = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.3rc1/platform-espressif32-2.0.3new.zip
-;platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/825/framework-arduinoespressif32-v4.4_work-c4b83228a5.tar.gz
+;platform                = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-v.2.0.3.zip
+;platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/837/framework-arduinoespressif32-v4.4_dev-6fa4526c0d.tar.gz
 build_unflags           = ${esp32_defaults.build_unflags}
 build_flags             = ${esp32_defaults.build_flags}
 


### PR DESCRIPTION
## Description:

Change the file size check for ESP32 firmware file upload. Now the check is made on the file size of the firmware file, compared to the available size on the OTA target partition.

Since there is no reliable way to know the size of an uploaded file, I added `fsz` as URL (`u2?fsz=<size>`) argument to indicate the file size. If this argument is missing, it default to `0` which means that OTA update is tried anyways.

No change for ESP8266

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
