### PR TITLE
Prepare for one Tasmota pio Platform

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -46,10 +46,10 @@ FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
 if "CORE32SOLO1" in extra_flags:
     # enable next line when one Platform PR is done!
     #FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
-    #print ("-----extra_flags----", extra_flags)
+    print ("Build with Solo1 framework")
 elif "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
-    #print ("-----build_flags----", build_flags)
+    print ("Build with ITEAD framework)
 
 variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
 

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -43,7 +43,7 @@ sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
-if "CORE32SOLO1" in extra_flags:
+if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags:
     # enable next line when one Platform PR is done!
     #FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
     print ("Build with Solo1 framework")

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -49,7 +49,7 @@ if "CORE32SOLO1" in extra_flags:
     print ("Build with Solo1 framework")
 elif "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
-    print ("Build with ITEAD framework)
+    print ("Build with ITEAD framework")
 
 variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
 

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -22,6 +22,13 @@ Import("env")
 
 env = DefaultEnvironment()
 platform = env.PioPlatform()
+board = env.BoardConfig()
+extra_flags = board.get("build.extra_flags", "")
+extra_flags = [element.replace("-D", " ") for element in extra_flags]
+extra_flags = ''.join(extra_flags)
+build_flags = env.GetProjectOption("build_flags")
+build_flags = [element.replace("-D", " ") for element in build_flags]
+build_flags = ''.join(build_flags)
 
 from genericpath import exists
 import os
@@ -36,6 +43,13 @@ sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+if "CORE32SOLO1" in extra_flags:
+    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
+    #print ("-----extra_flags----", extra_flags)
+elif "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
+    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
+    #print ("-----build_flags----", build_flags)
+
 variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
 
 def esp32_create_chip_string(chip):

--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -44,7 +44,8 @@ import esptool
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
 if "CORE32SOLO1" in extra_flags:
-    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
+    # enable next line when one Platform PR is done!
+    #FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
     #print ("-----extra_flags----", extra_flags)
 elif "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
     FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")


### PR DESCRIPTION
## Description:

A later PR will reduce the 3 Tasmota Platforms for the 3 different Arduino cores to one Platform . This will simplify setup and no more framework reinstalls are needed, when compiling Tasmota for solo1 or for ITEAD devices (Zigbee Bridge Pro / NSPanel). This will make it possible (again) to build Tasmota without Internet connection. 

The setup is already done, and needs some more testing. It is here:  [https://github.com/Jason2866/Tasmota/tree/refac_pio](https://github.com/Jason2866/Tasmota/tree/refac_pio
)

This PR prepares for this, there should be no functional change.
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
