### PR TITLE
Add support alias for ds18x20 sensors. 

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -751,6 +751,9 @@
 // Commands xsns_02_analog.ino
 #define D_CMND_ADCPARAM "AdcParam"
 
+// Commands xsns_05_ds18x20.ino
+#define D_CMND_DS_ALIAS "DS18Alias"
+
 // xsns_70_veml6075.ino
 #define D_JSON_UVA_INTENSITY "UvaIntensity"
 #define D_JSON_UVB_INTENSITY  "UvbIntensity"

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -579,6 +579,7 @@
 // -- One wire sensors ----------------------------
 #define USE_DS18x20                              // Add support for DS18x20 sensors with id sort, single scan and read retry (+2k6 code)
 //  #define W1_PARASITE_POWER                      // Optimize for parasite powered sensors
+#define DS18x20_USE_ID_ALIAS
 
 // -- I2C sensors ---------------------------------
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -579,7 +579,7 @@
 // -- One wire sensors ----------------------------
 #define USE_DS18x20                              // Add support for DS18x20 sensors with id sort, single scan and read retry (+2k6 code)
 //  #define W1_PARASITE_POWER                      // Optimize for parasite powered sensors
-#define DS18x20_USE_ID_ALIAS
+//  #define DS18x20_USE_ID_ALIAS
 
 // -- I2C sensors ---------------------------------
 #define USE_I2C                                  // I2C using library wire (+10k code, 0k2 mem, 124 iram)

--- a/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
@@ -28,8 +28,8 @@
 //#define USE_DS18x20_RECONFIGURE    // When sensor is lost keep retrying or re-configure
 //#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
       
-#define DS18x20_USE_ID_ALIAS
-/* Use alias for fixed sensor name in scripts by autoexec. Command: DS18Alias XXXXXXXXXXXXXXXX,N where XXXXXXXXXXXXXXXX full serial and N number 1-255
+/* #define DS18x20_USE_ID_ALIAS in my_user_config.h or user_config_override.h
+  * Use alias for fixed sensor name in scripts by autoexec. Command: DS18Alias XXXXXXXXXXXXXXXX,N where XXXXXXXXXXXXXXXX full serial and N number 1-255
   * Result in JSON:  "DS18Alias_2":{"Id":"000003287CD8","Temperature":26.3} (example with N=2)
   * add 8 bytes used memory
 */

--- a/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_05_ds18x20.ino
@@ -27,6 +27,12 @@
 
 //#define USE_DS18x20_RECONFIGURE    // When sensor is lost keep retrying or re-configure
 //#define DS18x20_USE_ID_AS_NAME      // Use last 3 bytes for naming of sensors
+      
+#define DS18x20_USE_ID_ALIAS
+/* Use alias for fixed sensor name in scripts by autoexec. Command: DS18Alias XXXXXXXXXXXXXXXX,N where XXXXXXXXXXXXXXXX full serial and N number 1-255
+  * Result in JSON:  "DS18Alias_2":{"Id":"000003287CD8","Temperature":26.3} (example with N=2)
+  * add 8 bytes used memory
+*/
 
 #define DS18S20_CHIPID       0x10  // +/-0.5C 9-bit
 #define DS1822_CHIPID        0x22  // +/-2C 12-bit
@@ -54,6 +60,9 @@ struct {
   uint8_t address[8];
   uint8_t index;
   uint8_t valid;
+#ifdef DS18x20_USE_ID_ALIAS
+  uint8_t alias;
+#endif //DS18x20_USE_ID_ALIAS  
 } ds18x20_sensor[DS18X20_MAX_SENSORS];
 
 struct {
@@ -325,6 +334,9 @@ void Ds18x20Init(void) {
       for (uint32_t j = 6; j > 0; j--) {
         ids[DS18X20Data.sensors] = ids[DS18X20Data.sensors] << 8 | ds18x20_sensor[DS18X20Data.sensors].address[j];
       }
+#ifdef DS18x20_USE_ID_ALIAS      
+      ds18x20_sensor[DS18X20Data.sensors].alias=0;
+#endif
       DS18X20Data.sensors++;
     }
   }
@@ -434,7 +446,15 @@ void Ds18x20Name(uint8_t sensor) {
     }
     snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%s"), DS18X20Data.name, IndexSeparator(), address);
 #else
+#ifdef DS18x20_USE_ID_ALIAS
+    if (ds18x20_sensor[sensor].alias) {
+      snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("DS18Alias%c%d"), IndexSeparator(), ds18x20_sensor[sensor].alias);
+    } else {
+#endif
     snprintf_P(DS18X20Data.name, sizeof(DS18X20Data.name), PSTR("%s%c%d"), DS18X20Data.name, IndexSeparator(), sensor +1);
+#ifdef DS18x20_USE_ID_ALIAS
+    }
+#endif
 #endif
   }
 }
@@ -513,6 +533,47 @@ void Ds18x20Show(bool json) {
   }
 }
 
+#ifdef DS18x20_USE_ID_ALIAS
+const char kds18Commands[] PROGMEM = "|"  // No prefix
+  D_CMND_DS_ALIAS;
+
+void (* const DSCommand[])(void) PROGMEM = {
+  &CmndDSAlias };
+
+void CmndDSAlias(void) {
+  uint8_t tmp;
+  uint8_t sensor=255;
+  char argument[XdrvMailbox.data_len];
+  char address[17];
+  
+  if (ArgC()==2) {
+    tmp=atoi(ArgV(argument, 2));
+    ArgV(argument,1);
+
+    for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
+      for (uint32_t j = 0; j < 8; j++) {
+        sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);
+      }
+      if (!strncmp(argument,address,12)) {
+        ds18x20_sensor[i].alias=tmp;
+        break;
+      }
+    }
+  }
+  Response_P(PSTR("{"));
+  for (uint32_t i = 0; i < DS18X20Data.sensors; i++) {
+    Ds18x20Name(i);
+    char address[17];
+    for (uint32_t j = 0; j < 8; j++) {
+      sprintf(address+2*j, "%02X", ds18x20_sensor[i].address[7-j]);  // Skip sensor type and crc
+    }
+    ResponseAppend_P(PSTR("\"%s\":{\"" D_JSON_ID "\":\"%s\"}"),DS18X20Data.name, address);
+    if (i < DS18X20Data.sensors-1) {ResponseAppend_P(PSTR(","));}
+  }
+  ResponseAppend_P(PSTR("}"));
+}
+#endif // DS18x20_USE_ID_ALIAS
+
 /*********************************************************************************************\
  * Interface
 \*********************************************************************************************/
@@ -536,6 +597,11 @@ bool Xsns05(uint8_t function) {
         Ds18x20Show(0);
         break;
 #endif  // USE_WEBSERVER
+#ifdef DS18x20_USE_ID_ALIAS
+      case FUNC_COMMAND:
+        result = DecodeCommand(kds18Commands, DSCommand);
+        break;
+#endif // DS18x20_USE_ID_ALIAS
     }
   }
   return result;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #6970
ESP8266 and ESP32 support now.
Added command
`DS18Alias XXXXXXXXXXXXXXXX,N`
where XXXXXXXXXXXXXXXX **full** SN of sensor and N - number 1..255
If use command without arguments in result printing current **full** SN and name in JSON
After set aliases you can use this in scripts or rules.
Initial settings can be make from autoexec.bat or MQTT

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
