### PR TITLE
Fix compiler warning in Berry lexer

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -336,7 +336,7 @@ static btokentype scan_decimal(blexer *lexer)
 {
     btokentype type = TokenInteger;
     match(lexer, is_digit);
-    if (decimal_dots(lexer) | scan_realexp(lexer)) {
+    if (decimal_dots(lexer) || scan_realexp(lexer)) {
         type = TokenReal;
     }
     lexer->buf.s[lexer->buf.len] = '\0';


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
