### PR TITLE
Berry crypto module, with AES_GCM by default and EC_CC25519 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.2.0.6]
 ### Added
 - Serial Modbus transmit enable GPIOs to all modbus energy drivers and modbus bridge (#17247)
+- Berry crypto module, with AES_GCM by default and EC_CC25519 optional
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/default/be_modtab.c
+++ b/lib/libesp32/berry/default/be_modtab.c
@@ -164,9 +164,7 @@ BERRY_LOCAL const bntvmodule* const be_module_table[] = {
     &be_native_module(flash),
     &be_native_module(partition_core),
     &be_native_module(crc),
-#ifdef USE_ALEXA_AVS
     &be_native_module(crypto),
-#endif
 #if defined(USE_BERRY_ULP) && ((CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3))
     &be_native_module(ULP),
 #endif // USE_BERRY_ULP

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -7,8 +7,6 @@
  *******************************************************************/
 #include "be_constobj.h"
 
-#ifdef USE_ALEXA_AVS
-
 extern int m_aes_gcm_init(bvm *vm);
 extern int m_aes_gcm_encryt(bvm *vm);
 extern int m_aes_gcm_decryt(bvm *vm);
@@ -23,7 +21,7 @@ extern int m_ec_c25519_sharedkey(bvm *vm);
 
 /* @const_object_info_begin
 
-class be_class_aes_gcm (scope: global, name: AES_GCM, strings: weak) {
+class be_class_aes_gcm (scope: global, name: AES_GCM) {
     .p1, var
     .p2, var
 
@@ -33,16 +31,14 @@ class be_class_aes_gcm (scope: global, name: AES_GCM, strings: weak) {
     tag, func(m_aes_gcm_tag)
 }
 
-class be_class_ec_c25519 (scope: global, name: EC_C25519, strings: weak) {
+class be_class_ec_c25519 (scope: global, name: EC_C25519) {
     public_key, func(m_ec_c25519_pubkey)
     shared_key, func(m_ec_c25519_sharedkey)
 }
 
-module crypto (scope: global, strings: weak) {
+module crypto (scope: global) {
   AES_GCM, class(be_class_aes_gcm)
   EC_C25519, class(be_class_ec_c25519)
 }
 
 @const_object_info_end */
-
-#endif // USE_ALEXA_AVS

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1096,6 +1096,9 @@
     #define USE_BERRY_WEBCLIENT_TIMEOUT  2000    // Default timeout in milliseconds
   #define USE_BERRY_TCPSERVER                    // Enable TCP socket server (+0.6k)
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)
+  // Berry crypto extensions below:
+  #define USE_BERRY_CRYPTO_AES_GCM               // enable AES GCM 256 bits
+  // #define USE_BERRY_CRYPTO_EC_C25519             // enable Elliptic Curve C C25519
 #define USE_CSE7761                              // Add support for CSE7761 Energy monitor as used in Sonoff Dual R3
 
 // -- LVGL Graphics Library ---------------------------------
@@ -1232,7 +1235,7 @@
 #endif
 #endif
 
-#if defined(USE_MQTT_TLS) || defined(USE_TELEGRAM) || defined(USE_WEBCLIENT_HTTPS) || defined(USE_ALEXA_AVS)
+#if defined(USE_MQTT_TLS) || defined(USE_TELEGRAM) || defined(USE_WEBCLIENT_HTTPS)
   #define USE_TLS                                // flag indicates we need to include TLS code
 #endif
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
@@ -19,7 +19,6 @@
 
 
 #ifdef USE_BERRY
-#ifdef USE_ALEXA_AVS
 
 #include <berry.h>
 #include "be_mem.h"
@@ -34,6 +33,7 @@ extern "C" {
   // `AES_GCM.init(secret_key:bytes(32), iv:bytes(12)) -> instance`
   int32_t m_aes_gcm_init(struct bvm *vm);
   int32_t m_aes_gcm_init(struct bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_AES_GCM
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 3 && be_isinstance(vm, 2) && be_isinstance(vm, 3)) {
       do {
@@ -77,11 +77,15 @@ extern "C" {
       } while (0);
     }
     be_raise(vm, kTypeError, nullptr);
+#else // USE_BERRY_CRYPTO_AES_GCM
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_AES_GCM
   }
 
   int32_t m_aes_gcm_encryt(bvm *vm);
   int32_t m_aes_gcm_decryt(bvm *vm);
   int32_t m_aes_gcm_encrypt_or_decryt(bvm *vm, int encrypt) {
+#ifdef USE_BERRY_CRYPTO_AES_GCM
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 2 && be_isinstance(vm, 2)) {
       do {
@@ -111,15 +115,27 @@ extern "C" {
       } while (0);
     }
     be_raise(vm, kTypeError, nullptr);
+#else // USE_BERRY_CRYPTO_AES_GCM
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_AES_GCM
   }
   int32_t m_aes_gcm_encryt(bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_AES_GCM
     return m_aes_gcm_encrypt_or_decryt(vm, 1);
+#else // USE_BERRY_CRYPTO_AES_GCM
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_AES_GCM
   }
   int32_t m_aes_gcm_decryt(bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_AES_GCM
     return m_aes_gcm_encrypt_or_decryt(vm, 0);
+#else // USE_BERRY_CRYPTO_AES_GCM
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_AES_GCM
   }
 
   int32_t m_aes_gcm_tag(bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_AES_GCM
     do {
       be_getglobal(vm, "bytes"); /* get the bytes class */ /* TODO eventually replace with be_getbuiltin */
 
@@ -137,6 +153,9 @@ extern "C" {
       // success
     } while (0);
     be_raise(vm, kTypeError, nullptr);
+#else // USE_BERRY_CRYPTO_AES_GCM
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_AES_GCM
   }
 }
 
@@ -151,6 +170,7 @@ extern "C" {
   // Computes the public key from a completely random private key of 32 bytes
   int32_t m_ec_c25519_pubkey(bvm *vm);
   int32_t m_ec_c25519_pubkey(bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_EC_C25519
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 2 && be_isbytes(vm, 2)) {
       size_t buf_len = 0;
@@ -173,12 +193,16 @@ extern "C" {
       be_raise(vm, "value_error", "invalid input");
     }
     be_raise(vm, kTypeError, nullptr);
+#else // USE_BERRY_CRYPTO_EC_C25519
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_EC_C25519
   }
 
   // crypto.EC_C25519().shared_key(my_private_key:bytes(32), their_public_key:bytes(32)) -> bytes(32)
   // Computes the shared pre-key. Normally this shared pre-key is hashed with another algorithm.
   int32_t m_ec_c25519_sharedkey(bvm *vm);
   int32_t m_ec_c25519_sharedkey(bvm *vm) {
+#ifdef USE_BERRY_CRYPTO_EC_C25519
     int32_t argc = be_top(vm); // Get the number of arguments
     if (argc >= 3 && be_isbytes(vm, 2) && be_isbytes(vm, 3)) {
       size_t sk_len = 0;
@@ -204,8 +228,10 @@ extern "C" {
       be_raise(vm, "value_error", "invalid input");
     }
     be_raise(vm, kTypeError, nullptr);
+#else // USE_BERRY_CRYPTO_EC_C25519
+    be_raise(vm, "Not implemented", nullptr);
+#endif // USE_BERRY_CRYPTO_EC_C25519
   }
 }
 
-#endif // USE_ALEXA_AVS
 #endif  // USE_BERRY


### PR DESCRIPTION
## Description:

Add Berry `import crypto` module:
- supports AES GCM 256 bits (enabled by default)
- EC CC25519 elliptic curve (requires specific build with `#define USE_BERRY_CRYPTO_EC_C25519`)

Code size impact is minimal because the crypto library for AES is already included with TLS support.

Example taken from https://wizardforcel.gitbooks.io/practical-cryptography-for-developers-book/content/symmetric-key-ciphers/aes-encrypt-decrypt-examples.html

``` berry
import crypto

key = bytes('233f8ce4ac6aa125927ccd98af5750d08c9c61d98a3f5d43cbf096b4caaebe80')
ciphertext = bytes('1334cd5d487f7f47924187c94424a2079656838e063e5521e7779e441aa513de268550a89917fbfb0492fc')
iv = bytes('2f3849399c60cb04b923bd33265b81c7')
authTag = bytes('af453a410d142bc6f926c0f3bc776390')

# decrypt ciphertext with key and iv
aes = crypto.AES_GCM(key, iv)
plaintext = aes.decrypt(ciphertext)
print(plaintext.asstring())
# 'Message for AES-256-GCM + Scrypt encryption'

tag = aes.tag()
print(tag == authTag)
# true
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
