### PR TITLE
Fix ESP32-S3 webcam bootloop

### DIFF
--- a/boards/esp32-cam.json
+++ b/boards/esp32-cam.json
@@ -4,7 +4,7 @@
       "ldscript": "esp32_out.ld"
     },
     "core": "esp32",
-    "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
+    "extra_flags": "-DCAMERA_MODEL_AI_THINKER -DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DHAS_PSRAM_FIX -mfix-esp32-psram-cache-issue -mfix-esp32-psram-cache-strategy=memw -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
     "f_cpu": "240000000L",
     "f_flash": "80000000L",
     "flash_mode": "dio",

--- a/boards/esp32s3cdc-cam.json
+++ b/boards/esp32s3cdc-cam.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": "-DCAMERA_MODEL_TTGO_T_CAM_SIM -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_16M -DESP32S3",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "partitions": "partitions/esp32_partition_app2944k_fs10M.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "espidf",
+    "arduino"
+  ],
+  "name": "LilyGo T-SIMCAM ESP32-S3 16M Flash 8MB PSRAM, Tasmota 2944k Code/OTA, 10M FS",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "before_reset": "usb_reset",
+    "speed": 460800
+  },
+  "url": "https://github.com/Xinyuan-LilyGO/LilyGo-Camera-Series",
+  "vendor": "LilyGo"
+}

