### PR TITLE
Tasmota ESP32 core 2.0.5.4

### DIFF
--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -10,6 +10,8 @@ build_unflags               = ${esp_defaults.build_unflags}
                               -fno-lto
                               -Wpointer-arith
 build_flags                 = ${esp_defaults.build_flags}
+                              ; comment next line to disable IPv6 support
+                              -DUSE_IPV6
                               -Wno-switch-unreachable
                               -Wno-stringop-overflow
                               -fno-exceptions

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -40,7 +40,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/v.2.0.5/platform-espressif32-v.2.0.5.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2022.12.0/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

support for IPv6. Thx @s-hadinger for!

It is enabled for all ESP32x builds

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
