### PR TITLE
Bugfix: RfSend command to support bits>32 for decimal command format

### DIFF
--- a/lib/lib_rf/rc-switch/src/RCSwitch.cpp
+++ b/lib/lib_rf/rc-switch/src/RCSwitch.cpp
@@ -149,8 +149,9 @@ static const RCSwitch::Protocol PROGMEM proto[] = {
   { 400,  0, { 0, 0 }, 1, {   1,  1 }, { 1,  2 }, { 2, 1 }, false, 43 },  // 31 (Mertik Maxitrol G6R-H4T1)
   { 365,  0, { 0, 0 }, 1, {  18,  1 }, { 3,  1 }, { 1, 3 }, true,   0 },  // 32 (1ByOne Doorbell) from @Fatbeard https://github.com/sui77/rc-switch/pull/277
   { 340,  0, { 0, 0 }, 1, {  14,  4 }, { 1,  2 }, { 2, 1 }, false,  0 },  // 33 (Dooya Control DC2708L)
-  { 120,  0, { 0, 0 }, 1, {   1, 28 }, { 1,  3 }, { 3, 1 }, false,  0 },   // 34 DIGOO SD10 - so as to use this protocol RCSWITCH_SEPARATION_LIMIT must be set to 2600
-  { 20,   0, { 0, 0 }, 1, { 239, 78 }, {20, 35 }, {35, 20}, false, 10000 } // 35 Dooya 5-Channel blinds remote DC1603
+  { 120,  0, { 0, 0 }, 1, {   1, 28 }, { 1,  3 }, { 3, 1 }, false,  0 },  // 34 DIGOO SD10 - so as to use this protocol RCSWITCH_SEPARATION_LIMIT must be set to 2600
+  { 20,   0, { 0, 0 }, 1, { 239, 78 }, {20, 35 }, {35, 20}, false, 10000},// 35 Dooya 5-Channel blinds remote DC1603
+  { 250,  0, { 0, 0 }, 1, {  18,  6 }, { 1,  3 }, { 3, 1 }, false,  0 }   // 36 Dooya remote DC2700AC for Dooya DT82TV curtains motor
 };
 
 enum {

--- a/tasmota/tasmota_xdrv_driver/xdrv_17_rcswitch.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_17_rcswitch.ino
@@ -180,7 +180,7 @@ void CmndRfSend(void)
       for (char *str = strtok_r(XdrvMailbox.data, ", ", &p); str && i < 5; str = strtok_r(nullptr, ", ", &p)) {
         switch (i++) {
         case 0:
-          data = strtoul(str, nullptr, 0);  // Allow decimal (5246996) and hexadecimal (0x501014) input
+          data = strtoull(str, nullptr, 0);  // Allow decimal (5246996) and hexadecimal (0x501014) input
           break;
         case 1:
           bits = atoi(str);


### PR DESCRIPTION
## Description:

There is a bug (typo) in RF Transceiver component: in decimal format of RfSend comand the "strtoul" is used (which is unsigned long int), while to support more than 32 bits the "strtoull" should be used (which is unsigned long long)

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
