### PR TITLE
add missing flash mode entrys for ESP32-S3

### DIFF
--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -8,6 +8,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
+    "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32s3.json
+++ b/boards/esp32s3.json
@@ -1,13 +1,13 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32s3_8M.json
+++ b/boards/esp32s3_8M.json
@@ -1,13 +1,13 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_8M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2944k_fs2M.csv"

--- a/boards/esp32s3_8M.json
+++ b/boards/esp32s3_8M.json
@@ -8,6 +8,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_8M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
+    "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2944k_fs2M.csv"

--- a/boards/esp32s3cdc-box.json
+++ b/boards/esp32s3cdc-box.json
@@ -8,6 +8,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_16M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
+    "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"

--- a/boards/esp32s3cdc-box.json
+++ b/boards/esp32s3cdc-box.json
@@ -8,7 +8,6 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_16M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"

--- a/boards/esp32s3cdc.json
+++ b/boards/esp32s3cdc.json
@@ -8,6 +8,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
+    "flash_mode": "qio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32s3cdc.json
+++ b/boards/esp32s3cdc.json
@@ -1,13 +1,13 @@
 {
   "build": {
     "arduino":{
-      "ldscript": "esp32s3_out.ld"
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi"
     },
     "core": "esp32",
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S3",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dio",
     "mcu": "esp32s3",
     "variant": "esp32s3",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"


### PR DESCRIPTION
## Description:

since the actual ones are not complete to set mode for flash and psram.

S3 is different for Flash Mode selection from the other MCUs!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
