### PR TITLE
Fix problems in ValidPin() due to #17724

### DIFF
--- a/tasmota/tasmota_support/support.ino
+++ b/tasmota/tasmota_support/support.ino
@@ -1646,7 +1646,7 @@ bool RedPin(uint32_t pin) // pin may be dangerous to change, display in RED in t
 #endif
 }
 
-uint32_t ValidPin(uint32_t pin, uint32_t gpio) {
+uint32_t ValidPin(uint32_t pin, uint32_t gpio, uint8_t isTuya = false) {
   if (FlashPin(pin)) {
     return GPIO_NONE;    // Disable flash pins GPIO6, GPIO7, GPIO8 and GPIO11
   }
@@ -1658,7 +1658,7 @@ uint32_t ValidPin(uint32_t pin, uint32_t gpio) {
 #elif defined(CONFIG_IDF_TARGET_ESP32)
 // ignore
 #else // not ESP32C3 and not ESP32S2
-  if (((WEMOS == Settings->module) || (TUYA_DIMMER == Settings->module) || (USER_MODULE == Settings->module)) && !Settings->flag3.user_esp8285_enable) {  // SetOption51 - Enable ESP8285 user GPIO's
+  if (((WEMOS == Settings->module) || isTuya) && !Settings->flag3.user_esp8285_enable) {  // SetOption51 - Enable ESP8285 user GPIO's
     if ((9 == pin) || (10 == pin)) {
       return GPIO_NONE;  // Disable possible flash GPIO9 and GPIO10
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -1111,7 +1111,7 @@ void TuyaNormalPowerModePacketProcess(void)
         // If LED_1 not yet configured
         if (!led1_set) {
           // Check is the GPIO is not already in use and if it is valid
-          if (!Settings->my_gp.io[led1_gpio] && ValidPin(led1_gpio,GPIO_LED1)) {
+          if (!Settings->my_gp.io[led1_gpio] && ValidPin(led1_gpio,GPIO_LED1, true)) {
             Settings->my_gp.io[led1_gpio] = AGPIO(GPIO_LED1);
             TasmotaGlobal.restart_flag = 2;
             AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: Set LED1 on gpio%d, will restart"), led1_gpio);
@@ -1122,7 +1122,7 @@ void TuyaNormalPowerModePacketProcess(void)
         // If KEY_1 not yet configured
         if (!key1_set) {
           // Check is the GPIO is not already in use and if it is valid
-          if (!Settings->my_gp.io[key1_gpio] && ValidPin(key1_gpio,GPIO_KEY1)) {
+          if (!Settings->my_gp.io[key1_gpio] && ValidPin(key1_gpio,GPIO_KEY1, true)) {
             Settings->my_gp.io[key1_gpio] = AGPIO(GPIO_KEY1);
             TasmotaGlobal.restart_flag = 2;
             AddLog(LOG_LEVEL_DEBUG, PSTR("TYA: Set KEY1 on gpio%d, will restart"), key1_gpio);


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes problem introduced by the changes on ValidPin() in #17724
https://github.com/arendst/Tasmota/pull/17724#issuecomment-1409011141

The changes on ValidPin() was creating problems when using a user template which makes use of GPIO9.
Although SO51 workarounds the problem, SO51 should not be required when using templates. SO51 goal is just to make GPIO9/10 visible in module configuration.

This revert to the base of the test for normal usage of ValidPin() except when called from Tuya in response to a command mode 2.


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
