### PR TITLE
Berry add `web_get_arg` event to drivers when `FUNC_WEB_GET_ARG` event is processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Berry `webclient` `set_follow_redirects(bool)`
 - Berry `webclient` `collect_headers()` and `set_headers`
 - Display TM1650 commands like TM1637 (#18109)
+- Berry add `web_get_arg` event to drivers when `FUNC_WEB_GET_ARG` event is processed
 
 ### Breaking Changed
 - Shelly Pro 4PM using standard MCP23xxx driver and needs one time Auto-Configuration

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_9_berry.ino
@@ -802,6 +802,9 @@ bool Xdrv52(uint32_t function)
     case FUNC_WEB_SENSOR:
       callBerryEventDispatcher(PSTR("web_sensor"), nullptr, 0, nullptr);
       break;
+    case FUNC_WEB_GET_ARG:
+      callBerryEventDispatcher(PSTR("web_get_arg"), nullptr, 0, nullptr);
+      break;
 
     case FUNC_JSON_APPEND:
       callBerryEventDispatcher(PSTR("json_append"), nullptr, 0, nullptr);


### PR DESCRIPTION
## Description:

Allows to process event when a sensor button is pressed on the main page.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
