### PR TITLE
remove "memory_type": "qspi_qspi"

### DIFF
--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
-      "memory_type": "qspi_qspi"
+      "ldscript": "esp32s3_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S3",

--- a/boards/esp32s3_8M.json
+++ b/boards/esp32s3_8M.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
-      "memory_type": "qspi_qspi"
+      "ldscript": "esp32s3_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_8M -DESP32S3",

--- a/boards/esp32s3cdc.json
+++ b/boards/esp32s3cdc.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld",
-      "memory_type": "qspi_qspi"
+      "ldscript": "esp32s3_out.ld"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",


### PR DESCRIPTION
## Description:

in S3 Boards manifests. The Option is default set and naming is changed in Arduino stage version.
Removing fixes compile error for Stage version. No impact to actual Tasmota core v2.0.3 version.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
