### PR TITLE
Zigbee extend plug-in modifiers to 16 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - ADE7953 when calibration data for second channel is used regression from v12.2.0.2
 - Shelly Pro 1/2 relay click at restart regression from v12.3.1.4
+- Zigbee extend plug-in modifiers to 16 bits
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_1z_libs.ino
@@ -111,8 +111,9 @@ public:
                                   // Bit #9 is `0` command is cluster specific, or `1` general_command
   uint8_t       key_suffix;       // append a suffix to key (default is 1, explicitly output if >1)
   uint8_t       attr_type;        // [opt] type of the attribute, default to Zunk (0xFF)
-  int8_t        attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
-  int8_t        attr_divider;     // [opt] divider
+  uint16_t      attr_multiplier;  // [opt] multiplier for attribute, defaults to 0x01 (no change)
+  uint16_t      attr_divider;     // [opt] divider
+  int16_t       attr_base;        // [opt] base for conversion
   uint16_t      manuf;            // manufacturer id (0 if none)
 
   // Constructor with all defaults
@@ -130,6 +131,7 @@ public:
     attr_type(0xFF),
     attr_multiplier(1),
     attr_divider(1),
+    attr_base(0),
     manuf(0)
     {};
 
@@ -789,6 +791,7 @@ void Z_attribute::deepCopy(const Z_attribute & rhs) {
   attr_type = rhs.attr_type;
   attr_multiplier = rhs.attr_multiplier;
   attr_divider = rhs.attr_divider;
+  attr_base = rhs.attr_base;
   // copy value
   copyVal(rhs);
   // don't touch next pointer

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_1_attributes.ino
@@ -530,10 +530,10 @@ public:
   uint16_t cluster = 0xFFFF;
   uint16_t attribute = 0xFFFF;
   const char * name = nullptr;
+  uint16_t multiplier = 1;
+  uint16_t divider = 1;
+  int16_t  base = 0;
   uint8_t zigbee_type = Znodata;
-  int8_t multiplier = 1;
-  int8_t divider = 1;
-  int8_t base = 0;
   uint8_t map_offset = 0;
   Z_Data_Type map_type = Z_Data_Type::Z_Unknown;
   uint16_t manuf = 0x0000;      // manuf code (if any)

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_5_2_converters.ino
@@ -1612,6 +1612,7 @@ void Z_parseAttributeKey_inner(uint16_t shortaddr, class Z_attribute & attr, uin
         attr.attr_type = matched_attr.zigbee_type;
         attr.attr_multiplier = matched_attr.multiplier;
         attr.attr_divider = matched_attr.divider;
+        attr.attr_base = matched_attr.base;
         attr.manuf = matched_attr.manuf;
       }
     }
@@ -1695,8 +1696,8 @@ void Z_Data::toAttributes(Z_attribute_list & attr_list) const {
     const Z_AttributeConverter *converter = &Z_PostProcess[i];
     uint8_t conv_export = pgm_read_byte(&converter->multiplier_idx) & Z_EXPORT_DATA;
     uint8_t conv_mapping = pgm_read_byte(&converter->mapping);
-    int8_t multiplier = 1;
-    int8_t divider = 1;
+    uint16_t multiplier = 1;
+    uint16_t divider = 1;
     int8_t multiplier8 = CmToMultiplier(pgm_read_byte(&converter->multiplier_idx));
     if (multiplier8 > 1) { multiplier = multiplier8; }
     if (multiplier8 < 0) { divider = -multiplier8; }

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_7_7_plugin.ino
@@ -214,8 +214,8 @@ bool ZbLoad_inner(const char *filename, File &fp) {
         uint16_t attr_id = 0xFFFF;
         uint16_t cluster_id = 0xFFFF;
         uint8_t  type_id = Zunk;
-        int8_t   multiplier = 1;
-        int8_t   divider = 1;
+        uint16_t multiplier = 1;
+        uint16_t divider = 1;
         int16_t  base = 0;
         char *   name = nullptr;
         uint16_t manuf = 0;
@@ -281,9 +281,9 @@ bool ZbLoad_inner(const char *filename, File &fp) {
         char * delimiter_slash2 = strchr(tok2, '/');
         uint16_t new_cluster_id = strtoul(tok2, &delimiter_slash2, 16);
         uint16_t new_attr_id = strtoul(delimiter_slash2+1, nullptr, 16);
-        int8_t multiplier = 1;
-        int8_t divider = 1;
-        int16_t base = 0;
+        uint16_t multiplier = 1;
+        uint16_t divider = 1;
+        int16_t  base = 0;
 
         // ADDITIONAL ELEMENTS?
         while (token = strtok_r(rest, ",", &rest)) {

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_A_impl.ino
@@ -232,7 +232,7 @@ void zigbeeZCLSendCmd(class ZCLFrame &zcl) {
 // I.e. multipliers and dividers are inversed
 // multiplier == 0: ignore
 // multiplier == 1: ignore
-void ZbApplyMultiplierForWrites(double &val_d, int8_t multiplier, int8_t divider, int8_t base) {
+void ZbApplyMultiplierForWrites(double &val_d, uint16_t multiplier, uint16_t divider, int16_t base) {
   if (0 != base) {
     val_d = val_d - base;
   }
@@ -253,7 +253,7 @@ bool ZbTuyaWrite(SBuffer & buf, const Z_attribute & attr) {
 
   if (attr.key_is_str || attr.key_is_cmd) { return false; }    // couldn't find attr if so skip
   if (attr.isNum()) {
-    ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, 0);
+    ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, attr.attr_base);
   }
   uint32_t u32 = val_d;
   int32_t  i32 = val_d;
@@ -312,7 +312,7 @@ bool ZbAppendWriteBuf(SBuffer & buf, const Z_attribute & attr, bool prepend_stat
 
   if (attr.key_is_str && attr.key_is_cmd) { return false; }    // couldn't find attr if so skip
   if (attr.isNum()) {
-    ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, 0);
+    ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, attr.attr_base);
   }
 
   // push the value in the buffer
@@ -433,7 +433,7 @@ void ZbSendReportWrite(class JsonParserToken val_pubwrite, class ZCLFrame & zcl)
         val_str = val_attr_rc.getStr();
         if (!val_attr_rc.isNull()) {
           val_d = val_attr_rc.getFloat();
-          ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, 0);
+          ZbApplyMultiplierForWrites(val_d, attr.attr_multiplier, attr.attr_divider, attr.attr_base);
         } else {
           val_d = NAN;
         }


### PR DESCRIPTION
## Description:

Extend Zigbee plug-in `mul`, `div` and `base` to 16 bits.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
