### PR TITLE
Add tuya commands CMD_GET_NETWORK_STATUS  and CMD_TEST_WIFI

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -1437,20 +1437,11 @@ void TuyaSetWifiStrength(void) {
 
 void TuyaCheckTestWifi(void){
   // MCU request the module if whose SSID is 'tuya_mdev_test' and returns the result and the signal strength in percentage.
+  // Assuming that nobody uses this test wifi, the payload is hardcoded.
   uint8_t payload_buffer[2] = {
     0x00,   //'tuya_mdev_test' wifi not found
     0x00    //signal strength = 0
   };
-  
-  String test_wifi_ssid = "tuya_mdev_test";
-  
-  if (WiFi.SSID() == test_wifi_ssid){
-    int32_t rssi = WiFi.RSSI();
-    int signal_strength = WifiGetRssiAsQuality(rssi);
-
-    payload_buffer[0] = (uint8_t) 1;
-    payload_buffer[1] = (uint8_t) signal_strength;
-  }
 
   TuyaSendCmd(TUYA_CMD_TEST_WIFI, payload_buffer, 2);
 }


### PR DESCRIPTION
## Description:
Add two tuya commands:
- Test Wi-Fi functionality (scanning)
- Get the current network status

See current Tuya Wifi Protocol Spec for more information (https://developer.tuya.com/en/docs/iot/tuya-cloud-universal-serial-port-access-protocol?id=K9hhi0xxtn9cb)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
