### PR TITLE
Deduplicate and fix %timer n%

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_09_timers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_09_timers.ino
@@ -253,10 +253,10 @@ uint16_t TimerGetTimeOfDay(uint8_t index)
   int16_t xtime = xtimer.time;
 #ifdef USE_SUNRISE
   if (xtimer.mode) {
-  if (xtime >= 12*60) xtime = 12*60 - xtime;
-  xtime += (int16_t)SunMinutes(xtimer.mode-1);
-  if (xtime <      0) xtime += 24*60;
-  if (xtime >= 24*60) xtime -= 24*60;
+    ApplyTimerOffsets(&xtimer);
+    xtime = xtimer.time;
+    if (xtime==2047 && xtimer.mode==1) xtime *= -1; // Sun always has already rises
+    if (xtime==2046 && xtimer.mode==2) xtime *= -1; // Sun always has already set   
   }
 #endif
 return xtime;

--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1458,19 +1458,7 @@ bool findNextVariableValue(char * &pVarname, float &value)
   } else if (sVarName.startsWith(F("TIMER"))) {
     uint32_t index = sVarName.substring(5).toInt();
     if (index > 0 && index <= MAX_TIMERS) {
-      value = Settings->timer[index -1].time;
-#if defined(USE_SUNRISE)
-      // Correct %timerN% values for sunrise/sunset timers
-      if ((1 == Settings->timer[index -1].mode) || (2 == Settings->timer[index -1].mode)) {
-        // in this context, time variable itself is merely an offset, with <720 being negative
-        value += -720 + SunMinutes(Settings->timer[index -1].mode -1);
-        if (2 == Settings->timer[index -1].mode) {
-          // To aid rule comparative statements, sunset past midnight (high lattitudes) is expressed past 24h00
-          // So sunset at 00h45 is at 24h45
-          if (value < 360) { value += 1440; }
-        }
-      }
-#endif  // USE_SUNRISE
+      value = TimerGetTimeOfDay(index -1);
     }
 #if defined(USE_SUNRISE)
   } else if (sVarName.equals(F("SUNRISE"))) {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #15230 & #16807 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

## Description
#16807 fixed a 3rd occurrence of %timerN% that #15230 had missed, and while discussing this with @barbudor we found that both were now duplicates of each other and would best be de-duplicated. While doing so, I found in fact both were a duplicate of yet another function. Additionally #15230 broke the permanent daylight capability introduced by #9543

## Tests
I ran both the original test cases from  #15230 (see immediately below) as well as a rather comprehensive set of cases of sunrise/sunset scenarios (see XLS for full set, and image for excerpt).

## Testcase #15230
```
Rule3 ON event#test DO backlog var1   %timer1%;var2 %timer2%; var3 %timer3%;var4 %timer4%;var5 %timer5%;var6   %timer6%;var7 %timer7%;var8 %timer8%;var9 %timer9%;var10 %timer10%;var11   %sunrise%;var12 %sunset% endon
Timer1   {"Enable":1,"Mode":1,"Time":"00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer2   {"Enable":1,"Mode":1,"Time":"-00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer3   {"Enable":1,"Mode":1,"Time":"11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer4   {"Enable":1,"Mode":1,"Time":"-11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer5   {"Enable":1,"Mode":2,"Time":"00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer6   {"Enable":1,"Mode":2,"Time":"-00:10","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer7   {"Enable":1,"Mode":2,"Time":"11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer8   {"Enable":1,"Mode":2,"Time":"-11:59","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer9   {"Enable":1,"Mode":1,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Action":3}
Timer10   {"Enable":1,"Mode":2,"Time":"00:00","Window":0,"Days":"1111111","Repeat":1,"Action":3}
backlog rule3;timers;event test
 
22:14:17.420 RUL: EVENT#TEST performs   "backlog var1 478;var2 458; var3 1187;var4 1189;var5 1151;var6 1131;var7   420;var8 422;var9 468;var10 1141;var11 468;var12 1141"
22:14:17.433 RSL: RESULT =   {"Var1":"478"}      => 07h48 + 00h10 => 07h58 = 478
22:14:17.683 RSL: RESULT =   {"Var2":"458"}      => 07h48 - 00h10 => 07h38 = 458
22:14:17.933 RSL: RESULT =   {"Var3":"1187"}     => 07h48 + 11h59 => 19h47 = 1187
22:14:18.183 RSL: RESULT =   {"Var4":"1189"}     => 07h48 - 11h59 => 19h49 = 1189
22:14:18.433 RSL: RESULT =   {"Var5":"1151"}     => 19h01 + 00h10 => 19h11 = 1151
22:14:18.683 RSL: RESULT =   {"Var6":"1131"}     => 19h01 - 00h10 => 18h51 = 1141
22:14:18.933 RSL: RESULT =   {"Var7":"420"}      => 19h01 + 11h59 => 07h00 = 420
22:14:19.182 RSL: RESULT =   {"Var8":"422"}      => 19h01 - 11h59 => 07h02 = 422
22:14:19.433 RSL: RESULT =   {"Var9":"468"}      => 07h48 + 00h00 => 07h48 = 468
22:14:19.683 RSL: RESULT =   {"Var10":"1141"}    => 19h01 + 00h00 => 19h48 = 1141
22:14:19.908 RSL: RESULT =   {"Var11":"468"}      => sunrise
22:14:20.158 RSL: RESULT =   {"Var12":"1141"}     => sunset
```

## New testcases
![image](https://user-images.githubusercontent.com/3198100/197879273-0252f939-98e2-43cf-baef-0d6da376a466.png)
[Tasmota.DayTime.xlsx](https://github.com/arendst/Tasmota/files/9863993/Tasmota.DayTime.xlsx)

