### PR TITLE
KNX fix javascript scrumbled by quote char

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_11_knx.ino
@@ -945,7 +945,7 @@ void HandleKNXConfiguration(void)
             "var GA_AREA=eb('GA_AREA');"
             "var GA_FDEF=eb('GA_FDEF');"
             "if(GA_FNUM!=null&&GA_FNUM.value=='0'&&GA_AREA.value=='0'&&GA_FDEF.value=='0'){"
-              "alert('" D_KNX_WARNING "');"
+              "alert(\"" D_KNX_WARNING "\");"
             "}"
           "}"
           "function CBwarning()"
@@ -954,7 +954,7 @@ void HandleKNXConfiguration(void)
             "var CB_AREA=eb('CB_AREA');"
             "var CB_FDEF=eb('CB_FDEF');"
             "if(CB_FNUM!=null&&CB_FNUM.value=='0'&&CB_AREA.value=='0'&&CB_FDEF.value=='0'){"
-              "alert('" D_KNX_WARNING "');"
+              "alert(\"" D_KNX_WARNING "\");"
             "}"
           "}"));
     WSContentSendStyle();


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes https://github.com/arendst/Tasmota/issues/16707

Javascript `alert('" D_KNX_WARNING '");` was broken by Italian translation introducing a `'` in the text
Replaced the single-quote by double-quote in the Javascript code

@bovirus Thanks a lot for this one. It took me 2 hours to figure it out 🤣
Please do not PR translation for features that you have not tested !

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
