### PR TITLE
Increase MCU clock for esp32 and esp32solo1

### DIFF
--- a/boards/esp32.json
+++ b/boards/esp32.json
@@ -5,7 +5,7 @@
       },
       "core": "esp32",
       "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M",
-      "f_cpu": "80000000L",
+      "f_cpu": "160000000L",
       "f_flash": "40000000L",
       "flash_mode": "dio",
       "mcu": "esp32",

--- a/boards/esp32_solo1.json
+++ b/boards/esp32_solo1.json
@@ -5,7 +5,7 @@
     },
     "core": "esp32",
     "extra_flags": "-DARDUINO_ESP32_DEV -DBOARD_HAS_PSRAM -DARDUINO_USB_CDC_ON_BOOT=0 -DESP32_4M -DCORE32SOLO1",
-    "f_cpu": "80000000L",
+    "f_cpu": "240000000L",
     "f_flash": "40000000L",
     "flash_mode": "dio",
     "mcu": "esp32",


### PR DESCRIPTION
## Description:

enhances default performance and more align to the other MCU variants.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
