### PR TITLE
Add SerialStart, SerialIgnore commands for Serial Bridge (both Hardware and Software)

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -365,6 +365,8 @@
 #define D_CMND_SERIALBUFFER "SerialBuffer"
 #define D_CMND_SERIALSEND "SerialSend"
 #define D_CMND_SERIALDELIMITER "SerialDelimiter"
+#define D_CMND_SERIALSTART "SerialStart"
+#define D_CMND_SERIALIGNORE "SerialIgnore"
 #define D_CMND_BAUDRATE "Baudrate"
 #define D_CMND_SERIALCONFIG "SerialConfig"
 #define D_CMND_TEMPLATE "Template"

--- a/tasmota/include/tasmota_types.h
+++ b/tasmota/include/tasmota_types.h
@@ -731,7 +731,8 @@ typedef struct {
   uint16_t      artnet_universe;           // 734
   uint16_t      modbus_sbaudrate;          // 736
 
-  uint8_t       free_esp32_738[5];         // 738
+  char          serialstart[4];            // 738  Serial Start Chars
+  uint8_t       serialignore;              // 73C  Serial recieved messages to ignore
 
   uint8_t       novasds_startingoffset;    // 73D
   uint8_t       web_color[18][3];          // 73E

--- a/tasmota/include/tasmota_version.h
+++ b/tasmota/include/tasmota_version.h
@@ -20,6 +20,6 @@
 #ifndef _TASMOTA_VERSION_H_
 #define _TASMOTA_VERSION_H_
 
-const uint32_t VERSION = 0x0C020005;   // 12.2.0.5
+const uint32_t VERSION = 0x0C020006;   // 12.2.0.6
 
 #endif  // _TASMOTA_VERSION_H_

--- a/tasmota/tasmota.ino
+++ b/tasmota/tasmota.ino
@@ -323,6 +323,7 @@ struct TasmotaGlobal_t {
   uint8_t light_driver;                     // Light module configured
   uint8_t light_type;                       // Light types
   uint8_t serial_in_byte;                   // Received byte
+  uint8_t serial_ignore_idx;                // Serial ignore recieved messages count
   uint8_t devices_present;                  // Max number of devices supported
   uint8_t masterlog_level;                  // Master log level used to override set log level
   uint8_t seriallog_level;                  // Current copy of Settings->seriallog_level

--- a/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_08_serial_bridge.ino
@@ -182,11 +182,7 @@ void SerialBridgeInput(void) {
     TasmotaGlobal.serial_ignore_idx++; //Add one to count of ignore messages
     if (!Settings->serialignore || (TasmotaGlobal.serial_ignore_idx == Settings->serialignore)) {  //If configured and we have reach serialIgnore value, then managed message
         TasmotaGlobal.serial_ignore_idx = 0;  //Reset count for next time
-        if (SerialBridgeSerial->hardwareSerial()) {
-            Response_P(PSTR("{\"" D_JSON_SERIALRECEIVED "\":"));
-        } else {
-            Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":"));
-        }
+        Response_P(PSTR("{\"" D_JSON_SSERIALRECEIVED "\":"));
 
         if (assume_json) {
           ResponseAppend_P(serial_bridge_buffer);
@@ -204,14 +200,10 @@ void SerialBridgeInput(void) {
         if (Settings->flag6.mqtt_disable_sserialrec ) {  // SetOption147  If it is activated, Tasmota will not publish SSerialReceived MQTT messages, but it will proccess event trigger rules
           XdrvRulesProcess(0);
         } else {
-          if (SerialBridgeSerial->hardwareSerial()) {
-            MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SERIALRECEIVED));
-          } else {
             MqttPublishPrefixTopicRulesProcess_P(RESULT_OR_TELE, PSTR(D_JSON_SSERIALRECEIVED));
-          }
         }
         if (!Settings->serialignore) {
-            //With serialignore each D_JSON_SERIALRECEIVED is better to delete and read again buffer
+            //With serialignore each D_JSON_SSERIALRECEIVED is better to delete and read again buffer
               while (SerialBridgeSerial->available()) { SerialBridgeSerial->read(); }
         }
     }


### PR DESCRIPTION
## Description:

Hi, I have done two new commands that are very usefull with SerialBridge. (both commands work with hardware or software serial bridge)

If this PR is merged, I will add a new PR for "tasmota docs"

**SerialStart**: it is configured to work up to 3 bytes. Buffer will begin to record only when this 1, 2 or 3 bytes are recieved in that order

**SerialIgnore (0 .. 255)**: usefull when you have a serial TX that send date every X seconds (in my case a Victron VE.Direct equipment that sends data every second) and you want to exclude data not to saturate your system. 

Both commans' configuration are preserved between restarts. Configuration is saved in flash

Also, I have added code to distinguish between **D_JSON_SSERIALRECEIVED and D_JSON_SERIALRECEIVED** in SerialBridge (hardware vs software serial)
CAUTION: before this change, every message is recieved as D_JSON_SSERIALRECEIVED, so people using hardware serial must check if they manage well D_JSON_SERIALRECEIVED 

Compiled and checked with gitpod.io

Examples:
  // SerialStart 0 to disable
  // SerialStart C1 to start only with C1
  // SerialStart C1,C2 to start with C1, C2
  // SerialStart C1,C2,C3 to start with C1, C2, C3
  // SerialStart show current chars
  // C1, C2, C3 must me decimal numbers representing ascii code ("PID" = 80 73 68):   serialstart 80,73,68

  // SerialIgnore 0 to disable => process all recieved messages
  // SerialIgnore 1 is identical as SerialIgnore 0
  // SerialIgnore X to "ignore" X serialrecieved messages
  // SerialIgnore show current value

Output message from gitpod.io before and after this PR:
```
RAM:   [=====     ]  50.9% (used 41676 bytes from 81920 bytes)
Flash: [======    ]  62.9% (used 644360 bytes from 1023984 bytes)

RAM:   [=====     ]  50.9% (used 41676 bytes from 81920 bytes)
Flash: [======    ]  63.0% (used 644952 bytes from 1023984 bytes)
```



**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
