### PR TITLE
MI32 legacy driver: refactor MI32 and BLE in Berry to module

### DIFF
--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -54,6 +54,9 @@ be_extern_native_module(ULP);
 #ifdef USE_ZIGBEE
 be_extern_native_module(zigbee);
 #endif // USE_ZIGBEE
+// BLE
+be_extern_native_module(MI32);
+be_extern_native_module(BLE);
 #ifdef USE_LVGL
 be_extern_native_module(lv);
 be_extern_native_module(lv_extra);
@@ -166,7 +169,10 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #if defined(USE_BERRY_ULP) && defined(CONFIG_IDF_TARGET_ESP32)
     &be_native_module(ULP),
 #endif // USE_BERRY_ULP
-
+#if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
+    &be_native_module(MI32),
+    &be_native_module(BLE),
+#endif //USE_MI_ESP32
     /* user-defined modules register end */
     NULL /* do not remove */
 };
@@ -201,9 +207,6 @@ be_extern_native_class(webclient);
 be_extern_native_class(tcpclient);
 be_extern_native_class(tcpserver);
 be_extern_native_class(energy_struct);
-// BLE
-be_extern_native_class(MI32);
-be_extern_native_class(BLE);
 // LVGL core classes
 be_extern_native_class(lv_color);
 be_extern_native_class(lv_font);
@@ -287,10 +290,6 @@ BERRY_LOCAL bclass_array be_class_table = {
 #ifdef USE_BERRY_INT64
     &be_native_class(int64),
 #endif
-#if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)
-    &be_native_class(MI32),
-    &be_native_class(BLE),
-#endif //USE_MI_ESP32
     NULL, /* do not remove */
 };
 

--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -4,6 +4,7 @@
  * To use: `import MI32`
  *******************************************************************/
 #include "be_constobj.h"
+#include "be_mapping.h"
 
 #ifdef USE_MI_ESP32
 extern int be_MI32_devices(bvm *vm);
@@ -13,10 +14,10 @@ extern int be_MI32_get_MAC(bvm *vm);
 extern int be_MI32_set_hum(bvm *vm);
 extern int be_MI32_set_temp(bvm *vm);
 
-#include "be_fixed_be_class_MI32.h"
+#include "be_fixed_MI32.h"
 
 /* @const_object_info_begin
-class be_class_MI32 (scope: global, name: MI32) {
+module MI32 (scope: global) {
   devices,    func(be_MI32_devices)
   get_name,   func(be_MI32_get_name)
   get_MAC,    func(be_MI32_get_MAC)
@@ -26,27 +27,49 @@ class be_class_MI32 (scope: global, name: MI32) {
 }
 @const_object_info_end */
 
-extern int be_BLE_reg_conn_cb(bvm *vm);
-extern int be_BLE_reg_adv_cb(bvm *vm);
-extern int be_BLE_set_MAC(bvm *vm);
-extern int be_BLE_set_characteristic(bvm *vm);
-extern int be_BLE_run(bvm *vm);
-extern int be_BLE_set_service(bvm *vm);
-extern int be_BLE_adv_watch(bvm *vm);
-extern int be_BLE_adv_block(bvm *vm);
+/********************************************************************
+ * Tasmota lib
+ * 
+ * To use: `import BLE`
+ *******************************************************************/
 
