### PR TITLE
Berry add spake2+ mods needed for Matter

### DIFF
--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_crypto_spake2p_matter.h
@@ -5,54 +5,11 @@
 #include "be_constobj.h"
 
 /********************************************************************
-** Solidified function: set_context
+** Solidified function: compute_pB
 ********************************************************************/
-be_local_closure(SPAKE2P_Matter_set_context,   /* name */
+be_local_closure(SPAKE2P_Matter_compute_pB,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(Context),
-    /* K1   */  be_nested_str_weak(A),
-    /* K2   */  be_nested_str_weak(B),
-    }),
-    be_str_weak(set_context),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x1C100404,  //  0001  EQ	R4	R2	R4
-      0x78120002,  //  0002  JMPF	R4	#0006
-      0x60100015,  //  0003  GETGBL	R4	G21
-      0x7C100000,  //  0004  CALL	R4	0
-      0x5C080800,  //  0005  MOVE	R2	R4
-      0x4C100000,  //  0006  LDNIL	R4
-      0x1C100604,  //  0007  EQ	R4	R3	R4
-      0x78120002,  //  0008  JMPF	R4	#000C
-      0x60100015,  //  0009  GETGBL	R4	G21
-      0x7C100000,  //  000A  CALL	R4	0
-      0x5C0C0800,  //  000B  MOVE	R3	R4
-      0x90020001,  //  000C  SETMBR	R0	K0	R1
-      0x90020202,  //  000D  SETMBR	R0	K1	R2
-      0x90020403,  //  000E  SETMBR	R0	K2	R3
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_ZV_prover
-********************************************************************/
-be_local_closure(SPAKE2P_Matter_compute_ZV_prover,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -60,50 +17,44 @@ be_local_closure(SPAKE2P_Matter_compute_ZV_prover,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(EC_P256),
-    /* K2   */  be_nested_str_weak(pB),
-    /* K3   */  be_nested_str_weak(neg),
-    /* K4   */  be_nested_str_weak(w0),
-    /* K5   */  be_nested_str_weak(muladd),
-    /* K6   */  be_nested_str_weak(01),
-    /* K7   */  be_nested_str_weak(N),
-    /* K8   */  be_nested_str_weak(Z),
-    /* K9   */  be_nested_str_weak(mul),
-    /* K10  */  be_nested_str_weak(x),
-    /* K11  */  be_nested_str_weak(V),
-    /* K12  */  be_nested_str_weak(w1),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_nested_str_weak(EC_P256),
+    /* K3   */  be_nested_str_weak(y),
+    /* K4   */  be_nested_str_weak(mod),
+    /* K5   */  be_nested_str_weak(pB),
+    /* K6   */  be_nested_str_weak(muladd),
+    /* K7   */  be_nested_str_weak(w0),
+    /* K8   */  be_nested_str_weak(N),
     }),
-    be_str_weak(compute_ZV_prover),
+    be_str_weak(compute_pB),
     &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
+    ( &(const binstruction[24]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x8C100703,  //  0004  GETMET	R4	R3	K3
-      0x88180104,  //  0005  GETMBR	R6	R0	K4
-      0x7C100400,  //  0006  CALL	R4	2
-      0x8C140705,  //  0007  GETMET	R5	R3	K5
-      0x601C0015,  //  0008  GETGBL	R7	G21
-      0x58200006,  //  0009  LDCONST	R8	K6
-      0x7C1C0200,  //  000A  CALL	R7	1
-      0x88200102,  //  000B  GETMBR	R8	R0	K2
-      0x5C240800,  //  000C  MOVE	R9	R4
-      0x88280107,  //  000D  GETMBR	R10	R0	K7
-      0x7C140A00,  //  000E  CALL	R5	5
-      0x8C180709,  //  000F  GETMET	R6	R3	K9
-      0x8820010A,  //  0010  GETMBR	R8	R0	K10
-      0x5C240A00,  //  0011  MOVE	R9	R5
-      0x7C180600,  //  0012  CALL	R6	3
-      0x90021006,  //  0013  SETMBR	R0	K8	R6
-      0x8C180709,  //  0014  GETMET	R6	R3	K9
-      0x8820010C,  //  0015  GETMBR	R8	R0	K12
-      0x5C240A00,  //  0016  MOVE	R9	R5
-      0x7C180600,  //  0017  CALL	R6	3
-      0x90021606,  //  0018  SETMBR	R0	K11	R6
-      0x80000000,  //  0019  RET	0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0203,  //  0002  EQ	R3	R1	R3
+      0x780E0003,  //  0003  JMPF	R3	#0008
+      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
+      0x5416001F,  //  0005  LDINT	R5	32
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x5C040600,  //  0007  MOVE	R1	R3
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C100704,  //  000A  GETMET	R4	R3	K4
+      0x5C180200,  //  000B  MOVE	R6	R1
+      0x7C100400,  //  000C  CALL	R4	2
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x8C100706,  //  000E  GETMET	R4	R3	K6
+      0x88180107,  //  000F  GETMBR	R6	R0	K7
+      0x881C0108,  //  0010  GETMBR	R7	R0	K8
+      0x88200103,  //  0011  GETMBR	R8	R0	K3
+      0x60240015,  //  0012  GETGBL	R9	G21
+      0x7C240000,  //  0013  CALL	R9	0
+      0x7C100A00,  //  0014  CALL	R4	5
+      0x90020A04,  //  0015  SETMBR	R0	K5	R4
+      0x88100105,  //  0016  GETMBR	R4	R0	K5
+      0x80040800,  //  0017  RET	1	R4
     })
   )
 );
