### PR TITLE
Zigbee add default plugin in flash

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -761,17 +761,6 @@ void ZCLFrame::computeSyntheticAttributes(Z_attribute_list& attr_list) {
           attr_list.addAttribute(0x0001, 0x0021).setUInt(toPercentageCR2032(mv) * 2);
         }
         break;
-      case 0x00010021:       // BatteryPercentage
-        if (modelId.startsWith(F("TRADFRI")) ||
-            modelId.startsWith(F("SYMFONISK"))) {
-          attr.setUInt(attr.getUInt() * 2);   // bug in IKEA remotes battery, need to double the value
-        }
-        break;
-      case 0x00060000:    // "Power" for lumi Door/Window is converted to "Contact"
-        if (modelId.startsWith(F("lumi.sensor_magnet"))) {
-          attr.setKeyId(0x0500, 0xFFF0 + ZA_Contact);    // change cluster and attribute to 0500/FFF0
-        }
-        break;
       case 0x02010008:    // Pi Heating Demand - solve Eutotronic bug
       case 0x02014008:    // Eurotronic Host Flags decoding
         {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_6_flash_fs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_6_flash_fs.ino
@@ -1,0 +1,142 @@
+/*
+  xdrv_23_zigbee_7_6_flash_fs.ino - implement a Flash based read-only triviall file-system
+
+  Copyright (C) 2022  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+#ifdef ESP32
+#include <vfs_api.h>
+#else
+#include "FSImpl.h"
+#endif
+
+/********************************************************************
+** Subfile implementation
+** 
+** Takes a string point in Flash and turn it to a read-only file
+********************************************************************/
+
+class FlashFileImpl;
+typedef std::shared_ptr<FlashFileImpl> FlashFileImplPtr;
+
+class FlashFileImpl : public FileImpl {
+public:
+
+  FlashFileImpl(const char* str) {
+    _buf = str;
+    _len = strlen_P(str);
+    _seek = 0;
+  }
+
+  virtual ~FlashFileImpl() {}
+
+  size_t write(const uint8_t *buf, size_t size) {
+    return 0;   // not accepted
+  }
+
+  size_t read(uint8_t* buf, size_t size) {
+    if (_seek < _len) {
+      if (size + _seek > _len) {
+        size = _len - _seek;  // always > 0 because of guarding test
+      }
+      memcpy_P(buf, _buf + _seek, size);
+      _seek += size;
+      return size;
+    }
+    return 0;   // abort
+  }
+
+  void flush() {
+    // do nothing
+  }
+
+  bool setBufferSize(size_t size) {
+    return true;
+  }
+
+  bool seek(uint32_t pos, SeekMode mode) {
+    // AddLog(LOG_LEVEL_DEBUG, "ZIP: seek pos=%i mode=%i", pos, mode);
+    if (SeekSet == mode) {
+      if (pos <= _len) {
+        _seek = pos;
+        return true;
+      }
+    } else if (SeekCur == mode) {
+      if (_seek + pos <= _len) {
+        _seek += pos;
+        return true;
+      }
+    } else if (SeekEnd == mode) {
+      _seek = _len;
+      return true;
+    }
+    return false;
+  }
+
+  size_t position() const {
+    return _seek;
+  }
+
+  size_t size() const {
+    return _len;
+  }
+
+  void close() {
+    // do nothing
+  }
+  time_t getLastWrite() {
+    return 0;
+  }
+
+  const char* path() const {
+    return "";
+  }
+
+  const char* name() const {
+    return "<internal>";
+  }
+
+  boolean isDirectory(void) {
+    return false;       // no directory allowed
+  }
+
+  FileImplPtr openNextFile(const char* mode) {
+    return nullptr;     // TODO
+  }
+
+  void rewindDirectory(void) {
+    // ignore
+  }
+
+  operator bool() {
+    return true;
+  }
+
+  // ESP8266 specific?
+  bool truncate(uint32_t size) { return false; }
+  const char* fullName() const { return ""; }
+  bool isFile() const { return true; }
+  bool isDirectory() const { return false; }
+
+protected:
+  const char *  _buf;
+  size_t        _len;
+  uint32_t      _seek;
+};
+
+#endif // USE_ZIGBEE

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_8_default_plugin.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_8_default_plugin.ino
@@ -1,0 +1,53 @@
+/*
+  xdrv_23_zigbee_7_8_default_plugin.ino - default plugin stored in Flash
+
+  Copyright (C) 2021  Theo Arends and Stephan Hadinger
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef USE_ZIGBEE
+
+/********************************************************************
+** Default plugin
+** 
+** Below is a the template loaded at boot
+** We simulate a read-only file from the filesystem
+********************************************************************/
+
+const char Z_DEF_PLUGIN[] PROGMEM =
+  "#Z2Tv1"                                      "\n"
+  
+  // bug in IKEA remotes battery, need to double the value
+  ":TRADFRI*,"                                  "\n"
+  ":SYMFONISK*,"                                "\n"
+  "0001/0021=0001/0021,mul:2"                   "\n"    // BatteryPercentage
+
+  // "Power" for lumi Door/Window is converted to "Contact"
+  ":lumi.sensor_magnet*,"                       "\n"
+  "0006/0000=0500/FFF2"                         "\n"    // 0xFFF0 + ZA_Contact
+;
+
+/********************************************************************
+** Load from flash
+********************************************************************/
+void ZbAutoLoadFromFlash(void) {
+  FlashFileImplPtr fp = FlashFileImplPtr(new FlashFileImpl(Z_DEF_PLUGIN));
+  File f = File(fp);
+  if (ZbLoad_inner(PSTR("<internal_plugin>"), f)) {
+    AddLog(LOG_LEVEL_INFO, "ZIG: ZbLoad '%s' loaded successfully", PSTR("<internal_plugin>"));
+  }
+}
+
+#endif // USE_ZIGBEE


### PR DESCRIPTION
## Description:

Define a default internal Zigbee plugin and simplify code for some specific devices like IKEA.

The default plugin is equivalent to a file containing:
```
#Z2Tv1
:TRADFRI*,
:SYMFONISK*,
0001/0021=0001/0021,mul:2
:lumi.sensor_magnet*,
0006/0000=0500/FFF2
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
