### PR TITLE
Zigbee load from FS before EEPROM

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4c_devices.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_4c_devices.ino
@@ -355,19 +355,6 @@ bool loadZigbeeDevices(void) {
   const char * storage_class = PSTR("");
   uint32_t file_version = 4;        // currently supporting v3 and v4
 
-#ifdef USE_ZIGBEE_EEPROM
-  if (zigbee.eeprom_ready) {
-    f.init(ZIGB_NAME4);                   // try v4 first
-    if (!f.valid()) {
-      f.init(ZIGB_NAME2);                 // else try v2
-      if (f.valid()) { file_version = 2; }  // v2 found
-    }
-    if (f.valid()) {
-      storage_class = PSTR("EEPROM");
-    }
-  }
-#endif // USE_ZIGBEE_EEPROM
-
 #ifdef USE_UFILESYS
   File file;
   if (!f.valid() && dfsp) {
@@ -382,6 +369,19 @@ bool loadZigbeeDevices(void) {
     }
   }
 #endif // USE_UFILESYS
+
+#ifdef USE_ZIGBEE_EEPROM
+  if (!f.valid() && zigbee.eeprom_ready) {
+    f.init(ZIGB_NAME4);                   // try v4 first
+    if (!f.valid()) {
+      f.init(ZIGB_NAME2);                 // else try v2
+      if (f.valid()) { file_version = 2; }  // v2 found
+    }
+    if (f.valid()) {
+      storage_class = PSTR("EEPROM");
+    }
+  }
+#endif // USE_ZIGBEE_EEPROM
 
 #ifdef ESP8266
   if (!f.valid() && flash_valid()) {


### PR DESCRIPTION
## Description:

Follow-up of #16718, read from file system `zbv4` first and revert to EEPROM if not present. This offers the best options and resilliency.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
