### PR TITLE
Add DS18x20 parasitic power usage on ESP32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - WS2812 sends signal to only ``Pixels`` leds instead of sending to 512 leds (#17055)
 - Zigbee improved Aqara plug support and completed cluster 0x0702 (#17073)
 - ESP32 LVGL library from v8.3.2 to v8.3.3 (no functional change)
+- Add parasitic power usage for DS18x20 on ESP32 defining W1_PARASITE_POWER
 
 ### Fixed
 - SenseAir S8 module detection (#17033)


### PR DESCRIPTION
## Description:

DS18x20 parasitic power usage doesn't work on ESP32, sensors are detected but always showing invalid 85° C.

For using DS18x20 parasitic power on ESP32 use `#define W1_PARASITE_POWER` optimization like on ESP82xx in relation with `USE_DS18x20`.

Testet with multiple DS18B20/DS18S20

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
