### PR TITLE
check for valid cdc config: board vs env

### DIFF
--- a/pio-tools/post_esp32.py
+++ b/pio-tools/post_esp32.py
@@ -139,6 +139,11 @@ def esp32_create_combined_bin(source, target, env):
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
     chip = env.get("BOARD_MCU")
     tasmota_platform = esp32_create_chip_string(chip)
+
+    if "-DUSE_USB_CDC_CONSOLE" in env.BoardConfig().get("build.extra_flags") and "cdc" not in tasmota_platform:
+        tasmota_platform += "cdc" 
+        print("WARNING: board definition uses CDC configuration, but environment name does not -> changing tasmota safeboot binary to:", tasmota_platform + "-safeboot.bin")
+ 
     if not os.path.exists(variants_dir):
         os.makedirs(variants_dir)
     if("safeboot" in firmware_name):


### PR DESCRIPTION
## Description:

This is primarily a convenience function while developing.
Our build system needs some information from the name of the build environment, which got more complexity in the past with the addition of `cdc` among other things.
The recommended way is still to append the `cdc` suffix to the platform name like i.e. `[env:tasmota32s3cdc]`, which will also create a sensible firmware name.

But while testing out things this change makes a bit easier to just drop in a board definition which uses `cdc` for any environment. Additionally it shows, that there is a discrepancy in the console, which should be resolved for a final environment.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
