### PR TITLE
Fix Zigbee auto-responder frame direction

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -2307,6 +2307,9 @@ void ZCLFrame::autoResponder(const uint16_t *attr_list_ids, size_t attr_len) {
     zcl.clusterSpecific = false;  /* not cluster specific */
     zcl.needResponse = false;     /* noresponse */
     zcl.direct = true;            /* direct response */
+    if (localShortAddr == 0x0000) {
+      zcl.direction = 1;          // if we are coordinator, then response is from client to server
+    }
     zcl.setTransac(transactseq);
     zcl.payload.addBuffer(buf);
     zigbeeZCLSendCmd(zcl);


### PR DESCRIPTION
## Description:

Fix an old bug for the auto-responder. When a device queries the coordinator for the current time, the response would be rejected because the direction bit was wrong.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
