### PR TITLE
Update xdrv_16_tuyamcu.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu.ino
@@ -802,7 +802,7 @@ void TuyaProcessStatePacket(void) {
     if (Tuya.buffer[dpidStart + 1] == 0) {
 #ifdef USE_ENERGY_SENSOR
         if (tuya_energy_enabled && fnId == TUYA_MCU_FUNC_POWER_COMBINED) {
-          if (dpDataLen == 8) {
+          if (dpDataLen >= 8) {
             uint16_t tmpVol = Tuya.buffer[dpidStart + 4] << 8 | Tuya.buffer[dpidStart + 5];
             uint16_t tmpCur = Tuya.buffer[dpidStart + 7] << 8 | Tuya.buffer[dpidStart + 8];
             uint16_t tmpPow = Tuya.buffer[dpidStart + 10] << 8 | Tuya.buffer[dpidStart + 11];


### PR DESCRIPTION
Support longer-form TUYA_MCU_FUNC_POWER_COMBINED payloads used by some devices, including "2P 63A TUYA APP WiFi Smart Circuit Earth Leakage Over Under Voltage Protector Relay Device Switch Breaker Energy Power kWh Meter".

## Description:

Extends eMylo EAI-90 support with other similar devices - I've encountered one with a longer payload (potentially earth leakage current?) which is being rejected by an unnecessarily exact payload length check.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
