### PR TITLE
Zigbee allow spaces in names

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -446,6 +446,36 @@ char* RemoveSpace(char* p) {
   return p;
 }
 
+// remove spaces at the beginning and end of the string (but not in the middle)
+char* TrimSpace(char *p) {
+  // Remove white-space character (' ','\t','\n','\v','\f','\r')
+  char* write = p;
+  char* read = p;
+  char ch = '.';
+
+  // skip all leading spaces
+  while (isspace(*read)) {
+    read++;
+  }
+  // copy the rest
+  do {
+    ch = *read++;
+    *write++ = ch;
+  } while (ch != '\0');
+  // move to end
+  read = p + strlen(p);
+  // move backwards
+  while (p != read) {
+    read--;
+    if (isspace(*read)) {
+      *read = '\0';
+    } else {
+      break;
+    }
+  }
+  return p;
+}
+
 char* RemoveControlCharacter(char* p) {
   // Remove control character (0x00 .. 0x1F and 0x7F)
   char* write = p;

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_2a_devices_impl.ino
@@ -651,7 +651,7 @@ Z_Device & Z_Devices::parseDeviceFromName(const char * param, uint16_t * parsed_
   size_t param_len = strlen(param);
   char dataBuf[param_len + 1];
   strcpy(dataBuf, param);
-  RemoveSpace(dataBuf);
+  TrimSpace(dataBuf);
   if (parsed_shortaddr != nullptr) { *parsed_shortaddr = BAD_SHORTADDR; }   // if it goes wrong, mark as bad
 
   if ((dataBuf[0] >= '0') && (dataBuf[0] <= '9') && (strlen(dataBuf) < 4)) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -1091,13 +1091,13 @@ void ZigbeeMapAllDevices(void) {
 //
 void CmndZbMap(void) {
   if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
 
   if (strlen(XdrvMailbox.data) == 0) {
     ZigbeeMapAllDevices();
     ResponseCmndDone();
   } else {
-  CmndZbBindState_or_Map(true);
+    CmndZbBindState_or_Map(true);
   }
 }
 
@@ -1301,7 +1301,7 @@ void CmndZbInfo_inner(const Z_Device & device) {
 }
 void CmndZbInfo(void) {
   if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
 
   if (strlen(XdrvMailbox.data) == 0) {
     // if empty, dump for all values
@@ -1352,7 +1352,7 @@ void CmndZbSave(void) {
 //
 void CmndZbLoad(void) {
   // can be called before Zigbee is initialized
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
   
   bool ret = true;;
   if (strcmp(XdrvMailbox.data, "*") == 0) {
@@ -1373,7 +1373,7 @@ void CmndZbLoad(void) {
 //
 void CmndZbUnload(void) {
   // can be called before Zigbee is initialized
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
   
   bool ret = ZbUnload(XdrvMailbox.data);
   if (ret) {
@@ -1466,7 +1466,7 @@ void CmndZbcie(void) {
 //   ZbRestore {"Device":"0x5ADF","Name":"Petite_Lampe","IEEEAddr":"0x90FD9FFFFE03B051","ModelId":"TRADFRI bulb E27 WS opal 980lm","Manufacturer":"IKEA of Sweden","Endpoints":["0x01","0xF2"]}
 void CmndZbRestore(void) {
   if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
 
   if (strlen(XdrvMailbox.data) == 0) {
     // if empty, log values for all devices
@@ -1703,7 +1703,7 @@ void CmndZbStatus(void) {
 //
 void CmndZbData(void) {
   if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
 
   if (strlen(XdrvMailbox.data) == 0) {
     // if empty, log values for all devices
@@ -1748,7 +1748,7 @@ void CmndZbConfig(void) {
   int8_t      zb_txradio_dbm = Settings->zb_txradio_dbm;
 
   // if (zigbee.init_phase) { ResponseCmndChar_P(PSTR(D_ZIGBEE_NOT_STARTED)); return; }
-  RemoveSpace(XdrvMailbox.data);
+  TrimSpace(XdrvMailbox.data);
   if (strlen(XdrvMailbox.data) > 0) {
     JsonParser parser(XdrvMailbox.data);
     JsonParserObject root = parser.getRootObject();


### PR DESCRIPTION
## Description:

Allow spaces in Zigbee friendly names.
Added `TrimSpaces()` function to `support.ino`

Fixes: #16592

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
