### PR TITLE
all ESP32 boards do support `dio`

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32-odroid.json
+++ b/boards/esp32-odroid.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ODROID_ESP32 -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "odroid_esp32",
     "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"

--- a/boards/esp32_16M.json
+++ b/boards/esp32_16M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_16M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"

--- a/boards/esp32_4M.json
+++ b/boards/esp32_4M.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
       "f_cpu": "80000000L",
       "f_flash": "40000000L",
-      "flash_mode": "dout",
+      "flash_mode": "dio",
       "mcu": "esp32",
       "variant": "esp32",
       "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"

--- a/boards/esp32_4M_FS.json
+++ b/boards/esp32_4M_FS.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
       "f_cpu": "80000000L",
       "f_flash": "40000000L",
-      "flash_mode": "dout",
+      "flash_mode": "dio",
       "mcu": "esp32",
       "variant": "esp32",
       "partitions": "partitions/esp32_partition_app1856k_fs1344k.csv"

--- a/boards/esp32_4M_Legacy.json
+++ b/boards/esp32_4M_Legacy.json
@@ -7,7 +7,7 @@
       "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
       "f_cpu": "80000000L",
       "f_flash": "40000000L",
-      "flash_mode": "dout",
+      "flash_mode": "dio",
       "mcu": "esp32",
       "variant": "esp32",
       "partitions": "partitions/esp32_partition_app1856k_fs320k.csv"

--- a/boards/esp32_8M.json
+++ b/boards/esp32_8M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_8M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "partitions/esp32_partition_app2944k_fs2M.csv"

--- a/boards/esp32_solo1_4M.json
+++ b/boards/esp32_solo1_4M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DARDUINO_ESP32_DEV -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DCORE32SOLO1",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp32",
     "variant": "esp32",
     "partitions": "partitions/esp32_partition_app2880k_fs320k.csv"


### PR DESCRIPTION
## Description:

`dout` was used since it was and is necessary for some ESP8266 devices. The settings for ESP32 where just adopted from the ESP8266 settings.
Since core 2.0.4 finally solved the bootloader issues which some cores had before, i consider it is now safe to do this change. Arduino IDE has since a long time `dio` as default for the boards.

When using `dio` as flash mode the 2nd stage bootloader does a check if switching to a faster mode (`qio`) is even possible. There are plans for the future from Arduino espressif crew to remove the `dout` mode in the future.
Using mode `dout` prevents the 2nd stage bootloader to do this test/switching.

Tested on all my ESP32 devices i have. None did fail with OTA upgrade nor wired flash.
**But there is always a chance for a corner case where thing can go wrong ;-)**

I would appreciate more tests from other contributors before merging this PR

@arendst It is all up to you  if and when you merge ;-)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
