### PR TITLE
Set correct OTA URL for all Tasmota build env 

### DIFF
--- a/platformio_tasmota_cenv_sample.ini
+++ b/platformio_tasmota_cenv_sample.ini
@@ -1,23 +1,27 @@
 [env:tasmota-rangeextender]
 build_flags                 = ${env.build_flags}
-                              -D FIRMWARE_RANGE_EXTENDER
-                              -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-                              -D USE_WIFI_RANGE_EXTENDER
-                              -D USE_WIFI_RANGE_EXTENDER_NAPT
+                              -DFIRMWARE_RANGE_EXTENDER
+                              -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+                              -DUSE_WIFI_RANGE_EXTENDER
+                              -DUSE_WIFI_RANGE_EXTENDER_NAPT
+                              -DOTA_URL='""'
 
 [env:tasmota32-rangeextender]
 extends                     = env:tasmota32_base
 build_flags                 = ${env:tasmota32_base.build_flags}
-                              -D FIRMWARE_TASMOTA32
-                              -D USE_WIFI_RANGE_EXTENDER
-                              -D USE_WIFI_RANGE_EXTENDER_NAPT
+                              -DFIRMWARE_TASMOTA32
+                              -DUSE_WIFI_RANGE_EXTENDER
+                              -DUSE_WIFI_RANGE_EXTENDER_NAPT
+                              -DOTA_URL='""'
 
 [env:tasmota32s3-file]
 extends                     = env:tasmota32_base
 board                       = esp32s3-qio_qspi
 board_build.f_cpu           = 240000000L
 board_build.f_flash         = 80000000L
-build_flags                 = ${env:tasmota32_base.build_flags} -D FIRMWARE_TASMOTA32
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_TASMOTA32
+                              -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
 ; !!! Real flash size needed, avoid autoresize since it is formating FS !!!
 board_upload.flash_size     = 8MB
 board_upload.maximum_size   = 8388608
@@ -31,25 +35,33 @@ custom_files_upload         = ${env:tasmota32_base.custom_files_upload}
                               https://github.com/tasmota/autoconf/raw/main/esp32s3/DevKitC-1.autoconf
 
 [env:tasmota32s3-qio_opi-all]
-extends                 = env:tasmota32_base
-board                   = esp32s3-qio_opi
-board_build.f_cpu       = 240000000L
-board_build.f_flash     = 80000000L
-build_flags             = ${env:tasmota32_base.build_flags} -DUSE_WEBCAM -DUSE_BERRY_ULP -DFIRMWARE_LVGL -DUSE_LVGL_OPENHASP
+extends                     = env:tasmota32_base
+board                       = esp32s3-qio_opi
+board_build.f_cpu           = 240000000L
+board_build.f_flash         = 80000000L
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DUSE_WEBCAM
+                              -DUSE_BERRY_ULP
+                              -DFIRMWARE_LVGL
+                              -DUSE_LVGL_OPENHASP
+                              -DOTA_URL='""'
 
 
 [env:tasmota32c3-bluetooth]
 extends                     = env:tasmota32c3
 build_flags                 = ${env:tasmota32c3.build_flags}
-                              -D USE_BLE_ESP32
-                              -D USE_MI_ESP32
-;                              -D USE_EQ3_ESP32
+                              -DUSE_BLE_ESP32
+                              -DUSE_MI_ESP32
+;                              -DUSE_EQ3_ESP32
+                              -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32s3-bluetooth]
 extends                     = env:tasmota32_base
 board                       = esp32s3
-build_flags                 = ${env:tasmota32_base.build_flags} -D FIRMWARE_BLUETOOTH
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DFIRMWARE_BLUETOOTH
+                              -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_ssl, lib/lib_i2c
 lib_ignore                  = TTGO TWatch Library
                               Micro-RTSP
@@ -61,6 +73,7 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
+                              -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio
                               ESP8266SAM
@@ -74,6 +87,7 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
+                              -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio
                               ESP8266SAM
@@ -87,6 +101,7 @@ build_flags                 = ${env:tasmota32_base.build_flags}
                               -DFIRMWARE_BLUETOOTH
                               -DUSE_MI_EXT_GUI
                               -DUSE_MI_HOMEKIT=1    ; 1 to enable; 0 to disable
