### PR TITLE
Extend fix #17619 to non-IPv6

### DIFF
--- a/tasmota/tasmota_support/support_wifi.ino
+++ b/tasmota/tasmota_support/support_wifi.ino
@@ -756,7 +756,6 @@ String IPForUrl(const IPAddress & ip)
 // IPv4 has always priority
 // Copy the value of the IP if pointer provided (optional)
 bool WifiGetIP(IPAddress *ip) {
-#ifdef USE_IPV6
   if ((uint32_t)WiFi.localIP() != 0) {
     if (ip != nullptr) { *ip = WiFi.localIP(); }
     return true;
@@ -765,18 +764,15 @@ bool WifiGetIP(IPAddress *ip) {
     if (ip != nullptr) { *ip = WiFi.softAPIP(); }
     return true;
   }
+#ifdef USE_IPV6
   IPAddress lip;
   if (WifiGetIPv6(&lip)) {
     if (ip != nullptr) { *ip = lip; }
     return true;
   }
   if (ip != nullptr) { *ip = IPAddress(); }
-  return false;
-#else
-  // IPv4 only
-  if (ip != nullptr) { *ip = WiFi.localIP(); }
-  return (uint32_t)WiFi.localIP() != 0;
 #endif // USE_IPV6
+  return false;
 }
 
 bool WifiHasIP(void) {


### PR DESCRIPTION
## Description:

#17619 did not cover non-IPv6 builds. The code is now simpler as well.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
