### PR TITLE
Zigbee plugin to fix Moes-Tuya KCTW1Z Humidity

### DIFF
--- a/tasmota/zigbee/Tuya_KCTW1Z.zb
+++ b/tasmota/zigbee/Tuya_KCTW1Z.zb
@@ -1,0 +1,5 @@
+#Z2Tv1
+# Tuya fix humidity by 10 
+# https://zigbee.blakadder.com/Tuya_KCTW1Z.html
+:TS0201,_TZ3000_ywagc4rj
+0405/0000=0405/0000,mul:10


### PR DESCRIPTION
For device TS0201,_TZ3000_ywagc4rj (Moes Temperature Sensor KCTW1Z)
Should work with TS0201:_TZ3000_itnrsufe, regarding https://zigbee.blakadder.com/Tuya_KCTW1Z.html , but not implemented

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
