### PR TITLE
Berry add up flag to ``tasmota.wifi()`` and ``tasmota.eth()``, always return MAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [12.3.1.4]
 ### Added
 - Berry ``crypto.EC_P256`` ECDSA signature (required by Matter protocol)
+- Berry add up flag to ``tasmota.wifi()`` and ``tasmota.eth()``, always return MAC
 
 ### Breaking Changed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -211,6 +211,8 @@ extern "C" {
     int32_t top = be_top(vm); // Get the number of arguments
     if (top == 1) {  // no argument (instance only)
       be_newobject(vm, "map");
+      be_map_insert_str(vm, "mac", WiFi.macAddress().c_str());
+      be_map_insert_bool(vm, "up", WifiHasIP());
       if (Settings->flag4.network_wifi) {
         int32_t rssi = WiFi.RSSI();
         bool show_rssi = false;
@@ -227,7 +229,6 @@ extern "C" {
         }
 #endif // USE_IPV6
         if (static_cast<uint32_t>(WiFi.localIP()) != 0) {
-          be_map_insert_str(vm, "mac", WiFi.macAddress().c_str());
           be_map_insert_str(vm, "ip", IPAddress((uint32_t)WiFi.localIP()).toString().c_str());   // quick fix for IPAddress bug
           show_rssi = true;
         }
@@ -250,8 +251,12 @@ extern "C" {
     if (top == 1) {  // no argument (instance only)
       be_newobject(vm, "map");
 #ifdef USE_ETHERNET
+      be_map_insert_bool(vm, "up", EthernetHasIP());
+      String eth_mac = EthernetMacAddress().c_str();
+      if (eth_mac != "00:00:00:00:00:00") {
+        be_map_insert_str(vm, "mac", eth_mac.c_str());
+      }
       if (static_cast<uint32_t>(EthernetLocalIP()) != 0) {
-        be_map_insert_str(vm, "mac", EthernetMacAddress().c_str());
         be_map_insert_str(vm, "ip", IPAddress((uint32_t)EthernetLocalIP()).toString().c_str());   // quick fix for IPAddress bug
       }
 #ifdef USE_IPV6
@@ -264,6 +269,8 @@ extern "C" {
         be_map_insert_str(vm, "ip6local", ipv6_addr.c_str());
       }
 #endif // USE_IPV6
+#else // USE_ETHERNET
+      be_map_insert_bool(vm, "up", bfalse);
 #endif // USE_ETHERNET
       be_pop(vm, 1);
       be_return(vm);


### PR DESCRIPTION
## Description:

Added `tasmota.wifi()['up']` and `tasmota.eth()['up']` that are always defined and return `true` if the connection is up (i.e. an IPv4 or IPv6 address is available), or `false` if the network is down.

Also always return the `MAC` address even if the connection is down.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
