### PR TITLE
Baudrate and serial config for modbus_bridge are now persistent

### DIFF
--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -833,8 +833,10 @@ typedef struct {
   uint8_t       shd_warmup_time;           // F5E
   uint8_t       tcp_config;                // F5F
   uint8_t       light_step_pixels;				 // F60
+  uint8_t       modbus_sbaudrate;          // F61
+  uint8_t       modbus_sconfig;            // F62
 
-  uint8_t       free_f61[19];              // F61 - Decrement if adding new Setting variables just above and below
+  uint8_t       free_f63[17];              // F63 - Decrement if adding new Setting variables just above and below
 
   // Only 32 bit boundary variables below
   SOBitfield6   flag6;                     // F74


### PR DESCRIPTION
## Description:

The baudrate and serial config where not saved when configuring. Also requesting the baudrate didn't return the correct baudrate. Baudrate and serial config are now saved and checked if valid before applied to serial port.

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/9586#issuecomment-1193781728

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4 **(N/A for TasmotaModbus)**
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
