### PR TITLE
TuyaMCU - Wifi signal strength use dB value, not quality

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -1427,10 +1427,9 @@ void TuyaSetWifiStrength(void) {
   uint16_t payload_len = 1;
   uint8_t payload_buffer[1];
   int32_t rssi = WiFi.RSSI();
-  int signal_strength = WifiGetRssiAsQuality(rssi);
+  payload_buffer[0] = (uint8_t)rssi;
 
-  AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: RX MCU Get Wifi Strength -> sending %d"), signal_strength);
-  payload_buffer[0] = (uint8_t)signal_strength;
+  AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: RX MCU Get Wifi Strength -> sending %d (0x%02X)"), rssi, payload_buffer[0]);
 
   TuyaSendCmd(TUYA_CMD_GET_WIFI_STRENGTH, payload_buffer, payload_len);
 }


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

Fix previous PR that was wrongly using SignalQuality

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
