### PR TITLE
Revert "ESP32 core 2.0.4pre"

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -38,20 +38,20 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-2.0.4pre.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-v.2.0.3.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-solo1-2.0.4pre.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32itead]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4pre/platform-espressif32-ITEAD-2.0.4pre.zip
-platform_packages           =
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
+platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/v2.0.3/framework-arduinoespressif32-itead.tar.gz
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
Reverts arendst/Tasmota#15897

Since it crashes when doing OTA updates for C3 from Tasmota v11 to v12 release to v12 development.

fyi @digiblur 