### PR TITLE
Berry fix potential crash when parsing unfinished strings

### DIFF
--- a/lib/libesp32/berry/src/be_lexer.c
+++ b/lib/libesp32/berry/src/be_lexer.c
@@ -419,6 +419,9 @@ static btokentype scan_string(blexer *lexer)
                 save(lexer); /* skip '\\.' */
             }
         }
+        if (c == EOS) {
+            be_lexerror(lexer, "unfinished string");
+        }
         c = next(lexer); /* skip '"' or '\'' */
         /* check if there's an additional string literal right after */
         skip_delimiter(lexer);


### PR DESCRIPTION
## Description:

Reporting from upstream https://github.com/berry-lang/berry/pull/274

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.3
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
