### PR TITLE
https:// as file source for Littlefs partition build

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -54,6 +54,14 @@ def esp32_build_filesystem(fs_size):
     for file in files:
         if "no_files" in file:
             continue
+        if "http" and "://" in file:
+            response = requests.get(file)
+            if response.ok:
+                target = join(filesystem_dir,file.split(os.path.sep)[-1])
+                open(target, "wb").write(response.content)
+            else:
+                print("Failed to download: ",file)
+            continue
         shutil.copy(file, filesystem_dir)
     if not os.listdir(filesystem_dir):
         print("No files added -> will NOT create littlefs.bin and NOT overwrite fs partition!")

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -19,6 +19,7 @@ build_flags                 = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASM
 ; example for custom file upload in Tasmota Filesystem
 ; custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
 ;                               tasmota/berry/modules/Partition_wizard.tapp
+;                               https://github.com/tasmota/autoconf/raw/main/esp32s3/DevKitC-1.autoconf
 
 ; *** Debug version used for PlatformIO Home Project Inspection
 [env:tasmota-debug]


### PR DESCRIPTION
as additional source to local ones.

Done by @Staars  Thx!
fyi @s-hadinger 

Example:
```
[env:tasmota32-zbbrdgpro]
extends                   = env:tasmota32_base
platform_packages         = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/v2.0.3/framework-arduinoespressif32-itead.tar.gz
board                     = esp32_4M_FS
build_flags               = ${env:tasmota32_base.build_flags}
                            -DFIRMWARE_TASMOTA32
                            -DUSE_ZIGBEE
                            -DUSE_TCP_BRIDGE
custom_files_upload       = ${env:tasmota32_base.custom_files_upload}
                             https://github.com/arendst/Tasmota/raw/development/tools/fw_SonoffZigbeeBridgePro_cc2652/Sonoff_ZBPro.autoconf
                             tasmota/berry/zigbee/cc2652_flasher.be
                             tasmota/berry/zigbee/intelhex.be
                             tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
                             tools/fw_SonoffZigbeeBridgePro_cc2652/SonoffZBPro_coord_20220219.hex
```
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
