### PR TITLE
Berry add crypto AES_CTR, HDMAC_SHA256, MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for IPv6 DNS records (AAAA) and IPv6 ``Ping`` for ESP32 and ESP8266 (#17417)
 - Berry support for ``crypto.SHA256`` (#17430)
 - Support for RGB displays (#17414)
+- Berry add crypto AES_CTR, HDMAC_SHA256, MD5
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -12,6 +12,10 @@ extern int m_aes_gcm_encryt(bvm *vm);
 extern int m_aes_gcm_decryt(bvm *vm);
 extern int m_aes_gcm_tag(bvm *vm);
 
+extern int m_aes_ctr_init(bvm *vm);
+extern int m_aes_ctr_run(bvm *vm);
+extern int m_aes_ctr_tag(bvm *vm);
+
 extern int m_ec_c25519_pubkey(bvm *vm);
 extern int m_ec_c25519_sharedkey(bvm *vm);
 
@@ -19,9 +23,17 @@ extern int m_hash_sha256_init(bvm *vm);
 extern int m_hash_sha256_update(bvm *vm);
 extern int m_hash_sha256_out(bvm *vm);
 
+extern int m_hmac_sha256_init(bvm *vm);
+extern int m_hmac_sha256_update(bvm *vm);
+extern int m_hmac_sha256_out(bvm *vm);
+
+extern const bclass be_class_md5;
+
 #include "be_fixed_be_class_aes_gcm.h"
+#include "be_fixed_be_class_aes_ctr.h"
 #include "be_fixed_be_class_ec_c25519.h"
 #include "be_fixed_be_class_sha256.h"
+#include "be_fixed_be_class_hmac_sha256.h"
 #include "be_fixed_crypto.h"
 
 /* @const_object_info_begin
@@ -34,6 +46,14 @@ class be_class_aes_gcm (scope: global, name: AES_GCM) {
     encrypt, func(m_aes_gcm_encryt)
     decrypt, func(m_aes_gcm_decryt)
     tag, func(m_aes_gcm_tag)
+}
+
+class be_class_aes_ctr (scope: global, name: AES_CTR) {
+    .p1, var
+
+    init, func(m_aes_ctr_init)
+    encrypt, func(m_aes_ctr_run)
+    decrypt, func(m_aes_ctr_run)
 }
 
 class be_class_ec_c25519 (scope: global, name: EC_C25519) {
@@ -49,10 +69,21 @@ class be_class_sha256 (scope: global, name: SHA256) {
     out, func(m_hash_sha256_out)
 }
 
+class be_class_hmac_sha256 (scope: global, name: HMAC_SHA256) {
+    .p, var
+
+    init, func(m_hmac_sha256_init)
+    update, func(m_hmac_sha256_update)
+    out, func(m_hmac_sha256_out)
+}
+
 module crypto (scope: global) {
   AES_GCM, class(be_class_aes_gcm)
+  AES_CTR, class(be_class_aes_ctr)
   EC_C25519, class(be_class_ec_c25519)
   SHA256, class(be_class_sha256)
+  HMAC_SHA256, class(be_class_hmac_sha256)
+  MD5, class(be_class_md5)
 }
 
 @const_object_info_end */

--- a/lib/libesp32/berry_tasmota/src/be_md5_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_md5_lib.c
@@ -11,8 +11,8 @@
 #include "esp_rom_md5.h"
 
 // `Md5.init() -> `
-int32_t m_md5_init(struct bvm *vm);
-int32_t m_md5_init(struct bvm *vm) {
+int m_md5_init(bvm *vm);
+int m_md5_init(bvm *vm) {
 
   md5_context_t * ctx = (md5_context_t *) be_os_malloc(sizeof(md5_context_t));
   if (!ctx) {
@@ -28,13 +28,11 @@ int32_t m_md5_init(struct bvm *vm) {
 // `Md5.update(content:bytes()) -> nil`
 //
 // Add raw bytes to the MD5 calculation
-int32_t m_md5_update(struct bvm *vm);
-int32_t m_md5_update(struct bvm *vm) {
+int m_md5_update(bvm *vm);
+int m_md5_update(bvm *vm) {
   int32_t argc = be_top(vm); // Get the number of arguments
-  if (argc >= 2 && be_isinstance(vm, 2)) {
+  if (argc >= 2 && be_isbytes(vm, 2)) {
     do {
-      be_getglobal(vm, "bytes"); /* get the bytes class */ /* TODO eventually replace with be_getbuiltin */
-      if (!be_isderived(vm, 2)) break;
       size_t length = 0;
       const void * bytes = be_tobytes(vm, 2, &length);
       if (!bytes) break;
@@ -57,8 +55,8 @@ int32_t m_md5_update(struct bvm *vm) {
 // `Md5.update(content:bytes()) -> nil`
 //
 // Add raw bytes to the MD5 calculation
-int32_t m_md5_finish(struct bvm *vm);
-int32_t m_md5_finish(struct bvm *vm) {
+int m_md5_finish(bvm *vm);
+int m_md5_finish(bvm *vm) {
   be_getmember(vm, 1, ".p");
   md5_context_t * ctx;
   ctx = (md5_context_t *) be_tocomptr(vm, -1);

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1106,8 +1106,10 @@
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)
   // Berry crypto extensions below:
   #define USE_BERRY_CRYPTO_AES_GCM               // enable AES GCM 256 bits
+  #define USE_BERRY_CRYPTO_AES_CTR               // enable AEC CTR 256 bits
   // #define USE_BERRY_CRYPTO_EC_C25519             // enable Elliptic Curve C C25519
   #define USE_BERRY_CRYPTO_SHA256                // enable SHA256 hash function
+  #define USE_BERRY_CRYPTO_HMAC_SHA256           // enable HMAC SHA256 hash function
 #define USE_CSE7761                              // Add support for CSE7761 Energy monitor as used in Sonoff Dual R3
 
 // -- LVGL Graphics Library ---------------------------------


### PR DESCRIPTION
## Description:

Add more crypto primitives needed for Matter in Berry. The underlying code from Bearssl is anyways used in TLS.

Added: `crypto.HMAC_SHA256`, `crypto.AES_CTR` and `crypto.MD5`.

Test vectors:
``` berry
# Test case from https://datatracker.ietf.org/doc/html/rfc4231
import crypto
key = bytes("4a656665")
msg = bytes("7768617420646f2079612077616e7420666f72206e6f7468696e673f")
h = crypto.HMAC_SHA256(key)
h.update(msg)
hmac = h.out()
assert(hmac == bytes("5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"))

# Test case from https://www.ietf.org/rfc/rfc3686.txt
import crypto
key = bytes("F6D66D6BD52D59BB0796365879EFF886C66DD51A5B6A99744B50590C87A23884")
iv = bytes("00FAAC24C1585EF15A43D875")
cc = 0x000001
aes = crypto.AES_CTR(key)
plain = bytes("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F")
cipher = aes.encrypt(plain, iv, cc)
assert(cipher == bytes("F05E231B3894612C49EE000B804EB2A9B8306B508F839D6A5530831D9344AF1C"))
plain2 = aes.decrypt(cipher, iv, cc)
assert(plain == plain2)

# Test vector
import crypto
h = crypto.MD5()
t = bytes().fromstring("The quick brown fox jumps over the lazy dog")
h.update(t)
m = h.finish()
assert(m == bytes("9e107d9d372bb6826bd81d3542a419d6"))
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
