### PR TITLE
Fix generic modbus single phase register output

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_29_modbus.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_29_modbus.ino
@@ -750,18 +750,19 @@ void EnergyModbusShow(bool json) {
         values[j] = NrgMbsUser[i].data[j];
       }
       uint32_t resolution = EnergyModbusResolution(NrgMbsUser[i].resolution);
+      uint32_t single = (!isnan(NrgMbsUser[i].data[1]) && !isnan(NrgMbsUser[i].data[2])) ? 0 : 1;
 
 #ifdef ENERGY_MODBUS_DEBUG_SHOW
       AddLog(LOG_LEVEL_DEBUG, PSTR("NRG: resolution %d -> %d"), NrgMbsUser[i].resolution, resolution);
 #endif
 
       if (json) {
-        ResponseAppend_P(PSTR(",\"%s\":%s"), NrgMbsUser[i].json_name, EnergyFormat(value_chr, values, resolution));
+        ResponseAppend_P(PSTR(",\"%s\":%s"), NrgMbsUser[i].json_name, EnergyFormat(value_chr, values, resolution, single));
 #ifdef USE_WEBSERVER
       } else {
         WSContentSend_PD(PSTR("{s}%s{m}%s %s{e}"),
           NrgMbsUser[i].gui_name,
-          WebEnergyFormat(value_chr, values, resolution),
+          WebEnergyFormat(value_chr, values, resolution, single),
           NrgMbsUser[i].gui_unit);
 #endif  // USE_WEBSERVER
       }


### PR DESCRIPTION
## Description:

fix user defined single phase register are displayed using 3 phase layout output null (see [comment](https://github.com/arendst/Tasmota/discussions/10862#discussioncomment-3943708) on discussion #10862 )

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

