### PR TITLE
Add support for Plantower PMSx003T AQI models with temperature and humidity

### DIFF
--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -173,7 +173,7 @@
 #endif
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
-  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMS5003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 #define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)

--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -173,6 +173,7 @@
 #endif
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 #define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -439,6 +439,7 @@
 #endif
 //#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 //#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 //#define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 //#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
@@ -655,6 +656,7 @@
 #endif
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 #define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)

--- a/tasmota/include/tasmota_configurations_ESP32.h
+++ b/tasmota/include/tasmota_configurations_ESP32.h
@@ -439,7 +439,7 @@
 #endif
 //#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
-  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMS5003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 //#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 //#define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 //#define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)
@@ -656,7 +656,7 @@
 #endif
 #define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
-  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMS5003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 #define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+0k7 code)
 #define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor
 #define USE_SR04                                 // Add support for HC-SR04 ultrasonic devices (+1k code)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -762,6 +762,7 @@
   #define CO2_HIGH             1200              // Above this CO2 value show red light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
 //#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 //#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+1k5 code)
   #define STARTING_OFFSET      30                // Turn on NovaSDS XX-seconds before tele_period is reached
 //#define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor (+1k4)

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -762,7 +762,7 @@
   #define CO2_HIGH             1200              // Above this CO2 value show red light (needs PWM or WS2812 RG(B) led and enable with SetOption18 1)
 //#define USE_PMS5003                              // Add support for PMS5003 and PMS7003 particle concentration sensor (+1k3 code)
   //#define PMS_MODEL_PMS3003                      // Enable support of PMS3003 instead of PMS5003/PMS7003 (needs the USE_PMS5003 above)
-  //#define PMS_MODEL_PMSx003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
+  //#define PMS_MODEL_PMS5003T                     // Enable support for PMSx003T models that report temperature and humidity (needs the USE_PMS5003 above)
 //#define USE_NOVA_SDS                             // Add support for SDS011 and SDS021 particle concentration sensor (+1k5 code)
   #define STARTING_OFFSET      30                // Turn on NovaSDS XX-seconds before tele_period is reached
 //#define USE_HPMA                                 // Add support for Honeywell HPMA115S0 particle concentration sensor (+1k4)