+                              -DOTA_URL='""'
 lib_extra_dirs              = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_div, lib/lib_ssl
 lib_ignore                  = ESP8266Audio
                               ESP8266SAM
@@ -103,12 +118,14 @@ check_tool                  = cppcheck
 check_skip_packages         = yes
 build_flags                 = ${env.build_flags}
 ;                              -Wstack-usage=300
+                              -DOTA_URL='""'
 
 [env:tasmota32-debug]
 extends                     = env:tasmota32_base
 build_type                  = debug
 build_unflags               = ${env:tasmota32_base.build_unflags}
 build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DOTA_URL='""'
 check_tool                  = cppcheck
                               ;clangtidy
 check_skip_packages         = yes
@@ -120,58 +137,63 @@ monitor_filters             = esp32_exception_decoder
 ; *** Install howto for Windows https://community.platformio.org/t/esp32-pio-unified-debugger/4541/20
 
 [env:tasmota32-ocd]
-build_type              = debug
-extends                 = env:tasmota32_base
-board                   = esp32
-debug_tool              = esp-prog
-upload_protocol         = esp-prog
-debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32_base.build_unflags}
-build_flags             = ${env:tasmota32_base.build_flags}
-monitor_filters         = esp32_exception_decoder
+build_type                  = debug
+extends                     = env:tasmota32_base
+board                       = esp32
+debug_tool                  = esp-prog
+upload_protocol             = esp-prog
+debug_init_break            = tbreak setup
+build_unflags               = ${env:tasmota32_base.build_unflags}
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DOTA_URL='""'
+monitor_filters             = esp32_exception_decoder
 
 [env:tasmota32solo1-ocd]
-build_type              = debug
-extends                 = env:tasmota32solo1
-board                   = esp32_solo1
-debug_tool              = esp-prog
-upload_protocol         = esp-prog
-debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32_base.build_unflags}
-build_flags             = ${env:tasmota32_base.build_flags}
-monitor_filters         = esp32_exception_decoder
+build_type                  = debug
+extends                     = env:tasmota32solo1
+board                       = esp32_solo1
+debug_tool                  = esp-prog
+upload_protocol             = esp-prog
+debug_init_break            = tbreak setup
+build_unflags               = ${env:tasmota32_base.build_unflags}
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DOTA_URL='""'
+monitor_filters             = esp32_exception_decoder
 
 [env:tasmota32s2-ocd]
-build_type              = debug
-extends                 = env:tasmota32_base
-board                   = esp32s2
-debug_tool              = esp-prog
-upload_protocol         = esp-prog
-debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32_base.build_unflags}
-build_flags             = ${env:tasmota32_base.build_flags}
-monitor_filters         = esp32_exception_decoder
+build_type                  = debug
+extends                     = env:tasmota32_base
+board                       = esp32s2
+debug_tool                  = esp-prog
+upload_protocol             = esp-prog
+debug_init_break            = tbreak setup
+build_unflags               = ${env:tasmota32_base.build_unflags}
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DOTA_URL='""'
+monitor_filters             = esp32_exception_decoder
 
 ; *** JTAG Debug versions (only C3/S3), uses inbuilt CDC/jtag. No extra jtag hardware required!
 
 [env:tasmota32s3cdc-ocd]
-build_type              = debug
-extends                 = env:tasmota32s3
-board                   = esp32s3cdc-qio_opi
-debug_tool              = esp-builtin
-upload_protocol         = esp-builtin
-debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32_base.build_unflags}
-build_flags             = ${env:tasmota32_base.build_flags}
-monitor_filters         = esp32_exception_decoder
+build_type                  = debug
+extends                     = env:tasmota32s3
+board                       = esp32s3cdc-qio_opi
+debug_tool                  = esp-builtin
+upload_protocol             = esp-builtin
+debug_init_break            = tbreak setup
+build_unflags               = ${env:tasmota32_base.build_unflags}
+build_flags                 = ${env:tasmota32_base.build_flags}
+                              -DOTA_URL='""'
+monitor_filters             = esp32_exception_decoder
 
 [env:tasmota32c3cdc-ocd]
