### PR TITLE
Fix IRsend GPIO init

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_05_irremote_full.ino
@@ -839,6 +839,13 @@ void IrRemoteCmndResponse(uint32_t error)
 void IrInit(void) {
   ir_send_active = PinUsed(GPIO_IRSEND, GPIO_ANY);
   ir_recv_active = PinUsed(GPIO_IRRECV, GPIO_ANY);
+  if (ir_send_active) {
+    for (uint32_t chan = 0; chan < MAX_IRSEND; chan++) {
+      if (PinUsed(GPIO_IRSEND, chan)) {
+        IrSendInitGPIO(chan);
+      }
+    }
+  }
 }
 
 /*********************************************************************************************\


### PR DESCRIPTION
## Description:

Fix missing GPIO initialization introduced in #16138

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
