### PR TITLE
Zigbee reenable leds for ESP32

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_9_serial.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_9_serial.ino
@@ -19,6 +19,8 @@
 
 #ifdef USE_ZIGBEE
 
+const uint32_t ZIGBEE_LED_SERIAL = 0;     // LED<1> blinks when receiving
+
 #ifdef USE_ZIGBEE_ZNP
 const uint32_t ZIGBEE_BUFFER_SIZE = 256;  // Max ZNP frame is SOF+LEN+CMD1+CMD2+250+FCS = 255
 const uint8_t  ZIGBEE_SOF = 0xFE;
@@ -28,11 +30,8 @@ const uint8_t  ZIGBEE_SOF_ALT = 0xFF;
 #ifdef USE_ZIGBEE_EZSP
 const uint32_t ZIGBEE_BUFFER_SIZE = 256;
 const uint8_t  ZIGBEE_EZSP_CANCEL = 0x1A;  // cancel byte
-const uint8_t  ZIGBEE_EZSP_EOF = 0x7E;          // end of frame
-const uint8_t  ZIGBEE_EZSP_ESCAPE = 0x7D;       // escape byte
-
-const uint32_t ZIGBEE_LED_RECEIVE = 0;     // LED<1> blinks when receiving
-const uint32_t ZIGBEE_LED_SEND = 0;        // LED<2> blinks when receiving
+const uint8_t  ZIGBEE_EZSP_EOF = 0x7E;     // end of frame
+const uint8_t  ZIGBEE_EZSP_ESCAPE = 0x7D;  // escape byte
 
 class EZSP_Serial_t {
 public:
@@ -47,26 +46,26 @@ public:
 
 EZSP_Serial_t EZSP_Serial;
 
+#endif // USE_ZIGBEE_EZSP
+
 //
 // Blink Led Status
 //
-const uint32_t Z_LED_STATUS_ON_MILLIS = 50;   // keep led on at least 50 ms
+const uint32_t Z_LED_STATUS_ON_MILLIS = 40;   // keep led on at least 40 ms
 bool Z_LedStatusSet(bool onoff) {
   static bool led_status_on = false;
   static uint32_t led_on_time = 0;
 
   if (onoff) {
-    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 1);
+    SetLedPowerIdx(ZIGBEE_LED_SERIAL, 1);
     led_status_on = true;
     led_on_time = millis();
   } else if ((led_status_on) && (TimePassedSince(led_on_time) >= Z_LED_STATUS_ON_MILLIS)) {
-    SetLedPowerIdx(ZIGBEE_LED_RECEIVE, 0);
+    SetLedPowerIdx(ZIGBEE_LED_SERIAL, 0);
     led_status_on = false;
   }
   return led_status_on;
 }
-
-#endif // USE_ZIGBEE_EZSP
 
 #include <TasmotaSerial.h>
 TasmotaSerial *ZigbeeSerial = nullptr;
@@ -89,7 +88,10 @@ void ZigbeeInputLoop(void) {
   // 04..FD - Data Field
   // FE (or last) - FCS Checksum
 
+  Z_LedStatusSet(false);
   while (ZigbeeSerial->available()) {
+    Z_LedStatusSet(true); // turn on receive LED<1>
+
     yield();
     uint8_t zigbee_in_byte = ZigbeeSerial->read();
 		//AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("ZbInput byte=%d len=%d"), zigbee_in_byte, zigbee_buffer->len());
@@ -331,6 +333,9 @@ void ZigbeeZNPSend(const uint8_t *msg, size_t len) {
 	uint8_t data_len = len - 2;		// removing CMD1 and CMD2
 
   if (ZigbeeSerial) {
+    // turn send led on
+    Z_LedStatusSet(true);
+
 		uint8_t fcs = data_len;
 
 		ZigbeeSerial->write(ZIGBEE_SOF);		// 0xFE


### PR DESCRIPTION
## Description:

Enable leds for Sonoff Zigbee Bridge Pro.

Like in the Sonoff Zignee Bridge:
- blue LED indicates Wifi and MQTT status (blinking) or Zigbee pairing mode (glowing)
- green LED indicates communication between ESP32 and Zigbee MCU, which is generally an indicator of Zigbee traffic

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
