### PR TITLE
Berry improved booleans

### DIFF
--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -281,6 +281,12 @@ bbool be_value2bool(bvm *vm, bvalue *v)
         return val2bool(v->v.i);
     case BE_REAL:
         return val2bool(v->v.r);
+    case BE_STRING:
+        return str_len(var_tostr(v)) != 0;
+    case BE_COMPTR:
+        return var_toobj(v) != NULL;
+    case BE_COMOBJ:
+        return ((bcommomobj*)var_toobj(v))->data != NULL;
     case BE_INSTANCE:
         return obj2bool(vm, v);
     default:

--- a/lib/libesp32/berry/tests/bool.be
+++ b/lib/libesp32/berry/tests/bool.be
@@ -33,7 +33,11 @@ assert(bool(nil) == false)
 
 assert(bool(-1) == true)
 assert(bool(3.5) == true)
-assert(bool('') == true)
+assert(bool('') == false)       # changed behavior
 assert(bool('a') == true)
 assert(bool(list) == true)
 assert(bool(list()) == true)
+
+import introspect
+assert(bool(introspect.toptr(0x1000)) == true)
+assert(bool(introspect.toptr(0)) == false)


### PR DESCRIPTION
## Description:

Improved implicit conversion to booleans:
- `bool("")` now returns `false` only if a string is empty, and `true` for any non-empty string (used to be always `true` for all strings)
- `bool(<comptr>)` and `bool(<comobj>)` now returns `false` if the pointer is `NULL` and `true` for any other value (used to always return `true`)

This should simplify some pieces of code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
