### PR TITLE
Update LedMatrix.cpp

### DIFF
--- a/lib/lib_display/LedControl/src/LedMatrix.cpp
+++ b/lib/lib_display/LedControl/src/LedMatrix.cpp
@@ -330,7 +330,22 @@ void LedMatrix::refresh()
             }
             else // ORIENTATION_TURN_RIGHT || ORIENTATION_TURN_LEFT
             {
-                // not implemented yet
+                col = addr % modulesPerRow;
+                pixelRow = (addr / modulesPerRow) * 8 + ledRow;
+                bufPos = pixelRow * modulesPerRow + col;
+
+                if (moduleOrientation == ORIENTATION_TURN_RIGHT)
+                {
+                    // ORIENTATION_TURN_RIGHT
+                    deviceDataBuff[addr] = buffer[bufPos];
+                    deviceRow = ledRow;
+                }
+                else
+                {
+                    // ORIENTATION_TURN_LEFT
+                    deviceDataBuff[maxDevices - 1 - addr] = revereBitorder(buffer[bufPos]);
+                    deviceRow = 7 - ledRow; // upside down
+                }
             }
         }
         setRow_allDevices(deviceRow, deviceDataBuff); 


### PR DESCRIPTION
I have a few MAX7219 modules that use a different column assignment and the 2 already implemented orientations did not work for me.

After these changes DisplayRotate 1 and DisplayRotate 3 commands do what they are supposed to do.

## Description:

**Related issue (if applicable):** fixes #

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
