### PR TITLE
allow webcam to reuse and share I2C bus 2

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_81_esp32_webcam.ino
@@ -191,8 +191,9 @@ bool WcPinUsed(void) {
   }
   if (!PinUsed(GPIO_WEBCAM_XCLK) || !PinUsed(GPIO_WEBCAM_PCLK) ||
       !PinUsed(GPIO_WEBCAM_VSYNC) || !PinUsed(GPIO_WEBCAM_HREF) ||
-      !PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) {
-    pin_used = false;
+      ((!PinUsed(GPIO_WEBCAM_SIOD) || !PinUsed(GPIO_WEBCAM_SIOC)) && !TasmotaGlobal.i2c_enabled_2)    // preferred option is to reuse and share I2Cbus 2
+      ) { 
+        pin_used = false;
   }
   return pin_used;
 }
@@ -341,8 +342,14 @@ uint32_t WcSetup(int32_t fsiz) {
     config.pin_pclk = Pin(GPIO_WEBCAM_PCLK);      // PCLK_GPIO_NUM;
     config.pin_vsync = Pin(GPIO_WEBCAM_VSYNC);    // VSYNC_GPIO_NUM;
     config.pin_href = Pin(GPIO_WEBCAM_HREF);      // HREF_GPIO_NUM;
-    config.pin_sscb_sda = Pin(GPIO_WEBCAM_SIOD);  // SIOD_GPIO_NUM;
-    config.pin_sscb_scl = Pin(GPIO_WEBCAM_SIOC);  // SIOC_GPIO_NUM;
+    config.pin_sccb_sda = Pin(GPIO_WEBCAM_SIOD);  // SIOD_GPIO_NUM; - unset to use shared I2C bus 2
+    config.pin_sccb_scl = Pin(GPIO_WEBCAM_SIOC);  // SIOC_GPIO_NUM;
+    if(TasmotaGlobal.i2c_enabled_2){              // configure SIOD and SIOC as SDA,2 and SCL,2
+      config.sccb_i2c_port = 1;                   // reuse initialized bus 2, can be shared now
+      if(config.pin_sccb_sda < 0){                // GPIO_WEBCAM_SIOD must not be set to really make it happen
+        AddLog(LOG_LEVEL_INFO, PSTR("CAM: use I2C bus 2"));
+      }
+    }
     config.pin_pwdn = Pin(GPIO_WEBCAM_PWDN);       // PWDN_GPIO_NUM;
     config.pin_reset = Pin(GPIO_WEBCAM_RESET);    // RESET_GPIO_NUM;
     AddLog(LOG_LEVEL_DEBUG, PSTR("CAM: Template pin config"));


### PR DESCRIPTION
## Description:

Any supported webcam on the ESP32 platform uses 2 pins for I2C connectivity (named SIOD_GPIO_NUM and SIOC_GPIO_NUM in Tasmota). Until now one of the two I2C busses is taken by the webcam driver exclusively.

If another device is physically connected to the same bus, it was not possible to use it in Tasmota, which was a limitation of the esp32-camera submodule and not Tasmotas webcam driver.

Since this change:
https://github.com/espressif/esp32-camera/pull/413
it is possible to use an initialized I2C bus.

This PR adds the possibility to reuse I2C bus number 2 (2 in Tasmota = 1 in ESP-IDF) to share it.
This is no breaking change for existing configurations/ templates. With the old pin config everything should work as before.

For the new functionality SIOD_GPIO_NUM must be unset and the physical pin must be configured as SDL,2. SIOC_GPIO_NUM becomes SCA,2.

If there is a device on the same bus with software support in the used Tasmota binary, it should work without further steps needed.
I could only test it with an ESP32-S3-Eye, where the QMA7981 accelerometer shares the I2C bus with the camera. Test was a done with a Berry driver, as this accelerometer has no driver support in Tasmota (and obviously it is not really needed).

Only breaking change would be to compile this driver with an old framework without the PR from above.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
