### PR TITLE
Add option for 4M3M ESP8266

### DIFF
--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -67,6 +67,8 @@ board                   = ${common.board}
 ;board                   = esp8266_2M1M
 ; Build variant 4MB = 1MB firmware, 1MB OTA, 2MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
 ;board                   = esp8266_4M2M
+; Build variant 4MB = 1MB firmware, 3MB filesystem (WEMOS D1 Mini, NodeMCU, Sonoff POW)
+;board                   = esp8266_4M3M
 ;board_build.f_cpu       = 160000000L
 ;board_build.f_flash     = 40000000L
 ; *** Define serial port used for erasing/flashing/terminal


### PR DESCRIPTION
Linker file exists, not documented. If more OTA space not needed, gives more room for files.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [ x] The pull request is done against the latest development branch
  - [ x] Only relevant files were touched
  - [ x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
