### PR TITLE
rm upload_port defaults

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,10 +35,8 @@ custom_unpack_dir           = unpacked_littlefs
 build_unflags               = ${core.build_unflags}
 build_flags                 = ${core.build_flags}
 monitor_speed               = 115200
-monitor_port                = COM5
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_resetmethod          = nodemcu
-upload_port                 = COM5
 extra_scripts               = ${esp_defaults.extra_scripts}
 lib_ldf_mode                = chain
 lib_compat_mode             = strict

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -72,7 +72,7 @@ board                   = ${common.board}
 ;board_build.f_flash     = 40000000L
 ; *** Define serial port used for erasing/flashing/terminal
 ;upload_port             = COM4
-;monitor_port            = ${env.upload_port}
+;monitor_port            = COM4
 extra_scripts           = ${esp_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py
 lib_ignore              =
@@ -113,9 +113,9 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 ;board_build.partitions  = partitions/esp32_partition_app2944k_fs2M.csv
 ; *** Serial port used for erasing/flashing the ESP32
 ;upload_port             = COM4
+;monitor_port            = COM4
 ;upload_speed            = 115200
 monitor_speed           = 115200
-;monitor_port            = ${env.upload_port}
 upload_resetmethod      = ${common.upload_resetmethod}
 extra_scripts           = ${esp32_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -70,9 +70,9 @@ board                   = ${common.board}
 ;board                   = esp8266_4M2M
 ;board_build.f_cpu       = 160000000L
 ;board_build.f_flash     = 40000000L
-;monitor_speed           = 115200
-; *** Serial port used for erasing/flashing the ESP82xx
-;upload_port             = COM5
+; *** Define serial port used for erasing/flashing/terminal
+;upload_port             = COM4
+;monitor_port            = ${env.upload_port}
 extra_scripts           = ${esp_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py
 lib_ignore              =
@@ -111,11 +111,11 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 ;board_upload.maximum_size = 8388608
 ;board_upload.arduino.flash_extra_images =
 ;board_build.partitions  = partitions/esp32_partition_app2944k_fs2M.csv
-monitor_speed           = 115200
 ; *** Serial port used for erasing/flashing the ESP32
-;upload_port             = ${common.upload_port}
-upload_port             = COM4
+;upload_port             = COM4
 ;upload_speed            = 115200
+monitor_speed           = 115200
+;monitor_port            = ${env.upload_port}
 upload_resetmethod      = ${common.upload_resetmethod}
 extra_scripts           = ${esp32_defaults.extra_scripts}
 ;                          pio-tools/obj-dump.py

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -7,7 +7,6 @@ board_build.filesystem      = ${common.board_build.filesystem}
 build_unflags               = ${common.build_unflags}
 build_flags                 = ${common.build_flags}
 monitor_speed               = ${common.monitor_speed}
-upload_port                 = ${common.upload_port}
 upload_resetmethod          = ${common.upload_resetmethod}
 extra_scripts               = ${common.extra_scripts}
 lib_ldf_mode                = ${common.lib_ldf_mode}

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -6,7 +6,6 @@ board_build.filesystem      = ${common.board_build.filesystem}
 custom_unpack_dir           = ${common.custom_unpack_dir}
 board                       = esp32
 monitor_speed               = 115200
-upload_port                 = ${common.upload_port}
 upload_resetmethod          = ${common.upload_resetmethod}
 extra_scripts               = ${esp32_defaults.extra_scripts}
 build_unflags               = ${core32.build_unflags}


### PR DESCRIPTION
## Description:

so auto detect port is active by default. Fixed Port can be defined in `platformio_override.ini` or in (custom) defined [env]

@barbudor @blakadder  Please test

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
