### PR TITLE
Zigbee display version of MCU software in UI

### DIFF
--- a/tasmota/xdrv_23_zigbee_1_headers.ino
+++ b/tasmota/xdrv_23_zigbee_1_headers.ino
@@ -97,6 +97,12 @@ public:
   ZB_RecvMsgFunc recv_func = nullptr;          // function to call when message is expected
   ZB_RecvMsgFunc recv_unexpected = nullptr;    // function called when unexpected message is received
 
+  // version
+  uint8_t major_rel = 0;
+  uint8_t minor_rel = 0;
+  uint8_t maint_rel = 0;
+  uint32_t revision = 0;
+  
   // Energy scan
   int8_t energy[USE_ZIGBEE_CHANNEL_COUNT];
 

--- a/tasmota/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/xdrv_23_zigbee_8_parsers.ino
@@ -447,20 +447,21 @@ int32_t ZNP_ReceiveCheckVersion(int32_t res, SBuffer &buf) {
   // MinorRel = 6
   // MaintRel = 3
   // Revision = 20190425 d (0x013414D9)
-  uint8_t major_rel = buf.get8(4);
-  uint8_t minor_rel = buf.get8(5);
-  uint8_t maint_rel = buf.get8(6);
-  uint32_t revision = buf.get32(7);
+  zigbee.major_rel = buf.get8(4);
+  zigbee.minor_rel = buf.get8(5);
+  zigbee.maint_rel = buf.get8(6);
+  zigbee.revision = buf.get32(7);
 
   Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
                   "\"Status\":%d,\"MajorRel\":%d,\"MinorRel\":%d"
                   ",\"MaintRel\":%d,\"Revision\":%d}}"),
-                  ZIGBEE_STATUS_CC_VERSION, major_rel, minor_rel,
-                  maint_rel, revision);
+                  ZIGBEE_STATUS_CC_VERSION,
+                  zigbee.major_rel, zigbee.minor_rel,
+                  zigbee.maint_rel, zigbee.revision);
 
   MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_ZIGBEE_STATE));
 
-  if ((0x02 == major_rel) && ((0x06 == minor_rel) || (0x07 == minor_rel))) {
+  if ((0x02 == zigbee.major_rel) && ((0x06 == zigbee.minor_rel) || (0x07 == zigbee.minor_rel))) {
   	return 0;	  // version 2.6.x and 2.7.x are ok
   } else {
     return ZIGBEE_LABEL_UNSUPPORTED_VERSION;  // abort
@@ -474,14 +475,17 @@ int32_t EZ_ReceiveCheckVersion(int32_t res, SBuffer &buf) {
   uint8_t stack_type = buf.get8(3);
   zigbee.ezsp_version = buf.get16(4);
 
+  zigbee.major_rel = (zigbee.ezsp_version & 0xF000) >> 12;
+  zigbee.minor_rel = (zigbee.ezsp_version & 0x0F00) >> 8;
+  zigbee.maint_rel = (zigbee.ezsp_version & 0x00F0) >> 4;
+  zigbee.revision = zigbee.ezsp_version & 0x000F;
+
   Response_P(PSTR("{\"" D_JSON_ZIGBEE_STATE "\":{"
                   "\"Status\":%d,\"Version\":\"%d.%d.%d.%d\",\"Protocol\":%d"
                   ",\"Stack\":%d}}"),
                   ZIGBEE_STATUS_EZ_VERSION,
-                  (zigbee.ezsp_version & 0xF000) >> 12,
-                  (zigbee.ezsp_version & 0x0F00) >> 8,
-                  (zigbee.ezsp_version & 0x00F0) >> 4,
-                  zigbee.ezsp_version & 0x000F,
+                  zigbee.major_rel, zigbee.minor_rel,
+                  zigbee.maint_rel, zigbee.revision,
                   protocol_version,
                   stack_type
                   );

--- a/tasmota/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/xdrv_23_zigbee_A_impl.ino
@@ -1931,6 +1931,19 @@ uint32_t convert_seconds_to_dhm(uint32_t seconds,  char *unit, uint8_t *color){
   return 0;
 }
 
+const char HTTP_ZB_VERSION[] PROGMEM =
+  "<div style='text-align:right;font-size:11px;color:#aaa;'>"
+  "Zigbee: "
+#if defined(USE_ZIGBEE_EZSP)
+  "EZSP"
+#elif defined(USE_ZIGBEE_ZNP)
+  "ZNP"
+#else
+  "unknown"
+#endif
+  " v%d.%d.%d.%d"
+  "</div>";
+
 const char HTTP_BTN_ZB_BUTTONS[] PROGMEM =
   "<button onclick='la(\"&zbj=1\");'>" D_ZIGBEE_PERMITJOIN "</button>"
   "<p></p>"
@@ -2113,6 +2126,12 @@ void ZigbeeShow(bool json)
       // PermitJoin in progress
 
       WSContentSend_P(msg[ZB_WEB_PERMITJOIN_ACTIVE], PSTR(D_ZIGBEE_PERMITJOIN_ACTIVE));
+    }
+    // show Zigbee MCU version
+    if (!zigbee.init_phase) {
+      WSContentSend_P(HTTP_ZB_VERSION,
+                      zigbee.major_rel, zigbee.minor_rel,
+                      zigbee.maint_rel, zigbee.revision);
     }
 #endif
   }


### PR DESCRIPTION
## Description:

Showing the zigbee MCU version in the UI. This will be useful with new devices like Sonoff Zigbee Bridge Pro.

![Zigbee_version](https://user-images.githubusercontent.com/49731213/170324481-3e511663-6506-4689-ac52-525650fb48e2.png)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
