### PR TITLE
Mi32 legacy: remove some legacy code

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -230,6 +230,7 @@ struct mi_sensor_t{
   uint8_t lastCnt; //device generated counter of the packet
   uint8_t shallSendMQTT;
   uint8_t MAC[6];
+  uint16_t PID;
   uint8_t *key;
   uint32_t lastTimeSeen;
   union {
@@ -335,6 +336,7 @@ const char kMI32_Commands[] PROGMEM = D_CMND_MI32 "|Key|Cfg|Option";
 
 void (*const MI32_Commands[])(void) PROGMEM = {&CmndMi32Key, &CmndMi32Cfg, &CmndMi32Option };
 
+#define UNKNOWN_MI  0
 #define FLORA       1
 #define MJ_HT_V1    2
 #define LYWSD02     3
@@ -351,8 +353,9 @@ void (*const MI32_Commands[])(void) PROGMEM = {&CmndMi32Key, &CmndMi32Cfg, &Cmnd
 #define SJWS01L     14
 #define PVVX        15
 #define YLKG08      16
+#define YLAI003     17
 
-#define MI32_TYPES    16 //count this manually
+#define MI32_TYPES    17 //count this manually
 
 const uint16_t kMI32DeviceID[MI32_TYPES]={ 0x0098, // Flora
                                   0x01aa, // MJ_HT_V1
@@ -369,29 +372,11 @@ const uint16_t kMI32DeviceID[MI32_TYPES]={ 0x0098, // Flora
                                   0x098b, // MCCGQ02
                                   0x0863, // SJWS01L
                                   0x944a, // PVVX -> this is a fake ID
-                                  0x03b6  // YLKG08 and YLKG07 - version w/wo mains
+                                  0x03b6, // YLKG08 and YLKG07 - version w/wo mains
+                                  0x07bf, // YLAI003
                                   };
 
-const char kMI32DeviceType1[] PROGMEM = "Flora";
-const char kMI32DeviceType2[] PROGMEM = "MJ_HT_V1";
-const char kMI32DeviceType3[] PROGMEM = "LYWSD02";
-const char kMI32DeviceType4[] PROGMEM = "LYWSD03";
-const char kMI32DeviceType5[] PROGMEM = "CGG1";
-const char kMI32DeviceType6[] PROGMEM = "CGD1";
-const char kMI32DeviceType7[] PROGMEM = "NLIGHT";
-const char kMI32DeviceType8[] PROGMEM = "MJYD2S";
-const char kMI32DeviceType9[] PROGMEM = "YLYK01"; //old name yeerc
-const char kMI32DeviceType10[] PROGMEM ="MHOC401";
-const char kMI32DeviceType11[] PROGMEM ="MHOC303";
-const char kMI32DeviceType12[] PROGMEM ="ATC";
-const char kMI32DeviceType13[] PROGMEM ="MCCGQ02";
-const char kMI32DeviceType14[] PROGMEM ="SJWS01L";
-const char kMI32DeviceType15[] PROGMEM ="PVVX";
-const char kMI32DeviceType16[] PROGMEM ="YLKG08";
-const char * kMI32DeviceType[] PROGMEM = {kMI32DeviceType1,kMI32DeviceType2,kMI32DeviceType3,kMI32DeviceType4,
-                                          kMI32DeviceType5,kMI32DeviceType6,kMI32DeviceType7,kMI32DeviceType8,
-                                          kMI32DeviceType9,kMI32DeviceType10,kMI32DeviceType11,kMI32DeviceType12,
-                                          kMI32DeviceType13,kMI32DeviceType14,kMI32DeviceType15,kMI32DeviceType16};
+const char kMI32DeviceType[] PROGMEM = {"Flora|MJ_HT_V1|LYWSD02|LYWSD03|CGG1|CGD1|NLIGHT|MJYD2S|YLYK01|MHOC401|MHOC303|ATC|MCCGQ02|SJWS01L|PVVX|YLKG08|YLAI003"};
 
 const char kMI32_ConnErrorMsg[] PROGMEM = "no Error|could not connect|did disconnect|got no service|got no characteristic|can not read|can not notify|can not write|did not write|notify time out";
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_MI32.ino
@@ -36,7 +36,7 @@ extern "C" {
 ********************************************************************/ 
 
   extern uint32_t MI32numberOfDevices();
-  extern const char * MI32getDeviceName(uint32_t slot);
+  extern char * MI32getDeviceName(uint32_t slot);
   extern void MI32setBatteryForSlot(uint32_t slot, uint8_t value);
   extern void MI32setHumidityForSlot(uint32_t slot, float value);
   extern void MI32setTemperatureForSlot(uint32_t slot, float value);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_homekit.c
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_homekit.c
@@ -32,6 +32,7 @@ static bool MIBridgeWasNeverConnected = true;
 
 #define CONFIG_EXAMPLE_SETUP_ID "MI32"
 
+#define UNKNOWN_MI  0
 #define FLORA       1
 #define MJ_HT_V1    2
 #define LYWSD02     3
@@ -140,6 +141,7 @@ static void MI32_bridge_thread_entry(void *p)
     /* Create and add the Accessory to the Bridge object*/
     uint32_t _numDevices = MI32numberOfDevices();
     for (uint32_t i = 0; i < _numDevices; i++) {
+        if(MI32getDeviceType(i) == UNKNOWN_MI) continue;
         char *accessory_name = MI32getDeviceName(i);
         char _serialNum[4] = {0};
         snprintf(_serialNum,sizeof(_serialNum),"%u", i);

--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_homekit.c
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi_homekit.c
@@ -18,7 +18,7 @@ static int MI32_accessory_identify(hap_acc_t *ha);
 static void MI32_bridge_thread_entry(void *p);
 
 extern uint32_t MI32numberOfDevices();
-extern const char *MI32getDeviceName(uint32_t slot);
+extern char *MI32getDeviceName(uint32_t slot);
 extern uint32_t MI32getDeviceType(uint32_t slot);
 extern void MI32saveHAPhandles(uint32_t slot, uint32_t type, void* handle);
 extern void MI32passHapEvent(uint32_t event);
@@ -48,6 +48,7 @@ static bool MIBridgeWasNeverConnected = true;
 #define SJWS01L     14
 #define PVVX        15
 #define YLKG08      16
+#define YLAI003     17
 
 /*********************************************************************************************\
  * Homekit
@@ -139,7 +140,7 @@ static void MI32_bridge_thread_entry(void *p)
     /* Create and add the Accessory to the Bridge object*/
     uint32_t _numDevices = MI32numberOfDevices();
     for (uint32_t i = 0; i < _numDevices; i++) {
-        char *accessory_name = (char*)MI32getDeviceName(i);
+        char *accessory_name = MI32getDeviceName(i);
         char _serialNum[4] = {0};
         snprintf(_serialNum,sizeof(_serialNum),"%u", i);
 


### PR DESCRIPTION
## Description:

1. Removed old HASS code.
2. Allow unknown (new) Mijia sensors, which are presented in the form `MI_PID`where `PID`is the 16-bit hex value of the product ID. If these sensors present known event/data types, they should work out of the box.
3. Save some flash space by refactoring the the sensor names in more tasmotish way.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
