### PR TITLE
S3 Temp sensor support

### DIFF
--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -656,17 +656,14 @@ float CpuTemperature(void) {
   return t;
 */
 #else
-  #ifndef CONFIG_IDF_TARGET_ESP32S3
     // Currently (20210801) repeated calls to temperatureRead() on ESP32C3 and ESP32S2 result in IDF error messages
-    static float t = NAN;
-    if (isnan(t)) {
-      t = (float)temperatureRead();  // In Celsius
+static float t = NAN;
+  if (isnan(t)) {
+    t = (float)temperatureRead();  // In Celsius
     }
     return t;
-  #else
-    return NAN;
   #endif
-#endif
+return NAN;
 }
 
 /*

--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -657,13 +657,12 @@ float CpuTemperature(void) {
 */
 #else
     // Currently (20210801) repeated calls to temperatureRead() on ESP32C3 and ESP32S2 result in IDF error messages
-static float t = NAN;
-  if (isnan(t)) {
-    t = (float)temperatureRead();  // In Celsius
+    static float t = NAN;
+    if (isnan(t)) {
+      t = (float)temperatureRead();  // In Celsius
     }
     return t;
-  #endif
-return NAN;
+#endif
 }
 
 /*

--- a/tasmota/tasmota_xsns_sensor/xsns_127_esp32_sensors.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_127_esp32_sensors.ino
@@ -19,7 +19,6 @@
 
 #ifdef ESP32
 #ifdef USE_ESP32_SENSORS
-#ifndef CONFIG_IDF_TARGET_ESP32S3
 /*********************************************************************************************\
  * ESP32 CPU Temperature and optional Hall Effect sensor
  *
@@ -139,7 +138,5 @@ bool Xsns127(uint8_t function) {
   }
   return result;
 }
-
-#endif  // Not CONFIG_IDF_TARGET_ESP32S3
 #endif  // USE_ESP32_SENSORS
 #endif  // ESP32


### PR DESCRIPTION
Temp Sensor is official supported in IDF and Arduino.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
