### PR TITLE
Zigbee ``SetOption144 1`` includes a timestamp in `ZbReceived` messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee include "BatteryPercentage" in all messages
 - Commands ``WifiScan`` and ``WifiTest`` (#16141)
 - Support for Catalan language translations by Albert Gonzalez (#16145)
+- Zigbee ``SetOption144 1`` includes a timestamp in `ZbReceived` messages
 
 ### Changed
 - ESP32 LVGL library from v8.2.0 to v8.3.0 (#16019)

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -171,7 +171,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t gui_module_name : 1;          // bit 27 (v11.1.0.3) - SetOption141 - (GUI) Disable display of GUI module name (1)
     uint32_t wait_for_wifi_result : 1;     // bit 28 (v11.1.0.4) - SetOption142 - (Wifi) Wait 1 second for wifi connection solving some FRITZ!Box modem issues (1)
     uint32_t zigbee_no_batt_autoprobe : 1; // bit 29 (v12.0.2.4) - SetOption143 - (Zigbee) Disable Battery auto-probe and using auto-binding
-    uint32_t spare30 : 1;                  // bit 30
+    uint32_t zigbee_include_time : 1;      // bit 30 (v12.0.2.4) - SetOption144 - (Zigbee) include time in `ZbReceived` messages like other sensors
     uint32_t spare31 : 1;                  // bit 31
   };
 } SOBitfield5;

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2_devices.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2_devices.ino
@@ -828,7 +828,7 @@ public:
   void jsonAddDataAttributes(Z_attribute_list & attr_list) const;
   void jsonAddDeviceAttributes(Z_attribute_list & attr_list) const;
   void jsonDumpSingleDevice(Z_attribute_list & attr_list, uint32_t dump_mode, bool add_name) const;
-  void jsonPublishAttrList(const char * json_prefix, const Z_attribute_list &attr_list) const;
+  void jsonPublishAttrList(const char * json_prefix, const Z_attribute_list &attr_list, bool include_time = false) const;
   void jsonLightState(Z_attribute_list & attr_list) const;
 
   // dump device attributes to ZbData


### PR DESCRIPTION
## Description:

`SetOption144 1` adds a timestamp in all `ZbReceived` message. Note that the timestamp is not added if `ZbReceived` is not present (depending on options and topic used).

Example:

With `SetOption144 1`

```
17:24:49.597 RSL: SENSOR = {"Time":"2022-08-09T17:24:49","ZbReceived":{"0x4846":{"Device":"0x4846","Name":"SNZB-02","Humidity":77.69,"BatteryPercentage":60,"Endpoint":1,"LinkQuality":196}}}
```

With `SetOption144 0``
```
17:26:19.748 RSL: SENSOR = {"ZbReceived":{"0x4846":{"Device":"0x4846","Name":"SNZB-02","Humidity":78.18,"BatteryPercentage":60,"Endpoint":1,"LinkQuality":167}}}
```

**Related issue (if applicable):** fixes #10034

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
