### PR TITLE
[BP5758D] Fix Sleep

### DIFF
--- a/tasmota/tasmota_xlgt_light/xlgt_08_bp5758d.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_08_bp5758d.ino
@@ -29,7 +29,7 @@
 #define XLGT_08             8
 
 // Layout: Bits B[7:8]=10 (address selection identification bits), B[5:6] sleep mode if set to 00, B[0:4] Address selection
-#define BP5758D_ADDR_SLEEP   0x86  //10 00 0110: Sleep mode bits set (OUT1 gray-scale level setup selected, ignored by chip)
+#define BP5758D_ADDR_SLEEP   0x80  //10 00 0110: Sleep mode bits set (OUT1-5 enable setup selected, ignored by chip)
 #define BP5758D_ADDR_SETUP   0x90  //10 01 0000: OUT1-5 enable/disable setup - used during init
 #define BP5758D_ADDR_OUT1_CR 0x91  //10 01 0001: OUT1 current range
 #define BP5758D_ADDR_OUT2_CR 0x92  //10 01 0010: OUT2 current range
@@ -44,6 +44,7 @@
 
 // Output enabled (OUT1-5, represented by lower 5 bits)
 #define BP5758D_ENABLE_OUTPUTS_ALL 0x1F
+#define BP5758D_DISABLE_OUTPUTS_ALL 0x00
 
 // Current values: Bit 6 to 0 represent 30mA, 32mA, 16mA, 8mA, 4mA, 2mA, 1mA respectively
 #define BP5758D_10MA 0x0A // 0 0001010
@@ -51,6 +52,8 @@
 #define BP5758D_15MA 0x0F // 0 0001111
 #define BP5758D_65MA 0x63 // 0 1100011
 #define BP5758D_90MA 0x7C // 0 1111100
+
+bool bIsSleeping = false; //Save sleep state of Lamp
 
 struct BP5758D {
   uint8_t clk = 0;
@@ -110,11 +113,22 @@ bool Bp5758dSetChannels(void) {
     
   // If we receive 0 for all channels, we'll assume that the lightbulb is off, and activate BP5758d's sleep mode.
   if (cur_col_10[0]==0 && cur_col_10[1]==0 && cur_col_10[2]==0 && cur_col_10[3]==0 && cur_col_10[4]==0) {
-    Bp5758dStart(BP5758D_ADDR_SLEEP);
-    Bp5758dStop();
-    return true;
+		BP5758DStart(BP5758D_ADDR_SLEEP);
+		bIsSleeping = true;
+		BP5758DStart(BP5758D_ADDR_SETUP); 		//Select B1: Output enable setup
+		BP5758DWriteByte(BP5758D_DISABLE_OUTPUTS_ALL); //Set all outputs to OFF
+		BP5758DStop(); 				//Stop transmission since we have to set Sleep mode (can probably be removed)
+		BP5758DStart(BP5758D_ADDR_SLEEP); 		//Enable sleep mode
+		BP5758DStop();
+		return;
   }
-    
+
+	if(bIsSleeping) {
+		bIsSleeping = false;				//No need to run it every time a val gets changed
+		BP5758DStart(BP5758D_ADDR_SETUP);		//Sleep mode gets disabled too since bits 5:6 get set to 01
+		BP5758DWriteByte(BP5758D_ENABLE_OUTPUTS_ALL);	//Set all outputs to ON
+		BP5758DStop();
+	}
   // Even though we could address changing channels only, in practice we observed that the lightbulb always sets all channels.
   Bp5758dStart(BP5758D_ADDR_OUT1_GL);
   // Brigtness values are transmitted as two bytes. The light-bulb accepts a 10-bit integer (0-1023) as an input value.
@@ -146,7 +160,7 @@ void Bp5758dModuleSelected(void)
     // Output enabled: enable all outputs since we're using a RGBCW light
     Bp5758dWrite(BP5758D_ENABLE_OUTPUTS_ALL);
     // Set currents for OUT1-OUT5
-    Bp5758dWrite(BP5758D_14MA);
+    Bp5758dWrite(BP5758D_14MA); //TODO: Make this configurable
     Bp5758dWrite(BP5758D_14MA);
     Bp5758dWrite(BP5758D_14MA);
     Bp5758dWrite(BP5758D_14MA);


### PR DESCRIPTION
BP5758D outputs have to be disabled before sleep.
See https://github.com/openshwprojects/OpenBK7231T_App/issues/221

## Description:

Some lamps with this driver "ghost turn on" after being turned off

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
