### PR TITLE
Support for IPv6 only networks on Ethernet (not yet Wifi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Berry crypto add ``HKDF_HMAC_SHA256``
 - Support for up to 3 single phase modbus energy monitoring device using generic Energy Modbus driver
 - Berry crypto add ``SPAKE2P_Matter`` for Matter support
+- Support for IPv6 only networks on Ethernet (not yet Wifi)
 
 ### Breaking Changed
 

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP32Wifi.cpp
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP32Wifi.cpp
@@ -21,6 +21,9 @@
 #include <ESP8266WiFi.h>
 #include <esp_wifi.h>
 
+extern void AddLog(uint32_t loglevel, PGM_P formatP, ...);
+enum LoggingLevels {LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE};
+
 //
 // Wifi
 //
@@ -32,49 +35,97 @@
 #include "lwip/dns.h"
 
 wl_status_t WiFiClass32::begin(const char* wpa2_ssid, wpa2_auth_method_t method, const char* wpa2_identity, const char* wpa2_username, const char *wpa2_password, const char* ca_pem, const char* client_crt, const char* client_key, int32_t channel, const uint8_t* bssid, bool connect) {
-  saveDNS();
+  scrubDNS();
   wl_status_t ret = WiFiClass::begin(wpa2_ssid, method, wpa2_identity, wpa2_username, wpa2_password, ca_pem, client_crt, client_key, channel, bssid, connect);
-  restoreDNS();
+  scrubDNS();
   return ret;
 }
 
 wl_status_t WiFiClass32::begin(const char* ssid, const char *passphrase, int32_t channel, const uint8_t* bssid, bool connect) {
-  saveDNS();
+  scrubDNS();
   wl_status_t ret = WiFiClass::begin(ssid, passphrase, channel, bssid, connect);
-  restoreDNS();
+  scrubDNS();
   return ret;
 }
 
 wl_status_t WiFiClass32::begin(char* ssid, char *passphrase, int32_t channel, const uint8_t* bssid, bool connect) {
-  saveDNS();
+  scrubDNS();
   wl_status_t ret = WiFiClass::begin(ssid, passphrase, channel, bssid, connect);
-  restoreDNS();
+  scrubDNS();
   return ret;
 }
 wl_status_t WiFiClass32::begin() {
-  saveDNS();
+  scrubDNS();
   wl_status_t ret = WiFiClass::begin();
-  restoreDNS();
+  scrubDNS();
   return ret;
 }
 
-void WiFiClass32::saveDNS(void) {
-  // save the DNS servers
-  for (uint32_t i=0; i<DNS_MAX_SERVERS; i++) {
-    const ip_addr_t * ip = dns_getserver(i);
-    if (!ip_addr_isany(ip)) {
-      dns_save[i] = *ip;
-    }
-  }
-}
+// scrubDNS
+//
+// LWIP has a single DNS table for all interfaces and for v4/v6
+// Unfortunately when trying to connect to Wifi, the dns server table is erased.
+//
+// We restore DNS previous values if they are empty
+// We restore or erase DNS entries if they are unsupported (v4 vs v6)
+extern bool WifiHasIPv4(void);
+extern bool EthernetHasIPv4(void);
+extern bool WifiHasIPv6(void);
+extern bool EthernetHasIPv6(void);
 
-void WiFiClass32::restoreDNS(void) {
-  // restore DNS server if it was removed
+void WiFiClass32::scrubDNS(void) {
+  // String dns_entry0 = IPAddress(dns_getserver(0)).toString();
+  // String dns_entry1 = IPAddress(dns_getserver(1)).toString();
+  // scan DNS entries
+  bool has_v4 = WifiHasIPv4() || EthernetHasIPv4();
+  bool has_v6 = false;
+#ifdef USE_IPV6
+  has_v6 = WifiHasIPv6() || EthernetHasIPv6();
+#endif
+
+  // First pass, save values
   for (uint32_t i=0; i<DNS_MAX_SERVERS; i++) {
-    if (ip_addr_isany(dns_getserver(i))) {
-      dns_setserver(i, &dns_save[i]);
+#ifdef USE_IPV6
+    const IPAddress ip_dns = IPAddress(dns_getserver(i));
+    // Step 1. save valid values from DNS
+    if (!ip_addr_isany_val((const ip_addr_t &)ip_dns)) {
+      if (ip_dns.isV4() && has_v4) {
+        dns_save4[i] = (ip_addr_t) ip_dns;    // dns entry is populated, save it in v4 slot
+      } else if (ip_dns.isV6() && has_v6) {
+        dns_save6[i] = (ip_addr_t) ip_dns;    // dns entry is populated, save it in v6 slot
+      }
     }
+
+    // Step 2. scrub addresses not supported
+    if (!has_v4) { dns_save4[i] = *IP4_ADDR_ANY; }
+    if (!has_v6) { dns_save6[i] = *IP_ADDR_ANY; }
+
+    // Step 3. restore saved value
+    if (has_v4 && has_v6) {   // if both IPv4 and IPv6 are active, prefer IPv4
+      if (!ip_addr_isany_val(dns_save4[i])) { dns_setserver(i, &dns_save4[i]); }
+      else { dns_setserver(i, &dns_save6[i]); }
+    } else if (has_v4) {
+      dns_setserver(i, &dns_save4[i]);
+    } else if (has_v6) {
+      dns_setserver(i, &dns_save6[i]);
+    } else {
+      dns_setserver(i, IP4_ADDR_ANY);
+    }
+#else // USE_IPV6
+    uint32_t ip_dns = ip_addr_get_ip4_u32(dns_getserver(i));
+    // Step 1. save valid values from DNS
+    if (has_v4 && (uint32_t)ip_dns != 0) {
+      ip_addr_set_ip4_u32_val(dns_save4[i], ip_dns);
+    }
+    // Step 2. scrub addresses not supported
+    if (!has_v4) {
+      ip_addr_set_ip4_u32_val(dns_save4[i], 0L);
+    }
+    // Step 3. restore saved value
+    dns_setserver(i, &dns_save4[i]);
+#endif // USE_IPV6
   }
+  // AddLog(LOG_LEVEL_DEBUG, "IP>: DNS: from(%s %s) to (%s %s) has4/6:%i-%i", dns_entry0.c_str(), dns_entry1.c_str(), IPAddress(dns_getserver(0)).toString().c_str(),  IPAddress(dns_getserver(1)).toString().c_str(), has_v4, has_v6);
 }
 
 void WiFiClass32::setSleepMode(int iSleepMode) {
@@ -190,6 +241,7 @@ int WiFiClass32::hostByName(const char* aHostname, IPAddress& aResult, int32_t t
   aResult = (uint32_t) 0;     // by default set to IPv4 0.0.0.0
   dns_ipaddr = *IP4_ADDR_ANY;  // by default set to IPv4 0.0.0.0
   
+  scrubDNS();    // internal calls to reconnect can zero the DNS servers, save DNS for future use
   ip_addr_counter++;      // increase counter, from now ignore previous responses
   clearStatusBits(WIFI_DNS_IDLE_BIT | WIFI_DNS_DONE_BIT);
   uint8_t v4v6priority = LWIP_DNS_ADDRTYPE_IPV4;

--- a/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
+++ b/lib/libesp32/ESP32-to-ESP8266-compat/src/ESP8266WiFi.h
@@ -60,10 +60,12 @@ public:
     int hostByName(const char* aHostname, IPAddress& aResult, int32_t timer_ms);
     int hostByName(const char* aHostname, IPAddress& aResult);
 
-    void saveDNS(void);
-    void restoreDNS(void);
+    void scrubDNS(void);
 protected:
-    ip_addr_t dns_save[DNS_MAX_SERVERS] = {};
+    ip_addr_t dns_save4[DNS_MAX_SERVERS] = {};      // IPv4 DNS servers
+#ifdef USE_IPV6
+    ip_addr_t dns_save6[DNS_MAX_SERVERS] = {};      // IPv6 DNS servers
+#endif // USE_IPV6
 };
 
 void wifi_station_disconnect();

--- a/tasmota/tasmota_support/support_command.ino
+++ b/tasmota/tasmota_support/support_command.ino
@@ -804,44 +804,51 @@ void CmndStatus(void)
   if ((0 == payload) || (5 == payload)) {
 #ifdef USE_IPV6
     if (5 == payload) { WifiDumpAddressesIPv6(); }
-#endif // USE_IPV6
+    Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
+                          D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
+                          D_JSON_DNSSERVER "1\":\"%s\",\"" D_JSON_DNSSERVER "2\":\"%s\",\""
+                          D_JSON_MAC "\":\"%s\""
+                          ",\"" D_JSON_IP6_GLOBAL "\":\"%s\",\"" D_JSON_IP6_LOCAL "\":\"%s\""),
+                          TasmotaGlobal.hostname,
+                          (uint32_t)WiFi.localIP(), Settings->ipv4_address[1], Settings->ipv4_address[2],
+                          DNSGetIPStr(0).c_str(), DNSGetIPStr(1).c_str(),
+                          WiFi.macAddress().c_str()
+                          ,WifiGetIPv6Str().c_str(), WifiGetIPv6LinkLocalStr().c_str());
+#else // USE_IPV6
     Response_P(PSTR("{\"" D_CMND_STATUS D_STATUS5_NETWORK "\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
                           D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
                           D_JSON_DNSSERVER "1\":\"%_I\",\"" D_JSON_DNSSERVER "2\":\"%_I\",\""
-                          D_JSON_MAC "\":\"%s\""
-#ifdef USE_IPV6
-                          ",\"" D_JSON_IP6_GLOBAL "\":\"%s\",\"" D_JSON_IP6_LOCAL "\":\"%s\""
-#endif // USE_IPV6
-                          ),
+                          D_JSON_MAC "\":\"%s\""),
                           TasmotaGlobal.hostname,
                           (uint32_t)WiFi.localIP(), Settings->ipv4_address[1], Settings->ipv4_address[2],
                           Settings->ipv4_address[3], Settings->ipv4_address[4],
-                          WiFi.macAddress().c_str()
-#ifdef USE_IPV6
-                          ,WifiGetIPv6().c_str(), WifiGetIPv6LinkLocal().c_str()
+                          WiFi.macAddress().c_str());
 #endif // USE_IPV6
-                          );
 #ifdef USE_TASMESH
     ResponseAppend_P(PSTR(",\"SoftAPMac\":\"%s\""), WiFi.softAPmacAddress().c_str());
 #endif  // USE_TASMESH
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)
+#ifdef USE_IPV6
+    ResponseAppend_P(PSTR(",\"Ethernet\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
+                          D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
+                          D_JSON_DNSSERVER "1\":\"%s\",\"" D_JSON_DNSSERVER "2\":\"%s\",\""
+                          D_JSON_MAC "\":\"%s\",\"" D_JSON_IP6_GLOBAL "\":\"%s\",\"" D_JSON_IP6_LOCAL "\":\"%s\"}"),
+                          EthernetHostname(),
+                          (uint32_t)EthernetLocalIP(), Settings->eth_ipv4_address[1], Settings->eth_ipv4_address[2],
+                          DNSGetIPStr(0).c_str(), DNSGetIPStr(1).c_str(),
+                          EthernetMacAddress().c_str(),
+                          EthernetGetIPv6Str().c_str(), EthernetGetIPv6LinkLocalStr().c_str());
+#else // USE_IPV6
     ResponseAppend_P(PSTR(",\"Ethernet\":{\"" D_CMND_HOSTNAME "\":\"%s\",\""
                           D_CMND_IPADDRESS "\":\"%_I\",\"" D_JSON_GATEWAY "\":\"%_I\",\"" D_JSON_SUBNETMASK "\":\"%_I\",\""
                           D_JSON_DNSSERVER "1\":\"%_I\",\"" D_JSON_DNSSERVER "2\":\"%_I\",\""
-                          D_JSON_MAC "\":\"%s\""
-
-#ifdef USE_IPV6
-                          ",\"" D_JSON_IP6_GLOBAL "\":\"%s\",\"" D_JSON_IP6_LOCAL "\":\"%s\""
-#endif // USE_IPV6
-                          "}"),
+                          D_JSON_MAC "\":\"%s\"}"),
                           EthernetHostname(),
                           (uint32_t)EthernetLocalIP(), Settings->eth_ipv4_address[1], Settings->eth_ipv4_address[2],
                           Settings->eth_ipv4_address[3], Settings->eth_ipv4_address[4],
                           EthernetMacAddress().c_str()
