### PR TITLE
Fix 1-pin ultrasonic sensor detection

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_22_sr04.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_22_sr04.ino
@@ -124,7 +124,7 @@ void Sr04TModeDetect(void) {
     if (PinUsed(GPIO_SR04_TRIG)) {
       SR04.type = (Sr04TMiddleValue(Sr04TMode3Distance(), Sr04TMode3Distance(), Sr04TMode3Distance()) != 0) ? SR04_MODE_SER_TRANSCEIVER : SR04_MODE_TRIGGER_ECHO;
     } else {
-      SR04.type = SR04.type = (Sr04TMiddleValue(Sr04TMode2Distance(), Sr04TMode2Distance(), Sr04TMode2Distance()) != 0) ? SR04_MODE_SER_RECEIVER : SR04_MODE_TRIGGER_ECHO;
+      SR04.type = (Sr04TMiddleValue(Sr04TMode2Distance(), Sr04TMode2Distance(), Sr04TMode2Distance()) != 0) ? SR04_MODE_SER_RECEIVER : SR04_MODE_TRIGGER_ECHO;
     }
   } else {
     SR04.type = SR04_MODE_TRIGGER_ECHO;

--- a/tasmota/tasmota_xsns_sensor/xsns_22_sr04.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_22_sr04.ino
@@ -124,7 +124,7 @@ void Sr04TModeDetect(void) {
     if (PinUsed(GPIO_SR04_TRIG)) {
       SR04.type = (Sr04TMiddleValue(Sr04TMode3Distance(), Sr04TMode3Distance(), Sr04TMode3Distance()) != 0) ? SR04_MODE_SER_TRANSCEIVER : SR04_MODE_TRIGGER_ECHO;
     } else {
-      SR04.type = SR04_MODE_SER_RECEIVER;
+      SR04.type = SR04.type = (Sr04TMiddleValue(Sr04TMode2Distance(), Sr04TMode2Distance(), Sr04TMode2Distance()) != 0) ? SR04_MODE_SER_RECEIVER : SR04_MODE_TRIGGER_ECHO;
     }
   } else {
     SR04.type = SR04_MODE_TRIGGER_ECHO;


### PR DESCRIPTION
## Description:

When 1 pin ultrasonic ranger is selected by selecting only Echo pin and this pin is a UART capable pin, sensor type is set as Serial TX only without testing whether it provides actual serial data.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
