### PR TITLE
Update BUILDs.md

### DIFF
--- a/BUILDS.md
+++ b/BUILDS.md
@@ -13,7 +13,8 @@ Note: `minimal` variant is not listed as it shouldn't be used outside of the [up
 | USE_UFILESYS          | - | - / x | - | - | - | - |
 | USE_ARDUINO_OTA       | - | - / - | - | - | - | - |
 | USE_DOMOTICZ          | - | x / x | x | x | x | - |
-| USE_HOME_ASSISTANT    | - | x / x | x | x | x | - |
+| USE_HOME_ASSISTANT    | - | - / - | - | - | - | - |
+| USE_TASMOTA_DISCOVERY | x | x / x | x | x | x | x |
 | USE_MQTT_TLS          | - | - / - | - | - | - | - |
 | USE_MQTT_AWS_IOT      | - | - / - | - | - | - | - |
 | USE_4K_RSA            | - | - / - | - | - | - | - |

--- a/BUILDS.md
+++ b/BUILDS.md
@@ -15,7 +15,7 @@ Note: `minimal` variant is not listed as it shouldn't be used outside of the [up
 | USE_DOMOTICZ          | - | x / x | x | x | x | - |
 | USE_HOME_ASSISTANT    | - | - / - | - | - | - | - |
 | USE_TASMOTA_DISCOVERY | x | x / x | x | x | x | x |
-| USE_MQTT_TLS          | - | - / - | - | - | - | - |
+| USE_MQTT_TLS*         | - | - / x | - | - | - | - |
 | USE_MQTT_AWS_IOT      | - | - / - | - | - | - | - |
 | USE_4K_RSA            | - | - / - | - | - | - | - |
 | USE_TELEGRAM          | - | - / - | - | - | - | - |
@@ -251,3 +251,5 @@ Note: `minimal` variant is not listed as it shouldn't be used outside of the [up
 | USE_I2S_AUDIO             |   |   / - |   |   |   |   |
 | USE_TTGO_WATCH            |   |   / - |   |   |   |   |
 | USE_SONOFF_SPM            |   |   / x |   |   |   |   |
+
+* USE_MQTT_TLS is enabled by default in every ESP32 variants


### PR DESCRIPTION
## Description:

Update BUILDs.md
- No more USE_HOME_ASSISTANT but USE_TASMOTA_DISCOVERY everywhere
- USE_MQTT_TLS is default in every ESP32 builds (as a consequence of autoconf being default)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
