### PR TITLE
Support for Ethernet in ESP32 safeboot firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for SGP40 gas and air quality sensor (#16341)
 - Support for Modbus writing using ModbusBridge by JeroenSt (#16351)
+- Support for Ethernet in ESP32 safeboot firmware
 
 ### Changed
 - TasmotaModbus library from v3.5.0 to v3.6.0 (#16351)

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -182,6 +182,7 @@
 #define USE_WEBCLIENT
 #define USE_WEBCLIENT_HTTPS
 #define USE_SERIAL_BRIDGE                        // Add support for software Serial Bridge console Tee (+0k8 code)
+#define USE_ETHERNET
 
 #endif  // FIRMWARE_SAFEBOOT
 


### PR DESCRIPTION
## Description:

I propose to include ETH support in ESP32 safeboot firmware. This allows to do OTA from ETH, otherwise you need to switch back to wifi - which can be problematic if wifi is out of range or disabled.

Code impact is 8.5kb, which raises safeboot from 91% to 94% of the 832kb partition.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
