### PR TITLE
Command ``UrlFetch <url>`` to download a file to filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Support of optional file calib.dat on ADE7953 based energy monitors like Shelly EM (#16486)
 - Command ``SetOption46 0..255`` to add 0..255 * 10 milliseconds power on delay before initializing I/O (#15438)
 - Zigbee support for decimal Voltage/Current/Power on power metering plugs
+- Command ``UrlFetch <url>`` to download a file to filesystem
 
 ### Changed
 - ESP32 Increase number of button GPIOs from 8 to 28 (#16518)

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -151,6 +151,8 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     load, closure(Tasmota_load_closure)
     wire_scan, closure(Tasmota_wire_scan_closure)
     time_str, closure(Tasmota_time_str_closure)
+    urlfetch, closure(Tasmota_urlfetch_closure)
+    urlfetch_cmd, closure(Tasmota_urlfetch_cmd_closure)
 
     add_cron, closure(Tasmota_add_cron_closure)
     run_cron, closure(Tasmota_run_cron_closure)

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -5,47 +5,85 @@
 #include "be_constobj.h"
 
 /********************************************************************
-** Solidified function: time_str
+** Solidified function: exec_rules
 ********************************************************************/
-be_local_closure(Tasmota_time_str,   /* name */
+be_local_closure(Tasmota_exec_rules,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
+    14,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(time_dump),
-    /* K2   */  be_nested_str(format),
-    /* K3   */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
-    /* K4   */  be_nested_str(year),
-    /* K5   */  be_nested_str(month),
-    /* K6   */  be_nested_str(day),
-    /* K7   */  be_nested_str(hour),
-    /* K8   */  be_nested_str(min),
-    /* K9   */  be_nested_str(sec),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str(cmd_res),
+    /* K1   */  be_nested_str(_rules),
+    /* K2   */  be_nested_str(json),
+    /* K3   */  be_nested_str(load),
+    /* K4   */  be_nested_str(log),
+    /* K5   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
+    /* K6   */  be_const_int(3),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str(try_rule),
+    /* K9   */  be_nested_str(trig),
+    /* K10  */  be_nested_str(f),
+    /* K11  */  be_const_int(1),
     }),
-    &be_const_str_time_str,
+    &be_const_str_exec_rules,
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0101,  //  0001  GETMET	R3	R0	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x8C100502,  //  0004  GETMET	R4	R2	K2
-      0x58180003,  //  0005  LDCONST	R6	K3
-      0x941C0704,  //  0006  GETIDX	R7	R3	K4
-      0x94200705,  //  0007  GETIDX	R8	R3	K5
-      0x94240706,  //  0008  GETIDX	R9	R3	K6
-      0x94280707,  //  0009  GETIDX	R10	R3	K7
-      0x942C0708,  //  000A  GETIDX	R11	R3	K8
-      0x94300709,  //  000B  GETIDX	R12	R3	K9
-      0x7C101000,  //  000C  CALL	R4	8
-      0x80040800,  //  000D  RET	1	R4
+    ( &(const binstruction[50]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x88100101,  //  0001  GETMBR	R4	R0	K1
+      0x74120002,  //  0002  JMPT	R4	#0006
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120029,  //  0005  JMPF	R4	#0030
+      0xA4120400,  //  0006  IMPORT	R4	K2
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90020005,  //  0008  SETMBR	R0	K0	R5
+      0x50140000,  //  0009  LDBOOL	R5	0	0
+      0x8C180903,  //  000A  GETMET	R6	R4	K3
+      0x5C200200,  //  000B  MOVE	R8	R1
+      0x7C180400,  //  000C  CALL	R6	2
+      0x4C1C0000,  //  000D  LDNIL	R7
+      0x1C1C0C07,  //  000E  EQ	R7	R6	R7
+      0x781E0004,  //  000F  JMPF	R7	#0015
+      0x8C1C0104,  //  0010  GETMET	R7	R0	K4
+      0x00260A01,  //  0011  ADD	R9	K5	R1
+      0x58280006,  //  0012  LDCONST	R10	K6
+      0x7C1C0600,  //  0013  CALL	R7	3
+      0x5C180200,  //  0014  MOVE	R6	R1
+      0x780A0014,  //  0015  JMPF	R2	#002B
+      0x881C0101,  //  0016  GETMBR	R7	R0	K1
+      0x781E0012,  //  0017  JMPF	R7	#002B
+      0x581C0007,  //  0018  LDCONST	R7	K7
+      0x6020000C,  //  0019  GETGBL	R8	G12
+      0x88240101,  //  001A  GETMBR	R9	R0	K1
+      0x7C200200,  //  001B  CALL	R8	1
+      0x14200E08,  //  001C  LT	R8	R7	R8
+      0x7822000C,  //  001D  JMPF	R8	#002B
+      0x88200101,  //  001E  GETMBR	R8	R0	K1
+      0x94201007,  //  001F  GETIDX	R8	R8	R7
+      0x8C240108,  //  0020  GETMET	R9	R0	K8
+      0x5C2C0C00,  //  0021  MOVE	R11	R6
+      0x88301109,  //  0022  GETMBR	R12	R8	K9
+      0x8834110A,  //  0023  GETMBR	R13	R8	K10
+      0x7C240800,  //  0024  CALL	R9	4
+      0x74260001,  //  0025  JMPT	R9	#0028
+      0x74160000,  //  0026  JMPT	R5	#0028
+      0x50140001,  //  0027  LDBOOL	R5	0	1
+      0x50140200,  //  0028  LDBOOL	R5	1	0
+      0x001C0F0B,  //  0029  ADD	R7	R7	K11
+      0x7001FFED,  //  002A  JMP		#0019
+      0x4C1C0000,  //  002B  LDNIL	R7
+      0x201C0607,  //  002C  NE	R7	R3	R7
+      0x781E0000,  //  002D  JMPF	R7	#002F
+      0x90020006,  //  002E  SETMBR	R0	K0	R6
+      0x80040A00,  //  002F  RET	1	R5
+      0x50100000,  //  0030  LDBOOL	R4	0	0
+      0x80040800,  //  0031  RET	1	R4
     })
   )
 );
@@ -53,55 +91,181 @@ be_local_closure(Tasmota_time_str,   /* name */
 
 
 /********************************************************************
-** Solidified function: exec_cmd
+** Solidified function: cmd
 ********************************************************************/
-be_local_closure(Tasmota_exec_cmd,   /* name */
+be_local_closure(Tasmota_cmd,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(_ccmd),
-    /* K1   */  be_nested_str(json),
-    /* K2   */  be_nested_str(load),
-    /* K3   */  be_nested_str(find_key_i),
-    /* K4   */  be_nested_str(resolvecmnd),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(cmd_res),
+    /* K1   */  be_nested_str(_cmd),
     }),
-    &be_const_str_exec_cmd,
+    &be_const_str_cmd,
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x78120016,  //  0001  JMPF	R4	#0019
-      0xA4120200,  //  0002  IMPORT	R4	K1
-      0x8C140902,  //  0003  GETMET	R5	R4	K2
-      0x5C1C0600,  //  0004  MOVE	R7	R3
-      0x7C140400,  //  0005  CALL	R5	2
-      0x8C180103,  //  0006  GETMET	R6	R0	K3
-      0x88200100,  //  0007  GETMBR	R8	R0	K0
-      0x5C240200,  //  0008  MOVE	R9	R1
-      0x7C180600,  //  0009  CALL	R6	3
-      0x4C1C0000,  //  000A  LDNIL	R7
-      0x201C0C07,  //  000B  NE	R7	R6	R7
-      0x781E000B,  //  000C  JMPF	R7	#0019
-      0x8C1C0104,  //  000D  GETMET	R7	R0	K4
-      0x5C240C00,  //  000E  MOVE	R9	R6
-      0x7C1C0400,  //  000F  CALL	R7	2
-      0x881C0100,  //  0010  GETMBR	R7	R0	K0
-      0x941C0E06,  //  0011  GETIDX	R7	R7	R6
-      0x5C200C00,  //  0012  MOVE	R8	R6
-      0x5C240400,  //  0013  MOVE	R9	R2
-      0x5C280600,  //  0014  MOVE	R10	R3
-      0x5C2C0A00,  //  0015  MOVE	R11	R5
-      0x7C1C0800,  //  0016  CALL	R7	4
-      0x501C0200,  //  0017  LDBOOL	R7	1	0
-      0x80040E00,  //  0018  RET	1	R7
-      0x50100000,  //  0019  LDBOOL	R4	0	0
-      0x80040800,  //  001A  RET	1	R4
+    ( &(const binstruction[14]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x500C0200,  //  0001  LDBOOL	R3	1	0
+      0x90020003,  //  0002  SETMBR	R0	K0	R3
+      0x8C0C0101,  //  0003  GETMET	R3	R0	K1
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x88100100,  //  0007  GETMBR	R4	R0	K0
+      0x50140200,  //  0008  LDBOOL	R5	1	0
+      0x20100805,  //  0009  NE	R4	R4	R5
+      0x78120000,  //  000A  JMPF	R4	#000C
+      0x880C0100,  //  000B  GETMBR	R3	R0	K0
+      0x90020002,  //  000C  SETMBR	R0	K0	R2
+      0x80040600,  //  000D  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: check_not_method
+********************************************************************/
+be_local_closure(Tasmota_check_not_method,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str(introspect),
+    /* K1   */  be_nested_str(function),
+    /* K2   */  be_nested_str(type_error),
+    /* K3   */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
+    /* K4   */  be_nested_str(ismethod),
+    /* K5   */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
+    }),
+    &be_const_str_check_not_method,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0004,  //  0001  GETGBL	R3	G4
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x200C0701,  //  0004  NE	R3	R3	K1
+      0x780E0000,  //  0005  JMPF	R3	#0007
+      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x50100200,  //  000A  LDBOOL	R4	1	0
+      0x1C0C0604,  //  000B  EQ	R3	R3	R4
+      0x780E0000,  //  000C  JMPF	R3	#000E
+      0xB0060505,  //  000D  RAISE	1	K2	K5
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_rule
+********************************************************************/
+be_local_closure(Tasmota_remove_rule,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str(_rules),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str(trig),
+    /* K3   */  be_nested_str(id),
+    /* K4   */  be_nested_str(remove),
+    /* K5   */  be_const_int(1),
+    }),
+    &be_const_str_remove_rule,
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x780E0016,  //  0001  JMPF	R3	#0019
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x6010000C,  //  0003  GETGBL	R4	G12
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x7C100200,  //  0005  CALL	R4	1
+      0x14100604,  //  0006  LT	R4	R3	R4
+      0x78120010,  //  0007  JMPF	R4	#0019
+      0x88100100,  //  0008  GETMBR	R4	R0	K0
+      0x94100803,  //  0009  GETIDX	R4	R4	R3
+      0x88100902,  //  000A  GETMBR	R4	R4	K2
+      0x1C100801,  //  000B  EQ	R4	R4	R1
+      0x78120009,  //  000C  JMPF	R4	#0017
+      0x88100100,  //  000D  GETMBR	R4	R0	K0
+      0x94100803,  //  000E  GETIDX	R4	R4	R3
+      0x88100903,  //  000F  GETMBR	R4	R4	K3
+      0x1C100802,  //  0010  EQ	R4	R4	R2
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x88100100,  //  0012  GETMBR	R4	R0	K0
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180600,  //  0014  MOVE	R6	R3
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020000,  //  0016  JMP		#0018
+      0x000C0705,  //  0017  ADD	R3	R3	K5
+      0x7001FFE9,  //  0018  JMP		#0003
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_driver
+********************************************************************/
+be_local_closure(Tasmota_remove_driver,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(_drivers),
+    /* K1   */  be_nested_str(find),
+    /* K2   */  be_nested_str(pop),
+    }),
+    &be_const_str_remove_driver,
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A000A,  //  0001  JMPF	R2	#000D
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x8C080501,  //  0003  GETMET	R2	R2	K1
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x4C0C0000,  //  0006  LDNIL	R3
+      0x200C0403,  //  0007  NE	R3	R2	R3
+      0x780E0003,  //  0008  JMPF	R3	#000D
+      0x880C0100,  //  0009  GETMBR	R3	R0	K0
+      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -168,61 +332,6 @@ be_local_closure(Tasmota_find_key_i,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_cron
-********************************************************************/
-be_local_closure(Tasmota_add_cron,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_crons),
-    /* K2   */  be_nested_str(ccronexpr),
-    /* K3   */  be_nested_str(next),
-    /* K4   */  be_nested_str(push),
-    /* K5   */  be_nested_str(Trigger),
-    }),
-    &be_const_str_add_cron,
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
-      0x5C180400,  //  0001  MOVE	R6	R2
-      0x7C100400,  //  0002  CALL	R4	2
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
-      0x74120002,  //  0004  JMPT	R4	#0008
-      0x60100012,  //  0005  GETGBL	R4	G18
-      0x7C100000,  //  0006  CALL	R4	0
-      0x90020204,  //  0007  SETMBR	R0	K1	R4
-      0xB8120400,  //  0008  GETNGBL	R4	K2
-      0x60140008,  //  0009  GETGBL	R5	G8
-      0x5C180200,  //  000A  MOVE	R6	R1
-      0x7C140200,  //  000B  CALL	R5	1
-      0x7C100200,  //  000C  CALL	R4	1
-      0x8C140903,  //  000D  GETMET	R5	R4	K3
-      0x7C140200,  //  000E  CALL	R5	1
-      0x88180101,  //  000F  GETMBR	R6	R0	K1
-      0x8C180D04,  //  0010  GETMET	R6	R6	K4
-      0xB8220A00,  //  0011  GETNGBL	R8	K5
-      0x5C240A00,  //  0012  MOVE	R9	R5
-      0x5C280400,  //  0013  MOVE	R10	R2
-      0x5C2C0600,  //  0014  MOVE	R11	R3
-      0x5C300800,  //  0015  MOVE	R12	R4
-      0x7C200800,  //  0016  CALL	R8	4
-      0x7C180400,  //  0017  CALL	R6	2
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: remove_timer
 ********************************************************************/
 be_local_closure(Tasmota_remove_timer,   /* name */
@@ -264,6 +373,74 @@ be_local_closure(Tasmota_remove_timer,   /* name */
       0x000C0705,  //  000F  ADD	R3	R3	K5
       0x7001FFF1,  //  0010  JMP		#0003
       0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: run_cron
+********************************************************************/
+be_local_closure(Tasmota_run_cron,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str(_crons),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str(ccronexpr),
+    /* K3   */  be_nested_str(now),
+    /* K4   */  be_nested_str(size),
+    /* K5   */  be_nested_str(trig),
+    /* K6   */  be_nested_str(next),
+    /* K7   */  be_nested_str(time_reached),
+    /* K8   */  be_nested_str(f),
+    /* K9   */  be_const_int(1),
+    }),
+    &be_const_str_run_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x7806001E,  //  0001  JMPF	R1	#0021
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x7C080200,  //  0005  CALL	R2	1
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x140C0203,  //  0009  LT	R3	R1	R3
+      0x780E0015,  //  000A  JMPF	R3	#0021
+      0x880C0100,  //  000B  GETMBR	R3	R0	K0
+      0x940C0601,  //  000C  GETIDX	R3	R3	R1
+      0x88100705,  //  000D  GETMBR	R4	R3	K5
+      0x1C100901,  //  000E  EQ	R4	R4	K1
+      0x78120003,  //  000F  JMPF	R4	#0014
+      0x8C100706,  //  0010  GETMET	R4	R3	K6
+      0x7C100200,  //  0011  CALL	R4	1
+      0x900E0A04,  //  0012  SETMBR	R3	K5	R4
+      0x7002000A,  //  0013  JMP		#001F
+      0x8C100707,  //  0014  GETMET	R4	R3	K7
+      0x7C100200,  //  0015  CALL	R4	1
+      0x78120007,  //  0016  JMPF	R4	#001F
+      0x88100708,  //  0017  GETMBR	R4	R3	K8
+      0x8C140706,  //  0018  GETMET	R5	R3	K6
+      0x7C140200,  //  0019  CALL	R5	1
+      0x900E0A05,  //  001A  SETMBR	R3	K5	R5
+      0x5C180800,  //  001B  MOVE	R6	R4
+      0x5C1C0400,  //  001C  MOVE	R7	R2
+      0x5C200A00,  //  001D  MOVE	R8	R5
+      0x7C180400,  //  001E  CALL	R6	2
+      0x00040309,  //  001F  ADD	R1	R1	K9
+      0x7001FFE4,  //  0020  JMP		#0006
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -328,9 +505,494 @@ be_local_closure(Tasmota_run_deferred,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_fast_loop
+** Solidified function: wire_scan
 ********************************************************************/
-be_local_closure(Tasmota_add_fast_loop,   /* name */
+be_local_closure(Tasmota_wire_scan,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(i2c_enabled),
+    /* K1   */  be_nested_str(wire1),
+    /* K2   */  be_nested_str(enabled),
+    /* K3   */  be_nested_str(detect),
+    /* K4   */  be_nested_str(wire2),
+    }),
+    &be_const_str_wire_scan,
+    &be_const_str_solidified,
+    ( &(const binstruction[33]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0005,  //  0002  JMPF	R3	#0009
+      0x8C0C0100,  //  0003  GETMET	R3	R0	K0
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x740E0001,  //  0006  JMPT	R3	#0009
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x80040600,  //  0008  RET	1	R3
+      0x880C0101,  //  0009  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x880C0101,  //  000D  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
+      0x5C140200,  //  000F  MOVE	R5	R1
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x780E0001,  //  0011  JMPF	R3	#0014
+      0x880C0101,  //  0012  GETMBR	R3	R0	K1
+      0x80040600,  //  0013  RET	1	R3
+      0x880C0104,  //  0014  GETMBR	R3	R0	K4
+      0x8C0C0702,  //  0015  GETMET	R3	R3	K2
+      0x7C0C0200,  //  0016  CALL	R3	1
+      0x780E0006,  //  0017  JMPF	R3	#001F
+      0x880C0104,  //  0018  GETMBR	R3	R0	K4
+      0x8C0C0703,  //  0019  GETMET	R3	R3	K3
+      0x5C140200,  //  001A  MOVE	R5	R1
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x780E0001,  //  001C  JMPF	R3	#001F
+      0x880C0104,  //  001D  GETMBR	R3	R0	K4
+      0x80040600,  //  001E  RET	1	R3
+      0x4C0C0000,  //  001F  LDNIL	R3
+      0x80040600,  //  0020  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: next_cron
+********************************************************************/
+be_local_closure(Tasmota_next_cron,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str(_crons),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str(size),
+    /* K3   */  be_nested_str(id),
+    /* K4   */  be_nested_str(trig),
+    /* K5   */  be_const_int(1),
+    }),
+    &be_const_str_next_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A000D,  //  0001  JMPF	R2	#0010
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100403,  //  0007  GETIDX	R4	R2	R3
+      0x88100903,  //  0008  GETMBR	R4	R4	K3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120002,  //  000A  JMPF	R4	#000E
+      0x94100403,  //  000B  GETIDX	R4	R2	R3
+      0x88100904,  //  000C  GETMBR	R4	R4	K4
+      0x80040800,  //  000D  RET	1	R4
+      0x000C0705,  //  000E  ADD	R3	R3	K5
+      0x7001FFF2,  //  000F  JMP		#0003
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_light
+********************************************************************/
+be_local_closure(Tasmota_set_light,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
+    /* K1   */  be_nested_str(light),
+    /* K2   */  be_nested_str(set),
+    }),
+    &be_const_str_set_light,
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x600C0001,  //  0000  GETGBL	R3	G1
+      0x58100000,  //  0001  LDCONST	R4	K0
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0xA40E0200,  //  0003  IMPORT	R3	K1
+      0x4C100000,  //  0004  LDNIL	R4
+      0x20100404,  //  0005  NE	R4	R2	R4
+      0x78120005,  //  0006  JMPF	R4	#000D
+      0x8C100702,  //  0007  GETMET	R4	R3	K2
+      0x5C180200,  //  0008  MOVE	R6	R1
+      0x5C1C0400,  //  0009  MOVE	R7	R2
+      0x7C100600,  //  000A  CALL	R4	3
+      0x80040800,  //  000B  RET	1	R4
+      0x70020003,  //  000C  JMP		#0011
+      0x8C100702,  //  000D  GETMET	R4	R3	K2
+      0x5C180200,  //  000E  MOVE	R6	R1
+      0x7C100400,  //  000F  CALL	R4	2
+      0x80040800,  //  0010  RET	1	R4
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fast_loop
+********************************************************************/
+be_local_closure(Tasmota_remove_fast_loop,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(_fl),
+    /* K1   */  be_nested_str(find),
+    /* K2   */  be_nested_str(remove),
+    }),
+    &be_const_str_remove_fast_loop,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0000,  //  0001  JMPT	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x88080100,  //  0003  GETMBR	R2	R0	K0
+      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x5C100200,  //  0005  MOVE	R4	R1
+      0x7C080400,  //  0006  CALL	R2	2
+      0x4C0C0000,  //  0007  LDNIL	R3
+      0x200C0403,  //  0008  NE	R3	R2	R3
+      0x780E0003,  //  0009  JMPF	R3	#000E
+      0x880C0100,  //  000A  GETMBR	R3	R0	K0
+      0x8C0C0702,  //  000B  GETMET	R3	R3	K2
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Tasmota_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        10,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str(urlfetch_cmd),
+        }),
+        &be_const_str__anonymous_,
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x68100000,  //  0000  GETUPV	R4	U0
+          0x8C100900,  //  0001  GETMET	R4	R4	K0
+          0x5C180000,  //  0002  MOVE	R6	R0
+          0x5C1C0200,  //  0003  MOVE	R7	R1
+          0x5C200400,  //  0004  MOVE	R8	R2
+          0x5C240600,  //  0005  MOVE	R9	R3
+          0x7C100A00,  //  0006  CALL	R4	5
+          0x80000000,  //  0007  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str(global),
+    /* K1   */  be_nested_str(ctypes_bytes_dyn),
+    /* K2   */  be_nested_str(_global_addr),
+    /* K3   */  be_nested_str(_global_def),
+    /* K4   */  be_nested_str(introspect),
+    /* K5   */  be_nested_str(_settings_ptr),
+    /* K6   */  be_nested_str(get),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str(settings),
+    /* K9   */  be_nested_str(toptr),
+    /* K10  */  be_nested_str(_settings_def),
+    /* K11  */  be_nested_str(wd),
+    /* K12  */  be_nested_str(),
+    /* K13  */  be_nested_str(_debug_present),
+    /* K14  */  be_nested_str(debug),
+    /* K15  */  be_nested_str(add_cmd),
+    /* K16  */  be_nested_str(UrlFetch),
+    }),
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x88080102,  //  0001  GETMBR	R2	R0	K2
+      0x880C0103,  //  0002  GETMBR	R3	R0	K3
+      0x7C040400,  //  0003  CALL	R1	2
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
+      0xA4060800,  //  0005  IMPORT	R1	K4
+      0x60080015,  //  0006  GETGBL	R2	G21
+      0x880C0105,  //  0007  GETMBR	R3	R0	K5
+      0x54120003,  //  0008  LDINT	R4	4
+      0x7C080400,  //  0009  CALL	R2	2
+      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x58100007,  //  000B  LDCONST	R4	K7
+      0x54160003,  //  000C  LDINT	R5	4
+      0x7C080600,  //  000D  CALL	R2	3
+      0x780A0006,  //  000E  JMPF	R2	#0016
+      0xB80E0200,  //  000F  GETNGBL	R3	K1
+      0x8C100309,  //  0010  GETMET	R4	R1	K9
+      0x5C180400,  //  0011  MOVE	R6	R2
+      0x7C100400,  //  0012  CALL	R4	2
+      0x8814010A,  //  0013  GETMBR	R5	R0	K10
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x90021003,  //  0015  SETMBR	R0	K8	R3
+      0x9002170C,  //  0016  SETMBR	R0	K11	K12
+      0x500C0000,  //  0017  LDBOOL	R3	0	0
+      0x90021A03,  //  0018  SETMBR	R0	K13	R3
+      0xA8020004,  //  0019  EXBLK	0	#001F
+      0xA40E1C00,  //  001A  IMPORT	R3	K14
+      0x50100200,  //  001B  LDBOOL	R4	1	0
+      0x90021A04,  //  001C  SETMBR	R0	K13	R4
+      0xA8040001,  //  001D  EXBLK	1	1
+      0x70020003,  //  001E  JMP		#0023
+      0xAC0C0000,  //  001F  CATCH	R3	0	0
+      0x70020000,  //  0020  JMP		#0022
+      0x70020000,  //  0021  JMP		#0023
+      0xB0080000,  //  0022  RAISE	2	R0	R0
+      0x8C0C010F,  //  0023  GETMET	R3	R0	K15
+      0x58140010,  //  0024  LDCONST	R5	K16
+      0x84180000,  //  0025  CLOSURE	R6	P0
+      0x7C0C0600,  //  0026  CALL	R3	3
+      0xA0000000,  //  0027  CLOSE	R0
+      0x80000000,  //  0028  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_timer
+********************************************************************/
+be_local_closure(Tasmota_set_timer,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(check_not_method),
+    /* K1   */  be_nested_str(_timers),
+    /* K2   */  be_nested_str(push),
+    /* K3   */  be_nested_str(Trigger),
+    /* K4   */  be_nested_str(millis),
+    }),
+    &be_const_str_set_timer,
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x5C180400,  //  0001  MOVE	R6	R2
+      0x7C100400,  //  0002  CALL	R4	2
+      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x74120002,  //  0004  JMPT	R4	#0008
+      0x60100012,  //  0005  GETGBL	R4	G18
+      0x7C100000,  //  0006  CALL	R4	0
+      0x90020204,  //  0007  SETMBR	R0	K1	R4
+      0x88100101,  //  0008  GETMBR	R4	R0	K1
+      0x8C100902,  //  0009  GETMET	R4	R4	K2
+      0xB81A0600,  //  000A  GETNGBL	R6	K3
+      0x8C1C0104,  //  000B  GETMET	R7	R0	K4
+      0x5C240200,  //  000C  MOVE	R9	R1
+      0x7C1C0400,  //  000D  CALL	R7	2
+      0x5C200400,  //  000E  MOVE	R8	R2
+      0x5C240600,  //  000F  MOVE	R9	R3
+      0x7C180600,  //  0010  CALL	R6	3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_cron
+********************************************************************/
+be_local_closure(Tasmota_add_cron,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str(check_not_method),
+    /* K1   */  be_nested_str(_crons),
+    /* K2   */  be_nested_str(ccronexpr),
+    /* K3   */  be_nested_str(next),
+    /* K4   */  be_nested_str(push),
+    /* K5   */  be_nested_str(Trigger),
+    }),
+    &be_const_str_add_cron,
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x8C100100,  //  0000  GETMET	R4	R0	K0
+      0x5C180400,  //  0001  MOVE	R6	R2
+      0x7C100400,  //  0002  CALL	R4	2
+      0x88100101,  //  0003  GETMBR	R4	R0	K1
+      0x74120002,  //  0004  JMPT	R4	#0008
+      0x60100012,  //  0005  GETGBL	R4	G18
+      0x7C100000,  //  0006  CALL	R4	0
+      0x90020204,  //  0007  SETMBR	R0	K1	R4
+      0xB8120400,  //  0008  GETNGBL	R4	K2
+      0x60140008,  //  0009  GETGBL	R5	G8
+      0x5C180200,  //  000A  MOVE	R6	R1
+      0x7C140200,  //  000B  CALL	R5	1
+      0x7C100200,  //  000C  CALL	R4	1
+      0x8C140903,  //  000D  GETMET	R5	R4	K3
+      0x7C140200,  //  000E  CALL	R5	1
+      0x88180101,  //  000F  GETMBR	R6	R0	K1
+      0x8C180D04,  //  0010  GETMET	R6	R6	K4
+      0xB8220A00,  //  0011  GETNGBL	R8	K5
+      0x5C240A00,  //  0012  MOVE	R9	R5
+      0x5C280400,  //  0013  MOVE	R10	R2
+      0x5C2C0600,  //  0014  MOVE	R11	R3
+      0x5C300800,  //  0015  MOVE	R12	R4
+      0x7C200800,  //  0016  CALL	R8	4
+      0x7C180400,  //  0017  CALL	R6	2
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: gc
+********************************************************************/
+be_local_closure(Tasmota_gc,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(gc),
+    /* K1   */  be_nested_str(collect),
+    /* K2   */  be_nested_str(allocated),
+    }),
+    &be_const_str_gc,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x7C080200,  //  0004  CALL	R2	1
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_light
+********************************************************************/
+be_local_closure(Tasmota_get_light,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
+    /* K1   */  be_nested_str(light),
+    /* K2   */  be_nested_str(get),
+    }),
+    &be_const_str_get_light,
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x60080001,  //  0000  GETGBL	R2	G1
+      0x580C0000,  //  0001  LDCONST	R3	K0
+      0x7C080200,  //  0002  CALL	R2	1
+      0xA40A0200,  //  0003  IMPORT	R2	K1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x200C0203,  //  0005  NE	R3	R1	R3
+      0x780E0004,  //  0006  JMPF	R3	#000C
+      0x8C0C0502,  //  0007  GETMET	R3	R2	K2
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80040600,  //  000A  RET	1	R3
+      0x70020002,  //  000B  JMP		#000F
+      0x8C0C0502,  //  000C  GETMET	R3	R2	K2
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x80040600,  //  000E  RET	1	R3
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_cmd
+********************************************************************/
+be_local_closure(Tasmota_remove_cmd,   /* name */
   be_nested_proto(
     5,                          /* nstack */
     2,                          /* argc */
@@ -340,41 +1002,20 @@ be_local_closure(Tasmota_add_fast_loop,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_fl),
-    /* K2   */  be_nested_str(function),
-    /* K3   */  be_nested_str(value_error),
-    /* K4   */  be_nested_str(argument_X20must_X20be_X20a_X20function),
-    /* K5   */  be_nested_str(global),
-    /* K6   */  be_nested_str(fast_loop_enabled),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str(push),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(_ccmd),
+    /* K1   */  be_nested_str(remove),
     }),
