### PR TITLE
Berry crypto.EC_P256 ECDSA signature ASN.1

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_crypto_lib.c
@@ -29,6 +29,8 @@ extern int m_ec_p256_pubkey(bvm *vm);
 extern int m_ec_p256_sharedkey(bvm *vm);
 extern int m_ec_p256_ecdsa_sign_sha256(bvm *vm);
 extern int m_ec_p256_ecdsa_verify_sha256(bvm *vm);
+extern int m_ec_p256_ecdsa_sign_sha256_asn1(bvm *vm);
+extern int m_ec_p256_ecdsa_verify_sha256_asn1(bvm *vm);
 extern int m_ec_p256_mod(bvm *vm);
 extern int m_ec_p256_neg(bvm *vm);
 extern int m_ec_p256_muladd(bvm *vm);
@@ -161,6 +163,8 @@ class be_class_ec_p256 (scope: global, name: EC_P256) {
     shared_key, static_func(m_ec_p256_sharedkey)
     ecdsa_sign_sha256, static_func(m_ec_p256_ecdsa_sign_sha256)
     ecdsa_verify_sha256, static_func(m_ec_p256_ecdsa_verify_sha256)
+    ecdsa_sign_sha256_asn1, static_func(m_ec_p256_ecdsa_sign_sha256_asn1)
+    ecdsa_verify_sha256_asn1, static_func(m_ec_p256_ecdsa_verify_sha256_asn1)
     mod, static_func(m_ec_p256_mod)
     neg, static_func(m_ec_p256_neg)
     muladd, static_func(m_ec_p256_muladd)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_crypto.ino
@@ -630,6 +630,71 @@ extern "C" {
     }
     be_raise(vm, kTypeError, nullptr);
   }
+
+  // crypto.EC_P256().ecdsa_sign_sha256_asn1(my_private_key:bytes(32), message:bytes()) -> bytes()
+  // Sign with ECDSA SHA256, result in ASN.1 format for CSR and certificate
+  int32_t m_ec_p256_ecdsa_sign_sha256_asn1(bvm *vm);
+  int32_t m_ec_p256_ecdsa_sign_sha256_asn1(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 2 && be_isbytes(vm, 1) && be_isbytes(vm, 2)) {
+      size_t sk_len = 0;
+      uint8_t * sk = (uint8_t*) be_tobytes(vm, 1, &sk_len);
+      size_t msg_len = 0;
+      const uint8_t * msg = (const uint8_t*) be_tobytes(vm, 2, &msg_len);
+      if (sk_len != 32) {
+        be_raise(vm, "value_error", "Key size invalid");
+      }
+
+      // first compute SHA-256 hash on the message
+      uint8_t hash[32];
+      br_sha256_context ctx;
+      br_sha256_init(&ctx);
+      br_sha256_update(&ctx, msg, msg_len);
+      br_sha256_out(&ctx, hash);
+ 
+      // run ECDSA on hash
+      uint8_t sign[72];         // hard limit for ECDSA SHA256 ASN.1 as per bearssl documentation
+      br_ec_private_key br_sk = { BR_EC_secp256r1, sk, 32 };
+      size_t sign_len = br_ecdsa_i15_sign_asn1(&BR_EC_P256_IMPL, &br_sha256_vtable, hash, &br_sk, sign);
+
+      be_pushbytes(vm, sign, sign_len);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
+  // `crypto.EC_P256().ecdsa_verify_sha256_asn1(public_key:bytes(65), message:bytes(), hash:bytes()) -> bool`
+  // Verify signature with ECDSA SHA256 with signature in ASN.1 format
+  int32_t m_ec_p256_ecdsa_verify_sha256_asn1(bvm *vm);
+  int32_t m_ec_p256_ecdsa_verify_sha256_asn1(bvm *vm) {
+    int32_t argc = be_top(vm); // Get the number of arguments
+    if (argc >= 3 && be_isbytes(vm, 1) && be_isbytes(vm, 2) && be_isbytes(vm, 3)) {
+      size_t pk_len = 0;
+      uint8_t * pk = (uint8_t*) be_tobytes(vm, 1, &pk_len);
+      size_t msg_len = 0;
+      const uint8_t * msg = (const uint8_t*) be_tobytes(vm, 2, &msg_len);
+      if (pk_len != 65) {
+        be_raise(vm, "value_error", "Key size invalid");
+      }
+      size_t sig_len = 0;
+      const uint8_t * sig = (const uint8_t*) be_tobytes(vm, 3, &sig_len);
+
+      // first compute SHA-256 hash on the message
+      uint8_t hash[32];
+      br_sha256_context ctx;
+      br_sha256_init(&ctx);
+      br_sha256_update(&ctx, msg, msg_len);
+      br_sha256_out(&ctx, hash);
+ 
+      // run ECDSA on hash
+      br_ec_public_key br_pk = { BR_EC_secp256r1, pk, pk_len };
+      uint32_t ret = br_ecdsa_i15_vrfy_asn1(&BR_EC_P256_IMPL, hash, sizeof(hash), &br_pk, sig, sig_len);
+
+      be_pushbool(vm, ret);
+      be_return(vm);
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
   /* Test values
   import crypto
   var priv = bytes('D42A43989B67211031FF194FBA791B5C3E03F9EC10ED561A4DEB2AA7BADB4772')


### PR DESCRIPTION
## Description:

Complement #17723 with ECDSA signature in ASN.1 format in addition to raw (BER) encoding. This is useful to generate a signature in a CSR (Certificate Signing Request) or to verify a certificate. This is required by Matter protocol.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
