### PR TITLE
Berry: Expose the ULP on ESP32S2 and ESP32S3 (RISCV version)

### DIFF
--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -166,7 +166,7 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
 #ifdef USE_ALEXA_AVS
     &be_native_module(crypto),
 #endif
-#if defined(USE_BERRY_ULP) && defined(CONFIG_IDF_TARGET_ESP32)
+#if defined(USE_BERRY_ULP)
     &be_native_module(ULP),
 #endif // USE_BERRY_ULP
 #if defined(USE_MI_ESP32) && !defined(USE_BLE_ESP32)

--- a/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_ULP_lib.c
@@ -6,9 +6,9 @@
 #include "be_constobj.h"
 #include "be_mapping.h"
 
-#if defined(USE_BERRY_ULP) && defined(CONFIG_IDF_TARGET_ESP32)
+#if defined(USE_BERRY_ULP) &&  (defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
 
-#include "esp32/ulp.h"
+// #include "esp32/ulp.h"
 #include "driver/rtc_io.h"
 #include "driver/gpio.h"
 #include "driver/adc.h"
@@ -37,8 +37,6 @@ BE_FUNC_CTYPE_DECLARE(be_ULP_sleep, "", "[i]");   // optional int arg
 extern void be_ULP_load(struct bvm *vm, const uint8_t *buf, size_t size);
 BE_FUNC_CTYPE_DECLARE(be_ULP_load, "", "@(bytes)~");   // pass: 1/ vm, 2/ bytes point, 3/ bytes size
 
-#include "be_fixed_ULP.h"
-
 /* @const_object_info_begin
 module ULP (scope: global) {
   run,          ctype_func(be_ULP_run)
@@ -51,5 +49,6 @@ module ULP (scope: global) {
   adc_config,   ctype_func(be_ULP_adc_config)
 }
 @const_object_info_end */
+#include "be_fixed_ULP.h"
 
 #endif // USE_BERRY_ULP


### PR DESCRIPTION
## Description:

Initially I thought about adding the FSM version too, but after playing with some examples I think, this not useful and would create (even more) confusion about the ULP usage.
This RISCV ULP is programmed in C, which unsurprisingly is a ton easier to do than the assembly code on the FSM versions of the ULP.
Binaries can only be created by building an ESP-IDF project and then using https://github.com/Staars/berry-examples/blob/main/ulp_helper/binS2Berry.py or the JS app in https://tasmota.github.io/docs/ULP/#export-from-esp-idf-project.
There are no real API changes on the Tasmota/Berry side, but in the ESP-IDF we have some differences between ESP32,..S2 and ..S3, which beside other major things include some enums. The major changes are abstracted away in the Berry bindings.
In my tests "everything" like ADC, GPIO, (bitbanged) I2C and OneWire did work as expected.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
