### PR TITLE
add RgxClients for ESP8266

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
@@ -95,10 +95,8 @@ const char kDrvRgxCommands[] PROGMEM = "Rgx|" // Prefix
                                        "|"
                                        "NAPT"
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
-#ifdef ESP32
                                        "|"
                                        "Clients"
-#endif // ESP32
                                        "|"
                                        "Address"
                                        "|"
@@ -111,9 +109,7 @@ void (*const DrvRgxCommand[])(void) PROGMEM = {
 #ifdef USE_WIFI_RANGE_EXTENDER_NAPT
     &CmndRgxNAPT,
 #endif // USE_WIFI_RANGE_EXTENDER_NAPT
-#ifdef ESP32
     &CmndRgxClients,
-#endif // ESP32
     &CmndRgxAddresses,
     &CmndRgxAddresses,
 };
@@ -172,17 +168,18 @@ void RgxCheckConfig(void)
   }
 }
 
-#ifdef ESP32
 void CmndRgxClients(void)
 {
+  Response_P(PSTR("{\"RgxClients\":{"));
+  const char *sep = "";
+
+#if defined(ESP32)
   wifi_sta_list_t wifi_sta_list = {0};
   tcpip_adapter_sta_list_t adapter_sta_list = {0};
 
   esp_wifi_ap_get_sta_list(&wifi_sta_list);
   tcpip_adapter_get_sta_list(&wifi_sta_list, &adapter_sta_list);
 
-  Response_P(PSTR("{\"RgxClients\":{"));
-  const char *sep = "";
   for (int i=0; i<adapter_sta_list.num; i++)
   {
     const uint8_t *m = adapter_sta_list.sta[i].mac;
@@ -190,9 +187,21 @@ void CmndRgxClients(void)
       sep, m[0], m[1], m[2], m[3], m[4], m[5], adapter_sta_list.sta[i].ip, wifi_sta_list.sta[i].rssi);
     sep = ",";
   }
+#elif defined(ESP8266)
+  struct station_info *station = wifi_softap_get_station_info();
+  while (station)
+  {
+    const uint8_t *m = station->bssid;
+    ResponseAppend_P(PSTR("%s\"%02X%02X%02X%02X%02X%02X\":{\"" D_CMND_IPADDRESS "\":\"%_I\"}"),
+      sep, m[0], m[1], m[2], m[3], m[4], m[5], station->ip.addr);
+    sep = ",";
+    station = STAILQ_NEXT(station, next);
+  }
+  wifi_softap_free_station_info();
+#endif
+
   ResponseAppend_P(PSTR("}}"));
 }
-#endif // ESP32
 
 void CmndRgxState(void)
 {


### PR DESCRIPTION
## Description:

recently added RgxClients command only supported ESP32 since the used API is different from ESP8266.
Now the ESP8266 API is also supported, although without RSSI values since the ESP8266 API doesn't provide them.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
