### PR TITLE
Fix IPv4 DNS resolution when IPv6 is enabled

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -893,6 +893,9 @@ bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
   }
 #else
   // DnsClient can't do one-shot mDNS queries so use WiFi.hostByName() for *.local
+#ifdef USE_IPV6
+  aResult.setV4();    // force IPv4 result for now, until DNS is updated to IPv6
+#endif
   size_t hostname_len = strlen(aHostname);
   if (strstr_P(aHostname, PSTR(".local")) == &aHostname[hostname_len] - 6) {
     if (WiFi.hostByName(aHostname, aResult)) {

--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -893,9 +893,7 @@ bool WifiHostByName(const char* aHostname, IPAddress& aResult) {
   }
 #else
   // DnsClient can't do one-shot mDNS queries so use WiFi.hostByName() for *.local
-#ifdef USE_IPV6
-  aResult.setV4();    // force IPv4 result for now, until DNS is updated to IPv6
-#endif
+  aResult = (uint32_t) 0x00000000L;    // indirectly force to be IPv4, since the client touches the binary format later
   size_t hostname_len = strlen(aHostname);
   if (strstr_P(aHostname, PSTR(".local")) == &aHostname[hostname_len] - 6) {
     if (WiFi.hostByName(aHostname, aResult)) {


### PR DESCRIPTION
## Description:

Fix a bug when IPv6 is enabled, DNS resolution wouldn't be marked as IPv4.

We are currently running `DnsClient` which is only able to do IPv4 `A` DNS resolutions. This may change in the future.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
