### PR TITLE
Fix unstable ETH on Olimex POE

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -154,6 +154,31 @@ void EthernetInit(void) {
   int eth_power = Pin(GPIO_ETH_PHY_POWER);
   int eth_mdc = Pin(GPIO_ETH_PHY_MDC);
   int eth_mdio = Pin(GPIO_ETH_PHY_MDIO);
+#ifdef ESP32
+  // fix an disconnection issue after rebooting Olimex POE - this forces a clean state for all GPIO involved in RMII
+  gpio_reset_pin((gpio_num_t)GPIO_ETH_PHY_POWER);
+  gpio_reset_pin((gpio_num_t)GPIO_ETH_PHY_MDC);
+  gpio_reset_pin((gpio_num_t)GPIO_ETH_PHY_MDIO);
+  gpio_reset_pin(GPIO_NUM_19);    // EMAC_TXD0 - hardcoded
+  gpio_reset_pin(GPIO_NUM_21);    // EMAC_TX_EN - hardcoded
+  gpio_reset_pin(GPIO_NUM_22);    // EMAC_TXD1 - hardcoded
+  gpio_reset_pin(GPIO_NUM_25);    // EMAC_RXD0 - hardcoded
+  gpio_reset_pin(GPIO_NUM_26);    // EMAC_RXD1 - hardcoded
+  gpio_reset_pin(GPIO_NUM_27);    // EMAC_RX_CRS_DV - hardcoded
+  switch (Settings->eth_clk_mode) {
+    case 0:   // ETH_CLOCK_GPIO0_IN
+    case 1:   // ETH_CLOCK_GPIO0_OUT
+      gpio_reset_pin(GPIO_NUM_0);
+      break;
+    case 2:   // ETH_CLOCK_GPIO16_OUT
+      gpio_reset_pin(GPIO_NUM_16);
+      break;
+    case 3:   // ETH_CLOCK_GPIO17_OUT
+      gpio_reset_pin(GPIO_NUM_17);
+      break;
+  }
+  delay(1);
+#endif
   if (!ETH.begin(Settings->eth_address, eth_power, eth_mdc, eth_mdio, (eth_phy_type_t)Settings->eth_type, (eth_clock_mode_t)Settings->eth_clk_mode)) {
     AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Bad PHY type or init error"));
     return;

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -154,7 +154,7 @@ void EthernetInit(void) {
   int eth_power = Pin(GPIO_ETH_PHY_POWER);
   int eth_mdc = Pin(GPIO_ETH_PHY_MDC);
   int eth_mdio = Pin(GPIO_ETH_PHY_MDIO);
-#ifdef ESP32
+#if CONFIG_IDF_TARGET_ESP32
   // fix an disconnection issue after rebooting Olimex POE - this forces a clean state for all GPIO involved in RMII
   gpio_reset_pin((gpio_num_t)GPIO_ETH_PHY_POWER);
   gpio_reset_pin((gpio_num_t)GPIO_ETH_PHY_MDC);
@@ -178,7 +178,7 @@ void EthernetInit(void) {
       break;
   }
   delay(1);
-#endif
+#endif // CONFIG_IDF_TARGET_ESP32
   if (!ETH.begin(Settings->eth_address, eth_power, eth_mdc, eth_mdio, (eth_phy_type_t)Settings->eth_type, (eth_clock_mode_t)Settings->eth_clk_mode)) {
     AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Bad PHY type or init error"));
     return;


### PR DESCRIPTION
## Description:

I have seen unstable ETH with Tube ZB based on POE Olimex module. Ethernet works fine at initial start but becomes broken at next reboot (connects and disconnects every 2 seconds).

This fix forces a clean reinitialization of all GPIOs involved in RMII, before starting up the ETH module. Seems to fix it completely.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
