### PR TITLE
Update ZeroCross Dimmer calibration on physical measurement

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light_utils.ino
@@ -34,12 +34,12 @@ typedef struct gamma_table_t {
 const gamma_table_t ac_dimmer_table[] = {   // don't put in PROGMEM for performance reasons
   {     0,      0 },
   {    10,     64 },
-  {    50,    144 },
-  {   100,    205 },
-  {   500,    500 },
-  {   900,    795 },
-  {   950,    866 },
-  {   990,    936 },
+  {    50,    175 },
+  {   100,    235 },
+  {   500,    485 },
+  {   900,    704 },
+  {   950,    748 },
+  {   990,    850 },
   {  1024,   1024 },
   { 0xFFFF, 0xFFFF }          // fail-safe if out of range
 };


### PR DESCRIPTION
Alligned with physical measurement of 1KW heating

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
