### PR TITLE
Multicast address typo in my_user_config.h

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -580,7 +580,7 @@
 //#define USE_LSC_MCSL                             // Add support for GPE Multi color smart light as sold by Action in the Netherlands (+1k1 code)
 
 // #define USE_LIGHT_ARTNET                         // Add support for DMX/ArtNet via UDP on port 6454 (+3.5k code)
-  #define USE_LIGHT_ARTNET_MCAST 239,255,25,54   // Multicast address used to listen: 239.255.25.24
+  #define USE_LIGHT_ARTNET_MCAST 239,255,25,54   // Multicast address used to listen: 239.255.25.54
 
 // -- Counter input -------------------------------
 #define USE_COUNTER                              // Enable inputs as counter (+0k8 code)


### PR DESCRIPTION
For ArtNet Multicast address the defined value and the value in the comment are different.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [X ] The pull request is done against the latest development branch
  - [X ] Only relevant files were touched
  - [X ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
