### PR TITLE
Fix ArtNet crash

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
@@ -146,8 +146,12 @@ void ArtNetProcessPacket(uint8_t * buf, size_t len) {
   if (artnet_conf.matrix) {
     // Ws2812 led strip
     size_t pix_size = Ws2812StripGetPixelSize();
+    // check that datalen does not exceed the number of columns
+    if (datalen > artnet_conf.cols * pix_size) { datalen = artnet_conf.cols * pix_size; }
+    // round to exact number of pixels
     datalen = datalen - (datalen % pix_size);
 
+    size_t offset_in_matrix = 0;
     if (artnet_conf.alt && (row % 2)) {
       for (int32_t i = idx, j = idx + datalen - pix_size; i < j; i += pix_size, j -= pix_size) {
           for (int32_t k = 0; k < pix_size; k++) {
@@ -156,6 +160,7 @@ void ArtNetProcessPacket(uint8_t * buf, size_t len) {
               buf[j+k] = temp;
           }
       }
+      offset_in_matrix = artnet_conf.cols * pix_size - datalen; // add a potential offset if the frame is smaller than the columns
     }
 
     // process dimmer
@@ -179,7 +184,7 @@ void ArtNetProcessPacket(uint8_t * buf, size_t len) {
 
     // process pixels
     size_t h_bytes = artnet_conf.cols * pix_size;   // size in bytes of a single row
-    size_t offset_in_matrix = artnet_conf.offs * pix_size + row * h_bytes;
+    offset_in_matrix += artnet_conf.offs * pix_size + row * h_bytes;
     if (datalen > h_bytes) { datalen = h_bytes; }   // copy at most one line
 
     Ws2812CopyPixels(&buf[idx], datalen, offset_in_matrix);
@@ -366,6 +371,8 @@ bool ArtNetStart(void) {
           Settings->light_pixels = artnet_conf.rows * artnet_conf.cols + artnet_conf.offs;
           Settings->light_rotation = 0;
           Ws2812ReinitStrip();
+        } else {
+          Ws2812Clear();
         }
       }
 


### PR DESCRIPTION
## Description:

Fix ArtNet crash when the buffer sent is bigger than the LED strip (too many columns).

Fix display of alternate lines when the buffer sent is smaller than the number of columns

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
