### PR TITLE
Added stop-condition before start-condition

### DIFF
--- a/tasmota/tasmota_xlgt_light/xlgt_08_bp5758d.ino
+++ b/tasmota/tasmota_xlgt_light/xlgt_08_bp5758d.ino
@@ -114,6 +114,7 @@ bool Bp5758dSetChannels(void) {
   if (cur_col_10[0]==0 && cur_col_10[1]==0 && cur_col_10[2]==0 && cur_col_10[3]==0 && cur_col_10[4]==0) {
     Bp5758dStart(BP5758D_ADDR_SETUP);
     Bp5758dWrite(BP5758D_DISABLE_OUTPUTS_ALL);
+    Bp5758dStop();
     Bp5758dStart(BP5758D_ADDR_SLEEP);
     Bp5758dStop();
     bIsSleeping = true;


### PR DESCRIPTION
Bp5758d does not support repeated-start-condition. Therefore it overwrite the next register ('current range setup' of red-channel)

A stop-condition is always needed before next start-condition

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
