### PR TITLE
fix typo in dingtian driver

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_90_esp32_dingtian_relay.ino
@@ -99,10 +99,10 @@ void DingtianInit(void) {
 
       Dingtian->first = TasmotaGlobal.devices_present;
       TasmotaGlobal.devices_present += Dingtian->count;
-      if (TasGlobal.devices_present > POWER_SIZE) {
-        TasGlobal.devices_present = POWER_SIZE;
+      if (TasmotaGlobal.devices_present > POWER_SIZE) {
+        TasmotaGlobal.devices_present = POWER_SIZE;
       }
-      AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: Dingtian relays: POWER%d to POWER%d"), Dingtian->first + 1, TasGlobal.devices_present);
+      AddLog(LOG_LEVEL_DEBUG, PSTR("DNGT: Dingtian relays: POWER%d to POWER%d"), Dingtian->first + 1, TasmotaGlobal.devices_present);
     }
   }
 }


### PR DESCRIPTION
## Description:

Fix a stupid typo in Dingtian driver : https://github.com/arendst/Tasmota/pull/17032

 
## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
