### PR TITLE
Add CCS811_V2 in I2CDevices list

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -45,6 +45,7 @@ Index | Define              | Driver   | Device   | Address(es) | Description
   22  | USE_MCP230xx        | xsns_29  | MCP23017 | 0x20 - 0x26 | 16-bit I/O expander
   23  | USE_MPR121          | xsns_30  | MPR121   | 0x5A - 0x5D | Proximity capacitive touch sensor
   24  | USE_CCS811          | xsns_31  | CCS811   | 0x5A        | Gas (TVOC) and air quality sensor
+  24' | USE_CCS811_V2       | xsns_31  | CCS811   | 0x5A - 0x5B | Gas (TVOC) and air quality sensor
   25  | USE_MPU6050         | xsns_32  | MPU6050  | 0x68 - 0x69 | 3-axis gyroscope and temperature sensor
   26  | USE_DS3231          | xsns_33  | DS3231   | 0x68        | Real time clock
   27  | USE_MGC3130         | xsns_36  | MGC3130  | 0x42        | Electric field sensor


### PR DESCRIPTION
## Description:

USE_CCS811_V2 is used in tasmota32 but not listed in the device list
As it support both 0x5A and 0x5B addresses, it is worth adding it to the list

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
