### PR TITLE
HMC5883 add missing closing brace

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_101_hmc5883l.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_101_hmc5883l.ino
@@ -173,7 +173,7 @@ const char HTTP_SNS_HMC5883L[] PROGMEM =
 
 void HMC5883L_Show(uint8_t json) {
   if (json) {
-    ResponseAppend_P(PSTR(",\"HMC5883L\":{\"" D_JSON_MX "\":%d,\"" D_JSON_MY "\":%d,\"" D_JSON_MZ "\":%d,\"" D_JSON_MAGNETICFLD "\":%u"),
+    ResponseAppend_P(PSTR(",\"HMC5883L\":{\"" D_JSON_MX "\":%d,\"" D_JSON_MY "\":%d,\"" D_JSON_MZ "\":%d,\"" D_JSON_MAGNETICFLD "\":%u}"),
       HMC5883L->MX, HMC5883L->MY, HMC5883L->MZ, HMC5883L->magnitude);
 #ifdef USE_WEBSERVER
   } else {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #17295 

Previous PR was missing a closing brace
the obvious was not so obvious

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
