### PR TITLE
Update xdrv_79_esp32_ble.ino

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_79_esp32_ble.ino
@@ -204,7 +204,7 @@ namespace BLE_ESP32 {
 /////////////////////////////////////////////////////
 
 #define BLE_ESP32_MAXNAMELEN 32
-#define BLE_ESP32_MAXALIASLEN 20
+#define BLE_ESP32_MAXALIASLEN 32
 
 
 #define MAX_BLE_DATA_LEN 100


### PR DESCRIPTION
Increase maximum length of Alias as the short MaxAlias is not in line with name length and limits the user (e.g. if sensors have room names as appendix like "_master_bathroom").

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
Self encountered issue that the short alias length limits the user in Home Automation environments. Although such a length is always a bit arbitrary, 32 chars is also in line with name length.

## Checklist:
  - [x ] The pull request is done against the latest development branch
  - [x ] Only relevant files were touched
  - [x ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x ] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [ x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
