### PR TITLE
Fix PWM for ESP32 variants

### DIFF
--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/esp8266toEsp32.cpp
@@ -37,7 +37,9 @@ enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_D
 
 // define our limits to ease any change from esp-idf
 #define MAX_TIMERS              LEDC_TIMER_MAX            // 4 timers for all ESP32 variants
-#define HAS_HIGHSPEED           SOC_LEDC_SUPPORT_HS_MODE  // are there 2 banks of timers/ledc
+#ifdef SOC_LEDC_SUPPORT_HS_MODE
+  #define PWM_HAS_HIGHSPEED  SOC_LEDC_SUPPORT_HS_MODE     // are there 2 banks of timers/ledc
+#endif
 
 
 // replicated from `tasmota.h`
@@ -89,7 +91,7 @@ void _analog_applyTimerConfig(int32_t timer) {
   if (ret != ESP_OK) {
     AddLog(LOG_LEVEL_ERROR, "PWM: ledc_timer_config %i failed ret=%i", timer, ret);
   }
-#ifdef HAS_HIGHSPEED
+#ifdef PWM_HAS_HIGHSPEED
   // apply the same parameter to the low-speed timer as well
   cfg.speed_mode = (ledc_mode_t) 1;         // first bank
   ret = ledc_timer_config(&cfg);


### PR DESCRIPTION
## Description:

Fix #defines for ESP32x variants when configuring channels for PWM.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
