### PR TITLE
Red Flag GPIOs 12/13 for C3

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -1561,7 +1561,7 @@ void SetModuleType(void)
 bool FlashPin(uint32_t pin)
 {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
-  return (pin > 10) && (pin < 18);        // ESP32C3 has GPIOs 11-17 reserved for Flash
+  return (((pin > 10) && (pin < 12)) || ((pin > 13) && (pin < 18)));  // ESP32C3 has GPIOs 11-17 reserved for Flash, with some boards GPIOs 12 13 are useable
 #elif defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
   return (pin > 21) && (pin < 33);        // ESP32S2 skip 22-32
 #elif defined(CONFIG_IDF_TARGET_ESP32)
@@ -1574,7 +1574,7 @@ bool FlashPin(uint32_t pin)
 bool RedPin(uint32_t pin) // pin may be dangerous to change, display in RED in template console
 {
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32C3
-  return false;     // no red pin on ESP32C3
+  return (12==pin)||(13==pin);  // ESP32C3: GPIOs 12 13 are usually used for Flash (mode QIO/QOUT)
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)
   return false;     // no red pin on ESP32S3
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)


### PR DESCRIPTION
## Description:

possible to use with [Luatos C3 board](https://wiki.luatos.com/chips/esp32c3/board.html). Only Flash modes `DIO` and `DOUT` are possible!

@s-hadinger Please check. Thx!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
