### PR TITLE
Berry regex `re` fix

### DIFF
--- a/lib/libesp32/berry/default/be_re_lib.c
+++ b/lib/libesp32/berry/default/be_re_lib.c
@@ -67,6 +67,7 @@ const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbo
 
   int sub_els = (code->sub + 1) * 2;
   const char *sub[sub_els];
+  memset(sub, 0, sub_els * sizeof sub[0]);
 
   if (!re1_5_recursiveloopprog(code, &subj, sub, sub_els, is_anchored)) {
     be_pushnil(vm);
@@ -74,12 +75,13 @@ const char *be_re_match_search_run(bvm *vm, ByteProg *code, const char *hay, bbo
   }
 
   be_newobject(vm, "list");
-  int k;
-  for(k = sub_els; k > 0; k--)
-    if(sub[k-1])
-      break;
+  int k = sub_els;
   for (int i = 0; i < k; i += 2) {
+    if (sub[i] == nil || sub[i+1] == nil) {
+      be_pushnil(vm);
+    } else {
     be_pushnstring(vm, sub[i], sub[i+1] - sub[i]);
+    }
     be_data_push(vm, -2);
     be_pop(vm, 1);
   }


### PR DESCRIPTION
## Description:

Fix crashes in `re.search()` when some groups do not capture any value.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
