### PR TITLE
ESP32 LVGL library from v8.3.2 to v8.3.3 (no functional change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 Framework (Core) from v2.0.5.2 to v2.0.5.3 (#17034)
 - TuyaMcu rewrite by btsimonh (#17051)
 - WS2812 sends signal to only ``Pixels`` leds instead of sending to 512 leds (#17055)
+- ESP32 LVGL library from v8.3.2 to v8.3.3 (no functional change)
 
 ### Fixed
 - SenseAir S8 module detection (#17033)

--- a/lib/libesp32_lvgl/lvgl/library.json
+++ b/lib/libesp32_lvgl/lvgl/library.json
@@ -1,6 +1,6 @@
 {
 	"name": "lvgl",
-	"version": "8.3.2",
+	"version": "8.3.3",
 	"keywords": "graphics, gui, embedded, tft, lvgl",
 	"description": "Graphics library to create embedded GUI with easy-to-use graphical elements, beautiful visual effects and low memory footprint. It offers anti-aliasing, opacity, and animations using only one frame buffer.",
 	"repository": {

--- a/lib/libesp32_lvgl/lvgl/library.properties
+++ b/lib/libesp32_lvgl/lvgl/library.properties
@@ -1,5 +1,5 @@
 name=lvgl
-version=8.3.2
+version=8.3.3
 author=kisvegabor
 maintainer=kisvegabor,embeddedt,pete-pjb
 sentence=Full-featured Graphics Library for Embedded Systems

--- a/lib/libesp32_lvgl/lvgl/lv_conf_template.h
+++ b/lib/libesp32_lvgl/lvgl/lv_conf_template.h
@@ -1,6 +1,6 @@
 /**
  * @file lv_conf.h
- * Configuration file for v8.3.2
+ * Configuration file for v8.3.3
  */
 
 /*

--- a/lib/libesp32_lvgl/lvgl/lvgl.h
+++ b/lib/libesp32_lvgl/lvgl/lvgl.h
@@ -15,7 +15,7 @@ extern "C" {
  ***************************/
 #define LVGL_VERSION_MAJOR 8
 #define LVGL_VERSION_MINOR 3
-#define LVGL_VERSION_PATCH 1
+#define LVGL_VERSION_PATCH 3
 #define LVGL_VERSION_INFO ""
 
 /*********************


### PR DESCRIPTION
## Description:

Update LVGL from 8.3.2 to 8.3.3.

v8.3.3 is the same as v8.3.2. It was released only because the version number was set incorrectly in lvgl.h.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
