### PR TITLE
Is2 update

### DIFF
--- a/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.h
+++ b/lib/lib_audio/ESP8266Audio/src/AudioOutputI2S.h
@@ -28,11 +28,15 @@
 #define I2S_PIN_NO_CHANGE -1
 #endif
 
+#ifdef ESP8266
+#define I2S_MCLK_MULTIPLE_DEFAULT 0
+#endif
+
 class AudioOutputI2S : public AudioOutput
 {
   public:
 #if defined(ESP32) || defined(ESP8266)
-    AudioOutputI2S(int port=0, int output_mode=EXTERNAL_I2S, int dma_buf_count = 8, int use_apll=APLL_DISABLE);
+    AudioOutputI2S(int port=0, int output_mode=EXTERNAL_I2S, int dma_buf_count = 8, int use_apll=APLL_DISABLE, uint8_t mult=I2S_MCLK_MULTIPLE_DEFAULT, uint32_t freq=0);
     bool SetPinout(int bclkPin, int wclkPin, int doutPin, int mclk = I2S_PIN_NO_CHANGE, int din = I2S_PIN_NO_CHANGE);
     enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
     enum : int { EXTERNAL_I2S = 0, INTERNAL_DAC = 1, INTERNAL_PDM = 2 };
@@ -69,6 +73,8 @@ class AudioOutputI2S : public AudioOutput
     uint8_t bclkPin;
     uint8_t wclkPin;
     uint8_t doutPin;
-    uint8_t dinPin;
-    uint8_t mclkPin;
+    int8_t dinPin;
+    int8_t mclkPin;
+    uint8_t mcmult;
+    uint32_t mclk_freq;
 };


### PR DESCRIPTION
## Description:

fixes for s3 box audio
mclk in dynamic configuration like in espressif examples causes the wlan to hang because of mclk interferences.
i had to use fixed mclk with 12 Mhz that according to the codecs data sheet is also allowed.
 
+ support for generic i2s microphone USE_I2S_MIC

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
