### PR TITLE
teleinfo fix build error with TELEINFO enabled

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_15_teleinfo.ino
@@ -530,7 +530,7 @@ bool ResponseAppendTInfo(char sep, bool all)
         if (me->name && me->value && *me->name && *me->value) {
 
             // Check back checksum in case of any memory corruption
-            if (me->checksum==tinfo.calcChecksum(me->name, me->value))) {
+            if (me->checksum==tinfo.calcChecksum(me->name, me->value)) {
 
                 // Does this label blacklisted ?
                 if (!isBlacklistedLabel(me->name)) {
@@ -582,7 +582,7 @@ bool ResponseAppendTInfo(char sep, bool all)
                 }
 
             } else {
-                AddLog(LOG_LEVEL_WARNING, PSTR("TIC: bad checksum for %s"), me->name);
+                AddLog(LOG_LEVEL_INFO, PSTR("TIC: bad checksum for %s"), me->name);
             }
         }
     }
@@ -909,8 +909,8 @@ bool TInfoCmd(void) {
                 case CMND_TELEINFO_STATS: {
                     char stats_name[MAX_TINFO_COMMAND_NAME];
                     // Get the raw name
-                    GetTextIndexed(statsname, MAX_TINFO_COMMAND_NAME, command_code, kTInfo_Commands);
-                    int l = strlen(stats_name);
+                    GetTextIndexed(stats_name, MAX_TINFO_COMMAND_NAME, command_code, kTInfo_Commands);
+                    int l = strlen(stats_name); 
                     // At least "EnergyConfig Stats" plus one space and one (or more) digit
                     // so "EnergyConfig Stats" or "EnergyConfig Stats 0"
                     if ( pValue ) {
@@ -919,7 +919,7 @@ bool TInfoCmd(void) {
                             Settings->teleinfo.show_stats = value ;
                             AddLog(LOG_LEVEL_INFO, PSTR("TIC: Show stats=%d"), value);
                         } else if (value == 2) {
-                            tinfo.clearstats();
+                            tinfo.clearStats();
                             AddLog(LOG_LEVEL_INFO, PSTR("TIC: Stats cleared"));
                         } else {
                             AddLog(LOG_LEVEL_INFO, PSTR("TIC: bad Stats param '%d'"), value);


### PR DESCRIPTION
## Description:

teleinfo fix compilation error with TELEINFO enabled

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
