### PR TITLE
Tasmota Core 2.0.4

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -38,20 +38,20 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-v.2.0.3.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-2.0.4.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-solo1-2.0.4.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32itead]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.3/platform-espressif32-solo1-v.2.0.3.zip
-platform_packages           = framework-arduinoespressif32 @ https://github.com/tasmota/esp32-arduino-lib-builder/releases/download/v2.0.3/framework-arduinoespressif32-itead.tar.gz
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-ITEAD-2.0.4.zip
+platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

based on released Espressif Arduino core 2.0.4 with some code modifications and changed settings in IDF 4.4.2 and Arduino core.

The core 2.0.4 is a bug fix release. Several bug fixes are made in IDF and Arduino code.
Too many to list. Changes made can be seen in espressif githubs

OTA updates tested from Tasmota release v11 to release v12 to latest devel with core 2.0.4. Doing a downgrade to devel v12 (core 2.0.3) and release v12 does work too.
Further OTA downgrading to v11 can brick the device (the same behaviour as before).
(Major Version downgrading is not supported)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
