### PR TITLE
Enable Ethernet for ESP32-solo1

### DIFF
--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -107,11 +107,6 @@ String EthernetMacAddress(void);
 
 #if CONFIG_IDF_TARGET_ESP32
 
-#ifdef CORE32SOLO1
-#ifdef USE_ETHERNET
-#undef USE_ETHERNET                                // ESP32-Solo1 does not support ethernet
-#endif
-#endif  // CORE32SOLO1
 
 #else   // Disable features not present in other ESP32 like ESP32C3, ESP32S2, ESP32S3 etc.
 #ifdef USE_ETHERNET


### PR DESCRIPTION
## Description:

replaces #16464

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
