### PR TITLE
MQTT now uses Tasmota's DNS resolver instead of LWIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 exception 28 when RtcNtpServer is enabled on restart (#17338)
 - Analog MQ exception 28 on restart (#17271)
 - ESP32 fix ``Ping``
+- MQTT now uses Tasmota's DNS resolver instead of LWIP
 
 ### Removed
 

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.cpp
@@ -299,7 +299,7 @@ int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port, int32_t timeout
     setLastError(ERR_TCP_CONNECT);
     return 0;
   }
-  return _connectSSL(nullptr);
+  return _connectSSL(_domain.isEmpty() ? nullptr : _domain.c_str());
 }
 #else // ESP32
 int WiFiClientSecure_light::connect(IPAddress ip, uint16_t port) {

--- a/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
+++ b/lib/lib_ssl/tls_mini/src/WiFiClientSecureLightBearSSL.h
@@ -126,6 +126,10 @@ class WiFiClientSecure_light : public WiFiClient {
 
     void setInsecure();
 
+    void setDomainName(const char * domain) {
+      _domain = domain;
+    }
+
   private:
     void _clear();
     bool _ctx_present;
@@ -171,6 +175,9 @@ class WiFiClientSecure_light : public WiFiClient {
 
     // record the maximum use of ThunkStack for monitoring
     size_t _max_thunkstack_use;
+
+    // domain name (string) that will be used with SNI when the address provided is already resolved
+    String _domain;
 
     // ALPN
     const char ** _alpn_names;

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -1065,11 +1065,12 @@ void MqttReconnect(void) {
   MqttClient.setCallback(MqttDataHandler);
 
   // Keep using hostname to solve rc -4 issues
-  if (!WifiDnsPresent(SettingsText(SET_MQTT_HOST))) {
+  IPAddress ip;
+  if (!WifiHostByName(SettingsText(SET_MQTT_HOST), ip)) {
     MqttDisconnected(-5);  // MQTT_DNS_DISCONNECTED
     return;
   }
-  MqttClient.setServer(SettingsText(SET_MQTT_HOST), Settings->mqtt_port);
+  MqttClient.setServer(ip, Settings->mqtt_port);
 
   if (2 == Mqtt.initial_connection_state) {  // Executed once just after power on and wifi is connected
     Mqtt.initial_connection_state = 1;
@@ -1085,9 +1086,11 @@ void MqttReconnect(void) {
   }
 
 #ifdef USE_MQTT_TLS
+
   uint32_t mqtt_connect_time = millis();
   if (Mqtt.mqtt_tls) {
     tlsClient->stop();
+    tlsClient->setDomainName(SettingsText(SET_MQTT_HOST));   // set domain name for TLS SNI (selection of certificate based on domain name)
   } else {
     MqttClient.setClient(EspClient);
   }


### PR DESCRIPTION
## Description:

MQTT now uses Tasmota DNS resolver with fine control over time-out, and avoid unnecassary double DNS resolution. In order to make TLS SNI working, a method `setDomainName()` is added to `WiFiClientSecure_light` to specify the SNI domain used.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
