### PR TITLE
Berry add string.replace()

### DIFF
--- a/lib/libesp32/berry/generate/be_const_strtab.h
+++ b/lib/libesp32/berry/generate/be_const_strtab.h
@@ -670,6 +670,7 @@ extern const bcstring be_const_str_remove_light;
 extern const bcstring be_const_str_remove_rule;
 extern const bcstring be_const_str_remove_timer;
 extern const bcstring be_const_str_remove_trailing_zeroes;
+extern const bcstring be_const_str_replace;
 extern const bcstring be_const_str_reset;
 extern const bcstring be_const_str_resize;
 extern const bcstring be_const_str_resolvecmnd;

--- a/lib/libesp32/berry/generate/be_const_strtab_def.h
+++ b/lib/libesp32/berry/generate/be_const_strtab_def.h
@@ -660,8 +660,9 @@ be_define_const_str(remove_cron, "remove_cron", 2914538962u, 0, 11, &be_const_st
 be_define_const_str(remove_driver, "remove_driver", 1030243768u, 0, 13, &be_const_str_send_multicast);
 be_define_const_str(remove_light, "remove_light", 1783624394u, 0, 12, &be_const_str_set_temp);
 be_define_const_str(remove_rule, "remove_rule", 3456211328u, 0, 11, NULL);
-be_define_const_str(remove_timer, "remove_timer", 4141472215u, 0, 12, &be_const_str_set_bat);
+be_define_const_str(remove_timer, "remove_timer", 4141472215u, 0, 12, &be_const_str_replace);
 be_define_const_str(remove_trailing_zeroes, "remove_trailing_zeroes", 2688378377u, 0, 22, &be_const_str_run_cron);
+be_define_const_str(replace, "replace", 2704835779u, 0, 7, &be_const_str_set_bat);
 be_define_const_str(reset, "reset", 1695364032u, 0, 5, &be_const_str_widget_ctor_cb);
 be_define_const_str(resize, "resize", 3514612129u, 0, 6, &be_const_str_setbits);
 be_define_const_str(resolvecmnd, "resolvecmnd", 993361485u, 0, 11, NULL);
@@ -1878,6 +1879,6 @@ static const bstring* const m_string_table[] = {
 
 static const struct bconststrtab m_const_string_table = {
     .size = 426,
-    .count = 875,
+    .count = 876,
     .table = m_string_table
 };

--- a/lib/libesp32/berry/generate/be_fixed_string.h
+++ b/lib/libesp32/berry/generate/be_fixed_string.h
@@ -1,22 +1,23 @@
 #include "be_constobj.h"
 
 static be_define_const_map_slots(m_libstring_map) {
+    { be_const_key(count, 4), be_const_func(str_count) },
+    { be_const_key(byte, 6), be_const_func(str_byte) },
+    { be_const_key(format, 8), be_const_func(str_format) },
+    { be_const_key(split, -1), be_const_func(str_split) },
+    { be_const_key(toupper, -1), be_const_func(str_toupper) },
     { be_const_key(char, -1), be_const_func(str_char) },
     { be_const_key(tr, -1), be_const_func(str_tr) },
-    { be_const_key(count, 4), be_const_func(str_count) },
-    { be_const_key(format, 7), be_const_func(str_format) },
-    { be_const_key(escape, -1), be_const_func(str_escape) },
-    { be_const_key(byte, -1), be_const_func(str_byte) },
-    { be_const_key(toupper, -1), be_const_func(str_toupper) },
-    { be_const_key(hex, -1), be_const_func(str_i2hex) },
+    { be_const_key(replace, 1), be_const_func(str_replace) },
+    { be_const_key(hex, 11), be_const_func(str_i2hex) },
+    { be_const_key(tolower, 5), be_const_func(str_tolower) },
     { be_const_key(find, -1), be_const_func(str_find) },
-    { be_const_key(split, 1), be_const_func(str_split) },
-    { be_const_key(tolower, -1), be_const_func(str_tolower) },
+    { be_const_key(escape, -1), be_const_func(str_escape) },
 };
 
 static be_define_const_map(
     m_libstring_map,
-    11
+    12
 );
 
 static be_define_const_module(

--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -845,6 +845,26 @@ static int str_tr(bvm *vm)
     be_return_nil(vm);
 }
 
+static int str_replace(bvm *vm)
+{
+    int top = be_top(vm);
+    if (top >= 3 && be_isstring(vm, 1) && be_isstring(vm, 2) && be_isstring(vm, 3)) {
+        be_pushntvfunction(vm, &str_split);
+        be_pushvalue(vm, 1);
+        be_pushvalue(vm, 2);
+        be_call(vm, 2);
+        be_pop(vm, 2);
+
+        be_getmember(vm, -1, "concat");     /* get `concat` method of list */
+        be_pushvalue(vm, -2);               /* get list instance as first arg */
+        be_pushvalue(vm, 3);
+        be_call(vm, 2);
+        be_pop(vm, 2);
+        be_return(vm);
+    }
+    be_return_nil(vm);
+}
+
 static int str_escape(bvm *vm)
 {
     int top = be_top(vm);
@@ -876,6 +896,7 @@ be_native_module_attr_table(string) {
     be_native_module_function("toupper", str_toupper),
     be_native_module_function("tr", str_tr),
     be_native_module_function("escape", str_escape),
+    be_native_module_function("replace", str_replace),
 };
 
 be_define_native_module(string, NULL);
@@ -893,6 +914,7 @@ module string (scope: global, depend: BE_USE_STRING_MODULE) {
     toupper, func(str_toupper)
     tr, func(str_tr)
     escape, func(str_escape)
+    replace, func(str_replace)
 }
 @const_object_info_end */
 #include "../generate/be_fixed_string.h"

--- a/lib/libesp32/berry/tests/string.be
+++ b/lib/libesp32/berry/tests/string.be
@@ -80,3 +80,11 @@ assert(string.tr("qwerty", "qwe", "_") == '_rty')
 # the following should not crash
 var s1 = 'A string of more than 128 bytes 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
 var s2 = string.format("%i, %s", 1, s1)
+
+# replace
+assert(string.replace("hello", "ll", "xx") == "hexxo")
+assert(string.replace("hellollo", "ll", "xx") == "hexxoxxo")
+assert(string.replace("hellollo", "aa", "xx") == "hellollo")
+assert(string.replace("hello", "ll", "") == "heo")
+assert(string.replace("hello", "", "xx") == "hello")
+assert(string.replace("hello", "", "") == "hello")


### PR DESCRIPTION
## Description:

Add Berry `string.replace(haystack:string, needle:string, food:string) -> string` accordingly to #15805

Example:

``` berry
import string
assert(string.replace("hello", "ll", "xx") == "hexxo")
assert(string.replace("hellollo", "ll", "xx") == "hexxoxxo")
assert(string.replace("hellollo", "aa", "xx") == "hellollo")
assert(string.replace("hello", "ll", "") == "heo")
assert(string.replace("hello", "", "xx") == "hello")
assert(string.replace("hello", "", "") == "hello")
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
