### PR TITLE
Try to workaround `extra_scripts` issues

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,14 +63,17 @@ lib_extra_dirs              =
 ; Uncomment and specify a folder where to place the firmware file(s) (default set to folder build_output)
 ;bin_dir = /tmp/bin_files/
 
-[esp_defaults]
+[scripts_defaults]
 extra_scripts               = pre:pio-tools/pre_source_dir.py
-                              pre:pio-tools/strip-floats.py
-                              pre:pio-tools/set_partition_table.py
-                              post:pio-tools/name-firmware.py
-                              post:pio-tools/gzip-firmware.py
-                              post:pio-tools/override_copy.py
-                              post:pio-tools/download_fs.py
+                              pio-tools/strip-floats.py
+                              pio-tools/set_partition_table.py
+                              pio-tools/name-firmware.py
+                              pio-tools/gzip-firmware.py
+                              pio-tools/override_copy.py
+                              pio-tools/download_fs.py
+
+[esp_defaults]
+extra_scripts               = ${scripts_defaults.extra_scripts}
 ; *** remove undesired all warnings
 build_unflags               = -Wall
 ;                              -mtarget-align


### PR DESCRIPTION
## Description:

Try to fix regression of not running all pio scripts. Strip floats is not done

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
