### PR TITLE
TuyaMCUBr: fix determination of the current weekday

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_65_tuyamcubr.ino
@@ -862,6 +862,11 @@ tuyamcubr_recv_time(struct tuyamcubr_softc *sc, uint8_t v,
     const uint8_t *data, size_t datalen)
 {
 	struct tuyamcubr_time tm;
+	uint8_t weekday;
+
+	weekday = RtcTime.day_of_week - 1;
+	if (weekday == 0)
+		weekday = 7;
 
 	/* check datalen? should be 0 */
 
@@ -872,7 +877,7 @@ tuyamcubr_recv_time(struct tuyamcubr_softc *sc, uint8_t v,
 	tm.hour = RtcTime.hour;
 	tm.minute = RtcTime.minute;
 	tm.second = RtcTime.second;
-	tm.weekday = (RtcTime.day_of_week - 1) || 7;
+	tm.weekday = weekday;
 
 	tuyamcubr_send(sc, TUYAMCUBR_CMD_TIME, &tm, sizeof(tm));
 }


### PR DESCRIPTION
## Description:

The result of c logical expressions is 0 or 1, not the values of the operands.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).
