### PR TITLE
add option to gz esp32 firmware files

### DIFF
--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -29,8 +29,7 @@ def map_gzip(source, target, env):
 if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_MAP_GZ, env):
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [map_gzip])
 
-# gzip only for ESP8266
-if env["PIOPLATFORM"] != "espressif32":
+if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_ESP32_GZ, env):
     from zopfli.gzip import compress
     def bin_gzip(source, target, env):
         # create string with location and file names based on variant
@@ -50,7 +49,7 @@ if env["PIOPLATFORM"] != "espressif32":
         ORG_FIRMWARE_SIZE = bin_file.stat().st_size
         GZ_FIRMWARE_SIZE = gzip_file.stat().st_size
 
-        if ORG_FIRMWARE_SIZE > 995326:
+        if ORG_FIRMWARE_SIZE > 995326 and env["PIOPLATFORM"] != "espressif32":
             print(
                 "\u001b[31;1m!!! Tasmota firmware size is too big with {} bytes. Max size is 995326 bytes !!! \u001b[0m".format(
                     ORG_FIRMWARE_SIZE

--- a/pio-tools/gzip-firmware.py
+++ b/pio-tools/gzip-firmware.py
@@ -29,7 +29,7 @@ def map_gzip(source, target, env):
 if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_MAP_GZ, env):
     env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", [map_gzip])
 
-if not tasmotapiolib.is_env_set(tasmotapiolib.DISABLE_ESP32_GZ, env):
+if tasmotapiolib.is_env_set(tasmotapiolib.ENABLE_ESP32_GZ, env) or env["PIOPLATFORM"] != "espressif32":
     from zopfli.gzip import compress
     def bin_gzip(source, target, env):
         # create string with location and file names based on variant

--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -27,8 +27,8 @@ import os
 # === AVAILABLE OVERRIDES ===
 # if set to 1, will not gzip bin files at all
 DISABLE_BIN_GZ = "disable_bin_gz"
-# if set to 1, will not gzip esp32 bin files
-DISABLE_ESP32_GZ = "disable_esp32_gz"
+# if set to 1, will gzip esp32 bin files
+ENABLE_ESP32_GZ = "enable_esp32_gz"
 # if set, an alternative ptah to put generated .bin files, relative to project directory
 BIN_DIR = "bin_dir"
 # if set to 1, will not gzip generated .map files

--- a/pio-tools/tasmotapiolib.py
+++ b/pio-tools/tasmotapiolib.py
@@ -25,8 +25,10 @@ import pathlib
 import os
 
 # === AVAILABLE OVERRIDES ===
-# if set to 1, will not gzip esp8266 bin files
+# if set to 1, will not gzip bin files at all
 DISABLE_BIN_GZ = "disable_bin_gz"
+# if set to 1, will not gzip esp32 bin files
+DISABLE_ESP32_GZ = "disable_esp32_gz"
 # if set, an alternative ptah to put generated .bin files, relative to project directory
 BIN_DIR = "bin_dir"
 # if set to 1, will not gzip generated .map files

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,8 +58,10 @@ lib_extra_dirs              =
 ;disable_map_gz = 1
 ; Uncomment and specify a folder where to place the map file(s) (default set to folder build_output)
 ;map_dir = /tmp/map_files/
-; Uncomment if you do NOT want additionally gzipped firmware file(s)
+; Uncomment if you do NOT want additionally gzipped firmware file(s) at all
 ;disable_bin_gz = 1
+; Comment if you want additionally gzipped esp32x firmware file(s)
+disable_esp32_gz = 1
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,8 +60,8 @@ lib_extra_dirs              =
 ;map_dir = /tmp/map_files/
 ; Uncomment if you do NOT want additionally gzipped firmware file(s) at all
 ;disable_bin_gz = 1
-; Comment if you want additionally gzipped esp32x firmware file(s)
-disable_esp32_gz = 1
+; Uncomment if you want additionally gzipped esp32x firmware file(s)
+;enable_esp32_gz = 1
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
 


### PR DESCRIPTION
## Description:

@arendst add option to gz esp32 files too.

Uncomment line 64 in `platformio.ini` to build gz firmware files for esp32 too.

```
; Uncomment if you want additionally gzipped esp32x firmware file(s)
;enable_esp32_gz = 1
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
