### PR TITLE
core2 does work with `qio`

### DIFF
--- a/boards/esp32-m5core2.json
+++ b/boards/esp32-m5core2.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_M5STACK_Core2 -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "qio",
     "mcu": "esp32",
     "variant": "m5stack_core2",
     "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"


### PR DESCRIPTION
## Description:

no need to use slowest flash mode `dout` with this device

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
