### PR TITLE
Fix json parsing

### DIFF
--- a/lib/default/jsmn-shadinger-1.0/src/JsonParser.cpp
+++ b/lib/default/jsmn-shadinger-1.0/src/JsonParser.cpp
@@ -408,6 +408,8 @@ void JsonParser::parse(char * json_in) {
   // TODO error checking
   if (_token_len >= 0) {
     postProcess(json_len);
+  } else {
+    this->free();   // invalid JSON
   }
 }
 


### PR DESCRIPTION
## Description:

Fix JSON parsing (for ex in Zigbee) that would not be marked as invalid when missing closing braces.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
