### PR TITLE
ESP32 fix ``Ping``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - TasmotaSerial ``read(buffer, size)`` regression from v9.3.0
 - RCSwitch exception 0/6 on some protocols (#17285)
 - ESP32 exception 28 when RtcNtpServer is enabled on restart (#17338)
+- ESP32 fix ``Ping``
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_38_ping.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_38_ping.ino
@@ -172,7 +172,7 @@ extern "C" {
       return 0;               // don't eat the packet and ignore it
     }
 
-    if (pbuf_header( p, -PBUF_IP_HLEN)==0) {
+    if (pbuf_header( p, -PBUF_TRANSPORT_HLEN)==0) {
       struct icmp_echo_hdr *iecho;
       iecho = (struct icmp_echo_hdr *)p->payload;
 


### PR DESCRIPTION
## Description:

Fix broken `Ping` command when `LWIP_IPV6` is enabled (which is the default now).
**Related issue (if applicable):** fixes #17361

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
