### PR TITLE
Berry ``crypto.AES_CCM`` (required by Matter protocol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Support for PCA9632 4-channel 8-bit PWM driver as light driver by Pascal Heinrich (#17557)
 - Berry `bytes()` now evaluates to `false` if empty
+- Berry ``crypto.AES_CCM`` (required by Matter protocol)
 
 ### Breaking Changed
 

--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -11,6 +11,11 @@
 extern int be_class_crypto_member(bvm *vm);
 extern int m_crypto_random(bvm *vm);
 
+extern int m_aes_ccm_init(bvm *vm);
+extern int m_aes_ccm_encryt(bvm *vm);
+extern int m_aes_ccm_decryt(bvm *vm);
+extern int m_aes_ccm_tag(bvm *vm);
+
 extern int m_aes_gcm_init(bvm *vm);
 extern int m_aes_gcm_encryt(bvm *vm);
 extern int m_aes_gcm_decryt(bvm *vm);
@@ -47,6 +52,7 @@ extern const bclass be_class_md5;
 #include "solidify/solidified_crypto_pbkdf2_hmac_sha256.h"
 #include "solidify/solidified_crypto_spake2p_matter.h"
 
+#include "be_fixed_be_class_aes_ccm.h"
 #include "be_fixed_be_class_aes_gcm.h"
 #include "be_fixed_be_class_aes_ctr.h"
 #include "be_fixed_be_class_ec_p256.h"
@@ -65,11 +71,17 @@ extern const bclass be_class_md5;
   #define USE_BERRY_CRYPTO_HMAC_SHA256
   #undef USE_BERRY_CRYPTO_HKDF_SHA256
   #define USE_BERRY_CRYPTO_HKDF_SHA256
+  #undef USE_BERRY_CRYPTO_AES_CCM
+  #define USE_BERRY_CRYPTO_AES_CCM
 #endif
 
 const be_const_member_t be_crypto_members[] = {
   // name with prefix '/' indicates a Berry class
   // entries need to be sorted (ignoring the prefix char)
+#ifdef USE_BERRY_CRYPTO_AES_CCM
+  { "/AES_CCM", (intptr_t) &be_class_aes_ccm },
+#endif // USE_BERRY_CRYPTO_AES_CTR
+
 #ifdef USE_BERRY_CRYPTO_AES_CTR
   { "/AES_CTR", (intptr_t) &be_class_aes_ctr },
 #endif // USE_BERRY_CRYPTO_AES_CTR
@@ -113,6 +125,16 @@ const size_t be_crypto_members_size = sizeof(be_crypto_members)/sizeof(be_crypto
 
 
 /* @const_object_info_begin
+
+class be_class_aes_ccm (scope: global, name: AES_CCM) {
+    .p1, var
+    .p2, var
+
+    init, func(m_aes_ccm_init)
+    encrypt, func(m_aes_ccm_encryt)
+    decrypt, func(m_aes_ccm_decryt)
+    tag, func(m_aes_ccm_tag)
+}
 
 class be_class_aes_gcm (scope: global, name: AES_GCM) {
     .p1, var

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -1120,7 +1120,8 @@
   // #define USE_BERRY_ULP                          // Enable ULP (Ultra Low Power) support (+4.9k)
   // Berry crypto extensions below:
   #define USE_BERRY_CRYPTO_AES_GCM               // enable AES GCM 256 bits
-  // #define USE_BERRY_CRYPTO_AES_CTR               // enable AEC CTR 256 bits
+  // #define USE_BERRY_CRYPTO_AES_CCM               // enable AES CCM 128 bits
+  // #define USE_BERRY_CRYPTO_AES_CTR               // enable AES CTR 256 bits
   // #define USE_BERRY_CRYPTO_EC_P256               // enable EC P256r1
   // #define USE_BERRY_CRYPTO_EC_C25519             // enable Elliptic Curve C C25519
   #define USE_BERRY_CRYPTO_SHA256                // enable SHA256 hash function


### PR DESCRIPTION
## Description:

Added support for `AES_CCM` with keys 128/256 bits. Required by Matter protocol. Requires `#define USE_BERRY_CRYPTO_AES_CCM`

Example:
``` berry
var k=bytes('404142434445464748494a4b4c4d4e4f')
var n=bytes('1011121314151617')
var a=bytes('000102030405060708090a0b0c0d0e0f')
var p=bytes('202122232425262728292a2b2c2d2e2f')

import crypto
var c = crypto.AES_CCM(k, n, a, size(p), 6)
var cipher = c.encrypt(p)
var tag = c.tag().resize(6)
assert(cipher == bytes('D2A1F0E051EA5F62081A7792073D593D'))
assert(tag == bytes('1FC64FBFACCD'))
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