-build_type              = debug
-extends                 = env:tasmota32c3
-board                   = esp32c3cdc
-debug_tool              = esp-builtin
-upload_protocol         = esp-builtin
-debug_init_break        = tbreak setup
-build_unflags           = ${env:tasmota32c3.build_unflags}
-build_flags             = ${env:tasmota32c3.build_flags}
-monitor_filters         = esp32_exception_decoder
+build_type                  = debug
+extends                     = env:tasmota32c3
+board                       = esp32c3cdc
+debug_tool                  = esp-builtin
+upload_protocol             = esp-builtin
+debug_init_break            = tbreak setup
+build_unflags               = ${env:tasmota32c3.build_unflags}
+build_flags                 = ${env:tasmota32c3.build_flags}
+                              -DOTA_URL='""'
+monitor_filters             = esp32_exception_decoder

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -101,7 +101,7 @@ build_flags             = ${env.build_flags} -DMY_LANGUAGE=es_ES -DOTA_URL='"htt
 build_flags             = ${env.build_flags} -DMY_LANGUAGE=fr_FR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-FR.bin.gz"'
 
 [env:tasmota-FY]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=fy_NL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-NL.bin.gz"'
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=fy_NL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-FY.bin.gz"'
 
 [env:tasmota-GR]
 build_flags             = ${env.build_flags} -DMY_LANGUAGE=el_GR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-GR.bin.gz"'

--- a/platformio_tasmota_env.ini
+++ b/platformio_tasmota_env.ini
@@ -32,118 +32,121 @@ lib_ignore                  =
 
 
 [env:tasmota]
+build_flags             = ${env.build_flags} -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota.bin.gz"'
 
 [env:tasmota-4M]
 board                   = esp8266_4M2M
+build_flags             = ${env.build_flags} -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-4M.bin.gz"'
+
 
 [env:tasmota-minimal]
-build_flags             = ${env.build_flags} -DFIRMWARE_MINIMAL
+build_flags             = ${env.build_flags} -DFIRMWARE_MINIMAL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-minimal.bin.gz"'
 lib_extra_dirs          =
 
 [env:tasmota-lite]
-build_flags             = ${env.build_flags} -DFIRMWARE_LITE
+build_flags             = ${env.build_flags} -DFIRMWARE_LITE -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-lite.bin.gz"'
 lib_extra_dirs          =
 
 [env:tasmota-knx]
-build_flags             = ${env.build_flags} -DFIRMWARE_KNX_NO_EMULATION
+build_flags             = ${env.build_flags} -DFIRMWARE_KNX_NO_EMULATION -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-knx.bin.gz"'
 lib_extra_dirs          = lib/lib_basic, lib/lib_div
 
 [env:tasmota-sensors]
-build_flags             = ${env.build_flags} -DFIRMWARE_SENSORS
+build_flags             = ${env.build_flags} -DFIRMWARE_SENSORS -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-sensors.bin.gz"'
 lib_extra_dirs          = lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div
 
 [env:tasmota-display]
-build_flags             = ${env.build_flags} -DFIRMWARE_DISPLAYS
+build_flags             = ${env.build_flags} -DFIRMWARE_DISPLAYS -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-display.bin.gz"'
 lib_extra_dirs          = lib/lib_basic, lib/lib_display
 
 [env:tasmota-ir]
-build_flags             = ${env.build_flags} -DFIRMWARE_IR
+build_flags             = ${env.build_flags} -DFIRMWARE_IR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-ir.bin.gz"'
 lib_extra_dirs          = lib/lib_basic
 
 [env:tasmota-zbbridge]
-build_flags             = ${env.build_flags} -DFIRMWARE_ZBBRIDGE
+build_flags             = ${env.build_flags} -DFIRMWARE_ZBBRIDGE -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-zbbridge.bin.gz"'
 board                   = esp8266_zbbridge
 lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/lib_div
 
 [env:tasmota-zigbee]
