### PR TITLE
Add build env for ZigbeeBridge Pro / NsPanel from Sonoff

### DIFF
--- a/.github/workflows/Tasmota_build_devel.yml
+++ b/.github/workflows/Tasmota_build_devel.yml
@@ -32,8 +32,10 @@ jobs:
           - tasmota-zbbridge
           - tasmota-zigbee
           - tasmota32
+          - tasmota32-zbbrdgpro
           - tasmota32-webcam
           - tasmota32-bluetooth
+          - tasmota32-nspanel
           - tasmota32-display
           - tasmota32-ir
           - tasmota32-lvgl
@@ -125,6 +127,8 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota32-lvgl.* ] || mv ./mv_firmware/firmware/tasmota32-lvgl.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-zbbrdgpro.* ] || mv ./mv_firmware/firmware/tasmota32-zbbrdgpro.* ./firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-nspanel.* ] || mv ./mv_firmware/firmware/tasmota32-nspanel.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32c3*.* ] || mv ./mv_firmware/firmware/tasmota32c3*.* ./firmware/tasmota32/

--- a/.github/workflows/Tasmota_build_master.yml
+++ b/.github/workflows/Tasmota_build_master.yml
@@ -31,8 +31,10 @@ jobs:
           - tasmota-zbbridge
           - tasmota-zigbee
           - tasmota32
+          - tasmota32-zbbrdgpro
           - tasmota32-webcam
           - tasmota32-bluetooth
+          - tasmota32-nspanel
           - tasmota32-display
           - tasmota32-ir
           - tasmota32-lvgl
@@ -132,6 +134,8 @@ jobs:
         [ ! -f ./mv_firmware/firmware/tasmota32-display.* ] || mv ./mv_firmware/firmware/tasmota32-display.* ./release-firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-lvgl.* ] || mv ./mv_firmware/firmware/tasmota32-lvgl.* ./release-firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-web*.* ] || mv ./mv_firmware/firmware/tasmota32-web*.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-zbbrdgpro.* ] || mv ./mv_firmware/firmware/tasmota32-zbbrdgpro.* ./release-firmware/tasmota32/
+        [ ! -f ./mv_firmware/firmware/tasmota32-nspanel.* ] || mv ./mv_firmware/firmware/tasmota32-nspanel.* ./release-firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-odroidgo.* ] || mv ./mv_firmware/firmware/tasmota32-odroidgo.* ./release-firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-core2.* ] || mv ./mv_firmware/firmware/tasmota32-core2.* ./release-firmware/tasmota32/
         [ ! -f ./mv_firmware/firmware/tasmota32-bluetooth.* ] || mv ./mv_firmware/firmware/tasmota32-bluetooth.* ./release-firmware/tasmota32/

--- a/.github/workflows/build_all_the_things.yml
+++ b/.github/workflows/build_all_the_things.yml
@@ -32,11 +32,13 @@ jobs:
           - tasmota-minimal
           - tasmota-sensors
           - tasmota-zbbridge
+          - tasmota32-zbbrdgpro
           - tasmota-zigbee
           - tasmota32
           - tasmota32-webcam
           - tasmota32-bluetooth
           - tasmota32-core2
+          - tasmota32-nspanel
           - tasmota32-display
           - tasmota32-ir
           - tasmota32-lvgl

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -27,6 +27,7 @@ default_envs            =
 ;                          tasmota-zbbridge
 ;                          tasmota-ir
 ;                          tasmota32
+;                          tasmota32-zbbrdgpro
 ;                          tasmota32-bluetooth
 ;                          tasmota32-webcam
 ;                          tasmota32-knx
@@ -41,6 +42,7 @@ default_envs            =
 ;                          tasmota32s3usb
 ;                          tasmota32-odroidgo
 ;                          tasmota32-core2
+;                          tasmota32-nspanel
 
 
 [env]
@@ -48,7 +50,7 @@ default_envs            =
 ;platform                = https://github.com/platformio/platform-espressif8266.git
 ;platform_packages       = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
 ;                          mcspr/toolchain-xtensa @ ~5.100300.211127
-;                          platformio/tool-esptoolpy @ ~1.30100
+;                          platformio/tool-esptoolpy @ ~1.30300
 ;build_unflags           = ${common.build_unflags}
 ;                          -Wswitch-unreachable
 ;build_flags             = ${common.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -49,3 +49,9 @@ platform                    = https://github.com/tasmota/platform-espressif32/re
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
+
+[core32itead]
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/v2.0.3/framework-arduinoespressif32-itead.tar.gz
+build_unflags               = ${esp32_defaults.build_unflags}
+build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -101,6 +101,13 @@ extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags} -DUSE_IR_REMOTE_FULL -DFIRMWARE_IR
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_ssl
 
