### PR TITLE
fix for deepsleep first calculation #13955

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_29_deepsleep.ino
@@ -118,11 +118,16 @@ void DeepSleepPrepare(void)
     RtcSettings.deepsleep_slip = tmin(tmax(RtcSettings.deepsleep_slip, 9000), 11000);
   }
 
+  AddLog(LOG_LEVEL_DEBUG, PSTR("DSPrep: time %ld, next %ld, slip %ld"),
+      timeslip, RtcSettings.nextwakeup, RtcSettings.deepsleep_slip );
   // It may happen that wakeup in just <5 seconds in future
   // In this case also add deepsleep to nextwakeup
   if (RtcSettings.nextwakeup <= (LocalTime() + DEEPSLEEP_MIN_TIME)) {
-    // ensure nextwakeup is at least in the future
+    // ensure nextwakeup is at least in the future, and add 5%
     RtcSettings.nextwakeup += (((LocalTime() + DEEPSLEEP_MIN_TIME - RtcSettings.nextwakeup) / Settings->deepsleep) + 1) * Settings->deepsleep;
+    RtcSettings.nextwakeup += Settings->deepsleep * 0.05;
+    AddLog(LOG_LEVEL_DEBUG, PSTR("DSPrep too short: time %ld, next %ld, slip %ld"),
+          timeslip, RtcSettings.nextwakeup, RtcSettings.deepsleep_slip);
   }
 
   String dt = GetDT(RtcSettings.nextwakeup);  // 2017-03-07T11:08:02


### PR DESCRIPTION
Signed-off-by: Reimer Prochnow <reimer-github@ideenhal.de>

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_

I made a fix for the first calculation of the deepsleep time, which was discussed in #13955 and is working since a couple of month for me now.
The deepsleep interval is untouched, but the very first time is prolonged to ensure that it's always after the desired timestamp, eg: 3600 -> ~ 3 minutes after xx:00 and never before xx:00, since this is confusing almost any tool I used (homeassistant energy dashboard, grafana)
300 -> xx:01, xx:06, xx:11 ....
