### PR TITLE
Mi32 legacy: Use notification queue for Berry

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -190,6 +190,7 @@ struct {
       uint32_t triggerBerryConnCB:1;
       uint32_t triggerNextConnJob:1;
       uint32_t readyForNextConnJob:1;
+      uint32_t discoverAttributes:1;
     };
     uint32_t all = 0;
   } mode;

--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -157,6 +157,11 @@ struct MI32connectionContextBerry_t{
   bool response;
 };
 
+struct MI32notificationBuffer_t{
+  uint8_t buffer[256];
+  uint16_t returnCharUUID;
+};
+
 struct {
   // uint32_t period;             // set manually in addition to TELE-period, is set to TELE-period after start
   TaskHandle_t ScanTask = nullptr;

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -119,7 +119,7 @@ extern "C" {
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
   extern bool MI32runBerryConnection(uint8_t operation, bool response);
-  extern bool MI32setBerryCtxSvc(const char *Svc);
+  extern bool MI32setBerryCtxSvc(const char *Svc, bool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
   extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type);
   extern bool MI32addMACtoBlockList(uint8_t *MAC, uint8_t type);
@@ -175,8 +175,12 @@ extern "C" {
   int be_BLE_set_service(bvm *vm);
   int be_BLE_set_service(bvm *vm){    
     int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 2 && be_isstring(vm, 2)) {
-      if (MI32setBerryCtxSvc(be_tostring(vm, 2))) be_return(vm);
+    if (argc > 1 && be_isstring(vm, 2)) {
+      bool discoverAttributes = false;
+      if(argc == 3 && be_isint(vm, 3)){
+        discoverAttributes = be_toint(vm,3)>0;
+      }
+      if (MI32setBerryCtxSvc(be_tostring(vm, 2),discoverAttributes)) be_return(vm);
     }
     be_raise(vm, kTypeError, nullptr);
   }

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -702,10 +702,11 @@ extern "C" {
     AddLog(LOG_LEVEL_INFO,PSTR("M32: Connection Ctx created"));
   }
 
-  bool MI32setBerryCtxSvc(const char *Svc){
+  bool MI32setBerryCtxSvc(const char *Svc, bool discoverAttributes){
     if(MI32.conCtx != nullptr){
       MI32.conCtx->serviceUUID = NimBLEUUID(Svc);
       AddLog(LOG_LEVEL_DEBUG,PSTR("M32: SVC: %s"),MI32.conCtx->serviceUUID.toString().c_str());
+      MI32.mode.discoverAttributes = discoverAttributes;
       return true;
     }
     return false;
@@ -1182,8 +1183,9 @@ void MI32ConnectionTask(void *pvParameters){
         timer++;
         vTaskDelay(10/ portTICK_PERIOD_MS);
       }
-      // TODO: make next line optional
-      // MI32Client->discoverAttributes(); // solves connection problems on i.e. yeelight dimmer
+      if(MI32.mode.discoverAttributes){
+        MI32Client->discoverAttributes(); // solves connection problems on i.e. yeelight dimmer
+      }
       NimBLERemoteService* pSvc = nullptr;
       NimBLERemoteCharacteristic* pChr = nullptr;
 


### PR DESCRIPTION
## Description:

Put all received notifications in a queue to not loose packets anymore for Berry.

Make it optional in Berry to discover all attributes of a BLE devices while connecting. Some sensors need it and some need to have it turned off. Default is off.
Will only influence the first Berry operation of a session, that instantiates the connection.
Usage:
```
ble = BLE()
ble.set_svc("FF00",1) # will discover all attributes - is slower and drains the battery faster, but sometimes it is needed

ble.set_svc("FF00")    # will not discover all attributes
ble.set_svc("FF00",0) # will not discover all attributes
```
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
