### PR TITLE
 Shelly has label `fs_1` for spiffs

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -106,7 +106,7 @@ void UfsInitOnce(void) {
 #ifdef ESP32
   // try lfs first
   ffsp = &LittleFS;
- if (!LittleFS.begin(true, "")) {         // force empty mount point to make it the fallback FS
+ if (!LittleFS.begin(true, "") && !LittleFS.begin(true, "", 5, "fs_1")) {         // force empty mount point to make it the fallback FS
     // ffat is second
     ffsp = &FFat;
    if (!FFat.begin(true, "")) {


### PR DESCRIPTION
prepare OTA convert for Shelly ESP32 devices

@arendst  Thx!

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
