### PR TITLE
Fix bug in Z_attribute::equalsCmd

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
@@ -561,7 +561,7 @@ bool Z_attribute::equalsKey(const Z_attribute & attr2, bool ignore_key_suffix) c
 
 bool Z_attribute::equalsId(uint16_t _cluster, uint16_t _attr_id, uint8_t suffix) const {
   if (key_is_cmd || key_is_str) { return false; }
-  if ((this->cluster == _cluster) && (this->attr_id == _attr_id) && (!this->key_is_cmd)) {
+  if ((this->cluster == _cluster) && (this->attr_id == _attr_id)) {
     if (suffix) {
       if (key_suffix == suffix) { return true; }
     } else {
@@ -574,7 +574,7 @@ bool Z_attribute::equalsId(uint16_t _cluster, uint16_t _attr_id, uint8_t suffix)
 bool Z_attribute::equalsCmd(uint16_t _cluster, uint8_t _cmd_id, bool _direction, bool cmd_general, uint8_t suffix) const {
   if (!key_is_cmd || key_is_str) { return false; }
   uint16_t _attr_id = _cmd_id | (_direction ? 0x100 : 0x000) | (cmd_general ? 0x200 : 0x000);
-  if ((this->cluster == _cluster) && (this->attr_id == _attr_id) && (this->key_is_cmd)) {
+  if ((this->cluster == _cluster) && (this->attr_id == _attr_id)) {
     if (suffix) {
       if (key_suffix == suffix) { return true; }
     } else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
@@ -572,9 +572,9 @@ bool Z_attribute::equalsId(uint16_t _cluster, uint16_t _attr_id, uint8_t suffix)
 }
 
 bool Z_attribute::equalsCmd(uint16_t _cluster, uint8_t _cmd_id, bool _direction, bool cmd_general, uint8_t suffix) const {
-  if (!key_is_cmd ||key_is_str) { return false; }
+  if (!key_is_cmd || key_is_str) { return false; }
   uint16_t _attr_id = _cmd_id | (_direction ? 0x100 : 0x000) | (cmd_general ? 0x200 : 0x000);
-  if ((this->cluster == _cluster) && (this->attr_id == _attr_id) && (!this->key_is_cmd)) {
+  if ((this->cluster == _cluster) && (this->attr_id == _attr_id) && (this->key_is_cmd)) {
     if (suffix) {
       if (key_suffix == suffix) { return true; }
     } else {


### PR DESCRIPTION
## Description:

Fix bug reported by @qlwz here: https://github.com/arendst/Tasmota/commit/289c3f6c55cfa46fcd45cf572b0cc8f14011b872#commitcomment-84443997

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
