### PR TITLE
Fix wrong flash_chip_id on ESP32, when DOUT is not used

### DIFF
--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -558,7 +558,7 @@ int32_t ESP_getHeapFragmentation(void) {
 
 uint32_t ESP_getFlashChipId(void)
 {
-  uint32_t id = bootloader_read_flash_id();
+  uint32_t id = g_rom_flashchip.device_id;
   id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
   return id;
 }


### PR DESCRIPTION
This also fixes the wrong reported flash size for flash modes: DIO, QUOUT and QIO. Now a global struct is used, which gets populated by the boot loader.

@Jason2866 Please test.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
