### PR TITLE
Include shutter tilt config in discovery message

### DIFF
--- a/tasmota/xdrv_12_discovery.ino
+++ b/tasmota/xdrv_12_discovery.ino
@@ -209,6 +209,18 @@ void TasDiscoverMessage(void) {
   }
 
   ResponseAppend_P(PSTR("],"                                   // Shutter Options (end)
+                        "\"sht\":["));                         // Shutter Tilt (start)
+  for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
+#ifdef USE_SHUTTER
+    ResponseAppend_P(PSTR("%s[%d,%d,%d]"), (i > 0 ? "," : ""),
+                          Settings->shutter_tilt_config[0][i],
+                          Settings->shutter_tilt_config[1][i],
+                          Settings->shutter_tilt_config[2][i]);
+#else
+    ResponseAppend_P(PSTR("%s[0,0,0]"), (i > 0 ? "," : ""));
+#endif  // USE_SHUTTER
+  }
+  ResponseAppend_P(PSTR("],"                                   // Shutter Tilt (end)
                         "\"ver\":1}"));                        // Discovery version
 }
 

--- a/tasmota/xdrv_12_home_assistant.ino
+++ b/tasmota/xdrv_12_home_assistant.ino
@@ -376,6 +376,18 @@ void HassDiscoverMessage(void) {
   }
 
   ResponseAppend_P(PSTR("],"                                   // Shutter Options (end)
+                        "\"sht\":["));                         // Shutter Tilt (start)
+  for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
+#ifdef USE_SHUTTER
+    ResponseAppend_P(PSTR("%s[%d,%d,%d]"), (i > 0 ? "," : ""),
+                          Settings->shutter_tilt_config[0][i],
+                          Settings->shutter_tilt_config[1][i],
+                          Settings->shutter_tilt_config[2][i]);
+#else
+    ResponseAppend_P(PSTR("%s[0,0,0]"), (i > 0 ? "," : ""));
+#endif  // USE_SHUTTER
+  }
+  ResponseAppend_P(PSTR("],"                                   // Shutter Tilt (end)
                         "\"ver\":1}"));                        // Discovery version
 }
 


### PR DESCRIPTION
## Description:
Include shutter tilt config in discovery message

**Related issue (if applicable):** https://github.com/home-assistant/core/issues/71452

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
