### PR TITLE
use `dio` as default for Esp32-S2 and ESP32-C3

### DIFF
--- a/boards/esp32c3.json
+++ b/boards/esp32c3.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
-      "flash_mode": "dout",
+      "flash_mode": "dio",
       "mcu": "esp32c3",
       "variant": "esp32c3",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32c3cdc.json
+++ b/boards/esp32c3cdc.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DESP32C3 -DUSE_USB_CDC_CONSOLE",
       "f_cpu": "160000000L",
       "f_flash": "80000000L",
-      "flash_mode": "dout",
+      "flash_mode": "dio",
       "mcu": "esp32c3",
       "variant": "esp32c3",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32s2.json
+++ b/boards/esp32s2.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32s2",
     "variant": "esp32s2",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32s2cdc.json
+++ b/boards/esp32s2cdc.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=0 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_4M -DESP32S2",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32s2",
     "variant": "esp32s2",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"


### PR DESCRIPTION
## Description:

since there are no boards which needs the slowest mode `dout`.
Support for flash mode `dout` will be removed in future https://github.com/espressif/esp32-arduino-lib-builder/pull/80#issuecomment-1222183199

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
