### PR TITLE
Matter support for subscriptions

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -75,9 +75,17 @@ class Matter_IM_Message
   end
 
   # ack received for previous message, proceed to next (if any)
+  # return true if we manage the ack ourselves, false if it needs to be done upper
   def ack_received(msg)
-    self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
+    if msg
+      self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
+    end
     self.ready = true
+    return true
+  end
+
+  # we received an ACK error, do any necessary cleaning
+  def ack_error(msg)
   end
 
   # get the exchange-id for this message
@@ -227,12 +235,59 @@ matter.IM_ReportData = Matter_IM_ReportData
 # Main difference is that we are the spontaneous inititor
 #################################################################################
 class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
+  var sub                         # subscription object
+  var report_data_phase           # true during reportdata
 
-  def init(message_handler, session, data)
+  def init(message_handler, session, data, sub)
     self.resp = matter.Frame.initiate_response(message_handler, session, 0x05 #-Report Data-#, true)
     self.data = data
     self.ready = true                # send immediately
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT
+    #
+    self.sub = sub
+    self.report_data_phase = true
+  end
+
+  # we received an ACK error, remove subscription
+  def ack_error(msg)
+    self.sub.remove_self()
+  end
+
+  # ack received for previous message, proceed to next (if any)
+  # return true if we manage the ack ourselves, false if it needs to be done upper
+  def ack_received(msg)
+    if self.report_data_phase
+      return super(self).ack_received(msg)
+    else
+      super(self).ack_received(nil)
+      return false                            # let the caller to the ack
+    end
+  end
+
+  # returns true if transaction is complete (remove object from queue)
+  # default responder for data
+  def send(responder)
+    if size(self.data.attribute_reports) > 0
+      if self.report_data_phase
+        var ret = super(self).send(responder)
+        if !ret   return false end              # ReportData needs to continue
+        # ReportData is finished
+        self.report_data_phase = false
+        return false
+      else
+        # send a simple ACK
+        var resp = self.resp.build_standalone_ack()
+        resp.encode()
+        resp.encrypt()
+        responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+        return true                             # we received a ack(), just finish
+      end
+
+    else
+      # simple heartbeat ReportData
+      super(self).send(responder)
+      return true                               # don't expect any response
+    end
   end
 end
 matter.IM_ReportDataSubscribed = Matter_IM_ReportDataSubscribed

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin.be
@@ -38,6 +38,12 @@ class Matter_Plugin
   end
 
   #############################################################
+  # signal that an attribute has been changed
+  def attribute_updated(endpoint, cluster, attribute, fabric_specific)
+    self.device.attribute_updated(endpoint, cluster, attribute, fabric_specific)
+  end
+
+  #############################################################
   # Which endpoints does it handle (list of numbers)
   def get_endpoints()
     return self.endpoints
@@ -64,47 +70,47 @@ class Matter_Plugin
 
   #############################################################
   # read attribute
-  def read_attribute(msg, ctx)
+  def read_attribute(session, ctx)
     return nil
   end
 
   #############################################################
   # read event
   # TODO
-  def read_event(msg, endpoint, cluster, eventid)
+  def read_event(session, endpoint, cluster, eventid)
     return nil
   end
 
   #############################################################
   # subscribe attribute
   # TODO
-  def subscribe_attribute(msg, endpoint, cluster, attribute)
+  def subscribe_attribute(session, endpoint, cluster, attribute)
     return nil
   end
 
   #############################################################
   # subscribe event
   # TODO
-  def subscribe_event(msg, endpoint, cluster, eventid)
+  def subscribe_event(session, endpoint, cluster, eventid)
     return nil
   end
 
   #############################################################
   # write attribute
-  def write_attribute(msg, ctx, write_data)
+  def write_attribute(session, ctx, write_data)
     return nil
   end
 
   #############################################################
   # invoke command
-  def invoke_request(msg, val, ctx)
+  def invoke_request(session, val, ctx)
     return nil
   end
 
   #############################################################
   # timed request
   # TODO - should we even support this?
-  def timed_request(msg, val, ctx)
+  def timed_request(session, val, ctx)
     return nil
   end
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_OnOff.be
@@ -49,7 +49,7 @@ class Matter_Plugin_OnOff : Matter_Plugin
   #############################################################
   # read an attribute
   #
-  def read_attribute(msg, ctx)
+  def read_attribute(session, ctx)
     import string
     var TLV = matter.TLV
     var cluster = ctx.cluster
@@ -105,11 +105,10 @@ class Matter_Plugin_OnOff : Matter_Plugin
   #
   # returns a TLV object if successful, contains the response
   #   or an `int` to indicate a status
-  def invoke_request(msg, val, ctx)
+  def invoke_request(session, val, ctx)
     var TLV = matter.TLV
     var cluster = ctx.cluster
     var command = ctx.command
-    var session = msg.session
 
     # ====================================================================================================
     if   cluster == 0x0003              # ========== Identify 1.2 p.16 ==========
@@ -140,17 +139,27 @@ class Matter_Plugin_OnOff : Matter_Plugin
     # ====================================================================================================
     elif cluster == 0x0006              # ========== On/Off 1.5 p.48 ==========
       if   command == 0x0000            # ---------- Off ----------
+        if self.onoff   self.onoff_changed(ctx) end
         self.onoff = false
         return true
       elif command == 0x0001            # ---------- On ----------
+        if !self.onoff   self.onoff_changed(ctx) end
         self.onoff = true
         return true
       elif command == 0x0002            # ---------- Toggle ----------
+        self.onoff_changed(ctx)
         self.onoff = !self.onoff
         return true
       end
     end
   end
+
+  #############################################################
+  # Signal that onoff attribute changed
+  def onoff_changed(ctx)
+    self.attribute_updated(ctx.endpoint, 0x0006, 0x0000)
+  end
+
 end
 matter.Plugin_OnOff = Matter_Plugin_OnOff
   

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
@@ -49,8 +49,9 @@ class Matter_Session
   var counter_snd                 # counter for outgoing messages
   var __exchange_id               # exchange id for locally initiated transaction, non-persistent
   # keep track of last known IP/Port of the fabric
-  var __ip
-  var __port
+  var __ip                        # IP of the last received packet
+  var __port                      # port of the last received packet
+  var __message_handler           # pointer to the message handler for this session
   # non-session counters
   var _counter_insecure_rcv       # counter for incoming messages
   var _counter_insecure_snd       # counter for outgoing messages

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -98,6 +98,7 @@ class Matter_UI
     webserver.content_send(string.format("<input type='number' min='1' max='99999998' name='passcode' value='%i'>", self.device.passcode))
     webserver.content_send("<p>Distinguish id:</p>")
     webserver.content_send(string.format("<input type='number' min='0' max='2047' name='discriminator' value='%i'>", self.device.discriminator))
+    webserver.content_send(string.format("<p><input type='checkbox' name='ipv4'%s>IPv4 only</p>", self.device.ipv4only ? " checked" : ""))
     webserver.content_send("<p></p><button name='passcode' class='button bgrn'>Change</button></form></p>")
     
 
@@ -205,6 +206,7 @@ class Matter_UI
         if webserver.has_arg("discriminator")
           self.device.discriminator = int(webserver.arg("discriminator"))
         end
+        self.device.ipv4only = webserver.arg("ipv4") == 'on'
         self.device.save_param()
 
         #- and force restart -#

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,49 +7,32 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_sessions
+** Solidified function: msg_received
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_sessions,   /* name */
+be_local_closure(Matter_Device_msg_received,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    9,                          /* nstack */
+    4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(get_deviceid),
-    /* K2   */  be_nested_str_weak(get_fabric),
-    /* K3   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K4   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(msg_received),
     }),
-    be_str_weak(mdns_announce_op_discovery_all_sessions),
+    be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x88080500,  //  0002  GETMBR	R2	R2	K0
-      0x7C040200,  //  0003  CALL	R1	1
-      0xA802000B,  //  0004  EXBLK	0	#0011
-      0x5C080200,  //  0005  MOVE	R2	R1
-      0x7C080000,  //  0006  CALL	R2	0
-      0x8C0C0501,  //  0007  GETMET	R3	R2	K1
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x780E0005,  //  0009  JMPF	R3	#0010
-      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
-      0x7C0C0200,  //  000B  CALL	R3	1
-      0x780E0002,  //  000C  JMPF	R3	#0010
-      0x8C0C0103,  //  000D  GETMET	R3	R0	K3
-      0x5C140400,  //  000E  MOVE	R5	R2
-      0x7C0C0400,  //  000F  CALL	R3	2
-      0x7001FFF3,  //  0010  JMP		#0005
-      0x58040004,  //  0011  LDCONST	R1	K4
-      0xAC040200,  //  0012  CATCH	R1	1	0
-      0xB0080000,  //  0013  RAISE	2	R0	R0
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0x5C180200,  //  0002  MOVE	R6	R1
+      0x5C1C0400,  //  0003  MOVE	R7	R2
+      0x5C200600,  //  0004  MOVE	R8	R3
+      0x7C100800,  //  0005  CALL	R4	4
+      0x80040800,  //  0006  RET	1	R4
     })
   )
 );
@@ -57,11 +40,98 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery_all_sessions,   /* nam
 
 
 /********************************************************************
-** Solidified function: start_operational_dicovery
+** Solidified function: start_udp
 ********************************************************************/
-be_local_closure(Matter_Device_start_operational_dicovery,   /* name */
+be_local_closure(Matter_Device_start_udp,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: packet_ack
+********************************************************************/
+be_local_closure(Matter_Device_packet_ack,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -69,49 +139,459 @@ be_local_closure(Matter_Device_start_operational_dicovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(salt),
-    /* K4   */  be_nested_str_weak(w0),
-    /* K5   */  be_nested_str_weak(w1),
-    /* K6   */  be_nested_str_weak(L),
-    /* K7   */  be_nested_str_weak(set_no_expiration),
-    /* K8   */  be_nested_str_weak(set_persist),
-    /* K9   */  be_nested_str_weak(close),
-    /* K10  */  be_nested_str_weak(sessions),
-    /* K11  */  be_nested_str_weak(save),
-    /* K12  */  be_nested_str_weak(mdns_announce_op_discovery),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(packet_ack),
     }),
-    be_str_weak(start_operational_dicovery),
+    be_str_weak(packet_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(plugins),
+    /* K2   */  be_nested_str_weak(invoke_request),
+    /* K3   */  be_nested_str_weak(status),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K6   */  be_const_int(1),
+    }),
+    be_str_weak(invoke_request),
     &be_const_str_solidified,
     ( &(const binstruction[25]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x6014000C,  //  0001  GETGBL	R5	G12
+      0x88180101,  //  0002  GETMBR	R6	R0	K1
+      0x7C140200,  //  0003  CALL	R5	1
+      0x14140805,  //  0004  LT	R5	R4	R5
+      0x78160011,  //  0005  JMPF	R5	#0018
+      0x88140101,  //  0006  GETMBR	R5	R0	K1
+      0x94140A04,  //  0007  GETIDX	R5	R5	R4
+      0x8C180B02,  //  0008  GETMET	R6	R5	K2
+      0x5C200200,  //  0009  MOVE	R8	R1
+      0x5C240400,  //  000A  MOVE	R9	R2
+      0x5C280600,  //  000B  MOVE	R10	R3
+      0x7C180800,  //  000C  CALL	R6	4
+      0x4C1C0000,  //  000D  LDNIL	R7
+      0x201C0C07,  //  000E  NE	R7	R6	R7
+      0x741E0004,  //  000F  JMPT	R7	#0015
+      0x881C0703,  //  0010  GETMBR	R7	R3	K3
+      0xB8220800,  //  0011  GETNGBL	R8	K4
+      0x88201105,  //  0012  GETMBR	R8	R8	K5
+      0x201C0E08,  //  0013  NE	R7	R7	R8
+      0x781E0000,  //  0014  JMPF	R7	#0016
+      0x80040C00,  //  0015  RET	1	R6
+      0x00100906,  //  0016  ADD	R4	R4	K6
+      0x7001FFE8,  //  0017  JMP		#0001
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_mdns_announce
+********************************************************************/
+be_local_closure(Matter_Device__start_mdns_announce,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[49]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(start),
+    /* K3   */  be_nested_str_weak(VP),
+    /* K4   */  be_nested_str_weak(vendorid),
+    /* K5   */  be_nested_str_weak(_X2B),
+    /* K6   */  be_nested_str_weak(productid),
+    /* K7   */  be_nested_str_weak(D),
+    /* K8   */  be_nested_str_weak(discriminator),
+    /* K9   */  be_nested_str_weak(CM),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_nested_str_weak(T),
+    /* K12  */  be_const_int(0),
+    /* K13  */  be_nested_str_weak(SII),
+    /* K14  */  be_nested_str_weak(SAI),
+    /* K15  */  be_nested_str_weak(tasmota),
+    /* K16  */  be_nested_str_weak(eth),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_nested_str_weak(replace),
+    /* K19  */  be_nested_str_weak(find),
+    /* K20  */  be_nested_str_weak(mac),
+    /* K21  */  be_nested_str_weak(_X3A),
+    /* K22  */  be_nested_str_weak(),
+    /* K23  */  be_nested_str_weak(ipv4only),
+    /* K24  */  be_nested_str_weak(add_hostname),
+    /* K25  */  be_nested_str_weak(ip6local),
+    /* K26  */  be_nested_str_weak(ip),
+    /* K27  */  be_nested_str_weak(ip6),
+    /* K28  */  be_nested_str_weak(add_service),
+    /* K29  */  be_nested_str_weak(_matterc),
+    /* K30  */  be_nested_str_weak(_udp),
+    /* K31  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K32  */  be_nested_str_weak(log),
+    /* K33  */  be_nested_str_weak(format),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K35  */  be_nested_str_weak(wifi),
+    /* K36  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K37  */  be_nested_str_weak(hostname_wifi),
+    /* K38  */  be_const_int(2),
+    /* K39  */  be_nested_str_weak(_L),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K41  */  be_const_int(3),
+    /* K42  */  be_nested_str_weak(add_subtype),
+    /* K43  */  be_nested_str_weak(_S),
+    /* K44  */  be_nested_str_weak(_V),
+    /* K45  */  be_nested_str_weak(_CM1),
+    /* K46  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K47  */  be_nested_str_weak(_X7C),
+    /* K48  */  be_nested_str_weak(mdns_announce_op_discovery_all_sessions),
+    }),
+    be_str_weak(_start_mdns_announce),
+    &be_const_str_solidified,
+    ( &(const binstruction[312]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x4C140000,  //  0003  LDNIL	R5
-      0x90020605,  //  0004  SETMBR	R0	K3	R5
-      0x4C140000,  //  0005  LDNIL	R5
-      0x90020805,  //  0006  SETMBR	R0	K4	R5
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020A05,  //  0008  SETMBR	R0	K5	R5
-      0x4C140000,  //  0009  LDNIL	R5
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x8C140307,  //  000B  GETMET	R5	R1	K7
-      0x7C140200,  //  000C  CALL	R5	1
-      0x8C140308,  //  000D  GETMET	R5	R1	K8
-      0x501C0200,  //  000E  LDBOOL	R7	1	0
-      0x7C140400,  //  000F  CALL	R5	2
-      0x8C140309,  //  0010  GETMET	R5	R1	K9
-      0x7C140200,  //  0011  CALL	R5	1
-      0x8814010A,  //  0012  GETMBR	R5	R0	K10
-      0x8C140B0B,  //  0013  GETMET	R5	R5	K11
-      0x7C140200,  //  0014  CALL	R5	1
-      0x8C14010C,  //  0015  GETMET	R5	R0	K12
-      0x5C1C0200,  //  0016  MOVE	R7	R1
-      0x7C140400,  //  0017  CALL	R5	2
-      0x80000000,  //  0018  RET	0
+      0x8C100502,  //  0002  GETMET	R4	R2	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x60100013,  //  0004  GETGBL	R4	G19
+      0x7C100000,  //  0005  CALL	R4	0
+      0x60140008,  //  0006  GETGBL	R5	G8
+      0x88180104,  //  0007  GETMBR	R6	R0	K4
+      0x7C140200,  //  0008  CALL	R5	1
+      0x00140B05,  //  0009  ADD	R5	R5	K5
+      0x60180008,  //  000A  GETGBL	R6	G8
+      0x881C0106,  //  000B  GETMBR	R7	R0	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00140A06,  //  000D  ADD	R5	R5	R6
+      0x98120605,  //  000E  SETIDX	R4	K3	R5
+      0x88140108,  //  000F  GETMBR	R5	R0	K8
+      0x98120E05,  //  0010  SETIDX	R4	K7	R5
+      0x9812130A,  //  0011  SETIDX	R4	K9	K10
+      0x9812170C,  //  0012  SETIDX	R4	K11	K12
+      0x54161387,  //  0013  LDINT	R5	5000
+      0x98121A05,  //  0014  SETIDX	R4	K13	R5
+      0x5416012B,  //  0015  LDINT	R5	300
+      0x98121C05,  //  0016  SETIDX	R4	K14	R5
+      0xA802010B,  //  0017  EXBLK	0	#0124
+      0x78060084,  //  0018  JMPF	R1	#009E
+      0xB8161E00,  //  0019  GETNGBL	R5	K15
+      0x8C140B10,  //  001A  GETMET	R5	R5	K16
+      0x7C140200,  //  001B  CALL	R5	1
+      0x8C180712,  //  001C  GETMET	R6	R3	K18
+      0x8C200B13,  //  001D  GETMET	R8	R5	K19
+      0x58280014,  //  001E  LDCONST	R10	K20
+      0x7C200400,  //  001F  CALL	R8	2
+      0x58240015,  //  0020  LDCONST	R9	K21
+      0x58280016,  //  0021  LDCONST	R10	K22
+      0x7C180800,  //  0022  CALL	R6	4
+      0x90022206,  //  0023  SETMBR	R0	K17	R6
+      0x88180117,  //  0024  GETMBR	R6	R0	K23
+      0x741A000F,  //  0025  JMPT	R6	#0036
+      0x8C180518,  //  0026  GETMET	R6	R2	K24
+      0x88200111,  //  0027  GETMBR	R8	R0	K17
+      0x8C240B13,  //  0028  GETMET	R9	R5	K19
+      0x582C0019,  //  0029  LDCONST	R11	K25
+      0x58300016,  //  002A  LDCONST	R12	K22
+      0x7C240600,  //  002B  CALL	R9	3
+      0x8C280B13,  //  002C  GETMET	R10	R5	K19
+      0x5830001A,  //  002D  LDCONST	R12	K26
+      0x58340016,  //  002E  LDCONST	R13	K22
+      0x7C280600,  //  002F  CALL	R10	3
+      0x8C2C0B13,  //  0030  GETMET	R11	R5	K19
+      0x5834001B,  //  0031  LDCONST	R13	K27
+      0x58380016,  //  0032  LDCONST	R14	K22
+      0x7C2C0600,  //  0033  CALL	R11	3
+      0x7C180A00,  //  0034  CALL	R6	5
+      0x70020006,  //  0035  JMP		#003D
+      0x8C180518,  //  0036  GETMET	R6	R2	K24
+      0x88200111,  //  0037  GETMBR	R8	R0	K17
+      0x8C240B13,  //  0038  GETMET	R9	R5	K19
+      0x582C001A,  //  0039  LDCONST	R11	K26
+      0x58300016,  //  003A  LDCONST	R12	K22
+      0x7C240600,  //  003B  CALL	R9	3
+      0x7C180600,  //  003C  CALL	R6	3
+      0x8C18051C,  //  003D  GETMET	R6	R2	K28
+      0x5820001D,  //  003E  LDCONST	R8	K29
+      0x5824001E,  //  003F  LDCONST	R9	K30
+      0x542A15A3,  //  0040  LDINT	R10	5540
+      0x5C2C0800,  //  0041  MOVE	R11	R4
+      0x8830011F,  //  0042  GETMBR	R12	R0	K31
+      0x88340111,  //  0043  GETMBR	R13	R0	K17
+      0x7C180E00,  //  0044  CALL	R6	7
+      0xB81A1E00,  //  0045  GETNGBL	R6	K15
+      0x8C180D20,  //  0046  GETMET	R6	R6	K32
+      0x8C200721,  //  0047  GETMET	R8	R3	K33
+      0x58280022,  //  0048  LDCONST	R10	K34
+      0x78060001,  //  0049  JMPF	R1	#004C
+      0x582C0010,  //  004A  LDCONST	R11	K16
+      0x70020000,  //  004B  JMP		#004D
+      0x582C0023,  //  004C  LDCONST	R11	K35
+      0x78060001,  //  004D  JMPF	R1	#0050
+      0x8830011F,  //  004E  GETMBR	R12	R0	K31
+      0x70020000,  //  004F  JMP		#0051
+      0x88300124,  //  0050  GETMBR	R12	R0	K36
+      0x78060001,  //  0051  JMPF	R1	#0054
+      0x88340111,  //  0052  GETMBR	R13	R0	K17
+      0x70020000,  //  0053  JMP		#0055
+      0x88340125,  //  0054  GETMBR	R13	R0	K37
+      0x7C200A00,  //  0055  CALL	R8	5
+      0x58240026,  //  0056  LDCONST	R9	K38
+      0x7C180600,  //  0057  CALL	R6	3
+      0x60180008,  //  0058  GETGBL	R6	G8
+      0x881C0108,  //  0059  GETMBR	R7	R0	K8
+      0x54220FFE,  //  005A  LDINT	R8	4095
+      0x2C1C0E08,  //  005B  AND	R7	R7	R8
+      0x7C180200,  //  005C  CALL	R6	1
+      0x001A4E06,  //  005D  ADD	R6	K39	R6
+      0xB81E1E00,  //  005E  GETNGBL	R7	K15
+      0x8C1C0F20,  //  005F  GETMET	R7	R7	K32
+      0x00265006,  //  0060  ADD	R9	K40	R6
+      0x58280029,  //  0061  LDCONST	R10	K41
+      0x7C1C0600,  //  0062  CALL	R7	3
+      0x8C1C052A,  //  0063  GETMET	R7	R2	K42
+      0x5824001D,  //  0064  LDCONST	R9	K29
+      0x5828001E,  //  0065  LDCONST	R10	K30
+      0x882C011F,  //  0066  GETMBR	R11	R0	K31
+      0x88300111,  //  0067  GETMBR	R12	R0	K17
+      0x5C340C00,  //  0068  MOVE	R13	R6
+      0x7C1C0C00,  //  0069  CALL	R7	6
+      0x601C0008,  //  006A  GETGBL	R7	G8
+      0x88200108,  //  006B  GETMBR	R8	R0	K8
+      0x54260EFF,  //  006C  LDINT	R9	3840
+      0x2C201009,  //  006D  AND	R8	R8	R9
+      0x54260007,  //  006E  LDINT	R9	8
+      0x3C201009,  //  006F  SHR	R8	R8	R9
+      0x7C1C0200,  //  0070  CALL	R7	1
+      0x001E5607,  //  0071  ADD	R7	K43	R7
+      0x5C180E00,  //  0072  MOVE	R6	R7
+      0xB81E1E00,  //  0073  GETNGBL	R7	K15
+      0x8C1C0F20,  //  0074  GETMET	R7	R7	K32
+      0x00265006,  //  0075  ADD	R9	K40	R6
+      0x58280029,  //  0076  LDCONST	R10	K41
+      0x7C1C0600,  //  0077  CALL	R7	3
+      0x8C1C052A,  //  0078  GETMET	R7	R2	K42
+      0x5824001D,  //  0079  LDCONST	R9	K29
+      0x5828001E,  //  007A  LDCONST	R10	K30
+      0x882C011F,  //  007B  GETMBR	R11	R0	K31
+      0x88300111,  //  007C  GETMBR	R12	R0	K17
+      0x5C340C00,  //  007D  MOVE	R13	R6
+      0x7C1C0C00,  //  007E  CALL	R7	6
+      0x601C0008,  //  007F  GETGBL	R7	G8
+      0x88200104,  //  0080  GETMBR	R8	R0	K4
+      0x7C1C0200,  //  0081  CALL	R7	1
+      0x001E5807,  //  0082  ADD	R7	K44	R7
+      0x5C180E00,  //  0083  MOVE	R6	R7
+      0xB81E1E00,  //  0084  GETNGBL	R7	K15
+      0x8C1C0F20,  //  0085  GETMET	R7	R7	K32
+      0x00265006,  //  0086  ADD	R9	K40	R6
+      0x58280029,  //  0087  LDCONST	R10	K41
+      0x7C1C0600,  //  0088  CALL	R7	3
+      0x8C1C052A,  //  0089  GETMET	R7	R2	K42
+      0x5824001D,  //  008A  LDCONST	R9	K29
+      0x5828001E,  //  008B  LDCONST	R10	K30
+      0x882C011F,  //  008C  GETMBR	R11	R0	K31
+      0x88300111,  //  008D  GETMBR	R12	R0	K17
+      0x5C340C00,  //  008E  MOVE	R13	R6
+      0x7C1C0C00,  //  008F  CALL	R7	6
+      0x5818002D,  //  0090  LDCONST	R6	K45
+      0xB81E1E00,  //  0091  GETNGBL	R7	K15
+      0x8C1C0F20,  //  0092  GETMET	R7	R7	K32
+      0x00265006,  //  0093  ADD	R9	K40	R6
+      0x58280029,  //  0094  LDCONST	R10	K41
+      0x7C1C0600,  //  0095  CALL	R7	3
+      0x8C1C052A,  //  0096  GETMET	R7	R2	K42
+      0x5824001D,  //  0097  LDCONST	R9	K29
+      0x5828001E,  //  0098  LDCONST	R10	K30
+      0x882C011F,  //  0099  GETMBR	R11	R0	K31
+      0x88300111,  //  009A  GETMBR	R12	R0	K17
+      0x5C340C00,  //  009B  MOVE	R13	R6
+      0x7C1C0C00,  //  009C  CALL	R7	6
+      0x70020083,  //  009D  JMP		#0122
+      0xB8161E00,  //  009E  GETNGBL	R5	K15
+      0x8C140B23,  //  009F  GETMET	R5	R5	K35
+      0x7C140200,  //  00A0  CALL	R5	1
+      0x8C180712,  //  00A1  GETMET	R6	R3	K18
+      0x8C200B13,  //  00A2  GETMET	R8	R5	K19
+      0x58280014,  //  00A3  LDCONST	R10	K20
+      0x7C200400,  //  00A4  CALL	R8	2
+      0x58240015,  //  00A5  LDCONST	R9	K21
+      0x58280016,  //  00A6  LDCONST	R10	K22
+      0x7C180800,  //  00A7  CALL	R6	4
+      0x90024A06,  //  00A8  SETMBR	R0	K37	R6
+      0x88180117,  //  00A9  GETMBR	R6	R0	K23
+      0x741A000F,  //  00AA  JMPT	R6	#00BB
+      0x8C180518,  //  00AB  GETMET	R6	R2	K24
+      0x88200125,  //  00AC  GETMBR	R8	R0	K37
+      0x8C240B13,  //  00AD  GETMET	R9	R5	K19
+      0x582C0019,  //  00AE  LDCONST	R11	K25
+      0x58300016,  //  00AF  LDCONST	R12	K22
+      0x7C240600,  //  00B0  CALL	R9	3
+      0x8C280B13,  //  00B1  GETMET	R10	R5	K19
+      0x5830001A,  //  00B2  LDCONST	R12	K26
+      0x58340016,  //  00B3  LDCONST	R13	K22
+      0x7C280600,  //  00B4  CALL	R10	3
+      0x8C2C0B13,  //  00B5  GETMET	R11	R5	K19
+      0x5834001B,  //  00B6  LDCONST	R13	K27
+      0x58380016,  //  00B7  LDCONST	R14	K22
+      0x7C2C0600,  //  00B8  CALL	R11	3
+      0x7C180A00,  //  00B9  CALL	R6	5
+      0x70020006,  //  00BA  JMP		#00C2
+      0x8C180518,  //  00BB  GETMET	R6	R2	K24
+      0x88200125,  //  00BC  GETMBR	R8	R0	K37
+      0x8C240B13,  //  00BD  GETMET	R9	R5	K19
+      0x582C001A,  //  00BE  LDCONST	R11	K26
+      0x58300016,  //  00BF  LDCONST	R12	K22
+      0x7C240600,  //  00C0  CALL	R9	3
+      0x7C180600,  //  00C1  CALL	R6	3
+      0x8C18051C,  //  00C2  GETMET	R6	R2	K28
+      0x5820001D,  //  00C3  LDCONST	R8	K29
+      0x5824001E,  //  00C4  LDCONST	R9	K30
+      0x542A15A3,  //  00C5  LDINT	R10	5540
+      0x5C2C0800,  //  00C6  MOVE	R11	R4
+      0x88300124,  //  00C7  GETMBR	R12	R0	K36
+      0x88340125,  //  00C8  GETMBR	R13	R0	K37
+      0x7C180E00,  //  00C9  CALL	R6	7
+      0xB81A1E00,  //  00CA  GETNGBL	R6	K15
+      0x8C180D20,  //  00CB  GETMET	R6	R6	K32
+      0x8C200721,  //  00CC  GETMET	R8	R3	K33
+      0x58280022,  //  00CD  LDCONST	R10	K34
+      0x78060001,  //  00CE  JMPF	R1	#00D1
+      0x582C0010,  //  00CF  LDCONST	R11	K16
+      0x70020000,  //  00D0  JMP		#00D2
+      0x582C0023,  //  00D1  LDCONST	R11	K35
+      0x78060001,  //  00D2  JMPF	R1	#00D5
+      0x8830011F,  //  00D3  GETMBR	R12	R0	K31
+      0x70020000,  //  00D4  JMP		#00D6
+      0x88300124,  //  00D5  GETMBR	R12	R0	K36
+      0x78060001,  //  00D6  JMPF	R1	#00D9
+      0x88340111,  //  00D7  GETMBR	R13	R0	K17
+      0x70020000,  //  00D8  JMP		#00DA
+      0x88340125,  //  00D9  GETMBR	R13	R0	K37
+      0x7C200A00,  //  00DA  CALL	R8	5
+      0x58240026,  //  00DB  LDCONST	R9	K38
+      0x7C180600,  //  00DC  CALL	R6	3
+      0x60180008,  //  00DD  GETGBL	R6	G8
+      0x881C0108,  //  00DE  GETMBR	R7	R0	K8
+      0x54220FFE,  //  00DF  LDINT	R8	4095
+      0x2C1C0E08,  //  00E0  AND	R7	R7	R8
+      0x7C180200,  //  00E1  CALL	R6	1
+      0x001A4E06,  //  00E2  ADD	R6	K39	R6
+      0xB81E1E00,  //  00E3  GETNGBL	R7	K15
+      0x8C1C0F20,  //  00E4  GETMET	R7	R7	K32
+      0x00265006,  //  00E5  ADD	R9	K40	R6
+      0x58280029,  //  00E6  LDCONST	R10	K41
+      0x7C1C0600,  //  00E7  CALL	R7	3
+      0x8C1C052A,  //  00E8  GETMET	R7	R2	K42
+      0x5824001D,  //  00E9  LDCONST	R9	K29
+      0x5828001E,  //  00EA  LDCONST	R10	K30
+      0x882C0124,  //  00EB  GETMBR	R11	R0	K36
+      0x88300125,  //  00EC  GETMBR	R12	R0	K37
+      0x5C340C00,  //  00ED  MOVE	R13	R6
+      0x7C1C0C00,  //  00EE  CALL	R7	6
+      0x601C0008,  //  00EF  GETGBL	R7	G8
+      0x88200108,  //  00F0  GETMBR	R8	R0	K8
+      0x54260EFF,  //  00F1  LDINT	R9	3840
+      0x2C201009,  //  00F2  AND	R8	R8	R9
+      0x54260007,  //  00F3  LDINT	R9	8
+      0x3C201009,  //  00F4  SHR	R8	R8	R9
+      0x7C1C0200,  //  00F5  CALL	R7	1
+      0x001E5607,  //  00F6  ADD	R7	K43	R7
+      0x5C180E00,  //  00F7  MOVE	R6	R7
+      0xB81E1E00,  //  00F8  GETNGBL	R7	K15
+      0x8C1C0F20,  //  00F9  GETMET	R7	R7	K32
+      0x00265006,  //  00FA  ADD	R9	K40	R6
+      0x58280029,  //  00FB  LDCONST	R10	K41
+      0x7C1C0600,  //  00FC  CALL	R7	3
+      0x8C1C052A,  //  00FD  GETMET	R7	R2	K42
+      0x5824001D,  //  00FE  LDCONST	R9	K29
+      0x5828001E,  //  00FF  LDCONST	R10	K30
+      0x882C0124,  //  0100  GETMBR	R11	R0	K36
+      0x88300125,  //  0101  GETMBR	R12	R0	K37
+      0x5C340C00,  //  0102  MOVE	R13	R6
+      0x7C1C0C00,  //  0103  CALL	R7	6
+      0x601C0008,  //  0104  GETGBL	R7	G8
+      0x88200104,  //  0105  GETMBR	R8	R0	K4
+      0x7C1C0200,  //  0106  CALL	R7	1
+      0x001E5807,  //  0107  ADD	R7	K44	R7
+      0x5C180E00,  //  0108  MOVE	R6	R7
+      0xB81E1E00,  //  0109  GETNGBL	R7	K15
+      0x8C1C0F20,  //  010A  GETMET	R7	R7	K32
+      0x00265006,  //  010B  ADD	R9	K40	R6
+      0x58280029,  //  010C  LDCONST	R10	K41
+      0x7C1C0600,  //  010D  CALL	R7	3
+      0x8C1C052A,  //  010E  GETMET	R7	R2	K42
+      0x5824001D,  //  010F  LDCONST	R9	K29
+      0x5828001E,  //  0110  LDCONST	R10	K30
+      0x882C0124,  //  0111  GETMBR	R11	R0	K36
+      0x88300125,  //  0112  GETMBR	R12	R0	K37
+      0x5C340C00,  //  0113  MOVE	R13	R6
+      0x7C1C0C00,  //  0114  CALL	R7	6
+      0x5818002D,  //  0115  LDCONST	R6	K45
+      0xB81E1E00,  //  0116  GETNGBL	R7	K15
+      0x8C1C0F20,  //  0117  GETMET	R7	R7	K32
+      0x00265006,  //  0118  ADD	R9	K40	R6
+      0x58280029,  //  0119  LDCONST	R10	K41
+      0x7C1C0600,  //  011A  CALL	R7	3
+      0x8C1C052A,  //  011B  GETMET	R7	R2	K42
+      0x5824001D,  //  011C  LDCONST	R9	K29
+      0x5828001E,  //  011D  LDCONST	R10	K30
+      0x882C0124,  //  011E  GETMBR	R11	R0	K36
+      0x88300125,  //  011F  GETMBR	R12	R0	K37
+      0x5C340C00,  //  0120  MOVE	R13	R6
+      0x7C1C0C00,  //  0121  CALL	R7	6
+      0xA8040001,  //  0122  EXBLK	1	1
+      0x70020010,  //  0123  JMP		#0135
+      0xAC140002,  //  0124  CATCH	R5	0	2
+      0x7002000D,  //  0125  JMP		#0134
+      0xB81E1E00,  //  0126  GETNGBL	R7	K15
+      0x8C1C0F20,  //  0127  GETMET	R7	R7	K32
+      0x60240008,  //  0128  GETGBL	R9	G8
+      0x5C280A00,  //  0129  MOVE	R10	R5
+      0x7C240200,  //  012A  CALL	R9	1
+      0x00265C09,  //  012B  ADD	R9	K46	R9
+      0x0024132F,  //  012C  ADD	R9	R9	K47
+      0x60280008,  //  012D  GETGBL	R10	G8
+      0x5C2C0C00,  //  012E  MOVE	R11	R6
+      0x7C280200,  //  012F  CALL	R10	1
+      0x0024120A,  //  0130  ADD	R9	R9	R10
+      0x58280026,  //  0131  LDCONST	R10	K38
+      0x7C1C0600,  //  0132  CALL	R7	3
+      0x70020000,  //  0133  JMP		#0135
+      0xB0080000,  //  0134  RAISE	2	R0	R0
+      0x8C140130,  //  0135  GETMET	R5	R0	K48
+      0x7C140200,  //  0136  CALL	R5	1
+      0x80000000,  //  0137  RET	0
     })
   )
 );
@@ -202,7 +682,7 @@ be_local_closure(Matter_Device_init,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[39]) {     /* constants */
+    ( &(const bvalue[40]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -217,35 +697,36 @@ be_local_closure(Matter_Device_init,   /* name */
     /* K11  */  be_nested_str_weak(PRODUCT_ID),
     /* K12  */  be_nested_str_weak(iterations),
     /* K13  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K14  */  be_nested_str_weak(load_param),
-    /* K15  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K16  */  be_nested_str_weak(random),
-    /* K17  */  be_nested_str_weak(tohex),
-    /* K18  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K19  */  be_nested_str_weak(sessions),
-    /* K20  */  be_nested_str_weak(Session_Store),
-    /* K21  */  be_nested_str_weak(load),
-    /* K22  */  be_nested_str_weak(message_handler),
-    /* K23  */  be_nested_str_weak(MessageHandler),
-    /* K24  */  be_nested_str_weak(ui),
-    /* K25  */  be_nested_str_weak(push),
-    /* K26  */  be_nested_str_weak(Plugin_Root),
-    /* K27  */  be_nested_str_weak(Plugin_OnOff),
-    /* K28  */  be_nested_str_weak(start_mdns_announce_hostnames),
-    /* K29  */  be_nested_str_weak(wifi),
-    /* K30  */  be_nested_str_weak(up),
-    /* K31  */  be_nested_str_weak(start_udp),
-    /* K32  */  be_nested_str_weak(UDP_PORT),
-    /* K33  */  be_nested_str_weak(add_rule),
-    /* K34  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K35  */  be_nested_str_weak(eth),
-    /* K36  */  be_nested_str_weak(Eth_X23Connected),
-    /* K37  */  be_nested_str_weak(start_basic_commissioning),
-    /* K38  */  be_nested_str_weak(add_driver),
+    /* K14  */  be_nested_str_weak(ipv4only),
+    /* K15  */  be_nested_str_weak(load_param),
+    /* K16  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K17  */  be_nested_str_weak(random),
+    /* K18  */  be_nested_str_weak(tohex),
+    /* K19  */  be_nested_str_weak(commissioning_instance_eth),
+    /* K20  */  be_nested_str_weak(sessions),
+    /* K21  */  be_nested_str_weak(Session_Store),
+    /* K22  */  be_nested_str_weak(load),
+    /* K23  */  be_nested_str_weak(message_handler),
+    /* K24  */  be_nested_str_weak(MessageHandler),
+    /* K25  */  be_nested_str_weak(ui),
+    /* K26  */  be_nested_str_weak(push),
+    /* K27  */  be_nested_str_weak(Plugin_Root),
+    /* K28  */  be_nested_str_weak(Plugin_OnOff),
+    /* K29  */  be_nested_str_weak(start_mdns_announce_hostnames),
+    /* K30  */  be_nested_str_weak(wifi),
+    /* K31  */  be_nested_str_weak(up),
+    /* K32  */  be_nested_str_weak(start_udp),
+    /* K33  */  be_nested_str_weak(UDP_PORT),
+    /* K34  */  be_nested_str_weak(add_rule),
+    /* K35  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K36  */  be_nested_str_weak(eth),
+    /* K37  */  be_nested_str_weak(Eth_X23Connected),
+    /* K38  */  be_nested_str_weak(start_basic_commissioning),
+    /* K39  */  be_nested_str_weak(add_driver),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[107]) {  /* code */
+    ( &(const binstruction[109]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0xB80E0400,  //  0002  GETNGBL	R3	K2
@@ -268,91 +749,407 @@ be_local_closure(Matter_Device_init,   /* name */
       0x90021403,  //  0013  SETMBR	R0	K10	R3
       0x880C010D,  //  0014  GETMBR	R3	R0	K13
       0x90021803,  //  0015  SETMBR	R0	K12	R3
-      0x8C0C010E,  //  0016  GETMET	R3	R0	K14
-      0x7C0C0200,  //  0017  CALL	R3	1
-      0x8C0C0310,  //  0018  GETMET	R3	R1	K16
-      0x54160007,  //  0019  LDINT	R5	8
-      0x7C0C0400,  //  001A  CALL	R3	2
-      0x8C0C0711,  //  001B  GETMET	R3	R3	K17
-      0x7C0C0200,  //  001C  CALL	R3	1
-      0x90021E03,  //  001D  SETMBR	R0	K15	R3
-      0x8C0C0310,  //  001E  GETMET	R3	R1	K16
-      0x54160007,  //  001F  LDINT	R5	8
-      0x7C0C0400,  //  0020  CALL	R3	2
-      0x8C0C0711,  //  0021  GETMET	R3	R3	K17
-      0x7C0C0200,  //  0022  CALL	R3	1
-      0x90022403,  //  0023  SETMBR	R0	K18	R3
-      0xB80E0800,  //  0024  GETNGBL	R3	K4
-      0x8C0C0714,  //  0025  GETMET	R3	R3	K20
-      0x7C0C0200,  //  0026  CALL	R3	1
-      0x90022603,  //  0027  SETMBR	R0	K19	R3
-      0x880C0113,  //  0028  GETMBR	R3	R0	K19
-      0x8C0C0715,  //  0029  GETMET	R3	R3	K21
-      0x7C0C0200,  //  002A  CALL	R3	1
-      0xB80E0800,  //  002B  GETNGBL	R3	K4
-      0x8C0C0717,  //  002C  GETMET	R3	R3	K23
-      0x5C140000,  //  002D  MOVE	R5	R0
-      0x7C0C0400,  //  002E  CALL	R3	2
-      0x90022C03,  //  002F  SETMBR	R0	K22	R3
-      0xB80E0800,  //  0030  GETNGBL	R3	K4
-      0x8C0C0706,  //  0031  GETMET	R3	R3	K6
-      0x5C140000,  //  0032  MOVE	R5	R0
-      0x7C0C0400,  //  0033  CALL	R3	2
-      0x90023003,  //  0034  SETMBR	R0	K24	R3
-      0x880C0107,  //  0035  GETMBR	R3	R0	K7
-      0x8C0C0719,  //  0036  GETMET	R3	R3	K25
-      0xB8160800,  //  0037  GETNGBL	R5	K4
-      0x8C140B1A,  //  0038  GETMET	R5	R5	K26
-      0x5C1C0000,  //  0039  MOVE	R7	R0
-      0x7C140400,  //  003A  CALL	R5	2
-      0x7C0C0400,  //  003B  CALL	R3	2
-      0x880C0107,  //  003C  GETMBR	R3	R0	K7
-      0x8C0C0719,  //  003D  GETMET	R3	R3	K25
-      0xB8160800,  //  003E  GETNGBL	R5	K4
-      0x8C140B1B,  //  003F  GETMET	R5	R5	K27
-      0x5C1C0000,  //  0040  MOVE	R7	R0
-      0x7C140400,  //  0041  CALL	R5	2
-      0x7C0C0400,  //  0042  CALL	R3	2
-      0x8C0C011C,  //  0043  GETMET	R3	R0	K28
-      0x7C0C0200,  //  0044  CALL	R3	1
-      0xB80E0400,  //  0045  GETNGBL	R3	K2
-      0x8C0C071D,  //  0046  GETMET	R3	R3	K29
-      0x7C0C0200,  //  0047  CALL	R3	1
-      0x940C071E,  //  0048  GETIDX	R3	R3	K30
-      0x780E0003,  //  0049  JMPF	R3	#004E
-      0x8C0C011F,  //  004A  GETMET	R3	R0	K31
-      0x88140120,  //  004B  GETMBR	R5	R0	K32
-      0x7C0C0400,  //  004C  CALL	R3	2
-      0x70020005,  //  004D  JMP		#0054
-      0xB80E0400,  //  004E  GETNGBL	R3	K2
-      0x8C0C0721,  //  004F  GETMET	R3	R3	K33
-      0x58140022,  //  0050  LDCONST	R5	K34
-      0x84180000,  //  0051  CLOSURE	R6	P0
-      0x5C1C0000,  //  0052  MOVE	R7	R0
-      0x7C0C0800,  //  0053  CALL	R3	4
-      0xB80E0400,  //  0054  GETNGBL	R3	K2
-      0x8C0C0723,  //  0055  GETMET	R3	R3	K35
-      0x7C0C0200,  //  0056  CALL	R3	1
-      0x940C071E,  //  0057  GETIDX	R3	R3	K30
-      0x780E0003,  //  0058  JMPF	R3	#005D
-      0x8C0C011F,  //  0059  GETMET	R3	R0	K31
-      0x88140120,  //  005A  GETMBR	R5	R0	K32
-      0x7C0C0400,  //  005B  CALL	R3	2
-      0x70020005,  //  005C  JMP		#0063
-      0xB80E0400,  //  005D  GETNGBL	R3	K2
-      0x8C0C0721,  //  005E  GETMET	R3	R3	K33
-      0x58140024,  //  005F  LDCONST	R5	K36
-      0x84180001,  //  0060  CLOSURE	R6	P1
-      0x5C1C0000,  //  0061  MOVE	R7	R0
-      0x7C0C0800,  //  0062  CALL	R3	4
-      0x8C0C0125,  //  0063  GETMET	R3	R0	K37
-      0x7C0C0200,  //  0064  CALL	R3	1
-      0xB80E0400,  //  0065  GETNGBL	R3	K2
-      0x8C0C0726,  //  0066  GETMET	R3	R3	K38
-      0x5C140000,  //  0067  MOVE	R5	R0
-      0x7C0C0400,  //  0068  CALL	R3	2
-      0xA0000000,  //  0069  CLOSE	R0
-      0x80000000,  //  006A  RET	0
+      0x500C0000,  //  0016  LDBOOL	R3	0	0
+      0x90021C03,  //  0017  SETMBR	R0	K14	R3
+      0x8C0C010F,  //  0018  GETMET	R3	R0	K15
+      0x7C0C0200,  //  0019  CALL	R3	1
+      0x8C0C0311,  //  001A  GETMET	R3	R1	K17
+      0x54160007,  //  001B  LDINT	R5	8
+      0x7C0C0400,  //  001C  CALL	R3	2
+      0x8C0C0712,  //  001D  GETMET	R3	R3	K18
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x90022003,  //  001F  SETMBR	R0	K16	R3
+      0x8C0C0311,  //  0020  GETMET	R3	R1	K17
+      0x54160007,  //  0021  LDINT	R5	8
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x8C0C0712,  //  0023  GETMET	R3	R3	K18
+      0x7C0C0200,  //  0024  CALL	R3	1
+      0x90022603,  //  0025  SETMBR	R0	K19	R3
+      0xB80E0800,  //  0026  GETNGBL	R3	K4
+      0x8C0C0715,  //  0027  GETMET	R3	R3	K21
+      0x7C0C0200,  //  0028  CALL	R3	1
+      0x90022803,  //  0029  SETMBR	R0	K20	R3
+      0x880C0114,  //  002A  GETMBR	R3	R0	K20
+      0x8C0C0716,  //  002B  GETMET	R3	R3	K22
+      0x7C0C0200,  //  002C  CALL	R3	1
+      0xB80E0800,  //  002D  GETNGBL	R3	K4
+      0x8C0C0718,  //  002E  GETMET	R3	R3	K24
+      0x5C140000,  //  002F  MOVE	R5	R0
+      0x7C0C0400,  //  0030  CALL	R3	2
+      0x90022E03,  //  0031  SETMBR	R0	K23	R3
+      0xB80E0800,  //  0032  GETNGBL	R3	K4
+      0x8C0C0706,  //  0033  GETMET	R3	R3	K6
+      0x5C140000,  //  0034  MOVE	R5	R0
+      0x7C0C0400,  //  0035  CALL	R3	2
+      0x90023203,  //  0036  SETMBR	R0	K25	R3
+      0x880C0107,  //  0037  GETMBR	R3	R0	K7
+      0x8C0C071A,  //  0038  GETMET	R3	R3	K26
+      0xB8160800,  //  0039  GETNGBL	R5	K4
+      0x8C140B1B,  //  003A  GETMET	R5	R5	K27
+      0x5C1C0000,  //  003B  MOVE	R7	R0
+      0x7C140400,  //  003C  CALL	R5	2
+      0x7C0C0400,  //  003D  CALL	R3	2
+      0x880C0107,  //  003E  GETMBR	R3	R0	K7
+      0x8C0C071A,  //  003F  GETMET	R3	R3	K26
+      0xB8160800,  //  0040  GETNGBL	R5	K4
+      0x8C140B1C,  //  0041  GETMET	R5	R5	K28
+      0x5C1C0000,  //  0042  MOVE	R7	R0
+      0x7C140400,  //  0043  CALL	R5	2
+      0x7C0C0400,  //  0044  CALL	R3	2
+      0x8C0C011D,  //  0045  GETMET	R3	R0	K29
+      0x7C0C0200,  //  0046  CALL	R3	1
+      0xB80E0400,  //  0047  GETNGBL	R3	K2
+      0x8C0C071E,  //  0048  GETMET	R3	R3	K30
+      0x7C0C0200,  //  0049  CALL	R3	1
+      0x940C071F,  //  004A  GETIDX	R3	R3	K31
+      0x780E0003,  //  004B  JMPF	R3	#0050
+      0x8C0C0120,  //  004C  GETMET	R3	R0	K32
+      0x88140121,  //  004D  GETMBR	R5	R0	K33
+      0x7C0C0400,  //  004E  CALL	R3	2
+      0x70020005,  //  004F  JMP		#0056
+      0xB80E0400,  //  0050  GETNGBL	R3	K2
+      0x8C0C0722,  //  0051  GETMET	R3	R3	K34
+      0x58140023,  //  0052  LDCONST	R5	K35
+      0x84180000,  //  0053  CLOSURE	R6	P0
+      0x5C1C0000,  //  0054  MOVE	R7	R0
+      0x7C0C0800,  //  0055  CALL	R3	4
+      0xB80E0400,  //  0056  GETNGBL	R3	K2
+      0x8C0C0724,  //  0057  GETMET	R3	R3	K36
+      0x7C0C0200,  //  0058  CALL	R3	1
+      0x940C071F,  //  0059  GETIDX	R3	R3	K31
+      0x780E0003,  //  005A  JMPF	R3	#005F
+      0x8C0C0120,  //  005B  GETMET	R3	R0	K32
+      0x88140121,  //  005C  GETMBR	R5	R0	K33
+      0x7C0C0400,  //  005D  CALL	R3	2
+      0x70020005,  //  005E  JMP		#0065
+      0xB80E0400,  //  005F  GETNGBL	R3	K2
+      0x8C0C0722,  //  0060  GETMET	R3	R3	K34
+      0x58140025,  //  0061  LDCONST	R5	K37
+      0x84180001,  //  0062  CLOSURE	R6	P1
+      0x5C1C0000,  //  0063  MOVE	R7	R0
+      0x7C0C0800,  //  0064  CALL	R3	4
+      0x8C0C0126,  //  0065  GETMET	R3	R0	K38
+      0x7C0C0200,  //  0066  CALL	R3	1
+      0xB80E0400,  //  0067  GETNGBL	R3	K2
+      0x8C0C0727,  //  0068  GETMET	R3	R3	K39
+      0x5C140000,  //  0069  MOVE	R5	R0
+      0x7C0C0400,  //  006A  CALL	R3	2
+      0xA0000000,  //  006B  CLOSE	R0
+      0x80000000,  //  006C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: finish_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_finish_commissioning,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(finish_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_param
+********************************************************************/
+be_local_closure(Matter_Device_save_param,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(dump),
+    /* K2   */  be_nested_str_weak(distinguish),
+    /* K3   */  be_nested_str_weak(discriminator),
+    /* K4   */  be_nested_str_weak(passcode),
+    /* K5   */  be_nested_str_weak(ipv4only),
+    /* K6   */  be_nested_str_weak(string),
+    /* K7   */  be_nested_str_weak(FILENAME),
+    /* K8   */  be_nested_str_weak(w),
+    /* K9   */  be_nested_str_weak(write),
+    /* K10  */  be_nested_str_weak(close),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K14  */  be_nested_str_weak(_X7C),
+    /* K15  */  be_const_int(2),
+    }),
+    be_str_weak(save_param),
+    &be_const_str_solidified,
+    ( &(const binstruction[45]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x60100013,  //  0002  GETGBL	R4	G19
+      0x7C100000,  //  0003  CALL	R4	0
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x98120405,  //  0005  SETIDX	R4	K2	R5
+      0x88140104,  //  0006  GETMBR	R5	R0	K4
+      0x98120805,  //  0007  SETIDX	R4	K4	R5
+      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x98120A05,  //  0009  SETIDX	R4	K5	R5
+      0x7C080400,  //  000A  CALL	R2	2
+      0xA802000D,  //  000B  EXBLK	0	#001A
+      0xA40E0C00,  //  000C  IMPORT	R3	K6
+      0x60100011,  //  000D  GETGBL	R4	G17
+      0x88140107,  //  000E  GETMBR	R5	R0	K7
+      0x58180008,  //  000F  LDCONST	R6	K8
+      0x7C100400,  //  0010  CALL	R4	2
+      0x8C140909,  //  0011  GETMET	R5	R4	K9
+      0x5C1C0400,  //  0012  MOVE	R7	R2
+      0x7C140400,  //  0013  CALL	R5	2
+      0x8C14090A,  //  0014  GETMET	R5	R4	K10
+      0x7C140200,  //  0015  CALL	R5	1
+      0xA8040001,  //  0016  EXBLK	1	1
+      0x80040400,  //  0017  RET	1	R2
+      0xA8040001,  //  0018  EXBLK	1	1
+      0x70020011,  //  0019  JMP		#002C
+      0xAC0C0002,  //  001A  CATCH	R3	0	2
+      0x7002000E,  //  001B  JMP		#002B
+      0xB8161600,  //  001C  GETNGBL	R5	K11
+      0x8C140B0C,  //  001D  GETMET	R5	R5	K12
+      0x601C0008,  //  001E  GETGBL	R7	G8
+      0x5C200600,  //  001F  MOVE	R8	R3
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x001E1A07,  //  0021  ADD	R7	K13	R7
+      0x001C0F0E,  //  0022  ADD	R7	R7	K14
+      0x60200008,  //  0023  GETGBL	R8	G8
+      0x5C240800,  //  0024  MOVE	R9	R4
+      0x7C200200,  //  0025  CALL	R8	1
+      0x001C0E08,  //  0026  ADD	R7	R7	R8
+      0x5820000F,  //  0027  LDCONST	R8	K15
+      0x7C140600,  //  0028  CALL	R5	3
+      0x80040400,  //  0029  RET	1	R2
+      0x70020000,  //  002A  JMP		#002C
+      0xB0080000,  //  002B  RAISE	2	R0	R0
+      0x80000000,  //  002C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_deviceid),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(eth),
+    /* K13  */  be_nested_str_weak(find),
+    /* K14  */  be_nested_str_weak(up),
+    /* K15  */  be_nested_str_weak(format),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matter),
+    /* K21  */  be_nested_str_weak(_tcp),
+    /* K22  */  be_nested_str_weak(_I),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K24  */  be_nested_str_weak(add_subtype),
+    /* K25  */  be_nested_str_weak(wifi),
+    /* K26  */  be_nested_str_weak(hostname_wifi),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K28  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_announce_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[122]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA8020064,  //  0002  EXBLK	0	#0068
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x00261406,  //  0013  ADD	R9	K10	R6
+      0x5828000B,  //  0014  LDCONST	R10	K11
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0xB81E1000,  //  0016  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
+      0x5824000E,  //  001A  LDCONST	R9	K14
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x781E0020,  //  001C  JMPF	R7	#003E
+      0xB81E1000,  //  001D  GETNGBL	R7	K8
+      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
+      0x8C24070F,  //  001F  GETMET	R9	R3	K15
+      0x582C0010,  //  0020  LDCONST	R11	K16
+      0x5830000C,  //  0021  LDCONST	R12	K12
+      0x5C340C00,  //  0022  MOVE	R13	R6
+      0x88380111,  //  0023  GETMBR	R14	R0	K17
+      0x7C240A00,  //  0024  CALL	R9	5
+      0x58280012,  //  0025  LDCONST	R10	K18
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
+      0x58240014,  //  0028  LDCONST	R9	K20
+      0x58280015,  //  0029  LDCONST	R10	K21
+      0x542E15A3,  //  002A  LDINT	R11	5540
+      0x4C300000,  //  002B  LDNIL	R12
+      0x5C340C00,  //  002C  MOVE	R13	R6
+      0x88380111,  //  002D  GETMBR	R14	R0	K17
+      0x7C1C0E00,  //  002E  CALL	R7	7
+      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x001E2C07,  //  0031  ADD	R7	K22	R7
+      0xB8221000,  //  0032  GETNGBL	R8	K8
+      0x8C201109,  //  0033  GETMET	R8	R8	K9
+      0x002A2E07,  //  0034  ADD	R10	K23	R7
+      0x582C0012,  //  0035  LDCONST	R11	K18
+      0x7C200600,  //  0036  CALL	R8	3
+      0x8C200518,  //  0037  GETMET	R8	R2	K24
+      0x58280014,  //  0038  LDCONST	R10	K20
+      0x582C0015,  //  0039  LDCONST	R11	K21
+      0x5C300C00,  //  003A  MOVE	R12	R6
+      0x88340111,  //  003B  GETMBR	R13	R0	K17
+      0x5C380E00,  //  003C  MOVE	R14	R7
+      0x7C200C00,  //  003D  CALL	R8	6
+      0xB81E1000,  //  003E  GETNGBL	R7	K8
+      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
+      0x7C1C0200,  //  0040  CALL	R7	1
+      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
+      0x5824000E,  //  0042  LDCONST	R9	K14
+      0x7C1C0400,  //  0043  CALL	R7	2
+      0x781E0020,  //  0044  JMPF	R7	#0066
+      0xB81E1000,  //  0045  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
+      0x8C24070F,  //  0047  GETMET	R9	R3	K15
+      0x582C0010,  //  0048  LDCONST	R11	K16
+      0x58300019,  //  0049  LDCONST	R12	K25
+      0x5C340C00,  //  004A  MOVE	R13	R6
+      0x8838011A,  //  004B  GETMBR	R14	R0	K26
+      0x7C240A00,  //  004C  CALL	R9	5
+      0x58280012,  //  004D  LDCONST	R10	K18
+      0x7C1C0600,  //  004E  CALL	R7	3
+      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
+      0x58240014,  //  0050  LDCONST	R9	K20
+      0x58280015,  //  0051  LDCONST	R10	K21
+      0x542E15A3,  //  0052  LDINT	R11	5540
+      0x4C300000,  //  0053  LDNIL	R12
+      0x5C340C00,  //  0054  MOVE	R13	R6
+      0x8838011A,  //  0055  GETMBR	R14	R0	K26
+      0x7C1C0E00,  //  0056  CALL	R7	7
+      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0058  CALL	R7	1
+      0x001E2C07,  //  0059  ADD	R7	K22	R7
+      0xB8221000,  //  005A  GETNGBL	R8	K8
+      0x8C201109,  //  005B  GETMET	R8	R8	K9
+      0x002A2E07,  //  005C  ADD	R10	K23	R7
+      0x582C0012,  //  005D  LDCONST	R11	K18
+      0x7C200600,  //  005E  CALL	R8	3
+      0x8C200518,  //  005F  GETMET	R8	R2	K24
+      0x58280014,  //  0060  LDCONST	R10	K20
+      0x582C0015,  //  0061  LDCONST	R11	K21
+      0x5C300C00,  //  0062  MOVE	R12	R6
+      0x8834011A,  //  0063  GETMBR	R13	R0	K26
+      0x5C380E00,  //  0064  MOVE	R14	R7
+      0x7C200C00,  //  0065  CALL	R8	6
+      0xA8040001,  //  0066  EXBLK	1	1
+      0x70020010,  //  0067  JMP		#0079
+      0xAC100002,  //  0068  CATCH	R4	0	2
+      0x7002000D,  //  0069  JMP		#0078
+      0xB81A1000,  //  006A  GETNGBL	R6	K8
+      0x8C180D09,  //  006B  GETMET	R6	R6	K9
+      0x60200008,  //  006C  GETGBL	R8	G8
+      0x5C240800,  //  006D  MOVE	R9	R4
+      0x7C200200,  //  006E  CALL	R8	1
+      0x00223608,  //  006F  ADD	R8	K27	R8
+      0x0020111C,  //  0070  ADD	R8	R8	K28
+      0x60240008,  //  0071  GETGBL	R9	G8
+      0x5C280A00,  //  0072  MOVE	R10	R5
+      0x7C240200,  //  0073  CALL	R9	1
+      0x00201009,  //  0074  ADD	R8	R8	R9
+      0x5824000B,  //  0075  LDCONST	R9	K11
+      0x7C180600,  //  0076  CALL	R6	3
+      0x70020000,  //  0077  JMP		#0079
+      0xB0080000,  //  0078  RAISE	2	R0	R0
+      0x80000000,  //  0079  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(compute_pbkdf),
+    /* K1   */  be_nested_str_weak(passcode),
+    }),
+    be_str_weak(start_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -502,81 +1299,81 @@ be_local_closure(Matter_Device_compute_pbkdf,   /* name */
 
 
 /********************************************************************
-** Solidified function: save_param
+** Solidified function: sort_distinct
 ********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
+be_local_closure(Matter_Device_sort_distinct,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    7,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(dump),
-    /* K2   */  be_nested_str_weak(distinguish),
-    /* K3   */  be_nested_str_weak(discriminator),
-    /* K4   */  be_nested_str_weak(passcode),
-    /* K5   */  be_nested_str_weak(string),
-    /* K6   */  be_nested_str_weak(FILENAME),
-    /* K7   */  be_nested_str_weak(w),
-    /* K8   */  be_nested_str_weak(write),
-    /* K9   */  be_nested_str_weak(close),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K13  */  be_nested_str_weak(_X7C),
-    /* K14  */  be_const_int(2),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Device),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(stop_iteration),
+    /* K4   */  be_nested_str_weak(remove),
     }),
-    be_str_weak(save_param),
+    be_str_weak(sort_distinct),
     &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x60100013,  //  0002  GETGBL	R4	G19
-      0x7C100000,  //  0003  CALL	R4	0
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x98120405,  //  0005  SETIDX	R4	K2	R5
-      0x88140104,  //  0006  GETMBR	R5	R0	K4
-      0x98120805,  //  0007  SETIDX	R4	K4	R5
-      0x7C080400,  //  0008  CALL	R2	2
-      0xA802000D,  //  0009  EXBLK	0	#0018
-      0xA40E0A00,  //  000A  IMPORT	R3	K5
-      0x60100011,  //  000B  GETGBL	R4	G17
-      0x88140106,  //  000C  GETMBR	R5	R0	K6
-      0x58180007,  //  000D  LDCONST	R6	K7
-      0x7C100400,  //  000E  CALL	R4	2
-      0x8C140908,  //  000F  GETMET	R5	R4	K8
-      0x5C1C0400,  //  0010  MOVE	R7	R2
-      0x7C140400,  //  0011  CALL	R5	2
-      0x8C140909,  //  0012  GETMET	R5	R4	K9
-      0x7C140200,  //  0013  CALL	R5	1
-      0xA8040001,  //  0014  EXBLK	1	1
-      0x80040400,  //  0015  RET	1	R2
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x70020011,  //  0017  JMP		#002A
-      0xAC0C0002,  //  0018  CATCH	R3	0	2
-      0x7002000E,  //  0019  JMP		#0029
-      0xB8161400,  //  001A  GETNGBL	R5	K10
-      0x8C140B0B,  //  001B  GETMET	R5	R5	K11
-      0x601C0008,  //  001C  GETGBL	R7	G8
-      0x5C200600,  //  001D  MOVE	R8	R3
-      0x7C1C0200,  //  001E  CALL	R7	1
-      0x001E1807,  //  001F  ADD	R7	K12	R7
-      0x001C0F0D,  //  0020  ADD	R7	R7	K13
-      0x60200008,  //  0021  GETGBL	R8	G8
-      0x5C240800,  //  0022  MOVE	R9	R4
-      0x7C200200,  //  0023  CALL	R8	1
-      0x001C0E08,  //  0024  ADD	R7	R7	R8
-      0x5820000E,  //  0025  LDCONST	R8	K14
-      0x7C140600,  //  0026  CALL	R5	3
-      0x80040400,  //  0027  RET	1	R2
-      0x70020000,  //  0028  JMP		#002A
-      0xB0080000,  //  0029  RAISE	2	R0	R0
-      0x80000000,  //  002A  RET	0
+    ( &(const binstruction[53]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x60080010,  //  0001  GETGBL	R2	G16
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x040C0701,  //  0005  SUB	R3	R3	K1
+      0x400E0203,  //  0006  CONNECT	R3	K1	R3
+      0x7C080200,  //  0007  CALL	R2	1
+      0xA8020010,  //  0008  EXBLK	0	#001A
+      0x5C0C0400,  //  0009  MOVE	R3	R2
+      0x7C0C0000,  //  000A  CALL	R3	0
+      0x94100003,  //  000B  GETIDX	R4	R0	R3
+      0x5C140600,  //  000C  MOVE	R5	R3
+      0x24180B02,  //  000D  GT	R6	R5	K2
+      0x781A0008,  //  000E  JMPF	R6	#0018
+      0x04180B01,  //  000F  SUB	R6	R5	K1
+      0x94180006,  //  0010  GETIDX	R6	R0	R6
+      0x24180C04,  //  0011  GT	R6	R6	R4
+      0x781A0004,  //  0012  JMPF	R6	#0018
+      0x04180B01,  //  0013  SUB	R6	R5	K1
+      0x94180006,  //  0014  GETIDX	R6	R0	R6
+      0x98000A06,  //  0015  SETIDX	R0	R5	R6
+      0x04140B01,  //  0016  SUB	R5	R5	K1
+      0x7001FFF4,  //  0017  JMP		#000D
+      0x98000A04,  //  0018  SETIDX	R0	R5	R4
+      0x7001FFEE,  //  0019  JMP		#0009
+      0x58080003,  //  001A  LDCONST	R2	K3
+      0xAC080200,  //  001B  CATCH	R2	1	0
+      0xB0080000,  //  001C  RAISE	2	R0	R0
+      0x58080001,  //  001D  LDCONST	R2	K1
+      0x600C000C,  //  001E  GETGBL	R3	G12
+      0x5C100000,  //  001F  MOVE	R4	R0
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x180C0701,  //  0021  LE	R3	R3	K1
+      0x780E0000,  //  0022  JMPF	R3	#0024
+      0x80040000,  //  0023  RET	1	R0
+      0x940C0102,  //  0024  GETIDX	R3	R0	K2
+      0x6010000C,  //  0025  GETGBL	R4	G12
+      0x5C140000,  //  0026  MOVE	R5	R0
+      0x7C100200,  //  0027  CALL	R4	1
+      0x14100404,  //  0028  LT	R4	R2	R4
+      0x78120009,  //  0029  JMPF	R4	#0034
+      0x94100002,  //  002A  GETIDX	R4	R0	R2
+      0x1C100803,  //  002B  EQ	R4	R4	R3
+      0x78120003,  //  002C  JMPF	R4	#0031
+      0x8C100104,  //  002D  GETMET	R4	R0	K4
+      0x5C180400,  //  002E  MOVE	R6	R2
+      0x7C100400,  //  002F  CALL	R4	2
+      0x70020001,  //  0030  JMP		#0033
+      0x940C0002,  //  0031  GETIDX	R3	R0	R2
+      0x00080501,  //  0032  ADD	R2	R2	K1
+      0x7001FFF0,  //  0033  JMP		#0025
+      0x80040000,  //  0034  RET	1	R0
     })
   )
 );
@@ -584,9 +1381,140 @@ be_local_closure(Matter_Device_save_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_operational_dicovery_deferred
+** Solidified function: start_mdns_announce_hostnames
 ********************************************************************/
-be_local_closure(Matter_Device_start_operational_dicovery_deferred,   /* name */
+be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_start_mdns_announce),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_device_mdns),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080000,  //  0002  LDBOOL	R2	0	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 5]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_start_mdns_announce),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        /* K4   */  be_nested_str_weak(matter_device_mdns),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[10]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x50080200,  //  0002  LDBOOL	R2	1	0
+          0x7C000400,  //  0003  CALL	R0	2
+          0xB8020200,  //  0004  GETNGBL	R0	K1
+          0x8C000102,  //  0005  GETMET	R0	R0	K2
+          0x58080003,  //  0006  LDCONST	R2	K3
+          0x580C0004,  //  0007  LDCONST	R3	K4
+          0x7C000600,  //  0008  CALL	R0	3
+          0x80000000,  //  0009  RET	0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(wifi),
+    /* K2   */  be_nested_str_weak(up),
+    /* K3   */  be_nested_str_weak(_start_mdns_announce),
+    /* K4   */  be_nested_str_weak(add_rule),
+    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
+    /* K6   */  be_nested_str_weak(eth),
+    /* K7   */  be_nested_str_weak(Eth_X23Connected),
+    }),
+    be_str_weak(start_mdns_announce_hostnames),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040302,  //  0003  GETIDX	R1	R1	K2
+      0x78060003,  //  0004  JMPF	R1	#0009
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x500C0000,  //  0006  LDBOOL	R3	0	0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x70020005,  //  0008  JMP		#000F
+      0xB8060000,  //  0009  GETNGBL	R1	K0
+      0x8C040304,  //  000A  GETMET	R1	R1	K4
+      0x580C0005,  //  000B  LDCONST	R3	K5
+      0x84100000,  //  000C  CLOSURE	R4	P0
+      0x5C140000,  //  000D  MOVE	R5	R0
+      0x7C040800,  //  000E  CALL	R1	4
+      0xB8060000,  //  000F  GETNGBL	R1	K0
+      0x8C040306,  //  0010  GETMET	R1	R1	K6
+      0x7C040200,  //  0011  CALL	R1	1
+      0x94040302,  //  0012  GETIDX	R1	R1	K2
+      0x78060003,  //  0013  JMPF	R1	#0018
+      0x8C040103,  //  0014  GETMET	R1	R0	K3
+      0x500C0200,  //  0015  LDBOOL	R3	1	0
+      0x7C040400,  //  0016  CALL	R1	2
+      0x70020005,  //  0017  JMP		#001E
+      0xB8060000,  //  0018  GETNGBL	R1	K0
+      0x8C040304,  //  0019  GETMET	R1	R1	K4
+      0x580C0007,  //  001A  LDCONST	R3	K7
+      0x84100001,  //  001B  CLOSURE	R4	P1
+      0x5C140000,  //  001C  MOVE	R5	R0
+      0x7C040800,  //  001D  CALL	R1	4
+      0xA0000000,  //  001E  CLOSE	R0
+      0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
@@ -608,7 +1536,7 @@ be_local_closure(Matter_Device_start_operational_dicovery_deferred,   /* name */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
         ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_operational_dicovery),
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
         }),
         be_str_weak(_X3Clambda_X3E),
         &be_const_str_solidified,
@@ -627,7 +1555,7 @@ be_local_closure(Matter_Device_start_operational_dicovery_deferred,   /* name */
     /* K1   */  be_nested_str_weak(set_timer),
     /* K2   */  be_const_int(0),
     }),
-    be_str_weak(start_operational_dicovery_deferred),
+    be_str_weak(start_commissioning_complete_deferred),
     &be_const_str_solidified,
     ( &(const binstruction[ 7]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -644,11 +1572,11 @@ be_local_closure(Matter_Device_start_operational_dicovery_deferred,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_active_endpoints
+** Solidified function: start_operational_dicovery
 ********************************************************************/
-be_local_closure(Matter_Device_get_active_endpoints,   /* name */
+be_local_closure(Matter_Device_start_operational_dicovery,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    8,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -656,325 +1584,49 @@ be_local_closure(Matter_Device_get_active_endpoints,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(plugins),
-    /* K1   */  be_nested_str_weak(get_endpoints),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find),
-    /* K4   */  be_nested_str_weak(push),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(string),
+    /* K3   */  be_nested_str_weak(salt),
+    /* K4   */  be_nested_str_weak(w0),
+    /* K5   */  be_nested_str_weak(w1),
+    /* K6   */  be_nested_str_weak(L),
+    /* K7   */  be_nested_str_weak(set_no_expiration),
+    /* K8   */  be_nested_str_weak(set_persist),
+    /* K9   */  be_nested_str_weak(close),
+    /* K10  */  be_nested_str_weak(sessions),
+    /* K11  */  be_nested_str_weak(save),
+    /* K12  */  be_nested_str_weak(mdns_announce_op_discovery),
     }),
-    be_str_weak(get_active_endpoints),
+    be_str_weak(start_operational_dicovery),
     &be_const_str_solidified,
-    ( &(const binstruction[38]) {  /* code */
-      0x60080012,  //  0000  GETGBL	R2	G18
-      0x7C080000,  //  0001  CALL	R2	0
-      0x600C0010,  //  0002  GETGBL	R3	G16
-      0x88100100,  //  0003  GETMBR	R4	R0	K0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0xA802001B,  //  0005  EXBLK	0	#0022
-      0x5C100600,  //  0006  MOVE	R4	R3
-      0x7C100000,  //  0007  CALL	R4	0
-      0x8C140901,  //  0008  GETMET	R5	R4	K1
-      0x7C140200,  //  0009  CALL	R5	1
-      0x60180010,  //  000A  GETGBL	R6	G16
-      0x5C1C0A00,  //  000B  MOVE	R7	R5
-      0x7C180200,  //  000C  CALL	R6	1
-      0xA802000F,  //  000D  EXBLK	0	#001E
-      0x5C1C0C00,  //  000E  MOVE	R7	R6
-      0x7C1C0000,  //  000F  CALL	R7	0
-      0x78060002,  //  0010  JMPF	R1	#0014
-      0x1C200F02,  //  0011  EQ	R8	R7	K2
-      0x78220000,  //  0012  JMPF	R8	#0014
-      0x7001FFF9,  //  0013  JMP		#000E
-      0x8C200503,  //  0014  GETMET	R8	R2	K3
-      0x5C280E00,  //  0015  MOVE	R10	R7
-      0x7C200400,  //  0016  CALL	R8	2
-      0x4C240000,  //  0017  LDNIL	R9
-      0x1C201009,  //  0018  EQ	R8	R8	R9
-      0x78220002,  //  0019  JMPF	R8	#001D
-      0x8C200504,  //  001A  GETMET	R8	R2	K4
-      0x5C280E00,  //  001B  MOVE	R10	R7
-      0x7C200400,  //  001C  CALL	R8	2
-      0x7001FFEF,  //  001D  JMP		#000E
-      0x58180005,  //  001E  LDCONST	R6	K5
-      0xAC180200,  //  001F  CATCH	R6	1	0
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0x7001FFE3,  //  0021  JMP		#0006
-      0x580C0005,  //  0022  LDCONST	R3	K5
-      0xAC0C0200,  //  0023  CATCH	R3	1	0
-      0xB0080000,  //  0024  RAISE	2	R0	R0
-      0x80040400,  //  0025  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_send
-********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_response),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88140100,  //  0000  GETMBR	R5	R0	K0
-      0x8C140B01,  //  0001  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0002  MOVE	R7	R1
-      0x5C200400,  //  0003  MOVE	R8	R2
-      0x5C240600,  //  0004  MOVE	R9	R3
-      0x5C280800,  //  0005  MOVE	R10	R4
-      0x7C140A00,  //  0006  CALL	R5	5
-      0x80040A00,  //  0007  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: finish_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_finish_commissioning,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(finish_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Device_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(message_handler),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(stop),
-    }),
-    be_str_weak(stop),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060002,  //  0001  JMPF	R1	#0005
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C040301,  //  0003  GETMET	R1	R1	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(compute_pbkdf),
-    /* K1   */  be_nested_str_weak(passcode),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: load_param
-********************************************************************/
-be_local_closure(Matter_Device_load_param,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(FILENAME),
-    /* K3   */  be_nested_str_weak(read),
-    /* K4   */  be_nested_str_weak(close),
-    /* K5   */  be_nested_str_weak(json),
-    /* K6   */  be_nested_str_weak(load),
-    /* K7   */  be_nested_str_weak(discriminator),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(distinguish),
-    /* K10  */  be_nested_str_weak(passcode),
-    /* K11  */  be_nested_str_weak(io_error),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
-    /* K15  */  be_nested_str_weak(_X7C),
-    /* K16  */  be_const_int(2),
-    /* K17  */  be_nested_str_weak(random),
-    /* K18  */  be_nested_str_weak(get),
-    /* K19  */  be_const_int(0),
-    /* K20  */  be_nested_str_weak(PASSCODE_DEFAULT),
-    /* K21  */  be_nested_str_weak(save_param),
-    }),
-    be_str_weak(load_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA8020014,  //  0002  EXBLK	0	#0018
-      0x600C0011,  //  0003  GETGBL	R3	G17
-      0x88100102,  //  0004  GETMBR	R4	R0	K2
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C100703,  //  0006  GETMET	R4	R3	K3
-      0x7C100200,  //  0007  CALL	R4	1
-      0x8C140704,  //  0008  GETMET	R5	R3	K4
-      0x7C140200,  //  0009  CALL	R5	1
-      0xA4160A00,  //  000A  IMPORT	R5	K5
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x5C200800,  //  000C  MOVE	R8	R4
-      0x7C180400,  //  000D  CALL	R6	2
-      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
-      0x58240009,  //  000F  LDCONST	R9	K9
-      0x7C1C0400,  //  0010  CALL	R7	2
-      0x90020E07,  //  0011  SETMBR	R0	K7	R7
-      0x8C1C0D08,  //  0012  GETMET	R7	R6	K8
-      0x5824000A,  //  0013  LDCONST	R9	K10
-      0x7C1C0400,  //  0014  CALL	R7	2
-      0x90021407,  //  0015  SETMBR	R0	K10	R7
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x70020012,  //  0017  JMP		#002B
-      0xAC0C0002,  //  0018  CATCH	R3	0	2
-      0x7002000F,  //  0019  JMP		#002A
-      0x2014070B,  //  001A  NE	R5	R3	K11
-      0x7816000C,  //  001B  JMPF	R5	#0029
-      0xB8161800,  //  001C  GETNGBL	R5	K12
-      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
-      0x601C0008,  //  001E  GETGBL	R7	G8
-      0x5C200600,  //  001F  MOVE	R8	R3
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1C07,  //  0021  ADD	R7	K14	R7
-      0x001C0F0F,  //  0022  ADD	R7	R7	K15
-      0x60200008,  //  0023  GETGBL	R8	G8
-      0x5C240800,  //  0024  MOVE	R9	R4
-      0x7C200200,  //  0025  CALL	R8	1
-      0x001C0E08,  //  0026  ADD	R7	R7	R8
-      0x58200010,  //  0027  LDCONST	R8	K16
-      0x7C140600,  //  0028  CALL	R5	3
-      0x70020000,  //  0029  JMP		#002B
-      0xB0080000,  //  002A  RAISE	2	R0	R0
-      0x500C0000,  //  002B  LDBOOL	R3	0	0
-      0x88100107,  //  002C  GETMBR	R4	R0	K7
-      0x4C140000,  //  002D  LDNIL	R5
-      0x1C100805,  //  002E  EQ	R4	R4	R5
-      0x7812000A,  //  002F  JMPF	R4	#003B
-      0x8C100511,  //  0030  GETMET	R4	R2	K17
-      0x58180010,  //  0031  LDCONST	R6	K16
-      0x7C100400,  //  0032  CALL	R4	2
-      0x8C100912,  //  0033  GETMET	R4	R4	K18
-      0x58180013,  //  0034  LDCONST	R6	K19
-      0x581C0010,  //  0035  LDCONST	R7	K16
-      0x7C100600,  //  0036  CALL	R4	3
-      0x54160FFE,  //  0037  LDINT	R5	4095
-      0x2C100805,  //  0038  AND	R4	R4	R5
-      0x90020E04,  //  0039  SETMBR	R0	K7	R4
-      0x500C0200,  //  003A  LDBOOL	R3	1	0
-      0x8810010A,  //  003B  GETMBR	R4	R0	K10
-      0x4C140000,  //  003C  LDNIL	R5
-      0x1C100805,  //  003D  EQ	R4	R4	R5
-      0x78120002,  //  003E  JMPF	R4	#0042
-      0x88100114,  //  003F  GETMBR	R4	R0	K20
-      0x90021404,  //  0040  SETMBR	R0	K10	R4
-      0x500C0200,  //  0041  LDBOOL	R3	1	0
-      0x780E0001,  //  0042  JMPF	R3	#0045
-      0x8C100115,  //  0043  GETMET	R4	R0	K21
-      0x7C100200,  //  0044  CALL	R4	1
-      0x80000000,  //  0045  RET	0
+    ( &(const binstruction[25]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0x4C140000,  //  0003  LDNIL	R5
+      0x90020605,  //  0004  SETMBR	R0	K3	R5
+      0x4C140000,  //  0005  LDNIL	R5
+      0x90020805,  //  0006  SETMBR	R0	K4	R5
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90020A05,  //  0008  SETMBR	R0	K5	R5
+      0x4C140000,  //  0009  LDNIL	R5
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x8C140307,  //  000B  GETMET	R5	R1	K7
+      0x7C140200,  //  000C  CALL	R5	1
+      0x8C140308,  //  000D  GETMET	R5	R1	K8
+      0x501C0200,  //  000E  LDBOOL	R7	1	0
+      0x7C140400,  //  000F  CALL	R5	2
+      0x8C140309,  //  0010  GETMET	R5	R1	K9
+      0x7C140200,  //  0011  CALL	R5	1
+      0x8814010A,  //  0012  GETMBR	R5	R0	K10
+      0x8C140B0B,  //  0013  GETMET	R5	R5	K11
+      0x7C140200,  //  0014  CALL	R5	1
+      0x8C14010C,  //  0015  GETMET	R5	R0	K12
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x7C140400,  //  0017  CALL	R5	2
+      0x80000000,  //  0018  RET	0
     })
   )
 );
@@ -1394,81 +2046,303 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
-** Solidified function: sort_distinct
+** Solidified function: attribute_updated
 ********************************************************************/
-be_local_closure(Matter_Device_sort_distinct,   /* name */
+be_local_closure(Matter_Device_attribute_updated,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
-    1,                          /* argc */
-    4,                          /* varg */
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Device),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(stop_iteration),
-    /* K4   */  be_nested_str_weak(remove),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
     }),
-    be_str_weak(sort_distinct),
+    be_str_weak(attribute_updated),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x60080010,  //  0001  GETGBL	R2	G16
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x040C0701,  //  0005  SUB	R3	R3	K1
-      0x400E0203,  //  0006  CONNECT	R3	K1	R3
-      0x7C080200,  //  0007  CALL	R2	1
-      0xA8020010,  //  0008  EXBLK	0	#001A
-      0x5C0C0400,  //  0009  MOVE	R3	R2
-      0x7C0C0000,  //  000A  CALL	R3	0
-      0x94100003,  //  000B  GETIDX	R4	R0	R3
-      0x5C140600,  //  000C  MOVE	R5	R3
-      0x24180B02,  //  000D  GT	R6	R5	K2
-      0x781A0008,  //  000E  JMPF	R6	#0018
-      0x04180B01,  //  000F  SUB	R6	R5	K1
-      0x94180006,  //  0010  GETIDX	R6	R0	R6
-      0x24180C04,  //  0011  GT	R6	R6	R4
-      0x781A0004,  //  0012  JMPF	R6	#0018
-      0x04180B01,  //  0013  SUB	R6	R5	K1
-      0x94180006,  //  0014  GETIDX	R6	R0	R6
-      0x98000A06,  //  0015  SETIDX	R0	R5	R6
-      0x04140B01,  //  0016  SUB	R5	R5	K1
-      0x7001FFF4,  //  0017  JMP		#000D
-      0x98000A04,  //  0018  SETIDX	R0	R5	R4
-      0x7001FFEE,  //  0019  JMP		#0009
-      0x58080003,  //  001A  LDCONST	R2	K3
-      0xAC080200,  //  001B  CATCH	R2	1	0
-      0xB0080000,  //  001C  RAISE	2	R0	R0
-      0x58080001,  //  001D  LDCONST	R2	K1
-      0x600C000C,  //  001E  GETGBL	R3	G12
-      0x5C100000,  //  001F  MOVE	R4	R0
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x180C0701,  //  0021  LE	R3	R3	K1
-      0x780E0000,  //  0022  JMPF	R3	#0024
-      0x80040000,  //  0023  RET	1	R0
-      0x940C0102,  //  0024  GETIDX	R3	R0	K2
-      0x6010000C,  //  0025  GETGBL	R4	G12
-      0x5C140000,  //  0026  MOVE	R5	R0
-      0x7C100200,  //  0027  CALL	R4	1
-      0x14100404,  //  0028  LT	R4	R2	R4
-      0x78120009,  //  0029  JMPF	R4	#0034
-      0x94100002,  //  002A  GETIDX	R4	R0	R2
-      0x1C100803,  //  002B  EQ	R4	R4	R3
-      0x78120003,  //  002C  JMPF	R4	#0031
-      0x8C100104,  //  002D  GETMET	R4	R0	K4
-      0x5C180400,  //  002E  MOVE	R6	R2
-      0x7C100400,  //  002F  CALL	R4	2
-      0x70020001,  //  0030  JMP		#0033
-      0x940C0002,  //  0031  GETIDX	R3	R0	R2
-      0x00080501,  //  0032  ADD	R2	R2	K1
-      0x7001FFF0,  //  0033  JMP		#0025
-      0x80040000,  //  0034  RET	1	R0
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Device_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(message_handler),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_Device_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_dicovery_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_dicovery_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_operational_dicovery),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_operational_dicovery_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
+    /* K3   */  be_const_int(2),
+    }),
+    be_str_weak(start_commissioning_complete),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C080600,  //  0004  CALL	R2	3
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_manual_pairing_code
+********************************************************************/
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(discriminator),
+    /* K2   */  be_nested_str_weak(passcode),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Verhoeff),
+    /* K7   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[31]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x540E0FFE,  //  0002  LDINT	R3	4095
+      0x2C080403,  //  0003  AND	R2	R2	R3
+      0x540E0009,  //  0004  LDINT	R3	10
+      0x3C080403,  //  0005  SHR	R2	R2	R3
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x541202FF,  //  0007  LDINT	R4	768
+      0x2C0C0604,  //  0008  AND	R3	R3	R4
+      0x54120005,  //  0009  LDINT	R4	6
+      0x380C0604,  //  000A  SHL	R3	R3	R4
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x54163FFE,  //  000C  LDINT	R5	16383
+      0x2C100805,  //  000D  AND	R4	R4	R5
+      0x300C0604,  //  000E  OR	R3	R3	R4
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x5416000D,  //  0010  LDINT	R5	14
+      0x3C100805,  //  0011  SHR	R4	R4	R5
+      0x8C140303,  //  0012  GETMET	R5	R1	K3
+      0x581C0004,  //  0013  LDCONST	R7	K4
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C140A00,  //  0017  CALL	R5	5
+      0xB81A0A00,  //  0018  GETNGBL	R6	K5
+      0x88180D06,  //  0019  GETMBR	R6	R6	K6
+      0x8C180D07,  //  001A  GETMET	R6	R6	K7
+      0x5C200A00,  //  001B  MOVE	R8	R5
+      0x7C180400,  //  001C  CALL	R6	2
+      0x00140A06,  //  001D  ADD	R5	R5	R6
+      0x80040A00,  //  001E  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop
+********************************************************************/
+be_local_closure(Matter_Device_stop,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(stop),
+    }),
+    be_str_weak(stop),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060002,  //  0001  JMPF	R1	#0005
+      0x88040100,  //  0002  GETMBR	R1	R0	K0
+      0x8C040301,  //  0003  GETMET	R1	R1	K1
+      0x7C040200,  //  0004  CALL	R1	1
+      0x80000000,  //  0005  RET	0
     })
   )
 );
@@ -1552,142 +2426,11 @@ be_local_closure(Matter_Device_compute_qrcode_content,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_mdns_announce_hostnames
+** Solidified function: load_param
 ********************************************************************/
-be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
+be_local_closure(Matter_Device_load_param,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_start_mdns_announce),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_device_mdns),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080000,  //  0002  LDBOOL	R2	0	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 5]) {     /* constants */
-        /* K0   */  be_nested_str_weak(_start_mdns_announce),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        /* K4   */  be_nested_str_weak(matter_device_mdns),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[10]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x50080200,  //  0002  LDBOOL	R2	1	0
-          0x7C000400,  //  0003  CALL	R0	2
-          0xB8020200,  //  0004  GETNGBL	R0	K1
-          0x8C000102,  //  0005  GETMET	R0	R0	K2
-          0x58080003,  //  0006  LDCONST	R2	K3
-          0x580C0004,  //  0007  LDCONST	R3	K4
-          0x7C000600,  //  0008  CALL	R0	3
-          0x80000000,  //  0009  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(wifi),
-    /* K2   */  be_nested_str_weak(up),
-    /* K3   */  be_nested_str_weak(_start_mdns_announce),
-    /* K4   */  be_nested_str_weak(add_rule),
-    /* K5   */  be_nested_str_weak(Wifi_X23Connected),
-    /* K6   */  be_nested_str_weak(eth),
-    /* K7   */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_mdns_announce_hostnames),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040302,  //  0003  GETIDX	R1	R1	K2
-      0x78060003,  //  0004  JMPF	R1	#0009
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x500C0000,  //  0006  LDBOOL	R3	0	0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x70020005,  //  0008  JMP		#000F
-      0xB8060000,  //  0009  GETNGBL	R1	K0
-      0x8C040304,  //  000A  GETMET	R1	R1	K4
-      0x580C0005,  //  000B  LDCONST	R3	K5
-      0x84100000,  //  000C  CLOSURE	R4	P0
-      0x5C140000,  //  000D  MOVE	R5	R0
-      0x7C040800,  //  000E  CALL	R1	4
-      0xB8060000,  //  000F  GETNGBL	R1	K0
-      0x8C040306,  //  0010  GETMET	R1	R1	K6
-      0x7C040200,  //  0011  CALL	R1	1
-      0x94040302,  //  0012  GETIDX	R1	R1	K2
-      0x78060003,  //  0013  JMPF	R1	#0018
-      0x8C040103,  //  0014  GETMET	R1	R0	K3
-      0x500C0200,  //  0015  LDBOOL	R3	1	0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x70020005,  //  0017  JMP		#001E
-      0xB8060000,  //  0018  GETNGBL	R1	K0
-      0x8C040304,  //  0019  GETMET	R1	R1	K4
-      0x580C0007,  //  001A  LDCONST	R3	K7
-      0x84100001,  //  001B  CLOSURE	R4	P1
-      0x5C140000,  //  001C  MOVE	R5	R0
-      0x7C040800,  //  001D  CALL	R1	4
-      0xA0000000,  //  001E  CLOSE	R0
-      0x80000000,  //  001F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_manual_pairing_code
-********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
+    12,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1695,50 +2438,113 @@ be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[23]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(discriminator),
-    /* K2   */  be_nested_str_weak(passcode),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Verhoeff),
-    /* K7   */  be_nested_str_weak(checksum),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(FILENAME),
+    /* K3   */  be_nested_str_weak(read),
+    /* K4   */  be_nested_str_weak(close),
+    /* K5   */  be_nested_str_weak(json),
+    /* K6   */  be_nested_str_weak(load),
+    /* K7   */  be_nested_str_weak(discriminator),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(distinguish),
+    /* K10  */  be_nested_str_weak(passcode),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(io_error),
+    /* K13  */  be_nested_str_weak(tasmota),
+    /* K14  */  be_nested_str_weak(log),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Aload_X20Exception_X3A),
+    /* K16  */  be_nested_str_weak(_X7C),
+    /* K17  */  be_const_int(2),
+    /* K18  */  be_nested_str_weak(random),
+    /* K19  */  be_nested_str_weak(get),
+    /* K20  */  be_const_int(0),
+    /* K21  */  be_nested_str_weak(PASSCODE_DEFAULT),
+    /* K22  */  be_nested_str_weak(save_param),
     }),
-    be_str_weak(compute_manual_pairing_code),
+    be_str_weak(load_param),
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
+    ( &(const binstruction[79]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x540E0FFE,  //  0002  LDINT	R3	4095
-      0x2C080403,  //  0003  AND	R2	R2	R3
-      0x540E0009,  //  0004  LDINT	R3	10
-      0x3C080403,  //  0005  SHR	R2	R2	R3
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x541202FF,  //  0007  LDINT	R4	768
-      0x2C0C0604,  //  0008  AND	R3	R3	R4
-      0x54120005,  //  0009  LDINT	R4	6
-      0x380C0604,  //  000A  SHL	R3	R3	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x54163FFE,  //  000C  LDINT	R5	16383
-      0x2C100805,  //  000D  AND	R4	R4	R5
-      0x300C0604,  //  000E  OR	R3	R3	R4
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x5416000D,  //  0010  LDINT	R5	14
-      0x3C100805,  //  0011  SHR	R4	R4	R5
-      0x8C140303,  //  0012  GETMET	R5	R1	K3
-      0x581C0004,  //  0013  LDCONST	R7	K4
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x5C280800,  //  0016  MOVE	R10	R4
-      0x7C140A00,  //  0017  CALL	R5	5
-      0xB81A0A00,  //  0018  GETNGBL	R6	K5
-      0x88180D06,  //  0019  GETMBR	R6	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200A00,  //  001B  MOVE	R8	R5
-      0x7C180400,  //  001C  CALL	R6	2
-      0x00140A06,  //  001D  ADD	R5	R5	R6
-      0x80040A00,  //  001E  RET	1	R5
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802001D,  //  0002  EXBLK	0	#0021
+      0x600C0011,  //  0003  GETGBL	R3	G17
+      0x88100102,  //  0004  GETMBR	R4	R0	K2
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x8C100703,  //  0006  GETMET	R4	R3	K3
+      0x7C100200,  //  0007  CALL	R4	1
+      0x8C140704,  //  0008  GETMET	R5	R3	K4
+      0x7C140200,  //  0009  CALL	R5	1
+      0xA4160A00,  //  000A  IMPORT	R5	K5
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x5C200800,  //  000C  MOVE	R8	R4
+      0x7C180400,  //  000D  CALL	R6	2
+      0x8C1C0D08,  //  000E  GETMET	R7	R6	K8
+      0x58240009,  //  000F  LDCONST	R9	K9
+      0x88280107,  //  0010  GETMBR	R10	R0	K7
+      0x7C1C0600,  //  0011  CALL	R7	3
+      0x90020E07,  //  0012  SETMBR	R0	K7	R7
+      0x8C1C0D08,  //  0013  GETMET	R7	R6	K8
+      0x5824000A,  //  0014  LDCONST	R9	K10
+      0x8828010A,  //  0015  GETMBR	R10	R0	K10
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x90021407,  //  0017  SETMBR	R0	K10	R7
+      0x601C0017,  //  0018  GETGBL	R7	G23
+      0x8C200D08,  //  0019  GETMET	R8	R6	K8
+      0x5828000B,  //  001A  LDCONST	R10	K11
+      0x502C0000,  //  001B  LDBOOL	R11	0	0
+      0x7C200600,  //  001C  CALL	R8	3
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0x90021607,  //  001E  SETMBR	R0	K11	R7
+      0xA8040001,  //  001F  EXBLK	1	1
+      0x70020012,  //  0020  JMP		#0034
+      0xAC0C0002,  //  0021  CATCH	R3	0	2
+      0x7002000F,  //  0022  JMP		#0033
+      0x2014070C,  //  0023  NE	R5	R3	K12
+      0x7816000C,  //  0024  JMPF	R5	#0032
+      0xB8161A00,  //  0025  GETNGBL	R5	K13
+      0x8C140B0E,  //  0026  GETMET	R5	R5	K14
+      0x601C0008,  //  0027  GETGBL	R7	G8
+      0x5C200600,  //  0028  MOVE	R8	R3
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x001E1E07,  //  002A  ADD	R7	K15	R7
+      0x001C0F10,  //  002B  ADD	R7	R7	K16
+      0x60200008,  //  002C  GETGBL	R8	G8
+      0x5C240800,  //  002D  MOVE	R9	R4
+      0x7C200200,  //  002E  CALL	R8	1
+      0x001C0E08,  //  002F  ADD	R7	R7	R8
+      0x58200011,  //  0030  LDCONST	R8	K17
+      0x7C140600,  //  0031  CALL	R5	3
+      0x70020000,  //  0032  JMP		#0034
+      0xB0080000,  //  0033  RAISE	2	R0	R0
+      0x500C0000,  //  0034  LDBOOL	R3	0	0
+      0x88100107,  //  0035  GETMBR	R4	R0	K7
+      0x4C140000,  //  0036  LDNIL	R5
+      0x1C100805,  //  0037  EQ	R4	R4	R5
+      0x7812000A,  //  0038  JMPF	R4	#0044
+      0x8C100512,  //  0039  GETMET	R4	R2	K18
+      0x58180011,  //  003A  LDCONST	R6	K17
+      0x7C100400,  //  003B  CALL	R4	2
+      0x8C100913,  //  003C  GETMET	R4	R4	K19
+      0x58180014,  //  003D  LDCONST	R6	K20
+      0x581C0011,  //  003E  LDCONST	R7	K17
+      0x7C100600,  //  003F  CALL	R4	3
+      0x54160FFE,  //  0040  LDINT	R5	4095
+      0x2C100805,  //  0041  AND	R4	R4	R5
+      0x90020E04,  //  0042  SETMBR	R0	K7	R4
+      0x500C0200,  //  0043  LDBOOL	R3	1	0
+      0x8810010A,  //  0044  GETMBR	R4	R0	K10
+      0x4C140000,  //  0045  LDNIL	R5
+      0x1C100805,  //  0046  EQ	R4	R4	R5
+      0x78120002,  //  0047  JMPF	R4	#004B
+      0x88100115,  //  0048  GETMBR	R4	R0	K21
+      0x90021404,  //  0049  SETMBR	R0	K10	R4
+      0x500C0200,  //  004A  LDBOOL	R3	1	0
+      0x780E0001,  //  004B  JMPF	R3	#004E
+      0x8C100116,  //  004C  GETMET	R4	R0	K22
+      0x7C100200,  //  004D  CALL	R4	1
+      0x80000000,  //  004E  RET	0
     })
   )
 );
@@ -1746,33 +2552,49 @@ be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_commissioning_complete
+** Solidified function: mdns_announce_op_discovery_all_sessions
 ********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_sessions,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    2,                          /* argc */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
-    /* K3   */  be_const_int(2),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(get_deviceid),
+    /* K2   */  be_nested_str_weak(get_fabric),
+    /* K3   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K4   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(start_commissioning_complete),
+    be_str_weak(mdns_announce_op_discovery_all_sessions),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
-      0x7C080600,  //  0004  CALL	R2	3
-      0x80000000,  //  0005  RET	0
+    ( &(const binstruction[21]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x88080500,  //  0002  GETMBR	R2	R2	K0
+      0x7C040200,  //  0003  CALL	R1	1
+      0xA802000B,  //  0004  EXBLK	0	#0011
+      0x5C080200,  //  0005  MOVE	R2	R1
+      0x7C080000,  //  0006  CALL	R2	0
+      0x8C0C0501,  //  0007  GETMET	R3	R2	K1
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x780E0005,  //  0009  JMPF	R3	#0010
+      0x8C0C0502,  //  000A  GETMET	R3	R2	K2
+      0x7C0C0200,  //  000B  CALL	R3	1
+      0x780E0002,  //  000C  JMPF	R3	#0010
+      0x8C0C0103,  //  000D  GETMET	R3	R0	K3
+      0x5C140400,  //  000E  MOVE	R5	R2
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x7001FFF3,  //  0010  JMP		#0005
+      0x58040004,  //  0011  LDCONST	R1	K4
+      0xAC040200,  //  0012  CATCH	R1	1	0
+      0xB0080000,  //  0013  RAISE	2	R0	R0
+      0x80000000,  //  0014  RET	0
     })
   )
 );
@@ -1780,525 +2602,12 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_commissioning_complete_deferred
+** Solidified function: msg_send
 ********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
+be_local_closure(Matter_Device_msg_send,   /* name */
   be_nested_proto(
     11,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(plugins),
-    /* K2   */  be_nested_str_weak(invoke_request),
-    /* K3   */  be_nested_str_weak(status),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K6   */  be_const_int(1),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x6014000C,  //  0001  GETGBL	R5	G12
-      0x88180101,  //  0002  GETMBR	R6	R0	K1
-      0x7C140200,  //  0003  CALL	R5	1
-      0x14140805,  //  0004  LT	R5	R4	R5
-      0x78160011,  //  0005  JMPF	R5	#0018
-      0x88140101,  //  0006  GETMBR	R5	R0	K1
-      0x94140A04,  //  0007  GETIDX	R5	R5	R4
-      0x8C180B02,  //  0008  GETMET	R6	R5	K2
-      0x5C200200,  //  0009  MOVE	R8	R1
-      0x5C240400,  //  000A  MOVE	R9	R2
-      0x5C280600,  //  000B  MOVE	R10	R3
-      0x7C180800,  //  000C  CALL	R6	4
-      0x4C1C0000,  //  000D  LDNIL	R7
-      0x201C0C07,  //  000E  NE	R7	R6	R7
-      0x741E0004,  //  000F  JMPT	R7	#0015
-      0x881C0703,  //  0010  GETMBR	R7	R3	K3
-      0xB8220800,  //  0011  GETNGBL	R8	K4
-      0x88201105,  //  0012  GETMBR	R8	R8	K5
-      0x201C0E08,  //  0013  NE	R7	R7	R8
-      0x781E0000,  //  0014  JMPF	R7	#0016
-      0x80040C00,  //  0015  RET	1	R6
-      0x00100906,  //  0016  ADD	R4	R4	K6
-      0x7001FFE8,  //  0017  JMP		#0001
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(Matter_Device_msg_received,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(msg_received),
-    }),
-    be_str_weak(msg_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0x5C180200,  //  0002  MOVE	R6	R1
-      0x5C1C0400,  //  0003  MOVE	R7	R2
-      0x5C200600,  //  0004  MOVE	R8	R3
-      0x7C100800,  //  0005  CALL	R4	4
-      0x80040800,  //  0006  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _start_mdns_announce
-********************************************************************/
-be_local_closure(Matter_Device__start_mdns_announce,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[48]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(start),
-    /* K3   */  be_nested_str_weak(VP),
-    /* K4   */  be_nested_str_weak(vendorid),
-    /* K5   */  be_nested_str_weak(_X2B),
-    /* K6   */  be_nested_str_weak(productid),
-    /* K7   */  be_nested_str_weak(D),
-    /* K8   */  be_nested_str_weak(discriminator),
-    /* K9   */  be_nested_str_weak(CM),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(T),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(SII),
-    /* K14  */  be_nested_str_weak(SAI),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(eth),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_nested_str_weak(replace),
-    /* K19  */  be_nested_str_weak(find),
-    /* K20  */  be_nested_str_weak(mac),
-    /* K21  */  be_nested_str_weak(_X3A),
-    /* K22  */  be_nested_str_weak(),
-    /* K23  */  be_nested_str_weak(add_hostname),
-    /* K24  */  be_nested_str_weak(ip6local),
-    /* K25  */  be_nested_str_weak(ip),
-    /* K26  */  be_nested_str_weak(ip6),
-    /* K27  */  be_nested_str_weak(add_service),
-    /* K28  */  be_nested_str_weak(_matterc),
-    /* K29  */  be_nested_str_weak(_udp),
-    /* K30  */  be_nested_str_weak(commissioning_instance_eth),
-    /* K31  */  be_nested_str_weak(log),
-    /* K32  */  be_nested_str_weak(format),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20starting_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K34  */  be_nested_str_weak(wifi),
-    /* K35  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K36  */  be_nested_str_weak(hostname_wifi),
-    /* K37  */  be_const_int(2),
-    /* K38  */  be_nested_str_weak(_L),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K40  */  be_const_int(3),
-    /* K41  */  be_nested_str_weak(add_subtype),
-    /* K42  */  be_nested_str_weak(_S),
-    /* K43  */  be_nested_str_weak(_V),
-    /* K44  */  be_nested_str_weak(_CM1),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K46  */  be_nested_str_weak(_X7C),
-    /* K47  */  be_nested_str_weak(mdns_announce_op_discovery_all_sessions),
-    }),
-    be_str_weak(_start_mdns_announce),
-    &be_const_str_solidified,
-    ( &(const binstruction[292]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100502,  //  0002  GETMET	R4	R2	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x60100013,  //  0004  GETGBL	R4	G19
-      0x7C100000,  //  0005  CALL	R4	0
-      0x60140008,  //  0006  GETGBL	R5	G8
-      0x88180104,  //  0007  GETMBR	R6	R0	K4
-      0x7C140200,  //  0008  CALL	R5	1
-      0x00140B05,  //  0009  ADD	R5	R5	K5
-      0x60180008,  //  000A  GETGBL	R6	G8
-      0x881C0106,  //  000B  GETMBR	R7	R0	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00140A06,  //  000D  ADD	R5	R5	R6
-      0x98120605,  //  000E  SETIDX	R4	K3	R5
-      0x88140108,  //  000F  GETMBR	R5	R0	K8
-      0x98120E05,  //  0010  SETIDX	R4	K7	R5
-      0x9812130A,  //  0011  SETIDX	R4	K9	K10
-      0x9812170C,  //  0012  SETIDX	R4	K11	K12
-      0x54161387,  //  0013  LDINT	R5	5000
-      0x98121A05,  //  0014  SETIDX	R4	K13	R5
-      0x5416012B,  //  0015  LDINT	R5	300
-      0x98121C05,  //  0016  SETIDX	R4	K14	R5
-      0xA80200F7,  //  0017  EXBLK	0	#0110
-      0x7806007A,  //  0018  JMPF	R1	#0094
-      0xB8161E00,  //  0019  GETNGBL	R5	K15
-      0x8C140B10,  //  001A  GETMET	R5	R5	K16
-      0x7C140200,  //  001B  CALL	R5	1
-      0x8C180712,  //  001C  GETMET	R6	R3	K18
-      0x8C200B13,  //  001D  GETMET	R8	R5	K19
-      0x58280014,  //  001E  LDCONST	R10	K20
-      0x7C200400,  //  001F  CALL	R8	2
-      0x58240015,  //  0020  LDCONST	R9	K21
-      0x58280016,  //  0021  LDCONST	R10	K22
-      0x7C180800,  //  0022  CALL	R6	4
-      0x90022206,  //  0023  SETMBR	R0	K17	R6
-      0x8C180517,  //  0024  GETMET	R6	R2	K23
-      0x88200111,  //  0025  GETMBR	R8	R0	K17
-      0x8C240B13,  //  0026  GETMET	R9	R5	K19
-      0x582C0018,  //  0027  LDCONST	R11	K24
-      0x58300016,  //  0028  LDCONST	R12	K22
-      0x7C240600,  //  0029  CALL	R9	3
-      0x8C280B13,  //  002A  GETMET	R10	R5	K19
-      0x58300019,  //  002B  LDCONST	R12	K25
-      0x58340016,  //  002C  LDCONST	R13	K22
-      0x7C280600,  //  002D  CALL	R10	3
-      0x8C2C0B13,  //  002E  GETMET	R11	R5	K19
-      0x5834001A,  //  002F  LDCONST	R13	K26
-      0x58380016,  //  0030  LDCONST	R14	K22
-      0x7C2C0600,  //  0031  CALL	R11	3
-      0x7C180A00,  //  0032  CALL	R6	5
-      0x8C18051B,  //  0033  GETMET	R6	R2	K27
-      0x5820001C,  //  0034  LDCONST	R8	K28
-      0x5824001D,  //  0035  LDCONST	R9	K29
-      0x542A15A3,  //  0036  LDINT	R10	5540
-      0x5C2C0800,  //  0037  MOVE	R11	R4
-      0x8830011E,  //  0038  GETMBR	R12	R0	K30
-      0x88340111,  //  0039  GETMBR	R13	R0	K17
-      0x7C180E00,  //  003A  CALL	R6	7
-      0xB81A1E00,  //  003B  GETNGBL	R6	K15
-      0x8C180D1F,  //  003C  GETMET	R6	R6	K31
-      0x8C200720,  //  003D  GETMET	R8	R3	K32
-      0x58280021,  //  003E  LDCONST	R10	K33
-      0x78060001,  //  003F  JMPF	R1	#0042
-      0x582C0010,  //  0040  LDCONST	R11	K16
-      0x70020000,  //  0041  JMP		#0043
-      0x582C0022,  //  0042  LDCONST	R11	K34
-      0x78060001,  //  0043  JMPF	R1	#0046
-      0x8830011E,  //  0044  GETMBR	R12	R0	K30
-      0x70020000,  //  0045  JMP		#0047
-      0x88300123,  //  0046  GETMBR	R12	R0	K35
-      0x78060001,  //  0047  JMPF	R1	#004A
-      0x88340111,  //  0048  GETMBR	R13	R0	K17
-      0x70020000,  //  0049  JMP		#004B
-      0x88340124,  //  004A  GETMBR	R13	R0	K36
-      0x7C200A00,  //  004B  CALL	R8	5
-      0x58240025,  //  004C  LDCONST	R9	K37
-      0x7C180600,  //  004D  CALL	R6	3
-      0x60180008,  //  004E  GETGBL	R6	G8
-      0x881C0108,  //  004F  GETMBR	R7	R0	K8
-      0x54220FFE,  //  0050  LDINT	R8	4095
-      0x2C1C0E08,  //  0051  AND	R7	R7	R8
-      0x7C180200,  //  0052  CALL	R6	1
-      0x001A4C06,  //  0053  ADD	R6	K38	R6
-      0xB81E1E00,  //  0054  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  0055  GETMET	R7	R7	K31
-      0x00264E06,  //  0056  ADD	R9	K39	R6
-      0x58280028,  //  0057  LDCONST	R10	K40
-      0x7C1C0600,  //  0058  CALL	R7	3
-      0x8C1C0529,  //  0059  GETMET	R7	R2	K41
-      0x5824001C,  //  005A  LDCONST	R9	K28
-      0x5828001D,  //  005B  LDCONST	R10	K29
-      0x882C011E,  //  005C  GETMBR	R11	R0	K30
-      0x88300111,  //  005D  GETMBR	R12	R0	K17
-      0x5C340C00,  //  005E  MOVE	R13	R6
-      0x7C1C0C00,  //  005F  CALL	R7	6
-      0x601C0008,  //  0060  GETGBL	R7	G8
-      0x88200108,  //  0061  GETMBR	R8	R0	K8
-      0x54260EFF,  //  0062  LDINT	R9	3840
-      0x2C201009,  //  0063  AND	R8	R8	R9
-      0x54260007,  //  0064  LDINT	R9	8
-      0x3C201009,  //  0065  SHR	R8	R8	R9
-      0x7C1C0200,  //  0066  CALL	R7	1
-      0x001E5407,  //  0067  ADD	R7	K42	R7
-      0x5C180E00,  //  0068  MOVE	R6	R7
-      0xB81E1E00,  //  0069  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  006A  GETMET	R7	R7	K31
-      0x00264E06,  //  006B  ADD	R9	K39	R6
-      0x58280028,  //  006C  LDCONST	R10	K40
-      0x7C1C0600,  //  006D  CALL	R7	3
-      0x8C1C0529,  //  006E  GETMET	R7	R2	K41
-      0x5824001C,  //  006F  LDCONST	R9	K28
-      0x5828001D,  //  0070  LDCONST	R10	K29
-      0x882C011E,  //  0071  GETMBR	R11	R0	K30
-      0x88300111,  //  0072  GETMBR	R12	R0	K17
-      0x5C340C00,  //  0073  MOVE	R13	R6
-      0x7C1C0C00,  //  0074  CALL	R7	6
-      0x601C0008,  //  0075  GETGBL	R7	G8
-      0x88200104,  //  0076  GETMBR	R8	R0	K4
-      0x7C1C0200,  //  0077  CALL	R7	1
-      0x001E5607,  //  0078  ADD	R7	K43	R7
-      0x5C180E00,  //  0079  MOVE	R6	R7
-      0xB81E1E00,  //  007A  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  007B  GETMET	R7	R7	K31
-      0x00264E06,  //  007C  ADD	R9	K39	R6
-      0x58280028,  //  007D  LDCONST	R10	K40
-      0x7C1C0600,  //  007E  CALL	R7	3
-      0x8C1C0529,  //  007F  GETMET	R7	R2	K41
-      0x5824001C,  //  0080  LDCONST	R9	K28
-      0x5828001D,  //  0081  LDCONST	R10	K29
-      0x882C011E,  //  0082  GETMBR	R11	R0	K30
-      0x88300111,  //  0083  GETMBR	R12	R0	K17
-      0x5C340C00,  //  0084  MOVE	R13	R6
-      0x7C1C0C00,  //  0085  CALL	R7	6
-      0x5818002C,  //  0086  LDCONST	R6	K44
-      0xB81E1E00,  //  0087  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  0088  GETMET	R7	R7	K31
-      0x00264E06,  //  0089  ADD	R9	K39	R6
-      0x58280028,  //  008A  LDCONST	R10	K40
-      0x7C1C0600,  //  008B  CALL	R7	3
-      0x8C1C0529,  //  008C  GETMET	R7	R2	K41
-      0x5824001C,  //  008D  LDCONST	R9	K28
-      0x5828001D,  //  008E  LDCONST	R10	K29
-      0x882C011E,  //  008F  GETMBR	R11	R0	K30
-      0x88300111,  //  0090  GETMBR	R12	R0	K17
-      0x5C340C00,  //  0091  MOVE	R13	R6
-      0x7C1C0C00,  //  0092  CALL	R7	6
-      0x70020079,  //  0093  JMP		#010E
-      0xB8161E00,  //  0094  GETNGBL	R5	K15
-      0x8C140B22,  //  0095  GETMET	R5	R5	K34
-      0x7C140200,  //  0096  CALL	R5	1
-      0x8C180712,  //  0097  GETMET	R6	R3	K18
-      0x8C200B13,  //  0098  GETMET	R8	R5	K19
-      0x58280014,  //  0099  LDCONST	R10	K20
-      0x7C200400,  //  009A  CALL	R8	2
-      0x58240015,  //  009B  LDCONST	R9	K21
-      0x58280016,  //  009C  LDCONST	R10	K22
-      0x7C180800,  //  009D  CALL	R6	4
-      0x90024806,  //  009E  SETMBR	R0	K36	R6
-      0x8C180517,  //  009F  GETMET	R6	R2	K23
-      0x88200124,  //  00A0  GETMBR	R8	R0	K36
-      0x8C240B13,  //  00A1  GETMET	R9	R5	K19
-      0x582C0018,  //  00A2  LDCONST	R11	K24
-      0x58300016,  //  00A3  LDCONST	R12	K22
-      0x7C240600,  //  00A4  CALL	R9	3
-      0x8C280B13,  //  00A5  GETMET	R10	R5	K19
-      0x58300019,  //  00A6  LDCONST	R12	K25
-      0x58340016,  //  00A7  LDCONST	R13	K22
-      0x7C280600,  //  00A8  CALL	R10	3
-      0x8C2C0B13,  //  00A9  GETMET	R11	R5	K19
-      0x5834001A,  //  00AA  LDCONST	R13	K26
-      0x58380016,  //  00AB  LDCONST	R14	K22
-      0x7C2C0600,  //  00AC  CALL	R11	3
-      0x7C180A00,  //  00AD  CALL	R6	5
-      0x8C18051B,  //  00AE  GETMET	R6	R2	K27
-      0x5820001C,  //  00AF  LDCONST	R8	K28
-      0x5824001D,  //  00B0  LDCONST	R9	K29
-      0x542A15A3,  //  00B1  LDINT	R10	5540
-      0x5C2C0800,  //  00B2  MOVE	R11	R4
-      0x88300123,  //  00B3  GETMBR	R12	R0	K35
-      0x88340124,  //  00B4  GETMBR	R13	R0	K36
-      0x7C180E00,  //  00B5  CALL	R6	7
-      0xB81A1E00,  //  00B6  GETNGBL	R6	K15
-      0x8C180D1F,  //  00B7  GETMET	R6	R6	K31
-      0x8C200720,  //  00B8  GETMET	R8	R3	K32
-      0x58280021,  //  00B9  LDCONST	R10	K33
-      0x78060001,  //  00BA  JMPF	R1	#00BD
-      0x582C0010,  //  00BB  LDCONST	R11	K16
-      0x70020000,  //  00BC  JMP		#00BE
-      0x582C0022,  //  00BD  LDCONST	R11	K34
-      0x78060001,  //  00BE  JMPF	R1	#00C1
-      0x8830011E,  //  00BF  GETMBR	R12	R0	K30
-      0x70020000,  //  00C0  JMP		#00C2
-      0x88300123,  //  00C1  GETMBR	R12	R0	K35
-      0x78060001,  //  00C2  JMPF	R1	#00C5
-      0x88340111,  //  00C3  GETMBR	R13	R0	K17
-      0x70020000,  //  00C4  JMP		#00C6
-      0x88340124,  //  00C5  GETMBR	R13	R0	K36
-      0x7C200A00,  //  00C6  CALL	R8	5
-      0x58240025,  //  00C7  LDCONST	R9	K37
-      0x7C180600,  //  00C8  CALL	R6	3
-      0x60180008,  //  00C9  GETGBL	R6	G8
-      0x881C0108,  //  00CA  GETMBR	R7	R0	K8
-      0x54220FFE,  //  00CB  LDINT	R8	4095
-      0x2C1C0E08,  //  00CC  AND	R7	R7	R8
-      0x7C180200,  //  00CD  CALL	R6	1
-      0x001A4C06,  //  00CE  ADD	R6	K38	R6
-      0xB81E1E00,  //  00CF  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  00D0  GETMET	R7	R7	K31
-      0x00264E06,  //  00D1  ADD	R9	K39	R6
-      0x58280028,  //  00D2  LDCONST	R10	K40
-      0x7C1C0600,  //  00D3  CALL	R7	3
-      0x8C1C0529,  //  00D4  GETMET	R7	R2	K41
-      0x5824001C,  //  00D5  LDCONST	R9	K28
-      0x5828001D,  //  00D6  LDCONST	R10	K29
-      0x882C0123,  //  00D7  GETMBR	R11	R0	K35
-      0x88300124,  //  00D8  GETMBR	R12	R0	K36
-      0x5C340C00,  //  00D9  MOVE	R13	R6
-      0x7C1C0C00,  //  00DA  CALL	R7	6
-      0x601C0008,  //  00DB  GETGBL	R7	G8
-      0x88200108,  //  00DC  GETMBR	R8	R0	K8
-      0x54260EFF,  //  00DD  LDINT	R9	3840
-      0x2C201009,  //  00DE  AND	R8	R8	R9
-      0x54260007,  //  00DF  LDINT	R9	8
-      0x3C201009,  //  00E0  SHR	R8	R8	R9
-      0x7C1C0200,  //  00E1  CALL	R7	1
-      0x001E5407,  //  00E2  ADD	R7	K42	R7
-      0x5C180E00,  //  00E3  MOVE	R6	R7
-      0xB81E1E00,  //  00E4  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  00E5  GETMET	R7	R7	K31
-      0x00264E06,  //  00E6  ADD	R9	K39	R6
-      0x58280028,  //  00E7  LDCONST	R10	K40
-      0x7C1C0600,  //  00E8  CALL	R7	3
-      0x8C1C0529,  //  00E9  GETMET	R7	R2	K41
-      0x5824001C,  //  00EA  LDCONST	R9	K28
-      0x5828001D,  //  00EB  LDCONST	R10	K29
-      0x882C0123,  //  00EC  GETMBR	R11	R0	K35
-      0x88300124,  //  00ED  GETMBR	R12	R0	K36
-      0x5C340C00,  //  00EE  MOVE	R13	R6
-      0x7C1C0C00,  //  00EF  CALL	R7	6
-      0x601C0008,  //  00F0  GETGBL	R7	G8
-      0x88200104,  //  00F1  GETMBR	R8	R0	K4
-      0x7C1C0200,  //  00F2  CALL	R7	1
-      0x001E5607,  //  00F3  ADD	R7	K43	R7
-      0x5C180E00,  //  00F4  MOVE	R6	R7
-      0xB81E1E00,  //  00F5  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  00F6  GETMET	R7	R7	K31
-      0x00264E06,  //  00F7  ADD	R9	K39	R6
-      0x58280028,  //  00F8  LDCONST	R10	K40
-      0x7C1C0600,  //  00F9  CALL	R7	3
-      0x8C1C0529,  //  00FA  GETMET	R7	R2	K41
-      0x5824001C,  //  00FB  LDCONST	R9	K28
-      0x5828001D,  //  00FC  LDCONST	R10	K29
-      0x882C0123,  //  00FD  GETMBR	R11	R0	K35
-      0x88300124,  //  00FE  GETMBR	R12	R0	K36
-      0x5C340C00,  //  00FF  MOVE	R13	R6
-      0x7C1C0C00,  //  0100  CALL	R7	6
-      0x5818002C,  //  0101  LDCONST	R6	K44
-      0xB81E1E00,  //  0102  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  0103  GETMET	R7	R7	K31
-      0x00264E06,  //  0104  ADD	R9	K39	R6
-      0x58280028,  //  0105  LDCONST	R10	K40
-      0x7C1C0600,  //  0106  CALL	R7	3
-      0x8C1C0529,  //  0107  GETMET	R7	R2	K41
-      0x5824001C,  //  0108  LDCONST	R9	K28
-      0x5828001D,  //  0109  LDCONST	R10	K29
-      0x882C0123,  //  010A  GETMBR	R11	R0	K35
-      0x88300124,  //  010B  GETMBR	R12	R0	K36
-      0x5C340C00,  //  010C  MOVE	R13	R6
-      0x7C1C0C00,  //  010D  CALL	R7	6
-      0xA8040001,  //  010E  EXBLK	1	1
-      0x70020010,  //  010F  JMP		#0121
-      0xAC140002,  //  0110  CATCH	R5	0	2
-      0x7002000D,  //  0111  JMP		#0120
-      0xB81E1E00,  //  0112  GETNGBL	R7	K15
-      0x8C1C0F1F,  //  0113  GETMET	R7	R7	K31
-      0x60240008,  //  0114  GETGBL	R9	G8
-      0x5C280A00,  //  0115  MOVE	R10	R5
-      0x7C240200,  //  0116  CALL	R9	1
-      0x00265A09,  //  0117  ADD	R9	K45	R9
-      0x0024132E,  //  0118  ADD	R9	R9	K46
-      0x60280008,  //  0119  GETGBL	R10	G8
-      0x5C2C0C00,  //  011A  MOVE	R11	R6
-      0x7C280200,  //  011B  CALL	R10	1
-      0x0024120A,  //  011C  ADD	R9	R9	R10
-      0x58280025,  //  011D  LDCONST	R10	K37
-      0x7C1C0600,  //  011E  CALL	R7	3
-      0x70020000,  //  011F  JMP		#0121
-      0xB0080000,  //  0120  RAISE	2	R0	R0
-      0x8C14012F,  //  0121  GETMET	R5	R0	K47
-      0x7C140200,  //  0122  CALL	R5	1
-      0x80000000,  //  0123  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: packet_ack
-********************************************************************/
-be_local_closure(Matter_Device_packet_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -2307,16 +2616,19 @@ be_local_closure(Matter_Device_packet_ack,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(packet_ack),
+    /* K1   */  be_nested_str_weak(send_response),
     }),
-    be_str_weak(packet_ack),
+    be_str_weak(msg_send),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x8C140B01,  //  0001  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0002  MOVE	R7	R1
+      0x5C200400,  //  0003  MOVE	R8	R2
+      0x5C240600,  //  0004  MOVE	R9	R3
+      0x5C280800,  //  0005  MOVE	R10	R4
+      0x7C140A00,  //  0006  CALL	R5	5
+      0x80040A00,  //  0007  RET	1	R5
     })
   )
 );
@@ -2324,11 +2636,11 @@ be_local_closure(Matter_Device_packet_ack,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery
+** Solidified function: get_active_endpoints
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+be_local_closure(Matter_Device_get_active_endpoints,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    11,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2336,249 +2648,55 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_deviceid),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(eth),
-    /* K13  */  be_nested_str_weak(find),
-    /* K14  */  be_nested_str_weak(up),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matter),
-    /* K21  */  be_nested_str_weak(_tcp),
-    /* K22  */  be_nested_str_weak(_I),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K24  */  be_nested_str_weak(add_subtype),
-    /* K25  */  be_nested_str_weak(wifi),
-    /* K26  */  be_nested_str_weak(hostname_wifi),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K28  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(plugins),
+    /* K1   */  be_nested_str_weak(get_endpoints),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find),
+    /* K4   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(mdns_announce_op_discovery),
+    be_str_weak(get_active_endpoints),
     &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA8020064,  //  0002  EXBLK	0	#0068
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+    ( &(const binstruction[38]) {  /* code */
+      0x60080012,  //  0000  GETGBL	R2	G18
+      0x7C080000,  //  0001  CALL	R2	0
+      0x600C0010,  //  0002  GETGBL	R3	G16
+      0x88100100,  //  0003  GETMBR	R4	R0	K0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0xA802001B,  //  0005  EXBLK	0	#0022
+      0x5C100600,  //  0006  MOVE	R4	R3
+      0x7C100000,  //  0007  CALL	R4	0
+      0x8C140901,  //  0008  GETMET	R5	R4	K1
+      0x7C140200,  //  0009  CALL	R5	1
+      0x60180010,  //  000A  GETGBL	R6	G16
+      0x5C1C0A00,  //  000B  MOVE	R7	R5
       0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x00261406,  //  0013  ADD	R9	K10	R6
-      0x5828000B,  //  0014  LDCONST	R10	K11
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0xB81E1000,  //  0016  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x781E0020,  //  001C  JMPF	R7	#003E
-      0xB81E1000,  //  001D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
-      0x8C24070F,  //  001F  GETMET	R9	R3	K15
-      0x582C0010,  //  0020  LDCONST	R11	K16
-      0x5830000C,  //  0021  LDCONST	R12	K12
-      0x5C340C00,  //  0022  MOVE	R13	R6
-      0x88380111,  //  0023  GETMBR	R14	R0	K17
-      0x7C240A00,  //  0024  CALL	R9	5
-      0x58280012,  //  0025  LDCONST	R10	K18
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
-      0x58240014,  //  0028  LDCONST	R9	K20
-      0x58280015,  //  0029  LDCONST	R10	K21
-      0x542E15A3,  //  002A  LDINT	R11	5540
-      0x4C300000,  //  002B  LDNIL	R12
-      0x5C340C00,  //  002C  MOVE	R13	R6
-      0x88380111,  //  002D  GETMBR	R14	R0	K17
-      0x7C1C0E00,  //  002E  CALL	R7	7
-      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x001E2C07,  //  0031  ADD	R7	K22	R7
-      0xB8221000,  //  0032  GETNGBL	R8	K8
-      0x8C201109,  //  0033  GETMET	R8	R8	K9
-      0x002A2E07,  //  0034  ADD	R10	K23	R7
-      0x582C0012,  //  0035  LDCONST	R11	K18
-      0x7C200600,  //  0036  CALL	R8	3
-      0x8C200518,  //  0037  GETMET	R8	R2	K24
-      0x58280014,  //  0038  LDCONST	R10	K20
-      0x582C0015,  //  0039  LDCONST	R11	K21
-      0x5C300C00,  //  003A  MOVE	R12	R6
-      0x88340111,  //  003B  GETMBR	R13	R0	K17
-      0x5C380E00,  //  003C  MOVE	R14	R7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0xB81E1000,  //  003E  GETNGBL	R7	K8
-      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
-      0x5824000E,  //  0042  LDCONST	R9	K14
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x781E0020,  //  0044  JMPF	R7	#0066
-      0xB81E1000,  //  0045  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
-      0x8C24070F,  //  0047  GETMET	R9	R3	K15
-      0x582C0010,  //  0048  LDCONST	R11	K16
-      0x58300019,  //  0049  LDCONST	R12	K25
-      0x5C340C00,  //  004A  MOVE	R13	R6
-      0x8838011A,  //  004B  GETMBR	R14	R0	K26
-      0x7C240A00,  //  004C  CALL	R9	5
-      0x58280012,  //  004D  LDCONST	R10	K18
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
-      0x58240014,  //  0050  LDCONST	R9	K20
-      0x58280015,  //  0051  LDCONST	R10	K21
-      0x542E15A3,  //  0052  LDINT	R11	5540
-      0x4C300000,  //  0053  LDNIL	R12
-      0x5C340C00,  //  0054  MOVE	R13	R6
-      0x8838011A,  //  0055  GETMBR	R14	R0	K26
-      0x7C1C0E00,  //  0056  CALL	R7	7
-      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0058  CALL	R7	1
-      0x001E2C07,  //  0059  ADD	R7	K22	R7
-      0xB8221000,  //  005A  GETNGBL	R8	K8
-      0x8C201109,  //  005B  GETMET	R8	R8	K9
-      0x002A2E07,  //  005C  ADD	R10	K23	R7
-      0x582C0012,  //  005D  LDCONST	R11	K18
-      0x7C200600,  //  005E  CALL	R8	3
-      0x8C200518,  //  005F  GETMET	R8	R2	K24
-      0x58280014,  //  0060  LDCONST	R10	K20
-      0x582C0015,  //  0061  LDCONST	R11	K21
-      0x5C300C00,  //  0062  MOVE	R12	R6
-      0x8834011A,  //  0063  GETMBR	R13	R0	K26
-      0x5C380E00,  //  0064  MOVE	R14	R7
-      0x7C200C00,  //  0065  CALL	R8	6
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x70020010,  //  0067  JMP		#0079
-      0xAC100002,  //  0068  CATCH	R4	0	2
-      0x7002000D,  //  0069  JMP		#0078
-      0xB81A1000,  //  006A  GETNGBL	R6	K8
-      0x8C180D09,  //  006B  GETMET	R6	R6	K9
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x5C240800,  //  006D  MOVE	R9	R4
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00223608,  //  006F  ADD	R8	K27	R8
-      0x0020111C,  //  0070  ADD	R8	R8	K28
-      0x60240008,  //  0071  GETGBL	R9	G8
-      0x5C280A00,  //  0072  MOVE	R10	R5
-      0x7C240200,  //  0073  CALL	R9	1
-      0x00201009,  //  0074  ADD	R8	R8	R9
-      0x5824000B,  //  0075  LDCONST	R9	K11
-      0x7C180600,  //  0076  CALL	R6	3
-      0x70020000,  //  0077  JMP		#0079
-      0xB0080000,  //  0078  RAISE	2	R0	R0
-      0x80000000,  //  0079  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_udp
-********************************************************************/
-be_local_closure(Matter_Device_start_udp,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
-    }),
-    be_str_weak(start_udp),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
+      0xA802000F,  //  000D  EXBLK	0	#001E
+      0x5C1C0C00,  //  000E  MOVE	R7	R6
+      0x7C1C0000,  //  000F  CALL	R7	0
+      0x78060002,  //  0010  JMPF	R1	#0014
+      0x1C200F02,  //  0011  EQ	R8	R7	K2
+      0x78220000,  //  0012  JMPF	R8	#0014
+      0x7001FFF9,  //  0013  JMP		#000E
+      0x8C200503,  //  0014  GETMET	R8	R2	K3
+      0x5C280E00,  //  0015  MOVE	R10	R7
+      0x7C200400,  //  0016  CALL	R8	2
+      0x4C240000,  //  0017  LDNIL	R9
+      0x1C201009,  //  0018  EQ	R8	R8	R9
+      0x78220002,  //  0019  JMPF	R8	#001D
+      0x8C200504,  //  001A  GETMET	R8	R2	K4
+      0x5C280E00,  //  001B  MOVE	R10	R7
+      0x7C200400,  //  001C  CALL	R8	2
+      0x7001FFEF,  //  001D  JMP		#000E
+      0x58180005,  //  001E  LDCONST	R6	K5
+      0xAC180200,  //  001F  CATCH	R6	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0x7001FFE3,  //  0021  JMP		#0006
+      0x580C0005,  //  0022  LDCONST	R3	K5
+      0xAC0C0200,  //  0023  CATCH	R3	1	0
+      0xB0080000,  //  0024  RAISE	2	R0	R0
+      0x80040400,  //  0025  RET	1	R2
     })
   )
 );
@@ -2589,60 +2707,63 @@ be_local_closure(Matter_Device_start_udp,   /* name */
 ** Solidified class: Matter_Device
 ********************************************************************/
 be_local_class(Matter_Device,
-    18,
+    19,
     NULL,
-    be_nested_map(50,
+    be_nested_map(53,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(mdns_announce_op_discovery_all_sessions, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_sessions_closure) },
-        { be_const_key_weak(salt, 31), be_const_var(14) },
-        { be_const_key_weak(start_operational_dicovery, -1), be_const_closure(Matter_Device_start_operational_dicovery_closure) },
-        { be_const_key_weak(w1, -1), be_const_var(16) },
-        { be_const_key_weak(L, -1), be_const_var(17) },
-        { be_const_key_weak(init, 42), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(compute_pbkdf, 12), be_const_closure(Matter_Device_compute_pbkdf_closure) },
-        { be_const_key_weak(ui, 4), be_const_var(4) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
-        { be_const_key_weak(start_operational_dicovery_deferred, 43), be_const_closure(Matter_Device_start_operational_dicovery_deferred_closure) },
-        { be_const_key_weak(productid, -1), be_const_var(10) },
+        { be_const_key_weak(discriminator, 16), be_const_var(11) },
+        { be_const_key_weak(w1, 37), be_const_var(17) },
         { be_const_key_weak(hostname_wifi, -1), be_const_var(7) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
-        { be_const_key_weak(finish_commissioning, -1), be_const_closure(Matter_Device_finish_commissioning_closure) },
-        { be_const_key_weak(every_second, 27), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(5) },
-        { be_const_key_weak(stop, 29), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(1) },
-        { be_const_key_weak(plugins, -1), be_const_var(0) },
-        { be_const_key_weak(FILENAME, 26), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(process_attribute_expansion, 30), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
-        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
-        { be_const_key_weak(iterations, -1), be_const_var(13) },
-        { be_const_key_weak(mdns_announce_op_discovery, 32), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
+        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
+        { be_const_key_weak(udp_server, 28), be_const_var(1) },
+        { be_const_key_weak(msg_send, 40), be_const_closure(Matter_Device_msg_send_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_sessions, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_sessions_closure) },
         { be_const_key_weak(passcode, -1), be_const_var(12) },
-        { be_const_key_weak(sessions, -1), be_const_var(3) },
-        { be_const_key_weak(compute_qrcode_content, -1), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
-        { be_const_key_weak(packet_ack, -1), be_const_closure(Matter_Device_packet_ack_closure) },
-        { be_const_key_weak(_start_mdns_announce, 36), be_const_closure(Matter_Device__start_mdns_announce_closure) },
-        { be_const_key_weak(vendorid, 45), be_const_var(9) },
-        { be_const_key_weak(discriminator, -1), be_const_var(11) },
-        { be_const_key_weak(w0, -1), be_const_var(15) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(get_active_endpoints, 41), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, 40), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(message_handler, -1), be_const_var(2) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(plugins, -1), be_const_var(0) },
+        { be_const_key_weak(invoke_request, 36), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(packet_ack, 51), be_const_closure(Matter_Device_packet_ack_closure) },
+        { be_const_key_weak(salt, 29), be_const_var(15) },
+        { be_const_key_weak(start_udp, 31), be_const_closure(Matter_Device_start_udp_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
         { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(hostname_eth, -1), be_const_var(8) },
-        { be_const_key_weak(commissioning_instance_eth, 46), be_const_var(6) },
-        { be_const_key_weak(sort_distinct, -1), be_const_static_closure(Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(start_udp, -1), be_const_closure(Matter_Device_start_udp_closure) },
-        { be_const_key_weak(save_param, 8), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(msg_received, 15), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(start_basic_commissioning, -1), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(compute_pbkdf, -1), be_const_closure(Matter_Device_compute_pbkdf_closure) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(6) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(hostname_eth, 41), be_const_var(8) },
+        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
         { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
+        { be_const_key_weak(start_operational_dicovery, -1), be_const_closure(Matter_Device_start_operational_dicovery_closure) },
+        { be_const_key_weak(attribute_updated, 2), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(compute_manual_pairing_code, 38), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(start_commissioning_complete, 22), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(3) },
+        { be_const_key_weak(start_operational_dicovery_deferred, 27), be_const_closure(Matter_Device_start_operational_dicovery_deferred_closure) },
+        { be_const_key_weak(finish_commissioning, 5), be_const_closure(Matter_Device_finish_commissioning_closure) },
+        { be_const_key_weak(commissioning_instance_wifi, 45), be_const_var(5) },
+        { be_const_key_weak(message_handler, -1), be_const_var(2) },
+        { be_const_key_weak(PRODUCT_ID, 47), be_const_int(32768) },
+        { be_const_key_weak(ipv4only, 34), be_const_var(13) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(iterations, 26), be_const_var(14) },
+        { be_const_key_weak(ui, -1), be_const_var(4) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(w0, -1), be_const_var(16) },
+        { be_const_key_weak(compute_qrcode_content, -1), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(L, -1), be_const_var(18) },
+        { be_const_key_weak(vendorid, 14), be_const_var(9) },
+        { be_const_key_weak(sort_distinct, 8), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(productid, 6), be_const_var(10) },
+        { be_const_key_weak(_start_mdns_announce, -1), be_const_closure(Matter_Device__start_mdns_announce_closure) },
+        { be_const_key_weak(get_active_endpoints, -1), be_const_closure(Matter_Device_get_active_endpoints_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -7,6 +7,651 @@
 extern const bclass be_class_Matter_IM;
 
 /********************************************************************
+** Solidified function: process_timed_request
+********************************************************************/
+be_local_closure(Matter_IM_process_timed_request,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TimedRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(format),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20TimedRequest_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K10  */  be_nested_str_weak(timeout),
+    /* K11  */  be_nested_str_weak(remote_ip),
+    /* K12  */  be_nested_str_weak(remote_port),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(send_status),
+    /* K15  */  be_nested_str_weak(SUCCESS),
+    }),
+    be_str_weak(process_timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[32]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0xB8160800,  //  000F  GETNGBL	R5	K4
+      0x8C140B05,  //  0010  GETMET	R5	R5	K5
+      0x8C1C0708,  //  0011  GETMET	R7	R3	K8
+      0x58240009,  //  0012  LDCONST	R9	K9
+      0x8828090A,  //  0013  GETMBR	R10	R4	K10
+      0x882C030B,  //  0014  GETMBR	R11	R1	K11
+      0x8830030C,  //  0015  GETMBR	R12	R1	K12
+      0x7C1C0A00,  //  0016  CALL	R7	5
+      0x5820000D,  //  0017  LDCONST	R8	K13
+      0x7C140600,  //  0018  CALL	R5	3
+      0x8C14010E,  //  0019  GETMET	R5	R0	K14
+      0x5C1C0200,  //  001A  MOVE	R7	R1
+      0xB8220200,  //  001B  GETNGBL	R8	K1
+      0x8820110F,  //  001C  GETMBR	R8	R8	K15
+      0x7C140600,  //  001D  CALL	R5	3
+      0x50140200,  //  001E  LDBOOL	R5	1	0
+      0x80040A00,  //  001F  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_read_request
+********************************************************************/
+be_local_closure(Matter_IM_process_read_request,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(ReadRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(attributes_requests),
+    /* K4   */  be_nested_str_weak(_inner_process_read_request),
+    /* K5   */  be_nested_str_weak(session),
+    /* K6   */  be_nested_str_weak(send_report_data),
+    }),
+    be_str_weak(process_read_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x4C140000,  //  0007  LDNIL	R5
+      0x20100805,  //  0008  NE	R4	R4	R5
+      0x78120007,  //  0009  JMPF	R4	#0012
+      0x8C100104,  //  000A  GETMET	R4	R0	K4
+      0x88180305,  //  000B  GETMBR	R6	R1	K5
+      0x5C1C0600,  //  000C  MOVE	R7	R3
+      0x7C100600,  //  000D  CALL	R4	3
+      0x8C140106,  //  000E  GETMET	R5	R0	K6
+      0x5C1C0200,  //  000F  MOVE	R7	R1
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x50100200,  //  0012  LDBOOL	R4	1	0
+      0x80040800,  //  0013  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_subscribe_update
+********************************************************************/
+be_local_closure(Matter_IM_send_subscribe_update,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(ReadRequestMessage),
+    /* K4   */  be_nested_str_weak(fabric_filtered),
+    /* K5   */  be_nested_str_weak(attributes_requests),
+    /* K6   */  be_nested_str_weak(updates),
+    /* K7   */  be_nested_str_weak(AttributePathIB),
+    /* K8   */  be_nested_str_weak(endpoint),
+    /* K9   */  be_nested_str_weak(cluster),
+    /* K10  */  be_nested_str_weak(attribute),
+    /* K11  */  be_nested_str_weak(push),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_nested_str_weak(tasmota),
+    /* K14  */  be_nested_str_weak(log),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_ack_X20_X20_X20sub_id_X3D),
+    /* K16  */  be_nested_str_weak(subscription_id),
+    /* K17  */  be_const_int(2),
+    /* K18  */  be_nested_str_weak(_inner_process_read_request),
+    /* K19  */  be_nested_str_weak(suppress_response),
+    /* K20  */  be_const_int(0),
+    /* K21  */  be_nested_str_weak(send_queue),
+    /* K22  */  be_nested_str_weak(IM_ReportDataSubscribed),
+    /* K23  */  be_nested_str_weak(__message_handler),
+    /* K24  */  be_nested_str_weak(send_enqueued),
+    }),
+    be_str_weak(send_subscribe_update),
+    &be_const_str_solidified,
+    ( &(const binstruction[66]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x880C0301,  //  0001  GETMBR	R3	R1	K1
+      0xB8120400,  //  0002  GETNGBL	R4	K2
+      0x8C100903,  //  0003  GETMET	R4	R4	K3
+      0x7C100200,  //  0004  CALL	R4	1
+      0x50140000,  //  0005  LDBOOL	R5	0	0
+      0x90120805,  //  0006  SETMBR	R4	K4	R5
+      0x60140012,  //  0007  GETGBL	R5	G18
+      0x7C140000,  //  0008  CALL	R5	0
+      0x90120A05,  //  0009  SETMBR	R4	K5	R5
+      0x60140010,  //  000A  GETGBL	R5	G16
+      0x88180306,  //  000B  GETMBR	R6	R1	K6
+      0x7C140200,  //  000C  CALL	R5	1
+      0xA802000F,  //  000D  EXBLK	0	#001E
+      0x5C180A00,  //  000E  MOVE	R6	R5
+      0x7C180000,  //  000F  CALL	R6	0
+      0xB81E0400,  //  0010  GETNGBL	R7	K2
+      0x8C1C0F07,  //  0011  GETMET	R7	R7	K7
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0x88200D08,  //  0013  GETMBR	R8	R6	K8
+      0x901E1008,  //  0014  SETMBR	R7	K8	R8
+      0x88200D09,  //  0015  GETMBR	R8	R6	K9
+      0x901E1208,  //  0016  SETMBR	R7	K9	R8
+      0x88200D0A,  //  0017  GETMBR	R8	R6	K10
+      0x901E1408,  //  0018  SETMBR	R7	K10	R8
+      0x88200905,  //  0019  GETMBR	R8	R4	K5
+      0x8C20110B,  //  001A  GETMET	R8	R8	K11
+      0x5C280E00,  //  001B  MOVE	R10	R7
+      0x7C200400,  //  001C  CALL	R8	2
+      0x7001FFEF,  //  001D  JMP		#000E
+      0x5814000C,  //  001E  LDCONST	R5	K12
+      0xAC140200,  //  001F  CATCH	R5	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0xB8161A00,  //  0021  GETNGBL	R5	K13
+      0x8C140B0E,  //  0022  GETMET	R5	R5	K14
+      0x601C0008,  //  0023  GETGBL	R7	G8
+      0x88200310,  //  0024  GETMBR	R8	R1	K16
+      0x7C1C0200,  //  0025  CALL	R7	1
+      0x001E1E07,  //  0026  ADD	R7	K15	R7
+      0x58200011,  //  0027  LDCONST	R8	K17
+      0x7C140600,  //  0028  CALL	R5	3
+      0x8C140112,  //  0029  GETMET	R5	R0	K18
+      0x5C1C0600,  //  002A  MOVE	R7	R3
+      0x5C200800,  //  002B  MOVE	R8	R4
+      0x7C140600,  //  002C  CALL	R5	3
+      0x6018000C,  //  002D  GETGBL	R6	G12
+      0x881C0905,  //  002E  GETMBR	R7	R4	K5
+      0x7C180200,  //  002F  CALL	R6	1
+      0x1C180D14,  //  0030  EQ	R6	R6	K20
+      0x90162606,  //  0031  SETMBR	R5	K19	R6
+      0x88180310,  //  0032  GETMBR	R6	R1	K16
+      0x90162006,  //  0033  SETMBR	R5	K16	R6
+      0x88180115,  //  0034  GETMBR	R6	R0	K21
+      0x8C180D0B,  //  0035  GETMET	R6	R6	K11
+      0xB8220400,  //  0036  GETNGBL	R8	K2
+      0x8C201116,  //  0037  GETMET	R8	R8	K22
+      0x88280717,  //  0038  GETMBR	R10	R3	K23
+      0x5C2C0600,  //  0039  MOVE	R11	R3
+      0x5C300A00,  //  003A  MOVE	R12	R5
+      0x5C340200,  //  003B  MOVE	R13	R1
+      0x7C200A00,  //  003C  CALL	R8	5
+      0x7C180400,  //  003D  CALL	R6	2
+      0x8C180118,  //  003E  GETMET	R6	R0	K24
+      0x88200717,  //  003F  GETMBR	R8	R3	K23
+      0x7C180400,  //  0040  CALL	R6	2
+      0x80000000,  //  0041  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_write_response
+********************************************************************/
+be_local_closure(Matter_IM_send_write_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_WriteResponse),
+    }),
+    be_str_weak(send_write_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_request
+********************************************************************/
+be_local_closure(Matter_IM_subscribe_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(keep_subscriptions),
+    /* K5   */  be_nested_str_weak(subs),
+    /* K6   */  be_nested_str_weak(remove_by_session),
+    /* K7   */  be_nested_str_weak(session),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeRequestMessage_X3D),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(new_subscription),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20sub_id_X3D),
+    /* K14  */  be_nested_str_weak(subscription_id),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(_inner_process_read_request),
+    /* K17  */  be_nested_str_weak(send_subscribe_response),
+    }),
+    be_str_weak(subscribe_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0x88140904,  //  0007  GETMBR	R5	R4	K4
+      0x74160003,  //  0008  JMPT	R5	#000D
+      0x88140105,  //  0009  GETMBR	R5	R0	K5
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x881C0307,  //  000B  GETMBR	R7	R1	K7
+      0x7C140400,  //  000C  CALL	R5	2
+      0xB8161000,  //  000D  GETNGBL	R5	K8
+      0x8C140B09,  //  000E  GETMET	R5	R5	K9
+      0x601C0008,  //  000F  GETGBL	R7	G8
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x001E1407,  //  0012  ADD	R7	K10	R7
+      0x5820000B,  //  0013  LDCONST	R8	K11
+      0x7C140600,  //  0014  CALL	R5	3
+      0x88140105,  //  0015  GETMBR	R5	R0	K5
+      0x8C140B0C,  //  0016  GETMET	R5	R5	K12
+      0x881C0307,  //  0017  GETMBR	R7	R1	K7
+      0x5C200800,  //  0018  MOVE	R8	R4
+      0x7C140600,  //  0019  CALL	R5	3
+      0xB81A1000,  //  001A  GETNGBL	R6	K8
+      0x8C180D09,  //  001B  GETMET	R6	R6	K9
+      0x60200008,  //  001C  GETGBL	R8	G8
+      0x88240B0E,  //  001D  GETMBR	R9	R5	K14
+      0x7C200200,  //  001E  CALL	R8	1
+      0x00221A08,  //  001F  ADD	R8	K13	R8
+      0x5824000F,  //  0020  LDCONST	R9	K15
+      0x7C180600,  //  0021  CALL	R6	3
+      0x8C180110,  //  0022  GETMET	R6	R0	K16
+      0x88200307,  //  0023  GETMBR	R8	R1	K7
+      0x5C240800,  //  0024  MOVE	R9	R4
+      0x7C180600,  //  0025  CALL	R6	3
+      0x881C0B0E,  //  0026  GETMBR	R7	R5	K14
+      0x901A1C07,  //  0027  SETMBR	R6	K14	R7
+      0x8C1C0111,  //  0028  GETMET	R7	R0	K17
+      0x5C240200,  //  0029  MOVE	R9	R1
+      0x5C280C00,  //  002A  MOVE	R10	R6
+      0x5C2C0A00,  //  002B  MOVE	R11	R5
+      0x7C1C0800,  //  002C  CALL	R7	4
+      0x501C0200,  //  002D  LDBOOL	R7	1	0
+      0x80040E00,  //  002E  RET	1	R7
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_write_response
+********************************************************************/
+be_local_closure(Matter_IM_process_write_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(WriteResponseMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteResponseMessage_X3D),
+    /* K7   */  be_const_int(2),
+    }),
+    be_str_weak(process_write_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x50140000,  //  000F  LDBOOL	R5	0	0
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_incoming
+********************************************************************/
+be_local_closure(Matter_IM_process_incoming,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[27]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20IM_X20message_X20),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(inspect),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(TLV),
+    /* K7   */  be_nested_str_weak(parse),
+    /* K8   */  be_nested_str_weak(raw),
+    /* K9   */  be_nested_str_weak(app_payload_idx),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20IM_X20TLV_X3A_X20),
+    /* K11  */  be_nested_str_weak(findsubval),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20InteractionModelRevision_X3D),
+    /* K13  */  be_nested_str_weak(nil),
+    /* K14  */  be_nested_str_weak(opcode),
+    /* K15  */  be_const_int(1),
+    /* K16  */  be_nested_str_weak(process_status_response),
+    /* K17  */  be_const_int(2),
+    /* K18  */  be_nested_str_weak(process_read_request),
+    /* K19  */  be_nested_str_weak(subscribe_request),
+    /* K20  */  be_nested_str_weak(subscribe_response),
+    /* K21  */  be_nested_str_weak(report_data),
+    /* K22  */  be_nested_str_weak(process_write_request),
+    /* K23  */  be_nested_str_weak(process_write_response),
+    /* K24  */  be_nested_str_weak(process_invoke_request),
+    /* K25  */  be_nested_str_weak(process_invoke_response),
+    /* K26  */  be_nested_str_weak(process_timed_request),
+    }),
+    be_str_weak(process_incoming),
+    &be_const_str_solidified,
+    ( &(const binstruction[128]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0xB8120600,  //  0002  GETNGBL	R4	K3
+      0x8C100904,  //  0003  GETMET	R4	R4	K4
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x00120404,  //  0006  ADD	R4	K2	R4
+      0x58140005,  //  0007  LDCONST	R5	K5
+      0x7C080600,  //  0008  CALL	R2	3
+      0xB80A0600,  //  0009  GETNGBL	R2	K3
+      0x88080506,  //  000A  GETMBR	R2	R2	K6
+      0x8C080507,  //  000B  GETMET	R2	R2	K7
+      0x88100308,  //  000C  GETMBR	R4	R1	K8
+      0x88140309,  //  000D  GETMBR	R5	R1	K9
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80E0000,  //  000F  GETNGBL	R3	K0
+      0x8C0C0701,  //  0010  GETMET	R3	R3	K1
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x5C180400,  //  0012  MOVE	R6	R2
+      0x7C140200,  //  0013  CALL	R5	1
+      0x00161405,  //  0014  ADD	R5	K10	R5
+      0x58180005,  //  0015  LDCONST	R6	K5
+      0x7C0C0600,  //  0016  CALL	R3	3
+      0x8C0C050B,  //  0017  GETMET	R3	R2	K11
+      0x541600FE,  //  0018  LDINT	R5	255
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0xB8120000,  //  001A  GETNGBL	R4	K0
+      0x8C100901,  //  001B  GETMET	R4	R4	K1
+      0x4C180000,  //  001C  LDNIL	R6
+      0x20180606,  //  001D  NE	R6	R3	R6
+      0x781A0003,  //  001E  JMPF	R6	#0023
+      0x60180008,  //  001F  GETGBL	R6	G8
+      0x5C1C0600,  //  0020  MOVE	R7	R3
+      0x7C180200,  //  0021  CALL	R6	1
+      0x70020000,  //  0022  JMP		#0024
+      0x5818000D,  //  0023  LDCONST	R6	K13
+      0x001A1806,  //  0024  ADD	R6	K12	R6
+      0x541E0003,  //  0025  LDINT	R7	4
+      0x7C100600,  //  0026  CALL	R4	3
+      0x8810030E,  //  0027  GETMBR	R4	R1	K14
+      0x1C14090F,  //  0028  EQ	R5	R4	K15
+      0x78160005,  //  0029  JMPF	R5	#0030
+      0x8C140110,  //  002A  GETMET	R5	R0	K16
+      0x5C1C0200,  //  002B  MOVE	R7	R1
+      0x5C200400,  //  002C  MOVE	R8	R2
+      0x7C140600,  //  002D  CALL	R5	3
+      0x80040A00,  //  002E  RET	1	R5
+      0x7002004D,  //  002F  JMP		#007E
+      0x1C140911,  //  0030  EQ	R5	R4	K17
+      0x78160005,  //  0031  JMPF	R5	#0038
+      0x8C140112,  //  0032  GETMET	R5	R0	K18
+      0x5C1C0200,  //  0033  MOVE	R7	R1
+      0x5C200400,  //  0034  MOVE	R8	R2
+      0x7C140600,  //  0035  CALL	R5	3
+      0x80040A00,  //  0036  RET	1	R5
+      0x70020045,  //  0037  JMP		#007E
+      0x1C140905,  //  0038  EQ	R5	R4	K5
+      0x78160005,  //  0039  JMPF	R5	#0040
+      0x8C140113,  //  003A  GETMET	R5	R0	K19
+      0x5C1C0200,  //  003B  MOVE	R7	R1
+      0x5C200400,  //  003C  MOVE	R8	R2
+      0x7C140600,  //  003D  CALL	R5	3
+      0x80040A00,  //  003E  RET	1	R5
+      0x7002003D,  //  003F  JMP		#007E
+      0x54160003,  //  0040  LDINT	R5	4
+      0x1C140805,  //  0041  EQ	R5	R4	R5
+      0x78160005,  //  0042  JMPF	R5	#0049
+      0x8C140114,  //  0043  GETMET	R5	R0	K20
+      0x5C1C0200,  //  0044  MOVE	R7	R1
+      0x5C200400,  //  0045  MOVE	R8	R2
+      0x7C140600,  //  0046  CALL	R5	3
+      0x80040A00,  //  0047  RET	1	R5
+      0x70020034,  //  0048  JMP		#007E
+      0x54160004,  //  0049  LDINT	R5	5
+      0x1C140805,  //  004A  EQ	R5	R4	R5
+      0x78160005,  //  004B  JMPF	R5	#0052
+      0x8C140115,  //  004C  GETMET	R5	R0	K21
+      0x5C1C0200,  //  004D  MOVE	R7	R1
+      0x5C200400,  //  004E  MOVE	R8	R2
+      0x7C140600,  //  004F  CALL	R5	3
+      0x80040A00,  //  0050  RET	1	R5
+      0x7002002B,  //  0051  JMP		#007E
+      0x54160005,  //  0052  LDINT	R5	6
+      0x1C140805,  //  0053  EQ	R5	R4	R5
+      0x78160005,  //  0054  JMPF	R5	#005B
+      0x8C140116,  //  0055  GETMET	R5	R0	K22
+      0x5C1C0200,  //  0056  MOVE	R7	R1
+      0x5C200400,  //  0057  MOVE	R8	R2
+      0x7C140600,  //  0058  CALL	R5	3
+      0x80040A00,  //  0059  RET	1	R5
+      0x70020022,  //  005A  JMP		#007E
+      0x54160006,  //  005B  LDINT	R5	7
+      0x1C140805,  //  005C  EQ	R5	R4	R5
+      0x78160005,  //  005D  JMPF	R5	#0064
+      0x8C140117,  //  005E  GETMET	R5	R0	K23
+      0x5C1C0200,  //  005F  MOVE	R7	R1
+      0x5C200400,  //  0060  MOVE	R8	R2
+      0x7C140600,  //  0061  CALL	R5	3
+      0x80040A00,  //  0062  RET	1	R5
+      0x70020019,  //  0063  JMP		#007E
+      0x54160007,  //  0064  LDINT	R5	8
+      0x1C140805,  //  0065  EQ	R5	R4	R5
+      0x78160005,  //  0066  JMPF	R5	#006D
+      0x8C140118,  //  0067  GETMET	R5	R0	K24
+      0x5C1C0200,  //  0068  MOVE	R7	R1
+      0x5C200400,  //  0069  MOVE	R8	R2
+      0x7C140600,  //  006A  CALL	R5	3
+      0x80040A00,  //  006B  RET	1	R5
+      0x70020010,  //  006C  JMP		#007E
+      0x54160008,  //  006D  LDINT	R5	9
+      0x1C140805,  //  006E  EQ	R5	R4	R5
+      0x78160005,  //  006F  JMPF	R5	#0076
+      0x8C140119,  //  0070  GETMET	R5	R0	K25
+      0x5C1C0200,  //  0071  MOVE	R7	R1
+      0x5C200400,  //  0072  MOVE	R8	R2
+      0x7C140600,  //  0073  CALL	R5	3
+      0x80040A00,  //  0074  RET	1	R5
+      0x70020007,  //  0075  JMP		#007E
+      0x54160009,  //  0076  LDINT	R5	10
+      0x1C140805,  //  0077  EQ	R5	R4	R5
+      0x78160004,  //  0078  JMPF	R5	#007E
+      0x8C14011A,  //  0079  GETMET	R5	R0	K26
+      0x5C1C0200,  //  007A  MOVE	R7	R1
+      0x5C200400,  //  007B  MOVE	R8	R2
+      0x7C140600,  //  007C  CALL	R5	3
+      0x80040A00,  //  007D  RET	1	R5
+      0x50140000,  //  007E  LDBOOL	R5	0	0
+      0x80040A00,  //  007F  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_sendqueue_by_exchangeid
+********************************************************************/
+be_local_closure(Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(get_exchangeid),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(remove_sendqueue_by_exchangeid),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x58080000,  //  0004  LDCONST	R2	K0
+      0x600C000C,  //  0005  GETGBL	R3	G12
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0007  CALL	R3	1
+      0x140C0403,  //  0008  LT	R3	R2	R3
+      0x780E000C,  //  0009  JMPF	R3	#0017
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x940C0602,  //  000B  GETIDX	R3	R3	R2
+      0x8C0C0702,  //  000C  GETMET	R3	R3	K2
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x1C0C0601,  //  000E  EQ	R3	R3	R1
+      0x780E0004,  //  000F  JMPF	R3	#0015
+      0x880C0101,  //  0010  GETMBR	R3	R0	K1
+      0x8C0C0703,  //  0011  GETMET	R3	R3	K3
+      0x5C140400,  //  0012  MOVE	R5	R2
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x70020000,  //  0014  JMP		#0016
+      0x00080504,  //  0015  ADD	R2	R2	K4
+      0x7001FFED,  //  0016  JMP		#0005
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: send_subscribe_response
 ********************************************************************/
 be_local_closure(Matter_IM_send_subscribe_response,   /* name */
@@ -45,360 +690,79 @@ be_local_closure(Matter_IM_send_subscribe_response,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_write_request
+** Solidified function: process_status_response
 ********************************************************************/
-be_local_closure(Matter_IM_process_write_request,   /* name */
+be_local_closure(Matter_IM_process_status_response,   /* name */
   be_nested_proto(
-    20,                          /* nstack */
+    12,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        19,                          /* nstack */
-        5,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[25]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(matter),
-        /* K2   */  be_nested_str_weak(get_attribute_name),
-        /* K3   */  be_nested_str_weak(cluster),
-        /* K4   */  be_nested_str_weak(attribute),
-        /* K5   */  be_nested_str_weak(_X20_X28),
-        /* K6   */  be_nested_str_weak(_X29),
-        /* K7   */  be_nested_str_weak(),
-        /* K8   */  be_nested_str_weak(status),
-        /* K9   */  be_nested_str_weak(UNSUPPORTED_WRITE),
-        /* K10  */  be_nested_str_weak(write_attribute),
-        /* K11  */  be_nested_str_weak(SUCCESS),
-        /* K12  */  be_nested_str_weak(AttributeStatusIB),
-        /* K13  */  be_nested_str_weak(path),
-        /* K14  */  be_nested_str_weak(AttributePathIB),
-        /* K15  */  be_nested_str_weak(StatusIB),
-        /* K16  */  be_nested_str_weak(endpoint),
-        /* K17  */  be_nested_str_weak(write_responses),
-        /* K18  */  be_nested_str_weak(push),
-        /* K19  */  be_nested_str_weak(tasmota),
-        /* K20  */  be_nested_str_weak(log),
-        /* K21  */  be_nested_str_weak(format),
-        /* K22  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K23  */  be_const_int(2),
-        /* K24  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
-        }),
-        be_str_weak(write_single_attribute),
-        &be_const_str_solidified,
-        ( &(const binstruction[96]) {  /* code */
-          0xA4160000,  //  0000  IMPORT	R5	K0
-          0xB81A0200,  //  0001  GETNGBL	R6	K1
-          0x8C180D02,  //  0002  GETMET	R6	R6	K2
-          0x88200503,  //  0003  GETMBR	R8	R2	K3
-          0x88240504,  //  0004  GETMBR	R9	R2	K4
-          0x7C180600,  //  0005  CALL	R6	3
-          0x781A0002,  //  0006  JMPF	R6	#000A
-          0x001E0A06,  //  0007  ADD	R7	K5	R6
-          0x001C0F06,  //  0008  ADD	R7	R7	K6
-          0x70020000,  //  0009  JMP		#000B
-          0x581C0007,  //  000A  LDCONST	R7	K7
-          0x5C180E00,  //  000B  MOVE	R6	R7
-          0xB81E0200,  //  000C  GETNGBL	R7	K1
-          0x881C0F09,  //  000D  GETMBR	R7	R7	K9
-          0x900A1007,  //  000E  SETMBR	R2	K8	R7
-          0x4C1C0000,  //  000F  LDNIL	R7
-          0x201C0207,  //  0010  NE	R7	R1	R7
-          0x781E0005,  //  0011  JMPF	R7	#0018
-          0x8C1C030A,  //  0012  GETMET	R7	R1	K10
-          0x68240000,  //  0013  GETUPV	R9	U0
-          0x5C280400,  //  0014  MOVE	R10	R2
-          0x5C2C0600,  //  0015  MOVE	R11	R3
-          0x7C1C0800,  //  0016  CALL	R7	4
-          0x70020000,  //  0017  JMP		#0019
-          0x4C1C0000,  //  0018  LDNIL	R7
-          0x781E0002,  //  0019  JMPF	R7	#001D
-          0xB8220200,  //  001A  GETNGBL	R8	K1
-          0x8820110B,  //  001B  GETMBR	R8	R8	K11
-          0x900A1008,  //  001C  SETMBR	R2	K8	R8
-          0x88200508,  //  001D  GETMBR	R8	R2	K8
-          0x4C240000,  //  001E  LDNIL	R9
-          0x20201009,  //  001F  NE	R8	R8	R9
-          0x78220032,  //  0020  JMPF	R8	#0054
-          0x78120030,  //  0021  JMPF	R4	#0053
-          0xB8220200,  //  0022  GETNGBL	R8	K1
-          0x8C20110C,  //  0023  GETMET	R8	R8	K12
-          0x7C200200,  //  0024  CALL	R8	1
-          0xB8260200,  //  0025  GETNGBL	R9	K1
-          0x8C24130E,  //  0026  GETMET	R9	R9	K14
-          0x7C240200,  //  0027  CALL	R9	1
-          0x90221A09,  //  0028  SETMBR	R8	K13	R9
-          0xB8260200,  //  0029  GETNGBL	R9	K1
-          0x8C24130F,  //  002A  GETMET	R9	R9	K15
-          0x7C240200,  //  002B  CALL	R9	1
-          0x90221009,  //  002C  SETMBR	R8	K8	R9
-          0x8824110D,  //  002D  GETMBR	R9	R8	K13
-          0x88280510,  //  002E  GETMBR	R10	R2	K16
-          0x9026200A,  //  002F  SETMBR	R9	K16	R10
-          0x8824110D,  //  0030  GETMBR	R9	R8	K13
-          0x88280503,  //  0031  GETMBR	R10	R2	K3
-          0x9026060A,  //  0032  SETMBR	R9	K3	R10
-          0x8824110D,  //  0033  GETMBR	R9	R8	K13
-          0x88280504,  //  0034  GETMBR	R10	R2	K4
-          0x9026080A,  //  0035  SETMBR	R9	K4	R10
-          0x88241108,  //  0036  GETMBR	R9	R8	K8
-          0x88280508,  //  0037  GETMBR	R10	R2	K8
-          0x9026100A,  //  0038  SETMBR	R9	K8	R10
-          0x88240111,  //  0039  GETMBR	R9	R0	K17
-          0x8C241312,  //  003A  GETMET	R9	R9	K18
-          0x5C2C1000,  //  003B  MOVE	R11	R8
-          0x7C240400,  //  003C  CALL	R9	2
-          0xB8262600,  //  003D  GETNGBL	R9	K19
-          0x8C241314,  //  003E  GETMET	R9	R9	K20
-          0x8C2C0B15,  //  003F  GETMET	R11	R5	K21
-          0x58340016,  //  0040  LDCONST	R13	K22
-          0x60380008,  //  0041  GETGBL	R14	G8
-          0x5C3C0400,  //  0042  MOVE	R15	R2
-          0x7C380200,  //  0043  CALL	R14	1
-          0x5C3C0C00,  //  0044  MOVE	R15	R6
-          0x88400508,  //  0045  GETMBR	R16	R2	K8
-          0x88440508,  //  0046  GETMBR	R17	R2	K8
-          0xB84A0200,  //  0047  GETNGBL	R18	K1
-          0x8848250B,  //  0048  GETMBR	R18	R18	K11
-          0x1C442212,  //  0049  EQ	R17	R17	R18
-          0x78460001,  //  004A  JMPF	R17	#004D
-          0x5844000B,  //  004B  LDCONST	R17	K11
-          0x70020000,  //  004C  JMP		#004E
-          0x58440007,  //  004D  LDCONST	R17	K7
-          0x7C2C0C00,  //  004E  CALL	R11	6
-          0x58300017,  //  004F  LDCONST	R12	K23
-          0x7C240600,  //  0050  CALL	R9	3
-          0x50240200,  //  0051  LDBOOL	R9	1	0
-          0x80041200,  //  0052  RET	1	R9
-          0x7002000A,  //  0053  JMP		#005F
-          0xB8222600,  //  0054  GETNGBL	R8	K19
-          0x8C201114,  //  0055  GETMET	R8	R8	K20
-          0x8C280B15,  //  0056  GETMET	R10	R5	K21
-          0x58300018,  //  0057  LDCONST	R12	K24
-          0x60340008,  //  0058  GETGBL	R13	G8
-          0x5C380400,  //  0059  MOVE	R14	R2
-          0x7C340200,  //  005A  CALL	R13	1
-          0x5C380C00,  //  005B  MOVE	R14	R6
-          0x7C280800,  //  005C  CALL	R10	4
-          0x582C0017,  //  005D  LDCONST	R11	K23
-          0x7C200600,  //  005E  CALL	R8	3
-          0x80000000,  //  005F  RET	0
-        })
-      ),
-      be_nested_proto(
-        9,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 3]) {  /* upvals */
-          be_local_const_upval(1, 7),
-          be_local_const_upval(1, 9),
-          be_local_const_upval(1, 13),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        0,                          /* has constants */
-        NULL,                       /* no const */
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 8]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x68100001,  //  0001  GETUPV	R4	U1
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x681C0002,  //  0004  GETUPV	R7	U2
-          0x5C200400,  //  0005  MOVE	R8	R2
-          0x7C0C0A00,  //  0006  CALL	R3	5
-          0x80040600,  //  0007  RET	1	R3
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[36]) {     /* constants */
+    ( &(const bvalue[16]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(WriteRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteRequestMessage_X3D),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(suppress_response),
-    /* K9   */  be_nested_str_weak(device),
-    /* K10  */  be_nested_str_weak(get_active_endpoints),
-    /* K11  */  be_nested_str_weak(MTR_X3A_X20IM_X3Awrite_request_X20processing_X20start),
-    /* K12  */  be_nested_str_weak(Path),
-    /* K13  */  be_nested_str_weak(write_requests),
-    /* K14  */  be_nested_str_weak(WriteResponseMessage),
-    /* K15  */  be_nested_str_weak(write_responses),
-    /* K16  */  be_nested_str_weak(path),
-    /* K17  */  be_nested_str_weak(data),
-    /* K18  */  be_nested_str_weak(endpoint),
-    /* K19  */  be_nested_str_weak(cluster),
-    /* K20  */  be_nested_str_weak(attribute),
-    /* K21  */  be_nested_str_weak(status),
-    /* K22  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K23  */  be_nested_str_weak(INVALID_ACTION),
-    /* K24  */  be_nested_str_weak(get_attribute_name),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
-    /* K26  */  be_nested_str_weak(_X20_X28),
-    /* K27  */  be_nested_str_weak(_X29),
-    /* K28  */  be_nested_str_weak(),
-    /* K29  */  be_const_int(2),
-    /* K30  */  be_nested_str_weak(process_attribute_expansion),
-    /* K31  */  be_nested_str_weak(stop_iteration),
-    /* K32  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessage_X3D),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessageTLV_X3D),
-    /* K34  */  be_nested_str_weak(to_TLV),
-    /* K35  */  be_nested_str_weak(send_write_response),
+    /* K1   */  be_nested_str_weak(findsubval),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K4   */  be_nested_str_weak(exchange_id),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(SUCCESS),
+    /* K7   */  be_nested_str_weak(tasmota),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus),
+    /* K10  */  be_const_int(2),
+    /* K11  */  be_nested_str_weak(ack_received),
+    /* K12  */  be_nested_str_weak(format),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K14  */  be_nested_str_weak(ack_error),
+    /* K15  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
     }),
-    be_str_weak(process_write_request),
+    be_str_weak(process_status_response),
     &be_const_str_solidified,
-    ( &(const binstruction[134]) {  /* code */
+    ( &(const binstruction[40]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x88140908,  //  000F  GETMBR	R5	R4	K8
-      0x88180109,  //  0010  GETMBR	R6	R0	K9
-      0x8C180D0A,  //  0011  GETMET	R6	R6	K10
-      0x7C180200,  //  0012  CALL	R6	1
-      0x841C0000,  //  0013  CLOSURE	R7	P0
-      0xB8220800,  //  0014  GETNGBL	R8	K4
-      0x8C201105,  //  0015  GETMET	R8	R8	K5
-      0x5828000B,  //  0016  LDCONST	R10	K11
-      0x542E0003,  //  0017  LDINT	R11	4
-      0x7C200600,  //  0018  CALL	R8	3
-      0xB8220200,  //  0019  GETNGBL	R8	K1
-      0x8C20110C,  //  001A  GETMET	R8	R8	K12
-      0x7C200200,  //  001B  CALL	R8	1
-      0x8824090D,  //  001C  GETMBR	R9	R4	K13
-      0x4C280000,  //  001D  LDNIL	R10
-      0x2024120A,  //  001E  NE	R9	R9	R10
-      0x78260062,  //  001F  JMPF	R9	#0083
-      0xB8260200,  //  0020  GETNGBL	R9	K1
-      0x8C24130E,  //  0021  GETMET	R9	R9	K14
-      0x7C240200,  //  0022  CALL	R9	1
-      0x60280012,  //  0023  GETGBL	R10	G18
-      0x7C280000,  //  0024  CALL	R10	0
-      0x90261E0A,  //  0025  SETMBR	R9	K15	R10
-      0x60280010,  //  0026  GETGBL	R10	G16
-      0x882C090D,  //  0027  GETMBR	R11	R4	K13
-      0x7C280200,  //  0028  CALL	R10	1
-      0xA802003D,  //  0029  EXBLK	0	#0068
-      0x5C2C1400,  //  002A  MOVE	R11	R10
-      0x7C2C0000,  //  002B  CALL	R11	0
-      0x88301710,  //  002C  GETMBR	R12	R11	K16
-      0x88341711,  //  002D  GETMBR	R13	R11	K17
-      0x88381912,  //  002E  GETMBR	R14	R12	K18
-      0x9022240E,  //  002F  SETMBR	R8	K18	R14
-      0x88381913,  //  0030  GETMBR	R14	R12	K19
-      0x9022260E,  //  0031  SETMBR	R8	K19	R14
-      0x88381914,  //  0032  GETMBR	R14	R12	K20
-      0x9022280E,  //  0033  SETMBR	R8	K20	R14
-      0xB83A0200,  //  0034  GETNGBL	R14	K1
-      0x88381D16,  //  0035  GETMBR	R14	R14	K22
-      0x90222A0E,  //  0036  SETMBR	R8	K21	R14
-      0x88381113,  //  0037  GETMBR	R14	R8	K19
-      0x4C3C0000,  //  0038  LDNIL	R15
-      0x1C381C0F,  //  0039  EQ	R14	R14	R15
-      0x743A0003,  //  003A  JMPT	R14	#003F
-      0x88381114,  //  003B  GETMBR	R14	R8	K20
-      0x4C3C0000,  //  003C  LDNIL	R15
-      0x1C381C0F,  //  003D  EQ	R14	R14	R15
-      0x783A000A,  //  003E  JMPF	R14	#004A
-      0xB83A0200,  //  003F  GETNGBL	R14	K1
-      0x88381D17,  //  0040  GETMBR	R14	R14	K23
-      0x90222A0E,  //  0041  SETMBR	R8	K21	R14
-      0x5C380E00,  //  0042  MOVE	R14	R7
-      0x5C3C1200,  //  0043  MOVE	R15	R9
-      0x4C400000,  //  0044  LDNIL	R16
-      0x5C441000,  //  0045  MOVE	R17	R8
-      0x4C480000,  //  0046  LDNIL	R18
-      0x504C0200,  //  0047  LDBOOL	R19	1	0
-      0x7C380A00,  //  0048  CALL	R14	5
-      0x7001FFDF,  //  0049  JMP		#002A
-      0x88381112,  //  004A  GETMBR	R14	R8	K18
-      0x4C3C0000,  //  004B  LDNIL	R15
-      0x1C381C0F,  //  004C  EQ	R14	R14	R15
-      0x783A0012,  //  004D  JMPF	R14	#0061
-      0xB83A0200,  //  004E  GETNGBL	R14	K1
-      0x8C381D18,  //  004F  GETMET	R14	R14	K24
-      0x88401113,  //  0050  GETMBR	R16	R8	K19
-      0x88441114,  //  0051  GETMBR	R17	R8	K20
-      0x7C380600,  //  0052  CALL	R14	3
-      0xB83E0800,  //  0053  GETNGBL	R15	K4
-      0x8C3C1F05,  //  0054  GETMET	R15	R15	K5
-      0x60440008,  //  0055  GETGBL	R17	G8
-      0x5C481000,  //  0056  MOVE	R18	R8
-      0x7C440200,  //  0057  CALL	R17	1
-      0x00463211,  //  0058  ADD	R17	K25	R17
-      0x783A0002,  //  0059  JMPF	R14	#005D
-      0x004A340E,  //  005A  ADD	R18	K26	R14
-      0x0048251B,  //  005B  ADD	R18	R18	K27
-      0x70020000,  //  005C  JMP		#005E
-      0x5848001C,  //  005D  LDCONST	R18	K28
-      0x00442212,  //  005E  ADD	R17	R17	R18
-      0x5848001D,  //  005F  LDCONST	R18	K29
-      0x7C3C0600,  //  0060  CALL	R15	3
-      0x88380109,  //  0061  GETMBR	R14	R0	K9
-      0x8C381D1E,  //  0062  GETMET	R14	R14	K30
-      0x5C401000,  //  0063  MOVE	R16	R8
-      0x84440001,  //  0064  CLOSURE	R17	P1
-      0x7C380600,  //  0065  CALL	R14	3
-      0xA0280000,  //  0066  CLOSE	R10
-      0x7001FFC1,  //  0067  JMP		#002A
-      0x5828001F,  //  0068  LDCONST	R10	K31
-      0xAC280200,  //  0069  CATCH	R10	1	0
-      0xB0080000,  //  006A  RAISE	2	R0	R0
-      0xB82A0800,  //  006B  GETNGBL	R10	K4
-      0x8C281505,  //  006C  GETMET	R10	R10	K5
-      0x60300008,  //  006D  GETGBL	R12	G8
-      0x5C341200,  //  006E  MOVE	R13	R9
-      0x7C300200,  //  006F  CALL	R12	1
-      0x0032400C,  //  0070  ADD	R12	K32	R12
-      0x54360003,  //  0071  LDINT	R13	4
-      0x7C280600,  //  0072  CALL	R10	3
-      0xB82A0800,  //  0073  GETNGBL	R10	K4
-      0x8C281505,  //  0074  GETMET	R10	R10	K5
-      0x60300008,  //  0075  GETGBL	R12	G8
-      0x8C341322,  //  0076  GETMET	R13	R9	K34
-      0x7C340200,  //  0077  CALL	R13	1
-      0x7C300200,  //  0078  CALL	R12	1
-      0x0032420C,  //  0079  ADD	R12	K33	R12
-      0x58340007,  //  007A  LDCONST	R13	K7
-      0x7C280600,  //  007B  CALL	R10	3
-      0x5C280A00,  //  007C  MOVE	R10	R5
-      0x742A0003,  //  007D  JMPT	R10	#0082
-      0x8C280123,  //  007E  GETMET	R10	R0	K35
-      0x5C300200,  //  007F  MOVE	R12	R1
-      0x5C341200,  //  0080  MOVE	R13	R9
-      0x7C280600,  //  0081  CALL	R10	3
-      0xA0240000,  //  0082  CLOSE	R9
-      0x50240200,  //  0083  LDBOOL	R9	1	0
-      0xA0000000,  //  0084  CLOSE	R0
-      0x80041200,  //  0085  RET	1	R9
+      0x8C100501,  //  0001  GETMET	R4	R2	K1
+      0x58180002,  //  0002  LDCONST	R6	K2
+      0x541E00FE,  //  0003  LDINT	R7	255
+      0x7C100600,  //  0004  CALL	R4	3
+      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x881C0304,  //  0006  GETMBR	R7	R1	K4
+      0x7C140400,  //  0007  CALL	R5	2
+      0xB81A0A00,  //  0008  GETNGBL	R6	K5
+      0x88180D06,  //  0009  GETMBR	R6	R6	K6
+      0x1C180806,  //  000A  EQ	R6	R4	R6
+      0x781A000A,  //  000B  JMPF	R6	#0017
+      0xB81A0E00,  //  000C  GETNGBL	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x58200009,  //  000E  LDCONST	R8	K9
+      0x5824000A,  //  000F  LDCONST	R9	K10
+      0x7C180600,  //  0010  CALL	R6	3
+      0x78160003,  //  0011  JMPF	R5	#0016
+      0x8C180B0B,  //  0012  GETMET	R6	R5	K11
+      0x5C200200,  //  0013  MOVE	R8	R1
+      0x7C180400,  //  0014  CALL	R6	2
+      0x80040C00,  //  0015  RET	1	R6
+      0x7002000E,  //  0016  JMP		#0026
+      0xB81A0E00,  //  0017  GETNGBL	R6	K7
+      0x8C180D08,  //  0018  GETMET	R6	R6	K8
+      0x8C20070C,  //  0019  GETMET	R8	R3	K12
+      0x5828000D,  //  001A  LDCONST	R10	K13
+      0x5C2C0800,  //  001B  MOVE	R11	R4
+      0x7C200600,  //  001C  CALL	R8	3
+      0x5824000A,  //  001D  LDCONST	R9	K10
+      0x7C180600,  //  001E  CALL	R6	3
+      0x78160005,  //  001F  JMPF	R5	#0026
+      0x8C180B0E,  //  0020  GETMET	R6	R5	K14
+      0x5C200200,  //  0021  MOVE	R8	R1
+      0x7C180400,  //  0022  CALL	R6	2
+      0x8C18010F,  //  0023  GETMET	R6	R0	K15
+      0x88200304,  //  0024  GETMBR	R8	R1	K4
+      0x7C180400,  //  0025  CALL	R6	2
+      0x50180000,  //  0026  LDBOOL	R6	0	0
+      0x80040C00,  //  0027  RET	1	R6
     })
   )
 );
@@ -625,7 +989,7 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
         0,                          /* varg */
         1,                          /* has upvals */
         ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 4),
+          be_local_const_upval(1, 3),
           be_local_const_upval(1, 6),
         }),
         0,                          /* has sup protos */
@@ -677,10 +1041,10 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
     be_str_weak(_inner_process_read_request),
     &be_const_str_solidified,
     ( &(const binstruction[104]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x84100000,  //  0003  CLOSURE	R4	P0
+      0x840C0000,  //  0000  CLOSURE	R3	P0
+      0x88100100,  //  0001  GETMBR	R4	R0	K0
+      0x8C100901,  //  0002  GETMET	R4	R4	K1
+      0x7C100200,  //  0003  CALL	R4	1
       0xB8160400,  //  0004  GETNGBL	R5	K2
       0x8C140B03,  //  0005  GETMET	R5	R5	K3
       0x7C140200,  //  0006  CALL	R5	1
@@ -788,81 +1152,9 @@ be_local_closure(Matter_IM__inner_process_read_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_timed_request
+** Solidified function: report_data
 ********************************************************************/
-be_local_closure(Matter_IM_process_timed_request,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TimedRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20TimedRequest_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K10  */  be_nested_str_weak(timeout),
-    /* K11  */  be_nested_str_weak(remote_ip),
-    /* K12  */  be_nested_str_weak(remote_port),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(send_status),
-    /* K15  */  be_nested_str_weak(SUCCESS),
-    }),
-    be_str_weak(process_timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0xB8160800,  //  000F  GETNGBL	R5	K4
-      0x8C140B05,  //  0010  GETMET	R5	R5	K5
-      0x8C1C0708,  //  0011  GETMET	R7	R3	K8
-      0x58240009,  //  0012  LDCONST	R9	K9
-      0x8828090A,  //  0013  GETMBR	R10	R4	K10
-      0x882C030B,  //  0014  GETMBR	R11	R1	K11
-      0x8830030C,  //  0015  GETMBR	R12	R1	K12
-      0x7C1C0A00,  //  0016  CALL	R7	5
-      0x5820000D,  //  0017  LDCONST	R8	K13
-      0x7C140600,  //  0018  CALL	R5	3
-      0x8C14010E,  //  0019  GETMET	R5	R0	K14
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0xB8220200,  //  001B  GETNGBL	R8	K1
-      0x8820110F,  //  001C  GETMBR	R8	R8	K15
-      0x7C140600,  //  001D  CALL	R5	3
-      0x50140200,  //  001E  LDBOOL	R5	1	0
-      0x80040A00,  //  001F  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_write_response
-********************************************************************/
-be_local_closure(Matter_IM_process_write_response,   /* name */
+be_local_closure(Matter_IM_report_data,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
@@ -875,14 +1167,14 @@ be_local_closure(Matter_IM_process_write_response,   /* name */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(WriteResponseMessage),
+    /* K2   */  be_nested_str_weak(ReportDataMessage),
     /* K3   */  be_nested_str_weak(from_TLV),
     /* K4   */  be_nested_str_weak(tasmota),
     /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteResponseMessage_X3D),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20ReportDataMessage_X3D),
     /* K7   */  be_const_int(2),
     }),
-    be_str_weak(process_write_response),
+    be_str_weak(report_data),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
@@ -902,334 +1194,6 @@ be_local_closure(Matter_IM_process_write_response,   /* name */
       0x7C140600,  //  000E  CALL	R5	3
       0x50140000,  //  000F  LDBOOL	R5	0	0
       0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_write_response
-********************************************************************/
-be_local_closure(Matter_IM_send_write_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_WriteResponse),
-    }),
-    be_str_weak(send_write_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_status
-********************************************************************/
-be_local_closure(Matter_IM_send_status,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_Status),
-    }),
-    be_str_weak(send_status),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_response
-********************************************************************/
-be_local_closure(Matter_IM_subscribe_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeResponsetMessage_X3D),
-    /* K7   */  be_const_int(2),
-    }),
-    be_str_weak(subscribe_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_read_request
-********************************************************************/
-be_local_closure(Matter_IM_process_read_request,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(ReadRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(attributes_requests),
-    /* K4   */  be_nested_str_weak(_inner_process_read_request),
-    /* K5   */  be_nested_str_weak(send_report_data),
-    }),
-    be_str_weak(process_read_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x88100703,  //  0006  GETMBR	R4	R3	K3
-      0x4C140000,  //  0007  LDNIL	R5
-      0x20100805,  //  0008  NE	R4	R4	R5
-      0x78120007,  //  0009  JMPF	R4	#0012
-      0x8C100104,  //  000A  GETMET	R4	R0	K4
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x7C100600,  //  000D  CALL	R4	3
-      0x8C140105,  //  000E  GETMET	R5	R0	K5
-      0x5C1C0200,  //  000F  MOVE	R7	R1
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x50100200,  //  0012  LDBOOL	R4	1	0
-      0x80040800,  //  0013  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_report_data
-********************************************************************/
-be_local_closure(Matter_IM_send_report_data,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_ReportData),
-    }),
-    be_str_weak(send_report_data),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_IM_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(subs),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0xB80A0600,  //  0004  GETNGBL	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_request
-********************************************************************/
-be_local_closure(Matter_IM_subscribe_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(keep_subscriptions),
-    /* K5   */  be_nested_str_weak(subs),
-    /* K6   */  be_nested_str_weak(remove_by_session),
-    /* K7   */  be_nested_str_weak(session),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeRequestMessage_X3D),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(new_subscription),
-    /* K13  */  be_nested_str_weak(_inner_process_read_request),
-    /* K14  */  be_nested_str_weak(subscription_id),
-    /* K15  */  be_nested_str_weak(send_subscribe_response),
-    }),
-    be_str_weak(subscribe_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x88140904,  //  0007  GETMBR	R5	R4	K4
-      0x74160003,  //  0008  JMPT	R5	#000D
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x881C0307,  //  000B  GETMBR	R7	R1	K7
-      0x7C140400,  //  000C  CALL	R5	2
-      0xB8161000,  //  000D  GETNGBL	R5	K8
-      0x8C140B09,  //  000E  GETMET	R5	R5	K9
-      0x601C0008,  //  000F  GETGBL	R7	G8
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x001E1407,  //  0012  ADD	R7	K10	R7
-      0x5820000B,  //  0013  LDCONST	R8	K11
-      0x7C140600,  //  0014  CALL	R5	3
-      0x88140105,  //  0015  GETMBR	R5	R0	K5
-      0x8C140B0C,  //  0016  GETMET	R5	R5	K12
-      0x881C0307,  //  0017  GETMBR	R7	R1	K7
-      0x5C200800,  //  0018  MOVE	R8	R4
-      0x7C140600,  //  0019  CALL	R5	3
-      0x8C18010D,  //  001A  GETMET	R6	R0	K13
-      0x5C200200,  //  001B  MOVE	R8	R1
-      0x5C240800,  //  001C  MOVE	R9	R4
-      0x7C180600,  //  001D  CALL	R6	3
-      0x881C0B0E,  //  001E  GETMBR	R7	R5	K14
-      0x901A1C07,  //  001F  SETMBR	R6	K14	R7
-      0x8C1C010F,  //  0020  GETMET	R7	R0	K15
-      0x5C240200,  //  0021  MOVE	R9	R1
-      0x5C280C00,  //  0022  MOVE	R10	R6
-      0x5C2C0A00,  //  0023  MOVE	R11	R5
-      0x7C1C0800,  //  0024  CALL	R7	4
-      0x501C0200,  //  0025  LDBOOL	R7	1	0
-      0x80040E00,  //  0026  RET	1	R7
     })
   )
 );
@@ -1292,6 +1256,721 @@ be_local_closure(Matter_IM_send_enqueued,   /* name */
 
 
 /********************************************************************
+** Solidified function: process_invoke_response
+********************************************************************/
+be_local_closure(Matter_IM_process_invoke_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20InvokeResponseMessage_X3D),
+    /* K7   */  be_const_int(2),
+    }),
+    be_str_weak(process_invoke_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x50140000,  //  000F  LDBOOL	R5	0	0
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_write_request
+********************************************************************/
+be_local_closure(Matter_IM_process_write_request,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        19,                          /* nstack */
+        5,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[26]) {     /* constants */
+        /* K0   */  be_nested_str_weak(string),
+        /* K1   */  be_nested_str_weak(matter),
+        /* K2   */  be_nested_str_weak(get_attribute_name),
+        /* K3   */  be_nested_str_weak(cluster),
+        /* K4   */  be_nested_str_weak(attribute),
+        /* K5   */  be_nested_str_weak(_X20_X28),
+        /* K6   */  be_nested_str_weak(_X29),
+        /* K7   */  be_nested_str_weak(),
+        /* K8   */  be_nested_str_weak(status),
+        /* K9   */  be_nested_str_weak(UNSUPPORTED_WRITE),
+        /* K10  */  be_nested_str_weak(write_attribute),
+        /* K11  */  be_nested_str_weak(session),
+        /* K12  */  be_nested_str_weak(SUCCESS),
+        /* K13  */  be_nested_str_weak(AttributeStatusIB),
+        /* K14  */  be_nested_str_weak(path),
+        /* K15  */  be_nested_str_weak(AttributePathIB),
+        /* K16  */  be_nested_str_weak(StatusIB),
+        /* K17  */  be_nested_str_weak(endpoint),
+        /* K18  */  be_nested_str_weak(write_responses),
+        /* K19  */  be_nested_str_weak(push),
+        /* K20  */  be_nested_str_weak(tasmota),
+        /* K21  */  be_nested_str_weak(log),
+        /* K22  */  be_nested_str_weak(format),
+        /* K23  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K24  */  be_const_int(2),
+        /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        }),
+        be_str_weak(write_single_attribute),
+        &be_const_str_solidified,
+        ( &(const binstruction[97]) {  /* code */
+          0xA4160000,  //  0000  IMPORT	R5	K0
+          0xB81A0200,  //  0001  GETNGBL	R6	K1
+          0x8C180D02,  //  0002  GETMET	R6	R6	K2
+          0x88200503,  //  0003  GETMBR	R8	R2	K3
+          0x88240504,  //  0004  GETMBR	R9	R2	K4
+          0x7C180600,  //  0005  CALL	R6	3
+          0x781A0002,  //  0006  JMPF	R6	#000A
+          0x001E0A06,  //  0007  ADD	R7	K5	R6
+          0x001C0F06,  //  0008  ADD	R7	R7	K6
+          0x70020000,  //  0009  JMP		#000B
+          0x581C0007,  //  000A  LDCONST	R7	K7
+          0x5C180E00,  //  000B  MOVE	R6	R7
+          0xB81E0200,  //  000C  GETNGBL	R7	K1
+          0x881C0F09,  //  000D  GETMBR	R7	R7	K9
+          0x900A1007,  //  000E  SETMBR	R2	K8	R7
+          0x4C1C0000,  //  000F  LDNIL	R7
+          0x201C0207,  //  0010  NE	R7	R1	R7
+          0x781E0006,  //  0011  JMPF	R7	#0019
+          0x8C1C030A,  //  0012  GETMET	R7	R1	K10
+          0x68240000,  //  0013  GETUPV	R9	U0
+          0x8824130B,  //  0014  GETMBR	R9	R9	K11
+          0x5C280400,  //  0015  MOVE	R10	R2
+          0x5C2C0600,  //  0016  MOVE	R11	R3
+          0x7C1C0800,  //  0017  CALL	R7	4
+          0x70020000,  //  0018  JMP		#001A
+          0x4C1C0000,  //  0019  LDNIL	R7
+          0x781E0002,  //  001A  JMPF	R7	#001E
+          0xB8220200,  //  001B  GETNGBL	R8	K1
+          0x8820110C,  //  001C  GETMBR	R8	R8	K12
+          0x900A1008,  //  001D  SETMBR	R2	K8	R8
+          0x88200508,  //  001E  GETMBR	R8	R2	K8
+          0x4C240000,  //  001F  LDNIL	R9
+          0x20201009,  //  0020  NE	R8	R8	R9
+          0x78220032,  //  0021  JMPF	R8	#0055
+          0x78120030,  //  0022  JMPF	R4	#0054
+          0xB8220200,  //  0023  GETNGBL	R8	K1
+          0x8C20110D,  //  0024  GETMET	R8	R8	K13
+          0x7C200200,  //  0025  CALL	R8	1
+          0xB8260200,  //  0026  GETNGBL	R9	K1
+          0x8C24130F,  //  0027  GETMET	R9	R9	K15
+          0x7C240200,  //  0028  CALL	R9	1
+          0x90221C09,  //  0029  SETMBR	R8	K14	R9
+          0xB8260200,  //  002A  GETNGBL	R9	K1
+          0x8C241310,  //  002B  GETMET	R9	R9	K16
+          0x7C240200,  //  002C  CALL	R9	1
+          0x90221009,  //  002D  SETMBR	R8	K8	R9
+          0x8824110E,  //  002E  GETMBR	R9	R8	K14
+          0x88280511,  //  002F  GETMBR	R10	R2	K17
+          0x9026220A,  //  0030  SETMBR	R9	K17	R10
+          0x8824110E,  //  0031  GETMBR	R9	R8	K14
+          0x88280503,  //  0032  GETMBR	R10	R2	K3
+          0x9026060A,  //  0033  SETMBR	R9	K3	R10
+          0x8824110E,  //  0034  GETMBR	R9	R8	K14
+          0x88280504,  //  0035  GETMBR	R10	R2	K4
+          0x9026080A,  //  0036  SETMBR	R9	K4	R10
+          0x88241108,  //  0037  GETMBR	R9	R8	K8
+          0x88280508,  //  0038  GETMBR	R10	R2	K8
+          0x9026100A,  //  0039  SETMBR	R9	K8	R10
+          0x88240112,  //  003A  GETMBR	R9	R0	K18
+          0x8C241313,  //  003B  GETMET	R9	R9	K19
+          0x5C2C1000,  //  003C  MOVE	R11	R8
+          0x7C240400,  //  003D  CALL	R9	2
+          0xB8262800,  //  003E  GETNGBL	R9	K20
+          0x8C241315,  //  003F  GETMET	R9	R9	K21
+          0x8C2C0B16,  //  0040  GETMET	R11	R5	K22
+          0x58340017,  //  0041  LDCONST	R13	K23
+          0x60380008,  //  0042  GETGBL	R14	G8
+          0x5C3C0400,  //  0043  MOVE	R15	R2
+          0x7C380200,  //  0044  CALL	R14	1
+          0x5C3C0C00,  //  0045  MOVE	R15	R6
+          0x88400508,  //  0046  GETMBR	R16	R2	K8
+          0x88440508,  //  0047  GETMBR	R17	R2	K8
+          0xB84A0200,  //  0048  GETNGBL	R18	K1
+          0x8848250C,  //  0049  GETMBR	R18	R18	K12
+          0x1C442212,  //  004A  EQ	R17	R17	R18
+          0x78460001,  //  004B  JMPF	R17	#004E
+          0x5844000C,  //  004C  LDCONST	R17	K12
+          0x70020000,  //  004D  JMP		#004F
+          0x58440007,  //  004E  LDCONST	R17	K7
+          0x7C2C0C00,  //  004F  CALL	R11	6
+          0x58300018,  //  0050  LDCONST	R12	K24
+          0x7C240600,  //  0051  CALL	R9	3
+          0x50240200,  //  0052  LDBOOL	R9	1	0
+          0x80041200,  //  0053  RET	1	R9
+          0x7002000A,  //  0054  JMP		#0060
+          0xB8222800,  //  0055  GETNGBL	R8	K20
+          0x8C201115,  //  0056  GETMET	R8	R8	K21
+          0x8C280B16,  //  0057  GETMET	R10	R5	K22
+          0x58300019,  //  0058  LDCONST	R12	K25
+          0x60340008,  //  0059  GETGBL	R13	G8
+          0x5C380400,  //  005A  MOVE	R14	R2
+          0x7C340200,  //  005B  CALL	R13	1
+          0x5C380C00,  //  005C  MOVE	R14	R6
+          0x7C280800,  //  005D  CALL	R10	4
+          0x582C0018,  //  005E  LDCONST	R11	K24
+          0x7C200600,  //  005F  CALL	R8	3
+          0x80000000,  //  0060  RET	0
+        })
+      ),
+      be_nested_proto(
+        9,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 3]) {  /* upvals */
+          be_local_const_upval(1, 7),
+          be_local_const_upval(1, 9),
+          be_local_const_upval(1, 13),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        0,                          /* has constants */
+        NULL,                       /* no const */
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 8]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x68100001,  //  0001  GETUPV	R4	U1
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x681C0002,  //  0004  GETUPV	R7	U2
+          0x5C200400,  //  0005  MOVE	R8	R2
+          0x7C0C0A00,  //  0006  CALL	R3	5
+          0x80040600,  //  0007  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[36]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(WriteRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteRequestMessage_X3D),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(suppress_response),
+    /* K9   */  be_nested_str_weak(device),
+    /* K10  */  be_nested_str_weak(get_active_endpoints),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20IM_X3Awrite_request_X20processing_X20start),
+    /* K12  */  be_nested_str_weak(Path),
+    /* K13  */  be_nested_str_weak(write_requests),
+    /* K14  */  be_nested_str_weak(WriteResponseMessage),
+    /* K15  */  be_nested_str_weak(write_responses),
+    /* K16  */  be_nested_str_weak(path),
+    /* K17  */  be_nested_str_weak(data),
+    /* K18  */  be_nested_str_weak(endpoint),
+    /* K19  */  be_nested_str_weak(cluster),
+    /* K20  */  be_nested_str_weak(attribute),
+    /* K21  */  be_nested_str_weak(status),
+    /* K22  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K23  */  be_nested_str_weak(INVALID_ACTION),
+    /* K24  */  be_nested_str_weak(get_attribute_name),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20Write_Attr_X20),
+    /* K26  */  be_nested_str_weak(_X20_X28),
+    /* K27  */  be_nested_str_weak(_X29),
+    /* K28  */  be_nested_str_weak(),
+    /* K29  */  be_const_int(2),
+    /* K30  */  be_nested_str_weak(process_attribute_expansion),
+    /* K31  */  be_nested_str_weak(stop_iteration),
+    /* K32  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessage_X3D),
+    /* K33  */  be_nested_str_weak(MTR_X3A_X20ReportWriteMessageTLV_X3D),
+    /* K34  */  be_nested_str_weak(to_TLV),
+    /* K35  */  be_nested_str_weak(send_write_response),
+    }),
+    be_str_weak(process_write_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[134]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x88140908,  //  000F  GETMBR	R5	R4	K8
+      0x88180109,  //  0010  GETMBR	R6	R0	K9
+      0x8C180D0A,  //  0011  GETMET	R6	R6	K10
+      0x7C180200,  //  0012  CALL	R6	1
+      0x841C0000,  //  0013  CLOSURE	R7	P0
+      0xB8220800,  //  0014  GETNGBL	R8	K4
+      0x8C201105,  //  0015  GETMET	R8	R8	K5
+      0x5828000B,  //  0016  LDCONST	R10	K11
+      0x542E0003,  //  0017  LDINT	R11	4
+      0x7C200600,  //  0018  CALL	R8	3
+      0xB8220200,  //  0019  GETNGBL	R8	K1
+      0x8C20110C,  //  001A  GETMET	R8	R8	K12
+      0x7C200200,  //  001B  CALL	R8	1
+      0x8824090D,  //  001C  GETMBR	R9	R4	K13
+      0x4C280000,  //  001D  LDNIL	R10
+      0x2024120A,  //  001E  NE	R9	R9	R10
+      0x78260062,  //  001F  JMPF	R9	#0083
+      0xB8260200,  //  0020  GETNGBL	R9	K1
+      0x8C24130E,  //  0021  GETMET	R9	R9	K14
+      0x7C240200,  //  0022  CALL	R9	1
+      0x60280012,  //  0023  GETGBL	R10	G18
+      0x7C280000,  //  0024  CALL	R10	0
+      0x90261E0A,  //  0025  SETMBR	R9	K15	R10
+      0x60280010,  //  0026  GETGBL	R10	G16
+      0x882C090D,  //  0027  GETMBR	R11	R4	K13
+      0x7C280200,  //  0028  CALL	R10	1
+      0xA802003D,  //  0029  EXBLK	0	#0068
+      0x5C2C1400,  //  002A  MOVE	R11	R10
+      0x7C2C0000,  //  002B  CALL	R11	0
+      0x88301710,  //  002C  GETMBR	R12	R11	K16
+      0x88341711,  //  002D  GETMBR	R13	R11	K17
+      0x88381912,  //  002E  GETMBR	R14	R12	K18
+      0x9022240E,  //  002F  SETMBR	R8	K18	R14
+      0x88381913,  //  0030  GETMBR	R14	R12	K19
+      0x9022260E,  //  0031  SETMBR	R8	K19	R14
+      0x88381914,  //  0032  GETMBR	R14	R12	K20
+      0x9022280E,  //  0033  SETMBR	R8	K20	R14
+      0xB83A0200,  //  0034  GETNGBL	R14	K1
+      0x88381D16,  //  0035  GETMBR	R14	R14	K22
+      0x90222A0E,  //  0036  SETMBR	R8	K21	R14
+      0x88381113,  //  0037  GETMBR	R14	R8	K19
+      0x4C3C0000,  //  0038  LDNIL	R15
+      0x1C381C0F,  //  0039  EQ	R14	R14	R15
+      0x743A0003,  //  003A  JMPT	R14	#003F
+      0x88381114,  //  003B  GETMBR	R14	R8	K20
+      0x4C3C0000,  //  003C  LDNIL	R15
+      0x1C381C0F,  //  003D  EQ	R14	R14	R15
+      0x783A000A,  //  003E  JMPF	R14	#004A
+      0xB83A0200,  //  003F  GETNGBL	R14	K1
+      0x88381D17,  //  0040  GETMBR	R14	R14	K23
+      0x90222A0E,  //  0041  SETMBR	R8	K21	R14
+      0x5C380E00,  //  0042  MOVE	R14	R7
+      0x5C3C1200,  //  0043  MOVE	R15	R9
+      0x4C400000,  //  0044  LDNIL	R16
+      0x5C441000,  //  0045  MOVE	R17	R8
+      0x4C480000,  //  0046  LDNIL	R18
+      0x504C0200,  //  0047  LDBOOL	R19	1	0
+      0x7C380A00,  //  0048  CALL	R14	5
+      0x7001FFDF,  //  0049  JMP		#002A
+      0x88381112,  //  004A  GETMBR	R14	R8	K18
+      0x4C3C0000,  //  004B  LDNIL	R15
+      0x1C381C0F,  //  004C  EQ	R14	R14	R15
+      0x783A0012,  //  004D  JMPF	R14	#0061
+      0xB83A0200,  //  004E  GETNGBL	R14	K1
+      0x8C381D18,  //  004F  GETMET	R14	R14	K24
+      0x88401113,  //  0050  GETMBR	R16	R8	K19
+      0x88441114,  //  0051  GETMBR	R17	R8	K20
+      0x7C380600,  //  0052  CALL	R14	3
+      0xB83E0800,  //  0053  GETNGBL	R15	K4
+      0x8C3C1F05,  //  0054  GETMET	R15	R15	K5
+      0x60440008,  //  0055  GETGBL	R17	G8
+      0x5C481000,  //  0056  MOVE	R18	R8
+      0x7C440200,  //  0057  CALL	R17	1
+      0x00463211,  //  0058  ADD	R17	K25	R17
+      0x783A0002,  //  0059  JMPF	R14	#005D
+      0x004A340E,  //  005A  ADD	R18	K26	R14
+      0x0048251B,  //  005B  ADD	R18	R18	K27
+      0x70020000,  //  005C  JMP		#005E
+      0x5848001C,  //  005D  LDCONST	R18	K28
+      0x00442212,  //  005E  ADD	R17	R17	R18
+      0x5848001D,  //  005F  LDCONST	R18	K29
+      0x7C3C0600,  //  0060  CALL	R15	3
+      0x88380109,  //  0061  GETMBR	R14	R0	K9
+      0x8C381D1E,  //  0062  GETMET	R14	R14	K30
+      0x5C401000,  //  0063  MOVE	R16	R8
+      0x84440001,  //  0064  CLOSURE	R17	P1
+      0x7C380600,  //  0065  CALL	R14	3
+      0xA0280000,  //  0066  CLOSE	R10
+      0x7001FFC1,  //  0067  JMP		#002A
+      0x5828001F,  //  0068  LDCONST	R10	K31
+      0xAC280200,  //  0069  CATCH	R10	1	0
+      0xB0080000,  //  006A  RAISE	2	R0	R0
+      0xB82A0800,  //  006B  GETNGBL	R10	K4
+      0x8C281505,  //  006C  GETMET	R10	R10	K5
+      0x60300008,  //  006D  GETGBL	R12	G8
+      0x5C341200,  //  006E  MOVE	R13	R9
+      0x7C300200,  //  006F  CALL	R12	1
+      0x0032400C,  //  0070  ADD	R12	K32	R12
+      0x54360003,  //  0071  LDINT	R13	4
+      0x7C280600,  //  0072  CALL	R10	3
+      0xB82A0800,  //  0073  GETNGBL	R10	K4
+      0x8C281505,  //  0074  GETMET	R10	R10	K5
+      0x60300008,  //  0075  GETGBL	R12	G8
+      0x8C341322,  //  0076  GETMET	R13	R9	K34
+      0x7C340200,  //  0077  CALL	R13	1
+      0x7C300200,  //  0078  CALL	R12	1
+      0x0032420C,  //  0079  ADD	R12	K33	R12
+      0x58340007,  //  007A  LDCONST	R13	K7
+      0x7C280600,  //  007B  CALL	R10	3
+      0x5C280A00,  //  007C  MOVE	R10	R5
+      0x742A0003,  //  007D  JMPT	R10	#0082
+      0x8C280123,  //  007E  GETMET	R10	R0	K35
+      0x5C300200,  //  007F  MOVE	R12	R1
+      0x5C341200,  //  0080  MOVE	R13	R9
+      0x7C280600,  //  0081  CALL	R10	3
+      0xA0240000,  //  0082  CLOSE	R9
+      0x50240200,  //  0083  LDBOOL	R9	1	0
+      0xA0000000,  //  0084  CLOSE	R0
+      0x80041200,  //  0085  RET	1	R9
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_sendqueue_by_exchangeid
+********************************************************************/
+be_local_closure(Matter_IM_find_sendqueue_by_exchangeid,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(get_exchangeid),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(find_sendqueue_by_exchangeid),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x58080000,  //  0005  LDCONST	R2	K0
+      0x600C000C,  //  0006  GETGBL	R3	G12
+      0x88100101,  //  0007  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0x140C0403,  //  0009  LT	R3	R2	R3
+      0x780E0008,  //  000A  JMPF	R3	#0014
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x940C0602,  //  000C  GETIDX	R3	R3	R2
+      0x8C100702,  //  000D  GETMET	R4	R3	K2
+      0x7C100200,  //  000E  CALL	R4	1
+      0x1C100801,  //  000F  EQ	R4	R4	R1
+      0x78120000,  //  0010  JMPF	R4	#0012
+      0x80040600,  //  0011  RET	1	R3
+      0x00080503,  //  0012  ADD	R2	R2	K3
+      0x7001FFF1,  //  0013  JMP		#0006
+      0x4C0C0000,  //  0014  LDNIL	R3
+      0x80040600,  //  0015  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_status
+********************************************************************/
+be_local_closure(Matter_IM_send_status,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_Status),
+    }),
+    be_str_weak(send_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_report_data
+********************************************************************/
+be_local_closure(Matter_IM_send_report_data,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_ReportData),
+    }),
+    be_str_weak(send_report_data),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_IM_every_second,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: subscribe_response
+********************************************************************/
+be_local_closure(Matter_IM_subscribe_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(SubscribeResponseMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeResponsetMessage_X3D),
+    /* K7   */  be_const_int(2),
+    }),
+    be_str_weak(subscribe_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x50140000,  //  000F  LDBOOL	R5	0	0
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_invoke_response
+********************************************************************/
+be_local_closure(Matter_IM_send_invoke_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_InvokeResponse),
+    }),
+    be_str_weak(send_invoke_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_IM_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(subs),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0xB80A0600,  //  0004  GETNGBL	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_IM_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: process_invoke_request
 ********************************************************************/
 be_local_closure(Matter_IM_process_invoke_request,   /* name */
@@ -1304,7 +1983,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
+    ( &(const bvalue[45]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
@@ -1332,23 +2011,24 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
     /* K24  */  be_const_int(2),
     /* K25  */  be_nested_str_weak(device),
     /* K26  */  be_nested_str_weak(invoke_request),
-    /* K27  */  be_nested_str_weak(command_fields),
-    /* K28  */  be_nested_str_weak(InvokeResponseIB),
-    /* K29  */  be_nested_str_weak(CommandStatusIB),
-    /* K30  */  be_nested_str_weak(CommandPathIB),
-    /* K31  */  be_nested_str_weak(StatusIB),
-    /* K32  */  be_nested_str_weak(SUCCESS),
-    /* K33  */  be_nested_str_weak(push),
-    /* K34  */  be_nested_str_weak(CommandDataIB),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s_X20_X25s),
-    /* K36  */  be_nested_str_weak(stop_iteration),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20invoke_responses_X3D),
-    /* K38  */  be_const_int(0),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20InvokeResponse_X3D),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20InvokeResponseTLV_X3D),
-    /* K41  */  be_nested_str_weak(to_TLV),
-    /* K42  */  be_const_int(3),
-    /* K43  */  be_nested_str_weak(send_invoke_response),
+    /* K27  */  be_nested_str_weak(session),
+    /* K28  */  be_nested_str_weak(command_fields),
+    /* K29  */  be_nested_str_weak(InvokeResponseIB),
+    /* K30  */  be_nested_str_weak(CommandStatusIB),
+    /* K31  */  be_nested_str_weak(CommandPathIB),
+    /* K32  */  be_nested_str_weak(StatusIB),
+    /* K33  */  be_nested_str_weak(SUCCESS),
+    /* K34  */  be_nested_str_weak(push),
+    /* K35  */  be_nested_str_weak(CommandDataIB),
+    /* K36  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s_X20_X25s),
+    /* K37  */  be_nested_str_weak(stop_iteration),
+    /* K38  */  be_nested_str_weak(MTR_X3A_X20invoke_responses_X3D),
+    /* K39  */  be_const_int(0),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20InvokeResponse_X3D),
+    /* K41  */  be_nested_str_weak(MTR_X3A_X20InvokeResponseTLV_X3D),
+    /* K42  */  be_nested_str_weak(to_TLV),
+    /* K43  */  be_const_int(3),
+    /* K44  */  be_nested_str_weak(send_invoke_response),
     }),
     be_str_weak(process_invoke_request),
     &be_const_str_solidified,
@@ -1421,23 +2101,23 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x7C280600,  //  0041  CALL	R10	3
       0x88280119,  //  0042  GETMBR	R10	R0	K25
       0x8C28151A,  //  0043  GETMET	R10	R10	K26
-      0x5C300200,  //  0044  MOVE	R12	R1
-      0x8834111B,  //  0045  GETMBR	R13	R8	K27
+      0x8830031B,  //  0044  GETMBR	R12	R1	K27
+      0x8834111C,  //  0045  GETMBR	R13	R8	K28
       0x5C380800,  //  0046  MOVE	R14	R4
       0x7C280800,  //  0047  CALL	R10	4
       0xB82E0800,  //  0048  GETNGBL	R11	K4
-      0x8C2C171C,  //  0049  GETMET	R11	R11	K28
+      0x8C2C171D,  //  0049  GETMET	R11	R11	K29
       0x7C2C0200,  //  004A  CALL	R11	1
       0x50300200,  //  004B  LDBOOL	R12	1	0
       0x1C30140C,  //  004C  EQ	R12	R10	R12
       0x78320023,  //  004D  JMPF	R12	#0072
       0xB8320800,  //  004E  GETNGBL	R12	K4
-      0x8C30191D,  //  004F  GETMET	R12	R12	K29
+      0x8C30191E,  //  004F  GETMET	R12	R12	K30
       0x7C300200,  //  0050  CALL	R12	1
       0x902E200C,  //  0051  SETMBR	R11	K16	R12
       0x88301710,  //  0052  GETMBR	R12	R11	K16
       0xB8360800,  //  0053  GETNGBL	R13	K4
-      0x8C341B1E,  //  0054  GETMET	R13	R13	K30
+      0x8C341B1F,  //  0054  GETMET	R13	R13	K31
       0x7C340200,  //  0055  CALL	R13	1
       0x90321A0D,  //  0056  SETMBR	R12	K13	R13
       0x88301710,  //  0057  GETMBR	R12	R11	K16
@@ -1454,16 +2134,16 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x90321E0D,  //  0062  SETMBR	R12	K15	R13
       0x88301710,  //  0063  GETMBR	R12	R11	K16
       0xB8360800,  //  0064  GETNGBL	R13	K4
-      0x8C341B1F,  //  0065  GETMET	R13	R13	K31
+      0x8C341B20,  //  0065  GETMET	R13	R13	K32
       0x7C340200,  //  0066  CALL	R13	1
       0x9032200D,  //  0067  SETMBR	R12	K16	R13
       0x88301710,  //  0068  GETMBR	R12	R11	K16
       0x88301910,  //  0069  GETMBR	R12	R12	K16
       0xB8360800,  //  006A  GETNGBL	R13	K4
-      0x88341B20,  //  006B  GETMBR	R13	R13	K32
+      0x88341B21,  //  006B  GETMBR	R13	R13	K33
       0x9032200D,  //  006C  SETMBR	R12	K16	R13
       0x88300D0B,  //  006D  GETMBR	R12	R6	K11
-      0x8C301921,  //  006E  GETMET	R12	R12	K33
+      0x8C301922,  //  006E  GETMET	R12	R12	K34
       0x5C381600,  //  006F  MOVE	R14	R11
       0x7C300400,  //  0070  CALL	R12	2
       0x70020059,  //  0071  JMP		#00CC
@@ -1471,12 +2151,12 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x2030140C,  //  0073  NE	R12	R10	R12
       0x7832002F,  //  0074  JMPF	R12	#00A5
       0xB8320800,  //  0075  GETNGBL	R12	K4
-      0x8C301922,  //  0076  GETMET	R12	R12	K34
+      0x8C301923,  //  0076  GETMET	R12	R12	K35
       0x7C300200,  //  0077  CALL	R12	1
       0x902E1E0C,  //  0078  SETMBR	R11	K15	R12
       0x8830170F,  //  0079  GETMBR	R12	R11	K15
       0xB8360800,  //  007A  GETNGBL	R13	K4
-      0x8C341B1E,  //  007B  GETMET	R13	R13	K30
+      0x8C341B1F,  //  007B  GETMET	R13	R13	K31
       0x7C340200,  //  007C  CALL	R13	1
       0x90321A0D,  //  007D  SETMBR	R12	K13	R13
       0x8830170F,  //  007E  GETMBR	R12	R11	K15
@@ -1492,9 +2172,9 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x8834090F,  //  0088  GETMBR	R13	R4	K15
       0x90321E0D,  //  0089  SETMBR	R12	K15	R13
       0x8830170F,  //  008A  GETMBR	R12	R11	K15
-      0x9032360A,  //  008B  SETMBR	R12	K27	R10
+      0x9032380A,  //  008B  SETMBR	R12	K28	R10
       0x88300D0B,  //  008C  GETMBR	R12	R6	K11
-      0x8C301921,  //  008D  GETMET	R12	R12	K33
+      0x8C301922,  //  008D  GETMET	R12	R12	K34
       0x5C381600,  //  008E  MOVE	R14	R11
       0x7C300400,  //  008F  CALL	R12	2
       0xB8320800,  //  0090  GETNGBL	R12	K4
@@ -1506,7 +2186,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0xB8320200,  //  0096  GETNGBL	R12	K1
       0x8C301902,  //  0097  GETMET	R12	R12	K2
       0x8C380713,  //  0098  GETMET	R14	R3	K19
-      0x58400023,  //  0099  LDCONST	R16	K35
+      0x58400024,  //  0099  LDCONST	R16	K36
       0x60440008,  //  009A  GETGBL	R17	G8
       0x5C480800,  //  009B  MOVE	R18	R4
       0x7C440200,  //  009C  CALL	R17	1
@@ -1523,12 +2203,12 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x2030180D,  //  00A7  NE	R12	R12	R13
       0x78320022,  //  00A8  JMPF	R12	#00CC
       0xB8320800,  //  00A9  GETNGBL	R12	K4
-      0x8C30191D,  //  00AA  GETMET	R12	R12	K29
+      0x8C30191E,  //  00AA  GETMET	R12	R12	K30
       0x7C300200,  //  00AB  CALL	R12	1
       0x902E200C,  //  00AC  SETMBR	R11	K16	R12
       0x88301710,  //  00AD  GETMBR	R12	R11	K16
       0xB8360800,  //  00AE  GETNGBL	R13	K4
-      0x8C341B1E,  //  00AF  GETMET	R13	R13	K30
+      0x8C341B1F,  //  00AF  GETMET	R13	R13	K31
       0x7C340200,  //  00B0  CALL	R13	1
       0x90321A0D,  //  00B1  SETMBR	R12	K13	R13
       0x88301710,  //  00B2  GETMBR	R12	R11	K16
@@ -1545,7 +2225,7 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x90321E0D,  //  00BD  SETMBR	R12	K15	R13
       0x88301710,  //  00BE  GETMBR	R12	R11	K16
       0xB8360800,  //  00BF  GETNGBL	R13	K4
-      0x8C341B1F,  //  00C0  GETMET	R13	R13	K31
+      0x8C341B20,  //  00C0  GETMET	R13	R13	K32
       0x7C340200,  //  00C1  CALL	R13	1
       0x9032200D,  //  00C2  SETMBR	R12	K16	R13
       0x88301710,  //  00C3  GETMBR	R12	R11	K16
@@ -1553,12 +2233,12 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x88340910,  //  00C5  GETMBR	R13	R4	K16
       0x9032200D,  //  00C6  SETMBR	R12	K16	R13
       0x88300D0B,  //  00C7  GETMBR	R12	R6	K11
-      0x8C301921,  //  00C8  GETMET	R12	R12	K33
+      0x8C301922,  //  00C8  GETMET	R12	R12	K34
       0x5C381600,  //  00C9  MOVE	R14	R11
       0x7C300400,  //  00CA  CALL	R12	2
       0x7001FFFF,  //  00CB  JMP		#00CC
       0x7001FF51,  //  00CC  JMP		#001F
-      0x581C0024,  //  00CD  LDCONST	R7	K36
+      0x581C0025,  //  00CD  LDCONST	R7	K37
       0xAC1C0200,  //  00CE  CATCH	R7	1	0
       0xB0080000,  //  00CF  RAISE	2	R0	R0
       0xB81E0200,  //  00D0  GETNGBL	R7	K1
@@ -1566,32 +2246,32 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
       0x60240008,  //  00D2  GETGBL	R9	G8
       0x88280D0B,  //  00D3  GETMBR	R10	R6	K11
       0x7C240200,  //  00D4  CALL	R9	1
-      0x00264A09,  //  00D5  ADD	R9	K37	R9
+      0x00264C09,  //  00D5  ADD	R9	K38	R9
       0x542A0003,  //  00D6  LDINT	R10	4
       0x7C1C0600,  //  00D7  CALL	R7	3
       0x601C000C,  //  00D8  GETGBL	R7	G12
       0x88200D0B,  //  00D9  GETMBR	R8	R6	K11
       0x7C1C0200,  //  00DA  CALL	R7	1
-      0x241C0F26,  //  00DB  GT	R7	R7	K38
+      0x241C0F27,  //  00DB  GT	R7	R7	K39
       0x781E0015,  //  00DC  JMPF	R7	#00F3
       0xB81E0200,  //  00DD  GETNGBL	R7	K1
       0x8C1C0F02,  //  00DE  GETMET	R7	R7	K2
       0x60240008,  //  00DF  GETGBL	R9	G8
       0x5C280C00,  //  00E0  MOVE	R10	R6
       0x7C240200,  //  00E1  CALL	R9	1
-      0x00264E09,  //  00E2  ADD	R9	K39	R9
+      0x00265009,  //  00E2  ADD	R9	K40	R9
       0x542A0003,  //  00E3  LDINT	R10	4
       0x7C1C0600,  //  00E4  CALL	R7	3
       0xB81E0200,  //  00E5  GETNGBL	R7	K1
       0x8C1C0F02,  //  00E6  GETMET	R7	R7	K2
       0x60240008,  //  00E7  GETGBL	R9	G8
-      0x8C280D29,  //  00E8  GETMET	R10	R6	K41
+      0x8C280D2A,  //  00E8  GETMET	R10	R6	K42
       0x7C280200,  //  00E9  CALL	R10	1
       0x7C240200,  //  00EA  CALL	R9	1
-      0x00265009,  //  00EB  ADD	R9	K40	R9
-      0x5828002A,  //  00EC  LDCONST	R10	K42
+      0x00265209,  //  00EB  ADD	R9	K41	R9
+      0x5828002B,  //  00EC  LDCONST	R10	K43
       0x7C1C0600,  //  00ED  CALL	R7	3
-      0x8C1C012B,  //  00EE  GETMET	R7	R0	K43
+      0x8C1C012C,  //  00EE  GETMET	R7	R0	K44
       0x5C240200,  //  00EF  MOVE	R9	R1
       0x5C280C00,  //  00F0  MOVE	R10	R6
       0x7C1C0600,  //  00F1  CALL	R7	3
@@ -1608,568 +2288,40 @@ be_local_closure(Matter_IM_process_invoke_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: process_invoke_response
-********************************************************************/
-be_local_closure(Matter_IM_process_invoke_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20InvokeResponseMessage_X3D),
-    /* K7   */  be_const_int(2),
-    }),
-    be_str_weak(process_invoke_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_sendqueue_by_exchangeid
-********************************************************************/
-be_local_closure(Matter_IM_find_sendqueue_by_exchangeid,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(get_exchangeid),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(find_sendqueue_by_exchangeid),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x58080000,  //  0005  LDCONST	R2	K0
-      0x600C000C,  //  0006  GETGBL	R3	G12
-      0x88100101,  //  0007  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0008  CALL	R3	1
-      0x140C0403,  //  0009  LT	R3	R2	R3
-      0x780E0008,  //  000A  JMPF	R3	#0014
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x940C0602,  //  000C  GETIDX	R3	R3	R2
-      0x8C100702,  //  000D  GETMET	R4	R3	K2
-      0x7C100200,  //  000E  CALL	R4	1
-      0x1C100801,  //  000F  EQ	R4	R4	R1
-      0x78120000,  //  0010  JMPF	R4	#0012
-      0x80040600,  //  0011  RET	1	R3
-      0x00080503,  //  0012  ADD	R2	R2	K3
-      0x7001FFF1,  //  0013  JMP		#0006
-      0x4C0C0000,  //  0014  LDNIL	R3
-      0x80040600,  //  0015  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: report_data
-********************************************************************/
-be_local_closure(Matter_IM_report_data,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ReportDataMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20ReportDataMessage_X3D),
-    /* K7   */  be_const_int(2),
-    }),
-    be_str_weak(report_data),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_invoke_response
-********************************************************************/
-be_local_closure(Matter_IM_send_invoke_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_InvokeResponse),
-    }),
-    be_str_weak(send_invoke_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_status_response
-********************************************************************/
-be_local_closure(Matter_IM_process_status_response,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(SUCCESS),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20_X3EStatus),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K10  */  be_nested_str_weak(exchange_id),
-    /* K11  */  be_nested_str_weak(ack_received),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    }),
-    be_str_weak(process_status_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[34]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100501,  //  0001  GETMET	R4	R2	K1
-      0x58180002,  //  0002  LDCONST	R6	K2
-      0x541E00FE,  //  0003  LDINT	R7	255
-      0x7C100600,  //  0004  CALL	R4	3
-      0xB8160600,  //  0005  GETNGBL	R5	K3
-      0x88140B04,  //  0006  GETMBR	R5	R5	K4
-      0x1C140805,  //  0007  EQ	R5	R4	R5
-      0x7816000E,  //  0008  JMPF	R5	#0018
-      0xB8160A00,  //  0009  GETNGBL	R5	K5
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x581C0007,  //  000B  LDCONST	R7	K7
-      0x58200008,  //  000C  LDCONST	R8	K8
-      0x7C140600,  //  000D  CALL	R5	3
-      0x8C140109,  //  000E  GETMET	R5	R0	K9
-      0x881C030A,  //  000F  GETMBR	R7	R1	K10
-      0x7C140400,  //  0010  CALL	R5	2
-      0x78160004,  //  0011  JMPF	R5	#0017
-      0x8C180B0B,  //  0012  GETMET	R6	R5	K11
-      0x5C200200,  //  0013  MOVE	R8	R1
-      0x7C180400,  //  0014  CALL	R6	2
-      0x50180200,  //  0015  LDBOOL	R6	1	0
-      0x80040C00,  //  0016  RET	1	R6
-      0x70020007,  //  0017  JMP		#0020
-      0xB8160A00,  //  0018  GETNGBL	R5	K5
-      0x8C140B06,  //  0019  GETMET	R5	R5	K6
-      0x8C1C070C,  //  001A  GETMET	R7	R3	K12
-      0x5824000D,  //  001B  LDCONST	R9	K13
-      0x5C280800,  //  001C  MOVE	R10	R4
-      0x7C1C0600,  //  001D  CALL	R7	3
-      0x58200008,  //  001E  LDCONST	R8	K8
-      0x7C140600,  //  001F  CALL	R5	3
-      0x50140000,  //  0020  LDBOOL	R5	0	0
-      0x80040A00,  //  0021  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_subscribe_update
-********************************************************************/
-be_local_closure(Matter_IM_send_subscribe_update,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[13]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(ReportDataMessage),
-    /* K4   */  be_nested_str_weak(subscription_id),
-    /* K5   */  be_nested_str_weak(attribute_reports),
-    /* K6   */  be_nested_str_weak(suppress_response),
-    /* K7   */  be_nested_str_weak(send_queue),
-    /* K8   */  be_nested_str_weak(push),
-    /* K9   */  be_nested_str_weak(IM_ReportDataSubscribed),
-    /* K10  */  be_nested_str_weak(device),
-    /* K11  */  be_nested_str_weak(message_handler),
-    /* K12  */  be_nested_str_weak(send_enqueued),
-    }),
-    be_str_weak(send_subscribe_update),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x7C100200,  //  0004  CALL	R4	1
-      0x88140304,  //  0005  GETMBR	R5	R1	K4
-      0x90120805,  //  0006  SETMBR	R4	K4	R5
-      0x60140012,  //  0007  GETGBL	R5	G18
-      0x7C140000,  //  0008  CALL	R5	0
-      0x90120A05,  //  0009  SETMBR	R4	K5	R5
-      0x50140200,  //  000A  LDBOOL	R5	1	0
-      0x90120C05,  //  000B  SETMBR	R4	K6	R5
-      0x88140107,  //  000C  GETMBR	R5	R0	K7
-      0x8C140B08,  //  000D  GETMET	R5	R5	K8
-      0xB81E0400,  //  000E  GETNGBL	R7	K2
-      0x8C1C0F09,  //  000F  GETMET	R7	R7	K9
-      0x8824010A,  //  0010  GETMBR	R9	R0	K10
-      0x8824130B,  //  0011  GETMBR	R9	R9	K11
-      0x5C280600,  //  0012  MOVE	R10	R3
-      0x5C2C0800,  //  0013  MOVE	R11	R4
-      0x7C1C0800,  //  0014  CALL	R7	4
-      0x7C140400,  //  0015  CALL	R5	2
-      0x8C14010C,  //  0016  GETMET	R5	R0	K12
-      0x881C010A,  //  0017  GETMBR	R7	R0	K10
-      0x881C0F0B,  //  0018  GETMBR	R7	R7	K11
-      0x7C140400,  //  0019  CALL	R5	2
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_incoming
-********************************************************************/
-be_local_closure(Matter_IM_process_incoming,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20IM_X20message_X20),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(inspect),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(TLV),
-    /* K7   */  be_nested_str_weak(parse),
-    /* K8   */  be_nested_str_weak(raw),
-    /* K9   */  be_nested_str_weak(app_payload_idx),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20IM_X20TLV_X3A_X20),
-    /* K11  */  be_nested_str_weak(findsubval),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20InteractionModelRevision_X3D),
-    /* K13  */  be_nested_str_weak(nil),
-    /* K14  */  be_nested_str_weak(opcode),
-    /* K15  */  be_const_int(1),
-    /* K16  */  be_nested_str_weak(process_status_response),
-    /* K17  */  be_const_int(2),
-    /* K18  */  be_nested_str_weak(process_read_request),
-    /* K19  */  be_nested_str_weak(subscribe_request),
-    /* K20  */  be_nested_str_weak(subscribe_response),
-    /* K21  */  be_nested_str_weak(report_data),
-    /* K22  */  be_nested_str_weak(process_write_request),
-    /* K23  */  be_nested_str_weak(process_write_response),
-    /* K24  */  be_nested_str_weak(process_invoke_request),
-    /* K25  */  be_nested_str_weak(process_invoke_response),
-    /* K26  */  be_nested_str_weak(process_timed_request),
-    }),
-    be_str_weak(process_incoming),
-    &be_const_str_solidified,
-    ( &(const binstruction[128]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0xB8120600,  //  0002  GETNGBL	R4	K3
-      0x8C100904,  //  0003  GETMET	R4	R4	K4
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x58140005,  //  0007  LDCONST	R5	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x88080506,  //  000A  GETMBR	R2	R2	K6
-      0x8C080507,  //  000B  GETMET	R2	R2	K7
-      0x88100308,  //  000C  GETMBR	R4	R1	K8
-      0x88140309,  //  000D  GETMBR	R5	R1	K9
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80E0000,  //  000F  GETNGBL	R3	K0
-      0x8C0C0701,  //  0010  GETMET	R3	R3	K1
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x5C180400,  //  0012  MOVE	R6	R2
-      0x7C140200,  //  0013  CALL	R5	1
-      0x00161405,  //  0014  ADD	R5	K10	R5
-      0x58180005,  //  0015  LDCONST	R6	K5
-      0x7C0C0600,  //  0016  CALL	R3	3
-      0x8C0C050B,  //  0017  GETMET	R3	R2	K11
-      0x541600FE,  //  0018  LDINT	R5	255
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0xB8120000,  //  001A  GETNGBL	R4	K0
-      0x8C100901,  //  001B  GETMET	R4	R4	K1
-      0x4C180000,  //  001C  LDNIL	R6
-      0x20180606,  //  001D  NE	R6	R3	R6
-      0x781A0003,  //  001E  JMPF	R6	#0023
-      0x60180008,  //  001F  GETGBL	R6	G8
-      0x5C1C0600,  //  0020  MOVE	R7	R3
-      0x7C180200,  //  0021  CALL	R6	1
-      0x70020000,  //  0022  JMP		#0024
-      0x5818000D,  //  0023  LDCONST	R6	K13
-      0x001A1806,  //  0024  ADD	R6	K12	R6
-      0x541E0003,  //  0025  LDINT	R7	4
-      0x7C100600,  //  0026  CALL	R4	3
-      0x8810030E,  //  0027  GETMBR	R4	R1	K14
-      0x1C14090F,  //  0028  EQ	R5	R4	K15
-      0x78160005,  //  0029  JMPF	R5	#0030
-      0x8C140110,  //  002A  GETMET	R5	R0	K16
-      0x5C1C0200,  //  002B  MOVE	R7	R1
-      0x5C200400,  //  002C  MOVE	R8	R2
-      0x7C140600,  //  002D  CALL	R5	3
-      0x80040A00,  //  002E  RET	1	R5
-      0x7002004D,  //  002F  JMP		#007E
-      0x1C140911,  //  0030  EQ	R5	R4	K17
-      0x78160005,  //  0031  JMPF	R5	#0038
-      0x8C140112,  //  0032  GETMET	R5	R0	K18
-      0x5C1C0200,  //  0033  MOVE	R7	R1
-      0x5C200400,  //  0034  MOVE	R8	R2
-      0x7C140600,  //  0035  CALL	R5	3
-      0x80040A00,  //  0036  RET	1	R5
-      0x70020045,  //  0037  JMP		#007E
-      0x1C140905,  //  0038  EQ	R5	R4	K5
-      0x78160005,  //  0039  JMPF	R5	#0040
-      0x8C140113,  //  003A  GETMET	R5	R0	K19
-      0x5C1C0200,  //  003B  MOVE	R7	R1
-      0x5C200400,  //  003C  MOVE	R8	R2
-      0x7C140600,  //  003D  CALL	R5	3
-      0x80040A00,  //  003E  RET	1	R5
-      0x7002003D,  //  003F  JMP		#007E
-      0x54160003,  //  0040  LDINT	R5	4
-      0x1C140805,  //  0041  EQ	R5	R4	R5
-      0x78160005,  //  0042  JMPF	R5	#0049
-      0x8C140114,  //  0043  GETMET	R5	R0	K20
-      0x5C1C0200,  //  0044  MOVE	R7	R1
-      0x5C200400,  //  0045  MOVE	R8	R2
-      0x7C140600,  //  0046  CALL	R5	3
-      0x80040A00,  //  0047  RET	1	R5
-      0x70020034,  //  0048  JMP		#007E
-      0x54160004,  //  0049  LDINT	R5	5
-      0x1C140805,  //  004A  EQ	R5	R4	R5
-      0x78160005,  //  004B  JMPF	R5	#0052
-      0x8C140115,  //  004C  GETMET	R5	R0	K21
-      0x5C1C0200,  //  004D  MOVE	R7	R1
-      0x5C200400,  //  004E  MOVE	R8	R2
-      0x7C140600,  //  004F  CALL	R5	3
-      0x80040A00,  //  0050  RET	1	R5
-      0x7002002B,  //  0051  JMP		#007E
-      0x54160005,  //  0052  LDINT	R5	6
-      0x1C140805,  //  0053  EQ	R5	R4	R5
-      0x78160005,  //  0054  JMPF	R5	#005B
-      0x8C140116,  //  0055  GETMET	R5	R0	K22
-      0x5C1C0200,  //  0056  MOVE	R7	R1
-      0x5C200400,  //  0057  MOVE	R8	R2
-      0x7C140600,  //  0058  CALL	R5	3
-      0x80040A00,  //  0059  RET	1	R5
-      0x70020022,  //  005A  JMP		#007E
-      0x54160006,  //  005B  LDINT	R5	7
-      0x1C140805,  //  005C  EQ	R5	R4	R5
-      0x78160005,  //  005D  JMPF	R5	#0064
-      0x8C140117,  //  005E  GETMET	R5	R0	K23
-      0x5C1C0200,  //  005F  MOVE	R7	R1
-      0x5C200400,  //  0060  MOVE	R8	R2
-      0x7C140600,  //  0061  CALL	R5	3
-      0x80040A00,  //  0062  RET	1	R5
-      0x70020019,  //  0063  JMP		#007E
-      0x54160007,  //  0064  LDINT	R5	8
-      0x1C140805,  //  0065  EQ	R5	R4	R5
-      0x78160005,  //  0066  JMPF	R5	#006D
-      0x8C140118,  //  0067  GETMET	R5	R0	K24
-      0x5C1C0200,  //  0068  MOVE	R7	R1
-      0x5C200400,  //  0069  MOVE	R8	R2
-      0x7C140600,  //  006A  CALL	R5	3
-      0x80040A00,  //  006B  RET	1	R5
-      0x70020010,  //  006C  JMP		#007E
-      0x54160008,  //  006D  LDINT	R5	9
-      0x1C140805,  //  006E  EQ	R5	R4	R5
-      0x78160005,  //  006F  JMPF	R5	#0076
-      0x8C140119,  //  0070  GETMET	R5	R0	K25
-      0x5C1C0200,  //  0071  MOVE	R7	R1
-      0x5C200400,  //  0072  MOVE	R8	R2
-      0x7C140600,  //  0073  CALL	R5	3
-      0x80040A00,  //  0074  RET	1	R5
-      0x70020007,  //  0075  JMP		#007E
-      0x54160009,  //  0076  LDINT	R5	10
-      0x1C140805,  //  0077  EQ	R5	R4	R5
-      0x78160004,  //  0078  JMPF	R5	#007E
-      0x8C14011A,  //  0079  GETMET	R5	R0	K26
-      0x5C1C0200,  //  007A  MOVE	R7	R1
-      0x5C200400,  //  007B  MOVE	R8	R2
-      0x7C140600,  //  007C  CALL	R5	3
-      0x80040A00,  //  007D  RET	1	R5
-      0x50140000,  //  007E  LDBOOL	R5	0	0
-      0x80040A00,  //  007F  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_IM_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs),
-    /* K1   */  be_nested_str_weak(every_second),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_IM
 ********************************************************************/
 be_local_class(Matter_IM,
     3,
     NULL,
-    be_nested_map(25,
+    be_nested_map(27,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(send_subscribe_response, -1), be_const_closure(Matter_IM_send_subscribe_response_closure) },
-        { be_const_key_weak(process_write_request, -1), be_const_closure(Matter_IM_process_write_request_closure) },
-        { be_const_key_weak(_inner_process_read_request, -1), be_const_closure(Matter_IM__inner_process_read_request_closure) },
-        { be_const_key_weak(process_timed_request, 10), be_const_closure(Matter_IM_process_timed_request_closure) },
-        { be_const_key_weak(process_write_response, -1), be_const_closure(Matter_IM_process_write_response_closure) },
-        { be_const_key_weak(send_write_response, 12), be_const_closure(Matter_IM_send_write_response_closure) },
-        { be_const_key_weak(send_status, 9), be_const_closure(Matter_IM_send_status_closure) },
-        { be_const_key_weak(subscribe_response, -1), be_const_closure(Matter_IM_subscribe_response_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_IM_every_second_closure) },
-        { be_const_key_weak(send_report_data, -1), be_const_closure(Matter_IM_send_report_data_closure) },
-        { be_const_key_weak(send_subscribe_update, 23), be_const_closure(Matter_IM_send_subscribe_update_closure) },
-        { be_const_key_weak(device, 21), be_const_var(0) },
+        { be_const_key_weak(process_timed_request, 1), be_const_closure(Matter_IM_process_timed_request_closure) },
+        { be_const_key_weak(process_invoke_request, 16), be_const_closure(Matter_IM_process_invoke_request_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_IM_every_250ms_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_IM_init_closure) },
-        { be_const_key_weak(subscribe_request, -1), be_const_closure(Matter_IM_subscribe_request_closure) },
-        { be_const_key_weak(send_enqueued, -1), be_const_closure(Matter_IM_send_enqueued_closure) },
-        { be_const_key_weak(process_invoke_request, 8), be_const_closure(Matter_IM_process_invoke_request_closure) },
-        { be_const_key_weak(process_invoke_response, -1), be_const_closure(Matter_IM_process_invoke_response_closure) },
-        { be_const_key_weak(send_invoke_response, -1), be_const_closure(Matter_IM_send_invoke_response_closure) },
+        { be_const_key_weak(send_subscribe_update, -1), be_const_closure(Matter_IM_send_subscribe_update_closure) },
+        { be_const_key_weak(subs, 10), be_const_var(1) },
         { be_const_key_weak(report_data, -1), be_const_closure(Matter_IM_report_data_closure) },
-        { be_const_key_weak(find_sendqueue_by_exchangeid, 17), be_const_closure(Matter_IM_find_sendqueue_by_exchangeid_closure) },
-        { be_const_key_weak(process_status_response, -1), be_const_closure(Matter_IM_process_status_response_closure) },
-        { be_const_key_weak(subs, -1), be_const_var(1) },
+        { be_const_key_weak(process_write_response, 19), be_const_closure(Matter_IM_process_write_response_closure) },
         { be_const_key_weak(process_incoming, -1), be_const_closure(Matter_IM_process_incoming_closure) },
-        { be_const_key_weak(process_read_request, 7), be_const_closure(Matter_IM_process_read_request_closure) },
+        { be_const_key_weak(remove_sendqueue_by_exchangeid, -1), be_const_closure(Matter_IM_remove_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(process_invoke_response, 25), be_const_closure(Matter_IM_process_invoke_response_closure) },
+        { be_const_key_weak(process_status_response, 2), be_const_closure(Matter_IM_process_status_response_closure) },
+        { be_const_key_weak(_inner_process_read_request, -1), be_const_closure(Matter_IM__inner_process_read_request_closure) },
+        { be_const_key_weak(subscribe_request, 6), be_const_closure(Matter_IM_subscribe_request_closure) },
+        { be_const_key_weak(send_enqueued, -1), be_const_closure(Matter_IM_send_enqueued_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_IM_every_second_closure) },
+        { be_const_key_weak(process_write_request, -1), be_const_closure(Matter_IM_process_write_request_closure) },
         { be_const_key_weak(send_queue, -1), be_const_var(2) },
+        { be_const_key_weak(find_sendqueue_by_exchangeid, -1), be_const_closure(Matter_IM_find_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(send_status, -1), be_const_closure(Matter_IM_send_status_closure) },
+        { be_const_key_weak(send_report_data, -1), be_const_closure(Matter_IM_send_report_data_closure) },
+        { be_const_key_weak(process_read_request, 15), be_const_closure(Matter_IM_process_read_request_closure) },
+        { be_const_key_weak(subscribe_response, -1), be_const_closure(Matter_IM_subscribe_response_closure) },
+        { be_const_key_weak(send_invoke_response, -1), be_const_closure(Matter_IM_send_invoke_response_closure) },
+        { be_const_key_weak(device, 3), be_const_var(0) },
+        { be_const_key_weak(send_subscribe_response, 26), be_const_closure(Matter_IM_send_subscribe_response_closure) },
+        { be_const_key_weak(send_write_response, -1), be_const_closure(Matter_IM_send_write_response_closure) },
     })),
     be_str_weak(Matter_IM)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -148,6 +148,136 @@ void be_load_Matter_Path_class(bvm *vm) {
 extern const bclass be_class_Matter_IM_Message;
 
 /********************************************************************
+** Solidified function: ack_received
+********************************************************************/
+be_local_closure(Matter_IM_Message_ack_received,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resp),
+    /* K1   */  be_nested_str_weak(build_response),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(x_flag_r),
+    /* K4   */  be_nested_str_weak(ready),
+    }),
+    be_str_weak(ack_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0x78060007,  //  0000  JMPF	R1	#0009
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x88100902,  //  0003  GETMBR	R4	R4	K2
+      0x88140100,  //  0004  GETMBR	R5	R0	K0
+      0x88140B03,  //  0005  GETMBR	R5	R5	K3
+      0x88180100,  //  0006  GETMBR	R6	R0	K0
+      0x7C080800,  //  0007  CALL	R2	4
+      0x90020002,  //  0008  SETMBR	R0	K0	R2
+      0x50080200,  //  0009  LDBOOL	R2	1	0
+      0x90020802,  //  000A  SETMBR	R0	K4	R2
+      0x50080200,  //  000B  LDBOOL	R2	1	0
+      0x80040400,  //  000C  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ack_error
+********************************************************************/
+be_local_closure(Matter_IM_Message_ack_error,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(ack_error),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_IM_Message_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resp),
+    /* K1   */  be_nested_str_weak(build_response),
+    /* K2   */  be_nested_str_weak(ready),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x8C100301,  //  0000  GETMET	R4	R1	K1
+      0x5C180400,  //  0001  MOVE	R6	R2
+      0x5C1C0600,  //  0002  MOVE	R7	R3
+      0x7C100600,  //  0003  CALL	R4	3
+      0x90020004,  //  0004  SETMBR	R0	K0	R4
+      0x50100200,  //  0005  LDBOOL	R4	1	0
+      0x90020404,  //  0006  SETMBR	R0	K2	R4
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_exchangeid
+********************************************************************/
+be_local_closure(Matter_IM_Message_get_exchangeid,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resp),
+    /* K1   */  be_nested_str_weak(exchange_id),
+    }),
+    be_str_weak(get_exchangeid),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: send
 ********************************************************************/
 be_local_closure(Matter_IM_Message_send,   /* name */
@@ -200,124 +330,21 @@ be_local_closure(Matter_IM_Message_send,   /* name */
 
 
 /********************************************************************
-** Solidified function: ack_received
-********************************************************************/
-be_local_closure(Matter_IM_Message_ack_received,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(build_response),
-    /* K2   */  be_nested_str_weak(opcode),
-    /* K3   */  be_nested_str_weak(x_flag_r),
-    /* K4   */  be_nested_str_weak(ready),
-    }),
-    be_str_weak(ack_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x8C080301,  //  0000  GETMET	R2	R1	K1
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x88100902,  //  0002  GETMBR	R4	R4	K2
-      0x88140100,  //  0003  GETMBR	R5	R0	K0
-      0x88140B03,  //  0004  GETMBR	R5	R5	K3
-      0x88180100,  //  0005  GETMBR	R6	R0	K0
-      0x7C080800,  //  0006  CALL	R2	4
-      0x90020002,  //  0007  SETMBR	R0	K0	R2
-      0x50080200,  //  0008  LDBOOL	R2	1	0
-      0x90020802,  //  0009  SETMBR	R0	K4	R2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_exchangeid
-********************************************************************/
-be_local_closure(Matter_IM_Message_get_exchangeid,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    }),
-    be_str_weak(get_exchangeid),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_IM_Message_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(build_response),
-    /* K2   */  be_nested_str_weak(ready),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x8C100301,  //  0000  GETMET	R4	R1	K1
-      0x5C180400,  //  0001  MOVE	R6	R2
-      0x5C1C0600,  //  0002  MOVE	R7	R3
-      0x7C100600,  //  0003  CALL	R4	3
-      0x90020004,  //  0004  SETMBR	R0	K0	R4
-      0x50100200,  //  0005  LDBOOL	R4	1	0
-      0x90020404,  //  0006  SETMBR	R0	K2	R4
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_IM_Message
 ********************************************************************/
 be_local_class(Matter_IM_Message,
     3,
     NULL,
-    be_nested_map(7,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(resp, -1), be_const_var(0) },
-        { be_const_key_weak(ready, 6), be_const_var(1) },
+        { be_const_key_weak(ack_received, 2), be_const_closure(Matter_IM_Message_ack_received_closure) },
         { be_const_key_weak(send, -1), be_const_closure(Matter_IM_Message_send_closure) },
-        { be_const_key_weak(ack_received, -1), be_const_closure(Matter_IM_Message_ack_received_closure) },
         { be_const_key_weak(get_exchangeid, -1), be_const_closure(Matter_IM_Message_get_exchangeid_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Message_init_closure) },
+        { be_const_key_weak(resp, 6), be_const_var(0) },
+        { be_const_key_weak(ready, -1), be_const_var(1) },
         { be_const_key_weak(data, -1), be_const_var(2) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Message_init_closure) },
+        { be_const_key_weak(ack_error, 1), be_const_closure(Matter_IM_Message_ack_error_closure) },
     })),
     be_str_weak(Matter_IM_Message)
 );
@@ -796,19 +823,180 @@ void be_load_Matter_IM_ReportData_class(bvm *vm) {
 extern const bclass be_class_Matter_IM_ReportDataSubscribed;
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: ack_error
 ********************************************************************/
-be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
+be_local_closure(Matter_IM_ReportDataSubscribed_ack_error,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
-    4,                          /* argc */
+    4,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sub),
+    /* K1   */  be_nested_str_weak(remove_self),
+    }),
+    be_str_weak(ack_error),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send
+********************************************************************/
+be_local_closure(Matter_IM_ReportDataSubscribed_send,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[14]) {     /* constants */
+    /* K0   */  be_nested_str_weak(data),
+    /* K1   */  be_nested_str_weak(attribute_reports),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(report_data_phase),
+    /* K4   */  be_nested_str_weak(send),
+    /* K5   */  be_nested_str_weak(resp),
+    /* K6   */  be_nested_str_weak(build_standalone_ack),
+    /* K7   */  be_nested_str_weak(encode),
+    /* K8   */  be_nested_str_weak(encrypt),
+    /* K9   */  be_nested_str_weak(send_response),
+    /* K10  */  be_nested_str_weak(raw),
+    /* K11  */  be_nested_str_weak(remote_ip),
+    /* K12  */  be_nested_str_weak(remote_port),
+    /* K13  */  be_nested_str_weak(message_counter),
+    }),
+    be_str_weak(send),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x6008000C,  //  0000  GETGBL	R2	G12
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x880C0701,  //  0002  GETMBR	R3	R3	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x24080502,  //  0004  GT	R2	R2	K2
+      0x780A0020,  //  0005  JMPF	R2	#0027
+      0x88080103,  //  0006  GETMBR	R2	R0	K3
+      0x780A000E,  //  0007  JMPF	R2	#0017
+      0x60080003,  //  0008  GETGBL	R2	G3
+      0x5C0C0000,  //  0009  MOVE	R3	R0
+      0x7C080200,  //  000A  CALL	R2	1
+      0x8C080504,  //  000B  GETMET	R2	R2	K4
+      0x5C100200,  //  000C  MOVE	R4	R1
+      0x7C080400,  //  000D  CALL	R2	2
+      0x5C0C0400,  //  000E  MOVE	R3	R2
+      0x740E0001,  //  000F  JMPT	R3	#0012
+      0x500C0000,  //  0010  LDBOOL	R3	0	0
+      0x80040600,  //  0011  RET	1	R3
+      0x500C0000,  //  0012  LDBOOL	R3	0	0
+      0x90020603,  //  0013  SETMBR	R0	K3	R3
+      0x500C0000,  //  0014  LDBOOL	R3	0	0
+      0x80040600,  //  0015  RET	1	R3
+      0x7002000E,  //  0016  JMP		#0026
+      0x88080105,  //  0017  GETMBR	R2	R0	K5
+      0x8C080506,  //  0018  GETMET	R2	R2	K6
+      0x7C080200,  //  0019  CALL	R2	1
+      0x8C0C0507,  //  001A  GETMET	R3	R2	K7
+      0x7C0C0200,  //  001B  CALL	R3	1
+      0x8C0C0508,  //  001C  GETMET	R3	R2	K8
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0x8C0C0309,  //  001E  GETMET	R3	R1	K9
+      0x8814050A,  //  001F  GETMBR	R5	R2	K10
+      0x8818050B,  //  0020  GETMBR	R6	R2	K11
+      0x881C050C,  //  0021  GETMBR	R7	R2	K12
+      0x8820050D,  //  0022  GETMBR	R8	R2	K13
+      0x7C0C0A00,  //  0023  CALL	R3	5
+      0x500C0200,  //  0024  LDBOOL	R3	1	0
+      0x80040600,  //  0025  RET	1	R3
+      0x70020007,  //  0026  JMP		#002F
+      0x60080003,  //  0027  GETGBL	R2	G3
+      0x5C0C0000,  //  0028  MOVE	R3	R0
+      0x7C080200,  //  0029  CALL	R2	1
+      0x8C080504,  //  002A  GETMET	R2	R2	K4
+      0x5C100200,  //  002B  MOVE	R4	R1
+      0x7C080400,  //  002C  CALL	R2	2
+      0x50080200,  //  002D  LDBOOL	R2	1	0
+      0x80040400,  //  002E  RET	1	R2
+      0x80000000,  //  002F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: ack_received
+********************************************************************/
+be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(report_data_phase),
+    /* K1   */  be_nested_str_weak(ack_received),
+    }),
+    be_str_weak(ack_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0007,  //  0001  JMPF	R2	#000A
+      0x60080003,  //  0002  GETGBL	R2	G3
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x80040400,  //  0008  RET	1	R2
+      0x70020007,  //  0009  JMP		#0012
+      0x60080003,  //  000A  GETGBL	R2	G3
+      0x5C0C0000,  //  000B  MOVE	R3	R0
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C080501,  //  000D  GETMET	R2	R2	K1
+      0x4C100000,  //  000E  LDNIL	R4
+      0x7C080400,  //  000F  CALL	R2	2
+      0x50080000,  //  0010  LDBOOL	R2	0	0
+      0x80040400,  //  0011  RET	1	R2
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(resp),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(Frame),
@@ -819,29 +1007,34 @@ be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
     /* K7   */  be_nested_str_weak(tasmota),
     /* K8   */  be_nested_str_weak(millis),
     /* K9   */  be_nested_str_weak(MSG_TIMEOUT),
+    /* K10  */  be_nested_str_weak(sub),
+    /* K11  */  be_nested_str_weak(report_data_phase),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xB8120200,  //  0000  GETNGBL	R4	K1
-      0x88100902,  //  0001  GETMBR	R4	R4	K2
-      0x8C100903,  //  0002  GETMET	R4	R4	K3
-      0x5C180200,  //  0003  MOVE	R6	R1
-      0x5C1C0400,  //  0004  MOVE	R7	R2
-      0x54220004,  //  0005  LDINT	R8	5
-      0x50240200,  //  0006  LDBOOL	R9	1	0
-      0x7C100A00,  //  0007  CALL	R4	5
-      0x90020004,  //  0008  SETMBR	R0	K0	R4
+    ( &(const binstruction[22]) {  /* code */
+      0xB8160200,  //  0000  GETNGBL	R5	K1
+      0x88140B02,  //  0001  GETMBR	R5	R5	K2
+      0x8C140B03,  //  0002  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0003  MOVE	R7	R1
+      0x5C200400,  //  0004  MOVE	R8	R2
+      0x54260004,  //  0005  LDINT	R9	5
+      0x50280200,  //  0006  LDBOOL	R10	1	0
+      0x7C140A00,  //  0007  CALL	R5	5
+      0x90020005,  //  0008  SETMBR	R0	K0	R5
       0x90020803,  //  0009  SETMBR	R0	K4	R3
-      0x50100200,  //  000A  LDBOOL	R4	1	0
-      0x90020A04,  //  000B  SETMBR	R0	K5	R4
-      0xB8120E00,  //  000C  GETNGBL	R4	K7
-      0x8C100908,  //  000D  GETMET	R4	R4	K8
-      0x7C100200,  //  000E  CALL	R4	1
-      0x88140109,  //  000F  GETMBR	R5	R0	K9
-      0x00100805,  //  0010  ADD	R4	R4	R5
-      0x90020C04,  //  0011  SETMBR	R0	K6	R4
-      0x80000000,  //  0012  RET	0
+      0x50140200,  //  000A  LDBOOL	R5	1	0
+      0x90020A05,  //  000B  SETMBR	R0	K5	R5
+      0xB8160E00,  //  000C  GETNGBL	R5	K7
+      0x8C140B08,  //  000D  GETMET	R5	R5	K8
+      0x7C140200,  //  000E  CALL	R5	1
+      0x88180109,  //  000F  GETMBR	R6	R0	K9
+      0x00140A06,  //  0010  ADD	R5	R5	R6
+      0x90020C05,  //  0011  SETMBR	R0	K6	R5
+      0x90021404,  //  0012  SETMBR	R0	K10	R4
+      0x50140200,  //  0013  LDBOOL	R5	1	0
+      0x90021605,  //  0014  SETMBR	R0	K11	R5
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -853,11 +1046,16 @@ be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
 ********************************************************************/
 extern const bclass be_class_Matter_IM_ReportData;
 be_local_class(Matter_IM_ReportDataSubscribed,
-    0,
+    2,
     &be_class_Matter_IM_ReportData,
-    be_nested_map(1,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(sub, 5), be_const_var(0) },
+        { be_const_key_weak(ack_error, 0), be_const_closure(Matter_IM_ReportDataSubscribed_ack_error_closure) },
+        { be_const_key_weak(ack_received, -1), be_const_closure(Matter_IM_ReportDataSubscribed_ack_received_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_IM_ReportDataSubscribed_init_closure) },
+        { be_const_key_weak(report_data_phase, -1), be_const_var(1) },
+        { be_const_key_weak(send, -1), be_const_closure(Matter_IM_ReportDataSubscribed_send_closure) },
     })),
     be_str_weak(Matter_IM_ReportDataSubscribed)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -7,111 +7,30 @@
 extern const bclass be_class_Matter_IM_Subscription;
 
 /********************************************************************
-** Solidified function: init
+** Solidified function: remove_self
 ********************************************************************/
-be_local_closure(Matter_IM_Subscription_init,   /* name */
+be_local_closure(Matter_IM_Subscription_remove_self,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
+    4,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subscription_id),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(min_interval_floor),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(min_interval),
-    /* K5   */  be_nested_str_weak(max_interval_ceiling),
-    /* K6   */  be_nested_str_weak(max_interval),
-    /* K7   */  be_nested_str_weak(fabric_filtered),
-    /* K8   */  be_nested_str_weak(path_list),
-    /* K9   */  be_nested_str_weak(attributes_requests),
-    /* K10  */  be_nested_str_weak(matter),
-    /* K11  */  be_nested_str_weak(Path),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_nested_str_weak(cluster),
-    /* K14  */  be_nested_str_weak(attribute),
-    /* K15  */  be_nested_str_weak(push),
-    /* K16  */  be_nested_str_weak(stop_iteration),
-    /* K17  */  be_nested_str_weak(updates),
-    /* K18  */  be_nested_str_weak(clear_and_arm),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(log),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20new_X20subsctiption_X20),
-    /* K22  */  be_nested_str_weak(inspect),
-    /* K23  */  be_const_int(2),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs),
+    /* K1   */  be_nested_str_weak(remove_sub),
     }),
-    be_str_weak(init),
+    be_str_weak(remove_self),
     &be_const_str_solidified,
-    ( &(const binstruction[64]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x88100702,  //  0002  GETMBR	R4	R3	K2
-      0x14140903,  //  0003  LT	R5	R4	K3
-      0x78160000,  //  0004  JMPF	R5	#0006
-      0x58100003,  //  0005  LDCONST	R4	K3
-      0x5416003B,  //  0006  LDINT	R5	60
-      0x24140805,  //  0007  GT	R5	R4	R5
-      0x78160000,  //  0008  JMPF	R5	#000A
-      0x5412003B,  //  0009  LDINT	R4	60
-      0x90020804,  //  000A  SETMBR	R0	K4	R4
-      0x88140705,  //  000B  GETMBR	R5	R3	K5
-      0x541A003B,  //  000C  LDINT	R6	60
-      0x14180A06,  //  000D  LT	R6	R5	R6
-      0x781A0000,  //  000E  JMPF	R6	#0010
-      0x5416003B,  //  000F  LDINT	R5	60
-      0x541A0E0F,  //  0010  LDINT	R6	3600
-      0x24180A06,  //  0011  GT	R6	R5	R6
-      0x781A0000,  //  0012  JMPF	R6	#0014
-      0x54160E0F,  //  0013  LDINT	R5	3600
-      0x90020C05,  //  0014  SETMBR	R0	K6	R5
-      0x88180707,  //  0015  GETMBR	R6	R3	K7
-      0x90020E06,  //  0016  SETMBR	R0	K7	R6
-      0x60180012,  //  0017  GETGBL	R6	G18
-      0x7C180000,  //  0018  CALL	R6	0
-      0x90021006,  //  0019  SETMBR	R0	K8	R6
-      0x60180010,  //  001A  GETGBL	R6	G16
-      0x881C0709,  //  001B  GETMBR	R7	R3	K9
-      0x7C180200,  //  001C  CALL	R6	1
-      0xA802000F,  //  001D  EXBLK	0	#002E
-      0x5C1C0C00,  //  001E  MOVE	R7	R6
-      0x7C1C0000,  //  001F  CALL	R7	0
-      0xB8221400,  //  0020  GETNGBL	R8	K10
-      0x8C20110B,  //  0021  GETMET	R8	R8	K11
-      0x7C200200,  //  0022  CALL	R8	1
-      0x88240F0C,  //  0023  GETMBR	R9	R7	K12
-      0x90221809,  //  0024  SETMBR	R8	K12	R9
-      0x88240F0D,  //  0025  GETMBR	R9	R7	K13
-      0x90221A09,  //  0026  SETMBR	R8	K13	R9
-      0x88240F0E,  //  0027  GETMBR	R9	R7	K14
-      0x90221C09,  //  0028  SETMBR	R8	K14	R9
-      0x88240108,  //  0029  GETMBR	R9	R0	K8
-      0x8C24130F,  //  002A  GETMET	R9	R9	K15
-      0x5C2C1000,  //  002B  MOVE	R11	R8
-      0x7C240400,  //  002C  CALL	R9	2
-      0x7001FFEF,  //  002D  JMP		#001E
-      0x58180010,  //  002E  LDCONST	R6	K16
-      0xAC180200,  //  002F  CATCH	R6	1	0
-      0xB0080000,  //  0030  RAISE	2	R0	R0
-      0x60180012,  //  0031  GETGBL	R6	G18
-      0x7C180000,  //  0032  CALL	R6	0
-      0x90022206,  //  0033  SETMBR	R0	K17	R6
-      0x8C180112,  //  0034  GETMET	R6	R0	K18
-      0x7C180200,  //  0035  CALL	R6	1
-      0xB81A2600,  //  0036  GETNGBL	R6	K19
-      0x8C180D14,  //  0037  GETMET	R6	R6	K20
-      0xB8221400,  //  0038  GETNGBL	R8	K10
-      0x8C201116,  //  0039  GETMET	R8	R8	K22
-      0x5C280000,  //  003A  MOVE	R10	R0
-      0x7C200400,  //  003B  CALL	R8	2
-      0x00222A08,  //  003C  ADD	R8	K21	R8
-      0x58240017,  //  003D  LDCONST	R9	K23
-      0x7C180600,  //  003E  CALL	R6	3
-      0x80000000,  //  003F  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -119,70 +38,172 @@ be_local_closure(Matter_IM_Subscription_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: attribute_updated
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_IM_Subscription_attribute_updated,   /* name */
+be_local_closure(Matter_IM_Subscription_init,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
+    13,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs),
+    /* K1   */  be_nested_str_weak(subscription_id),
+    /* K2   */  be_nested_str_weak(session),
+    /* K3   */  be_nested_str_weak(min_interval_floor),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(min_interval),
+    /* K6   */  be_nested_str_weak(max_interval_ceiling),
+    /* K7   */  be_nested_str_weak(max_interval),
+    /* K8   */  be_nested_str_weak(fabric_filtered),
+    /* K9   */  be_nested_str_weak(path_list),
+    /* K10  */  be_nested_str_weak(attributes_requests),
+    /* K11  */  be_nested_str_weak(matter),
+    /* K12  */  be_nested_str_weak(Path),
+    /* K13  */  be_nested_str_weak(endpoint),
+    /* K14  */  be_nested_str_weak(cluster),
+    /* K15  */  be_nested_str_weak(attribute),
+    /* K16  */  be_nested_str_weak(push),
+    /* K17  */  be_nested_str_weak(stop_iteration),
+    /* K18  */  be_nested_str_weak(updates),
+    /* K19  */  be_nested_str_weak(clear_and_arm),
+    /* K20  */  be_nested_str_weak(tasmota),
+    /* K21  */  be_nested_str_weak(log),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20new_X20subsctiption_X20),
+    /* K23  */  be_nested_str_weak(inspect),
+    /* K24  */  be_const_int(3),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[65]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x88140903,  //  0003  GETMBR	R5	R4	K3
+      0x14180B04,  //  0004  LT	R6	R5	K4
+      0x781A0000,  //  0005  JMPF	R6	#0007
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x541A003B,  //  0007  LDINT	R6	60
+      0x24180A06,  //  0008  GT	R6	R5	R6
+      0x781A0000,  //  0009  JMPF	R6	#000B
+      0x5416003B,  //  000A  LDINT	R5	60
+      0x90020A05,  //  000B  SETMBR	R0	K5	R5
+      0x88180906,  //  000C  GETMBR	R6	R4	K6
+      0x541E003B,  //  000D  LDINT	R7	60
+      0x141C0C07,  //  000E  LT	R7	R6	R7
+      0x781E0000,  //  000F  JMPF	R7	#0011
+      0x541A003B,  //  0010  LDINT	R6	60
+      0x541E0E0F,  //  0011  LDINT	R7	3600
+      0x241C0C07,  //  0012  GT	R7	R6	R7
+      0x781E0000,  //  0013  JMPF	R7	#0015
+      0x541A0E0F,  //  0014  LDINT	R6	3600
+      0x90020E06,  //  0015  SETMBR	R0	K7	R6
+      0x881C0908,  //  0016  GETMBR	R7	R4	K8
+      0x90021007,  //  0017  SETMBR	R0	K8	R7
+      0x601C0012,  //  0018  GETGBL	R7	G18
+      0x7C1C0000,  //  0019  CALL	R7	0
+      0x90021207,  //  001A  SETMBR	R0	K9	R7
+      0x601C0010,  //  001B  GETGBL	R7	G16
+      0x8820090A,  //  001C  GETMBR	R8	R4	K10
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0xA802000F,  //  001E  EXBLK	0	#002F
+      0x5C200E00,  //  001F  MOVE	R8	R7
+      0x7C200000,  //  0020  CALL	R8	0
+      0xB8261600,  //  0021  GETNGBL	R9	K11
+      0x8C24130C,  //  0022  GETMET	R9	R9	K12
+      0x7C240200,  //  0023  CALL	R9	1
+      0x8828110D,  //  0024  GETMBR	R10	R8	K13
+      0x90261A0A,  //  0025  SETMBR	R9	K13	R10
+      0x8828110E,  //  0026  GETMBR	R10	R8	K14
+      0x90261C0A,  //  0027  SETMBR	R9	K14	R10
+      0x8828110F,  //  0028  GETMBR	R10	R8	K15
+      0x90261E0A,  //  0029  SETMBR	R9	K15	R10
+      0x88280109,  //  002A  GETMBR	R10	R0	K9
+      0x8C281510,  //  002B  GETMET	R10	R10	K16
+      0x5C301200,  //  002C  MOVE	R12	R9
+      0x7C280400,  //  002D  CALL	R10	2
+      0x7001FFEF,  //  002E  JMP		#001F
+      0x581C0011,  //  002F  LDCONST	R7	K17
+      0xAC1C0200,  //  0030  CATCH	R7	1	0
+      0xB0080000,  //  0031  RAISE	2	R0	R0
+      0x601C0012,  //  0032  GETGBL	R7	G18
+      0x7C1C0000,  //  0033  CALL	R7	0
+      0x90022407,  //  0034  SETMBR	R0	K18	R7
+      0x8C1C0113,  //  0035  GETMET	R7	R0	K19
+      0x7C1C0200,  //  0036  CALL	R7	1
+      0xB81E2800,  //  0037  GETNGBL	R7	K20
+      0x8C1C0F15,  //  0038  GETMET	R7	R7	K21
+      0xB8261600,  //  0039  GETNGBL	R9	K11
+      0x8C241317,  //  003A  GETMET	R9	R9	K23
+      0x5C2C0000,  //  003B  MOVE	R11	R0
+      0x7C240400,  //  003C  CALL	R9	2
+      0x00262C09,  //  003D  ADD	R9	K22	R9
+      0x58280018,  //  003E  LDCONST	R10	K24
+      0x7C1C0600,  //  003F  CALL	R7	3
+      0x80000000,  //  0040  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _add_attribute_unique_path
+********************************************************************/
+be_local_closure(Matter_IM_Subscription__add_attribute_unique_path,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(path_list),
+    /* K1   */  be_nested_str_weak(updates),
     /* K2   */  be_nested_str_weak(endpoint),
     /* K3   */  be_nested_str_weak(cluster),
     /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(updates),
+    /* K5   */  be_const_int(1),
     /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_const_int(1),
     }),
-    be_str_weak(attribute_updated),
+    be_str_weak(_add_attribute_unique_path),
     &be_const_str_solidified,
-    ( &(const binstruction[39]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0x6010000C,  //  0001  GETGBL	R4	G12
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x7C100200,  //  0003  CALL	R4	1
-      0x14100604,  //  0004  LT	R4	R3	R4
-      0x7812001F,  //  0005  JMPF	R4	#0026
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x94100803,  //  0007  GETIDX	R4	R4	R3
-      0x88140902,  //  0008  GETMBR	R5	R4	K2
-      0x4C180000,  //  0009  LDNIL	R6
-      0x1C140A06,  //  000A  EQ	R5	R5	R6
-      0x74160003,  //  000B  JMPT	R5	#0010
-      0x88140902,  //  000C  GETMBR	R5	R4	K2
-      0x88180302,  //  000D  GETMBR	R6	R1	K2
-      0x1C140A06,  //  000E  EQ	R5	R5	R6
-      0x78160013,  //  000F  JMPF	R5	#0024
-      0x88140903,  //  0010  GETMBR	R5	R4	K3
-      0x4C180000,  //  0011  LDNIL	R6
-      0x1C140A06,  //  0012  EQ	R5	R5	R6
-      0x74160003,  //  0013  JMPT	R5	#0018
-      0x88140903,  //  0014  GETMBR	R5	R4	K3
-      0x88180303,  //  0015  GETMBR	R6	R1	K3
-      0x1C140A06,  //  0016  EQ	R5	R5	R6
-      0x7816000B,  //  0017  JMPF	R5	#0024
-      0x88140904,  //  0018  GETMBR	R5	R4	K4
-      0x4C180000,  //  0019  LDNIL	R6
-      0x1C140A06,  //  001A  EQ	R5	R5	R6
-      0x74160003,  //  001B  JMPT	R5	#0020
-      0x88140904,  //  001C  GETMBR	R5	R4	K4
-      0x88180304,  //  001D  GETMBR	R6	R1	K4
-      0x1C140A06,  //  001E  EQ	R5	R5	R6
-      0x78160003,  //  001F  JMPF	R5	#0024
-      0x88140105,  //  0020  GETMBR	R5	R0	K5
-      0x8C140B06,  //  0021  GETMET	R5	R5	K6
-      0x5C1C0200,  //  0022  MOVE	R7	R1
-      0x7C140400,  //  0023  CALL	R5	2
-      0x000C0707,  //  0024  ADD	R3	R3	K7
-      0x7001FFDA,  //  0025  JMP		#0001
-      0x80000000,  //  0026  RET	0
+    ( &(const binstruction[28]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0010,  //  0005  JMPF	R3	#0017
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x88100702,  //  0008  GETMBR	R4	R3	K2
+      0x88140302,  //  0009  GETMBR	R5	R1	K2
+      0x1C100805,  //  000A  EQ	R4	R4	R5
+      0x78120008,  //  000B  JMPF	R4	#0015
+      0x88100703,  //  000C  GETMBR	R4	R3	K3
+      0x88140303,  //  000D  GETMBR	R5	R1	K3
+      0x1C100805,  //  000E  EQ	R4	R4	R5
+      0x78120004,  //  000F  JMPF	R4	#0015
+      0x88100704,  //  0010  GETMBR	R4	R3	K4
+      0x88140304,  //  0011  GETMBR	R5	R1	K4
+      0x1C100805,  //  0012  EQ	R4	R4	R5
+      0x78120000,  //  0013  JMPF	R4	#0015
+      0x80000800,  //  0014  RET	0
+      0x00080505,  //  0015  ADD	R2	R2	K5
+      0x7001FFE9,  //  0016  JMP		#0001
+      0x880C0101,  //  0017  GETMBR	R3	R0	K1
+      0x8C0C0706,  //  0018  GETMET	R3	R3	K6
+      0x5C140200,  //  0019  MOVE	R5	R1
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x80000000,  //  001B  RET	0
     })
   )
 );
@@ -202,32 +223,110 @@ be_local_closure(Matter_IM_Subscription_clear_and_arm,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str_weak(updates),
     /* K1   */  be_nested_str_weak(clear),
-    /* K2   */  be_nested_str_weak(expiration),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(millis),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(millis),
+    /* K4   */  be_nested_str_weak(expiration),
     /* K5   */  be_nested_str_weak(max_interval),
     /* K6   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
+    /* K7   */  be_nested_str_weak(not_before),
+    /* K8   */  be_nested_str_weak(min_interval),
+    /* K9   */  be_const_int(1),
     }),
     be_str_weak(clear_and_arm),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[20]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x7C040200,  //  0002  CALL	R1	1
-      0xB8060600,  //  0003  GETNGBL	R1	K3
-      0x8C040304,  //  0004  GETMET	R1	R1	K4
+      0xB8060400,  //  0003  GETNGBL	R1	K2
+      0x8C040303,  //  0004  GETMET	R1	R1	K3
       0x7C040200,  //  0005  CALL	R1	1
       0x88080105,  //  0006  GETMBR	R2	R0	K5
       0x880C0106,  //  0007  GETMBR	R3	R0	K6
       0x04080403,  //  0008  SUB	R2	R2	R3
       0x540E03E7,  //  0009  LDINT	R3	1000
       0x08080403,  //  000A  MUL	R2	R2	R3
-      0x00040202,  //  000B  ADD	R1	R1	R2
-      0x90020401,  //  000C  SETMBR	R0	K2	R1
-      0x80000000,  //  000D  RET	0
+      0x00080202,  //  000B  ADD	R2	R1	R2
+      0x90020802,  //  000C  SETMBR	R0	K4	R2
+      0x88080108,  //  000D  GETMBR	R2	R0	K8
+      0x540E03E7,  //  000E  LDINT	R3	1000
+      0x08080403,  //  000F  MUL	R2	R2	R3
+      0x00080202,  //  0010  ADD	R2	R1	R2
+      0x04080509,  //  0011  SUB	R2	R2	K9
+      0x90020E02,  //  0012  SETMBR	R0	K7	R2
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated_ctx
+********************************************************************/
+be_local_closure(Matter_IM_Subscription_attribute_updated_ctx,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(path_list),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(_add_attribute_unique_path),
+    /* K6   */  be_const_int(1),
+    }),
+    be_str_weak(attribute_updated_ctx),
+    &be_const_str_solidified,
+    ( &(const binstruction[38]) {  /* code */
+      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x6010000C,  //  0001  GETGBL	R4	G12
+      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x7C100200,  //  0003  CALL	R4	1
+      0x14100604,  //  0004  LT	R4	R3	R4
+      0x7812001E,  //  0005  JMPF	R4	#0025
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x94100803,  //  0007  GETIDX	R4	R4	R3
+      0x88140902,  //  0008  GETMBR	R5	R4	K2
+      0x4C180000,  //  0009  LDNIL	R6
+      0x1C140A06,  //  000A  EQ	R5	R5	R6
+      0x74160003,  //  000B  JMPT	R5	#0010
+      0x88140902,  //  000C  GETMBR	R5	R4	K2
+      0x88180302,  //  000D  GETMBR	R6	R1	K2
+      0x1C140A06,  //  000E  EQ	R5	R5	R6
+      0x78160012,  //  000F  JMPF	R5	#0023
+      0x88140903,  //  0010  GETMBR	R5	R4	K3
+      0x4C180000,  //  0011  LDNIL	R6
+      0x1C140A06,  //  0012  EQ	R5	R5	R6
+      0x74160003,  //  0013  JMPT	R5	#0018
+      0x88140903,  //  0014  GETMBR	R5	R4	K3
+      0x88180303,  //  0015  GETMBR	R6	R1	K3
+      0x1C140A06,  //  0016  EQ	R5	R5	R6
+      0x7816000A,  //  0017  JMPF	R5	#0023
+      0x88140904,  //  0018  GETMBR	R5	R4	K4
+      0x4C180000,  //  0019  LDNIL	R6
+      0x1C140A06,  //  001A  EQ	R5	R5	R6
+      0x74160003,  //  001B  JMPT	R5	#0020
+      0x88140904,  //  001C  GETMBR	R5	R4	K4
+      0x88180304,  //  001D  GETMBR	R6	R1	K4
+      0x1C140A06,  //  001E  EQ	R5	R5	R6
+      0x78160002,  //  001F  JMPF	R5	#0023
+      0x8C140105,  //  0020  GETMET	R5	R0	K5
+      0x5C1C0200,  //  0021  MOVE	R7	R1
+      0x7C140400,  //  0022  CALL	R5	2
+      0x000C0706,  //  0023  ADD	R3	R3	K6
+      0x7001FFDB,  //  0024  JMP		#0001
+      0x80000000,  //  0025  RET	0
     })
   )
 );
@@ -238,22 +337,26 @@ be_local_closure(Matter_IM_Subscription_clear_and_arm,   /* name */
 ** Solidified class: Matter_IM_Subscription
 ********************************************************************/
 be_local_class(Matter_IM_Subscription,
-    8,
+    10,
     NULL,
-    be_nested_map(12,
+    be_nested_map(16,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(expiration, -1), be_const_var(6) },
-        { be_const_key_weak(updates, 9), be_const_var(7) },
-        { be_const_key_weak(fabric_filtered, -1), be_const_var(5) },
-        { be_const_key_weak(max_interval, 10), be_const_var(4) },
-        { be_const_key_weak(session, -1), be_const_var(1) },
-        { be_const_key_weak(min_interval, -1), be_const_var(3) },
-        { be_const_key_weak(MAX_INTERVAL_MARGIN, -1), be_const_int(10) },
-        { be_const_key_weak(attribute_updated, 4), be_const_closure(Matter_IM_Subscription_attribute_updated_closure) },
-        { be_const_key_weak(subscription_id, -1), be_const_var(0) },
-        { be_const_key_weak(clear_and_arm, -1), be_const_closure(Matter_IM_Subscription_clear_and_arm_closure) },
-        { be_const_key_weak(path_list, 11), be_const_var(2) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Subscription_init_closure) },
+        { be_const_key_weak(remove_self, -1), be_const_closure(Matter_IM_Subscription_remove_self_closure) },
+        { be_const_key_weak(min_interval, -1), be_const_var(4) },
+        { be_const_key_weak(subs, -1), be_const_var(0) },
+        { be_const_key_weak(init, 15), be_const_closure(Matter_IM_Subscription_init_closure) },
+        { be_const_key_weak(subscription_id, -1), be_const_var(1) },
+        { be_const_key_weak(updates, -1), be_const_var(9) },
+        { be_const_key_weak(MAX_INTERVAL_MARGIN, -1), be_const_int(5) },
+        { be_const_key_weak(session, 11), be_const_var(2) },
+        { be_const_key_weak(expiration, 14), be_const_var(8) },
+        { be_const_key_weak(fabric_filtered, -1), be_const_var(6) },
+        { be_const_key_weak(_add_attribute_unique_path, 9), be_const_closure(Matter_IM_Subscription__add_attribute_unique_path_closure) },
+        { be_const_key_weak(max_interval, -1), be_const_var(5) },
+        { be_const_key_weak(attribute_updated_ctx, -1), be_const_closure(Matter_IM_Subscription_attribute_updated_ctx_closure) },
+        { be_const_key_weak(clear_and_arm, 12), be_const_closure(Matter_IM_Subscription_clear_and_arm_closure) },
+        { be_const_key_weak(not_before, -1), be_const_var(7) },
+        { be_const_key_weak(path_list, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_IM_Subscription)
 );
@@ -268,11 +371,139 @@ void be_load_Matter_IM_Subscription_class(bvm *vm) {
 extern const bclass be_class_Matter_IM_Subscription_Shop;
 
 /********************************************************************
+** Solidified function: get_by_id
+********************************************************************/
+be_local_closure(Matter_IM_Subscription_Shop_get_by_id,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(subs),
+    /* K2   */  be_nested_str_weak(subscription_id),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(get_by_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0009,  //  0005  JMPF	R3	#0010
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x880C0702,  //  0008  GETMBR	R3	R3	K2
+      0x1C0C0601,  //  0009  EQ	R3	R3	R1
+      0x780E0002,  //  000A  JMPF	R3	#000E
+      0x880C0101,  //  000B  GETMBR	R3	R0	K1
+      0x940C0602,  //  000C  GETIDX	R3	R3	R2
+      0x80040600,  //  000D  RET	1	R3
+      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x7001FFF0,  //  000F  JMP		#0001
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_IM_Subscription_Shop_every_250ms,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(subs),
+    /* K2   */  be_nested_str_weak(updates),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(time_reached),
+    /* K5   */  be_nested_str_weak(not_before),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(send_subscribe_update),
+    /* K8   */  be_nested_str_weak(clear_and_arm),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(expiration),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[48]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x14080202,  //  0004  LT	R2	R1	R2
+      0x780A0013,  //  0005  JMPF	R2	#001A
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x94080401,  //  0007  GETIDX	R2	R2	R1
+      0x600C000C,  //  0008  GETGBL	R3	G12
+      0x88100502,  //  0009  GETMBR	R4	R2	K2
+      0x7C0C0200,  //  000A  CALL	R3	1
+      0x240C0700,  //  000B  GT	R3	R3	K0
+      0x780E000A,  //  000C  JMPF	R3	#0018
+      0xB80E0600,  //  000D  GETNGBL	R3	K3
+      0x8C0C0704,  //  000E  GETMET	R3	R3	K4
+      0x88140505,  //  000F  GETMBR	R5	R2	K5
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x780E0005,  //  0011  JMPF	R3	#0018
+      0x880C0106,  //  0012  GETMBR	R3	R0	K6
+      0x8C0C0707,  //  0013  GETMET	R3	R3	K7
+      0x5C140400,  //  0014  MOVE	R5	R2
+      0x7C0C0400,  //  0015  CALL	R3	2
+      0x8C0C0508,  //  0016  GETMET	R3	R2	K8
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x00040309,  //  0018  ADD	R1	R1	K9
+      0x7001FFE6,  //  0019  JMP		#0001
+      0x58040000,  //  001A  LDCONST	R1	K0
+      0x6008000C,  //  001B  GETGBL	R2	G12
+      0x880C0101,  //  001C  GETMBR	R3	R0	K1
+      0x7C080200,  //  001D  CALL	R2	1
+      0x14080202,  //  001E  LT	R2	R1	R2
+      0x780A000E,  //  001F  JMPF	R2	#002F
+      0x88080101,  //  0020  GETMBR	R2	R0	K1
+      0x94080401,  //  0021  GETIDX	R2	R2	R1
+      0xB80E0600,  //  0022  GETNGBL	R3	K3
+      0x8C0C0704,  //  0023  GETMET	R3	R3	K4
+      0x8814050A,  //  0024  GETMBR	R5	R2	K10
+      0x7C0C0400,  //  0025  CALL	R3	2
+      0x780E0005,  //  0026  JMPF	R3	#002D
+      0x880C0106,  //  0027  GETMBR	R3	R0	K6
+      0x8C0C0707,  //  0028  GETMET	R3	R3	K7
+      0x5C140400,  //  0029  MOVE	R5	R2
+      0x7C0C0400,  //  002A  CALL	R3	2
+      0x8C0C0508,  //  002B  GETMET	R3	R2	K8
+      0x7C0C0200,  //  002C  CALL	R3	1
+      0x00040309,  //  002D  ADD	R1	R1	K9
+      0x7001FFEB,  //  002E  JMP		#001B
+      0x80000000,  //  002F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: new_subscription
 ********************************************************************/
 be_local_closure(Matter_IM_Subscription_Shop_new_subscription,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    11,                          /* nstack */
     3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -294,7 +525,7 @@ be_local_closure(Matter_IM_Subscription_Shop_new_subscription,   /* name */
     }),
     be_str_weak(new_subscription),
     &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
+    ( &(const binstruction[33]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0x8C100701,  //  0001  GETMET	R4	R3	K1
       0x58180002,  //  0002  LDCONST	R6	K2
@@ -318,15 +549,16 @@ be_local_closure(Matter_IM_Subscription_Shop_new_subscription,   /* name */
       0x7001FFF2,  //  0014  JMP		#0008
       0xB8160C00,  //  0015  GETNGBL	R5	K6
       0x8C140B07,  //  0016  GETMET	R5	R5	K7
-      0x5C1C0800,  //  0017  MOVE	R7	R4
-      0x5C200200,  //  0018  MOVE	R8	R1
-      0x5C240400,  //  0019  MOVE	R9	R2
-      0x7C140800,  //  001A  CALL	R5	4
-      0x88180108,  //  001B  GETMBR	R6	R0	K8
-      0x8C180D09,  //  001C  GETMET	R6	R6	K9
-      0x5C200A00,  //  001D  MOVE	R8	R5
-      0x7C180400,  //  001E  CALL	R6	2
-      0x80040A00,  //  001F  RET	1	R5
+      0x5C1C0000,  //  0017  MOVE	R7	R0
+      0x5C200800,  //  0018  MOVE	R8	R4
+      0x5C240200,  //  0019  MOVE	R9	R1
+      0x5C280400,  //  001A  MOVE	R10	R2
+      0x7C140A00,  //  001B  CALL	R5	5
+      0x88180108,  //  001C  GETMBR	R6	R0	K8
+      0x8C180D09,  //  001D  GETMET	R6	R6	K9
+      0x5C200A00,  //  001E  MOVE	R8	R5
+      0x7C180400,  //  001F  CALL	R6	2
+      0x80040A00,  //  0020  RET	1	R5
     })
   )
 );
@@ -334,54 +566,42 @@ be_local_closure(Matter_IM_Subscription_Shop_new_subscription,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_second
+** Solidified function: attribute_updated_ctx
 ********************************************************************/
-be_local_closure(Matter_IM_Subscription_Shop_every_second,   /* name */
+be_local_closure(Matter_IM_Subscription_Shop_attribute_updated_ctx,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    8,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_const_int(0),
     /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(im),
-    /* K6   */  be_nested_str_weak(send_subscribe_update),
-    /* K7   */  be_nested_str_weak(clear_and_arm),
-    /* K8   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(attribute_updated_ctx),
+    /* K3   */  be_const_int(1),
     }),
-    be_str_weak(every_second),
+    be_str_weak(attribute_updated_ctx),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A000E,  //  0005  JMPF	R2	#0015
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E0005,  //  000C  JMPF	R3	#0013
-      0x880C0105,  //  000D  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  000E  GETMET	R3	R3	K6
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x8C0C0507,  //  0011  GETMET	R3	R2	K7
-      0x7C0C0200,  //  0012  CALL	R3	1
-      0x00040308,  //  0013  ADD	R1	R1	K8
-      0x7001FFEB,  //  0014  JMP		#0001
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[15]) {  /* code */
+      0x580C0000,  //  0000  LDCONST	R3	K0
+      0x6010000C,  //  0001  GETGBL	R4	G12
+      0x88140101,  //  0002  GETMBR	R5	R0	K1
+      0x7C100200,  //  0003  CALL	R4	1
+      0x14100604,  //  0004  LT	R4	R3	R4
+      0x78120007,  //  0005  JMPF	R4	#000E
+      0x88100101,  //  0006  GETMBR	R4	R0	K1
+      0x94100803,  //  0007  GETIDX	R4	R4	R3
+      0x8C100902,  //  0008  GETMET	R4	R4	K2
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x5C1C0400,  //  000A  MOVE	R7	R2
+      0x7C100600,  //  000B  CALL	R4	3
+      0x000C0703,  //  000C  ADD	R3	R3	K3
+      0x7001FFF2,  //  000D  JMP		#0001
+      0x80000000,  //  000E  RET	0
     })
   )
 );
@@ -413,6 +633,52 @@ be_local_closure(Matter_IM_Subscription_Shop_init,   /* name */
       0x7C080000,  //  0002  CALL	R2	0
       0x90020202,  //  0003  SETMBR	R0	K1	R2
       0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_sub
+********************************************************************/
+be_local_closure(Matter_IM_Subscription_Shop_remove_sub,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(subs),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(remove_sub),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E000A,  //  0005  JMPF	R3	#0011
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x1C0C0601,  //  0008  EQ	R3	R3	R1
+      0x780E0004,  //  0009  JMPF	R3	#000F
+      0x880C0101,  //  000A  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  000B  GETMET	R3	R3	K2
+      0x5C140400,  //  000C  MOVE	R5	R2
+      0x7C0C0400,  //  000D  CALL	R3	2
+      0x70020000,  //  000E  JMP		#0010
+      0x00080503,  //  000F  ADD	R2	R2	K3
+      0x7001FFEF,  //  0010  JMP		#0001
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -468,109 +734,22 @@ be_local_closure(Matter_IM_Subscription_Shop_remove_by_session,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_by_id
-********************************************************************/
-be_local_closure(Matter_IM_Subscription_Shop_get_by_id,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(subscription_id),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(get_by_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0009,  //  0005  JMPF	R3	#0010
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x880C0702,  //  0008  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  0009  EQ	R3	R3	R1
-      0x780E0002,  //  000A  JMPF	R3	#000E
-      0x880C0101,  //  000B  GETMBR	R3	R0	K1
-      0x940C0602,  //  000C  GETIDX	R3	R3	R2
-      0x80040600,  //  000D  RET	1	R3
-      0x00080503,  //  000E  ADD	R2	R2	K3
-      0x7001FFF0,  //  000F  JMP		#0001
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: attribute_updated
-********************************************************************/
-be_local_closure(Matter_IM_Subscription_Shop_attribute_updated,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(subs),
-    /* K2   */  be_nested_str_weak(attribute_updated),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(attribute_updated),
-    &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0x6010000C,  //  0001  GETGBL	R4	G12
-      0x88140101,  //  0002  GETMBR	R5	R0	K1
-      0x7C100200,  //  0003  CALL	R4	1
-      0x14100604,  //  0004  LT	R4	R3	R4
-      0x78120007,  //  0005  JMPF	R4	#000E
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x94100803,  //  0007  GETIDX	R4	R4	R3
-      0x8C100902,  //  0008  GETMET	R4	R4	K2
-      0x5C180200,  //  0009  MOVE	R6	R1
-      0x5C1C0400,  //  000A  MOVE	R7	R2
-      0x7C100600,  //  000B  CALL	R4	3
-      0x000C0703,  //  000C  ADD	R3	R3	K3
-      0x7001FFF2,  //  000D  JMP		#0001
-      0x80000000,  //  000E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_IM_Subscription_Shop
 ********************************************************************/
 be_local_class(Matter_IM_Subscription_Shop,
     2,
     NULL,
-    be_nested_map(8,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_IM_Subscription_Shop_attribute_updated_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_IM_Subscription_Shop_every_second_closure) },
-        { be_const_key_weak(subs, -1), be_const_var(0) },
-        { be_const_key_weak(init, 5), be_const_closure(Matter_IM_Subscription_Shop_init_closure) },
-        { be_const_key_weak(remove_by_session, -1), be_const_closure(Matter_IM_Subscription_Shop_remove_by_session_closure) },
-        { be_const_key_weak(im, 6), be_const_var(1) },
         { be_const_key_weak(get_by_id, -1), be_const_closure(Matter_IM_Subscription_Shop_get_by_id_closure) },
-        { be_const_key_weak(new_subscription, 0), be_const_closure(Matter_IM_Subscription_Shop_new_subscription_closure) },
+        { be_const_key_weak(attribute_updated_ctx, -1), be_const_closure(Matter_IM_Subscription_Shop_attribute_updated_ctx_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_IM_Subscription_Shop_every_250ms_closure) },
+        { be_const_key_weak(remove_sub, 1), be_const_closure(Matter_IM_Subscription_Shop_remove_sub_closure) },
+        { be_const_key_weak(new_subscription, 3), be_const_closure(Matter_IM_Subscription_Shop_new_subscription_closure) },
+        { be_const_key_weak(subs, -1), be_const_var(0) },
+        { be_const_key_weak(im, 7), be_const_var(1) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Subscription_Shop_init_closure) },
+        { be_const_key_weak(remove_by_session, -1), be_const_closure(Matter_IM_Subscription_Shop_remove_by_session_closure) },
     })),
     be_str_weak(Matter_IM_Subscription_Shop)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -313,7 +313,7 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
     }),
     be_str_weak(build_standalone_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[49]) {  /* code */
+    ( &(const binstruction[54]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x60080006,  //  0001  GETGBL	R2	G6
       0x5C0C0000,  //  0002  MOVE	R3	R0
@@ -341,28 +341,33 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
       0x880C010A,  //  0018  GETMBR	R3	R0	K10
       0x880C070F,  //  0019  GETMBR	R3	R3	K15
       0x900A1C03,  //  001A  SETMBR	R2	K14	R3
-      0x900A2109,  //  001B  SETMBR	R2	K16	K9
-      0x540E000F,  //  001C  LDINT	R3	16
-      0x900A2203,  //  001D  SETMBR	R2	K17	R3
-      0x880C0112,  //  001E  GETMBR	R3	R0	K18
-      0x900A2403,  //  001F  SETMBR	R2	K18	R3
-      0x900A2709,  //  0020  SETMBR	R2	K19	K9
-      0x900A2906,  //  0021  SETMBR	R2	K20	K6
-      0x880C010B,  //  0022  GETMBR	R3	R0	K11
-      0x900A2A03,  //  0023  SETMBR	R2	K21	R3
-      0x900A2D06,  //  0024  SETMBR	R2	K22	K6
-      0xB80E2E00,  //  0025  GETNGBL	R3	K23
-      0x8C0C0718,  //  0026  GETMET	R3	R3	K24
-      0x8C140319,  //  0027  GETMET	R5	R1	K25
-      0x581C001A,  //  0028  LDCONST	R7	K26
-      0xB8223600,  //  0029  GETNGBL	R8	K27
-      0x8C20111C,  //  002A  GETMET	R8	R8	K28
-      0x88280511,  //  002B  GETMBR	R10	R2	K17
-      0x7C200400,  //  002C  CALL	R8	2
-      0x7C140600,  //  002D  CALL	R5	3
-      0x5818001D,  //  002E  LDCONST	R6	K29
-      0x7C0C0600,  //  002F  CALL	R3	3
-      0x80040400,  //  0030  RET	1	R2
+      0x880C0110,  //  001B  GETMBR	R3	R0	K16
+      0x780E0001,  //  001C  JMPF	R3	#001F
+      0x580C0009,  //  001D  LDCONST	R3	K9
+      0x70020000,  //  001E  JMP		#0020
+      0x580C0006,  //  001F  LDCONST	R3	K6
+      0x900A2003,  //  0020  SETMBR	R2	K16	R3
+      0x540E000F,  //  0021  LDINT	R3	16
+      0x900A2203,  //  0022  SETMBR	R2	K17	R3
+      0x880C0112,  //  0023  GETMBR	R3	R0	K18
+      0x900A2403,  //  0024  SETMBR	R2	K18	R3
+      0x900A2709,  //  0025  SETMBR	R2	K19	K9
+      0x900A2906,  //  0026  SETMBR	R2	K20	K6
+      0x880C010B,  //  0027  GETMBR	R3	R0	K11
+      0x900A2A03,  //  0028  SETMBR	R2	K21	R3
+      0x900A2D06,  //  0029  SETMBR	R2	K22	K6
+      0xB80E2E00,  //  002A  GETNGBL	R3	K23
+      0x8C0C0718,  //  002B  GETMET	R3	R3	K24
+      0x8C140319,  //  002C  GETMET	R5	R1	K25
+      0x581C001A,  //  002D  LDCONST	R7	K26
+      0xB8223600,  //  002E  GETNGBL	R8	K27
+      0x8C20111C,  //  002F  GETMET	R8	R8	K28
+      0x88280511,  //  0030  GETMBR	R10	R2	K17
+      0x7C200400,  //  0031  CALL	R8	2
+      0x7C140600,  //  0032  CALL	R5	3
+      0x5818001D,  //  0033  LDCONST	R6	K29
+      0x7C0C0600,  //  0034  CALL	R3	3
+      0x80040400,  //  0035  RET	1	R2
     })
   )
 );
@@ -418,7 +423,7 @@ be_local_closure(Matter_Frame_build_response,   /* name */
     }),
     be_str_weak(build_response),
     &be_const_str_solidified,
-    ( &(const binstruction[86]) {  /* code */
+    ( &(const binstruction[91]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x4C140000,  //  0001  LDNIL	R5
       0x1C140605,  //  0002  EQ	R5	R3	R5
@@ -466,45 +471,50 @@ be_local_closure(Matter_Frame_build_response,   /* name */
       0x7C140200,  //  002C  CALL	R5	1
       0x900E1A05,  //  002D  SETMBR	R3	K13	R5
       0x900E1709,  //  002E  SETMBR	R3	K11	K9
-      0x900E2309,  //  002F  SETMBR	R3	K17	K9
-      0x900E2401,  //  0030  SETMBR	R3	K18	R1
-      0x88140113,  //  0031  GETMBR	R5	R0	K19
-      0x900E2605,  //  0032  SETMBR	R3	K19	R5
-      0x88140114,  //  0033  GETMBR	R5	R0	K20
-      0x900E2805,  //  0034  SETMBR	R3	K20	R5
-      0x88140115,  //  0035  GETMBR	R5	R0	K21
-      0x78160002,  //  0036  JMPF	R5	#003A
-      0x900E2D06,  //  0037  SETMBR	R3	K22	K6
-      0x8814010D,  //  0038  GETMBR	R5	R0	K13
-      0x900E2E05,  //  0039  SETMBR	R3	K23	R5
-      0x780A0001,  //  003A  JMPF	R2	#003D
-      0x58140006,  //  003B  LDCONST	R5	K6
-      0x70020000,  //  003C  JMP		#003E
-      0x58140009,  //  003D  LDCONST	R5	K9
-      0x900E2A05,  //  003E  SETMBR	R3	K21	R5
-      0x8814070B,  //  003F  GETMBR	R5	R3	K11
-      0x1C140B09,  //  0040  EQ	R5	R5	K9
-      0x78160012,  //  0041  JMPF	R5	#0055
-      0xB8163000,  //  0042  GETNGBL	R5	K24
-      0x8C140B19,  //  0043  GETMET	R5	R5	K25
-      0x881C0712,  //  0044  GETMBR	R7	R3	K18
-      0x7C140400,  //  0045  CALL	R5	2
-      0x5C180A00,  //  0046  MOVE	R6	R5
-      0x741A0004,  //  0047  JMPT	R6	#004D
-      0x8C18091A,  //  0048  GETMET	R6	R4	K26
-      0x5820001B,  //  0049  LDCONST	R8	K27
-      0x88240712,  //  004A  GETMBR	R9	R3	K18
-      0x7C180600,  //  004B  CALL	R6	3
-      0x5C140C00,  //  004C  MOVE	R5	R6
-      0xB81A3800,  //  004D  GETNGBL	R6	K28
-      0x8C180D1D,  //  004E  GETMET	R6	R6	K29
-      0x8C20091A,  //  004F  GETMET	R8	R4	K26
-      0x5828001E,  //  0050  LDCONST	R10	K30
-      0x5C2C0A00,  //  0051  MOVE	R11	R5
-      0x7C200600,  //  0052  CALL	R8	3
-      0x5824001F,  //  0053  LDCONST	R9	K31
-      0x7C180600,  //  0054  CALL	R6	3
-      0x80040600,  //  0055  RET	1	R3
+      0x88140111,  //  002F  GETMBR	R5	R0	K17
+      0x78160001,  //  0030  JMPF	R5	#0033
+      0x58140009,  //  0031  LDCONST	R5	K9
+      0x70020000,  //  0032  JMP		#0034
+      0x58140006,  //  0033  LDCONST	R5	K6
+      0x900E2205,  //  0034  SETMBR	R3	K17	R5
+      0x900E2401,  //  0035  SETMBR	R3	K18	R1
+      0x88140113,  //  0036  GETMBR	R5	R0	K19
+      0x900E2605,  //  0037  SETMBR	R3	K19	R5
+      0x88140114,  //  0038  GETMBR	R5	R0	K20
+      0x900E2805,  //  0039  SETMBR	R3	K20	R5
+      0x88140115,  //  003A  GETMBR	R5	R0	K21
+      0x78160002,  //  003B  JMPF	R5	#003F
+      0x900E2D06,  //  003C  SETMBR	R3	K22	K6
+      0x8814010D,  //  003D  GETMBR	R5	R0	K13
+      0x900E2E05,  //  003E  SETMBR	R3	K23	R5
+      0x780A0001,  //  003F  JMPF	R2	#0042
+      0x58140006,  //  0040  LDCONST	R5	K6
+      0x70020000,  //  0041  JMP		#0043
+      0x58140009,  //  0042  LDCONST	R5	K9
+      0x900E2A05,  //  0043  SETMBR	R3	K21	R5
+      0x8814070B,  //  0044  GETMBR	R5	R3	K11
+      0x1C140B09,  //  0045  EQ	R5	R5	K9
+      0x78160012,  //  0046  JMPF	R5	#005A
+      0xB8163000,  //  0047  GETNGBL	R5	K24
+      0x8C140B19,  //  0048  GETMET	R5	R5	K25
+      0x881C0712,  //  0049  GETMBR	R7	R3	K18
+      0x7C140400,  //  004A  CALL	R5	2
+      0x5C180A00,  //  004B  MOVE	R6	R5
+      0x741A0004,  //  004C  JMPT	R6	#0052
+      0x8C18091A,  //  004D  GETMET	R6	R4	K26
+      0x5820001B,  //  004E  LDCONST	R8	K27
+      0x88240712,  //  004F  GETMBR	R9	R3	K18
+      0x7C180600,  //  0050  CALL	R6	3
+      0x5C140C00,  //  0051  MOVE	R5	R6
+      0xB81A3800,  //  0052  GETNGBL	R6	K28
+      0x8C180D1D,  //  0053  GETMET	R6	R6	K29
+      0x8C20091A,  //  0054  GETMET	R8	R4	K26
+      0x5828001E,  //  0055  LDCONST	R10	K30
+      0x5C2C0A00,  //  0056  MOVE	R11	R5
+      0x7C200600,  //  0057  CALL	R8	3
+      0x5824001F,  //  0058  LDCONST	R9	K31
+      0x7C180600,  //  0059  CALL	R6	3
+      0x80040600,  //  005A  RET	1	R3
     })
   )
 );
@@ -552,7 +562,7 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
     }),
     be_str_weak(initiate_response),
     &be_const_str_solidified,
-    ( &(const binstruction[46]) {  /* code */
+    ( &(const binstruction[48]) {  /* code */
       0x58140000,  //  0000  LDCONST	R5	K0
       0xA41A0200,  //  0001  IMPORT	R6	K1
       0x4C1C0000,  //  0002  LDNIL	R7
@@ -591,14 +601,16 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
       0x001C0F12,  //  0023  ADD	R7	R7	K18
       0x90062807,  //  0024  SETMBR	R1	K20	R7
       0x881C0314,  //  0025  GETMBR	R7	R1	K20
-      0x90122A07,  //  0026  SETMBR	R4	K21	R7
-      0x90122D12,  //  0027  SETMBR	R4	K22	K18
-      0x780E0001,  //  0028  JMPF	R3	#002B
-      0x581C0012,  //  0029  LDCONST	R7	K18
-      0x70020000,  //  002A  JMP		#002C
-      0x581C0009,  //  002B  LDCONST	R7	K9
-      0x90122E07,  //  002C  SETMBR	R4	K23	R7
-      0x80040800,  //  002D  RET	1	R4
+      0x5422FFFF,  //  0026  LDINT	R8	65536
+      0x301C0E08,  //  0027  OR	R7	R7	R8
+      0x90122A07,  //  0028  SETMBR	R4	K21	R7
+      0x90122D12,  //  0029  SETMBR	R4	K22	K18
+      0x780E0001,  //  002A  JMPF	R3	#002D
+      0x581C0012,  //  002B  LDCONST	R7	K18
+      0x70020000,  //  002C  JMP		#002E
+      0x581C0009,  //  002D  LDCONST	R7	K9
+      0x90122E07,  //  002E  SETMBR	R4	K23	R7
+      0x80040800,  //  002F  RET	1	R4
     })
   )
 );
@@ -818,7 +830,7 @@ be_local_closure(Matter_Frame_encode,   /* name */
     }),
     be_str_weak(encode),
     &be_const_str_solidified,
-    ( &(const binstruction[144]) {  /* code */
+    ( &(const binstruction[146]) {  /* code */
       0x60080015,  //  0000  GETGBL	R2	G21
       0x7C080000,  //  0001  CALL	R2	0
       0x880C0100,  //  0002  GETMBR	R3	R0	K0
@@ -940,29 +952,31 @@ be_local_closure(Matter_Frame_encode,   /* name */
       0x7C0C0600,  //  0076  CALL	R3	3
       0x8C0C0505,  //  0077  GETMET	R3	R2	K5
       0x88140118,  //  0078  GETMBR	R5	R0	K24
-      0x58180008,  //  0079  LDCONST	R6	K8
-      0x7C0C0600,  //  007A  CALL	R3	3
-      0x8C0C0505,  //  007B  GETMET	R3	R2	K5
-      0x88140119,  //  007C  GETMBR	R5	R0	K25
-      0x58180008,  //  007D  LDCONST	R6	K8
-      0x7C0C0600,  //  007E  CALL	R3	3
-      0x880C0115,  //  007F  GETMBR	R3	R0	K21
-      0x780E0003,  //  0080  JMPF	R3	#0085
-      0x8C0C0505,  //  0081  GETMET	R3	R2	K5
-      0x8814011A,  //  0082  GETMBR	R5	R0	K26
-      0x541A0003,  //  0083  LDINT	R6	4
-      0x7C0C0600,  //  0084  CALL	R3	3
-      0x600C000C,  //  0085  GETGBL	R3	G12
-      0x5C100400,  //  0086  MOVE	R4	R2
-      0x7C0C0200,  //  0087  CALL	R3	1
-      0x90023603,  //  0088  SETMBR	R0	K27	R3
-      0x78060000,  //  0089  JMPF	R1	#008B
-      0x400C0401,  //  008A  CONNECT	R3	R2	R1
-      0x8C0C011C,  //  008B  GETMET	R3	R0	K28
-      0x5C140400,  //  008C  MOVE	R5	R2
-      0x7C0C0400,  //  008D  CALL	R3	2
-      0x90023A02,  //  008E  SETMBR	R0	K29	R2
-      0x80040400,  //  008F  RET	1	R2
+      0x541AFFFE,  //  0079  LDINT	R6	65535
+      0x2C140A06,  //  007A  AND	R5	R5	R6
+      0x58180008,  //  007B  LDCONST	R6	K8
+      0x7C0C0600,  //  007C  CALL	R3	3
+      0x8C0C0505,  //  007D  GETMET	R3	R2	K5
+      0x88140119,  //  007E  GETMBR	R5	R0	K25
+      0x58180008,  //  007F  LDCONST	R6	K8
+      0x7C0C0600,  //  0080  CALL	R3	3
+      0x880C0115,  //  0081  GETMBR	R3	R0	K21
+      0x780E0003,  //  0082  JMPF	R3	#0087
+      0x8C0C0505,  //  0083  GETMET	R3	R2	K5
+      0x8814011A,  //  0084  GETMBR	R5	R0	K26
+      0x541A0003,  //  0085  LDINT	R6	4
+      0x7C0C0600,  //  0086  CALL	R3	3
+      0x600C000C,  //  0087  GETGBL	R3	G12
+      0x5C100400,  //  0088  MOVE	R4	R2
+      0x7C0C0200,  //  0089  CALL	R3	1
+      0x90023603,  //  008A  SETMBR	R0	K27	R3
+      0x78060000,  //  008B  JMPF	R1	#008D
+      0x400C0401,  //  008C  CONNECT	R3	R2	R1
+      0x8C0C011C,  //  008D  GETMET	R3	R0	K28
+      0x5C140400,  //  008E  MOVE	R5	R2
+      0x7C0C0400,  //  008F  CALL	R3	2
+      0x90023A02,  //  0090  SETMBR	R0	K29	R2
+      0x80040400,  //  0091  RET	1	R2
     })
   )
 );
@@ -1005,7 +1019,7 @@ be_local_closure(Matter_Frame_decode_payload,   /* name */
     }),
     be_str_weak(decode_payload),
     &be_const_str_solidified,
-    ( &(const binstruction[87]) {  /* code */
+    ( &(const binstruction[93]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x88080101,  //  0001  GETMBR	R2	R0	K1
       0x8C0C0503,  //  0002  GETMET	R3	R2	K3
@@ -1058,41 +1072,47 @@ be_local_closure(Matter_Frame_decode_payload,   /* name */
       0x5818000A,  //  0031  LDCONST	R6	K10
       0x7C0C0600,  //  0032  CALL	R3	3
       0x90021C03,  //  0033  SETMBR	R0	K14	R3
-      0x8C0C0503,  //  0034  GETMET	R3	R2	K3
-      0x54160003,  //  0035  LDINT	R5	4
-      0x00140205,  //  0036  ADD	R5	R1	R5
-      0x5818000A,  //  0037  LDCONST	R6	K10
-      0x7C0C0600,  //  0038  CALL	R3	3
-      0x90021E03,  //  0039  SETMBR	R0	K15	R3
-      0x540E0005,  //  003A  LDINT	R3	6
-      0x00040203,  //  003B  ADD	R1	R1	R3
-      0x880C0105,  //  003C  GETMBR	R3	R0	K5
-      0x780E0005,  //  003D  JMPF	R3	#0044
-      0x8C0C0503,  //  003E  GETMET	R3	R2	K3
-      0x5C140200,  //  003F  MOVE	R5	R1
-      0x5818000A,  //  0040  LDCONST	R6	K10
-      0x7C0C0600,  //  0041  CALL	R3	3
-      0x90022003,  //  0042  SETMBR	R0	K16	R3
-      0x0004030A,  //  0043  ADD	R1	R1	K10
-      0x880C010B,  //  0044  GETMBR	R3	R0	K11
-      0x780E0006,  //  0045  JMPF	R3	#004D
-      0x8C0C0503,  //  0046  GETMET	R3	R2	K3
-      0x5C140200,  //  0047  MOVE	R5	R1
-      0x541A0003,  //  0048  LDINT	R6	4
-      0x7C0C0600,  //  0049  CALL	R3	3
-      0x90022203,  //  004A  SETMBR	R0	K17	R3
-      0x540E0003,  //  004B  LDINT	R3	4
-      0x00040203,  //  004C  ADD	R1	R1	R3
-      0x880C0107,  //  004D  GETMBR	R3	R0	K7
-      0x780E0005,  //  004E  JMPF	R3	#0055
-      0x8C0C0503,  //  004F  GETMET	R3	R2	K3
-      0x5C140200,  //  0050  MOVE	R5	R1
-      0x5818000A,  //  0051  LDCONST	R6	K10
-      0x7C0C0600,  //  0052  CALL	R3	3
-      0x0010070A,  //  0053  ADD	R4	R3	K10
-      0x00040204,  //  0054  ADD	R1	R1	R4
-      0x90022401,  //  0055  SETMBR	R0	K18	R1
-      0x80040000,  //  0056  RET	1	R0
+      0x880C010C,  //  0034  GETMBR	R3	R0	K12
+      0x740E0003,  //  0035  JMPT	R3	#003A
+      0x880C010E,  //  0036  GETMBR	R3	R0	K14
+      0x5412FFFF,  //  0037  LDINT	R4	65536
+      0x300C0604,  //  0038  OR	R3	R3	R4
+      0x90021C03,  //  0039  SETMBR	R0	K14	R3
+      0x8C0C0503,  //  003A  GETMET	R3	R2	K3
+      0x54160003,  //  003B  LDINT	R5	4
+      0x00140205,  //  003C  ADD	R5	R1	R5
+      0x5818000A,  //  003D  LDCONST	R6	K10
+      0x7C0C0600,  //  003E  CALL	R3	3
+      0x90021E03,  //  003F  SETMBR	R0	K15	R3
+      0x540E0005,  //  0040  LDINT	R3	6
+      0x00040203,  //  0041  ADD	R1	R1	R3
+      0x880C0105,  //  0042  GETMBR	R3	R0	K5
+      0x780E0005,  //  0043  JMPF	R3	#004A
+      0x8C0C0503,  //  0044  GETMET	R3	R2	K3
+      0x5C140200,  //  0045  MOVE	R5	R1
+      0x5818000A,  //  0046  LDCONST	R6	K10
+      0x7C0C0600,  //  0047  CALL	R3	3
+      0x90022003,  //  0048  SETMBR	R0	K16	R3
+      0x0004030A,  //  0049  ADD	R1	R1	K10
+      0x880C010B,  //  004A  GETMBR	R3	R0	K11
+      0x780E0006,  //  004B  JMPF	R3	#0053
+      0x8C0C0503,  //  004C  GETMET	R3	R2	K3
+      0x5C140200,  //  004D  MOVE	R5	R1
+      0x541A0003,  //  004E  LDINT	R6	4
+      0x7C0C0600,  //  004F  CALL	R3	3
+      0x90022203,  //  0050  SETMBR	R0	K17	R3
+      0x540E0003,  //  0051  LDINT	R3	4
+      0x00040203,  //  0052  ADD	R1	R1	R3
+      0x880C0107,  //  0053  GETMBR	R3	R0	K7
+      0x780E0005,  //  0054  JMPF	R3	#005B
+      0x8C0C0503,  //  0055  GETMET	R3	R2	K3
+      0x5C140200,  //  0056  MOVE	R5	R1
+      0x5818000A,  //  0057  LDCONST	R6	K10
+      0x7C0C0600,  //  0058  CALL	R3	3
+      0x0010070A,  //  0059  ADD	R4	R3	K10
+      0x00040204,  //  005A  ADD	R1	R1	R4
+      0x90022401,  //  005B  SETMBR	R0	K18	R1
+      0x80040000,  //  005C  RET	1	R0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -41,469 +41,6 @@ be_local_closure(Matter_MessageHandler_send_response,   /* name */
 
 
 /********************************************************************
-** Solidified function: msg_received
-********************************************************************/
-be_local_closure(Matter_MessageHandler_msg_received,   /* name */
-  be_nested_proto(
-    18,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[69]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20raw_X3D),
-    /* K4   */  be_nested_str_weak(tohex),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Frame),
-    /* K7   */  be_nested_str_weak(decode_header),
-    /* K8   */  be_nested_str_weak(local_session_id),
-    /* K9   */  be_const_int(0),
-    /* K10  */  be_nested_str_weak(sec_sesstype),
-    /* K11  */  be_nested_str_weak(device),
-    /* K12  */  be_nested_str_weak(sessions),
-    /* K13  */  be_nested_str_weak(find_session_source_id_unsecure),
-    /* K14  */  be_nested_str_weak(source_node_id),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20find_X20session_X20by_X20source_node_id_X20_X3D_X20),
-    /* K16  */  be_nested_str_weak(session_id_X20_X3D_X20),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(__ip),
-    /* K19  */  be_nested_str_weak(__port),
-    /* K20  */  be_nested_str_weak(session),
-    /* K21  */  be_nested_str_weak(counter_rcv),
-    /* K22  */  be_nested_str_weak(validate),
-    /* K23  */  be_nested_str_weak(message_counter),
-    /* K24  */  be_nested_str_weak(format),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
-    /* K26  */  be_nested_str_weak(val),
-    /* K27  */  be_nested_str_weak(decode_payload),
-    /* K28  */  be_nested_str_weak(packet_ack),
-    /* K29  */  be_nested_str_weak(ack_message_counter),
-    /* K30  */  be_nested_str_weak(opcode),
-    /* K31  */  be_nested_str_weak(get_opcode_name),
-    /* K32  */  be_nested_str_weak(0x_X2502X),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K34  */  be_const_int(2),
-    /* K35  */  be_nested_str_weak(commissioning),
-    /* K36  */  be_nested_str_weak(process_incoming),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
-    /* K38  */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X20),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20frame_X3D),
-    /* K41  */  be_nested_str_weak(inspect),
-    /* K42  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20encrypted_X20message_X20_X3D_X20),
-    /* K43  */  be_nested_str_weak(_X20counter_X3D),
-    /* K44  */  be_nested_str_weak(decrypt),
-    /* K45  */  be_nested_str_weak(raw),
-    /* K46  */  be_nested_str_weak(payload_idx),
-    /* K47  */  be_const_int(1),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
-    /* K49  */  be_nested_str_weak(MTR_X3A_X20decrypted_X20message_X3A_X20protocol_id_X3A),
-    /* K50  */  be_nested_str_weak(protocol_id),
-    /* K51  */  be_nested_str_weak(_X20opcode_X3D),
-    /* K52  */  be_nested_str_weak(_X20exchange_id_X3D),
-    /* K53  */  be_nested_str_weak(exchange_id),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
-    /* K55  */  be_nested_str_weak(im),
-    /* K56  */  be_nested_str_weak(send_enqueued),
-    /* K57  */  be_nested_str_weak(x_flag_r),
-    /* K58  */  be_nested_str_weak(build_standalone_ack),
-    /* K59  */  be_nested_str_weak(encode),
-    /* K60  */  be_nested_str_weak(encrypt),
-    /* K61  */  be_nested_str_weak(send_response),
-    /* K62  */  be_nested_str_weak(remote_ip),
-    /* K63  */  be_nested_str_weak(remote_port),
-    /* K64  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K65  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K66  */  be_nested_str_weak(_X3B),
-    /* K67  */  be_nested_str_weak(debug),
-    /* K68  */  be_nested_str_weak(traceback),
-    }),
-    be_str_weak(msg_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[313]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0x50140000,  //  0001  LDBOOL	R5	0	0
-      0xA802011F,  //  0002  EXBLK	0	#0123
-      0xB81A0200,  //  0003  GETNGBL	R6	K1
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x8C200304,  //  0005  GETMET	R8	R1	K4
-      0x7C200200,  //  0006  CALL	R8	1
-      0x00220608,  //  0007  ADD	R8	K3	R8
-      0x54260003,  //  0008  LDINT	R9	4
-      0x7C180600,  //  0009  CALL	R6	3
-      0xB81A0A00,  //  000A  GETNGBL	R6	K5
-      0x8C180D06,  //  000B  GETMET	R6	R6	K6
-      0x5C200000,  //  000C  MOVE	R8	R0
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C180A00,  //  0010  CALL	R6	5
-      0x8C1C0D07,  //  0011  GETMET	R7	R6	K7
-      0x7C1C0200,  //  0012  CALL	R7	1
-      0x5C200E00,  //  0013  MOVE	R8	R7
-      0x74220002,  //  0014  JMPT	R8	#0018
-      0x50200000,  //  0015  LDBOOL	R8	0	0
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x80041000,  //  0017  RET	1	R8
-      0x88200D08,  //  0018  GETMBR	R8	R6	K8
-      0x1C201109,  //  0019  EQ	R8	R8	K9
-      0x7822005B,  //  001A  JMPF	R8	#0077
-      0x88200D0A,  //  001B  GETMBR	R8	R6	K10
-      0x1C201109,  //  001C  EQ	R8	R8	K9
-      0x78220058,  //  001D  JMPF	R8	#0077
-      0x8820010B,  //  001E  GETMBR	R8	R0	K11
-      0x8820110C,  //  001F  GETMBR	R8	R8	K12
-      0x8C20110D,  //  0020  GETMET	R8	R8	K13
-      0x88280D0E,  //  0021  GETMBR	R10	R6	K14
-      0x542E0059,  //  0022  LDINT	R11	90
-      0x7C200600,  //  0023  CALL	R8	3
-      0xB8260200,  //  0024  GETNGBL	R9	K1
-      0x8C241302,  //  0025  GETMET	R9	R9	K2
-      0x602C0008,  //  0026  GETGBL	R11	G8
-      0x88300D0E,  //  0027  GETMBR	R12	R6	K14
-      0x7C2C0200,  //  0028  CALL	R11	1
-      0x002E1E0B,  //  0029  ADD	R11	K15	R11
-      0x002C1710,  //  002A  ADD	R11	R11	K16
-      0x60300008,  //  002B  GETGBL	R12	G8
-      0x88341108,  //  002C  GETMBR	R13	R8	K8
-      0x7C300200,  //  002D  CALL	R12	1
-      0x002C160C,  //  002E  ADD	R11	R11	R12
-      0x58300011,  //  002F  LDCONST	R12	K17
-      0x7C240600,  //  0030  CALL	R9	3
-      0x780A0000,  //  0031  JMPF	R2	#0033
-      0x90222402,  //  0032  SETMBR	R8	K18	R2
-      0x780E0000,  //  0033  JMPF	R3	#0035
-      0x90222603,  //  0034  SETMBR	R8	K19	R3
-      0x901A2808,  //  0035  SETMBR	R6	K20	R8
-      0x88240115,  //  0036  GETMBR	R9	R0	K21
-      0x8C241316,  //  0037  GETMET	R9	R9	K22
-      0x882C0D17,  //  0038  GETMBR	R11	R6	K23
-      0x50300000,  //  0039  LDBOOL	R12	0	0
-      0x7C240600,  //  003A  CALL	R9	3
-      0x7426000D,  //  003B  JMPT	R9	#004A
-      0xB8260200,  //  003C  GETNGBL	R9	K1
-      0x8C241302,  //  003D  GETMET	R9	R9	K2
-      0x8C2C0918,  //  003E  GETMET	R11	R4	K24
-      0x58340019,  //  003F  LDCONST	R13	K25
-      0x88380D17,  //  0040  GETMBR	R14	R6	K23
-      0x883C0115,  //  0041  GETMBR	R15	R0	K21
-      0x8C3C1F1A,  //  0042  GETMET	R15	R15	K26
-      0x7C3C0200,  //  0043  CALL	R15	1
-      0x7C2C0800,  //  0044  CALL	R11	4
-      0x58300011,  //  0045  LDCONST	R12	K17
-      0x7C240600,  //  0046  CALL	R9	3
-      0x50240000,  //  0047  LDBOOL	R9	0	0
-      0xA8040001,  //  0048  EXBLK	1	1
-      0x80041200,  //  0049  RET	1	R9
-      0x8C240D1B,  //  004A  GETMET	R9	R6	K27
-      0x7C240200,  //  004B  CALL	R9	1
-      0x74260002,  //  004C  JMPT	R9	#0050
-      0x50240000,  //  004D  LDBOOL	R9	0	0
-      0xA8040001,  //  004E  EXBLK	1	1
-      0x80041200,  //  004F  RET	1	R9
-      0x8824010B,  //  0050  GETMBR	R9	R0	K11
-      0x8C24131C,  //  0051  GETMET	R9	R9	K28
-      0x882C0D1D,  //  0052  GETMBR	R11	R6	K29
-      0x7C240400,  //  0053  CALL	R9	2
-      0x88240D1E,  //  0054  GETMBR	R9	R6	K30
-      0x542A000F,  //  0055  LDINT	R10	16
-      0x2024120A,  //  0056  NE	R9	R9	R10
-      0x78260014,  //  0057  JMPF	R9	#006D
-      0xB8260A00,  //  0058  GETNGBL	R9	K5
-      0x8C24131F,  //  0059  GETMET	R9	R9	K31
-      0x882C0D1E,  //  005A  GETMBR	R11	R6	K30
-      0x7C240400,  //  005B  CALL	R9	2
-      0x5C281200,  //  005C  MOVE	R10	R9
-      0x742A0004,  //  005D  JMPT	R10	#0063
-      0x8C280918,  //  005E  GETMET	R10	R4	K24
-      0x58300020,  //  005F  LDCONST	R12	K32
-      0x88340D1E,  //  0060  GETMBR	R13	R6	K30
-      0x7C280600,  //  0061  CALL	R10	3
-      0x5C241400,  //  0062  MOVE	R9	R10
-      0xB82A0200,  //  0063  GETNGBL	R10	K1
-      0x8C281502,  //  0064  GETMET	R10	R10	K2
-      0x8C300918,  //  0065  GETMET	R12	R4	K24
-      0x58380021,  //  0066  LDCONST	R14	K33
-      0x5C3C1200,  //  0067  MOVE	R15	R9
-      0x5C400400,  //  0068  MOVE	R16	R2
-      0x5C440600,  //  0069  MOVE	R17	R3
-      0x7C300A00,  //  006A  CALL	R12	5
-      0x58340022,  //  006B  LDCONST	R13	K34
-      0x7C280600,  //  006C  CALL	R10	3
-      0x88240123,  //  006D  GETMBR	R9	R0	K35
-      0x8C241324,  //  006E  GETMET	R9	R9	K36
-      0x5C2C0C00,  //  006F  MOVE	R11	R6
-      0x5C300400,  //  0070  MOVE	R12	R2
-      0x5C340600,  //  0071  MOVE	R13	R3
-      0x7C240800,  //  0072  CALL	R9	4
-      0x50240200,  //  0073  LDBOOL	R9	1	0
-      0xA8040001,  //  0074  EXBLK	1	1
-      0x80041200,  //  0075  RET	1	R9
-      0x700200A7,  //  0076  JMP		#011F
-      0xB8220200,  //  0077  GETNGBL	R8	K1
-      0x8C201102,  //  0078  GETMET	R8	R8	K2
-      0x8C280918,  //  0079  GETMET	R10	R4	K24
-      0x58300025,  //  007A  LDCONST	R12	K37
-      0x88340D08,  //  007B  GETMBR	R13	R6	K8
-      0x88380D17,  //  007C  GETMBR	R14	R6	K23
-      0x7C280800,  //  007D  CALL	R10	4
-      0x582C0011,  //  007E  LDCONST	R11	K17
-      0x7C200600,  //  007F  CALL	R8	3
-      0x8820010B,  //  0080  GETMBR	R8	R0	K11
-      0x8820110C,  //  0081  GETMBR	R8	R8	K12
-      0x8C201126,  //  0082  GETMET	R8	R8	K38
-      0x88280D08,  //  0083  GETMBR	R10	R6	K8
-      0x7C200400,  //  0084  CALL	R8	2
-      0x4C240000,  //  0085  LDNIL	R9
-      0x1C241009,  //  0086  EQ	R9	R8	R9
-      0x78260013,  //  0087  JMPF	R9	#009C
-      0xB8260200,  //  0088  GETNGBL	R9	K1
-      0x8C241302,  //  0089  GETMET	R9	R9	K2
-      0x602C0008,  //  008A  GETGBL	R11	G8
-      0x88300D08,  //  008B  GETMBR	R12	R6	K8
-      0x7C2C0200,  //  008C  CALL	R11	1
-      0x002E4E0B,  //  008D  ADD	R11	K39	R11
-      0x58300011,  //  008E  LDCONST	R12	K17
-      0x7C240600,  //  008F  CALL	R9	3
-      0xB8260200,  //  0090  GETNGBL	R9	K1
-      0x8C241302,  //  0091  GETMET	R9	R9	K2
-      0xB82E0A00,  //  0092  GETNGBL	R11	K5
-      0x8C2C1729,  //  0093  GETMET	R11	R11	K41
-      0x5C340C00,  //  0094  MOVE	R13	R6
-      0x7C2C0400,  //  0095  CALL	R11	2
-      0x002E500B,  //  0096  ADD	R11	K40	R11
-      0x58300011,  //  0097  LDCONST	R12	K17
-      0x7C240600,  //  0098  CALL	R9	3
-      0x50240000,  //  0099  LDBOOL	R9	0	0
-      0xA8040001,  //  009A  EXBLK	1	1
-      0x80041200,  //  009B  RET	1	R9
-      0x780A0000,  //  009C  JMPF	R2	#009E
-      0x90222402,  //  009D  SETMBR	R8	K18	R2
-      0x780E0000,  //  009E  JMPF	R3	#00A0
-      0x90222603,  //  009F  SETMBR	R8	K19	R3
-      0x901A2808,  //  00A0  SETMBR	R6	K20	R8
-      0x88241115,  //  00A1  GETMBR	R9	R8	K21
-      0x8C241316,  //  00A2  GETMET	R9	R9	K22
-      0x882C0D17,  //  00A3  GETMBR	R11	R6	K23
-      0x50300200,  //  00A4  LDBOOL	R12	1	0
-      0x7C240600,  //  00A5  CALL	R9	3
-      0x74260011,  //  00A6  JMPT	R9	#00B9
-      0xB8260200,  //  00A7  GETNGBL	R9	K1
-      0x8C241302,  //  00A8  GETMET	R9	R9	K2
-      0x602C0008,  //  00A9  GETGBL	R11	G8
-      0x88300D17,  //  00AA  GETMBR	R12	R6	K23
-      0x7C2C0200,  //  00AB  CALL	R11	1
-      0x002E540B,  //  00AC  ADD	R11	K42	R11
-      0x002C172B,  //  00AD  ADD	R11	R11	K43
-      0x60300008,  //  00AE  GETGBL	R12	G8
-      0x88341115,  //  00AF  GETMBR	R13	R8	K21
-      0x8C341B1A,  //  00B0  GETMET	R13	R13	K26
-      0x7C340200,  //  00B1  CALL	R13	1
-      0x7C300200,  //  00B2  CALL	R12	1
-      0x002C160C,  //  00B3  ADD	R11	R11	R12
-      0x58300011,  //  00B4  LDCONST	R12	K17
-      0x7C240600,  //  00B5  CALL	R9	3
-      0x50240000,  //  00B6  LDBOOL	R9	0	0
-      0xA8040001,  //  00B7  EXBLK	1	1
-      0x80041200,  //  00B8  RET	1	R9
-      0x8C240D2C,  //  00B9  GETMET	R9	R6	K44
-      0x7C240200,  //  00BA  CALL	R9	1
-      0x5C281200,  //  00BB  MOVE	R10	R9
-      0x742A0002,  //  00BC  JMPT	R10	#00C0
-      0x50280000,  //  00BD  LDBOOL	R10	0	0
-      0xA8040001,  //  00BE  EXBLK	1	1
-      0x80041400,  //  00BF  RET	1	R10
-      0x88280D2E,  //  00C0  GETMBR	R10	R6	K46
-      0x0428152F,  //  00C1  SUB	R10	R10	K47
-      0x402A120A,  //  00C2  CONNECT	R10	K9	R10
-      0x882C0D2D,  //  00C3  GETMBR	R11	R6	K45
-      0x9428160A,  //  00C4  GETIDX	R10	R11	R10
-      0x901A5A0A,  //  00C5  SETMBR	R6	K45	R10
-      0x88280D2D,  //  00C6  GETMBR	R10	R6	K45
-      0x40281409,  //  00C7  CONNECT	R10	R10	R9
-      0xB82A0200,  //  00C8  GETNGBL	R10	K1
-      0x8C281502,  //  00C9  GETMET	R10	R10	K2
-      0x8C300918,  //  00CA  GETMET	R12	R4	K24
-      0x58380030,  //  00CB  LDCONST	R14	K48
-      0x883C0D2E,  //  00CC  GETMBR	R15	R6	K46
-      0x88400D2D,  //  00CD  GETMBR	R16	R6	K45
-      0x8C402104,  //  00CE  GETMET	R16	R16	K4
-      0x7C400200,  //  00CF  CALL	R16	1
-      0x7C300800,  //  00D0  CALL	R12	4
-      0x58340011,  //  00D1  LDCONST	R13	K17
-      0x7C280600,  //  00D2  CALL	R10	3
-      0x8C280D1B,  //  00D3  GETMET	R10	R6	K27
-      0x7C280200,  //  00D4  CALL	R10	1
-      0xB82A0200,  //  00D5  GETNGBL	R10	K1
-      0x8C281502,  //  00D6  GETMET	R10	R10	K2
-      0x60300008,  //  00D7  GETGBL	R12	G8
-      0x88340D32,  //  00D8  GETMBR	R13	R6	K50
-      0x7C300200,  //  00D9  CALL	R12	1
-      0x0032620C,  //  00DA  ADD	R12	K49	R12
-      0x00301933,  //  00DB  ADD	R12	R12	K51
-      0x60340008,  //  00DC  GETGBL	R13	G8
-      0x88380D1E,  //  00DD  GETMBR	R14	R6	K30
-      0x7C340200,  //  00DE  CALL	R13	1
-      0x0030180D,  //  00DF  ADD	R12	R12	R13
-      0x00301934,  //  00E0  ADD	R12	R12	K52
-      0x60340008,  //  00E1  GETGBL	R13	G8
-      0x88380D35,  //  00E2  GETMBR	R14	R6	K53
-      0x7C340200,  //  00E3  CALL	R13	1
-      0x0030180D,  //  00E4  ADD	R12	R12	R13
-      0x58340011,  //  00E5  LDCONST	R13	K17
-      0x7C280600,  //  00E6  CALL	R10	3
-      0x8828010B,  //  00E7  GETMBR	R10	R0	K11
-      0x8C28151C,  //  00E8  GETMET	R10	R10	K28
-      0x88300D1D,  //  00E9  GETMBR	R12	R6	K29
-      0x7C280400,  //  00EA  CALL	R10	2
-      0x88280D32,  //  00EB  GETMBR	R10	R6	K50
-      0x1C2C1509,  //  00EC  EQ	R11	R10	K9
-      0x782E000A,  //  00ED  JMPF	R11	#00F9
-      0xB82E0200,  //  00EE  GETNGBL	R11	K1
-      0x8C2C1702,  //  00EF  GETMET	R11	R11	K2
-      0xB8360A00,  //  00F0  GETNGBL	R13	K5
-      0x8C341B29,  //  00F1  GETMET	R13	R13	K41
-      0x5C3C0C00,  //  00F2  MOVE	R15	R6
-      0x7C340400,  //  00F3  CALL	R13	2
-      0x00366C0D,  //  00F4  ADD	R13	K54	R13
-      0x58380011,  //  00F5  LDCONST	R14	K17
-      0x7C2C0600,  //  00F6  CALL	R11	3
-      0x50140200,  //  00F7  LDBOOL	R5	1	0
-      0x70020025,  //  00F8  JMP		#011F
-      0x1C2C152F,  //  00F9  EQ	R11	R10	K47
-      0x782E001B,  //  00FA  JMPF	R11	#0117
-      0x882C0137,  //  00FB  GETMBR	R11	R0	K55
-      0x8C2C1724,  //  00FC  GETMET	R11	R11	K36
-      0x5C340C00,  //  00FD  MOVE	R13	R6
-      0x5C380400,  //  00FE  MOVE	R14	R2
-      0x5C3C0600,  //  00FF  MOVE	R15	R3
-      0x7C2C0800,  //  0100  CALL	R11	4
-      0x5C141600,  //  0101  MOVE	R5	R11
-      0x78160004,  //  0102  JMPF	R5	#0108
-      0x882C0137,  //  0103  GETMBR	R11	R0	K55
-      0x8C2C1738,  //  0104  GETMET	R11	R11	K56
-      0x5C340000,  //  0105  MOVE	R13	R0
-      0x7C2C0400,  //  0106  CALL	R11	2
-      0x7002000D,  //  0107  JMP		#0116
-      0x882C0D39,  //  0108  GETMBR	R11	R6	K57
-      0x782E000B,  //  0109  JMPF	R11	#0116
-      0x8C2C0D3A,  //  010A  GETMET	R11	R6	K58
-      0x7C2C0200,  //  010B  CALL	R11	1
-      0x8C30173B,  //  010C  GETMET	R12	R11	K59
-      0x7C300200,  //  010D  CALL	R12	1
-      0x8C30173C,  //  010E  GETMET	R12	R11	K60
-      0x7C300200,  //  010F  CALL	R12	1
-      0x8C30013D,  //  0110  GETMET	R12	R0	K61
-      0x8838172D,  //  0111  GETMBR	R14	R11	K45
-      0x883C173E,  //  0112  GETMBR	R15	R11	K62
-      0x8840173F,  //  0113  GETMBR	R16	R11	K63
-      0x88441717,  //  0114  GETMBR	R17	R11	K23
-      0x7C300A00,  //  0115  CALL	R12	5
-      0x70020007,  //  0116  JMP		#011F
-      0xB82E0200,  //  0117  GETNGBL	R11	K1
-      0x8C2C1702,  //  0118  GETMET	R11	R11	K2
-      0x60340008,  //  0119  GETGBL	R13	G8
-      0x5C381400,  //  011A  MOVE	R14	R10
-      0x7C340200,  //  011B  CALL	R13	1
-      0x0036800D,  //  011C  ADD	R13	K64	R13
-      0x58380011,  //  011D  LDCONST	R14	K17
-      0x7C2C0600,  //  011E  CALL	R11	3
-      0xA8040001,  //  011F  EXBLK	1	1
-      0x80040A00,  //  0120  RET	1	R5
-      0xA8040001,  //  0121  EXBLK	1	1
-      0x70020014,  //  0122  JMP		#0138
-      0xAC180002,  //  0123  CATCH	R6	0	2
-      0x70020011,  //  0124  JMP		#0137
-      0xB8220200,  //  0125  GETNGBL	R8	K1
-      0x8C201102,  //  0126  GETMET	R8	R8	K2
-      0x60280008,  //  0127  GETGBL	R10	G8
-      0x5C2C0C00,  //  0128  MOVE	R11	R6
-      0x7C280200,  //  0129  CALL	R10	1
-      0x002A820A,  //  012A  ADD	R10	K65	R10
-      0x00281542,  //  012B  ADD	R10	R10	K66
-      0x602C0008,  //  012C  GETGBL	R11	G8
-      0x5C300E00,  //  012D  MOVE	R12	R7
-      0x7C2C0200,  //  012E  CALL	R11	1
-      0x0028140B,  //  012F  ADD	R10	R10	R11
-      0x7C200400,  //  0130  CALL	R8	2
-      0xA4228600,  //  0131  IMPORT	R8	K67
-      0x8C241144,  //  0132  GETMET	R9	R8	K68
-      0x7C240200,  //  0133  CALL	R9	1
-      0x50240000,  //  0134  LDBOOL	R9	0	0
-      0x80041200,  //  0135  RET	1	R9
-      0x70020000,  //  0136  JMP		#0138
-      0xB0080000,  //  0137  RAISE	2	R0	R0
-      0x80000000,  //  0138  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_MessageHandler_add_session,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    7,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(device),
-    /* K7   */  be_nested_str_weak(sessions),
-    /* K8   */  be_nested_str_weak(create_session),
-    /* K9   */  be_nested_str_weak(set_keys),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[23]) {  /* code */
-      0xA41E0000,  //  0000  IMPORT	R7	K0
-      0xB8220200,  //  0001  GETNGBL	R8	K1
-      0x8C201102,  //  0002  GETMET	R8	R8	K2
-      0x8C280F03,  //  0003  GETMET	R10	R7	K3
-      0x58300004,  //  0004  LDCONST	R12	K4
-      0x5C340200,  //  0005  MOVE	R13	R1
-      0x5C380400,  //  0006  MOVE	R14	R2
-      0x7C280800,  //  0007  CALL	R10	4
-      0x582C0005,  //  0008  LDCONST	R11	K5
-      0x7C200600,  //  0009  CALL	R8	3
-      0x88200106,  //  000A  GETMBR	R8	R0	K6
-      0x88201107,  //  000B  GETMBR	R8	R8	K7
-      0x8C201108,  //  000C  GETMET	R8	R8	K8
-      0x5C280200,  //  000D  MOVE	R10	R1
-      0x5C2C0400,  //  000E  MOVE	R11	R2
-      0x7C200600,  //  000F  CALL	R8	3
-      0x8C241109,  //  0010  GETMET	R9	R8	K9
-      0x5C2C0600,  //  0011  MOVE	R11	R3
-      0x5C300800,  //  0012  MOVE	R12	R4
-      0x5C340A00,  //  0013  MOVE	R13	R5
-      0x5C380C00,  //  0014  MOVE	R14	R6
-      0x7C240A00,  //  0015  CALL	R9	5
-      0x80000000,  //  0016  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: init
 ********************************************************************/
 be_local_closure(Matter_MessageHandler_init,   /* name */
@@ -586,22 +123,521 @@ be_local_closure(Matter_MessageHandler_every_second,   /* name */
 
 
 /********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_MessageHandler_add_session,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    7,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20add_session_X20local_session_id_X3D_X25i_X20initiator_session_id_X3D_X25i),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(device),
+    /* K7   */  be_nested_str_weak(sessions),
+    /* K8   */  be_nested_str_weak(create_session),
+    /* K9   */  be_nested_str_weak(set_keys),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[23]) {  /* code */
+      0xA41E0000,  //  0000  IMPORT	R7	K0
+      0xB8220200,  //  0001  GETNGBL	R8	K1
+      0x8C201102,  //  0002  GETMET	R8	R8	K2
+      0x8C280F03,  //  0003  GETMET	R10	R7	K3
+      0x58300004,  //  0004  LDCONST	R12	K4
+      0x5C340200,  //  0005  MOVE	R13	R1
+      0x5C380400,  //  0006  MOVE	R14	R2
+      0x7C280800,  //  0007  CALL	R10	4
+      0x582C0005,  //  0008  LDCONST	R11	K5
+      0x7C200600,  //  0009  CALL	R8	3
+      0x88200106,  //  000A  GETMBR	R8	R0	K6
+      0x88201107,  //  000B  GETMBR	R8	R8	K7
+      0x8C201108,  //  000C  GETMET	R8	R8	K8
+      0x5C280200,  //  000D  MOVE	R10	R1
+      0x5C2C0400,  //  000E  MOVE	R11	R2
+      0x7C200600,  //  000F  CALL	R8	3
+      0x8C241109,  //  0010  GETMET	R9	R8	K9
+      0x5C2C0600,  //  0011  MOVE	R11	R3
+      0x5C300800,  //  0012  MOVE	R12	R4
+      0x5C340A00,  //  0013  MOVE	R13	R5
+      0x5C380C00,  //  0014  MOVE	R14	R6
+      0x7C240A00,  //  0015  CALL	R9	5
+      0x80000000,  //  0016  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: msg_received
+********************************************************************/
+be_local_closure(Matter_MessageHandler_msg_received,   /* name */
+  be_nested_proto(
+    18,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[70]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20raw_X3D),
+    /* K4   */  be_nested_str_weak(tohex),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Frame),
+    /* K7   */  be_nested_str_weak(decode_header),
+    /* K8   */  be_nested_str_weak(local_session_id),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_nested_str_weak(sec_sesstype),
+    /* K11  */  be_nested_str_weak(device),
+    /* K12  */  be_nested_str_weak(sessions),
+    /* K13  */  be_nested_str_weak(find_session_source_id_unsecure),
+    /* K14  */  be_nested_str_weak(source_node_id),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20find_X20session_X20by_X20source_node_id_X20_X3D_X20),
+    /* K16  */  be_nested_str_weak(session_id_X20_X3D_X20),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(__ip),
+    /* K19  */  be_nested_str_weak(__port),
+    /* K20  */  be_nested_str_weak(__message_handler),
+    /* K21  */  be_nested_str_weak(session),
+    /* K22  */  be_nested_str_weak(counter_rcv),
+    /* K23  */  be_nested_str_weak(validate),
+    /* K24  */  be_nested_str_weak(message_counter),
+    /* K25  */  be_nested_str_weak(format),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
+    /* K27  */  be_nested_str_weak(val),
+    /* K28  */  be_nested_str_weak(decode_payload),
+    /* K29  */  be_nested_str_weak(packet_ack),
+    /* K30  */  be_nested_str_weak(ack_message_counter),
+    /* K31  */  be_nested_str_weak(opcode),
+    /* K32  */  be_nested_str_weak(get_opcode_name),
+    /* K33  */  be_nested_str_weak(0x_X2502X),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K35  */  be_const_int(2),
+    /* K36  */  be_nested_str_weak(commissioning),
+    /* K37  */  be_nested_str_weak(process_incoming),
+    /* K38  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
+    /* K39  */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X20),
+    /* K41  */  be_nested_str_weak(MTR_X3A_X20frame_X3D),
+    /* K42  */  be_nested_str_weak(inspect),
+    /* K43  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20encrypted_X20message_X20_X3D_X20),
+    /* K44  */  be_nested_str_weak(_X20counter_X3D),
+    /* K45  */  be_nested_str_weak(decrypt),
+    /* K46  */  be_nested_str_weak(raw),
+    /* K47  */  be_nested_str_weak(payload_idx),
+    /* K48  */  be_const_int(1),
+    /* K49  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
+    /* K50  */  be_nested_str_weak(MTR_X3A_X20decrypted_X20message_X3A_X20protocol_id_X3A),
+    /* K51  */  be_nested_str_weak(protocol_id),
+    /* K52  */  be_nested_str_weak(_X20opcode_X3D),
+    /* K53  */  be_nested_str_weak(_X20exchange_id_X3D),
+    /* K54  */  be_nested_str_weak(exchange_id),
+    /* K55  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
+    /* K56  */  be_nested_str_weak(im),
+    /* K57  */  be_nested_str_weak(send_enqueued),
+    /* K58  */  be_nested_str_weak(x_flag_r),
+    /* K59  */  be_nested_str_weak(build_standalone_ack),
+    /* K60  */  be_nested_str_weak(encode),
+    /* K61  */  be_nested_str_weak(encrypt),
+    /* K62  */  be_nested_str_weak(send_response),
+    /* K63  */  be_nested_str_weak(remote_ip),
+    /* K64  */  be_nested_str_weak(remote_port),
+    /* K65  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+    /* K66  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+    /* K67  */  be_nested_str_weak(_X3B),
+    /* K68  */  be_nested_str_weak(debug),
+    /* K69  */  be_nested_str_weak(traceback),
+    }),
+    be_str_weak(msg_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[317]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x50140000,  //  0001  LDBOOL	R5	0	0
+      0xA8020123,  //  0002  EXBLK	0	#0127
+      0xB81A0200,  //  0003  GETNGBL	R6	K1
+      0x8C180D02,  //  0004  GETMET	R6	R6	K2
+      0x8C200304,  //  0005  GETMET	R8	R1	K4
+      0x7C200200,  //  0006  CALL	R8	1
+      0x00220608,  //  0007  ADD	R8	K3	R8
+      0x54260003,  //  0008  LDINT	R9	4
+      0x7C180600,  //  0009  CALL	R6	3
+      0xB81A0A00,  //  000A  GETNGBL	R6	K5
+      0x8C180D06,  //  000B  GETMET	R6	R6	K6
+      0x5C200000,  //  000C  MOVE	R8	R0
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C180A00,  //  0010  CALL	R6	5
+      0x8C1C0D07,  //  0011  GETMET	R7	R6	K7
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0x5C200E00,  //  0013  MOVE	R8	R7
+      0x74220002,  //  0014  JMPT	R8	#0018
+      0x50200000,  //  0015  LDBOOL	R8	0	0
+      0xA8040001,  //  0016  EXBLK	1	1
+      0x80041000,  //  0017  RET	1	R8
+      0x88200D08,  //  0018  GETMBR	R8	R6	K8
+      0x1C201109,  //  0019  EQ	R8	R8	K9
+      0x7822005C,  //  001A  JMPF	R8	#0078
+      0x88200D0A,  //  001B  GETMBR	R8	R6	K10
+      0x1C201109,  //  001C  EQ	R8	R8	K9
+      0x78220059,  //  001D  JMPF	R8	#0078
+      0x8820010B,  //  001E  GETMBR	R8	R0	K11
+      0x8820110C,  //  001F  GETMBR	R8	R8	K12
+      0x8C20110D,  //  0020  GETMET	R8	R8	K13
+      0x88280D0E,  //  0021  GETMBR	R10	R6	K14
+      0x542E0059,  //  0022  LDINT	R11	90
+      0x7C200600,  //  0023  CALL	R8	3
+      0xB8260200,  //  0024  GETNGBL	R9	K1
+      0x8C241302,  //  0025  GETMET	R9	R9	K2
+      0x602C0008,  //  0026  GETGBL	R11	G8
+      0x88300D0E,  //  0027  GETMBR	R12	R6	K14
+      0x7C2C0200,  //  0028  CALL	R11	1
+      0x002E1E0B,  //  0029  ADD	R11	K15	R11
+      0x002C1710,  //  002A  ADD	R11	R11	K16
+      0x60300008,  //  002B  GETGBL	R12	G8
+      0x88341108,  //  002C  GETMBR	R13	R8	K8
+      0x7C300200,  //  002D  CALL	R12	1
+      0x002C160C,  //  002E  ADD	R11	R11	R12
+      0x58300011,  //  002F  LDCONST	R12	K17
+      0x7C240600,  //  0030  CALL	R9	3
+      0x780A0000,  //  0031  JMPF	R2	#0033
+      0x90222402,  //  0032  SETMBR	R8	K18	R2
+      0x780E0000,  //  0033  JMPF	R3	#0035
+      0x90222603,  //  0034  SETMBR	R8	K19	R3
+      0x90222800,  //  0035  SETMBR	R8	K20	R0
+      0x901A2A08,  //  0036  SETMBR	R6	K21	R8
+      0x88240116,  //  0037  GETMBR	R9	R0	K22
+      0x8C241317,  //  0038  GETMET	R9	R9	K23
+      0x882C0D18,  //  0039  GETMBR	R11	R6	K24
+      0x50300000,  //  003A  LDBOOL	R12	0	0
+      0x7C240600,  //  003B  CALL	R9	3
+      0x7426000D,  //  003C  JMPT	R9	#004B
+      0xB8260200,  //  003D  GETNGBL	R9	K1
+      0x8C241302,  //  003E  GETMET	R9	R9	K2
+      0x8C2C0919,  //  003F  GETMET	R11	R4	K25
+      0x5834001A,  //  0040  LDCONST	R13	K26
+      0x88380D18,  //  0041  GETMBR	R14	R6	K24
+      0x883C0116,  //  0042  GETMBR	R15	R0	K22
+      0x8C3C1F1B,  //  0043  GETMET	R15	R15	K27
+      0x7C3C0200,  //  0044  CALL	R15	1
+      0x7C2C0800,  //  0045  CALL	R11	4
+      0x58300011,  //  0046  LDCONST	R12	K17
+      0x7C240600,  //  0047  CALL	R9	3
+      0x50240000,  //  0048  LDBOOL	R9	0	0
+      0xA8040001,  //  0049  EXBLK	1	1
+      0x80041200,  //  004A  RET	1	R9
+      0x8C240D1C,  //  004B  GETMET	R9	R6	K28
+      0x7C240200,  //  004C  CALL	R9	1
+      0x74260002,  //  004D  JMPT	R9	#0051
+      0x50240000,  //  004E  LDBOOL	R9	0	0
+      0xA8040001,  //  004F  EXBLK	1	1
+      0x80041200,  //  0050  RET	1	R9
+      0x8824010B,  //  0051  GETMBR	R9	R0	K11
+      0x8C24131D,  //  0052  GETMET	R9	R9	K29
+      0x882C0D1E,  //  0053  GETMBR	R11	R6	K30
+      0x7C240400,  //  0054  CALL	R9	2
+      0x88240D1F,  //  0055  GETMBR	R9	R6	K31
+      0x542A000F,  //  0056  LDINT	R10	16
+      0x2024120A,  //  0057  NE	R9	R9	R10
+      0x78260014,  //  0058  JMPF	R9	#006E
+      0xB8260A00,  //  0059  GETNGBL	R9	K5
+      0x8C241320,  //  005A  GETMET	R9	R9	K32
+      0x882C0D1F,  //  005B  GETMBR	R11	R6	K31
+      0x7C240400,  //  005C  CALL	R9	2
+      0x5C281200,  //  005D  MOVE	R10	R9
+      0x742A0004,  //  005E  JMPT	R10	#0064
+      0x8C280919,  //  005F  GETMET	R10	R4	K25
+      0x58300021,  //  0060  LDCONST	R12	K33
+      0x88340D1F,  //  0061  GETMBR	R13	R6	K31
+      0x7C280600,  //  0062  CALL	R10	3
+      0x5C241400,  //  0063  MOVE	R9	R10
+      0xB82A0200,  //  0064  GETNGBL	R10	K1
+      0x8C281502,  //  0065  GETMET	R10	R10	K2
+      0x8C300919,  //  0066  GETMET	R12	R4	K25
+      0x58380022,  //  0067  LDCONST	R14	K34
+      0x5C3C1200,  //  0068  MOVE	R15	R9
+      0x5C400400,  //  0069  MOVE	R16	R2
+      0x5C440600,  //  006A  MOVE	R17	R3
+      0x7C300A00,  //  006B  CALL	R12	5
+      0x58340023,  //  006C  LDCONST	R13	K35
+      0x7C280600,  //  006D  CALL	R10	3
+      0x88240124,  //  006E  GETMBR	R9	R0	K36
+      0x8C241325,  //  006F  GETMET	R9	R9	K37
+      0x5C2C0C00,  //  0070  MOVE	R11	R6
+      0x5C300400,  //  0071  MOVE	R12	R2
+      0x5C340600,  //  0072  MOVE	R13	R3
+      0x7C240800,  //  0073  CALL	R9	4
+      0x50240200,  //  0074  LDBOOL	R9	1	0
+      0xA8040001,  //  0075  EXBLK	1	1
+      0x80041200,  //  0076  RET	1	R9
+      0x700200AA,  //  0077  JMP		#0123
+      0xB8220200,  //  0078  GETNGBL	R8	K1
+      0x8C201102,  //  0079  GETMET	R8	R8	K2
+      0x8C280919,  //  007A  GETMET	R10	R4	K25
+      0x58300026,  //  007B  LDCONST	R12	K38
+      0x88340D08,  //  007C  GETMBR	R13	R6	K8
+      0x88380D18,  //  007D  GETMBR	R14	R6	K24
+      0x7C280800,  //  007E  CALL	R10	4
+      0x582C0011,  //  007F  LDCONST	R11	K17
+      0x7C200600,  //  0080  CALL	R8	3
+      0x8820010B,  //  0081  GETMBR	R8	R0	K11
+      0x8820110C,  //  0082  GETMBR	R8	R8	K12
+      0x8C201127,  //  0083  GETMET	R8	R8	K39
+      0x88280D08,  //  0084  GETMBR	R10	R6	K8
+      0x7C200400,  //  0085  CALL	R8	2
+      0x4C240000,  //  0086  LDNIL	R9
+      0x1C241009,  //  0087  EQ	R9	R8	R9
+      0x78260013,  //  0088  JMPF	R9	#009D
+      0xB8260200,  //  0089  GETNGBL	R9	K1
+      0x8C241302,  //  008A  GETMET	R9	R9	K2
+      0x602C0008,  //  008B  GETGBL	R11	G8
+      0x88300D08,  //  008C  GETMBR	R12	R6	K8
+      0x7C2C0200,  //  008D  CALL	R11	1
+      0x002E500B,  //  008E  ADD	R11	K40	R11
+      0x58300011,  //  008F  LDCONST	R12	K17
+      0x7C240600,  //  0090  CALL	R9	3
+      0xB8260200,  //  0091  GETNGBL	R9	K1
+      0x8C241302,  //  0092  GETMET	R9	R9	K2
+      0xB82E0A00,  //  0093  GETNGBL	R11	K5
+      0x8C2C172A,  //  0094  GETMET	R11	R11	K42
+      0x5C340C00,  //  0095  MOVE	R13	R6
+      0x7C2C0400,  //  0096  CALL	R11	2
+      0x002E520B,  //  0097  ADD	R11	K41	R11
+      0x58300011,  //  0098  LDCONST	R12	K17
+      0x7C240600,  //  0099  CALL	R9	3
+      0x50240000,  //  009A  LDBOOL	R9	0	0
+      0xA8040001,  //  009B  EXBLK	1	1
+      0x80041200,  //  009C  RET	1	R9
+      0x780A0000,  //  009D  JMPF	R2	#009F
+      0x90222402,  //  009E  SETMBR	R8	K18	R2
+      0x780E0000,  //  009F  JMPF	R3	#00A1
+      0x90222603,  //  00A0  SETMBR	R8	K19	R3
+      0x90222800,  //  00A1  SETMBR	R8	K20	R0
+      0x901A2A08,  //  00A2  SETMBR	R6	K21	R8
+      0x88241116,  //  00A3  GETMBR	R9	R8	K22
+      0x8C241317,  //  00A4  GETMET	R9	R9	K23
+      0x882C0D18,  //  00A5  GETMBR	R11	R6	K24
+      0x50300200,  //  00A6  LDBOOL	R12	1	0
+      0x7C240600,  //  00A7  CALL	R9	3
+      0x74260011,  //  00A8  JMPT	R9	#00BB
+      0xB8260200,  //  00A9  GETNGBL	R9	K1
+      0x8C241302,  //  00AA  GETMET	R9	R9	K2
+      0x602C0008,  //  00AB  GETGBL	R11	G8
+      0x88300D18,  //  00AC  GETMBR	R12	R6	K24
+      0x7C2C0200,  //  00AD  CALL	R11	1
+      0x002E560B,  //  00AE  ADD	R11	K43	R11
+      0x002C172C,  //  00AF  ADD	R11	R11	K44
+      0x60300008,  //  00B0  GETGBL	R12	G8
+      0x88341116,  //  00B1  GETMBR	R13	R8	K22
+      0x8C341B1B,  //  00B2  GETMET	R13	R13	K27
+      0x7C340200,  //  00B3  CALL	R13	1
+      0x7C300200,  //  00B4  CALL	R12	1
+      0x002C160C,  //  00B5  ADD	R11	R11	R12
+      0x58300011,  //  00B6  LDCONST	R12	K17
+      0x7C240600,  //  00B7  CALL	R9	3
+      0x50240000,  //  00B8  LDBOOL	R9	0	0
+      0xA8040001,  //  00B9  EXBLK	1	1
+      0x80041200,  //  00BA  RET	1	R9
+      0x8C240D2D,  //  00BB  GETMET	R9	R6	K45
+      0x7C240200,  //  00BC  CALL	R9	1
+      0x5C281200,  //  00BD  MOVE	R10	R9
+      0x742A0002,  //  00BE  JMPT	R10	#00C2
+      0x50280000,  //  00BF  LDBOOL	R10	0	0
+      0xA8040001,  //  00C0  EXBLK	1	1
+      0x80041400,  //  00C1  RET	1	R10
+      0x88280D2F,  //  00C2  GETMBR	R10	R6	K47
+      0x04281530,  //  00C3  SUB	R10	R10	K48
+      0x402A120A,  //  00C4  CONNECT	R10	K9	R10
+      0x882C0D2E,  //  00C5  GETMBR	R11	R6	K46
+      0x9428160A,  //  00C6  GETIDX	R10	R11	R10
+      0x901A5C0A,  //  00C7  SETMBR	R6	K46	R10
+      0x88280D2E,  //  00C8  GETMBR	R10	R6	K46
+      0x40281409,  //  00C9  CONNECT	R10	R10	R9
+      0xB82A0200,  //  00CA  GETNGBL	R10	K1
+      0x8C281502,  //  00CB  GETMET	R10	R10	K2
+      0x8C300919,  //  00CC  GETMET	R12	R4	K25
+      0x58380031,  //  00CD  LDCONST	R14	K49
+      0x883C0D2F,  //  00CE  GETMBR	R15	R6	K47
+      0x88400D2E,  //  00CF  GETMBR	R16	R6	K46
+      0x8C402104,  //  00D0  GETMET	R16	R16	K4
+      0x7C400200,  //  00D1  CALL	R16	1
+      0x7C300800,  //  00D2  CALL	R12	4
+      0x58340011,  //  00D3  LDCONST	R13	K17
+      0x7C280600,  //  00D4  CALL	R10	3
+      0x8C280D1C,  //  00D5  GETMET	R10	R6	K28
+      0x7C280200,  //  00D6  CALL	R10	1
+      0xB82A0200,  //  00D7  GETNGBL	R10	K1
+      0x8C281502,  //  00D8  GETMET	R10	R10	K2
+      0x60300008,  //  00D9  GETGBL	R12	G8
+      0x88340D33,  //  00DA  GETMBR	R13	R6	K51
+      0x7C300200,  //  00DB  CALL	R12	1
+      0x0032640C,  //  00DC  ADD	R12	K50	R12
+      0x00301934,  //  00DD  ADD	R12	R12	K52
+      0x60340008,  //  00DE  GETGBL	R13	G8
+      0x88380D1F,  //  00DF  GETMBR	R14	R6	K31
+      0x7C340200,  //  00E0  CALL	R13	1
+      0x0030180D,  //  00E1  ADD	R12	R12	R13
+      0x00301935,  //  00E2  ADD	R12	R12	K53
+      0x60340008,  //  00E3  GETGBL	R13	G8
+      0x88380D36,  //  00E4  GETMBR	R14	R6	K54
+      0x543EFFFE,  //  00E5  LDINT	R15	65535
+      0x2C381C0F,  //  00E6  AND	R14	R14	R15
+      0x7C340200,  //  00E7  CALL	R13	1
+      0x0030180D,  //  00E8  ADD	R12	R12	R13
+      0x58340011,  //  00E9  LDCONST	R13	K17
+      0x7C280600,  //  00EA  CALL	R10	3
+      0x8828010B,  //  00EB  GETMBR	R10	R0	K11
+      0x8C28151D,  //  00EC  GETMET	R10	R10	K29
+      0x88300D1E,  //  00ED  GETMBR	R12	R6	K30
+      0x7C280400,  //  00EE  CALL	R10	2
+      0x88280D33,  //  00EF  GETMBR	R10	R6	K51
+      0x1C2C1509,  //  00F0  EQ	R11	R10	K9
+      0x782E000A,  //  00F1  JMPF	R11	#00FD
+      0xB82E0200,  //  00F2  GETNGBL	R11	K1
+      0x8C2C1702,  //  00F3  GETMET	R11	R11	K2
+      0xB8360A00,  //  00F4  GETNGBL	R13	K5
+      0x8C341B2A,  //  00F5  GETMET	R13	R13	K42
+      0x5C3C0C00,  //  00F6  MOVE	R15	R6
+      0x7C340400,  //  00F7  CALL	R13	2
+      0x00366E0D,  //  00F8  ADD	R13	K55	R13
+      0x58380011,  //  00F9  LDCONST	R14	K17
+      0x7C2C0600,  //  00FA  CALL	R11	3
+      0x50140200,  //  00FB  LDBOOL	R5	1	0
+      0x70020025,  //  00FC  JMP		#0123
+      0x1C2C1530,  //  00FD  EQ	R11	R10	K48
+      0x782E001B,  //  00FE  JMPF	R11	#011B
+      0x882C0138,  //  00FF  GETMBR	R11	R0	K56
+      0x8C2C1725,  //  0100  GETMET	R11	R11	K37
+      0x5C340C00,  //  0101  MOVE	R13	R6
+      0x5C380400,  //  0102  MOVE	R14	R2
+      0x5C3C0600,  //  0103  MOVE	R15	R3
+      0x7C2C0800,  //  0104  CALL	R11	4
+      0x5C141600,  //  0105  MOVE	R5	R11
+      0x78160004,  //  0106  JMPF	R5	#010C
+      0x882C0138,  //  0107  GETMBR	R11	R0	K56
+      0x8C2C1739,  //  0108  GETMET	R11	R11	K57
+      0x5C340000,  //  0109  MOVE	R13	R0
+      0x7C2C0400,  //  010A  CALL	R11	2
+      0x7002000D,  //  010B  JMP		#011A
+      0x882C0D3A,  //  010C  GETMBR	R11	R6	K58
+      0x782E000B,  //  010D  JMPF	R11	#011A
+      0x8C2C0D3B,  //  010E  GETMET	R11	R6	K59
+      0x7C2C0200,  //  010F  CALL	R11	1
+      0x8C30173C,  //  0110  GETMET	R12	R11	K60
+      0x7C300200,  //  0111  CALL	R12	1
+      0x8C30173D,  //  0112  GETMET	R12	R11	K61
+      0x7C300200,  //  0113  CALL	R12	1
+      0x8C30013E,  //  0114  GETMET	R12	R0	K62
+      0x8838172E,  //  0115  GETMBR	R14	R11	K46
+      0x883C173F,  //  0116  GETMBR	R15	R11	K63
+      0x88401740,  //  0117  GETMBR	R16	R11	K64
+      0x88441718,  //  0118  GETMBR	R17	R11	K24
+      0x7C300A00,  //  0119  CALL	R12	5
+      0x70020007,  //  011A  JMP		#0123
+      0xB82E0200,  //  011B  GETNGBL	R11	K1
+      0x8C2C1702,  //  011C  GETMET	R11	R11	K2
+      0x60340008,  //  011D  GETGBL	R13	G8
+      0x5C381400,  //  011E  MOVE	R14	R10
+      0x7C340200,  //  011F  CALL	R13	1
+      0x0036820D,  //  0120  ADD	R13	K65	R13
+      0x58380011,  //  0121  LDCONST	R14	K17
+      0x7C2C0600,  //  0122  CALL	R11	3
+      0xA8040001,  //  0123  EXBLK	1	1
+      0x80040A00,  //  0124  RET	1	R5
+      0xA8040001,  //  0125  EXBLK	1	1
+      0x70020014,  //  0126  JMP		#013C
+      0xAC180002,  //  0127  CATCH	R6	0	2
+      0x70020011,  //  0128  JMP		#013B
+      0xB8220200,  //  0129  GETNGBL	R8	K1
+      0x8C201102,  //  012A  GETMET	R8	R8	K2
+      0x60280008,  //  012B  GETGBL	R10	G8
+      0x5C2C0C00,  //  012C  MOVE	R11	R6
+      0x7C280200,  //  012D  CALL	R10	1
+      0x002A840A,  //  012E  ADD	R10	K66	R10
+      0x00281543,  //  012F  ADD	R10	R10	K67
+      0x602C0008,  //  0130  GETGBL	R11	G8
+      0x5C300E00,  //  0131  MOVE	R12	R7
+      0x7C2C0200,  //  0132  CALL	R11	1
+      0x0028140B,  //  0133  ADD	R10	R10	R11
+      0x7C200400,  //  0134  CALL	R8	2
+      0xA4228800,  //  0135  IMPORT	R8	K68
+      0x8C241145,  //  0136  GETMET	R9	R8	K69
+      0x7C240200,  //  0137  CALL	R9	1
+      0x50240000,  //  0138  LDBOOL	R9	0	0
+      0x80041200,  //  0139  RET	1	R9
+      0x70020000,  //  013A  JMP		#013C
+      0xB0080000,  //  013B  RAISE	2	R0	R0
+      0x80000000,  //  013C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_MessageHandler_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(im),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_MessageHandler
 ********************************************************************/
 be_local_class(Matter_MessageHandler,
     4,
     NULL,
-    be_nested_map(9,
+    be_nested_map(10,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_MessageHandler_every_second_closure) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_MessageHandler_msg_received_closure) },
+        { be_const_key_weak(commissioning, 2), be_const_var(1) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_MessageHandler_every_250ms_closure) },
         { be_const_key_weak(counter_rcv, -1), be_const_var(3) },
-        { be_const_key_weak(commissioning, 0), be_const_var(1) },
-        { be_const_key_weak(device, 5), be_const_var(0) },
-        { be_const_key_weak(init, 8), be_const_closure(Matter_MessageHandler_init_closure) },
-        { be_const_key_weak(send_response, 4), be_const_closure(Matter_MessageHandler_send_response_closure) },
-        { be_const_key_weak(add_session, 2), be_const_closure(Matter_MessageHandler_add_session_closure) },
-        { be_const_key_weak(im, -1), be_const_var(2) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_MessageHandler_add_session_closure) },
+        { be_const_key_weak(init, 9), be_const_closure(Matter_MessageHandler_init_closure) },
+        { be_const_key_weak(im, 4), be_const_var(2) },
+        { be_const_key_weak(send_response, 6), be_const_closure(Matter_MessageHandler_send_response_closure) },
+        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_MessageHandler_msg_received_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_MessageHandler_every_second_closure) },
     })),
     be_str_weak(Matter_MessageHandler)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin.h
@@ -7,12 +7,12 @@
 extern const bclass be_class_Matter_Plugin;
 
 /********************************************************************
-** Solidified function: read_event
+** Solidified function: read_attribute
 ********************************************************************/
-be_local_closure(Matter_Plugin_read_event,   /* name */
+be_local_closure(Matter_Plugin_read_attribute,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
+    4,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -20,11 +20,45 @@ be_local_closure(Matter_Plugin_read_event,   /* name */
     NULL,                       /* no sub protos */
     0,                          /* has constants */
     NULL,                       /* no const */
-    be_str_weak(read_event),
+    be_str_weak(read_attribute),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x80040600,  //  0001  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Plugin_attribute_updated,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(attribute_updated),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x8C140B01,  //  0001  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0002  MOVE	R7	R1
+      0x5C200400,  //  0003  MOVE	R8	R2
+      0x5C240600,  //  0004  MOVE	R9	R3
+      0x5C280800,  //  0005  MOVE	R10	R4
+      0x7C140A00,  //  0006  CALL	R5	5
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -66,75 +100,24 @@ be_local_closure(Matter_Plugin_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: has
+** Solidified function: subscribe_attribute
 ********************************************************************/
-be_local_closure(Matter_Plugin_has,   /* name */
+be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
   be_nested_proto(
     6,                          /* nstack */
-    3,                          /* argc */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(endpoints),
-    /* K3   */  be_nested_str_weak(find),
-    }),
-    be_str_weak(has),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[15]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x7C0C0400,  //  0003  CALL	R3	2
-      0x780E0006,  //  0004  JMPF	R3	#000C
-      0x880C0102,  //  0005  GETMBR	R3	R0	K2
-      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0x500C0001,  //  000C  LDBOOL	R3	0	1
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x80040600,  //  000E  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_attribute_list
-********************************************************************/
-be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(clusters),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(EMPTY_LIST),
-    }),
-    be_str_weak(get_attribute_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140400,  //  0002  MOVE	R5	R2
-      0x88180102,  //  0003  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x80040600,  //  0005  RET	1	R3
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
     })
   )
 );
@@ -188,81 +171,6 @@ be_local_closure(Matter_Plugin_get_cluster_list,   /* name */
 
 
 /********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Plugin_invoke_request,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C100000,  //  0000  LDNIL	R4
-      0x80040800,  //  0001  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: read_attribute
-********************************************************************/
-be_local_closure(Matter_Plugin_read_attribute,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(read_attribute),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x80040600,  //  0001  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_event
-********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_event,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_event),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_cluster_map
 ********************************************************************/
 be_local_closure(Matter_Plugin_get_cluster_map,   /* name */
@@ -283,6 +191,31 @@ be_local_closure(Matter_Plugin_get_cluster_map,   /* name */
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Plugin_invoke_request,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C100000,  //  0000  LDNIL	R4
+      0x80040800,  //  0001  RET	1	R4
     })
   )
 );
@@ -317,6 +250,31 @@ be_local_closure(Matter_Plugin_get_endpoints,   /* name */
 
 
 /********************************************************************
+** Solidified function: subscribe_event
+********************************************************************/
+be_local_closure(Matter_Plugin_subscribe_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(subscribe_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: write_attribute
 ********************************************************************/
 be_local_closure(Matter_Plugin_write_attribute,   /* name */
@@ -335,6 +293,74 @@ be_local_closure(Matter_Plugin_write_attribute,   /* name */
     ( &(const binstruction[ 2]) {  /* code */
       0x4C100000,  //  0000  LDNIL	R4
       0x80040800,  //  0001  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: has
+********************************************************************/
+be_local_closure(Matter_Plugin_has,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(endpoints),
+    /* K3   */  be_nested_str_weak(find),
+    }),
+    be_str_weak(has),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x7C0C0400,  //  0003  CALL	R3	2
+      0x780E0006,  //  0004  JMPF	R3	#000C
+      0x880C0102,  //  0005  GETMBR	R3	R0	K2
+      0x8C0C0703,  //  0006  GETMET	R3	R3	K3
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x4C100000,  //  0009  LDNIL	R4
+      0x200C0604,  //  000A  NE	R3	R3	R4
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0x500C0001,  //  000C  LDBOOL	R3	0	1
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x80040600,  //  000E  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: read_event
+********************************************************************/
+be_local_closure(Matter_Plugin_read_event,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(read_event),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x80040A00,  //  0001  RET	1	R5
     })
   )
 );
@@ -367,24 +393,32 @@ be_local_closure(Matter_Plugin_timed_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: subscribe_attribute
+** Solidified function: get_attribute_list
 ********************************************************************/
-be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
+be_local_closure(Matter_Plugin_get_attribute_list,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(subscribe_attribute),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(clusters),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(EMPTY_LIST),
+    }),
+    be_str_weak(get_attribute_list),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x80040A00,  //  0001  RET	1	R5
+    ( &(const binstruction[ 6]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140400,  //  0002  MOVE	R5	R2
+      0x88180102,  //  0003  GETMBR	R6	R0	K2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x80040600,  //  0005  RET	1	R3
     })
   )
 );
@@ -397,32 +431,33 @@ be_local_closure(Matter_Plugin_subscribe_attribute,   /* name */
 be_local_class(Matter_Plugin,
     3,
     NULL,
-    be_nested_map(18,
+    be_nested_map(19,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(read_event, -1), be_const_closure(Matter_Plugin_read_event_closure) },
-        { be_const_key_weak(get_cluster_list, -1), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
-        { be_const_key_weak(endpoints, 1), be_const_var(1) },
-        { be_const_key_weak(get_attribute_list, 9), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Plugin_invoke_request_closure) },
         { be_const_key_weak(read_attribute, -1), be_const_closure(Matter_Plugin_read_attribute_closure) },
-        { be_const_key_weak(has, 13), be_const_closure(Matter_Plugin_has_closure) },
-        { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
-        { be_const_key_weak(get_cluster_map, -1), be_const_closure(Matter_Plugin_get_cluster_map_closure) },
-        { be_const_key_weak(clusters, -1), be_const_var(2) },
-        { be_const_key_weak(EMPTY_MAP, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
-        be_const_map( *     be_nested_map(0,
-    ( (struct bmapnode*) &(const bmapnode[]) {
-    }))    ) } )) },
-        { be_const_key_weak(get_endpoints, -1), be_const_closure(Matter_Plugin_get_endpoints_closure) },
-        { be_const_key_weak(write_attribute, 2), be_const_closure(Matter_Plugin_write_attribute_closure) },
-        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
-        { be_const_key_weak(init, 4), be_const_closure(Matter_Plugin_init_closure) },
-        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
         { be_const_key_weak(EMPTY_LIST, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(0,
     ( (struct bvalue*) &(const bvalue[]) {
     }))    ) } )) },
+        { be_const_key_weak(clusters, 9), be_const_var(2) },
+        { be_const_key_weak(get_endpoints, -1), be_const_closure(Matter_Plugin_get_endpoints_closure) },
+        { be_const_key_weak(subscribe_attribute, -1), be_const_closure(Matter_Plugin_subscribe_attribute_closure) },
+        { be_const_key_weak(get_cluster_list, 3), be_const_closure(Matter_Plugin_get_cluster_list_closure) },
+        { be_const_key_weak(timed_request, -1), be_const_closure(Matter_Plugin_timed_request_closure) },
+        { be_const_key_weak(EMPTY_MAP, 8), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        be_const_map( *     be_nested_map(0,
+    ( (struct bmapnode*) &(const bmapnode[]) {
+    }))    ) } )) },
+        { be_const_key_weak(subscribe_event, -1), be_const_closure(Matter_Plugin_subscribe_event_closure) },
+        { be_const_key_weak(endpoints, 18), be_const_var(1) },
+        { be_const_key_weak(invoke_request, 7), be_const_closure(Matter_Plugin_invoke_request_closure) },
+        { be_const_key_weak(write_attribute, -1), be_const_closure(Matter_Plugin_write_attribute_closure) },
+        { be_const_key_weak(attribute_updated, 14), be_const_closure(Matter_Plugin_attribute_updated_closure) },
+        { be_const_key_weak(init, 2), be_const_closure(Matter_Plugin_init_closure) },
+        { be_const_key_weak(has, -1), be_const_closure(Matter_Plugin_has_closure) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(read_event, 6), be_const_closure(Matter_Plugin_read_event_closure) },
+        { be_const_key_weak(get_attribute_list, -1), be_const_closure(Matter_Plugin_get_attribute_list_closure) },
+        { be_const_key_weak(get_cluster_map, -1), be_const_closure(Matter_Plugin_get_cluster_map_closure) },
     })),
     be_str_weak(Matter_Plugin)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_OnOff.h
@@ -7,11 +7,44 @@
 extern const bclass be_class_Matter_Plugin_OnOff;
 
 /********************************************************************
+** Solidified function: onoff_changed
+********************************************************************/
+be_local_closure(Matter_Plugin_OnOff_onoff_changed,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attribute_updated),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(onoff_changed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x54160005,  //  0002  LDINT	R5	6
+      0x58180002,  //  0003  LDCONST	R6	K2
+      0x7C080800,  //  0004  CALL	R2	4
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: invoke_request
 ********************************************************************/
 be_local_closure(Matter_Plugin_OnOff_invoke_request,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    13,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -24,88 +57,100 @@ be_local_closure(Matter_Plugin_OnOff_invoke_request,   /* name */
     /* K1   */  be_nested_str_weak(TLV),
     /* K2   */  be_nested_str_weak(cluster),
     /* K3   */  be_nested_str_weak(command),
-    /* K4   */  be_nested_str_weak(session),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(Matter_TLV_struct),
-    /* K9   */  be_nested_str_weak(add_TLV),
-    /* K10  */  be_nested_str_weak(U2),
-    /* K11  */  be_nested_str_weak(onoff),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_const_int(1),
+    /* K7   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K8   */  be_nested_str_weak(add_TLV),
+    /* K9   */  be_nested_str_weak(U2),
+    /* K10  */  be_nested_str_weak(onoff),
+    /* K11  */  be_nested_str_weak(onoff_changed),
     /* K12  */  be_const_int(2),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[69]) {  /* code */
+    ( &(const binstruction[81]) {  /* code */
       0xB8120000,  //  0000  GETNGBL	R4	K0
       0x88100901,  //  0001  GETMBR	R4	R4	K1
       0x88140702,  //  0002  GETMBR	R5	R3	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
-      0x881C0304,  //  0004  GETMBR	R7	R1	K4
-      0x1C200B05,  //  0005  EQ	R8	R5	K5
-      0x78220016,  //  0006  JMPF	R8	#001E
-      0x1C200D06,  //  0007  EQ	R8	R6	K6
-      0x78220002,  //  0008  JMPF	R8	#000C
-      0x50200200,  //  0009  LDBOOL	R8	1	0
-      0x80041000,  //  000A  RET	1	R8
-      0x70020010,  //  000B  JMP		#001D
-      0x1C200D07,  //  000C  EQ	R8	R6	K7
-      0x78220009,  //  000D  JMPF	R8	#0018
-      0x8C200908,  //  000E  GETMET	R8	R4	K8
-      0x7C200200,  //  000F  CALL	R8	1
-      0x8C241109,  //  0010  GETMET	R9	R8	K9
-      0x582C0006,  //  0011  LDCONST	R11	K6
-      0x8830090A,  //  0012  GETMBR	R12	R4	K10
-      0x58340006,  //  0013  LDCONST	R13	K6
-      0x7C240800,  //  0014  CALL	R9	4
-      0x900E0706,  //  0015  SETMBR	R3	K3	K6
-      0x80041000,  //  0016  RET	1	R8
-      0x70020004,  //  0017  JMP		#001D
-      0x5422003F,  //  0018  LDINT	R8	64
-      0x1C200C08,  //  0019  EQ	R8	R6	R8
-      0x78220001,  //  001A  JMPF	R8	#001D
-      0x50200200,  //  001B  LDBOOL	R8	1	0
-      0x80041000,  //  001C  RET	1	R8
-      0x70020025,  //  001D  JMP		#0044
-      0x54220003,  //  001E  LDINT	R8	4
-      0x1C200A08,  //  001F  EQ	R8	R5	R8
-      0x78220002,  //  0020  JMPF	R8	#0024
-      0x50200200,  //  0021  LDBOOL	R8	1	0
-      0x80041000,  //  0022  RET	1	R8
-      0x7002001F,  //  0023  JMP		#0044
-      0x54220004,  //  0024  LDINT	R8	5
-      0x1C200A08,  //  0025  EQ	R8	R5	R8
-      0x78220002,  //  0026  JMPF	R8	#002A
-      0x50200200,  //  0027  LDBOOL	R8	1	0
-      0x80041000,  //  0028  RET	1	R8
-      0x70020019,  //  0029  JMP		#0044
-      0x54220005,  //  002A  LDINT	R8	6
-      0x1C200A08,  //  002B  EQ	R8	R5	R8
-      0x78220016,  //  002C  JMPF	R8	#0044
-      0x1C200D06,  //  002D  EQ	R8	R6	K6
-      0x78220004,  //  002E  JMPF	R8	#0034
-      0x50200000,  //  002F  LDBOOL	R8	0	0
-      0x90021608,  //  0030  SETMBR	R0	K11	R8
-      0x50200200,  //  0031  LDBOOL	R8	1	0
-      0x80041000,  //  0032  RET	1	R8
-      0x7002000F,  //  0033  JMP		#0044
-      0x1C200D07,  //  0034  EQ	R8	R6	K7
-      0x78220004,  //  0035  JMPF	R8	#003B
-      0x50200200,  //  0036  LDBOOL	R8	1	0
-      0x90021608,  //  0037  SETMBR	R0	K11	R8
-      0x50200200,  //  0038  LDBOOL	R8	1	0
-      0x80041000,  //  0039  RET	1	R8
-      0x70020008,  //  003A  JMP		#0044
-      0x1C200D0C,  //  003B  EQ	R8	R6	K12
-      0x78220006,  //  003C  JMPF	R8	#0044
-      0x8820010B,  //  003D  GETMBR	R8	R0	K11
-      0x78220000,  //  003E  JMPF	R8	#0040
-      0x50200001,  //  003F  LDBOOL	R8	0	1
-      0x50200200,  //  0040  LDBOOL	R8	1	0
-      0x90021608,  //  0041  SETMBR	R0	K11	R8
-      0x50200200,  //  0042  LDBOOL	R8	1	0
-      0x80041000,  //  0043  RET	1	R8
-      0x80000000,  //  0044  RET	0
+      0x1C1C0B04,  //  0004  EQ	R7	R5	K4
+      0x781E0016,  //  0005  JMPF	R7	#001D
+      0x1C1C0D05,  //  0006  EQ	R7	R6	K5
+      0x781E0002,  //  0007  JMPF	R7	#000B
+      0x501C0200,  //  0008  LDBOOL	R7	1	0
+      0x80040E00,  //  0009  RET	1	R7
+      0x70020010,  //  000A  JMP		#001C
+      0x1C1C0D06,  //  000B  EQ	R7	R6	K6
+      0x781E0009,  //  000C  JMPF	R7	#0017
+      0x8C1C0907,  //  000D  GETMET	R7	R4	K7
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x8C200F08,  //  000F  GETMET	R8	R7	K8
+      0x58280005,  //  0010  LDCONST	R10	K5
+      0x882C0909,  //  0011  GETMBR	R11	R4	K9
+      0x58300005,  //  0012  LDCONST	R12	K5
+      0x7C200800,  //  0013  CALL	R8	4
+      0x900E0705,  //  0014  SETMBR	R3	K3	K5
+      0x80040E00,  //  0015  RET	1	R7
+      0x70020004,  //  0016  JMP		#001C
+      0x541E003F,  //  0017  LDINT	R7	64
+      0x1C1C0C07,  //  0018  EQ	R7	R6	R7
+      0x781E0001,  //  0019  JMPF	R7	#001C
+      0x501C0200,  //  001A  LDBOOL	R7	1	0
+      0x80040E00,  //  001B  RET	1	R7
+      0x70020032,  //  001C  JMP		#0050
+      0x541E0003,  //  001D  LDINT	R7	4
+      0x1C1C0A07,  //  001E  EQ	R7	R5	R7
+      0x781E0002,  //  001F  JMPF	R7	#0023
+      0x501C0200,  //  0020  LDBOOL	R7	1	0
+      0x80040E00,  //  0021  RET	1	R7
+      0x7002002C,  //  0022  JMP		#0050
+      0x541E0004,  //  0023  LDINT	R7	5
+      0x1C1C0A07,  //  0024  EQ	R7	R5	R7
+      0x781E0002,  //  0025  JMPF	R7	#0029
+      0x501C0200,  //  0026  LDBOOL	R7	1	0
+      0x80040E00,  //  0027  RET	1	R7
+      0x70020026,  //  0028  JMP		#0050
+      0x541E0005,  //  0029  LDINT	R7	6
+      0x1C1C0A07,  //  002A  EQ	R7	R5	R7
+      0x781E0023,  //  002B  JMPF	R7	#0050
+      0x1C1C0D05,  //  002C  EQ	R7	R6	K5
+      0x781E0009,  //  002D  JMPF	R7	#0038
+      0x881C010A,  //  002E  GETMBR	R7	R0	K10
+      0x781E0002,  //  002F  JMPF	R7	#0033
+      0x8C1C010B,  //  0030  GETMET	R7	R0	K11
+      0x5C240600,  //  0031  MOVE	R9	R3
+      0x7C1C0400,  //  0032  CALL	R7	2
+      0x501C0000,  //  0033  LDBOOL	R7	0	0
+      0x90021407,  //  0034  SETMBR	R0	K10	R7
+      0x501C0200,  //  0035  LDBOOL	R7	1	0
+      0x80040E00,  //  0036  RET	1	R7
+      0x70020017,  //  0037  JMP		#0050
+      0x1C1C0D06,  //  0038  EQ	R7	R6	K6
+      0x781E0009,  //  0039  JMPF	R7	#0044
+      0x881C010A,  //  003A  GETMBR	R7	R0	K10
+      0x741E0002,  //  003B  JMPT	R7	#003F
+      0x8C1C010B,  //  003C  GETMET	R7	R0	K11
+      0x5C240600,  //  003D  MOVE	R9	R3
+      0x7C1C0400,  //  003E  CALL	R7	2
+      0x501C0200,  //  003F  LDBOOL	R7	1	0
+      0x90021407,  //  0040  SETMBR	R0	K10	R7
+      0x501C0200,  //  0041  LDBOOL	R7	1	0
+      0x80040E00,  //  0042  RET	1	R7
+      0x7002000B,  //  0043  JMP		#0050
+      0x1C1C0D0C,  //  0044  EQ	R7	R6	K12
+      0x781E0009,  //  0045  JMPF	R7	#0050
+      0x8C1C010B,  //  0046  GETMET	R7	R0	K11
+      0x5C240600,  //  0047  MOVE	R9	R3
+      0x7C1C0400,  //  0048  CALL	R7	2
+      0x881C010A,  //  0049  GETMBR	R7	R0	K10
+      0x781E0000,  //  004A  JMPF	R7	#004C
+      0x501C0001,  //  004B  LDBOOL	R7	0	1
+      0x501C0200,  //  004C  LDBOOL	R7	1	0
+      0x90021407,  //  004D  SETMBR	R0	K10	R7
+      0x501C0200,  //  004E  LDBOOL	R7	1	0
+      0x80040E00,  //  004F  RET	1	R7
+      0x80000000,  //  0050  RET	0
     })
   )
 );
@@ -320,17 +365,24 @@ extern const bclass be_class_Matter_Plugin;
 be_local_class(Matter_Plugin_OnOff,
     1,
     &be_class_Matter_Plugin,
-    be_nested_map(7,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(invoke_request, 1), be_const_closure(Matter_Plugin_OnOff_invoke_request_closure) },
-        { be_const_key_weak(read_attribute, 4), be_const_closure(Matter_Plugin_OnOff_read_attribute_closure) },
+        { be_const_key_weak(read_attribute, 6), be_const_closure(Matter_Plugin_OnOff_read_attribute_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_Plugin_OnOff_init_closure) },
-        { be_const_key_weak(TYPES, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        { be_const_key_weak(TYPES, 0), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
         be_const_list( *     be_nested_list(1,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(256),
     }))    ) } )) },
-        { be_const_key_weak(CLUSTERS, 6), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
+        { be_const_key_weak(invoke_request, 1), be_const_closure(Matter_Plugin_OnOff_invoke_request_closure) },
+        { be_const_key_weak(onoff, -1), be_const_var(0) },
+        { be_const_key_weak(ENDPOINTS, 4), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
+        be_const_list( *     be_nested_list(1,
+    ( (struct bvalue*) &(const bvalue[]) {
+        be_const_int(1),
+    }))    ) } )) },
+        { be_const_key_weak(onoff_changed, 7), be_const_closure(Matter_Plugin_OnOff_onoff_changed_closure) },
+        { be_const_key_weak(CLUSTERS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_map, {
         be_const_map( *     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_int(5, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
@@ -368,12 +420,6 @@ be_local_class(Matter_Plugin_OnOff,
     ( (struct bvalue*) &(const bvalue[]) {
         be_const_int(0),
     }))    ) } )) },
-    }))    ) } )) },
-        { be_const_key_weak(onoff, 2), be_const_var(0) },
-        { be_const_key_weak(ENDPOINTS, -1), be_const_simple_instance(be_nested_simple_instance(&be_class_list, {
-        be_const_list( *     be_nested_list(1,
-    ( (struct bvalue*) &(const bvalue[]) {
-        be_const_int(1),
     }))    ) } )) },
     })),
     be_str_weak(Matter_Plugin_OnOff)

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[82]) {     /* constants */
+    ( &(const bvalue[81]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -28,84 +28,83 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
     /* K5   */  be_const_int(0),
     /* K6   */  be_nested_str_weak(create_TLV),
     /* K7   */  be_nested_str_weak(U8),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(__breadcrumb),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K12  */  be_nested_str_weak(add_TLV),
-    /* K13  */  be_nested_str_weak(U2),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(U1),
-    /* K16  */  be_const_int(3),
-    /* K17  */  be_nested_str_weak(BOOL),
-    /* K18  */  be_nested_str_weak(Matter_TLV_array),
-    /* K19  */  be_nested_str_weak(tasmota),
-    /* K20  */  be_nested_str_weak(eth),
-    /* K21  */  be_nested_str_weak(up),
-    /* K22  */  be_nested_str_weak(add_struct),
-    /* K23  */  be_nested_str_weak(UTF1),
-    /* K24  */  be_nested_str_weak(ethernet),
-    /* K25  */  be_nested_str_weak(NULL),
-    /* K26  */  be_nested_str_weak(fromhex),
-    /* K27  */  be_nested_str_weak(replace),
-    /* K28  */  be_nested_str_weak(find),
-    /* K29  */  be_nested_str_weak(mac),
-    /* K30  */  be_nested_str_weak(),
-    /* K31  */  be_nested_str_weak(_X3A),
-    /* K32  */  be_nested_str_weak(B1),
-    /* K33  */  be_nested_str_weak(add_array),
-    /* K34  */  be_nested_str_weak(get_ip_bytes),
-    /* K35  */  be_nested_str_weak(ip),
-    /* K36  */  be_nested_str_weak(ip6local),
-    /* K37  */  be_nested_str_weak(ip6),
-    /* K38  */  be_nested_str_weak(wifi),
-    /* K39  */  be_nested_str_weak(cmd),
-    /* K40  */  be_nested_str_weak(Status_X201),
-    /* K41  */  be_nested_str_weak(StatusPRM),
-    /* K42  */  be_nested_str_weak(BootCount),
-    /* K43  */  be_nested_str_weak(U4),
-    /* K44  */  be_nested_str_weak(Status_X2011),
-    /* K45  */  be_nested_str_weak(StatusSTS),
-    /* K46  */  be_nested_str_weak(UptimeSec),
-    /* K47  */  be_nested_str_weak(int64),
-    /* K48  */  be_nested_str_weak(rtc),
-    /* K49  */  be_nested_str_weak(utc),
-    /* K50  */  be_const_int(1000000),
-    /* K51  */  be_nested_str_weak(local),
-    /* K52  */  be_nested_str_weak(device),
-    /* K53  */  be_nested_str_weak(sessions),
-    /* K54  */  be_nested_str_weak(sessions_active),
-    /* K55  */  be_nested_str_weak(B2),
-    /* K56  */  be_nested_str_weak(noc),
-    /* K57  */  be_nested_str_weak(icac),
-    /* K58  */  be_nested_str_weak(stop_iteration),
-    /* K59  */  be_nested_str_weak(parse),
-    /* K60  */  be_nested_str_weak(get_ca),
-    /* K61  */  be_nested_str_weak(findsubval),
-    /* K62  */  be_nested_str_weak(admin_vendor),
-    /* K63  */  be_nested_str_weak(fabric),
-    /* K64  */  be_nested_str_weak(deviceid),
-    /* K65  */  be_nested_str_weak(fabric_label),
-    /* K66  */  be_nested_str_weak(Tasmota),
-    /* K67  */  be_nested_str_weak(vendorid),
-    /* K68  */  be_nested_str_weak(DeviceName),
-    /* K69  */  be_nested_str_weak(FriendlyName),
-    /* K70  */  be_nested_str_weak(FriendlyName1),
-    /* K71  */  be_nested_str_weak(XX),
-    /* K72  */  be_nested_str_weak(Status_X202),
-    /* K73  */  be_nested_str_weak(StatusFWR),
-    /* K74  */  be_nested_str_weak(Hardware),
-    /* K75  */  be_nested_str_weak(Version),
-    /* K76  */  be_nested_str_weak(locale),
-    /* K77  */  be_nested_str_weak(TYPES),
-    /* K78  */  be_nested_str_weak(get_cluster_list),
-    /* K79  */  be_nested_str_weak(get_active_endpoints),
-    /* K80  */  be_nested_str_weak(status),
-    /* K81  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
+    /* K8   */  be_nested_str_weak(__breadcrumb),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K11  */  be_nested_str_weak(add_TLV),
+    /* K12  */  be_nested_str_weak(U2),
+    /* K13  */  be_const_int(2),
+    /* K14  */  be_nested_str_weak(U1),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(BOOL),
+    /* K17  */  be_nested_str_weak(Matter_TLV_array),
+    /* K18  */  be_nested_str_weak(tasmota),
+    /* K19  */  be_nested_str_weak(eth),
+    /* K20  */  be_nested_str_weak(up),
+    /* K21  */  be_nested_str_weak(add_struct),
+    /* K22  */  be_nested_str_weak(UTF1),
+    /* K23  */  be_nested_str_weak(ethernet),
+    /* K24  */  be_nested_str_weak(NULL),
+    /* K25  */  be_nested_str_weak(fromhex),
+    /* K26  */  be_nested_str_weak(replace),
+    /* K27  */  be_nested_str_weak(find),
+    /* K28  */  be_nested_str_weak(mac),
+    /* K29  */  be_nested_str_weak(),
+    /* K30  */  be_nested_str_weak(_X3A),
+    /* K31  */  be_nested_str_weak(B1),
+    /* K32  */  be_nested_str_weak(add_array),
+    /* K33  */  be_nested_str_weak(get_ip_bytes),
+    /* K34  */  be_nested_str_weak(ip),
+    /* K35  */  be_nested_str_weak(ip6local),
+    /* K36  */  be_nested_str_weak(ip6),
+    /* K37  */  be_nested_str_weak(wifi),
+    /* K38  */  be_nested_str_weak(cmd),
+    /* K39  */  be_nested_str_weak(Status_X201),
+    /* K40  */  be_nested_str_weak(StatusPRM),
+    /* K41  */  be_nested_str_weak(BootCount),
+    /* K42  */  be_nested_str_weak(U4),
+    /* K43  */  be_nested_str_weak(Status_X2011),
+    /* K44  */  be_nested_str_weak(StatusSTS),
+    /* K45  */  be_nested_str_weak(UptimeSec),
+    /* K46  */  be_nested_str_weak(int64),
+    /* K47  */  be_nested_str_weak(rtc),
+    /* K48  */  be_nested_str_weak(utc),
+    /* K49  */  be_const_int(1000000),
+    /* K50  */  be_nested_str_weak(local),
+    /* K51  */  be_nested_str_weak(device),
+    /* K52  */  be_nested_str_weak(sessions),
+    /* K53  */  be_nested_str_weak(sessions_active),
+    /* K54  */  be_nested_str_weak(B2),
+    /* K55  */  be_nested_str_weak(noc),
+    /* K56  */  be_nested_str_weak(icac),
+    /* K57  */  be_nested_str_weak(stop_iteration),
+    /* K58  */  be_nested_str_weak(parse),
+    /* K59  */  be_nested_str_weak(get_ca),
+    /* K60  */  be_nested_str_weak(findsubval),
+    /* K61  */  be_nested_str_weak(admin_vendor),
+    /* K62  */  be_nested_str_weak(fabric),
+    /* K63  */  be_nested_str_weak(deviceid),
+    /* K64  */  be_nested_str_weak(fabric_label),
+    /* K65  */  be_nested_str_weak(Tasmota),
+    /* K66  */  be_nested_str_weak(vendorid),
+    /* K67  */  be_nested_str_weak(DeviceName),
+    /* K68  */  be_nested_str_weak(FriendlyName),
+    /* K69  */  be_nested_str_weak(FriendlyName1),
+    /* K70  */  be_nested_str_weak(XX),
+    /* K71  */  be_nested_str_weak(Status_X202),
+    /* K72  */  be_nested_str_weak(StatusFWR),
+    /* K73  */  be_nested_str_weak(Hardware),
+    /* K74  */  be_nested_str_weak(Version),
+    /* K75  */  be_nested_str_weak(locale),
+    /* K76  */  be_nested_str_weak(TYPES),
+    /* K77  */  be_nested_str_weak(get_cluster_list),
+    /* K78  */  be_nested_str_weak(get_active_endpoints),
+    /* K79  */  be_nested_str_weak(status),
+    /* K80  */  be_nested_str_weak(UNSUPPORTED_CLUSTER),
     }),
     be_str_weak(read_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[809]) {  /* code */
+    ( &(const binstruction[808]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
       0xB8120200,  //  0001  GETNGBL	R4	K1
       0x88100902,  //  0002  GETMBR	R4	R4	K2
@@ -113,808 +112,807 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x88180504,  //  0004  GETMBR	R6	R2	K4
       0x541E002F,  //  0005  LDINT	R7	48
       0x1C1C0A07,  //  0006  EQ	R7	R5	R7
-      0x781E0031,  //  0007  JMPF	R7	#003A
+      0x781E0030,  //  0007  JMPF	R7	#0039
       0x1C1C0D05,  //  0008  EQ	R7	R6	K5
-      0x781E0006,  //  0009  JMPF	R7	#0011
+      0x781E0005,  //  0009  JMPF	R7	#0010
       0x8C1C0906,  //  000A  GETMET	R7	R4	K6
       0x88240907,  //  000B  GETMBR	R9	R4	K7
       0x88280308,  //  000C  GETMBR	R10	R1	K8
-      0x88281509,  //  000D  GETMBR	R10	R10	K9
-      0x7C1C0600,  //  000E  CALL	R7	3
-      0x80040E00,  //  000F  RET	1	R7
-      0x70020027,  //  0010  JMP		#0039
-      0x1C1C0D0A,  //  0011  EQ	R7	R6	K10
-      0x781E000D,  //  0012  JMPF	R7	#0021
-      0x8C1C090B,  //  0013  GETMET	R7	R4	K11
-      0x7C1C0200,  //  0014  CALL	R7	1
-      0x8C200F0C,  //  0015  GETMET	R8	R7	K12
-      0x58280005,  //  0016  LDCONST	R10	K5
-      0x882C090D,  //  0017  GETMBR	R11	R4	K13
-      0x5432003B,  //  0018  LDINT	R12	60
-      0x7C200800,  //  0019  CALL	R8	4
-      0x8C200F0C,  //  001A  GETMET	R8	R7	K12
-      0x5828000A,  //  001B  LDCONST	R10	K10
-      0x882C090D,  //  001C  GETMBR	R11	R4	K13
-      0x54320383,  //  001D  LDINT	R12	900
-      0x7C200800,  //  001E  CALL	R8	4
-      0x80040E00,  //  001F  RET	1	R7
-      0x70020017,  //  0020  JMP		#0039
-      0x1C1C0D0E,  //  0021  EQ	R7	R6	K14
-      0x781E0005,  //  0022  JMPF	R7	#0029
-      0x8C1C0906,  //  0023  GETMET	R7	R4	K6
-      0x8824090F,  //  0024  GETMBR	R9	R4	K15
-      0x5828000E,  //  0025  LDCONST	R10	K14
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x80040E00,  //  0027  RET	1	R7
-      0x7002000F,  //  0028  JMP		#0039
-      0x1C1C0D10,  //  0029  EQ	R7	R6	K16
-      0x781E0005,  //  002A  JMPF	R7	#0031
-      0x8C1C0906,  //  002B  GETMET	R7	R4	K6
-      0x8824090F,  //  002C  GETMBR	R9	R4	K15
-      0x5828000E,  //  002D  LDCONST	R10	K14
-      0x7C1C0600,  //  002E  CALL	R7	3
-      0x80040E00,  //  002F  RET	1	R7
-      0x70020007,  //  0030  JMP		#0039
-      0x541E0003,  //  0031  LDINT	R7	4
-      0x1C1C0C07,  //  0032  EQ	R7	R6	R7
-      0x781E0004,  //  0033  JMPF	R7	#0039
-      0x8C1C0906,  //  0034  GETMET	R7	R4	K6
-      0x88240911,  //  0035  GETMBR	R9	R4	K17
-      0x50280000,  //  0036  LDBOOL	R10	0	0
-      0x7C1C0600,  //  0037  CALL	R7	3
-      0x80040E00,  //  0038  RET	1	R7
-      0x700202ED,  //  0039  JMP		#0328
-      0x541E0031,  //  003A  LDINT	R7	50
-      0x1C1C0A07,  //  003B  EQ	R7	R5	R7
-      0x781E0000,  //  003C  JMPF	R7	#003E
-      0x700202E9,  //  003D  JMP		#0328
-      0x541E0032,  //  003E  LDINT	R7	51
-      0x1C1C0A07,  //  003F  EQ	R7	R5	R7
-      0x781E00DA,  //  0040  JMPF	R7	#011C
-      0x1C1C0D05,  //  0041  EQ	R7	R6	K5
-      0x781E00B5,  //  0042  JMPF	R7	#00F9
-      0x8C1C0912,  //  0043  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0044  CALL	R7	1
-      0xB8222600,  //  0045  GETNGBL	R8	K19
-      0x8C201114,  //  0046  GETMET	R8	R8	K20
-      0x7C200200,  //  0047  CALL	R8	1
-      0x94241115,  //  0048  GETIDX	R9	R8	K21
-      0x78260053,  //  0049  JMPF	R9	#009E
-      0x8C240F16,  //  004A  GETMET	R9	R7	K22
-      0x4C2C0000,  //  004B  LDNIL	R11
-      0x7C240400,  //  004C  CALL	R9	2
-      0x8C28130C,  //  004D  GETMET	R10	R9	K12
-      0x58300005,  //  004E  LDCONST	R12	K5
-      0x88340917,  //  004F  GETMBR	R13	R4	K23
-      0x58380018,  //  0050  LDCONST	R14	K24
-      0x7C280800,  //  0051  CALL	R10	4
-      0x8C28130C,  //  0052  GETMET	R10	R9	K12
-      0x5830000A,  //  0053  LDCONST	R12	K10
-      0x88340911,  //  0054  GETMBR	R13	R4	K17
-      0x5838000A,  //  0055  LDCONST	R14	K10
-      0x7C280800,  //  0056  CALL	R10	4
-      0x8C28130C,  //  0057  GETMET	R10	R9	K12
-      0x5830000E,  //  0058  LDCONST	R12	K14
-      0x88340911,  //  0059  GETMBR	R13	R4	K17
-      0x5838000A,  //  005A  LDCONST	R14	K10
-      0x7C280800,  //  005B  CALL	R10	4
-      0x8C28130C,  //  005C  GETMET	R10	R9	K12
-      0x58300010,  //  005D  LDCONST	R12	K16
-      0x88340919,  //  005E  GETMBR	R13	R4	K25
-      0x4C380000,  //  005F  LDNIL	R14
-      0x7C280800,  //  0060  CALL	R10	4
-      0x60280015,  //  0061  GETGBL	R10	G21
-      0x7C280000,  //  0062  CALL	R10	0
-      0x8C28151A,  //  0063  GETMET	R10	R10	K26
-      0x8C30071B,  //  0064  GETMET	R12	R3	K27
-      0x8C38111C,  //  0065  GETMET	R14	R8	K28
-      0x5840001D,  //  0066  LDCONST	R16	K29
-      0x5844001E,  //  0067  LDCONST	R17	K30
-      0x7C380600,  //  0068  CALL	R14	3
-      0x583C001F,  //  0069  LDCONST	R15	K31
-      0x5840001E,  //  006A  LDCONST	R16	K30
-      0x7C300800,  //  006B  CALL	R12	4
-      0x7C280400,  //  006C  CALL	R10	2
-      0x8C2C130C,  //  006D  GETMET	R11	R9	K12
-      0x54360003,  //  006E  LDINT	R13	4
-      0x88380920,  //  006F  GETMBR	R14	R4	K32
-      0x5C3C1400,  //  0070  MOVE	R15	R10
-      0x7C2C0800,  //  0071  CALL	R11	4
-      0x8C2C1321,  //  0072  GETMET	R11	R9	K33
-      0x54360004,  //  0073  LDINT	R13	5
-      0x7C2C0400,  //  0074  CALL	R11	2
-      0x8C30170C,  //  0075  GETMET	R12	R11	K12
-      0x4C380000,  //  0076  LDNIL	R14
-      0x883C0920,  //  0077  GETMBR	R15	R4	K32
-      0xB8420200,  //  0078  GETNGBL	R16	K1
-      0x8C402122,  //  0079  GETMET	R16	R16	K34
-      0x8C48111C,  //  007A  GETMET	R18	R8	K28
-      0x58500023,  //  007B  LDCONST	R20	K35
-      0x5854001E,  //  007C  LDCONST	R21	K30
-      0x7C480600,  //  007D  CALL	R18	3
-      0x7C400400,  //  007E  CALL	R16	2
-      0x7C300800,  //  007F  CALL	R12	4
-      0x8C301321,  //  0080  GETMET	R12	R9	K33
-      0x543A0005,  //  0081  LDINT	R14	6
-      0x7C300400,  //  0082  CALL	R12	2
-      0x8C34190C,  //  0083  GETMET	R13	R12	K12
-      0x4C3C0000,  //  0084  LDNIL	R15
-      0x88400920,  //  0085  GETMBR	R16	R4	K32
-      0xB8460200,  //  0086  GETNGBL	R17	K1
-      0x8C442322,  //  0087  GETMET	R17	R17	K34
-      0x8C4C111C,  //  0088  GETMET	R19	R8	K28
-      0x58540024,  //  0089  LDCONST	R21	K36
-      0x5858001E,  //  008A  LDCONST	R22	K30
-      0x7C4C0600,  //  008B  CALL	R19	3
-      0x7C440400,  //  008C  CALL	R17	2
-      0x7C340800,  //  008D  CALL	R13	4
-      0x8C34190C,  //  008E  GETMET	R13	R12	K12
-      0x4C3C0000,  //  008F  LDNIL	R15
-      0x88400920,  //  0090  GETMBR	R16	R4	K32
-      0xB8460200,  //  0091  GETNGBL	R17	K1
-      0x8C442322,  //  0092  GETMET	R17	R17	K34
-      0x8C4C111C,  //  0093  GETMET	R19	R8	K28
-      0x58540025,  //  0094  LDCONST	R21	K37
-      0x5858001E,  //  0095  LDCONST	R22	K30
-      0x7C4C0600,  //  0096  CALL	R19	3
-      0x7C440400,  //  0097  CALL	R17	2
-      0x7C340800,  //  0098  CALL	R13	4
-      0x8C34130C,  //  0099  GETMET	R13	R9	K12
-      0x543E0006,  //  009A  LDINT	R15	7
-      0x8840090F,  //  009B  GETMBR	R16	R4	K15
-      0x5844000E,  //  009C  LDCONST	R17	K14
-      0x7C340800,  //  009D  CALL	R13	4
-      0xB8262600,  //  009E  GETNGBL	R9	K19
-      0x8C241326,  //  009F  GETMET	R9	R9	K38
-      0x7C240200,  //  00A0  CALL	R9	1
-      0x94281315,  //  00A1  GETIDX	R10	R9	K21
-      0x782A0053,  //  00A2  JMPF	R10	#00F7
-      0x8C280F16,  //  00A3  GETMET	R10	R7	K22
-      0x4C300000,  //  00A4  LDNIL	R12
-      0x7C280400,  //  00A5  CALL	R10	2
-      0x8C2C150C,  //  00A6  GETMET	R11	R10	K12
-      0x58340005,  //  00A7  LDCONST	R13	K5
-      0x88380917,  //  00A8  GETMBR	R14	R4	K23
-      0x583C0026,  //  00A9  LDCONST	R15	K38
-      0x7C2C0800,  //  00AA  CALL	R11	4
-      0x8C2C150C,  //  00AB  GETMET	R11	R10	K12
-      0x5834000A,  //  00AC  LDCONST	R13	K10
-      0x88380911,  //  00AD  GETMBR	R14	R4	K17
-      0x583C000A,  //  00AE  LDCONST	R15	K10
-      0x7C2C0800,  //  00AF  CALL	R11	4
-      0x8C2C150C,  //  00B0  GETMET	R11	R10	K12
-      0x5834000E,  //  00B1  LDCONST	R13	K14
-      0x88380911,  //  00B2  GETMBR	R14	R4	K17
-      0x583C000A,  //  00B3  LDCONST	R15	K10
-      0x7C2C0800,  //  00B4  CALL	R11	4
-      0x8C2C150C,  //  00B5  GETMET	R11	R10	K12
-      0x58340010,  //  00B6  LDCONST	R13	K16
-      0x88380919,  //  00B7  GETMBR	R14	R4	K25
-      0x4C3C0000,  //  00B8  LDNIL	R15
-      0x7C2C0800,  //  00B9  CALL	R11	4
-      0x602C0015,  //  00BA  GETGBL	R11	G21
-      0x7C2C0000,  //  00BB  CALL	R11	0
-      0x8C2C171A,  //  00BC  GETMET	R11	R11	K26
-      0x8C34071B,  //  00BD  GETMET	R13	R3	K27
-      0x8C3C131C,  //  00BE  GETMET	R15	R9	K28
-      0x5844001D,  //  00BF  LDCONST	R17	K29
-      0x5848001E,  //  00C0  LDCONST	R18	K30
-      0x7C3C0600,  //  00C1  CALL	R15	3
-      0x5840001F,  //  00C2  LDCONST	R16	K31
-      0x5844001E,  //  00C3  LDCONST	R17	K30
-      0x7C340800,  //  00C4  CALL	R13	4
-      0x7C2C0400,  //  00C5  CALL	R11	2
-      0x8C30150C,  //  00C6  GETMET	R12	R10	K12
-      0x543A0003,  //  00C7  LDINT	R14	4
-      0x883C0920,  //  00C8  GETMBR	R15	R4	K32
-      0x5C401600,  //  00C9  MOVE	R16	R11
-      0x7C300800,  //  00CA  CALL	R12	4
-      0x8C301521,  //  00CB  GETMET	R12	R10	K33
-      0x543A0004,  //  00CC  LDINT	R14	5
-      0x7C300400,  //  00CD  CALL	R12	2
-      0x8C34190C,  //  00CE  GETMET	R13	R12	K12
-      0x4C3C0000,  //  00CF  LDNIL	R15
-      0x88400920,  //  00D0  GETMBR	R16	R4	K32
-      0xB8460200,  //  00D1  GETNGBL	R17	K1
-      0x8C442322,  //  00D2  GETMET	R17	R17	K34
-      0x8C4C131C,  //  00D3  GETMET	R19	R9	K28
-      0x58540023,  //  00D4  LDCONST	R21	K35
-      0x5858001E,  //  00D5  LDCONST	R22	K30
-      0x7C4C0600,  //  00D6  CALL	R19	3
-      0x7C440400,  //  00D7  CALL	R17	2
-      0x7C340800,  //  00D8  CALL	R13	4
-      0x8C341521,  //  00D9  GETMET	R13	R10	K33
-      0x543E0005,  //  00DA  LDINT	R15	6
-      0x7C340400,  //  00DB  CALL	R13	2
-      0x8C381B0C,  //  00DC  GETMET	R14	R13	K12
-      0x4C400000,  //  00DD  LDNIL	R16
-      0x88440920,  //  00DE  GETMBR	R17	R4	K32
-      0xB84A0200,  //  00DF  GETNGBL	R18	K1
-      0x8C482522,  //  00E0  GETMET	R18	R18	K34
-      0x8C50131C,  //  00E1  GETMET	R20	R9	K28
-      0x58580024,  //  00E2  LDCONST	R22	K36
-      0x585C001E,  //  00E3  LDCONST	R23	K30
-      0x7C500600,  //  00E4  CALL	R20	3
-      0x7C480400,  //  00E5  CALL	R18	2
-      0x7C380800,  //  00E6  CALL	R14	4
-      0x8C381B0C,  //  00E7  GETMET	R14	R13	K12
-      0x4C400000,  //  00E8  LDNIL	R16
-      0x88440920,  //  00E9  GETMBR	R17	R4	K32
-      0xB84A0200,  //  00EA  GETNGBL	R18	K1
-      0x8C482522,  //  00EB  GETMET	R18	R18	K34
-      0x8C50131C,  //  00EC  GETMET	R20	R9	K28
-      0x58580025,  //  00ED  LDCONST	R22	K37
-      0x585C001E,  //  00EE  LDCONST	R23	K30
-      0x7C500600,  //  00EF  CALL	R20	3
-      0x7C480400,  //  00F0  CALL	R18	2
-      0x7C380800,  //  00F1  CALL	R14	4
-      0x8C38150C,  //  00F2  GETMET	R14	R10	K12
-      0x54420006,  //  00F3  LDINT	R16	7
-      0x8844090F,  //  00F4  GETMBR	R17	R4	K15
-      0x5848000A,  //  00F5  LDCONST	R18	K10
-      0x7C380800,  //  00F6  CALL	R14	4
-      0x80040E00,  //  00F7  RET	1	R7
-      0x70020021,  //  00F8  JMP		#011B
-      0x1C1C0D0A,  //  00F9  EQ	R7	R6	K10
-      0x781E000A,  //  00FA  JMPF	R7	#0106
-      0x8C1C0906,  //  00FB  GETMET	R7	R4	K6
-      0x8824090D,  //  00FC  GETMBR	R9	R4	K13
-      0xB82A2600,  //  00FD  GETNGBL	R10	K19
-      0x8C281527,  //  00FE  GETMET	R10	R10	K39
-      0x58300028,  //  00FF  LDCONST	R12	K40
-      0x7C280400,  //  0100  CALL	R10	2
+      0x7C1C0600,  //  000D  CALL	R7	3
+      0x80040E00,  //  000E  RET	1	R7
+      0x70020027,  //  000F  JMP		#0038
+      0x1C1C0D09,  //  0010  EQ	R7	R6	K9
+      0x781E000D,  //  0011  JMPF	R7	#0020
+      0x8C1C090A,  //  0012  GETMET	R7	R4	K10
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x8C200F0B,  //  0014  GETMET	R8	R7	K11
+      0x58280005,  //  0015  LDCONST	R10	K5
+      0x882C090C,  //  0016  GETMBR	R11	R4	K12
+      0x5432003B,  //  0017  LDINT	R12	60
+      0x7C200800,  //  0018  CALL	R8	4
+      0x8C200F0B,  //  0019  GETMET	R8	R7	K11
+      0x58280009,  //  001A  LDCONST	R10	K9
+      0x882C090C,  //  001B  GETMBR	R11	R4	K12
+      0x54320383,  //  001C  LDINT	R12	900
+      0x7C200800,  //  001D  CALL	R8	4
+      0x80040E00,  //  001E  RET	1	R7
+      0x70020017,  //  001F  JMP		#0038
+      0x1C1C0D0D,  //  0020  EQ	R7	R6	K13
+      0x781E0005,  //  0021  JMPF	R7	#0028
+      0x8C1C0906,  //  0022  GETMET	R7	R4	K6
+      0x8824090E,  //  0023  GETMBR	R9	R4	K14
+      0x5828000D,  //  0024  LDCONST	R10	K13
+      0x7C1C0600,  //  0025  CALL	R7	3
+      0x80040E00,  //  0026  RET	1	R7
+      0x7002000F,  //  0027  JMP		#0038
+      0x1C1C0D0F,  //  0028  EQ	R7	R6	K15
+      0x781E0005,  //  0029  JMPF	R7	#0030
+      0x8C1C0906,  //  002A  GETMET	R7	R4	K6
+      0x8824090E,  //  002B  GETMBR	R9	R4	K14
+      0x5828000D,  //  002C  LDCONST	R10	K13
+      0x7C1C0600,  //  002D  CALL	R7	3
+      0x80040E00,  //  002E  RET	1	R7
+      0x70020007,  //  002F  JMP		#0038
+      0x541E0003,  //  0030  LDINT	R7	4
+      0x1C1C0C07,  //  0031  EQ	R7	R6	R7
+      0x781E0004,  //  0032  JMPF	R7	#0038
+      0x8C1C0906,  //  0033  GETMET	R7	R4	K6
+      0x88240910,  //  0034  GETMBR	R9	R4	K16
+      0x50280000,  //  0035  LDBOOL	R10	0	0
+      0x7C1C0600,  //  0036  CALL	R7	3
+      0x80040E00,  //  0037  RET	1	R7
+      0x700202ED,  //  0038  JMP		#0327
+      0x541E0031,  //  0039  LDINT	R7	50
+      0x1C1C0A07,  //  003A  EQ	R7	R5	R7
+      0x781E0000,  //  003B  JMPF	R7	#003D
+      0x700202E9,  //  003C  JMP		#0327
+      0x541E0032,  //  003D  LDINT	R7	51
+      0x1C1C0A07,  //  003E  EQ	R7	R5	R7
+      0x781E00DA,  //  003F  JMPF	R7	#011B
+      0x1C1C0D05,  //  0040  EQ	R7	R6	K5
+      0x781E00B5,  //  0041  JMPF	R7	#00F8
+      0x8C1C0911,  //  0042  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0043  CALL	R7	1
+      0xB8222400,  //  0044  GETNGBL	R8	K18
+      0x8C201113,  //  0045  GETMET	R8	R8	K19
+      0x7C200200,  //  0046  CALL	R8	1
+      0x94241114,  //  0047  GETIDX	R9	R8	K20
+      0x78260053,  //  0048  JMPF	R9	#009D
+      0x8C240F15,  //  0049  GETMET	R9	R7	K21
+      0x4C2C0000,  //  004A  LDNIL	R11
+      0x7C240400,  //  004B  CALL	R9	2
+      0x8C28130B,  //  004C  GETMET	R10	R9	K11
+      0x58300005,  //  004D  LDCONST	R12	K5
+      0x88340916,  //  004E  GETMBR	R13	R4	K22
+      0x58380017,  //  004F  LDCONST	R14	K23
+      0x7C280800,  //  0050  CALL	R10	4
+      0x8C28130B,  //  0051  GETMET	R10	R9	K11
+      0x58300009,  //  0052  LDCONST	R12	K9
+      0x88340910,  //  0053  GETMBR	R13	R4	K16
+      0x58380009,  //  0054  LDCONST	R14	K9
+      0x7C280800,  //  0055  CALL	R10	4
+      0x8C28130B,  //  0056  GETMET	R10	R9	K11
+      0x5830000D,  //  0057  LDCONST	R12	K13
+      0x88340910,  //  0058  GETMBR	R13	R4	K16
+      0x58380009,  //  0059  LDCONST	R14	K9
+      0x7C280800,  //  005A  CALL	R10	4
+      0x8C28130B,  //  005B  GETMET	R10	R9	K11
+      0x5830000F,  //  005C  LDCONST	R12	K15
+      0x88340918,  //  005D  GETMBR	R13	R4	K24
+      0x4C380000,  //  005E  LDNIL	R14
+      0x7C280800,  //  005F  CALL	R10	4
+      0x60280015,  //  0060  GETGBL	R10	G21
+      0x7C280000,  //  0061  CALL	R10	0
+      0x8C281519,  //  0062  GETMET	R10	R10	K25
+      0x8C30071A,  //  0063  GETMET	R12	R3	K26
+      0x8C38111B,  //  0064  GETMET	R14	R8	K27
+      0x5840001C,  //  0065  LDCONST	R16	K28
+      0x5844001D,  //  0066  LDCONST	R17	K29
+      0x7C380600,  //  0067  CALL	R14	3
+      0x583C001E,  //  0068  LDCONST	R15	K30
+      0x5840001D,  //  0069  LDCONST	R16	K29
+      0x7C300800,  //  006A  CALL	R12	4
+      0x7C280400,  //  006B  CALL	R10	2
+      0x8C2C130B,  //  006C  GETMET	R11	R9	K11
+      0x54360003,  //  006D  LDINT	R13	4
+      0x8838091F,  //  006E  GETMBR	R14	R4	K31
+      0x5C3C1400,  //  006F  MOVE	R15	R10
+      0x7C2C0800,  //  0070  CALL	R11	4
+      0x8C2C1320,  //  0071  GETMET	R11	R9	K32
+      0x54360004,  //  0072  LDINT	R13	5
+      0x7C2C0400,  //  0073  CALL	R11	2
+      0x8C30170B,  //  0074  GETMET	R12	R11	K11
+      0x4C380000,  //  0075  LDNIL	R14
+      0x883C091F,  //  0076  GETMBR	R15	R4	K31
+      0xB8420200,  //  0077  GETNGBL	R16	K1
+      0x8C402121,  //  0078  GETMET	R16	R16	K33
+      0x8C48111B,  //  0079  GETMET	R18	R8	K27
+      0x58500022,  //  007A  LDCONST	R20	K34
+      0x5854001D,  //  007B  LDCONST	R21	K29
+      0x7C480600,  //  007C  CALL	R18	3
+      0x7C400400,  //  007D  CALL	R16	2
+      0x7C300800,  //  007E  CALL	R12	4
+      0x8C301320,  //  007F  GETMET	R12	R9	K32
+      0x543A0005,  //  0080  LDINT	R14	6
+      0x7C300400,  //  0081  CALL	R12	2
+      0x8C34190B,  //  0082  GETMET	R13	R12	K11
+      0x4C3C0000,  //  0083  LDNIL	R15
+      0x8840091F,  //  0084  GETMBR	R16	R4	K31
+      0xB8460200,  //  0085  GETNGBL	R17	K1
+      0x8C442321,  //  0086  GETMET	R17	R17	K33
+      0x8C4C111B,  //  0087  GETMET	R19	R8	K27
+      0x58540023,  //  0088  LDCONST	R21	K35
+      0x5858001D,  //  0089  LDCONST	R22	K29
+      0x7C4C0600,  //  008A  CALL	R19	3
+      0x7C440400,  //  008B  CALL	R17	2
+      0x7C340800,  //  008C  CALL	R13	4
+      0x8C34190B,  //  008D  GETMET	R13	R12	K11
+      0x4C3C0000,  //  008E  LDNIL	R15
+      0x8840091F,  //  008F  GETMBR	R16	R4	K31
+      0xB8460200,  //  0090  GETNGBL	R17	K1
+      0x8C442321,  //  0091  GETMET	R17	R17	K33
+      0x8C4C111B,  //  0092  GETMET	R19	R8	K27
+      0x58540024,  //  0093  LDCONST	R21	K36
+      0x5858001D,  //  0094  LDCONST	R22	K29
+      0x7C4C0600,  //  0095  CALL	R19	3
+      0x7C440400,  //  0096  CALL	R17	2
+      0x7C340800,  //  0097  CALL	R13	4
+      0x8C34130B,  //  0098  GETMET	R13	R9	K11
+      0x543E0006,  //  0099  LDINT	R15	7
+      0x8840090E,  //  009A  GETMBR	R16	R4	K14
+      0x5844000D,  //  009B  LDCONST	R17	K13
+      0x7C340800,  //  009C  CALL	R13	4
+      0xB8262400,  //  009D  GETNGBL	R9	K18
+      0x8C241325,  //  009E  GETMET	R9	R9	K37
+      0x7C240200,  //  009F  CALL	R9	1
+      0x94281314,  //  00A0  GETIDX	R10	R9	K20
+      0x782A0053,  //  00A1  JMPF	R10	#00F6
+      0x8C280F15,  //  00A2  GETMET	R10	R7	K21
+      0x4C300000,  //  00A3  LDNIL	R12
+      0x7C280400,  //  00A4  CALL	R10	2
+      0x8C2C150B,  //  00A5  GETMET	R11	R10	K11
+      0x58340005,  //  00A6  LDCONST	R13	K5
+      0x88380916,  //  00A7  GETMBR	R14	R4	K22
+      0x583C0025,  //  00A8  LDCONST	R15	K37
+      0x7C2C0800,  //  00A9  CALL	R11	4
+      0x8C2C150B,  //  00AA  GETMET	R11	R10	K11
+      0x58340009,  //  00AB  LDCONST	R13	K9
+      0x88380910,  //  00AC  GETMBR	R14	R4	K16
+      0x583C0009,  //  00AD  LDCONST	R15	K9
+      0x7C2C0800,  //  00AE  CALL	R11	4
+      0x8C2C150B,  //  00AF  GETMET	R11	R10	K11
+      0x5834000D,  //  00B0  LDCONST	R13	K13
+      0x88380910,  //  00B1  GETMBR	R14	R4	K16
+      0x583C0009,  //  00B2  LDCONST	R15	K9
+      0x7C2C0800,  //  00B3  CALL	R11	4
+      0x8C2C150B,  //  00B4  GETMET	R11	R10	K11
+      0x5834000F,  //  00B5  LDCONST	R13	K15
+      0x88380918,  //  00B6  GETMBR	R14	R4	K24
+      0x4C3C0000,  //  00B7  LDNIL	R15
+      0x7C2C0800,  //  00B8  CALL	R11	4
+      0x602C0015,  //  00B9  GETGBL	R11	G21
+      0x7C2C0000,  //  00BA  CALL	R11	0
+      0x8C2C1719,  //  00BB  GETMET	R11	R11	K25
+      0x8C34071A,  //  00BC  GETMET	R13	R3	K26
+      0x8C3C131B,  //  00BD  GETMET	R15	R9	K27
+      0x5844001C,  //  00BE  LDCONST	R17	K28
+      0x5848001D,  //  00BF  LDCONST	R18	K29
+      0x7C3C0600,  //  00C0  CALL	R15	3
+      0x5840001E,  //  00C1  LDCONST	R16	K30
+      0x5844001D,  //  00C2  LDCONST	R17	K29
+      0x7C340800,  //  00C3  CALL	R13	4
+      0x7C2C0400,  //  00C4  CALL	R11	2
+      0x8C30150B,  //  00C5  GETMET	R12	R10	K11
+      0x543A0003,  //  00C6  LDINT	R14	4
+      0x883C091F,  //  00C7  GETMBR	R15	R4	K31
+      0x5C401600,  //  00C8  MOVE	R16	R11
+      0x7C300800,  //  00C9  CALL	R12	4
+      0x8C301520,  //  00CA  GETMET	R12	R10	K32
+      0x543A0004,  //  00CB  LDINT	R14	5
+      0x7C300400,  //  00CC  CALL	R12	2
+      0x8C34190B,  //  00CD  GETMET	R13	R12	K11
+      0x4C3C0000,  //  00CE  LDNIL	R15
+      0x8840091F,  //  00CF  GETMBR	R16	R4	K31
+      0xB8460200,  //  00D0  GETNGBL	R17	K1
+      0x8C442321,  //  00D1  GETMET	R17	R17	K33
+      0x8C4C131B,  //  00D2  GETMET	R19	R9	K27
+      0x58540022,  //  00D3  LDCONST	R21	K34
+      0x5858001D,  //  00D4  LDCONST	R22	K29
+      0x7C4C0600,  //  00D5  CALL	R19	3
+      0x7C440400,  //  00D6  CALL	R17	2
+      0x7C340800,  //  00D7  CALL	R13	4
+      0x8C341520,  //  00D8  GETMET	R13	R10	K32
+      0x543E0005,  //  00D9  LDINT	R15	6
+      0x7C340400,  //  00DA  CALL	R13	2
+      0x8C381B0B,  //  00DB  GETMET	R14	R13	K11
+      0x4C400000,  //  00DC  LDNIL	R16
+      0x8844091F,  //  00DD  GETMBR	R17	R4	K31
+      0xB84A0200,  //  00DE  GETNGBL	R18	K1
+      0x8C482521,  //  00DF  GETMET	R18	R18	K33
+      0x8C50131B,  //  00E0  GETMET	R20	R9	K27
+      0x58580023,  //  00E1  LDCONST	R22	K35
+      0x585C001D,  //  00E2  LDCONST	R23	K29
+      0x7C500600,  //  00E3  CALL	R20	3
+      0x7C480400,  //  00E4  CALL	R18	2
+      0x7C380800,  //  00E5  CALL	R14	4
+      0x8C381B0B,  //  00E6  GETMET	R14	R13	K11
+      0x4C400000,  //  00E7  LDNIL	R16
+      0x8844091F,  //  00E8  GETMBR	R17	R4	K31
+      0xB84A0200,  //  00E9  GETNGBL	R18	K1
+      0x8C482521,  //  00EA  GETMET	R18	R18	K33
+      0x8C50131B,  //  00EB  GETMET	R20	R9	K27
+      0x58580024,  //  00EC  LDCONST	R22	K36
+      0x585C001D,  //  00ED  LDCONST	R23	K29
+      0x7C500600,  //  00EE  CALL	R20	3
+      0x7C480400,  //  00EF  CALL	R18	2
+      0x7C380800,  //  00F0  CALL	R14	4
+      0x8C38150B,  //  00F1  GETMET	R14	R10	K11
+      0x54420006,  //  00F2  LDINT	R16	7
+      0x8844090E,  //  00F3  GETMBR	R17	R4	K14
+      0x58480009,  //  00F4  LDCONST	R18	K9
+      0x7C380800,  //  00F5  CALL	R14	4
+      0x80040E00,  //  00F6  RET	1	R7
+      0x70020021,  //  00F7  JMP		#011A
+      0x1C1C0D09,  //  00F8  EQ	R7	R6	K9
+      0x781E000A,  //  00F9  JMPF	R7	#0105
+      0x8C1C0906,  //  00FA  GETMET	R7	R4	K6
+      0x8824090C,  //  00FB  GETMBR	R9	R4	K12
+      0xB82A2400,  //  00FC  GETNGBL	R10	K18
+      0x8C281526,  //  00FD  GETMET	R10	R10	K38
+      0x58300027,  //  00FE  LDCONST	R12	K39
+      0x7C280400,  //  00FF  CALL	R10	2
+      0x94281528,  //  0100  GETIDX	R10	R10	K40
       0x94281529,  //  0101  GETIDX	R10	R10	K41
-      0x9428152A,  //  0102  GETIDX	R10	R10	K42
-      0x7C1C0600,  //  0103  CALL	R7	3
-      0x80040E00,  //  0104  RET	1	R7
-      0x70020014,  //  0105  JMP		#011B
-      0x1C1C0D0E,  //  0106  EQ	R7	R6	K14
-      0x781E000A,  //  0107  JMPF	R7	#0113
-      0x8C1C0906,  //  0108  GETMET	R7	R4	K6
-      0x8824092B,  //  0109  GETMBR	R9	R4	K43
-      0xB82A2600,  //  010A  GETNGBL	R10	K19
-      0x8C281527,  //  010B  GETMET	R10	R10	K39
-      0x5830002C,  //  010C  LDCONST	R12	K44
-      0x7C280400,  //  010D  CALL	R10	2
+      0x7C1C0600,  //  0102  CALL	R7	3
+      0x80040E00,  //  0103  RET	1	R7
+      0x70020014,  //  0104  JMP		#011A
+      0x1C1C0D0D,  //  0105  EQ	R7	R6	K13
+      0x781E000A,  //  0106  JMPF	R7	#0112
+      0x8C1C0906,  //  0107  GETMET	R7	R4	K6
+      0x8824092A,  //  0108  GETMBR	R9	R4	K42
+      0xB82A2400,  //  0109  GETNGBL	R10	K18
+      0x8C281526,  //  010A  GETMET	R10	R10	K38
+      0x5830002B,  //  010B  LDCONST	R12	K43
+      0x7C280400,  //  010C  CALL	R10	2
+      0x9428152C,  //  010D  GETIDX	R10	R10	K44
       0x9428152D,  //  010E  GETIDX	R10	R10	K45
-      0x9428152E,  //  010F  GETIDX	R10	R10	K46
-      0x7C1C0600,  //  0110  CALL	R7	3
-      0x80040E00,  //  0111  RET	1	R7
-      0x70020007,  //  0112  JMP		#011B
-      0x541E0007,  //  0113  LDINT	R7	8
-      0x1C1C0C07,  //  0114  EQ	R7	R6	R7
-      0x781E0004,  //  0115  JMPF	R7	#011B
-      0x8C1C0906,  //  0116  GETMET	R7	R4	K6
-      0x88240911,  //  0117  GETMBR	R9	R4	K17
-      0x50280000,  //  0118  LDBOOL	R10	0	0
-      0x7C1C0600,  //  0119  CALL	R7	3
-      0x80040E00,  //  011A  RET	1	R7
-      0x7002020B,  //  011B  JMP		#0328
-      0x541E0033,  //  011C  LDINT	R7	52
-      0x1C1C0A07,  //  011D  EQ	R7	R5	R7
-      0x781E0000,  //  011E  JMPF	R7	#0120
-      0x70020207,  //  011F  JMP		#0328
-      0x541E0037,  //  0120  LDINT	R7	56
-      0x1C1C0A07,  //  0121  EQ	R7	R5	R7
-      0x781E002C,  //  0122  JMPF	R7	#0150
-      0x1C1C0D05,  //  0123  EQ	R7	R6	K5
-      0x781E000F,  //  0124  JMPF	R7	#0135
-      0xB81E5E00,  //  0125  GETNGBL	R7	K47
-      0xB8222600,  //  0126  GETNGBL	R8	K19
-      0x8C201130,  //  0127  GETMET	R8	R8	K48
-      0x7C200200,  //  0128  CALL	R8	1
-      0x94201131,  //  0129  GETIDX	R8	R8	K49
-      0x7C1C0200,  //  012A  CALL	R7	1
-      0xB8225E00,  //  012B  GETNGBL	R8	K47
-      0x58240032,  //  012C  LDCONST	R9	K50
-      0x7C200200,  //  012D  CALL	R8	1
-      0x081C0E08,  //  012E  MUL	R7	R7	R8
-      0x8C200906,  //  012F  GETMET	R8	R4	K6
-      0x88280907,  //  0130  GETMBR	R10	R4	K7
-      0x5C2C0E00,  //  0131  MOVE	R11	R7
-      0x7C200600,  //  0132  CALL	R8	3
-      0x80041000,  //  0133  RET	1	R8
-      0x70020019,  //  0134  JMP		#014F
-      0x1C1C0D0A,  //  0135  EQ	R7	R6	K10
-      0x781E0005,  //  0136  JMPF	R7	#013D
-      0x8C1C0906,  //  0137  GETMET	R7	R4	K6
-      0x8824090F,  //  0138  GETMBR	R9	R4	K15
-      0x58280010,  //  0139  LDCONST	R10	K16
-      0x7C1C0600,  //  013A  CALL	R7	3
-      0x80040E00,  //  013B  RET	1	R7
-      0x70020011,  //  013C  JMP		#014F
-      0x541E0006,  //  013D  LDINT	R7	7
-      0x1C1C0C07,  //  013E  EQ	R7	R6	R7
-      0x781E000E,  //  013F  JMPF	R7	#014F
-      0xB81E5E00,  //  0140  GETNGBL	R7	K47
-      0xB8222600,  //  0141  GETNGBL	R8	K19
-      0x8C201130,  //  0142  GETMET	R8	R8	K48
-      0x7C200200,  //  0143  CALL	R8	1
-      0x94201133,  //  0144  GETIDX	R8	R8	K51
-      0x7C1C0200,  //  0145  CALL	R7	1
-      0xB8225E00,  //  0146  GETNGBL	R8	K47
-      0x58240032,  //  0147  LDCONST	R9	K50
-      0x7C200200,  //  0148  CALL	R8	1
-      0x081C0E08,  //  0149  MUL	R7	R7	R8
-      0x8C200906,  //  014A  GETMET	R8	R4	K6
-      0x88280907,  //  014B  GETMBR	R10	R4	K7
-      0x5C2C0E00,  //  014C  MOVE	R11	R7
-      0x7C200600,  //  014D  CALL	R8	3
-      0x80041000,  //  014E  RET	1	R8
-      0x700201D7,  //  014F  JMP		#0328
-      0x541E003D,  //  0150  LDINT	R7	62
-      0x1C1C0A07,  //  0151  EQ	R7	R5	R7
-      0x781E0082,  //  0152  JMPF	R7	#01D6
-      0x1C1C0D05,  //  0153  EQ	R7	R6	K5
-      0x781E001D,  //  0154  JMPF	R7	#0173
-      0x8C1C0912,  //  0155  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0156  CALL	R7	1
-      0x60200010,  //  0157  GETGBL	R8	G16
-      0x88240134,  //  0158  GETMBR	R9	R0	K52
-      0x88241335,  //  0159  GETMBR	R9	R9	K53
-      0x8C241336,  //  015A  GETMET	R9	R9	K54
-      0x7C240200,  //  015B  CALL	R9	1
-      0x7C200200,  //  015C  CALL	R8	1
-      0xA802000F,  //  015D  EXBLK	0	#016E
-      0x5C241000,  //  015E  MOVE	R9	R8
-      0x7C240000,  //  015F  CALL	R9	0
-      0x8C280F16,  //  0160  GETMET	R10	R7	K22
-      0x4C300000,  //  0161  LDNIL	R12
-      0x7C280400,  //  0162  CALL	R10	2
-      0x8C2C150C,  //  0163  GETMET	R11	R10	K12
-      0x5834000A,  //  0164  LDCONST	R13	K10
-      0x88380937,  //  0165  GETMBR	R14	R4	K55
-      0x883C1338,  //  0166  GETMBR	R15	R9	K56
-      0x7C2C0800,  //  0167  CALL	R11	4
-      0x8C2C150C,  //  0168  GETMET	R11	R10	K12
-      0x5834000E,  //  0169  LDCONST	R13	K14
-      0x88380937,  //  016A  GETMBR	R14	R4	K55
-      0x883C1339,  //  016B  GETMBR	R15	R9	K57
-      0x7C2C0800,  //  016C  CALL	R11	4
-      0x7001FFEF,  //  016D  JMP		#015E
-      0x5820003A,  //  016E  LDCONST	R8	K58
-      0xAC200200,  //  016F  CATCH	R8	1	0
-      0xB0080000,  //  0170  RAISE	2	R0	R0
-      0x80040E00,  //  0171  RET	1	R7
-      0x70020061,  //  0172  JMP		#01D5
-      0x1C1C0D0A,  //  0173  EQ	R7	R6	K10
-      0x781E0032,  //  0174  JMPF	R7	#01A8
-      0x8C1C0912,  //  0175  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0176  CALL	R7	1
-      0x60200010,  //  0177  GETGBL	R8	G16
-      0x88240134,  //  0178  GETMBR	R9	R0	K52
-      0x88241335,  //  0179  GETMBR	R9	R9	K53
-      0x8C241336,  //  017A  GETMET	R9	R9	K54
-      0x7C240200,  //  017B  CALL	R9	1
-      0x7C200200,  //  017C  CALL	R8	1
-      0xA8020024,  //  017D  EXBLK	0	#01A3
-      0x5C241000,  //  017E  MOVE	R9	R8
-      0x7C240000,  //  017F  CALL	R9	0
-      0x8C28093B,  //  0180  GETMET	R10	R4	K59
-      0x8C30133C,  //  0181  GETMET	R12	R9	K60
-      0x7C300200,  //  0182  CALL	R12	1
-      0x7C280400,  //  0183  CALL	R10	2
-      0x8C2C0F16,  //  0184  GETMET	R11	R7	K22
-      0x4C340000,  //  0185  LDNIL	R13
-      0x7C2C0400,  //  0186  CALL	R11	2
-      0x8C30170C,  //  0187  GETMET	R12	R11	K12
-      0x5838000A,  //  0188  LDCONST	R14	K10
-      0x883C0937,  //  0189  GETMBR	R15	R4	K55
-      0x8C40153D,  //  018A  GETMET	R16	R10	K61
-      0x544A0008,  //  018B  LDINT	R18	9
-      0x7C400400,  //  018C  CALL	R16	2
-      0x7C300800,  //  018D  CALL	R12	4
-      0x8C30170C,  //  018E  GETMET	R12	R11	K12
-      0x5838000E,  //  018F  LDCONST	R14	K14
-      0x883C090D,  //  0190  GETMBR	R15	R4	K13
-      0x8840133E,  //  0191  GETMBR	R16	R9	K62
-      0x7C300800,  //  0192  CALL	R12	4
-      0x8C30170C,  //  0193  GETMET	R12	R11	K12
-      0x58380010,  //  0194  LDCONST	R14	K16
-      0x883C0907,  //  0195  GETMBR	R15	R4	K7
-      0x8840133F,  //  0196  GETMBR	R16	R9	K63
-      0x7C300800,  //  0197  CALL	R12	4
-      0x8C30170C,  //  0198  GETMET	R12	R11	K12
-      0x543A0003,  //  0199  LDINT	R14	4
-      0x883C0907,  //  019A  GETMBR	R15	R4	K7
-      0x88401340,  //  019B  GETMBR	R16	R9	K64
-      0x7C300800,  //  019C  CALL	R12	4
-      0x8C30170C,  //  019D  GETMET	R12	R11	K12
-      0x543A0004,  //  019E  LDINT	R14	5
-      0x883C0917,  //  019F  GETMBR	R15	R4	K23
-      0x88401341,  //  01A0  GETMBR	R16	R9	K65
-      0x7C300800,  //  01A1  CALL	R12	4
-      0x7001FFDA,  //  01A2  JMP		#017E
-      0x5820003A,  //  01A3  LDCONST	R8	K58
-      0xAC200200,  //  01A4  CATCH	R8	1	0
-      0xB0080000,  //  01A5  RAISE	2	R0	R0
-      0x80040E00,  //  01A6  RET	1	R7
-      0x7002002C,  //  01A7  JMP		#01D5
-      0x1C1C0D0E,  //  01A8  EQ	R7	R6	K14
-      0x781E0005,  //  01A9  JMPF	R7	#01B0
-      0x8C1C0906,  //  01AA  GETMET	R7	R4	K6
-      0x8824090F,  //  01AB  GETMBR	R9	R4	K15
-      0x542A0004,  //  01AC  LDINT	R10	5
-      0x7C1C0600,  //  01AD  CALL	R7	3
-      0x80040E00,  //  01AE  RET	1	R7
-      0x70020024,  //  01AF  JMP		#01D5
-      0x1C1C0D10,  //  01B0  EQ	R7	R6	K16
-      0x781E000B,  //  01B1  JMPF	R7	#01BE
-      0x881C0134,  //  01B2  GETMBR	R7	R0	K52
-      0x881C0F35,  //  01B3  GETMBR	R7	R7	K53
-      0x8C1C0F36,  //  01B4  GETMET	R7	R7	K54
-      0x7C1C0200,  //  01B5  CALL	R7	1
-      0x8C200906,  //  01B6  GETMET	R8	R4	K6
-      0x8828090F,  //  01B7  GETMBR	R10	R4	K15
-      0x602C000C,  //  01B8  GETGBL	R11	G12
-      0x5C300E00,  //  01B9  MOVE	R12	R7
-      0x7C2C0200,  //  01BA  CALL	R11	1
-      0x7C200600,  //  01BB  CALL	R8	3
-      0x80041000,  //  01BC  RET	1	R8
-      0x70020016,  //  01BD  JMP		#01D5
-      0x541E0003,  //  01BE  LDINT	R7	4
-      0x1C1C0C07,  //  01BF  EQ	R7	R6	R7
-      0x781E0000,  //  01C0  JMPF	R7	#01C2
-      0x70020012,  //  01C1  JMP		#01D5
-      0x541E0004,  //  01C2  LDINT	R7	5
-      0x1C1C0C07,  //  01C3  EQ	R7	R6	R7
-      0x781E000F,  //  01C4  JMPF	R7	#01D5
-      0x881C0134,  //  01C5  GETMBR	R7	R0	K52
-      0x881C0F35,  //  01C6  GETMBR	R7	R7	K53
-      0x8C1C0F36,  //  01C7  GETMET	R7	R7	K54
-      0x7C1C0200,  //  01C8  CALL	R7	1
-      0x8C200F1C,  //  01C9  GETMET	R8	R7	K28
-      0x88280308,  //  01CA  GETMBR	R10	R1	K8
-      0x7C200400,  //  01CB  CALL	R8	2
-      0x4C240000,  //  01CC  LDNIL	R9
-      0x1C241009,  //  01CD  EQ	R9	R8	R9
-      0x78260000,  //  01CE  JMPF	R9	#01D0
-      0x58200005,  //  01CF  LDCONST	R8	K5
-      0x8C240906,  //  01D0  GETMET	R9	R4	K6
-      0x882C090F,  //  01D1  GETMBR	R11	R4	K15
-      0x5C301000,  //  01D2  MOVE	R12	R8
-      0x7C240600,  //  01D3  CALL	R9	3
-      0x80041200,  //  01D4  RET	1	R9
-      0x70020151,  //  01D5  JMP		#0328
-      0x541E003B,  //  01D6  LDINT	R7	60
-      0x1C1C0A07,  //  01D7  EQ	R7	R5	R7
-      0x781E0000,  //  01D8  JMPF	R7	#01DA
-      0x7002014D,  //  01D9  JMP		#0328
-      0x541E0027,  //  01DA  LDINT	R7	40
-      0x1C1C0A07,  //  01DB  EQ	R7	R5	R7
-      0x781E0080,  //  01DC  JMPF	R7	#025E
-      0x1C1C0D05,  //  01DD  EQ	R7	R6	K5
-      0x781E0005,  //  01DE  JMPF	R7	#01E5
-      0x8C1C0906,  //  01DF  GETMET	R7	R4	K6
-      0x8824090D,  //  01E0  GETMBR	R9	R4	K13
-      0x58280005,  //  01E1  LDCONST	R10	K5
-      0x7C1C0600,  //  01E2  CALL	R7	3
-      0x80040E00,  //  01E3  RET	1	R7
-      0x70020077,  //  01E4  JMP		#025D
-      0x1C1C0D0A,  //  01E5  EQ	R7	R6	K10
-      0x781E0005,  //  01E6  JMPF	R7	#01ED
-      0x8C1C0906,  //  01E7  GETMET	R7	R4	K6
-      0x88240917,  //  01E8  GETMBR	R9	R4	K23
-      0x58280042,  //  01E9  LDCONST	R10	K66
-      0x7C1C0600,  //  01EA  CALL	R7	3
-      0x80040E00,  //  01EB  RET	1	R7
-      0x7002006F,  //  01EC  JMP		#025D
-      0x1C1C0D0E,  //  01ED  EQ	R7	R6	K14
-      0x781E0006,  //  01EE  JMPF	R7	#01F6
-      0x8C1C0906,  //  01EF  GETMET	R7	R4	K6
-      0x8824090D,  //  01F0  GETMBR	R9	R4	K13
-      0x88280134,  //  01F1  GETMBR	R10	R0	K52
-      0x88281543,  //  01F2  GETMBR	R10	R10	K67
-      0x7C1C0600,  //  01F3  CALL	R7	3
-      0x80040E00,  //  01F4  RET	1	R7
-      0x70020066,  //  01F5  JMP		#025D
-      0x1C1C0D10,  //  01F6  EQ	R7	R6	K16
-      0x781E0009,  //  01F7  JMPF	R7	#0202
-      0x8C1C0906,  //  01F8  GETMET	R7	R4	K6
-      0x88240917,  //  01F9  GETMBR	R9	R4	K23
-      0xB82A2600,  //  01FA  GETNGBL	R10	K19
-      0x8C281527,  //  01FB  GETMET	R10	R10	K39
-      0x58300044,  //  01FC  LDCONST	R12	K68
-      0x7C280400,  //  01FD  CALL	R10	2
-      0x94281544,  //  01FE  GETIDX	R10	R10	K68
-      0x7C1C0600,  //  01FF  CALL	R7	3
-      0x80040E00,  //  0200  RET	1	R7
-      0x7002005A,  //  0201  JMP		#025D
-      0x541E0003,  //  0202  LDINT	R7	4
-      0x1C1C0C07,  //  0203  EQ	R7	R6	R7
-      0x781E0005,  //  0204  JMPF	R7	#020B
-      0x8C1C0906,  //  0205  GETMET	R7	R4	K6
-      0x8824090D,  //  0206  GETMBR	R9	R4	K13
-      0x542A7FFF,  //  0207  LDINT	R10	32768
-      0x7C1C0600,  //  0208  CALL	R7	3
-      0x80040E00,  //  0209  RET	1	R7
-      0x70020051,  //  020A  JMP		#025D
-      0x541E0004,  //  020B  LDINT	R7	5
-      0x1C1C0C07,  //  020C  EQ	R7	R6	R7
-      0x781E0009,  //  020D  JMPF	R7	#0218
-      0x8C1C0906,  //  020E  GETMET	R7	R4	K6
-      0x88240917,  //  020F  GETMBR	R9	R4	K23
-      0xB82A2600,  //  0210  GETNGBL	R10	K19
-      0x8C281527,  //  0211  GETMET	R10	R10	K39
-      0x58300045,  //  0212  LDCONST	R12	K69
-      0x7C280400,  //  0213  CALL	R10	2
-      0x94281546,  //  0214  GETIDX	R10	R10	K70
-      0x7C1C0600,  //  0215  CALL	R7	3
-      0x80040E00,  //  0216  RET	1	R7
-      0x70020044,  //  0217  JMP		#025D
-      0x541E0005,  //  0218  LDINT	R7	6
-      0x1C1C0C07,  //  0219  EQ	R7	R6	R7
-      0x781E0005,  //  021A  JMPF	R7	#0221
-      0x8C1C0906,  //  021B  GETMET	R7	R4	K6
-      0x88240917,  //  021C  GETMBR	R9	R4	K23
-      0x58280047,  //  021D  LDCONST	R10	K71
-      0x7C1C0600,  //  021E  CALL	R7	3
-      0x80040E00,  //  021F  RET	1	R7
-      0x7002003B,  //  0220  JMP		#025D
-      0x541E0006,  //  0221  LDINT	R7	7
-      0x1C1C0C07,  //  0222  EQ	R7	R6	R7
-      0x781E0005,  //  0223  JMPF	R7	#022A
-      0x8C1C0906,  //  0224  GETMET	R7	R4	K6
-      0x8824090D,  //  0225  GETMBR	R9	R4	K13
-      0x58280005,  //  0226  LDCONST	R10	K5
-      0x7C1C0600,  //  0227  CALL	R7	3
-      0x80040E00,  //  0228  RET	1	R7
-      0x70020032,  //  0229  JMP		#025D
-      0x541E0007,  //  022A  LDINT	R7	8
-      0x1C1C0C07,  //  022B  EQ	R7	R6	R7
-      0x781E000A,  //  022C  JMPF	R7	#0238
-      0x8C1C0906,  //  022D  GETMET	R7	R4	K6
-      0x88240917,  //  022E  GETMBR	R9	R4	K23
-      0xB82A2600,  //  022F  GETNGBL	R10	K19
-      0x8C281527,  //  0230  GETMET	R10	R10	K39
-      0x58300048,  //  0231  LDCONST	R12	K72
-      0x7C280400,  //  0232  CALL	R10	2
+      0x7C1C0600,  //  010F  CALL	R7	3
+      0x80040E00,  //  0110  RET	1	R7
+      0x70020007,  //  0111  JMP		#011A
+      0x541E0007,  //  0112  LDINT	R7	8
+      0x1C1C0C07,  //  0113  EQ	R7	R6	R7
+      0x781E0004,  //  0114  JMPF	R7	#011A
+      0x8C1C0906,  //  0115  GETMET	R7	R4	K6
+      0x88240910,  //  0116  GETMBR	R9	R4	K16
+      0x50280000,  //  0117  LDBOOL	R10	0	0
+      0x7C1C0600,  //  0118  CALL	R7	3
+      0x80040E00,  //  0119  RET	1	R7
+      0x7002020B,  //  011A  JMP		#0327
+      0x541E0033,  //  011B  LDINT	R7	52
+      0x1C1C0A07,  //  011C  EQ	R7	R5	R7
+      0x781E0000,  //  011D  JMPF	R7	#011F
+      0x70020207,  //  011E  JMP		#0327
+      0x541E0037,  //  011F  LDINT	R7	56
+      0x1C1C0A07,  //  0120  EQ	R7	R5	R7
+      0x781E002C,  //  0121  JMPF	R7	#014F
+      0x1C1C0D05,  //  0122  EQ	R7	R6	K5
+      0x781E000F,  //  0123  JMPF	R7	#0134
+      0xB81E5C00,  //  0124  GETNGBL	R7	K46
+      0xB8222400,  //  0125  GETNGBL	R8	K18
+      0x8C20112F,  //  0126  GETMET	R8	R8	K47
+      0x7C200200,  //  0127  CALL	R8	1
+      0x94201130,  //  0128  GETIDX	R8	R8	K48
+      0x7C1C0200,  //  0129  CALL	R7	1
+      0xB8225C00,  //  012A  GETNGBL	R8	K46
+      0x58240031,  //  012B  LDCONST	R9	K49
+      0x7C200200,  //  012C  CALL	R8	1
+      0x081C0E08,  //  012D  MUL	R7	R7	R8
+      0x8C200906,  //  012E  GETMET	R8	R4	K6
+      0x88280907,  //  012F  GETMBR	R10	R4	K7
+      0x5C2C0E00,  //  0130  MOVE	R11	R7
+      0x7C200600,  //  0131  CALL	R8	3
+      0x80041000,  //  0132  RET	1	R8
+      0x70020019,  //  0133  JMP		#014E
+      0x1C1C0D09,  //  0134  EQ	R7	R6	K9
+      0x781E0005,  //  0135  JMPF	R7	#013C
+      0x8C1C0906,  //  0136  GETMET	R7	R4	K6
+      0x8824090E,  //  0137  GETMBR	R9	R4	K14
+      0x5828000F,  //  0138  LDCONST	R10	K15
+      0x7C1C0600,  //  0139  CALL	R7	3
+      0x80040E00,  //  013A  RET	1	R7
+      0x70020011,  //  013B  JMP		#014E
+      0x541E0006,  //  013C  LDINT	R7	7
+      0x1C1C0C07,  //  013D  EQ	R7	R6	R7
+      0x781E000E,  //  013E  JMPF	R7	#014E
+      0xB81E5C00,  //  013F  GETNGBL	R7	K46
+      0xB8222400,  //  0140  GETNGBL	R8	K18
+      0x8C20112F,  //  0141  GETMET	R8	R8	K47
+      0x7C200200,  //  0142  CALL	R8	1
+      0x94201132,  //  0143  GETIDX	R8	R8	K50
+      0x7C1C0200,  //  0144  CALL	R7	1
+      0xB8225C00,  //  0145  GETNGBL	R8	K46
+      0x58240031,  //  0146  LDCONST	R9	K49
+      0x7C200200,  //  0147  CALL	R8	1
+      0x081C0E08,  //  0148  MUL	R7	R7	R8
+      0x8C200906,  //  0149  GETMET	R8	R4	K6
+      0x88280907,  //  014A  GETMBR	R10	R4	K7
+      0x5C2C0E00,  //  014B  MOVE	R11	R7
+      0x7C200600,  //  014C  CALL	R8	3
+      0x80041000,  //  014D  RET	1	R8
+      0x700201D7,  //  014E  JMP		#0327
+      0x541E003D,  //  014F  LDINT	R7	62
+      0x1C1C0A07,  //  0150  EQ	R7	R5	R7
+      0x781E0082,  //  0151  JMPF	R7	#01D5
+      0x1C1C0D05,  //  0152  EQ	R7	R6	K5
+      0x781E001D,  //  0153  JMPF	R7	#0172
+      0x8C1C0911,  //  0154  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0155  CALL	R7	1
+      0x60200010,  //  0156  GETGBL	R8	G16
+      0x88240133,  //  0157  GETMBR	R9	R0	K51
+      0x88241334,  //  0158  GETMBR	R9	R9	K52
+      0x8C241335,  //  0159  GETMET	R9	R9	K53
+      0x7C240200,  //  015A  CALL	R9	1
+      0x7C200200,  //  015B  CALL	R8	1
+      0xA802000F,  //  015C  EXBLK	0	#016D
+      0x5C241000,  //  015D  MOVE	R9	R8
+      0x7C240000,  //  015E  CALL	R9	0
+      0x8C280F15,  //  015F  GETMET	R10	R7	K21
+      0x4C300000,  //  0160  LDNIL	R12
+      0x7C280400,  //  0161  CALL	R10	2
+      0x8C2C150B,  //  0162  GETMET	R11	R10	K11
+      0x58340009,  //  0163  LDCONST	R13	K9
+      0x88380936,  //  0164  GETMBR	R14	R4	K54
+      0x883C1337,  //  0165  GETMBR	R15	R9	K55
+      0x7C2C0800,  //  0166  CALL	R11	4
+      0x8C2C150B,  //  0167  GETMET	R11	R10	K11
+      0x5834000D,  //  0168  LDCONST	R13	K13
+      0x88380936,  //  0169  GETMBR	R14	R4	K54
+      0x883C1338,  //  016A  GETMBR	R15	R9	K56
+      0x7C2C0800,  //  016B  CALL	R11	4
+      0x7001FFEF,  //  016C  JMP		#015D
+      0x58200039,  //  016D  LDCONST	R8	K57
+      0xAC200200,  //  016E  CATCH	R8	1	0
+      0xB0080000,  //  016F  RAISE	2	R0	R0
+      0x80040E00,  //  0170  RET	1	R7
+      0x70020061,  //  0171  JMP		#01D4
+      0x1C1C0D09,  //  0172  EQ	R7	R6	K9
+      0x781E0032,  //  0173  JMPF	R7	#01A7
+      0x8C1C0911,  //  0174  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0175  CALL	R7	1
+      0x60200010,  //  0176  GETGBL	R8	G16
+      0x88240133,  //  0177  GETMBR	R9	R0	K51
+      0x88241334,  //  0178  GETMBR	R9	R9	K52
+      0x8C241335,  //  0179  GETMET	R9	R9	K53
+      0x7C240200,  //  017A  CALL	R9	1
+      0x7C200200,  //  017B  CALL	R8	1
+      0xA8020024,  //  017C  EXBLK	0	#01A2
+      0x5C241000,  //  017D  MOVE	R9	R8
+      0x7C240000,  //  017E  CALL	R9	0
+      0x8C28093A,  //  017F  GETMET	R10	R4	K58
+      0x8C30133B,  //  0180  GETMET	R12	R9	K59
+      0x7C300200,  //  0181  CALL	R12	1
+      0x7C280400,  //  0182  CALL	R10	2
+      0x8C2C0F15,  //  0183  GETMET	R11	R7	K21
+      0x4C340000,  //  0184  LDNIL	R13
+      0x7C2C0400,  //  0185  CALL	R11	2
+      0x8C30170B,  //  0186  GETMET	R12	R11	K11
+      0x58380009,  //  0187  LDCONST	R14	K9
+      0x883C0936,  //  0188  GETMBR	R15	R4	K54
+      0x8C40153C,  //  0189  GETMET	R16	R10	K60
+      0x544A0008,  //  018A  LDINT	R18	9
+      0x7C400400,  //  018B  CALL	R16	2
+      0x7C300800,  //  018C  CALL	R12	4
+      0x8C30170B,  //  018D  GETMET	R12	R11	K11
+      0x5838000D,  //  018E  LDCONST	R14	K13
+      0x883C090C,  //  018F  GETMBR	R15	R4	K12
+      0x8840133D,  //  0190  GETMBR	R16	R9	K61
+      0x7C300800,  //  0191  CALL	R12	4
+      0x8C30170B,  //  0192  GETMET	R12	R11	K11
+      0x5838000F,  //  0193  LDCONST	R14	K15
+      0x883C0907,  //  0194  GETMBR	R15	R4	K7
+      0x8840133E,  //  0195  GETMBR	R16	R9	K62
+      0x7C300800,  //  0196  CALL	R12	4
+      0x8C30170B,  //  0197  GETMET	R12	R11	K11
+      0x543A0003,  //  0198  LDINT	R14	4
+      0x883C0907,  //  0199  GETMBR	R15	R4	K7
+      0x8840133F,  //  019A  GETMBR	R16	R9	K63
+      0x7C300800,  //  019B  CALL	R12	4
+      0x8C30170B,  //  019C  GETMET	R12	R11	K11
+      0x543A0004,  //  019D  LDINT	R14	5
+      0x883C0916,  //  019E  GETMBR	R15	R4	K22
+      0x88401340,  //  019F  GETMBR	R16	R9	K64
+      0x7C300800,  //  01A0  CALL	R12	4
+      0x7001FFDA,  //  01A1  JMP		#017D
+      0x58200039,  //  01A2  LDCONST	R8	K57
+      0xAC200200,  //  01A3  CATCH	R8	1	0
+      0xB0080000,  //  01A4  RAISE	2	R0	R0
+      0x80040E00,  //  01A5  RET	1	R7
+      0x7002002C,  //  01A6  JMP		#01D4
+      0x1C1C0D0D,  //  01A7  EQ	R7	R6	K13
+      0x781E0005,  //  01A8  JMPF	R7	#01AF
+      0x8C1C0906,  //  01A9  GETMET	R7	R4	K6
+      0x8824090E,  //  01AA  GETMBR	R9	R4	K14
+      0x542A0004,  //  01AB  LDINT	R10	5
+      0x7C1C0600,  //  01AC  CALL	R7	3
+      0x80040E00,  //  01AD  RET	1	R7
+      0x70020024,  //  01AE  JMP		#01D4
+      0x1C1C0D0F,  //  01AF  EQ	R7	R6	K15
+      0x781E000B,  //  01B0  JMPF	R7	#01BD
+      0x881C0133,  //  01B1  GETMBR	R7	R0	K51
+      0x881C0F34,  //  01B2  GETMBR	R7	R7	K52
+      0x8C1C0F35,  //  01B3  GETMET	R7	R7	K53
+      0x7C1C0200,  //  01B4  CALL	R7	1
+      0x8C200906,  //  01B5  GETMET	R8	R4	K6
+      0x8828090E,  //  01B6  GETMBR	R10	R4	K14
+      0x602C000C,  //  01B7  GETGBL	R11	G12
+      0x5C300E00,  //  01B8  MOVE	R12	R7
+      0x7C2C0200,  //  01B9  CALL	R11	1
+      0x7C200600,  //  01BA  CALL	R8	3
+      0x80041000,  //  01BB  RET	1	R8
+      0x70020016,  //  01BC  JMP		#01D4
+      0x541E0003,  //  01BD  LDINT	R7	4
+      0x1C1C0C07,  //  01BE  EQ	R7	R6	R7
+      0x781E0000,  //  01BF  JMPF	R7	#01C1
+      0x70020012,  //  01C0  JMP		#01D4
+      0x541E0004,  //  01C1  LDINT	R7	5
+      0x1C1C0C07,  //  01C2  EQ	R7	R6	R7
+      0x781E000F,  //  01C3  JMPF	R7	#01D4
+      0x881C0133,  //  01C4  GETMBR	R7	R0	K51
+      0x881C0F34,  //  01C5  GETMBR	R7	R7	K52
+      0x8C1C0F35,  //  01C6  GETMET	R7	R7	K53
+      0x7C1C0200,  //  01C7  CALL	R7	1
+      0x8C200F1B,  //  01C8  GETMET	R8	R7	K27
+      0x5C280200,  //  01C9  MOVE	R10	R1
+      0x7C200400,  //  01CA  CALL	R8	2
+      0x4C240000,  //  01CB  LDNIL	R9
+      0x1C241009,  //  01CC  EQ	R9	R8	R9
+      0x78260000,  //  01CD  JMPF	R9	#01CF
+      0x58200005,  //  01CE  LDCONST	R8	K5
+      0x8C240906,  //  01CF  GETMET	R9	R4	K6
+      0x882C090E,  //  01D0  GETMBR	R11	R4	K14
+      0x5C301000,  //  01D1  MOVE	R12	R8
+      0x7C240600,  //  01D2  CALL	R9	3
+      0x80041200,  //  01D3  RET	1	R9
+      0x70020151,  //  01D4  JMP		#0327
+      0x541E003B,  //  01D5  LDINT	R7	60
+      0x1C1C0A07,  //  01D6  EQ	R7	R5	R7
+      0x781E0000,  //  01D7  JMPF	R7	#01D9
+      0x7002014D,  //  01D8  JMP		#0327
+      0x541E0027,  //  01D9  LDINT	R7	40
+      0x1C1C0A07,  //  01DA  EQ	R7	R5	R7
+      0x781E0080,  //  01DB  JMPF	R7	#025D
+      0x1C1C0D05,  //  01DC  EQ	R7	R6	K5
+      0x781E0005,  //  01DD  JMPF	R7	#01E4
+      0x8C1C0906,  //  01DE  GETMET	R7	R4	K6
+      0x8824090C,  //  01DF  GETMBR	R9	R4	K12
+      0x58280005,  //  01E0  LDCONST	R10	K5
+      0x7C1C0600,  //  01E1  CALL	R7	3
+      0x80040E00,  //  01E2  RET	1	R7
+      0x70020077,  //  01E3  JMP		#025C
+      0x1C1C0D09,  //  01E4  EQ	R7	R6	K9
+      0x781E0005,  //  01E5  JMPF	R7	#01EC
+      0x8C1C0906,  //  01E6  GETMET	R7	R4	K6
+      0x88240916,  //  01E7  GETMBR	R9	R4	K22
+      0x58280041,  //  01E8  LDCONST	R10	K65
+      0x7C1C0600,  //  01E9  CALL	R7	3
+      0x80040E00,  //  01EA  RET	1	R7
+      0x7002006F,  //  01EB  JMP		#025C
+      0x1C1C0D0D,  //  01EC  EQ	R7	R6	K13
+      0x781E0006,  //  01ED  JMPF	R7	#01F5
+      0x8C1C0906,  //  01EE  GETMET	R7	R4	K6
+      0x8824090C,  //  01EF  GETMBR	R9	R4	K12
+      0x88280133,  //  01F0  GETMBR	R10	R0	K51
+      0x88281542,  //  01F1  GETMBR	R10	R10	K66
+      0x7C1C0600,  //  01F2  CALL	R7	3
+      0x80040E00,  //  01F3  RET	1	R7
+      0x70020066,  //  01F4  JMP		#025C
+      0x1C1C0D0F,  //  01F5  EQ	R7	R6	K15
+      0x781E0009,  //  01F6  JMPF	R7	#0201
+      0x8C1C0906,  //  01F7  GETMET	R7	R4	K6
+      0x88240916,  //  01F8  GETMBR	R9	R4	K22
+      0xB82A2400,  //  01F9  GETNGBL	R10	K18
+      0x8C281526,  //  01FA  GETMET	R10	R10	K38
+      0x58300043,  //  01FB  LDCONST	R12	K67
+      0x7C280400,  //  01FC  CALL	R10	2
+      0x94281543,  //  01FD  GETIDX	R10	R10	K67
+      0x7C1C0600,  //  01FE  CALL	R7	3
+      0x80040E00,  //  01FF  RET	1	R7
+      0x7002005A,  //  0200  JMP		#025C
+      0x541E0003,  //  0201  LDINT	R7	4
+      0x1C1C0C07,  //  0202  EQ	R7	R6	R7
+      0x781E0005,  //  0203  JMPF	R7	#020A
+      0x8C1C0906,  //  0204  GETMET	R7	R4	K6
+      0x8824090C,  //  0205  GETMBR	R9	R4	K12
+      0x542A7FFF,  //  0206  LDINT	R10	32768
+      0x7C1C0600,  //  0207  CALL	R7	3
+      0x80040E00,  //  0208  RET	1	R7
+      0x70020051,  //  0209  JMP		#025C
+      0x541E0004,  //  020A  LDINT	R7	5
+      0x1C1C0C07,  //  020B  EQ	R7	R6	R7
+      0x781E0009,  //  020C  JMPF	R7	#0217
+      0x8C1C0906,  //  020D  GETMET	R7	R4	K6
+      0x88240916,  //  020E  GETMBR	R9	R4	K22
+      0xB82A2400,  //  020F  GETNGBL	R10	K18
+      0x8C281526,  //  0210  GETMET	R10	R10	K38
+      0x58300044,  //  0211  LDCONST	R12	K68
+      0x7C280400,  //  0212  CALL	R10	2
+      0x94281545,  //  0213  GETIDX	R10	R10	K69
+      0x7C1C0600,  //  0214  CALL	R7	3
+      0x80040E00,  //  0215  RET	1	R7
+      0x70020044,  //  0216  JMP		#025C
+      0x541E0005,  //  0217  LDINT	R7	6
+      0x1C1C0C07,  //  0218  EQ	R7	R6	R7
+      0x781E0005,  //  0219  JMPF	R7	#0220
+      0x8C1C0906,  //  021A  GETMET	R7	R4	K6
+      0x88240916,  //  021B  GETMBR	R9	R4	K22
+      0x58280046,  //  021C  LDCONST	R10	K70
+      0x7C1C0600,  //  021D  CALL	R7	3
+      0x80040E00,  //  021E  RET	1	R7
+      0x7002003B,  //  021F  JMP		#025C
+      0x541E0006,  //  0220  LDINT	R7	7
+      0x1C1C0C07,  //  0221  EQ	R7	R6	R7
+      0x781E0005,  //  0222  JMPF	R7	#0229
+      0x8C1C0906,  //  0223  GETMET	R7	R4	K6
+      0x8824090C,  //  0224  GETMBR	R9	R4	K12
+      0x58280005,  //  0225  LDCONST	R10	K5
+      0x7C1C0600,  //  0226  CALL	R7	3
+      0x80040E00,  //  0227  RET	1	R7
+      0x70020032,  //  0228  JMP		#025C
+      0x541E0007,  //  0229  LDINT	R7	8
+      0x1C1C0C07,  //  022A  EQ	R7	R6	R7
+      0x781E000A,  //  022B  JMPF	R7	#0237
+      0x8C1C0906,  //  022C  GETMET	R7	R4	K6
+      0x88240916,  //  022D  GETMBR	R9	R4	K22
+      0xB82A2400,  //  022E  GETNGBL	R10	K18
+      0x8C281526,  //  022F  GETMET	R10	R10	K38
+      0x58300047,  //  0230  LDCONST	R12	K71
+      0x7C280400,  //  0231  CALL	R10	2
+      0x94281548,  //  0232  GETIDX	R10	R10	K72
       0x94281549,  //  0233  GETIDX	R10	R10	K73
-      0x9428154A,  //  0234  GETIDX	R10	R10	K74
-      0x7C1C0600,  //  0235  CALL	R7	3
-      0x80040E00,  //  0236  RET	1	R7
-      0x70020024,  //  0237  JMP		#025D
-      0x541E0008,  //  0238  LDINT	R7	9
-      0x1C1C0C07,  //  0239  EQ	R7	R6	R7
-      0x781E0005,  //  023A  JMPF	R7	#0241
-      0x8C1C0906,  //  023B  GETMET	R7	R4	K6
-      0x8824090D,  //  023C  GETMBR	R9	R4	K13
-      0x58280005,  //  023D  LDCONST	R10	K5
-      0x7C1C0600,  //  023E  CALL	R7	3
-      0x80040E00,  //  023F  RET	1	R7
-      0x7002001B,  //  0240  JMP		#025D
-      0x541E0009,  //  0241  LDINT	R7	10
-      0x1C1C0C07,  //  0242  EQ	R7	R6	R7
-      0x781E000A,  //  0243  JMPF	R7	#024F
-      0x8C1C0906,  //  0244  GETMET	R7	R4	K6
-      0x88240917,  //  0245  GETMBR	R9	R4	K23
-      0xB82A2600,  //  0246  GETNGBL	R10	K19
-      0x8C281527,  //  0247  GETMET	R10	R10	K39
-      0x58300048,  //  0248  LDCONST	R12	K72
-      0x7C280400,  //  0249  CALL	R10	2
-      0x94281549,  //  024A  GETIDX	R10	R10	K73
-      0x9428154B,  //  024B  GETIDX	R10	R10	K75
-      0x7C1C0600,  //  024C  CALL	R7	3
-      0x80040E00,  //  024D  RET	1	R7
-      0x7002000D,  //  024E  JMP		#025D
-      0x541E0011,  //  024F  LDINT	R7	18
-      0x1C1C0C07,  //  0250  EQ	R7	R6	R7
-      0x781E000A,  //  0251  JMPF	R7	#025D
-      0x8C1C0906,  //  0252  GETMET	R7	R4	K6
-      0x88240917,  //  0253  GETMBR	R9	R4	K23
-      0xB82A2600,  //  0254  GETNGBL	R10	K19
-      0x8C281526,  //  0255  GETMET	R10	R10	K38
-      0x7C280200,  //  0256  CALL	R10	1
-      0x8C28151C,  //  0257  GETMET	R10	R10	K28
-      0x5830001D,  //  0258  LDCONST	R12	K29
-      0x5834001E,  //  0259  LDCONST	R13	K30
-      0x7C280600,  //  025A  CALL	R10	3
-      0x7C1C0600,  //  025B  CALL	R7	3
-      0x80040E00,  //  025C  RET	1	R7
-      0x700200C9,  //  025D  JMP		#0328
-      0x541E003E,  //  025E  LDINT	R7	63
-      0x1C1C0A07,  //  025F  EQ	R7	R5	R7
-      0x781E0000,  //  0260  JMPF	R7	#0262
-      0x700200C5,  //  0261  JMP		#0328
-      0x541E0029,  //  0262  LDINT	R7	42
-      0x1C1C0A07,  //  0263  EQ	R7	R5	R7
-      0x781E001D,  //  0264  JMPF	R7	#0283
-      0x1C1C0D05,  //  0265  EQ	R7	R6	K5
-      0x781E0003,  //  0266  JMPF	R7	#026B
-      0x8C1C0912,  //  0267  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0268  CALL	R7	1
-      0x80040E00,  //  0269  RET	1	R7
-      0x70020016,  //  026A  JMP		#0282
-      0x1C1C0D0A,  //  026B  EQ	R7	R6	K10
-      0x781E0005,  //  026C  JMPF	R7	#0273
-      0x8C1C0906,  //  026D  GETMET	R7	R4	K6
-      0x88240911,  //  026E  GETMBR	R9	R4	K17
-      0x58280005,  //  026F  LDCONST	R10	K5
-      0x7C1C0600,  //  0270  CALL	R7	3
-      0x80040E00,  //  0271  RET	1	R7
-      0x7002000E,  //  0272  JMP		#0282
-      0x1C1C0D0E,  //  0273  EQ	R7	R6	K14
-      0x781E0005,  //  0274  JMPF	R7	#027B
-      0x8C1C0906,  //  0275  GETMET	R7	R4	K6
-      0x8824090F,  //  0276  GETMBR	R9	R4	K15
-      0x5828000A,  //  0277  LDCONST	R10	K10
-      0x7C1C0600,  //  0278  CALL	R7	3
-      0x80040E00,  //  0279  RET	1	R7
-      0x70020006,  //  027A  JMP		#0282
-      0x1C1C0D10,  //  027B  EQ	R7	R6	K16
-      0x781E0004,  //  027C  JMPF	R7	#0282
-      0x8C1C0906,  //  027D  GETMET	R7	R4	K6
-      0x88240919,  //  027E  GETMBR	R9	R4	K25
-      0x4C280000,  //  027F  LDNIL	R10
-      0x7C1C0600,  //  0280  CALL	R7	3
-      0x80040E00,  //  0281  RET	1	R7
-      0x700200A4,  //  0282  JMP		#0328
-      0x541E002A,  //  0283  LDINT	R7	43
-      0x1C1C0A07,  //  0284  EQ	R7	R5	R7
-      0x781E0016,  //  0285  JMPF	R7	#029D
-      0x1C1C0D05,  //  0286  EQ	R7	R6	K5
-      0x781E0007,  //  0287  JMPF	R7	#0290
-      0x8C1C0906,  //  0288  GETMET	R7	R4	K6
-      0x88240917,  //  0289  GETMBR	R9	R4	K23
-      0xB82A2600,  //  028A  GETNGBL	R10	K19
-      0x8C28154C,  //  028B  GETMET	R10	R10	K76
-      0x7C280200,  //  028C  CALL	R10	1
-      0x7C1C0600,  //  028D  CALL	R7	3
-      0x80040E00,  //  028E  RET	1	R7
-      0x7002000B,  //  028F  JMP		#029C
-      0x1C1C0D0A,  //  0290  EQ	R7	R6	K10
-      0x781E0009,  //  0291  JMPF	R7	#029C
-      0x8C1C0912,  //  0292  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0293  CALL	R7	1
-      0x8C200F0C,  //  0294  GETMET	R8	R7	K12
-      0x4C280000,  //  0295  LDNIL	R10
-      0x882C0917,  //  0296  GETMBR	R11	R4	K23
-      0xB8322600,  //  0297  GETNGBL	R12	K19
-      0x8C30194C,  //  0298  GETMET	R12	R12	K76
-      0x7C300200,  //  0299  CALL	R12	1
-      0x7C200800,  //  029A  CALL	R8	4
-      0x80040E00,  //  029B  RET	1	R7
-      0x7002008A,  //  029C  JMP		#0328
-      0x541E002B,  //  029D  LDINT	R7	44
-      0x1C1C0A07,  //  029E  EQ	R7	R5	R7
-      0x781E001C,  //  029F  JMPF	R7	#02BD
-      0x1C1C0D05,  //  02A0  EQ	R7	R6	K5
-      0x781E0005,  //  02A1  JMPF	R7	#02A8
-      0x8C1C0906,  //  02A2  GETMET	R7	R4	K6
-      0x8824090F,  //  02A3  GETMBR	R9	R4	K15
-      0x5828000A,  //  02A4  LDCONST	R10	K10
-      0x7C1C0600,  //  02A5  CALL	R7	3
-      0x80040E00,  //  02A6  RET	1	R7
-      0x70020013,  //  02A7  JMP		#02BC
-      0x1C1C0D0A,  //  02A8  EQ	R7	R6	K10
-      0x781E0005,  //  02A9  JMPF	R7	#02B0
-      0x8C1C0906,  //  02AA  GETMET	R7	R4	K6
-      0x8824090F,  //  02AB  GETMBR	R9	R4	K15
-      0x542A0003,  //  02AC  LDINT	R10	4
-      0x7C1C0600,  //  02AD  CALL	R7	3
-      0x80040E00,  //  02AE  RET	1	R7
-      0x7002000B,  //  02AF  JMP		#02BC
-      0x1C1C0D0E,  //  02B0  EQ	R7	R6	K14
-      0x781E0009,  //  02B1  JMPF	R7	#02BC
-      0x8C1C0912,  //  02B2  GETMET	R7	R4	K18
-      0x7C1C0200,  //  02B3  CALL	R7	1
-      0x8C200F0C,  //  02B4  GETMET	R8	R7	K12
-      0x4C280000,  //  02B5  LDNIL	R10
-      0x8C2C0906,  //  02B6  GETMET	R11	R4	K6
-      0x8834090F,  //  02B7  GETMBR	R13	R4	K15
-      0x543A0003,  //  02B8  LDINT	R14	4
-      0x7C2C0600,  //  02B9  CALL	R11	3
-      0x7C200600,  //  02BA  CALL	R8	3
-      0x80040E00,  //  02BB  RET	1	R7
-      0x7002006A,  //  02BC  JMP		#0328
-      0x541E0030,  //  02BD  LDINT	R7	49
-      0x1C1C0A07,  //  02BE  EQ	R7	R5	R7
-      0x781E0010,  //  02BF  JMPF	R7	#02D1
-      0x1C1C0D10,  //  02C0  EQ	R7	R6	K16
-      0x781E0005,  //  02C1  JMPF	R7	#02C8
-      0x8C1C0906,  //  02C2  GETMET	R7	R4	K6
-      0x8824090F,  //  02C3  GETMBR	R9	R4	K15
-      0x542A001D,  //  02C4  LDINT	R10	30
-      0x7C1C0600,  //  02C5  CALL	R7	3
-      0x80040E00,  //  02C6  RET	1	R7
-      0x70020007,  //  02C7  JMP		#02D0
-      0x541EFFFB,  //  02C8  LDINT	R7	65532
-      0x1C1C0C07,  //  02C9  EQ	R7	R6	R7
-      0x781E0004,  //  02CA  JMPF	R7	#02D0
-      0x8C1C0906,  //  02CB  GETMET	R7	R4	K6
-      0x8824092B,  //  02CC  GETMBR	R9	R4	K43
-      0x58280005,  //  02CD  LDCONST	R10	K5
-      0x7C1C0600,  //  02CE  CALL	R7	3
-      0x80040E00,  //  02CF  RET	1	R7
-      0x70020056,  //  02D0  JMP		#0328
-      0x541E001C,  //  02D1  LDINT	R7	29
-      0x1C1C0A07,  //  02D2  EQ	R7	R5	R7
-      0x781E0050,  //  02D3  JMPF	R7	#0325
-      0x1C1C0D05,  //  02D4  EQ	R7	R6	K5
-      0x781E0019,  //  02D5  JMPF	R7	#02F0
-      0x8C1C0912,  //  02D6  GETMET	R7	R4	K18
-      0x7C1C0200,  //  02D7  CALL	R7	1
-      0x60200010,  //  02D8  GETGBL	R8	G16
-      0x8824014D,  //  02D9  GETMBR	R9	R0	K77
-      0x7C200200,  //  02DA  CALL	R8	1
-      0xA802000E,  //  02DB  EXBLK	0	#02EB
-      0x5C241000,  //  02DC  MOVE	R9	R8
-      0x7C240000,  //  02DD  CALL	R9	0
-      0x8C280F16,  //  02DE  GETMET	R10	R7	K22
-      0x7C280200,  //  02DF  CALL	R10	1
-      0x8C2C150C,  //  02E0  GETMET	R11	R10	K12
-      0x58340005,  //  02E1  LDCONST	R13	K5
-      0x8838090D,  //  02E2  GETMBR	R14	R4	K13
-      0x5C3C1200,  //  02E3  MOVE	R15	R9
-      0x7C2C0800,  //  02E4  CALL	R11	4
-      0x8C2C150C,  //  02E5  GETMET	R11	R10	K12
-      0x5834000A,  //  02E6  LDCONST	R13	K10
-      0x8838090D,  //  02E7  GETMBR	R14	R4	K13
-      0x583C000A,  //  02E8  LDCONST	R15	K10
-      0x7C2C0800,  //  02E9  CALL	R11	4
-      0x7001FFF0,  //  02EA  JMP		#02DC
-      0x5820003A,  //  02EB  LDCONST	R8	K58
-      0xAC200200,  //  02EC  CATCH	R8	1	0
-      0xB0080000,  //  02ED  RAISE	2	R0	R0
-      0x80040E00,  //  02EE  RET	1	R7
-      0x70020033,  //  02EF  JMP		#0324
-      0x1C1C0D0A,  //  02F0  EQ	R7	R6	K10
-      0x781E0013,  //  02F1  JMPF	R7	#0306
-      0x8C1C0912,  //  02F2  GETMET	R7	R4	K18
-      0x7C1C0200,  //  02F3  CALL	R7	1
-      0x60200010,  //  02F4  GETGBL	R8	G16
-      0x8C24014E,  //  02F5  GETMET	R9	R0	K78
-      0x7C240200,  //  02F6  CALL	R9	1
-      0x7C200200,  //  02F7  CALL	R8	1
-      0xA8020007,  //  02F8  EXBLK	0	#0301
-      0x5C241000,  //  02F9  MOVE	R9	R8
-      0x7C240000,  //  02FA  CALL	R9	0
-      0x8C280F0C,  //  02FB  GETMET	R10	R7	K12
-      0x4C300000,  //  02FC  LDNIL	R12
-      0x8834092B,  //  02FD  GETMBR	R13	R4	K43
-      0x5C381200,  //  02FE  MOVE	R14	R9
-      0x7C280800,  //  02FF  CALL	R10	4
-      0x7001FFF7,  //  0300  JMP		#02F9
-      0x5820003A,  //  0301  LDCONST	R8	K58
-      0xAC200200,  //  0302  CATCH	R8	1	0
-      0xB0080000,  //  0303  RAISE	2	R0	R0
-      0x80040E00,  //  0304  RET	1	R7
-      0x7002001D,  //  0305  JMP		#0324
-      0x1C1C0D0E,  //  0306  EQ	R7	R6	K14
-      0x781E0003,  //  0307  JMPF	R7	#030C
-      0x8C1C0912,  //  0308  GETMET	R7	R4	K18
-      0x7C1C0200,  //  0309  CALL	R7	1
-      0x80040E00,  //  030A  RET	1	R7
-      0x70020017,  //  030B  JMP		#0324
-      0x1C1C0D10,  //  030C  EQ	R7	R6	K16
-      0x781E0015,  //  030D  JMPF	R7	#0324
-      0x881C0134,  //  030E  GETMBR	R7	R0	K52
-      0x8C1C0F4F,  //  030F  GETMET	R7	R7	K79
-      0x50240200,  //  0310  LDBOOL	R9	1	0
-      0x7C1C0400,  //  0311  CALL	R7	2
-      0x8C200912,  //  0312  GETMET	R8	R4	K18
-      0x7C200200,  //  0313  CALL	R8	1
-      0x60240010,  //  0314  GETGBL	R9	G16
-      0x5C280E00,  //  0315  MOVE	R10	R7
-      0x7C240200,  //  0316  CALL	R9	1
-      0xA8020007,  //  0317  EXBLK	0	#0320
-      0x5C281200,  //  0318  MOVE	R10	R9
-      0x7C280000,  //  0319  CALL	R10	0
-      0x8C2C110C,  //  031A  GETMET	R11	R8	K12
-      0x4C340000,  //  031B  LDNIL	R13
-      0x8838090D,  //  031C  GETMBR	R14	R4	K13
-      0x5C3C1400,  //  031D  MOVE	R15	R10
-      0x7C2C0800,  //  031E  CALL	R11	4
-      0x7001FFF7,  //  031F  JMP		#0318
-      0x5824003A,  //  0320  LDCONST	R9	K58
-      0xAC240200,  //  0321  CATCH	R9	1	0
-      0xB0080000,  //  0322  RAISE	2	R0	R0
-      0x80041000,  //  0323  RET	1	R8
-      0x70020002,  //  0324  JMP		#0328
-      0xB81E0200,  //  0325  GETNGBL	R7	K1
-      0x881C0F51,  //  0326  GETMBR	R7	R7	K81
-      0x900AA007,  //  0327  SETMBR	R2	K80	R7
-      0x80000000,  //  0328  RET	0
+      0x7C1C0600,  //  0234  CALL	R7	3
+      0x80040E00,  //  0235  RET	1	R7
+      0x70020024,  //  0236  JMP		#025C
+      0x541E0008,  //  0237  LDINT	R7	9
+      0x1C1C0C07,  //  0238  EQ	R7	R6	R7
+      0x781E0005,  //  0239  JMPF	R7	#0240
+      0x8C1C0906,  //  023A  GETMET	R7	R4	K6
+      0x8824090C,  //  023B  GETMBR	R9	R4	K12
+      0x58280005,  //  023C  LDCONST	R10	K5
+      0x7C1C0600,  //  023D  CALL	R7	3
+      0x80040E00,  //  023E  RET	1	R7
+      0x7002001B,  //  023F  JMP		#025C
+      0x541E0009,  //  0240  LDINT	R7	10
+      0x1C1C0C07,  //  0241  EQ	R7	R6	R7
+      0x781E000A,  //  0242  JMPF	R7	#024E
+      0x8C1C0906,  //  0243  GETMET	R7	R4	K6
+      0x88240916,  //  0244  GETMBR	R9	R4	K22
+      0xB82A2400,  //  0245  GETNGBL	R10	K18
+      0x8C281526,  //  0246  GETMET	R10	R10	K38
+      0x58300047,  //  0247  LDCONST	R12	K71
+      0x7C280400,  //  0248  CALL	R10	2
+      0x94281548,  //  0249  GETIDX	R10	R10	K72
+      0x9428154A,  //  024A  GETIDX	R10	R10	K74
+      0x7C1C0600,  //  024B  CALL	R7	3
+      0x80040E00,  //  024C  RET	1	R7
+      0x7002000D,  //  024D  JMP		#025C
+      0x541E0011,  //  024E  LDINT	R7	18
+      0x1C1C0C07,  //  024F  EQ	R7	R6	R7
+      0x781E000A,  //  0250  JMPF	R7	#025C
+      0x8C1C0906,  //  0251  GETMET	R7	R4	K6
+      0x88240916,  //  0252  GETMBR	R9	R4	K22
+      0xB82A2400,  //  0253  GETNGBL	R10	K18
+      0x8C281525,  //  0254  GETMET	R10	R10	K37
+      0x7C280200,  //  0255  CALL	R10	1
+      0x8C28151B,  //  0256  GETMET	R10	R10	K27
+      0x5830001C,  //  0257  LDCONST	R12	K28
+      0x5834001D,  //  0258  LDCONST	R13	K29
+      0x7C280600,  //  0259  CALL	R10	3
+      0x7C1C0600,  //  025A  CALL	R7	3
+      0x80040E00,  //  025B  RET	1	R7
+      0x700200C9,  //  025C  JMP		#0327
+      0x541E003E,  //  025D  LDINT	R7	63
+      0x1C1C0A07,  //  025E  EQ	R7	R5	R7
+      0x781E0000,  //  025F  JMPF	R7	#0261
+      0x700200C5,  //  0260  JMP		#0327
+      0x541E0029,  //  0261  LDINT	R7	42
+      0x1C1C0A07,  //  0262  EQ	R7	R5	R7
+      0x781E001D,  //  0263  JMPF	R7	#0282
+      0x1C1C0D05,  //  0264  EQ	R7	R6	K5
+      0x781E0003,  //  0265  JMPF	R7	#026A
+      0x8C1C0911,  //  0266  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0267  CALL	R7	1
+      0x80040E00,  //  0268  RET	1	R7
+      0x70020016,  //  0269  JMP		#0281
+      0x1C1C0D09,  //  026A  EQ	R7	R6	K9
+      0x781E0005,  //  026B  JMPF	R7	#0272
+      0x8C1C0906,  //  026C  GETMET	R7	R4	K6
+      0x88240910,  //  026D  GETMBR	R9	R4	K16
+      0x58280005,  //  026E  LDCONST	R10	K5
+      0x7C1C0600,  //  026F  CALL	R7	3
+      0x80040E00,  //  0270  RET	1	R7
+      0x7002000E,  //  0271  JMP		#0281
+      0x1C1C0D0D,  //  0272  EQ	R7	R6	K13
+      0x781E0005,  //  0273  JMPF	R7	#027A
+      0x8C1C0906,  //  0274  GETMET	R7	R4	K6
+      0x8824090E,  //  0275  GETMBR	R9	R4	K14
+      0x58280009,  //  0276  LDCONST	R10	K9
+      0x7C1C0600,  //  0277  CALL	R7	3
+      0x80040E00,  //  0278  RET	1	R7
+      0x70020006,  //  0279  JMP		#0281
+      0x1C1C0D0F,  //  027A  EQ	R7	R6	K15
+      0x781E0004,  //  027B  JMPF	R7	#0281
+      0x8C1C0906,  //  027C  GETMET	R7	R4	K6
+      0x88240918,  //  027D  GETMBR	R9	R4	K24
+      0x4C280000,  //  027E  LDNIL	R10
+      0x7C1C0600,  //  027F  CALL	R7	3
+      0x80040E00,  //  0280  RET	1	R7
+      0x700200A4,  //  0281  JMP		#0327
+      0x541E002A,  //  0282  LDINT	R7	43
+      0x1C1C0A07,  //  0283  EQ	R7	R5	R7
+      0x781E0016,  //  0284  JMPF	R7	#029C
+      0x1C1C0D05,  //  0285  EQ	R7	R6	K5
+      0x781E0007,  //  0286  JMPF	R7	#028F
+      0x8C1C0906,  //  0287  GETMET	R7	R4	K6
+      0x88240916,  //  0288  GETMBR	R9	R4	K22
+      0xB82A2400,  //  0289  GETNGBL	R10	K18
+      0x8C28154B,  //  028A  GETMET	R10	R10	K75
+      0x7C280200,  //  028B  CALL	R10	1
+      0x7C1C0600,  //  028C  CALL	R7	3
+      0x80040E00,  //  028D  RET	1	R7
+      0x7002000B,  //  028E  JMP		#029B
+      0x1C1C0D09,  //  028F  EQ	R7	R6	K9
+      0x781E0009,  //  0290  JMPF	R7	#029B
+      0x8C1C0911,  //  0291  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0292  CALL	R7	1
+      0x8C200F0B,  //  0293  GETMET	R8	R7	K11
+      0x4C280000,  //  0294  LDNIL	R10
+      0x882C0916,  //  0295  GETMBR	R11	R4	K22
+      0xB8322400,  //  0296  GETNGBL	R12	K18
+      0x8C30194B,  //  0297  GETMET	R12	R12	K75
+      0x7C300200,  //  0298  CALL	R12	1
+      0x7C200800,  //  0299  CALL	R8	4
+      0x80040E00,  //  029A  RET	1	R7
+      0x7002008A,  //  029B  JMP		#0327
+      0x541E002B,  //  029C  LDINT	R7	44
+      0x1C1C0A07,  //  029D  EQ	R7	R5	R7
+      0x781E001C,  //  029E  JMPF	R7	#02BC
+      0x1C1C0D05,  //  029F  EQ	R7	R6	K5
+      0x781E0005,  //  02A0  JMPF	R7	#02A7
+      0x8C1C0906,  //  02A1  GETMET	R7	R4	K6
+      0x8824090E,  //  02A2  GETMBR	R9	R4	K14
+      0x58280009,  //  02A3  LDCONST	R10	K9
+      0x7C1C0600,  //  02A4  CALL	R7	3
+      0x80040E00,  //  02A5  RET	1	R7
+      0x70020013,  //  02A6  JMP		#02BB
+      0x1C1C0D09,  //  02A7  EQ	R7	R6	K9
+      0x781E0005,  //  02A8  JMPF	R7	#02AF
+      0x8C1C0906,  //  02A9  GETMET	R7	R4	K6
+      0x8824090E,  //  02AA  GETMBR	R9	R4	K14
+      0x542A0003,  //  02AB  LDINT	R10	4
+      0x7C1C0600,  //  02AC  CALL	R7	3
+      0x80040E00,  //  02AD  RET	1	R7
+      0x7002000B,  //  02AE  JMP		#02BB
+      0x1C1C0D0D,  //  02AF  EQ	R7	R6	K13
+      0x781E0009,  //  02B0  JMPF	R7	#02BB
+      0x8C1C0911,  //  02B1  GETMET	R7	R4	K17
+      0x7C1C0200,  //  02B2  CALL	R7	1
+      0x8C200F0B,  //  02B3  GETMET	R8	R7	K11
+      0x4C280000,  //  02B4  LDNIL	R10
+      0x8C2C0906,  //  02B5  GETMET	R11	R4	K6
+      0x8834090E,  //  02B6  GETMBR	R13	R4	K14
+      0x543A0003,  //  02B7  LDINT	R14	4
+      0x7C2C0600,  //  02B8  CALL	R11	3
+      0x7C200600,  //  02B9  CALL	R8	3
+      0x80040E00,  //  02BA  RET	1	R7
+      0x7002006A,  //  02BB  JMP		#0327
+      0x541E0030,  //  02BC  LDINT	R7	49
+      0x1C1C0A07,  //  02BD  EQ	R7	R5	R7
+      0x781E0010,  //  02BE  JMPF	R7	#02D0
+      0x1C1C0D0F,  //  02BF  EQ	R7	R6	K15
+      0x781E0005,  //  02C0  JMPF	R7	#02C7
+      0x8C1C0906,  //  02C1  GETMET	R7	R4	K6
+      0x8824090E,  //  02C2  GETMBR	R9	R4	K14
+      0x542A001D,  //  02C3  LDINT	R10	30
+      0x7C1C0600,  //  02C4  CALL	R7	3
+      0x80040E00,  //  02C5  RET	1	R7
+      0x70020007,  //  02C6  JMP		#02CF
+      0x541EFFFB,  //  02C7  LDINT	R7	65532
+      0x1C1C0C07,  //  02C8  EQ	R7	R6	R7
+      0x781E0004,  //  02C9  JMPF	R7	#02CF
+      0x8C1C0906,  //  02CA  GETMET	R7	R4	K6
+      0x8824092A,  //  02CB  GETMBR	R9	R4	K42
+      0x58280005,  //  02CC  LDCONST	R10	K5
+      0x7C1C0600,  //  02CD  CALL	R7	3
+      0x80040E00,  //  02CE  RET	1	R7
+      0x70020056,  //  02CF  JMP		#0327
+      0x541E001C,  //  02D0  LDINT	R7	29
+      0x1C1C0A07,  //  02D1  EQ	R7	R5	R7
+      0x781E0050,  //  02D2  JMPF	R7	#0324
+      0x1C1C0D05,  //  02D3  EQ	R7	R6	K5
+      0x781E0019,  //  02D4  JMPF	R7	#02EF
+      0x8C1C0911,  //  02D5  GETMET	R7	R4	K17
+      0x7C1C0200,  //  02D6  CALL	R7	1
+      0x60200010,  //  02D7  GETGBL	R8	G16
+      0x8824014C,  //  02D8  GETMBR	R9	R0	K76
+      0x7C200200,  //  02D9  CALL	R8	1
+      0xA802000E,  //  02DA  EXBLK	0	#02EA
+      0x5C241000,  //  02DB  MOVE	R9	R8
+      0x7C240000,  //  02DC  CALL	R9	0
+      0x8C280F15,  //  02DD  GETMET	R10	R7	K21
+      0x7C280200,  //  02DE  CALL	R10	1
+      0x8C2C150B,  //  02DF  GETMET	R11	R10	K11
+      0x58340005,  //  02E0  LDCONST	R13	K5
+      0x8838090C,  //  02E1  GETMBR	R14	R4	K12
+      0x5C3C1200,  //  02E2  MOVE	R15	R9
+      0x7C2C0800,  //  02E3  CALL	R11	4
+      0x8C2C150B,  //  02E4  GETMET	R11	R10	K11
+      0x58340009,  //  02E5  LDCONST	R13	K9
+      0x8838090C,  //  02E6  GETMBR	R14	R4	K12
+      0x583C0009,  //  02E7  LDCONST	R15	K9
+      0x7C2C0800,  //  02E8  CALL	R11	4
+      0x7001FFF0,  //  02E9  JMP		#02DB
+      0x58200039,  //  02EA  LDCONST	R8	K57
+      0xAC200200,  //  02EB  CATCH	R8	1	0
+      0xB0080000,  //  02EC  RAISE	2	R0	R0
+      0x80040E00,  //  02ED  RET	1	R7
+      0x70020033,  //  02EE  JMP		#0323
+      0x1C1C0D09,  //  02EF  EQ	R7	R6	K9
+      0x781E0013,  //  02F0  JMPF	R7	#0305
+      0x8C1C0911,  //  02F1  GETMET	R7	R4	K17
+      0x7C1C0200,  //  02F2  CALL	R7	1
+      0x60200010,  //  02F3  GETGBL	R8	G16
+      0x8C24014D,  //  02F4  GETMET	R9	R0	K77
+      0x7C240200,  //  02F5  CALL	R9	1
+      0x7C200200,  //  02F6  CALL	R8	1
+      0xA8020007,  //  02F7  EXBLK	0	#0300
+      0x5C241000,  //  02F8  MOVE	R9	R8
+      0x7C240000,  //  02F9  CALL	R9	0
+      0x8C280F0B,  //  02FA  GETMET	R10	R7	K11
+      0x4C300000,  //  02FB  LDNIL	R12
+      0x8834092A,  //  02FC  GETMBR	R13	R4	K42
+      0x5C381200,  //  02FD  MOVE	R14	R9
+      0x7C280800,  //  02FE  CALL	R10	4
+      0x7001FFF7,  //  02FF  JMP		#02F8
+      0x58200039,  //  0300  LDCONST	R8	K57
+      0xAC200200,  //  0301  CATCH	R8	1	0
+      0xB0080000,  //  0302  RAISE	2	R0	R0
+      0x80040E00,  //  0303  RET	1	R7
+      0x7002001D,  //  0304  JMP		#0323
+      0x1C1C0D0D,  //  0305  EQ	R7	R6	K13
+      0x781E0003,  //  0306  JMPF	R7	#030B
+      0x8C1C0911,  //  0307  GETMET	R7	R4	K17
+      0x7C1C0200,  //  0308  CALL	R7	1
+      0x80040E00,  //  0309  RET	1	R7
+      0x70020017,  //  030A  JMP		#0323
+      0x1C1C0D0F,  //  030B  EQ	R7	R6	K15
+      0x781E0015,  //  030C  JMPF	R7	#0323
+      0x881C0133,  //  030D  GETMBR	R7	R0	K51
+      0x8C1C0F4E,  //  030E  GETMET	R7	R7	K78
+      0x50240200,  //  030F  LDBOOL	R9	1	0
+      0x7C1C0400,  //  0310  CALL	R7	2
+      0x8C200911,  //  0311  GETMET	R8	R4	K17
+      0x7C200200,  //  0312  CALL	R8	1
+      0x60240010,  //  0313  GETGBL	R9	G16
+      0x5C280E00,  //  0314  MOVE	R10	R7
+      0x7C240200,  //  0315  CALL	R9	1
+      0xA8020007,  //  0316  EXBLK	0	#031F
+      0x5C281200,  //  0317  MOVE	R10	R9
+      0x7C280000,  //  0318  CALL	R10	0
+      0x8C2C110B,  //  0319  GETMET	R11	R8	K11
+      0x4C340000,  //  031A  LDNIL	R13
+      0x8838090C,  //  031B  GETMBR	R14	R4	K12
+      0x5C3C1400,  //  031C  MOVE	R15	R10
+      0x7C2C0800,  //  031D  CALL	R11	4
+      0x7001FFF7,  //  031E  JMP		#0317
+      0x58240039,  //  031F  LDCONST	R9	K57
+      0xAC240200,  //  0320  CATCH	R9	1	0
+      0xB0080000,  //  0321  RAISE	2	R0	R0
+      0x80041000,  //  0322  RET	1	R8
+      0x70020002,  //  0323  JMP		#0327
+      0xB81E0200,  //  0324  GETNGBL	R7	K1
+      0x881C0F50,  //  0325  GETMBR	R7	R7	K80
+      0x900A9E07,  //  0326  SETMBR	R2	K79	R7
+      0x80000000,  //  0327  RET	0
     })
   )
 );
@@ -926,7 +924,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    13,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -934,7 +932,7 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
@@ -943,16 +941,17 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
     /* K5   */  be_const_int(0),
     /* K6   */  be_nested_str_weak(int),
     /* K7   */  be_nested_str_weak(int64),
-    /* K8   */  be_nested_str_weak(session),
-    /* K9   */  be_nested_str_weak(__breadcrumb),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_nested_str_weak(INVALID_ACTION),
+    /* K8   */  be_nested_str_weak(__breadcrumb),
+    /* K9   */  be_nested_str_weak(attribute_updated),
+    /* K10  */  be_nested_str_weak(endpoint),
+    /* K11  */  be_nested_str_weak(status),
+    /* K12  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K13  */  be_const_int(1),
+    /* K14  */  be_nested_str_weak(INVALID_ACTION),
     }),
     be_str_weak(write_attribute),
     &be_const_str_solidified,
-    ( &(const binstruction[98]) {  /* code */
+    ( &(const binstruction[102]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
@@ -960,9 +959,9 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
       0x881C0504,  //  0004  GETMBR	R7	R2	K4
       0x5422002F,  //  0005  LDINT	R8	48
       0x1C200C08,  //  0006  EQ	R8	R6	R8
-      0x78220016,  //  0007  JMPF	R8	#001F
+      0x7822001A,  //  0007  JMPF	R8	#0023
       0x1C200F05,  //  0008  EQ	R8	R7	K5
-      0x78220013,  //  0009  JMPF	R8	#001E
+      0x78220017,  //  0009  JMPF	R8	#0022
       0x60200004,  //  000A  GETGBL	R8	G4
       0x5C240600,  //  000B  MOVE	R9	R3
       0x7C200200,  //  000C  CALL	R8	1
@@ -972,85 +971,89 @@ be_local_closure(Matter_Plugin_Root_write_attribute,   /* name */
       0x5C240600,  //  0010  MOVE	R9	R3
       0xB82A0E00,  //  0011  GETNGBL	R10	K7
       0x7C200400,  //  0012  CALL	R8	2
-      0x78220004,  //  0013  JMPF	R8	#0019
-      0x88200308,  //  0014  GETMBR	R8	R1	K8
-      0x90221203,  //  0015  SETMBR	R8	K9	R3
-      0x50200200,  //  0016  LDBOOL	R8	1	0
-      0x80041000,  //  0017  RET	1	R8
-      0x70020004,  //  0018  JMP		#001E
-      0xB8220200,  //  0019  GETNGBL	R8	K1
-      0x8820110B,  //  001A  GETMBR	R8	R8	K11
-      0x900A1408,  //  001B  SETMBR	R2	K10	R8
-      0x50200000,  //  001C  LDBOOL	R8	0	0
-      0x80041000,  //  001D  RET	1	R8
-      0x70020041,  //  001E  JMP		#0061
-      0x5422001E,  //  001F  LDINT	R8	31
-      0x1C200C08,  //  0020  EQ	R8	R6	R8
-      0x78220004,  //  0021  JMPF	R8	#0027
-      0x1C200F05,  //  0022  EQ	R8	R7	K5
-      0x78220001,  //  0023  JMPF	R8	#0026
-      0x50200200,  //  0024  LDBOOL	R8	1	0
-      0x80041000,  //  0025  RET	1	R8
-      0x70020039,  //  0026  JMP		#0061
-      0x54220027,  //  0027  LDINT	R8	40
-      0x1C200C08,  //  0028  EQ	R8	R6	R8
-      0x7822000B,  //  0029  JMPF	R8	#0036
-      0x54220004,  //  002A  LDINT	R8	5
-      0x1C200E08,  //  002B  EQ	R8	R7	R8
-      0x78220002,  //  002C  JMPF	R8	#0030
-      0x50200200,  //  002D  LDBOOL	R8	1	0
-      0x80041000,  //  002E  RET	1	R8
-      0x70020004,  //  002F  JMP		#0035
-      0x54220005,  //  0030  LDINT	R8	6
-      0x1C200E08,  //  0031  EQ	R8	R7	R8
-      0x78220001,  //  0032  JMPF	R8	#0035
-      0x50200200,  //  0033  LDBOOL	R8	1	0
-      0x80041000,  //  0034  RET	1	R8
-      0x7002002A,  //  0035  JMP		#0061
-      0x54220029,  //  0036  LDINT	R8	42
-      0x1C200C08,  //  0037  EQ	R8	R6	R8
-      0x78220004,  //  0038  JMPF	R8	#003E
-      0x1C200F05,  //  0039  EQ	R8	R7	K5
-      0x78220001,  //  003A  JMPF	R8	#003D
-      0x50200200,  //  003B  LDBOOL	R8	1	0
-      0x80041000,  //  003C  RET	1	R8
-      0x70020022,  //  003D  JMP		#0061
-      0x5422002A,  //  003E  LDINT	R8	43
-      0x1C200C08,  //  003F  EQ	R8	R6	R8
-      0x78220007,  //  0040  JMPF	R8	#0049
-      0x1C200F05,  //  0041  EQ	R8	R7	K5
-      0x78220004,  //  0042  JMPF	R8	#0048
-      0xB8220200,  //  0043  GETNGBL	R8	K1
-      0x8820110B,  //  0044  GETMBR	R8	R8	K11
-      0x900A1408,  //  0045  SETMBR	R2	K10	R8
-      0x50200000,  //  0046  LDBOOL	R8	0	0
-      0x80041000,  //  0047  RET	1	R8
-      0x70020017,  //  0048  JMP		#0061
-      0x5422002B,  //  0049  LDINT	R8	44
-      0x1C200C08,  //  004A  EQ	R8	R6	R8
-      0x78220009,  //  004B  JMPF	R8	#0056
-      0x1C200F05,  //  004C  EQ	R8	R7	K5
-      0x78220002,  //  004D  JMPF	R8	#0051
-      0x50200200,  //  004E  LDBOOL	R8	1	0
-      0x80041000,  //  004F  RET	1	R8
-      0x70020003,  //  0050  JMP		#0055
-      0x1C200F0C,  //  0051  EQ	R8	R7	K12
-      0x78220001,  //  0052  JMPF	R8	#0055
-      0x50200200,  //  0053  LDBOOL	R8	1	0
-      0x80041000,  //  0054  RET	1	R8
-      0x7002000A,  //  0055  JMP		#0061
-      0x54220030,  //  0056  LDINT	R8	49
-      0x1C200C08,  //  0057  EQ	R8	R6	R8
-      0x78220007,  //  0058  JMPF	R8	#0061
-      0x54220003,  //  0059  LDINT	R8	4
-      0x1C200E08,  //  005A  EQ	R8	R7	R8
-      0x78220004,  //  005B  JMPF	R8	#0061
-      0xB8220200,  //  005C  GETNGBL	R8	K1
-      0x8820110D,  //  005D  GETMBR	R8	R8	K13
-      0x900A1408,  //  005E  SETMBR	R2	K10	R8
-      0x50200000,  //  005F  LDBOOL	R8	0	0
-      0x80041000,  //  0060  RET	1	R8
-      0x80000000,  //  0061  RET	0
+      0x78220008,  //  0013  JMPF	R8	#001D
+      0x90061003,  //  0014  SETMBR	R1	K8	R3
+      0x8C200109,  //  0015  GETMET	R8	R0	K9
+      0x8828050A,  //  0016  GETMBR	R10	R2	K10
+      0x882C0503,  //  0017  GETMBR	R11	R2	K3
+      0x88300504,  //  0018  GETMBR	R12	R2	K4
+      0x7C200800,  //  0019  CALL	R8	4
+      0x50200200,  //  001A  LDBOOL	R8	1	0
+      0x80041000,  //  001B  RET	1	R8
+      0x70020004,  //  001C  JMP		#0022
+      0xB8220200,  //  001D  GETNGBL	R8	K1
+      0x8820110C,  //  001E  GETMBR	R8	R8	K12
+      0x900A1608,  //  001F  SETMBR	R2	K11	R8
+      0x50200000,  //  0020  LDBOOL	R8	0	0
+      0x80041000,  //  0021  RET	1	R8
+      0x70020041,  //  0022  JMP		#0065
+      0x5422001E,  //  0023  LDINT	R8	31
+      0x1C200C08,  //  0024  EQ	R8	R6	R8
+      0x78220004,  //  0025  JMPF	R8	#002B
+      0x1C200F05,  //  0026  EQ	R8	R7	K5
+      0x78220001,  //  0027  JMPF	R8	#002A
+      0x50200200,  //  0028  LDBOOL	R8	1	0
+      0x80041000,  //  0029  RET	1	R8
+      0x70020039,  //  002A  JMP		#0065
+      0x54220027,  //  002B  LDINT	R8	40
+      0x1C200C08,  //  002C  EQ	R8	R6	R8
+      0x7822000B,  //  002D  JMPF	R8	#003A
+      0x54220004,  //  002E  LDINT	R8	5
+      0x1C200E08,  //  002F  EQ	R8	R7	R8
+      0x78220002,  //  0030  JMPF	R8	#0034
+      0x50200200,  //  0031  LDBOOL	R8	1	0
+      0x80041000,  //  0032  RET	1	R8
+      0x70020004,  //  0033  JMP		#0039
+      0x54220005,  //  0034  LDINT	R8	6
+      0x1C200E08,  //  0035  EQ	R8	R7	R8
+      0x78220001,  //  0036  JMPF	R8	#0039
+      0x50200200,  //  0037  LDBOOL	R8	1	0
+      0x80041000,  //  0038  RET	1	R8
+      0x7002002A,  //  0039  JMP		#0065
+      0x54220029,  //  003A  LDINT	R8	42
+      0x1C200C08,  //  003B  EQ	R8	R6	R8
+      0x78220004,  //  003C  JMPF	R8	#0042
+      0x1C200F05,  //  003D  EQ	R8	R7	K5
+      0x78220001,  //  003E  JMPF	R8	#0041
+      0x50200200,  //  003F  LDBOOL	R8	1	0
+      0x80041000,  //  0040  RET	1	R8
+      0x70020022,  //  0041  JMP		#0065
+      0x5422002A,  //  0042  LDINT	R8	43
+      0x1C200C08,  //  0043  EQ	R8	R6	R8
+      0x78220007,  //  0044  JMPF	R8	#004D
+      0x1C200F05,  //  0045  EQ	R8	R7	K5
+      0x78220004,  //  0046  JMPF	R8	#004C
+      0xB8220200,  //  0047  GETNGBL	R8	K1
+      0x8820110C,  //  0048  GETMBR	R8	R8	K12
+      0x900A1608,  //  0049  SETMBR	R2	K11	R8
+      0x50200000,  //  004A  LDBOOL	R8	0	0
+      0x80041000,  //  004B  RET	1	R8
+      0x70020017,  //  004C  JMP		#0065
+      0x5422002B,  //  004D  LDINT	R8	44
+      0x1C200C08,  //  004E  EQ	R8	R6	R8
+      0x78220009,  //  004F  JMPF	R8	#005A
+      0x1C200F05,  //  0050  EQ	R8	R7	K5
+      0x78220002,  //  0051  JMPF	R8	#0055
+      0x50200200,  //  0052  LDBOOL	R8	1	0
+      0x80041000,  //  0053  RET	1	R8
+      0x70020003,  //  0054  JMP		#0059
+      0x1C200F0D,  //  0055  EQ	R8	R7	K13
+      0x78220001,  //  0056  JMPF	R8	#0059
+      0x50200200,  //  0057  LDBOOL	R8	1	0
+      0x80041000,  //  0058  RET	1	R8
+      0x7002000A,  //  0059  JMP		#0065
+      0x54220030,  //  005A  LDINT	R8	49
+      0x1C200C08,  //  005B  EQ	R8	R6	R8
+      0x78220007,  //  005C  JMPF	R8	#0065
+      0x54220003,  //  005D  LDINT	R8	4
+      0x1C200E08,  //  005E  EQ	R8	R7	R8
+      0x78220004,  //  005F  JMPF	R8	#0065
+      0xB8220200,  //  0060  GETNGBL	R8	K1
+      0x8820110E,  //  0061  GETMBR	R8	R8	K14
+      0x900A1608,  //  0062  SETMBR	R2	K11	R8
+      0x50200000,  //  0063  LDBOOL	R8	0	0
+      0x80041000,  //  0064  RET	1	R8
+      0x80000000,  //  0065  RET	0
     })
   )
 );
@@ -1102,7 +1105,7 @@ be_local_closure(Matter_Plugin_Root_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
   be_nested_proto(
-    29,                          /* nstack */
+    28,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1110,579 +1113,577 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[73]) {     /* constants */
+    ( &(const bvalue[72]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(matter),
     /* K2   */  be_nested_str_weak(TLV),
     /* K3   */  be_nested_str_weak(cluster),
     /* K4   */  be_nested_str_weak(command),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(findsubval),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(__breadcrumb),
-    /* K10  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K11  */  be_nested_str_weak(add_TLV),
-    /* K12  */  be_nested_str_weak(U1),
-    /* K13  */  be_nested_str_weak(UTF1),
-    /* K14  */  be_nested_str_weak(),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(XX),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(set_no_expiration),
-    /* K19  */  be_nested_str_weak(device),
-    /* K20  */  be_nested_str_weak(start_commissioning_complete_deferred),
-    /* K21  */  be_nested_str_weak(status),
-    /* K22  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K23  */  be_nested_str_weak(B2),
-    /* K24  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
-    /* K25  */  be_nested_str_weak(PAI_Cert_FFF1),
-    /* K26  */  be_nested_str_weak(CD_FFF1_8000),
-    /* K27  */  be_nested_str_weak(B1),
-    /* K28  */  be_nested_str_weak(U4),
-    /* K29  */  be_nested_str_weak(tasmota),
-    /* K30  */  be_nested_str_weak(rtc),
-    /* K31  */  be_nested_str_weak(utc),
-    /* K32  */  be_nested_str_weak(encode),
-    /* K33  */  be_nested_str_weak(get_ac),
-    /* K34  */  be_nested_str_weak(log),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20attestation_tbs_X3D),
-    /* K36  */  be_nested_str_weak(tohex),
-    /* K37  */  be_nested_str_weak(EC_P256),
-    /* K38  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K39  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
-    /* K40  */  be_nested_str_weak(gen_CSR),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20nocsr_tbs_X3D),
-    /* K42  */  be_nested_str_weak(set_ca),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20received_X20ca_root_X3D),
-    /* K44  */  be_nested_str_weak(SUCCESS),
-    /* K45  */  be_nested_str_weak(get_ca),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
-    /* K47  */  be_nested_str_weak(set_noc),
-    /* K48  */  be_nested_str_weak(set_ipk_epoch_key),
-    /* K49  */  be_nested_str_weak(admin_subject),
-    /* K50  */  be_nested_str_weak(admin_vendor),
-    /* K51  */  be_nested_str_weak(parse),
-    /* K52  */  be_nested_str_weak(findsub),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
-    /* K54  */  be_nested_str_weak(int),
-    /* K55  */  be_nested_str_weak(int64),
-    /* K56  */  be_nested_str_weak(tobytes),
-    /* K57  */  be_const_int(2147483647),
-    /* K58  */  be_nested_str_weak(fromstring),
-    /* K59  */  be_nested_str_weak(CompressedFabric),
-    /* K60  */  be_nested_str_weak(HKDF_SHA256),
-    /* K61  */  be_nested_str_weak(copy),
-    /* K62  */  be_nested_str_weak(reverse),
-    /* K63  */  be_nested_str_weak(derive),
-    /* K64  */  be_nested_str_weak(set_fabric_device),
-    /* K65  */  be_nested_str_weak(start_operational_dicovery_deferred),
-    /* K66  */  be_nested_str_weak(set_fabric_label),
-    /* K67  */  be_nested_str_weak(sessions),
-    /* K68  */  be_nested_str_weak(sessions_active),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K70  */  be_nested_str_weak(fabric),
-    /* K71  */  be_nested_str_weak(remove_session),
-    /* K72  */  be_nested_str_weak(save),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(findsubval),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(__breadcrumb),
+    /* K9   */  be_nested_str_weak(Matter_TLV_struct),
+    /* K10  */  be_nested_str_weak(add_TLV),
+    /* K11  */  be_nested_str_weak(U1),
+    /* K12  */  be_nested_str_weak(UTF1),
+    /* K13  */  be_nested_str_weak(),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(XX),
+    /* K16  */  be_const_int(3),
+    /* K17  */  be_nested_str_weak(set_no_expiration),
+    /* K18  */  be_nested_str_weak(device),
+    /* K19  */  be_nested_str_weak(start_commissioning_complete_deferred),
+    /* K20  */  be_nested_str_weak(status),
+    /* K21  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K22  */  be_nested_str_weak(B2),
+    /* K23  */  be_nested_str_weak(DAC_Cert_FFF1_8000),
+    /* K24  */  be_nested_str_weak(PAI_Cert_FFF1),
+    /* K25  */  be_nested_str_weak(CD_FFF1_8000),
+    /* K26  */  be_nested_str_weak(B1),
+    /* K27  */  be_nested_str_weak(U4),
+    /* K28  */  be_nested_str_weak(tasmota),
+    /* K29  */  be_nested_str_weak(rtc),
+    /* K30  */  be_nested_str_weak(utc),
+    /* K31  */  be_nested_str_weak(encode),
+    /* K32  */  be_nested_str_weak(get_ac),
+    /* K33  */  be_nested_str_weak(log),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20attestation_tbs_X3D),
+    /* K35  */  be_nested_str_weak(tohex),
+    /* K36  */  be_nested_str_weak(EC_P256),
+    /* K37  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K38  */  be_nested_str_weak(DAC_Priv_FFF1_8000),
+    /* K39  */  be_nested_str_weak(gen_CSR),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20nocsr_tbs_X3D),
+    /* K41  */  be_nested_str_weak(set_ca),
+    /* K42  */  be_nested_str_weak(MTR_X3A_X20received_X20ca_root_X3D),
+    /* K43  */  be_nested_str_weak(SUCCESS),
+    /* K44  */  be_nested_str_weak(get_ca),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20AdNOC_X20without_X20CA),
+    /* K46  */  be_nested_str_weak(set_noc),
+    /* K47  */  be_nested_str_weak(set_ipk_epoch_key),
+    /* K48  */  be_nested_str_weak(admin_subject),
+    /* K49  */  be_nested_str_weak(admin_vendor),
+    /* K50  */  be_nested_str_weak(parse),
+    /* K51  */  be_nested_str_weak(findsub),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20Error_X3A_X20no_X20fabricid_X20nor_X20deviceid_X20in_X20NOC_X20certificate),
+    /* K53  */  be_nested_str_weak(int),
+    /* K54  */  be_nested_str_weak(int64),
+    /* K55  */  be_nested_str_weak(tobytes),
+    /* K56  */  be_const_int(2147483647),
+    /* K57  */  be_nested_str_weak(fromstring),
+    /* K58  */  be_nested_str_weak(CompressedFabric),
+    /* K59  */  be_nested_str_weak(HKDF_SHA256),
+    /* K60  */  be_nested_str_weak(copy),
+    /* K61  */  be_nested_str_weak(reverse),
+    /* K62  */  be_nested_str_weak(derive),
+    /* K63  */  be_nested_str_weak(set_fabric_device),
+    /* K64  */  be_nested_str_weak(start_operational_dicovery_deferred),
+    /* K65  */  be_nested_str_weak(set_fabric_label),
+    /* K66  */  be_nested_str_weak(sessions),
+    /* K67  */  be_nested_str_weak(sessions_active),
+    /* K68  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K69  */  be_nested_str_weak(fabric),
+    /* K70  */  be_nested_str_weak(remove_session),
+    /* K71  */  be_nested_str_weak(save),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[495]) {  /* code */
+    ( &(const binstruction[494]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xB8160200,  //  0001  GETNGBL	R5	K1
       0x88140B02,  //  0002  GETMBR	R5	R5	K2
       0x88180703,  //  0003  GETMBR	R6	R3	K3
       0x881C0704,  //  0004  GETMBR	R7	R3	K4
-      0x88200305,  //  0005  GETMBR	R8	R1	K5
-      0x5426002F,  //  0006  LDINT	R9	48
-      0x1C240C09,  //  0007  EQ	R9	R6	R9
-      0x78260050,  //  0008  JMPF	R9	#005A
-      0x1C240F06,  //  0009  EQ	R9	R7	K6
-      0x78260017,  //  000A  JMPF	R9	#0023
-      0x8C240507,  //  000B  GETMET	R9	R2	K7
-      0x582C0006,  //  000C  LDCONST	R11	K6
-      0x54320383,  //  000D  LDINT	R12	900
-      0x7C240600,  //  000E  CALL	R9	3
-      0x8C280507,  //  000F  GETMET	R10	R2	K7
-      0x58300008,  //  0010  LDCONST	R12	K8
-      0x58340006,  //  0011  LDCONST	R13	K6
-      0x7C280600,  //  0012  CALL	R10	3
-      0x9022120A,  //  0013  SETMBR	R8	K9	R10
-      0x8C2C0B0A,  //  0014  GETMET	R11	R5	K10
-      0x7C2C0200,  //  0015  CALL	R11	1
-      0x8C30170B,  //  0016  GETMET	R12	R11	K11
-      0x58380006,  //  0017  LDCONST	R14	K6
-      0x883C0B0C,  //  0018  GETMBR	R15	R5	K12
-      0x58400006,  //  0019  LDCONST	R16	K6
-      0x7C300800,  //  001A  CALL	R12	4
-      0x8C30170B,  //  001B  GETMET	R12	R11	K11
-      0x58380008,  //  001C  LDCONST	R14	K8
-      0x883C0B0D,  //  001D  GETMBR	R15	R5	K13
-      0x5840000E,  //  001E  LDCONST	R16	K14
-      0x7C300800,  //  001F  CALL	R12	4
-      0x900E0908,  //  0020  SETMBR	R3	K4	K8
-      0x80041600,  //  0021  RET	1	R11
-      0x70020035,  //  0022  JMP		#0059
-      0x1C240F0F,  //  0023  EQ	R9	R7	K15
-      0x7826001A,  //  0024  JMPF	R9	#0040
-      0x8C240507,  //  0025  GETMET	R9	R2	K7
-      0x582C0006,  //  0026  LDCONST	R11	K6
-      0x7C240400,  //  0027  CALL	R9	2
-      0x8C280507,  //  0028  GETMET	R10	R2	K7
-      0x58300008,  //  0029  LDCONST	R12	K8
-      0x58340010,  //  002A  LDCONST	R13	K16
-      0x7C280600,  //  002B  CALL	R10	3
-      0x8C2C0507,  //  002C  GETMET	R11	R2	K7
-      0x5834000F,  //  002D  LDCONST	R13	K15
-      0x58380006,  //  002E  LDCONST	R14	K6
-      0x7C2C0600,  //  002F  CALL	R11	3
-      0x9022120B,  //  0030  SETMBR	R8	K9	R11
-      0x8C300B0A,  //  0031  GETMET	R12	R5	K10
-      0x7C300200,  //  0032  CALL	R12	1
-      0x8C34190B,  //  0033  GETMET	R13	R12	K11
-      0x583C0006,  //  0034  LDCONST	R15	K6
-      0x88400B0C,  //  0035  GETMBR	R16	R5	K12
-      0x58440006,  //  0036  LDCONST	R17	K6
-      0x7C340800,  //  0037  CALL	R13	4
-      0x8C34190B,  //  0038  GETMET	R13	R12	K11
-      0x583C0008,  //  0039  LDCONST	R15	K8
-      0x88400B0D,  //  003A  GETMBR	R16	R5	K13
-      0x5844000E,  //  003B  LDCONST	R17	K14
-      0x7C340800,  //  003C  CALL	R13	4
-      0x900E0911,  //  003D  SETMBR	R3	K4	K17
-      0x80041800,  //  003E  RET	1	R12
-      0x70020018,  //  003F  JMP		#0059
-      0x54260003,  //  0040  LDINT	R9	4
-      0x1C240E09,  //  0041  EQ	R9	R7	R9
-      0x78260015,  //  0042  JMPF	R9	#0059
-      0x90221306,  //  0043  SETMBR	R8	K9	K6
-      0x8C241112,  //  0044  GETMET	R9	R8	K18
-      0x7C240200,  //  0045  CALL	R9	1
-      0x8C240B0A,  //  0046  GETMET	R9	R5	K10
-      0x7C240200,  //  0047  CALL	R9	1
-      0x8C28130B,  //  0048  GETMET	R10	R9	K11
-      0x58300006,  //  0049  LDCONST	R12	K6
-      0x88340B0C,  //  004A  GETMBR	R13	R5	K12
-      0x58380006,  //  004B  LDCONST	R14	K6
-      0x7C280800,  //  004C  CALL	R10	4
-      0x8C28130B,  //  004D  GETMET	R10	R9	K11
-      0x58300008,  //  004E  LDCONST	R12	K8
-      0x88340B0D,  //  004F  GETMBR	R13	R5	K13
-      0x5838000E,  //  0050  LDCONST	R14	K14
-      0x7C280800,  //  0051  CALL	R10	4
-      0x542A0004,  //  0052  LDINT	R10	5
-      0x900E080A,  //  0053  SETMBR	R3	K4	R10
-      0x88280113,  //  0054  GETMBR	R10	R0	K19
-      0x8C281514,  //  0055  GETMET	R10	R10	K20
-      0x5C301000,  //  0056  MOVE	R12	R8
-      0x7C280400,  //  0057  CALL	R10	2
-      0x80041200,  //  0058  RET	1	R9
-      0x70020193,  //  0059  JMP		#01EE
-      0x5426003D,  //  005A  LDINT	R9	62
-      0x1C240C09,  //  005B  EQ	R9	R6	R9
-      0x78260190,  //  005C  JMPF	R9	#01EE
-      0x1C240F0F,  //  005D  EQ	R9	R7	K15
-      0x7826001D,  //  005E  JMPF	R9	#007D
-      0x8C240507,  //  005F  GETMET	R9	R2	K7
-      0x582C0006,  //  0060  LDCONST	R11	K6
-      0x7C240400,  //  0061  CALL	R9	2
-      0x20281308,  //  0062  NE	R10	R9	K8
-      0x782A0006,  //  0063  JMPF	R10	#006B
-      0x2028130F,  //  0064  NE	R10	R9	K15
-      0x782A0004,  //  0065  JMPF	R10	#006B
-      0xB82A0200,  //  0066  GETNGBL	R10	K1
-      0x88281516,  //  0067  GETMBR	R10	R10	K22
-      0x900E2A0A,  //  0068  SETMBR	R3	K21	R10
-      0x4C280000,  //  0069  LDNIL	R10
-      0x80041400,  //  006A  RET	1	R10
-      0x8C280B0A,  //  006B  GETMET	R10	R5	K10
-      0x7C280200,  //  006C  CALL	R10	1
-      0x8C2C150B,  //  006D  GETMET	R11	R10	K11
-      0x58340006,  //  006E  LDCONST	R13	K6
-      0x88380B17,  //  006F  GETMBR	R14	R5	K23
-      0x1C3C1308,  //  0070  EQ	R15	R9	K8
-      0x783E0003,  //  0071  JMPF	R15	#0076
-      0xB83E0200,  //  0072  GETNGBL	R15	K1
-      0x8C3C1F18,  //  0073  GETMET	R15	R15	K24
-      0x7C3C0200,  //  0074  CALL	R15	1
-      0x70020002,  //  0075  JMP		#0079
-      0xB83E0200,  //  0076  GETNGBL	R15	K1
-      0x8C3C1F19,  //  0077  GETMET	R15	R15	K25
-      0x7C3C0200,  //  0078  CALL	R15	1
-      0x7C2C0800,  //  0079  CALL	R11	4
-      0x900E0911,  //  007A  SETMBR	R3	K4	K17
-      0x80041400,  //  007B  RET	1	R10
-      0x70020170,  //  007C  JMP		#01EE
-      0x1C240F06,  //  007D  EQ	R9	R7	K6
-      0x78260044,  //  007E  JMPF	R9	#00C4
-      0x8C240507,  //  007F  GETMET	R9	R2	K7
-      0x582C0006,  //  0080  LDCONST	R11	K6
-      0x7C240400,  //  0081  CALL	R9	2
-      0x6028000C,  //  0082  GETGBL	R10	G12
-      0x5C2C1200,  //  0083  MOVE	R11	R9
-      0x7C280200,  //  0084  CALL	R10	1
-      0x542E001F,  //  0085  LDINT	R11	32
-      0x2028140B,  //  0086  NE	R10	R10	R11
-      0x782A0001,  //  0087  JMPF	R10	#008A
-      0x4C280000,  //  0088  LDNIL	R10
-      0x80041400,  //  0089  RET	1	R10
-      0x900E0908,  //  008A  SETMBR	R3	K4	K8
-      0x8C280B0A,  //  008B  GETMET	R10	R5	K10
-      0x7C280200,  //  008C  CALL	R10	1
-      0x8C2C150B,  //  008D  GETMET	R11	R10	K11
-      0x58340008,  //  008E  LDCONST	R13	K8
-      0x88380B17,  //  008F  GETMBR	R14	R5	K23
-      0xB83E0200,  //  0090  GETNGBL	R15	K1
-      0x8C3C1F1A,  //  0091  GETMET	R15	R15	K26
-      0x7C3C0200,  //  0092  CALL	R15	1
-      0x7C2C0800,  //  0093  CALL	R11	4
-      0x8C2C150B,  //  0094  GETMET	R11	R10	K11
-      0x5834000F,  //  0095  LDCONST	R13	K15
-      0x88380B1B,  //  0096  GETMBR	R14	R5	K27
-      0x5C3C1200,  //  0097  MOVE	R15	R9
-      0x7C2C0800,  //  0098  CALL	R11	4
-      0x8C2C150B,  //  0099  GETMET	R11	R10	K11
-      0x58340011,  //  009A  LDCONST	R13	K17
-      0x88380B1C,  //  009B  GETMBR	R14	R5	K28
-      0xB83E3A00,  //  009C  GETNGBL	R15	K29
-      0x8C3C1F1E,  //  009D  GETMET	R15	R15	K30
-      0x7C3C0200,  //  009E  CALL	R15	1
-      0x943C1F1F,  //  009F  GETIDX	R15	R15	K31
-      0x7C2C0800,  //  00A0  CALL	R11	4
-      0x8C2C1520,  //  00A1  GETMET	R11	R10	K32
-      0x7C2C0200,  //  00A2  CALL	R11	1
-      0x8C301121,  //  00A3  GETMET	R12	R8	K33
-      0x7C300200,  //  00A4  CALL	R12	1
-      0x0034160C,  //  00A5  ADD	R13	R11	R12
-      0xB83A3A00,  //  00A6  GETNGBL	R14	K29
-      0x8C381D22,  //  00A7  GETMET	R14	R14	K34
-      0x8C401B24,  //  00A8  GETMET	R16	R13	K36
-      0x7C400200,  //  00A9  CALL	R16	1
-      0x00424610,  //  00AA  ADD	R16	K35	R16
-      0x58440011,  //  00AB  LDCONST	R17	K17
-      0x7C380600,  //  00AC  CALL	R14	3
-      0x8C380925,  //  00AD  GETMET	R14	R4	K37
-      0x7C380200,  //  00AE  CALL	R14	1
-      0x8C381D26,  //  00AF  GETMET	R14	R14	K38
-      0xB8420200,  //  00B0  GETNGBL	R16	K1
-      0x8C402127,  //  00B1  GETMET	R16	R16	K39
-      0x7C400200,  //  00B2  CALL	R16	1
-      0x5C441A00,  //  00B3  MOVE	R17	R13
-      0x7C380600,  //  00B4  CALL	R14	3
-      0x8C3C0B0A,  //  00B5  GETMET	R15	R5	K10
-      0x7C3C0200,  //  00B6  CALL	R15	1
-      0x8C401F0B,  //  00B7  GETMET	R16	R15	K11
-      0x58480006,  //  00B8  LDCONST	R18	K6
-      0x884C0B17,  //  00B9  GETMBR	R19	R5	K23
-      0x5C501600,  //  00BA  MOVE	R20	R11
-      0x7C400800,  //  00BB  CALL	R16	4
-      0x8C401F0B,  //  00BC  GETMET	R16	R15	K11
-      0x58480008,  //  00BD  LDCONST	R18	K8
-      0x884C0B1B,  //  00BE  GETMBR	R19	R5	K27
-      0x5C501C00,  //  00BF  MOVE	R20	R14
-      0x7C400800,  //  00C0  CALL	R16	4
-      0x900E0908,  //  00C1  SETMBR	R3	K4	K8
-      0x80041E00,  //  00C2  RET	1	R15
-      0x70020129,  //  00C3  JMP		#01EE
-      0x54260003,  //  00C4  LDINT	R9	4
-      0x1C240E09,  //  00C5  EQ	R9	R7	R9
-      0x78260040,  //  00C6  JMPF	R9	#0108
-      0x8C240507,  //  00C7  GETMET	R9	R2	K7
-      0x582C0006,  //  00C8  LDCONST	R11	K6
-      0x7C240400,  //  00C9  CALL	R9	2
-      0x6028000C,  //  00CA  GETGBL	R10	G12
-      0x5C2C1200,  //  00CB  MOVE	R11	R9
-      0x7C280200,  //  00CC  CALL	R10	1
-      0x542E001F,  //  00CD  LDINT	R11	32
-      0x2028140B,  //  00CE  NE	R10	R10	R11
-      0x782A0001,  //  00CF  JMPF	R10	#00D2
-      0x4C280000,  //  00D0  LDNIL	R10
-      0x80041400,  //  00D1  RET	1	R10
-      0x8C280507,  //  00D2  GETMET	R10	R2	K7
-      0x58300008,  //  00D3  LDCONST	R12	K8
-      0x50340000,  //  00D4  LDBOOL	R13	0	0
-      0x7C280600,  //  00D5  CALL	R10	3
-      0x8C2C1128,  //  00D6  GETMET	R11	R8	K40
-      0x7C2C0200,  //  00D7  CALL	R11	1
-      0x8C300B0A,  //  00D8  GETMET	R12	R5	K10
-      0x7C300200,  //  00D9  CALL	R12	1
-      0x8C34190B,  //  00DA  GETMET	R13	R12	K11
-      0x583C0008,  //  00DB  LDCONST	R15	K8
-      0x88400B17,  //  00DC  GETMBR	R16	R5	K23
-      0x5C441600,  //  00DD  MOVE	R17	R11
-      0x7C340800,  //  00DE  CALL	R13	4
-      0x8C34190B,  //  00DF  GETMET	R13	R12	K11
-      0x583C000F,  //  00E0  LDCONST	R15	K15
-      0x88400B1B,  //  00E1  GETMBR	R16	R5	K27
-      0x5C441200,  //  00E2  MOVE	R17	R9
-      0x7C340800,  //  00E3  CALL	R13	4
-      0x8C341920,  //  00E4  GETMET	R13	R12	K32
-      0x7C340200,  //  00E5  CALL	R13	1
-      0x8C381121,  //  00E6  GETMET	R14	R8	K33
-      0x7C380200,  //  00E7  CALL	R14	1
-      0x00381A0E,  //  00E8  ADD	R14	R13	R14
-      0xB83E3A00,  //  00E9  GETNGBL	R15	K29
-      0x8C3C1F22,  //  00EA  GETMET	R15	R15	K34
-      0x8C441D24,  //  00EB  GETMET	R17	R14	K36
-      0x7C440200,  //  00EC  CALL	R17	1
-      0x00465211,  //  00ED  ADD	R17	K41	R17
-      0x58480011,  //  00EE  LDCONST	R18	K17
-      0x7C3C0600,  //  00EF  CALL	R15	3
-      0x8C3C0925,  //  00F0  GETMET	R15	R4	K37
-      0x7C3C0200,  //  00F1  CALL	R15	1
-      0x8C3C1F26,  //  00F2  GETMET	R15	R15	K38
-      0xB8460200,  //  00F3  GETNGBL	R17	K1
-      0x8C442327,  //  00F4  GETMET	R17	R17	K39
-      0x7C440200,  //  00F5  CALL	R17	1
-      0x5C481C00,  //  00F6  MOVE	R18	R14
-      0x7C3C0600,  //  00F7  CALL	R15	3
-      0x8C400B0A,  //  00F8  GETMET	R16	R5	K10
-      0x7C400200,  //  00F9  CALL	R16	1
-      0x8C44210B,  //  00FA  GETMET	R17	R16	K11
-      0x584C0006,  //  00FB  LDCONST	R19	K6
-      0x88500B17,  //  00FC  GETMBR	R20	R5	K23
-      0x5C541A00,  //  00FD  MOVE	R21	R13
-      0x7C440800,  //  00FE  CALL	R17	4
-      0x8C44210B,  //  00FF  GETMET	R17	R16	K11
-      0x584C0008,  //  0100  LDCONST	R19	K8
-      0x88500B1B,  //  0101  GETMBR	R20	R5	K27
-      0x5C541E00,  //  0102  MOVE	R21	R15
-      0x7C440800,  //  0103  CALL	R17	4
-      0x54460004,  //  0104  LDINT	R17	5
-      0x900E0811,  //  0105  SETMBR	R3	K4	R17
-      0x80042000,  //  0106  RET	1	R16
-      0x700200E5,  //  0107  JMP		#01EE
-      0x5426000A,  //  0108  LDINT	R9	11
-      0x1C240E09,  //  0109  EQ	R9	R7	R9
-      0x78260012,  //  010A  JMPF	R9	#011E
-      0x8C240507,  //  010B  GETMET	R9	R2	K7
-      0x582C0006,  //  010C  LDCONST	R11	K6
-      0x7C240400,  //  010D  CALL	R9	2
-      0x8C28112A,  //  010E  GETMET	R10	R8	K42
-      0x5C301200,  //  010F  MOVE	R12	R9
-      0x7C280400,  //  0110  CALL	R10	2
-      0xB82A3A00,  //  0111  GETNGBL	R10	K29
-      0x8C281522,  //  0112  GETMET	R10	R10	K34
-      0x8C301324,  //  0113  GETMET	R12	R9	K36
-      0x7C300200,  //  0114  CALL	R12	1
-      0x0032560C,  //  0115  ADD	R12	K43	R12
-      0x58340011,  //  0116  LDCONST	R13	K17
-      0x7C280600,  //  0117  CALL	R10	3
-      0xB82A0200,  //  0118  GETNGBL	R10	K1
-      0x8828152C,  //  0119  GETMBR	R10	R10	K44
-      0x900E2A0A,  //  011A  SETMBR	R3	K21	R10
-      0x4C280000,  //  011B  LDNIL	R10
-      0x80041400,  //  011C  RET	1	R10
-      0x700200CF,  //  011D  JMP		#01EE
-      0x54260005,  //  011E  LDINT	R9	6
-      0x1C240E09,  //  011F  EQ	R9	R7	R9
-      0x78260091,  //  0120  JMPF	R9	#01B3
-      0x8C240507,  //  0121  GETMET	R9	R2	K7
-      0x582C0006,  //  0122  LDCONST	R11	K6
-      0x7C240400,  //  0123  CALL	R9	2
-      0x8C280507,  //  0124  GETMET	R10	R2	K7
-      0x58300008,  //  0125  LDCONST	R12	K8
-      0x7C280400,  //  0126  CALL	R10	2
-      0x8C2C0507,  //  0127  GETMET	R11	R2	K7
-      0x5834000F,  //  0128  LDCONST	R13	K15
-      0x7C2C0400,  //  0129  CALL	R11	2
-      0x8C300507,  //  012A  GETMET	R12	R2	K7
-      0x58380011,  //  012B  LDCONST	R14	K17
-      0x7C300400,  //  012C  CALL	R12	2
-      0x8C340507,  //  012D  GETMET	R13	R2	K7
-      0x543E0003,  //  012E  LDINT	R15	4
-      0x7C340400,  //  012F  CALL	R13	2
-      0x8C38112D,  //  0130  GETMET	R14	R8	K45
-      0x7C380200,  //  0131  CALL	R14	1
-      0x4C3C0000,  //  0132  LDNIL	R15
-      0x1C381C0F,  //  0133  EQ	R14	R14	R15
-      0x783A0006,  //  0134  JMPF	R14	#013C
-      0xB83A3A00,  //  0135  GETNGBL	R14	K29
-      0x8C381D22,  //  0136  GETMET	R14	R14	K34
-      0x5840002E,  //  0137  LDCONST	R16	K46
-      0x5844000F,  //  0138  LDCONST	R17	K15
-      0x7C380600,  //  0139  CALL	R14	3
-      0x4C380000,  //  013A  LDNIL	R14
-      0x80041C00,  //  013B  RET	1	R14
-      0x8C38112F,  //  013C  GETMET	R14	R8	K47
+      0x5422002F,  //  0005  LDINT	R8	48
+      0x1C200C08,  //  0006  EQ	R8	R6	R8
+      0x78220050,  //  0007  JMPF	R8	#0059
+      0x1C200F05,  //  0008  EQ	R8	R7	K5
+      0x78220017,  //  0009  JMPF	R8	#0022
+      0x8C200506,  //  000A  GETMET	R8	R2	K6
+      0x58280005,  //  000B  LDCONST	R10	K5
+      0x542E0383,  //  000C  LDINT	R11	900
+      0x7C200600,  //  000D  CALL	R8	3
+      0x8C240506,  //  000E  GETMET	R9	R2	K6
+      0x582C0007,  //  000F  LDCONST	R11	K7
+      0x58300005,  //  0010  LDCONST	R12	K5
+      0x7C240600,  //  0011  CALL	R9	3
+      0x90061009,  //  0012  SETMBR	R1	K8	R9
+      0x8C280B09,  //  0013  GETMET	R10	R5	K9
+      0x7C280200,  //  0014  CALL	R10	1
+      0x8C2C150A,  //  0015  GETMET	R11	R10	K10
+      0x58340005,  //  0016  LDCONST	R13	K5
+      0x88380B0B,  //  0017  GETMBR	R14	R5	K11
+      0x583C0005,  //  0018  LDCONST	R15	K5
+      0x7C2C0800,  //  0019  CALL	R11	4
+      0x8C2C150A,  //  001A  GETMET	R11	R10	K10
+      0x58340007,  //  001B  LDCONST	R13	K7
+      0x88380B0C,  //  001C  GETMBR	R14	R5	K12
+      0x583C000D,  //  001D  LDCONST	R15	K13
+      0x7C2C0800,  //  001E  CALL	R11	4
+      0x900E0907,  //  001F  SETMBR	R3	K4	K7
+      0x80041400,  //  0020  RET	1	R10
+      0x70020035,  //  0021  JMP		#0058
+      0x1C200F0E,  //  0022  EQ	R8	R7	K14
+      0x7822001A,  //  0023  JMPF	R8	#003F
+      0x8C200506,  //  0024  GETMET	R8	R2	K6
+      0x58280005,  //  0025  LDCONST	R10	K5
+      0x7C200400,  //  0026  CALL	R8	2
+      0x8C240506,  //  0027  GETMET	R9	R2	K6
+      0x582C0007,  //  0028  LDCONST	R11	K7
+      0x5830000F,  //  0029  LDCONST	R12	K15
+      0x7C240600,  //  002A  CALL	R9	3
+      0x8C280506,  //  002B  GETMET	R10	R2	K6
+      0x5830000E,  //  002C  LDCONST	R12	K14
+      0x58340005,  //  002D  LDCONST	R13	K5
+      0x7C280600,  //  002E  CALL	R10	3
+      0x9006100A,  //  002F  SETMBR	R1	K8	R10
+      0x8C2C0B09,  //  0030  GETMET	R11	R5	K9
+      0x7C2C0200,  //  0031  CALL	R11	1
+      0x8C30170A,  //  0032  GETMET	R12	R11	K10
+      0x58380005,  //  0033  LDCONST	R14	K5
+      0x883C0B0B,  //  0034  GETMBR	R15	R5	K11
+      0x58400005,  //  0035  LDCONST	R16	K5
+      0x7C300800,  //  0036  CALL	R12	4
+      0x8C30170A,  //  0037  GETMET	R12	R11	K10
+      0x58380007,  //  0038  LDCONST	R14	K7
+      0x883C0B0C,  //  0039  GETMBR	R15	R5	K12
+      0x5840000D,  //  003A  LDCONST	R16	K13
+      0x7C300800,  //  003B  CALL	R12	4
+      0x900E0910,  //  003C  SETMBR	R3	K4	K16
+      0x80041600,  //  003D  RET	1	R11
+      0x70020018,  //  003E  JMP		#0058
+      0x54220003,  //  003F  LDINT	R8	4
+      0x1C200E08,  //  0040  EQ	R8	R7	R8
+      0x78220015,  //  0041  JMPF	R8	#0058
+      0x90061105,  //  0042  SETMBR	R1	K8	K5
+      0x8C200311,  //  0043  GETMET	R8	R1	K17
+      0x7C200200,  //  0044  CALL	R8	1
+      0x8C200B09,  //  0045  GETMET	R8	R5	K9
+      0x7C200200,  //  0046  CALL	R8	1
+      0x8C24110A,  //  0047  GETMET	R9	R8	K10
+      0x582C0005,  //  0048  LDCONST	R11	K5
+      0x88300B0B,  //  0049  GETMBR	R12	R5	K11
+      0x58340005,  //  004A  LDCONST	R13	K5
+      0x7C240800,  //  004B  CALL	R9	4
+      0x8C24110A,  //  004C  GETMET	R9	R8	K10
+      0x582C0007,  //  004D  LDCONST	R11	K7
+      0x88300B0C,  //  004E  GETMBR	R12	R5	K12
+      0x5834000D,  //  004F  LDCONST	R13	K13
+      0x7C240800,  //  0050  CALL	R9	4
+      0x54260004,  //  0051  LDINT	R9	5
+      0x900E0809,  //  0052  SETMBR	R3	K4	R9
+      0x88240112,  //  0053  GETMBR	R9	R0	K18
+      0x8C241313,  //  0054  GETMET	R9	R9	K19
+      0x5C2C0200,  //  0055  MOVE	R11	R1
+      0x7C240400,  //  0056  CALL	R9	2
+      0x80041000,  //  0057  RET	1	R8
+      0x70020193,  //  0058  JMP		#01ED
+      0x5422003D,  //  0059  LDINT	R8	62
+      0x1C200C08,  //  005A  EQ	R8	R6	R8
+      0x78220190,  //  005B  JMPF	R8	#01ED
+      0x1C200F0E,  //  005C  EQ	R8	R7	K14
+      0x7822001D,  //  005D  JMPF	R8	#007C
+      0x8C200506,  //  005E  GETMET	R8	R2	K6
+      0x58280005,  //  005F  LDCONST	R10	K5
+      0x7C200400,  //  0060  CALL	R8	2
+      0x20241107,  //  0061  NE	R9	R8	K7
+      0x78260006,  //  0062  JMPF	R9	#006A
+      0x2024110E,  //  0063  NE	R9	R8	K14
+      0x78260004,  //  0064  JMPF	R9	#006A
+      0xB8260200,  //  0065  GETNGBL	R9	K1
+      0x88241315,  //  0066  GETMBR	R9	R9	K21
+      0x900E2809,  //  0067  SETMBR	R3	K20	R9
+      0x4C240000,  //  0068  LDNIL	R9
+      0x80041200,  //  0069  RET	1	R9
+      0x8C240B09,  //  006A  GETMET	R9	R5	K9
+      0x7C240200,  //  006B  CALL	R9	1
+      0x8C28130A,  //  006C  GETMET	R10	R9	K10
+      0x58300005,  //  006D  LDCONST	R12	K5
+      0x88340B16,  //  006E  GETMBR	R13	R5	K22
+      0x1C381107,  //  006F  EQ	R14	R8	K7
+      0x783A0003,  //  0070  JMPF	R14	#0075
+      0xB83A0200,  //  0071  GETNGBL	R14	K1
+      0x8C381D17,  //  0072  GETMET	R14	R14	K23
+      0x7C380200,  //  0073  CALL	R14	1
+      0x70020002,  //  0074  JMP		#0078
+      0xB83A0200,  //  0075  GETNGBL	R14	K1
+      0x8C381D18,  //  0076  GETMET	R14	R14	K24
+      0x7C380200,  //  0077  CALL	R14	1
+      0x7C280800,  //  0078  CALL	R10	4
+      0x900E0910,  //  0079  SETMBR	R3	K4	K16
+      0x80041200,  //  007A  RET	1	R9
+      0x70020170,  //  007B  JMP		#01ED
+      0x1C200F05,  //  007C  EQ	R8	R7	K5
+      0x78220044,  //  007D  JMPF	R8	#00C3
+      0x8C200506,  //  007E  GETMET	R8	R2	K6
+      0x58280005,  //  007F  LDCONST	R10	K5
+      0x7C200400,  //  0080  CALL	R8	2
+      0x6024000C,  //  0081  GETGBL	R9	G12
+      0x5C281000,  //  0082  MOVE	R10	R8
+      0x7C240200,  //  0083  CALL	R9	1
+      0x542A001F,  //  0084  LDINT	R10	32
+      0x2024120A,  //  0085  NE	R9	R9	R10
+      0x78260001,  //  0086  JMPF	R9	#0089
+      0x4C240000,  //  0087  LDNIL	R9
+      0x80041200,  //  0088  RET	1	R9
+      0x900E0907,  //  0089  SETMBR	R3	K4	K7
+      0x8C240B09,  //  008A  GETMET	R9	R5	K9
+      0x7C240200,  //  008B  CALL	R9	1
+      0x8C28130A,  //  008C  GETMET	R10	R9	K10
+      0x58300007,  //  008D  LDCONST	R12	K7
+      0x88340B16,  //  008E  GETMBR	R13	R5	K22
+      0xB83A0200,  //  008F  GETNGBL	R14	K1
+      0x8C381D19,  //  0090  GETMET	R14	R14	K25
+      0x7C380200,  //  0091  CALL	R14	1
+      0x7C280800,  //  0092  CALL	R10	4
+      0x8C28130A,  //  0093  GETMET	R10	R9	K10
+      0x5830000E,  //  0094  LDCONST	R12	K14
+      0x88340B1A,  //  0095  GETMBR	R13	R5	K26
+      0x5C381000,  //  0096  MOVE	R14	R8
+      0x7C280800,  //  0097  CALL	R10	4
+      0x8C28130A,  //  0098  GETMET	R10	R9	K10
+      0x58300010,  //  0099  LDCONST	R12	K16
+      0x88340B1B,  //  009A  GETMBR	R13	R5	K27
+      0xB83A3800,  //  009B  GETNGBL	R14	K28
+      0x8C381D1D,  //  009C  GETMET	R14	R14	K29
+      0x7C380200,  //  009D  CALL	R14	1
+      0x94381D1E,  //  009E  GETIDX	R14	R14	K30
+      0x7C280800,  //  009F  CALL	R10	4
+      0x8C28131F,  //  00A0  GETMET	R10	R9	K31
+      0x7C280200,  //  00A1  CALL	R10	1
+      0x8C2C0320,  //  00A2  GETMET	R11	R1	K32
+      0x7C2C0200,  //  00A3  CALL	R11	1
+      0x0030140B,  //  00A4  ADD	R12	R10	R11
+      0xB8363800,  //  00A5  GETNGBL	R13	K28
+      0x8C341B21,  //  00A6  GETMET	R13	R13	K33
+      0x8C3C1923,  //  00A7  GETMET	R15	R12	K35
+      0x7C3C0200,  //  00A8  CALL	R15	1
+      0x003E440F,  //  00A9  ADD	R15	K34	R15
+      0x58400010,  //  00AA  LDCONST	R16	K16
+      0x7C340600,  //  00AB  CALL	R13	3
+      0x8C340924,  //  00AC  GETMET	R13	R4	K36
+      0x7C340200,  //  00AD  CALL	R13	1
+      0x8C341B25,  //  00AE  GETMET	R13	R13	K37
+      0xB83E0200,  //  00AF  GETNGBL	R15	K1
+      0x8C3C1F26,  //  00B0  GETMET	R15	R15	K38
+      0x7C3C0200,  //  00B1  CALL	R15	1
+      0x5C401800,  //  00B2  MOVE	R16	R12
+      0x7C340600,  //  00B3  CALL	R13	3
+      0x8C380B09,  //  00B4  GETMET	R14	R5	K9
+      0x7C380200,  //  00B5  CALL	R14	1
+      0x8C3C1D0A,  //  00B6  GETMET	R15	R14	K10
+      0x58440005,  //  00B7  LDCONST	R17	K5
+      0x88480B16,  //  00B8  GETMBR	R18	R5	K22
+      0x5C4C1400,  //  00B9  MOVE	R19	R10
+      0x7C3C0800,  //  00BA  CALL	R15	4
+      0x8C3C1D0A,  //  00BB  GETMET	R15	R14	K10
+      0x58440007,  //  00BC  LDCONST	R17	K7
+      0x88480B1A,  //  00BD  GETMBR	R18	R5	K26
+      0x5C4C1A00,  //  00BE  MOVE	R19	R13
+      0x7C3C0800,  //  00BF  CALL	R15	4
+      0x900E0907,  //  00C0  SETMBR	R3	K4	K7
+      0x80041C00,  //  00C1  RET	1	R14
+      0x70020129,  //  00C2  JMP		#01ED
+      0x54220003,  //  00C3  LDINT	R8	4
+      0x1C200E08,  //  00C4  EQ	R8	R7	R8
+      0x78220040,  //  00C5  JMPF	R8	#0107
+      0x8C200506,  //  00C6  GETMET	R8	R2	K6
+      0x58280005,  //  00C7  LDCONST	R10	K5
+      0x7C200400,  //  00C8  CALL	R8	2
+      0x6024000C,  //  00C9  GETGBL	R9	G12
+      0x5C281000,  //  00CA  MOVE	R10	R8
+      0x7C240200,  //  00CB  CALL	R9	1
+      0x542A001F,  //  00CC  LDINT	R10	32
+      0x2024120A,  //  00CD  NE	R9	R9	R10
+      0x78260001,  //  00CE  JMPF	R9	#00D1
+      0x4C240000,  //  00CF  LDNIL	R9
+      0x80041200,  //  00D0  RET	1	R9
+      0x8C240506,  //  00D1  GETMET	R9	R2	K6
+      0x582C0007,  //  00D2  LDCONST	R11	K7
+      0x50300000,  //  00D3  LDBOOL	R12	0	0
+      0x7C240600,  //  00D4  CALL	R9	3
+      0x8C280327,  //  00D5  GETMET	R10	R1	K39
+      0x7C280200,  //  00D6  CALL	R10	1
+      0x8C2C0B09,  //  00D7  GETMET	R11	R5	K9
+      0x7C2C0200,  //  00D8  CALL	R11	1
+      0x8C30170A,  //  00D9  GETMET	R12	R11	K10
+      0x58380007,  //  00DA  LDCONST	R14	K7
+      0x883C0B16,  //  00DB  GETMBR	R15	R5	K22
+      0x5C401400,  //  00DC  MOVE	R16	R10
+      0x7C300800,  //  00DD  CALL	R12	4
+      0x8C30170A,  //  00DE  GETMET	R12	R11	K10
+      0x5838000E,  //  00DF  LDCONST	R14	K14
+      0x883C0B1A,  //  00E0  GETMBR	R15	R5	K26
+      0x5C401000,  //  00E1  MOVE	R16	R8
+      0x7C300800,  //  00E2  CALL	R12	4
+      0x8C30171F,  //  00E3  GETMET	R12	R11	K31
+      0x7C300200,  //  00E4  CALL	R12	1
+      0x8C340320,  //  00E5  GETMET	R13	R1	K32
+      0x7C340200,  //  00E6  CALL	R13	1
+      0x0034180D,  //  00E7  ADD	R13	R12	R13
+      0xB83A3800,  //  00E8  GETNGBL	R14	K28
+      0x8C381D21,  //  00E9  GETMET	R14	R14	K33
+      0x8C401B23,  //  00EA  GETMET	R16	R13	K35
+      0x7C400200,  //  00EB  CALL	R16	1
+      0x00425010,  //  00EC  ADD	R16	K40	R16
+      0x58440010,  //  00ED  LDCONST	R17	K16
+      0x7C380600,  //  00EE  CALL	R14	3
+      0x8C380924,  //  00EF  GETMET	R14	R4	K36
+      0x7C380200,  //  00F0  CALL	R14	1
+      0x8C381D25,  //  00F1  GETMET	R14	R14	K37
+      0xB8420200,  //  00F2  GETNGBL	R16	K1
+      0x8C402126,  //  00F3  GETMET	R16	R16	K38
+      0x7C400200,  //  00F4  CALL	R16	1
+      0x5C441A00,  //  00F5  MOVE	R17	R13
+      0x7C380600,  //  00F6  CALL	R14	3
+      0x8C3C0B09,  //  00F7  GETMET	R15	R5	K9
+      0x7C3C0200,  //  00F8  CALL	R15	1
+      0x8C401F0A,  //  00F9  GETMET	R16	R15	K10
+      0x58480005,  //  00FA  LDCONST	R18	K5
+      0x884C0B16,  //  00FB  GETMBR	R19	R5	K22
+      0x5C501800,  //  00FC  MOVE	R20	R12
+      0x7C400800,  //  00FD  CALL	R16	4
+      0x8C401F0A,  //  00FE  GETMET	R16	R15	K10
+      0x58480007,  //  00FF  LDCONST	R18	K7
+      0x884C0B1A,  //  0100  GETMBR	R19	R5	K26
+      0x5C501C00,  //  0101  MOVE	R20	R14
+      0x7C400800,  //  0102  CALL	R16	4
+      0x54420004,  //  0103  LDINT	R16	5
+      0x900E0810,  //  0104  SETMBR	R3	K4	R16
+      0x80041E00,  //  0105  RET	1	R15
+      0x700200E5,  //  0106  JMP		#01ED
+      0x5422000A,  //  0107  LDINT	R8	11
+      0x1C200E08,  //  0108  EQ	R8	R7	R8
+      0x78220012,  //  0109  JMPF	R8	#011D
+      0x8C200506,  //  010A  GETMET	R8	R2	K6
+      0x58280005,  //  010B  LDCONST	R10	K5
+      0x7C200400,  //  010C  CALL	R8	2
+      0x8C240329,  //  010D  GETMET	R9	R1	K41
+      0x5C2C1000,  //  010E  MOVE	R11	R8
+      0x7C240400,  //  010F  CALL	R9	2
+      0xB8263800,  //  0110  GETNGBL	R9	K28
+      0x8C241321,  //  0111  GETMET	R9	R9	K33
+      0x8C2C1123,  //  0112  GETMET	R11	R8	K35
+      0x7C2C0200,  //  0113  CALL	R11	1
+      0x002E540B,  //  0114  ADD	R11	K42	R11
+      0x58300010,  //  0115  LDCONST	R12	K16
+      0x7C240600,  //  0116  CALL	R9	3
+      0xB8260200,  //  0117  GETNGBL	R9	K1
+      0x8824132B,  //  0118  GETMBR	R9	R9	K43
+      0x900E2809,  //  0119  SETMBR	R3	K20	R9
+      0x4C240000,  //  011A  LDNIL	R9
+      0x80041200,  //  011B  RET	1	R9
+      0x700200CF,  //  011C  JMP		#01ED
+      0x54220005,  //  011D  LDINT	R8	6
+      0x1C200E08,  //  011E  EQ	R8	R7	R8
+      0x78220091,  //  011F  JMPF	R8	#01B2
+      0x8C200506,  //  0120  GETMET	R8	R2	K6
+      0x58280005,  //  0121  LDCONST	R10	K5
+      0x7C200400,  //  0122  CALL	R8	2
+      0x8C240506,  //  0123  GETMET	R9	R2	K6
+      0x582C0007,  //  0124  LDCONST	R11	K7
+      0x7C240400,  //  0125  CALL	R9	2
+      0x8C280506,  //  0126  GETMET	R10	R2	K6
+      0x5830000E,  //  0127  LDCONST	R12	K14
+      0x7C280400,  //  0128  CALL	R10	2
+      0x8C2C0506,  //  0129  GETMET	R11	R2	K6
+      0x58340010,  //  012A  LDCONST	R13	K16
+      0x7C2C0400,  //  012B  CALL	R11	2
+      0x8C300506,  //  012C  GETMET	R12	R2	K6
+      0x543A0003,  //  012D  LDINT	R14	4
+      0x7C300400,  //  012E  CALL	R12	2
+      0x8C34032C,  //  012F  GETMET	R13	R1	K44
+      0x7C340200,  //  0130  CALL	R13	1
+      0x4C380000,  //  0131  LDNIL	R14
+      0x1C341A0E,  //  0132  EQ	R13	R13	R14
+      0x78360006,  //  0133  JMPF	R13	#013B
+      0xB8363800,  //  0134  GETNGBL	R13	K28
+      0x8C341B21,  //  0135  GETMET	R13	R13	K33
+      0x583C002D,  //  0136  LDCONST	R15	K45
+      0x5840000E,  //  0137  LDCONST	R16	K14
+      0x7C340600,  //  0138  CALL	R13	3
+      0x4C340000,  //  0139  LDNIL	R13
+      0x80041A00,  //  013A  RET	1	R13
+      0x8C34032E,  //  013B  GETMET	R13	R1	K46
+      0x5C3C1000,  //  013C  MOVE	R15	R8
       0x5C401200,  //  013D  MOVE	R16	R9
-      0x5C441400,  //  013E  MOVE	R17	R10
-      0x7C380600,  //  013F  CALL	R14	3
-      0x8C381130,  //  0140  GETMET	R14	R8	K48
-      0x5C401600,  //  0141  MOVE	R16	R11
-      0x7C380400,  //  0142  CALL	R14	2
-      0x9022620C,  //  0143  SETMBR	R8	K49	R12
-      0x9022640D,  //  0144  SETMBR	R8	K50	R13
-      0xB83A0200,  //  0145  GETNGBL	R14	K1
-      0x88381D02,  //  0146  GETMBR	R14	R14	K2
-      0x8C381D33,  //  0147  GETMET	R14	R14	K51
-      0x5C401200,  //  0148  MOVE	R16	R9
-      0x7C380400,  //  0149  CALL	R14	2
-      0x8C3C1D34,  //  014A  GETMET	R15	R14	K52
-      0x54460005,  //  014B  LDINT	R17	6
-      0x7C3C0400,  //  014C  CALL	R15	2
-      0x8C401F07,  //  014D  GETMET	R16	R15	K7
-      0x544A0014,  //  014E  LDINT	R18	21
-      0x7C400400,  //  014F  CALL	R16	2
-      0x8C441F07,  //  0150  GETMET	R17	R15	K7
-      0x544E0010,  //  0151  LDINT	R19	17
-      0x7C440400,  //  0152  CALL	R17	2
-      0x5C482000,  //  0153  MOVE	R18	R16
-      0x784A0001,  //  0154  JMPF	R18	#0157
-      0x5C482200,  //  0155  MOVE	R18	R17
-      0x744A0006,  //  0156  JMPT	R18	#015E
-      0xB84A3A00,  //  0157  GETNGBL	R18	K29
-      0x8C482522,  //  0158  GETMET	R18	R18	K34
-      0x58500035,  //  0159  LDCONST	R20	K53
-      0x5854000F,  //  015A  LDCONST	R21	K15
-      0x7C480600,  //  015B  CALL	R18	3
-      0x50480000,  //  015C  LDBOOL	R18	0	0
-      0x80042400,  //  015D  RET	1	R18
-      0x60480004,  //  015E  GETGBL	R18	G4
-      0x5C4C2000,  //  015F  MOVE	R19	R16
-      0x7C480200,  //  0160  CALL	R18	1
-      0x1C482536,  //  0161  EQ	R18	R18	K54
-      0x784A0006,  //  0162  JMPF	R18	#016A
-      0xB84A6E00,  //  0163  GETNGBL	R18	K55
-      0x5C4C2000,  //  0164  MOVE	R19	R16
-      0x7C480200,  //  0165  CALL	R18	1
-      0x8C482538,  //  0166  GETMET	R18	R18	K56
-      0x7C480200,  //  0167  CALL	R18	1
-      0x5C402400,  //  0168  MOVE	R16	R18
-      0x70020002,  //  0169  JMP		#016D
-      0x8C482138,  //  016A  GETMET	R18	R16	K56
-      0x7C480200,  //  016B  CALL	R18	1
-      0x5C402400,  //  016C  MOVE	R16	R18
-      0x60480004,  //  016D  GETGBL	R18	G4
-      0x5C4C2200,  //  016E  MOVE	R19	R17
-      0x7C480200,  //  016F  CALL	R18	1
-      0x1C482536,  //  0170  EQ	R18	R18	K54
-      0x784A0006,  //  0171  JMPF	R18	#0179
-      0xB84A6E00,  //  0172  GETNGBL	R18	K55
-      0x5C4C2200,  //  0173  MOVE	R19	R17
-      0x7C480200,  //  0174  CALL	R18	1
-      0x8C482538,  //  0175  GETMET	R18	R18	K56
-      0x7C480200,  //  0176  CALL	R18	1
-      0x5C442400,  //  0177  MOVE	R17	R18
-      0x70020002,  //  0178  JMP		#017C
-      0x8C482338,  //  0179  GETMET	R18	R17	K56
-      0x7C480200,  //  017A  CALL	R18	1
-      0x5C442400,  //  017B  MOVE	R17	R18
-      0xB84A0200,  //  017C  GETNGBL	R18	K1
-      0x88482502,  //  017D  GETMBR	R18	R18	K2
-      0x8C482533,  //  017E  GETMET	R18	R18	K51
-      0x8C50112D,  //  017F  GETMET	R20	R8	K45
-      0x7C500200,  //  0180  CALL	R20	1
-      0x7C480400,  //  0181  CALL	R18	2
-      0x8C482507,  //  0182  GETMET	R18	R18	K7
-      0x54520008,  //  0183  LDINT	R20	9
-      0x7C480400,  //  0184  CALL	R18	2
-      0x404E1139,  //  0185  CONNECT	R19	K8	K57
-      0x94482413,  //  0186  GETIDX	R18	R18	R19
-      0x60500015,  //  0187  GETGBL	R20	G21
-      0x7C500000,  //  0188  CALL	R20	0
-      0x8C50293A,  //  0189  GETMET	R20	R20	K58
-      0x5858003B,  //  018A  LDCONST	R22	K59
-      0x7C500400,  //  018B  CALL	R20	2
-      0x5C4C2800,  //  018C  MOVE	R19	R20
-      0x8C50093C,  //  018D  GETMET	R20	R4	K60
-      0x7C500200,  //  018E  CALL	R20	1
-      0x8C54213D,  //  018F  GETMET	R21	R16	K61
-      0x7C540200,  //  0190  CALL	R21	1
-      0x8C542B3E,  //  0191  GETMET	R21	R21	K62
-      0x7C540200,  //  0192  CALL	R21	1
-      0x8C58293F,  //  0193  GETMET	R22	R20	K63
-      0x5C602400,  //  0194  MOVE	R24	R18
-      0x5C642A00,  //  0195  MOVE	R25	R21
-      0x5C682600,  //  0196  MOVE	R26	R19
-      0x546E0007,  //  0197  LDINT	R27	8
-      0x7C580A00,  //  0198  CALL	R22	5
-      0x8C5C1140,  //  0199  GETMET	R23	R8	K64
+      0x7C340600,  //  013E  CALL	R13	3
+      0x8C34032F,  //  013F  GETMET	R13	R1	K47
+      0x5C3C1400,  //  0140  MOVE	R15	R10
+      0x7C340400,  //  0141  CALL	R13	2
+      0x9006600B,  //  0142  SETMBR	R1	K48	R11
+      0x9006620C,  //  0143  SETMBR	R1	K49	R12
+      0xB8360200,  //  0144  GETNGBL	R13	K1
+      0x88341B02,  //  0145  GETMBR	R13	R13	K2
+      0x8C341B32,  //  0146  GETMET	R13	R13	K50
+      0x5C3C1000,  //  0147  MOVE	R15	R8
+      0x7C340400,  //  0148  CALL	R13	2
+      0x8C381B33,  //  0149  GETMET	R14	R13	K51
+      0x54420005,  //  014A  LDINT	R16	6
+      0x7C380400,  //  014B  CALL	R14	2
+      0x8C3C1D06,  //  014C  GETMET	R15	R14	K6
+      0x54460014,  //  014D  LDINT	R17	21
+      0x7C3C0400,  //  014E  CALL	R15	2
+      0x8C401D06,  //  014F  GETMET	R16	R14	K6
+      0x544A0010,  //  0150  LDINT	R18	17
+      0x7C400400,  //  0151  CALL	R16	2
+      0x5C441E00,  //  0152  MOVE	R17	R15
+      0x78460001,  //  0153  JMPF	R17	#0156
+      0x5C442000,  //  0154  MOVE	R17	R16
+      0x74460006,  //  0155  JMPT	R17	#015D
+      0xB8463800,  //  0156  GETNGBL	R17	K28
+      0x8C442321,  //  0157  GETMET	R17	R17	K33
+      0x584C0034,  //  0158  LDCONST	R19	K52
+      0x5850000E,  //  0159  LDCONST	R20	K14
+      0x7C440600,  //  015A  CALL	R17	3
+      0x50440000,  //  015B  LDBOOL	R17	0	0
+      0x80042200,  //  015C  RET	1	R17
+      0x60440004,  //  015D  GETGBL	R17	G4
+      0x5C481E00,  //  015E  MOVE	R18	R15
+      0x7C440200,  //  015F  CALL	R17	1
+      0x1C442335,  //  0160  EQ	R17	R17	K53
+      0x78460006,  //  0161  JMPF	R17	#0169
+      0xB8466C00,  //  0162  GETNGBL	R17	K54
+      0x5C481E00,  //  0163  MOVE	R18	R15
+      0x7C440200,  //  0164  CALL	R17	1
+      0x8C442337,  //  0165  GETMET	R17	R17	K55
+      0x7C440200,  //  0166  CALL	R17	1
+      0x5C3C2200,  //  0167  MOVE	R15	R17
+      0x70020002,  //  0168  JMP		#016C
+      0x8C441F37,  //  0169  GETMET	R17	R15	K55
+      0x7C440200,  //  016A  CALL	R17	1
+      0x5C3C2200,  //  016B  MOVE	R15	R17
+      0x60440004,  //  016C  GETGBL	R17	G4
+      0x5C482000,  //  016D  MOVE	R18	R16
+      0x7C440200,  //  016E  CALL	R17	1
+      0x1C442335,  //  016F  EQ	R17	R17	K53
+      0x78460006,  //  0170  JMPF	R17	#0178
+      0xB8466C00,  //  0171  GETNGBL	R17	K54
+      0x5C482000,  //  0172  MOVE	R18	R16
+      0x7C440200,  //  0173  CALL	R17	1
+      0x8C442337,  //  0174  GETMET	R17	R17	K55
+      0x7C440200,  //  0175  CALL	R17	1
+      0x5C402200,  //  0176  MOVE	R16	R17
+      0x70020002,  //  0177  JMP		#017B
+      0x8C442137,  //  0178  GETMET	R17	R16	K55
+      0x7C440200,  //  0179  CALL	R17	1
+      0x5C402200,  //  017A  MOVE	R16	R17
+      0xB8460200,  //  017B  GETNGBL	R17	K1
+      0x88442302,  //  017C  GETMBR	R17	R17	K2
+      0x8C442332,  //  017D  GETMET	R17	R17	K50
+      0x8C4C032C,  //  017E  GETMET	R19	R1	K44
+      0x7C4C0200,  //  017F  CALL	R19	1
+      0x7C440400,  //  0180  CALL	R17	2
+      0x8C442306,  //  0181  GETMET	R17	R17	K6
+      0x544E0008,  //  0182  LDINT	R19	9
+      0x7C440400,  //  0183  CALL	R17	2
+      0x404A0F38,  //  0184  CONNECT	R18	K7	K56
+      0x94442212,  //  0185  GETIDX	R17	R17	R18
+      0x604C0015,  //  0186  GETGBL	R19	G21
+      0x7C4C0000,  //  0187  CALL	R19	0
+      0x8C4C2739,  //  0188  GETMET	R19	R19	K57
+      0x5854003A,  //  0189  LDCONST	R21	K58
+      0x7C4C0400,  //  018A  CALL	R19	2
+      0x5C482600,  //  018B  MOVE	R18	R19
+      0x8C4C093B,  //  018C  GETMET	R19	R4	K59
+      0x7C4C0200,  //  018D  CALL	R19	1
+      0x8C501F3C,  //  018E  GETMET	R20	R15	K60
+      0x7C500200,  //  018F  CALL	R20	1
+      0x8C50293D,  //  0190  GETMET	R20	R20	K61
+      0x7C500200,  //  0191  CALL	R20	1
+      0x8C54273E,  //  0192  GETMET	R21	R19	K62
+      0x5C5C2200,  //  0193  MOVE	R23	R17
+      0x5C602800,  //  0194  MOVE	R24	R20
+      0x5C642400,  //  0195  MOVE	R25	R18
+      0x546A0007,  //  0196  LDINT	R26	8
+      0x7C540A00,  //  0197  CALL	R21	5
+      0x8C58033F,  //  0198  GETMET	R22	R1	K63
+      0x5C601E00,  //  0199  MOVE	R24	R15
       0x5C642000,  //  019A  MOVE	R25	R16
-      0x5C682200,  //  019B  MOVE	R26	R17
-      0x5C6C2C00,  //  019C  MOVE	R27	R22
-      0x7C5C0800,  //  019D  CALL	R23	4
-      0x885C0113,  //  019E  GETMBR	R23	R0	K19
-      0x8C5C2F41,  //  019F  GETMET	R23	R23	K65
-      0x5C641000,  //  01A0  MOVE	R25	R8
-      0x7C5C0400,  //  01A1  CALL	R23	2
-      0x8C5C0B0A,  //  01A2  GETMET	R23	R5	K10
-      0x7C5C0200,  //  01A3  CALL	R23	1
-      0x8C602F0B,  //  01A4  GETMET	R24	R23	K11
-      0x58680006,  //  01A5  LDCONST	R26	K6
-      0x886C0B0C,  //  01A6  GETMBR	R27	R5	K12
-      0xB8720200,  //  01A7  GETNGBL	R28	K1
-      0x8870392C,  //  01A8  GETMBR	R28	R28	K44
-      0x7C600800,  //  01A9  CALL	R24	4
-      0x8C602F0B,  //  01AA  GETMET	R24	R23	K11
-      0x58680008,  //  01AB  LDCONST	R26	K8
-      0x886C0B0C,  //  01AC  GETMBR	R27	R5	K12
-      0x58700008,  //  01AD  LDCONST	R28	K8
-      0x7C600800,  //  01AE  CALL	R24	4
-      0x54620007,  //  01AF  LDINT	R24	8
-      0x900E0818,  //  01B0  SETMBR	R3	K4	R24
-      0x80042E00,  //  01B1  RET	1	R23
-      0x7002003A,  //  01B2  JMP		#01EE
-      0x54260008,  //  01B3  LDINT	R9	9
-      0x1C240E09,  //  01B4  EQ	R9	R7	R9
-      0x7826000B,  //  01B5  JMPF	R9	#01C2
-      0x8C240507,  //  01B6  GETMET	R9	R2	K7
-      0x582C0006,  //  01B7  LDCONST	R11	K6
-      0x7C240400,  //  01B8  CALL	R9	2
-      0x8C281142,  //  01B9  GETMET	R10	R8	K66
-      0x5C301200,  //  01BA  MOVE	R12	R9
-      0x7C280400,  //  01BB  CALL	R10	2
-      0xB82A0200,  //  01BC  GETNGBL	R10	K1
-      0x8828152C,  //  01BD  GETMBR	R10	R10	K44
-      0x900E2A0A,  //  01BE  SETMBR	R3	K21	R10
-      0x4C280000,  //  01BF  LDNIL	R10
-      0x80041400,  //  01C0  RET	1	R10
-      0x7002002B,  //  01C1  JMP		#01EE
-      0x54260009,  //  01C2  LDINT	R9	10
-      0x1C240E09,  //  01C3  EQ	R9	R7	R9
-      0x78260028,  //  01C4  JMPF	R9	#01EE
-      0x8C240507,  //  01C5  GETMET	R9	R2	K7
-      0x582C0006,  //  01C6  LDCONST	R11	K6
-      0x7C240400,  //  01C7  CALL	R9	2
-      0x88280113,  //  01C8  GETMBR	R10	R0	K19
-      0x88281543,  //  01C9  GETMBR	R10	R10	K67
-      0x8C281544,  //  01CA  GETMET	R10	R10	K68
-      0x7C280200,  //  01CB  CALL	R10	1
-      0x282C1308,  //  01CC  GE	R11	R9	K8
-      0x782E001A,  //  01CD  JMPF	R11	#01E9
-      0x602C000C,  //  01CE  GETGBL	R11	G12
-      0x5C301400,  //  01CF  MOVE	R12	R10
-      0x7C2C0200,  //  01D0  CALL	R11	1
-      0x182C120B,  //  01D1  LE	R11	R9	R11
-      0x782E0015,  //  01D2  JMPF	R11	#01E9
-      0x042C1308,  //  01D3  SUB	R11	R9	K8
-      0x942C140B,  //  01D4  GETIDX	R11	R10	R11
-      0xB8323A00,  //  01D5  GETNGBL	R12	K29
-      0x8C301922,  //  01D6  GETMET	R12	R12	K34
-      0x88381146,  //  01D7  GETMBR	R14	R8	K70
-      0x8C381D3D,  //  01D8  GETMET	R14	R14	K61
-      0x7C380200,  //  01D9  CALL	R14	1
-      0x8C381D3E,  //  01DA  GETMET	R14	R14	K62
-      0x7C380200,  //  01DB  CALL	R14	1
-      0x8C381D24,  //  01DC  GETMET	R14	R14	K36
-      0x7C380200,  //  01DD  CALL	R14	1
-      0x003A8A0E,  //  01DE  ADD	R14	K69	R14
-      0x7C300400,  //  01DF  CALL	R12	2
-      0x88300113,  //  01E0  GETMBR	R12	R0	K19
-      0x88301943,  //  01E1  GETMBR	R12	R12	K67
-      0x8C301947,  //  01E2  GETMET	R12	R12	K71
-      0x7C300200,  //  01E3  CALL	R12	1
-      0x88300113,  //  01E4  GETMBR	R12	R0	K19
-      0x88301943,  //  01E5  GETMBR	R12	R12	K67
-      0x8C301948,  //  01E6  GETMET	R12	R12	K72
-      0x7C300200,  //  01E7  CALL	R12	1
-      0x7001FFFF,  //  01E8  JMP		#01E9
-      0xB82E0200,  //  01E9  GETNGBL	R11	K1
-      0x882C172C,  //  01EA  GETMBR	R11	R11	K44
-      0x900E2A0B,  //  01EB  SETMBR	R3	K21	R11
-      0x4C2C0000,  //  01EC  LDNIL	R11
-      0x80041600,  //  01ED  RET	1	R11
-      0x80000000,  //  01EE  RET	0
+      0x5C682A00,  //  019B  MOVE	R26	R21
+      0x7C580800,  //  019C  CALL	R22	4
+      0x88580112,  //  019D  GETMBR	R22	R0	K18
+      0x8C582D40,  //  019E  GETMET	R22	R22	K64
+      0x5C600200,  //  019F  MOVE	R24	R1
+      0x7C580400,  //  01A0  CALL	R22	2
+      0x8C580B09,  //  01A1  GETMET	R22	R5	K9
+      0x7C580200,  //  01A2  CALL	R22	1
+      0x8C5C2D0A,  //  01A3  GETMET	R23	R22	K10
+      0x58640005,  //  01A4  LDCONST	R25	K5
+      0x88680B0B,  //  01A5  GETMBR	R26	R5	K11
+      0xB86E0200,  //  01A6  GETNGBL	R27	K1
+      0x886C372B,  //  01A7  GETMBR	R27	R27	K43
+      0x7C5C0800,  //  01A8  CALL	R23	4
+      0x8C5C2D0A,  //  01A9  GETMET	R23	R22	K10
+      0x58640007,  //  01AA  LDCONST	R25	K7
+      0x88680B0B,  //  01AB  GETMBR	R26	R5	K11
+      0x586C0007,  //  01AC  LDCONST	R27	K7
+      0x7C5C0800,  //  01AD  CALL	R23	4
+      0x545E0007,  //  01AE  LDINT	R23	8
+      0x900E0817,  //  01AF  SETMBR	R3	K4	R23
+      0x80042C00,  //  01B0  RET	1	R22
+      0x7002003A,  //  01B1  JMP		#01ED
+      0x54220008,  //  01B2  LDINT	R8	9
+      0x1C200E08,  //  01B3  EQ	R8	R7	R8
+      0x7822000B,  //  01B4  JMPF	R8	#01C1
+      0x8C200506,  //  01B5  GETMET	R8	R2	K6
+      0x58280005,  //  01B6  LDCONST	R10	K5
+      0x7C200400,  //  01B7  CALL	R8	2
+      0x8C240341,  //  01B8  GETMET	R9	R1	K65
+      0x5C2C1000,  //  01B9  MOVE	R11	R8
+      0x7C240400,  //  01BA  CALL	R9	2
+      0xB8260200,  //  01BB  GETNGBL	R9	K1
+      0x8824132B,  //  01BC  GETMBR	R9	R9	K43
+      0x900E2809,  //  01BD  SETMBR	R3	K20	R9
+      0x4C240000,  //  01BE  LDNIL	R9
+      0x80041200,  //  01BF  RET	1	R9
+      0x7002002B,  //  01C0  JMP		#01ED
+      0x54220009,  //  01C1  LDINT	R8	10
+      0x1C200E08,  //  01C2  EQ	R8	R7	R8
+      0x78220028,  //  01C3  JMPF	R8	#01ED
+      0x8C200506,  //  01C4  GETMET	R8	R2	K6
+      0x58280005,  //  01C5  LDCONST	R10	K5
+      0x7C200400,  //  01C6  CALL	R8	2
+      0x88240112,  //  01C7  GETMBR	R9	R0	K18
+      0x88241342,  //  01C8  GETMBR	R9	R9	K66
+      0x8C241343,  //  01C9  GETMET	R9	R9	K67
+      0x7C240200,  //  01CA  CALL	R9	1
+      0x28281107,  //  01CB  GE	R10	R8	K7
+      0x782A001A,  //  01CC  JMPF	R10	#01E8
+      0x6028000C,  //  01CD  GETGBL	R10	G12
+      0x5C2C1200,  //  01CE  MOVE	R11	R9
+      0x7C280200,  //  01CF  CALL	R10	1
+      0x1828100A,  //  01D0  LE	R10	R8	R10
+      0x782A0015,  //  01D1  JMPF	R10	#01E8
+      0x04281107,  //  01D2  SUB	R10	R8	K7
+      0x9428120A,  //  01D3  GETIDX	R10	R9	R10
+      0xB82E3800,  //  01D4  GETNGBL	R11	K28
+      0x8C2C1721,  //  01D5  GETMET	R11	R11	K33
+      0x88340345,  //  01D6  GETMBR	R13	R1	K69
+      0x8C341B3C,  //  01D7  GETMET	R13	R13	K60
+      0x7C340200,  //  01D8  CALL	R13	1
+      0x8C341B3D,  //  01D9  GETMET	R13	R13	K61
+      0x7C340200,  //  01DA  CALL	R13	1
+      0x8C341B23,  //  01DB  GETMET	R13	R13	K35
+      0x7C340200,  //  01DC  CALL	R13	1
+      0x0036880D,  //  01DD  ADD	R13	K68	R13
+      0x7C2C0400,  //  01DE  CALL	R11	2
+      0x882C0112,  //  01DF  GETMBR	R11	R0	K18
+      0x882C1742,  //  01E0  GETMBR	R11	R11	K66
+      0x8C2C1746,  //  01E1  GETMET	R11	R11	K70
+      0x7C2C0200,  //  01E2  CALL	R11	1
+      0x882C0112,  //  01E3  GETMBR	R11	R0	K18
+      0x882C1742,  //  01E4  GETMBR	R11	R11	K66
+      0x8C2C1747,  //  01E5  GETMET	R11	R11	K71
+      0x7C2C0200,  //  01E6  CALL	R11	1
+      0x7001FFFF,  //  01E7  JMP		#01E8
+      0xB82A0200,  //  01E8  GETNGBL	R10	K1
+      0x8828152B,  //  01E9  GETMBR	R10	R10	K43
+      0x900E280A,  //  01EA  SETMBR	R3	K20	R10
+      0x4C280000,  //  01EB  LDNIL	R10
+      0x80041400,  //  01EC  RET	1	R10
+      0x80000000,  //  01ED  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -7,32 +7,40 @@
 extern const bclass be_class_Matter_Session;
 
 /********************************************************************
-** Solidified function: set_fabric_label
+** Solidified function: get_ca_pub
 ********************************************************************/
-be_local_closure(Matter_Session_set_fabric_label,   /* name */
+be_local_closure(Matter_Session_get_ca_pub,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
+    5,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(fabric_label),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TLV),
+    /* K3   */  be_nested_str_weak(parse),
+    /* K4   */  be_nested_str_weak(findsubval),
     }),
-    be_str_weak(set_fabric_label),
+    be_str_weak(get_ca_pub),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A0000,  //  0004  JMPF	R2	#0006
-      0x90020201,  //  0005  SETMBR	R0	K1	R1
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060008,  //  0001  JMPF	R1	#000B
+      0xB8060200,  //  0002  GETNGBL	R1	K1
+      0x88040302,  //  0003  GETMBR	R1	R1	K2
+      0x8C040303,  //  0004  GETMET	R1	R1	K3
+      0x880C0100,  //  0005  GETMBR	R3	R0	K0
+      0x7C040400,  //  0006  CALL	R1	2
+      0x8C080304,  //  0007  GETMET	R2	R1	K4
+      0x54120008,  //  0008  LDINT	R4	9
+      0x7C080400,  //  0009  CALL	R2	2
+      0x80040400,  //  000A  RET	1	R2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -40,9 +48,9 @@ be_local_closure(Matter_Session_set_fabric_label,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_no_expiration
+** Solidified function: get_noc
 ********************************************************************/
-be_local_closure(Matter_Session_set_no_expiration,   /* name */
+be_local_closure(Matter_Session_get_noc,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -53,14 +61,123 @@ be_local_closure(Matter_Session_set_no_expiration,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expiration),
+    /* K0   */  be_nested_str_weak(noc),
     }),
-    be_str_weak(set_no_expiration),
+    be_str_weak(get_noc),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_i2r_privacy
+********************************************************************/
+be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_i2r_privacy),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(HKDF_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_nested_str_weak(get_i2r),
+    /* K5   */  be_nested_str_weak(fromstring),
+    /* K6   */  be_nested_str_weak(PrivacyKey),
+    }),
+    be_str_weak(get_i2r_privacy),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x7806000F,  //  0003  JMPF	R1	#0014
+      0xA4060200,  //  0004  IMPORT	R1	K1
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x7C080200,  //  0006  CALL	R2	1
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x8C100104,  //  0008  GETMET	R4	R0	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x60140015,  //  000A  GETGBL	R5	G21
+      0x7C140000,  //  000B  CALL	R5	0
+      0x60180015,  //  000C  GETGBL	R6	G21
+      0x7C180000,  //  000D  CALL	R6	0
+      0x8C180D05,  //  000E  GETMET	R6	R6	K5
+      0x58200006,  //  000F  LDCONST	R8	K6
+      0x7C180400,  //  0010  CALL	R6	2
+      0x541E000F,  //  0011  LDINT	R7	16
+      0x7C080A00,  //  0012  CALL	R2	5
+      0x90020002,  //  0013  SETMBR	R0	K0	R2
+      0x88040100,  //  0014  GETMBR	R1	R0	K0
+      0x80040200,  //  0015  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(set_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_persist
+********************************************************************/
+be_local_closure(Matter_Session_set_persist,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_persist),
+    }),
+    be_str_weak(set_persist),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -95,11 +212,11 @@ be_local_closure(Matter_Session_set_mode,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_expire_time
+** Solidified function: set_ca
 ********************************************************************/
-be_local_closure(Matter_Session_set_expire_time,   /* name */
+be_local_closure(Matter_Session_set_ca,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    2,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -108,70 +225,13 @@ be_local_closure(Matter_Session_set_expire_time,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expiration),
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
     }),
-    be_str_weak(set_expire_time),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_i2r
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    }),
-    be_str_weak(get_i2r),
+    be_str_weak(set_ca),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(get_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -222,97 +282,159 @@ be_local_closure(Matter_Session_set_expire_in_seconds,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_ipk_epoch_key
+** Solidified function: fromjson
 ********************************************************************/
-be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
+be_local_closure(Matter_Session_fromjson,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
+    16,                          /* nstack */
     2,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Session),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(introspect),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Session),
+    /* K5   */  be_nested_str_weak(keys),
+    /* K6   */  be_nested_str_weak(counter_rcv),
+    /* K7   */  be_nested_str_weak(reset),
+    /* K8   */  be_nested_str_weak(counter_snd),
+    /* K9   */  be_nested_str_weak(find),
+    /* K10  */  be_nested_str_weak(0x),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(set),
+    /* K13  */  be_nested_str_weak(fromhex),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_const_int(2147483647),
+    /* K16  */  be_nested_str_weak(_X24_X24),
+    /* K17  */  be_nested_str_weak(fromb64),
+    /* K18  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(fromjson),
+    &be_const_str_solidified,
+    ( &(const binstruction[88]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0xB8160600,  //  0003  GETNGBL	R5	K3
+      0x8C140B04,  //  0004  GETMET	R5	R5	K4
+      0x5C1C0000,  //  0005  MOVE	R7	R0
+      0x7C140400,  //  0006  CALL	R5	2
+      0x60180010,  //  0007  GETGBL	R6	G16
+      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x7C180200,  //  000A  CALL	R6	1
+      0xA8020047,  //  000B  EXBLK	0	#0054
+      0x5C1C0C00,  //  000C  MOVE	R7	R6
+      0x7C1C0000,  //  000D  CALL	R7	0
+      0x94200207,  //  000E  GETIDX	R8	R1	R7
+      0x1C240F06,  //  000F  EQ	R9	R7	K6
+      0x78260006,  //  0010  JMPF	R9	#0018
+      0x88240B06,  //  0011  GETMBR	R9	R5	K6
+      0x8C241307,  //  0012  GETMET	R9	R9	K7
+      0x602C0009,  //  0013  GETGBL	R11	G9
+      0x5C301000,  //  0014  MOVE	R12	R8
+      0x7C2C0200,  //  0015  CALL	R11	1
+      0x7C240400,  //  0016  CALL	R9	2
+      0x7002003A,  //  0017  JMP		#0053
+      0x1C240F08,  //  0018  EQ	R9	R7	K8
+      0x78260006,  //  0019  JMPF	R9	#0021
+      0x88240B08,  //  001A  GETMBR	R9	R5	K8
+      0x8C241307,  //  001B  GETMET	R9	R9	K7
+      0x602C0009,  //  001C  GETGBL	R11	G9
+      0x5C301000,  //  001D  MOVE	R12	R8
+      0x7C2C0200,  //  001E  CALL	R11	1
+      0x7C240400,  //  001F  CALL	R9	2
+      0x70020031,  //  0020  JMP		#0053
+      0x60240004,  //  0021  GETGBL	R9	G4
+      0x5C281000,  //  0022  MOVE	R10	R8
+      0x7C240200,  //  0023  CALL	R9	1
+      0x1C241301,  //  0024  EQ	R9	R9	K1
+      0x78260027,  //  0025  JMPF	R9	#004E
+      0x8C240709,  //  0026  GETMET	R9	R3	K9
+      0x5C2C1000,  //  0027  MOVE	R11	R8
+      0x5830000A,  //  0028  LDCONST	R12	K10
+      0x7C240600,  //  0029  CALL	R9	3
+      0x1C24130B,  //  002A  EQ	R9	R9	K11
+      0x7826000A,  //  002B  JMPF	R9	#0037
+      0x8C24090C,  //  002C  GETMET	R9	R4	K12
+      0x5C2C0A00,  //  002D  MOVE	R11	R5
+      0x5C300E00,  //  002E  MOVE	R12	R7
+      0x60340015,  //  002F  GETGBL	R13	G21
+      0x7C340000,  //  0030  CALL	R13	0
+      0x8C341B0D,  //  0031  GETMET	R13	R13	K13
+      0x403E1D0F,  //  0032  CONNECT	R15	K14	K15
+      0x943C100F,  //  0033  GETIDX	R15	R8	R15
+      0x7C340400,  //  0034  CALL	R13	2
+      0x7C240800,  //  0035  CALL	R9	4
+      0x70020015,  //  0036  JMP		#004D
+      0x8C240709,  //  0037  GETMET	R9	R3	K9
+      0x5C2C1000,  //  0038  MOVE	R11	R8
+      0x58300010,  //  0039  LDCONST	R12	K16
+      0x7C240600,  //  003A  CALL	R9	3
+      0x1C24130B,  //  003B  EQ	R9	R9	K11
+      0x7826000A,  //  003C  JMPF	R9	#0048
+      0x8C24090C,  //  003D  GETMET	R9	R4	K12
+      0x5C2C0A00,  //  003E  MOVE	R11	R5
+      0x5C300E00,  //  003F  MOVE	R12	R7
+      0x60340015,  //  0040  GETGBL	R13	G21
+      0x7C340000,  //  0041  CALL	R13	0
+      0x8C341B11,  //  0042  GETMET	R13	R13	K17
+      0x403E1D0F,  //  0043  CONNECT	R15	K14	K15
+      0x943C100F,  //  0044  GETIDX	R15	R8	R15
+      0x7C340400,  //  0045  CALL	R13	2
+      0x7C240800,  //  0046  CALL	R9	4
+      0x70020004,  //  0047  JMP		#004D
+      0x8C24090C,  //  0048  GETMET	R9	R4	K12
+      0x5C2C0A00,  //  0049  MOVE	R11	R5
+      0x5C300E00,  //  004A  MOVE	R12	R7
+      0x5C341000,  //  004B  MOVE	R13	R8
+      0x7C240800,  //  004C  CALL	R9	4
+      0x70020004,  //  004D  JMP		#0053
+      0x8C24090C,  //  004E  GETMET	R9	R4	K12
+      0x5C2C0A00,  //  004F  MOVE	R11	R5
+      0x5C300E00,  //  0050  MOVE	R12	R7
+      0x5C341000,  //  0051  MOVE	R13	R8
+      0x7C240800,  //  0052  CALL	R9	4
+      0x7001FFB7,  //  0053  JMP		#000C
+      0x58180012,  //  0054  LDCONST	R6	K18
+      0xAC180200,  //  0055  CATCH	R6	1	0
+      0xB0080000,  //  0056  RAISE	2	R0	R0
+      0x80040A00,  //  0057  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_noc
+********************************************************************/
+be_local_closure(Matter_Session_set_noc,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(noc),
+    /* K1   */  be_nested_str_weak(icac),
     }),
-    be_str_weak(set_ipk_epoch_key),
+    be_str_weak(set_noc),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
+    ( &(const binstruction[ 3]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_deviceid
-********************************************************************/
-be_local_closure(Matter_Session_get_deviceid,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(deviceid),
-    }),
-    be_str_weak(get_deviceid),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: has_expired
-********************************************************************/
-be_local_closure(Matter_Session_has_expired,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(rtc),
-    /* K2   */  be_nested_str_weak(utc),
-    /* K3   */  be_nested_str_weak(expiration),
-    }),
-    be_str_weak(has_expired),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0003,  //  0002  JMPF	R2	#0007
-      0xB80A0000,  //  0003  GETNGBL	R2	K0
-      0x8C080501,  //  0004  GETMET	R2	R2	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x94040502,  //  0006  GETIDX	R1	R2	K2
-      0x88080103,  //  0007  GETMBR	R2	R0	K3
-      0x4C0C0000,  //  0008  LDNIL	R3
-      0x20080403,  //  0009  NE	R2	R2	R3
-      0x780A0002,  //  000A  JMPF	R2	#000E
-      0x88080103,  //  000B  GETMBR	R2	R0	K3
-      0x28080202,  //  000C  GE	R2	R1	R2
-      0x80040400,  //  000D  RET	1	R2
-      0x50080000,  //  000E  LDBOOL	R2	0	0
-      0x80040400,  //  000F  RET	1	R2
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -340,69 +462,6 @@ be_local_closure(Matter_Session_get_r2i,   /* name */
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric),
-    }),
-    be_str_weak(get_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_keys
-********************************************************************/
-be_local_closure(Matter_Session_set_keys,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    /* K1   */  be_nested_str_weak(_i2r_privacy),
-    /* K2   */  be_nested_str_weak(r2ikey),
-    /* K3   */  be_nested_str_weak(attestation_challenge),
-    /* K4   */  be_nested_str_weak(session_timestamp),
-    }),
-    be_str_weak(set_keys),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x4C140000,  //  0001  LDNIL	R5
-      0x90020205,  //  0002  SETMBR	R0	K1	R5
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020603,  //  0004  SETMBR	R0	K3	R3
-      0x90020804,  //  0005  SETMBR	R0	K4	R4
-      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -556,327 +615,6 @@ be_local_closure(Matter_Session_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(__GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x4C040000,  //  0008  LDNIL	R1
-      0x80040200,  //  0009  RET	1	R1
-      0xA4060400,  //  000A  IMPORT	R1	K2
-      0x8C080303,  //  000B  GETMET	R2	R1	K3
-      0x7C080200,  //  000C  CALL	R2	1
-      0x600C0015,  //  000D  GETGBL	R3	G21
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C100506,  //  0012  GETMET	R4	R2	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
-      0x881C0101,  //  0014  GETMBR	R7	R0	K1
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x5426000F,  //  0016  LDINT	R9	16
-      0x7C100A00,  //  0017  CALL	R4	5
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca_pub
-********************************************************************/
-be_local_closure(Matter_Session_get_ca_pub,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TLV),
-    /* K3   */  be_nested_str_weak(parse),
-    /* K4   */  be_nested_str_weak(findsubval),
-    }),
-    be_str_weak(get_ca_pub),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060008,  //  0001  JMPF	R1	#000B
-      0xB8060200,  //  0002  GETNGBL	R1	K1
-      0x88040302,  //  0003  GETMBR	R1	R1	K2
-      0x8C040303,  //  0004  GETMET	R1	R1	K3
-      0x880C0100,  //  0005  GETMBR	R3	R0	K0
-      0x7C040400,  //  0006  CALL	R1	2
-      0x8C080304,  //  0007  GETMET	R2	R1	K4
-      0x54120008,  //  0008  LDINT	R4	9
-      0x7C080400,  //  0009  CALL	R2	2
-      0x80040400,  //  000A  RET	1	R2
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fromjson
-********************************************************************/
-be_local_closure(Matter_Session_fromjson,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Session),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Session),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_nested_str_weak(counter_rcv),
-    /* K7   */  be_nested_str_weak(reset),
-    /* K8   */  be_nested_str_weak(counter_snd),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(0x),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(set),
-    /* K13  */  be_nested_str_weak(fromhex),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_const_int(2147483647),
-    /* K16  */  be_nested_str_weak(_X24_X24),
-    /* K17  */  be_nested_str_weak(fromb64),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(fromjson),
-    &be_const_str_solidified,
-    ( &(const binstruction[88]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0xB8160600,  //  0003  GETNGBL	R5	K3
-      0x8C140B04,  //  0004  GETMET	R5	R5	K4
-      0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x7C140400,  //  0006  CALL	R5	2
-      0x60180010,  //  0007  GETGBL	R6	G16
-      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x7C180200,  //  000A  CALL	R6	1
-      0xA8020047,  //  000B  EXBLK	0	#0054
-      0x5C1C0C00,  //  000C  MOVE	R7	R6
-      0x7C1C0000,  //  000D  CALL	R7	0
-      0x94200207,  //  000E  GETIDX	R8	R1	R7
-      0x1C240F06,  //  000F  EQ	R9	R7	K6
-      0x78260006,  //  0010  JMPF	R9	#0018
-      0x88240B06,  //  0011  GETMBR	R9	R5	K6
-      0x8C241307,  //  0012  GETMET	R9	R9	K7
-      0x602C0009,  //  0013  GETGBL	R11	G9
-      0x5C301000,  //  0014  MOVE	R12	R8
-      0x7C2C0200,  //  0015  CALL	R11	1
-      0x7C240400,  //  0016  CALL	R9	2
-      0x7002003A,  //  0017  JMP		#0053
-      0x1C240F08,  //  0018  EQ	R9	R7	K8
-      0x78260006,  //  0019  JMPF	R9	#0021
-      0x88240B08,  //  001A  GETMBR	R9	R5	K8
-      0x8C241307,  //  001B  GETMET	R9	R9	K7
-      0x602C0009,  //  001C  GETGBL	R11	G9
-      0x5C301000,  //  001D  MOVE	R12	R8
-      0x7C2C0200,  //  001E  CALL	R11	1
-      0x7C240400,  //  001F  CALL	R9	2
-      0x70020031,  //  0020  JMP		#0053
-      0x60240004,  //  0021  GETGBL	R9	G4
-      0x5C281000,  //  0022  MOVE	R10	R8
-      0x7C240200,  //  0023  CALL	R9	1
-      0x1C241301,  //  0024  EQ	R9	R9	K1
-      0x78260027,  //  0025  JMPF	R9	#004E
-      0x8C240709,  //  0026  GETMET	R9	R3	K9
-      0x5C2C1000,  //  0027  MOVE	R11	R8
-      0x5830000A,  //  0028  LDCONST	R12	K10
-      0x7C240600,  //  0029  CALL	R9	3
-      0x1C24130B,  //  002A  EQ	R9	R9	K11
-      0x7826000A,  //  002B  JMPF	R9	#0037
-      0x8C24090C,  //  002C  GETMET	R9	R4	K12
-      0x5C2C0A00,  //  002D  MOVE	R11	R5
-      0x5C300E00,  //  002E  MOVE	R12	R7
-      0x60340015,  //  002F  GETGBL	R13	G21
-      0x7C340000,  //  0030  CALL	R13	0
-      0x8C341B0D,  //  0031  GETMET	R13	R13	K13
-      0x403E1D0F,  //  0032  CONNECT	R15	K14	K15
-      0x943C100F,  //  0033  GETIDX	R15	R8	R15
-      0x7C340400,  //  0034  CALL	R13	2
-      0x7C240800,  //  0035  CALL	R9	4
-      0x70020015,  //  0036  JMP		#004D
-      0x8C240709,  //  0037  GETMET	R9	R3	K9
-      0x5C2C1000,  //  0038  MOVE	R11	R8
-      0x58300010,  //  0039  LDCONST	R12	K16
-      0x7C240600,  //  003A  CALL	R9	3
-      0x1C24130B,  //  003B  EQ	R9	R9	K11
-      0x7826000A,  //  003C  JMPF	R9	#0048
-      0x8C24090C,  //  003D  GETMET	R9	R4	K12
-      0x5C2C0A00,  //  003E  MOVE	R11	R5
-      0x5C300E00,  //  003F  MOVE	R12	R7
-      0x60340015,  //  0040  GETGBL	R13	G21
-      0x7C340000,  //  0041  CALL	R13	0
-      0x8C341B11,  //  0042  GETMET	R13	R13	K17
-      0x403E1D0F,  //  0043  CONNECT	R15	K14	K15
-      0x943C100F,  //  0044  GETIDX	R15	R8	R15
-      0x7C340400,  //  0045  CALL	R13	2
-      0x7C240800,  //  0046  CALL	R9	4
-      0x70020004,  //  0047  JMP		#004D
-      0x8C24090C,  //  0048  GETMET	R9	R4	K12
-      0x5C2C0A00,  //  0049  MOVE	R11	R5
-      0x5C300E00,  //  004A  MOVE	R12	R7
-      0x5C341000,  //  004B  MOVE	R13	R8
-      0x7C240800,  //  004C  CALL	R9	4
-      0x70020004,  //  004D  JMP		#0053
-      0x8C24090C,  //  004E  GETMET	R9	R4	K12
-      0x5C2C0A00,  //  004F  MOVE	R11	R5
-      0x5C300E00,  //  0050  MOVE	R12	R7
-      0x5C341000,  //  0051  MOVE	R13	R8
-      0x7C240800,  //  0052  CALL	R9	4
-      0x7001FFB7,  //  0053  JMP		#000C
-      0x58180012,  //  0054  LDCONST	R6	K18
-      0xAC180200,  //  0055  CATCH	R6	1	0
-      0xB0080000,  //  0056  RAISE	2	R0	R0
-      0x80040A00,  //  0057  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ca
-********************************************************************/
-be_local_closure(Matter_Session_set_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(set_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pk
-********************************************************************/
-be_local_closure(Matter_Session_get_pk,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(no_private_key),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(random),
-    }),
-    be_str_weak(get_pk),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x74060004,  //  0001  JMPT	R1	#0007
-      0xA4060200,  //  0002  IMPORT	R1	K1
-      0x8C080302,  //  0003  GETMET	R2	R1	K2
-      0x5412001F,  //  0004  LDINT	R4	32
-      0x7C080400,  //  0005  CALL	R2	2
-      0x90020002,  //  0006  SETMBR	R0	K0	R2
-      0x88040100,  //  0007  GETMBR	R1	R0	K0
-      0x80040200,  //  0008  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_persist
-********************************************************************/
-be_local_closure(Matter_Session_set_persist,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
-    }),
-    be_str_weak(set_persist),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: close
 ********************************************************************/
 be_local_closure(Matter_Session_close,   /* name */
@@ -977,6 +715,117 @@ be_local_closure(Matter_Session_close,   /* name */
       0xB0080000,  //  0038  RAISE	2	R0	R0
       0x90020001,  //  0039  SETMBR	R0	K0	R1
       0x80000000,  //  003A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: has_expired
+********************************************************************/
+be_local_closure(Matter_Session_has_expired,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(rtc),
+    /* K2   */  be_nested_str_weak(utc),
+    /* K3   */  be_nested_str_weak(expiration),
+    }),
+    be_str_weak(has_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0003,  //  0002  JMPF	R2	#0007
+      0xB80A0000,  //  0003  GETNGBL	R2	K0
+      0x8C080501,  //  0004  GETMET	R2	R2	K1
+      0x7C080200,  //  0005  CALL	R2	1
+      0x94040502,  //  0006  GETIDX	R1	R2	K2
+      0x88080103,  //  0007  GETMBR	R2	R0	K3
+      0x4C0C0000,  //  0008  LDNIL	R3
+      0x20080403,  //  0009  NE	R2	R2	R3
+      0x780A0002,  //  000A  JMPF	R2	#000E
+      0x88080103,  //  000B  GETMBR	R2	R0	K3
+      0x28080202,  //  000C  GE	R2	R1	R2
+      0x80040400,  //  000D  RET	1	R2
+      0x50080000,  //  000E  LDBOOL	R2	0	0
+      0x80040400,  //  000F  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_device
+********************************************************************/
+be_local_closure(Matter_Session_set_fabric_device,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric),
+    /* K1   */  be_nested_str_weak(deviceid),
+    /* K2   */  be_nested_str_weak(fabric_compressed),
+    /* K3   */  be_nested_str_weak(__store),
+    /* K4   */  be_nested_str_weak(remove_redundant_session),
+    }),
+    be_str_weak(set_fabric_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x88100103,  //  0003  GETMBR	R4	R0	K3
+      0x8C100904,  //  0004  GETMET	R4	R4	K4
+      0x5C180000,  //  0005  MOVE	R6	R0
+      0x7C100400,  //  0006  CALL	R4	2
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_expire_time
+********************************************************************/
+be_local_closure(Matter_Session_set_expire_time,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expiration),
+    }),
+    be_str_weak(set_expire_time),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080009,  //  0000  GETGBL	R2	G9
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -1093,12 +942,66 @@ be_local_closure(Matter_Session_gen_CSR,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_noc
+** Solidified function: get_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_set_noc,   /* name */
+be_local_closure(Matter_Session_get_fabric,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
-    3,                          /* argc */
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric),
+    }),
+    be_str_weak(get_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(get_fabric_compressed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_label
+********************************************************************/
+be_local_closure(Matter_Session_set_fabric_label,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1106,69 +1009,47 @@ be_local_closure(Matter_Session_set_noc,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    /* K1   */  be_nested_str_weak(icac),
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(set_noc),
+    be_str_weak(set_fabric_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0000,  //  0004  JMPF	R2	#0006
+      0x90020201,  //  0005  SETMBR	R0	K1	R1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_no_expiration
+********************************************************************/
+be_local_closure(Matter_Session_set_no_expiration,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expiration),
+    }),
+    be_str_weak(set_no_expiration),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
       0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_noc
-********************************************************************/
-be_local_closure(Matter_Session_get_noc,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    }),
-    be_str_weak(get_noc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ac
-********************************************************************/
-be_local_closure(Matter_Session_get_ac,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attestation_challenge),
-    }),
-    be_str_weak(get_ac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1248,6 +1129,245 @@ be_local_closure(Matter_Session_init,   /* name */
 
 
 /********************************************************************
+** Solidified function: save
+********************************************************************/
+be_local_closure(Matter_Session_save,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(__store),
+    /* K1   */  be_nested_str_weak(save),
+    }),
+    be_str_weak(save),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_keys
+********************************************************************/
+be_local_closure(Matter_Session_set_keys,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    /* K1   */  be_nested_str_weak(_i2r_privacy),
+    /* K2   */  be_nested_str_weak(r2ikey),
+    /* K3   */  be_nested_str_weak(attestation_challenge),
+    /* K4   */  be_nested_str_weak(session_timestamp),
+    }),
+    be_str_weak(set_keys),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x4C140000,  //  0001  LDNIL	R5
+      0x90020205,  //  0002  SETMBR	R0	K1	R5
+      0x90020402,  //  0003  SETMBR	R0	K2	R2
+      0x90020603,  //  0004  SETMBR	R0	K3	R3
+      0x90020804,  //  0005  SETMBR	R0	K4	R4
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ac
+********************************************************************/
+be_local_closure(Matter_Session_get_ac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attestation_challenge),
+    }),
+    be_str_weak(get_ac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_group_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(HKDF_SHA256),
+    /* K4   */  be_nested_str_weak(fromstring),
+    /* K5   */  be_nested_str_weak(__GROUP_KEY),
+    /* K6   */  be_nested_str_weak(derive),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x74060003,  //  0003  JMPT	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x4C040000,  //  0008  LDNIL	R1
+      0x80040200,  //  0009  RET	1	R1
+      0xA4060400,  //  000A  IMPORT	R1	K2
+      0x8C080303,  //  000B  GETMET	R2	R1	K3
+      0x7C080200,  //  000C  CALL	R2	1
+      0x600C0015,  //  000D  GETGBL	R3	G21
+      0x7C0C0000,  //  000E  CALL	R3	0
+      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
+      0x88140105,  //  0010  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8C100506,  //  0012  GETMET	R4	R2	K6
+      0x88180100,  //  0013  GETMBR	R6	R0	K0
+      0x881C0101,  //  0014  GETMBR	R7	R0	K1
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x5426000F,  //  0016  LDINT	R9	16
+      0x7C100A00,  //  0017  CALL	R4	5
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(get_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pk
+********************************************************************/
+be_local_closure(Matter_Session_get_pk,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(no_private_key),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(random),
+    }),
+    be_str_weak(get_pk),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x74060004,  //  0001  JMPT	R1	#0007
+      0xA4060200,  //  0002  IMPORT	R1	K1
+      0x8C080302,  //  0003  GETMET	R2	R1	K2
+      0x5412001F,  //  0004  LDINT	R4	32
+      0x7C080400,  //  0005  CALL	R2	2
+      0x90020002,  //  0006  SETMBR	R0	K0	R2
+      0x88040100,  //  0007  GETMBR	R1	R0	K0
+      0x80040200,  //  0008  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_i2r
+********************************************************************/
+be_local_closure(Matter_Session_get_i2r,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    }),
+    be_str_weak(get_i2r),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_icac
 ********************************************************************/
 be_local_closure(Matter_Session_get_icac,   /* name */
@@ -1302,96 +1422,6 @@ be_local_closure(Matter_Session_get_mode,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_fabric_device
-********************************************************************/
-be_local_closure(Matter_Session_set_fabric_device,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric),
-    /* K1   */  be_nested_str_weak(deviceid),
-    /* K2   */  be_nested_str_weak(fabric_compressed),
-    /* K3   */  be_nested_str_weak(__store),
-    /* K4   */  be_nested_str_weak(remove_redundant_session),
-    }),
-    be_str_weak(set_fabric_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x88100103,  //  0003  GETMBR	R4	R0	K3
-      0x8C100904,  //  0004  GETMET	R4	R4	K4
-      0x5C180000,  //  0005  MOVE	R6	R0
-      0x7C100400,  //  0006  CALL	R4	2
-      0x80000000,  //  0007  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_i2r_privacy
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_i2r_privacy),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(HKDF_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_nested_str_weak(get_i2r),
-    /* K5   */  be_nested_str_weak(fromstring),
-    /* K6   */  be_nested_str_weak(PrivacyKey),
-    }),
-    be_str_weak(get_i2r_privacy),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x7806000F,  //  0003  JMPF	R1	#0014
-      0xA4060200,  //  0004  IMPORT	R1	K1
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
-      0x7C080200,  //  0006  CALL	R2	1
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x8C100104,  //  0008  GETMET	R4	R0	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x60140015,  //  000A  GETGBL	R5	G21
-      0x7C140000,  //  000B  CALL	R5	0
-      0x60180015,  //  000C  GETGBL	R6	G21
-      0x7C180000,  //  000D  CALL	R6	0
-      0x8C180D05,  //  000E  GETMET	R6	R6	K5
-      0x58200006,  //  000F  LDCONST	R8	K6
-      0x7C180400,  //  0010  CALL	R6	2
-      0x541E000F,  //  0011  LDINT	R7	16
-      0x7C080A00,  //  0012  CALL	R2	5
-      0x90020002,  //  0013  SETMBR	R0	K0	R2
-      0x88040100,  //  0014  GETMBR	R1	R0	K0
-      0x80040200,  //  0015  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_ca
 ********************************************************************/
 be_local_closure(Matter_Session_get_ca,   /* name */
@@ -1419,39 +1449,9 @@ be_local_closure(Matter_Session_get_ca,   /* name */
 
 
 /********************************************************************
-** Solidified function: save
+** Solidified function: get_deviceid
 ********************************************************************/
-be_local_closure(Matter_Session_save,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(__store),
-    /* K1   */  be_nested_str_weak(save),
-    }),
-    be_str_weak(save),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+be_local_closure(Matter_Session_get_deviceid,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1462,9 +1462,9 @@ be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_compressed),
+    /* K0   */  be_nested_str_weak(deviceid),
     }),
-    be_str_weak(get_fabric_compressed),
+    be_str_weak(get_deviceid),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -1479,85 +1479,86 @@ be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
 ** Solidified class: Matter_Session
 ********************************************************************/
 be_local_class(Matter_Session,
-    39,
+    40,
     NULL,
-    be_nested_map(75,
+    be_nested_map(76,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(peer_node_id, -1), be_const_var(19) },
-        { be_const_key_weak(fabric_label, -1), be_const_var(31) },
-        { be_const_key_weak(set_fabric_label, 1), be_const_closure(Matter_Session_set_fabric_label_closure) },
-        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
-        { be_const_key_weak(get_ca, 61), be_const_closure(Matter_Session_get_ca_closure) },
-        { be_const_key_weak(set_mode, -1), be_const_closure(Matter_Session_set_mode_closure) },
-        { be_const_key_weak(set_expire_time, -1), be_const_closure(Matter_Session_set_expire_time_closure) },
-        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
-        { be_const_key_weak(__CASE, -1), be_const_int(2) },
-        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(_future_local_session_id, -1), be_const_var(7) },
-        { be_const_key_weak(set_expire_in_seconds, 13), be_const_closure(Matter_Session_set_expire_in_seconds_closure) },
-        { be_const_key_weak(admin_vendor, -1), be_const_var(33) },
-        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Session_fromjson_closure) },
-        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
-        { be_const_key_weak(expiration, -1), be_const_var(37) },
-        { be_const_key_weak(get_deviceid, 63), be_const_closure(Matter_Session_get_deviceid_closure) },
-        { be_const_key_weak(has_expired, -1), be_const_closure(Matter_Session_has_expired_closure) },
-        { be_const_key_weak(i2rkey, -1), be_const_var(15) },
-        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
-        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
-        { be_const_key_weak(admin_subject, 34), be_const_var(32) },
-        { be_const_key_weak(noc, -1), be_const_var(23) },
-        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
+        { be_const_key_weak(get_deviceid, -1), be_const_closure(Matter_Session_get_deviceid_closure) },
+        { be_const_key_weak(_counter_insecure_rcv, -1), be_const_var(14) },
+        { be_const_key_weak(deviceid, -1), be_const_var(31) },
+        { be_const_key_weak(_Msg2, -1), be_const_var(36) },
         { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Session_get_ca_pub_closure) },
-        { be_const_key_weak(ipk_epoch_key, 14), be_const_var(25) },
-        { be_const_key_weak(tojson, 54), be_const_closure(Matter_Session_tojson_closure) },
-        { be_const_key_weak(_i2r_privacy, 66), be_const_var(17) },
-        { be_const_key_weak(get_icac, 39), be_const_closure(Matter_Session_get_icac_closure) },
-        { be_const_key_weak(init, 35), be_const_closure(Matter_Session_init_closure) },
-        { be_const_key_weak(shared_secret, 29), be_const_var(27) },
-        { be_const_key_weak(set_persist, -1), be_const_closure(Matter_Session_set_persist_closure) },
-        { be_const_key_weak(resumption_id, -1), be_const_var(26) },
-        { be_const_key_weak(r2ikey, 38), be_const_var(16) },
-        { be_const_key_weak(__breadcrumb, 60), be_const_var(20) },
-        { be_const_key_weak(local_session_id, 19), be_const_var(2) },
-        { be_const_key_weak(__GROUP_KEY, 22), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(deviceid, -1), be_const_var(30) },
-        { be_const_key_weak(source_node_id, -1), be_const_var(5) },
-        { be_const_key_weak(attestation_challenge, 25), be_const_var(18) },
-        { be_const_key_weak(no_private_key, 62), be_const_var(21) },
-        { be_const_key_weak(_future_initiator_session_id, 4), be_const_var(6) },
-        { be_const_key_weak(fabric, -1), be_const_var(28) },
-        { be_const_key_weak(counter_rcv, -1), be_const_var(8) },
-        { be_const_key_weak(__ip, -1), be_const_var(11) },
-        { be_const_key_weak(_counter_insecure_rcv, -1), be_const_var(13) },
-        { be_const_key_weak(gen_CSR, 59), be_const_closure(Matter_Session_gen_CSR_closure) },
-        { be_const_key_weak(__port, 33), be_const_var(12) },
-        { be_const_key_weak(mode, 28), be_const_var(1) },
-        { be_const_key_weak(session_timestamp, 42), be_const_var(4) },
-        { be_const_key_weak(__store, -1), be_const_var(0) },
-        { be_const_key_weak(icac, -1), be_const_var(24) },
-        { be_const_key_weak(counter_snd, -1), be_const_var(9) },
-        { be_const_key_weak(_counter_insecure_snd, -1), be_const_var(14) },
-        { be_const_key_weak(_Msg1, 12), be_const_var(34) },
-        { be_const_key_weak(set_ipk_epoch_key, 44), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
-        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Session_get_noc_closure) },
-        { be_const_key_weak(_Msg2, -1), be_const_var(35) },
-        { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
-        { be_const_key_weak(set_noc, -1), be_const_closure(Matter_Session_set_noc_closure) },
-        { be_const_key_weak(_chunked_attr_reports, 27), be_const_var(38) },
-        { be_const_key_weak(_persist, -1), be_const_var(36) },
-        { be_const_key_weak(__exchange_id, -1), be_const_var(10) },
-        { be_const_key_weak(__PASE, -1), be_const_int(1) },
-        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
-        { be_const_key_weak(fabric_compressed, -1), be_const_var(29) },
-        { be_const_key_weak(close, 71), be_const_closure(Matter_Session_close_closure) },
-        { be_const_key_weak(root_ca_certificate, -1), be_const_var(22) },
+        { be_const_key_weak(__ip, 7), be_const_var(11) },
+        { be_const_key_weak(_i2r_privacy, -1), be_const_var(18) },
+        { be_const_key_weak(__exchange_id, 26), be_const_var(10) },
+        { be_const_key_weak(session_timestamp, -1), be_const_var(4) },
         { be_const_key_weak(set_fabric_device, -1), be_const_closure(Matter_Session_set_fabric_device_closure) },
-        { be_const_key_weak(initiator_session_id, -1), be_const_var(3) },
-        { be_const_key_weak(get_i2r_privacy, -1), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
-        { be_const_key_weak(set_keys, 3), be_const_closure(Matter_Session_set_keys_closure) },
-        { be_const_key_weak(save, -1), be_const_closure(Matter_Session_save_closure) },
+        { be_const_key_weak(set_expire_time, -1), be_const_closure(Matter_Session_set_expire_time_closure) },
+        { be_const_key_weak(admin_vendor, 69), be_const_var(34) },
+        { be_const_key_weak(r2ikey, 13), be_const_var(17) },
+        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
+        { be_const_key_weak(_Msg1, -1), be_const_var(35) },
+        { be_const_key_weak(set_mode, 66), be_const_closure(Matter_Session_set_mode_closure) },
+        { be_const_key_weak(set_persist, 75), be_const_closure(Matter_Session_set_persist_closure) },
+        { be_const_key_weak(set_expire_in_seconds, 10), be_const_closure(Matter_Session_set_expire_in_seconds_closure) },
+        { be_const_key_weak(mode, 33), be_const_var(1) },
+        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Session_fromjson_closure) },
+        { be_const_key_weak(__port, 54), be_const_var(12) },
+        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Session_get_icac_closure) },
+        { be_const_key_weak(__GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(noc, 12), be_const_var(24) },
+        { be_const_key_weak(expiration, -1), be_const_var(38) },
+        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
+        { be_const_key_weak(__breadcrumb, -1), be_const_var(21) },
+        { be_const_key_weak(__CASE, -1), be_const_int(2) },
+        { be_const_key_weak(__PASE, -1), be_const_int(1) },
+        { be_const_key_weak(has_expired, 39), be_const_closure(Matter_Session_has_expired_closure) },
+        { be_const_key_weak(_chunked_attr_reports, -1), be_const_var(39) },
+        { be_const_key_weak(local_session_id, -1), be_const_var(2) },
+        { be_const_key_weak(set_ipk_epoch_key, 70), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
+        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
+        { be_const_key_weak(tojson, 46), be_const_closure(Matter_Session_tojson_closure) },
+        { be_const_key_weak(_counter_insecure_snd, -1), be_const_var(15) },
+        { be_const_key_weak(_future_initiator_session_id, -1), be_const_var(6) },
+        { be_const_key_weak(fabric_label, -1), be_const_var(32) },
+        { be_const_key_weak(no_private_key, -1), be_const_var(22) },
+        { be_const_key_weak(set_no_expiration, -1), be_const_closure(Matter_Session_set_no_expiration_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_init_closure) },
+        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
+        { be_const_key_weak(peer_node_id, -1), be_const_var(20) },
         { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
-        { be_const_key_weak(set_no_expiration, 0), be_const_closure(Matter_Session_set_no_expiration_closure) },
+        { be_const_key_weak(fabric_compressed, 28), be_const_var(30) },
+        { be_const_key_weak(save, 62), be_const_closure(Matter_Session_save_closure) },
+        { be_const_key_weak(_future_local_session_id, 25), be_const_var(7) },
+        { be_const_key_weak(counter_snd, -1), be_const_var(9) },
+        { be_const_key_weak(set_keys, -1), be_const_closure(Matter_Session_set_keys_closure) },
+        { be_const_key_weak(__message_handler, -1), be_const_var(13) },
+        { be_const_key_weak(attestation_challenge, -1), be_const_var(19) },
+        { be_const_key_weak(counter_rcv, 40), be_const_var(8) },
+        { be_const_key_weak(get_i2r_privacy, 45), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
+        { be_const_key_weak(resumption_id, 57), be_const_var(27) },
+        { be_const_key_weak(set_noc, -1), be_const_closure(Matter_Session_set_noc_closure) },
+        { be_const_key_weak(get_r2i, 50), be_const_closure(Matter_Session_get_r2i_closure) },
+        { be_const_key_weak(__store, 48), be_const_var(0) },
+        { be_const_key_weak(shared_secret, 31), be_const_var(28) },
+        { be_const_key_weak(_persist, -1), be_const_var(37) },
+        { be_const_key_weak(initiator_session_id, 0), be_const_var(3) },
+        { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
+        { be_const_key_weak(icac, 35), be_const_var(25) },
+        { be_const_key_weak(set_fabric_label, 30), be_const_closure(Matter_Session_set_fabric_label_closure) },
+        { be_const_key_weak(ipk_epoch_key, -1), be_const_var(26) },
+        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
+        { be_const_key_weak(admin_subject, -1), be_const_var(33) },
+        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
+        { be_const_key_weak(get_noc, 21), be_const_closure(Matter_Session_get_noc_closure) },
+        { be_const_key_weak(i2rkey, 73), be_const_var(16) },
+        { be_const_key_weak(fabric, 9), be_const_var(29) },
+        { be_const_key_weak(source_node_id, -1), be_const_var(5) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Session_get_ca_closure) },
+        { be_const_key_weak(close, -1), be_const_closure(Matter_Session_close_closure) },
+        { be_const_key_weak(root_ca_certificate, 5), be_const_var(23) },
+        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
     })),
     be_str_weak(Matter_Session)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_UDPPacket_sent;
 ********************************************************************/
 be_local_closure(Matter_UDPPacket_sent_init,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    9,                          /* nstack */
     5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -25,28 +25,114 @@ be_local_closure(Matter_UDPPacket_sent_init,   /* name */
     /* K2   */  be_nested_str_weak(port),
     /* K3   */  be_nested_str_weak(msg_id),
     /* K4   */  be_nested_str_weak(retries),
-    /* K5   */  be_nested_str_weak(RETRIES),
+    /* K5   */  be_const_int(0),
     /* K6   */  be_nested_str_weak(next_try),
     /* K7   */  be_nested_str_weak(tasmota),
     /* K8   */  be_nested_str_weak(millis),
-    /* K9   */  be_nested_str_weak(RETRY_MS),
+    /* K9   */  be_nested_str_weak(backoff_time),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
       0x90020202,  //  0001  SETMBR	R0	K1	R2
       0x90020403,  //  0002  SETMBR	R0	K2	R3
       0x90020604,  //  0003  SETMBR	R0	K3	R4
-      0x88140105,  //  0004  GETMBR	R5	R0	K5
-      0x90020805,  //  0005  SETMBR	R0	K4	R5
-      0xB8160E00,  //  0006  GETNGBL	R5	K7
-      0x8C140B08,  //  0007  GETMET	R5	R5	K8
+      0x90020905,  //  0004  SETMBR	R0	K4	K5
+      0xB8160E00,  //  0005  GETNGBL	R5	K7
+      0x8C140B08,  //  0006  GETMET	R5	R5	K8
+      0x7C140200,  //  0007  CALL	R5	1
+      0x8C180109,  //  0008  GETMET	R6	R0	K9
+      0x88200104,  //  0009  GETMBR	R8	R0	K4
+      0x7C180400,  //  000A  CALL	R6	2
+      0x00140A06,  //  000B  ADD	R5	R5	R6
+      0x90020C05,  //  000C  SETMBR	R0	K6	R5
+      0x80000000,  //  000D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: backoff_time
+********************************************************************/
+be_local_closure(Matter_UDPPacket_sent_backoff_time,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 2]) {     /* constants */
+        /* K0   */  be_const_int(1),
+        /* K1   */  be_const_int(0),
+        }),
+        be_str_weak(power_int),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x58080000,  //  0000  LDCONST	R2	K0
+          0x240C0301,  //  0001  GT	R3	R1	K1
+          0x780E0002,  //  0002  JMPF	R3	#0006
+          0x08080400,  //  0003  MUL	R2	R2	R0
+          0x04040300,  //  0004  SUB	R1	R1	K0
+          0x7001FFFA,  //  0005  JMP		#0001
+          0x80040400,  //  0006  RET	1	R2
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(math),
+    /* K1   */  be_nested_str_weak(rand),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_const_int(1),
+    /* K4   */  be_const_real_hex(0x3FCCCCCD),
+    /* K5   */  be_const_real_hex(0x3F800000),
+    /* K6   */  be_const_real_hex(0x3E800000),
+    }),
+    be_str_weak(backoff_time),
+    &be_const_str_solidified,
+    ( &(const binstruction[28]) {  /* code */
+      0x84080000,  //  0000  CLOSURE	R2	P0
+      0xA40E0000,  //  0001  IMPORT	R3	K0
+      0x5412012B,  //  0002  LDINT	R4	300
+      0x6014000A,  //  0003  GETGBL	R5	G10
+      0x8C180701,  //  0004  GETMET	R6	R3	K1
+      0x7C180200,  //  0005  CALL	R6	1
+      0x541E00FE,  //  0006  LDINT	R7	255
+      0x2C180C07,  //  0007  AND	R6	R6	R7
       0x7C140200,  //  0008  CALL	R5	1
-      0x88180109,  //  0009  GETMBR	R6	R0	K9
-      0x00140A06,  //  000A  ADD	R5	R5	R6
-      0x90020C05,  //  000B  SETMBR	R0	K6	R5
-      0x80000000,  //  000C  RET	0
+      0x541A00FE,  //  0009  LDINT	R6	255
+      0x0C140A06,  //  000A  DIV	R5	R5	R6
+      0x24180302,  //  000B  GT	R6	R1	K2
+      0x781A0001,  //  000C  JMPF	R6	#000F
+      0x04180303,  //  000D  SUB	R6	R1	K3
+      0x70020000,  //  000E  JMP		#0010
+      0x58180002,  //  000F  LDCONST	R6	K2
+      0x5C1C0400,  //  0010  MOVE	R7	R2
+      0x58200004,  //  0011  LDCONST	R8	K4
+      0x5C240C00,  //  0012  MOVE	R9	R6
+      0x7C1C0400,  //  0013  CALL	R7	2
+      0x081C0807,  //  0014  MUL	R7	R4	R7
+      0x08200B06,  //  0015  MUL	R8	R5	K6
+      0x00220A08,  //  0016  ADD	R8	K5	R8
+      0x081C0E08,  //  0017  MUL	R7	R7	R8
+      0x60200009,  //  0018  GETGBL	R8	G9
+      0x5C240E00,  //  0019  MOVE	R9	R7
+      0x7C200200,  //  001A  CALL	R8	1
+      0x80041000,  //  001B  RET	1	R8
     })
   )
 );
@@ -131,18 +217,17 @@ be_local_closure(Matter_UDPPacket_sent_send,   /* name */
 be_local_class(Matter_UDPPacket_sent,
     6,
     NULL,
-    be_nested_map(10,
+    be_nested_map(9,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(RETRY_MS, 7), be_const_int(500) },
-        { be_const_key_weak(raw, 4), be_const_var(0) },
-        { be_const_key_weak(next_try, 9), be_const_var(5) },
-        { be_const_key_weak(retries, -1), be_const_var(4) },
-        { be_const_key_weak(send, 6), be_const_closure(Matter_UDPPacket_sent_send_closure) },
+        { be_const_key_weak(send, 7), be_const_closure(Matter_UDPPacket_sent_send_closure) },
+        { be_const_key_weak(msg_id, -1), be_const_var(3) },
+        { be_const_key_weak(retries, 8), be_const_var(4) },
+        { be_const_key_weak(backoff_time, -1), be_const_closure(Matter_UDPPacket_sent_backoff_time_closure) },
+        { be_const_key_weak(next_try, 0), be_const_var(5) },
+        { be_const_key_weak(raw, 3), be_const_var(0) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_UDPPacket_sent_init_closure) },
-        { be_const_key_weak(RETRIES, -1), be_const_int(4) },
         { be_const_key_weak(port, -1), be_const_var(2) },
         { be_const_key_weak(addr, -1), be_const_var(1) },
-        { be_const_key_weak(msg_id, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_UDPPacket_sent)
 );
@@ -155,6 +240,62 @@ void be_load_Matter_UDPPacket_sent_class(bvm *vm) {
 }
 
 extern const bclass be_class_Matter_UDPServer;
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_UDPServer_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(listening),
+    /* K1   */  be_nested_str_weak(udp_socket),
+    /* K2   */  be_nested_str_weak(udp),
+    /* K3   */  be_nested_str_weak(begin),
+    /* K4   */  be_nested_str_weak(address),
+    /* K5   */  be_nested_str_weak(port),
+    /* K6   */  be_nested_str_weak(network_error),
+    /* K7   */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
+    /* K8   */  be_nested_str_weak(dispatch_cb),
+    /* K9   */  be_nested_str_weak(tasmota),
+    /* K10  */  be_nested_str_weak(add_driver),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0011,  //  0001  JMPT	R2	#0014
+      0xB80A0400,  //  0002  GETNGBL	R2	K2
+      0x7C080000,  //  0003  CALL	R2	0
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x7C080600,  //  0009  CALL	R2	3
+      0x5C0C0400,  //  000A  MOVE	R3	R2
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0xB0060D07,  //  000C  RAISE	1	K6	K7
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x90020003,  //  000E  SETMBR	R0	K0	R3
+      0x90021001,  //  000F  SETMBR	R0	K8	R1
+      0xB80E1200,  //  0010  GETNGBL	R3	K9
+      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
 
 /********************************************************************
 ** Solidified function: init
@@ -202,35 +343,11 @@ be_local_closure(Matter_UDPServer_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: every_second
+** Solidified function: resend_packets
 ********************************************************************/
-be_local_closure(Matter_UDPServer_every_second,   /* name */
+be_local_closure(Matter_UDPServer_resend_packets,   /* name */
   be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop
-********************************************************************/
-be_local_closure(Matter_UDPServer_stop,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
+    11,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -238,28 +355,143 @@ be_local_closure(Matter_UDPServer_stop,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(listening),
-    /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(stop),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(remove_driver),
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(packets_sent),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(time_reached),
+    /* K3   */  be_nested_str_weak(next_try),
+    /* K4   */  be_nested_str_weak(retries),
+    /* K5   */  be_nested_str_weak(RETRIES),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(MTR_X3A_X20resending_X20packet_X20id_X3D),
+    /* K8   */  be_nested_str_weak(msg_id),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(send),
+    /* K11  */  be_nested_str_weak(udp_socket),
+    /* K12  */  be_nested_str_weak(millis),
+    /* K13  */  be_nested_str_weak(backoff_time),
+    /* K14  */  be_const_int(1),
+    /* K15  */  be_nested_str_weak(string),
+    /* K16  */  be_nested_str_weak(remove),
+    /* K17  */  be_nested_str_weak(format),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20target_X20unreachable_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K19  */  be_nested_str_weak(addr),
+    /* K20  */  be_nested_str_weak(port),
+    /* K21  */  be_const_int(2),
+    /* K22  */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(stop),
+    be_str_weak(resend_packets),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060008,  //  0001  JMPF	R1	#000B
-      0x88040101,  //  0002  GETMBR	R1	R0	K1
-      0x8C040302,  //  0003  GETMET	R1	R1	K2
-      0x7C040200,  //  0004  CALL	R1	1
-      0x50040000,  //  0005  LDBOOL	R1	0	0
-      0x90020001,  //  0006  SETMBR	R0	K0	R1
-      0xB8060600,  //  0007  GETNGBL	R1	K3
-      0x8C040304,  //  0008  GETMET	R1	R1	K4
-      0x5C0C0000,  //  0009  MOVE	R3	R0
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80000000,  //  000B  RET	0
+    ( &(const binstruction[57]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x7C040200,  //  0002  CALL	R1	1
+      0xA8020030,  //  0003  EXBLK	0	#0035
+      0x5C080200,  //  0004  MOVE	R2	R1
+      0x7C080000,  //  0005  CALL	R2	0
+      0xB80E0200,  //  0006  GETNGBL	R3	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x88140503,  //  0008  GETMBR	R5	R2	K3
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x780E0028,  //  000A  JMPF	R3	#0034
+      0x880C0504,  //  000B  GETMBR	R3	R2	K4
+      0x88100105,  //  000C  GETMBR	R4	R0	K5
+      0x180C0604,  //  000D  LE	R3	R3	R4
+      0x780E0016,  //  000E  JMPF	R3	#0026
+      0xB80E0200,  //  000F  GETNGBL	R3	K1
+      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x60140008,  //  0011  GETGBL	R5	G8
+      0x88180508,  //  0012  GETMBR	R6	R2	K8
+      0x7C140200,  //  0013  CALL	R5	1
+      0x00160E05,  //  0014  ADD	R5	K7	R5
+      0x58180009,  //  0015  LDCONST	R6	K9
+      0x7C0C0600,  //  0016  CALL	R3	3
+      0x8C0C050A,  //  0017  GETMET	R3	R2	K10
+      0x8814010B,  //  0018  GETMBR	R5	R0	K11
+      0x7C0C0400,  //  0019  CALL	R3	2
+      0xB80E0200,  //  001A  GETNGBL	R3	K1
+      0x8C0C070C,  //  001B  GETMET	R3	R3	K12
+      0x7C0C0200,  //  001C  CALL	R3	1
+      0x8C10050D,  //  001D  GETMET	R4	R2	K13
+      0x88180504,  //  001E  GETMBR	R6	R2	K4
+      0x7C100400,  //  001F  CALL	R4	2
+      0x000C0604,  //  0020  ADD	R3	R3	R4
+      0x900A0603,  //  0021  SETMBR	R2	K3	R3
+      0x880C0504,  //  0022  GETMBR	R3	R2	K4
+      0x000C070E,  //  0023  ADD	R3	R3	K14
+      0x900A0803,  //  0024  SETMBR	R2	K4	R3
+      0x7002000D,  //  0025  JMP		#0034
+      0xA40E1E00,  //  0026  IMPORT	R3	K15
+      0x88100100,  //  0027  GETMBR	R4	R0	K0
+      0x8C100910,  //  0028  GETMET	R4	R4	K16
+      0x88180508,  //  0029  GETMBR	R6	R2	K8
+      0x7C100400,  //  002A  CALL	R4	2
+      0xB8120200,  //  002B  GETNGBL	R4	K1
+      0x8C100906,  //  002C  GETMET	R4	R4	K6
+      0x8C180711,  //  002D  GETMET	R6	R3	K17
+      0x58200012,  //  002E  LDCONST	R8	K18
+      0x88240513,  //  002F  GETMBR	R9	R2	K19
+      0x88280514,  //  0030  GETMBR	R10	R2	K20
+      0x7C180800,  //  0031  CALL	R6	4
+      0x581C0015,  //  0032  LDCONST	R7	K21
+      0x7C100600,  //  0033  CALL	R4	3
+      0x7001FFCE,  //  0034  JMP		#0004
+      0x58040016,  //  0035  LDCONST	R1	K22
+      0xAC040200,  //  0036  CATCH	R1	1	0
+      0xB0080000,  //  0037  RAISE	2	R0	R0
+      0x80000000,  //  0038  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: packet_ack
+********************************************************************/
+be_local_closure(Matter_UDPServer_packet_ack,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(packets_sent),
+    /* K1   */  be_nested_str_weak(contains),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(MTR_X3A_X20removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
+    }),
+    be_str_weak(packet_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x7C080400,  //  0007  CALL	R2	2
+      0x780A000B,  //  0008  JMPF	R2	#0015
+      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x8C080502,  //  000A  GETMET	R2	R2	K2
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x7C080400,  //  000C  CALL	R2	2
+      0xB80A0600,  //  000D  GETNGBL	R2	K3
+      0x8C080504,  //  000E  GETMET	R2	R2	K4
+      0x60100008,  //  000F  GETGBL	R4	G8
+      0x5C140200,  //  0010  MOVE	R5	R1
+      0x7C100200,  //  0011  CALL	R4	1
+      0x00120A04,  //  0012  ADD	R4	K5	R4
+      0x54160003,  //  0013  LDINT	R5	4
+      0x7C080600,  //  0014  CALL	R2	3
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -352,99 +584,23 @@ be_local_closure(Matter_UDPServer_every_50ms,   /* name */
 
 
 /********************************************************************
-** Solidified function: resend_packets
+** Solidified function: every_second
 ********************************************************************/
-be_local_closure(Matter_UDPServer_resend_packets,   /* name */
+be_local_closure(Matter_UDPServer_every_second,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    1,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(packets_sent),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(time_reached),
-    /* K3   */  be_nested_str_weak(next_try),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20resending_X20packet_X20id_X3D),
-    /* K6   */  be_nested_str_weak(msg_id),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(send),
-    /* K9   */  be_nested_str_weak(udp_socket),
-    /* K10  */  be_nested_str_weak(retries),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(string),
-    /* K14  */  be_nested_str_weak(remove),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20non_X2Dacked_X20packet_X20to_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
-    /* K17  */  be_nested_str_weak(addr),
-    /* K18  */  be_nested_str_weak(port),
-    /* K19  */  be_nested_str_weak(millis),
-    /* K20  */  be_nested_str_weak(RETRY_MS),
-    /* K21  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(resend_packets),
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(every_second),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x7C040200,  //  0002  CALL	R1	1
-      0xA802002D,  //  0003  EXBLK	0	#0032
-      0x5C080200,  //  0004  MOVE	R2	R1
-      0x7C080000,  //  0005  CALL	R2	0
-      0xB80E0200,  //  0006  GETNGBL	R3	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x88140503,  //  0008  GETMBR	R5	R2	K3
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x780E0025,  //  000A  JMPF	R3	#0031
-      0xB80E0200,  //  000B  GETNGBL	R3	K1
-      0x8C0C0704,  //  000C  GETMET	R3	R3	K4
-      0x60140008,  //  000D  GETGBL	R5	G8
-      0x88180506,  //  000E  GETMBR	R6	R2	K6
-      0x7C140200,  //  000F  CALL	R5	1
-      0x00160A05,  //  0010  ADD	R5	K5	R5
-      0x58180007,  //  0011  LDCONST	R6	K7
-      0x7C0C0600,  //  0012  CALL	R3	3
-      0x8C0C0508,  //  0013  GETMET	R3	R2	K8
-      0x88140109,  //  0014  GETMBR	R5	R0	K9
-      0x7C0C0400,  //  0015  CALL	R3	2
-      0x880C050A,  //  0016  GETMBR	R3	R2	K10
-      0x040C070B,  //  0017  SUB	R3	R3	K11
-      0x900A1403,  //  0018  SETMBR	R2	K10	R3
-      0x880C050A,  //  0019  GETMBR	R3	R2	K10
-      0x180C070C,  //  001A  LE	R3	R3	K12
-      0x780E000E,  //  001B  JMPF	R3	#002B
-      0xA40E1A00,  //  001C  IMPORT	R3	K13
-      0x88100100,  //  001D  GETMBR	R4	R0	K0
-      0x8C10090E,  //  001E  GETMET	R4	R4	K14
-      0x88180506,  //  001F  GETMBR	R6	R2	K6
-      0x7C100400,  //  0020  CALL	R4	2
-      0xB8120200,  //  0021  GETNGBL	R4	K1
-      0x8C100904,  //  0022  GETMET	R4	R4	K4
-      0x8C18070F,  //  0023  GETMET	R6	R3	K15
-      0x58200010,  //  0024  LDCONST	R8	K16
-      0x88240511,  //  0025  GETMBR	R9	R2	K17
-      0x88280512,  //  0026  GETMBR	R10	R2	K18
-      0x7C180800,  //  0027  CALL	R6	4
-      0x581C0007,  //  0028  LDCONST	R7	K7
-      0x7C100600,  //  0029  CALL	R4	3
-      0x70020005,  //  002A  JMP		#0031
-      0xB80E0200,  //  002B  GETNGBL	R3	K1
-      0x8C0C0713,  //  002C  GETMET	R3	R3	K19
-      0x7C0C0200,  //  002D  CALL	R3	1
-      0x88100514,  //  002E  GETMBR	R4	R2	K20
-      0x000C0604,  //  002F  ADD	R3	R3	R4
-      0x900A0603,  //  0030  SETMBR	R2	K3	R3
-      0x7001FFD1,  //  0031  JMP		#0004
-      0x58040015,  //  0032  LDCONST	R1	K21
-      0xAC040200,  //  0033  CATCH	R1	1	0
-      0xB0080000,  //  0034  RAISE	2	R0	R0
-      0x80000000,  //  0035  RET	0
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -452,55 +608,40 @@ be_local_closure(Matter_UDPServer_resend_packets,   /* name */
 
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: stop
 ********************************************************************/
-be_local_closure(Matter_UDPServer_start,   /* name */
+be_local_closure(Matter_UDPServer_stop,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    4,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(listening),
     /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(udp),
-    /* K3   */  be_nested_str_weak(begin),
-    /* K4   */  be_nested_str_weak(address),
-    /* K5   */  be_nested_str_weak(port),
-    /* K6   */  be_nested_str_weak(network_error),
-    /* K7   */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
-    /* K8   */  be_nested_str_weak(dispatch_cb),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(add_driver),
+    /* K2   */  be_nested_str_weak(stop),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(remove_driver),
     }),
-    be_str_weak(start),
+    be_str_weak(stop),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x740A0011,  //  0001  JMPT	R2	#0014
-      0xB80A0400,  //  0002  GETNGBL	R2	K2
-      0x7C080000,  //  0003  CALL	R2	0
-      0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x88100104,  //  0007  GETMBR	R4	R0	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
-      0x7C080600,  //  0009  CALL	R2	3
-      0x5C0C0400,  //  000A  MOVE	R3	R2
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0xB0060D07,  //  000C  RAISE	1	K6	K7
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x90020003,  //  000E  SETMBR	R0	K0	R3
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0xB80E1200,  //  0010  GETNGBL	R3	K9
-      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80000000,  //  0014  RET	0
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x78060008,  //  0001  JMPF	R1	#000B
+      0x88040101,  //  0002  GETMBR	R1	R0	K1
+      0x8C040302,  //  0003  GETMET	R1	R1	K2
+      0x7C040200,  //  0004  CALL	R1	1
+      0x50040000,  //  0005  LDBOOL	R1	0	0
+      0x90020001,  //  0006  SETMBR	R0	K0	R1
+      0xB8060600,  //  0007  GETNGBL	R1	K3
+      0x8C040304,  //  0008  GETMET	R1	R1	K4
+      0x5C0C0000,  //  0009  MOVE	R3	R0
+      0x7C040400,  //  000A  CALL	R1	2
+      0x80000000,  //  000B  RET	0
     })
   )
 );
@@ -551,80 +692,29 @@ be_local_closure(Matter_UDPServer_send_response,   /* name */
 
 
 /********************************************************************
-** Solidified function: packet_ack
-********************************************************************/
-be_local_closure(Matter_UDPServer_packet_ack,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(packets_sent),
-    /* K1   */  be_nested_str_weak(contains),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(MTR_X3A_X20removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
-    }),
-    be_str_weak(packet_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x780A000B,  //  0008  JMPF	R2	#0015
-      0x88080100,  //  0009  GETMBR	R2	R0	K0
-      0x8C080502,  //  000A  GETMET	R2	R2	K2
-      0x5C100200,  //  000B  MOVE	R4	R1
-      0x7C080400,  //  000C  CALL	R2	2
-      0xB80A0600,  //  000D  GETNGBL	R2	K3
-      0x8C080504,  //  000E  GETMET	R2	R2	K4
-      0x60100008,  //  000F  GETGBL	R4	G8
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C100200,  //  0011  CALL	R4	1
-      0x00120A04,  //  0012  ADD	R4	K5	R4
-      0x54160003,  //  0013  LDINT	R5	4
-      0x7C080600,  //  0014  CALL	R2	3
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_UDPServer
 ********************************************************************/
 be_local_class(Matter_UDPServer,
     6,
     NULL,
-    be_nested_map(15,
+    be_nested_map(16,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, 1), be_const_closure(Matter_UDPServer_init_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_UDPServer_every_second_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_UDPServer_stop_closure) },
-        { be_const_key_weak(udp_socket, -1), be_const_var(3) },
-        { be_const_key_weak(address, -1), be_const_var(0) },
-        { be_const_key_weak(dispatch_cb, -1), be_const_var(4) },
-        { be_const_key_weak(packet_ack, 7), be_const_closure(Matter_UDPServer_packet_ack_closure) },
-        { be_const_key_weak(MAX_PACKETS_READ, 13), be_const_int(4) },
-        { be_const_key_weak(every_50ms, 6), be_const_closure(Matter_UDPServer_every_50ms_closure) },
-        { be_const_key_weak(listening, -1), be_const_var(2) },
-        { be_const_key_weak(port, -1), be_const_var(1) },
-        { be_const_key_weak(start, -1), be_const_closure(Matter_UDPServer_start_closure) },
+        { be_const_key_weak(MAX_PACKETS_READ, 14), be_const_int(4) },
         { be_const_key_weak(send_response, -1), be_const_closure(Matter_UDPServer_send_response_closure) },
+        { be_const_key_weak(stop, -1), be_const_closure(Matter_UDPServer_stop_closure) },
+        { be_const_key_weak(init, 12), be_const_closure(Matter_UDPServer_init_closure) },
         { be_const_key_weak(resend_packets, -1), be_const_closure(Matter_UDPServer_resend_packets_closure) },
-        { be_const_key_weak(packets_sent, -1), be_const_var(5) },
+        { be_const_key_weak(RETRIES, 2), be_const_int(4) },
+        { be_const_key_weak(port, -1), be_const_var(1) },
+        { be_const_key_weak(packet_ack, -1), be_const_closure(Matter_UDPServer_packet_ack_closure) },
+        { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_UDPServer_every_50ms_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_UDPServer_every_second_closure) },
+        { be_const_key_weak(listening, -1), be_const_var(2) },
+        { be_const_key_weak(dispatch_cb, -1), be_const_var(4) },
+        { be_const_key_weak(address, -1), be_const_var(0) },
+        { be_const_key_weak(packets_sent, 11), be_const_var(5) },
+        { be_const_key_weak(udp_socket, -1), be_const_var(3) },
+        { be_const_key_weak(start, 1), be_const_closure(Matter_UDPServer_start_closure) },
     })),
     be_str_weak(Matter_UDPServer)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
+    ( &(const bvalue[28]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(content_send),
@@ -42,12 +42,16 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
     /* K19  */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
     /* K20  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X272047_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
     /* K21  */  be_nested_str_weak(discriminator),
-    /* K22  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K23  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K22  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
+    /* K23  */  be_nested_str_weak(ipv4only),
+    /* K24  */  be_nested_str_weak(_X20checked),
+    /* K25  */  be_nested_str_weak(),
+    /* K26  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3Cbutton_X20name_X3D_X27passcode_X27_X20class_X3D_X27button_X20bgrn_X27_X3EChange_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+    /* K27  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
     }),
     be_str_weak(show_commissioning_info),
     &be_const_str_solidified,
-    ( &(const binstruction[70]) {  /* code */
+    ( &(const binstruction[81]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0x8C0C0302,  //  0002  GETMET	R3	R1	K2
@@ -112,12 +116,23 @@ be_local_closure(Matter_UI_show_commissioning_info,   /* name */
       0x7C1C0600,  //  003D  CALL	R7	3
       0x7C140400,  //  003E  CALL	R5	2
       0x8C140302,  //  003F  GETMET	R5	R1	K2
-      0x581C0016,  //  0040  LDCONST	R7	K22
-      0x7C140400,  //  0041  CALL	R5	2
-      0x8C140302,  //  0042  GETMET	R5	R1	K2
-      0x581C0017,  //  0043  LDCONST	R7	K23
-      0x7C140400,  //  0044  CALL	R5	2
-      0x80000000,  //  0045  RET	0
+      0x8C1C0506,  //  0040  GETMET	R7	R2	K6
+      0x58240016,  //  0041  LDCONST	R9	K22
+      0x88280104,  //  0042  GETMBR	R10	R0	K4
+      0x88281517,  //  0043  GETMBR	R10	R10	K23
+      0x782A0001,  //  0044  JMPF	R10	#0047
+      0x58280018,  //  0045  LDCONST	R10	K24
+      0x70020000,  //  0046  JMP		#0048
+      0x58280019,  //  0047  LDCONST	R10	K25
+      0x7C1C0600,  //  0048  CALL	R7	3
+      0x7C140400,  //  0049  CALL	R5	2
+      0x8C140302,  //  004A  GETMET	R5	R1	K2
+      0x581C001A,  //  004B  LDCONST	R7	K26
+      0x7C140400,  //  004C  CALL	R5	2
+      0x8C140302,  //  004D  GETMET	R5	R1	K2
+      0x581C001B,  //  004E  LDCONST	R7	K27
+      0x7C140400,  //  004F  CALL	R5	2
+      0x80000000,  //  0050  RET	0
     })
   )
 );
@@ -518,7 +533,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[40]) {     /* constants */
+    ( &(const bvalue[43]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(check_privileged_access),
     /* K2   */  be_nested_str_weak(string),
@@ -530,39 +545,42 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
     /* K8   */  be_nested_str_weak(discriminator),
     /* K9   */  be_nested_str_weak(device),
     /* K10  */  be_nested_str_weak(arg),
-    /* K11  */  be_nested_str_weak(save_param),
-    /* K12  */  be_nested_str_weak(redirect),
-    /* K13  */  be_nested_str_weak(_X2F_X3Frst_X3D),
-    /* K14  */  be_nested_str_weak(enable),
-    /* K15  */  be_nested_str_weak(tasmota),
-    /* K16  */  be_nested_str_weak(cmd),
-    /* K17  */  be_nested_str_weak(SetOption),
-    /* K18  */  be_nested_str_weak(matter),
-    /* K19  */  be_nested_str_weak(MATTER_OPTION),
-    /* K20  */  be_nested_str_weak(_X201),
-    /* K21  */  be_nested_str_weak(disable),
-    /* K22  */  be_nested_str_weak(_X200),
-    /* K23  */  be_nested_str_weak(del_session),
-    /* K24  */  be_nested_str_weak(sessions),
-    /* K25  */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K26  */  be_nested_str_weak(remove_session),
-    /* K27  */  be_nested_str_weak(save),
-    /* K28  */  be_nested_str_weak(log),
-    /* K29  */  be_nested_str_weak(format),
-    /* K30  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
-    /* K31  */  be_const_int(2),
-    /* K32  */  be_nested_str_weak(content_start),
-    /* K33  */  be_nested_str_weak(Parameter_X20error),
-    /* K34  */  be_nested_str_weak(content_send_style),
-    /* K35  */  be_nested_str_weak(content_send),
-    /* K36  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
-    /* K37  */  be_nested_str_weak(content_button),
-    /* K38  */  be_nested_str_weak(BUTTON_MANAGEMENT),
-    /* K39  */  be_nested_str_weak(content_stop),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(ipv4),
+    /* K13  */  be_nested_str_weak(on),
+    /* K14  */  be_nested_str_weak(save_param),
+    /* K15  */  be_nested_str_weak(redirect),
+    /* K16  */  be_nested_str_weak(_X2F_X3Frst_X3D),
+    /* K17  */  be_nested_str_weak(enable),
+    /* K18  */  be_nested_str_weak(tasmota),
+    /* K19  */  be_nested_str_weak(cmd),
+    /* K20  */  be_nested_str_weak(SetOption),
+    /* K21  */  be_nested_str_weak(matter),
+    /* K22  */  be_nested_str_weak(MATTER_OPTION),
+    /* K23  */  be_nested_str_weak(_X201),
+    /* K24  */  be_nested_str_weak(disable),
+    /* K25  */  be_nested_str_weak(_X200),
+    /* K26  */  be_nested_str_weak(del_session),
+    /* K27  */  be_nested_str_weak(sessions),
+    /* K28  */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K29  */  be_nested_str_weak(remove_session),
+    /* K30  */  be_nested_str_weak(save),
+    /* K31  */  be_nested_str_weak(log),
+    /* K32  */  be_nested_str_weak(format),
+    /* K33  */  be_nested_str_weak(BRY_X3A_X20Exception_X3E_X20_X27_X25s_X27_X20_X2D_X20_X25s),
+    /* K34  */  be_const_int(2),
+    /* K35  */  be_nested_str_weak(content_start),
+    /* K36  */  be_nested_str_weak(Parameter_X20error),
+    /* K37  */  be_nested_str_weak(content_send_style),
+    /* K38  */  be_nested_str_weak(content_send),
+    /* K39  */  be_nested_str_weak(_X3Cp_X20style_X3D_X27width_X3A340px_X3B_X27_X3E_X3Cb_X3EException_X3A_X3C_X2Fb_X3E_X3Cbr_X3E_X27_X25s_X27_X3Cbr_X3E_X25s_X3C_X2Fp_X3E),
+    /* K40  */  be_nested_str_weak(content_button),
+    /* K41  */  be_nested_str_weak(BUTTON_MANAGEMENT),
+    /* K42  */  be_nested_str_weak(content_stop),
     }),
     be_str_weak(page_part_ctl),
     &be_const_str_solidified,
-    ( &(const binstruction[144]) {  /* code */
+    ( &(const binstruction[150]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x8C080301,  //  0001  GETMET	R2	R1	K1
       0x7C080200,  //  0002  CALL	R2	1
@@ -574,7 +592,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0xA4120800,  //  0008  IMPORT	R4	K4
       0x8C140705,  //  0009  GETMET	R5	R3	K5
       0x7C140200,  //  000A  CALL	R5	1
-      0xA8020064,  //  000B  EXBLK	0	#0071
+      0xA802006A,  //  000B  EXBLK	0	#0077
       0x8C180306,  //  000C  GETMET	R6	R1	K6
       0x58200007,  //  000D  LDCONST	R8	K7
       0x7C180400,  //  000E  CALL	R6	2
@@ -582,7 +600,7 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x8C180306,  //  0010  GETMET	R6	R1	K6
       0x58200008,  //  0011  LDCONST	R8	K8
       0x7C180400,  //  0012  CALL	R6	2
-      0x781A001C,  //  0013  JMPF	R6	#0031
+      0x781A0022,  //  0013  JMPF	R6	#0037
       0x8C180306,  //  0014  GETMET	R6	R1	K6
       0x58200007,  //  0015  LDCONST	R8	K7
       0x7C180400,  //  0016  CALL	R6	2
@@ -606,107 +624,113 @@ be_local_closure(Matter_UI_page_part_ctl,   /* name */
       0x7C1C0200,  //  0028  CALL	R7	1
       0x901A1007,  //  0029  SETMBR	R6	K8	R7
       0x88180109,  //  002A  GETMBR	R6	R0	K9
-      0x8C180D0B,  //  002B  GETMET	R6	R6	K11
-      0x7C180200,  //  002C  CALL	R6	1
-      0x8C18030C,  //  002D  GETMET	R6	R1	K12
-      0x5820000D,  //  002E  LDCONST	R8	K13
-      0x7C180400,  //  002F  CALL	R6	2
-      0x7002003D,  //  0030  JMP		#006F
-      0x8C180306,  //  0031  GETMET	R6	R1	K6
-      0x5820000E,  //  0032  LDCONST	R8	K14
-      0x7C180400,  //  0033  CALL	R6	2
-      0x781A000C,  //  0034  JMPF	R6	#0042
-      0xB81A1E00,  //  0035  GETNGBL	R6	K15
-      0x8C180D10,  //  0036  GETMET	R6	R6	K16
-      0x60200008,  //  0037  GETGBL	R8	G8
-      0xB8262400,  //  0038  GETNGBL	R9	K18
-      0x88241313,  //  0039  GETMBR	R9	R9	K19
-      0x7C200200,  //  003A  CALL	R8	1
-      0x00222208,  //  003B  ADD	R8	K17	R8
-      0x00201114,  //  003C  ADD	R8	R8	K20
-      0x7C180400,  //  003D  CALL	R6	2
-      0x8C18030C,  //  003E  GETMET	R6	R1	K12
-      0x5820000D,  //  003F  LDCONST	R8	K13
-      0x7C180400,  //  0040  CALL	R6	2
-      0x7002002C,  //  0041  JMP		#006F
-      0x8C180306,  //  0042  GETMET	R6	R1	K6
-      0x58200015,  //  0043  LDCONST	R8	K21
-      0x7C180400,  //  0044  CALL	R6	2
-      0x781A000C,  //  0045  JMPF	R6	#0053
-      0xB81A1E00,  //  0046  GETNGBL	R6	K15
-      0x8C180D10,  //  0047  GETMET	R6	R6	K16
-      0x60200008,  //  0048  GETGBL	R8	G8
-      0xB8262400,  //  0049  GETNGBL	R9	K18
-      0x88241313,  //  004A  GETMBR	R9	R9	K19
-      0x7C200200,  //  004B  CALL	R8	1
-      0x00222208,  //  004C  ADD	R8	K17	R8
-      0x00201116,  //  004D  ADD	R8	R8	K22
-      0x7C180400,  //  004E  CALL	R6	2
-      0x8C18030C,  //  004F  GETMET	R6	R1	K12
-      0x5820000D,  //  0050  LDCONST	R8	K13
-      0x7C180400,  //  0051  CALL	R6	2
-      0x7002001B,  //  0052  JMP		#006F
-      0x8C180306,  //  0053  GETMET	R6	R1	K6
-      0x58200017,  //  0054  LDCONST	R8	K23
-      0x7C180400,  //  0055  CALL	R6	2
-      0x781A0017,  //  0056  JMPF	R6	#006F
-      0x88180109,  //  0057  GETMBR	R6	R0	K9
-      0x88180D18,  //  0058  GETMBR	R6	R6	K24
-      0x8C180D19,  //  0059  GETMET	R6	R6	K25
-      0x60200009,  //  005A  GETGBL	R8	G9
-      0x8C24030A,  //  005B  GETMET	R9	R1	K10
-      0x582C0017,  //  005C  LDCONST	R11	K23
-      0x7C240400,  //  005D  CALL	R9	2
-      0x7C200200,  //  005E  CALL	R8	1
-      0x7C180400,  //  005F  CALL	R6	2
-      0x4C1C0000,  //  0060  LDNIL	R7
-      0x201C0C07,  //  0061  NE	R7	R6	R7
-      0x781E0008,  //  0062  JMPF	R7	#006C
-      0x881C0109,  //  0063  GETMBR	R7	R0	K9
-      0x881C0F18,  //  0064  GETMBR	R7	R7	K24
-      0x8C1C0F1A,  //  0065  GETMET	R7	R7	K26
-      0x5C240C00,  //  0066  MOVE	R9	R6
-      0x7C1C0400,  //  0067  CALL	R7	2
-      0x881C0109,  //  0068  GETMBR	R7	R0	K9
-      0x881C0F18,  //  0069  GETMBR	R7	R7	K24
-      0x8C1C0F1B,  //  006A  GETMET	R7	R7	K27
-      0x7C1C0200,  //  006B  CALL	R7	1
-      0x8C1C030C,  //  006C  GETMET	R7	R1	K12
-      0x5824000D,  //  006D  LDCONST	R9	K13
-      0x7C1C0400,  //  006E  CALL	R7	2
-      0xA8040001,  //  006F  EXBLK	1	1
-      0x7002001D,  //  0070  JMP		#008F
-      0xAC180002,  //  0071  CATCH	R6	0	2
-      0x7002001A,  //  0072  JMP		#008E
-      0xB8221E00,  //  0073  GETNGBL	R8	K15
-      0x8C20111C,  //  0074  GETMET	R8	R8	K28
-      0x8C28051D,  //  0075  GETMET	R10	R2	K29
-      0x5830001E,  //  0076  LDCONST	R12	K30
-      0x5C340C00,  //  0077  MOVE	R13	R6
-      0x5C380E00,  //  0078  MOVE	R14	R7
-      0x7C280800,  //  0079  CALL	R10	4
-      0x582C001F,  //  007A  LDCONST	R11	K31
-      0x7C200600,  //  007B  CALL	R8	3
-      0x8C200320,  //  007C  GETMET	R8	R1	K32
-      0x58280021,  //  007D  LDCONST	R10	K33
-      0x7C200400,  //  007E  CALL	R8	2
-      0x8C200322,  //  007F  GETMET	R8	R1	K34
-      0x7C200200,  //  0080  CALL	R8	1
-      0x8C200323,  //  0081  GETMET	R8	R1	K35
-      0x8C28051D,  //  0082  GETMET	R10	R2	K29
-      0x58300024,  //  0083  LDCONST	R12	K36
-      0x5C340C00,  //  0084  MOVE	R13	R6
-      0x5C380E00,  //  0085  MOVE	R14	R7
-      0x7C280800,  //  0086  CALL	R10	4
-      0x7C200400,  //  0087  CALL	R8	2
-      0x8C200325,  //  0088  GETMET	R8	R1	K37
-      0x88280326,  //  0089  GETMBR	R10	R1	K38
-      0x7C200400,  //  008A  CALL	R8	2
-      0x8C200327,  //  008B  GETMET	R8	R1	K39
-      0x7C200200,  //  008C  CALL	R8	1
-      0x70020000,  //  008D  JMP		#008F
-      0xB0080000,  //  008E  RAISE	2	R0	R0
-      0x80000000,  //  008F  RET	0
+      0x8C1C030A,  //  002B  GETMET	R7	R1	K10
+      0x5824000C,  //  002C  LDCONST	R9	K12
+      0x7C1C0400,  //  002D  CALL	R7	2
+      0x1C1C0F0D,  //  002E  EQ	R7	R7	K13
+      0x901A1607,  //  002F  SETMBR	R6	K11	R7
+      0x88180109,  //  0030  GETMBR	R6	R0	K9
+      0x8C180D0E,  //  0031  GETMET	R6	R6	K14
+      0x7C180200,  //  0032  CALL	R6	1
+      0x8C18030F,  //  0033  GETMET	R6	R1	K15
+      0x58200010,  //  0034  LDCONST	R8	K16
+      0x7C180400,  //  0035  CALL	R6	2
+      0x7002003D,  //  0036  JMP		#0075
+      0x8C180306,  //  0037  GETMET	R6	R1	K6
+      0x58200011,  //  0038  LDCONST	R8	K17
+      0x7C180400,  //  0039  CALL	R6	2
+      0x781A000C,  //  003A  JMPF	R6	#0048
+      0xB81A2400,  //  003B  GETNGBL	R6	K18
+      0x8C180D13,  //  003C  GETMET	R6	R6	K19
+      0x60200008,  //  003D  GETGBL	R8	G8
+      0xB8262A00,  //  003E  GETNGBL	R9	K21
+      0x88241316,  //  003F  GETMBR	R9	R9	K22
+      0x7C200200,  //  0040  CALL	R8	1
+      0x00222808,  //  0041  ADD	R8	K20	R8
+      0x00201117,  //  0042  ADD	R8	R8	K23
+      0x7C180400,  //  0043  CALL	R6	2
+      0x8C18030F,  //  0044  GETMET	R6	R1	K15
+      0x58200010,  //  0045  LDCONST	R8	K16
+      0x7C180400,  //  0046  CALL	R6	2
+      0x7002002C,  //  0047  JMP		#0075
+      0x8C180306,  //  0048  GETMET	R6	R1	K6
+      0x58200018,  //  0049  LDCONST	R8	K24
+      0x7C180400,  //  004A  CALL	R6	2
+      0x781A000C,  //  004B  JMPF	R6	#0059
+      0xB81A2400,  //  004C  GETNGBL	R6	K18
+      0x8C180D13,  //  004D  GETMET	R6	R6	K19
+      0x60200008,  //  004E  GETGBL	R8	G8
+      0xB8262A00,  //  004F  GETNGBL	R9	K21
+      0x88241316,  //  0050  GETMBR	R9	R9	K22
+      0x7C200200,  //  0051  CALL	R8	1
+      0x00222808,  //  0052  ADD	R8	K20	R8
+      0x00201119,  //  0053  ADD	R8	R8	K25
+      0x7C180400,  //  0054  CALL	R6	2
+      0x8C18030F,  //  0055  GETMET	R6	R1	K15
+      0x58200010,  //  0056  LDCONST	R8	K16
+      0x7C180400,  //  0057  CALL	R6	2
+      0x7002001B,  //  0058  JMP		#0075
+      0x8C180306,  //  0059  GETMET	R6	R1	K6
+      0x5820001A,  //  005A  LDCONST	R8	K26
+      0x7C180400,  //  005B  CALL	R6	2
+      0x781A0017,  //  005C  JMPF	R6	#0075
+      0x88180109,  //  005D  GETMBR	R6	R0	K9
+      0x88180D1B,  //  005E  GETMBR	R6	R6	K27
+      0x8C180D1C,  //  005F  GETMET	R6	R6	K28
+      0x60200009,  //  0060  GETGBL	R8	G9
+      0x8C24030A,  //  0061  GETMET	R9	R1	K10
+      0x582C001A,  //  0062  LDCONST	R11	K26
+      0x7C240400,  //  0063  CALL	R9	2
+      0x7C200200,  //  0064  CALL	R8	1
+      0x7C180400,  //  0065  CALL	R6	2
+      0x4C1C0000,  //  0066  LDNIL	R7
+      0x201C0C07,  //  0067  NE	R7	R6	R7
+      0x781E0008,  //  0068  JMPF	R7	#0072
+      0x881C0109,  //  0069  GETMBR	R7	R0	K9
+      0x881C0F1B,  //  006A  GETMBR	R7	R7	K27
+      0x8C1C0F1D,  //  006B  GETMET	R7	R7	K29
+      0x5C240C00,  //  006C  MOVE	R9	R6
+      0x7C1C0400,  //  006D  CALL	R7	2
+      0x881C0109,  //  006E  GETMBR	R7	R0	K9
+      0x881C0F1B,  //  006F  GETMBR	R7	R7	K27
+      0x8C1C0F1E,  //  0070  GETMET	R7	R7	K30
+      0x7C1C0200,  //  0071  CALL	R7	1
+      0x8C1C030F,  //  0072  GETMET	R7	R1	K15
+      0x58240010,  //  0073  LDCONST	R9	K16
+      0x7C1C0400,  //  0074  CALL	R7	2
+      0xA8040001,  //  0075  EXBLK	1	1
+      0x7002001D,  //  0076  JMP		#0095
+      0xAC180002,  //  0077  CATCH	R6	0	2
+      0x7002001A,  //  0078  JMP		#0094
+      0xB8222400,  //  0079  GETNGBL	R8	K18
+      0x8C20111F,  //  007A  GETMET	R8	R8	K31
+      0x8C280520,  //  007B  GETMET	R10	R2	K32
+      0x58300021,  //  007C  LDCONST	R12	K33
+      0x5C340C00,  //  007D  MOVE	R13	R6
+      0x5C380E00,  //  007E  MOVE	R14	R7
+      0x7C280800,  //  007F  CALL	R10	4
+      0x582C0022,  //  0080  LDCONST	R11	K34
+      0x7C200600,  //  0081  CALL	R8	3
+      0x8C200323,  //  0082  GETMET	R8	R1	K35
+      0x58280024,  //  0083  LDCONST	R10	K36
+      0x7C200400,  //  0084  CALL	R8	2
+      0x8C200325,  //  0085  GETMET	R8	R1	K37
+      0x7C200200,  //  0086  CALL	R8	1
+      0x8C200326,  //  0087  GETMET	R8	R1	K38
+      0x8C280520,  //  0088  GETMET	R10	R2	K32
+      0x58300027,  //  0089  LDCONST	R12	K39
+      0x5C340C00,  //  008A  MOVE	R13	R6
+      0x5C380E00,  //  008B  MOVE	R14	R7
+      0x7C280800,  //  008C  CALL	R10	4
+      0x7C200400,  //  008D  CALL	R8	2
+      0x8C200328,  //  008E  GETMET	R8	R1	K40
+      0x88280329,  //  008F  GETMBR	R10	R1	K41
+      0x7C200400,  //  0090  CALL	R8	2
+      0x8C20032A,  //  0091  GETMET	R8	R1	K42
+      0x7C200200,  //  0092  CALL	R8	1
+      0x70020000,  //  0093  JMP		#0095
+      0xB0080000,  //  0094  RAISE	2	R0	R0
+      0x80000000,  //  0095  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter new features:
- full support for Subscriptions on attributes, including heartbeat, min/max time and reporting of changed attributes. It's only missing the removal of subscription if the heartbeat returns a status report with error
- support for exponential backoff when resending packets
- support a special mode "IPv4 only" to remove IPv6 addresses in mDNS announce. Matter protocol normally mandates IPv6 but all tools do support IPv4 as well. Sometimes IPv4 can help solving routing issues.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
