### PR TITLE
mDNS resolution for *.local fixes #16269

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -807,6 +807,17 @@ void wifiKeepAlive(void) {
 #endif  // ESP8266
 
 bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
+  // DnsClient can't do one-shot mDNS queries so use WiFi.hostByName() for *.local
+  size_t hostname_len = strlen(aHostname);
+  if (strstr(aHostname, ".local") == &aHostname[hostname_len] - 6) {
+    if (WiFi.hostByName(aHostname, aResult)) {
+        // Host name resolved
+        if (0xFFFFFFFF != (uint32_t)aResult) {
+            return true;
+        }
+    return false;
+    }
+  }
   // Use this instead of WiFi.hostByName or connect(host_name,.. to block less if DNS server is not found
   uint32_t dns_address = (!TasmotaGlobal.global_state.eth_down) ? Settings->eth_ipv4_address[3] : Settings->ipv4_address[3];
   DnsClient.begin((IPAddress)dns_address);


### PR DESCRIPTION
"Add user control over DNS timeout reducing blocking"  https://github.com/arendst/Tasmota/commit/c988ba16451186c55873793978e7730619a25074 created DnsClient so that a timeout can be used to prevent blocking on ESP32, but it can't do one-shot mDNS queries. Use WiFi.hostByName () for those.

## Description:

**Related issue (if applicable):** fixes #16269

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