--- a/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
@@ -81,7 +81,7 @@ struct pmsX003data {
   uint16_t temperature10x, humidity10x;
 #else
   uint16_t particles_50um, particles_100um;
-#endif
+#endif // PMS_MODEL_PMSx003T
   uint16_t unused;
 #endif  // PMS_MODEL_PMS3003
   uint16_t checksum;

--- a/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
@@ -26,6 +26,7 @@
  * Hardware Serial will be selected if GPIO3 = [PMS5003]
  * You can either support PMS3003 or PMS5003-7003 at one time. To enable the PMS3003 support
  * you must enable the define PMS_MODEL_PMS3003 on your configuration file.
+ * For PMSx003T models that report temperature and humidity define PMS_MODEL_PMSx003T
 \*********************************************************************************************/
 
 #define XSNS_18             18
@@ -75,7 +76,12 @@ struct pmsX003data {
 #ifdef PMS_MODEL_PMS3003
   uint16_t reserved1, reserved2, reserved3;
 #else
-  uint16_t particles_03um, particles_05um, particles_10um, particles_25um, particles_50um, particles_100um;
+  uint16_t particles_03um, particles_05um, particles_10um, particles_25um;
+#ifdef PMS_MODEL_PMSx003T
+  uint16_t temperature10x, humidity10x;
+#else
+  uint16_t particles_50um, particles_100um;
+#endif
   uint16_t unused;
 #endif  // PMS_MODEL_PMS3003
   uint16_t checksum;
@@ -289,24 +295,40 @@ const char HTTP_PMS5003_SNS[] PROGMEM =
   "{s}PMS5003 " D_PARTICALS_BEYOND " 0.5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 1 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 2.5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
+#ifdef PMS_MODEL_PMSx003T
+  "{s}PMS5003 " D_TEMPERATURE "{m}%*_f " D_UNIT_DEGREE "%c{e}"
+  "{s}PMS5003 " D_HUMIDITY "{m}%*_f " D_UNIT_PERCENT "{e}";
+#else
   "{s}PMS5003 " D_PARTICALS_BEYOND " 5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 10 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}";      // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
+#endif  // PMS_MODEL_PMSx003T
 #endif  // PMS_MODEL_PMS3003
 #endif  // USE_WEBSERVER
 
 void PmsShow(bool json)
 {
   if (Pms.valid) {
+#ifdef PMS_MODEL_PMSx003T
+    float temperature = ConvertTemp(pms_data.temperature10x/10.0);
+    float humidity = ConvertHumidity(pms_data.humidity10x/10.0);
+#endif // PMS_MODEL_PMSx003T
     if (json) {
 #ifdef PMS_MODEL_PMS3003
       ResponseAppend_P(PSTR(",\"PMS3003\":{\"CF1\":%d,\"CF2.5\":%d,\"CF10\":%d,\"PM1\":%d,\"PM2.5\":%d,\"PM10\":%d}"),
         pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env);
 #else
-      ResponseAppend_P(PSTR(",\"PMS5003\":{\"CF1\":%d,\"CF2.5\":%d,\"CF10\":%d,\"PM1\":%d,\"PM2.5\":%d,\"PM10\":%d,\"PB0.3\":%d,\"PB0.5\":%d,\"PB1\":%d,\"PB2.5\":%d,\"PB5\":%d,\"PB10\":%d}"),
+      ResponseAppend_P(PSTR(",\"PMS5003\":{\"CF1\":%d,\"CF2.5\":%d,\"CF10\":%d,\"PM1\":%d,\"PM2.5\":%d,\"PM10\":%d,\"PB0.3\":%d,\"PB0.5\":%d,\"PB1\":%d,\"PB2.5\":%d,"),
         pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env,
-        pms_data.particles_03um, pms_data.particles_05um, pms_data.particles_10um, pms_data.particles_25um, pms_data.particles_50um, pms_data.particles_100um);
+        pms_data.particles_03um, pms_data.particles_05um, pms_data.particles_10um, pms_data.particles_25um);
+#ifdef PMS_MODEL_PMSx003T
+      ResponseAppend_P(PSTR("\"" D_JSON_TEMPERATURE "\":%*_f,\"" D_JSON_HUMIDITY "\":%*_f}"),
+        Settings->flag2.temperature_resolution, &temperature, Settings->flag2.humidity_resolution, &humidity);
+#else
+      ResponseAppend_P(PSTR("\"PB5\":%d,\"PB10\":%d}"),
+        pms_data.particles_50um, pms_data.particles_100um);
+#endif  // PMS_MODEL_PMSx003T
 #endif  // PMS_MODEL_PMS3003
 #ifdef USE_DOMOTICZ
       if (0 == TasmotaGlobal.tele_period) {
@@ -322,6 +344,10 @@ void PmsShow(bool json)
         WSContentSend_PD(HTTP_PMS3003_SNS,
 //        pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env);
+#elif defined(PMS_MODEL_PMSx003T)
+        WSContentSend_PD(HTTP_PMS5003_SNS,
+        pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env,
+        pms_data.particles_03um, pms_data.particles_05um, pms_data.particles_10um, pms_data.particles_25um, Settings->flag2.temperature_resolution, &temperature, TempUnit(), Settings->flag2.humidity_resolution, &humidity);
 #else
         WSContentSend_PD(HTTP_PMS5003_SNS,
 //        pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,

--- a/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_18_pms5003.ino
@@ -26,7 +26,7 @@
  * Hardware Serial will be selected if GPIO3 = [PMS5003]
  * You can either support PMS3003 or PMS5003-7003 at one time. To enable the PMS3003 support
  * you must enable the define PMS_MODEL_PMS3003 on your configuration file.
- * For PMSx003T models that report temperature and humidity define PMS_MODEL_PMSx003T
+ * For PMSx003T models that report temperature and humidity define PMS_MODEL_PMS5003T
 \*********************************************************************************************/
 
 #define XSNS_18             18
@@ -77,11 +77,11 @@ struct pmsX003data {
   uint16_t reserved1, reserved2, reserved3;
 #else
   uint16_t particles_03um, particles_05um, particles_10um, particles_25um;
-#ifdef PMS_MODEL_PMSx003T
+#ifdef PMS_MODEL_PMS5003T
   uint16_t temperature10x, humidity10x;
 #else
   uint16_t particles_50um, particles_100um;
-#endif // PMS_MODEL_PMSx003T
+#endif // PMS_MODEL_PMS5003T
   uint16_t unused;
 #endif  // PMS_MODEL_PMS3003
   uint16_t checksum;
@@ -295,23 +295,23 @@ const char HTTP_PMS5003_SNS[] PROGMEM =
   "{s}PMS5003 " D_PARTICALS_BEYOND " 0.5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 1 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 2.5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
-#ifdef PMS_MODEL_PMSx003T
+#ifdef PMS_MODEL_PMS5003T
   "{s}PMS5003 " D_TEMPERATURE "{m}%*_f " D_UNIT_DEGREE "%c{e}"
   "{s}PMS5003 " D_HUMIDITY "{m}%*_f " D_UNIT_PERCENT "{e}";
 #else
   "{s}PMS5003 " D_PARTICALS_BEYOND " 5 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}"
   "{s}PMS5003 " D_PARTICALS_BEYOND " 10 " D_UNIT_MICROMETER "{m}%d " D_UNIT_PARTS_PER_DECILITER "{e}";      // {s} = <tr><th>, {m} = </th><td>, {e} = </td></tr>
-#endif  // PMS_MODEL_PMSx003T
+#endif  // PMS_MODEL_PMS5003T
 #endif  // PMS_MODEL_PMS3003
 #endif  // USE_WEBSERVER
 
 void PmsShow(bool json)
 {
   if (Pms.valid) {
-#ifdef PMS_MODEL_PMSx003T
+#ifdef PMS_MODEL_PMS5003T
     float temperature = ConvertTemp(pms_data.temperature10x/10.0);
     float humidity = ConvertHumidity(pms_data.humidity10x/10.0);
-#endif // PMS_MODEL_PMSx003T
+#endif // PMS_MODEL_PMS5003T
     if (json) {
 #ifdef PMS_MODEL_PMS3003
       ResponseAppend_P(PSTR(",\"PMS3003\":{\"CF1\":%d,\"CF2.5\":%d,\"CF10\":%d,\"PM1\":%d,\"PM2.5\":%d,\"PM10\":%d}"),
@@ -322,13 +322,13 @@ void PmsShow(bool json)
         pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env,
         pms_data.particles_03um, pms_data.particles_05um, pms_data.particles_10um, pms_data.particles_25um);
-#ifdef PMS_MODEL_PMSx003T
+#ifdef PMS_MODEL_PMS5003T
       ResponseAppend_P(PSTR("\"" D_JSON_TEMPERATURE "\":%*_f,\"" D_JSON_HUMIDITY "\":%*_f}"),
         Settings->flag2.temperature_resolution, &temperature, Settings->flag2.humidity_resolution, &humidity);
 #else
       ResponseAppend_P(PSTR("\"PB5\":%d,\"PB10\":%d}"),
         pms_data.particles_50um, pms_data.particles_100um);
-#endif  // PMS_MODEL_PMSx003T
+#endif  // PMS_MODEL_PMS5003T
 #endif  // PMS_MODEL_PMS3003
 #ifdef USE_DOMOTICZ
       if (0 == TasmotaGlobal.tele_period) {
@@ -344,7 +344,7 @@ void PmsShow(bool json)
         WSContentSend_PD(HTTP_PMS3003_SNS,
 //        pms_data.pm10_standard, pms_data.pm25_standard, pms_data.pm100_standard,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env);
-#elif defined(PMS_MODEL_PMSx003T)
+#elif defined(PMS_MODEL_PMS5003T)
         WSContentSend_PD(HTTP_PMS5003_SNS,
         pms_data.pm10_env, pms_data.pm25_env, pms_data.pm100_env,
         pms_data.particles_03um, pms_data.particles_05um, pms_data.particles_10um, pms_data.particles_25um, Settings->flag2.temperature_resolution, &temperature, TempUnit(), Settings->flag2.humidity_resolution, &humidity);


### PR DESCRIPTION
## Description:

Plantower makes a variant of the PMSx003 modules with a T suffix that will report temperature and humidity.  They keep the same protocol but just repurpose the last two integers (particles_50um and particles_100um become temperature and humidity).  Tested it on my esp8266 and esp32 both with and without PMS_MODEL_PMS5003T defined and all looks good:

![image](https://user-images.githubusercontent.com/15239392/199086928-ba91524c-9494-4c60-9c64-6a27632f6463.png)

and console:

```
11:53:07.492 CMD: status 8
11:53:07.503 MQT: stat/HargroveBellevue_Office_Aqi/STATUS8 = {"StatusSNS":{"Time":"2022-10-31T11:53:07","PMS5003":{"CF1":5,"CF2.5":8,"CF10":8,"PM1":5,"PM2.5":8,"PM10":8,"PB0.3":996,"PB0.5":264,"PB1":59,"PB2.5":2,"Temperature":69.6,"Humidity":46.9},"TempUnit":"F"}}
```



**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
