### PR TITLE
xsns_40_pn532.ino Saving the PN532 password and PACK in Settings

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_40_pn532.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_40_pn532.ino
@@ -106,8 +106,10 @@ void PN532_Init(void) {
         PN532_SAMConfig();
         AddLog(LOG_LEVEL_INFO,"NFC: PN532 NFC Reader detected v%u.%u",(ver>>16) & 0xFF, (ver>>8) & 0xFF);
         Pn532.present = true;
+#ifdef USE_PN532_DATA_FUNCTION
         Pn532.pwd_auth=Settings->pn532_password;
         Pn532.pwd_pack=Settings->pn532_pack;
+#endif
       }
     }
   }

--- a/tasmota/tasmota_xsns_sensor/xsns_40_pn532.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_40_pn532.ino
@@ -85,8 +85,8 @@ struct PN532 {
 #ifdef USE_PN532_DATA_FUNCTION
   uint8_t newdata[16];
   uint8_t function = 0;
-  uint32_t pwd_auth=0x64636261;
-  uint16_t pwd_pack=0x6665;
+  uint32_t pwd_auth;
+  uint16_t pwd_pack;
   uint32_t pwd_auth_new;
   uint16_t pwd_pack_new;
 #endif  // USE_PN532_DATA_FUNCTION
@@ -106,6 +106,8 @@ void PN532_Init(void) {
         PN532_SAMConfig();
         AddLog(LOG_LEVEL_INFO,"NFC: PN532 NFC Reader detected v%u.%u",(ver>>16) & 0xFF, (ver>>8) & 0xFF);
         Pn532.present = true;
+        Pn532.pwd_auth=Settings->pn532_password;
+        Pn532.pwd_pack=Settings->pn532_pack;
       }
     }
   }
@@ -708,6 +710,9 @@ bool PN532_Command(void) {
     if (ArgC() > 2) {
       Pn532.pwd_pack=strtoul(ArgV(argument,3),nullptr,0);
     }
+    Settings->pn532_password=Pn532.pwd_auth;
+    Settings->pn532_pack=Pn532.pwd_pack;
+
     serviced = true;
   }
   if (!strcmp_P(argument,PSTR("SET_PWD"))) {


### PR DESCRIPTION
## Description: xsns_40_pn532.ino Saving the PN532 password and PACK in Settings

added saving to persistent slots (#16939)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
