### PR TITLE
Berry add `wc.set_follow_redirects(bool)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Extended Tariff command for forced tariff (#18080)
 - Berry support for Tensorflow Lite (TFL) by Christiaan Baars (#18119)
 - Zigbee send Tuya 'magic spell' to unlock devices when pairing (#18144)
+- Berry add `wc.set_follow_redirects(bool)`
 
 ### Breaking Changed
 - Shelly Pro 4PM using standard MCP23xxx driver and needs one time Auto-Configuration

--- a/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
@@ -14,6 +14,7 @@ extern int wc_urlencode(bvm *vm);
 extern int wc_begin(bvm *vm);
 extern int wc_set_timeouts(bvm *vm);
 extern int wc_set_useragent(bvm *vm);
+extern int wc_set_follow_redirects(bvm *vm);
 extern int wc_set_auth(bvm *vm);
 extern int wc_connected(bvm *vm);
 extern int wc_close(bvm *vm);
@@ -47,6 +48,7 @@ class be_class_webclient (scope: global, name: webclient) {
     begin, func(wc_begin)
     set_timeouts, func(wc_set_timeouts)
     set_useragent, func(wc_set_useragent)
+    set_follow_redirects, func(wc_set_follow_redirects)
     set_auth, func(wc_set_auth)
     close, func(wc_close)
     add_header, func(wc_addheader)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -259,6 +259,20 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // wc.set_follow_redirects(bool) -> self
+  int32_t wc_set_follow_redirects(struct bvm *vm);
+  int32_t wc_set_follow_redirects(struct bvm *vm) {
+    int32_t argc = be_top(vm);
+    if (argc >= 2 && be_isbool(vm, 2)) {
+      HTTPClientLight * cl = wc_getclient(vm);
+      bbool follow = be_tobool(vm, 2);
+      cl->setFollowRedirects(follow ? HTTPC_STRICT_FOLLOW_REDIRECTS : HTTPC_DISABLE_FOLLOW_REDIRECTS);
+      be_pushvalue(vm, 1);
+      be_return(vm);  /* return self */
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
   // wc.wc_set_auth(auth:string | (user:string, password:string)) -> self
   int32_t wc_set_auth(struct bvm *vm);
   int32_t wc_set_auth(struct bvm *vm) {


### PR DESCRIPTION
## Description:

Berry webclient `wc.set_follow_redirects(bool)` enables or disables following reditects.
- if `false`: (`HTTPC_DISABLE_FOLLOW_REDIRECTS`) no redirection will be followed.
- if `true`: (`HTTPC_STRICT_FOLLOW_REDIRECTS`) strict RFC2616, only requests using GET or HEAD methods will be redirected (using the same method), since the RFC requires end-user confirmation in other cases.

``` berry
cl = webclient()
cl.set_follow_redirects(true)
cl.begin("https://raw.githubusercontent.com/tasmota/autoconf/main/esp32_manifest.json")

r = cl.GET()
print(r)

s = cl.get_string()
print(s)
```
## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
