### PR TITLE
ESP32 core 2.0.4pre

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -38,20 +38,20 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-v.2.0.3.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-2.0.4pre.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-solo1-2.0.4pre.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32itead]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/v2.0.3/framework-arduinoespressif32-itead.tar.gz
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-ITEAD-2.0.4pre.zip
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

- fixes in IDF/Arduino. The version is close to the upcoming official 2.0.4 version.
- ULP enabled for the ESP32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4pre
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