@@ -243,15 +194,15 @@ be_local_class(SPAKE_Hasher,
 ********************************************************************/
 be_local_closure(SPAKE2P_Matter_compute_TT_hash,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    1,                          /* argc */
+    14,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_const_class(be_class_SPAKE_Hasher),
     /* K1   */  be_nested_str_weak(crypto),
     /* K2   */  be_nested_str_weak(add_item),
@@ -267,170 +218,138 @@ be_local_closure(SPAKE2P_Matter_compute_TT_hash,   /* name */
     /* K12  */  be_nested_str_weak(w0),
     /* K13  */  be_nested_str_weak(Kmain),
     /* K14  */  be_nested_str_weak(out),
-    /* K15  */  be_nested_str_weak(HKDF_SHA256),
-    /* K16  */  be_nested_str_weak(derive),
-    /* K17  */  be_nested_str_weak(fromstring),
-    /* K18  */  be_nested_str_weak(ConfirmationKeys),
-    /* K19  */  be_nested_str_weak(KcA),
-    /* K20  */  be_const_int(0),
-    /* K21  */  be_nested_str_weak(KcB),
-    /* K22  */  be_nested_str_weak(K_shared),
-    /* K23  */  be_nested_str_weak(SharedKey),
-    /* K24  */  be_nested_str_weak(cA),
-    /* K25  */  be_nested_str_weak(HMAC_SHA256),
-    /* K26  */  be_nested_str_weak(update),
-    /* K27  */  be_nested_str_weak(cB),
+    /* K15  */  be_nested_str_weak(Ke),
+    /* K16  */  be_const_int(0),
+    /* K17  */  be_nested_str_weak(HKDF_SHA256),
+    /* K18  */  be_nested_str_weak(derive),
+    /* K19  */  be_nested_str_weak(fromstring),
+    /* K20  */  be_nested_str_weak(ConfirmationKeys),
+    /* K21  */  be_nested_str_weak(KcA),
+    /* K22  */  be_nested_str_weak(KcB),
+    /* K23  */  be_nested_str_weak(K_shared),
+    /* K24  */  be_nested_str_weak(SharedKey),
+    /* K25  */  be_nested_str_weak(cA),
+    /* K26  */  be_nested_str_weak(HMAC_SHA256),
+    /* K27  */  be_nested_str_weak(update),
+    /* K28  */  be_nested_str_weak(cB),
     }),
     be_str_weak(compute_TT_hash),
     &be_const_str_solidified,
-    ( &(const binstruction[91]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
+    ( &(const binstruction[114]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
       0xB4000000,  //  0001  CLASS	K0
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x5C0C0200,  //  0003  MOVE	R3	R1
-      0x7C0C0000,  //  0004  CALL	R3	0
-      0x8C100702,  //  0005  GETMET	R4	R3	K2
-      0x88180103,  //  0006  GETMBR	R6	R0	K3
-      0x7C100400,  //  0007  CALL	R4	2
-      0x8C100702,  //  0008  GETMET	R4	R3	K2
-      0x88180104,  //  0009  GETMBR	R6	R0	K4
-      0x7C100400,  //  000A  CALL	R4	2
-      0x8C100702,  //  000B  GETMET	R4	R3	K2
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
-      0x7C100400,  //  000D  CALL	R4	2
-      0x8C100702,  //  000E  GETMET	R4	R3	K2
-      0x88180106,  //  000F  GETMBR	R6	R0	K6
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C100702,  //  0011  GETMET	R4	R3	K2
-      0x88180107,  //  0012  GETMBR	R6	R0	K7
-      0x7C100400,  //  0013  CALL	R4	2
-      0x8C100702,  //  0014  GETMET	R4	R3	K2
-      0x88180108,  //  0015  GETMBR	R6	R0	K8
-      0x7C100400,  //  0016  CALL	R4	2
-      0x8C100702,  //  0017  GETMET	R4	R3	K2
-      0x88180109,  //  0018  GETMBR	R6	R0	K9
-      0x7C100400,  //  0019  CALL	R4	2
-      0x8C100702,  //  001A  GETMET	R4	R3	K2
-      0x8818010A,  //  001B  GETMBR	R6	R0	K10
-      0x7C100400,  //  001C  CALL	R4	2
-      0x8C100702,  //  001D  GETMET	R4	R3	K2
-      0x8818010B,  //  001E  GETMBR	R6	R0	K11
-      0x7C100400,  //  001F  CALL	R4	2
-      0x8C100702,  //  0020  GETMET	R4	R3	K2
-      0x8818010C,  //  0021  GETMBR	R6	R0	K12
-      0x7C100400,  //  0022  CALL	R4	2
-      0x8C10070E,  //  0023  GETMET	R4	R3	K14
-      0x7C100200,  //  0024  CALL	R4	1
-      0x90021A04,  //  0025  SETMBR	R0	K13	R4
-      0x8C10050F,  //  0026  GETMET	R4	R2	K15
-      0x7C100200,  //  0027  CALL	R4	1
-      0x8C140910,  //  0028  GETMET	R5	R4	K16
-      0x881C010D,  //  0029  GETMBR	R7	R0	K13
-      0x60200015,  //  002A  GETGBL	R8	G21
-      0x7C200000,  //  002B  CALL	R8	0
-      0x60240015,  //  002C  GETGBL	R9	G21
-      0x7C240000,  //  002D  CALL	R9	0
-      0x8C241311,  //  002E  GETMET	R9	R9	K17
-      0x582C0012,  //  002F  LDCONST	R11	K18
-      0x7C240400,  //  0030  CALL	R9	2
-      0x542A003F,  //  0031  LDINT	R10	64
-      0x7C140A00,  //  0032  CALL	R5	5
-      0x541A001E,  //  0033  LDINT	R6	31
-      0x401A2806,  //  0034  CONNECT	R6	K20	R6
-      0x94180A06,  //  0035  GETIDX	R6	R5	R6
-      0x90022606,  //  0036  SETMBR	R0	K19	R6
-      0x541A001F,  //  0037  LDINT	R6	32
-      0x541E003E,  //  0038  LDINT	R7	63
-      0x40180C07,  //  0039  CONNECT	R6	R6	R7
-      0x94180A06,  //  003A  GETIDX	R6	R5	R6
-      0x90022A06,  //  003B  SETMBR	R0	K21	R6
-      0x8C180910,  //  003C  GETMET	R6	R4	K16
-      0x8820010D,  //  003D  GETMBR	R8	R0	K13
-      0x60240015,  //  003E  GETGBL	R9	G21
-      0x7C240000,  //  003F  CALL	R9	0
-      0x60280015,  //  0040  GETGBL	R10	G21
-      0x7C280000,  //  0041  CALL	R10	0
-      0x8C281511,  //  0042  GETMET	R10	R10	K17
-      0x58300017,  //  0043  LDCONST	R12	K23
-      0x7C280400,  //  0044  CALL	R10	2
-      0x542E001F,  //  0045  LDINT	R11	32
-      0x7C180A00,  //  0046  CALL	R6	5
-      0x90022C06,  //  0047  SETMBR	R0	K22	R6
-      0x8C180519,  //  0048  GETMET	R6	R2	K25
-      0x88200113,  //  0049  GETMBR	R8	R0	K19
-      0x7C180400,  //  004A  CALL	R6	2
-      0x8C180D1A,  //  004B  GETMET	R6	R6	K26
-      0x88200109,  //  004C  GETMBR	R8	R0	K9
-      0x7C180400,  //  004D  CALL	R6	2
-      0x8C180D0E,  //  004E  GETMET	R6	R6	K14
-      0x7C180200,  //  004F  CALL	R6	1
-      0x90023006,  //  0050  SETMBR	R0	K24	R6
-      0x8C180519,  //  0051  GETMET	R6	R2	K25
-      0x88200115,  //  0052  GETMBR	R8	R0	K21
-      0x7C180400,  //  0053  CALL	R6	2
-      0x8C180D1A,  //  0054  GETMET	R6	R6	K26
-      0x88200108,  //  0055  GETMBR	R8	R0	K8
-      0x7C180400,  //  0056  CALL	R6	2
-      0x8C180D0E,  //  0057  GETMET	R6	R6	K14
-      0x7C180200,  //  0058  CALL	R6	1
-      0x90023606,  //  0059  SETMBR	R0	K27	R6
-      0x80000000,  //  005A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_pA
-********************************************************************/
-be_local_closure(SPAKE2P_Matter_compute_pA,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(x),
-    /* K4   */  be_nested_str_weak(mod),
-    /* K5   */  be_nested_str_weak(pA),
-    /* K6   */  be_nested_str_weak(muladd),
-    /* K7   */  be_nested_str_weak(w0),
-    /* K8   */  be_nested_str_weak(M),
-    }),
-    be_str_weak(compute_pA),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0203,  //  0002  EQ	R3	R1	R3
-      0x780E0003,  //  0003  JMPF	R3	#0008
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x5416001F,  //  0005  LDINT	R5	32
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x5C040600,  //  0007  MOVE	R1	R3
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C100704,  //  000A  GETMET	R4	R3	K4
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x7C100400,  //  000C  CALL	R4	2
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0x8C100706,  //  000E  GETMET	R4	R3	K6
-      0x88180107,  //  000F  GETMBR	R6	R0	K7
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x88200103,  //  0011  GETMBR	R8	R0	K3
-      0x60240015,  //  0012  GETGBL	R9	G21
-      0x7C240000,  //  0013  CALL	R9	0
-      0x7C100A00,  //  0014  CALL	R4	5
-      0x90020A04,  //  0015  SETMBR	R0	K5	R4
-      0x80000000,  //  0016  RET	0
+      0xA40E0200,  //  0002  IMPORT	R3	K1
+      0x5C100400,  //  0003  MOVE	R4	R2
+      0x7C100000,  //  0004  CALL	R4	0
+      0x8C140902,  //  0005  GETMET	R5	R4	K2
+      0x881C0103,  //  0006  GETMBR	R7	R0	K3
+      0x7C140400,  //  0007  CALL	R5	2
+      0x8C140902,  //  0008  GETMET	R5	R4	K2
+      0x881C0104,  //  0009  GETMBR	R7	R0	K4
+      0x7C140400,  //  000A  CALL	R5	2
+      0x8C140902,  //  000B  GETMET	R5	R4	K2
+      0x881C0105,  //  000C  GETMBR	R7	R0	K5
+      0x7C140400,  //  000D  CALL	R5	2
+      0x8C140902,  //  000E  GETMET	R5	R4	K2
+      0x881C0106,  //  000F  GETMBR	R7	R0	K6
+      0x7C140400,  //  0010  CALL	R5	2
+      0x8C140902,  //  0011  GETMET	R5	R4	K2
+      0x881C0107,  //  0012  GETMBR	R7	R0	K7
+      0x7C140400,  //  0013  CALL	R5	2
+      0x8C140902,  //  0014  GETMET	R5	R4	K2
+      0x881C0108,  //  0015  GETMBR	R7	R0	K8
+      0x7C140400,  //  0016  CALL	R5	2
+      0x8C140902,  //  0017  GETMET	R5	R4	K2
+      0x881C0109,  //  0018  GETMBR	R7	R0	K9
+      0x7C140400,  //  0019  CALL	R5	2
+      0x8C140902,  //  001A  GETMET	R5	R4	K2
+      0x881C010A,  //  001B  GETMBR	R7	R0	K10
+      0x7C140400,  //  001C  CALL	R5	2
+      0x8C140902,  //  001D  GETMET	R5	R4	K2
+      0x881C010B,  //  001E  GETMBR	R7	R0	K11
+      0x7C140400,  //  001F  CALL	R5	2
+      0x8C140902,  //  0020  GETMET	R5	R4	K2
+      0x881C010C,  //  0021  GETMBR	R7	R0	K12
+      0x7C140400,  //  0022  CALL	R5	2
+      0x8C14090E,  //  0023  GETMET	R5	R4	K14
+      0x7C140200,  //  0024  CALL	R5	1
+      0x90021A05,  //  0025  SETMBR	R0	K13	R5
+      0x7806000A,  //  0026  JMPF	R1	#0032
+      0x5416000F,  //  0027  LDINT	R5	16
+      0x541A001E,  //  0028  LDINT	R6	31
+      0x40140A06,  //  0029  CONNECT	R5	R5	R6
+      0x8818010D,  //  002A  GETMBR	R6	R0	K13
+      0x94140C05,  //  002B  GETIDX	R5	R6	R5
+      0x90021E05,  //  002C  SETMBR	R0	K15	R5
+      0x5416000E,  //  002D  LDINT	R5	15
+      0x40162005,  //  002E  CONNECT	R5	K16	R5
+      0x8818010D,  //  002F  GETMBR	R6	R0	K13
+      0x94140C05,  //  0030  GETIDX	R5	R6	R5
+      0x90021A05,  //  0031  SETMBR	R0	K13	R5
+      0x8C140711,  //  0032  GETMET	R5	R3	K17
+      0x7C140200,  //  0033  CALL	R5	1
+      0x8C180B12,  //  0034  GETMET	R6	R5	K18
+      0x8820010D,  //  0035  GETMBR	R8	R0	K13
+      0x60240015,  //  0036  GETGBL	R9	G21
+      0x7C240000,  //  0037  CALL	R9	0
+      0x60280015,  //  0038  GETGBL	R10	G21
+      0x7C280000,  //  0039  CALL	R10	0
+      0x8C281513,  //  003A  GETMET	R10	R10	K19
+      0x58300014,  //  003B  LDCONST	R12	K20
+      0x7C280400,  //  003C  CALL	R10	2
+      0x542E003F,  //  003D  LDINT	R11	64
+      0x7C180A00,  //  003E  CALL	R6	5
+      0x78060003,  //  003F  JMPF	R1	#0044
+      0x541E000E,  //  0040  LDINT	R7	15
+      0x401E2007,  //  0041  CONNECT	R7	K16	R7
+      0x941C0C07,  //  0042  GETIDX	R7	R6	R7
+      0x70020002,  //  0043  JMP		#0047
+      0x541E001E,  //  0044  LDINT	R7	31
+      0x401E2007,  //  0045  CONNECT	R7	K16	R7
+      0x941C0C07,  //  0046  GETIDX	R7	R6	R7
+      0x90022A07,  //  0047  SETMBR	R0	K21	R7
+      0x78060004,  //  0048  JMPF	R1	#004E
+      0x541E000F,  //  0049  LDINT	R7	16
+      0x5422001E,  //  004A  LDINT	R8	31
+      0x401C0E08,  //  004B  CONNECT	R7	R7	R8
+      0x941C0C07,  //  004C  GETIDX	R7	R6	R7
+      0x70020003,  //  004D  JMP		#0052
+      0x541E001F,  //  004E  LDINT	R7	32
+      0x5422003E,  //  004F  LDINT	R8	63
+      0x401C0E08,  //  0050  CONNECT	R7	R7	R8
+      0x941C0C07,  //  0051  GETIDX	R7	R6	R7
+      0x90022C07,  //  0052  SETMBR	R0	K22	R7
+      0x8C1C0B12,  //  0053  GETMET	R7	R5	K18
+      0x8824010D,  //  0054  GETMBR	R9	R0	K13
+      0x60280015,  //  0055  GETGBL	R10	G21
+      0x7C280000,  //  0056  CALL	R10	0
+      0x602C0015,  //  0057  GETGBL	R11	G21
+      0x7C2C0000,  //  0058  CALL	R11	0
+      0x8C2C1713,  //  0059  GETMET	R11	R11	K19
+      0x58340018,  //  005A  LDCONST	R13	K24
+      0x7C2C0400,  //  005B  CALL	R11	2
+      0x5432001F,  //  005C  LDINT	R12	32
+      0x7C1C0A00,  //  005D  CALL	R7	5
+      0x90022E07,  //  005E  SETMBR	R0	K23	R7
+      0x8C1C071A,  //  005F  GETMET	R7	R3	K26
+      0x88240115,  //  0060  GETMBR	R9	R0	K21
+      0x7C1C0400,  //  0061  CALL	R7	2
+      0x8C1C0F1B,  //  0062  GETMET	R7	R7	K27
+      0x88240109,  //  0063  GETMBR	R9	R0	K9
+      0x7C1C0400,  //  0064  CALL	R7	2
+      0x8C1C0F0E,  //  0065  GETMET	R7	R7	K14
+      0x7C1C0200,  //  0066  CALL	R7	1
+      0x90023207,  //  0067  SETMBR	R0	K25	R7
+      0x8C1C071A,  //  0068  GETMET	R7	R3	K26
+      0x88240116,  //  0069  GETMBR	R9	R0	K22
+      0x7C1C0400,  //  006A  CALL	R7	2
+      0x8C1C0F1B,  //  006B  GETMET	R7	R7	K27
+      0x88240108,  //  006C  GETMBR	R9	R0	K8
+      0x7C1C0400,  //  006D  CALL	R7	2
+      0x8C1C0F0E,  //  006E  GETMET	R7	R7	K14
+      0x7C1C0200,  //  006F  CALL	R7	1
+      0x90023807,  //  0070  SETMBR	R0	K28	R7
+      0x80000000,  //  0071  RET	0
     })
   )
 );