-#include "be_fixed_be_class_BLE.h"
+extern void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
+BE_FUNC_CTYPE_DECLARE(be_BLE_reg_conn_cb, "", "cc");
+
+extern void be_BLE_reg_adv_cb(void* function, uint8_t *buffer);
+BE_FUNC_CTYPE_DECLARE(be_BLE_reg_adv_cb, "", "c[c]");
+
+extern void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+BE_FUNC_CTYPE_DECLARE(be_BLE_set_MAC, "", "@(bytes)~[i]");
+
+extern void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
+BE_FUNC_CTYPE_DECLARE(be_BLE_set_characteristic, "", "@s");
+
+extern void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response);
+BE_FUNC_CTYPE_DECLARE(be_BLE_run, "", "@i[b]");
+
+extern void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes);
+BE_FUNC_CTYPE_DECLARE(be_BLE_set_service, "", "@s[b]");
+
+extern void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+BE_FUNC_CTYPE_DECLARE(be_BLE_adv_watch, "", "@(bytes)~[i]");
+
+extern void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+BE_FUNC_CTYPE_DECLARE(be_BLE_adv_block, "", "@(bytes)~[i]");
+
+
+#include "be_fixed_BLE.h"
 
 /* @const_object_info_begin
-class be_class_BLE (scope: global, name: BLE, strings: weak) {
-  conn_cb,    func(be_BLE_reg_conn_cb)
-  set_svc,    func(be_BLE_set_service)
-  run,        func(be_BLE_run)
-  set_chr,    func(be_BLE_set_characteristic)
-  adv_cb,     func(be_BLE_reg_adv_cb)
-  set_MAC,    func(be_BLE_set_MAC)
-  adv_watch,  func(be_BLE_adv_watch)
-  adv_block,  func(be_BLE_adv_block)
+module BLE (scope: global) {
+  conn_cb,    ctype_func(be_BLE_reg_conn_cb)
+  set_svc,    ctype_func(be_BLE_set_service)
+  run,        ctype_func(be_BLE_run)
+  set_chr,    ctype_func(be_BLE_set_characteristic)
+  adv_cb,     ctype_func(be_BLE_reg_adv_cb)
+  set_MAC,    ctype_func(be_BLE_set_MAC)
+  adv_watch,  ctype_func(be_BLE_adv_watch)
+  adv_block,  ctype_func(be_BLE_adv_block)
 }
 @const_object_info_end */
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -118,121 +118,107 @@ extern "C" {
 ********************************************************************/ 
   extern void MI32setBerryAdvCB(void* function, uint8_t *buffer);
   extern void MI32setBerryConnCB(void* function, uint8_t *buffer);
-  extern bool MI32runBerryConnection(uint8_t operation, bool response);
-  extern bool MI32setBerryCtxSvc(const char *Svc, bool discoverAttributes);
+  extern bool MI32runBerryConnection(uint8_t operation, bbool response);
+  extern bool MI32setBerryCtxSvc(const char *Svc, bbool discoverAttributes);
   extern bool MI32setBerryCtxChr(const char *Chr);
   extern bool MI32setBerryCtxMAC(uint8_t *MAC, uint8_t type);
   extern bool MI32addMACtoBlockList(uint8_t *MAC, uint8_t type);
   extern bool MI32addMACtoWatchList(uint8_t *MAC, uint8_t type);
 
 
-  int be_BLE_reg_conn_cb(bvm *vm);
-  int be_BLE_reg_conn_cb(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 3 && be_iscomptr(vm, 2)) {
-      void* cb = be_tocomptr(vm, 2);
-      size_t len;
-      uint8_t * buf = (uint8_t*)be_tobytes(vm, 3, &len);
-      MI32setBerryConnCB(cb,buf);
-      be_return(vm);
-    }
-    be_raise(vm, kTypeError, nullptr);
+  void be_BLE_reg_conn_cb(void* function, uint8_t *buffer);
+  void be_BLE_reg_conn_cb(void* function, uint8_t *buffer){    
+    MI32setBerryConnCB(function,buffer);
   }
 
-  int be_BLE_reg_adv_cb(bvm *vm);
-  int be_BLE_reg_adv_cb(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 3 && be_iscomptr(vm, 2)) {
-      void* cb = be_tocomptr(vm, 2);
-      size_t len;
-      uint8_t * buf = (uint8_t*)be_tobytes(vm, 3, &len);
-      MI32setBerryAdvCB(cb,buf);
-      be_return(vm); // Return
+  void be_BLE_reg_adv_cb(void* function, uint8_t *buffer);
+  void be_BLE_reg_adv_cb(void* function, uint8_t *buffer){
+    if(function == 0){
+      MI32setBerryAdvCB(NULL,NULL);
     }
-    else if(argc == 2 && be_isint(vm, 2)){
-      if(be_toint(vm, 2) == 0){
-        MI32setBerryAdvCB(NULL,NULL);
-        be_return(vm); // Return
-      }
+    else if(buffer){
+      MI32setBerryAdvCB(function,buffer);
     }
-    be_raise(vm, kTypeError, nullptr);
   }
 
-  int be_BLE_set_MAC(bvm *vm);
-  int be_BLE_set_MAC(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc > 1 && be_isbytes(vm, 2)) {
-      size_t len = 6;
-      uint8_t type = 0;
-      if(argc == 3 && be_isint(vm, 3)){
-        type = be_toint(vm,3);
-      }
-      if (MI32setBerryCtxMAC((uint8_t*)be_tobytes(vm, 2, &len),type)) be_return(vm);
+  bool be_BLE_MAC_size(struct bvm *vm, size_t size){
+    if(size != 6){
+       be_raisef(vm, "ble_error", "BLE: wrong size of MAC");
+       return false;
     }
-    be_raise(vm, kTypeError, nullptr);
+    return true;
   }
 
-  int be_BLE_set_service(bvm *vm);
-  int be_BLE_set_service(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc > 1 && be_isstring(vm, 2)) {
-      bool discoverAttributes = false;
-      if(argc == 3 && be_isint(vm, 3)){
-        discoverAttributes = be_toint(vm,3)>0;
-      }
-      if (MI32setBerryCtxSvc(be_tostring(vm, 2),discoverAttributes)) be_return(vm);
+  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+  void be_BLE_set_MAC(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){
+    if(!be_BLE_MAC_size(vm, size)){
+      return;
     }
-    be_raise(vm, kTypeError, nullptr);
+    uint8_t _type = 0;
+    if(type){
+      _type = type;
+    }
+    if (MI32setBerryCtxMAC(buf,_type)) return;
+
+    be_raisef(vm, "ble_error", "BLE: could not set MAC");
   }
 
-  int be_BLE_set_characteristic(bvm *vm);
-  int be_BLE_set_characteristic(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 2 && be_isstring(vm, 2)) {
-      if (MI32setBerryCtxChr(be_tostring(vm, 2))) be_return(vm);
+  void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes);
+  void be_BLE_set_service(struct bvm *vm, const char *Svc, bbool discoverAttributes){    
+    bool _discoverAttributes = false;
+    if(discoverAttributes){
+      _discoverAttributes = discoverAttributes ;
     }
-    be_raise(vm, kTypeError, nullptr);
+    if (MI32setBerryCtxSvc(Svc,_discoverAttributes)) return;
+
+    be_raisef(vm, "ble_error", "BLE: could not set service");
   }
 
-  int be_BLE_run(bvm *vm);
-  int be_BLE_run(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if ((argc > 1) && be_isint(vm, 2)) {
-      bool response = false;
-      if(argc == 3 && be_isint(vm, 3)){
-        response = be_toint(vm,3)>0;
-      }
-      if (MI32runBerryConnection(be_toint(vm, 2),response)) be_return(vm);
-    }
-    be_raise(vm, kTypeError, nullptr);
+  void be_BLE_set_characteristic(struct bvm *vm, const char *Chr);
+  void be_BLE_set_characteristic(struct bvm *vm, const char *Chr){
+      
+    if (MI32setBerryCtxChr(Chr)) return;
+
+    be_raisef(vm, "ble_error", "BLE: could not set characteristic");
   }
 
-  int be_BLE_adv_block(bvm *vm);
-  int be_BLE_adv_block(bvm *vm){    
-  int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc > 1 && be_isbytes(vm, 2)) {
-      size_t len = 6;
-      uint8_t type = 0;
-      if(argc == 3 && be_isint(vm, 3)){
-        type = be_toint(vm,3);
-      }
-    if(MI32addMACtoBlockList((uint8_t*)be_tobytes(vm, 2, &len),type)) be_return(vm);
-  }
-  be_raise(vm, kTypeError, nullptr);
+  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response);
+  void be_BLE_run(struct bvm *vm, uint8_t operation, bbool response){
+    bool _response = false;    
+    if(response){
+      _response = response;
+    }
+    if (MI32runBerryConnection(operation,_response)) return;
+
+    be_raisef(vm, "ble_error", "BLE: could not run operation");
   }
 
-  int be_BLE_adv_watch(bvm *vm);
-  int be_BLE_adv_watch(bvm *vm){    
-  int32_t argc = be_top(vm); // Get the number of arguments
-  if (argc > 1 && be_isbytes(vm, 2)) {
-    size_t len = 6;
-    uint8_t type = 0;
-    if(argc == 3 && be_isint(vm, 3)){
-      type = be_toint(vm,3);
+  void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+  void be_BLE_adv_block(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){    
+    if(!be_BLE_MAC_size(vm, size)){
+      return;
     }
-    if (MI32addMACtoWatchList((uint8_t*)be_tobytes(vm, 2, &len),type)) be_return(vm);
+    uint8_t _type = 0;
+    if(type){
+      _type = type;
+    }
+    if(MI32addMACtoBlockList(buf, _type)) return;
+  
+  be_raisef(vm, "ble_error", "BLE: could not block MAC");
   }
-  be_raise(vm, kTypeError, nullptr);
+
+  void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type);
+  void be_BLE_adv_watch(struct bvm *vm, uint8_t *buf, size_t size, uint8_t type){    
+    if(!be_BLE_MAC_size(vm, size)){
+      return;
+    }
+    uint8_t _type = 0;
+    if(type){
+      _type = type;
+    }
+    if(MI32addMACtoWatchList(buf, _type)) return;
+
+  be_raisef(vm, "ble_error", "BLE: could not add MAC to watch list");
   }
 
 } //extern "C"


### PR DESCRIPTION
## Description:

Both are some kind of singletons, so it makes more sense to use modules instead of classes, that talk to one driver and to one BLE device.
Usage is now in the kind of:
```
import BLE
self.buf = bytes(-96)
var cbp = tasmota.gen_cb(/svc,man -> self.cb(svc,man))
BLE.adv_cb(cbp,self.buf)
```
This is a breaking change, but does not influence any of the standard builds.

Additionally it now uses c-type function declarations for the BLE part.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
