### PR TITLE
don't touch AP_STA mode only if Rgx is up

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -218,7 +218,7 @@ void WifiBegin(uint8_t flag, uint8_t channel)
   WifiSetMode(WIFI_STA);    // Disable AP mode
 */
 #ifdef USE_WIFI_RANGE_EXTENDER
-  if (WiFi.getMode() != WIFI_AP_STA) {  // Preserve range extender connections (#17103)
+  if (WiFi.getMode() != WIFI_AP_STA || !RgxApUp()) {  // Preserve range extender connections (#17103)
     WiFi.disconnect(true);  // Delete SDK wifi config
     delay(200);
     WifiSetMode(WIFI_STA);  // Disable AP mode

--- a/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_58_range_extender.ino
@@ -149,6 +149,12 @@ typedef struct
 
 TRgxSettings RgxSettings;
 
+// externalize to be able to protect Rgx AP from teardown
+bool RgxApUp()
+{
+  return RgxSettings.status == RGX_CONFIGURED || RgxSettings.status == RGX_SETUP_NAPT;
+}
+
 // Check the current configuration is complete, updating RgxSettings.status
 void RgxCheckConfig(void)
 {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes PR #17103 
* WifiManager AP shows up as ESP* (-> @sfromis)
* Hostname not set for ESP8266 (-> @Jason2866) 

Previous PR didn't allow WifiBegin() to disconnect if wifi mode was AP_STA. This broke WifiManager functions. 
The new PR only interferes if Rgx AP is up and not while WifiManager AP is active.

Tested on ESP32 and ESP8266:
* WifiConfig 2 -> wifi manager comes up with AP name == hostname. I guess that is intended behavior.
* Reset 2 -> device reboots and starts a tasmota-* AP, no ESP* AP. 
* Range extender still fully works, port forwardings are kept active and not lost
* Switching from AP1 to AP2 works
* WifiScan 1 works while Rgx is active
* Hostname is set (visible e.g. in web info page)

I hope its ok to call RgxApUp() in WifiBegin() (i.e. over ino boundaries)? 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
