### PR TITLE
Prepare for DMX Artnet support on ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Berry add `bytes().setbytes()` (#16892)
 - Support for Shelly Pro 1/2 (#16773)
 - Add Zigbee router firmware for Sonoff ZBBridgePro (#16900)
+- Prepare for DMX Artnet support on ESP32
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -29,6 +29,7 @@ extern int l_wifi(bvm *vm);
 extern int l_eth(bvm *vm);
 extern int l_yield(bvm *vm);
 extern int l_delay(bvm *vm);
+extern int l_delay_microseconds(bvm *vm);
 extern int l_scaleuint(bvm *vm);
 extern int l_logInfo(bvm *vm);
 extern int l_save(bvm *vm);
@@ -102,6 +103,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     eth, func(l_eth)
     yield, func(l_yield)
     delay, func(l_delay)
+    delay_microseconds, func(l_delay_microseconds)
     scale_uint, func(l_scaleuint)
     log, func(l_logInfo)
     save, func(l_save)

--- a/lib/libesp32/berry_tasmota/src/embedded/leds.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/leds.be
@@ -249,6 +249,8 @@ class Leds : Leds_ntv
       var offset
       var h, w
       var alternate     # are rows in alternate mode (even/odd are reversed)
+      var pix_buffer
+      var pix_size
     
       def init(strip, w, h, offset)
         self.strip = strip
@@ -256,6 +258,9 @@ class Leds : Leds_ntv
         self.h = h
         self.w = w
         self.alternate = false
+
+        self.pix_buffer = self.strip.pixels_buffer()
+        self.pix_size = self.strip.pixel_size()
       end
     
       def clear()
@@ -270,6 +275,7 @@ class Leds : Leds_ntv
         # don't trigger on segment, you will need to trigger on full strip instead
         if bool(force) || (self.offset == 0 && self.w * self.h == self.strip.leds)
           self.strip.show()
+          self.pix_buffer = self.strip.pixels_buffer()  # update buffer after show()
         end
       end
       def can_show()
@@ -282,10 +288,10 @@ class Leds : Leds_ntv
         self.strip.dirty()
       end
       def pixels_buffer()
-        return nil
+        return self.strip.pixels_buffer()
       end
       def pixel_size()
-        return self.strip.pixel_size()
+        return self.pix_size
       end
       def pixel_count()
         return self.w * self.h
@@ -302,6 +308,14 @@ class Leds : Leds_ntv
       end
       def get_pixel_color(idx)
         return self.strip.get_pixel_color(idx + self.offseta)
+      end
+
+      # setbytes(row, bytes)
+      # sets the raw bytes for `row`, copying at most 3 or 4 x col  bytes
+      def set_bytes(row, buf, offset)
+        var h_bytes = self.h * self.pix_size
+        var offset_in_matrix = self.offset + row * h_bytes
+        self.pix_buffer.setbytes(offset_in_matrix, buf, offset, h_bytes)
       end
 
       # Leds_matrix specific

--- a/lib/libesp32/berry_tasmota/src/embedded/leds_animator.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/leds_animator.be
@@ -17,7 +17,8 @@ class Leds_animator
     #
     self.clear()        # clear all leds first
     #
-    tasmota.add_driver(self)
+    tasmota.add_fast_loop(/-> self.fast_loop())
+    # it may be useful to reduce Sleep time here
   end
 
   def add_anim(anim)
@@ -43,7 +44,7 @@ class Leds_animator
     return self.bri
   end
 
-  def every_50ms()
+  def fast_loop()
     if self.running
       # run animators first
       var i = 0

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -736,66 +736,9 @@ be_local_closure(Leds_is_dirty,   /* name */
 
 
 /********************************************************************
-** Solidified function: pixel_count
+** Solidified function: pixels_buffer
 ********************************************************************/
-be_local_closure(Leds_matrix_pixel_count,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(w),
-    /* K1   */  be_nested_str(h),
-    }),
-    &be_const_str_pixel_count,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x08040202,  //  0002  MUL	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_alternate
-********************************************************************/
-be_local_closure(Leds_matrix_set_alternate,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str(alternate),
-    }),
-    &be_const_str_set_alternate,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixel_size
-********************************************************************/
-be_local_closure(Leds_matrix_pixel_size,   /* name */
+be_local_closure(Leds_matrix_pixels_buffer,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -807,15 +750,63 @@ be_local_closure(Leds_matrix_pixel_size,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(pixel_size),
+    /* K1   */  be_nested_str(pixels_buffer),
     }),
-    &be_const_str_pixel_size,
+    &be_const_str_pixels_buffer,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
       0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Leds_matrix_init,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str(strip),
+    /* K1   */  be_nested_str(offset),
+    /* K2   */  be_nested_str(h),
+    /* K3   */  be_nested_str(w),
+    /* K4   */  be_nested_str(alternate),
+    /* K5   */  be_nested_str(pix_buffer),
+    /* K6   */  be_nested_str(pixels_buffer),
+    /* K7   */  be_nested_str(pix_size),
+    /* K8   */  be_nested_str(pixel_size),
+    }),
+    &be_const_str_init,
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020204,  //  0001  SETMBR	R0	K1	R4
+      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x90020602,  //  0003  SETMBR	R0	K3	R2
+      0x50140000,  //  0004  LDBOOL	R5	0	0
+      0x90020805,  //  0005  SETMBR	R0	K4	R5
+      0x88140100,  //  0006  GETMBR	R5	R0	K0
+      0x8C140B06,  //  0007  GETMET	R5	R5	K6
+      0x7C140200,  //  0008  CALL	R5	1
+      0x90020A05,  //  0009  SETMBR	R0	K5	R5
+      0x88140100,  //  000A  GETMBR	R5	R0	K0
+      0x8C140B08,  //  000B  GETMET	R5	R5	K8
+      0x7C140200,  //  000C  CALL	R5	1
+      0x90020E05,  //  000D  SETMBR	R0	K7	R5
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -851,6 +842,180 @@ be_local_closure(Leds_matrix_set_pixel_color,   /* name */
       0x5C200600,  //  0005  MOVE	R8	R3
       0x7C100800,  //  0006  CALL	R4	4
       0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: begin
+********************************************************************/
+be_local_closure(Leds_matrix_begin,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    &be_const_str_begin,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pixel_color
+********************************************************************/
+be_local_closure(Leds_matrix_get_pixel_color,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(strip),
+    /* K1   */  be_nested_str(get_pixel_color),
+    /* K2   */  be_nested_str(offseta),
+    }),
+    &be_const_str_get_pixel_color,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x88100102,  //  0002  GETMBR	R4	R0	K2
+      0x00100204,  //  0003  ADD	R4	R1	R4
+      0x7C080400,  //  0004  CALL	R2	2
+      0x80040400,  //  0005  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: pixel_size
+********************************************************************/
+be_local_closure(Leds_matrix_pixel_size,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str(pix_size),
+    }),
+    &be_const_str_pixel_size,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_alternate
+********************************************************************/
+be_local_closure(Leds_matrix_set_alternate,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str(alternate),
+    }),
+    &be_const_str_set_alternate,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: can_show
+********************************************************************/
+be_local_closure(Leds_matrix_can_show,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(strip),
+    /* K1   */  be_nested_str(can_show),
+    }),
+    &be_const_str_can_show,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: clear
+********************************************************************/
+be_local_closure(Leds_matrix_clear,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str(clear_to),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str(show),
+    }),
+    &be_const_str_clear,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x580C0001,  //  0001  LDCONST	R3	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x8C040102,  //  0003  GETMET	R1	R0	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -919,6 +1084,36 @@ be_local_closure(Leds_matrix_set_matrix_pixel_color,   /* name */
 
 
 /********************************************************************
+** Solidified function: pixel_count
+********************************************************************/
+be_local_closure(Leds_matrix_pixel_count,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str(w),
+    /* K1   */  be_nested_str(h),
+    }),
+    &be_const_str_pixel_count,
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x08040202,  //  0002  MUL	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: show
 ********************************************************************/
 be_local_closure(Leds_matrix_show,   /* name */
@@ -931,7 +1126,7 @@ be_local_closure(Leds_matrix_show,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str(offset),
     /* K1   */  be_const_int(0),
     /* K2   */  be_nested_str(w),
@@ -939,58 +1134,34 @@ be_local_closure(Leds_matrix_show,   /* name */
     /* K4   */  be_nested_str(strip),
     /* K5   */  be_nested_str(leds),
     /* K6   */  be_nested_str(show),
+    /* K7   */  be_nested_str(pix_buffer),
+    /* K8   */  be_nested_str(pixels_buffer),
     }),
     &be_const_str_show,
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
+    ( &(const binstruction[22]) {  /* code */
       0x60080017,  //  0000  GETGBL	R2	G23
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x740A0009,  //  0003  JMPT	R2	#000E
       0x88080100,  //  0004  GETMBR	R2	R0	K0
       0x1C080501,  //  0005  EQ	R2	R2	K1
-      0x780A0009,  //  0006  JMPF	R2	#0011
+      0x780A000D,  //  0006  JMPF	R2	#0015
       0x88080102,  //  0007  GETMBR	R2	R0	K2
       0x880C0103,  //  0008  GETMBR	R3	R0	K3
       0x08080403,  //  0009  MUL	R2	R2	R3
       0x880C0104,  //  000A  GETMBR	R3	R0	K4
       0x880C0705,  //  000B  GETMBR	R3	R3	K5
       0x1C080403,  //  000C  EQ	R2	R2	R3
-      0x780A0002,  //  000D  JMPF	R2	#0011
+      0x780A0006,  //  000D  JMPF	R2	#0015
       0x88080104,  //  000E  GETMBR	R2	R0	K4
       0x8C080506,  //  000F  GETMET	R2	R2	K6
       0x7C080200,  //  0010  CALL	R2	1
-      0x80000000,  //  0011  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_dirty
-********************************************************************/
-be_local_closure(Leds_matrix_is_dirty,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(is_dirty),
-    }),
-    &be_const_str_is_dirty,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
+      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x8C080508,  //  0012  GETMET	R2	R2	K8
+      0x7C080200,  //  0013  CALL	R2	1
+      0x90020E02,  //  0014  SETMBR	R0	K7	R2
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -1045,100 +1216,6 @@ be_local_closure(Leds_matrix_clear_to,   /* name */
 
 
 /********************************************************************
-** Solidified function: clear
-********************************************************************/
-be_local_closure(Leds_matrix_clear,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(clear_to),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str(show),
-    }),
-    &be_const_str_clear,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x580C0001,  //  0001  LDCONST	R3	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x8C040102,  //  0003  GETMET	R1	R0	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: pixels_buffer
-********************************************************************/
-be_local_closure(Leds_matrix_pixels_buffer,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    &be_const_str_pixels_buffer,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Leds_matrix_init,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(offset),
-    /* K2   */  be_nested_str(h),
-    /* K3   */  be_nested_str(w),
-    /* K4   */  be_nested_str(alternate),
-    }),
-    &be_const_str_init,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020204,  //  0001  SETMBR	R0	K1	R4
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x90020602,  //  0003  SETMBR	R0	K3	R2
-      0x50140000,  //  0004  LDBOOL	R5	0	0
-      0x90020805,  //  0005  SETMBR	R0	K4	R5
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: dirty
 ********************************************************************/
 be_local_closure(Leds_matrix_dirty,   /* name */
@@ -1162,39 +1239,6 @@ be_local_closure(Leds_matrix_dirty,   /* name */
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pixel_color
-********************************************************************/
-be_local_closure(Leds_matrix_get_pixel_color,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(get_pixel_color),
-    /* K2   */  be_nested_str(offseta),
-    }),
-    &be_const_str_get_pixel_color,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x00100204,  //  0003  ADD	R4	R1	R4
-      0x7C080400,  //  0004  CALL	R2	2
-      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
@@ -1229,33 +1273,9 @@ be_local_closure(Leds_matrix_get_alternate,   /* name */
 
 
 /********************************************************************
-** Solidified function: begin
+** Solidified function: is_dirty
 ********************************************************************/
-be_local_closure(Leds_matrix_begin,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    &be_const_str_begin,
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: can_show
-********************************************************************/
-be_local_closure(Leds_matrix_can_show,   /* name */
+be_local_closure(Leds_matrix_is_dirty,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -1267,9 +1287,9 @@ be_local_closure(Leds_matrix_can_show,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str(strip),
-    /* K1   */  be_nested_str(can_show),
+    /* K1   */  be_nested_str(is_dirty),
     }),
-    &be_const_str_can_show,
+    &be_const_str_is_dirty,
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -1283,34 +1303,80 @@ be_local_closure(Leds_matrix_can_show,   /* name */
 
 
 /********************************************************************
+** Solidified function: set_bytes
+********************************************************************/
+be_local_closure(Leds_matrix_set_bytes,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str(h),
+    /* K1   */  be_nested_str(pix_size),
+    /* K2   */  be_nested_str(offset),
+    /* K3   */  be_nested_str(pix_buffer),
+    /* K4   */  be_nested_str(setbytes),
+    }),
+    &be_const_str_set_bytes,
+    &be_const_str_solidified,
+    ( &(const binstruction[14]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x88140101,  //  0001  GETMBR	R5	R0	K1
+      0x08100805,  //  0002  MUL	R4	R4	R5
+      0x88140102,  //  0003  GETMBR	R5	R0	K2
+      0x08180204,  //  0004  MUL	R6	R1	R4
+      0x00140A06,  //  0005  ADD	R5	R5	R6
+      0x88180103,  //  0006  GETMBR	R6	R0	K3
+      0x8C180D04,  //  0007  GETMET	R6	R6	K4
+      0x5C200A00,  //  0008  MOVE	R8	R5
+      0x5C240400,  //  0009  MOVE	R9	R2
+      0x5C280600,  //  000A  MOVE	R10	R3
+      0x5C2C0800,  //  000B  MOVE	R11	R4
+      0x7C180A00,  //  000C  CALL	R6	5
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Leds_matrix
 ********************************************************************/
 be_local_class(Leds_matrix,
-    5,
+    7,
     NULL,
-    be_nested_map(21,
+    be_nested_map(24,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key(pixel_count, -1), be_const_closure(Leds_matrix_pixel_count_closure) },
-        { be_const_key(h, 6), be_const_var(2) },
-        { be_const_key(set_alternate, 7), be_const_closure(Leds_matrix_set_alternate_closure) },
-        { be_const_key(pixel_size, 16), be_const_closure(Leds_matrix_pixel_size_closure) },
-        { be_const_key(set_pixel_color, 19), be_const_closure(Leds_matrix_set_pixel_color_closure) },
-        { be_const_key(set_matrix_pixel_color, 10), be_const_closure(Leds_matrix_set_matrix_pixel_color_closure) },
-        { be_const_key(show, -1), be_const_closure(Leds_matrix_show_closure) },
-        { be_const_key(alternate, -1), be_const_var(4) },
-        { be_const_key(strip, -1), be_const_var(0) },
-        { be_const_key(clear_to, -1), be_const_closure(Leds_matrix_clear_to_closure) },
-        { be_const_key(w, 15), be_const_var(3) },
-        { be_const_key(pixels_buffer, -1), be_const_closure(Leds_matrix_pixels_buffer_closure) },
+        { be_const_key(set_bytes, -1), be_const_closure(Leds_matrix_set_bytes_closure) },
+        { be_const_key(pix_buffer, -1), be_const_var(5) },
+        { be_const_key(pix_size, 20), be_const_var(6) },
         { be_const_key(init, -1), be_const_closure(Leds_matrix_init_closure) },
-        { be_const_key(dirty, -1), be_const_closure(Leds_matrix_dirty_closure) },
-        { be_const_key(get_pixel_color, -1), be_const_closure(Leds_matrix_get_pixel_color_closure) },
-        { be_const_key(get_alternate, 17), be_const_closure(Leds_matrix_get_alternate_closure) },
-        { be_const_key(offset, 8), be_const_var(1) },
-        { be_const_key(clear, -1), be_const_closure(Leds_matrix_clear_closure) },
+        { be_const_key(set_pixel_color, 16), be_const_closure(Leds_matrix_set_pixel_color_closure) },
+        { be_const_key(alternate, -1), be_const_var(4) },
         { be_const_key(begin, -1), be_const_closure(Leds_matrix_begin_closure) },
-        { be_const_key(is_dirty, -1), be_const_closure(Leds_matrix_is_dirty_closure) },
+        { be_const_key(h, -1), be_const_var(2) },
+        { be_const_key(get_pixel_color, -1), be_const_closure(Leds_matrix_get_pixel_color_closure) },
+        { be_const_key(pixel_size, 21), be_const_closure(Leds_matrix_pixel_size_closure) },
+        { be_const_key(set_alternate, -1), be_const_closure(Leds_matrix_set_alternate_closure) },
         { be_const_key(can_show, -1), be_const_closure(Leds_matrix_can_show_closure) },
+        { be_const_key(get_alternate, 13), be_const_closure(Leds_matrix_get_alternate_closure) },
+        { be_const_key(w, -1), be_const_var(3) },
+        { be_const_key(set_matrix_pixel_color, 12), be_const_closure(Leds_matrix_set_matrix_pixel_color_closure) },
+        { be_const_key(pixel_count, -1), be_const_closure(Leds_matrix_pixel_count_closure) },
+        { be_const_key(show, -1), be_const_closure(Leds_matrix_show_closure) },
+        { be_const_key(offset, -1), be_const_var(1) },
+        { be_const_key(clear_to, 17), be_const_closure(Leds_matrix_clear_to_closure) },
+        { be_const_key(dirty, -1), be_const_closure(Leds_matrix_dirty_closure) },
+        { be_const_key(clear, 10), be_const_closure(Leds_matrix_clear_closure) },
+        { be_const_key(strip, -1), be_const_var(0) },
+        { be_const_key(is_dirty, -1), be_const_closure(Leds_matrix_is_dirty_closure) },
+        { be_const_key(pixels_buffer, 0), be_const_closure(Leds_matrix_pixels_buffer_closure) },
     })),
     (bstring*) &be_const_str_Leds_matrix
 );

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds_animator.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds_animator.h
@@ -14,8 +14,32 @@ be_local_closure(Leds_animator_init,   /* name */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(fast_loop),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80040000,  //  0003  RET	1	R0
+        })
+      ),
+    }),
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(strip),
@@ -25,11 +49,11 @@ be_local_closure(Leds_animator_init,   /* name */
     /* K4   */  be_nested_str_weak(animators),
     /* K5   */  be_nested_str_weak(clear),
     /* K6   */  be_nested_str_weak(tasmota),
-    /* K7   */  be_nested_str_weak(add_driver),
+    /* K7   */  be_nested_str_weak(add_fast_loop),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
+    ( &(const binstruction[19]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
       0x540A0031,  //  0001  LDINT	R2	50
       0x90020202,  //  0002  SETMBR	R0	K1	R2
@@ -45,9 +69,10 @@ be_local_closure(Leds_animator_init,   /* name */
       0x7C080200,  //  000C  CALL	R2	1
       0xB80A0C00,  //  000D  GETNGBL	R2	K6
       0x8C080507,  //  000E  GETMET	R2	R2	K7
-      0x5C100000,  //  000F  MOVE	R4	R0
+      0x84100000,  //  000F  CLOSURE	R4	P0
       0x7C080400,  //  0010  CALL	R2	2
-      0x80000000,  //  0011  RET	0
+      0xA0000000,  //  0011  CLOSE	R0
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -55,11 +80,11 @@ be_local_closure(Leds_animator_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_bri
+** Solidified function: add_anim
 ********************************************************************/
-be_local_closure(Leds_animator_set_bri,   /* name */
+be_local_closure(Leds_animator_add_anim,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -67,14 +92,21 @@ be_local_closure(Leds_animator_set_bri,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(bri),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(animators),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(run),
     }),
-    be_str_weak(set_bri),
+    be_str_weak(add_anim),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x8C080302,  //  0004  GETMET	R2	R1	K2
+      0x7C080200,  //  0005  CALL	R2	1
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -103,6 +135,62 @@ be_local_closure(Leds_animator_stop,   /* name */
       0x50040000,  //  0000  LDBOOL	R1	0	0
       0x90020001,  //  0001  SETMBR	R0	K0	R1
       0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fast_loop
+********************************************************************/
+be_local_closure(Leds_animator_fast_loop,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(running),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(animators),
+    /* K3   */  be_nested_str_weak(is_running),
+    /* K4   */  be_nested_str_weak(animate),
+    /* K5   */  be_const_int(1),
+    /* K6   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(fast_loop),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060015,  //  0001  JMPF	R1	#0018
+      0x58040001,  //  0002  LDCONST	R1	K1
+      0x6008000C,  //  0003  GETGBL	R2	G12
+      0x880C0102,  //  0004  GETMBR	R3	R0	K2
+      0x7C080200,  //  0005  CALL	R2	1
+      0x14080202,  //  0006  LT	R2	R1	R2
+      0x780A000D,  //  0007  JMPF	R2	#0016
+      0x88080102,  //  0008  GETMBR	R2	R0	K2
+      0x94080401,  //  0009  GETIDX	R2	R2	R1
+      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x780E0003,  //  000C  JMPF	R3	#0011
+      0x8C0C0504,  //  000D  GETMET	R3	R2	K4
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x00040305,  //  000F  ADD	R1	R1	K5
+      0x70020003,  //  0010  JMP		#0015
+      0x880C0102,  //  0011  GETMBR	R3	R0	K2
+      0x8C0C0706,  //  0012  GETMET	R3	R3	K6
+      0x5C140200,  //  0013  MOVE	R5	R1
+      0x7C0C0400,  //  0014  CALL	R3	2
+      0x7001FFEC,  //  0015  JMP		#0003
+      0x8C080104,  //  0016  GETMET	R2	R0	K4
+      0x7C080200,  //  0017  CALL	R2	1
+      0x80000000,  //  0018  RET	0
     })
   )
 );
@@ -165,55 +253,26 @@ be_local_closure(Leds_animator_remove,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_50ms
+** Solidified function: set_bri
 ********************************************************************/
-be_local_closure(Leds_animator_every_50ms,   /* name */
+be_local_closure(Leds_animator_set_bri,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(running),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(animators),
-    /* K3   */  be_nested_str_weak(is_running),
-    /* K4   */  be_nested_str_weak(animate),
-    /* K5   */  be_const_int(1),
-    /* K6   */  be_nested_str_weak(remove),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(bri),
     }),
-    be_str_weak(every_50ms),
+    be_str_weak(set_bri),
     &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060015,  //  0001  JMPF	R1	#0018
-      0x58040001,  //  0002  LDCONST	R1	K1
-      0x6008000C,  //  0003  GETGBL	R2	G12
-      0x880C0102,  //  0004  GETMBR	R3	R0	K2
-      0x7C080200,  //  0005  CALL	R2	1
-      0x14080202,  //  0006  LT	R2	R1	R2
-      0x780A000D,  //  0007  JMPF	R2	#0016
-      0x88080102,  //  0008  GETMBR	R2	R0	K2
-      0x94080401,  //  0009  GETIDX	R2	R2	R1
-      0x8C0C0503,  //  000A  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x780E0003,  //  000C  JMPF	R3	#0011
-      0x8C0C0504,  //  000D  GETMET	R3	R2	K4
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x00040305,  //  000F  ADD	R1	R1	K5
-      0x70020003,  //  0010  JMP		#0015
-      0x880C0102,  //  0011  GETMBR	R3	R0	K2
-      0x8C0C0706,  //  0012  GETMET	R3	R3	K6
-      0x5C140200,  //  0013  MOVE	R5	R1
-      0x7C0C0400,  //  0014  CALL	R3	2
-      0x7001FFEC,  //  0015  JMP		#0003
-      0x8C080104,  //  0016  GETMET	R2	R0	K4
-      0x7C080200,  //  0017  CALL	R2	1
-      0x80000000,  //  0018  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -276,40 +335,6 @@ be_local_closure(Leds_animator_start,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_anim
-********************************************************************/
-be_local_closure(Leds_animator_add_anim,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(animators),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(run),
-    }),
-    be_str_weak(add_anim),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x8C080302,  //  0004  GETMET	R2	R1	K2
-      0x7C080200,  //  0005  CALL	R2	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: clear
 ********************************************************************/
 be_local_closure(Leds_animator_clear,   /* name */
@@ -352,18 +377,18 @@ be_local_class(Leds_animator,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(init, 12), be_const_closure(Leds_animator_init_closure) },
         { be_const_key_weak(clear, -1), be_const_closure(Leds_animator_clear_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(Leds_animator_stop_closure) },
-        { be_const_key_weak(strip, 4), be_const_var(0) },
+        { be_const_key_weak(stop, 13), be_const_closure(Leds_animator_stop_closure) },
+        { be_const_key_weak(add_anim, 4), be_const_closure(Leds_animator_add_anim_closure) },
         { be_const_key_weak(pixel_count, 6), be_const_var(1) },
         { be_const_key_weak(animate, -1), be_const_closure(Leds_animator_animate_closure) },
-        { be_const_key_weak(add_anim, 13), be_const_closure(Leds_animator_add_anim_closure) },
+        { be_const_key_weak(animators, 7), be_const_var(4) },
+        { be_const_key_weak(strip, -1), be_const_var(0) },
         { be_const_key_weak(bri, -1), be_const_var(2) },
-        { be_const_key_weak(every_50ms, -1), be_const_closure(Leds_animator_every_50ms_closure) },
-        { be_const_key_weak(remove, 7), be_const_closure(Leds_animator_remove_closure) },
+        { be_const_key_weak(remove, 8), be_const_closure(Leds_animator_remove_closure) },
         { be_const_key_weak(get_bri, -1), be_const_closure(Leds_animator_get_bri_closure) },
         { be_const_key_weak(start, -1), be_const_closure(Leds_animator_start_closure) },
         { be_const_key_weak(running, -1), be_const_var(3) },
-        { be_const_key_weak(animators, -1), be_const_var(4) },
+        { be_const_key_weak(fast_loop, -1), be_const_closure(Leds_animator_fast_loop_closure) },
         { be_const_key_weak(set_bri, 1), be_const_closure(Leds_animator_set_bri_closure) },
     })),
     be_str_weak(Leds_animator)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -325,6 +325,19 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // Berry: tasmota.delay_microseconds(timer:int) -> nil
+  //
+  int32_t l_delay_microseconds(struct bvm *vm);
+  int32_t l_delay_microseconds(struct bvm *vm) {
+    int32_t top = be_top(vm); // Get the number of arguments
+    if (top == 2 && be_isint(vm, 2)) {  // only 1 argument of type string accepted
+      uint32_t timer = be_toint(vm, 2);
+      delayMicroseconds(timer);
+      be_return_nil(vm); // Return
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
   // Berry: `yield() -> nil`
   // ESP object
   int32_t l_yield(bvm *vm);


### PR DESCRIPTION
## Description:

The changes here make it possible in the near future to create a Berry app to support DMX/Artnet (UDP based) animations on WS2812 led matrix.

Changes:
- add `tasmota.delay_microseconds(us:int) -> nil`: wait for `us` microseconds
- refactor `Leds_matrix` to allow for pixel buffer copy and solidification of code

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
