### PR TITLE
MI32 legacy: refactor MI32 functions to CTYPE_DECLARATION

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_MI32_lib.c
@@ -7,23 +7,34 @@
 #include "be_mapping.h"
 
 #ifdef USE_MI_ESP32
-extern int be_MI32_devices(bvm *vm);
-extern int be_MI32_set_bat(bvm *vm);
-extern int be_MI32_get_name(bvm *vm);
-extern int be_MI32_get_MAC(bvm *vm);
-extern int be_MI32_set_hum(bvm *vm);
-extern int be_MI32_set_temp(bvm *vm);
+extern int be_MI32_devices(void);
+BE_FUNC_CTYPE_DECLARE(be_MI32_devices, "i", "");
+
+extern void be_MI32_set_bat(int slot, int bat_val);
+BE_FUNC_CTYPE_DECLARE(be_MI32_set_bat, "", "ii");
+
+extern const char * be_MI32_get_name(int slot);
+BE_FUNC_CTYPE_DECLARE(be_MI32_get_name, "s", "i");
+
+extern uint8_t *be_MI32_get_MAC(int32_t slot, size_t *size);
+BE_FUNC_CTYPE_DECLARE(be_MI32_get_MAC, "&", "i");
+
+extern void be_MI32_set_hum(int slot, int hum_val);
+BE_FUNC_CTYPE_DECLARE(be_MI32_set_hum, "", "ii");
+
+extern void be_MI32_set_temp(int slot, int temp_val);
+BE_FUNC_CTYPE_DECLARE(be_MI32_set_temp, "", "ii");
 
 #include "be_fixed_MI32.h"
 
 /* @const_object_info_begin
 module MI32 (scope: global) {
-  devices,    func(be_MI32_devices)
-  get_name,   func(be_MI32_get_name)
-  get_MAC,    func(be_MI32_get_MAC)
-  set_bat,    func(be_MI32_set_bat)
-  set_hum,    func(be_MI32_set_hum)
-  set_temp,   func(be_MI32_set_temp)
+  devices,    ctype_func(be_MI32_devices)
+  get_name,   ctype_func(be_MI32_get_name)
+  get_MAC,    ctype_func(be_MI32_get_MAC)
+  set_bat,    ctype_func(be_MI32_set_bat)
+  set_hum,    ctype_func(be_MI32_set_hum)
+  set_temp,   ctype_func(be_MI32_set_temp)
 }
 @const_object_info_end */
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -42,74 +42,33 @@ extern "C" {
   extern void MI32setTemperatureForSlot(uint32_t slot, float value);
   extern uint8_t * MI32getDeviceMAC(uint32_t slot);
 
-  int be_MI32_devices(bvm *vm);
-  int be_MI32_devices(bvm *vm) {
-    uint32_t devices  = MI32numberOfDevices();
-    be_pushint(vm, devices);
-    be_return(vm);
+  int be_MI32_devices(void) {
+    return MI32numberOfDevices();
   }
 
-  int be_MI32_set_bat(bvm *vm);
-  int be_MI32_set_bat(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 3 && be_isint(vm, 2) && be_isint(vm, 3)) {
-      uint32_t slot = be_toint(vm, 2);
-      int32_t bat_val = be_toint(vm, 3);
-      MI32setBatteryForSlot(slot,bat_val);
-      be_return(vm); // Return
-    }
-    be_raise(vm, kTypeError, nullptr);
+  void be_MI32_set_bat(int slot, int bat_val){    
+    MI32setBatteryForSlot(slot,bat_val);
   }
 
-  int be_MI32_get_name(bvm *vm);
-  int be_MI32_get_name(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 2 && be_isint(vm, 2)) {
-      uint32_t slot = be_toint(vm, 2);
-      const char * name = MI32getDeviceName(slot);
-      be_pushstring(vm,name);
-      be_return(vm); // Return
-    }
-    be_raise(vm, kTypeError, nullptr);
+  const char* be_MI32_get_name(int slot){    
+    return  MI32getDeviceName(slot);
   }
 
-  int be_MI32_get_MAC(bvm *vm);
-  int be_MI32_get_MAC(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 2 && be_isint(vm, 2)) {
-      uint32_t slot = be_toint(vm, 2);
-      uint8_t *buffer = MI32getDeviceMAC(slot);
-      size_t len = 6;
-      if(buffer != NULL) {
-        be_pushbytes(vm,buffer,len);
-        be_return(vm); // Return
-      }
+  uint8_t *be_MI32_get_MAC(int32_t slot, size_t *size){
+    *size = 6;
+    uint8_t * buffer = MI32getDeviceMAC(slot);
+    if(buffer == nullptr){
+      *size = 0;
     }
-    be_raise(vm, kTypeError, nullptr);
+    return buffer;
   }
 
-  int be_MI32_set_hum(bvm *vm);
-  int be_MI32_set_hum(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 3 && be_isint(vm, 2) && be_isreal(vm, 3)) {
-      uint32_t slot = be_toint(vm, 2);
-      float hum_val = be_toreal(vm, 3);
-      MI32setHumidityForSlot(slot,hum_val);
-      be_return(vm); // Return
-    }
-    be_raise(vm, kTypeError, nullptr);
+  void be_MI32_set_hum(int slot, int hum_val){    
+    MI32setHumidityForSlot(slot,hum_val);
   }
 
-  int be_MI32_set_temp(bvm *vm);
-  int be_MI32_set_temp(bvm *vm){    
-    int32_t argc = be_top(vm); // Get the number of arguments
-    if (argc == 3 && be_isint(vm, 2) && be_isreal(vm, 3)) {
-      uint32_t slot = be_toint(vm, 2);
-      float temp_val = be_toreal(vm, 3);
-      MI32setTemperatureForSlot(slot,temp_val);
-      be_return(vm); // Return
-    }
-    be_raise(vm, kTypeError, nullptr);
+  void be_MI32_set_temp(int slot, int temp_val){    
+    MI32setTemperatureForSlot(slot,temp_val);
   }
 
 
@@ -233,7 +192,7 @@ BLE.set_svc
 BLE.set_chr
 
 BLE.set_MAC
-BLE.run(op)
+BLE.run(op, optional: bool response)
 be_BLE_op:
 1 read
 2 write


### PR DESCRIPTION
## Description:

Refactoring the remaining functions to ctype declaration, which fixes some bugs from the last PR while transitioning from class to module.

No API changes. No influence on official builds.

Thanks to @s-hadinger for help.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
