### PR TITLE
Zigbee fix crash on ESP8266 #17397

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Zigbee fix crash on ESP8266 #17397
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
@@ -165,8 +165,8 @@ bool ZbLoad_inner(const char *filename, File &fp) {
     if (filename_imported == nullptr) {
       // allocate only once the filename for multiple entries
       // freed only by `ZbUnload`
-      filename_imported = (char*) malloc(strlen(filename)+1);
-      strcpy(filename_imported, filename);
+      filename_imported = (char*) malloc(strlen_P(filename)+1);
+      strcpy_P(filename_imported, filename);
     }
 
     // there is a non-empty line, containing no space/tab/crlf


### PR DESCRIPTION
## Description:

Fix crash on Zigbee ESP8266 based Tasmota.

**Related issue (if applicable):** fixes #17397

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
