### PR TITLE
Berry improve precompiled gen.sh

### DIFF
--- a/lib/libesp32/berry/gen.sh
+++ b/lib/libesp32/berry/gen.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+#
+# generate all precompiled Berry structures from multiple modules
+#
+# Should be eventually included in the build process
+#
+rm generate/be_*.h
 python3 tools/pycoc/main.py -o generate src default ../berry_tasmota/src ../berry_mapping/src ../berry_int64/src ../../libesp32_lvgl/lv_binding_berry/src ../../libesp32_lvgl/lv_binding_berry/generate -c default/berry_conf.h


### PR DESCRIPTION
## Description:

`gen.sh` is used to generate pre-compiled classes and modules of Berry. This new version removes unused files, and could be eventually included in the build system.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
