### PR TITLE
`DIO` as default flash mode for ESP82xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Breaking Changed
 
 ### Changed
+- Default Flash Mode changed from ``DOUT`` to ``DIO`` for ESP8266/ESP8285
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Download one of the released binaries from http://ota.tasmota.com/tasmota/releas
 ## Important User Compilation Information
 If you want to compile Tasmota yourself keep in mind the following:
 
-- For ESP8285 based devices only Flash Mode **DOUT** is supported. Do not use Flash Mode DIO / QIO / QOUT as it might seem to brick your device.
-- For ESP8285 based devices Tasmota uses a 1M linker script WITHOUT spiffs **1M (no SPIFFS)** for optimal code space.
+- For ESP8285 based devices Flash Mode **DOUT** and **DIO** are supported. Do not use Flash Mode QIO / QOUT as it might seem to brick your device.
 - To make compile time changes to Tasmota use the `user_config_override.h` file. It assures keeping your custom settings when you download and compile a new version. You have to make a copy from the provided `user_config_override_sample.h` file and add your setting overrides.
 
 ## Configuration Information

--- a/boards/esp8266_1M.json
+++ b/boards/esp8266_1M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_1M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },

--- a/boards/esp8266_2M1M.json
+++ b/boards/esp8266_2M1M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_2M -DESP8266_2M1M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },

--- a/boards/esp8266_2M256.json
+++ b/boards/esp8266_2M256.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_2M -DESP8266_2M256",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },

--- a/boards/esp8266_4M2M.json
+++ b/boards/esp8266_4M2M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M2M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },

--- a/boards/esp8266_4M3M.json
+++ b/boards/esp8266_4M3M.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_4M -DESP8266_4M3M",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },

--- a/boards/esp8266_zbbridge.json
+++ b/boards/esp8266_zbbridge.json
@@ -7,7 +7,7 @@
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01 -DESP8266_2M -DESP8266_2M256",
     "f_cpu": "160000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dout",
+    "flash_mode": "dio",
     "mcu": "esp8266",
     "variant": "generic"
   },


### PR DESCRIPTION
## Description:

all ESP82xx do support flash mode `dio`, no need for using slower flash mode `dout`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
