### PR TITLE
zigbee prepare for multiple Alexa devices per zigbee device

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_20_hue.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_20_hue.ino
@@ -619,10 +619,26 @@ void HueLightStatus2(uint8_t device, String *response)
 }
 #endif // USE_LIGHT
 
-// generate a unique lightId mixing local IP address and device number
-// it is limited to 32 devices.
-// last 24 bits of Mac address + 4 bits of local light + high bit for relays 16-31, relay 32 is mapped to 0
-// Zigbee extension: bit 29 = 1, and last 16 bits = short address of Zigbee device
+// generate a unique lightId mixing local mac address and device number
+//
+// Bits:
+//   0.. 3: low 4 bits of lightId - starting at 1 (encodes for 32+1..15 if bit 28 is 0, or 16..31 if bit 28 is 1)
+//   4..27: low 24 bits of mac address
+//      28: used to encode lightId 16..32
+//      29: zigbee device (1=zigbee, short address is encoded bit 15..0)
+//  31..32: unused, must be set to 0
+//
+// When in Zigbee mode (bit 29 == 1)
+//   0..15: short address of zigbee device
+//  16..23: endpoint on zigbee device (0..249), 0 means default endpoint (usually 1)
+//  24..28: unused, must be 0
+//      29: 1 (zigbee mode)
+//  31..32: unused, must be set to 0
+//
+// Parameters:
+//  - relay_id: contains the lightId (1..32) or the Zigbee endpoint (0..250, 0 means default endpoint)
+//  - z_shortaddr: Zigbee short addresses. Non-zero means Zigbee, zero means local (non-zigbee)
+//
 uint32_t EncodeLightIdZigbee(uint8_t relay_id, uint16_t z_shortaddr)
 {
   uint8_t mac[6];
@@ -637,9 +653,9 @@ uint32_t EncodeLightIdZigbee(uint8_t relay_id, uint16_t z_shortaddr)
   }
   id |= (relay_id & 0xF);
 #ifdef USE_ZIGBEE
-  if ((z_shortaddr) && (!relay_id)) {
+  if (z_shortaddr) {
     // fror Zigbee devices, we have relay_id == 0 and shortaddr != 0
-    id = (1 << 29) | z_shortaddr;
+    id = (1 << 29) | (relay_id << 16) | z_shortaddr;
   }
 #endif
 
@@ -651,11 +667,8 @@ uint32_t EncodeLightId(uint8_t relay_id)
   return EncodeLightIdZigbee(relay_id, 0);
 }
 
-// get hue_id and decode the relay_id
-// 4 LSB decode to 1-15, if bit 28 is set, it encodes 16-31, if 0 then 32
-// Zigbee:
-// If the Id encodes a Zigbee device (meaning bit 29 is set)
-// it returns 0 and sets the 'shortaddr' to the device short address
+// See above for encoding
+// 
 uint32_t DecodeLightIdZigbee(uint32_t hue_id, uint16_t * shortaddr)
 {
   uint8_t relay_id = hue_id & 0xF;
@@ -670,7 +683,7 @@ uint32_t DecodeLightIdZigbee(uint32_t hue_id, uint16_t * shortaddr)
   if (hue_id & (1 << 29)) {
     // this is actually a Zigbee ID
     if (shortaddr) { *shortaddr = hue_id & 0xFFFF; }
-    relay_id = 0;
+    relay_id = (hue_id >> 16) & 0xFF;
   }
 #endif // USE_ZIGBEE
   return relay_id;
@@ -974,9 +987,9 @@ void HueLights(String *path_req)
     device = DecodeLightId(device_id);
 #ifdef USE_ZIGBEE
     uint16_t shortaddr;
-    device = DecodeLightIdZigbee(device_id, &shortaddr);
+    device = DecodeLightIdZigbee(device_id, &shortaddr);  // device is endpoint when in Zigbee mode
     if (shortaddr) {
-      code = ZigbeeHandleHue(shortaddr, device_id, response);
+      code = ZigbeeHandleHue(shortaddr, device_id, device, response);
       goto exit;
     }
 #endif // USE_ZIGBEE

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_6_5_hue.ino
@@ -223,7 +223,7 @@ void ZigbeeHueHS(uint16_t shortaddr, uint16_t hue, uint8_t sat) {
   light.setHue(hue);
 }
 
-int32_t ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, String &response) {
+int32_t ZigbeeHandleHue(uint16_t shortaddr, uint32_t device_id, uint8_t endpoint, String &response) {
   uint8_t  bri, sat;
   uint16_t ct, hue;
 


### PR DESCRIPTION
## Description:

Prepare for Alexa to control multiple ways zigbee switches, allowing to distinguish endpoints on the same device.

The feature is not yet available.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
