### PR TITLE
Berry add ``udp->close()`` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - WS2812 and Light Art-Net DMX control over UDP port 6454 (#17059)
 - Command ``SwitchMode 16`` sending only MQTT message on inverted switch change (#17028)
 - Support for HMC5883L 3-Axis Digital Compass sensor by Andreas Achtzehn (#17069)
+- Berry add ``udp->stop()`` method
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_udp_lib.cpp
+++ b/lib/libesp32/berry_tasmota/src/be_udp_lib.cpp
@@ -37,7 +37,7 @@ extern "C" {
     return be_call_c_func(vm, (void*) &be_udp_deinit_ntv, "=.p", "");
   }
 
-  // udp.begin(address:string, port:int) -> nil
+  // udp.begin(address:string, port:int) -> bool
   int32_t be_udp_begin_ntv(WiFiUDP *udp, const char *host, int32_t port) {
     IPAddress addr((uint32_t)0);
     // if no host or host is "" then we defult to INADDR_ANY (0.0.0.0)
@@ -48,6 +48,14 @@ extern "C" {
   }
   int32_t be_udp_begin(struct bvm *vm) {
     return be_call_c_func(vm, (void*) &be_udp_begin_ntv, "b", ".si");
+  }
+
+  // udp.stop() -> nil
+  void be_udp_stop_ntv(WiFiUDP *udp) {
+    udp->stop();
+  }
+  int32_t be_udp_stop(struct bvm *vm) {
+    return be_call_c_func(vm, (void*) &be_udp_stop_ntv, "b", ".");
   }
 
   // udp.begin_multicast(address:string, port:int) -> nil
@@ -159,6 +167,7 @@ class be_class_udp (scope: global, name: udp) {
     begin, func(be_udp_begin)
     begin_multicast, func(be_udp_begin_mcast)
     read, func(be_udp_read)
+    stop, func(be_udp_stop)
 }
 @const_object_info_end */
 


### PR DESCRIPTION
## Description:

Add missing `close()` method to udp class

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
