### PR TITLE
Changes for new upcoming core 2.0.5

### DIFF
--- a/platformio_override.ini.off
+++ b/platformio_override.ini.off
@@ -1,0 +1,171 @@
+; ***  Example PlatformIO Project Configuration Override File   ***
+; ***  Changes done here override settings in platformio.ini    ***
+;
+; *****************************************************************
+; ***  to activate rename this file to platformio_override.ini  ***
+; *****************************************************************
+;
+; Please visit documentation for the options and examples
+; http://docs.platformio.org/en/stable/projectconf.html
+
+[platformio]
+; For best Gitpod performance remove the ";" in the next line. Needed Platformio files are cached and installed at first run
+;core_dir = .platformio
+; For unrelated compile errors with Windows it can help to shorten Platformio project path
+;workspace_dir = c:\.pio
+
+; *** Build/upload environment
+default_envs            =
+; *** Uncomment the line(s) below to select version(s)
+;                          tasmota
+;                          tasmota-debug
+;                          tasmota-minimal
+;                          tasmota-lite
+;                          tasmota-knx
+;                          tasmota-sensors
+;                          tasmota-display
+;                          tasmota-zbbridge
+;                          tasmota-ir
+                          tasmota32
+;                          tasmota32-zbbrdgpro
+;                          tasmota32-bluetooth
+;                          tasmota32-webcam
+;                          tasmota32-knx
+;                          tasmota32-sensors
+;                          tasmota32-lvgl
+;                          tasmota32-ir
+;                          tasmota32solo1
+;                          tasmota32c3
+;                          tasmota32c3cdc
+;                          tasmota32s2
+;                          tasmota32s2cdc
+;                          tasmota32s3
+;                          tasmota32s3cdc
+;                          tasmota32-odroidgo
+;                          tasmota32-core2
+;                          tasmota32-nspanel
+
+
+[env]
+; Activate Development core by removing ";" the next lines
+;platform                = https://github.com/platformio/platform-espressif8266.git
+;platform_packages       = framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+;                          mcspr/toolchain-xtensa @ ~5.100300.211127
+;                          platformio/tool-esptoolpy @ ~1.30300
+;build_unflags           = ${common.build_unflags}
+;                          -Wswitch-unreachable
+;build_flags             = ${common.build_flags}
+;                          -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED
+;                          -Wno-switch-unreachable
+; *** Optional Debug messages
+;                         -DDEBUG_TASMOTA_CORE
+;                         -DDEBUG_TASMOTA_DRIVER
+;                         -DDEBUG_TASMOTA_SENSOR
+; Build variant 1MB = 1MB firmware no filesystem (default)
+board                   = ${common.board}
+; Build variant 2MB = 1MB firmware, 1MB filesystem (most Shelly devices)
+;board                   = esp8266_2M1M
+; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
+;board                   = esp8266_4M2M
+;board_build.f_cpu       = 160000000L
+;board_build.f_flash     = 40000000L
+;monitor_speed           = 115200
+; *** Serial port used for erasing/flashing the ESP82xx
+;upload_port             = COM5
+extra_scripts           = ${esp_defaults.extra_scripts}
+;                          pio-tools/obj-dump.py
+lib_ignore              =
+                          Servo(esp8266)
+                          ESP8266AVRISP
+                          ESP8266LLMNR
+                          ESP8266NetBIOS
+                          ESP8266SSDP
+                          SP8266WiFiMesh
+                          Ethernet(esp8266)
+                          GDBStub
+                          TFT_Touch_Shield_V2
+                          ESP8266HTTPUpdateServer
+                          ESP8266WiFiMesh
+                          EspSoftwareSerial
+                          SPISlave
+                          Hash
+; Disable next if you want to use ArduinoOTA in Tasmota (default disabled)
+                          ArduinoOTA
+lib_extra_dirs          = ${library.lib_extra_dirs}
+
+
+[env:tasmota32_base]
+; *** Uncomment next lines ";" to enable development Tasmota Arduino version ESP32
+platform                = https://github.com/jason2866/platform-espressif32.git#Tasmota/205
+platform_packages       = framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/releases/download/996/framework-arduinoespressif32-IDF_Arduino-cd58a68f7.zip
+build_unflags           = ${esp32_defaults.build_unflags}
+build_flags             = ${esp32_defaults.build_flags}
+
+; Build variant ESP32 4M Flash, Tasmota 1856k Code/OTA, 1344k LITTLEFS (default)
+;board                   = esp32_4M
+; Build variant ESP32 8M Flash, Tasmota 2944k Code/OTA, 2112k LITTLEFS
+;board                   = esp32_8M
+; Build variant ESP32 16M Flash, Tasmota 2944k Code/OTA, 10M LITTLEFS
+;board                   = esp32_16M
+;board_build.f_cpu       = 240000000L
+;board_build.f_flash     = 40000000L
+monitor_speed           = 115200
+; *** Serial port used for erasing/flashing the ESP32
+;upload_port             = ${common.upload_port}
+upload_port             = COM4
+;upload_speed            = 115200
+upload_resetmethod      = ${common.upload_resetmethod}
+extra_scripts           = ${esp32_defaults.extra_scripts}
+;                          pio-tools/obj-dump.py
+lib_ignore              =
+                          HTTPUpdateServer
+                          ESP RainMaker
+                          WiFiProv
+                          USB
+                          SPIFFS
+                          ESP32 Azure IoT Arduino
+                          ESP32 Async UDP
+                          ESP32 BLE Arduino
+;                          SimpleBLE
+                          NetBIOS
+                          ESP32
+                          Preferences
+                          BluetoothSerial
+; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
+                          ArduinoOTA
+
+lib_extra_dirs           = ${library.lib_extra_dirs}
+; *** ESP32 lib. ALWAYS needed for ESP32 !!!
+                          lib/libesp32
+; *** comment the following line if you dont use LVGL in a Tasmota32 build. Reduces compile time
+                          lib/libesp32_lvgl
+; *** comment the following line if you dont use ESP32 Audio in a Tasmota32 build. Reduces compile time
+;                          lib/libesp32_audio
+; *** uncomment the following line if you use Bluetooth or Apple Homekit in a Tasmota32 build. Reduces compile time
+;                          lib/libesp32_div
+; *** uncomment the following line if you use Epaper driver epidy in your Tasmota32 build. Reduces compile time
+;                          lib/libesp32_eink
+
+
+[library]
+shared_libdeps_dir      = lib
+; *** Library disable / enable for variant Tasmota(32). Disable reduces compile time
+; *** !!! Disabling needed libs will generate compile errors !!!
+; *** The resulting firmware will NOT be different if you leave all libs enabled
+; *** Disabling by putting a ";" in front of the lib name
+; *** If you dont know what it is all about, do not change
+lib_extra_dirs           =
+; *** Only disabled for Tasmota minimal and Tasmota light. For all other variants needed!
+                           lib/lib_basic
+; **** I2C devices. Most sensors. Disable only if you dont have ANY I2C device enabled
+                           lib/lib_i2c
+; *** Displays. Disable if you dont have any Display activated
+                           lib/lib_display
+; *** Bear SSL and base64. Disable if you dont have SSL or TLS activated
+                           lib/lib_ssl
+; *** Audio needs a lot of time to compile. Mostly not used functions. Recommended to disable
+                           lib/lib_audio
+; *** RF 433 stuff (not RF Bridge). Recommended to disable
+                           lib/lib_rf
+; *** Mostly not used functions. Recommended to disable
+                           lib/lib_div

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -749,7 +749,7 @@ uint32_t CfgTime(void) {
 void SettingsErase(uint8_t type) {
   /*
     For Arduino core and SDK:
-    Erase only works from flash start address to SDK recognized flash end address (flashchip->chip_size = ESP.getFlashChipSize).
+    Erase only works from flash start address to SDK recognized flash end address (flashchip->chip_size = ESP_getFlashChipSize).
     Addresses above SDK recognized size (up to ESP.getFlashChipRealSize) are not accessable.
     For Esptool:
     The only way to erase whole flash is esptool which uses direct SPI writes to flash.
@@ -779,7 +779,7 @@ void SettingsErase(uint8_t type) {
 */
     EsptoolErase(_sectorStart, FLASH_FS_START);
     _sectorStart = EEPROM_LOCATION;
-    _sectorEnd = ESP.getFlashChipSize() / SPI_FLASH_SEC_SIZE;  // Flash size as seen by SDK
+    _sectorEnd = ESP_getFlashChipSize() / SPI_FLASH_SEC_SIZE;  // Flash size as seen by SDK
   }
   else if (3 == type) {    // QPC Reached = QPC and Tasmota and SDK parameter area (0x0F3xxx - 0x0FFFFF)
 #ifdef USE_UFILESYS

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -774,8 +774,11 @@ void CmndStatus(void)
                           ESP_getSketchSize()/1024, ESP_getFreeSketchSpace()/1024, ESP_getFreeHeap1024(),
 #ifdef ESP32
                           uxTaskGetStackHighWaterMark(nullptr) / 1024, ESP.getPsramSize()/1024, ESP.getFreePsram()/1024,
+                          ESP_getFlashChipMagicSize()/1024, ESP.getFlashChipSize()/1024
 #endif  // ESP32
-                          ESP.getFlashChipSize()/1024, ESP_getFlashChipRealSize()/1024
+#ifdef ESP8266
+                          ESP_getFlashChipSize()/1024, ESP.getFlashChipRealSize()/1024
+#endif // ESP8266
                           , ESP_getFlashChipId()
                           , ESP.getFlashChipSpeed()/1000000, ESP_getFlashChipMode().c_str());
     ResponseAppendFeatures();

--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -65,6 +65,10 @@ uint32_t ESP_getFlashChipRealSize(void) {
   return ESP.getFlashChipRealSize();
 }
 
+uint32_t ESP_getFlashChipSize(void) {
+  return ESP.getFlashChipSize();
+}
+
 void ESP_Restart(void) {
 //  ESP.restart();            // This results in exception 3 on restarts on core 2.3.0
   ESP.reset();
@@ -312,17 +316,22 @@ extern "C" {
 #if ESP_IDF_VERSION_MAJOR > 3       // IDF 4+
   #if CONFIG_IDF_TARGET_ESP32       // ESP32/PICO-D4
     #include "esp32/rom/spi_flash.h"
+    #define ESP_FLASH_IMAGE_BASE 0x1000     // Flash offset containing magic flash size and spi mode
   #elif CONFIG_IDF_TARGET_ESP32S2   // ESP32-S2
     #include "esp32s2/rom/spi_flash.h"
+    #define ESP_FLASH_IMAGE_BASE 0x1000     // Flash offset containing magic flash size and spi mode
   #elif CONFIG_IDF_TARGET_ESP32S3   // ESP32-S3
     #include "esp32s3/rom/spi_flash.h"
+    #define ESP_FLASH_IMAGE_BASE 0x0000     // Esp32s3 is located at 0x0000
   #elif CONFIG_IDF_TARGET_ESP32C3   // ESP32-C3
     #include "esp32c3/rom/spi_flash.h"
+    #define ESP_FLASH_IMAGE_BASE 0x0000     // Esp32c3 is located at 0x0000
   #else
     #error Target CONFIG_IDF_TARGET is not supported
   #endif
 #else // ESP32 Before IDF 4.0
   #include "rom/spi_flash.h"
+  #define ESP_FLASH_IMAGE_BASE 0x1000
 #endif
 
 uint32_t EspProgramSize(const char *label) {
@@ -520,6 +529,33 @@ uint32_t ESP_getChipId(void) {
   return id;
 }
 
+uint32_t ESP_getFlashChipMagicSize(void)
+{
+    esp_image_header_t fhdr;
+    if(ESP.flashRead(ESP_FLASH_IMAGE_BASE, (uint32_t*)&fhdr, sizeof(esp_image_header_t)) && fhdr.magic != ESP_IMAGE_HEADER_MAGIC) {
+        return 0;
+    }
+    return ESP_magicFlashChipSize(fhdr.spi_size);
+}
+
+uint32_t ESP_magicFlashChipSize(uint8_t byte)
+{
+    switch(byte & 0x0F) {
+    case 0x0: // 8 MBit (1MB)
+        return 1048576;
+    case 0x1: // 16 MBit (2MB)
+        return 2097152;
+    case 0x2: // 32 MBit (4MB)
+        return 4194304;
+    case 0x3: // 64 MBit (8MB)
+        return 8388608;
+    case 0x4: // 128 MBit (16MB)
+        return 16777216;
+    default: // fail?
+        return 0;
+    }
+}
+
 uint32_t ESP_getSketchSize(void) {
   static uint32_t sketchsize = 0;
 
@@ -556,20 +592,6 @@ int32_t ESP_getHeapFragmentation(void) {
   int32_t free_maxmem = 100 - (int32_t)(ESP_getMaxAllocHeap() * 100 / ESP_getFreeHeap());
   if (free_maxmem < 0) { free_maxmem = 0; }
   return free_maxmem;
-}
-
-uint32_t ESP_getFlashChipId(void)
-{
-//  uint32_t id = bootloader_read_flash_id();
-  uint32_t id = g_rom_flashchip.device_id;
-  id = ((id & 0xff) << 16) | ((id >> 16) & 0xff) | (id & 0xff00);
-  return id;
-}
-
-uint32_t ESP_getFlashChipRealSize(void)
-{
-  uint32_t id = (ESP_getFlashChipId() >> 16) & 0xFF;
-  return 2 << (id - 1);
 }
 
 void ESP_Restart(void) {
@@ -983,30 +1005,7 @@ typedef enum {
 } FlashMode_t;
 */
 String ESP_getFlashChipMode(void) {
-#if ESP8266
   uint32_t flash_mode = ESP.getFlashChipMode();
-#else
-  #if CONFIG_IDF_TARGET_ESP32S2
-  const uint32_t spi_ctrl = REG_READ(PERIPHS_SPI_FLASH_CTRL);
-  #else
-  const uint32_t spi_ctrl = REG_READ(SPI_CTRL_REG(0));
-  #endif
-  uint32_t flash_mode;
-  /* Not all of the following constants are already defined in older versions of spi_reg.h, so do it manually for now*/
-  if (spi_ctrl & BIT(24)) { //SPI_FREAD_QIO
-      flash_mode = 0;
-  } else if (spi_ctrl & BIT(20)) { //SPI_FREAD_QUAD
-      flash_mode = 1;
-  } else if (spi_ctrl &  BIT(23)) { //SPI_FREAD_DIO
-      flash_mode = 2;
-  } else if (spi_ctrl & BIT(14)) { // SPI_FREAD_DUAL
-      flash_mode = 3;
-  } else if (spi_ctrl & BIT(13)) { //SPI_FASTRD_MODE
-      flash_mode = 4;
-  } else {
-      flash_mode = 5;
-  }
-#endif
   if (flash_mode > 5) { flash_mode = 3; }
   char stemp[6];
   return GetTextIndexed(stemp, sizeof(stemp), flash_mode, kFlashModes);

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2445,8 +2445,14 @@ void HandleInformation(void)
   WSContentSend_P(PSTR("}1}2&nbsp;"));  // Empty line
   WSContentSend_P(PSTR("}1" D_ESP_CHIP_ID "}2%d (%s)"), ESP_getChipId(), GetDeviceHardwareRevision().c_str());
   WSContentSend_P(PSTR("}1" D_FLASH_CHIP_ID "}20x%06X (%s)"), ESP_getFlashChipId(), ESP_getFlashChipMode().c_str());
-  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d KB"), ESP_getFlashChipRealSize() / 1024);
-  WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d KB"), ESP.getFlashChipSize() / 1024);
+#ifdef ESP32
+  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d KB"), ESP.getFlashChipSize() / 1024);
+  WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d KB"), ESP_getFlashChipMagicSize() / 1024);
+#endif // ESP32
+#ifdef ESP8266
+  WSContentSend_P(PSTR("}1" D_FLASH_CHIP_SIZE "}2%d KB"), ESP.getFlashChipRealSize() / 1024);
+  WSContentSend_P(PSTR("}1" D_PROGRAM_FLASH_SIZE "}2%d KB"), ESP_getFlashChipSize() / 1024);
+#endif // ESP8266
   WSContentSend_P(PSTR("}1" D_PROGRAM_SIZE "}2%d KB"), ESP_getSketchSize() / 1024);
   WSContentSend_P(PSTR("}1" D_FREE_PROGRAM_SPACE "}2%d KB"), ESP_getFreeSketchSpace() / 1024);
 #ifdef ESP32

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -182,8 +182,14 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top == 1) {  // no argument (instance only)
       be_newobject(vm, "map");
-      be_map_insert_int(vm, "flash", ESP.getFlashChipSize() / 1024);
-      be_map_insert_int(vm, "flash_real", ESP_getFlashChipRealSize() / 1024);
+#ifdef ESP32
+      be_map_insert_int(vm, "flash", ESP_getFlashChipMagicSize() / 1024);
+      be_map_insert_int(vm, "flash_real", ESP.getFlashChipSize() / 1024);
+#endif // ESP32
+#ifdef ESP8266
+      be_map_insert_int(vm, "flash", ESP_getFlashChipSize() / 1024);
+      be_map_insert_int(vm, "flash_real", ESP.getFlashChipRealSize() / 1024);
+#endif // ESP8266
       be_map_insert_int(vm, "program", ESP_getSketchSize() / 1024);
       be_map_insert_int(vm, "program_free", ESP_getFreeSketchSpace() / 1024);
       be_map_insert_int(vm, "heap_free", ESP_getFreeHeap() / 1024);


### PR DESCRIPTION
The upcoming new core has functions included now which has been before in Tasmota.
Others where dropped and added in Tasmota.

Flash real size is now in core
Flash chip magic size now in Tasmota `ESP_getFlashChipMagicSize`

Description:
This branch prepares Tasmota for the new core and is for testing. Everything should work as with core 2.0.4
