### PR TITLE
Improve mdns logging

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1193,7 +1193,7 @@
  * Mutual exclude options
 \*********************************************************************************************/
 
-#if defined(USE_DISCOVERY) && (defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT))
+#if defined(ESP8266) && defined(USE_DISCOVERY) && (defined(USE_MQTT_AWS_IOT) || defined(USE_MQTT_AWS_IOT_LIGHT))
   #error "Select either USE_DISCOVERY or USE_MQTT_AWS_IOT, mDNS takes too much code space and is not needed for AWS IoT"
 #endif
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -488,7 +488,7 @@
 // -- mDNS ----------------------------------------
 //#define USE_DISCOVERY                            // Enable mDNS for the following services (+8k code or +23.5k code with core 2_5_x, +0.3k mem)
   #define WEBSERVER_ADVERTISE                    // Provide access to webserver by name <Hostname>.local/
-  #define MQTT_HOST_DISCOVERY                    // Find MQTT host server (overrides MQTT_HOST if found)
+  // #define MQTT_HOST_DISCOVERY                    // Find MQTT host server (overrides MQTT_HOST if found) - disabled by default because it causes blocked repeated 3000ms pauses
 
 // -- Time ----------------------------------------
 #define USE_TIMERS                               // Add support for up to 16 timers (+2k2 code)

--- a/tasmota/tasmota_support/support_network.ino
+++ b/tasmota/tasmota_support/support_network.ino
@@ -31,7 +31,7 @@ void StartMdns(void) {
     if (!Mdns.begun) {
       MDNS.end(); // close existing or MDNS.begin will fail
       Mdns.begun = (uint8_t)MDNS.begin(TasmotaGlobal.hostname);
-      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MDNS "%s"), (Mdns.begun) ? PSTR(D_INITIALIZED) : PSTR(D_FAILED));
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_MDNS "%s '%s.local'"), (Mdns.begun) ? PSTR(D_INITIALIZED) : PSTR(D_FAILED), TasmotaGlobal.hostname);
     }
   }
 }


### PR DESCRIPTION
## Description:

Add MDNS logging of the advertized name
```
00:00:03.668 mDN: Initialized 'tasmota-1C8664-1636.local'
```

Remove error when compiling with MDNS and TLS on ESP32 (we don't have memory constraint contrary to ESP8266)

Disable `#define MQTT_HOST_DISCOVERY` by default. Discovery of the MQTT server is not that useful since its address is supposed to be known, or to be in a local dns server. On the contrary having each Tasmota device advertizing its own address does make sense - which is covered with `#define WEBSERVER_ADVERTISE`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
