### PR TITLE
Fix upload_port is mandatory to compile custom build on Linux

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -71,7 +71,7 @@ board                   = ${common.board}
 ;board_build.f_cpu       = 160000000L
 ;board_build.f_flash     = 40000000L
 ; *** Define serial port used for erasing/flashing/terminal
-upload_port             = 
+upload_port             = ${common.upload_port}
 monitor_port            = ${env.upload_port}
 extra_scripts           = ${esp_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py
@@ -112,7 +112,7 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 ;board_upload.arduino.flash_extra_images =
 ;board_build.partitions  = partitions/esp32_partition_app2944k_fs2M.csv
 ; *** Serial port used for erasing/flashing the ESP32
-upload_port             = 
+upload_port             = ${common.upload_port}
 ;upload_speed            = 115200
 monitor_port            = ${env.upload_port}
 upload_resetmethod      = ${common.upload_resetmethod}


### PR DESCRIPTION
## Description:

Upload port setting is now mandatory to compile (even without upload), at least on Linux
Custom builds fails because they use the upload_port from platformio_override(_sample).ini which are empty
PR makes them inherit from the default env 

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
