### PR TITLE
Berry add ``introspect.setmodule(name:string, value:any) -> nil``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Zigbee support for decimal Voltage/Current/Power on power metering plugs
 - Command ``UrlFetch <url>`` to download a file to filesystem
 - Zigbee basic support for Green Power
+- Berry add ``introspect.setmodule(name:string, value:any) -> nil``
 
 ### Changed
 - ESP32 Increase number of button GPIOs from 8 to 28 (#16518)

--- a/lib/libesp32/berry/src/be_module.c
+++ b/lib/libesp32/berry/src/be_module.c
@@ -245,7 +245,7 @@ static bvalue* load_cached(bvm *vm, bstring *path)
     return v;
 }
 
-static void cache_module(bvm *vm, bstring *name)
+void be_cache_module(bvm *vm, bstring *name)
 {
     bvalue *v;
     if (vm->module.loaded == NULL) {
@@ -282,7 +282,7 @@ int be_module_load(bvm *vm, bstring *path)
         if (res == BE_OK) {
             /* on first load of the module, try running the '()' function */
             module_init(vm);
-            cache_module(vm, path);
+            be_cache_module(vm, path);
         }
     }
     return res;

--- a/lib/libesp32/berry/src/be_module.h
+++ b/lib/libesp32/berry/src/be_module.h
@@ -34,6 +34,7 @@ typedef struct bmodule {
 bmodule* be_module_new(bvm *vm);
 void be_module_delete(bvm *vm, bmodule *module);
 int be_module_load(bvm *vm, bstring *path);
+void be_cache_module(bvm *vm, bstring *name);
 int be_module_attr(bvm *vm, bmodule *module, bstring *attr, bvalue *dst);
 bbool be_module_setmember(bvm *vm, bmodule *module, bstring *attr, bvalue *src);
 const char* be_module_name(bmodule *module);

--- a/lib/libesp32/berry/tests/module.be
+++ b/lib/libesp32/berry/tests/module.be
@@ -1,0 +1,45 @@
+# test for monkey patching of modules
+
+import string
+import introspect
+
+var string_orig = string
+
+introspect.setmodule("string", 42)
+import string
+assert(string == 42)
+
+# set back original value
+introspect.setmodule("string", string_orig)
+import string
+assert(type(string) == 'module')
+assert(str(string) == '<module: string>')
+
+#
+# demo, how to monkey patch string with a new function `foo()` returning `bar`
+#
+import string
+import introspect
+var string_orig = string            # keep a copy of the original string module
+var string_alt = module('string')   # create a new module
+
+# function `super()` is a closure to capture the original value of string
+string_alt.super = def()
+    return string_orig
+end
+
+# function `member()` is a clousre to capture the original value of string module
+string_alt.member = def(k)
+    import introspect
+    return introspect.get(string_orig, k, true)
+end
+
+string_alt.foo = def() return 'bar' end
+
+# replace the entry for module "string", from now on each `import string` will use `string_alt`
+introspect.setmodule("string", string_alt)
+import string
+
+# test the new string module
+assert(string.tolower('abCD') == 'abcd')
+assert(string.foo() == 'bar')


### PR DESCRIPTION
## Description:

Add the ability to change an entry for an existing module. This allows for monkey patching, but can be risky.

Simple example of extending the `string` module with `string.foo()` to return `'bar'`:

``` berry
#
# demo, how to monkey patch string with a new function `foo()` returning `bar`
#
import string
import introspect
var string_orig = string            # keep a copy of the original string module
var string_alt = module('string')   # create a new module

# function `super()` is a closure to capture the original value of string
string_alt.super = def()
    return string_orig
end

# function `member()` is a clousre to capture the original value of string module
string_alt.member = def(k)
    import introspect
    return introspect.get(string_orig, k, true)
end

string_alt.foo = def() return 'bar' end

# replace the entry for module "string", from now on each `import string` will use `string_alt`
introspect.setmodule("string", string_alt)
import string
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
