### PR TITLE
Berry fix crash on ESP32 early revisions

### DIFF
--- a/lib/libesp32/berry/src/be_vm.c
+++ b/lib/libesp32/berry/src/be_vm.c
@@ -114,7 +114,13 @@
     if (var_isint(a) && var_isint(b)) { \
         res = ibinop(op, a, b); \
     } else if (var_isnumber(a) && var_isnumber(b)) { \
-        res = var2real(a) op var2real(b); \
+        /* res = var2real(a) op var2real(b); */ \
+        union bvaldata x, y;        /* TASMOTA workaround for ESP32 rev0 bug */ \
+        x.i = a->v.i;\
+        if (var_isint(a)) { x.r = (breal) x.i; }\
+        y.i = b->v.i;\
+        if (var_isint(b)) { y.r = (breal) y.i; }\
+        res = x.r op y.r; \
     } else if (var_isstr(a) && var_isstr(b)) { \
         bstring *s1 = var_tostr(a), *s2 = var_tostr(b); \
         res = be_strcmp(s1, s2) op 0; \


### PR DESCRIPTION
## Description:

The following was reported to crash:
``` berry
import math
var test = 3
var test1 = 5
print(math.abs(test-test1) < 0.25)
```

This is caused by a bug in ESP32 hardware. The constant table containing the value `0.25` is stored in IRAM (to free some memory). IRAM accepts only 32bits aligned access. However there is a bug in early ESP32 revision, causing a load for a floating point number to be seen as non-aligned although it is aligned. Worth mentioning that this bug is not documented but fixed in Rev3.

This patch is the same that was used for ADD. The trick is to force a load of int32 from IRAM via `union` and then convert it to float within a register. 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
