### PR TITLE
Partition_core suppport unknown types

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -1,5 +1,6 @@
 extern const bcstring be_const_str_;
 extern const bcstring be_const_str_00;
+extern const bcstring be_const_str_0x_X2502X;
 extern const bcstring be_const_str_AA50;
 extern const bcstring be_const_str_AES_GCM;
 extern const bcstring be_const_str_ALIGN_BOTTOM_MID;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -50,6 +50,7 @@ be_define_const_str(_X2Fac, "/ac", 3904651978u, 0, 3, &be_const_str_pow);
 be_define_const_str(_X2Flights_X2F, "/lights/", 2370247908u, 0, 8, &be_const_str_AudioGeneratorMP3);
 be_define_const_str(_X2Fstate_X2F, "/state/", 4226179876u, 0, 7, &be_const_str_keys);
 be_define_const_str(00, "00", 569209421u, 0, 2, &be_const_str_find_op);
+be_define_const_str(0x_X2502X, "0x%02X", 2626549866u, 0, 6, &be_const_str_settings);
 be_define_const_str(_X3A, ":", 1057798253u, 0, 1, &be_const_str_compile);
 be_define_const_str(_X3C, "<", 957132539u, 0, 1, &be_const_str_instance_X20required);
 be_define_const_str(_X3C_X2Fform_X3E_X3C_X2Fp_X3E, "</form></p>", 3546571739u, 0, 11, NULL);
@@ -1459,7 +1460,7 @@ static const bstring* const m_string_table[] = {
     (const bstring *)&be_const_str_TASMOTA,
     (const bstring *)&be_const_str__X2F,
     (const bstring *)&be_const_str_lower,
-    (const bstring *)&be_const_str_settings,
+    (const bstring *)&be_const_str_0x_X2502X,
     NULL,
     (const bstring *)&be_const_str__X2E,
     (const bstring *)&be_const_str_SERIAL_6N2,
@@ -1542,6 +1543,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 505,
-    .count = 1033,
+    .count = 1034,
     .table = m_string_table
 };

--- a/lib/libesp32/berry_tasmota/src/be_partition_core_module.c
+++ b/lib/libesp32/berry_tasmota/src/be_partition_core_module.c
@@ -1311,7 +1311,7 @@ be_local_closure(Partition_info_is_factory,   /* name */
 ********************************************************************/
 be_local_closure(Partition_info_type_to_string,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1319,16 +1319,19 @@ be_local_closure(Partition_info_type_to_string,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
+    ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str(type),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str(app),
     /* K3   */  be_const_int(1),
     /* K4   */  be_nested_str(data),
+    /* K5   */  be_nested_str(string),
+    /* K6   */  be_nested_str(format),
+    /* K7   */  be_nested_str(0x_X2502X),
     }),
     &be_const_str_type_to_string,
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
+    ( &(const binstruction[15]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x1C040301,  //  0001  EQ	R1	R1	K1
       0x78060001,  //  0002  JMPF	R1	#0005
@@ -1338,7 +1341,12 @@ be_local_closure(Partition_info_type_to_string,   /* name */
       0x1C040303,  //  0006  EQ	R1	R1	K3
       0x78060000,  //  0007  JMPF	R1	#0009
       0x80060800,  //  0008  RET	1	K4
-      0x80000000,  //  0009  RET	0
+      0xA4060A00,  //  0009  IMPORT	R1	K5
+      0x8C080306,  //  000A  GETMET	R2	R1	K6
+      0x58100007,  //  000B  LDCONST	R4	K7
+      0x88140100,  //  000C  GETMBR	R5	R0	K0
+      0x7C080600,  //  000D  CALL	R2	3
+      0x80040400,  //  000E  RET	1	R2
     })
   )
 );
@@ -1453,7 +1461,7 @@ be_local_closure(Partition_info_init,   /* name */
 ********************************************************************/
 be_local_closure(Partition_info_subtype_to_string,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1461,7 +1469,7 @@ be_local_closure(Partition_info_subtype_to_string,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
+    ( &(const bvalue[21]) {     /* constants */
     /* K0   */  be_nested_str(type),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str(subtype),
@@ -1480,10 +1488,13 @@ be_local_closure(Partition_info_subtype_to_string,   /* name */
     /* K15  */  be_nested_str(esphttpd),
     /* K16  */  be_nested_str(fat),
     /* K17  */  be_nested_str(spiffs),
+    /* K18  */  be_nested_str(string),
+    /* K19  */  be_nested_str(format),
+    /* K20  */  be_nested_str(0x_X2502X),
     }),
     &be_const_str_subtype_to_string,
     &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
+    ( &(const binstruction[88]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x1C040301,  //  0001  EQ	R1	R1	K1
       0x7806001A,  //  0002  JMPF	R1	#001E
@@ -1566,7 +1577,12 @@ be_local_closure(Partition_info_subtype_to_string,   /* name */
       0x1C040202,  //  004F  EQ	R1	R1	R2
       0x78060000,  //  0050  JMPF	R1	#0052
       0x80062200,  //  0051  RET	1	K17
-      0x80000000,  //  0052  RET	0
+      0xA4062400,  //  0052  IMPORT	R1	K18
+      0x8C080313,  //  0053  GETMET	R2	R1	K19
+      0x58100014,  //  0054  LDCONST	R4	K20
+      0x88140102,  //  0055  GETMBR	R5	R0	K2
+      0x7C080600,  //  0056  CALL	R2	3
+      0x80040400,  //  0057  RET	1	R2
     })
   )
 );

--- a/lib/libesp32/berry_tasmota/src/embedded/partition_core.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/partition_core.be
@@ -146,6 +146,8 @@ class Partition_info
     if   self.type == 0 return "app"
     elif self.type == 1  return "data"
     end
+    import string
+    return string.format("0x%02X", self.type)
   end
 
   def subtype_to_string()
@@ -166,6 +168,8 @@ class Partition_info
       elif self.subtype == 0x82  return "spiffs"
       end
     end
+    import string
+    return string.format("0x%02X", self.subtype)
   end
 
   # Human readable version of Partition information


### PR DESCRIPTION
## Description:

Berry partition_core, avoid crashing when type or subtype of the partition is unknwon.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
