### PR TITLE
Zigbee plugin allow matches to 'starts wth'

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -342,18 +342,43 @@ public:
     manufacturer = (const char*)_manuf;
   }
 
+  // check if a matches b, return true if so
+  //
+  // Special behavior:
+  // - return true if `a` is empty or null
+  // - return false if `b` is null
+  // - matches start of `a` if `a` ends with `'*'`
+  // - exact match otherwise
+  static bool matchStar(const char *_a, const char *_b) {
+    if (_a == nullptr || *_a == '\0') { return true; }
+    if (_b == nullptr) { return false; }
+
+    const char *a = _a;
+    const char *b = _b;
+    while (1) {
+      if (a[0] == '*' && a[1] == '\0') {  // pattern ends with '*'
+        return true;    // matches worked until now, accept match
+      }
+      if (*a != *b) {
+        return false;
+      }
+      if (*a == '\0') {
+        return true;
+      }
+      a++;
+      b++;
+    }
+  }
+
   bool match(const char *match_model, const char *match_manuf) const {
     bool match = true;
-    if (model.length() > 0) {
-      if (!model.equals(match_model)) {
-        match = false;
-      }
+    if (!matchStar(model.c_str(), match_model)) {
+      match = false;
     }
-    if (manufacturer.length() > 0) {
-      if (!manufacturer.equals(match_manuf)) {
+    if (!matchStar(manufacturer.c_str(), match_manuf)) {
         match = false;
-      }
     }
+    // AddLog(LOG_LEVEL_DEBUG, ">match device(%s, %s) compared to (%s, %s) = %i", match_model, match_manuf, model.c_str(), manufacturer.c_str(), match);
     return match;
   }
 


### PR DESCRIPTION
## Description:

Zigbee plugin, allow wildcard at the end of modelid or manufacturer id to capture all values starting with a prefix.

Example `:TS0001,_TZ3000_*` captures all manufacturer ids starting with `_TZ3000_`

Note: `*` wildcard is only allowed as last character for modelid or manufacturerid

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
