### PR TITLE
Set LED state on SO87 change

### DIFF
--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1386,6 +1386,9 @@ void CmndSetoptionBase(bool indexed) {
               case 25:                     // SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
                 TasmotaGlobal.restart_flag = 2;
                 break;
+              case 5:                      // SetOption87 - (PWM Dimmer) Turn red LED on (1) when powered off
+                TasmotaGlobal.restore_powered_off_led_counter = 1;
+                break;
             }
           }
           else if (5 == ptype) {           // SetOption114 .. 145

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -1386,9 +1386,11 @@ void CmndSetoptionBase(bool indexed) {
               case 25:                     // SetOption107 - Virtual CT Channel - signals whether the hardware white is cold CW (true) or warm WW (false)
                 TasmotaGlobal.restart_flag = 2;
                 break;
+#ifdef USE_PWM_DIMMER
               case 5:                      // SetOption87 - (PWM Dimmer) Turn red LED on (1) when powered off
                 TasmotaGlobal.restore_powered_off_led_counter = 1;
                 break;
+#endif  // USE_PWM_DIMMER
             }
           }
           else if (5 == ptype) {           // SetOption114 .. 145


### PR DESCRIPTION
## Description:

Set LED state on SO87 change. Previously, after an SO87 change, the LED state was only updated after a power state change.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
