### PR TITLE
Fix for error on first command sent to S8 module

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_17_senseair.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_17_senseair.ino
@@ -70,7 +70,7 @@ void Senseair250ms(void)              // Every 250 mSec
     if (data_ready) {
       uint8_t error = SenseairModbus->Receive16BitRegister(&value);
       if (error) {
-        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "SenseAir response error %d"), error);
+        AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "SenseAir read register %02X gave response error %d"), (uint16_t)start_addresses[senseair_read_state], error);
       } else {
         switch(senseair_read_state) {
           case 0:                // 0x1A (26) READ_TYPE_LOW - S8: fe 04 02 01 77 ec 92
@@ -104,15 +104,16 @@ void Senseair250ms(void)              // Every 250 mSec
             AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "SenseAir temp adjustment %d"), value);
             break;
         }
-      }
-      senseair_read_state++;
-      if (2 == senseair_type) {  // S8
-        if (3 == senseair_read_state) {
-          senseair_read_state = 1;
-        }
-      } else {                   // K30, K70
-        if (sizeof(start_addresses) == senseair_read_state) {
-          senseair_read_state = 1;
+
+        senseair_read_state++;
+        if (2 == senseair_type) {  // S8
+          if (3 == senseair_read_state) {
+            senseair_read_state = 1;
+          }
+        } else {                   // K30, K70
+          if (sizeof(start_addresses) == senseair_read_state) {
+            senseair_read_state = 1;
+          }
         }
       }
     }


### PR DESCRIPTION
## Description:

I have a SenseAir S8 module that often times gives an error on the first command (maybe a poor power supply or buggy module?).  The current logic in xsns_17 is to only query 0x1A (Sensor Type ID Low) once at startup.  If the command is successful then senseair_type gets the value 2 for the S8 and everything is good.  But if it fails we increment senseair_read_state and leave the old value of senseair_type==1 which falsely things it is a K30 module and gives a number of errors after that.  We will never check the sensor type ID again so it will stay in this bad state until the next restart.

To fix this I moved the code to advance the read state inside the success block which allows for retries on failures at startup.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
