### PR TITLE
IPv6 support for Ethernet (ESP32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Serial Modbus transmit enable GPIOs to all modbus energy drivers and modbus bridge (#17247)
 - Berry crypto module, with AES_GCM by default and EC_CC25519 optional
+- IPv6 support for Ethernet (ESP32)
 
 ### Breaking Changed
 

--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -808,6 +808,7 @@
 #define D_LOG_UPLOAD "UPL: "       // Upload
 #define D_LOG_UPNP "UPP: "         // UPnP
 #define D_LOG_WIFI "WIF: "         // Wifi
+#define D_LOG_ETH "ETH: "          // Ethernet
 #define D_LOG_ZIGBEE "ZIG: "       // Zigbee
 #define D_LOG_TCP "TCP: "          // TCP bridge
 #define D_LOG_BERRY "BRY: "        // Berry scripting language

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -828,11 +828,20 @@ void CmndStatus(void)
     ResponseAppend_P(PSTR(",\"Ethernet\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
                           D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
                           D_JSON_DNSSERVER "1\":\"%_I\",\"" D_JSON_DNSSERVER "2\":\"%_I\",\""
-                          D_JSON_MAC "\":\"%s\"}"),
+                          D_JSON_MAC "\":\"%s\""
+
+#if LWIP_IPV6
+                          ",\"" D_JSON_IP6_GLOBAL "\":\"%s\",\"" D_JSON_IP6_LOCAL "\":\"%s\""
+#endif // LWIP_IPV6
+                          "}"),
                           EthernetHostname(),
                           (uint32_t)EthernetLocalIP(), Settings->eth_ipv4_address[1], Settings->eth_ipv4_address[2],
                           Settings->eth_ipv4_address[3], Settings->eth_ipv4_address[4],
-                          EthernetMacAddress().c_str());
+                          EthernetMacAddress().c_str()
+#if LWIP_IPV6
+                          ,EthernetGetIPv6().c_str(), EthernetGetIPv6LinkLocal().c_str()
+#endif // LWIP_IPV6
+                          );
 #endif  // USE_ETHERNET
     ResponseAppend_P(PSTR(",\"" D_CMND_WEBSERVER "\":%d,\"HTTP_API\":%d,\"" D_CMND_WIFICONFIG "\":%d,\"" D_CMND_WIFIPOWER "\":%s}}"),
                           Settings->webserver, Settings->flag5.disable_referer_chk, Settings->sta_config, WifiGetOutputPower().c_str());

--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -2362,11 +2362,11 @@ void HandleInformation(void)
 #if LWIP_IPV6
     String ipv6_addr = WifiGetIPv6();
     if (ipv6_addr != "") {
-      WSContentSend_P(PSTR("}1 IPv6 Global }2%s"), ipv6_addr.c_str());
+      WSContentSend_P(PSTR("}1 IPv6 Global (wifi)}2%s"), ipv6_addr.c_str());
     }
     ipv6_addr = WifiGetIPv6LinkLocal();
     if (ipv6_addr != "") {
-      WSContentSend_P(PSTR("}1 IPv6 Link-Local }2%s"), ipv6_addr.c_str());
+      WSContentSend_P(PSTR("}1 IPv6 Local (wifi)}2%s"), ipv6_addr.c_str());
     }
 #endif  // LWIP_IPV6 = 1
     if (static_cast<uint32_t>(WiFi.localIP()) != 0) {
@@ -2387,6 +2387,16 @@ void HandleInformation(void)
       WSContentSend_P(PSTR("}1<hr/>}2<hr/>"));
     }
     WSContentSend_P(PSTR("}1" D_HOSTNAME "}2%s%s"), EthernetHostname(), (Mdns.begun) ? PSTR(".local") : "");
