### PR TITLE
Berry `bytes()` now evaluates to `false` if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.3.1.3]
 ### Added
 - Support for PCA9632 4-channel 8-bit PWM driver as light driver by Pascal Heinrich (#17557)
+- Berry `bytes()` now evaluates to `false` if empty
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry/src/be_byteslib.c
+++ b/lib/libesp32/berry/src/be_byteslib.c
@@ -1125,6 +1125,13 @@ static int m_size(bvm *vm)
     be_return(vm);
 }
 
+static int m_tobool(bvm *vm)
+{
+    buf_impl attr = m_read_attributes(vm, 1);
+    be_pushbool(vm, attr.len > 0 ? 1 : 0);
+    be_return(vm);
+}
+
 static int m_resize(bvm *vm)
 {
     int argc = be_top(vm);
@@ -1668,6 +1675,7 @@ void be_load_byteslib(bvm *vm)
         { "deinit", m_deinit },
         { "tostring", m_tostring },
         { "asstring", m_asstring },
+        { "tobool", m_tobool },
         { "fromstring", m_fromstring },
         { "tob64", m_tob64 },
         { "fromb64", m_fromb64 },
@@ -1714,6 +1722,7 @@ class be_class_bytes (scope: global, name: bytes) {
     deinit, func(m_deinit)
     tostring, func(m_tostring)
     asstring, func(m_asstring)
+    tobool, func(m_tobool)
     fromstring, func(m_fromstring)
     tob64, func(m_tob64)
     fromb64, func(m_fromb64)


### PR DESCRIPTION
## Description:

Minor change to Berry. `bytes()` object evaluate to false if empty, it used to always evaluate to `true`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