-    &be_const_str_add_fast_loop,
+    &be_const_str_remove_cmd,
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x5C100200,  //  0001  MOVE	R4	R1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x88080101,  //  0003  GETMBR	R2	R0	K1
-      0x740A0002,  //  0004  JMPT	R2	#0008
-      0x60080012,  //  0005  GETGBL	R2	G18
-      0x7C080000,  //  0006  CALL	R2	0
-      0x90020202,  //  0007  SETMBR	R0	K1	R2
-      0x60080004,  //  0008  GETGBL	R2	G4
-      0x5C0C0200,  //  0009  MOVE	R3	R1
-      0x7C080200,  //  000A  CALL	R2	1
-      0x20080502,  //  000B  NE	R2	R2	K2
-      0x780A0000,  //  000C  JMPF	R2	#000E
-      0xB0060704,  //  000D  RAISE	1	K3	K4
-      0x88080105,  //  000E  GETMBR	R2	R0	K5
-      0x900A0D07,  //  000F  SETMBR	R2	K6	K7
-      0x88080101,  //  0010  GETMBR	R2	R0	K1
-      0x8C080508,  //  0011  GETMET	R2	R2	K8
-      0x5C100200,  //  0012  MOVE	R4	R1
-      0x7C080400,  //  0013  CALL	R2	2
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0003,  //  0001  JMPF	R2	#0006
+      0x88080100,  //  0002  GETMBR	R2	R0	K0
+      0x8C080501,  //  0003  GETMET	R2	R2	K1
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -382,11 +1023,11 @@ be_local_closure(Tasmota_add_fast_loop,   /* name */
 
 
 /********************************************************************
-** Solidified function: exec_tele
+** Solidified function: add_driver
 ********************************************************************/
-be_local_closure(Tasmota_exec_tele,   /* name */
+be_local_closure(Tasmota_add_driver,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -394,64 +1035,34 @@ be_local_closure(Tasmota_exec_tele,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(_rules),
-    /* K1   */  be_nested_str(json),
-    /* K2   */  be_nested_str(load),
-    /* K3   */  be_nested_str(log),
-    /* K4   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str(Tele),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(try_rule),
-    /* K9   */  be_nested_str(trig),
-    /* K10  */  be_nested_str(f),
-    /* K11  */  be_const_int(1),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(instance),
+    /* K1   */  be_nested_str(value_error),
+    /* K2   */  be_nested_str(instance_X20required),
+    /* K3   */  be_nested_str(_drivers),
+    /* K4   */  be_nested_str(push),
     }),
-    &be_const_str_exec_tele,
+    &be_const_str_add_driver,
     &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0024,  //  0001  JMPF	R2	#0027
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x50100000,  //  0006  LDBOOL	R4	0	0
-      0x4C140000,  //  0007  LDNIL	R5
-      0x1C140605,  //  0008  EQ	R5	R3	R5
-      0x78160004,  //  0009  JMPF	R5	#000F
-      0x8C140103,  //  000A  GETMET	R5	R0	K3
-      0x001E0801,  //  000B  ADD	R7	K4	R1
-      0x58200005,  //  000C  LDCONST	R8	K5
-      0x7C140600,  //  000D  CALL	R5	3
-      0x5C0C0200,  //  000E  MOVE	R3	R1
-      0x60140013,  //  000F  GETGBL	R5	G19
-      0x7C140000,  //  0010  CALL	R5	0
-      0x98160C03,  //  0011  SETIDX	R5	K6	R3
-      0x5C0C0A00,  //  0012  MOVE	R3	R5
-      0x58140007,  //  0013  LDCONST	R5	K7
-      0x6018000C,  //  0014  GETGBL	R6	G12
-      0x881C0100,  //  0015  GETMBR	R7	R0	K0
-      0x7C180200,  //  0016  CALL	R6	1
-      0x14180A06,  //  0017  LT	R6	R5	R6
-      0x781A000C,  //  0018  JMPF	R6	#0026
-      0x88180100,  //  0019  GETMBR	R6	R0	K0
-      0x94180C05,  //  001A  GETIDX	R6	R6	R5
-      0x8C1C0108,  //  001B  GETMET	R7	R0	K8
-      0x5C240600,  //  001C  MOVE	R9	R3
-      0x88280D09,  //  001D  GETMBR	R10	R6	K9
-      0x882C0D0A,  //  001E  GETMBR	R11	R6	K10
-      0x7C1C0800,  //  001F  CALL	R7	4
-      0x741E0001,  //  0020  JMPT	R7	#0023
-      0x74120000,  //  0021  JMPT	R4	#0023
-      0x50100001,  //  0022  LDBOOL	R4	0	1
-      0x50100200,  //  0023  LDBOOL	R4	1	0
-      0x00140B0B,  //  0024  ADD	R5	R5	K11
-      0x7001FFED,  //  0025  JMP		#0014
-      0x80040800,  //  0026  RET	1	R4
-      0x50080000,  //  0027  LDBOOL	R2	0	0
-      0x80040400,  //  0028  RET	1	R2
+    ( &(const binstruction[18]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x20080500,  //  0003  NE	R2	R2	K0
+      0x780A0000,  //  0004  JMPF	R2	#0006
+      0xB0060302,  //  0005  RAISE	1	K1	K2
+      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0x780A0004,  //  0007  JMPF	R2	#000D
+      0x88080103,  //  0008  GETMBR	R2	R0	K3
+      0x8C080504,  //  0009  GETMET	R2	R2	K4
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x7C080400,  //  000B  CALL	R2	2
+      0x70020003,  //  000C  JMP		#0011
+      0x60080012,  //  000D  GETGBL	R2	G18
+      0x7C080000,  //  000E  CALL	R2	0
+      0x400C0401,  //  000F  CONNECT	R3	R2	R1
+      0x90020602,  //  0010  SETMBR	R0	K3	R2
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -939,6 +1550,382 @@ be_local_closure(Tasmota_load,   /* name */
 
 
 /********************************************************************
+** Solidified function: urlfetch
+********************************************************************/
+be_local_closure(Tasmota_urlfetch,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str(string),
+    /* K1   */  be_nested_str(split),
+    /* K2   */  be_nested_str(_X2F),
+    /* K3   */  be_nested_str(pop),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str(index_X2Ehtml),
+    /* K6   */  be_nested_str(webclient),
+    /* K7   */  be_nested_str(begin),
+    /* K8   */  be_nested_str(GET),
+    /* K9   */  be_nested_str(status_X3A_X20),
+    /* K10  */  be_nested_str(connection_error),
+    /* K11  */  be_nested_str(write_file),
+    /* K12  */  be_nested_str(close),
+    /* K13  */  be_nested_str(log),
+    /* K14  */  be_nested_str(BRY_X3A_X20Fetched_X20),
+    /* K15  */  be_const_int(3),
+    }),
+    &be_const_str_urlfetch,
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E000D,  //  0002  JMPF	R3	#0011
+      0xA40E0000,  //  0003  IMPORT	R3	K0
+      0x8C100701,  //  0004  GETMET	R4	R3	K1
+      0x5C180200,  //  0005  MOVE	R6	R1
+      0x581C0002,  //  0006  LDCONST	R7	K2
+      0x7C100600,  //  0007  CALL	R4	3
+      0x8C100903,  //  0008  GETMET	R4	R4	K3
+      0x7C100200,  //  0009  CALL	R4	1
+      0x5C080800,  //  000A  MOVE	R2	R4
+      0x6010000C,  //  000B  GETGBL	R4	G12
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C100200,  //  000D  CALL	R4	1
+      0x1C100904,  //  000E  EQ	R4	R4	K4
+      0x78120000,  //  000F  JMPF	R4	#0011
+      0x58080005,  //  0010  LDCONST	R2	K5
+      0xB80E0C00,  //  0011  GETNGBL	R3	K6
+      0x7C0C0000,  //  0012  CALL	R3	0
+      0x8C100707,  //  0013  GETMET	R4	R3	K7
+      0x5C180200,  //  0014  MOVE	R6	R1
+      0x7C100400,  //  0015  CALL	R4	2
+      0x8C100708,  //  0016  GETMET	R4	R3	K8
+      0x7C100200,  //  0017  CALL	R4	1
+      0x541600C7,  //  0018  LDINT	R5	200
+      0x20140805,  //  0019  NE	R5	R4	R5
+      0x78160004,  //  001A  JMPF	R5	#0020
+      0x60140008,  //  001B  GETGBL	R5	G8
+      0x5C180800,  //  001C  MOVE	R6	R4
+      0x7C140200,  //  001D  CALL	R5	1
+      0x00161205,  //  001E  ADD	R5	K9	R5
+      0xB0061405,  //  001F  RAISE	1	K10	R5
+      0x8C14070B,  //  0020  GETMET	R5	R3	K11
+      0x5C1C0400,  //  0021  MOVE	R7	R2
+      0x7C140400,  //  0022  CALL	R5	2
+      0x8C18070C,  //  0023  GETMET	R6	R3	K12
+      0x7C180200,  //  0024  CALL	R6	1
+      0x8C18010D,  //  0025  GETMET	R6	R0	K13
+      0x60200008,  //  0026  GETGBL	R8	G8
+      0x5C240A00,  //  0027  MOVE	R9	R5
+      0x7C200200,  //  0028  CALL	R8	1
+      0x00221C08,  //  0029  ADD	R8	K14	R8
+      0x5824000F,  //  002A  LDCONST	R9	K15
+      0x7C180600,  //  002B  CALL	R6	3
+      0x80040800,  //  002C  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: exec_tele
+********************************************************************/
+be_local_closure(Tasmota_exec_tele,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str(_rules),
+    /* K1   */  be_nested_str(json),
+    /* K2   */  be_nested_str(load),
+    /* K3   */  be_nested_str(log),
+    /* K4   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str(Tele),
+    /* K7   */  be_const_int(0),
+    /* K8   */  be_nested_str(try_rule),
+    /* K9   */  be_nested_str(trig),
+    /* K10  */  be_nested_str(f),
+    /* K11  */  be_const_int(1),
+    }),
+    &be_const_str_exec_tele,
+    &be_const_str_solidified,
+    ( &(const binstruction[41]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0024,  //  0001  JMPF	R2	#0027
+      0xA40A0200,  //  0002  IMPORT	R2	K1
+      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0x5C140200,  //  0004  MOVE	R5	R1
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x50100000,  //  0006  LDBOOL	R4	0	0
+      0x4C140000,  //  0007  LDNIL	R5
+      0x1C140605,  //  0008  EQ	R5	R3	R5
+      0x78160004,  //  0009  JMPF	R5	#000F
+      0x8C140103,  //  000A  GETMET	R5	R0	K3
+      0x001E0801,  //  000B  ADD	R7	K4	R1
+      0x58200005,  //  000C  LDCONST	R8	K5
+      0x7C140600,  //  000D  CALL	R5	3
+      0x5C0C0200,  //  000E  MOVE	R3	R1
+      0x60140013,  //  000F  GETGBL	R5	G19
+      0x7C140000,  //  0010  CALL	R5	0
+      0x98160C03,  //  0011  SETIDX	R5	K6	R3
+      0x5C0C0A00,  //  0012  MOVE	R3	R5
+      0x58140007,  //  0013  LDCONST	R5	K7
+      0x6018000C,  //  0014  GETGBL	R6	G12
+      0x881C0100,  //  0015  GETMBR	R7	R0	K0
+      0x7C180200,  //  0016  CALL	R6	1
+      0x14180A06,  //  0017  LT	R6	R5	R6
+      0x781A000C,  //  0018  JMPF	R6	#0026
+      0x88180100,  //  0019  GETMBR	R6	R0	K0
+      0x94180C05,  //  001A  GETIDX	R6	R6	R5
+      0x8C1C0108,  //  001B  GETMET	R7	R0	K8
+      0x5C240600,  //  001C  MOVE	R9	R3
+      0x88280D09,  //  001D  GETMBR	R10	R6	K9
+      0x882C0D0A,  //  001E  GETMBR	R11	R6	K10
+      0x7C1C0800,  //  001F  CALL	R7	4
+      0x741E0001,  //  0020  JMPT	R7	#0023
+      0x74120000,  //  0021  JMPT	R4	#0023
+      0x50100001,  //  0022  LDBOOL	R4	0	1
+      0x50100200,  //  0023  LDBOOL	R4	1	0
+      0x00140B0B,  //  0024  ADD	R5	R5	K11
+      0x7001FFED,  //  0025  JMP		#0014
+      0x80040800,  //  0026  RET	1	R4
+      0x50080000,  //  0027  LDBOOL	R2	0	0
+      0x80040400,  //  0028  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: time_str
+********************************************************************/
+be_local_closure(Tasmota_time_str,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str(string),
+    /* K1   */  be_nested_str(time_dump),
+    /* K2   */  be_nested_str(format),
+    /* K3   */  be_nested_str(_X2504d_X2D_X2502d_X2D_X2502dT_X2502d_X3A_X2502d_X3A_X2502d),
+    /* K4   */  be_nested_str(year),
+    /* K5   */  be_nested_str(month),
+    /* K6   */  be_nested_str(day),
+    /* K7   */  be_nested_str(hour),
+    /* K8   */  be_nested_str(min),
+    /* K9   */  be_nested_str(sec),
+    }),
+    &be_const_str_time_str,
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0101,  //  0001  GETMET	R3	R0	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x8C100502,  //  0004  GETMET	R4	R2	K2
+      0x58180003,  //  0005  LDCONST	R6	K3
+      0x941C0704,  //  0006  GETIDX	R7	R3	K4
+      0x94200705,  //  0007  GETIDX	R8	R3	K5
+      0x94240706,  //  0008  GETIDX	R9	R3	K6
+      0x94280707,  //  0009  GETIDX	R10	R3	K7
+      0x942C0708,  //  000A  GETIDX	R11	R3	K8
+      0x94300709,  //  000B  GETIDX	R12	R3	K9
+      0x7C101000,  //  000C  CALL	R4	8
+      0x80040800,  //  000D  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: urlfetch_cmd
+********************************************************************/
+be_local_closure(Tasmota_urlfetch_cmd,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str(string),
+    /* K1   */  be_nested_str(find),
+    /* K2   */  be_nested_str(http),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str(resp_cmnd_str),
+    /* K5   */  be_nested_str(URL_X20must_X20start_X20with_X20_X27http_X28s_X29_X27),
+    /* K6   */  be_nested_str(urlfetch),
+    /* K7   */  be_nested_str(resp_cmnd_failed),
+    /* K8   */  be_nested_str(tasmota),
+    /* K9   */  be_nested_str(resp_cmnd_done),
+    }),
+    &be_const_str_urlfetch_cmd,
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	K0
+      0x8C180B01,  //  0001  GETMET	R6	R5	K1
+      0x5C200600,  //  0002  MOVE	R8	R3
+      0x58240002,  //  0003  LDCONST	R9	K2
+      0x7C180600,  //  0004  CALL	R6	3
+      0x20180D03,  //  0005  NE	R6	R6	K3
+      0x781A0003,  //  0006  JMPF	R6	#000B
+      0x8C180104,  //  0007  GETMET	R6	R0	K4
+      0x58200005,  //  0008  LDCONST	R8	K5
+      0x7C180400,  //  0009  CALL	R6	2
+      0x80000C00,  //  000A  RET	0
+      0xA802000A,  //  000B  EXBLK	0	#0017
+      0x8C180106,  //  000C  GETMET	R6	R0	K6
+      0x5C200600,  //  000D  MOVE	R8	R3
+      0x7C180400,  //  000E  CALL	R6	2
+      0x141C0D03,  //  000F  LT	R7	R6	K3
+      0x781E0003,  //  0010  JMPF	R7	#0015
+      0x8C1C0107,  //  0011  GETMET	R7	R0	K7
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0xA8040001,  //  0013  EXBLK	1	1
+      0x80000E00,  //  0014  RET	0
+      0xA8040001,  //  0015  EXBLK	1	1
+      0x70020006,  //  0016  JMP		#001E
+      0xAC180002,  //  0017  CATCH	R6	0	2
+      0x70020003,  //  0018  JMP		#001D
+      0x8C200107,  //  0019  GETMET	R8	R0	K7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x80001000,  //  001B  RET	0
+      0x70020000,  //  001C  JMP		#001E
+      0xB0080000,  //  001D  RAISE	2	R0	R0
+      0xB81A1000,  //  001E  GETNGBL	R6	K8
+      0x8C180D09,  //  001F  GETMET	R6	R6	K9
+      0x7C180200,  //  0020  CALL	R6	1
+      0x80000000,  //  0021  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: hs2rgb
+********************************************************************/
+be_local_closure(Tasmota_hs2rgb,   /* name */
+  be_nested_proto(
+    17,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str(tasmota),
+    /* K2   */  be_nested_str(scale_uint),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_const_int(3),
+    }),
+    &be_const_str_hs2rgb,
+    &be_const_str_solidified,
+    ( &(const binstruction[68]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x1C0C0403,  //  0001  EQ	R3	R2	R3
+      0x780E0000,  //  0002  JMPF	R3	#0004
+      0x540A00FE,  //  0003  LDINT	R2	255
+      0x540E00FE,  //  0004  LDINT	R3	255
+      0x541200FE,  //  0005  LDINT	R4	255
+      0x541600FE,  //  0006  LDINT	R5	255
+      0x541A0167,  //  0007  LDINT	R6	360
+      0x10040206,  //  0008  MOD	R1	R1	R6
+      0x24180500,  //  0009  GT	R6	R2	K0
+      0x781A0031,  //  000A  JMPF	R6	#003D
+      0x541A003B,  //  000B  LDINT	R6	60
+      0x0C180206,  //  000C  DIV	R6	R1	R6
+      0x541E003B,  //  000D  LDINT	R7	60
+      0x101C0207,  //  000E  MOD	R7	R1	R7
+      0x542200FE,  //  000F  LDINT	R8	255
+      0x04201002,  //  0010  SUB	R8	R8	R2
+      0xB8260200,  //  0011  GETNGBL	R9	K1
+      0x8C241302,  //  0012  GETMET	R9	R9	K2
+      0x5C2C0E00,  //  0013  MOVE	R11	R7
+      0x58300000,  //  0014  LDCONST	R12	K0
+      0x5436003B,  //  0015  LDINT	R13	60
+      0x543A00FE,  //  0016  LDINT	R14	255
+      0x5C3C1000,  //  0017  MOVE	R15	R8
+      0x7C240C00,  //  0018  CALL	R9	6
+      0xB82A0200,  //  0019  GETNGBL	R10	K1
+      0x8C281502,  //  001A  GETMET	R10	R10	K2
+      0x5C300E00,  //  001B  MOVE	R12	R7
+      0x58340000,  //  001C  LDCONST	R13	K0
+      0x543A003B,  //  001D  LDINT	R14	60
+      0x5C3C1000,  //  001E  MOVE	R15	R8
+      0x544200FE,  //  001F  LDINT	R16	255
+      0x7C280C00,  //  0020  CALL	R10	6
+      0x1C2C0D00,  //  0021  EQ	R11	R6	K0
+      0x782E0002,  //  0022  JMPF	R11	#0026
+      0x5C141400,  //  0023  MOVE	R5	R10
+      0x5C101000,  //  0024  MOVE	R4	R8
+      0x70020016,  //  0025  JMP		#003D
+      0x1C2C0D03,  //  0026  EQ	R11	R6	K3
+      0x782E0002,  //  0027  JMPF	R11	#002B
+      0x5C0C1200,  //  0028  MOVE	R3	R9
+      0x5C101000,  //  0029  MOVE	R4	R8
+      0x70020011,  //  002A  JMP		#003D
+      0x1C2C0D04,  //  002B  EQ	R11	R6	K4
+      0x782E0002,  //  002C  JMPF	R11	#0030
+      0x5C0C1000,  //  002D  MOVE	R3	R8
+      0x5C101400,  //  002E  MOVE	R4	R10
+      0x7002000C,  //  002F  JMP		#003D
+      0x1C2C0D05,  //  0030  EQ	R11	R6	K5
+      0x782E0002,  //  0031  JMPF	R11	#0035
+      0x5C0C1000,  //  0032  MOVE	R3	R8
+      0x5C141200,  //  0033  MOVE	R5	R9
+      0x70020007,  //  0034  JMP		#003D
+      0x542E0003,  //  0035  LDINT	R11	4
+      0x1C2C0C0B,  //  0036  EQ	R11	R6	R11
+      0x782E0002,  //  0037  JMPF	R11	#003B
+      0x5C0C1400,  //  0038  MOVE	R3	R10
+      0x5C141000,  //  0039  MOVE	R5	R8
+      0x70020001,  //  003A  JMP		#003D
+      0x5C141000,  //  003B  MOVE	R5	R8
+      0x5C101200,  //  003C  MOVE	R4	R9
+      0x541A000F,  //  003D  LDINT	R6	16
+      0x38180606,  //  003E  SHL	R6	R3	R6
+      0x541E0007,  //  003F  LDINT	R7	8
+      0x381C0A07,  //  0040  SHL	R7	R5	R7
+      0x30180C07,  //  0041  OR	R6	R6	R7
+      0x30180C04,  //  0042  OR	R6	R6	R4
+      0x80040C00,  //  0043  RET	1	R6
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: try_rule
 ********************************************************************/
 be_local_closure(Tasmota_try_rule,   /* name */
@@ -1120,11 +2107,67 @@ be_local_closure(Tasmota_try_rule,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_rule
+** Solidified function: exec_cmd
 ********************************************************************/
-be_local_closure(Tasmota_remove_rule,   /* name */
+be_local_closure(Tasmota_exec_cmd,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(_ccmd),
+    /* K1   */  be_nested_str(json),
+    /* K2   */  be_nested_str(load),
+    /* K3   */  be_nested_str(find_key_i),
+    /* K4   */  be_nested_str(resolvecmnd),
+    }),
+    &be_const_str_exec_cmd,
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x78120016,  //  0001  JMPF	R4	#0019
+      0xA4120200,  //  0002  IMPORT	R4	K1
+      0x8C140902,  //  0003  GETMET	R5	R4	K2
+      0x5C1C0600,  //  0004  MOVE	R7	R3
+      0x7C140400,  //  0005  CALL	R5	2
+      0x8C180103,  //  0006  GETMET	R6	R0	K3
+      0x88200100,  //  0007  GETMBR	R8	R0	K0
+      0x5C240200,  //  0008  MOVE	R9	R1
+      0x7C180600,  //  0009  CALL	R6	3
+      0x4C1C0000,  //  000A  LDNIL	R7
+      0x201C0C07,  //  000B  NE	R7	R6	R7
+      0x781E000B,  //  000C  JMPF	R7	#0019
+      0x8C1C0104,  //  000D  GETMET	R7	R0	K4
+      0x5C240C00,  //  000E  MOVE	R9	R6
+      0x7C1C0400,  //  000F  CALL	R7	2
+      0x881C0100,  //  0010  GETMBR	R7	R0	K0
+      0x941C0E06,  //  0011  GETIDX	R7	R7	R6
+      0x5C200C00,  //  0012  MOVE	R8	R6
+      0x5C240400,  //  0013  MOVE	R9	R2
+      0x5C280600,  //  0014  MOVE	R10	R3
+      0x5C2C0A00,  //  0015  MOVE	R11	R5
+      0x7C1C0800,  //  0016  CALL	R7	4
+      0x501C0200,  //  0017  LDBOOL	R7	1	0
+      0x80040E00,  //  0018  RET	1	R7
+      0x50100000,  //  0019  LDBOOL	R4	0	0
+      0x80040800,  //  001A  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_cmd
+********************************************************************/
+be_local_closure(Tasmota_add_cmd,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1132,130 +2175,33 @@ be_local_closure(Tasmota_remove_rule,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_rules),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(trig),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(remove),
-    /* K5   */  be_const_int(1),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(check_not_method),
+    /* K1   */  be_nested_str(_ccmd),
+    /* K2   */  be_nested_str(function),
+    /* K3   */  be_nested_str(value_error),
+    /* K4   */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
     }),
-    &be_const_str_remove_rule,
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x780E0016,  //  0001  JMPF	R3	#0019
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x6010000C,  //  0003  GETGBL	R4	G12
-      0x88140100,  //  0004  GETMBR	R5	R0	K0
-      0x7C100200,  //  0005  CALL	R4	1
-      0x14100604,  //  0006  LT	R4	R3	R4
-      0x78120010,  //  0007  JMPF	R4	#0019
-      0x88100100,  //  0008  GETMBR	R4	R0	K0
-      0x94100803,  //  0009  GETIDX	R4	R4	R3
-      0x88100902,  //  000A  GETMBR	R4	R4	K2
-      0x1C100801,  //  000B  EQ	R4	R4	R1
-      0x78120009,  //  000C  JMPF	R4	#0017
-      0x88100100,  //  000D  GETMBR	R4	R0	K0
-      0x94100803,  //  000E  GETIDX	R4	R4	R3
-      0x88100903,  //  000F  GETMBR	R4	R4	K3
-      0x1C100802,  //  0010  EQ	R4	R4	R2
-      0x78120004,  //  0011  JMPF	R4	#0017
-      0x88100100,  //  0012  GETMBR	R4	R0	K0
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180600,  //  0014  MOVE	R6	R3
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020000,  //  0016  JMP		#0018
-      0x000C0705,  //  0017  ADD	R3	R3	K5
-      0x7001FFE9,  //  0018  JMP		#0003
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: cmd
-********************************************************************/
-be_local_closure(Tasmota_cmd,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(cmd_res),
-    /* K1   */  be_nested_str(_cmd),
-    }),
-    &be_const_str_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x90020003,  //  0002  SETMBR	R0	K0	R3
-      0x8C0C0101,  //  0003  GETMET	R3	R0	K1
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x50140200,  //  0008  LDBOOL	R5	1	0
-      0x20100805,  //  0009  NE	R4	R4	R5
-      0x78120000,  //  000A  JMPF	R4	#000C
-      0x880C0100,  //  000B  GETMBR	R3	R0	K0
-      0x90020002,  //  000C  SETMBR	R0	K0	R2
-      0x80040600,  //  000D  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_cron
-********************************************************************/
-be_local_closure(Tasmota_remove_cron,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_crons),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(remove),
-    /* K5   */  be_const_int(1),
-    }),
-    &be_const_str_remove_cron,
+    &be_const_str_add_cmd,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A000E,  //  0001  JMPF	R2	#0011
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120009,  //  0006  JMPF	R4	#0011
-      0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100903,  //  0008  GETMBR	R4	R4	K3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120003,  //  000A  JMPF	R4	#000F
-      0x8C100504,  //  000B  GETMET	R4	R2	K4
-      0x5C180600,  //  000C  MOVE	R6	R3
-      0x7C100400,  //  000D  CALL	R4	2
-      0x70020000,  //  000E  JMP		#0010
-      0x000C0705,  //  000F  ADD	R3	R3	K5
-      0x7001FFF1,  //  0010  JMP		#0003
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140400,  //  0001  MOVE	R5	R2
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x880C0101,  //  0003  GETMBR	R3	R0	K1
+      0x740E0002,  //  0004  JMPT	R3	#0008
+      0x600C0013,  //  0005  GETGBL	R3	G19
+      0x7C0C0000,  //  0006  CALL	R3	0
+      0x90020203,  //  0007  SETMBR	R0	K1	R3
+      0x600C0004,  //  0008  GETGBL	R3	G4
+      0x5C100400,  //  0009  MOVE	R4	R2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x1C0C0702,  //  000B  EQ	R3	R3	K2
+      0x780E0002,  //  000C  JMPF	R3	#0010
+      0x880C0101,  //  000D  GETMBR	R3	R0	K1
+      0x980C0202,  //  000E  SETIDX	R3	R1	R2
+      0x70020000,  //  000F  JMP		#0011
+      0xB0060704,  //  0010  RAISE	1	K3	K4
       0x80000000,  //  0011  RET	0
     })
   )
