### PR TITLE
generate berry structures before every build process

### DIFF
--- a/pio-tools/gen-berry-structures.py
+++ b/pio-tools/gen-berry-structures.py
@@ -1,4 +1,6 @@
 Import("env")
+env = DefaultEnvironment()
+platform = env.PioPlatform()
 import os
 import subprocess
 from os.path import join

--- a/pio-tools/gen-berry-structures.py
+++ b/pio-tools/gen-berry-structures.py
@@ -1,0 +1,12 @@
+Import("env")
+import os
+import subprocess
+from os.path import join
+
+# generate all precompiled Berry structures from multiple modules
+CURRENT_DIR = os.getcwd()
+BERRY_GEN_DIR = join(CURRENT_DIR, "lib", "libesp32","berry")
+os.chdir(BERRY_GEN_DIR)
+cmd = ("python3",join("tools","coc","coc"),"-o","generate","src","default",join("..","berry_tasmota","src"),join("..","berry_mapping","src"),join("..","berry_int64","src"),join("..","..","libesp32_lvgl","lv_binding_berry","src"),join("..","..","libesp32_lvgl","lv_binding_berry","generate"),"-c",join("default","berry_conf.h"))
+returncode = subprocess.call(cmd, shell=False)
+os.chdir(CURRENT_DIR)

--- a/pio-tools/gen-berry-structures.py
+++ b/pio-tools/gen-berry-structures.py
@@ -5,7 +5,7 @@ from os.path import join
 
 # generate all precompiled Berry structures from multiple modules
 CURRENT_DIR = os.getcwd()
-BERRY_GEN_DIR = join(CURRENT_DIR, "lib", "libesp32","berry")
+BERRY_GEN_DIR = join(env.subst("$PROJECT_DIR"), "lib", "libesp32","berry")
 os.chdir(BERRY_GEN_DIR)
 cmd = ("python3",join("tools","coc","coc"),"-o","generate","src","default",join("..","berry_tasmota","src"),join("..","berry_mapping","src"),join("..","berry_int64","src"),join("..","..","libesp32_lvgl","lv_binding_berry","src"),join("..","..","libesp32_lvgl","lv_binding_berry","generate"),"-c",join("default","berry_conf.h"))
 returncode = subprocess.call(cmd, shell=False)

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -35,6 +35,7 @@ build_flags                 = ${esp_defaults.build_flags}
                               -Wl,--wrap=_Z11analogWritehi  ; `analogWrite(unsigned char, int)` use the Tasmota version of analogWrite for deeper integration and phase control
                               -Wl,--wrap=ledcReadFreq  ; `uint32_t ledcReadFreq(uint8_t chan)`
 extra_scripts               = pre:pio-tools/add_c_flags.py
+                                  pio-tools/gen-berry-structures.py
                               post:pio-tools/post_esp32.py
                               ${esp_defaults.extra_scripts}
 


### PR DESCRIPTION
## Description:

ATM every code change touching Berry must add script generated files to the Tasmota repository.
This PR shall be step 1 of a change here, by doing it in the `pre:`section of every build in a simple Python script.
Step 2 would be to remove every file from `lib/libesp32/berry/generate/`and ignoring it for Git in the future.

@Jason2866 @s-hadinger Plz, check.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
