### PR TITLE
Berry int() now accepts hex strings

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -168,21 +168,9 @@ static int check_next(blexer *lexer, int c)
     return 0;
 }
 
-static int char2hex(int c)
-{
-    if (c >= '0' && c <= '9') {
-        return c - '0';
-    } else if (c >= 'a' && c <= 'f') {
-        return c - 'a' + 0x0A;
-    } else if (c >= 'A' && c <= 'F') {
-        return c - 'A' + 0x0A;
-    }
-    return -1;
-}
-
 static int check2hex(blexer *lexer, int c)
 {
-    c = char2hex(c);
+    c = be_char2hex(c);
     if (c < 0) {
         be_lexerror(lexer, "invalid hexadecimal number");
     }
@@ -333,7 +321,7 @@ static bint scan_hexadecimal(blexer *lexer)
 {
     bint res = 0;
     int dig, num = 0;
-    while ((dig = char2hex(lgetc(lexer))) >= 0) {
+    while ((dig = be_char2hex(lgetc(lexer))) >= 0) {
         res = ((bint)res << 4) + dig;
         next(lexer);
         ++num;

--- a/lib/libesp32/berry/src/be_strlib.h
+++ b/lib/libesp32/berry/src/be_strlib.h
@@ -19,6 +19,7 @@ bstring* be_strcat(bvm *vm, bstring *s1, bstring *s2);
 int be_strcmp(bstring *s1, bstring *s2);
 bstring* be_num2str(bvm *vm, bvalue *v);
 void be_val2str(bvm *vm, int index);
+int be_char2hex(int c);
 size_t be_strlcpy(char *dst, const char *src, size_t size);
 const char* be_splitpath(const char *path);
 const char* be_splitname(const char *path);

--- a/lib/libesp32/berry/tests/int.be
+++ b/lib/libesp32/berry/tests/int.be
@@ -6,3 +6,9 @@ class Test_int
 end
 t=Test_int()
 assert(int(t) == 42)
+
+#- int can parse hex strings -#
+assert(int("0x00") == 0)
+assert(int("0X1") == 1)
+assert(int("0x000000F") == 15)
+assert(int("0x1000") == 0x1000)


### PR DESCRIPTION
## Description:

`int()` is now able to parse hex strings starting with `0x` or `0X. This is now consistent with Barry lexer and parser.

``` berry
> print(int("0x10"))
16
```

Applied from https://github.com/berry-lang/berry/pull/255

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
