### PR TITLE
Berry crypto add ``random`` to generate series of random bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.3.1.2]
 ### Added
 - Berry crypto add ``EC_P256`` and ``PBKDF2_HMAC_SHA256`` algorithms required by Matter protocol
+- Berry crypto add ``random`` to generate series of random bytes
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -9,6 +9,7 @@
 #include "be_mapping.h"
 
 extern int be_class_crypto_member(bvm *vm);
+extern int m_crypto_random(bvm *vm);
 
 extern int m_aes_gcm_init(bvm *vm);
 extern int m_aes_gcm_encryt(bvm *vm);
@@ -145,6 +146,7 @@ class be_class_pbkdf2_hmac_sha256 (scope: global, name: PBKDF2_HMAC_SHA256) {
 
 module crypto (scope: global) {
   member, func(be_class_crypto_member)
+  random, func(m_crypto_random)
 }
 
 @const_object_info_end */

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
@@ -40,6 +40,32 @@ extern "C" {
 }
 
 /*********************************************************************************************\
+ * Random bytes generator
+ * 
+ * As long as Wifi or BLE is enable, it uses a hardware source for true randomnesss
+ * 
+\*********************************************************************************************/
+extern "C" {
+  // `crypto.random(num_bytes:int) -> bytes(num_bytes)`
+  //
+  // Generates a series of random bytes
+  int m_crypto_random(bvm *vm);
+  int m_crypto_random(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 1 && be_isint(vm, 1)) {
+      int32_t n = be_toint(vm, 1);
+      if (n < 0 || n > 4096) { be_raise(vm, "value_error", ""); }
+
+      uint8_t rand_bytes[n];
+      esp_fill_random(rand_bytes, n);
+      be_pushbytes(vm, rand_bytes, n);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+}
+
+/*********************************************************************************************\
  * AES_GCM class
  * 
 \*********************************************************************************************/


### PR DESCRIPTION
## Description:

Add a random bytes generator using ESP32 hardware random source.

`crypto.random(rand_bytes:int) -> bytes(rand_bytes)`

Example:
``` berry
import crypto
print(crypto.random(32))    # generate 32 random bytes
# bytes('2B35D74F5ED9FC32121FA626114A3460228CC2A9916BD4391611B21D54C8A3DC')
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