@@ -478,6 +397,106 @@ be_local_closure(SPAKE2P_Matter_init,   /* name */
       0x90020A01,  //  000C  SETMBR	R0	K5	R1
       0x90020C02,  //  000D  SETMBR	R0	K6	R2
       0x90020E03,  //  000E  SETMBR	R0	K7	R3
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_pA
+********************************************************************/
+be_local_closure(SPAKE2P_Matter_compute_pA,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_nested_str_weak(EC_P256),
+    /* K3   */  be_nested_str_weak(x),
+    /* K4   */  be_nested_str_weak(mod),
+    /* K5   */  be_nested_str_weak(pA),
+    /* K6   */  be_nested_str_weak(muladd),
+    /* K7   */  be_nested_str_weak(w0),
+    /* K8   */  be_nested_str_weak(M),
+    }),
+    be_str_weak(compute_pA),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x1C0C0203,  //  0002  EQ	R3	R1	R3
+      0x780E0003,  //  0003  JMPF	R3	#0008
+      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
+      0x5416001F,  //  0005  LDINT	R5	32
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x5C040600,  //  0007  MOVE	R1	R3
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x8C100704,  //  000A  GETMET	R4	R3	K4
+      0x5C180200,  //  000B  MOVE	R6	R1
+      0x7C100400,  //  000C  CALL	R4	2
+      0x90020604,  //  000D  SETMBR	R0	K3	R4
+      0x8C100706,  //  000E  GETMET	R4	R3	K6
+      0x88180107,  //  000F  GETMBR	R6	R0	K7
+      0x881C0108,  //  0010  GETMBR	R7	R0	K8
+      0x88200103,  //  0011  GETMBR	R8	R0	K3
+      0x60240015,  //  0012  GETGBL	R9	G21
+      0x7C240000,  //  0013  CALL	R9	0
+      0x7C100A00,  //  0014  CALL	R4	5
+      0x90020A04,  //  0015  SETMBR	R0	K5	R4
+      0x88100105,  //  0016  GETMBR	R4	R0	K5
+      0x80040800,  //  0017  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_context
+********************************************************************/
+be_local_closure(SPAKE2P_Matter_set_context,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(Context),
+    /* K1   */  be_nested_str_weak(A),
+    /* K2   */  be_nested_str_weak(B),
+    }),
+    be_str_weak(set_context),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x1C100404,  //  0001  EQ	R4	R2	R4
+      0x78120002,  //  0002  JMPF	R4	#0006
+      0x60100015,  //  0003  GETGBL	R4	G21
+      0x7C100000,  //  0004  CALL	R4	0
+      0x5C080800,  //  0005  MOVE	R2	R4
+      0x4C100000,  //  0006  LDNIL	R4
+      0x1C100604,  //  0007  EQ	R4	R3	R4
+      0x78120002,  //  0008  JMPF	R4	#000C
+      0x60100015,  //  0009  GETGBL	R4	G21
+      0x7C100000,  //  000A  CALL	R4	0
+      0x5C0C0800,  //  000B  MOVE	R3	R4
+      0x90020001,  //  000C  SETMBR	R0	K0	R1
+      0x90020202,  //  000D  SETMBR	R0	K1	R2
+      0x90020403,  //  000E  SETMBR	R0	K2	R3
       0x80000000,  //  000F  RET	0
     })
   )
