### PR TITLE
Berry fix reference when exeception is raised

### DIFF
--- a/lib/libesp32/berry/src/be_exec.h
+++ b/lib/libesp32/berry/src/be_exec.h
@@ -45,6 +45,7 @@ struct bexecptframe {
     struct blongjmp errjmp; /* long jump information */
     int depth; /* function call stack depth */
     binstruction *ip; /* instruction pointer */
+    int refcount; /* save object reference stack */
 };
 
 void be_throw(bvm *vm, int errorcode);

--- a/lib/libesp32/berry/tests/reference.be
+++ b/lib/libesp32/berry/tests/reference.be
@@ -1,0 +1,31 @@
+# try to exercise bug in reference
+
+class failable
+    var fail        # if 'true', tostring() raises an exception
+
+    def tostring()
+        if self.fail
+            raise "internal_error", "FAIL"
+            return "FAIL"
+        else
+            return "SUCCESS"
+        end
+    end
+end
+f = failable()
+
+l1 = [1, 2, f]
+l2 = ["foo", l1]
+l1.push(l1)
+
+assert(str(l2) == "['foo', [1, 2, SUCCESS, [...]]]")
+assert(str(l1) == "[1, 2, SUCCESS, [...]]")
+
+f.fail = true
+try
+    print(str(l1))
+except ..
+end
+
+f.fail = false
+assert(str(l1) == "[1, 2, SUCCESS, [...]]")  # FAILS


### PR DESCRIPTION
## Description:

Fixes a rare bug when an exception is raised while converting a list/map to a string. Report of https://github.com/berry-lang/berry/pull/277

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
