### PR TITLE
WS2812 sends signal to only ``Pixels`` leds instead of sending to 512 leds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Reverted Flash Mode back from ``DIO`` to ``DOUT`` for ESP8266/ESP8285 (#17019)
 - ESP32 Framework (Core) from v2.0.5.2 to v2.0.5.3 (#17034)
 - TuyaMcu rewrite by btsimonh (#17051)
+- WS2812 sends signal to only ``Pixels`` leds instead of sending to 512 leds
 
 ### Fixed
 - SenseAir S8 module detection (#17033)


### PR DESCRIPTION
## Description:

Optimization to have Neopixel buffer adjusted to the actual size of `Pixels` instead of sending always signal for 512 leds. When changing `Pixels`, the Neopixel object is deleted and a new one created. This makes shorter pauses when sending WS2812 stream.

Added some WS2812 APIs for future use.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
