### PR TITLE
Zigbee plugin mul/div extended to 16 bits

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -318,8 +318,8 @@ public:
   }
 
   uint8_t       type;             // zigbee type, Zunk by default
-  int8_t        multiplier;       // multiply by x (ignore if 0 or 1)
-  int8_t        divider;          // divide by x (ignore if 0 or 1)
+  int16_t       multiplier;       // multiply by x (ignore if 0 or 1)
+  int16_t       divider;          // divide by x (ignore if 0 or 1)
   int16_t       base;             // add x (ignore if 0)
   uint16_t      cluster;          // cluster number
   uint16_t      attribute;        // attribute number
@@ -354,8 +354,8 @@ public:
   uint16_t      attribute;        // attribute to match
   uint16_t      new_cluster;      // replace with this cluster
   uint16_t      new_attribute;    // replace with this attribute
-  int8_t        multiplier;       // multiply by x (ignore if 0 or 1)
-  int8_t        divider;          // divide by x (ignore if 0 or 1)
+  int16_t       multiplier;       // multiply by x (ignore if 0 or 1)
+  int16_t       divider;          // divide by x (ignore if 0 or 1)
   int16_t       base;           // add x (ignore if 0)
 };
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -318,8 +318,8 @@ public:
   }
 
   uint8_t       type;             // zigbee type, Zunk by default
-  int16_t       multiplier;       // multiply by x (ignore if 0 or 1)
-  int16_t       divider;          // divide by x (ignore if 0 or 1)
+  uint16_t      multiplier;       // multiply by x (ignore if 0 or 1)
+  uint16_t      divider;          // divide by x (ignore if 0 or 1)
   int16_t       base;             // add x (ignore if 0)
   uint16_t      cluster;          // cluster number
   uint16_t      attribute;        // attribute number
@@ -354,8 +354,8 @@ public:
   uint16_t      attribute;        // attribute to match
   uint16_t      new_cluster;      // replace with this cluster
   uint16_t      new_attribute;    // replace with this attribute
-  int16_t       multiplier;       // multiply by x (ignore if 0 or 1)
-  int16_t       divider;          // divide by x (ignore if 0 or 1)
+  uint16_t      multiplier;       // multiply by x (ignore if 0 or 1)
+  uint16_t      divider;          // divide by x (ignore if 0 or 1)
   int16_t       base;           // add x (ignore if 0)
 };
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1000,8 +1000,8 @@ void ZCLFrame::parseReadConfigAttributes(uint16_t shortaddr, Z_attribute_list& a
     }
 
     // find the multiplier
-    int16_t multiplier = 1;
-    int16_t divider = 1;
+    uint16_t multiplier = 1;
+    uint16_t divider = 1;
     int16_t base = 0;
     Z_attribute_match matched_attr = Z_findAttributeMatcherById(shortaddr, cluster, attrid, false);
     if (matched_attr.found()) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1000,8 +1000,8 @@ void ZCLFrame::parseReadConfigAttributes(uint16_t shortaddr, Z_attribute_list& a
     }
 
     // find the multiplier
-    int8_t multiplier = 1;
-    int8_t divider = 1;
+    int16_t multiplier = 1;
+    int16_t divider = 1;
     int16_t base = 0;
     Z_attribute_match matched_attr = Z_findAttributeMatcherById(shortaddr, cluster, attrid, false);
     if (matched_attr.found()) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
@@ -386,7 +386,7 @@ bool ZbUnload(const char *filename_raw) {
 }
 
 // append modifiers like mul/div/manuf
-void Z_AppendModifiers(char * buf, size_t buf_len, int8_t multiplier, int8_t divider, int16_t base, uint16_t manuf) {
+void Z_AppendModifiers(char * buf, size_t buf_len, uint16_t multiplier, uint16_t divider, int16_t base, uint16_t manuf) {
   if (multiplier != 0 && multiplier != 1) {
     ext_snprintf_P(buf, buf_len, "%s,%s%i", buf, Z_MUL, multiplier);
   }


### PR DESCRIPTION
## Description:

Zigbee plugins multiplier/divider is now stored in 16 bits to allow values `0..65535`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
