### PR TITLE
Berry fix regression

### DIFF
--- a/lib/libesp32/berry/src/be_globallib.c
+++ b/lib/libesp32/berry/src/be_globallib.c
@@ -72,7 +72,6 @@ static int m_setglobal(bvm *vm)
     if (top >= 2 && be_isstring(vm, 1)) {
         const char * name = be_tostring(vm, 1);
         be_setglobal(vm, name);
-        be_return(vm);
     }
     be_return_nil(vm);
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_7_berry_embedded.ino
@@ -31,8 +31,8 @@ const char berry_prog[] =
 #ifdef USE_BERRY_PYTHON_COMPAT
   // enable python syntax compatibility mode
   "import python_compat "
-  "import cb "
 #endif
+  "import cb "
 
 #ifdef USE_ENERGY_SENSOR
   "import energy "


### PR DESCRIPTION
## Description:

Fix regression from #15932 (`BRY: Exception> 'attribute_error' - 'module' value has no writable attribute 'False'`)
Also fix a compilation directive wrongly placed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
