### PR TITLE
Rm pip "zopfli" install from pio script

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -3,14 +3,6 @@ import os
 import shutil
 import pathlib
 import tasmotapiolib
-
-# Upgrade pip
-env.Execute("$PYTHONEXE -m pip install --upgrade pip")
-# Install zopfli gz compressor from the PyPi registry
-env.Execute("$PYTHONEXE -m pip install zopfli")
-
-# Import zoepfli compress
-from zopfli.gzip import compress
 import gzip
 
 def map_gzip(source, target, env):
@@ -39,7 +31,7 @@ if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_MAP_GZ, env):
 
 # gzip only for ESP8266
 if env["PIOPLATFORM"] != "espressif32":
-
+    from zopfli.gzip import compress
     def bin_gzip(source, target, env):
         # create string with location and file names based on variant
         bin_file = tasmotapiolib.get_final_bin_path(env)

--- a/platformio.ini
+++ b/platformio.ini
@@ -110,7 +110,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/v2.7.4.9/platform-espressif8266-2.7.4.9.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/v2.7.4/platform-espressif8266-2.7.4.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}


### PR DESCRIPTION
## Description:

it is now integrated in esp8266 Pio platform.

- Change Version scheme for esp8266 Platform from "2.7.4.x" to "2.7.4.date".  Platform is now "2.7.4.20221113"
   The Arduino framework is still the same as before (2.7.4.9)
<img width="787" alt="Bildschirmfoto 2022-11-13 um 18 13 09" src="https://user-images.githubusercontent.com/24528715/201534684-da87d61e-a428-402a-8ad2-d7cb06ee1284.png">

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
