### PR TITLE
Fix subscribe topic match comparison

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_10_rules.ino
@@ -1174,7 +1174,7 @@ bool RulesMqttData(void) {
     event_item = subscriptions.get(index);
 
     //AddLog(LOG_LEVEL_DEBUG, PSTR("RUL: Match MQTT message Topic %s with subscription topic %s"), sTopic.c_str(), event_item.Topic.c_str());
-    if (sTopic.startsWith(event_item.Topic)) {
+    if ((sTopic == event_item.Topic) || sTopic.startsWith(event_item.Topic+"/")) {
       //This topic is subscribed by us, so serve it
       serviced = true;
       String value;


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #18108

Currently topic matching is made using:
```
if (sTopic.startsWith(event_item.Topic))
```
where `sTopic` is the topic of the currently received message and `event_item.Topic` is the subscribed topic
With such lazy comparison, a publish on `something/ABC/state` would trigger both the events subscribed on `something/A/#` and `something/ABC/#` which is not the intended result.

The fix consist in matching for either strict equality OR starting with "subscribed topic + `/`"

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [X] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
