### PR TITLE
Added support for OLED display 72x40px

### DIFF
--- a/lib/lib_display/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
+++ b/lib/lib_display/Adafruit_SSD1306-1.3.0-gemu-1.1/Adafruit_SSD1306.cpp
@@ -570,6 +570,13 @@ boolean Adafruit_SSD1306::begin(uint8_t vcs, uint8_t addr, boolean reset,
       SSD1306_SETCONTRAST };              // 0x81
     ssd1306_commandList(init4d, sizeof(init4d));
     ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF);
+  } else if((WIDTH == 72) && (HEIGHT == 40)) {
+    static const uint8_t PROGMEM init4d[] = {
+      SSD1306_SETCOMPINS,                 // 0xDA
+      0x12,
+      SSD1306_SETCONTRAST };              // 0x81
+    ssd1306_commandList(init4d, sizeof(init4d));
+    ssd1306_command1((vccstate == SSD1306_EXTERNALVCC) ? 0x9F : 0xCF);
   } else {
     // Other screen varieties -- TBD
   }
@@ -931,6 +938,9 @@ void Adafruit_SSD1306::display(void) {
   if ((64 == WIDTH) && (48 == HEIGHT)) {    // for 64x48, we need to shift by 32 in both directions
     col_start += 32;
     col_end += 32;
+  } else if ((72 == WIDTH) && (40 == HEIGHT)) {    // for 72x40, we need to shift by 27 in both directions
+    col_start += 27;
+    col_end += 27;
   }
 
   TRANSACTION_START

--- a/tasmota/tasmota_xdsp_display/xdsp_02_ssd1306.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_02_ssd1306.ino
@@ -64,10 +64,10 @@ void SSD1306InitDriver(void) {
   if (XDSP_02 == Settings->display_model) {
     I2cSetActiveFound(Settings->display_address[0], "SSD1306");
 
-    if ((Settings->display_width != 64) && (Settings->display_width != 96) && (Settings->display_width != 128)) {
+    if ((Settings->display_width != 72) && (Settings->display_width != 64) && (Settings->display_width != 96) && (Settings->display_width != 128)) {
       Settings->display_width = 128;
     }
-    if ((Settings->display_height != 16) && (Settings->display_height != 32) && (Settings->display_height != 48) && (Settings->display_height != 64)) {
+    if ((Settings->display_height != 40) && (Settings->display_height != 16) && (Settings->display_height != 32) && (Settings->display_height != 48) && (Settings->display_height != 64)) {
       Settings->display_height = 64;
     }
 


### PR DESCRIPTION
## Description:

* Small OLED display with ssd1306 driver and resolution 72x40px must be added to the list of supported displays. Also, some shift in video ram must be added.
* Changes are made for https://templates.blakadder.com/01space_ESP32-C3-0_42LCD.html

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
