### PR TITLE
Simplified SBuffer

### DIFF
--- a/lib/default/Ext-printf/src/SBuffer.hpp
+++ b/lib/default/Ext-printf/src/SBuffer.hpp
@@ -48,7 +48,7 @@ public:
   inline uint8_t *buf(size_t i = 0) const { return &_buf->buf[i]; }
   inline char    *charptr(size_t i = 0) const { return (char*) &_buf->buf[i]; }
 
-  virtual ~SBuffer(void) {
+  ~SBuffer(void) {
     delete[] _buf;
   }
 
@@ -258,6 +258,12 @@ public:
     return buf2;
   }
 
+  static SBuffer SBufferFromBytes(const uint8_t *bytes, size_t len2) {
+    SBuffer buf2(len2);
+    buf2.addBuffer(bytes, len2);
+    return buf2;
+  }
+
   // nullptr accepted
   static bool equalsSBuffer(const class SBuffer * buf1, const class SBuffer * buf2) {
     if (buf1 == buf2) { return true; }
@@ -290,18 +296,3 @@ protected:
   SBuffer_impl * _buf;
 
 } SBuffer;
-
-typedef class PreAllocatedSBuffer : public SBuffer {
-
-public:
-  PreAllocatedSBuffer(const size_t size, void * buffer) {
-    _buf = (SBuffer_impl*) buffer;
-    _buf->size = size - 4;
-    _buf->len = 0;
-  }
-
-  ~PreAllocatedSBuffer(void) {
-    // don't deallocate
-    _buf = nullptr;
-  }
-} PreAllocatedSBuffer;

--- a/tasmota/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/xdrv_23_zigbee_9_serial.ino
@@ -300,11 +300,8 @@ void ZigbeeInitSerial(void)
     ZigbeeSerial->begin(115200);
     if (ZigbeeSerial->hardwareSerial()) {
       ClaimSerial();
-      uint32_t aligned_buffer = ((uint32_t)TasmotaGlobal.serial_in_buffer + 3) & ~3;
-			zigbee_buffer = new PreAllocatedSBuffer(sizeof(TasmotaGlobal.serial_in_buffer) - 3, (char*) aligned_buffer);
-		} else {
-			zigbee_buffer = new SBuffer(ZIGBEE_BUFFER_SIZE);
 		}
+    zigbee_buffer = new SBuffer(ZIGBEE_BUFFER_SIZE);
 
     zigbee.active = true;
 		zigbee.init_phase = true;			// start the state machine


### PR DESCRIPTION
## Description:

Simplified `SBuffer` to remove all `virtual` methods and make it fit in 32 bits.

Zigbee adapted to always use a serial dynamic buffer (uses 256 more bytes on ESP8266)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