@@ -549,11 +568,11 @@ be_local_closure(SPAKE2P_Matter_compute_ZV_verifier,   /* name */
 
 
 /********************************************************************
-** Solidified function: compute_pB
+** Solidified function: compute_ZV_prover
 ********************************************************************/
-be_local_closure(SPAKE2P_Matter_compute_pB,   /* name */
+be_local_closure(SPAKE2P_Matter_compute_ZV_prover,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -561,43 +580,50 @@ be_local_closure(SPAKE2P_Matter_compute_pB,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[13]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(y),
-    /* K4   */  be_nested_str_weak(mod),
-    /* K5   */  be_nested_str_weak(pB),
-    /* K6   */  be_nested_str_weak(muladd),
-    /* K7   */  be_nested_str_weak(w0),
-    /* K8   */  be_nested_str_weak(N),
+    /* K1   */  be_nested_str_weak(EC_P256),
+    /* K2   */  be_nested_str_weak(pB),
+    /* K3   */  be_nested_str_weak(neg),
+    /* K4   */  be_nested_str_weak(w0),
+    /* K5   */  be_nested_str_weak(muladd),
+    /* K6   */  be_nested_str_weak(01),
+    /* K7   */  be_nested_str_weak(N),
+    /* K8   */  be_nested_str_weak(Z),
+    /* K9   */  be_nested_str_weak(mul),
+    /* K10  */  be_nested_str_weak(x),
+    /* K11  */  be_nested_str_weak(V),
+    /* K12  */  be_nested_str_weak(w1),
     }),
-    be_str_weak(compute_pB),
+    be_str_weak(compute_ZV_prover),
     &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
+    ( &(const binstruction[26]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x1C0C0203,  //  0002  EQ	R3	R1	R3
-      0x780E0003,  //  0003  JMPF	R3	#0008
-      0x8C0C0501,  //  0004  GETMET	R3	R2	K1
-      0x5416001F,  //  0005  LDINT	R5	32
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x5C040600,  //  0007  MOVE	R1	R3
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C100704,  //  000A  GETMET	R4	R3	K4
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x7C100400,  //  000C  CALL	R4	2
-      0x90020604,  //  000D  SETMBR	R0	K3	R4
-      0x8C100706,  //  000E  GETMET	R4	R3	K6
-      0x88180107,  //  000F  GETMBR	R6	R0	K7
-      0x881C0108,  //  0010  GETMBR	R7	R0	K8
-      0x88200103,  //  0011  GETMBR	R8	R0	K3
-      0x60240015,  //  0012  GETGBL	R9	G21
-      0x7C240000,  //  0013  CALL	R9	0
-      0x7C100A00,  //  0014  CALL	R4	5
-      0x90020A04,  //  0015  SETMBR	R0	K5	R4
-      0x80000000,  //  0016  RET	0
+      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x90020401,  //  0003  SETMBR	R0	K2	R1
+      0x8C100703,  //  0004  GETMET	R4	R3	K3
+      0x88180104,  //  0005  GETMBR	R6	R0	K4
+      0x7C100400,  //  0006  CALL	R4	2
+      0x8C140705,  //  0007  GETMET	R5	R3	K5
+      0x601C0015,  //  0008  GETGBL	R7	G21
+      0x58200006,  //  0009  LDCONST	R8	K6
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x88200102,  //  000B  GETMBR	R8	R0	K2
+      0x5C240800,  //  000C  MOVE	R9	R4
+      0x88280107,  //  000D  GETMBR	R10	R0	K7
+      0x7C140A00,  //  000E  CALL	R5	5
+      0x8C180709,  //  000F  GETMET	R6	R3	K9
+      0x8820010A,  //  0010  GETMBR	R8	R0	K10
+      0x5C240A00,  //  0011  MOVE	R9	R5
+      0x7C180600,  //  0012  CALL	R6	3
+      0x90021006,  //  0013  SETMBR	R0	K8	R6
+      0x8C180709,  //  0014  GETMET	R6	R3	K9
+      0x8820010C,  //  0015  GETMBR	R8	R0	K12
+      0x5C240A00,  //  0016  MOVE	R9	R5
+      0x7C180600,  //  0017  CALL	R6	3
+      0x90021606,  //  0018  SETMBR	R0	K11	R6
+      0x80000000,  //  0019  RET	0
     })
   )
 );
