### PR TITLE
Berry prefer `static var` syntax

### DIFF
--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -1446,26 +1446,32 @@ static void classdef_stmt(bparser *parser, bclass *c, bbool is_static)
 static void classstatic_stmt(bparser *parser, bclass *c, bexpdesc *e)
 {
     bstring *name;
-    /* 'static' ID ['=' expr] {',' ID ['=' expr] } */
+    /* 'static' ['var'] ID ['=' expr] {',' ID ['=' expr] } */
+    /* 'static' 'def' ID '(' varlist ')' block 'end' */
     scan_next_token(parser); /* skip 'static' */
     if (next_type(parser) == KeyDef) {  /* 'static' 'def' ... */
         classdef_stmt(parser, c, btrue);
-    } else if (match_id(parser, name) != NULL) {
-        check_class_attr(parser, c, name);
-        be_class_member_bind(parser->vm, c, name, bfalse);
-        class_static_assignment_expr(parser, e, name);
-
-        while (match_skip(parser, OptComma)) { /* ',' */
-            if (match_id(parser, name) != NULL) {
-                check_class_attr(parser, c, name);
-                be_class_member_bind(parser->vm, c, name, bfalse);
-                class_static_assignment_expr(parser, e, name);
-            } else {
-                parser_error(parser, "class static error");
-            }
-        }
     } else {
-        parser_error(parser, "class static error");
+        if (next_type(parser) == KeyVar) {
+            scan_next_token(parser); /* skip 'var' if any */
+        }
+        if (match_id(parser, name) != NULL) {
+            check_class_attr(parser, c, name);
+            be_class_member_bind(parser->vm, c, name, bfalse);
+            class_static_assignment_expr(parser, e, name);
+
+            while (match_skip(parser, OptComma)) { /* ',' */
+                if (match_id(parser, name) != NULL) {
+                    check_class_attr(parser, c, name);
+                    be_class_member_bind(parser->vm, c, name, bfalse);
+                    class_static_assignment_expr(parser, e, name);
+                } else {
+                    parser_error(parser, "class static error");
+                }
+            }
+        } else {
+            parser_error(parser, "class static error");
+        }
     }
 }
 

--- a/lib/libesp32/berry/tests/class_static.be
+++ b/lib/libesp32/berry/tests/class_static.be
@@ -8,11 +8,11 @@ def assert_attribute_error(f)
 end
 
 class A
-    static a
+    static a    #- deprecated syntax -#
     def init() self.b = 2 end
     def f() end 
     var b 
-    static c, s, r
+    static var c, s, r  #- preferred syntax -#
 end
 
 assert(A.a == nil)

--- a/lib/libesp32/berry/tools/grammar/berry.ebnf
+++ b/lib/libesp32/berry/tools/grammar/berry.ebnf
@@ -17,7 +17,7 @@ func_body = '(' [arg_field {',' arg_field}] ')' block 'end';
 arg_field = ['*'] ID;
 (* class define statement *)
 class_stmt = 'class' ID [':' ID] class_block 'end';
-class_block = {'var' ID {',' ID} | 'static' ID ['=' expr] {',' ID ['=' expr] } | 'static' func_stmt | func_stmt};
+class_block = {'var' ID {',' ID} | 'static' ['var'] ID ['=' expr] {',' ID ['=' expr] } | 'static' func_stmt | func_stmt};
 import_stmt = 'import' (ID (['as' ID] | {',' ID}) | STRING 'as' ID);
 (* exceptional handling statement *)
 try_stmt = 'try' block except_block {except_block} 'end';
@@ -28,12 +28,13 @@ throw_stmt = 'raise' expr [',' expr];
 var_stmt = 'var' ID ['=' expr] {',' ID ['=' expr]};
 (* expression define *)
 expr_stmt = expr [assign_op expr];
-expr = suffix_expr | unop expr | expr binop expr | cond_expr;
+expr = suffix_expr | unop expr | expr binop expr | range_expr | cond_expr;
 cond_expr = expr '?' expr ':' expr; (* conditional expression *)
 assign_op = '=' | '+=' | '-=' | '*=' | '/=' |
             '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=';
-binop = '..' | '<' | '<=' | '==' | '!=' | '>' | '>=' | '||' | '&&' |
+binop = '<' | '<=' | '==' | '!=' | '>' | '>=' | '||' | '&&' |
         '<<' | '>>' | '&' | '|' | '^' | '+' | '-' | '*' | '/' | '%';
+range_expr = expr '..' [expr]
 unop = '-' | '!' | '~';
 suffix_expr = primary_expr {call_expr | ('.' ID) | '[' expr ']'};
 primary_expr = '(' expr ')' | simple_expr | list_expr | map_expr | anon_func | lambda_expr;


### PR DESCRIPTION
## Description:

Original syntax:

``` berry
class A
  static a = 1
  static b = "foo"
  static def f()
    return 0
  end
end
```

The new preferred syntax is to use `static var` instead of just `static` (the original syntax is still accepted):

``` berry
class A
  static var a = 1
  static var b = "foo"
  static def f()
    return 0
  end
end
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
