### PR TITLE
add board definition for S3-EYE

### DIFF
--- a/boards/esp32s3cdc-eye.json
+++ b/boards/esp32s3cdc-eye.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_opi"
+    },
+    "core": "esp32",
+    "extra_flags": "-DCAMERA_MODEL_ESP32S3_EYE -DBOARD_HAS_PSRAM -DARDUINO_USB_MODE=1 -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0 -DUSE_USB_CDC_CONSOLE -DESP32_8M -DESP32S3",
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "esp32s3",
+    "partitions": "partitions/esp32_partition_app2944k_fs2M.csv"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "ethernet"
+  ],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": [
+      "esp-builtin"
+    ],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "espidf",
+    "arduino"
+  ],
+  "name": "ESP32-S3-EYE 8M Flash 8MB OPI PSRAM, Tasmota 2944k Code/OTA, 2M FS",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "before_reset": "usb_reset",
+    "speed": 460800
+  },
+  "url": "https://github.com/espressif/esp-who/blob/master/docs/en/get-started/ESP32-S3-EYE_Getting_Started_Guide.md",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
## Description:

Add board definition for S3-EYE with 8 MB Flash and 8 MB PSRAM (QIO/OPI).
Tested on a Maple Eye ESP32-S3 Board including webcam functionality, which can run the binaries for the S3-EYE and should be compatible.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
