### PR TITLE
Zigbee extend div and offset for plugin

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
@@ -110,7 +110,8 @@ public:
                                   // The high 8 bits are `0` command sent to device or `1` command received from device
   uint8_t       key_suffix;       // append a suffix to key (default is 1, explicitly output if >1)
   uint8_t       attr_type;        // [opt] type of the attribute, default to Zunk (0xFF)
-  uint8_t       attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
+  int8_t        attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
+  int8_t        attr_divider;     // [opt] divider
   uint16_t      manuf;            // manufacturer id (0 if none)
 
   // Constructor with all defaults
@@ -127,6 +128,7 @@ public:
     key_suffix(1),
     attr_type(0xFF),
     attr_multiplier(1),
+    attr_divider(1),
     manuf(0)
     {};
 
@@ -784,6 +786,7 @@ void Z_attribute::deepCopy(const Z_attribute & rhs) {
   key_suffix = rhs.key_suffix;
   attr_type = rhs.attr_type;
   attr_multiplier = rhs.attr_multiplier;
+  attr_divider = rhs.attr_divider;
   // copy value
   copyVal(rhs);
   // don't touch next pointer

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -273,7 +273,9 @@ class Z_plugin_attribute {
 public:
   
   Z_plugin_attribute(void) :
-    type(Zunk), multiplier(1), cluster(0xFFFF), attribute(0xFFFF), manuf(0)
+    type(Zunk),
+    multiplier(1), divider(1), base(0),
+    cluster(0xFFFF), attribute(0xFFFF), manuf(0)
     {};
 
   void set(uint16_t cluster, uint16_t attribute, const char *name, uint8_t type = Zunk) {
@@ -284,7 +286,9 @@ public:
   }
 
   uint8_t       type;             // zigbee type, Zunk by default
-  int8_t        multiplier;       // multiplier, values 0, 1, 2, 5, 10, 100, -2, -5, -10, -100,
+  int8_t        multiplier;       // multiply by x (ignore if 0 or 1)
+  int8_t        divider;          // divide by x (ignore if 0 or 1)
+  int16_t       base;             // add x (ignore if 0)
   uint16_t      cluster;          // cluster number
   uint16_t      attribute;        // attribute number
   uint16_t      manuf;            // manufacturer code, 0 if none
@@ -298,15 +302,18 @@ class Z_attribute_synonym {
 public:
   Z_attribute_synonym(void) :
     cluster(0xFFFF), attribute(0xFFFF), new_cluster(0xFFFF), new_attribute(0xFFFF),
-    multiplier(1)
+    multiplier(1), divider(1), base(0)
     {};
   
-  void set(uint16_t cluster, uint16_t attribute, uint16_t new_cluster, uint16_t new_attribute, int8_t multiplier = 1) {
+  void set(uint16_t cluster, uint16_t attribute, uint16_t new_cluster, uint16_t new_attribute,
+          int8_t multiplier = 1, int8_t divider = 1, int16_t base = 0) {
     this->cluster = cluster;
     this->attribute = attribute;
     this->new_cluster = new_cluster;
     this->new_attribute = new_attribute;
     this->multiplier = multiplier;
+    this->divider = divider;
+    this->base = base;
   }
 
   inline bool found(void) const { return cluster != 0xFFFF && attribute != 0xFFFF; }
@@ -315,7 +322,9 @@ public:
   uint16_t      attribute;        // attribute to match
   uint16_t      new_cluster;      // replace with this cluster
   uint16_t      new_attribute;    // replace with this attribute
-  int8_t        multiplier;       // mutliplier if different than 1 (otherwise don't change value)
+  int8_t        multiplier;       // multiply by x (ignore if 0 or 1)
+  int8_t        divider;          // divide by x (ignore if 0 or 1)
+  int16_t       base;           // add x (ignore if 0)
 };
 
 //
@@ -457,6 +466,8 @@ public:
   const char * name = nullptr;
   uint8_t zigbee_type = Znodata;
   int8_t multiplier = 1;
+  int8_t divider = 1;
+  int8_t base = 0;
   uint8_t map_offset = 0;
   Z_Data_Type map_type = Z_Data_Type::Z_Unknown;
   uint16_t manuf = 0x0000;      // manuf code (if any)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -1568,7 +1568,7 @@ void Z_AutoConfigReportingForCluster(uint16_t shortaddr, uint16_t groupaddr, uin
         buf.add16(min_interval);
         buf.add16(max_interval);
         if (!Z_isDiscreteDataType(attr_matched.zigbee_type)) {   // report_change is only valid for non-discrete data types (numbers)
-          ZbApplyMultiplier(report_change, attr_matched.multiplier);
+          ZbApplyMultiplier(report_change, attr_matched.multiplier, attr_matched.divider, attr_matched.base);
           // encode value
           int32_t res = encodeSingleAttribute(buf, report_change, "", attr_matched.zigbee_type);
           if (res < 0) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_zigbee.ino
@@ -254,15 +254,16 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_zigbee_zcl_attribute_struct = {
     sizeof(Z_attribute),  /* size in bytes */
-    8,  /* number of elements */
+    9,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[8]) {
+    (const be_ctypes_structure_item_t[9]) {
       { "_attr_id", offsetof(Z_attribute, attr_id), 0, 0, ctypes_u16, 0 },
       { "_cluster", offsetof(Z_attribute, cluster), 0, 0, ctypes_u16, 0 },
       { "_cmd", offsetof(Z_attribute, attr_id), 0, 0, ctypes_u8, 0 },       // low 8 bits of attr_id
       { "_direction", offsetof(Z_attribute, attr_id) + 1, 0, 0, ctypes_u8, 0 },       // high 8 bits of attr_id
       { "_iscmd", offsetof(Z_attribute, key_is_cmd), 0, 0, ctypes_u8, 0 },
       { "attr_multiplier", offsetof(Z_attribute, attr_multiplier), 0, 0, ctypes_i8, 0 },
+      { "attr_divider", offsetof(Z_attribute, attr_divider), 0, 0, ctypes_i8, 0 },
       { "attr_type", offsetof(Z_attribute, attr_type), 0, 0, ctypes_u8, 0 },
       // { "key", offsetof(Z_attribute, key), 0, 0, ctypes_ptr32, 0 },
       // { "key_is_pmem", offsetof(Z_attribute, key_is_pmem), 0, 0, ctypes_u8, 0 },


### PR DESCRIPTION
## Description:

Extend the Zigbee Device plugin modifiers:
- `mul:<x>` : multiply by `x` (integer 8 bits, can be negative)
- `div:<x>` : divide by `x` (integer 8 bits, can be negative)
- `add:<x>` : add `x` to the result (integer 16 bits, can be negative)

With this scheme you can now do affine function: `y = mul * x / div + add`

For example, to implement a boolean not (change `1` to `0` and `0` to `1`), use `mul:-1,add:1`. Explanation: the function `y = 1 - x` transforms 1 to 0 and 0 to 1.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