-#ifdef USE_IPV6
-                          ,EthernetGetIPv6().c_str(), EthernetGetIPv6LinkLocal().c_str()
+
 #endif // USE_IPV6
-                          );
 #endif  // USE_ETHERNET
     ResponseAppend_P(PSTR(",\"" D_CMND_WEBSERVER "\":%d,\"HTTP_API\":%d,\"" D_CMND_WIFICONFIG "\":%d,\"" D_CMND_WIFIPOWER "\":%s}}"),
                           Settings->webserver, Settings->flag5.disable_referer_chk, Settings->sta_config, WifiGetOutputPower().c_str());

--- a/tasmota/tasmota_support/support_tasmota.ino
+++ b/tasmota/tasmota_support/support_tasmota.ino
@@ -1576,14 +1576,10 @@ void Every250mSeconds(void)
         if (Settings->webserver) {
 
 #ifdef ESP8266
-          if (!WifiIsInManagerMode()) { StartWebserver(Settings->webserver, WiFi.localIP()); }
+          if (!WifiIsInManagerMode()) { StartWebserver(Settings->webserver); }
 #endif  // ESP8266
 #ifdef ESP32
-#ifdef USE_ETHERNET
-          StartWebserver(Settings->webserver, (EthernetLocalIP()) ? EthernetLocalIP() : WiFi.localIP());
-#else
-          StartWebserver(Settings->webserver, WiFi.localIP());
-#endif
+          StartWebserver(Settings->webserver);
 #endif  // ESP32
 
 #ifdef USE_DISCOVERY

--- a/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_02_9_mqtt.ino
@@ -972,8 +972,8 @@ void MqttConnected(void) {
           ResponseAppend_P(PSTR(",\"" D_CMND_HOSTNAME "\":\"%s\",\"" D_CMND_IPADDRESS "\":\"%_I\""),
             TasmotaGlobal.hostname, (uint32_t)WiFi.localIP());
 #ifdef USE_IPV6
-          ResponseAppend_P(PSTR(",\"" D_JSON_IP6_GLOBAL "\":\"%s\""), WifiGetIPv6().c_str());
-          ResponseAppend_P(PSTR(",\"" D_JSON_IP6_LOCAL "\":\"%s\""), WifiGetIPv6LinkLocal().c_str());
+          ResponseAppend_P(PSTR(",\"" D_JSON_IP6_GLOBAL "\":\"%s\""), WifiGetIPv6Str().c_str());
+          ResponseAppend_P(PSTR(",\"" D_JSON_IP6_LOCAL "\":\"%s\""), WifiGetIPv6LinkLocalStr().c_str());
 #endif  // USE_IPV6
         }
 #if defined(ESP32) && CONFIG_IDF_TARGET_ESP32 && defined(USE_ETHERNET)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -215,12 +215,12 @@ extern "C" {
         int32_t rssi = WiFi.RSSI();
         bool show_rssi = false;
 #ifdef USE_IPV6
-        String ipv6_addr = WifiGetIPv6();
+        String ipv6_addr = WifiGetIPv6Str();
         if (ipv6_addr != "") {
           be_map_insert_str(vm, "ip6", ipv6_addr.c_str());
           show_rssi = true;
         }
-        ipv6_addr = WifiGetIPv6LinkLocal();
+        ipv6_addr = WifiGetIPv6LinkLocalStr();
         if (ipv6_addr != "") {
           be_map_insert_str(vm, "ip6local", ipv6_addr.c_str());
           show_rssi = true;
@@ -255,11 +255,11 @@ extern "C" {
         be_map_insert_str(vm, "ip", IPAddress((uint32_t)EthernetLocalIP()).toString().c_str());   // quick fix for IPAddress bug
       }
 #ifdef USE_IPV6
-      String ipv6_addr = EthernetGetIPv6();
+      String ipv6_addr = EthernetGetIPv6Str();
       if (ipv6_addr != "") {
         be_map_insert_str(vm, "ip6", ipv6_addr.c_str());
       }
-      ipv6_addr = EthernetGetIPv6LinkLocal();
+      ipv6_addr = EthernetGetIPv6LinkLocalStr();
       if (ipv6_addr != "") {
         be_map_insert_str(vm, "ip6local", ipv6_addr.c_str());
       }


### PR DESCRIPTION
## Description:

IPv4/IPv6 refactoring and cleaning to support IPv6 only networks:
- Support RDNSS with SLAAC to discover DNS server on IPv6 only network
- `Status 5` debug logging improved
- DNS scrubbing: two sets of DNS server is kept aside: v4 and v6. Since LWIP removes DNS servers at each connection, scrubbing copies back the servers to LWIP. v4 servers are preferred if IPv4 is enabled.
- `SetOption149` is ignored if network is v4-only or v6-only
- Changed NTP servers to support dual-stack DNS
- `StartWebserver()` doesn't take an IP anymore. Web server always listen on all interfaces and dual-stack. The IP argument was only used for logging, IP is now discovered by `StartWebserver()`

New unified IP functions:
```

IP detection revised for full IPv4 / IPv6 support

In general, each interface (Wifi/Eth) can have 1x IPv4 and
2x IPv6 (Global routable address and Link-Local starting witn fe80:...)

We always use an IPv4 address if one is assigned, and revert to
IPv6 only on networks that are v6 only.
Ethernet calls can be safely used even if the USE_ETHERNET is not enabled

New APIs:
- general form is:
  `bool XXXGetIPYYY(IPAddress*)` returns `true` if the address exists and copies the address
                                 if the pointer is non-null.
  `bool XXXHasIPYYY()`           same as above but only returns `true` or `false`
  `String XXXGetIPYYYStr()`      returns the IP as a `String` or empty `String` if none

  `XXX` can be `Wifi` or `Eth`
  `YYY` can be `` for any address, `v6` for IPv6 global address or `v6LinkLocal` for Link-local

- Legacy `Wifi.localIP()` and `ETH.localIP()` always return IPv4 and nothing on IPv6 only networks

- v4/v6:
  `WifiGetIP`, `WifiGetIPStr`, `WifiHasIP`: get preferred v4/v6 address for Wifi
  `EthernetGetIP`, `EthernetGetIPStr`, `EthernetHasIP`: get preferred v4/v6 for Ethernet

- Main IP to be used dual stack v4/v6
  `hasIP`, `IPGetListeningAddress`, `IPGetListeningAddressStr`: any IP to listen to for Web Server
            IPv4 is always preferred, and Eth is preferred over Wifi.
  `IPForUrl`: converts v4/v6 to use in URL, enclosing v6 in []

- v6 only:
   `WifiGetIPv6`, `WifiGetIPv6Str`, `WifiHasIPv6`
   `WifiGetIPv6LinkLocal`, `WifiGetIPv6LinkLocalStr`
   `EthernetGetIPv6, `EthernetHasIPv6`, `EthernetGetIPv6Str`
   `EthernetGetIPv6LinkLocal`, `EthernetGetIPv6LinkLocalStr`

- v4 only:
   `WifiGetIPv4`, `WifiGetIPv4Str`, `WifiHasIPv4`
   `EthernetGetIPv4`, `EthernetGetIPv4Str`, `EthernetHasIPv4`

- DNS reporting actual values used (not the Settings):
   `DNSGetIP(n)`, `DNSGetIPStr(n)` with n=`0`/`1` (same dns for Wifi and Eth)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.5
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
