### PR TITLE
Tuya sequence fix

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -92,7 +92,10 @@ struct TUYA {
   uint32_t ignore_dimmer_cmd_timeout = 0; // Time until which received dimmer commands should be ignored
   bool ignore_tuyareceived = false;       // When a modeset changes ignore stat
   bool active;
+  uint32_t time_last_cmd;                 // to compute timeout on response and not sending another message
 } Tuya;
+
+#define TUYA_CMD_TIMEOUT        200
 
 #define D_JSON_TUYA_MCU_RECEIVED "TuyaReceived"
 
@@ -477,6 +480,7 @@ void TuyaSendCmd(uint8_t cmd, uint8_t payload[] = nullptr, uint16_t payload_len 
   }
   TuyaSerial->write(checksum);
   TuyaSerial->flush();
+  Tuya.time_last_cmd = millis() | 1; // cheap trick to avoid 0
   snprintf_P(log_data, sizeof(log_data), PSTR("%s%02x\""), log_data, checksum);
   AddLogData(LOG_LEVEL_DEBUG, log_data);
 }
@@ -1287,6 +1291,7 @@ void TuyaSerialInput(void)
       uint8_t dpDataType = 0;
       char DataStr[15];
       bool isCmdToSuppress = false;
+      Tuya.time_last_cmd = 0;
 
       if (len > 0) {
         ResponseAppend_P(PSTR(",\"CmndData\":\"%s\""), ToHex_P((unsigned char*)&Tuya.buffer[6], len, hex_char, sizeof(hex_char)));
@@ -1567,7 +1572,7 @@ void TuyaSensorsShow(bool json)
           case 82:
           case 83:
           case 84:
-            WSContentSend_PD(PSTR("{s}Timer%d{m}%d{e}"), (sensor-80), Tuya.Sensors[sensor-71]); // No UoM for timers since they can be sec or min
+            WSContentSend_PD(PSTR("{s}Timer%d{m}%u{e}"), (sensor-80), Tuya.Sensors[sensor-71]); // No UoM for timers since they can be sec or min
             break;
         }
       }
@@ -1650,6 +1655,12 @@ bool Xdrv16(uint32_t function) {
         result = TuyaButtonPressed();
         break;
       case FUNC_EVERY_SECOND:
+        if (Tuya.time_last_cmd) {
+          if ((millis()-Tuya.time_last_cmd) < TUYA_CMD_TIMEOUT)
+            break; // don't send anything if we are already waiting for an answer
+          else
+            Tuya.time_last_cmd = 0;
+        }
         if (TuyaSerial && Tuya.wifi_state != TuyaGetTuyaWifiState()) { TuyaSetWifiLed(); }
         if (!Tuya.low_power_mode) {
           Tuya.heartbeat_timer++;

--- a/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_16_tuyamcu_v1.ino
@@ -1421,7 +1421,9 @@ uint8_t TuyaGetTuyaWifiState(void) {
       break;
   }
 
-  if (MqttIsConnected()) {
+  // When Wifi is connected, Say "connected to cloud" if mqtt is disabled or mqtt is connected
+  // avoid MCU to resets ESP to desperately get state 4 while MQTT is not enabled
+  if ((3 == wifi_state) && (!Settings->flag.mqtt_enabled || MqttIsConnected())) {
     wifi_state = 0x04;
   }
 


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** final fixes from https://github.com/arendst/Tasmota/discussions/17625#discussioncomment-5125335

1) It happens sometimes that the driver's state machine sends a command but the EVERY_SECOND also send a Wifi State before the reponse from the command was received. This seems to loose the MCU in limbos.
Now if a command is sent and no answer received, WifiState and others won't be sent from EVERY_SECOND unless a 200ms timeout expired

2) It happens that some MCU would reset the ESP if it doesn't receive Wifi State 4 (connected to cloud) which is normally sent only after MQTT is connected. But is MQTT is not used, this is never sent and the ESP is resetted by the MCU
Added a test to send Wifi State 4 as soon as Wifi is connected is MQTT is not enabled

3) Changed the timer type in TuyaSNS result from signed (%d) to unsigned (%u) following #18048


## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
