### PR TITLE
ESP32 enhancements to stepper shutter motor

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -68,12 +68,19 @@ int32_t _analog_pin2chan(uint32_t pin) {    // returns -1 if uallocated
   return -1;
 }
 
-void _analogWriteFreqRange(void) {
+void _analogWriteFreqRange(uint8_t pin) {
   _analogInit();      // make sure the mapping array is initialized
-  for (uint32_t channel = 0; channel < MAX_PWMS; channel++) {
-    if (pwm_channel[channel] < 255) {
-      ledcSetup(channel, pwm_frequency, pwm_bit_num);
-    }
+  if (pin = 255) {
+   for (uint32_t channel = 0; channel < MAX_PWMS; channel++) {
+     if (pwm_channel[channel] < 255) {
+       ledcSetup(channel, pwm_frequency, pwm_bit_num);
+     }
+   }
+  } else {
+   int32_t chan = _analog_pin2chan(pin);
+   if (chan >= 0) {
+     ledcSetup(chan, pwm_frequency, pwm_bit_num);
+   }
   }
 }
 
@@ -89,12 +96,22 @@ uint32_t _analogGetResolution(uint32_t x) {
 
 void analogWriteRange(uint32_t range) {
   pwm_bit_num = _analogGetResolution(range);
-  _analogWriteFreqRange();
+  _analogWriteFreqRange(255);
+}
+
+void analogWriteRange(uint32_t range, uint8_t pin) {
+  pwm_bit_num = _analogGetResolution(range);
+  _analogWriteFreqRange(pin);
 }
 
 void analogWriteFreq(uint32_t freq) {
   pwm_frequency = freq;
-  _analogWriteFreqRange();
+  _analogWriteFreqRange(255);
+}
+
+void analogWriteFreq(uint32_t freq, uint8_t pin) {
+  pwm_frequency = freq;
+  _analogWriteFreqRange(pin);
 }
 
 int32_t analogAttach(uint32_t pin, bool output_invert) {    // returns ledc channel used, or -1 if failed

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -11,7 +11,6 @@
 
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
  */
 
 #ifdef ESP32
@@ -70,16 +69,16 @@ int32_t _analog_pin2chan(uint32_t pin) {    // returns -1 if uallocated
 
 void _analogWriteFreqRange(uint8_t pin) {
   _analogInit();      // make sure the mapping array is initialized
-  if (pin = 255) {
+  if (pin == 255) {
    for (uint32_t channel = 0; channel < MAX_PWMS; channel++) {
      if (pwm_channel[channel] < 255) {
        ledcSetup(channel, pwm_frequency, pwm_bit_num);
      }
    }
   } else {
-   int32_t chan = _analog_pin2chan(pin);
-   if (chan >= 0) {
-     ledcSetup(chan, pwm_frequency, pwm_bit_num);
+   int32_t channel = _analog_pin2chan(pin);
+   if (channel >= 0) {
+     ledcSetup(channel, pwm_frequency, pwm_bit_num);
    }
   }
 }
@@ -126,7 +125,7 @@ int32_t analogAttach(uint32_t pin, bool output_invert) {    // returns ledc chan
 
       // ledcAttachPin(pin, channel);  -- replicating here because we want the default duty
       uint8_t group=(chan/8), channel=(chan%8), timer=((chan/2)%4);
-      
+
       // AddLog(LOG_LEVEL_INFO, "PWM: ledc_channel pin=%i out_invert=%i", pin, output_invert);
       ledc_channel_config_t ledc_channel = {
           (int)pin,          // gpio
@@ -139,7 +138,6 @@ int32_t analogAttach(uint32_t pin, bool output_invert) {    // returns ledc chan
           { output_invert ? 1u : 0u },// output_invert
       };
       ledc_channel_config(&ledc_channel);
-
 
       ledcSetup(channel, pwm_frequency, pwm_bit_num);
       // Serial.printf("PWM: New attach pin %d to channel %d\n", pin, channel);
@@ -160,19 +158,18 @@ extern "C" void __wrap__Z11analogWritehi(uint8_t pin, int val) {
 /*
   The primary goal of this function is to add phase control to PWM ledc
   functions.
-
+  
   Phase control allows to stress less the power supply of LED lights.
   By default all phases are starting at the same moment. This means
   the the power supply always takes a power hit at the start of each
   new cycle, even if the average power is low.
-
-  Phase control is also of major importance for H-bridge where 
+  Phase control is also of major importance for H-bridge where
   both PWM lines should NEVER be active at the same time.
-
+  
   Unfortunately Arduino Core does not allow any customization nor
   extendibility for the ledc/analogWrite functions. We have therefore
   no other choice than duplicating part of Arduino code.
-
+  
   WARNING: this means it can easily break if ever Arduino internal
   implementation changes.
 */

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.h
@@ -26,7 +26,9 @@
 
 // input range is in full range, ledc needs bits
 void analogWriteRange(uint32_t range);
+void analogWriteRange(uint32_t range, uint8_t pin);
 void analogWriteFreq(uint32_t freq);
+void analogWriteFreq(uint32_t freq, uint8_t pin);
 int32_t analogAttach(uint32_t pin, bool output_invert = false);   // returns the ledc channel, or -1 if failed. This is implicitly called by analogWrite if the channel was not already allocated
 void analogWrite(uint8_t pin, int val);
 


### PR DESCRIPTION
## Description:
ESP32 does not support frequency changes in shutter driver for stepper motors. This is fixed now. Anyhow there is limitation that the frequency is changed on all channels even if this "prevented" by the software. An additional change for multiple shutters is required.


**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#15877

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
