### PR TITLE
Fix zigbee attribute writes and configuration

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -278,10 +278,12 @@ uint8_t toPercentageCR2032(uint32_t voltage) {
 // Adds to buf:
 // - n bytes: value (typically between 1 and 4 bytes, or bigger for strings)
 // returns number of bytes of attribute, or <0 if error
+// If the value is `NAN`, the value encoded is the "zigbee invalid value"
 int32_t encodeSingleAttribute(SBuffer &buf, double val_d, const char *val_str, uint8_t attrtype) {
   uint32_t len = Z_getDatatypeLen(attrtype);    // pre-compute length, overloaded for variable length attributes
-  uint32_t u32 = val_d;
-  int32_t  i32 = val_d;
+  bool nan = isnan(val_d);
+  uint32_t u32 = nan ? 0xFFFFFFFF : roundf(val_d);
+  int32_t  i32 = roundf(val_d);
   float    f32 = val_d;
 
   switch (attrtype) {
@@ -315,13 +317,13 @@ int32_t encodeSingleAttribute(SBuffer &buf, double val_d, const char *val_str, u
 
     // signed 8
     case Zint8:      // int8
-      buf.add8(i32);
+      buf.add8(nan ? 0x80 : i32);
       break;
     case Zint16:      // int16
-      buf.add16(i32);
+      buf.add16(nan ? 0x8000 : i32);
       break;
     case Zint32:      // int32
-      buf.add32(i32);
+      buf.add32(nan ? 0x80000000 : i32);
       break;
 
     case Zsingle:      // float

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -1594,7 +1594,7 @@ void Z_AutoConfigReportingForCluster(uint16_t shortaddr, uint16_t groupaddr, uin
         buf.add16(min_interval);
         buf.add16(max_interval);
         if (!Z_isDiscreteDataType(attr_matched.zigbee_type)) {   // report_change is only valid for non-discrete data types (numbers)
-          ZbApplyMultiplier(report_change, attr_matched.multiplier, attr_matched.divider, attr_matched.base);
+          ZbApplyMultiplierForWrites(report_change, attr_matched.multiplier, attr_matched.divider, attr_matched.base);
           // encode value
           int32_t res = encodeSingleAttribute(buf, report_change, "", attr_matched.zigbee_type);
           if (res < 0) {


### PR DESCRIPTION
## Description:

Fix attribute reporting and attribute write bug, that would invert the multiplier/divider. The bug was introduced in #16340

**Related issue (if applicable):** fixes #16558

This PR also allows to pass "zigbee invalid value" by passing `null` instead of a value.
Example :
```ZbSend {"Device":"0x6EC0","Config":{"Temperature":{"MinInterval":30,"MaxInterval":-1,"ReportableChange":null}}}```
sends 
```ZigbeeZCLSend device: 0x6EC0, endpoint:1, cluster:0x0402, cmd:0x06, send:"000000291E00FFFF0080"```

Also fixes a rounding error when multipler/divider is applied.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
