### PR TITLE
Setoption147 (MQTT) Disable publish SSerialReceived MQTT messages. If disabled, you must use event trigger rules instead.

### DIFF
--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -283,8 +283,8 @@ String EthernetMacAddress(void);
 #ifndef MQTT_CLEAN_SESSION
 #define MQTT_CLEAN_SESSION          1          // 0 = No clean session, 1 = Clean session (default)
 #endif
-#ifndef MQTT_SSERIALRECEIVED
-#define MQTT_SSERIALRECEIVED        1          // 0 = Disable sserialreceived mqtt messages, 1 = Enable sserialreceived mqtt messages (default)
+#ifndef MQTT_DISABLE_SSERIALRECEIVED        
+#define MQTT_DISABLE_SSERIALRECEIVED 0         // 1 = Disable sserialreceived mqtt messages, 0 = Enable sserialreceived mqtt messages (default)
 #endif
 #ifndef MQTT_LWT_OFFLINE
 #define MQTT_LWT_OFFLINE            "Offline"  // MQTT LWT offline topic message

--- a/tasmota/include/tasmota_globals.h
+++ b/tasmota/include/tasmota_globals.h
@@ -283,6 +283,9 @@ String EthernetMacAddress(void);
 #ifndef MQTT_CLEAN_SESSION
 #define MQTT_CLEAN_SESSION          1          // 0 = No clean session, 1 = Clean session (default)
 #endif
+#ifndef MQTT_SSERIALRECEIVED
+#define MQTT_SSERIALRECEIVED        1          // 0 = Disable sserialreceived mqtt messages, 1 = Enable sserialreceived mqtt messages (default)
+#endif
 #ifndef MQTT_LWT_OFFLINE
 #define MQTT_LWT_OFFLINE            "Offline"  // MQTT LWT offline topic message
 #endif

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -180,7 +180,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption146 .. SetOption177
     uint32_t use_esp32_temperature : 1;    // bit 0  (v12.1.1.1) - SetOption146 - (ESP32) Show ESP32 internal temperature sensor
-    uint32_t mqtt_disable_sserialrec : 1;  // bit 1  (v12.1.1.1) - SetOption147 - (MQTT) Disable publish SSerialReceived MQTT messages, you must use event trigger rules instead.
+    uint32_t mqtt_disable_sserialrec : 1;  // bit 1  (v12.1.1.2) - SetOption147 - (MQTT) Disable publish SSerialReceived MQTT messages, you must use event trigger rules instead.
     uint32_t spare02 : 1;                  // bit 2
     uint32_t spare03 : 1;                  // bit 3
     uint32_t spare04 : 1;                  // bit 4

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -180,7 +180,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption146 .. SetOption177
     uint32_t use_esp32_temperature : 1;    // bit 0  (v12.1.1.1) - SetOption146 - (ESP32) Show ESP32 internal temperature sensor
-    uint32_t mqtt_disable_sserialrec : 1;  // bit 1  (v12.x.x.x) - SetOption147 - (MQTT) Disable publish SSerialReceived MQTT messages, you must use event trigger rules instead.
+    uint32_t mqtt_disable_sserialrec : 1;  // bit 1  (v12.1.1.1) - SetOption147 - (MQTT) Disable publish SSerialReceived MQTT messages, you must use event trigger rules instead.
     uint32_t spare02 : 1;                  // bit 2
     uint32_t spare03 : 1;                  // bit 3
     uint32_t spare04 : 1;                  // bit 4

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -180,7 +180,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption146 .. SetOption177
     uint32_t use_esp32_temperature : 1;    // bit 0  (v12.1.1.1) - SetOption146 - (ESP32) Show ESP32 internal temperature sensor
