### PR TITLE
better fix on init: shuttermotorstop

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -402,7 +402,10 @@ void ShutterInit(void)
     Settings->shutter_accuracy = 1;
     Settings->shutter_mode = ShutterGlobal.position_mode;
     // initialize MotorStop time with 500ms if not set
-    Settings->shutter_motorstop = (Settings->shutter_motorstop == 0) ? 500 : tmin(5000,Settings->shutter_motorstop);
+    // typical not set start values are 0 and 65535
+    if (Settings->shutter_motorstop > 5000 || Settings->shutter_motorstop == 0) {
+        Settings->shutter_motorstop = 500;
+    }
   }
 }
 


### PR DESCRIPTION
try to avoid get  5000 if the init value is 65535. More focus on setting the standard of 500 on nearly any case

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
