### PR TITLE
Zigbee include "BatteryPercentage" in all messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Support for multiple ``IRsend`` GPIOs
 - Zigbee added recording of when the battery was last reported
 - Zigbee add Battery auto-probe (can be disabled with ``SetOption143 1``)
+- Zigbee include "BatteryPercentage" in all messages
 
 ### Changed
 - ESP32 LVGL library from v8.2.0 to v8.3.0

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -628,6 +628,7 @@
 #define D_CMND_ZIGBEE_SAVE "Save"
   #define D_CMND_ZIGBEE_LINKQUALITY "LinkQuality"
   #define D_CMND_ZIGBEE_CLUSTER "Cluster"
+  #define D_CMND_ZIGBEE_BATTPERCENT "BatteryPercentage"
   #define D_CMND_ZIGBEE_ENDPOINT "Endpoint"
   #define D_CMND_ZIGBEE_GROUP "Group"
   #define D_CMND_ZIGBEE_MANUF "Manuf"

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4b_data.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4b_data.ino
@@ -46,7 +46,7 @@ int32_t hydrateDeviceWideData(class Z_Device & device, const SBuffer & buf, size
   }
   device.last_seen = buf.get32(start+1);
   device.lqi = buf.get8(start + 5);
-  device.batterypercent = buf.get8(start + 6);
+  device.batt_percent = buf.get8(start + 6);
   if (segment_len >= 10) {
     device.batt_last_seen = buf.get32(start+7);
   }
@@ -124,7 +124,7 @@ SBuffer hibernateDeviceData(const struct Z_Device & device) {
     buf.add8(10);        // 10 bytes
     buf.add32(device.last_seen);
     buf.add8(device.lqi);
-    buf.add8(device.batterypercent);
+    buf.add8(device.batt_percent);
     // now storing batt_last_seen
     buf.add32(device.batt_last_seen);
 
@@ -279,6 +279,19 @@ void Z_SaveDataTimer(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, u
   hibernateAllData();
   Z_Set_Save_Data_Timer(0);     // set a new timer
 }
+
+//
+// Callback for saving all data once, used after receiving important events
+//
+int32_t Z_Set_Save_Data_Timer_Once(uint8_t value) {
+  zigbee_devices.setTimer(0x0000, 0, 0 /* now */, 0, 0, Z_CAT_ALWAYS, 0 /* value */, &Z_SaveDataTimerOnce);
+  return 0;                              // continue
+}
+
+void Z_SaveDataTimerOnce(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluster, uint8_t endpoint, uint32_t value) {
+  hibernateAllData();
+}
+
 
 #ifdef USE_ZIGBEE_EEPROM
 void ZFS_Erase(void) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -1703,7 +1703,7 @@ void Z_IncomingMessage(class ZCLFrame &zcl_received) {
       Z_Query_Battery(srcaddr);   // do battery auto-probing when receiving commands
     }
 
-    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZCL_RAW_RECEIVED ": {\"0x%04X\":{%s}}"), srcaddr, attr_list.toString().c_str());
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ZIGBEE D_JSON_ZIGBEEZCL_RAW_RECEIVED ": {\"0x%04X\":{%s}}"), srcaddr, attr_list.toString(false, false).c_str()); // don't include battery
 
     // discard the message if it was sent by us (broadcast or group loopback)
     if (srcaddr == localShortAddr) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -2039,8 +2039,8 @@ void ZigbeeShow(bool json)
           }
           snprintf_P(sbatt, sizeof(sbatt),
             msg[ZB_WEB_BATTERY],
-            device.batterypercent, dhm,
-            changeUIntScale(device.batterypercent, 0, 100, 0, 14),
+            device.batt_percent, dhm,
+            changeUIntScale(device.batt_percent, 0, 100, 0, 14),
             (color & 0xFF0000) >> 16, (color & 0x00FF00) >> 8, (color & 0x0000FF)
           );
         }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -66,7 +66,7 @@ extern "C" {
     return d->lqi == 255 ? -1 : d->lqi;
   }
   int32_t zd_battery(const class Z_Device* d) {
-    return d->batterypercent == 255 ? -1 : d->batterypercent;
+    return d->batt_percent == 255 ? -1 : d->batt_percent;
   }
   int32_t zd_battery_lastseen(const class Z_Device* d) {
     return 0;   // TODO not yet known


### PR DESCRIPTION
## Description:

Now that Battery Percentage is more reliable, `"BatteryPercentage"` is included in all received MQTT messages with the last known value.

Ex:
```
RSL: SENSOR = {"ZbReceived":{"0x4846":{"Device":"0x4846","Name":"SNZB-02","Humidity":73.35,"BatteryPercentage":9,"Endpoint":1,"LinkQuality":182}}}
```

An automatic `ZbSave` is triggered when updated Battery data is received, which prevents from losing this data (it is otherwise saved once per hour).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
