### PR TITLE
Cleaning unused variables

### DIFF
--- a/lib/default/Unishox-1.0-shadinger/src/unishox.cpp
+++ b/lib/default/Unishox-1.0-shadinger/src/unishox.cpp
@@ -252,7 +252,6 @@ int32_t Unishox::unishox_compress(const char *p_in, size_t p_len, char *p_out, s
   out = p_out;
   len_out = p_len_out;
 
-  char *ptr;
   byte bits;
 
   int ll;

--- a/lib/default/jsmn-shadinger-1.0/src/jsmn.cpp
+++ b/lib/default/jsmn-shadinger-1.0/src/jsmn.cpp
@@ -391,7 +391,7 @@ static uint32_t json_encode_utf8(char* str, uint32_t val) {
 
 void json_unescape(char* string) {
 	size_t outlength = 0;
-	uint32_t hexval, numbytes;
+	uint32_t numbytes;
 
   char c;
 	for (uint32_t i = 0; (c = string[i]) != 0; i++) {

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -717,7 +717,6 @@ static int m_tostring(bvm *vm)
 
 static int m_tohex(bvm *vm)
 {
-    int argc = be_top(vm);
     buf_impl attr = m_read_attributes(vm, 1);
     if (attr.bufptr) {              /* pointer looks valid */
         int32_t len = attr.len;

--- a/lib/libesp32/berry_mapping/src/be_cb_module.c
+++ b/lib/libesp32/berry_mapping/src/be_cb_module.c
@@ -153,7 +153,6 @@ static int32_t be_cb_make_cb(bvm *vm) {
   int32_t argc = be_top(vm);
   if (argc >= 1 && be_isfunction(vm, 1)) {
 
-    bvalue *v = be_indexof(vm, 1);
     for (be_callback_handler_list_t *elt = be_callback_handler_list_head; elt != NULL; elt = elt->next) {
       if (elt->vm == vm || elt->vm == NULL) {   // if elt->vm is NULL then we accept any VM
         // call the handler and check result
@@ -215,7 +214,6 @@ static int32_t be_cb_gen_cb(bvm *vm) {
 \*********************************************************************************************/
 static int32_t be_cb_get_cb_list(bvm *vm) {
   be_newobject(vm, "list");
-  int32_t i;
   for (uint32_t i=0; i < BE_MAX_CB; i++) {
     if (be_cb_hooks[i].vm) {
       if (vm == be_cb_hooks[i].vm) {  // make sure it corresponds to this vm

--- a/lib/libesp32/berry_tasmota/src/be_ctypes.c
+++ b/lib/libesp32/berry_tasmota/src/be_ctypes.c
@@ -144,8 +144,6 @@ int be_ctypes_init(bvm *vm) {
 // copy ctypes_bytes, with same class and same content
 //
 int be_ctypes_copy(bvm *vm) {
-    size_t len;
-    const void * src = be_tobytes(vm, 1, &len);
     be_classof(vm, 1);
     // stack: 1/self + class_object
     be_call(vm, 0);     // call empty constructor to build empty resizable copy
@@ -184,7 +182,6 @@ int be_ctypes_copy(bvm *vm) {
 // arg2: name of the argument
 // The class has a `_def` static class attribute with the C low-level mapping definition
 int be_ctypes_member(bvm *vm) {
-    int argc = be_top(vm);
     be_getmember(vm, 1, "_def");
     const be_ctypes_structure_t *definitions;
     definitions = (const be_ctypes_structure_t *) be_tocomptr(vm, -1);
@@ -276,8 +273,6 @@ int be_ctypes_member(bvm *vm) {
 // 2: name of member
 // 3: value
 int be_ctypes_setmember(bvm *vm) {
-    int argc = be_top(vm);
-
     // If the value is an instance, we call 'toint()' and replace the value
     if (be_isinstance(vm, 3)) {
 

--- a/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_path_tasmota_lib.c
@@ -62,7 +62,6 @@ static int m_path_remove(bvm *vm)
 extern int be_format_fs(void);
 static int m_path_format(bvm *vm)
 {
-    const char *path = NULL;
     if (be_top(vm) >= 1 && be_isbool(vm, 1)) {
         if (be_tobool(vm, 1)) {
             be_pushbool(vm, be_format_fs());

--- a/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
+++ b/lib/libesp32_lvgl/lv_binding_berry/src/lv_berry.c
@@ -181,8 +181,6 @@ int lco_init(bvm *vm) {
   int argc = be_top(vm);
   lv_color_t lv_color = {};       // default value is all zeroes (black)
 
-  uint32_t color32 = 0x000000;    // default to black
-
   if (argc > 1) {
     if (be_isint(vm, 2)) {        // color is RGB 24 bits
       lv_color = lv_color_hex(be_toint(vm, 2));
@@ -209,7 +207,6 @@ int lco_tostring(bvm *vm) {
 }
 
 int lco_toint(bvm *vm) {
-  lv_color_t lv_color = {};
   be_getmember(vm, 1, "_p");
   uint32_t ntv_color = be_toint(vm, -1);
   be_pushint(vm, ntv_color);

--- a/tasmota/tasmota_support/support_pwm.ino
+++ b/tasmota/tasmota_support/support_pwm.ino
@@ -76,7 +76,6 @@ void PwmApplyGPIO(bool force_update_all) {
 
     // compute phase
     uint32_t pwm_phase = TasmotaGlobal.pwm_cur_phase[i];    // pwm_phase is the logical phase of the active pulse, ignoring inverted
-    uint32_t gpio_phase = pwm_phase;          // gpio is the physical phase taking into account inverted
     if (TasmotaGlobal.pwm_phase[i] >= 0) {
       pwm_phase = TasmotaGlobal.pwm_phase[i]; // if explicit set explicitly, 
     } else if (Settings->flag5.pwm_force_same_phase) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_webserver.ino
@@ -3797,7 +3797,7 @@ bool Xdrv01(uint8_t function)
               }
               Web.wifi_test_AP_TIMEOUT = true;
           }
-          int n = WiFi.scanNetworks(); // restart scan
+          WiFi.scanNetworks(); // restart scan
         }
       }
       break;

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2347,7 +2347,7 @@ bool calcGammaBulbs(uint16_t cur_col_10[5]) {
     calcGammaBulb5Channels_8(*pivot, from10);
     calcGammaBulb5Channels_8(*(pivot+1), to10);
 
-    vct_pivot_t   *pivot1 = pivot + 1;
+    // vct_pivot_t   *pivot1 = pivot + 1;
     // AddLog(LOG_LEVEL_INFO, PSTR("+++ from_ct %d, to_ct %d [%03X,%03X,%03X,%03X,%03X] - [%03X,%03X,%03X,%03X,%03X]"),
     //           *from_ct, *(from_ct+1), (*pivot)[0], (*pivot)[1], (*pivot)[2], (*pivot)[3], (*pivot)[4],
     //           (*pivot1)[0], (*pivot1)[1], (*pivot1)[2], (*pivot1)[3], (*pivot1)[4]);

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1868,7 +1868,6 @@ bool findNextLogicObjectValue(char * &pointer, bool &value)
  */
 bool evaluateLogicalExpression(const char * expression, int len)
 {
-  bool bResult = false;
   //Make a copy first
   char expbuff[len + 1];
   memcpy(expbuff, expression, len);

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -665,7 +665,6 @@ Z_Device & Z_Devices::parseDeviceFromName(const char * param, uint16_t * parsed_
 // Add "Device":"0x1234","Name":"FrienflyName"
 void Z_Device::jsonAddDeviceNamme(Z_attribute_list & attr_list) const {
   const char * fname = friendlyName;
-  bool use_fname = (Settings->flag4.zigbee_use_names) && (fname);    // should we replace shortaddr with friendlyname?
 
   attr_list.addAttributePMEM(PSTR(D_JSON_ZIGBEE_DEVICE)).setHex32(shortaddr);
   if (fname) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
@@ -226,7 +226,6 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
 int32_t ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, String &response) {
   uint8_t  bri, sat;
   uint16_t ct, hue;
-  int code = 200;
 
   int8_t bulbtype = zigbee_devices.getHueBulbtype(shortaddr);
   if (bulbtype < 0) {  // respond only if eligible

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -1954,8 +1954,6 @@ int32_t ZNP_ReceiveAfIncomingMessage(int32_t res, const SBuffer &buf) {
   // uint32_t        timestamp = buf.get32(13);
   uint8_t         seqnumber = buf.get8(17);
 
-  bool            defer_attributes = false;     // do we defer attributes reporting to coalesce
-
   ZCLFrame zcl_received = ZCLFrame::parseRawFrame(buf, 19, buf.get8(18), clusterid, groupid,
                               srcaddr,
                               srcendpoint, dstendpoint, wasbroadcast,

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -182,7 +182,7 @@ extern "C" {
             uint8_t g = (rgbw & 0xFF00) >> 8;
             uint8_t b = (rgbw & 0xFF);
             if (s_ws2812_grb)       s_ws2812_grb->ClearTo(RgbColor(r, g, b));
-            if (s_sk6812_grbw)      s_sk6812_grbw->ClearTo(RgbwColor(r, g, b, 0));
+            if (s_sk6812_grbw)      s_sk6812_grbw->ClearTo(RgbwColor(r, g, b, w));
             }
             break;
           case 10: // # 10 : SetPixelColor (idx:int, color:??) -> void
@@ -194,7 +194,7 @@ extern "C" {
             uint8_t g = (rgbw & 0xFF00) >> 8;
             uint8_t b = (rgbw & 0xFF);
             if (s_ws2812_grb)       s_ws2812_grb->SetPixelColor(idx, RgbColor(r, g, b));
-            if (s_sk6812_grbw)      s_sk6812_grbw->SetPixelColor(idx, RgbwColor(r, g, b, 0));
+            if (s_sk6812_grbw)      s_sk6812_grbw->SetPixelColor(idx, RgbwColor(r, g, b, w));
             }
             break;
           case 11: // # 11 : GetPixelColor (idx:int) -> color:??

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_light_state.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_light_state.ino
@@ -95,8 +95,6 @@ int32_t ls_get_power(class LightStateClass* l) {
 }
 void ls_set_xy(class LightStateClass* l, float x, float y) {
   uint8_t rr, gg, bb;
-  uint16_t hue;
-  uint8_t sat;
   XyToRgb(x, y, &rr, &gg, &bb);
   l->setRGB(rr, gg, bb, false);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -112,7 +112,6 @@ bool callBerryRule(const char *event, bool teleperiod) {
   bool exec_rule = !save_rules_busy;       // true if the rule is executed, false if we only record the value
   // if (berry.rules_busy) { return false; }
   berry.rules_busy = true;
-  char * json_event = XdrvMailbox.data;
   bool serviced = false;
   serviced = callBerryEventDispatcher(teleperiod ? "tele" : "rule", nullptr, exec_rule, event ? event : XdrvMailbox.data);
   berry.rules_busy = save_rules_busy;
@@ -345,9 +344,6 @@ void BerryInit(void) {
 void BrLoad(const char * script_name) {
   if (berry.vm == nullptr || TasmotaGlobal.no_autoexec) { return; }   // abort is berry is not running, or bootloop prevention kicked in
 
-  int32_t ret_code1, ret_code2;
-  bool berry_init_ok = false;
-
   be_getglobal(berry.vm, PSTR("load"));
   if (!be_isnil(berry.vm, -1)) {
     be_pushstring(berry.vm, script_name);
@@ -376,7 +372,7 @@ void BrLoad(const char * script_name) {
 //
 void CmndBrRun(void) {
   int32_t ret_code;
-  const char * ret_type, * ret_val;
+  const char * ret_val;
 
   if (berry.vm == nullptr) { ResponseCmndChar_P(PSTR(D_BR_NOT_STARTED)); return; }
 


### PR DESCRIPTION
## Description:

I did a compilation with `-Wunused-variable` and removed most of the variables marked as unused by the compiler. Some false positive depends on compilation `#ifdef` and were not removed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
