### PR TITLE
Stop shutter after longpress of buttons

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -856,7 +856,7 @@ void ShutterButtonHandler(void)
     if (Shutter[shutter_index].direction && Button.hold_timer[button_index] > 0) {
       XdrvMailbox.index = shutter_index +1;
       XdrvMailbox.payload = XdrvMailbox.index;
-      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Shtr%d, Button %d, hold %d, dir %d, index %d, payload %d"), shutter_index+1, button_index+1, Button.hold_timer[button_index],Shutter[shutter_index].direction,XdrvMailbox.index,XdrvMailbox.payload);
+      //AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Shtr%d, Button %d, hold %d, dir %d, index %d, payload %d"), shutter_index+1, button_index+1, Button.hold_timer[button_index],Shutter[shutter_index].direction,XdrvMailbox.index,XdrvMailbox.payload);
       CmndShutterStop();
     }
     Button.hold_timer[button_index] = 0;

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -853,6 +853,12 @@ void ShutterButtonHandler(void)
   }
 
   if (NOT_PRESSED == button) {
+    if (Shutter[shutter_index].direction && Button.hold_timer[button_index] > 0) {
+      XdrvMailbox.index = shutter_index +1;
+      XdrvMailbox.payload = XdrvMailbox.index;
+      AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("SHT: Shtr%d, Button %d, hold %d, dir %d, index %d, payload %d"), shutter_index+1, button_index+1, Button.hold_timer[button_index],Shutter[shutter_index].direction,XdrvMailbox.index,XdrvMailbox.payload);
+      CmndShutterStop();
+    }
     Button.hold_timer[button_index] = 0;
   } else {
     Button.hold_timer[button_index]++;


### PR DESCRIPTION
## Description:
https://github.com/arendst/Tasmota/discussions/16198
Longpress start an action but you cannot benefit from the release of the button. Now the shutter stops after releasing the button after longpress
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
