### PR TITLE
libteleinfo, Added special char to some values

### DIFF
--- a/lib/lib_div/LibTeleinfo/src/LibTeleinfo.cpp
+++ b/lib/lib_div/LibTeleinfo/src/LibTeleinfo.cpp
@@ -711,7 +711,7 @@ unsigned char TInfo::calcChecksum(char *etiquette, char *valeur, char * horodate
       while(*valeur) {
         c = *valeur++ ;
         // Add another validity check since checksum may not be sufficient (space authorized in Standard mode)
-        if ( (c>='A' && c<='Z') || (c>='0' && c<='9') || c==' ' || c=='.' || c=='-' || c=='+') {
+        if ( (c>='A' && c<='Z') || (c>='0' && c<='9') || c==' ' || c=='.' || c=='-' || c=='+' || c=='/') {
           sum += c ;
         } else {
           return 0;


### PR DESCRIPTION
## Description:

added `/`as valid value 

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
