### PR TITLE
Berry stricter strict mode

### DIFF
--- a/lib/libesp32/berry/src/be_parser.c
+++ b/lib/libesp32/berry/src/be_parser.c
@@ -469,6 +469,12 @@ static int new_upval(bvm *vm, bfuncinfo *finfo, bstring *name, bexpdesc *var)
 static void new_var(bparser *parser, bstring *name, bexpdesc *var)
 {
     bfuncinfo *finfo = parser->finfo;
+    if (comp_is_strict(parser->vm)) {
+        /* check if we are masking a builtin */
+        if (be_builtin_class_find(parser->vm, name) >= 0) {
+            push_error(parser, "strict: redefinition of builtin '%s'", str(name));
+        }
+    }
     if (finfo->prev || finfo->binfo->prev || parser->islocal) {
         init_exp(var, ETLOCAL, 0);
         var->v.idx = new_localvar(parser, name); /* if local, contains the index in current local var list */
@@ -982,7 +988,6 @@ static void compound_assign(bparser *parser, int op, bexpdesc *l, bexpdesc *r)
 /* A new implicit local variable is created if no global has the same name (excluding builtins) */
 /* This means that you can override a builtin silently */
 /* This also means that a function cannot create a global, they must preexist or create with `global` module */
-/* TODO add warning in strict mode */
 static int check_newvar(bparser *parser, bexpdesc *e)
 {
     if (e->type == ETGLOBAL) {

--- a/lib/libesp32/berry/src/be_var.c
+++ b/lib/libesp32/berry/src/be_var.c
@@ -132,6 +132,21 @@ int be_builtin_find(bvm *vm, bstring *name)
     return -1; /* not found */
 }
 
+/* find in the list of builtins or classes - used by strict to avoid accidental change of those */
+int be_builtin_class_find(bvm *vm, bstring *name)
+{
+    bvalue *res = be_map_findstr(vm, builtin(vm).vtab, name);
+    if (res) {
+        return var_toidx(res);
+    } else {
+        int idx = global_native_class_find(vm, name);
+        if (idx >= 0) {
+            return idx;
+        }
+    }
+    return -1; /* not found */
+}
+
 bstring* be_builtin_name(bvm *vm, int index)
 {
     bmap *map = builtin(vm).vtab;

--- a/lib/libesp32/berry/src/be_var.h
+++ b/lib/libesp32/berry/src/be_var.h
@@ -23,6 +23,7 @@ int be_global_new(bvm *vm, bstring *name);
 bvalue* be_global_var(bvm *vm, int index);
 void be_global_release_space(bvm *vm);
 int be_builtin_find(bvm *vm, bstring *name);
+int be_builtin_class_find(bvm *vm, bstring *name);
 bstring* be_builtin_name(bvm *vm, int index);
 int be_builtin_new(bvm *vm, bstring *name);
 void be_bulitin_release_space(bvm *vm);


### PR DESCRIPTION
## Description:

Make the Berry strict mode even stricter and avoid masking a builtin or class name with a local variable.

Before the following was ok:
``` berry
> var bytes = 0
> def f() var size = 1 end
```

Now:
``` berry
> var bytes = 0
BRY: Exception> 'syntax_error' - input:1: strict: redefinition of builtin 'bytes'

> def f() var size = 1 end
BRY: Exception> 'syntax_error' - input:1: strict: redefinition of builtin 'size'
```

If you really want to shoot you in the foot, the only way to mask a builtin with a global variable is via the `global` module. For example `global.bytes = 0` will indeed mask the `bytes` class -- which you shouldn't!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