-build_flags             = ${env.build_flags} -DUSE_ZIGBEE -DUSE_CCLOADER -DUSE_UFILESYS
+build_flags             = ${env.build_flags} -DUSE_ZIGBEE -DUSE_CCLOADER -DUSE_UFILESYS -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-zigbee.bin.gz"'
 board                   = esp8266_4M2M
 board_build.f_cpu       = 160000000L
 
 [env:tasmota-AD]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=ca_AD
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ca_AD -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmot-AD.bin.gz"'
 
 [env:tasmota-AF]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=af_AF
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=af_AF -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-AF.bin.gz"'
 
 [env:tasmota-BG]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=bg_BG
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=bg_BG -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-BG.bin.gz"'
 
 [env:tasmota-BR]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_BR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_BR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-BR.bin.gz"'
 
 [env:tasmota-CN]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_CN
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_CN -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-CN.bin.gz"'
 
 [env:tasmota-CZ]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=cs_CZ
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=cs_CZ -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-CZ.bin.gz"'
 
 [env:tasmota-DE]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=de_DE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=de_DE -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-DE.bin.gz"'
 
 [env:tasmota-ES]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=es_ES
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=es_ES -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-ES.bin.gz"'
 
 [env:tasmota-FR]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=fr_FR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=fr_FR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-FR.bin.gz"'
 
 [env:tasmota-FY]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=fy_NL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=fy_NL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-NL.bin.gz"'
 
 [env:tasmota-GR]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=el_GR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=el_GR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-GR.bin.gz"'
 
 [env:tasmota-HE]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=he_HE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=he_HE -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-HE.bin.gz"'
 
 [env:tasmota-HU]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=hu_HU
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=hu_HU -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-HU.bin.gz"'
 
 [env:tasmota-IT]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=it_IT
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=it_IT -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-IT.bin.gz"'
 
 [env:tasmota-KO]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=ko_KO
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ko_KO -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-KO.bin.gz"'
 
 [env:tasmota-NL]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=nl_NL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=nl_NL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-NL.bin.gz"'
 
 [env:tasmota-PL]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=pl_PL
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pl_PL -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-PL.bin.gz"'
 
 [env:tasmota-PT]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_PT
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=pt_PT -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-PT.bin.gz"'
 
 [env:tasmota-RO]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=ro_RO
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ro_RO -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-RO.bin.gz"'
 
 [env:tasmota-RU]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=ru_RU
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=ru_RU -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-RU.bin.gz"'
 
 [env:tasmota-SE]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=sv_SE
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=sv_SE -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-SE.bin.gz"'
 
 [env:tasmota-SK]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=sk_SK
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=sk_SK -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-SK.bin.gz"'
 
 [env:tasmota-TR]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=tr_TR
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=tr_TR -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-TR.bin.gz"'
 
 [env:tasmota-TW]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_TW
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=zh_TW -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-TW.bin.gz"'
 
 [env:tasmota-UK]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=uk_UA
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=uk_UA -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-UK.bin.gz"'
 
 [env:tasmota-VN]
-build_flags             = ${env.build_flags} -DMY_LANGUAGE=vi_VN
+build_flags             = ${env.build_flags} -DMY_LANGUAGE=vi_VN -DOTA_URL='"http://ota.tasmota.com/tasmota/release/tasmota-VN.bin.gz"'

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -1,48 +1,50 @@
 [env:tasmota32_base]
