### PR TITLE
Berry coc support unicode

### DIFF
--- a/lib/libesp32/berry/tools/coc/str_build.py
+++ b/lib/libesp32/berry/tools/coc/str_build.py
@@ -1,6 +1,20 @@
 import json
 from coc_string import *
 
+# from https://stackoverflow.com/questions/14945095/how-to-escape-string-for-generated-c (simplified)
+def escape_c(s, encoding='ascii'):
+    result = ''
+    for c in s:
+        if not (32 <= ord(c) < 127):
+            result += '\\%03o' % ord(c)
+        elif c == '\\':
+            result += "\\\\"
+        elif c == '"':
+            result += "\\\""
+        else:
+            result += c
+    return '"' + result + '"'
+
 class str_info:
     def __init__(self):
         self.hash = 0
@@ -91,7 +105,7 @@ class str_build:
                 else:
                     next = "NULL"
                 istr += "be_define_const_str("
-                istr += node + ", " + json.dumps(info.str) + ", "
+                istr += node + ", " + escape_c(info.str) + ", "
                 istr += str(info.hash) + "u, " + str(info.extra) + ", "
                 istr += str(len(info.str)) + ", " + next + ");\n"
                 strings[info.str] = istr
@@ -104,7 +118,7 @@ class str_build:
         ostr += "\n/* weak strings */\n"
         for k in self.str_weak:
             ostr += "be_define_const_str("
-            ostr += escape_operator(k) + ", " + json.dumps(k) + ", "
+            ostr += escape_operator(k) + ", " + escape_c(k) + ", "
             ostr += "0u, 0, " + str(len(k)) + ", NULL);\n"
 
         ostr += "\n"


### PR DESCRIPTION
## Description:

Berry: make the coc compiler correctly espace unicode string literals.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
