### PR TITLE
Tasmota Esp32 core 2041

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
   - [ ] Only relevant files were touched
   - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
   - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
-  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4
+  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
   - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
 
 _NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -38,20 +38,20 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-2.0.4.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-2.0.4.1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 
 [core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-solo1-2.0.4.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-solo1-2.0.4.1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}
 
 [core32itead]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4/platform-espressif32-ITEAD-2.0.4.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.4.1/platform-espressif32-ITEAD-2.0.4.1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

Fixes/changes in IDF wifi libs to solve issues with Tasmota `so56` `so57` not working for some AP brands

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
