### PR TITLE
octal flash needs flashed in mode `dout`

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -138,7 +138,7 @@ def esp32_create_combined_bin(source, target, env):
     flash_mode = env.BoardConfig().get("build.flash_mode", "dio")
     memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
 
-    if flash_mode == "qio" or flash_mode == "qout"
+    if flash_mode == "qio" or flash_mode == "qout":
         flash_mode = "dio"
     if memory_type == "opi_opi" or memory_type == "opi_qspi":
         flash_mode = "dout"

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -136,9 +136,11 @@ def esp32_create_combined_bin(source, target, env):
     flash_freq = str(flash_freq).replace("L", "")
     flash_freq = str(int(int(flash_freq) / 1000000)) + "m"
     flash_mode = env.BoardConfig().get("build.flash_mode", "dio")
-    if flash_mode == "qio":
+    memory_type = env.BoardConfig().get("build.arduino.memory_type", "qio_qspi")
+
+    if flash_mode == "qio" or flash_mode == "qout"
         flash_mode = "dio"
-    elif flash_mode == "qout":
+    if memory_type == "opi_opi" or memory_type == "opi_qspi":
         flash_mode = "dout"
     cmd = [
         "--chip",


### PR DESCRIPTION
flash modes `qio, qout, dio` can all be flashed in mode `dio`

Since no S3 device with opi flash, i could NOT test. The info for is from esptool.py and IDF source code.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
