### PR TITLE
Meaning of SetOption15 swapped in decode-status.py

### DIFF
--- a/tools/decode-status.py
+++ b/tools/decode-status.py
@@ -65,7 +65,7 @@ a_setoption = [[
     "(Settings) Switch between dynamic (0) or fixed (1) slot flash save location",
     "(Button) Support only single press (1) to speed up button press recognition",
     "(Interlock) Power interlock mode",
-    "(Light) Switch between commands PWM (1) or COLOR/DIMMER/CT/CHANNEL (0)",
+    "(Light) Switch between commands PWM (0) or COLOR/DIMMER/CT/CHANNEL (1)",
     "(WS2812) Switch between clockwise (0) or counter-clockwise (1)",
     "(Light) Switch between decimal (1) or hexadecimal (0) output",
     "(Light) Pair light signal (1) with CO2 sensor",


### PR DESCRIPTION
Noticed that the text incorrectly said value 1 for direct PWM control, and 0 for the default as a light. Should be a simple uncontroversial fix.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [*] The pull request is done against the latest development branch
  - [*] Only relevant files were touched
  - [*] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [*] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
