### PR TITLE
Berry add `tasmota.locale()`

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_tasmota_lib.c
@@ -35,6 +35,7 @@ extern int l_scaleuint(bvm *vm);
 extern int l_logInfo(bvm *vm);
 extern int l_save(bvm *vm);
 extern int t_random_byte(bvm *vm);
+extern int l_locale(bvm *vm);
 
 extern int l_read_sensors(bvm *vm);
 
@@ -109,6 +110,7 @@ class be_class_tasmota (scope: global, name: Tasmota) {
     scale_uint, func(l_scaleuint)
     log, func(l_logInfo)
     save, func(l_save)
+    locale, func(l_locale)
 
     read_sensors, func(l_read_sensors)
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -157,8 +157,16 @@ extern "C" {
     }
     be_raise(vm, kTypeError, nullptr);
   }
+  
+  // Berry: tasmota.locale() -> string
+  //
+  int32_t l_locale(struct bvm *vm);
+  int32_t l_locale(struct bvm *vm) {
+    be_pushstring(vm, D_HTML_LANGUAGE);
+    be_return(vm);
+  }
 
-  // Berry: tasmota.time_reached(timer:int) -> bool
+  // Berry: tasmota.rtc() -> map
   //
   int32_t l_rtc(struct bvm *vm);
   int32_t l_rtc(struct bvm *vm) {


### PR DESCRIPTION
## Description:

Add Berry `tasmota.locale()` to get the current locale (ex: `en`) of the compiled firmware.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
