### PR TITLE
fix VSC intelisense warning

### DIFF
--- a/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-0.1.0/package.json
+++ b/lib/libesp32/berry/tools/plugins/vscode/skiars.berry-0.1.0/package.json
@@ -3,7 +3,6 @@
     "displayName": "Berry Script Language",
     "description": "A small embedded script language.",
     "version": "0.1.0",
-    "icon": "berry-icon.png",
     "publisher": "skiars",
     "engines": {
         "vscode": "^1.15.1"


### PR DESCRIPTION
by removing the not needed icon in the json.

NO code impact. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
