### PR TITLE
Zigbee support for decimal Voltage/Current/Power on power metering plugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Berry automated solidification of code
 - Support of optional file calib.dat on ADE7953 based energy monitors like Shelly EM (#16486)
 - Command ``SetOption46 0..255`` to add 0..255 * 10 milliseconds power on delay before initializing I/O (#15438)
+- Zigbee support for decimal Voltage/Current/Power on power metering plugs
 
 ### Changed
 - ESP32 Increase number of button GPIOs from 8 to 28 (#16518)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -2260,10 +2260,12 @@ void ZigbeeShow(bool json)
           if (plug_voltage || plug_power) {
             WSContentSend_P(PSTR(" &#9889; "));
             if (plug_voltage) {
-              WSContentSend_P(PSTR(" %dV"), plug.getMainsVoltage());
+              float mains_voltage = plug.getMainsVoltage();
+              WSContentSend_P(PSTR(" %-1_fV"), &mains_voltage);
             }
             if (plug_power) {
-              WSContentSend_P(PSTR(" %dW"), plug.getMainsPower());
+              float mains_power = plug.getMainsPower();
+              WSContentSend_P(PSTR(" %-1_fW"), &mains_power);
             }
           }
           WSContentSend_P(PSTR("{e}"));


### PR DESCRIPTION
## Description:

Zigbee automatically probe for Voltage/Current/Power multiplier or divisor, and apply to attributes and GUI. This is required for Schneider Electric Zigbee plug.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.4.1
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