-    uint32_t mqtt_sserialreceived : 1;     // bit 1  (v12.x.x.x) - SetOption147 - (MQTT) Enable publish SSerialReceived MQTT messages. If disabled, use event rules instead.
+    uint32_t mqtt_disable_sserialrec : 1;  // bit 1  (v12.x.x.x) - SetOption147 - (MQTT) Disable publish SSerialReceived MQTT messages, you must use event trigger rules instead.
     uint32_t spare02 : 1;                  // bit 2
     uint32_t spare03 : 1;                  // bit 3
     uint32_t spare04 : 1;                  // bit 4

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -180,7 +180,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
   uint32_t data;                           // Allow bit manipulation using SetOption
   struct {                                 // SetOption146 .. SetOption177
     uint32_t use_esp32_temperature : 1;    // bit 0  (v12.1.1.1) - SetOption146 - (ESP32) Show ESP32 internal temperature sensor
-    uint32_t spare01 : 1;                  // bit 1
+    uint32_t mqtt_sserialreceived : 1;     // bit 1  (v12.x.x.x) - SetOption147 - (MQTT) Enable publish SSerialReceived MQTT messages. If disabled, use event rules instead.
     uint32_t spare02 : 1;                  // bit 2
     uint32_t spare03 : 1;                  // bit 3
     uint32_t spare04 : 1;                  // bit 4

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -428,6 +428,7 @@
 
 #define MQTT_TELE_RETAIN       0                 // Tele messages may send retain flag (0 = off, 1 = on)
 #define MQTT_CLEAN_SESSION     1                 // Mqtt clean session connection (0 = No clean session, 1 = Clean session (default))
+#define MQTT_DISABLE_SSERIALRECEIVED 0           // 1 = Disable sserialreceived mqtt messages, 0 = Enable sserialreceived mqtt messages (default)
 
 // -- MQTT - Domoticz -----------------------------
 #define USE_DOMOTICZ                             // Enable Domoticz (+6k code, +0.3k mem)

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -1256,6 +1256,7 @@ void SettingsDefaultSet2(void) {
   Settings->flag3 = flag3;
   Settings->flag4 = flag4;
   Settings->flag5 = flag5;
+  Settings->flag6 = flag6;
 }
 
 void SettingsDefaultSet3(void) {

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -992,6 +992,7 @@ void SettingsDefaultSet2(void) {
   flag5.mqtt_status_retain |= MQTT_STATUS_RETAIN;
   flag5.mqtt_switches |= MQTT_SWITCHES;
   flag5.mqtt_persistent |= ~MQTT_CLEAN_SESSION;
+  flag6.mqtt_sserialreceived |= MQTT_SSERIALRECEIVED;
 //  flag.mqtt_serial |= 0;
   flag.device_index_enable |= MQTT_POWER_FORMAT;
   flag3.time_append_timezone |= MQTT_APPEND_TIMEZONE;

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -838,7 +838,7 @@ void SettingsDefaultSet2(void) {
   SOBitfield3  flag3 = { 0 };
   SOBitfield4  flag4 = { 0 };
   SOBitfield5  flag5 = { 0 };
-  SOBitfield5  flag6 = { 0 };
+  SOBitfield6  flag6 = { 0 };
   SysMBitfield1  flag2 = { 0 };
   SysMBitfield2  mbflag2 = { 0 };
 

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -838,6 +838,7 @@ void SettingsDefaultSet2(void) {
   SOBitfield3  flag3 = { 0 };
   SOBitfield4  flag4 = { 0 };
   SOBitfield5  flag5 = { 0 };
+  SOBitfield5  flag6 = { 0 };
   SysMBitfield1  flag2 = { 0 };
   SysMBitfield2  mbflag2 = { 0 };
 

--- a/tasmota/tasmota_support/settings.ino
+++ b/tasmota/tasmota_support/settings.ino
@@ -993,7 +993,7 @@ void SettingsDefaultSet2(void) {
   flag5.mqtt_status_retain |= MQTT_STATUS_RETAIN;
   flag5.mqtt_switches |= MQTT_SWITCHES;
   flag5.mqtt_persistent |= ~MQTT_CLEAN_SESSION;
-  flag6.mqtt_sserialreceived |= MQTT_SSERIALRECEIVED;
+  flag6.mqtt_disable_sserialrec |= MQTT_DISABLE_SSERIALRECEIVED;
 //  flag.mqtt_serial |= 0;
   flag.device_index_enable |= MQTT_POWER_FORMAT;
   flag3.time_append_timezone |= MQTT_APPEND_TIMEZONE;

--- a/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
@@ -167,11 +167,11 @@ void SerialBridgeInput(void) {
     }
     ResponseJsonEnd();
 
-    if (Settings->flag6.mqtt_sserialreceived) {  // SetOption147  (MQTT) Enable publish SSerialReceived MQTT messages. If disabled, use event rules instead.
-      MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
+    if (Settings->flag6.mqtt_disable_sserialrec ) {  // SetOption147  If it is activated, Tasmota will not publish SSerialReceived MQTT messages, but it will proccess event trigger rules
+       XdrvRulesProcess(0);
     } else {
-      XdrvRulesProcess(0);
-    }
+      MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
+    }    
     serial_bridge_in_byte_counter = 0;
   }
 }

--- a/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
@@ -167,7 +167,11 @@ void SerialBridgeInput(void) {
     }
     ResponseJsonEnd();
 
-    MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
+    if (Settings->flag6.mqtt_sserialreceived) {  // SetOption147  (MQTT) Enable publish SSerialReceived MQTT messages. If disabled, use event rules instead.
+      MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
+    } else {
+      XdrvRulesProcess(0);
+    }
     serial_bridge_in_byte_counter = 0;
   }
 }


### PR DESCRIPTION
## Description:

This option helps when we have a device that send by its own serial data every X seconds.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

Add SetOption147  (MQTT) Enable publish SSerialReceived MQTT messages. If disabled, use event rules instead.

If it is disabled, tasmota will not publish an MQTT message every time a SSerialReceived event fires.

Use rules to control how and when publish these messages.

DEfault value is ENABLED so anyone is affected if they don't change this 147 option value.