### PR TITLE
Berry support for `crypto.SHA256`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.3.1.1] 20221216
 ### Added
 - Support for IPv6 DNS records (AAAA) and IPv6 ``Ping`` for ESP32 and ESP8266
+- Berry support for ``crypto.SHA256``
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -15,8 +15,13 @@ extern int m_aes_gcm_tag(bvm *vm);
 extern int m_ec_c25519_pubkey(bvm *vm);
 extern int m_ec_c25519_sharedkey(bvm *vm);
 
+extern int m_hash_sha256_init(bvm *vm);
+extern int m_hash_sha256_update(bvm *vm);
+extern int m_hash_sha256_out(bvm *vm);
+
 #include "be_fixed_be_class_aes_gcm.h"
 #include "be_fixed_be_class_ec_c25519.h"
+#include "be_fixed_be_class_sha256.h"
 #include "be_fixed_crypto.h"
 
 /* @const_object_info_begin
@@ -36,9 +41,18 @@ class be_class_ec_c25519 (scope: global, name: EC_C25519) {
     shared_key, func(m_ec_c25519_sharedkey)
 }
 
+class be_class_sha256 (scope: global, name: SHA256) {
+    .p, var
+
+    init, func(m_hash_sha256_init)
+    update, func(m_hash_sha256_update)
+    out, func(m_hash_sha256_out)
+}
+
 module crypto (scope: global) {
   AES_GCM, class(be_class_aes_gcm)
   EC_C25519, class(be_class_ec_c25519)
+  SHA256, class(be_class_sha256)
 }
 
 @const_object_info_end */

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1107,6 +1107,7 @@
   // Berry crypto extensions below:
   #define USE_BERRY_CRYPTO_AES_GCM               // enable AES GCM 256 bits
   // #define USE_BERRY_CRYPTO_EC_C25519             // enable Elliptic Curve C C25519
+  #define USE_BERRY_CRYPTO_SHA256                // enable SHA256 hash function
 #define USE_CSE7761                              // Add support for CSE7761 Energy monitor as used in Sonoff Dual R3
 
 // -- LVGL Graphics Library ---------------------------------


### PR DESCRIPTION
## Description:

Add Berry support for SHA256. See documentation for examples. This will be needed for the Matter protocol. Size impact is minimal because SHA256 is already used in TLS.

Example test vectors from https://www.dlitz.net/crypto/shad256-test-vectors/

``` berry
import crypto
h = crypto.SHA256()

# SHA256 of empty message
assert(h.out() == bytes("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))

# (first 16 bytes of RC4 keystream where the key = 0)
h.update(bytes("de188941a3375d3a8a061e67576e926d"))
assert(h.out() == bytes("067c531269735ca7f541fdaca8f0dc76305d3cada140f89372a410fe5eff6e4d"))
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
