### PR TITLE
Allow sendmail on ESP8266 to support emails without < and >

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_1_webserver_mail.ino
@@ -22,10 +22,12 @@
  * #define EMAIL_SERVER "smtp.gmail.com"
  * #define EMAIL_PORT 465
  *
+ * Note : starting with this update, it is not required anymore to include emails in < > as they will
+ * be automatically added if needed
  * if email body consist of a single * and scripter is present
  * and a section >m is found, the lines in this section (until #) are sent as email body
- * 
- * Some mail servers do not accept the IP address in the HELO (or EHLO) message but only a fully qualified 
+ *
+ * Some mail servers do not accept the IP address in the HELO (or EHLO) message but only a fully qualified
  * domain name (FQDN). To overcome this, use the following define to override this behavior and enter the desired FQDN
  * #define EMAIL_USER_DOMAIN "googlemail.com"
  *
@@ -111,7 +113,7 @@ String SendEmail::readClient() {
   return r;
 }
 
-bool SendEmail::send(const String& from, const String& to, const String& subject, const char *msg) {
+bool SendEmail::send(const String& _from, const String& _to, const String& subject, const char *msg) {
   if (!host.length()) { return false; }
 
   client->setTimeout(timeout);
@@ -128,6 +130,10 @@ bool SendEmail::send(const String& from, const String& to, const String& subject
 #endif
     return false;
   }
+
+  String from, to;
+  from = ('<' == *_from.c_str()) ? _from : ("<" + _from + ">");
+  to = ('<' == *_to.c_str()) ? _to : ("<" + _to +">");
 
   String buffer = readClient();
 #ifdef DEBUG_EMAIL_PORT


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #18062

Originally ESP8266 mail client required the emails to be provided enclosed in brackets such as "<foo@bar.com>" while the ESP32 version didn't required that.
Support for emails without the brackets has been added to ESP8266 to uniformisation (looks simpler than changing the ESP32 client)

Tested on a gmail account with both cases

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [-] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
__