### PR TITLE
Fix ADC_temp alternate mode

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -51,8 +51,8 @@
 //                                        ADC0
 // Mode 1 : NTC towards 3V3 (Sinilink Thermostat Relay Board (XY-WFT1)
 // 3V3 --- NTC ---v--- ANALOG_NTC_BRIDGE_RESISTANCE --- Gnd
-//          |
-//         ADC0
+//                |
+//               ADC0
 #define ANALOG_NTC_BRIDGE_RESISTANCE  32000            // NTC Voltage bridge resistor
 #define ANALOG_NTC_RESISTANCE         10000            // NTC Resistance
 #define ANALOG_NTC_B_COEFFICIENT      3350             // NTC Beta Coefficient
@@ -831,7 +831,7 @@ void CmndAdcParam(void) {
       }
       char param3[33];
       dtostrfd(((double)Adc[idx].param3)/10000, precision, param3);
-      ResponseAppend_P(PSTR(",%s"), param3);
+      ResponseAppend_P(PSTR(",%s,%d"), param3, Adc[idx].param4);
     }
     ResponseAppend_P(PSTR("]}"));
   }

--- a/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_02_analog.ino
@@ -501,13 +501,19 @@ void AdcEverySecond(void) {
       // double Rt = (adc * Adc[idx].param1 * MAX_ADC_V) / (ANALOG_RANGE * ANALOG_V33 - (double)adc * MAX_ADC_V);
       // MAX_ADC_V in ESP8266 is 1
       // MAX_ADC_V in ESP32 is 3.3
-      if (Adc[idx].param4) { // Alternate mode
-        adc = ANALOG_RANGE - adc;
-      }
+      double Rt;
 #ifdef ESP8266
-      double Rt = (adc * Adc[idx].param1) / (ANALOG_RANGE * ANALOG_V33 - (double)adc);  // Shelly param1 = 32000 (ANALOG_NTC_BRIDGE_RESISTANCE)
+      if (Adc[idx].param4) { // Alternate mode
+        Rt = (double)Adc[idx].param1 * (ANALOG_RANGE * ANALOG_V33 - (double)adc) / (double)adc;
+      } else {
+        Rt = (double)Adc[idx].param1 * (double)adc / (ANALOG_RANGE * ANALOG_V33 - (double)adc);
+      }
 #else
-      double Rt = (adc * Adc[idx].param1) / (ANALOG_RANGE - (double)adc);
+      if (Adc[idx].param4) { // Alternate mode
+        Rt = (double)Adc[idx].param1 * (ANALOG_RANGE - (double)adc) / (double)adc;
+      } else {
+        Rt = (double)Adc[idx].param1 * (double)adc / (ANALOG_RANGE - (double)adc);
+      }
 #endif
       double BC = (double)Adc[idx].param3 / 10000;                                      // Shelly param3 = 3350 (ANALOG_NTC_B_COEFFICIENT)
       double T = BC / (BC / ANALOG_T0 + TaylorLog(Rt / (double)Adc[idx].param2));       // Shelly param2 = 10000 (ANALOG_NTC_RESISTANCE)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes some errors in previous https://github.com/arendst/Tasmota/pull/16667

Calculations in alternate mode were not correct.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