@@ -1264,11 +2210,11 @@ be_local_closure(Tasmota_remove_cron,   /* name */
 
 
 /********************************************************************
-** Solidified function: next_cron
+** Solidified function: find_op
 ********************************************************************/
-be_local_closure(Tasmota_next_cron,   /* name */
+be_local_closure(Tasmota_find_op,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    13,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1277,33 +2223,57 @@ be_local_closure(Tasmota_next_cron,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(_crons),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(size),
-    /* K3   */  be_nested_str(id),
-    /* K4   */  be_nested_str(trig),
+    /* K0   */  be_nested_str(string),
+    /* K1   */  be_nested_str(_X3D_X3C_X3E_X21),
+    /* K2   */  be_nested_str(_find_op),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str(split),
     /* K5   */  be_const_int(1),
     }),
-    &be_const_str_next_cron,
+    &be_const_str_find_op,
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A000D,  //  0001  JMPF	R2	#0010
-      0x580C0001,  //  0002  LDCONST	R3	K1
-      0x8C100502,  //  0003  GETMET	R4	R2	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100604,  //  0005  LT	R4	R3	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100403,  //  0007  GETIDX	R4	R2	R3
-      0x88100903,  //  0008  GETMBR	R4	R4	K3
-      0x1C100801,  //  0009  EQ	R4	R4	R1
-      0x78120002,  //  000A  JMPF	R4	#000E
-      0x94100403,  //  000B  GETIDX	R4	R2	R3
-      0x88100904,  //  000C  GETMBR	R4	R4	K4
-      0x80040800,  //  000D  RET	1	R4
-      0x000C0705,  //  000E  ADD	R3	R3	K5
-      0x7001FFF2,  //  000F  JMP		#0003
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[41]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x8C100102,  //  0002  GETMET	R4	R0	K2
+      0x5C180200,  //  0003  MOVE	R6	R1
+      0x501C0000,  //  0004  LDBOOL	R7	0	0
+      0x7C100600,  //  0005  CALL	R4	3
+      0x28140903,  //  0006  GE	R5	R4	K3
+      0x78160018,  //  0007  JMPF	R5	#0021
+      0x8C140504,  //  0008  GETMET	R5	R2	K4
+      0x5C1C0200,  //  0009  MOVE	R7	R1
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C140600,  //  000B  CALL	R5	3
+      0x94180B03,  //  000C  GETIDX	R6	R5	K3
+      0x941C0B05,  //  000D  GETIDX	R7	R5	K5
+      0x8C200102,  //  000E  GETMET	R8	R0	K2
+      0x5C280E00,  //  000F  MOVE	R10	R7
+      0x502C0200,  //  0010  LDBOOL	R11	1	0
+      0x7C200600,  //  0011  CALL	R8	3
+      0x5C101000,  //  0012  MOVE	R4	R8
+      0x28200903,  //  0013  GE	R8	R4	K3
+      0x7822000B,  //  0014  JMPF	R8	#0021
+      0x8C200504,  //  0015  GETMET	R8	R2	K4
+      0x5C280E00,  //  0016  MOVE	R10	R7
+      0x5C2C0800,  //  0017  MOVE	R11	R4
+      0x7C200600,  //  0018  CALL	R8	3
+      0x94241103,  //  0019  GETIDX	R9	R8	K3
+      0x94281105,  //  001A  GETIDX	R10	R8	K5
+      0x602C0012,  //  001B  GETGBL	R11	G18
+      0x7C2C0000,  //  001C  CALL	R11	0
+      0x40301606,  //  001D  CONNECT	R12	R11	R6
+      0x40301609,  //  001E  CONNECT	R12	R11	R9
+      0x4030160A,  //  001F  CONNECT	R12	R11	R10
+      0x80041600,  //  0020  RET	1	R11
+      0x60140012,  //  0021  GETGBL	R5	G18
+      0x7C140000,  //  0022  CALL	R5	0
+      0x40180A01,  //  0023  CONNECT	R6	R5	R1
+      0x4C180000,  //  0024  LDNIL	R6
+      0x40180A06,  //  0025  CONNECT	R6	R5	R6
+      0x4C180000,  //  0026  LDNIL	R6
+      0x40180A06,  //  0027  CONNECT	R6	R5	R6
+      0x80040A00,  //  0028  RET	1	R5
     })
   )
 );
