### PR TITLE
TuyaMCUBr: support on/true/off/false/toggle in the tuyamcubool command.

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
@@ -586,18 +586,15 @@ tuyamcubr_cmnd_data_bool(void)
 		return;
 	}
 
-	if (strcasecmp(XdrvMailbox.data, "off") == 0 ||
-	    strcasecmp(XdrvMailbox.data, "false") == 0 ||
-	    strcmp(XdrvMailbox.data, "0") == 0)
-		value = 0;
-	else if (strcasecmp(XdrvMailbox.data, "on") == 0 ||
-	    strcasecmp(XdrvMailbox.data, "true") == 0 ||
-	    strcmp(XdrvMailbox.data, "1") == 0)
-		value = 1;
-	else if (strcasecmp(XdrvMailbox.data, "toggle") == 0 ||
-	    strcmp(XdrvMailbox.data, "2") == 0)
+	switch (XdrvMailbox.payload) {
+	case 0:
+	case 1:
+		value = XdrvMailbox.payload;
+		break;
+	case 2:
 		value = !dp->dp_value;
-	else {
+		break;
+	default:
 		ResponseCmndChar_P(PSTR("Invalid"));
 		return;
 	}

--- a/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
@@ -567,7 +567,56 @@ tuyamcubr_cmnd_data(struct tuyamcubr_softc *sc, uint8_t type)
 static void
 tuyamcubr_cmnd_data_bool(void)
 {
-	tuyamcubr_cmnd_data(tuyamcubr_sc, TUYAMCUBR_DATA_TYPE_BOOL);
+	struct tuyamcubr_softc *sc = tuyamcubr_sc;
+	struct {
+		struct tuyamcubr_data_header h;
+		uint8_t value[1];
+	} data;
+	struct tuyamcubr_dp *dp;
+	uint32_t value;
+
+	dp = tuyamcubr_find_dp(sc, XdrvMailbox.index, TUYAMCUBR_DATA_TYPE_BOOL);
+	if (dp == NULL) {
+		ResponseCmndChar_P(PSTR("Unknown DpId"));
+		return;
+	}
+
+	if (XdrvMailbox.data_len == 0) {
+		ResponseCmndNumber(dp->dp_value);
+		return;
+	}
+
+	if (strcasecmp(XdrvMailbox.data, "off") == 0 ||
+	    strcasecmp(XdrvMailbox.data, "false") == 0 ||
+	    strcmp(XdrvMailbox.data, "0") == 0)
+		value = 0;
+	else if (strcasecmp(XdrvMailbox.data, "on") == 0 ||
+	    strcasecmp(XdrvMailbox.data, "true") == 0 ||
+	    strcmp(XdrvMailbox.data, "1") == 0)
+		value = 1;
+	else if (strcasecmp(XdrvMailbox.data, "toggle") == 0 ||
+	    strcmp(XdrvMailbox.data, "2") == 0)
+		value = !dp->dp_value;
+	else {
+		ResponseCmndChar_P(PSTR("Invalid"));
+		return;
+	}
+
+	dp->dp_value = value;
+
+	data.h.dpid = dp->dp_id;
+	data.h.type = dp->dp_type;
+	data.h.len = htons(sizeof(data.value));
+	data.value[0] = value;
+
+	tuyamcubr_send(sc, TUYAMCUBR_CMD_SET_DP, &data, sizeof(data));
+	tuyamcubr_rule_dp(sc, dp);
+
+	ResponseCmndNumber(dp->dp_value);
+
+	/* SetOption59 */
+	if (Settings->flag3.hass_tele_on_power)
+		tuyamcubr_publish_dp(sc, dp);
 }
 
 static void


### PR DESCRIPTION
## Description:

I wanted a tasmotized wall switch to be able to blindly send "toggle" to a fan/light and have it do the right thing. The dp value is kept by the driver, so it can easily read, modify, and write it.

I'm hardcoding the "on"/"off"/"toggle" values to compare against, should I be getting them from a macro instead?

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
