### PR TITLE
Expanded ModbusBridge startaddress from 8 to 16 bits allowing addresses 0..65535

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_100_modbus_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_100_modbus_bridge.ino
@@ -111,7 +111,7 @@ struct ModbusBridge
   uint8_t count = 0;
   uint16_t registerCount = 0;
   uint8_t deviceAddress = 0;
-  uint8_t startAddress = 0;
+  uint16_t startAddress = 0;
 };
 
 ModbusBridge modbusBridge;


### PR DESCRIPTION
## Description:

The modbus startaddress has to be 16 bits in order to use the full address range of the registers.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
