### PR TITLE
ESP32 DMX ArtNet optimization to avoid any object allocation and avoid garbage collector pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Berry ``bytes().reverse()`` method (#16977)
 - ESP32 Support for DMX ArtNet Led matrix animations (#16984)
 - Command ``SetOption47 1..255`` to delay power on relay state in seconds reducing power surge. ``SO47 1`` delays until network connected. ``SO47 2`` delays until mqtt connected
+- ESP32 DMX ArtNet optimization to avoid any object allocation and avoid garbage collector pauses
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/embedded/leds.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/leds.be
@@ -117,8 +117,14 @@ class Leds : Leds_ntv
   def dirty()
     self.call_native(5)
   end
-  def pixels_buffer()
-    return self.call_native(6)
+  def pixels_buffer(old_buf)
+    var buf = self.call_native(6)   # address of buffer in memory
+    if old_buf == nil
+      return bytes(buf, self.pixel_size() * self.pixel_count())
+    else
+      old_buf._change_buffer(buf)
+      return old_buf
+    end
   end
   def pixel_size()
     return self.call_native(7)
@@ -275,7 +281,7 @@ class Leds : Leds_ntv
         # don't trigger on segment, you will need to trigger on full strip instead
         if bool(force) || (self.offset == 0 && self.w * self.h == self.strip.leds)
           self.strip.show()
-          self.pix_buffer = self.strip.pixels_buffer()  # update buffer after show()
+          self.pix_buffer = self.strip.pixels_buffer(self.pix_buffer)  # update buffer after show()
         end
       end
       def can_show()

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_leds.h
@@ -1118,7 +1118,7 @@ be_local_closure(Leds_matrix_pixel_count,   /* name */
 ********************************************************************/
 be_local_closure(Leds_matrix_show,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1139,29 +1139,30 @@ be_local_closure(Leds_matrix_show,   /* name */
     }),
     &be_const_str_show,
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
+    ( &(const binstruction[23]) {  /* code */
       0x60080017,  //  0000  GETGBL	R2	G23
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x740A0009,  //  0003  JMPT	R2	#000E
       0x88080100,  //  0004  GETMBR	R2	R0	K0
       0x1C080501,  //  0005  EQ	R2	R2	K1
-      0x780A000D,  //  0006  JMPF	R2	#0015
+      0x780A000E,  //  0006  JMPF	R2	#0016
       0x88080102,  //  0007  GETMBR	R2	R0	K2
       0x880C0103,  //  0008  GETMBR	R3	R0	K3
       0x08080403,  //  0009  MUL	R2	R2	R3
       0x880C0104,  //  000A  GETMBR	R3	R0	K4
       0x880C0705,  //  000B  GETMBR	R3	R3	K5
       0x1C080403,  //  000C  EQ	R2	R2	R3
-      0x780A0006,  //  000D  JMPF	R2	#0015
+      0x780A0007,  //  000D  JMPF	R2	#0016
       0x88080104,  //  000E  GETMBR	R2	R0	K4
       0x8C080506,  //  000F  GETMET	R2	R2	K6
       0x7C080200,  //  0010  CALL	R2	1
       0x88080104,  //  0011  GETMBR	R2	R0	K4
       0x8C080508,  //  0012  GETMET	R2	R2	K8
-      0x7C080200,  //  0013  CALL	R2	1
-      0x90020E02,  //  0014  SETMBR	R0	K7	R2
-      0x80000000,  //  0015  RET	0
+      0x88100107,  //  0013  GETMBR	R4	R0	K7
+      0x7C080400,  //  0014  CALL	R2	2
+      0x90020E02,  //  0015  SETMBR	R0	K7	R2
+      0x80000000,  //  0016  RET	0
     })
   )
 );
@@ -1452,24 +1453,44 @@ be_local_closure(Leds_create_matrix,   /* name */
 ********************************************************************/
 be_local_closure(Leds_pixels_buffer,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str(call_native),
+    /* K1   */  be_nested_str(pixel_size),
+    /* K2   */  be_nested_str(pixel_count),
+    /* K3   */  be_nested_str(_change_buffer),
     }),
     &be_const_str_pixels_buffer,
     &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x540E0005,  //  0001  LDINT	R3	6
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
+    ( &(const binstruction[21]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x54120005,  //  0001  LDINT	R4	6
+      0x7C080400,  //  0002  CALL	R2	2
+      0x4C0C0000,  //  0003  LDNIL	R3
+      0x1C0C0203,  //  0004  EQ	R3	R1	R3
+      0x780E0009,  //  0005  JMPF	R3	#0010
+      0x600C0015,  //  0006  GETGBL	R3	G21
+      0x5C100400,  //  0007  MOVE	R4	R2
+      0x8C140101,  //  0008  GETMET	R5	R0	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x8C180102,  //  000A  GETMET	R6	R0	K2
+      0x7C180200,  //  000B  CALL	R6	1
+      0x08140A06,  //  000C  MUL	R5	R5	R6
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x80040600,  //  000E  RET	1	R3
+      0x70020003,  //  000F  JMP		#0014
+      0x8C0C0303,  //  0010  GETMET	R3	R1	K3
+      0x5C140400,  //  0011  MOVE	R5	R2
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x80040200,  //  0013  RET	1	R1
+      0x80000000,  //  0014  RET	0
     })
   )
 );

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_leds.ino
@@ -151,19 +151,11 @@ extern "C" {
             break;
           case 6: // # 06 : Pixels       void -> bytes() (mapped to the buffer)
             {
-            size_t pixels_bytes;
-            if (s_ws2812_grb)       pixels_bytes = s_ws2812_grb->PixelsSize();
-            if (s_sk6812_grbw)      pixels_bytes = s_sk6812_grbw->PixelsSize();
-
             uint8_t * pixels;
             if (s_ws2812_grb)       pixels = s_ws2812_grb->Pixels();
             if (s_sk6812_grbw)      pixels = s_sk6812_grbw->Pixels();
             
-            be_getbuiltin(vm, "bytes");
             be_pushcomptr(vm, pixels);
-            be_pushint(vm, pixels_bytes);
-            be_call(vm, 2);
-            be_pop(vm, 2);
             }
             break;
           case 7: // # 07 : PixelSize    void -> int


### PR DESCRIPTION
## Description:

Optimization for ESP32 DMX/ArtNet WS2812 animations. Now the loop avoids allocating any new Berry object. The effect is that no garbage collector is triggered during animations:
- `udp_server.read([old_packet:bytes]) -> bytes or nil` now takes an optional `bytes()` parameter to store the content in-place instead of allocating a new object. The in-place `bytes()` buffer is resized if necessary
- `leds.pixels_buffer([old_buf:bytes]) -> bytes` takes an optional argument. You can now pass the `bytes()` object previously returned by this function, and the pointer is simply changed instead of reallocating a new `bytes()` object

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
