### PR TITLE
remove absolute url

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_50_filesystem.ino
@@ -609,7 +609,7 @@ const char UFS_FORM_FILE_UPGc[] PROGMEM =
   "<div style='text-align:left;color:#%06x;'>" D_FS_SIZE " %s MB - " D_FS_FREE " %s MB";
 
 const char UFS_FORM_FILE_UPGc1[] PROGMEM =
-    " &nbsp;&nbsp;<a href='http://%_I/ufsd?dir=%d'>%s</a>";
+    " &nbsp;&nbsp;<a href='/ufsd?dir=%d'>%s</a>";
 
 const char UFS_FORM_FILE_UPGc2[] PROGMEM =
   "</div>";
@@ -719,7 +719,7 @@ void UfsDirectory(void) {
   WSContentSend_PD(UFS_FORM_FILE_UPGc, WebColor(COL_TEXT), ts, fs);
 
   if (ufs_dir) {
-    WSContentSend_P(UFS_FORM_FILE_UPGc1, (uint32_t)WiFi.localIP(), (ufs_dir == 1)?2:1, (ufs_dir == 1)?PSTR("SDCard"):PSTR("FlashFS"));
+    WSContentSend_P(UFS_FORM_FILE_UPGc1, (ufs_dir == 1)?2:1, (ufs_dir == 1)?PSTR("SDCard"):PSTR("FlashFS"));
   }
   WSContentSend_P(UFS_FORM_FILE_UPGc2);
 


### PR DESCRIPTION
## Description:
The "Manage File System" page uses an absolute URI including wifi ip to switch between flash and sd card. If your device uses an ethernet port and has wifi turned off or not configured, the link target resolves to `http://0.0.0.0/ufsd?`.

This PR changes the target to only use a relative URI without ip. So the browser will use the ip or hostname of the current page.

## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

I have only a ESP32 dev board and cannot test on ESP8266 hardware, but the change is minimal and should also be valid for this platform.