### PR TITLE
Add I2C example for M5Stack DigiClock

### DIFF
--- a/tasmota/berry/drivers/M5Stack_DigiClock.be
+++ b/tasmota/berry/drivers/M5Stack_DigiClock.be
@@ -1,0 +1,38 @@
+# Simple driver for M5Stack DigiClock I2C 7 segments LED
+#
+# https://docs.m5stack.com/en/unit/digi_clock
+
+class M5Stack_DigiClock
+  static var I2C_ADDR = 0x30                # default I2C address is 0x30
+  var led
+  var addr
+
+  def init(addr)
+    if !addr    addr = self.I2C_ADDR end
+
+    self.addr = addr
+    self.led = tasmota.wire_scan(addr)
+
+    if self.led == nil    raise "configuration_error", "Could not find DigiClock I2C device" end
+  end
+
+  def set_brightness(b)
+    if b < 0      b = 0 end
+    if b > 8      b = 8 end
+    self.led.write(self.addr, 0x30, b, 1)
+  end
+
+  def set_text(t)
+    self.led.write_bytes(0x30, 0x20, bytes().fromstring(str(t)))
+  end
+end
+
+return M5Stack_DigiClock
+
+#-
+
+var led = M5Stack_DigiClock()
+led.set_brightness(1)
+led.set_text("1234")
+
+-#


### PR DESCRIPTION
## Description:

Mini-driver for M5Stack DigiClock https://docs.m5stack.com/en/unit/digi_clock
![image](https://user-images.githubusercontent.com/49731213/223509959-a353dfdf-f5fb-4eae-bab5-e73d3d4be201.png)


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
