### PR TITLE
MI32 legacy: hide BLE sensors from discovery to do this in Berry

### DIFF
--- a/tasmota/include/xsns_62_esp32_mi.h
+++ b/tasmota/include/xsns_62_esp32_mi.h
@@ -201,7 +201,6 @@ struct {
     uint32_t allwaysAggregate:1; // always show all known values of one sensor in brdigemode
     uint32_t noSummary:1;        // no sensor values at TELE-period
     uint32_t directBridgeMode:1; // send every received BLE-packet as a MQTT-message in real-time
-    uint32_t showRSSI:1;
     uint32_t activeScan:1;
     uint32_t ignoreBogusBattery:1;
     uint32_t minimalSummary:1;   // DEPRECATED!!


### PR DESCRIPTION
## Description:

The Xiamoi-type BLE sensors do not fit well in the current scheme of Tasmota autodiscovery as they are not really connected to one ESP32, so it is better to hide them.

But it is possible to announce them to Homeassistant in an "unlinked" way without adding any extra code to the driver, just by injecting the necessary data including some template programming.

Using the following script https://github.com/Staars/berry-examples/blob/main/disco.be
and i.e. launching it in `auto exec.bat` by adding:
`br load("disco")`
will add all sensors configured in `mi32cfg` without further steps needed.

Example with 11 sensors in the MQTT panel of HA:
![devices_ble_mqtt](https://user-images.githubusercontent.com/5481060/202791568-4e3fd268-351b-41c7-82f5-400f9d391c29.png)

It is the possible to deploy the mi32cfg file on different ESP's, which will contribute as data sources automatically:
![atc](https://user-images.githubusercontent.com/5481060/202791810-ab019fae-9a22-4262-9a42-562de8be55ae.png)

This automatic way will for sure not work for everybody's needs, but it should be relatively easy to adapt it, like adding aliases to the JSON and so on.

My first contact with Homeassistant is something like 2 weeks ago, so it is very well possible, that I did not stumble across better ways to implement this.


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
