### PR TITLE
Fix %timerN% rule variables for SunRise/Sunset timers

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1459,6 +1459,18 @@ bool findNextVariableValue(char * &pVarname, float &value)
     uint32_t index = sVarName.substring(5).toInt();
     if (index > 0 && index <= MAX_TIMERS) {
       value = Settings->timer[index -1].time;
+#if defined(USE_SUNRISE)
+      // Correct %timerN% values for sunrise/sunset timers
+      if (Settings->timer[index -1].mode == 1 || Settings->timer[index -1].mode == 2) {
+        // in this context, time variable itself is merely an offset, with <720 being negative
+        value += -720 + SunMinutes(Settings->timer[index -1].mode -1);
+      }
+      if (Settings->timer[index -1].mode == 2) {
+        // To aid rule comparative statements, sunset past midnight (high lattitudes) is expressed past 24h00
+        // So sunset at 00h45 is at 24h45
+        if (value<360) { value += 1440; }
+      }
+#endif  // USE_SUNRISE
     }
 #if defined(USE_SUNRISE)
   } else if (sVarName.equals(F("SUNRISE"))) {


### PR DESCRIPTION
Enhance %timerN% rule variables to also work for timers with SunRise/SunSet configuration

## Description:

The %timerN% variables added by #14619 only work with hard-scheduled timers. For sunrise/sunset, it is incorrectly interpreting the offset time as real time. This fix corrects that.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

## Use case

It allows for a very nice paired-timer setup that takes "what if sunrise before on" and "what if sunset after off" into account.
As well as recalculate correct time of day on/off state after power cycle.

While it does require some static rules, it allows to set the desired times using the UI, for causal use by less savvy family members. 

```
# Program the schedule timers in UI with your desired times
# Odd timers 1,3 interpreted by the rules as ON, even timers 2,4 are OFF
# Example times:
#       Timer1 ON  at 06h00   (unless if past timer 2)
#       Timer2 OFF at SunUp   (always)
#       Timer3 ON  at SunDown (unless if past timer 4)
#       Timer4 OFF at 23h00   (always)
# Note, this fails if SunDown past midnight, hence of SunDown <06h00 then SunDown=SunDown+24h00
# Further rules will then calculate the "unless if" part and switch accordingly

Timers 1
Timer1 {"Enable":1,"Mode":0,"Time":"06:00","Window":0,"Days":"1111111","Repeat":1,"Output":2,"Action":3}
Timer2 {"Enable":1,"Mode":1,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Output":2,"Action":3}
Timer3 {"Enable":1,"Mode":2,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Output":2,"Action":3}
Timer4 {"Enable":1,"Mode":0,"Time":"23:00","Window":0,"Days":"1111111","Repeat":1,"Output":2,"Action":3}

Rule2
ON System#Init DO backlog Power1 0; Power1 0 ENDON
ON Time#Initialized DO Backlog var1 0; event checktime=%time% ENDON
ON Clock#Timer DO Backlog var1 0; event checktime=%time% ENDON
ON event#checktime>=%timer1% DO var1 1 ENDON
ON event#checktime>=%timer2% DO var1 0 ENDON
ON event#checktime>=%timer3% DO var1 1 ENDON
ON event#checktime>=%timer4% DO var1 0 ENDON
ON event#checktime DO Power1 %var1% ENDON
Rule2 1
```
