### PR TITLE
Berry tasmota.cmd() can mute logs

### DIFF
--- a/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
+++ b/lib/libesp32/berry_tasmota/src/embedded/tasmota_class.be
@@ -637,9 +637,20 @@ class Tasmota
   end
 
   # cmd high-level function
-  def cmd(command)
+  # mute: (opt, bool) if true temporarily reduce log_level to 1
+  def cmd(command, mute)
     var save_cmd_res = self.cmd_res     # restore value on exit (for reentrant)
     self.cmd_res = true      # signal buffer capture
+
+    var seriallog_level = tasmota.global.seriallog_level
+    var mqttlog_level   = tasmota.settings.mqttlog_level
+    var weblog_level    = tasmota.settings.weblog_level
+
+    if mute                 # mute logging
+      if seriallog_level >= 2       tasmota.global.seriallog_level = 1    end
+      if mqttlog_level   >= 2       tasmota.settings.mqttlog_level = 1    end
+      if weblog_level    >= 2       tasmota.settings.weblog_level  = 1    end
+    end
 
     self._cmd(command)
     
@@ -649,6 +660,12 @@ class Tasmota
     end
     self.cmd_res = save_cmd_res       # restore previous state
     
+    # restore log_level
+    if mute
+      tasmota.global.seriallog_level = seriallog_level
+      tasmota.settings.mqttlog_level = mqttlog_level
+      tasmota.settings.weblog_level = weblog_level
+    end
     return ret
   end
 