-framework                   = ${common.framework}
-platform                    = ${core32.platform}
-platform_packages           = ${core32.platform_packages}
-board_build.filesystem      = ${common.board_build.filesystem}
-custom_unpack_dir           = ${common.custom_unpack_dir}
-board                       = esp32
-monitor_speed               = 115200
-upload_resetmethod          = ${common.upload_resetmethod}
-extra_scripts               = ${esp32_defaults.extra_scripts}
-build_unflags               = ${core32.build_unflags}
-build_flags                 = ${core32.build_flags}
-lib_ldf_mode                = ${common.lib_ldf_mode}
-lib_compat_mode             = ${common.lib_compat_mode}
-lib_extra_dirs              = ${common.lib_extra_dirs}
-                              lib/libesp32
-                              lib/libesp32_lvgl
-                              lib/libesp32_div
-                              lib/libesp32_eink
-                              lib/libesp32_audio
-lib_ignore                  =
-                              HTTPUpdateServer
-                              ESP RainMaker
-                              WiFiProv
-                              USB
-                              SPIFFS
-                              ESP32 Azure IoT Arduino
-                              ESP32 Async UDP
-                              ESP32 BLE Arduino
-;                              SimpleBLE
-                              NetBIOS
-                              ESP32
-                              Preferences
-                              BluetoothSerial
+framework               = ${common.framework}
+platform                = ${core32.platform}
+platform_packages       = ${core32.platform_packages}
+board_build.filesystem  = ${common.board_build.filesystem}
+custom_unpack_dir       = ${common.custom_unpack_dir}
+board                   = esp32
+monitor_speed           = 115200
+upload_resetmethod      = ${common.upload_resetmethod}
+extra_scripts           = ${esp32_defaults.extra_scripts}
+build_unflags           = ${core32.build_unflags}
+build_flags             = ${core32.build_flags}
+lib_ldf_mode            = ${common.lib_ldf_mode}
+lib_compat_mode         = ${common.lib_compat_mode}
+lib_extra_dirs          = ${common.lib_extra_dirs}
+                          lib/libesp32
+                          lib/libesp32_lvgl
+                          lib/libesp32_div
+                          lib/libesp32_eink
+                          lib/libesp32_audio
+lib_ignore              =
+                          HTTPUpdateServer
+                          ESP RainMaker
+                          WiFiProv
+                          USB
+                          SPIFFS
+                          ESP32 Azure IoT Arduino
+                          ESP32 Async UDP
+                          ESP32 BLE Arduino
+;                          SimpleBLE
+                          NetBIOS
+                          ESP32
+                          Preferences
+                          BluetoothSerial
 ; Disable next if you want to use ArduinoOTA in Tasmota32 (default disabled)
-                              ArduinoOTA
+                          ArduinoOTA
 ; Add files to Filesystem for all env (global). Remove no files entry and add add a line with the file to include
 ; Example for adding the Partition Manager
 ; custom_files_upload =
 ; tasmota/berry/modules/Partition_Manager.tapp
-custom_files_upload         = no_files
+custom_files_upload     = no_files
 
 [env:tasmota32-safeboot]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -51,19 +53,25 @@ lib_ignore              =
 
 [env:tasmota32]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32.bin"'
 
 [env:tasmota32-webcam]
 extends                 = env:tasmota32_base
 board                   = esp32-fix
 board_build.f_cpu       = 240000000L
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_WEBCAM -DCAMERA_MODEL_AI_THINKER
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_WEBCAM -DCAMERA_MODEL_AI_THINKER
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-webcam.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 
 [env:tasmota32-odroidgo]
 extends                 = env:tasmota32-lvgl
 board_build.f_cpu       = 240000000L
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DARDUINO_ODROID_ESP32
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32 -DARDUINO_ODROID_ESP32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-lvgl.bin"'
 board                   = esp32-fix
 
 [env:tasmota32-core2]
@@ -71,39 +79,56 @@ extends                 = env:tasmota32-lvgl
 board_build.flash_mode  = qio
 board_build.f_cpu       = 240000000L
 board_build.f_flash     = 80000000L
