### PR TITLE
sendmail override domain for SMTP EHLO command

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
@@ -24,6 +24,10 @@
  *
  * if email body consist of a single * and scripter is present
  * and a section >m is found, the lines in this section (until #) are sent as email body
+ * 
+ * Some mail servers do not accept the IP address in the HELO (or EHLO) message but only a fully qualified 
+ * domain name (FQDN). To overcome this, use the following define to override this behavior and enter the desired FQDN
+ * #define EMAIL_USER_DOMAIN "googlemail.com"
  *
  * sendmail works with pre2.6 using Light BearSSL
  * HW Watchdog 8.44 sec.
@@ -132,7 +136,11 @@ bool SendEmail::send(const String& from, const String& to, const String& subject
   if (!buffer.startsWith(F("220"))) { return false; }
 
   buffer = F("EHLO ");
+#ifdef EMAIL_USER_DOMAIN
+  buffer += EMAIL_USER_DOMAIN;
+#else
   buffer += client->localIP().toString();
+#endif
   client->println(buffer);
 #ifdef DEBUG_EMAIL_PORT
   MailWriteAddLogBuffer(&buffer);


### PR DESCRIPTION
## Description:

Some mail servers do not accept the IP address in the HELO (or EHLO) message but only a fully qualified 
domain name (FQDN). 

I saw that the implementation of the sendmail function for ESP8266 by default put the IP address in the HELO SMTP command

To overcome this, use the EMAIL_USER_DOMAIN define to override this behavior and enter the desired FQDN

Example:
```
 #define EMAIL_USER_DOMAIN "googlemail.com"
```

I have verified that the implementation for ESP32 is not affected by this problem as it handles things differently, by default inserts "googlemail.com" with a fallback of "mydomain.com" 
see: `session.login.user_domain = "googlemail.com";` in `tasmota\tasmota_xdrv_driver\xdrv_01_2_webserver_esp32_mail.ino` 
and `lib\libesp32\lib_mail\src\ESP_Mail_Client.cpp` line 1554 

**Related issue (if applicable):** none

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_