### PR TITLE
Use adjusted bri for LED's after timeout

### DIFF
--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -240,6 +240,7 @@ struct TasmotaGlobal_t {
   uint8_t discovery_counter;                // Delayed discovery counter
 #ifdef USE_PWM_DIMMER
   uint8_t restore_powered_off_led_counter;  // Seconds before powered-off LED (LEDLink) is restored
+  uint8_t pwm_dimmer_led_bri;               // Adjusted brightness LED level
 #endif  // USE_PWM_DIMMER
 
 #ifndef SUPPORT_IF_STATEMENT

--- a/tasmota/xdrv_04_light.ino
+++ b/tasmota/xdrv_04_light.ino
@@ -2168,7 +2168,10 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
 
 #ifdef USE_PWM_DIMMER
     // Animate brightness LEDs to follow PWM dimmer brightness
-    if (PWM_DIMMER == TasmotaGlobal.module_type) PWMDimmerSetBrightnessLeds(change10to8(max_col));
+    if (PWM_DIMMER == TasmotaGlobal.module_type) {
+      TasmotaGlobal.pwm_dimmer_led_bri = change10to8(max_col);
+      PWMDimmerSetBrightnessLeds(-1);
+    }
 #endif  // USE_PWM_DIMMER
   }
 //  char msg[24];

--- a/tasmota/xdrv_35_pwm_dimmer.ino
+++ b/tasmota/xdrv_35_pwm_dimmer.ino
@@ -152,7 +152,7 @@ void PWMModulePreInit(void)
 #endif  // USE_PWM_DIMMER_REMOTE
 }
 
-// bri: -1 = set to current light bri, -2 = timeout, 0-255 = set to bri
+// bri: -1 = set to last local light bri, -2 = timeout, 0-255 = set to bri
 void PWMDimmerSetBrightnessLeds(int32_t bri)
 {
   // Find out how many of the LEDs have their ledmask bit set.
@@ -169,7 +169,7 @@ void PWMDimmerSetBrightnessLeds(int32_t bri)
   if (leds) {
     led_timeout_seconds = 5;
     if (bri < 0) {
-      bri = ((bri == -2 && Settings->flag4.led_timeout) || !Light.power ? 0 : light_state.getBri());
+      bri = ((bri == -2 && Settings->flag4.led_timeout) || !Light.power ? 0 : TasmotaGlobal.pwm_dimmer_led_bri);
       if (!bri || !Settings->flag4.led_timeout) led_timeout_seconds = 0;
     }
 
@@ -438,13 +438,13 @@ void PWMDimmerHandleButton(uint32_t button_index, bool pressed)
           if (!active_remote_pwm_dimmer) {
 #endif // USE_PWM_DIMMER_REMOTE
 
-            // Toggle the powered-off LED option.
+            // Toggle the LED timeout.
             if (down_button_tapped) {
                 Settings->flag4.led_timeout ^= 1;
                 if (Light.power) PWMDimmerSetBrightnessLeds(Settings->flag4.led_timeout ? 0 : -1);
             }
 
-            // Toggle the LED timeout.
+            // Toggle the powered-off LED option.
             else {
                 Settings->flag4.powered_off_led ^= 1;
                 PWMDimmerSetPoweredOffLed();


### PR DESCRIPTION
## Description:

The PWM Dimmer module would show the unadjusted (non-LEDTable) brightness after the timeout. This PR fixes this by saving the last adjusted brightness level and restoring that level after a timeout.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
