### PR TITLE
Publish CLEAR message on button HOLD release when SO73 is ON

### DIFF
--- a/tasmota/tasmota_support/support_button _v3.ino
+++ b/tasmota/tasmota_support/support_button _v3.ino
@@ -35,7 +35,7 @@ const uint8_t BUTTON_FAST_PROBE_INTERVAL = 2;  // Time in milliseconds between b
 const uint8_t BUTTON_AC_PERIOD = (20 + BUTTON_FAST_PROBE_INTERVAL - 1) / BUTTON_FAST_PROBE_INTERVAL;   // Duration of an AC wave in probe intervals
 
 const char kMultiPress[] PROGMEM =
-  "|SINGLE|DOUBLE|TRIPLE|QUAD|PENTA|";
+  "|SINGLE|DOUBLE|TRIPLE|QUAD|PENTA|CLEAR|";
 
 #include <Ticker.h>
 
@@ -388,6 +388,9 @@ void ButtonHandler(void) {
 
         if (NOT_PRESSED == button) {
           Button.hold_timer[button_index] = 0;
+          if (Settings->flag3.mqtt_buttons && PRESSED == Button.last_state[button_index] && !Button.press_counter[button_index]) { // SetOption73 (0) - Decouple button from relay and send just mqtt topic
+            MqttButtonTopic(button_index + 1, 6, 0);
+          }
         } else {
           Button.hold_timer[button_index]++;
           if (Settings->flag.button_single) {                  // SetOption13 (0) - Allow only single button press for immediate action


### PR DESCRIPTION
## Description:
This commit adds a feature for Buttons to publish a CLEAR message when a Button is released after an HOLD.
This only happens when SO73 is ON.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [ X I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
