### PR TITLE
Berry solidify to file

### DIFF
--- a/lib/libesp32/berry/src/be_debug.c
+++ b/lib/libesp32/berry/src/be_debug.c
@@ -15,6 +15,7 @@
 #include "be_strlib.h"
 #include "be_exec.h"
 #include "be_mem.h"
+#include "be_sys.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -46,13 +47,17 @@ static const char* opc2str(bopcode op)
     return op < array_count(opc_tab) ? opc_tab[op] : "ERROP";
 }
 
-void be_print_inst(binstruction ins, int pc)
+void be_print_inst(binstruction ins, int pc, void* fout)
 {
     char __lbuf[INST_BUF_SIZE];
     bopcode op = IGET_OP(ins);
 
     logbuf("  %.4X  ", pc);
-    be_writestring(__lbuf);
+    if (fout) {
+        be_fwrite(fout, __lbuf, strlen(__lbuf));
+    } else {
+        be_writestring(__lbuf);
+    }                            
     switch (op) {
     case OP_ADD: case OP_SUB: case OP_MUL: case OP_DIV:
     case OP_MOD: case OP_LT: case OP_LE: case OP_EQ:
@@ -132,8 +137,12 @@ void be_print_inst(binstruction ins, int pc)
         logbuf("%s", opc2str(op));
         break;
     }
-    be_writestring(__lbuf);
-    be_writenewline();
+    logbuf("%s\n", __lbuf);
+    if (fout) {
+        be_fwrite(fout, __lbuf, strlen(__lbuf));
+    } else {
+        be_writestring(__lbuf);
+    }                   
 }
 #endif
 
@@ -159,7 +168,7 @@ void be_dumpclosure(bclosure *cl)
             logfmt("; line %d\n", (++lineinfo)->linenumber);
         }
 #endif
-        be_print_inst(*code++, pc);
+        be_print_inst(*code++, pc, NULL);
     }
 }
 #endif

--- a/lib/libesp32/berry/src/be_debug.h
+++ b/lib/libesp32/berry/src/be_debug.h
@@ -22,7 +22,7 @@ bbool be_debug_varname(bvm *vm, int level, int index);
 bbool be_debug_upvname(bvm *vm, int level, int index);
 
 #if BE_USE_DEBUG_MODULE
-void be_print_inst(binstruction ins, int pc);
+void be_print_inst(binstruction ins, int pc, void* fout);
 #endif
 
 #endif


### PR DESCRIPTION
## Description:

Berry solidify can now dump to a file

`solidify.dump(object:any, [, strings_weak:bool, file_out:file]) -> nil`

Solidify can take a third argument as writable file to output the solidified code. If not specified, it goes to Tasmota logging.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
