### PR TITLE
Berry webserver raw content

### DIFF
--- a/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webserver_lib.c
@@ -16,6 +16,7 @@ extern int w_webserver_state(bvm *vm);
 extern int w_webserver_check_privileged_access(bvm *vm);
 extern int w_webserver_redirect(bvm *vm);
 extern int w_webserver_content_start(bvm *vm);
+extern int w_webserver_content_open(bvm *vm);
 extern int w_webserver_content_send(bvm *vm);
 extern int w_webserver_content_response(bvm *vm);
 extern int w_webserver_content_send_style(bvm *vm);
@@ -42,6 +43,7 @@ module webserver (scope: global) {
     content_response, func(w_webserver_content_response)
     content_send_style, func(w_webserver_content_send_style)
     content_flush, func(w_webserver_content_flush)
+    content_open, func(w_webserver_content_open)
     content_start, func(w_webserver_content_start)
     content_stop, func(w_webserver_content_stop)
     content_button, func(w_webserver_content_button)


### PR DESCRIPTION
## Description:

Add ability to serve raw content on `webserver`:
- `webserver.content_open(http_code:int, mimetype:string) -> nil` allows to respond with custom HTTP code and custom mime-type
- `webserver.content_send(string or comptr) -> nil` accepts either a `string` or a `comptr` (a pointer to a C string in Flash). The latter can be used to serve static content from flash, like JS, image or CSS.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