--- a/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
+++ b/lib/libesp32/berry_tasmota/src/solidify/solidified_tasmota_class.h
@@ -97,35 +97,78 @@ be_local_closure(Tasmota_exec_rules,   /* name */
 ********************************************************************/
 be_local_closure(Tasmota_cmd,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    10,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[10]) {     /* constants */
     /* K0   */  be_nested_str(cmd_res),
-    /* K1   */  be_nested_str(_cmd),
+    /* K1   */  be_nested_str(tasmota),
+    /* K2   */  be_nested_str(global),
+    /* K3   */  be_nested_str(seriallog_level),
+    /* K4   */  be_nested_str(settings),
+    /* K5   */  be_nested_str(mqttlog_level),
+    /* K6   */  be_nested_str(weblog_level),
+    /* K7   */  be_const_int(2),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_nested_str(_cmd),
     }),
     &be_const_str_cmd,
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x90020003,  //  0002  SETMBR	R0	K0	R3
-      0x8C0C0101,  //  0003  GETMET	R3	R0	K1
-      0x5C140200,  //  0004  MOVE	R5	R1
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x4C0C0000,  //  0006  LDNIL	R3
-      0x88100100,  //  0007  GETMBR	R4	R0	K0
-      0x50140200,  //  0008  LDBOOL	R5	1	0
-      0x20100805,  //  0009  NE	R4	R4	R5
-      0x78120000,  //  000A  JMPF	R4	#000C
-      0x880C0100,  //  000B  GETMBR	R3	R0	K0
-      0x90020002,  //  000C  SETMBR	R0	K0	R2
-      0x80040600,  //  000D  RET	1	R3
+    ( &(const binstruction[49]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x50100200,  //  0001  LDBOOL	R4	1	0
+      0x90020004,  //  0002  SETMBR	R0	K0	R4
+      0xB8120200,  //  0003  GETNGBL	R4	K1
+      0x88100902,  //  0004  GETMBR	R4	R4	K2
+      0x88100903,  //  0005  GETMBR	R4	R4	K3
+      0xB8160200,  //  0006  GETNGBL	R5	K1
+      0x88140B04,  //  0007  GETMBR	R5	R5	K4
+      0x88140B05,  //  0008  GETMBR	R5	R5	K5
+      0xB81A0200,  //  0009  GETNGBL	R6	K1
+      0x88180D04,  //  000A  GETMBR	R6	R6	K4
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x780A000E,  //  000C  JMPF	R2	#001C
+      0x281C0907,  //  000D  GE	R7	R4	K7
+      0x781E0002,  //  000E  JMPF	R7	#0012
+      0xB81E0200,  //  000F  GETNGBL	R7	K1
+      0x881C0F02,  //  0010  GETMBR	R7	R7	K2
+      0x901E0708,  //  0011  SETMBR	R7	K3	K8
+      0x281C0B07,  //  0012  GE	R7	R5	K7
+      0x781E0002,  //  0013  JMPF	R7	#0017
+      0xB81E0200,  //  0014  GETNGBL	R7	K1
+      0x881C0F04,  //  0015  GETMBR	R7	R7	K4
+      0x901E0B08,  //  0016  SETMBR	R7	K5	K8
+      0x281C0D07,  //  0017  GE	R7	R6	K7
+      0x781E0002,  //  0018  JMPF	R7	#001C
+      0xB81E0200,  //  0019  GETNGBL	R7	K1
+      0x881C0F04,  //  001A  GETMBR	R7	R7	K4
+      0x901E0D08,  //  001B  SETMBR	R7	K6	K8
+      0x8C1C0109,  //  001C  GETMET	R7	R0	K9
+      0x5C240200,  //  001D  MOVE	R9	R1
+      0x7C1C0400,  //  001E  CALL	R7	2
+      0x4C1C0000,  //  001F  LDNIL	R7
+      0x88200100,  //  0020  GETMBR	R8	R0	K0
+      0x50240200,  //  0021  LDBOOL	R9	1	0
+      0x20201009,  //  0022  NE	R8	R8	R9
+      0x78220000,  //  0023  JMPF	R8	#0025
+      0x881C0100,  //  0024  GETMBR	R7	R0	K0
+      0x90020003,  //  0025  SETMBR	R0	K0	R3
+      0x780A0008,  //  0026  JMPF	R2	#0030
+      0xB8220200,  //  0027  GETNGBL	R8	K1
+      0x88201102,  //  0028  GETMBR	R8	R8	K2
+      0x90220604,  //  0029  SETMBR	R8	K3	R4
+      0xB8220200,  //  002A  GETNGBL	R8	K1
+      0x88201104,  //  002B  GETMBR	R8	R8	K4
+      0x90220A05,  //  002C  SETMBR	R8	K5	R5
+      0xB8220200,  //  002D  GETNGBL	R8	K1
+      0x88201104,  //  002E  GETMBR	R8	R8	K4
+      0x90220C06,  //  002F  SETMBR	R8	K6	R6
+      0x80040E00,  //  0030  RET	1	R7
     })
   )
 );

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota_global.ino
@@ -33,24 +33,32 @@ extern "C" {
 
   extern const be_ctypes_structure_t be_tasmota_global_struct = {
     sizeof(TasmotaGlobal),  /* size in bytes */
-    4,  /* number of elements */
+    8,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[4]) {
+    (const be_ctypes_structure_item_t[8]) {
       // Warning: fields below need to be in alphabetical order
       { "devices_present", offsetof(TasmotaGlobal_t, devices_present), 0, 0, ctypes_u8, 0 },
       { "fast_loop_enabled", offsetof(TasmotaGlobal_t, berry_fast_loop_enabled), 0, 0, ctypes_u8, 0 },
+      { "masterlog_level", offsetof(TasmotaGlobal_t, masterlog_level), 0, 0, ctypes_u8, 0 },
       { "restart_flag", offsetof(TasmotaGlobal_t, restart_flag), 0, 0, ctypes_u8, 0 },
+      { "seriallog_level", offsetof(TasmotaGlobal_t, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TasmotaGlobal_t, sleep), 0, 0, ctypes_u8, 0 },
+      { "syslog_level", offsetof(TasmotaGlobal_t, syslog_level), 0, 0, ctypes_u8, 0 },
+      { "templog_level", offsetof(TasmotaGlobal_t, templog_level), 0, 0, ctypes_u8, 0 },
   }};
 
   extern const be_ctypes_structure_t be_tasmota_settings_struct = {
     sizeof(TSettings),  /* size in bytes */
-    2,  /* number of elements */
+    6,  /* number of elements */
     nullptr,
-    (const be_ctypes_structure_item_t[2]) {
+    (const be_ctypes_structure_item_t[6]) {
       // Warning: fields below need to be in alphabetical order
       { "bootcount", offsetof(TSettings, bootcount), 0, 0, ctypes_u16, 0 },
+      { "mqttlog_level", offsetof(TSettings, mqttlog_level), 0, 0, ctypes_u8, 0 },
+      { "seriallog_level", offsetof(TSettings, seriallog_level), 0, 0, ctypes_u8, 0 },
       { "sleep", offsetof(TSettings, sleep), 0, 0, ctypes_u8, 0 },
+      { "syslog_level", offsetof(TSettings, syslog_level), 0, 0, ctypes_u8, 0 },
+      { "weblog_level", offsetof(TSettings, weblog_level), 0, 0, ctypes_u8, 0 },
   }};
 
 }


### PR DESCRIPTION
## Description:

Now the Berry `tasmota.cmd(cmd:string [, mute:bool]) -> map` takes an optional `mute` attribute. If `mute` is `true`, logging (serial, web, mqtt) is reduced to `1` (only severe errors) to avoid polluting the logs.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
