### PR TITLE
Berry has persistent MQTT subscriptions: auto-subscribe at (re)connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [12.1.1.2]
 ### Added
+- Berry has persistent MQTT subscriptions: auto-subscribe at (re)connection
 
 ### Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -13,7 +13,7 @@ extern const be_ctypes_structure_t be_tasmota_settings_struct;
 
 extern int l_getFreeHeap(bvm *vm);
 extern int l_arch(bvm *vm);
-extern int l_publish(bvm *vm);
+extern int be_mqtt_publish(bvm *vm);
 extern int l_publish_result(bvm *vm);
 extern int l_publish_rule(bvm *vm);
 extern int l_cmd(bvm *vm);
@@ -2562,7 +2562,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
 
     get_free_heap, func(l_getFreeHeap)
     arch, func(l_arch)
-    publish, func(l_publish)
+    publish, func(be_mqtt_publish)
     publish_result, func(l_publish_result)
     publish_rule, func(l_publish_rule)
     _cmd, func(l_cmd)

--- a/lib/libesp32/berry_tasmota/src/embedded/mqtt.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/mqtt.be
@@ -1,0 +1,171 @@
+#- ------------------------------------------------------------ -#
+#  Module `lv_tasmota` - piggybacks on `lv` to extend it
+#- ------------------------------------------------------------ -#
+
+#-
+
+import path 
+path.remove("mqtt.bec")
+import solidify
+load('mqtt.be')
+var f = open("mqtt.c", "w")
+solidify.dump(MQTT, false, f)
+f.close()
+print("Ok")
+
+-#
+
+class MQTT_ntv end    # for solidification only
+
+
+class MQTT : MQTT_ntv
+  var topics
+
+  # def init()
+  # end
+  def lazy_init()
+    if self.topics == nil
+      self.topics = []
+      tasmota.add_driver(self)
+      tasmota.add_rule("Mqtt#Connected", / -> self.mqtt_connect())    # call mqtt_connect() when the connection occurs
+    end
+  end
+
+  def mqtt_listener_class()
+
+    class mqtt_listener
+      var topic           # topic as a list of subtopics
+      var fulltopic       # fulltopic as string
+      var closure
+
+      def init(topic, closure)
+        import string
+        self.fulltopic = topic
+        self.topic = string.split(topic, '/')
+        self.closure = closure
+      end
+
+      def tostring()
+        import string
+        return string.format("<instance: %s('%s')>", classname(self), self.fulltopic)
+      end
+
+      def mqtt_data(topic, idx, payload_s, payload_b)
+        # check if the topic matches the patter
+        import string
+        var topic_elts = string.split(topic, '/')
+        var topic_sz = size(topic_elts)
+        var pat = self.topic
+        var pat_sz = size(pat)
+        var i = 0
+        while i < pat_sz
+          var pat_elt = pat[i]
+
+          if pat_elt == '#'
+            # joker, munch whatever is left
+            # '#' is supposed to be the last character of the topic (we don't check it)
+            break
+          elif i >= topic_sz
+            # the topic is too short - no match
+            return false
+          elif pat_elt == '+'
+            # pass
+          elif pat_elt != topic_elts[i]
+            # topic element are different - no match
+            return false
+          end
+
+          i += 1
+        end
+
+        if i >= pat_sz && pat_sz != topic_sz
+          # the topic is too long and the pattern did not finish with '#' - no match
+          return false
+        end
+
+        var cl = self.closure
+        var ret = cl(topic, idx, payload_s, payload_b)
+        if ret == nil   ret = true end    # return true if the return value is forgotten
+        return ret
+      end
+    end
+    return mqtt_listener
+  end
+
+  def subscribe(topic, closure)
+    self.lazy_init()
+    var found = false
+    for m : self.topics
+      if m.fulltopic == topic && m.closure == closure
+        return                                       # we have already the subscription, ignore
+      end
+    end
+    var mqtt_listener = self.mqtt_listener_class()
+    if type(closure) == 'function'
+      tasmota.check_not_method(closure)
+      self.topics.push(mqtt_listener(topic, closure))
+    else
+      self.topics.push(mqtt_listener(topic))
+    end
+    self._subscribe(topic)
+  end
+
+  # if topic == nil, unsuscribe to all
+  def unsubscribe(topic)
+    if self.topics == nil  return end                 # nothing to do
+    
+    var i = 0
+    while i < size(self.topics)
+      if topic == nil || self.topics[i].fulltopic == topic
+        if topic == nil self._unsubscribe(self.topics[i].fulltopic) end
+        self.topics.remove(i)   # remove and don't increment
+      else
+        i += 1
+      end
+    end
+
+    if topic != nil  self._unsubscribe(topic) end
+  end
+
+  def mqtt_data(topic, idx, payload_s, payload_b)
+    if self.topics == nil  return end
+    var ret = false
+    for m : self.topics
+      if m.closure != nil                                         # if no closure attached, skip it
+        var res = m.mqtt_data(topic, idx, payload_s, payload_b)   # stop propagation?
+        ret = ret || res
+      end
+    end
+    return ret    # return true to stop propagation as a Tasmota cmd
+  end
+
+  def mqtt_connect()    # called when MQTT connects or re-connects
+    tasmota.log("BRY: mqtt subscribe all registered topics", 3)
+    for m : self.topics
+      var fulltopic = m.fulltopic
+      self._subscribe(fulltopic)
+    end
+    return false
+  end
+end
+
+#-
+# example
+
+import mqtt
+def p1(a,b,c) print("mqtt1",a,b,c) end
+def p2(a,b,c) print("mqtt2",a,b,c) end
+def p3(a,b,c) print("mqtt3",a,b,c) end
+
+mqtt.subscribe("/a/b", p1)
+mqtt.subscribe("/a/b/c", p2)
+#mqtt.subscribe("#", p3)
+
+print(">unsub /a/b")
+mqtt.unsubscribe("/a/b")
+print(">unsub all")
+mqtt.unsubscribe()
+
+
+-#
+

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_mqtt.ino
@@ -25,54 +25,46 @@
 
 // Berry: `tasmota.publish(topic, payload [, retain:bool, start:int, len:int]) -> nil``
 // is_method is true if called from Tasmota class, false if called from mqtt module
