### PR TITLE
Added Seeed Grove Multichannel Gas Sensor v2

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -107,3 +107,4 @@ Index | Define              | Driver   | Device   | Address(es) | Description
   70  | USE_LUXV30B         | xsns_99  | LUXV30B  | 0x4A        | DFRobot SEN0390 V30B lux sensor
   71  | USE_QMC5883L        | xsns_33  | QMC5883L | 0x0D        | Magnetic Field Sensor
   72  | USE_INA3221         | xsns_100 | INA3221  | 0x40-0x43   | 3-channels Voltage and Current sensor
+  73  | USE_MGS_V2          | xsns_101 | GMXXX    | 0x08        | Grove Multichannel Gas Sensor V2

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/custom.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.gitlab-ci.yml
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+build:
+  tags:
+    - nas
+  script:
+    - wget -c https://files.seeedstudio.com/arduino/seeed-arduino-ci.sh
+    - chmod +x seeed-arduino-ci.sh
+    - bash $PWD/seeed-arduino-ci.sh test
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.travis.yml
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/.travis.yml
@@ -1,0 +1,21 @@
+
+language: generic
+dist: bionic
+sudo: false
+cache:
+  directories:
+    - ~/arduino_ide
+    - ~/.arduino15/packages/
+
+before_install:
+   - wget -c https://files.seeedstudio.com/arduino/seeed-arduino-ci.sh
+
+script:
+   - chmod +x seeed-arduino-ci.sh
+   - cat $PWD/seeed-arduino-ci.sh
+   - bash $PWD/seeed-arduino-ci.sh test
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/CODE_OF_CONDUCT.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at  zuobaozhu@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/CONTRIBUTING.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## Contributing guidelines
+
+All guidelines for contributing to the Seeed_Arduino_MultiGas repository can be found at [`How to contribute guideline`](https://github.com/Seeed-Studio/Seeed_Arduino_MultiGas/wiki/How_to_contribute).

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/LICENSE
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Seeed Technology Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/README.md
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/README.md
@@ -1,0 +1,25 @@
+# Seeed Grove_Multichannel_Gas_Sensor V2.0  [![Build Status](https://travis-ci.com/Seeed-Studio/Seeed_Multichannel_Gas_Sensor.svg?branch=master)](https://travis-ci.com/Seeed-Studio/Seeed_Multichannel_Gas_Sensor)
+## Introduction 
+An Arduino library for Grove Multichannel Gas Sensor V2.0
+
+## Usage
+    1.Git clone this resp to your Arduino IDE's libraries directory.
+    2.Run the demo "demo_background" on examples directory.
+    
+----
+
+This software is written by Wayen Weng for seeed studio and is licensed under [The MIT License](http://opensource.org/licenses/mit-license.php). Check License.txt for more information.<br>
+
+Contributing to this software is warmly welcomed. You can do this basically by<br>
+[forking](https://help.github.com/articles/fork-a-repo), committing modifications and then [pulling requests](https://help.github.com/articles/using-pull-requests) (follow the links above<br>
+for operating guide). Adding change log and your contact into file header is encouraged.<br>
+Thanks for your contribution.
+
+Seeed Studio is an open hardware facilitation company based in Shenzhen, China. <br>
+Benefiting from local manufacture power and convenient global logistic system, <br>
+we integrate resources to serve new era of innovation. Seeed also works with <br>
+global distributors and partners to push open hardware movement.<br>
+
+
+[![Analytics](https://ga-beacon.appspot.com/UA-46589105-3/grove-human-presence-sensor)](https://github.com/igrigorik/ga-beacon)
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_background/demo_background.ino
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_background/demo_background.ino
@@ -1,0 +1,68 @@
+/*
+    Multichannel_gas_sensor_V2.0.ino
+    Description: A terminal for Seeed Grove Multichannel gas sensor V2.0.
+    2019 Copyright (c) Seeed Technology Inc.  All right reserved.
+    Author: Hongtai Liu(lht856@foxmail.com)
+    2019-9-29
+
+    The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.1  USA
+*/
+
+#include <Multichannel_Gas_GMXXX.h>
+
+// if you use the software I2C to drive the sensor, you can uncommnet the define SOFTWAREWIRE which in Multichannel_Gas_GMXXX.h.
+#ifdef SOFTWAREWIRE
+    #include <SoftwareWire.h>
+    SoftwareWire myWire(3, 2);
+    GAS_GMXXX<SoftwareWire> gas;
+#else
+    #include <Wire.h>
+    GAS_GMXXX<TwoWire> gas;
+#endif
+
+static uint8_t recv_cmd[8] = {};
+
+void setup() {
+    Serial.begin(9600);
+    // If you have changed the I2C address of gas sensor, you must to be specify the address of I2C.
+    //The default addrss is 0x08;
+    gas.begin(Wire, 0x08); // use the hardware I2C
+    //gas.begin(MyWire, 0x08); // use the software I2C
+    //gas.setAddress(0x64); change thee I2C address
+
+}
+
+void loop() {
+    uint8_t len = 0;
+    uint8_t addr = 0;
+    uint8_t i;
+    uint32_t val = 0;
+
+    val = gas.getGM102B(); Serial.print("GM102B: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.getGM302B(); Serial.print("GM302B: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.getGM502B(); Serial.print("GM502B: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.getGM702B(); Serial.print("GM702B: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+
+    delay(2000);
+}
+
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_background_gas_name/demo_background_gas_name.ino
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_background_gas_name/demo_background_gas_name.ino
@@ -1,0 +1,68 @@
+/*
+    Multichannel_gas_sensor_V2.0.ino
+    Description: A terminal for Seeed Grove Multichannel gas sensor V2.0.
+    2019 Copyright (c) Seeed Technology Inc.  All right reserved.
+    Author: Hongtai Liu(lht856@foxmail.com)
+    2019-9-29
+
+    The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.1  USA
+*/
+
+#include <Multichannel_Gas_GMXXX.h>
+
+// if you use the software I2C to drive the sensor, you can uncommnet the define SOFTWAREWIRE which in Multichannel_Gas_GMXXX.h.
+#ifdef SOFTWAREWIRE
+    #include <SoftwareWire.h>
+    SoftwareWire myWire(3, 2);
+    GAS_GMXXX<SoftwareWire> gas;
+#else
+    #include <Wire.h>
+    GAS_GMXXX<TwoWire> gas;
+#endif
+
+static uint8_t recv_cmd[8] = {};
+
+void setup() {
+    Serial.begin(9600);
+    // If you have changed the I2C address of gas sensor, you must to be specify the address of I2C.
+    //The default addrss is 0x08;
+    gas.begin(Wire, 0x08); // use the hardware I2C
+    //gas.begin(MyWire, 0x08); // use the software I2C
+    //gas.setAddress(0x64); change thee I2C address
+
+}
+
+void loop() {
+    uint8_t len = 0;
+    uint8_t addr = 0;
+    uint8_t i;
+    uint32_t val = 0;
+
+    val = gas.measure_NO2(); Serial.print("NO2: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.measure_C2H5OH(); Serial.print("C2H5OH: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.measure_VOC(); Serial.print("VOC: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+    val = gas.measure_CO(); Serial.print("CO: "); Serial.print(val); Serial.print("  =  ");
+    Serial.print(gas.calcVol(val)); Serial.println("V");
+
+    delay(2000);
+}
+
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_terminal/demo_terminal.ino
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/examples/demo_terminal/demo_terminal.ino
@@ -1,0 +1,110 @@
+/*
+    demo_terminal.ino
+    Description: A terminal for Seeed Grove Multichannel gas sensor V2.0.
+    2019 Copyright (c) Seeed Technology Inc.  All right reserved.
+    Author: Hongtai Liu(lht856@foxmail.com)
+    2019-6-18
+
+    modify: delete GM402B GM802B moudle.
+          2019-9-29
+
+    The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.1  USA
+*/
+
+#include <Multichannel_Gas_GMXXX.h>
+
+// if you use the software I2C to drive the sensor, you can uncommnet the define SOFTWAREWIRE which in Multichannel_Gas_GMXXX.h.
+#ifdef SOFTWAREWIRE
+    #include <SoftwareWire.h>
+    SoftwareWire myWire(3, 2);
+    GAS_GMXXX<SoftwareWire> gas;
+#else
+    #include <Wire.h>
+    GAS_GMXXX<TwoWire> gas;
+#endif
+
+static uint8_t recv_cmd[8] = {};
+
+void setup() {
+    Serial.begin(9600);
+    // If you have changed the I2C address of gas sensor, you must to be specify the address of I2C.
+    //The default addrss is 0x08;
+    gas.begin(Wire, 0x08); // use the hardware I2C
+    //gas.begin(MyWire, 0x08); // use the software I2C
+    printMenu();
+}
+
+void loop() {
+    uint8_t len = 0;
+    uint8_t addr = 0;
+    uint8_t i;
+    uint32_t val = 0;
+    if (Serial.available()) {
+        char chr = '\0';
+        while (chr != '\n') { // Blockly read data from serial monitor
+            chr = Serial.read();
+            // Serial.print(chr);
+            recv_cmd[len++] = chr;
+        }
+    }
+
+    if (len > 0) {
+        switch (recv_cmd[0]) {
+            case '1': val = gas.getGM102B(); Serial.print("GM102B: "); Serial.print(val); Serial.print("  =  ");
+                Serial.print(gas.calcVol(val)); Serial.println("V"); break;
+            case '2': val = gas.getGM302B(); Serial.print("GM302B: "); Serial.print(val); Serial.print("  =  ");
+                Serial.print(gas.calcVol(val)); Serial.println("V"); break;
+            case '3': val = gas.getGM502B(); Serial.print("GM502B: "); Serial.print(val); Serial.print("  =  ");
+                Serial.print(gas.calcVol(val)); Serial.println("V"); break;
+            case '4': val = gas.getGM702B(); Serial.print("GM702B: "); Serial.print(val); Serial.print("  =  ");
+                Serial.print(gas.calcVol(val)); Serial.println("V"); break;
+            case 'D': Serial.println("Unpreheated！The next read will automatically preheated！"); break;
+            case 'M': //the cmd M100 mean that change the sensor I2C address to 100(0x64);
+                for (i = 1; recv_cmd[i + 1] != '\n'; i++) {
+                    addr *= 10;
+                    addr += (recv_cmd[i] - '0');
+                }
+                if (addr == 0 || addr > 127) {
+                    Serial.println("the address must to be between 1 and 127"); break;
+                } else {
+                    gas.changeGMXXXAddr(addr);
+                    Serial.println("change the sensor I2C address to:"); Serial.println(addr); break;
+                }
+            default: printMenu(); break;
+        }
+        // clean data buffer
+        for (i = 0; i < sizeof(recv_cmd); i++) {
+            recv_cmd[i] = '\0';
+        }
+    }
+    delay(100);
+}
+
+void printMenu() {
+    Serial.println(
+        "----------------Multichannel_gas_sensor V2.0----------------\n"
+        "         1: get the value of GM102B.                        \n"
+        "         2: get the value of GM302B.                        \n"
+        "         3: get the value of GM502B.                        \n"
+        "         4: get the value of GM702B.                        \n"
+        "         D: unpreheated the Multichannel_gas_sensor.        \n"
+        "M[address]: change the Multichannel_gas_sensor I2C address. \n"
+        " other key: print the meun.                                 \n"
+        "------------------------------------------------------------\n"
+    );
+}

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/keywords.txt
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/keywords.txt
@@ -1,0 +1,33 @@
+  
+#######################################
+# Syntax Coloring Map For Grove multichannel_gas_sensor V2.0
+#######################################
+Multichannel_Gas_GMXXX	KEYWORD1
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+gas	KEYWORD1
+GAS_GMXXX	KEYWORD1
+
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+getGM102B	KEYWORD2
+getGM302B	KEYWORD2
+getGM402B	KEYWORD2
+getGM502B	KEYWORD2
+getGM702B	KEYWORD2
+getGM802B	KEYWORD2
+
+preheated	KEYWORD2
+unPreheated	KEYWORD2
+changeGMXXXAddr	KEYWORD2
+calcVol	KEYWORD2
+setAddress	KEYWORD2
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/library.properties
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/library.properties
@@ -1,0 +1,9 @@
+name=Seeed Arduino MultiGas
+version=1.0.1
+author=Hongtai Liu<lht856@foxmail.com>
+maintainer=Hongtai Liu<lht856@foxmail.com>
+sentence=Arduino library for controlling Grove Multichannel_Gas_Sensor V2.0
+paragraph=Arduino library for controlling Grove Multichannel_Gas_Sensor V2.0
+category=Sensors
+url=https://github.com/Seeed-Studio/Seeed_Arduino_MultiGas
+architectures=*

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/src/Multichannel_Gas_GMXXX.cpp
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/src/Multichannel_Gas_GMXXX.cpp
@@ -1,0 +1,233 @@
+/*
+    Multichannel_Gas_GMXXX.cpp
+    Description: A drive for Seeed Grove Multichannel gas sensor V2.0.
+    2019 Copyright (c) Seeed Technology Inc.  All right reserved.
+    Author: Hongtai Liu(lht856@foxmail.com)
+    2019-6-18
+
+    The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.1  USA
+*/
+
+#include <Arduino.h>
+#ifdef SOFTWAREWIRE
+    #include <SoftwareWire.h>
+#else
+    #include <Wire.h>
+#endif
+
+#include "Multichannel_Gas_GMXXX.h"
+
+template<class T>
+GAS_GMXXX<T>::GAS_GMXXX() {
+
+}
+
+/**
+    @description: start a instance
+    @param {type}  wire(SoftwareWire or TwoWire), address(uint_8)
+    @return: None
+*/
+template<class T>
+void GAS_GMXXX<T>::begin(T& wire, uint8_t address) {
+    _Wire = &wire;
+    _Wire->begin();
+    GMXXX_ADDRESS = address;
+    preheated();
+    isPreheated = true;
+}
+
+
+/**
+    @description:  set the I2C address, use after begin.
+    @param {type}  address(uint_8)
+    @return: None
+*/
+template<class T>
+void GAS_GMXXX<T>::setAddress(uint8_t address) {
+    GMXXX_ADDRESS = address;
+    preheated();
+    isPreheated = true;
+}
+
+
+/**
+    @description:  transmit a byte to I2C device
+    @param {type}  cmd(uint_8)
+    @return: None
+*/
+template<class T>
+void GAS_GMXXX<T>::GMXXXWriteByte(uint8_t cmd) {
+    _Wire->beginTransmission(GMXXX_ADDRESS); // transmit to device #4
+    _Wire->write(cmd);              // sends one byte
+    _Wire->endTransmission();    // stop transmitting
+    delay(1);
+}
+
+/**
+    @description:  read 4 bytes from I2C device
+    @param {type}  cmd(uint_8)
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::GMXXXRead32() {
+    uint8_t index = 0;
+    uint32_t value = 0;
+    _Wire->requestFrom((int)GMXXX_ADDRESS, (int)4);
+    while (_Wire->available()) { // slave may send less than requested
+        uint8_t byte = _Wire->read(); // receive a byte as character
+        value += byte << (8 * index);
+        index++;
+    }
+    delay(1);
+    return value;
+}
+
+/**
+    @description:  warmming up the gas sensor
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+void GAS_GMXXX<T>::preheated() {
+    GMXXXWriteByte(WARMING_UP);
+    isPreheated = true;
+}
+
+/**
+    @description:  disable warmming up the gas sensor
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+void GAS_GMXXX<T>::unPreheated() {
+    GMXXXWriteByte(WARMING_DOWN);
+    isPreheated = false;
+}
+
+/**
+    @description:  get the adc value of GM102B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM102B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_102B);
+    return GMXXXRead32();
+}
+
+/**
+    @description:  get the adc value of GM302B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM302B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_302B);
+    return GMXXXRead32();
+}
+
+#ifdef GM_402B
+/**
+    @description:  get the adc value of GM402B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM402B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_402B);
+    return GMXXXRead32();
+}
+#endif
+
+/**
+    @description:  get the adc value of GM502B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM502B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_502B);
+    return GMXXXRead32();
+}
+
+/**
+    @description:  get the adc value of GM702B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM702B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_702B);
+    return GMXXXRead32();
+}
+
+#ifdef GM_802B
+/**
+    @description:  get the adc value of GM802B
+    @param {type}:  None
+    @return: uint32_t
+*/
+template<class T>
+uint32_t GAS_GMXXX<T>::getGM802B() {
+    if (!isPreheated) {
+        preheated();
+    }
+    GMXXXWriteByte(GM_802B);
+    return GMXXXRead32();
+}
+#endif
+
+/**
+    @description:  change the I2C address of gas sonsor.
+    @param {type}:  addres(uint8_t)
+    @return: None
+*/
+template<class T>
+void GAS_GMXXX<T>::changeGMXXXAddr(uint8_t address) {
+    if (address == 0 || address > 127) {
+        address = 0x08;
+    }
+    _Wire->beginTransmission(GMXXX_ADDRESS); // transmit to device #4
+    _Wire->write(CHANGE_I2C_ADDR);
+    _Wire->write(address);// sends one byte
+    _Wire->endTransmission();    // stop transmitting
+
+    GMXXX_ADDRESS = address;
+}
+
+#ifdef SOFTWAREWIRE
+    template class GAS_GMXXX<SoftwareWire>;
+#endif
+
+template class GAS_GMXXX<TwoWire>;
+

--- a/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/src/Multichannel_Gas_GMXXX.h
+++ b/lib/lib_i2c/Seeed_Arduino_MultiGas_v2/src/Multichannel_Gas_GMXXX.h
@@ -1,0 +1,95 @@
+/*
+    Multichannel_Gas_GMXXX.h
+    Description: A drive for Seeed Grove Multichannel gas sensor V2.0.
+    2019 Copyright (c) Seeed Technology Inc.  All right reserved.
+    Author: Hongtai Liu(lht856@foxmail.com)
+    2019-6-18
+
+    The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.1  USA
+*/
+#ifndef __GAS_GMXXX__
+#define __GAS_GMXXX__
+
+//#define SOFTWAREWIRE
+#ifdef SOFTWAREWIRE
+    #include <SoftwareWire.h>
+#else
+    #include <Wire.h>
+#endif
+
+#if defined(ARDUINO_ARCH_AVR) // AVR verf 5V
+#define GM_VERF 5
+#else
+#define GM_VERF 3.3
+#endif
+
+#define GM_RESOLUTION 1023
+
+//command
+#define GM_102B 0x01
+#define GM_302B 0x03
+//#define GM_402B 0x04
+#define GM_502B 0x05
+#define GM_702B 0x07
+//#define GM_802B 0x08
+#define CHANGE_I2C_ADDR 0x55
+#define WARMING_UP 0xFE
+#define WARMING_DOWN  0xFF
+
+template <class T>
+class GAS_GMXXX {
+  public:
+    GAS_GMXXX();
+    void begin(T& wire = Wire, uint8_t address = 0x08);
+    void setAddress(uint8_t address = 0x08);
+    void preheated();
+    void unPreheated();
+    void changeGMXXXAddr(uint8_t address = 0x08);
+    uint32_t measure_NO2(){
+        return getGM102B();
+    };
+    uint32_t getGM102B();
+    uint32_t measure_C2H5OH(){
+        return getGM302B();
+    };
+    uint32_t getGM302B();
+    #ifdef GM_402B
+    uint32_t getGM402B();
+    #endif
+    uint32_t measure_VOC(){
+        return getGM502B();
+    };
+    uint32_t getGM502B();
+    uint32_t measure_CO(){
+        return getGM702B();
+    };
+    uint32_t getGM702B();
+    #ifdef GM_802B
+    uint32_t getGM802B();
+    #endif
+    inline float calcVol(uint32_t adc, float verf = GM_VERF, int resolution = GM_RESOLUTION) {
+        return (adc * verf) / (resolution * 1.0);
+    };
+  private:
+    T* _Wire;
+    bool isPreheated;
+    uint8_t GMXXX_ADDRESS;
+    void GMXXXWriteByte(uint8_t cmd);
+    uint32_t GMXXXRead32();
+};
+#endif

--- a/tasmota/tasmota_xsns_sensor/xsns_101_mgs_v2.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_101_mgs_v2.ino
@@ -1,0 +1,100 @@
+/*
+  xsns_101_mgs_v2.ino - Xadow and Grove Mutichannel Gas sensor support for Tasmota
+
+  Copyright (C) 2021  Jeroen Vermeulen and Theo Arends
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_I2C
+#ifdef USE_MGS_V2
+/*********************************************************************************************\
+ * Grove - Multichannel Gas Sensor
+ * https://wiki.seeedstudio.com/Grove-Multichannel-Gas-Sensor-V2
+ *
+ * https://github.com/Seeed-Studio/Seeed_Arduino_MultiGas
+\*********************************************************************************************/
+
+#define XSNS_101           101
+#define XI2C_73            73  // See I2CDEVICES.md
+
+#ifndef MGS_V2_SENSOR_ADDR
+#define MGS_V2_SENSOR_ADDR    0x08             // Default Mutichannel Gas sensor i2c address
+#endif
+
+#include "Multichannel_Gas_GMXXX.h"
+GAS_GMXXX<TwoWire> gasGMXXX;
+bool mgs_v2_detected = false;
+
+void MGSv2Prepare(void)
+{
+  if (!I2cSetDevice(MGS_V2_SENSOR_ADDR)) { return; }
+
+  gasGMXXX.begin(Wire, MGS_V2_SENSOR_ADDR);
+  I2cSetActiveFound(MGS_V2_SENSOR_ADDR, "MultiGas");
+  mgs_v2_detected = true;
+}
+
+#ifdef USE_WEBSERVER
+const char HTTP_MGS_GAS[] PROGMEM = "{s}MGSv2 %s{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";  // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+#endif // USE_WEBSERVER
+
+void MGSv2Show(bool json)
+{
+  char buffer[33];
+  if (json) {
+    ResponseAppend_P(PSTR(",\"NO2\":%d"), gasGMXXX.measure_NO2());
+    ResponseAppend_P(PSTR(",\"C2H5OH\":%d}"), gasGMXXX.measure_C2H5OH());
+    ResponseAppend_P(PSTR(",\"VOC\":%d"), gasGMXXX.measure_VOC());
+    ResponseAppend_P(PSTR(",\"CO\":%d"), gasGMXXX.measure_CO());
+#ifdef USE_WEBSERVER
+  } else {
+    WSContentSend_PD(HTTP_MGS_GAS, "NO2", gasGMXXX.measure_NO2());
+    WSContentSend_PD(HTTP_MGS_GAS, "C2H5OH", gasGMXXX.measure_C2H5OH());
+    WSContentSend_PD(HTTP_MGS_GAS, "VOC", gasGMXXX.measure_VOC());
+    WSContentSend_PD(HTTP_MGS_GAS, "CO", gasGMXXX.measure_CO());
+#endif // USE_WEBSERVER
+  }
+}
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xsns101(uint8_t function)
+{
+  if (!I2cEnabled(XI2C_73)) { return false; }
+
+  bool result = false;
+
+  if (FUNC_INIT == function) {
+    MGSv2Prepare();
+  }
+  else if (mgs_v2_detected) {
+    switch (function) {
+      case FUNC_JSON_APPEND:
+        MGSv2Show(1);
+        break;
+  #ifdef USE_WEBSERVER
+      case FUNC_WEB_SENSOR:
+        MGSv2Show(0);
+        break;
+  #endif  // USE_WEBSERVER
+    }
+  }
+  return result;
+}
+
+#endif  // USE_MGS_V2
+#endif  // USE_I2C

--- a/tasmota/tasmota_xsns_sensor/xsns_101_mgs_v2.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_101_mgs_v2.ino
@@ -47,7 +47,7 @@ void MGSv2Prepare(void)
 }
 
 #ifdef USE_WEBSERVER
-const char HTTP_MGS_GAS[] PROGMEM = "{s}MGSv2 %s{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";  // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+const char HTTP_MGS_V2_GAS[] PROGMEM = "{s}MGSv2 %s{m}%d " D_UNIT_PARTS_PER_MILLION "{e}";  // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
 #endif // USE_WEBSERVER
 
 void MGSv2Show(bool json)
@@ -60,10 +60,10 @@ void MGSv2Show(bool json)
     ResponseAppend_P(PSTR(",\"CO\":%d"), gasGMXXX.measure_CO());
 #ifdef USE_WEBSERVER
   } else {
-    WSContentSend_PD(HTTP_MGS_GAS, "NO2", gasGMXXX.measure_NO2());
-    WSContentSend_PD(HTTP_MGS_GAS, "C2H5OH", gasGMXXX.measure_C2H5OH());
-    WSContentSend_PD(HTTP_MGS_GAS, "VOC", gasGMXXX.measure_VOC());
-    WSContentSend_PD(HTTP_MGS_GAS, "CO", gasGMXXX.measure_CO());
+    WSContentSend_PD(HTTP_MGS_V2_GAS, "NO2", gasGMXXX.measure_NO2());
+    WSContentSend_PD(HTTP_MGS_V2_GAS, "C2H5OH", gasGMXXX.measure_C2H5OH());
+    WSContentSend_PD(HTTP_MGS_V2_GAS, "VOC", gasGMXXX.measure_VOC());
+    WSContentSend_PD(HTTP_MGS_V2_GAS, "CO", gasGMXXX.measure_CO());
 #endif // USE_WEBSERVER
   }
 }


### PR DESCRIPTION
## Description: Seeed Grove Multichannel Gas Sensor v2
`#define USE_MGS_V2`

The sensor measures NO2, C2H5OH, VOC and CO.

This sensor uses I2C and by use address `0x08` by default. In de [documentation](https://wiki.seeedstudio.com/Grove-Multichannel-Gas-Sensor-V2/#specification) it also mentions `0x55`.
The address can be changed in `user_config_override.h` like this:
```
#define MGS_V2_SENSOR_ADDR 0x55
```

Because the sensors need to warm up, very high values may be shown at first. This can take up to 24 hours.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
