### PR TITLE
Epoch in Berry time map

### DIFF
--- a/lib/libesp32/berry/src/be_timelib.c
+++ b/lib/libesp32/berry/src/be_timelib.c
@@ -37,6 +37,7 @@ static int m_dump(bvm *vm)
         time_insert(vm, "min", t->tm_min);
         time_insert(vm, "sec", t->tm_sec);
         time_insert(vm, "weekday", t->tm_wday);
+        time_insert(vm, "epoch", ts);
         be_pop(vm, 1);
         be_return(vm);
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -265,6 +265,7 @@ extern "C" {
     be_map_insert_int(vm, "min", t->tm_min);
     be_map_insert_int(vm, "sec", t->tm_sec);
     be_map_insert_int(vm, "weekday", t->tm_wday);
+    be_map_insert_int(vm, "epoch", mktime(t));
     if (unparsed) be_map_insert_str(vm, "unparsed", unparsed);
     be_pop(vm, 1);
   }


### PR DESCRIPTION
When handling time and intervals in Berry, I found no feature for getting from parsing a string timestamp to the calculation-friendly epoch value, only to the map of broken-down time fields. When getting data from the outside, like a MQTT subscription, time stamps are usually in human-readable text format, which is great, but when doing programming, like a simple duration between two timestamps, having the epoch is highly useful.

@s-hadinger - Do you agree with this enhancement, or does it "need improvement"?

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

No issue fixed, but I suggested this small enhancement on Discord some time ago.
https://discord.com/channels/479389167382691863/826169659811168276/984930495848665119

## Checklist:
  - [*] The pull request is done against the latest development branch
  - [*] Only relevant files were touched
  - [*] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [*] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [*] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
