### PR TITLE
fix wrong flashmode report

### DIFF
--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -121,6 +121,8 @@ String GetDeviceHardwareRevision(void) {
 #ifdef ESP32
 
 #include "bootloader_flash.h"
+#include "soc/soc.h"
+#include "soc/spi_reg.h"
 // ESP32_ARCH contains the name of the architecture (used by autoconf)
 #if CONFIG_IDF_TARGET_ESP32
   #ifdef CORE32SOLO1
@@ -981,7 +983,26 @@ typedef enum {
 } FlashMode_t;
 */
 String ESP_getFlashChipMode(void) {
+#if ESP8266
   uint32_t flash_mode = ESP.getFlashChipMode();
+#else
+  uint32_t spi_ctrl = REG_READ(SPI_CTRL_REG(0));
+  uint32_t flash_mode;
+  /* Not all of the following constants are already defined in older versions of spi_reg.h, so do it manually for now*/
+  if (spi_ctrl & BIT(24)) { //SPI_FREAD_QIO
+      flash_mode = 0;
+  } else if (spi_ctrl & BIT(20)) { //SPI_FREAD_QUAD
+      flash_mode = 1;
+  } else if (spi_ctrl &  BIT(23)) { //SPI_FREAD_DIO
+      flash_mode = 2;
+  } else if (spi_ctrl & BIT(14)) { // SPI_FREAD_DUAL
+      flash_mode = 3;
+  } else if (spi_ctrl & BIT(13)) { //SPI_FASTRD_MODE
+      flash_mode = 4;
+  } else {
+      flash_mode = 5;
+  }
+#endif
   if (flash_mode > 5) { flash_mode = 3; }
   char stemp[6];
   return GetTextIndexed(stemp, sizeof(stemp), flash_mode, kFlashModes);


### PR DESCRIPTION
## Description:
ATM Tasmota reports the flash mode of the first boot loader, which might be changed later in the boot process.
This uses the same method as in the `bootloader_esp32.c`from the ESP-IDF and updates the value.
In the future this might be handled differently from Espressif's side by storing this value at boot time in a global struct.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
