### PR TITLE
Add option FORCE_USE_ETHERNET for single core MCUs that support it

### DIFF
--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -107,9 +107,11 @@ String EthernetMacAddress(void);
 
 #if CONFIG_IDF_TARGET_ESP32
 
-#ifdef CORE32SOLO1
+#ifdef CORE32SOLO1                                 // ESP32-SOLO-1 OEM variant (Xiaomi devices) does not support ethernet...
+#ifndef FORCE_USE_ETHERNET                         // ...but ESP32-MINI-1 single core supports ethernet.
 #ifdef USE_ETHERNET
-#undef USE_ETHERNET                                // ESP32-Solo1 does not support ethernet
+#undef USE_ETHERNET                                
+#endif
 #endif
 #endif  // CORE32SOLO1
 


### PR DESCRIPTION
## Description:

Enables users to forcibly enable Ethernet for ESP32-MINI-1 MCUs made before 2022 and some versions of the ESP32-SOLO-1.

To use this feature, users only need to add `#define FORCE_USE_ETHERNET` to their `user_config_override.h` file.

The way it is implemented should not change the way users currently use Tasmota, but would enable this specific option in TasmoCompiler. I think this is the least invasive way to add this functionality.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
