### PR TITLE
all scripts working

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -65,15 +65,16 @@ lib_extra_dirs              =
 
 [scripts_defaults]
 extra_scripts               = pre:pio-tools/pre_source_dir.py
-                              pio-tools/strip-floats.py
-                              pio-tools/set_partition_table.py
-                              pio-tools/name-firmware.py
-                              pio-tools/gzip-firmware.py
-                              pio-tools/override_copy.py
-                              pio-tools/download_fs.py
+                              pre:pio-tools/set_partition_table.py
+                              pre:pio-tools/override_copy.py
+                              post:pio-tools/strip-floats.py
 
 [esp_defaults]
-extra_scripts               = ${scripts_defaults.extra_scripts}
+extra_scripts               = post:pio-tools/name-firmware.py
+                              post:pio-tools/gzip-firmware.py
+                              post:pio-tools/download_fs.py
+;                              post:pio-tools/obj-dump.py
+                              ${scripts_defaults.extra_scripts}
 ; *** remove undesired all warnings
 build_unflags               = -Wall
 ;                              -mtarget-align
@@ -93,6 +94,7 @@ build_flags                 = -DCORE_DEBUG_LEVEL=0
 ; *********************************************************************
 
 [esp82xx_defaults]
+extra_scripts               = ${esp_defaults.extra_scripts}
 build_flags                 = ${esp_defaults.build_flags}
                               -DNDEBUG
                               -DFP_IN_IROM

--- a/platformio_override_sample.ini
+++ b/platformio_override_sample.ini
@@ -72,8 +72,6 @@ board                   = ${common.board}
 ; *** Define serial port used for erasing/flashing/terminal
 ;upload_port             = COM4
 ;monitor_port            = COM4
-extra_scripts           = ${esp_defaults.extra_scripts}
-;                          pio-tools/obj-dump.py
 lib_ignore              =
                           Servo(esp8266)
                           ESP8266AVRISP
@@ -116,8 +114,6 @@ lib_extra_dirs          = ${library.lib_extra_dirs}
 ;upload_speed            = 115200
 monitor_speed           = 115200
 upload_resetmethod      = ${common.upload_resetmethod}
-extra_scripts           = ${esp32_defaults.extra_scripts}
-;                          pio-tools/obj-dump.py
 lib_ignore              =
                           HTTPUpdateServer
                           ESP RainMaker


### PR DESCRIPTION
## Description:

Again refactor of `extra_scripts`. All Platformio extra scripts seems to work now as the should.
Hopefully this lasts, since it is a workaround of a nasty Platformio bug.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
