### PR TITLE
MI32 legacy: add webcam widget to dashboard

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_62_esp32_mi.ino
@@ -1910,6 +1910,14 @@ void MI32sendEnergyWidget(){
   }
 }
 #endif //USE_MI_ESP32_ENERGY
+#ifdef USE_WEBCAM
+void MI32sendCamWidget(){
+    if (Wc.CamServer && Wc.up) {
+      WSContentSend_P(PSTR("<img class='box' id='cam' src='http://%_I:81/stream'>"),
+        (uint32_t)WiFi.localIP());
+    }
+}
+#endif //USE_WEBCAM
 
 void MI32sendWidget(uint32_t slot){
   auto _sensor = MIBLEsensors[slot];
@@ -2044,6 +2052,9 @@ void MI32InitGUI(void){
 #ifdef USE_MI_ESP32_ENERGY
   MI32sendEnergyWidget();
 #endif //USE_MI_ESP32_ENERGY
+#ifdef USE_WEBCAM
+  MI32sendCamWidget();
+#endif //USE_WEBCAM 
   WSContentSend_P(PSTR("</div>"));
   WSContentSpaceButton(BUTTON_MAIN);
   WSContentStop();


### PR DESCRIPTION
## Description:

Add a widget to the dashboard with the webcam live video.
The S3 can easily handle this and I need to find a way to put more stress on the system :)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
