### PR TITLE
Zigbee fix ambiguous 0xFFFE device

### DIFF
--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -201,8 +201,8 @@ void zigbeeZCLSendCmd(class ZCLMessage &zcl) {
     zcl.transacSet = true;
   }
 
-  AddLog(LOG_LEVEL_DEBUG, PSTR("ZigbeeZCLSend device: 0x%04X, group: 0x%04X, endpoint:%d, cluster:0x%04X, cmd:0x%02X, send:\"%_B\""),
-            zcl.shortaddr, zcl.groupaddr, zcl.endpoint, zcl.cluster, zcl.cmd, &zcl.buf);
+  AddLog(LOG_LEVEL_DEBUG, PSTR("ZigbeeZCLSend %s: 0x%04X, endpoint:%d, cluster:0x%04X, cmd:0x%02X, send:\"%_B\""),
+            zcl.validShortaddr() ? "device":"group", zcl.validShortaddr() ? zcl.shortaddr : zcl.groupaddr, zcl.endpoint, zcl.cluster, zcl.cmd, &zcl.buf);
 
   ZigbeeZCLSend_Raw(zcl);
 


### PR DESCRIPTION
## Description:

Fix logs to be more explicit whether the message sent is unicast or broadcast.

Before: (device = 0xFFFE would implicitly mean a broadcast since this address is invalid)
```
unicast:
ZigbeeZCLSend device: 0x1234, group: 0x0000, endpoint:255, cluster:0x0008, cmd:0x04, send:"0A0A00"

broadcats:
ZigbeeZCLSend device: 0xFFFE, group: 0x0065, endpoint:255, cluster:0x0008, cmd:0x04, send:"0A0A00"
```

After: (now explicit)
```
unicast:
ZigbeeZCLSend device: 0x1234, endpoint:255, cluster:0x0008, cmd:0x04, send:"0A0A00"

broadcats:
ZigbeeZCLSend group: 0x0065, endpoint:255, cluster:0x0008, cmd:0x04, send:"0A0A00"
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