@@ -1311,175 +2281,53 @@ be_local_closure(Tasmota_next_cron,   /* name */
 
 
 /********************************************************************
-** Solidified function: hs2rgb
+** Solidified function: add_fast_loop
 ********************************************************************/
-be_local_closure(Tasmota_hs2rgb,   /* name */
+be_local_closure(Tasmota_add_fast_loop,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
-    3,                          /* argc */
+    5,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str(tasmota),
-    /* K2   */  be_nested_str(scale_uint),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_const_int(3),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str(check_not_method),
+    /* K1   */  be_nested_str(_fl),
+    /* K2   */  be_nested_str(function),
+    /* K3   */  be_nested_str(value_error),
+    /* K4   */  be_nested_str(argument_X20must_X20be_X20a_X20function),
+    /* K5   */  be_nested_str(global),
+    /* K6   */  be_nested_str(fast_loop_enabled),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str(push),
     }),
-    &be_const_str_hs2rgb,
+    &be_const_str_add_fast_loop,
     &be_const_str_solidified,
-    ( &(const binstruction[68]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x1C0C0403,  //  0001  EQ	R3	R2	R3
-      0x780E0000,  //  0002  JMPF	R3	#0004
-      0x540A00FE,  //  0003  LDINT	R2	255
-      0x540E00FE,  //  0004  LDINT	R3	255
-      0x541200FE,  //  0005  LDINT	R4	255
-      0x541600FE,  //  0006  LDINT	R5	255
-      0x541A0167,  //  0007  LDINT	R6	360
-      0x10040206,  //  0008  MOD	R1	R1	R6
-      0x24180500,  //  0009  GT	R6	R2	K0
-      0x781A0031,  //  000A  JMPF	R6	#003D
-      0x541A003B,  //  000B  LDINT	R6	60
-      0x0C180206,  //  000C  DIV	R6	R1	R6
-      0x541E003B,  //  000D  LDINT	R7	60
-      0x101C0207,  //  000E  MOD	R7	R1	R7
-      0x542200FE,  //  000F  LDINT	R8	255
-      0x04201002,  //  0010  SUB	R8	R8	R2
-      0xB8260200,  //  0011  GETNGBL	R9	K1
-      0x8C241302,  //  0012  GETMET	R9	R9	K2
-      0x5C2C0E00,  //  0013  MOVE	R11	R7
-      0x58300000,  //  0014  LDCONST	R12	K0
-      0x5436003B,  //  0015  LDINT	R13	60
-      0x543A00FE,  //  0016  LDINT	R14	255
-      0x5C3C1000,  //  0017  MOVE	R15	R8
-      0x7C240C00,  //  0018  CALL	R9	6
-      0xB82A0200,  //  0019  GETNGBL	R10	K1
-      0x8C281502,  //  001A  GETMET	R10	R10	K2
-      0x5C300E00,  //  001B  MOVE	R12	R7
-      0x58340000,  //  001C  LDCONST	R13	K0
-      0x543A003B,  //  001D  LDINT	R14	60
-      0x5C3C1000,  //  001E  MOVE	R15	R8
-      0x544200FE,  //  001F  LDINT	R16	255
-      0x7C280C00,  //  0020  CALL	R10	6
-      0x1C2C0D00,  //  0021  EQ	R11	R6	K0
-      0x782E0002,  //  0022  JMPF	R11	#0026
-      0x5C141400,  //  0023  MOVE	R5	R10
-      0x5C101000,  //  0024  MOVE	R4	R8
-      0x70020016,  //  0025  JMP		#003D
-      0x1C2C0D03,  //  0026  EQ	R11	R6	K3
-      0x782E0002,  //  0027  JMPF	R11	#002B
-      0x5C0C1200,  //  0028  MOVE	R3	R9
-      0x5C101000,  //  0029  MOVE	R4	R8
-      0x70020011,  //  002A  JMP		#003D
-      0x1C2C0D04,  //  002B  EQ	R11	R6	K4
-      0x782E0002,  //  002C  JMPF	R11	#0030
-      0x5C0C1000,  //  002D  MOVE	R3	R8
-      0x5C101400,  //  002E  MOVE	R4	R10
-      0x7002000C,  //  002F  JMP		#003D
-      0x1C2C0D05,  //  0030  EQ	R11	R6	K5
-      0x782E0002,  //  0031  JMPF	R11	#0035
-      0x5C0C1000,  //  0032  MOVE	R3	R8
-      0x5C141200,  //  0033  MOVE	R5	R9
-      0x70020007,  //  0034  JMP		#003D
-      0x542E0003,  //  0035  LDINT	R11	4
-      0x1C2C0C0B,  //  0036  EQ	R11	R6	R11
-      0x782E0002,  //  0037  JMPF	R11	#003B
-      0x5C0C1400,  //  0038  MOVE	R3	R10
-      0x5C141000,  //  0039  MOVE	R5	R8
-      0x70020001,  //  003A  JMP		#003D
-      0x5C141000,  //  003B  MOVE	R5	R8
-      0x5C101200,  //  003C  MOVE	R4	R9
-      0x541A000F,  //  003D  LDINT	R6	16
-      0x38180606,  //  003E  SHL	R6	R3	R6
-      0x541E0007,  //  003F  LDINT	R7	8
-      0x381C0A07,  //  0040  SHL	R7	R5	R7
-      0x30180C07,  //  0041  OR	R6	R6	R7
-      0x30180C04,  //  0042  OR	R6	R6	R4
-      0x80040C00,  //  0043  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_light
-********************************************************************/
-be_local_closure(Tasmota_set_light,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota_X2Eset_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eset_X28_X29),
-    /* K1   */  be_nested_str(light),
-    /* K2   */  be_nested_str(set),
-    }),
-    &be_const_str_set_light,
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x600C0001,  //  0000  GETGBL	R3	G1
-      0x58100000,  //  0001  LDCONST	R4	K0
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0xA40E0200,  //  0003  IMPORT	R3	K1
-      0x4C100000,  //  0004  LDNIL	R4
-      0x20100404,  //  0005  NE	R4	R2	R4
-      0x78120005,  //  0006  JMPF	R4	#000D
-      0x8C100702,  //  0007  GETMET	R4	R3	K2
-      0x5C180200,  //  0008  MOVE	R6	R1
-      0x5C1C0400,  //  0009  MOVE	R7	R2
-      0x7C100600,  //  000A  CALL	R4	3
-      0x80040800,  //  000B  RET	1	R4
-      0x70020003,  //  000C  JMP		#0011
-      0x8C100702,  //  000D  GETMET	R4	R3	K2
-      0x5C180200,  //  000E  MOVE	R6	R1
-      0x7C100400,  //  000F  CALL	R4	2
-      0x80040800,  //  0010  RET	1	R4
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gc
-********************************************************************/
-be_local_closure(Tasmota_gc,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(gc),
-    /* K1   */  be_nested_str(collect),
-    /* K2   */  be_nested_str(allocated),
-    }),
-    &be_const_str_gc,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x7C080200,  //  0004  CALL	R2	1
-      0x80040400,  //  0005  RET	1	R2
+    ( &(const binstruction[21]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x5C100200,  //  0001  MOVE	R4	R1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x88080101,  //  0003  GETMBR	R2	R0	K1
+      0x740A0002,  //  0004  JMPT	R2	#0008
+      0x60080012,  //  0005  GETGBL	R2	G18
+      0x7C080000,  //  0006  CALL	R2	0
+      0x90020202,  //  0007  SETMBR	R0	K1	R2
+      0x60080004,  //  0008  GETGBL	R2	G4
+      0x5C0C0200,  //  0009  MOVE	R3	R1
+      0x7C080200,  //  000A  CALL	R2	1
+      0x20080502,  //  000B  NE	R2	R2	K2
+      0x780A0000,  //  000C  JMPF	R2	#000E
+      0xB0060704,  //  000D  RAISE	1	K3	K4
+      0x88080105,  //  000E  GETMBR	R2	R0	K5
+      0x900A0D07,  //  000F  SETMBR	R2	K6	K7
+      0x88080101,  //  0010  GETMBR	R2	R0	K1
+      0x8C080508,  //  0011  GETMET	R2	R2	K8
+      0x5C100200,  //  0012  MOVE	R4	R1
+      0x7C080400,  //  0013  CALL	R2	2
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -1542,136 +2390,30 @@ be_local_closure(Tasmota_add_rule,   /* name */
 
 
 /********************************************************************
-** Solidified function: wire_scan
+** Solidified function: gen_cb
 ********************************************************************/
-be_local_closure(Tasmota_wire_scan,   /* name */
+be_local_closure(Tasmota_gen_cb,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    3,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(i2c_enabled),
-    /* K1   */  be_nested_str(wire1),
-    /* K2   */  be_nested_str(enabled),
-    /* K3   */  be_nested_str(detect),
-    /* K4   */  be_nested_str(wire2),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(cb),
+    /* K1   */  be_nested_str(gen_cb),
     }),
-    &be_const_str_wire_scan,
+    &be_const_str_gen_cb,
     &be_const_str_solidified,
-    ( &(const binstruction[33]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0005,  //  0002  JMPF	R3	#0009
-      0x8C0C0100,  //  0003  GETMET	R3	R0	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x740E0001,  //  0006  JMPT	R3	#0009
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x80040600,  //  0008  RET	1	R3
-      0x880C0101,  //  0009  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x780E0006,  //  000C  JMPF	R3	#0014
-      0x880C0101,  //  000D  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  000E  GETMET	R3	R3	K3
-      0x5C140200,  //  000F  MOVE	R5	R1
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x780E0001,  //  0011  JMPF	R3	#0014
-      0x880C0101,  //  0012  GETMBR	R3	R0	K1
-      0x80040600,  //  0013  RET	1	R3
-      0x880C0104,  //  0014  GETMBR	R3	R0	K4
-      0x8C0C0702,  //  0015  GETMET	R3	R3	K2
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0x780E0006,  //  0017  JMPF	R3	#001F
-      0x880C0104,  //  0018  GETMBR	R3	R0	K4
-      0x8C0C0703,  //  0019  GETMET	R3	R3	K3
-      0x5C140200,  //  001A  MOVE	R5	R1
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0x780E0001,  //  001C  JMPF	R3	#001F
-      0x880C0104,  //  001D  GETMBR	R3	R0	K4
-      0x80040600,  //  001E  RET	1	R3
-      0x4C0C0000,  //  001F  LDNIL	R3
-      0x80040600,  //  0020  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Tasmota_init,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str(global),
-    /* K1   */  be_nested_str(ctypes_bytes_dyn),
-    /* K2   */  be_nested_str(_global_addr),
-    /* K3   */  be_nested_str(_global_def),
-    /* K4   */  be_nested_str(introspect),
-    /* K5   */  be_nested_str(_settings_ptr),
-    /* K6   */  be_nested_str(get),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(settings),
-    /* K9   */  be_nested_str(toptr),
-    /* K10  */  be_nested_str(_settings_def),
-    /* K11  */  be_nested_str(wd),
-    /* K12  */  be_nested_str(),
-    /* K13  */  be_nested_str(_debug_present),
-    /* K14  */  be_nested_str(debug),
-    }),
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[36]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x88080102,  //  0001  GETMBR	R2	R0	K2
-      0x880C0103,  //  0002  GETMBR	R3	R0	K3
-      0x7C040400,  //  0003  CALL	R1	2
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0xA4060800,  //  0005  IMPORT	R1	K4
-      0x60080015,  //  0006  GETGBL	R2	G21
-      0x880C0105,  //  0007  GETMBR	R3	R0	K5
-      0x54120003,  //  0008  LDINT	R4	4
-      0x7C080400,  //  0009  CALL	R2	2
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x58100007,  //  000B  LDCONST	R4	K7
-      0x54160003,  //  000C  LDINT	R5	4
-      0x7C080600,  //  000D  CALL	R2	3
-      0x780A0006,  //  000E  JMPF	R2	#0016
-      0xB80E0200,  //  000F  GETNGBL	R3	K1
-      0x8C100309,  //  0010  GETMET	R4	R1	K9
-      0x5C180400,  //  0011  MOVE	R6	R2
-      0x7C100400,  //  0012  CALL	R4	2
-      0x8814010A,  //  0013  GETMBR	R5	R0	K10
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x90021003,  //  0015  SETMBR	R0	K8	R3
-      0x9002170C,  //  0016  SETMBR	R0	K11	K12
-      0x500C0000,  //  0017  LDBOOL	R3	0	0
-      0x90021A03,  //  0018  SETMBR	R0	K13	R3
-      0xA8020004,  //  0019  EXBLK	0	#001F
-      0xA40E1C00,  //  001A  IMPORT	R3	K14
-      0x50100200,  //  001B  LDBOOL	R4	1	0
-      0x90021A04,  //  001C  SETMBR	R0	K13	R4
-      0xA8040001,  //  001D  EXBLK	1	1
-      0x70020003,  //  001E  JMP		#0023
-      0xAC0C0000,  //  001F  CATCH	R3	0	0
-      0x70020000,  //  0020  JMP		#0022
-      0x70020000,  //  0021  JMP		#0023
-      0xB0080000,  //  0022  RAISE	2	R0	R0
-      0x80000000,  //  0023  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x80040600,  //  0004  RET	1	R3
     })
   )
 );
