### PR TITLE
Typo in I2CDEVICES

### DIFF
--- a/I2CDEVICES.md
+++ b/I2CDEVICES.md
@@ -61,7 +61,7 @@ Index | Define              | Driver   | Device   | Address(es) | Description
   37  | USE_24C256          | xdrv_10  | 24C256   | 0x50        | Scripter EEPROM storage
   38  | USE_DISPLAY_ILI9488 | xdsp_08  | FT6236   | 0x38        | Touch panel controller
   39  | USE_DISPLAY_RA8876  | xdsp_10  | FT5316   | 0x38        | Touch panel controller
-  40  | USE_TSL2591         | xsns_57  | TLS2591  | 0x29        | Light intensity sensor
+  40  | USE_TSL2591         | xsns_57  | TSL2591  | 0x29        | Light intensity sensor
   41  | USE_DHT12           | xsns_58  | DHT12    | 0x5C        | Temperature and humidity sensor
   42  | USE_DS1624          | xsns_59  | DS1621   | 0x48 - 0x4F | Temperature sensor
   42  | USE_DS1624          | xsns_59  | DS1624   | 0x48 - 0x4F | Temperature sensor


### PR DESCRIPTION
Sensor name TSL2591 was misspelled. Is this file automatically duplicated on docs, or should I fix the copy there?

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
