### PR TITLE
Update uDisplay.cpp

### DIFF
--- a/lib/lib_display/UDisplay/uDisplay.cpp
+++ b/lib/lib_display/UDisplay/uDisplay.cpp
@@ -2590,6 +2590,9 @@ void uDisplay::SetLuts(void) {
 
 void uDisplay::DisplayFrame_42(void) {
 
+    if (epc_full_cnt) {
+      send_spi_cmds(epcoffs_full, epc_full_cnt);
+    }
     spi_command_EPD(saw_1);
     for(int i = 0; i < gxs / 8 * gys; i++) {
         spi_data8_EPD(0xFF);
@@ -2616,6 +2619,9 @@ void uDisplay::DisplayFrame_42(void) {
 
 
 void uDisplay::ClearFrame_42(void) {
+    if (epc_full_cnt) {
+      send_spi_cmds(epcoffs_full, epc_full_cnt);
+    }
     spi_command_EPD(saw_1);
     for (uint16_t j = 0; j < gys; j++) {
         for (uint16_t i = 0; i < gxs; i++) {


### PR DESCRIPTION
Enables adding a :f full update command for EPD42 (full update) compatible epaper displays with universal display  (a pull request to add WS_epaper27B_display.ini in for the 2.7" Rev. B Waveshare display has also been created)

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