@@ -1881,11 +2623,11 @@ be_local_closure(Tasmota_fast_loop,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_fast_loop
+** Solidified function: remove_cron
 ********************************************************************/
-be_local_closure(Tasmota_remove_fast_loop,   /* name */
+be_local_closure(Tasmota_remove_cron,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    7,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1893,589 +2635,35 @@ be_local_closure(Tasmota_remove_fast_loop,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_fl),
-    /* K1   */  be_nested_str(find),
-    /* K2   */  be_nested_str(remove),
-    }),
-    &be_const_str_remove_fast_loop,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x740A0000,  //  0001  JMPT	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x88080100,  //  0003  GETMBR	R2	R0	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
-      0x5C100200,  //  0005  MOVE	R4	R1
-      0x7C080400,  //  0006  CALL	R2	2
-      0x4C0C0000,  //  0007  LDNIL	R3
-      0x200C0403,  //  0008  NE	R3	R2	R3
-      0x780E0003,  //  0009  JMPF	R3	#000E
-      0x880C0100,  //  000A  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  000B  GETMET	R3	R3	K2
-      0x5C140400,  //  000C  MOVE	R5	R2
-      0x7C0C0400,  //  000D  CALL	R3	2
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: exec_rules
-********************************************************************/
-be_local_closure(Tasmota_exec_rules,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str(cmd_res),
-    /* K1   */  be_nested_str(_rules),
-    /* K2   */  be_nested_str(json),
-    /* K3   */  be_nested_str(load),
-    /* K4   */  be_nested_str(log),
-    /* K5   */  be_nested_str(BRY_X3A_X20ERROR_X2C_X20bad_X20json_X3A_X20),
-    /* K6   */  be_const_int(3),
-    /* K7   */  be_const_int(0),
-    /* K8   */  be_nested_str(try_rule),
-    /* K9   */  be_nested_str(trig),
-    /* K10  */  be_nested_str(f),
-    /* K11  */  be_const_int(1),
-    }),
-    &be_const_str_exec_rules,
-    &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x88100101,  //  0001  GETMBR	R4	R0	K1
-      0x74120002,  //  0002  JMPT	R4	#0006
-      0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120029,  //  0005  JMPF	R4	#0030
-      0xA4120400,  //  0006  IMPORT	R4	K2
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020005,  //  0008  SETMBR	R0	K0	R5
-      0x50140000,  //  0009  LDBOOL	R5	0	0
-      0x8C180903,  //  000A  GETMET	R6	R4	K3
-      0x5C200200,  //  000B  MOVE	R8	R1
-      0x7C180400,  //  000C  CALL	R6	2
-      0x4C1C0000,  //  000D  LDNIL	R7
-      0x1C1C0C07,  //  000E  EQ	R7	R6	R7
-      0x781E0004,  //  000F  JMPF	R7	#0015
-      0x8C1C0104,  //  0010  GETMET	R7	R0	K4
-      0x00260A01,  //  0011  ADD	R9	K5	R1
-      0x58280006,  //  0012  LDCONST	R10	K6
-      0x7C1C0600,  //  0013  CALL	R7	3
-      0x5C180200,  //  0014  MOVE	R6	R1
-      0x780A0014,  //  0015  JMPF	R2	#002B
-      0x881C0101,  //  0016  GETMBR	R7	R0	K1
-      0x781E0012,  //  0017  JMPF	R7	#002B
-      0x581C0007,  //  0018  LDCONST	R7	K7
-      0x6020000C,  //  0019  GETGBL	R8	G12
-      0x88240101,  //  001A  GETMBR	R9	R0	K1
-      0x7C200200,  //  001B  CALL	R8	1
-      0x14200E08,  //  001C  LT	R8	R7	R8
-      0x7822000C,  //  001D  JMPF	R8	#002B
-      0x88200101,  //  001E  GETMBR	R8	R0	K1
-      0x94201007,  //  001F  GETIDX	R8	R8	R7
-      0x8C240108,  //  0020  GETMET	R9	R0	K8
-      0x5C2C0C00,  //  0021  MOVE	R11	R6
-      0x88301109,  //  0022  GETMBR	R12	R8	K9
-      0x8834110A,  //  0023  GETMBR	R13	R8	K10
-      0x7C240800,  //  0024  CALL	R9	4
-      0x74260001,  //  0025  JMPT	R9	#0028
-      0x74160000,  //  0026  JMPT	R5	#0028
-      0x50140001,  //  0027  LDBOOL	R5	0	1
-      0x50140200,  //  0028  LDBOOL	R5	1	0
-      0x001C0F0B,  //  0029  ADD	R7	R7	K11
-      0x7001FFED,  //  002A  JMP		#0019
-      0x4C1C0000,  //  002B  LDNIL	R7
-      0x201C0607,  //  002C  NE	R7	R3	R7
-      0x781E0000,  //  002D  JMPF	R7	#002F
-      0x90020006,  //  002E  SETMBR	R0	K0	R6
-      0x80040A00,  //  002F  RET	1	R5
-      0x50100000,  //  0030  LDBOOL	R4	0	0
-      0x80040800,  //  0031  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_cmd
-********************************************************************/
-be_local_closure(Tasmota_add_cmd,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_ccmd),
-    /* K2   */  be_nested_str(function),
-    /* K3   */  be_nested_str(value_error),
-    /* K4   */  be_nested_str(the_X20second_X20argument_X20is_X20not_X20a_X20function),
-    }),
-    &be_const_str_add_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140400,  //  0001  MOVE	R5	R2
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x880C0101,  //  0003  GETMBR	R3	R0	K1
-      0x740E0002,  //  0004  JMPT	R3	#0008
-      0x600C0013,  //  0005  GETGBL	R3	G19
-      0x7C0C0000,  //  0006  CALL	R3	0
-      0x90020203,  //  0007  SETMBR	R0	K1	R3
-      0x600C0004,  //  0008  GETGBL	R3	G4
-      0x5C100400,  //  0009  MOVE	R4	R2
-      0x7C0C0200,  //  000A  CALL	R3	1
-      0x1C0C0702,  //  000B  EQ	R3	R3	K2
-      0x780E0002,  //  000C  JMPF	R3	#0010
-      0x880C0101,  //  000D  GETMBR	R3	R0	K1
-      0x980C0202,  //  000E  SETIDX	R3	R1	R2
-      0x70020000,  //  000F  JMP		#0011
-      0xB0060704,  //  0010  RAISE	1	K3	K4
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: run_cron
-********************************************************************/
-be_local_closure(Tasmota_run_cron,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str(_crons),
     /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(ccronexpr),
-    /* K3   */  be_nested_str(now),
-    /* K4   */  be_nested_str(size),
-    /* K5   */  be_nested_str(trig),
-    /* K6   */  be_nested_str(next),
-    /* K7   */  be_nested_str(time_reached),
-    /* K8   */  be_nested_str(f),
-    /* K9   */  be_const_int(1),
-    }),
-    &be_const_str_run_cron,
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x7806001E,  //  0001  JMPF	R1	#0021
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x7C080200,  //  0005  CALL	R2	1
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x8C0C0704,  //  0007  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x140C0203,  //  0009  LT	R3	R1	R3
-      0x780E0015,  //  000A  JMPF	R3	#0021
-      0x880C0100,  //  000B  GETMBR	R3	R0	K0
-      0x940C0601,  //  000C  GETIDX	R3	R3	R1
-      0x88100705,  //  000D  GETMBR	R4	R3	K5
-      0x1C100901,  //  000E  EQ	R4	R4	K1
-      0x78120003,  //  000F  JMPF	R4	#0014
-      0x8C100706,  //  0010  GETMET	R4	R3	K6
-      0x7C100200,  //  0011  CALL	R4	1
-      0x900E0A04,  //  0012  SETMBR	R3	K5	R4
-      0x7002000A,  //  0013  JMP		#001F
-      0x8C100707,  //  0014  GETMET	R4	R3	K7
-      0x7C100200,  //  0015  CALL	R4	1
-      0x78120007,  //  0016  JMPF	R4	#001F
-      0x88100708,  //  0017  GETMBR	R4	R3	K8
-      0x8C140706,  //  0018  GETMET	R5	R3	K6
-      0x7C140200,  //  0019  CALL	R5	1
-      0x900E0A05,  //  001A  SETMBR	R3	K5	R5
-      0x5C180800,  //  001B  MOVE	R6	R4
-      0x5C1C0400,  //  001C  MOVE	R7	R2
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x00040309,  //  001F  ADD	R1	R1	K9
-      0x7001FFE4,  //  0020  JMP		#0006
-      0x80000000,  //  0021  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: check_not_method
-********************************************************************/
-be_local_closure(Tasmota_check_not_method,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(introspect),
-    /* K1   */  be_nested_str(function),
-    /* K2   */  be_nested_str(type_error),
-    /* K3   */  be_nested_str(BRY_X3A_X20argument_X20must_X20be_X20a_X20function),
-    /* K4   */  be_nested_str(ismethod),
-    /* K5   */  be_nested_str(BRY_X3A_X20method_X20not_X20allowed_X2C_X20use_X20a_X20closure_X20like_X20_X27_X2F_X20args_X20_X2D_X3E_X20obj_X2Efunc_X28args_X29_X27),
-    }),
-    &be_const_str_check_not_method,
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x600C0004,  //  0001  GETGBL	R3	G4
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x200C0701,  //  0004  NE	R3	R3	K1
-      0x780E0000,  //  0005  JMPF	R3	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x50100200,  //  000A  LDBOOL	R4	1	0
-      0x1C0C0604,  //  000B  EQ	R3	R3	R4
-      0x780E0000,  //  000C  JMPF	R3	#000E
-      0xB0060505,  //  000D  RAISE	1	K2	K5
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gen_cb
-********************************************************************/
-be_local_closure(Tasmota_gen_cb,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(cb),
-    /* K1   */  be_nested_str(gen_cb),
-    }),
-    &be_const_str_gen_cb,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x80040600,  //  0004  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_timer
-********************************************************************/
-be_local_closure(Tasmota_set_timer,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(check_not_method),
-    /* K1   */  be_nested_str(_timers),
-    /* K2   */  be_nested_str(push),
-    /* K3   */  be_nested_str(Trigger),
-    /* K4   */  be_nested_str(millis),
-    }),
-    &be_const_str_set_timer,
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x8C100100,  //  0000  GETMET	R4	R0	K0
-      0x5C180400,  //  0001  MOVE	R6	R2
-      0x7C100400,  //  0002  CALL	R4	2
-      0x88100101,  //  0003  GETMBR	R4	R0	K1
-      0x74120002,  //  0004  JMPT	R4	#0008
-      0x60100012,  //  0005  GETGBL	R4	G18
-      0x7C100000,  //  0006  CALL	R4	0
-      0x90020204,  //  0007  SETMBR	R0	K1	R4
-      0x88100101,  //  0008  GETMBR	R4	R0	K1
-      0x8C100902,  //  0009  GETMET	R4	R4	K2
-      0xB81A0600,  //  000A  GETNGBL	R6	K3
-      0x8C1C0104,  //  000B  GETMET	R7	R0	K4
-      0x5C240200,  //  000C  MOVE	R9	R1
-      0x7C1C0400,  //  000D  CALL	R7	2
-      0x5C200400,  //  000E  MOVE	R8	R2
-      0x5C240600,  //  000F  MOVE	R9	R3
-      0x7C180600,  //  0010  CALL	R6	3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_op
-********************************************************************/
-be_local_closure(Tasmota_find_op,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str(string),
-    /* K1   */  be_nested_str(_X3D_X3C_X3E_X21),
-    /* K2   */  be_nested_str(_find_op),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str(split),
+    /* K2   */  be_nested_str(size),
+    /* K3   */  be_nested_str(id),
+    /* K4   */  be_nested_str(remove),
     /* K5   */  be_const_int(1),
     }),
