### PR TITLE
fix compilation for TTGO watch

### DIFF
--- a/lib/libesp32_div/TTGO_TWatch_Library/src/axp20x.cpp
+++ b/lib/libesp32_div/TTGO_TWatch_Library/src/axp20x.cpp
@@ -275,7 +275,7 @@ float AXP20X_Class::getTemp()
 {
     if (!_init)
         return AXP_NOT_INIT;
-    return _getRegistResult(AXP202_INTERNAL_TEMP_H8, AXP202_INTERNAL_TEMP_L4) * AXP202_INTERNAL_TEMP_STEP;
+    return (_getRegistResult(AXP202_INTERNAL_TEMP_H8, AXP202_INTERNAL_TEMP_L4) - 1447) * AXP202_INTERNAL_TEMP_STEP;
 }
 
 float AXP20X_Class::getTSTemp()


### PR DESCRIPTION
## Description:

The compilation is broken since IDF 4.0. Now Arduino functions are used with the closest possible result to change CPU frequencies compared to the old ESP-IDF version in the driver (lowest possible frequency is now 10 MHz).

Fixes the missing temperature offset in the underlying axp20x library.

Minimal changes of some function names in order to be less common.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
