### PR TITLE
Fix HASPmota.be with new strict mode

### DIFF
--- a/tasmota/berry/haspmota_src/haspmota_core/haspmota.be
+++ b/tasmota/berry/haspmota_src/haspmota_core/haspmota.be
@@ -1021,11 +1021,11 @@ class lvh_qrcode : lvh_obj
   def init(parent, page, jline)
     self._page = page
 
-    var size = jline.find("qr_size", 100)
+    var sz = jline.find("qr_size", 100)
     var dark_col = self.parse_color(jline.find("qr_dark_color", "#000000"))
     var light_col = self.parse_color(jline.find("qr_light_color", "#FFFFFF"))
 
-    self._lv_obj = lv.qrcode(parent, size, dark_col, light_col)
+    self._lv_obj = lv.qrcode(parent, sz, dark_col, light_col)
     self.post_init()
   end
 


### PR DESCRIPTION
## Description:

Fix HASPmota berry code after the new stricter mode. The precompiled `C` or `bec` files are unchanged.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
