### PR TITLE
allow DHT_MAX_SENSORS to be overridden

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_06_dht_v5.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_06_dht_v5.ino
@@ -35,7 +35,9 @@
 
 #define XSNS_06          6
 
+#ifndef DHT_MAX_SENSORS
 #define DHT_MAX_SENSORS  4
+#endif
 #define DHT_MAX_RETRY    8
 
 uint8_t dht_data[5];

--- a/tasmota/tasmota_xsns_sensor/xsns_06_dht_v6.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_06_dht_v6.ino
@@ -26,7 +26,9 @@
 
 #define XSNS_06          6
 
+#ifndef DHT_MAX_SENSORS
 #define DHT_MAX_SENSORS  4
+#endif
 #define DHT_MAX_RETRY    8
 
 uint32_t dht_maxcycles;

--- a/tasmota/tasmota_xsns_sensor/xsns_06_esp32_dht.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_06_esp32_dht.ino
@@ -31,7 +31,9 @@
 
 #define XSNS_06          6
 
+#ifndef DHT_MAX_SENSORS
 #define DHT_MAX_SENSORS  4
+#endif
 #define DHT_MAX_RETRY    8
 
 #include <DHT.h>


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** https://github.com/arendst/Tasmota/issues/5047

Allow DHT_MAX_SENSORS to be overriden in user_config_override.h


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