-    &be_const_str_find_op,
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x8C100102,  //  0002  GETMET	R4	R0	K2
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x501C0000,  //  0004  LDBOOL	R7	0	0
-      0x7C100600,  //  0005  CALL	R4	3
-      0x28140903,  //  0006  GE	R5	R4	K3
-      0x78160018,  //  0007  JMPF	R5	#0021
-      0x8C140504,  //  0008  GETMET	R5	R2	K4
-      0x5C1C0200,  //  0009  MOVE	R7	R1
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C140600,  //  000B  CALL	R5	3
-      0x94180B03,  //  000C  GETIDX	R6	R5	K3
-      0x941C0B05,  //  000D  GETIDX	R7	R5	K5
-      0x8C200102,  //  000E  GETMET	R8	R0	K2
-      0x5C280E00,  //  000F  MOVE	R10	R7
-      0x502C0200,  //  0010  LDBOOL	R11	1	0
-      0x7C200600,  //  0011  CALL	R8	3
-      0x5C101000,  //  0012  MOVE	R4	R8
-      0x28200903,  //  0013  GE	R8	R4	K3
-      0x7822000B,  //  0014  JMPF	R8	#0021
-      0x8C200504,  //  0015  GETMET	R8	R2	K4
-      0x5C280E00,  //  0016  MOVE	R10	R7
-      0x5C2C0800,  //  0017  MOVE	R11	R4
-      0x7C200600,  //  0018  CALL	R8	3
-      0x94241103,  //  0019  GETIDX	R9	R8	K3
-      0x94281105,  //  001A  GETIDX	R10	R8	K5
-      0x602C0012,  //  001B  GETGBL	R11	G18
-      0x7C2C0000,  //  001C  CALL	R11	0
-      0x40301606,  //  001D  CONNECT	R12	R11	R6
-      0x40301609,  //  001E  CONNECT	R12	R11	R9
-      0x4030160A,  //  001F  CONNECT	R12	R11	R10
-      0x80041600,  //  0020  RET	1	R11
-      0x60140012,  //  0021  GETGBL	R5	G18
-      0x7C140000,  //  0022  CALL	R5	0
-      0x40180A01,  //  0023  CONNECT	R6	R5	R1
-      0x4C180000,  //  0024  LDNIL	R6
-      0x40180A06,  //  0025  CONNECT	R6	R5	R6
-      0x4C180000,  //  0026  LDNIL	R6
-      0x40180A06,  //  0027  CONNECT	R6	R5	R6
-      0x80040A00,  //  0028  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_driver
-********************************************************************/
-be_local_closure(Tasmota_remove_driver,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(_drivers),
-    /* K1   */  be_nested_str(find),
-    /* K2   */  be_nested_str(pop),
-    }),
-    &be_const_str_remove_driver,
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A000A,  //  0001  JMPF	R2	#000D
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x8C080501,  //  0003  GETMET	R2	R2	K1
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x200C0403,  //  0007  NE	R3	R2	R3
-      0x780E0003,  //  0008  JMPF	R3	#000D
-      0x880C0100,  //  0009  GETMBR	R3	R0	K0
-      0x8C0C0702,  //  000A  GETMET	R3	R3	K2
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_light
-********************************************************************/
-be_local_closure(Tasmota_get_light,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(tasmota_X2Eget_light_X28_X29_X20is_X20deprecated_X2C_X20use_X20light_X2Eget_X28_X29),
-    /* K1   */  be_nested_str(light),
-    /* K2   */  be_nested_str(get),
-    }),
-    &be_const_str_get_light,
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x60080001,  //  0000  GETGBL	R2	G1
-      0x580C0000,  //  0001  LDCONST	R3	K0
-      0x7C080200,  //  0002  CALL	R2	1
-      0xA40A0200,  //  0003  IMPORT	R2	K1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x200C0203,  //  0005  NE	R3	R1	R3
-      0x780E0004,  //  0006  JMPF	R3	#000C
-      0x8C0C0502,  //  0007  GETMET	R3	R2	K2
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80040600,  //  000A  RET	1	R3
-      0x70020002,  //  000B  JMP		#000F
-      0x8C0C0502,  //  000C  GETMET	R3	R2	K2
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x80040600,  //  000E  RET	1	R3
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_driver
-********************************************************************/
-be_local_closure(Tasmota_add_driver,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(instance),
-    /* K1   */  be_nested_str(value_error),
-    /* K2   */  be_nested_str(instance_X20required),
-    /* K3   */  be_nested_str(_drivers),
-    /* K4   */  be_nested_str(push),
-    }),
-    &be_const_str_add_driver,
+    &be_const_str_remove_cron,
     &be_const_str_solidified,
     ( &(const binstruction[18]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x20080500,  //  0003  NE	R2	R2	K0
-      0x780A0000,  //  0004  JMPF	R2	#0006
-      0xB0060302,  //  0005  RAISE	1	K1	K2
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
-      0x780A0004,  //  0007  JMPF	R2	#000D
-      0x88080103,  //  0008  GETMBR	R2	R0	K3
-      0x8C080504,  //  0009  GETMET	R2	R2	K4
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x7C080400,  //  000B  CALL	R2	2
-      0x70020003,  //  000C  JMP		#0011
-      0x60080012,  //  000D  GETGBL	R2	G18
-      0x7C080000,  //  000E  CALL	R2	0
-      0x400C0401,  //  000F  CONNECT	R3	R2	R1
-      0x90020602,  //  0010  SETMBR	R0	K3	R2
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_cmd
-********************************************************************/
-be_local_closure(Tasmota_remove_cmd,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(_ccmd),
-    /* K1   */  be_nested_str(remove),
-    }),
-    &be_const_str_remove_cmd,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0003,  //  0001  JMPF	R2	#0006
-      0x88080100,  //  0002  GETMBR	R2	R0	K0
-      0x8C080501,  //  0003  GETMET	R2	R2	K1
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x80000000,  //  0006  RET	0
+      0x780A000E,  //  0001  JMPF	R2	#0011
+      0x580C0001,  //  0002  LDCONST	R3	K1
+      0x8C100502,  //  0003  GETMET	R4	R2	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100604,  //  0005  LT	R4	R3	R4
+      0x78120009,  //  0006  JMPF	R4	#0011
+      0x94100403,  //  0007  GETIDX	R4	R2	R3
+      0x88100903,  //  0008  GETMBR	R4	R4	K3
+      0x1C100801,  //  0009  EQ	R4	R4	R1
+      0x78120003,  //  000A  JMPF	R4	#000F
+      0x8C100504,  //  000B  GETMET	R4	R2	K4
+      0x5C180600,  //  000C  MOVE	R6	R3
+      0x7C100400,  //  000D  CALL	R4	2
+      0x70020000,  //  000E  JMP		#0010
+      0x000C0705,  //  000F  ADD	R3	R3	K5
+      0x7001FFF1,  //  0010  JMP		#0003
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -2488,55 +2676,57 @@ be_local_closure(Tasmota_remove_cmd,   /* name */
 be_local_class(Tasmota,
     13,
     NULL,
-    be_nested_map(47,
+    be_nested_map(49,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(find_key_i, -1), be_const_closure(Tasmota_find_key_i_closure) },
-        { be_const_key(exec_cmd, 42), be_const_closure(Tasmota_exec_cmd_closure) },
-        { be_const_key(remove_cmd, -1), be_const_closure(Tasmota_remove_cmd_closure) },
+        { be_const_key(exec_rules, 45), be_const_closure(Tasmota_exec_rules_closure) },
+        { be_const_key(cmd, 30), be_const_closure(Tasmota_cmd_closure) },
+        { be_const_key(remove_cron, -1), be_const_closure(Tasmota_remove_cron_closure) },
+        { be_const_key(remove_rule, 23), be_const_closure(Tasmota_remove_rule_closure) },
+        { be_const_key(run_deferred, -1), be_const_closure(Tasmota_run_deferred_closure) },
+        { be_const_key(find_key_i, 22), be_const_closure(Tasmota_find_key_i_closure) },
+        { be_const_key(remove_timer, -1), be_const_closure(Tasmota_remove_timer_closure) },
+        { be_const_key(_crons, -1), be_const_var(3) },
+        { be_const_key(gen_cb, -1), be_const_closure(Tasmota_gen_cb_closure) },
         { be_const_key(add_cron, -1), be_const_closure(Tasmota_add_cron_closure) },
-        { be_const_key(_timers, -1), be_const_var(2) },
-        { be_const_key(remove_timer, 35), be_const_closure(Tasmota_remove_timer_closure) },
-        { be_const_key(run_deferred, 20), be_const_closure(Tasmota_run_deferred_closure) },
-        { be_const_key(add_fast_loop, -1), be_const_closure(Tasmota_add_fast_loop_closure) },
-        { be_const_key(exec_tele, 18), be_const_closure(Tasmota_exec_tele_closure) },
-        { be_const_key(load, -1), be_const_closure(Tasmota_load_closure) },
-        { be_const_key(add_driver, -1), be_const_closure(Tasmota_add_driver_closure) },
-        { be_const_key(remove_rule, 43), be_const_closure(Tasmota_remove_rule_closure) },
-        { be_const_key(cmd, 28), be_const_closure(Tasmota_cmd_closure) },
-        { be_const_key(remove_cron, 30), be_const_closure(Tasmota_remove_cron_closure) },
-        { be_const_key(next_cron, -1), be_const_closure(Tasmota_next_cron_closure) },
+        { be_const_key(_rules, -1), be_const_var(1) },
+        { be_const_key(_drivers, 4), be_const_var(5) },
+        { be_const_key(wire1, -1), be_const_var(6) },
+        { be_const_key(run_cron, 7), be_const_closure(Tasmota_run_cron_closure) },
+        { be_const_key(wire_scan, 9), be_const_closure(Tasmota_wire_scan_closure) },
+        { be_const_key(add_rule, -1), be_const_closure(Tasmota_add_rule_closure) },
+        { be_const_key(_fl, 36), be_const_var(0) },
         { be_const_key(get_light, -1), be_const_closure(Tasmota_get_light_closure) },
-        { be_const_key(set_light, 15), be_const_closure(Tasmota_set_light_closure) },
+        { be_const_key(find_op, -1), be_const_closure(Tasmota_find_op_closure) },
+        { be_const_key(init, -1), be_const_closure(Tasmota_init_closure) },
+        { be_const_key(_ccmd, -1), be_const_var(4) },
+        { be_const_key(set_timer, -1), be_const_closure(Tasmota_set_timer_closure) },
+        { be_const_key(urlfetch, -1), be_const_closure(Tasmota_urlfetch_closure) },
+        { be_const_key(exec_cmd, -1), be_const_closure(Tasmota_exec_cmd_closure) },
         { be_const_key(gc, -1), be_const_closure(Tasmota_gc_closure) },
-        { be_const_key(remove_driver, -1), be_const_closure(Tasmota_remove_driver_closure) },
-        { be_const_key(init, 0), be_const_closure(Tasmota_init_closure) },
-        { be_const_key(remove_fast_loop, -1), be_const_closure(Tasmota_remove_fast_loop_closure) },
-        { be_const_key(time_str, 19), be_const_closure(Tasmota_time_str_closure) },
-        { be_const_key(global, -1), be_const_var(9) },
+        { be_const_key(remove_fast_loop, 17), be_const_closure(Tasmota_remove_fast_loop_closure) },
+        { be_const_key(remove_cmd, -1), be_const_closure(Tasmota_remove_cmd_closure) },
+        { be_const_key(add_driver, 18), be_const_closure(Tasmota_add_driver_closure) },
+        { be_const_key(settings, 41), be_const_var(10) },
         { be_const_key(wire2, -1), be_const_var(7) },
+        { be_const_key(remove_driver, -1), be_const_closure(Tasmota_remove_driver_closure) },
+        { be_const_key(check_not_method, 29), be_const_closure(Tasmota_check_not_method_closure) },
+        { be_const_key(set_light, 37), be_const_closure(Tasmota_set_light_closure) },
+        { be_const_key(cmd_res, -1), be_const_var(8) },
+        { be_const_key(wd, 8), be_const_var(11) },
+        { be_const_key(urlfetch_cmd, -1), be_const_closure(Tasmota_urlfetch_cmd_closure) },
+        { be_const_key(global, 39), be_const_var(9) },
+        { be_const_key(time_str, -1), be_const_closure(Tasmota_time_str_closure) },
+        { be_const_key(try_rule, -1), be_const_closure(Tasmota_try_rule_closure) },
+        { be_const_key(exec_tele, -1), be_const_closure(Tasmota_exec_tele_closure) },
+        { be_const_key(add_cmd, -1), be_const_closure(Tasmota_add_cmd_closure) },
+        { be_const_key(load, -1), be_const_closure(Tasmota_load_closure) },
+        { be_const_key(add_fast_loop, -1), be_const_closure(Tasmota_add_fast_loop_closure) },
+        { be_const_key(next_cron, 15), be_const_closure(Tasmota_next_cron_closure) },
+        { be_const_key(_debug_present, -1), be_const_var(12) },
+        { be_const_key(_timers, -1), be_const_var(2) },
         { be_const_key(event, -1), be_const_closure(Tasmota_event_closure) },
         { be_const_key(fast_loop, -1), be_const_closure(Tasmota_fast_loop_closure) },
-        { be_const_key(cmd_res, 27), be_const_var(8) },
-        { be_const_key(_crons, -1), be_const_var(3) },
-        { be_const_key(add_cmd, -1), be_const_closure(Tasmota_add_cmd_closure) },
-        { be_const_key(_debug_present, -1), be_const_var(12) },
-        { be_const_key(wd, 22), be_const_var(11) },
-        { be_const_key(gen_cb, 34), be_const_closure(Tasmota_gen_cb_closure) },
-        { be_const_key(check_not_method, -1), be_const_closure(Tasmota_check_not_method_closure) },
-        { be_const_key(hs2rgb, 31), be_const_closure(Tasmota_hs2rgb_closure) },
-        { be_const_key(_rules, -1), be_const_var(1) },
-        { be_const_key(run_cron, -1), be_const_closure(Tasmota_run_cron_closure) },
-        { be_const_key(set_timer, -1), be_const_closure(Tasmota_set_timer_closure) },
-        { be_const_key(find_op, -1), be_const_closure(Tasmota_find_op_closure) },
-        { be_const_key(_drivers, 26), be_const_var(5) },
-        { be_const_key(_ccmd, -1), be_const_var(4) },
-        { be_const_key(settings, -1), be_const_var(10) },
-        { be_const_key(wire1, -1), be_const_var(6) },
-        { be_const_key(wire_scan, -1), be_const_closure(Tasmota_wire_scan_closure) },
-        { be_const_key(add_rule, -1), be_const_closure(Tasmota_add_rule_closure) },
-        { be_const_key(exec_rules, 10), be_const_closure(Tasmota_exec_rules_closure) },
-        { be_const_key(try_rule, 2), be_const_closure(Tasmota_try_rule_closure) },
-        { be_const_key(_fl, -1), be_const_var(0) },
+        { be_const_key(hs2rgb, 2), be_const_closure(Tasmota_hs2rgb_closure) },
     })),
     (bstring*) &be_const_str_Tasmota
 );


### PR DESCRIPTION
## Description:

Add command `UrlFetch <url>` to download directry from http(s) to filesystem (ESP32 only). This command is implemented in Berry.

Added `tasmota.urlfetch(url:string [, filename:string]) -> bytes:int`. `filename` is optional, needed if you want to change the name of the file from the url suffix. Returns the number of bytes downloaded or `-1` if failed.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
