### PR TITLE
MI32: fix scan mode switching, return option values

### DIFF
--- a/tasmota/xsns_62_esp32_mi.h
+++ b/tasmota/xsns_62_esp32_mi.h
@@ -169,6 +169,8 @@ struct {
       uint32_t autoScan:1;
       uint32_t canScan:1;
       uint32_t runningScan:1;
+      uint32_t updateScan:1;
+      uint32_t deleteScanTask:1;
 
       uint32_t canConnect:1;
       uint32_t willConnect:1;
@@ -387,7 +389,7 @@ const char * kMI32DeviceType[] PROGMEM = {kMI32DeviceType1,kMI32DeviceType2,kMI3
 
 const char kMI32_ConnErrorMsg[] PROGMEM = "no Error|could not connect|did disconnect|got no service|got no characteristic|can not read|can not notify|can not write|did not write|notify time out";
 
-const char kMI32_BLEInfoMsg[] PROGMEM = "Scan ended|Got Notification|Did connect|Did disconnect|Still connected|Start scanning";
+const char kMI32_BLEInfoMsg[] PROGMEM = "Scan ended|Got Notification|Did connect|Did disconnect|Still connected|Start passive scanning|Start active scanning";
 
 const char kMI32_HKInfoMsg[] PROGMEM = "HAP core started|HAP core did not start!!|HAP controller disconnected|HAP controller connected|HAP outlet added";
 
@@ -426,7 +428,8 @@ enum MI32_BLEInfoMsg {
   MI32_DID_CONNECT,
   MI32_DID_DISCONNECT,
   MI32_STILL_CONNECTED,
-  MI32_START_SCANNING
+  MI32_START_SCANNING_PASSIVE,
+  MI32_START_SCANNING_ACTIVE
 };
 
 enum MI32_HKInfoMsg {


### PR DESCRIPTION
## Description:

Switching between passive and active scanning works now.
MI32option commands return the value, usable i.e. in Berry.
Using the "duplicate filter" of the NimBLE driver by default now, but this will require more real tests to really judge its value. The hard coded filter size (of 40) will not be perfect for every situation, but should be fine for all Xiaomi sensors, as new sensor data should always pass this filter.

The main intention for this small update was to be able to write a generic BLE scanner completely in Berry, which I will post in the comments.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
