### PR TITLE
Zigbee send Tuya 'magic spell' to unlock devices when pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Support for multiple MCP23008 as switch/button/relay
 - Support for multiple PCF8574 as switch/button/relay
 - Extended Tariff command for forced tariff (#18080)
+- Zigbee send Tuya 'magic spell' to unlock devices when pairing
 
 ### Breaking Changed
 - Shelly Pro 4PM using standard MCP23xxx driver and needs one time Auto-Configuration

--- a/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_23_zigbee_8_parsers.ino
@@ -1395,15 +1395,21 @@ void Z_SendSimpleDescReq(uint16_t shortaddr, uint16_t groupaddr, uint16_t cluste
 //    Iterate among
 //
 void Z_SendDeviceInfoRequest(uint16_t shortaddr) {
-  ZCLFrame zcl(4);   // message is 4 bytes
+  ZCLFrame zcl(12);   // message is 12 bytes
   zcl.shortaddr = shortaddr;
-  zcl.cluster = 0;
+  zcl.cluster = 0x0000;
   zcl.cmd = ZCL_READ_ATTRIBUTES;
   zcl.clusterSpecific = false;
   zcl.needResponse = true;
   zcl.direct = false;   // discover route
   zcl.payload.add16(0x0005);
   zcl.payload.add16(0x0004);
+  // Tuya needs a magic spell reading more attributes
+  // cf https://github.com/zigpy/zha-device-handlers/issues/2042
+  zcl.payload.add16(0x0000);  // Manufacturer Name
+  zcl.payload.add16(0x0001);  // Application Version
+  zcl.payload.add16(0x0007);  // Power Source
+  zcl.payload.add16(0xfffe);  // Unknown
   zigbeeZCLSendCmd(zcl);
 }
 


### PR DESCRIPTION
## Description:

Extend the attributes read when pairing a device. This happens to be the magic spell to unlock Tuya devices. Reading the superfluous attributes does no harm when non-Tuya devices.

See https://github.com/zigpy/zha-device-handlers/issues/2042

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
