### PR TITLE
Possibly fix PWM sleep problem

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_04_light.ino
@@ -1780,8 +1780,6 @@ void LightAnimate(void)
     if (TasmotaGlobal.sleep > PWM_MAX_SLEEP) {
       sleep_previous = TasmotaGlobal.sleep;     // save previous value of sleep
       TasmotaGlobal.sleep = PWM_MAX_SLEEP;      // set a maximum value (in milliseconds) to sleep to ensure that animations are smooth
-    } else {
-      sleep_previous = -1;                      // if low enough, don't change it
     }
   } else {
     if (sleep_previous > 0) {


### PR DESCRIPTION
## Description:

This PR needs validation by @s-hadinger 

**Related issue (if applicable):** fixes #https://github.com/arendst/Tasmota/discussions/17772

While introducing ArtNet 1.2.01 (#16984) a change was introduced in `LightAnimate(..)` to allow saving and restoration of `TasmotaGlobal.sleep` when it's value has been changed by ArtNet/Berry code while not changing `Settings->sleep`.
Unfortunately this change breaks the proper restoration of the sleep to it's initial value because of the highlighed else branch below:
![image](https://user-images.githubusercontent.com/2996042/214419606-8a5849ba-f324-4a32-ac4b-39ee4ae26858.png)

Removing this branch restore the previous behavior as tested on a standard PWM output.

However, I would appreciate a review by @s-hadinger ergarding possible impact in relation with ArtNet/berry code.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