--- a/lib/libesp32/esp32-camera/driver/include/camera_pins.h
+++ b/lib/libesp32/esp32-camera/driver/include/camera_pins.h
@@ -1,0 +1,337 @@
+
+#if defined(CAMERA_MODEL_WROVER_KIT)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  21
+#define SIOD_GPIO_NUM  26
+#define SIOC_GPIO_NUM  27
+
+#define Y9_GPIO_NUM    35
+#define Y8_GPIO_NUM    34
+#define Y7_GPIO_NUM    39
+#define Y6_GPIO_NUM    36
+#define Y5_GPIO_NUM    19
+#define Y4_GPIO_NUM    18
+#define Y3_GPIO_NUM    5
+#define Y2_GPIO_NUM    4
+#define VSYNC_GPIO_NUM 25
+#define HREF_GPIO_NUM  23
+#define PCLK_GPIO_NUM  22
+
+#elif defined(CAMERA_MODEL_ESP_EYE)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  4
+#define SIOD_GPIO_NUM  18
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    36
+#define Y8_GPIO_NUM    37
+#define Y7_GPIO_NUM    38
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    35
+#define Y4_GPIO_NUM    14
+#define Y3_GPIO_NUM    13
+#define Y2_GPIO_NUM    34
+#define VSYNC_GPIO_NUM 5
+#define HREF_GPIO_NUM  27
+#define PCLK_GPIO_NUM  25
+
+#elif defined(CAMERA_MODEL_ESP32S3_EYE)
+
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  15
+#define SIOD_GPIO_NUM  4
+#define SIOC_GPIO_NUM  5
+
+#define Y2_GPIO_NUM    11
+#define Y3_GPIO_NUM    9
+#define Y4_GPIO_NUM    8
+#define Y5_GPIO_NUM    10
+#define Y6_GPIO_NUM    12
+#define Y7_GPIO_NUM    18
+#define Y8_GPIO_NUM    17
+#define Y9_GPIO_NUM    16
+
+#define VSYNC_GPIO_NUM 6
+#define HREF_GPIO_NUM  7
+#define PCLK_GPIO_NUM  13
+
+#elif defined(CAMERA_MODEL_M5STACK_PSRAM)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM  27
+#define SIOD_GPIO_NUM  25
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    19
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    5
+#define Y4_GPIO_NUM    34
+#define Y3_GPIO_NUM    35
+#define Y2_GPIO_NUM    32
+#define VSYNC_GPIO_NUM 22
+#define HREF_GPIO_NUM  26
+#define PCLK_GPIO_NUM  21
+
+#elif defined(CAMERA_MODEL_M5STACK_V2_PSRAM)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM  27
+#define SIOD_GPIO_NUM  22
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    19
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    5
+#define Y4_GPIO_NUM    34
+#define Y3_GPIO_NUM    35
+#define Y2_GPIO_NUM    32
+#define VSYNC_GPIO_NUM 25
+#define HREF_GPIO_NUM  26
+#define PCLK_GPIO_NUM  21
+
+#elif defined(CAMERA_MODEL_M5STACK_WIDE)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM  27
+#define SIOD_GPIO_NUM  22
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    19
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    5
+#define Y4_GPIO_NUM    34
+#define Y3_GPIO_NUM    35
+#define Y2_GPIO_NUM    32
+#define VSYNC_GPIO_NUM 25
+#define HREF_GPIO_NUM  26
+#define PCLK_GPIO_NUM  21
+
+#elif defined(CAMERA_MODEL_M5STACK_ESP32CAM)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM  27
+#define SIOD_GPIO_NUM  25
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    19
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    5
+#define Y4_GPIO_NUM    34
+#define Y3_GPIO_NUM    35
+#define Y2_GPIO_NUM    17
+#define VSYNC_GPIO_NUM 22
+#define HREF_GPIO_NUM  26
+#define PCLK_GPIO_NUM  21
+
+#elif defined(CAMERA_MODEL_M5STACK_UNITCAM)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 15
+#define XCLK_GPIO_NUM  27
+#define SIOD_GPIO_NUM  25
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    19
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    5
+#define Y4_GPIO_NUM    34
+#define Y3_GPIO_NUM    35
+#define Y2_GPIO_NUM    32
+#define VSYNC_GPIO_NUM 22
+#define HREF_GPIO_NUM  26
+#define PCLK_GPIO_NUM  21
+
+#elif defined(CAMERA_MODEL_AI_THINKER)
+#define PWDN_GPIO_NUM  32
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  0
+#define SIOD_GPIO_NUM  26
+#define SIOC_GPIO_NUM  27
+
+#define Y9_GPIO_NUM    35
+#define Y8_GPIO_NUM    34
+#define Y7_GPIO_NUM    39
+#define Y6_GPIO_NUM    36
+#define Y5_GPIO_NUM    21
+#define Y4_GPIO_NUM    19
+#define Y3_GPIO_NUM    18
+#define Y2_GPIO_NUM    5
+#define VSYNC_GPIO_NUM 25
+#define HREF_GPIO_NUM  23
+#define PCLK_GPIO_NUM  22
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_V05)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  32
+#define SIOD_GPIO_NUM  13
+#define SIOC_GPIO_NUM  12
+
+#define Y9_GPIO_NUM    39
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    23
+#define Y6_GPIO_NUM    18
+#define Y5_GPIO_NUM    15
+#define Y4_GPIO_NUM    4
+#define Y3_GPIO_NUM    14
+#define Y2_GPIO_NUM    5
+#define VSYNC_GPIO_NUM 27
+#define HREF_GPIO_NUM  25
+#define PCLK_GPIO_NUM  19
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_V16)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  4
+#define SIOD_GPIO_NUM  18
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    36
+#define Y8_GPIO_NUM    15
+#define Y7_GPIO_NUM    12
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    35
+#define Y4_GPIO_NUM    14
+#define Y3_GPIO_NUM    13
+#define Y2_GPIO_NUM    34
+#define VSYNC_GPIO_NUM 5
+#define HREF_GPIO_NUM  27
+#define PCLK_GPIO_NUM  25
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_V162)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  4
+#define SIOD_GPIO_NUM  18
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    36
+#define Y8_GPIO_NUM    37
+#define Y7_GPIO_NUM    38
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    35
+#define Y4_GPIO_NUM    14
+#define Y3_GPIO_NUM    13
+#define Y2_GPIO_NUM    34
+#define VSYNC_GPIO_NUM 5
+#define HREF_GPIO_NUM  27
+#define PCLK_GPIO_NUM  25
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_V17)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  32
+#define SIOD_GPIO_NUM  13
+#define SIOC_GPIO_NUM  12
+
+#define Y9_GPIO_NUM    39
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    23
+#define Y6_GPIO_NUM    18
+#define Y5_GPIO_NUM    15
+#define Y4_GPIO_NUM    4
+#define Y3_GPIO_NUM    14
+#define Y2_GPIO_NUM    5
+#define VSYNC_GPIO_NUM 27
+#define HREF_GPIO_NUM  25
+#define PCLK_GPIO_NUM  19
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_MINI)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  32
+#define SIOD_GPIO_NUM  13
+#define SIOC_GPIO_NUM  12
+
+#define Y9_GPIO_NUM    39
+#define Y8_GPIO_NUM    36
+#define Y7_GPIO_NUM    38
+#define Y6_GPIO_NUM    37
+#define Y5_GPIO_NUM    15
+#define Y4_GPIO_NUM    4
+#define Y3_GPIO_NUM    14
+#define Y2_GPIO_NUM    5
+#define VSYNC_GPIO_NUM 27
+#define HREF_GPIO_NUM  25
+#define PCLK_GPIO_NUM  19
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAMERA_PLUS)
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  4
+#define SIOD_GPIO_NUM  18
+#define SIOC_GPIO_NUM  23
+
+#define Y9_GPIO_NUM    36
+#define Y8_GPIO_NUM    37
+#define Y7_GPIO_NUM    38
+#define Y6_GPIO_NUM    39
+#define Y5_GPIO_NUM    35
+#define Y4_GPIO_NUM    26
+#define Y3_GPIO_NUM    13
+#define Y2_GPIO_NUM    34
+#define VSYNC_GPIO_NUM 5
+#define HREF_GPIO_NUM  27
+#define PCLK_GPIO_NUM  25
+
+#elif defined(CAMERA_MODEL_TTGO_T_JOURNAL)
+
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  15
+#define SIOD_GPIO_NUM  4
+#define SIOC_GPIO_NUM  5
+
+#define Y9_GPIO_NUM    16
+#define Y8_GPIO_NUM    17
+#define Y7_GPIO_NUM    18
+#define Y6_GPIO_NUM    12
+#define Y5_GPIO_NUM    10
+#define Y4_GPIO_NUM    8
+#define Y3_GPIO_NUM    9
+#define Y2_GPIO_NUM    11
+#define VSYNC_GPIO_NUM 6
+#define HREF_GPIO_NUM  7
+#define PCLK_GPIO_NUM  13
+
+#elif defined(CAMERA_MODEL_TTGO_T_CAM_SIM)
+
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM 18
+#define XCLK_GPIO_NUM  14
+#define SIOD_GPIO_NUM  4
+#define SIOC_GPIO_NUM  5
+
+#define Y9_GPIO_NUM    15
+#define Y8_GPIO_NUM    16
+#define Y7_GPIO_NUM    17
+#define Y6_GPIO_NUM    12
+#define Y5_GPIO_NUM    10
+#define Y4_GPIO_NUM    8
+#define Y3_GPIO_NUM    9
+#define Y2_GPIO_NUM    11
+#define VSYNC_GPIO_NUM 6
+#define HREF_GPIO_NUM  7
+#define PCLK_GPIO_NUM  13
+
+#define PWR_ON_PIN     1
+#define PCIE_PWR_PIN   48
+#define PCIE_RST_PIN   48
+#define PCIE_TX_PIN    45
+#define PCIE_RX_PIN    46
+#define PCIE_LED_PIN   21
+#else
+#error "Camera model not selected"
+#endif

