### PR TITLE
Fix issues introduced to SHT3x driver during merge of #15349

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -104,8 +104,12 @@ bool Sht3xRead(uint32_t type, float &t, float &h, uint8_t i2c_address) {
   if ((Sht3xComputeCrc(&data[0], 2) != data[2]) || (Sht3xComputeCrc(&data[3], 2) != data[5])) {
     return false;
   }
-  t = (float)((((data[0] << 8) | data[1]) * 175) / 65535.0) - 45;
-  h = (float)((((data[3] << 8) | data[4]) * 100) / 65535.0);
+  t = ((float)(((data[0] << 8) | data[1]) * 175) / 65535.0) - 45.0;
+  if (type == SHT3X_TYPE_SHT4X) {
+    h = ((float)(((data[3] << 8) | data[4]) * 125) / 65535.0) - 6.0;
+  } else {
+    h = ((float)(((data[3] << 8) | data[4]) * 100) / 65535.0);
+  }
   return (!isnan(t) && !isnan(h));
 }
 

--- a/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_14_sht3x.ino
@@ -104,8 +104,8 @@ bool Sht3xRead(uint32_t type, float &t, float &h, uint8_t i2c_address) {
   if ((Sht3xComputeCrc(&data[0], 2) != data[2]) || (Sht3xComputeCrc(&data[3], 2) != data[5])) {
     return false;
   }
-  t = ConvertTemp((float)((((data[0] << 8) | data[1]) * 175) / 65535.0) - 45);
-  h = ConvertHumidity((float)((((data[3] << 8) | data[4]) * 100) / 65535.0));
+  t = (float)((((data[0] << 8) | data[1]) * 175) / 65535.0) - 45;
+  h = (float)((((data[3] << 8) | data[4]) * 100) / 65535.0);
   return (!isnan(t) && !isnan(h));
 }
 


### PR DESCRIPTION
## Description:
The modifications to the code during merge of #15349 introduced three issues which are fixed herewith:
* Detection of SHT40 sensors was broken. Apparently, detection of a SHT40 fails when the same address was probed for a SHT3x immediately before. The scheme was altered to first probe all addresses for one type of sensor and then scanning them again for the next type similar to the original PR. It was successfully tested with SHTC3 and SHT40 sensors.
* ConvertTemp and ConvertHumidity were called twice (in Sht3xShow and Sht3xRead)
* The different conversion of humidity from raw values for the SHT4x did not get included in the merge

**Related issue (if applicable):** fixes #15349

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
