### PR TITLE
IRremoteESP8266 library from v2.8.3 to v2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Increase number of button GPIOs from 8 to 28 (#16518)
 - IRremoteESP8266 library from v2.8.2 to v2.8.3
 - Tasmota Core32 from 2.0.4.1 to 2.0.5
+- IRremoteESP8266 library from v2.8.3 to v2.8.4
 
 ### Fixed
 

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README.md
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README.md
@@ -10,8 +10,8 @@
 This library enables you to **send _and_ receive** infra-red signals on an [ESP8266](https://github.com/esp8266/Arduino) or an
 [ESP32](https://github.com/espressif/arduino-esp32) using the [Arduino framework](https://www.arduino.cc/) using common 940nm IR LEDs and common IR receiver modules. e.g. TSOP{17,22,24,36,38,44,48}* demodulators etc.
 
-## v2.8.3 Now Available
-Version 2.8.3 of the library is now [available](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
+## v2.8.4 Now Available
+Version 2.8.4 of the library is now [available](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). You can view the [Release Notes](ReleaseNotes.md) for all the significant changes.
 
 #### Upgrading from pre-v2.0
 Usage of the library has been slightly changed in v2.0. You will need to change your usage to work with v2.0 and beyond. You can read more about the changes required on our [Upgrade to v2.0](https://github.com/crankyoldgit/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README_de.md
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README_de.md
@@ -11,8 +11,8 @@
 Diese Programmbibliothek ermöglicht das **Senden _und_ Empfangen** von Infrarotsignalen mit [ESP8266](https://github.com/esp8266/Arduino)- und
 [ESP32](https://github.com/espressif/arduino-esp32)-Mikrocontrollern mithilfe des [Arduino-Frameworks](https://www.arduino.cc/) und handelsüblichen 940nm Infrarot-LEDs undIR-Empfängermodulen, wie zum Beispiel TSOP{17,22,24,36,38,44,48}*-Demodulatoren.
 
-## v2.8.3 jetzt verfügbar
-Version 2.8.3 der Bibliothek ist nun [verfügbar](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Die [Versionshinweise](ReleaseNotes.md) enthalten alle wichtigen Neuerungen.
+## v2.8.4 jetzt verfügbar
+Version 2.8.4 der Bibliothek ist nun [verfügbar](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Die [Versionshinweise](ReleaseNotes.md) enthalten alle wichtigen Neuerungen.
 
 #### Hinweis für Nutzer von Versionen vor v2.0
 Die Benutzung der Bibliothek hat sich mit Version 2.0 leicht geändert. Einige Anpassungen im aufrufenden Code werden nötig sein, um mit Version ab 2.0 korrekt zu funktionieren. Mehr zu den Anpassungen finden sich auf unserer [Upgrade to v2.0](https://github.com/crankyoldgit/IRremoteESP8266/wiki/Upgrading-to-v2.0)-Seite.

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README_fr.md
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/README_fr.md
@@ -10,8 +10,8 @@
 Cette librairie vous permetra de **recevoir et d'envoyer des signaux** infrarouge sur le protocole [ESP8266](https://github.com/esp8266/Arduino) ou sur le protocole
 [ESP32](https://github.com/espressif/arduino-esp32) en utilisant le [Arduino framework](https://www.arduino.cc/) qui utilise la norme 940nm IR LEDs et le module basique de reception d'onde IR. Exemple : TSOP{17,22,24,36,38,44,48}* modules etc.
 
-## v2.8.3 disponible
-Version 2.8.3 de la libraire est maintenant [disponible](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Vous pouvez voir le [Release Notes](ReleaseNotes.md) pour tous les changements importants.
+## v2.8.4 disponible
+Version 2.8.4 de la libraire est maintenant [disponible](https://github.com/crankyoldgit/IRremoteESP8266/releases/latest). Vous pouvez voir le [Release Notes](ReleaseNotes.md) pour tous les changements importants.
 
 #### mise à jour depuis pre-v2.0
 L'utilisation de la librairie à un peu changer depuis la version in v2.0. Si vous voulez l'utiliser vous devrez changer votre utilisation aussi. Vous pouvez vous renseigner sur les précondition d'utilisation ici : [Upgrade to v2.0](https://github.com/crankyoldgit/IRremoteESP8266/wiki/Upgrading-to-v2.0) page.

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/ReleaseNotes.md
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## _v2.8.4 (20220918)_
+
+**[Bug Fixes]**
+ - [Bugfix] Handle gcc unsupported __VA_OPT___ macro (#1880 #1881)
+
+
 ## _v2.8.3 (20220915)_
 
 **[Bug Fixes]**

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/library.properties
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/library.properties
@@ -1,5 +1,5 @@
 name=IRremoteESP8266
-version=2.8.3
+version=2.8.4
 author=David Conran, Sebastien Warin, Mark Szabo, Ken Shirriff
 maintainer=David Conran, Mark Szabo, Sebastien Warin, Roi Dayan, Massimiliano Pinto, Christian Nilsson
 sentence=Send and receive infrared signals with multiple protocols (ESP8266/ESP32)

--- a/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/src/IRremoteESP8266.h
+++ b/lib/lib_basic/IRremoteESP8266/IRremoteESP8266/src/IRremoteESP8266.h
@@ -58,7 +58,7 @@
 // Minor version number (x.X.x)
 #define _IRREMOTEESP8266_VERSION_MINOR 8
 // Patch version number (x.x.X)
-#define _IRREMOTEESP8266_VERSION_PATCH 3
+#define _IRREMOTEESP8266_VERSION_PATCH 4
 // Macro to convert version info into an integer
 #define _IRREMOTEESP8266_VERSION_VAL(major, minor, patch) \
                                     (((major) << 16) | ((minor) << 8) | (patch))


### PR DESCRIPTION
## Description:

IRremoteESP8266 library from v2.8.3 to v2.8.4

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