-build_flags             = ${env:tasmota32-lvgl.build_flags} -DUSE_I2S_SAY_TIME -DUSE_I2S_WEBRADIO -DUSE_SENDMAIL
+build_flags             = ${env:tasmota32-lvgl.build_flags}
+                          -DUSE_I2S_SAY_TIME
+                          -DUSE_I2S_WEBRADIO
+                          -DUSE_SENDMAIL
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-lvgl.bin"'
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display, lib/lib_audio
 
 [env:tasmota32-bluetooth]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_BLUETOOTH
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_BLUETOOTH
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-bluetooth.bin"'
 lib_extra_dirs          = lib/libesp32, lib/libesp32_div, lib/lib_basic, lib/lib_i2c, lib/lib_ssl
 
 [env:tasmota32-display]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_DISPLAYS
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_DISPLAYS
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-display.bin"'
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_display, lib/lib_ssl
 
 [env:tasmota32-lvgl]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_LVGL
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_LVGL
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-lvgl.bin"'
 board_build.f_cpu       = 240000000L
 lib_extra_dirs          = lib/libesp32, lib/libesp32_lvgl, lib/lib_basic, lib/lib_i2c, lib/lib_rf, lib/lib_div, lib/lib_ssl, lib/lib_display
 
 [env:tasmota32-ir]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DUSE_IR_REMOTE_FULL -DFIRMWARE_IR
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DUSE_IR_REMOTE_FULL
+                          -DFIRMWARE_IR
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-ir.bin"'
 lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_ssl
 
 [env:tasmota32solo1]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32solo1.bin"'
 
 [env:tasmota32solo1-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32_solo1
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32solo1-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -114,6 +139,7 @@ lib_ignore              =
 extends                 = env:tasmota32_base
 board_build.partitions  = partitions/esp32_partition_app1856k_fs1344k.csv
 build_flags             = ${env:tasmota32_base.build_flags}
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-zbbrdgpro.bin"'
                           -DFIRMWARE_ZBBRDGPRO
                           -DFRAMEWORK_ARDUINO_ITEAD
 custom_files_upload     = ${env:tasmota32_base.custom_files_upload}
@@ -127,6 +153,7 @@ lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
 [env:tasmota32-nspanel]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags}
+                          -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32-nspanel.bin"'
                           -DFIRMWARE_NSPANEL
                           -DFRAMEWORK_ARDUINO_ITEAD
 
@@ -136,7 +163,7 @@ board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
                           -fno-lto
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
@@ -150,7 +177,7 @@ board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
                           -fno-lto
 lib_ignore              =
                           TTGO TWatch Library
