### PR TITLE
One Tasmota Platformio Platform for all framework variants

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -22,6 +22,13 @@ Import("env")
 
 env = DefaultEnvironment()
 platform = env.PioPlatform()
+board = env.BoardConfig()
+extra_flags = board.get("build.extra_flags", "")
+extra_flags = [element.replace("-D", " ") for element in extra_flags]
+extra_flags = ''.join(extra_flags)
+build_flags = env.GetProjectOption("build_flags")
+build_flags = [element.replace("-D", " ") for element in build_flags]
+build_flags = ''.join(build_flags)
 
 from genericpath import exists
 import os
@@ -36,6 +43,13 @@ sys.path.append(join(platform.get_package_dir("tool-esptoolpy")))
 import esptool
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+if "CORE32SOLO1" in extra_flags or "FRAMEWORK_ARDUINO_SOLO1" in build_flags:
+    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-solo1")
+    print ("Building with Solo1 framework")
+elif "FRAMEWORK_ARDUINO_ITEAD" in build_flags:
+    FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-ITEAD")
+    print ("Building with ITEAD framework")
+
 variants_dir = join(FRAMEWORK_DIR, "variants", "tasmota")
 
 def esp32_create_chip_string(chip):

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -40,20 +40,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5/platform-espressif32-2.0.5.zip
-platform_packages           =
-build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${esp32_defaults.build_flags}
-
-
-[core32solo1]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5/platform-espressif32-solo1-2.0.5.zip
-platform_packages           =
-build_unflags               = ${esp32_defaults.build_unflags}
-build_flags                 = ${esp32_defaults.build_flags}
-
-[core32itead]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5/platform-espressif32-ITEAD-2.0.5.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.5.1/platform-espressif32-2.0.5.1.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}

--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -111,12 +111,8 @@ monitor_filters         = esp32_exception_decoder
 [env:tasmota32solo1-ocd]
 build_type              = debug
 extends                 = env:tasmota32solo1
-platform                = ${core32solo1.platform}
-platform_packages       = ${core32solo1.platform_packages}
 board                   = esp32_solo1_4M
 debug_tool              = esp-prog
 upload_protocol         = esp-prog
 debug_init_break        = tbreak setup
-build_unflags           = ${core32solo1.build_unflags}
-build_flags             = ${core32solo1.build_flags}
 monitor_filters         = esp32_exception_decoder

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -104,15 +104,10 @@ lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_ssl
 [env:tasmota32solo1]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1_4M
-platform                = ${core32solo1.platform}
-platform_packages       = ${core32solo1.platform_packages}
-build_flags             = ${core32solo1.build_flags} -DFIRMWARE_TASMOTA32
 
 [env:tasmota32solo1-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1_4M
-platform                = ${core32solo1.platform}
-platform_packages       = ${core32solo1.platform_packages}
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
@@ -123,10 +118,9 @@ lib_ignore              =
 [env:tasmota32-zbbrdgpro]
 extends                 = env:tasmota32_base
 board                   = esp32_4M_FS
-platform                = ${core32itead.platform}
-platform_packages       = ${core32itead.platform_packages}
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_ZBBRDGPRO
+                          -DFRAMEWORK_ARDUINO_ITEAD
 custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
                           tools/fw_SonoffZigbeeBridgePro_cc2652/Sonoff_ZBPro.autoconf
                           tasmota/berry/zigbee/cc2652_flasher.be
@@ -137,10 +131,9 @@ lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
 
 [env:tasmota32-nspanel]
 extends                 = env:tasmota32_base
-platform                = ${core32itead.platform}
-platform_packages       = ${core32itead.platform_packages}
 build_flags             = ${env:tasmota32_base.build_flags}
                           -DFIRMWARE_NSPANEL
+                          -DFRAMEWORK_ARDUINO_ITEAD
 
 [env:tasmota32c3-safeboot]
 extends                 = env:tasmota32_base


### PR DESCRIPTION
## Description:

The PR reduces the 3 Tasmota Platforms for the different Arduino cores to one. This simplifys the setup and no more framework reinstalls will be done (when compiling Tasmota for solo1 or for ITEAD devices (Zigbee Bridge Pro / NSPanel)). 

This makes it again possible to build Tasmota without Internet connection.

To activate the needed framework for solo1 there are 2 possibilities.
The entry `-DCORE32SOLO1` in boards manifest under `extra_flags`
or the compile flag `-DFRAMEWORK_ARDUINO_SOLO1` in the env.
For selecting the ITEAD framework the compile flag
`-DFRAMEWORK_ARDUINO_ITEAD` needs to be added in the env.

Obsolets #16635

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
