### PR TITLE
Use Wifi.hostByName() for ESP8266

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -817,14 +817,16 @@ void wifiKeepAlive(void) {
 #endif  // ESP8266
 
 bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
+#ifdef ESP8266
+  if (WiFi.hostByName(aHostname, aResult, Settings->dns_timeout)) {
+    return true;
+  }
+#else
   // DnsClient can't do one-shot mDNS queries so use WiFi.hostByName() for *.local
   size_t hostname_len = strlen(aHostname);
   if (strstr_P(aHostname, PSTR(".local")) == &aHostname[hostname_len] - 6) {
     if (WiFi.hostByName(aHostname, aResult)) {
-      // Host name resolved
-      if (0xFFFFFFFF != (uint32_t)aResult) {
-        return true;
-      }
+      return true;
     }
   } else {
   // Use this instead of WiFi.hostByName or connect(host_name,.. to block less if DNS server is not found
@@ -834,6 +836,7 @@ bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
       return true;
     }
   }
+#endif
   AddLog(LOG_LEVEL_DEBUG, PSTR("DNS: Unable to resolve '%s'"), aHostname);
   return false;
 }


### PR DESCRIPTION
Saves ~1K on ESP8266. Also, the check for resolving to 255.255.255.255 is already done by Wifi.hostByName().

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
