### PR TITLE
Berry remove unused registry code

### DIFF
--- a/lib/libesp32/berry/src/be_api.c
+++ b/lib/libesp32/berry/src/be_api.c
@@ -1142,29 +1142,3 @@ BERRY_API bbool be_isge(bvm *vm)
     be_assert(vm->reg + 2 <= vm->top);
     return be_vm_isge(vm, vm->top - 2, vm->top - 1);
 }
-
-BERRY_API int be_register(bvm *vm, int index)
-{
-    bvalue *v;
-    if (!vm->registry) {
-        vm->registry = be_list_new(vm);
-        be_list_pool_init(vm, vm->registry);
-    }
-    be_assert(vm->registry != NULL);
-    v = be_indexof(vm, index);
-    return be_list_pool_alloc(vm, vm->registry, v);
-}
-
-BERRY_API void be_unregister(bvm *vm, int id)
-{
-    be_assert(vm->registry != NULL);
-    be_list_pool_free(vm->registry, id);
-}
-
-BERRY_API void be_getregister(bvm *vm, int id)
-{
-    blist *reg = vm->registry;
-    be_assert(reg && id > 0 && id < be_list_count(reg));
-    var_setval(vm->top, be_list_at(reg, id));
-    be_incrtop(vm);
-}

--- a/lib/libesp32/berry/src/be_gc.c
+++ b/lib/libesp32/berry/src/be_gc.c
@@ -370,7 +370,6 @@ static void premark_internal(bvm *vm)
     mark_gray(vm, gc_object(vm->module.loaded));
     mark_gray(vm, gc_object(vm->module.path));
     mark_gray(vm, gc_object(vm->ntvclass));
-    mark_gray(vm, gc_object(vm->registry));
 #if BE_USE_DEBUG_HOOK
     if (be_isgcobj(&vm->hook)) {
         mark_gray(vm, gc_object(var_toobj(&vm->hook)));

--- a/lib/libesp32/berry/src/be_vm.h
+++ b/lib/libesp32/berry/src/be_vm.h
@@ -102,7 +102,6 @@ struct bvm {
     struct bstringtable strtab; /* short string table */
     bstack tracestack; /* call state trace-stack */
     bmap *ntvclass; /* native class table */
-    blist *registry; /* registry list */
     struct bgc gc;
     bctypefunc ctypefunc; /* handler to ctype_func */
     bbyte compopt; /* compilation options */

--- a/lib/libesp32/berry/src/berry.h
+++ b/lib/libesp32/berry/src/berry.h
@@ -580,11 +580,6 @@ BERRY_API void be_module_path_set(bvm *vm, const char *path);
 BERRY_API void* be_pushbytes(bvm *vm, const void *buf, size_t len);
 BERRY_API const void* be_tobytes(bvm *vm, int index, size_t *len);
 
-/* registry operation */
-BERRY_API int be_register(bvm *vm, int index);
-BERRY_API void be_unregister(bvm *vm, int id);
-BERRY_API void be_getregister(bvm *vm, int id);
-
 /* debug APIs */
 BERRY_API void be_sethook(bvm *vm, const char *mask);
 BERRY_API void be_setntvhook(bvm *vm, bntvhook hook, void *data, int mask);


### PR DESCRIPTION
## Description:

Report of https://github.com/berry-lang/berry/pull/276

Internal registry code is nowhere used, so it is removed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
