### PR TITLE
Fix parameter for `wire.endtransmission()`

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_wire.ino
@@ -109,7 +109,7 @@ extern "C" {
     TwoWire & myWire = getWire(vm);
     if (top == 1 || (top == 2 && be_isbool(vm, 2))) {  // only 1 argument of type string accepted
       bool stop = true;
-      if (top == 1) {
+      if (top == 2) {
         stop = be_tobool(vm, 2);
       }
       uint32_t ret = myWire.endTransmission(stop);


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
