### PR TITLE
Fix redirect to cam.mjpg

### DIFF
--- a/tasmota/xdrv_81_esp32_webcam.ino
+++ b/tasmota/xdrv_81_esp32_webcam.ino
@@ -911,7 +911,7 @@ void HandleWebcamMjpegTask(void) {
 
 void HandleWebcamRoot(void) {
   //CamServer->redirect("http://" + String(ip) + ":81/cam.mjpeg");
-  Wc.CamServer->sendHeader("Location", WiFi.localIP().toString() + ":81/cam.mjpeg");
+  Wc.CamServer->sendHeader("Location", "/cam.mjpeg");
   Wc.CamServer->send(302, "", "");
   AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: Root called"));
 }


### PR DESCRIPTION
## Description:

Currently HandleWebcamRoot tries to redirect to /cam.mjpeg by including the ip address in the Location header, but this is interpreted by the browser as part of the url path.

I.E calling http://192.168.0.5:81/ will respond with `Location: 192.168.0.5:81/cam.mjpeg` but since the schema is missing from the url this will be interpreted by the brower as http://192.168.0.5:81/192.168.0.5:81/cam.mjpeg.

This fix simply redirects using only the path and lets the browser handle the host part of the url.

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
