### PR TITLE
Zigbee fix regression

### DIFF
--- a/tasmota/xdrv_23_zigbee_5_converters.ino
+++ b/tasmota/xdrv_23_zigbee_5_converters.ino
@@ -849,7 +849,7 @@ public:
   uint8_t                 transactseq = 0;    // transaction sequence number
   uint8_t                 cmd = 0;
   SBuffer                 payload;
-  uint16_t                cluster = 0;
+  uint16_t                cluster = 0xFFFF;   // invalid cluster by default
   uint16_t                groupaddr = 0;
   // information from decoded ZCL frame
   uint16_t                shortaddr = BAD_SHORTADDR;   // BAD_SHORTADDR is broadcast, so considered invalid


### PR DESCRIPTION
## Description:

Zigbee fix regression introduced by #15642 preventing auto-inference of cluster when using a command like `ZbSend {"Device":"0x27E5","Send":{"ShutterClose":""}}`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
