### PR TITLE
AC-Dimmer Power lookup table

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2191,11 +2191,11 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         }
         if (!Settings->flag4.zerocross_dimmer) {
 #ifdef ESP32
-          TasmotaGlobal.pwm_value[i] = cur_col;   // mark the new expected value
-          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", i, cur_col);
+          TasmotaGlobal.pwm_value[i] = ac_zero_cross_power(cur_col);   // mark the new expected value
+          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", i, cur_col2);
 #else // ESP32
-          analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
-          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
+          analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - ac_zero_cross_power(cur_col) : ac_zero_cross_power(cur_col));
+          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col2 : cur_col2);
 #endif // ESP32
         }
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -2192,10 +2192,10 @@ void LightSetOutputs(const uint16_t *cur_col_10) {
         if (!Settings->flag4.zerocross_dimmer) {
 #ifdef ESP32
           TasmotaGlobal.pwm_value[i] = ac_zero_cross_power(cur_col);   // mark the new expected value
-          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", i, cur_col2);
+          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", i, cur_col);
 #else // ESP32
           analogWrite(Pin(GPIO_PWM1, i), bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - ac_zero_cross_power(cur_col) : ac_zero_cross_power(cur_col));
-          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col2 : cur_col2);
+          // AddLog(LOG_LEVEL_DEBUG_MORE, "analogWrite-%i 0x%03X", bitRead(TasmotaGlobal.pwm_inverted, i) ? Settings->pwm_range - cur_col : cur_col);
 #endif // ESP32
         }
       }

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
@@ -42,7 +42,6 @@ const gamma_table_t ac_dimmer_table[] = {   // don't put in PROGMEM for performa
   {   99,    936 },
   {  100,   1000 },
   { 0xFFFF, 0xFFFF }          // fail-safe if out of range
-  { 0xFFFF, 0xFFFF }          // fail-safe if out of range
 };
 
 const gamma_table_t gamma_table[] = {   // don't put in PROGMEM for performance reasons

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
@@ -33,12 +33,15 @@ typedef struct gamma_table_t {
 
 const gamma_table_t ac_dimmer_table[] = {   // don't put in PROGMEM for performance reasons
   {    0,      0 },
+  {    1,     64 },
   {    5,    144 },
   {   10,    205 },
   {   50,    500 },
   {   90,    795 },
   {   95,    866 },
+  {   99,    936 },
   {  100,   1000 },
+  { 0xFFFF, 0xFFFF }          // fail-safe if out of range
   { 0xFFFF, 0xFFFF }          // fail-safe if out of range
 };
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
@@ -31,6 +31,17 @@ typedef struct gamma_table_t {
   uint16_t to_gamma;
 } gamma_table_t;
 
+const gamma_table_t ac_dimmer_table[] = {   // don't put in PROGMEM for performance reasons
+  {    0,      0 },
+  {    5,    144 },
+  {   10,    205 },
+  {   50,    500 },
+  {   90,    795 },
+  {   95,    866 },
+  {  100,   1000 },
+  { 0xFFFF, 0xFFFF }          // fail-safe if out of range
+};
+
 const gamma_table_t gamma_table[] = {   // don't put in PROGMEM for performance reasons
   {    1,      1 },
   {    4,      1 },
@@ -316,6 +327,11 @@ uint16_t ledGammaReverse_internal(uint16_t vg, const struct gamma_table_t *gt_pt
     from_src = to_src;
     from_gamma = to_gamma;
   }
+}
+
+// 10 bits power select to 10 bits timing based on sinus curve
+uint16_t ac_zero_cross_power(uint16_t v) {
+  return ledGamma_internal(v, ac_dimmer_table)/10;
 }
 
 // 10 bits in, 10 bits out


### PR DESCRIPTION
## Description:
AC-Dimmer was not linear on power because of the behavior AC-current to calculate the power through the integral over SINUS. Lookup table fix the linearity issue. 
**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
