### PR TITLE
Move matter strings to weak references

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_counter.cpp
+++ b/lib/libesp32/berry_matter/src/be_matter_counter.cpp
@@ -175,7 +175,7 @@ static int mc_tostring(bvm *vm) {
 #include "be_fixed_be_class_Matter_Counter.h"
 
 /* @const_object_info_begin
-class be_class_Matter_Counter (scope: global, name: Matter_Counter) {
+class be_class_Matter_Counter (scope: global, name: Matter_Counter, strings: weak) {
   _p, var
   init, ctype_func(mc_init)
   deinit, ctype_func(mc_deinit)

--- a/lib/libesp32/berry_matter/src/be_matter_module.c
+++ b/lib/libesp32/berry_matter/src/be_matter_module.c
@@ -175,7 +175,7 @@ static int matter_CD_FFF1_8000(bvm *vm) { return matter_return_static_bytes(vm, 
 
 /* @const_object_info_begin
 
-module matter (scope: global) {
+module matter (scope: global, strings: weak) {
   _LOGO, comptr(MATTER_LOGO)
   _QRCODE_MINJS, comptr(QRCODE_MINJS)
   MATTER_OPTION, int(151)       // SetOption151 enables Matter

--- a/lib/libesp32/berry_matter/src/be_matter_verhoeff.cpp
+++ b/lib/libesp32/berry_matter/src/be_matter_verhoeff.cpp
@@ -85,7 +85,7 @@ BE_FUNC_CTYPE_DECLARE(vh_validate, "b", "s")
 #include "be_fixed_be_class_Matter_Verhoeff.h"
 
 /* @const_object_info_begin
-class be_class_Matter_Verhoeff (scope: global, name: Matter_Verhoeff) {
+class be_class_Matter_Verhoeff (scope: global, name: Matter_Verhoeff, strings: weak) {
   checksum, static_ctype_func(vh_checksum)
   validate, static_ctype_func(vh_validate)
 }


### PR DESCRIPTION
## Description:

Move all Berry strings as weak references. They were mistakenly included in the set of strings for all builds. Removes 56 strings that are used only in Matter.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
