### PR TITLE
Fix linker error using #undef USE_WS2812 for ESP32

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_artnet.ino
@@ -21,6 +21,10 @@
 #ifdef USE_LIGHT
 #ifdef USE_LIGHT_ARTNET
 
+#ifndef USE_WS2812
+#define USE_WS2812                                    // needed since USE_LIGHT_ARTNET is enabled for ESP32 by default
+#endif
+
 #ifndef WS2812_ARTNET_UDP_BUFFER_SIZE
 #define WS2812_ARTNET_UDP_BUFFER_SIZE         140      // Max 30 columns with 4 bytes per pixel
 #endif


### PR DESCRIPTION
## Description:

Using `#undef USE_WS2812` in `user_config_override.h` causes linker error for functions

```
undefined reference to `Ws2812StripConfigured()'
undefined reference to `Ws2812ReinitStrip()'
undefined reference to `Ws2812Clear()'
undefined reference to `Ws2812StripGetPixelSize()'
undefined reference to `Ws2812CopyPixels(unsigned char const*, unsigned int, unsigned int)'
undefined reference to `Ws2812StripRefresh()'
```

since `USE_LIGHT_ARTNET` is default for ESP32 env.

can not be solve using `#undef USE_LIGHT_ARTNET` in `user_config_override.h`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
