### PR TITLE
Add optional support for DS3231 internal temperature sensor

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -718,6 +718,7 @@
 
 //  #define USE_RTC_CHIPS                          // Enable RTC chip support and NTP server - Select only one
 //    #define USE_DS3231                           // [I2cDriver26] Enable DS3231 RTC (I2C address 0x68) (+1k2 code)
+//    #define DS3231_ENABLE_TEMP                   //   In DS3231 driver, enable the internal temperature sensor
 //    #define USE_BM8563                           // [I2cDriver59] Enable BM8563 RTC - found in M5Stack - support both I2C buses on ESP32 (I2C address 0x51) (+2.5k code)
 //    #define USE_PCF85363                         // [I2cDriver66] Enable PCF85363 RTC - found Shelly 3EM (I2C address 0x51) (+0k7 code)
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #17770 

Allow to use the DS3231 internal temperature sensor if needed

Requires:
```
#define USE_RTC_CHIPS                          // Enable RTC chip support and NTP server - Select only one
  #define USE_DS3231                           // [I2cDriver26] Enable DS3231 RTC (I2C address 0x68) (+1k2 code)
  #define DS3231_ENABLE_TEMP                   //   In DS3231 driver, enable the internal temperature sensor
```
![image](https://user-images.githubusercontent.com/2996042/214125599-e043813b-2176-47b1-a85d-1285a9ea980d.png)
```
19:55:59.510 MQT: tele/nodemcu/SENSOR = {"Time":"2023-01-23T19:55:59+01:00","DS3231":{"Temperature":17.8},"TempUnit":"C"} (retained)
```

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
