### PR TITLE
MI32 (legacy): fix building without HomeKit

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -65,6 +65,9 @@
 
 #include "include/xsns_62_esp32_mi.h"
 
+#if USE_MI_HOMEKIT==0
+  #undef USE_MI_HOMEKIT
+#endif
 #ifdef USE_MI_HOMEKIT
 extern "C" void mi_homekit_main(void);
 extern "C" void mi_homekit_update_value(void* handle, float value, uint32_t type);
@@ -1154,8 +1157,8 @@ bool MI32StartConnectionTask(){
 
 void MI32ConnectionTask(void *pvParameters){
 #if !defined(CONFIG_IDF_TARGET_ESP32C3) //needs more testing ...
-    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM,false); //seems to be important for i.e. xbox controller, hopefully not breaking other things
-    NimBLEDevice::setSecurityAuth(true, true, true);
+    // NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM,false); //seems to be important for i.e. xbox controller, hopefully not breaking other things
+    // NimBLEDevice::setSecurityAuth(true, true, true);
 #endif //CONFIG_IDF_TARGET_ESP32C3
     MI32.conCtx->error = MI32_CONN_NO_ERROR;
     if (MI32ConnectActiveSensor()){


### PR DESCRIPTION
## Description:

1. Fix the build without HomeKit `-DUSE_MI_HOMEKIT=0`. 
2. Reverting settings for address type and securityAuth of the device to default, as it introduced glitches on the S3 and was not necessary for any use case so far.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
