### PR TITLE
Support for iBeacon scanning for the ESP32-C3

### DIFF
--- a/tasmota/xsns_52_esp32_ibeacon_ble.ino
+++ b/tasmota/xsns_52_esp32_ibeacon_ble.ino
@@ -52,7 +52,7 @@
 
 // for testing of BLE_ESP32, we remove xsns_52_ibeacon.ino completely, and instead add this modified xsns_52_ibeacon_BLE_ESP32.ino
 // in the future this may be more fine-grained, e.g. to allow hm17 for this, and BLE-ESP32 for other
-#if CONFIG_IDF_TARGET_ESP32
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32C3
 #ifdef USE_BLE_ESP32
 
 #define XSNS_52                       52


### PR DESCRIPTION
## Description:

Adds the ESP32C3 to the ESP32 check when checking to compile iBeacon support

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
