### PR TITLE
Minor changes to Berry crypto

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -40,7 +40,7 @@ extern int m_hmac_sha256_out(bvm *vm);
 
 extern int m_pbkdf2_hmac_sha256_f(bvm *vm);
 
-extern int m_hkdf_hmac_sha256_derive(bvm *vm);
+extern int m_hkdf_sha256_derive(bvm *vm);
 
 extern const bclass be_class_md5;
 
@@ -53,7 +53,7 @@ extern const bclass be_class_md5;
 #include "be_fixed_be_class_sha256.h"
 #include "be_fixed_be_class_hmac_sha256.h"
 #include "be_fixed_be_class_pbkdf2_hmac_sha256.h"
-#include "be_fixed_be_class_hkdf_hmac_sha256.h"
+#include "be_fixed_be_class_hkdf_sha256.h"
 #include "be_fixed_crypto.h"
 
 const be_const_member_t be_crypto_members[] = {
@@ -75,9 +75,9 @@ const be_const_member_t be_crypto_members[] = {
   { "/EC_P256", (intptr_t) &be_class_ec_p256 },
 #endif // USE_BERRY_CRYPTO_EC_P256
 
-#ifdef USE_BERRY_CRYPTO_HKDF_HMAC_SHA256
-  { "/HKDF_HMAC_SHA256", (intptr_t) &be_class_hkdf_hmac_sha256 },
-#endif // USE_BERRY_CRYPTO_HKDF_HMAC_SHA256
+#ifdef USE_BERRY_CRYPTO_HKDF_SHA256
+  { "/HKDF_SHA256", (intptr_t) &be_class_hkdf_sha256 },
+#endif // USE_BERRY_CRYPTO_HKDF_SHA256
 
 #ifdef USE_BERRY_CRYPTO_HMAC_SHA256
   { "/HMAC_SHA256", (intptr_t) &be_class_hmac_sha256 },
@@ -152,8 +152,8 @@ class be_class_pbkdf2_hmac_sha256 (scope: global, name: PBKDF2_HMAC_SHA256) {
     derive, closure(PBKDF2_HMAC_SHA256_closure)
 }
 
-class be_class_hkdf_hmac_sha256 (scope: global, name: HKDF_HMAC_SHA256) {
-    derive, static_func(m_hkdf_hmac_sha256_derive)
+class be_class_hkdf_sha256 (scope: global, name: HKDF_SHA256) {
+    derive, static_func(m_hkdf_sha256_derive)
 }
 
 module crypto (scope: global) {

--- a/lib/libesp32/berry_tasmota/src/be_md5_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_md5_lib.c
@@ -25,7 +25,7 @@ int m_md5_init(bvm *vm) {
   be_return_nil(vm);
 }
 
-// `Md5.update(content:bytes()) -> nil`
+// `Md5.update(content:bytes()) -> self`
 //
 // Add raw bytes to the MD5 calculation
 int m_md5_update(bvm *vm);
@@ -45,7 +45,8 @@ int m_md5_update(bvm *vm) {
       if (length > 0) {
         esp_rom_md5_update(ctx, (const uint8_t*) bytes, length);
       }
-      be_return_nil(vm);
+      be_pushvalue(vm, 1);
+      be_return(vm);
       // success
     } while (0);
   }

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1112,7 +1112,7 @@
   #define USE_BERRY_CRYPTO_SHA256                // enable SHA256 hash function
   #define USE_BERRY_CRYPTO_HMAC_SHA256           // enable HMAC SHA256 hash function
   // #define USE_BERRY_CRYPTO_PBKDF2_HMAC_SHA256    // PBKDF2 with HMAC SHA256, used in Matter protocol
-  // #define USE_BERRY_CRYPTO_HKDF_HMAC_SHA256      // HKDF with HMAC SHA256, used in Matter protocol
+  // #define USE_BERRY_CRYPTO_HKDF_SHA256      // HKDF with HMAC SHA256, used in Matter protocol
 #define USE_CSE7761                              // Add support for CSE7761 Energy monitor as used in Sonoff Dual R3
 
 // -- LVGL Graphics Library ---------------------------------


### PR DESCRIPTION
## Description:

Minor changes:
- hashing function now return `self` to allow chained called
- `HKDF_HMAC_SHA256` renamed to `HKDF_SHA256`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
