### PR TITLE
Berry add access to `restart_flag`

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -33,11 +33,12 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_global_struct = {
     sizeof(TasmotaGlobal),  /* size in bytes */
-    3,  /* number of elements */
+    4,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[3]) {
+    (const be_ctypes_structure_item_t[4]) {
       { "devices_present", offsetof(TasmotaGlobal_t, devices_present), 0, 0, ctypes_u8, 0 },
       { "fast_loop_enabled", offsetof(TasmotaGlobal_t, berry_fast_loop_enabled), 0, 0, ctypes_u8, 0 },
+      { "restart_flag", offsetof(TasmotaGlobal_t, restart_flag), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TasmotaGlobal_t, sleep), 0, 0, ctypes_u8, 0 },
   }};
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -44,9 +44,10 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_settings_struct = {
     sizeof(TSettings),  /* size in bytes */
-    1,  /* number of elements */
+    2,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[1]) {
+    (const be_ctypes_structure_item_t[2]) {
+      { "bootcount", offsetof(TSettings, bootcount), 0, 0, ctypes_u16, 0 },
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },
   }};
 


### PR DESCRIPTION
## Description:

Berry add ability to read/write the internal restart_flag attribute.

Use `tasmota.global.restart_flag`. For example forcing a restart internally is `tasmota.global.restart_flag = 2`

Also added `tasmota.settings.bootcount` to know the bootcount number from a script.

**Use with great care and only if you know what you are doing**

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