@@ -608,41 +634,42 @@ be_local_closure(SPAKE2P_Matter_compute_pB,   /* name */
 ** Solidified class: SPAKE2P_Matter
 ********************************************************************/
 be_local_class(SPAKE2P_Matter,
-    20,
+    21,
     NULL,
-    be_nested_map(31,
+    be_nested_map(32,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(pA, 23), be_const_var(3) },
-        { be_const_key_weak(set_context, 28), be_const_closure(SPAKE2P_Matter_set_context_closure) },
-        { be_const_key_weak(KcA, -1), be_const_var(10) },
-        { be_const_key_weak(cA, -1), be_const_var(13) },
-        { be_const_key_weak(K_shared, -1), be_const_var(12) },
-        { be_const_key_weak(A, 9), be_const_var(15) },
-        { be_const_key_weak(V, -1), be_const_var(6) },
-        { be_const_key_weak(compute_TT_hash, -1), be_const_closure(SPAKE2P_Matter_compute_TT_hash_closure) },
-        { be_const_key_weak(Kmain, -1), be_const_var(9) },
-        { be_const_key_weak(w0, -1), be_const_var(0) },
-        { be_const_key_weak(N, -1), be_const_var(19) },
-        { be_const_key_weak(x, -1), be_const_var(7) },
-        { be_const_key_weak(Context, 20), be_const_var(17) },
-        { be_const_key_weak(compute_pA, -1), be_const_closure(SPAKE2P_Matter_compute_pA_closure) },
-        { be_const_key_weak(w1, -1), be_const_var(1) },
-        { be_const_key_weak(B, 22), be_const_var(16) },
-        { be_const_key_weak(L, 25), be_const_var(2) },
-        { be_const_key_weak(cB, 10), be_const_var(14) },
-        { be_const_key_weak(spake_M_hex, -1), be_nested_str_weak(04886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f5ff355163e43ce224e0b0e65ff02ac8e5c7be09419c785e0ca547d55a12e2d20) },
-        { be_const_key_weak(spake_N_hex, -1), be_nested_str_weak(04d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b4907d60aa6bfade45008a636337f5168c64d9bd36034808cd564490b1e656edbe7) },
-        { be_const_key_weak(CRYPTO_GROUP_SIZE_BYTES, 7), be_const_int(32) },
-        { be_const_key_weak(CRYPTO_W_SIZE_BYTES, 6), be_const_int(40) },
-        { be_const_key_weak(pB, 8), be_const_var(4) },
-        { be_const_key_weak(M, -1), be_const_var(18) },
-        { be_const_key_weak(compute_ZV_verifier, -1), be_const_closure(SPAKE2P_Matter_compute_ZV_verifier_closure) },
-        { be_const_key_weak(KcB, 19), be_const_var(11) },
-        { be_const_key_weak(y, -1), be_const_var(8) },
-        { be_const_key_weak(Z, -1), be_const_var(5) },
-        { be_const_key_weak(compute_ZV_prover, 2), be_const_closure(SPAKE2P_Matter_compute_ZV_prover_closure) },
-        { be_const_key_weak(init, 5), be_const_closure(SPAKE2P_Matter_init_closure) },
+        { be_const_key_weak(compute_ZV_prover, 21), be_const_closure(SPAKE2P_Matter_compute_ZV_prover_closure) },
+        { be_const_key_weak(cA, -1), be_const_var(14) },
+        { be_const_key_weak(CRYPTO_W_SIZE_BYTES, -1), be_const_int(40) },
+        { be_const_key_weak(Kmain, 14), be_const_var(9) },
         { be_const_key_weak(compute_pB, -1), be_const_closure(SPAKE2P_Matter_compute_pB_closure) },
+        { be_const_key_weak(B, 31), be_const_var(17) },
+        { be_const_key_weak(K_shared, -1), be_const_var(12) },
+        { be_const_key_weak(x, -1), be_const_var(7) },
+        { be_const_key_weak(CRYPTO_GROUP_SIZE_BYTES, -1), be_const_int(32) },
+        { be_const_key_weak(V, 1), be_const_var(6) },
+        { be_const_key_weak(pA, -1), be_const_var(3) },
+        { be_const_key_weak(KcB, 27), be_const_var(11) },
+        { be_const_key_weak(A, -1), be_const_var(16) },
+        { be_const_key_weak(Z, 4), be_const_var(5) },
+        { be_const_key_weak(spake_M_hex, -1), be_nested_str_weak(04886e2f97ace46e55ba9dd7242579f2993b64e16ef3dcab95afd497333d8fa12f5ff355163e43ce224e0b0e65ff02ac8e5c7be09419c785e0ca547d55a12e2d20) },
+        { be_const_key_weak(compute_ZV_verifier, -1), be_const_closure(SPAKE2P_Matter_compute_ZV_verifier_closure) },
+        { be_const_key_weak(compute_TT_hash, 0), be_const_closure(SPAKE2P_Matter_compute_TT_hash_closure) },
+        { be_const_key_weak(N, -1), be_const_var(20) },
+        { be_const_key_weak(w0, -1), be_const_var(0) },
+        { be_const_key_weak(init, -1), be_const_closure(SPAKE2P_Matter_init_closure) },
+        { be_const_key_weak(compute_pA, 25), be_const_closure(SPAKE2P_Matter_compute_pA_closure) },
+        { be_const_key_weak(cB, -1), be_const_var(15) },
+        { be_const_key_weak(set_context, -1), be_const_closure(SPAKE2P_Matter_set_context_closure) },
+        { be_const_key_weak(pB, 22), be_const_var(4) },
+        { be_const_key_weak(M, -1), be_const_var(19) },
+        { be_const_key_weak(y, -1), be_const_var(8) },
+        { be_const_key_weak(spake_N_hex, 15), be_nested_str_weak(04d8bbd6c639c62937b04d997f38c3770719c629d7014d49a24b4f98baa1292b4907d60aa6bfade45008a636337f5168c64d9bd36034808cd564490b1e656edbe7) },
+        { be_const_key_weak(L, -1), be_const_var(2) },
+        { be_const_key_weak(Context, 8), be_const_var(18) },
+        { be_const_key_weak(Ke, -1), be_const_var(13) },
+        { be_const_key_weak(KcA, -1), be_const_var(10) },
+        { be_const_key_weak(w1, -1), be_const_var(1) },
     })),
     be_str_weak(SPAKE2P_Matter)
 );


### PR DESCRIPTION
## Description:

SPAKE2+ implementation in Matter has some gaps with the standard. This PR adds a parameter to apply the mods of Matter.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
