### PR TITLE
Berry allow setmember() to fail with `false` or `undefined`

### DIFF
--- a/lib/libesp32/berry/src/be_class.c
+++ b/lib/libesp32/berry/src/be_class.c
@@ -299,8 +299,8 @@ int be_instance_member(bvm *vm, binstance *instance, bstring *name, bvalue *dst)
                         return BE_NONE;     /* if the return value is module `undefined`, consider it is an error */
                     }
                 }
-                var_clearstatic(dst);
-                return type;
+                    var_clearstatic(dst);
+                    return type;
             }
         }
     }
@@ -339,6 +339,20 @@ bbool be_instance_setmember(bvm *vm, binstance *o, bstring *name, bvalue *src)
             vm->top += 4;   /* prevent collection results */
             be_dofunc(vm, top, 3); /* call method 'member' */
             vm->top -= 4;
+            /* if return value is `false` or `undefined` signal an unknown attribute */
+            int type = var_type(vm->top);
+            if (type == BE_BOOL) {
+                bbool ret = var_tobool(vm->top);
+                if (!ret) {
+                    return bfalse;
+                }
+            } else if (type == BE_MODULE) {
+                /* check if the module is named `undefined` */
+                bmodule *mod = var_toobj(vm->top);
+                if (strcmp(be_module_name(mod), "undefined") == 0) {
+                    return bfalse;     /* if the return value is module `undefined`, consider it is an error */
+                }
+            }
             return btrue;
         }
     }

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -339,7 +339,7 @@ int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst)
                 bmodule *mod = var_toobj(dst);
                 if (strcmp(be_module_name(mod), "undefined") == 0) {
                     return BE_NONE;     /* if the return value is module `undefined`, consider it is an error */
-                }
+            }
             }
             return type;
         }
@@ -373,6 +373,19 @@ bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src)
             vm->top += 3;   /* prevent collection results */
             be_dofunc(vm, top, 2); /* call method 'setmember' */
             vm->top -= 3;
+            int type = var_type(vm->top);
+            if (type == BE_BOOL) {
+                bbool ret = var_tobool(vm->top);
+                if (!ret) {
+                    return bfalse;
+                }
+            } else if (type == BE_MODULE) {
+                /* check if the module is named `undefined` */
+                bmodule *mod = var_toobj(vm->top);
+                if (strcmp(be_module_name(mod), "undefined") == 0) {
+                    return bfalse;     /* if the return value is module `undefined`, consider it is an error */
+                }
+            }
             return btrue;
         }
     }

--- a/lib/libesp32/berry/tests/virtual_methods2.be
+++ b/lib/libesp32/berry/tests/virtual_methods2.be
@@ -1,4 +1,14 @@
 #- virtual attributes -#
+
+def assert_attribute_error(f)
+    try
+        f()
+        assert(false, 'unexpected execution flow')
+    except .. as e, m
+        assert(e == 'attribute_error')
+    end
+end
+
 class Ta
     var a, b, virtual_c
     def init()
@@ -26,3 +36,4 @@ assert(ta.c == 3)
 ta.c = 30
 assert(ta.c == 30)
 assert(ta.virtual_c == 30)
+assert_attribute_error(def() ta.d = 0 end)


### PR DESCRIPTION
## Description:

Sync with upstream Berry. Now `setmember(name, value)` for `class` or `module` can return `false` or `undefined` to indicate that the attribute does not exist. Previously the only way was to raise an exception.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
