### PR TITLE
Berry LVGL fix memory leak in log reader

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_tasmota_log_reader_class.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_log_reader_class.cpp
@@ -6,7 +6,7 @@
 #include "be_mapping.h"
 
 extern uint32_t* tlr_init(void);                            BE_FUNC_CTYPE_DECLARE(tlr_init, "+_p", "")
-extern char* tlr_get_log(uint32_t* idx, int32_t log_level); BE_FUNC_CTYPE_DECLARE(tlr_get_log, "s", ".i")
+extern char* tlr_get_log(uint32_t* idx, int32_t log_level); BE_FUNC_CTYPE_DECLARE(tlr_get_log, "$", ".i")
 
 #include "be_fixed_be_class_tasmota_log_reader.h"
 


### PR DESCRIPTION
## Description:

Fix Berry class `tasmota_log_reader()` memory leak. Return type should be `$` instead of `s` indicating that the string object must be "freed()" by the caller.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
