### PR TITLE
Berry `int64.fromstring()` to convert a string to an int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - ESP32 preliminary support for Matter protocol, milestone 1 (commissioning) by Stephan Hadinger
 - Basic support for Shelly Pro 4PM
 - Command ``DhtDelay<sensor> <high_delay>,<low_delay>`` to allow user control over high and low delay in microseconds (#17944)
+- Berry `int64.fromstring()` to convert a string to an int64
 
 ### Breaking Changed
 - TM1638 button and led support are handled as virtual switches and relays (#11031)

--- a/lib/libesp32/berry_int64/src/be_int64_class.c
+++ b/lib/libesp32/berry_int64/src/be_int64_class.c
@@ -53,6 +53,15 @@ char* int64_tostring(int64_t *i64) {
 }
 BE_FUNC_CTYPE_DECLARE(int64_tostring, "s", ".")
 
+int64_t* int64_fromstring(bvm *vm, const char* s) {
+  int64_t *i64 = (int64_t*)be_malloc(vm, sizeof(int64_t));
+  if (i64 == NULL) { be_raise(vm, "memory_error", "cannot allocate buffer"); }
+  if (s) { *i64 = atoll(s); }
+  else   { *i64 = 0; }
+  return i64;
+}
+BE_FUNC_CTYPE_DECLARE(int64_fromstring, "int64", "@s")
+
 int32_t int64_toint(int64_t *i64) {
   return (int32_t) *i64;
 }
@@ -190,6 +199,7 @@ class be_class_int64 (scope: global, name: int64) {
   set, ctype_func(int64_set)
 
   tostring, ctype_func(int64_tostring)
+  fromstring, static_ctype_func(int64_fromstring)
   toint, ctype_func(int64_toint)
 
   +, ctype_func(int64_add)


### PR DESCRIPTION
## Description:

Add to `int64` a class method to convert from a string to an int64.

``` berry
print(9876543210)
1286608618     <- wrong because the number overflows 32 bits

print(int64.fromstring("9876543210"))
9876543210

print(int64.fromstring("9876543210") * int64(1000))
9876543210000
```

Note: int64 requires `#define USE_BERRY_INT64`

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
