### PR TITLE
PCF8574 input pin initialization fix

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
@@ -123,7 +123,9 @@ void Pcf8574Init(void)
     Pcf8574.max_connected_ports = 0;  // reset no of devices to avoid duplicate ports on duplicate init.
     for (uint32_t idx = 0; idx < Pcf8574.max_devices; idx++) { // suport up to 8 boards PCF8574
       uint8_t gpio = Pcf8574Read(idx);
+      gpio |= ~Settings->pcf8574_config[idx]; // TEST - Force input pullup
       Pcf8574.pin_mask[idx] = gpio;
+      Pcf8574Write(idx); // TEST - Force input pullup
 #ifdef USE_PCF8574_MQTTINPUT
       Pcf8574.last_input[idx] = gpio & ~Settings->pcf8574_config[idx];
 #endif // #ifdef USE_PCF8574_MQTTINPUT

--- a/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
@@ -123,9 +123,9 @@ void Pcf8574Init(void)
     Pcf8574.max_connected_ports = 0;  // reset no of devices to avoid duplicate ports on duplicate init.
     for (uint32_t idx = 0; idx < Pcf8574.max_devices; idx++) { // suport up to 8 boards PCF8574
       uint8_t gpio = Pcf8574Read(idx);
-      gpio &= Settings->pcf8574_config[idx]; // TEST - Force no input pullup
+      gpio |= ~Settings->pcf8574_config[idx]; // TEST - Force light pullup
       Pcf8574.pin_mask[idx] = gpio;
-      Pcf8574Write(idx); // TEST - Force no input pullup
+      Pcf8574Write(idx); // TEST - Force light pullup
 #ifdef USE_PCF8574_MQTTINPUT
       Pcf8574.last_input[idx] = gpio & ~Settings->pcf8574_config[idx];
 #endif // #ifdef USE_PCF8574_MQTTINPUT

--- a/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
@@ -123,9 +123,8 @@ void Pcf8574Init(void)
     Pcf8574.max_connected_ports = 0;  // reset no of devices to avoid duplicate ports on duplicate init.
     for (uint32_t idx = 0; idx < Pcf8574.max_devices; idx++) { // suport up to 8 boards PCF8574
       uint8_t gpio = Pcf8574Read(idx);
-      gpio |= ~Settings->pcf8574_config[idx]; // TEST - Force light pullup
-      Pcf8574.pin_mask[idx] = gpio;
-      Pcf8574Write(idx); // TEST - Force light pullup
+      Pcf8574.pin_mask[idx] = gpio | ~Settings->pcf8574_config[idx]; // Insure the input pins are actually writen a 1 for proper input operation
+      Pcf8574Write(idx); // Write back the register
 #ifdef USE_PCF8574_MQTTINPUT
       Pcf8574.last_input[idx] = gpio & ~Settings->pcf8574_config[idx];
 #endif // #ifdef USE_PCF8574_MQTTINPUT

--- a/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
@@ -123,8 +123,9 @@ void Pcf8574Init(void)
     Pcf8574.max_connected_ports = 0;  // reset no of devices to avoid duplicate ports on duplicate init.
     for (uint32_t idx = 0; idx < Pcf8574.max_devices; idx++) { // suport up to 8 boards PCF8574
       uint8_t gpio = Pcf8574Read(idx);
-      Pcf8574.pin_mask[idx] = gpio | ~Settings->pcf8574_config[idx]; // Insure the input pins are actually writen a 1 for proper input operation
-      Pcf8574Write(idx); // Write back the register
+      // Insure the input pins are actually writen a 1 for proper input operation
+      Pcf8574.pin_mask[idx] = gpio | ~Settings->pcf8574_config[idx];
+      Pcf8574Write(idx); // Write back to the register
 #ifdef USE_PCF8574_MQTTINPUT
       Pcf8574.last_input[idx] = gpio & ~Settings->pcf8574_config[idx];
 #endif // #ifdef USE_PCF8574_MQTTINPUT

--- a/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_28_pcf8574.ino
@@ -123,9 +123,9 @@ void Pcf8574Init(void)
     Pcf8574.max_connected_ports = 0;  // reset no of devices to avoid duplicate ports on duplicate init.
     for (uint32_t idx = 0; idx < Pcf8574.max_devices; idx++) { // suport up to 8 boards PCF8574
       uint8_t gpio = Pcf8574Read(idx);
-      gpio |= ~Settings->pcf8574_config[idx]; // TEST - Force input pullup
+      gpio &= Settings->pcf8574_config[idx]; // TEST - Force no input pullup
       Pcf8574.pin_mask[idx] = gpio;
-      Pcf8574Write(idx); // TEST - Force input pullup
+      Pcf8574Write(idx); // TEST - Force no input pullup
 #ifdef USE_PCF8574_MQTTINPUT
       Pcf8574.last_input[idx] = gpio & ~Settings->pcf8574_config[idx];
 #endif // #ifdef USE_PCF8574_MQTTINPUT


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #17399 

Due to the very specific "quasi-bidirectional" port architecture on PCF8574, an input port must be written a 1 to properly operate. This is normaly the case after power up due to internal circuitry.
Up to now Tasmota was not initializing this properly and could lead to non working input if someone change port to input write a 0 and change back to output.

This PR insure that input pins are written a 1 at  during driver initialization.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