-int32_t be_mqtt_publish(struct bvm *vm, bool is_method) {
-  int32_t top = be_top(vm); // Get the number of arguments
-  if (top >= 2+is_method && be_isstring(vm, 1+is_method) && (be_isstring(vm, 2+is_method) || be_isbytes(vm, 2+is_method))) {  // 2 mandatory string arguments
-    bool retain = false;
-    int32_t payload_start = 0;
-    int32_t len = -1;   // send all of it
-    if (top >= 3+is_method) { retain = be_tobool(vm, 3+is_method); }
-    if (top >= 4+is_method) {
-      payload_start = be_toint(vm, 4+is_method);
-      if (payload_start < 0) payload_start = 0;
-    }
-    if (top >= 5+is_method) { len = be_toint(vm, 5+is_method); }
-    const char * topic = be_tostring(vm, 1+is_method);
-    const char * payload = nullptr;
-    size_t payload_len = 0;
-
-    if (be_isstring(vm, 2+is_method)) {
-      payload = be_tostring(vm, 2+is_method);
-      payload_len = strlen(payload);
-    } else {
-      payload = (const char *) be_tobytes(vm, 2+is_method, &payload_len);
-    }
-    if (!payload) { be_raise(vm, "value_error", "Empty payload"); }
-
-    // adjust start and len
-    if (payload_start >= payload_len) { len = 0; }              // send empty packet
-    else if (len < 0) { len = payload_len - payload_start; }    // send all packet, adjust len
-    else if (payload_start + len > payload_len) { len = payload_len - payload_start; }    // len is too long, adjust
-    // adjust start
-    payload = payload + payload_start;
-
-    be_pop(vm, be_top(vm));   // clear stack to avoid any indirect warning message in subsequent calls to Berry
-
-    MqttPublishPayload(topic, payload, len, retain);
-
-    be_return_nil(vm); // Return
-  }
-  be_raise(vm, kTypeError, nullptr);
-}
-
 extern "C" {
-  int32_t l_publish(struct bvm *vm);
-  int32_t l_publish(struct bvm *vm) {
-    return be_mqtt_publish(vm, true);
-  }
-
+  int32_t be_mqtt_publish(struct bvm *vm);
   int32_t be_mqtt_publish(struct bvm *vm) {
-    return be_mqtt_publish(vm, false);
+    int32_t top = be_top(vm); // Get the number of arguments
+    if (top >= 3 && be_isstring(vm, 2) && (be_isstring(vm, 3) || be_isbytes(vm, 3))) {  // 2 mandatory string arguments
+      bool retain = false;
+      int32_t payload_start = 0;
+      int32_t len = -1;   // send all of it
+      if (top >= 4) { retain = be_tobool(vm, 4); }
+      if (top >= 5) {
+        payload_start = be_toint(vm, 5);
+        if (payload_start < 0) payload_start = 0;
+      }
+      if (top >= 6) { len = be_toint(vm, 6); }
+      const char * topic = be_tostring(vm, 2);
+      const char * payload = nullptr;
+      size_t payload_len = 0;
+
+      if (be_isstring(vm, 3)) {
+        payload = be_tostring(vm, 3);
+        payload_len = strlen(payload);
+      } else {
+        payload = (const char *) be_tobytes(vm, 3, &payload_len);
+      }
+      if (!payload) { be_raise(vm, "value_error", "Empty payload"); }
+
+      // adjust start and len
+      if (payload_start >= payload_len) { len = 0; }              // send empty packet
+      else if (len < 0) { len = payload_len - payload_start; }    // send all packet, adjust len
+      else if (payload_start + len > payload_len) { len = payload_len - payload_start; }    // len is too long, adjust
+      // adjust start
+      payload = payload + payload_start;
+
+      be_pop(vm, be_top(vm));   // clear stack to avoid any indirect warning message in subsequent calls to Berry
+
+      MqttPublishPayload(topic, payload, len, retain);
+
+      be_return_nil(vm); // Return
+    }
+    be_raise(vm, kTypeError, nullptr);
   }
 
   void be_mqtt_subscribe(const char* topic) {
@@ -83,6 +75,10 @@ extern "C" {
   void be_mqtt_unsubscribe(const char* topic) {
     if (!topic) { return; }
     MqttUnsubscribe(topic);
+  }
+
+  bbool be_mqtt_connected(void) {
+    return Mqtt.connected;
   }
 }
 


### PR DESCRIPTION
## Description:

The interface is unchanged for `import mqtt` but now subscriptions can be done even when MQTT is not connected (i.e. within `autoexec.be`) and manages automatically connection and reconnection.

Added `mqtt.connected() -> bool` to query if MQTT is connected or not.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
