### PR TITLE
add `Speed2 !` to cancel pending one-shot speed setting

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -3130,6 +3130,14 @@ void CmndFade(void)
 void CmndSpeed(void)
 {
   if (2 == XdrvMailbox.index) {
+    // Speed2 ! cancels use of Speed2 in the future
+    if ((1 == XdrvMailbox.data_len) && ('!' == XdrvMailbox.data[0])) {
+      Light.fade_once_enabled = false;
+      Light.speed_once_enabled = false;
+      ResponseCmndDone();
+      return;
+    }
+
     // Speed2 setting will be used only once, then revert to fade/speed
     if ((XdrvMailbox.payload >= 0) && (XdrvMailbox.payload <= 40)) {
       Light.fade_once_enabled = true;


### PR DESCRIPTION
## Description:

`Speed2 !` can be used to cancel the use of a preceding `Speed2` command. This is useful if you're using `Setoption20` (update of Dimmer/Color/CT without turning power on) so you can control things like the colour temperature of light from a cron job or schedule without the light turning on when you change the CT. However, if you have `Fade 1` and `Speed 2` as your normal speed/fade settings, and you change the CT with a command like `Backlog Speed2 20; CT 500` to get a gradual fade when the light is on, the `Speed2` isn't "consumed" until the light is turned on. When you turn the light on later, it takes 10 seconds instead of 1.

With `Speed2 !`, you can use `Backlog Speed2 20; CT 500; Speed2 !` as the scheduled command. If the light is on, the `Speed2 10` is used by CT command immediately because the light is already on. If the light is off, the CT command doesn't take effect, leaving the preceding `Speed2` change ready to go when the light is actually turned on. The `Speed2 !` clears that, so when you do turn the light on in the future it acts as expected (with the `Speed 2` setting).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
