### PR TITLE
Berry add `bytes().setbytes()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.2.0.1]
 ### Added
 - DS18x20 support on up to four GPIOs by md5sum-as (#16833)
+- Berry add `bytes().setbytes()`
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/tests/bytes.be
+++ b/lib/libesp32/berry/tests/bytes.be
@@ -202,3 +202,26 @@ assert(b == bytes())
 b = bytes("FFFEAABBCC")
 assert(b.tohex() == "FFFEAABBCC")
 assert(bytes().tohex() == "")
+
+# assign buffer to bytes
+var a0 = bytes("112233445566778899")
+b = bytes("aabbccddeeff")
+
+a = a0.copy()
+a.setbytes(0, b)            # assign from start
+assert(a == bytes('AABBCCDDEEFF778899'))
+a = a0.copy()
+a.setbytes(0, b, 0, 0)      # zero len
+assert(a == a0)
+a = a0.copy()
+a.setbytes(100, b)          # index out of range
+assert(a == a0)
+a = a0.copy()
+a.setbytes(6, b)          # entire buffer not fitting
+assert(a == bytes('112233445566AABBCC'))
+a = a0.copy()
+a.setbytes(6, b, 2, 2)
+assert(a == bytes('112233445566CCDD99'))
+a = b.copy()
+a.setbytes(0, a0)
+assert(a == bytes('112233445566'))


### PR DESCRIPTION
## Description:

Report of https://github.com/berry-lang/berry/pull/300

Add a new method to copy a portion from a bytes() buffer to another bytes() object.

`bytes().setbytes(offset_to:int, bytes_from:bytes [, offset_from:int, len_from:int]) -> nil`

Copies by default the entire content of a buffer passed as argument starting at `offset_to`. The target buffer is not resized, so any buffer that does not fit is truncated.

You can optionally copy only a sub-section of the buffer, from `offset_from` and copy `len_from` bytes.

This will be useful for adressable leds / WS2812 animations.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