--- a/lib/libesp32/esp32-camera/driver/include/camera_pins.h
+++ b/lib/libesp32/esp32-camera/driver/include/camera_pins.h
@@ -333,5 +333,21 @@
 #define PCIE_RX_PIN    46
 #define PCIE_LED_PIN   21
 #else
-#error "Camera model not selected"
+#define PWDN_GPIO_NUM  -1
+#define RESET_GPIO_NUM -1
+#define XCLK_GPIO_NUM  -1
+#define SIOD_GPIO_NUM  -1
+#define SIOC_GPIO_NUM  -1
+
+#define Y9_GPIO_NUM    -1
+#define Y8_GPIO_NUM    -1
+#define Y7_GPIO_NUM    -1
+#define Y6_GPIO_NUM    -1
+#define Y5_GPIO_NUM    -1
+#define Y4_GPIO_NUM    -1
+#define Y3_GPIO_NUM    -1
+#define Y2_GPIO_NUM    -1
+#define VSYNC_GPIO_NUM -1
+#define HREF_GPIO_NUM  -1
+#define PCLK_GPIO_NUM  -1
 #endif

--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -92,7 +92,7 @@
  *
  * Only boards with PSRAM should be used.
  * To speed up cam processing cpu frequency should be better set to 240Mhz
- * 
+ *
  * remarks for AI-THINKER
  * GPIO0 zero must be disconnected from any wire after programming because this pin drives the cam clock and does
  * not tolerate any capictive load
@@ -109,32 +109,12 @@
 #include "esp_camera.h"
 #include "sensor.h"
 #include "fb_gfx.h"
+#include "camera_pins.h"
 
 bool HttpCheckPriviledgedAccess(bool);
 extern ESP8266WebServer *Webserver;
 
 #define BOUNDARY "e8b8c539-047d-4777-a985-fbba6edff11e"
-
-
-
-// CAMERA_MODEL_AI_THINKER default template pins
-#define PWDN_GPIO_NUM     32
-#define RESET_GPIO_NUM    -1
-#define XCLK_GPIO_NUM      0
-#define SIOD_GPIO_NUM     26
-#define SIOC_GPIO_NUM     27
-
-#define Y9_GPIO_NUM       35
-#define Y8_GPIO_NUM       34
-#define Y7_GPIO_NUM       39
-#define Y6_GPIO_NUM       36
-#define Y5_GPIO_NUM       21
-#define Y4_GPIO_NUM       19
-#define Y3_GPIO_NUM       18
-#define Y2_GPIO_NUM        5
-#define VSYNC_GPIO_NUM    25
-#define HREF_GPIO_NUM     23
-#define PCLK_GPIO_NUM     22
 
 #ifndef MAX_PICSTORE
 #define MAX_PICSTORE 4


### PR DESCRIPTION
## Description:

since the default setting of the ESP32 Cam (AI-Thinker) is not compatible with ESP32-S3.
Solved with an include of a `*.h` file with GPIOs configs of cams.

Added in `esp32-cam` boards manifest the camera type. So there is no change in setup needed and the change
is fully backwards compatible.
EDIT: If no camera model is set, no config is done. Needs to be done later via a template
For the S3 cam variant there is an extensive setup needed to get it going. So an extra board.json is defined.
This is necessary since **EVERY** S3 board needs a 100% correct FLASH / PSRAM type setup and the flash size has
to be set correct too.  

@arendst I think this is the best way to do.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