+[env:tasmota32solo1]
+extends                 = env:tasmota32_base
+board                   = esp32_solo1_4M
+platform                = ${core32solo1.platform}
+platform_packages       = ${core32solo1.platform_packages}
+build_flags             = ${core32solo1.build_flags} -DFIRMWARE_TASMOTA32
+
 [env:tasmota32solo1-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1_4M
@@ -114,12 +121,27 @@ lib_ignore              =
                           Micro-RTSP
                           epdiy
 
-[env:tasmota32solo1]
+[env:tasmota32-zbbrdgpro]
 extends                 = env:tasmota32_base
-board                   = esp32_solo1_4M
-platform                = ${core32solo1.platform}
-platform_packages       = ${core32solo1.platform_packages}
-build_flags             = ${core32solo1.build_flags} -DFIRMWARE_TASMOTA32
+board                   = esp32_4M_FS
+platform                = ${core32itead.platform}
+platform_packages       = ${core32itead.platform_packages}
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_ZBBRDGPRO
+custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
+                          tools/fw_SonoffZigbeeBridgePro_cc2652/Sonoff_ZBPro.autoconf
+                          tasmota/berry/zigbee/cc2652_flasher.be
+                          tasmota/berry/zigbee/intelhex.be
+                          tasmota/berry/zigbee/sonoff_zb_pro_flasher.be
+                          tools/fw_SonoffZigbeeBridgePro_cc2652/SonoffZBPro_coord_20220219.hex
+lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
+
+[env:tasmota32-nspanel]
+extends                 = env:tasmota32_base
+platform                = ${core32itead.platform}
+platform_packages       = ${core32itead.platform_packages}
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_NSPANEL
 
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -438,6 +438,72 @@
 
 #endif  // FIRMWARE_TASMOTA_LVGL *******************************************************************
 
+/*********************************************************************************************\
+ * [tasmota32-zbbrdgpro]
+ * Provide an image for Sonoff Zigbee Bridge Pro
+\*********************************************************************************************/
+
+#ifdef FIRMWARE_ZBBRDGPRO
+
+#undef CODE_IMAGE_STR
+#define CODE_IMAGE_STR "zbbrdgpro"
+
+#undef MODULE
+#define MODULE                 WEMOS             // [Module] Select default module from tasmota_template.h
+#undef FALLBACK_MODULE
+#define FALLBACK_MODULE        WEMOS             // [Module2] Select default module on fast reboot where USER_MODULE is user template
+
+#undef USE_DOMOTICZ
+#undef USE_HOME_ASSISTANT
+#define USE_TASMOTA_DISCOVERY                    // Enable Tasmota Discovery support (+2k code)
+
+#define USE_WEBCLIENT_HTTPS
+
+#define USE_ZIGBEE
+#define USE_TCP_BRIDGE
+
+#define USE_ENHANCED_GUI_WIFI_SCAN
+
+#undef USE_ARMTRONIX_DIMMERS                    // Disable support for Armtronix Dimmers (+1k4 code)
+#undef USE_PS_16_DZ                             // Disable support for PS-16-DZ Dimmer (+2k code)
+#undef USE_SONOFF_IFAN                          // Disable support for Sonoff iFan02 and iFan03 (+2k code)
+//#define USE_BUZZER                               // Add support for a buzzer (+0k6 code)
+#undef USE_ARILUX_RF                            // Disable support for Arilux RF remote controller (+0k8 code, 252 iram (non 2.3.0))
+//#define USE_DEEPSLEEP                            // Add support for deepsleep (+1k code)
+#undef USE_EXS_DIMMER                           // Disable support for EX-Store WiFi Dimmer
+#undef USE_KEELOQ                               // Disable support for Jarolift rollers by Keeloq algorithm (+4k5 code)
+#undef USE_SONOFF_D1                            // Disable support for Sonoff D1 Dimmer (+0k7 code)
+#undef USE_SHELLY_DIMMER                        // Disable support for Shelly Dimmer (+3k code)
+
+#define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)
+#define USE_SPI                                // Hardware SPI using GPIO12(MISO), GPIO13(MOSI) and GPIO14(CLK) in addition to two user selectable GPIOs(CS and DC)
+
+#define USE_ETHERNET                             // Add support for ethernet (+20k code)
+
+//#ifndef USE_KNX
+//#define USE_KNX                                  // Enable KNX IP Protocol Support (+23k code, +3k3 mem)
+//#endif
+
+#endif // FIRMWARE_ZBBRDGPRO
+
+/*********************************************************************************************\
+ * [tasmota32-nspanel]
+ * Provide an image for ths Sonoff NsPanel
+\*********************************************************************************************/
+
+#ifdef FIRMWARE_NSPANEL
+
+#undef CODE_IMAGE_STR
+#define CODE_IMAGE_STR "nspanel"
+
+#undef MODULE
+#define MODULE                 WEMOS             // [Module] Select default module from tasmota_template.h
+#undef FALLBACK_MODULE
+#define FALLBACK_MODULE        WEMOS             // [Module2] Select default module on fast reboot where USER_MODULE is user template
+
+#define FIRMWARE_TASMOTA32
+
+#endif // FIRMWARE_NSPANEL
 
 /*********************************************************************************************\
  * [tasmota32.bin]


### PR DESCRIPTION
 and provide via Tasmota OTA Server.

@arendst Please check if the way i added in `tasmota_configurations_ESP32.h` is okay and working
@s-hadinger or @sfromis can you test the ZigbeeBridge Pro build? I stripped unneeded stuff.

I could not test the builds, since i am not at home (no ESP32 device by me...)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
