### PR TITLE
Berry add crc.sum()

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -919,6 +919,7 @@ extern const bcstring be_const_str_subscribe;
 extern const bcstring be_const_str_subtype;
 extern const bcstring be_const_str_subtype_to_string;
 extern const bcstring be_const_str_success;
+extern const bcstring be_const_str_sum;
 extern const bcstring be_const_str_super;
 extern const bcstring be_const_str_switch_factory;
 extern const bcstring be_const_str_sys;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -889,7 +889,7 @@ be_define_const_str(skip, "skip", 1097563074u, 0, 4, NULL);
 be_define_const_str(slots, "slots", 1023330342u, 0, 5, NULL);
 be_define_const_str(solidified, "solidified", 3257553487u, 0, 10, NULL);
 be_define_const_str(spiffs, "spiffs", 994943858u, 0, 6, &be_const_str_str);
-be_define_const_str(splash, "splash", 2531464038u, 0, 6, &be_const_str_wifi_arcs);
+be_define_const_str(splash, "splash", 2531464038u, 0, 6, &be_const_str_sum);
 be_define_const_str(splash_init, "splash_init", 1522992293u, 0, 11, &be_const_str_split);
 be_define_const_str(splash_remove, "splash_remove", 3132020807u, 0, 13, NULL);
 be_define_const_str(split, "split", 2276994531u, 0, 5, NULL);
@@ -911,6 +911,7 @@ be_define_const_str(subscribe, "subscribe", 2946386435u, 0, 9, NULL);
 be_define_const_str(subtype, "subtype", 2023873341u, 0, 7, &be_const_str_toint);
 be_define_const_str(subtype_to_string, "subtype_to_string", 2996733901u, 0, 17, &be_const_str_type_to_string);
 be_define_const_str(success, "success", 979353360u, 0, 7, &be_const_str_widget_struct_by_class);
+be_define_const_str(sum, "sum", 3712891560u, 0, 3, &be_const_str_wifi_arcs);
 be_define_const_str(super, "super", 4152230356u, 0, 5, NULL);
 be_define_const_str(switch_factory, "switch_factory", 4206217516u, 0, 14, NULL);
 be_define_const_str(sys, "sys", 3277365014u, 0, 3, NULL);
@@ -1545,6 +1546,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 506,
-    .count = 1035,
+    .count = 1036,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_crc.h
+++ b/lib/libesp32/berry/generate/be_fixed_crc.h
@@ -2,13 +2,14 @@
 
 static be_define_const_map_slots(m_libcrc_map) {
     { be_const_key(crc32, 1), be_const_ctype_func(c_crc32) },
-    { be_const_key(crc8, 2), be_const_ctype_func(c_crc8) },
+    { be_const_key(sum, -1), be_const_ctype_func(c_sum) },
     { be_const_key(crc16, -1), be_const_ctype_func(c_crc16) },
+    { be_const_key(crc8, -1), be_const_ctype_func(c_crc8) },
 };
 
 static be_define_const_map(
     m_libcrc_map,
-    3
+    4
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry_tasmota/src/be_crc32_module.c
+++ b/lib/libesp32/berry_tasmota/src/be_crc32_module.c
@@ -10,20 +10,29 @@
 
 #include "rom/crc.h"
 
-uint32_t c_crc32(uint32_t crc, const uint8_t* buf, size_t size) {
+static uint32_t c_crc32(uint32_t crc, const uint8_t* buf, size_t size) {
   return crc32_le(crc, buf, size);
 }
 BE_FUNC_CTYPE_DECLARE(c_crc32, "i", "i(bytes)~")
 
-uint32_t c_crc16(uint32_t crc, const uint8_t* buf, size_t size) {
+static uint32_t c_crc16(uint32_t crc, const uint8_t* buf, size_t size) {
   return crc16_le(crc, buf, size);
 }
 BE_FUNC_CTYPE_DECLARE(c_crc16, "i", "i(bytes)~")
 
-uint32_t c_crc8(uint32_t crc, const uint8_t* buf, size_t size) {
+static uint32_t c_crc8(uint32_t crc, const uint8_t* buf, size_t size) {
   return crc8_le(crc, buf, size);
 }
 BE_FUNC_CTYPE_DECLARE(c_crc8, "i", "i(bytes)~")
+
+static uint32_t c_sum(const uint8_t* buf, size_t size) {
+  uint32_t sum = 0;
+  for (uint32_t i = 0; i < size; i++) {
+    sum = (sum + buf[i]) & 0xFF;
+  }
+  return sum;
+}
+BE_FUNC_CTYPE_DECLARE(c_sum, "i", "(bytes)~")
 
 // const uint32_t crc32_tab[] = {
 //   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
@@ -83,6 +92,7 @@ module crc (scope: global) {
   crc32, ctype_func(c_crc32)
   crc16, ctype_func(c_crc16)
   crc8, ctype_func(c_crc8)
+  sum, ctype_func(c_sum)
 }
 @const_object_info_end */
 #include "be_fixed_crc.h"


### PR DESCRIPTION
## Description:

Berry add `crc.sum(data:bytes) -> int` to compute a simple sum of all the bytes in the buffer and return a single byte. This operation is often used as a simplistic checksum in some protocols.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
