### PR TITLE
Temperature error messages fixed in core 2.0.5

### DIFF
--- a/tasmota/tasmota_support/support_esp.ino
+++ b/tasmota/tasmota_support/support_esp.ino
@@ -672,22 +672,7 @@ void *special_malloc32(uint32_t size) {
 }
 
 float CpuTemperature(void) {
-#ifdef CONFIG_IDF_TARGET_ESP32
   return (float)temperatureRead();  // In Celsius
-/*
-  // These jumps are not stable either. Sometimes it jumps to 77.3
-  float t = (float)temperatureRead();  // In Celsius
-  if (t > 81) { t = t - 27.2; }        // Fix temp jump observed on some ESP32 like DualR3
-  return t;
-*/
-#else
-    // Currently (20210801) repeated calls to temperatureRead() on ESP32C3 and ESP32S2 result in IDF error messages
-    static float t = NAN;
-    if (isnan(t)) {
-      t = (float)temperatureRead();  // In Celsius
-    }
-    return t;
-#endif
 }
 
 /*


### PR DESCRIPTION
repeated calls to temperatureRead() on ESP32C3 and ESP32S2 are not resulting in IDF error messages anymore.

The PR removes the workaround.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