@@ -161,15 +188,18 @@ lib_ignore              =
 [env:tasmota32c3cdc-safeboot]
 extends                 = env:tasmota32c3-safeboot
 board                   = esp32c3cdc
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
+                          -fno-lto
 
 [env:tasmota32c3cdc]
 extends                 = env:tasmota32c3
 board                   = esp32c3cdc
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc.bin"'
 
 [env:tasmota32s2-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s2
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -179,7 +209,7 @@ lib_ignore              =
 [env:tasmota32s2]
 extends                 = env:tasmota32_base
 board                   = esp32s2
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
 lib_ignore              =
                           TTGO TWatch Library
                           NimBLE-Arduino
@@ -189,15 +219,17 @@ lib_ignore              =
 [env:tasmota32s2cdc-safeboot]
 extends                 = env:tasmota32s2-safeboot
 board                   = esp32s2cdc
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
 
 [env:tasmota32s2cdc]
 extends                 = env:tasmota32s2
 board                   = esp32s2cdc
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
 
 [env:tasmota32s3-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s3-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -207,7 +239,7 @@ lib_ignore              =
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 board                   = esp32s3-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
 lib_ignore              =
                           TTGO TWatch Library
                           Micro-RTSP
@@ -216,111 +248,113 @@ lib_ignore              =
 [env:tasmota32s3cdc-safeboot]
 extends                 = env:tasmota32s3-safeboot
 board                   = esp32s3cdc-qio_qspi
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
 
 [env:tasmota32s3cdc]
 extends                 = env:tasmota32s3
 board                   = esp32s3cdc-qio_qspi
+build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
 
 [env:tasmota32-AD]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ca_AD -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ca_AD -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-AD.bin"'
 
 [env:tasmota32-AF]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=af_AF -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=af_AF -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-AF.bin"'
 
 [env:tasmota32-BG]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=bg_BG -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=bg_BG -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-BG.bin"'
 
 [env:tasmota32-BR]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_BR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_BR -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-BR.bin"'
 
 [env:tasmota32-CN]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_CN -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_CN -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-CN.bin"'
 
 [env:tasmota32-CZ]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=cs_CZ -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=cs_CZ -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-CZ.bin"'
 
 [env:tasmota32-DE]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=de_DE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=de_DE -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-DE.bin"'
 
 [env:tasmota32-ES]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=es_ES -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=es_ES -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-ES.bin"'
 
 [env:tasmota32-FR]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fr_FR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fr_FR -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-FR.bin"'
 
 [env:tasmota32-FY]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fy_NL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=fy_NL -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-FY.bin"'
 
 [env:tasmota32-GR]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=el_GR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=el_GR -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-GR.bin"'
 
 [env:tasmota32-HE]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=he_HE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=he_HE -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-HE.bin"'
 
 [env:tasmota32-HU]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=hu_HU -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=hu_HU -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-HU.bin"'
 
 [env:tasmota32-IT]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=it_IT -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=it_IT -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-IT.bin"'
 
 [env:tasmota32-KO]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ko_KO -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ko_KO -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-KO.bin"'
 
 [env:tasmota32-NL]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=nl_NL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=nl_NL -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-NL.bin"'
 
 [env:tasmota32-PL]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pl_PL -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pl_PL -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-PL.bin"'
 
 [env:tasmota32-PT]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_PT -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=pt_PT -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-PT.bin"'
 
 [env:tasmota32-RO]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ro_RO -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ro_RO -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-RO.bin"'
 
 [env:tasmota32-RU]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ru_RU -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=ru_RU -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-RU.bin"'
 
 [env:tasmota32-SE]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sv_SE -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sv_SE -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-SE.bin"'
 
 [env:tasmota32-SK]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sk_SK -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=sk_SK -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-SK.bin"'
 
 [env:tasmota32-TR]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=tr_TR -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=tr_TR -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-TR.bin"'
 
 [env:tasmota32-TW]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_TW -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=zh_TW -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-TW.bin"'
 
 [env:tasmota32-UK]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=uk_UA -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=uk_UA -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-UK.bin"'
 
 [env:tasmota32-VN]
 extends                 = env:tasmota32_base
-build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=vi_VN -DFIRMWARE_TASMOTA32
+build_flags             = ${env:tasmota32_base.build_flags} -DMY_LANGUAGE=vi_VN -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-VN.bin"'

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -265,12 +265,16 @@ lib_ignore              =
 [env:tasmota32s3cdc-safeboot]
 extends                 = env:tasmota32s3-safeboot
 board                   = esp32s3cdc-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
 
 [env:tasmota32s3cdc]
 extends                 = env:tasmota32s3
 board                   = esp32s3cdc-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                         -DFIRMWARE_TASMOTA32
+                         -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
 
 [env:tasmota32-AD]
 extends                 = env:tasmota32_base

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -164,7 +164,8 @@ build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
                           -fno-lto
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
@@ -179,7 +180,8 @@ build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
 build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
                           -fno-lto
 lib_ignore              =
                           TTGO TWatch Library
@@ -191,7 +193,8 @@ lib_ignore              =
 extends                 = env:tasmota32c3-safeboot
 board                   = esp32c3cdc
 build_flags             = ${env:tasmota32_base.build_flags}
-                          -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
                           -fno-lto
 
 [env:tasmota32c3cdc]

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -274,7 +274,7 @@ extends                 = env:tasmota32s3
 board                   = esp32s3cdc-qio_qspi
 build_flags             = ${env:tasmota32_base.build_flags}
                          -DFIRMWARE_TASMOTA32
-                         -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3cdc.bin"'
 
 [env:tasmota32-AD]
 extends                 = env:tasmota32_base

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -163,7 +163,8 @@ board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3-safeboot.bin"'
                           -fno-lto
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
@@ -177,7 +178,8 @@ board                   = esp32c3
 build_unflags           = ${env:tasmota32_base.build_unflags}
                           -flto
                           -mtarget-align
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"'
                           -fno-lto
 lib_ignore              =
                           TTGO TWatch Library
@@ -188,18 +190,23 @@ lib_ignore              =
 [env:tasmota32c3cdc-safeboot]
 extends                 = env:tasmota32c3-safeboot
 board                   = esp32c3cdc
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc-safeboot.bin"'
                           -fno-lto
 
 [env:tasmota32c3cdc]
 extends                 = env:tasmota32c3
 board                   = esp32c3cdc
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32c3cdc.bin"'
 
 [env:tasmota32s2-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s2
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -209,7 +216,9 @@ lib_ignore              =
 [env:tasmota32s2]
 extends                 = env:tasmota32_base
 board                   = esp32s2
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"'
 lib_ignore              =
                           TTGO TWatch Library
                           NimBLE-Arduino
@@ -219,17 +228,23 @@ lib_ignore              =
 [env:tasmota32s2cdc-safeboot]
 extends                 = env:tasmota32s2-safeboot
 board                   = esp32s2cdc
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_SAFEBOOT
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc-safeboot.bin"'
 
 [env:tasmota32s2cdc]
 extends                 = env:tasmota32s2
 board                   = esp32s2cdc
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                          -DFIRMWARE_TASMOTA32
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s2cdc.bin"'
 
 [env:tasmota32s3-safeboot]
 extends                 = env:tasmota32_base
 board                   = esp32s3-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_SAFEBOOT -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                         -DFIRMWARE_SAFEBOOT
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3-safeboot.bin"'
 lib_extra_dirs          = lib/lib_ssl, lib/libesp32
 lib_ignore              =
                           Micro-RTSP
@@ -239,7 +254,9 @@ lib_ignore              =
 [env:tasmota32s3]
 extends                 = env:tasmota32_base
 board                   = esp32s3-qio_qspi
-build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_TASMOTA32 -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
+build_flags             = ${env:tasmota32_base.build_flags}
+                         -DFIRMWARE_TASMOTA32
+                         -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"'
 lib_ignore              =
                           TTGO TWatch Library
                           Micro-RTSP

--- a/platformio_tasmota_env32.ini
+++ b/platformio_tasmota_env32.ini
@@ -153,7 +153,7 @@ lib_extra_dirs          = lib/lib_basic, lib/lib_ssl, lib/libesp32
 [env:tasmota32-nspanel]
 extends                 = env:tasmota32_base
 build_flags             = ${env:tasmota32_base.build_flags}
-                          -DOTA_URL='"	http://ota.tasmota.com/tasmota32/release/tasmota32-nspanel.bin"'
+                          -DOTA_URL='"http://ota.tasmota.com/tasmota32/release/tasmota32-nspanel.bin"'
                           -DFIRMWARE_NSPANEL
                           -DFRAMEWORK_ARDUINO_ITEAD
 

--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -93,24 +93,6 @@
 #define WEB_LOG_LEVEL          LOG_LEVEL_INFO    // [WebLog] (LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE)
 #define MQTT_LOG_LEVEL         LOG_LEVEL_NONE    // [MqttLog] (LOG_LEVEL_NONE, LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_DEBUG, LOG_LEVEL_DEBUG_MORE)
 
-// -- Ota -----------------------------------------
-#ifdef ESP8266
-#define OTA_URL                "http://ota.tasmota.com/tasmota/release/tasmota.bin.gz"  // [OtaUrl]
-#endif  // ESP8266
-#ifdef ESP32
-#ifdef CONFIG_IDF_TARGET_ESP32C3
-#define OTA_URL                "https://ota.tasmota.com/tasmota32/release/tasmota32c3.bin"  // [OtaUrl]
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)
-#define OTA_URL                "https://ota.tasmota.com/tasmota32/release/tasmota32s2.bin"  // [OtaUrl]
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
-#define OTA_URL                "https://ota.tasmota.com/tasmota32/release/tasmota32s3.bin"  // [OtaUrl]
-#elif defined(CORE32SOLO1)
-#define OTA_URL                "https://ota.tasmota.com/tasmota32/release/tasmota32solo1.bin"  // [OtaUrl]
-#else
-#define OTA_URL                "https://ota.tasmota.com/tasmota32/release/tasmota32.bin"  // [OtaUrl]
-#endif  //  CONFIG_IDF_TARGET_ESP32C3
-#endif  // ESP32
-
 // -- MQTT ----------------------------------------
 #define MQTT_USE               true              // [SetOption3] Select default MQTT use (false = Off, true = On)
 


### PR DESCRIPTION
## Description:

The `OTA_URL` is now set in the PIO env. The attempts to do where not working in the past since the define (which is a Macro) was extended wrong.

By using the syntax `-D DEFINE_NEEDED='"string"'` the Macro is parsed and extended correctly.

All `#define OTA_URL` are removed in source code!
All [env) need to have `-DOTA_URL='"path_to_ota_file"'` or an empty entry `-DOTA_URL='""'`

This Option makes it possible to define more settings without the need of `user_config_override.h`.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.6
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
