### PR TITLE
Use accumulating energy instead of instant power for ADE7953

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_07_ade7953.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_07_ade7953.ino
@@ -274,7 +274,7 @@ void Ade7953Write(uint16_t reg, uint32_t val) {
 }
 
 int32_t Ade7953Read(uint16_t reg) {
-	uint32_t response = 0;
+  uint32_t response = 0;
 
   int size = Ade7953RegSize(reg);
   if (size) {
@@ -306,7 +306,7 @@ int32_t Ade7953Read(uint16_t reg) {
     }
 #endif  // USE_ESP32_SPI
   }
-	return response;
+  return response;
 }
 
 #ifdef ADE7953_DUMP_REGS
@@ -441,6 +441,11 @@ void Ade7953GetData(void) {
     acc_mode, reg[0][4], reg[1][4], reg[0][5], reg[1][5],
     reg[0][0], reg[1][0], reg[0][1], reg[1][1], reg[0][2], reg[1][2], reg[0][3], reg[1][3]);
 
+  // If the device is initializing, we read the energy registers to reset them, but don't report the values as the first read may be inaccurate
+  if (Ade7953.init_step) {
+    return;
+  }
+
   uint32_t apparent_power[2] = { 0, 0 };
   uint32_t reactive_power[2] = { 0, 0 };
 
@@ -495,14 +500,15 @@ void Ade7953GetData(void) {
 }
 
 void Ade7953EnergyEverySecond(void) {
-	if (Ade7953.init_step) {
+  if (Ade7953.init_step) {
     if (1 == Ade7953.init_step) {
       Ade7953Init();
-	  }
+      Ade7953GetData();
+    }
     Ade7953.init_step--;
-	}	else {
-		Ade7953GetData();
-	}
+  } else {
+    Ade7953GetData();
+  }
 }
 
 /*********************************************************************************************/

--- a/tasmota/tasmota_xnrg_energy/xnrg_07_ade7953.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_07_ade7953.ino
@@ -201,9 +201,11 @@ const uint16_t Ade7953CalibRegs[2][ADE7953_CALIBREGS] {
 
 const uint8_t  ADE7953_REGISTERS = 6;
 const uint16_t Ade7953Registers[2][ADE7953_REGISTERS] {
-  { ADE7953_IRMSA, ADE7953_AWATT, ADE7953_AVA, ADE7953_AVAR, ADE7953_VRMS, ADE7943_Period },
-  { ADE7953_IRMSB, ADE7953_BWATT, ADE7953_BVA, ADE7953_BVAR, ADE7953_VRMS, ADE7943_Period }
+  { ADE7953_IRMSA, ADE7953_AENERGYA, ADE7953_APENERGYA, ADE7953_RENERGYA, ADE7953_VRMS, ADE7943_Period },
+  { ADE7953_IRMSB, ADE7953_AENERGYB, ADE7953_APENERGYB, ADE7953_RENERGYB, ADE7953_VRMS, ADE7943_Period }
 };
+
+const float ADE7953_LSB_PER_WATTSECOND = 2.5;
 
 struct Ade7953 {
   uint32_t voltage_rms[2] = { 0, 0 };
@@ -466,9 +468,9 @@ void Ade7953GetData(void) {
       Energy.frequency[channel] = 223750.0f / ((float)reg[channel][5] + 1);
       divider = (Ade7953.calib_data[channel][ADE7953_CAL_VGAIN] != ADE7953_GAIN_DEFAULT) ? 10000 : Settings->energy_voltage_calibration;
       Energy.voltage[channel] = (float)Ade7953.voltage_rms[channel] / divider;
-      divider = (Ade7953.calib_data[channel][ADE7953_CAL_WGAIN + channel] != ADE7953_GAIN_DEFAULT) ? 44 : (Settings->energy_power_calibration / 10);
+      divider = (Ade7953.calib_data[channel][ADE7953_CAL_WGAIN + channel] != ADE7953_GAIN_DEFAULT) ? ADE7953_LSB_PER_WATTSECOND : (Settings->energy_power_calibration / 10);
       Energy.active_power[channel] = (float)Ade7953.active_power[channel] / divider;
-      divider = (Ade7953.calib_data[channel][ADE7953_CAL_VARGAIN + channel] != ADE7953_GAIN_DEFAULT) ? 44 : (Settings->energy_power_calibration / 10);
+      divider = (Ade7953.calib_data[channel][ADE7953_CAL_VARGAIN + channel] != ADE7953_GAIN_DEFAULT) ? ADE7953_LSB_PER_WATTSECOND : (Settings->energy_power_calibration / 10);
       Energy.reactive_power[channel] = (float)reactive_power[channel] / divider;
       if (ADE7953_SHELLY_EM == Ade7953.model) {
         if (bitRead(acc_mode, 10 +channel)) {        // APSIGN
@@ -478,7 +480,7 @@ void Ade7953GetData(void) {
           Energy.reactive_power[channel] *= -1;
         }
       }
-      divider = (Ade7953.calib_data[channel][ADE7953_CAL_VAGAIN + channel] != ADE7953_GAIN_DEFAULT) ? 44 : (Settings->energy_power_calibration / 10);
+      divider = (Ade7953.calib_data[channel][ADE7953_CAL_VAGAIN + channel] != ADE7953_GAIN_DEFAULT) ? ADE7953_LSB_PER_WATTSECOND : (Settings->energy_power_calibration / 10);
       Energy.apparent_power[channel] = (float)apparent_power[channel] / divider;
       if (0 == Energy.active_power[channel]) {
         Energy.current[channel] = 0;


### PR DESCRIPTION
## Description:

Instead of using the instant power registers ([`AWATT`, `AVA`, `AVAR`](https://github.com/arendst/Tasmota/blob/c7a864231ab2af3597f58bcbe188a54495bbc4e9/tasmota/tasmota_xnrg_energy/xnrg_07_ade7953.ino#L169), etc.) to determine active, reactive and apparent power:
- We use accumulating energy registers (`AENERGYA`, `APENERGYA`, `RENERGYA`, etc.).
- These registers are read once per second inside the `Ade7953EnergyEverySecond` > `Ade7953GetData` function.
- The energy accumulated over one second (in watt second) is converted to watts to obtain **the average power over the last second**.
- These registers are read-with-reset registers. This means that the contents of these registers are reset to 0 after a read operation.
- This will allow the accumulated energy variable reported by Tasmota to be a lot more accurate because the energy registers have a 4.83 μs sampling time - handled in hardware (versus a 1 second sampling time in the current approach based on accumulating instant power every second).
- This will allow a much more precise calculation of the total energy consumed especially in situations where current varies rapidly.
- I have tested this build over the last couple of days and there was no issue.

### Caveat:
Users on the current version of Tasmota will have to recalibrate their power.
- They can use `PowerSet` with a known load to recalibrate.
- Or they can divide their `PowerCal` by `23.41494` (this was determined empirically and may vary slightly case by case).

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

