### PR TITLE
Berry fix json crash

### DIFF
--- a/lib/libesp32/berry/src/be_strlib.c
+++ b/lib/libesp32/berry/src/be_strlib.c
@@ -263,6 +263,9 @@ BERRY_API bint be_str2int(const char *str, const char **endstr)
         while ((c = be_char2hex(*str++)) >= 0) {
             sum = sum * 16 + c;
         }
+        if (endstr) {
+            *endstr = str - 1;
+        }
         return sum;
     } else {
         /* decimal literal */


### PR DESCRIPTION
## Description:

Fixes https://github.com/berry-lang/berry/issues/287 (crash when parsing JSON with hex numbers).

Thanks @darcyg

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
