### PR TITLE
Fix build environment name check for esp32.

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -41,8 +41,9 @@ variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
 def esp32_create_chip_string(chip):
     tasmota_platform = env.subst("$BUILD_DIR").split(os.path.sep)[-1]
     tasmota_platform = tasmota_platform.split('-')[0]
-    if 'tasmota' and chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
+    if 'tasmota' + chip[3:] not in tasmota_platform: # quick check for a valid name like 'tasmota' + '32c3'
         print('Unexpected naming conventions in this build environment -> Undefined behavior for further build process!!')
+        print("Expected build environment name like 'tasmota32-whatever-you-want'")
     return tasmota_platform
 
 def esp32_build_filesystem(fs_size):


### PR DESCRIPTION
## Description:
This PR fixes a check for a valid environment name, which should be `tasmota` + `board_version` for defined [boards](https://github.com/arendst/Tasmota/tree/development/boards). Like `tasmota32` for [esp32_4M](https://github.com/arendst/Tasmota/blob/f4851dbf5531811216e7c14547a3167c326d799e/boards/esp32_4M.json#L34) board.   

Validation of an environment name was incorrect. It checked that only chip's number (`chip[3:]`) is present in the name but not a _tasmota_ string. 

There was no warning message about invalid environment name and esptool exited with `No such file or directory` ... `variants/tasmota/tasmota32-safeboot.bin` error. It happens when env name prefix, such as `[env:esp32-custom]`, does not match a filename-prefix (for example [tasmota32](https://github.com/arendst/Tasmota/blob/f4851dbf5531811216e7c14547a3167c326d799e/boards/esp32_4M.json#L34)) specified in board's json file.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).