### PR TITLE
Zigbee grey buttons when not started

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -2077,7 +2077,14 @@ const char HTTP_ZB_VERSION[] PROGMEM =
 const char HTTP_BTN_ZB_BUTTONS[] PROGMEM =
   "<button onclick='la(\"&zbj=1\");'>" D_ZIGBEE_PERMITJOIN "</button>"
   "<p></p>"
-  "<form action='zbm' method='get'><button>" D_ZIGBEE_MAP "</button></form>";
+  "<a href='zbm'><button>" D_ZIGBEE_MAP "</button></a>"
+  "<p></p>";
+
+const char HTTP_BTN_ZB_BUTTONS_DISABLED[] PROGMEM =
+  "<button style='background-color:#%06X' disabled>" D_ZIGBEE_PERMITJOIN "</button>"
+  "<p></p>"
+  "<button style='background-color:#%06X' disabled>" D_ZIGBEE_MAP "</button>"
+  "<p></p>";
 
 void ZigbeeShow(bool json)
 {
@@ -2275,6 +2282,10 @@ void ZigbeeShow(bool json)
       WSContentSend_P(HTTP_ZB_VERSION,
                       zigbee.major_rel, zigbee.minor_rel,
                       zigbee.maint_rel, zigbee.revision);
+      WSContentSend_P(HTTP_BTN_ZB_BUTTONS);
+    } else {
+      uint32_t grey = WebColor(COL_FORM);
+      WSContentSend_P(HTTP_BTN_ZB_BUTTONS_DISABLED, grey, grey);
     }
 #endif
   }
@@ -2365,9 +2376,6 @@ bool Xdrv23(uint8_t function) {
 #endif  // USE_ZIGBEE_EZSP
         WebServer_on(PSTR("/zbm"), ZigbeeShowMap, HTTP_GET);     // add web handler for Zigbee map
         WebServer_on(PSTR("/zbr"), ZigbeeMapRefresh, HTTP_GET);     // add web handler for Zigbee map refresh
-        break;
-      case FUNC_WEB_ADD_MAIN_BUTTON:
-        WSContentSend_P(HTTP_BTN_ZB_BUTTONS);
         break;
 #endif  // USE_WEBSERVER
       case FUNC_PRE_INIT:


### PR DESCRIPTION
## Description:

Zigbee: make the buttons "Zigbee Permit Join" and "Zigbee Map" greyed out and disabled when Zigbee has not successfully started.

<img width="352" alt="Capture d’écran 2022-09-09 à 23 52 36" src="https://user-images.githubusercontent.com/49731213/189450942-b1b1476a-4aa5-41f0-a68a-6c3ea124a93c.png">


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
