### PR TITLE
Berry fix crash when generating bytecode of empty class

### DIFF
--- a/lib/libesp32/berry/src/be_bytecode.c
+++ b/lib/libesp32/berry/src/be_bytecode.c
@@ -160,17 +160,19 @@ static bstring** save_members(bvm *vm, void *fp, bclass *c, int nvar)
 static void save_class(bvm *vm, void *fp, bclass *c)
 {
     bstring **vars;
-    int i, count = be_map_count(c->members);
+    int i, count = c->members ? be_map_count(c->members) : 0;
     int nvar = c->nvar - be_class_closure_count(c);
     save_string(fp, c->name);
     save_long(fp, nvar); /* member variables count */
     save_long(fp, count - nvar); /* method count */
-    vars = save_members(vm, fp, c, nvar);
-    if (vars != NULL) {
-        for (i = 0; i < nvar; ++i) {
-            save_string(fp, vars[i]);
+    if (count > 0) {
+        vars = save_members(vm, fp, c, nvar);
+        if (vars != NULL) {
+            for (i = 0; i < nvar; ++i) {
+                save_string(fp, vars[i]);
+            }
+            be_free(vm, vars, sizeof(bstring *) * nvar);
         }
-        be_free(vm, vars, sizeof(bstring *) * nvar);
     }
 }
 


### PR DESCRIPTION
## Description:

When generating bytecode (i.e. .bec file), it would crash because of a missing test for null pointer.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
