### PR TITLE
Fix type for BinaryInValue

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -732,7 +732,7 @@ const Z_AttributeConverter Z_PostProcess[] PROGMEM = {
   { Zstring,  Cx000F, 0x002E,  Z_(BinaryInInactiveText),Cm1, 0 },
   { Zbool,    Cx000F, 0x0051,  Z_(BinaryInOutOfService),Cm1, 0 },
   { Zenum8,   Cx000F, 0x0054,  Z_(BinaryInPolarity),    Cm1, 0 },
-  { Zstring,  Cx000F, 0x0055,  Z_(BinaryInValue),       Cm1, 0 },
+  { Zbool,    Cx000F, 0x0055,  Z_(BinaryInValue),       Cm1, 0 },
   // { 0xFF, Cx000F, 0x0057,  (BinaryInPriorityArray),Cm1, 0 },
   { Zenum8,   Cx000F, 0x0067,  Z_(BinaryInReliability), Cm1, 0 },
   { Zmap8,    Cx000F, 0x006F,  Z_(BinaryInStatusFlags), Cm1, 0 },


### PR DESCRIPTION
## Description:

Fix type for `BinaryInValue` 000F/0055 which should be `bool` and not `string`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
