### PR TITLE
Pio: Target: Erase and Upload

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -111,7 +111,7 @@ build_flags                 = ${esp_defaults.build_flags}
 
 [core]
 ; *** Esp8266 Tasmota modified Arduino core based on core 2.7.4. Added Backport for PWM selection
-platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/v2.7.4/platform-espressif8266-2.7.4.zip
+platform                    = https://github.com/tasmota/platform-espressif8266/releases/download/2022.12.0/platform-espressif8266.zip
 platform_packages           =
 build_unflags               = ${esp_defaults.build_unflags}
 build_flags                 = ${esp82xx_defaults.build_flags}

--- a/platformio_tasmota32.ini
+++ b/platformio_tasmota32.ini
@@ -42,7 +42,7 @@ extra_scripts               = pre:pio-tools/add_c_flags.py
                               ${esp_defaults.extra_scripts}
 
 [core32]
-platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2022.12.0/platform-espressif32.zip
+platform                    = https://github.com/tasmota/platform-espressif32/releases/download/2022.12.1/platform-espressif32.zip
 platform_packages           =
 build_unflags               = ${esp32_defaults.build_unflags}
 build_flags                 = ${esp32_defaults.build_flags}


### PR DESCRIPTION
## Description:

adds a new entry in VSC/Platformio menu, which makes erase flash and upload Tasmota firmware in one step possible.

 
<img width="238" alt="Bildschirmfoto 2022-12-22 um 00 00 01" src="https://user-images.githubusercontent.com/24528715/209108143-59e8ccbe-5169-4fdd-bdb1-f1d40e77dfdf.png">

or doing `pio run -t erase_upload` (with optional '-e <environment>') from the commandline

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