+#if LWIP_IPV6
+    String ipv6_eth_addr = EthernetGetIPv6();
+    if (ipv6_eth_addr != "") {
+      WSContentSend_P(PSTR("}1 IPv6 Global (eth)}2%s"), ipv6_eth_addr.c_str());
+    }
+    ipv6_eth_addr = EthernetGetIPv6LinkLocal();
+    if (ipv6_eth_addr != "") {
+      WSContentSend_P(PSTR("}1 IPv6 Local (eth)}2%s"), ipv6_eth_addr.c_str());
+    }
+#endif  // LWIP_IPV6 = 1
     WSContentSend_P(PSTR("}1" D_MAC_ADDRESS "}2%s"), EthernetMacAddress().c_str());
     WSContentSend_P(PSTR("}1" D_IP_ADDRESS " (eth)}2%_I"), (uint32_t)EthernetLocalIP());
   }

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -228,7 +228,7 @@ extern "C" {
 #endif
         if (static_cast<uint32_t>(WiFi.localIP()) != 0) {
           be_map_insert_str(vm, "mac", WiFi.macAddress().c_str());
-          be_map_insert_str(vm, "ip", WiFi.localIP().toString().c_str());
+          be_map_insert_str(vm, "ip", IPAddress46((uint32_t)WiFi.localIP()).toString().c_str());   // quick fix for IPAddress bug
           show_rssi = true;
         }
         if (show_rssi) {
@@ -252,8 +252,18 @@ extern "C" {
 #ifdef USE_ETHERNET
       if (static_cast<uint32_t>(EthernetLocalIP()) != 0) {
         be_map_insert_str(vm, "mac", EthernetMacAddress().c_str());
-        be_map_insert_str(vm, "ip", EthernetLocalIP().toString().c_str());
+        be_map_insert_str(vm, "ip", IPAddress46((uint32_t)EthernetLocalIP()).toString().c_str());   // quick fix for IPAddress bug
       }
+#if LWIP_IPV6
+      String ipv6_addr = EthernetGetIPv6();
+      if (ipv6_addr != "") {
+        be_map_insert_str(vm, "ip6", ipv6_addr.c_str());
+      }
+      ipv6_addr = EthernetGetIPv6LinkLocal();
+      if (ipv6_addr != "") {
+        be_map_insert_str(vm, "ip6local", ipv6_addr.c_str());
+      }
+#endif
 #endif
       be_pop(vm, 1);
       be_return(vm);

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -85,6 +85,7 @@
 char eth_hostname[sizeof(TasmotaGlobal.hostname)];
 uint8_t eth_config_change;
 
+void EthernetEvent(arduino_event_t *event);
 void EthernetEvent(arduino_event_t *event) {
   switch (event->event_id) {
     case ARDUINO_EVENT_ETH_START:

--- a/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_82_esp32_ethernet.ino
@@ -85,19 +85,28 @@
 char eth_hostname[sizeof(TasmotaGlobal.hostname)];
 uint8_t eth_config_change;
 
-void EthernetEvent(WiFiEvent_t event) {
-  switch (event) {
+void EthernetEvent(arduino_event_t *event) {
+  switch (event->event_id) {
     case ARDUINO_EVENT_ETH_START:
-      AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: " D_ATTEMPTING_CONNECTION));
+      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH D_ATTEMPTING_CONNECTION));
       ETH.setHostname(eth_hostname);
       break;
+
     case ARDUINO_EVENT_ETH_CONNECTED:
-      AddLog(LOG_LEVEL_INFO, PSTR("ETH: " D_CONNECTED " at %dMbps%s"),
-        ETH.linkSpeed(), (ETH.fullDuplex()) ? " Full Duplex" : "");
+#if LWIP_IPV6
+      ETH.enableIpV6();   // enable Link-Local 
+#endif
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ETH D_CONNECTED " at %dMbps%s, Mac %s, Hostname %s"),
+        ETH.linkSpeed(), (ETH.fullDuplex()) ? " Full Duplex" : "",
+        ETH.macAddress().c_str(), eth_hostname
+        );
+        
+      // AddLog(LOG_LEVEL_DEBUG, D_LOG_ETH "ETH.enableIpV6() -> %i", ETH.enableIpV6());
       break;
+      
     case ARDUINO_EVENT_ETH_GOT_IP:
-      AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Mac %s, IPAddress %_I, Hostname %s"),
-        ETH.macAddress().c_str(), (uint32_t)ETH.localIP(), eth_hostname);
+      // AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH "Mac %s, IPAddress %_I, Hostname %s"),
+      //   ETH.macAddress().c_str(), (uint32_t)ETH.localIP(), eth_hostname);
       Settings->eth_ipv4_address[1] = (uint32_t)ETH.gatewayIP();
       Settings->eth_ipv4_address[2] = (uint32_t)ETH.subnetMask();
       if (0 == Settings->eth_ipv4_address[0]) {  // At this point ETH.dnsIP() are NOT correct unless DHCP
@@ -107,15 +116,18 @@ void EthernetEvent(WiFiEvent_t event) {
       TasmotaGlobal.rules_flag.eth_connected = 1;
       TasmotaGlobal.global_state.eth_down = 0;
       break;
+
     case ARDUINO_EVENT_ETH_DISCONNECTED:
-      AddLog(LOG_LEVEL_INFO, PSTR("ETH: Disconnected"));
+      AddLog(LOG_LEVEL_INFO, PSTR(D_LOG_ETH "Disconnected"));
       TasmotaGlobal.rules_flag.eth_disconnected = 1;
       TasmotaGlobal.global_state.eth_down = 1;
       break;
+
     case ARDUINO_EVENT_ETH_STOP:
-      AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Stopped"));
+      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH "Stopped"));
       TasmotaGlobal.global_state.eth_down = 1;
       break;
+
     default:
       break;
   }
@@ -130,10 +142,21 @@ void EthernetSetIp(void) {
              Settings->eth_ipv4_address[4]);      // IPAddress dns2
 }
 
+// Returns only IPv6 global address (no loopback and no link-local)
+String EthernetGetIPv6(void)
+{
+  return WifiFindIPv6(false, "en");
+}
+
+String EthernetGetIPv6LinkLocal(void)
+{
+  return WifiFindIPv6(true, "en");
+}
+
 void EthernetInit(void) {
   if (!Settings->flag4.network_ethernet) { return; }
   if (!PinUsed(GPIO_ETH_PHY_MDC) && !PinUsed(GPIO_ETH_PHY_MDIO)) {
-    AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: No ETH MDC and/or ETH MDIO GPIO defined"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH "No ETH MDC and/or ETH MDIO GPIO defined"));
     return;
   }
 
@@ -180,7 +203,7 @@ void EthernetInit(void) {
   delay(1);
 #endif // CONFIG_IDF_TARGET_ESP32
   if (!ETH.begin(Settings->eth_address, eth_power, eth_mdc, eth_mdio, (eth_phy_type_t)Settings->eth_type, (eth_clock_mode_t)Settings->eth_clk_mode)) {
-    AddLog(LOG_LEVEL_DEBUG, PSTR("ETH: Bad PHY type or init error"));
+    AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_ETH "Bad PHY type or init error"));
     return;
   };
 


### PR DESCRIPTION
## Description:

Extend experimental support for IPv6 to Ethernet (ESP32 only).

Known problems: `Ping` command is broken with IPv4 and IPv6 on ESP32

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
