### PR TITLE
Zigbee disable autoresponder for broadcast messages from self

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -1489,8 +1489,10 @@ void ZCLFrame::parseReadAttributes(Z_attribute_list& attr_list) {
   attr_list.addAttributePMEM(PSTR("Read")).setStrRaw(attr_numbers.toString().c_str());
   attr_list.addAttributePMEM(PSTR("ReadNames")).setStrRaw(attr_names.toString(true).c_str());
 
-  // call auto-responder
-  autoResponder(read_attr_ids, len/2);
+  // call auto-responder only if src address if different from ourselves and it was a broadcast
+  if (_srcaddr != localShortAddr || !_wasbroadcast) {
+    autoResponder(read_attr_ids, len/2);
+  }
 }
 
 // ZCL_CONFIGURE_REPORTING_RESPONSE


### PR DESCRIPTION
## Description:

Disable Zigbee auto-responder if the request is a broadcast and was sent from ourselves. 

You can still request directly yourself (like 0x0000) through unicast.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
