### PR TITLE
Berry allow bool key

### DIFF
--- a/lib/libesp32/berry/src/be_map.c
+++ b/lib/libesp32/berry/src/be_map.c
@@ -112,6 +112,7 @@ static int eqnode(bvm *vm, bmapnode *node, bvalue *key, uint32_t hash)
 #endif
         if(keytype(k) == key->type && hashcode(k) == hash) {
             switch (key->type) {
+            case BE_BOOL: return var_tobool(key) == var_tobool(k);
             case BE_INT: return var_toint(key) == var_toint(k);
             case BE_REAL: return var_toreal(key) == var_toreal(k);
             case BE_STRING: return be_eqstr(var_tostr(key), var_tostr(k));


### PR DESCRIPTION
## Description:

Berry: allow keys of maps to be booleans.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
