### PR TITLE
set used flash mode in factory.bin

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -132,12 +132,18 @@ def esp32_create_combined_bin(source, target, env):
     else:
         esp32_fetch_safeboot_bin(tasmota_platform)
     flash_size = env.BoardConfig().get("upload.flash_size", "4MB")
+    flash_freq = "keep"
+    flash_mode = env.BoardConfig().get("build.flash_mode", "dout")
     cmd = [
         "--chip",
         chip,
         "merge_bin",
         "-o",
         new_file_name,
+        "--flash_mode",
+        flash_mode,
+        "--flash_freq",
+        flash_freq,
         "--flash_size",
         flash_size,
     ]


### PR DESCRIPTION
## Description:

Since Core 2.0.4 setting the used Flash Mode is needed

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
