### PR TITLE
Filesystem escape special chars

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -2734,6 +2734,54 @@ void AddLogSpi(bool hardware, uint32_t clk, uint32_t mosi, uint32_t miso) {
 }
 
 /*********************************************************************************************\
+ * HTML and URL encode
+\*********************************************************************************************/
+
+const char kUnescapeCode[] = "&><\"\'\\";
+const char kEscapeCode[] PROGMEM = "&amp;|&gt;|&lt;|&quot;|&apos;|&#92;";
+
+String HtmlEscape(const String unescaped) {
+  char escaped[10];
+  size_t ulen = unescaped.length();
+  String result;
+  result.reserve(ulen);          // pre-reserve the required space to avoid mutiple reallocations
+  for (size_t i = 0; i < ulen; i++) {
+    char c = unescaped[i];
+    char *p = strchr(kUnescapeCode, c);
+    if (p != nullptr) {
+      result += GetTextIndexed(escaped, sizeof(escaped), p - kUnescapeCode, kEscapeCode);
+    } else {
+      result += c;
+    }
+  }
+  return result;
+}
+
+String UrlEscape(const char *unescaped) {
+  static const char *hex = "0123456789ABCDEF";
+  String result;
+  result.reserve(strlen(unescaped));
+
+  while (*unescaped != '\0') {
+    if (('a' <= *unescaped && *unescaped <= 'z') ||
+        ('A' <= *unescaped && *unescaped <= 'Z') ||
+        ('0' <= *unescaped && *unescaped <= '9') ||
+        *unescaped == '-' || *unescaped == '_' || *unescaped == '.' || *unescaped == '~')
+    {
+      result += *unescaped;
+    }
+    else
+    {
+      result += '%';
+      result += hex[*unescaped >> 4];
+      result += hex[*unescaped & 0xf];
+    }
+    unescaped++;
+  }
+  return result;
+}
+
+/*********************************************************************************************\
  * Uncompress static PROGMEM strings
 \*********************************************************************************************/
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2325,25 +2325,6 @@ void HandleRestoreConfiguration(void)
 
 #ifndef FIRMWARE_MINIMAL_ONLY
 
-const char kUnescapeCode[] = "&><\"\'\\";
-const char kEscapeCode[] PROGMEM = "&amp;|&gt;|&lt;|&quot;|&apos;|&#92;";
-
-String HtmlEscape(const String unescaped) {
-  char escaped[10];
-  size_t ulen = unescaped.length();
-  String result = "";
-  for (size_t i = 0; i < ulen; i++) {
-    char c = unescaped[i];
-    char *p = strchr(kUnescapeCode, c);
-    if (p != nullptr) {
-      result += GetTextIndexed(escaped, sizeof(escaped), p - kUnescapeCode, kEscapeCode);
-    } else {
-      result += c;
-    }
-  }
-  return result;
-}
-
 void HandleInformation(void)
 {
   if (!HttpCheckPriviledgedAccess()) { return; }

--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -790,44 +790,47 @@ void UfsListDir(char *path, uint8_t depth) {
 
       if (!hiddable || !isSDC() ) {
 
-      for (uint8_t cnt = 0; cnt<depth; cnt++) {
-        *cp++ = '-';
-      }
-
-      sprintf(cp, format, ep);
-      if (entry.isDirectory()) {
-        ext_snprintf_P(npath, sizeof(npath), UFS_FORM_SDC_HREF, pp, ep);
-        WSContentSend_P(UFS_FORM_SDC_DIRd, npath, ep, name);
-        uint8_t plen = strlen(path);
-        if (plen > 1) {
-          strcat(path, "/");
+        for (uint8_t cnt = 0; cnt<depth; cnt++) {
+          *cp++ = '-';
         }
-        strcat(path, ep);
-        UfsListDir(path, depth + 4);
-        path[plen] = 0;
-      } else {
-#ifdef GUI_TRASH_FILE
-        char delpath[128];
-        ext_snprintf_P(delpath, sizeof(delpath), UFS_FORM_SDC_HREFdel, pp, ep);
-#else
-        char delpath[2];
-        delpath[0]=0;
-#endif // GUI_TRASH_FILE
-#ifdef GUI_EDIT_FILE
-        char editpath[128];
-        ext_snprintf_P(editpath, sizeof(editpath), UFS_FORM_SDC_HREFedit, pp, ep);
-#else
-        char editpath[2];
-        editpath[0]=0;
-#endif // GUI_TRASH_FILE
-        ext_snprintf_P(npath, sizeof(npath), UFS_FORM_SDC_HREF, pp, ep);
-        WSContentSend_P(UFS_FORM_SDC_DIRb, hiddable ? UFS_FORM_SDC_DIR_HIDDABLE : UFS_FORM_SDC_DIR_NORMAL, npath, ep, name, tstr.c_str(), entry.size(), delpath, editpath);
+
+        String pp_escaped_string = UrlEscape(pp);
+        String ep_escaped_string = UrlEscape(ep);
+        const char* ppe = pp_escaped_string.c_str();    // this can't be merged on a single line otherwise the String object can be freed
+        const char* epe = ep_escaped_string.c_str();
+        sprintf(cp, format, ep);
+        if (entry.isDirectory()) {
+          ext_snprintf_P(npath, sizeof(npath), UFS_FORM_SDC_HREF, ppe, epe);
+          WSContentSend_P(UFS_FORM_SDC_DIRd, npath, ep, name);
+          uint8_t plen = strlen(path);
+          if (plen > 1) {
+            strcat(path, "/");
+          }
+          strcat(path, ep);
+          UfsListDir(path, depth + 4);
+          path[plen] = 0;
+        } else {
+  #ifdef GUI_TRASH_FILE
+          char delpath[128];
+          ext_snprintf_P(delpath, sizeof(delpath), UFS_FORM_SDC_HREFdel, ppe, epe);
+  #else
+          char delpath[2];
+          delpath[0]=0;
+  #endif // GUI_TRASH_FILE
+  #ifdef GUI_EDIT_FILE
+          char editpath[128];
+          ext_snprintf_P(editpath, sizeof(editpath), UFS_FORM_SDC_HREFedit, ppe, epe);
+  #else
+          char editpath[2];
+          editpath[0]=0;
+  #endif // GUI_TRASH_FILE
+          ext_snprintf_P(npath, sizeof(npath), UFS_FORM_SDC_HREF, ppe, epe);
+          WSContentSend_P(UFS_FORM_SDC_DIRb, hiddable ? UFS_FORM_SDC_DIR_HIDDABLE : UFS_FORM_SDC_DIR_NORMAL, npath, epe, 
+                          HtmlEscape(name).c_str(), tstr.c_str(), entry.size(), delpath, editpath);
+        }
+        entry.close();
       }
-      entry.close();
     }
-
-  }
-
     dir.close();
   }
 }


### PR DESCRIPTION
## Description:

Escape special characters for file names in filesystem WebUI.

Escape functions moved to `support.ino`

Also fix in indentation.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
