### PR TITLE
Fix missing sign of current power value on smart meter AS2020

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_scripter.ino
@@ -3993,7 +3993,7 @@ extern char *SML_GetSVal(uint32_t index);
           } else {
 
 
-#ifdef ED300L
+#if defined(ED300L) || defined(AS2020)
             fvar = SML_Status(fvar1);
 #else
             fvar = 0;

--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -1236,7 +1236,7 @@ void Hexdump(uint8_t *sbuff, uint32_t slen) {
   AddLogData(LOG_LEVEL_INFO, cbuff);
 }
 
-#ifdef ED300L
+#if defined(ED300L) || defined(AS2020)
 uint8_t sml_status[MAX_METERS];
 uint8_t g_mindex;
 #endif
@@ -1281,6 +1281,16 @@ double dval;
   }
   if (*cp==0x63 && *cpx==0 && *(cpx+1)==0x01 && *(cpx+2)==0x08 && *(cpx+3)==0) {
       sml_status[g_mindex]=*(cp+2);
+  }
+#endif
+#ifdef AS2020
+  unsigned char *cpx=cp-5;
+  // decode OBIS 0180 amd extract direction info
+  if (*cp==0x64 && *cpx==0 && *(cpx+1)==0x01 && *(cpx+2)==0x08 && *(cpx+3)==0) {
+      sml_status[g_mindex]=*(cp+2);
+  }
+  if (*cp==0x63 && *cpx==0 && *(cpx+1)==0x01 && *(cpx+2)==0x08 && *(cpx+3)==0) {
+      sml_status[g_mindex]=*(cp+1);
   }
 #endif
 
@@ -1394,6 +1404,15 @@ double dval;
     // decode current power OBIS 00 0F 07 00
     if (*cpx==0x00 && *(cpx+1)==0x0f && *(cpx+2)==0x07 && *(cpx+3)==0) {
         if (sml_status[g_mindex]&0x20) {
+          // and invert sign on solar feed
+          dval*=-1;
+        }
+    }
+  #endif
+  #ifdef AS2020
+    // decode current power OBIS 00 10 07 00
+    if (*cpx==0x00 && *(cpx+1)==0x10 && *(cpx+2)==0x07 && *(cpx+3)==0) {
+        if (sml_status[g_mindex]&0x08) {
           // and invert sign on solar feed
           dval*=-1;
         }
@@ -2099,7 +2118,7 @@ void SML_Decode(uint8_t index) {
         // matches, get value
         dvalid[vindex] = 1;
         mp++;
-#ifdef ED300L
+#if defined(ED300L) || defined(AS2020)
         g_mindex=mindex;
 #endif
         if (*mp == '#') {
@@ -3026,7 +3045,7 @@ uint32_t SML_SetBaud(uint32_t meter, uint32_t br) {
 uint32_t SML_Status(uint32_t meter) {
   if (meter<1 || meter>meters_used) return 0;
   meter--;
-#ifdef ED300L
+#if defined(ED300L) || defined(AS2020)
   return sml_status[meter];
 #else
   return 0;


### PR DESCRIPTION
## Description:

Currently, the Smart Meter Honeywell AS2020 returns only positive current power values. Its like the ED300L, the status for the power direction is contained in OBIS 1.8.0. But the difference is, that the direction is on Bit 11 (not Bit 5) and the current power value has a different OBIS code.

The SML decoding discussion for the AS2020 is here: https://www.mikrocontroller.net/topic/538936

To enable the fix, its necessary to add the following to the `user_config_override.h`:
```
#ifndef AS2020
#define AS2020
#endif
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
