### PR TITLE
Berry add `webclient` `collect_headers()` and `set_headers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 - Extended Tariff command for forced tariff (#18080)
 - Berry support for Tensorflow Lite (TFL) by Christiaan Baars (#18119)
 - Zigbee send Tuya 'magic spell' to unlock devices when pairing (#18144)
-- Berry add `wc.set_follow_redirects(bool)`
+- Berry add `webclient` `set_follow_redirects(bool)`
+- Berry add `webclient` `collect_headers()` and `set_headers`
 
 ### Breaking Changed
 - Shelly Pro 4PM using standard MCP23xxx driver and needs one time Auto-Configuration

--- a/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
+++ b/lib/libesp32/berry_tasmota/src/be_webclient_lib.c
@@ -16,6 +16,8 @@ extern int wc_set_timeouts(bvm *vm);
 extern int wc_set_useragent(bvm *vm);
 extern int wc_set_follow_redirects(bvm *vm);
 extern int wc_set_auth(bvm *vm);
+extern int wc_collect_headers(bvm *vm);
+extern int wc_get_header(bvm *vm);
 extern int wc_connected(bvm *vm);
 extern int wc_close(bvm *vm);
 extern int wc_addheader(bvm *vm);
@@ -50,6 +52,11 @@ class be_class_webclient (scope: global, name: webclient) {
     set_useragent, func(wc_set_useragent)
     set_follow_redirects, func(wc_set_follow_redirects)
     set_auth, func(wc_set_auth)
+
+    // collect response headers
+    collect_headers, func(wc_collect_headers)
+    get_header, func(wc_get_header)
+
     close, func(wc_close)
     add_header, func(wc_addheader)
     GET, func(wc_GET)

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_webclient.ino
@@ -273,6 +273,41 @@ extern "C" {
     be_raise(vm, kTypeError, nullptr);
   }
 
+  // wc.collect_headers( [header:string]+ ) -> self
+  int32_t wc_collect_headers(struct bvm *vm);
+  int32_t wc_collect_headers(struct bvm *vm) {
+    int32_t argc = be_top(vm);
+    if (argc >= 2) {
+      size_t header_len = argc-1;
+      const char** header_array = (const char**) be_os_malloc((header_len) * sizeof(const char*));
+      if (!header_array) { be_throw(vm, BE_MALLOC_FAIL); }
+
+      for (int32_t i = 0; i < header_len; i++) {
+        header_array[i] = be_tostring(vm, i + 2);
+      }
+      HTTPClientLight * cl = wc_getclient(vm);
+      cl->collectHeaders(header_array, header_len);
+
+      be_os_free(header_array);
+    }
+    be_pushvalue(vm, 1);
+    be_return(vm);  /* return self */
+  }
+
+  // wc.get_header(header_name:string) -> string
+  int32_t wc_get_header(struct bvm *vm);
+  int32_t wc_get_header(struct bvm *vm) {
+    int32_t argc = be_top(vm);
+    if (argc >= 2 && be_isstring(vm, 2)) {
+      HTTPClientLight * cl = wc_getclient(vm);
+      const char * header_name = be_tostring(vm, 2);
+      String ret = cl->header(header_name);
+      be_pushstring(vm, ret.c_str());
+      be_return(vm);  /* return self */
+    }
+    be_raise(vm, kTypeError, nullptr);
+  }
+
   // wc.wc_set_auth(auth:string | (user:string, password:string)) -> self
   int32_t wc_set_auth(struct bvm *vm);
   int32_t wc_set_auth(struct bvm *vm) {


### PR DESCRIPTION
## Description:

Berry `webclient`, more generalized way to collect response headers.
- `wc.collect_headers( [header_name:string]* ) -> self`: registers a list of header names that needs to be collected from the response
- `wc.get_header(header_name:string) -> string`: returns the header value for a header name (case sensitive). Returns "" (empty string) if no header.

Example: `http://ota.tasmota.com/tasmota32` redirected to `http://ota.tasmota.com/tasmota32/`

Version 1: (follow redirects)
``` berry
cl = webclient()
cl.set_follow_redirects(true)
cl.begin("http://ota.tasmota.com/tasmota32")
r = cl.GET()
print(r)
s = cl.get_string()
print(s)
```

Example 2: don't follow redirects and retrieve the new URL
``` berry
cl = webclient()
cl.set_follow_redirects(false)
cl.collect_headers("Location")
cl.begin("http://ota.tasmota.com/tasmota32")
r = cl.GET()
print(r)
if r == 301 || r == 302
  print("Location:", cl.get_header("Location"))
elif r == 200
  s = cl.get_string()
  print(s)
end
cl.close()
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
