### PR TITLE
Add `#define TASMOTA`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -85,6 +85,7 @@ build_flags                 = -DCORE_DEBUG_LEVEL=0
                               -free
                               -fipa-pta
                               -Wreturn-type
+                              -DTASMOTA  ; flag indicating that we are compiling Tasmota
 ; *********************************************************************
 ; *** Use custom settings from file user_config_override.h
                               -DUSE_CONFIG_OVERRIDE


### PR DESCRIPTION
## Description:

Add an implicit `#define TASMOTA` to indicate that Tasmota compilation is occurring vs a standalone compilation of a library (primarily Berry).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
