### PR TITLE
SD Card support for > 1MB tasmota builds

### DIFF
--- a/tasmota/include/tasmota_configurations.h
+++ b/tasmota/include/tasmota_configurations.h
@@ -1023,6 +1023,8 @@
     #define USE_UFILESYS
       #define GUI_TRASH_FILE
       #define GUI_EDIT_FILE
+    #define USE_SPI
+    #define USE_SDCARD
     #define USE_PING
   #endif // FIRMWARE_MINIMAL
 


### PR DESCRIPTION
## Description:

No change for standard Tasmota 1M esp8266 precompiled builds.
Using an env for 2 or 4 MB flash esp8266 boards now includes  SPI / SD Card support -> `tasmota-4M` build

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
