### PR TITLE
Respect m_flags.skip in OpenTherm polling.

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_69_opentherm_protocol.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_69_opentherm_protocol.ino
@@ -539,7 +539,7 @@ unsigned long sns_opentherm_get_next_request(struct OT_BOILER_STATUS_T *boilerSt
     {
         struct OpenThermCommandT *cmd = &sns_opentherm_commands[sns_opentherm_current_command];
         // Return error if command known as not supported
-        if (!cmd->m_flags.notSupported)
+        if (!cmd->m_flags.notSupported && !cmd->m_flags.skip)
         {
             // Retrurn OT compatible request
             return cmd->m_ot_make_request(cmd, boilerStatus);


### PR DESCRIPTION
## Description:

Currently OpenTherm regularly (and I think unnecessarily) calls the Boiler Lock-Out Reset command, with an error message on the console. I think it is because the poller does not respect the m_flags.skip marker, which I suggest to fix in this pull request.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
