### PR TITLE
modbus debug off

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -53,7 +53,7 @@
 #define TMSBSIZ 256
 #endif
 
-#define MODBUS_DEBUG
+//#define MODBUS_DEBUG
 
 // addresses a bug in meter DWS74
 //#define DWS74_BUG


### PR DESCRIPTION
## Description:

modbus debug should be off by default

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
