### PR TITLE
Matter fix Network Featuremap

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -110,7 +110,7 @@ class Matter_Device
     self.compute_pbkdf(self.passcode)
 
     # if no fabric is configured, automatically open commissioning at restart
-    if size(self.sessions.fabrics) == 0
+    if self.sessions.count_active_fabrics() == 0
       self.start_basic_commissioning()
     end
   end
@@ -274,6 +274,7 @@ class Matter_Device
   #
   def start_commissioning_complete(session)
     tasmota.log("MTR: *** Commissioning complete ***", 2)
+    self.stop_basic_commissioning()     # by default close commissioning when it's complete
   end
 
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Expirable.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Expirable.be
@@ -169,6 +169,18 @@ class Matter_Expirable_list : list
   end
 
   #############################################################
+  # Count the number of persistable objects
+  def count_persistables()
+    var ret = 0
+    var idx = 0
+    while idx < size(self)
+      if self[idx]._persist   ret += 1  end
+      idx += 1
+    end
+    return ret
+  end
+
+  #############################################################
   # every_second
   def every_second()
     self.remove_expired()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -269,7 +269,7 @@ class Matter_Plugin_Root : Matter_Plugin
       if   attribute == 0x0003          #  ---------- ConnectMaxTimeSeconds / uint8 ----------
         return TLV.create_TLV(TLV.U1, 30)    # 30 - value taking from example in esp-matter
       elif attribute == 0xFFFC          #  ---------- FeatureMap / map32 ----------
-        return TLV.create_TLV(TLV.U4, 0)    # 15s ??? TOOD what should we put here?
+        return TLV.create_TLV(TLV.U4, 0x04)  # Put Eth for now which should work for any on-network
       end
 
     # ====================================================================================================

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Session.be
@@ -602,6 +602,15 @@ class Matter_Session_Store
   end
 
   #############################################################
+  # Count active fabrics
+  #
+  # Count the number of commissionned fabrics, i.e. persisted
+  def count_active_fabrics(f)
+    self.remove_expired()      # clean before saving
+    return self.fabrics.count_persistables()
+  end
+
+  #############################################################
   # add session 
   def create_session(local_session_id, initiator_session_id)
     var session = self.get_session_by_local_session_id(local_session_id)

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -160,7 +160,7 @@ class Matter_UI
     webserver.content_send("<p>Passcode:</p>")
     webserver.content_send(string.format("<input type='number' min='1' max='99999998' name='passcode' value='%i'>", self.device.passcode))
     webserver.content_send("<p>Distinguish id:</p>")
-    webserver.content_send(string.format("<input type='number' min='0' max='2047' name='discriminator' value='%i'>", self.device.discriminator))
+    webserver.content_send(string.format("<input type='number' min='0' max='4095' name='discriminator' value='%i'>", self.device.discriminator))
     webserver.content_send(string.format("<p><input type='checkbox' name='ipv4'%s>IPv4 only</p>", self.device.ipv4only ? " checked" : ""))
     webserver.content_send("<p></p><button name='passcode' class='button bgrn'>Change</button></form></p>")
     webserver.content_send("<p></p></fieldset><p></p>")
@@ -314,6 +314,14 @@ class Matter_UI
       end
 
       # mtc0 = close, mtc1 = open commissioning
+      var fabrics_count = self.device.sessions.count_active_fabrics()
+      if fabrics_count == 0
+        webserver.content_send(string.format("<div style='text-align:right;font-size:11px;color:#aaa;'>%s</div>", "No active associaition"))
+      else
+        var plural = fabrics_count > 1
+        webserver.content_send(string.format("<div style='text-align:right;font-size:11px;color:#aaa;'>%s</div>", str(fabrics_count) + " active association" + (plural ? "s" : "")))
+      end
+
       webserver.content_send(string.format("<button onclick='la(\"&mtc%i=1\");'>", self.device.commissioning_open == nil ? 1 : 0))
       webserver.content_send(matter._LOGO)
       if self.device.commissioning_open == nil

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -1516,25 +1516,24 @@ be_local_closure(Matter_Device_init_basic_commissioning,   /* name */
     /* K0   */  be_nested_str_weak(compute_pbkdf),
     /* K1   */  be_nested_str_weak(passcode),
     /* K2   */  be_nested_str_weak(sessions),
-    /* K3   */  be_nested_str_weak(fabrics),
+    /* K3   */  be_nested_str_weak(count_active_fabrics),
     /* K4   */  be_const_int(0),
     /* K5   */  be_nested_str_weak(start_basic_commissioning),
     }),
     be_str_weak(init_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[11]) {  /* code */
       0x8C040100,  //  0000  GETMET	R1	R0	K0
       0x880C0101,  //  0001  GETMBR	R3	R0	K1
       0x7C040400,  //  0002  CALL	R1	2
-      0x6004000C,  //  0003  GETGBL	R1	G12
-      0x88080102,  //  0004  GETMBR	R2	R0	K2
-      0x88080503,  //  0005  GETMBR	R2	R2	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x1C040304,  //  0007  EQ	R1	R1	K4
-      0x78060001,  //  0008  JMPF	R1	#000B
-      0x8C040105,  //  0009  GETMET	R1	R0	K5
-      0x7C040200,  //  000A  CALL	R1	1
-      0x80000000,  //  000B  RET	0
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040303,  //  0004  GETMET	R1	R1	K3
+      0x7C040200,  //  0005  CALL	R1	1
+      0x1C040304,  //  0006  EQ	R1	R1	K4
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x8C040105,  //  0008  GETMET	R1	R0	K5
+      0x7C040200,  //  0009  CALL	R1	1
+      0x80000000,  //  000A  RET	0
     })
   )
 );
@@ -2371,21 +2370,24 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 5]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
     /* K1   */  be_nested_str_weak(log),
     /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
     /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(stop_basic_commissioning),
     }),
     be_str_weak(start_commissioning_complete),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
+    ( &(const binstruction[ 8]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x58100002,  //  0002  LDCONST	R4	K2
       0x58140003,  //  0003  LDCONST	R5	K3
       0x7C080600,  //  0004  CALL	R2	3
-      0x80000000,  //  0005  RET	0
+      0x8C080104,  //  0005  GETMET	R2	R0	K4
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80000000,  //  0007  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
@@ -399,11 +399,11 @@ void be_load_Matter_Expirable_class(bvm *vm) {
 extern const bclass be_class_Matter_Expirable_list;
 
 /********************************************************************
-** Solidified function: every_second
+** Solidified function: count_persistables
 ********************************************************************/
-be_local_closure(Matter_Expirable_list_every_second,   /* name */
+be_local_closure(Matter_Expirable_list_count_persistables,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    5,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -411,15 +411,79 @@ be_local_closure(Matter_Expirable_list_every_second,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(_persist),
+    /* K2   */  be_const_int(1),
     }),
-    be_str_weak(every_second),
+    be_str_weak(count_persistables),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[14]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x140C0403,  //  0005  LT	R3	R2	R3
+      0x780E0005,  //  0006  JMPF	R3	#000D
+      0x940C0002,  //  0007  GETIDX	R3	R0	R2
+      0x880C0701,  //  0008  GETMBR	R3	R3	K1
+      0x780E0000,  //  0009  JMPF	R3	#000B
+      0x00040302,  //  000A  ADD	R1	R1	K2
+      0x00080502,  //  000B  ADD	R2	R2	K2
+      0x7001FFF4,  //  000C  JMP		#0002
+      0x80040200,  //  000D  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_expired
+********************************************************************/
+be_local_closure(Matter_Expirable_list_remove_expired,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(has_expired),
+    /* K2   */  be_nested_str_weak(_persist),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(remove_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x50040000,  //  0000  LDBOOL	R1	0	0
+      0x58080000,  //  0001  LDCONST	R2	K0
+      0x600C000C,  //  0002  GETGBL	R3	G12
+      0x5C100000,  //  0003  MOVE	R4	R0
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x140C0403,  //  0005  LT	R3	R2	R3
+      0x780E000D,  //  0006  JMPF	R3	#0015
+      0x940C0002,  //  0007  GETIDX	R3	R0	R2
+      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0007,  //  000A  JMPF	R3	#0013
+      0x940C0002,  //  000B  GETIDX	R3	R0	R2
+      0x880C0702,  //  000C  GETMBR	R3	R3	K2
+      0x780E0000,  //  000D  JMPF	R3	#000F
+      0x50040200,  //  000E  LDBOOL	R1	1	0
+      0x8C0C0103,  //  000F  GETMET	R3	R0	K3
+      0x5C140400,  //  0010  MOVE	R5	R2
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x70020000,  //  0012  JMP		#0014
+      0x00080504,  //  0013  ADD	R2	R2	K4
+      0x7001FFEC,  //  0014  JMP		#0002
+      0x80040200,  //  0015  RET	1	R1
     })
   )
 );
@@ -475,58 +539,11 @@ be_local_closure(Matter_Expirable_list_setitem,   /* name */
 
 
 /********************************************************************
-** Solidified function: push
+** Solidified function: every_second
 ********************************************************************/
-be_local_closure(Matter_Expirable_list_push,   /* name */
+be_local_closure(Matter_Expirable_list_every_second,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Expirable),
-    /* K2   */  be_nested_str_weak(type_error),
-    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
-    /* K4   */  be_nested_str_weak(set_parent_list),
-    /* K5   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(push),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x740A0000,  //  0005  JMPT	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C080304,  //  0007  GETMET	R2	R1	K4
-      0x5C100000,  //  0008  MOVE	R4	R0
-      0x7C080400,  //  0009  CALL	R2	2
-      0x60080003,  //  000A  GETGBL	R2	G3
-      0x5C0C0000,  //  000B  MOVE	R3	R0
-      0x7C080200,  //  000C  CALL	R2	1
-      0x8C080505,  //  000D  GETMET	R2	R2	K5
-      0x5C100200,  //  000E  MOVE	R4	R1
-      0x7C080400,  //  000F  CALL	R2	2
-      0x80040400,  //  0010  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_expired
-********************************************************************/
-be_local_closure(Matter_Expirable_list_remove_expired,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
+    3,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -534,38 +551,15 @@ be_local_closure(Matter_Expirable_list_remove_expired,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(has_expired),
-    /* K2   */  be_nested_str_weak(_persist),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_const_int(1),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
     }),
-    be_str_weak(remove_expired),
+    be_str_weak(every_second),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x50040000,  //  0000  LDBOOL	R1	0	0
-      0x58080000,  //  0001  LDCONST	R2	K0
-      0x600C000C,  //  0002  GETGBL	R3	G12
-      0x5C100000,  //  0003  MOVE	R4	R0
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x140C0403,  //  0005  LT	R3	R2	R3
-      0x780E000D,  //  0006  JMPF	R3	#0015
-      0x940C0002,  //  0007  GETIDX	R3	R0	R2
-      0x8C0C0701,  //  0008  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0007,  //  000A  JMPF	R3	#0013
-      0x940C0002,  //  000B  GETIDX	R3	R0	R2
-      0x880C0702,  //  000C  GETMBR	R3	R3	K2
-      0x780E0000,  //  000D  JMPF	R3	#000F
-      0x50040200,  //  000E  LDBOOL	R1	1	0
-      0x8C0C0103,  //  000F  GETMET	R3	R0	K3
-      0x5C140400,  //  0010  MOVE	R5	R2
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x70020000,  //  0012  JMP		#0014
-      0x00080504,  //  0013  ADD	R2	R2	K4
-      0x7001FFEC,  //  0014  JMP		#0002
-      0x80040200,  //  0015  RET	1	R1
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -632,19 +626,67 @@ be_local_closure(Matter_Expirable_list_persistables,   /* name */
 
 
 /********************************************************************
+** Solidified function: push
+********************************************************************/
+be_local_closure(Matter_Expirable_list_push,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Expirable),
+    /* K2   */  be_nested_str_weak(type_error),
+    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
+    /* K4   */  be_nested_str_weak(set_parent_list),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(push),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0000,  //  0005  JMPT	R2	#0007
+      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0x8C080304,  //  0007  GETMET	R2	R1	K4
+      0x5C100000,  //  0008  MOVE	R4	R0
+      0x7C080400,  //  0009  CALL	R2	2
+      0x60080003,  //  000A  GETGBL	R2	G3
+      0x5C0C0000,  //  000B  MOVE	R3	R0
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C080505,  //  000D  GETMET	R2	R2	K5
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x7C080400,  //  000F  CALL	R2	2
+      0x80040400,  //  0010  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Expirable_list
 ********************************************************************/
 extern const bclass be_class_list;
 be_local_class(Matter_Expirable_list,
     0,
     &be_class_list,
-    be_nested_map(5,
+    be_nested_map(6,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(every_second, 4), be_const_closure(Matter_Expirable_list_every_second_closure) },
+        { be_const_key_weak(count_persistables, -1), be_const_closure(Matter_Expirable_list_count_persistables_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Expirable_list_every_second_closure) },
         { be_const_key_weak(setitem, -1), be_const_closure(Matter_Expirable_list_setitem_closure) },
-        { be_const_key_weak(push, -1), be_const_closure(Matter_Expirable_list_push_closure) },
-        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Expirable_list_remove_expired_closure) },
+        { be_const_key_weak(remove_expired, 1), be_const_closure(Matter_Expirable_list_remove_expired_closure) },
         { be_const_key_weak(persistables, -1), be_const_closure(Matter_Expirable_list_persistables_closure) },
+        { be_const_key_weak(push, -1), be_const_closure(Matter_Expirable_list_push_closure) },
     })),
     be_str_weak(Matter_Expirable_list)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -855,7 +855,7 @@ be_local_closure(Matter_Plugin_Root_read_attribute,   /* name */
       0x781E0004,  //  02E8  JMPF	R7	#02EE
       0x8C1C0906,  //  02E9  GETMET	R7	R4	K6
       0x8824092A,  //  02EA  GETMBR	R9	R4	K42
-      0x58280005,  //  02EB  LDCONST	R10	K5
+      0x542A0003,  //  02EB  LDINT	R10	4
       0x7C1C0600,  //  02EC  CALL	R7	3
       0x80040E00,  //  02ED  RET	1	R7
       0x70020059,  //  02EE  JMP		#0349

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -2741,6 +2741,537 @@ void be_load_Matter_Session_class(bvm *vm) {
 extern const bclass be_class_Matter_Session_Store;
 
 /********************************************************************
+** Solidified function: remove_expired
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(every_second),
+    /* K2   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(remove_expired),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040102,  //  0003  GETMBR	R1	R0	K2
+      0x8C040301,  //  0004  GETMET	R1	R1	K1
+      0x7C040200,  //  0005  CALL	R1	1
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_add_session,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x4C0C0000,  //  0000  LDNIL	R3
+      0x200C0403,  //  0001  NE	R3	R2	R3
+      0x780E0002,  //  0002  JMPF	R3	#0006
+      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
+      0x5C140200,  //  0008  MOVE	R5	R1
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x80000000,  //  000A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_local_session_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(local_session_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_local_session_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Session_Store_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_create_fabric,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Fabric),
+    }),
+    be_str_weak(create_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80040200,  //  0004  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: find_session_by_resumption_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(resumption_id),
+    /* K3   */  be_nested_str_weak(shared_secret),
+    /* K4   */  be_nested_str_weak(update),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(find_session_by_resumption_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x5C080200,  //  0000  MOVE	R2	R1
+      0x740A0001,  //  0001  JMPT	R2	#0004
+      0x4C080000,  //  0002  LDNIL	R2
+      0x80040400,  //  0003  RET	1	R2
+      0x58080000,  //  0004  LDCONST	R2	K0
+      0x880C0101,  //  0005  GETMBR	R3	R0	K1
+      0x6010000C,  //  0006  GETGBL	R4	G12
+      0x5C140600,  //  0007  MOVE	R5	R3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x14100404,  //  0009  LT	R4	R2	R4
+      0x7812000C,  //  000A  JMPF	R4	#0018
+      0x94100602,  //  000B  GETIDX	R4	R3	R2
+      0x88140902,  //  000C  GETMBR	R5	R4	K2
+      0x1C140A01,  //  000D  EQ	R5	R5	R1
+      0x78160006,  //  000E  JMPF	R5	#0016
+      0x88140903,  //  000F  GETMBR	R5	R4	K3
+      0x4C180000,  //  0010  LDNIL	R6
+      0x20140A06,  //  0011  NE	R5	R5	R6
+      0x78160002,  //  0012  JMPF	R5	#0016
+      0x8C140904,  //  0013  GETMET	R5	R4	K4
+      0x7C140200,  //  0014  CALL	R5	1
+      0x80040800,  //  0015  RET	1	R4
+      0x00080505,  //  0016  ADD	R2	R2	K5
+      0x7001FFED,  //  0017  JMP		#0006
+      0x80000000,  //  0018  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_session_by_source_node_id
+********************************************************************/
+be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(source_node_id),
+    /* K3   */  be_nested_str_weak(update),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(get_session_by_source_node_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0001,  //  0002  JMPF	R2	#0005
+      0x4C080000,  //  0003  LDNIL	R2
+      0x80040400,  //  0004  RET	1	R2
+      0x6008000C,  //  0005  GETGBL	R2	G12
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C080200,  //  0007  CALL	R2	1
+      0x580C0001,  //  0008  LDCONST	R3	K1
+      0x88100100,  //  0009  GETMBR	R4	R0	K0
+      0x14140602,  //  000A  LT	R5	R3	R2
+      0x78160008,  //  000B  JMPF	R5	#0015
+      0x94140803,  //  000C  GETIDX	R5	R4	R3
+      0x88180B02,  //  000D  GETMBR	R6	R5	K2
+      0x1C180C01,  //  000E  EQ	R6	R6	R1
+      0x781A0002,  //  000F  JMPF	R6	#0013
+      0x8C180B03,  //  0010  GETMET	R6	R5	K3
+      0x7C180200,  //  0011  CALL	R6	1
+      0x80040A00,  //  0012  RET	1	R5
+      0x000C0704,  //  0013  ADD	R3	R3	K4
+      0x7001FFF4,  //  0014  JMP		#000A
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(sessions),
+    /* K2   */  be_nested_str_weak(remove),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(remove_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x6010000C,  //  0002  GETGBL	R4	G12
+      0x88140101,  //  0003  GETMBR	R5	R0	K1
+      0x7C100200,  //  0004  CALL	R4	1
+      0x14100404,  //  0005  LT	R4	R2	R4
+      0x78120008,  //  0006  JMPF	R4	#0010
+      0x94100602,  //  0007  GETIDX	R4	R3	R2
+      0x1C100801,  //  0008  EQ	R4	R4	R1
+      0x78120003,  //  0009  JMPF	R4	#000E
+      0x8C100702,  //  000A  GETMET	R4	R3	K2
+      0x5C180400,  //  000B  MOVE	R6	R2
+      0x7C100400,  //  000C  CALL	R4	2
+      0x70020000,  //  000D  JMP		#000F
+      0x00080503,  //  000E  ADD	R2	R2	K3
+      0x7001FFF1,  //  000F  JMP		#0002
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: create_session
+********************************************************************/
+be_local_closure(Matter_Session_Store_create_session,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K1   */  be_nested_str_weak(remove_session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Session),
+    /* K4   */  be_nested_str_weak(sessions),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(create_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
+      0x5C140200,  //  0001  MOVE	R5	R1
+      0x7C0C0400,  //  0002  CALL	R3	2
+      0x4C100000,  //  0003  LDNIL	R4
+      0x20100604,  //  0004  NE	R4	R3	R4
+      0x78120002,  //  0005  JMPF	R4	#0009
+      0x8C100101,  //  0006  GETMET	R4	R0	K1
+      0x5C180600,  //  0007  MOVE	R6	R3
+      0x7C100400,  //  0008  CALL	R4	2
+      0xB8120400,  //  0009  GETNGBL	R4	K2
+      0x8C100903,  //  000A  GETMET	R4	R4	K3
+      0x5C180000,  //  000B  MOVE	R6	R0
+      0x5C1C0200,  //  000C  MOVE	R7	R1
+      0x5C200400,  //  000D  MOVE	R8	R2
+      0x7C100800,  //  000E  CALL	R4	4
+      0x5C0C0800,  //  000F  MOVE	R3	R4
+      0x88100104,  //  0010  GETMBR	R4	R0	K4
+      0x8C100905,  //  0011  GETMET	R4	R4	K5
+      0x5C180600,  //  0012  MOVE	R6	R3
+      0x7C100400,  //  0013  CALL	R4	2
+      0x80040600,  //  0014  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_Store_init,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Expirable_list),
+    /* K3   */  be_nested_str_weak(fabrics),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x90020001,  //  0003  SETMBR	R0	K0	R1
+      0xB8060200,  //  0004  GETNGBL	R1	K1
+      0x8C040302,  //  0005  GETMET	R1	R1	K2
+      0x7C040200,  //  0006  CALL	R1	1
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_add_fabric,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Fabric),
+    /* K2   */  be_nested_str_weak(value_error),
+    /* K3   */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
+    /* K4   */  be_nested_str_weak(fabrics),
+    /* K5   */  be_nested_str_weak(find),
+    /* K6   */  be_nested_str_weak(remove_redundant_fabric),
+    /* K7   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0000,  //  0005  JMPT	R2	#0007
+      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0x88080104,  //  0007  GETMBR	R2	R0	K4
+      0x8C080505,  //  0008  GETMET	R2	R2	K5
+      0x5C100200,  //  0009  MOVE	R4	R1
+      0x7C080400,  //  000A  CALL	R2	2
+      0x4C0C0000,  //  000B  LDNIL	R3
+      0x1C080403,  //  000C  EQ	R2	R2	R3
+      0x780A0006,  //  000D  JMPF	R2	#0015
+      0x8C080106,  //  000E  GETMET	R2	R0	K6
+      0x5C100200,  //  000F  MOVE	R4	R1
+      0x7C080400,  //  0010  CALL	R2	2
+      0x88080104,  //  0011  GETMBR	R2	R0	K4
+      0x8C080507,  //  0012  GETMET	R2	R2	K7
+      0x5C100200,  //  0013  MOVE	R4	R1
+      0x7C080400,  //  0014  CALL	R2	2
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_redundant_fabric
+********************************************************************/
+be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(fabric_id),
+    /* K3   */  be_nested_str_weak(device_id),
+    /* K4   */  be_nested_str_weak(remove),
+    /* K5   */  be_const_int(1),
+    }),
+    be_str_weak(remove_redundant_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[26]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E0012,  //  0005  JMPF	R3	#0019
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x20100601,  //  0008  NE	R4	R3	R1
+      0x7812000C,  //  0009  JMPF	R4	#0017
+      0x88100702,  //  000A  GETMBR	R4	R3	K2
+      0x88140302,  //  000B  GETMBR	R5	R1	K2
+      0x1C100805,  //  000C  EQ	R4	R4	R5
+      0x78120008,  //  000D  JMPF	R4	#0017
+      0x88100703,  //  000E  GETMBR	R4	R3	K3
+      0x88140303,  //  000F  GETMBR	R5	R1	K3
+      0x1C100805,  //  0010  EQ	R4	R4	R5
+      0x78120004,  //  0011  JMPF	R4	#0017
+      0x88100101,  //  0012  GETMBR	R4	R0	K1
+      0x8C100904,  //  0013  GETMET	R4	R4	K4
+      0x5C180400,  //  0014  MOVE	R6	R2
+      0x7C100400,  //  0015  CALL	R4	2
+      0x70020000,  //  0016  JMP		#0018
+      0x00080505,  //  0017  ADD	R2	R2	K5
+      0x7001FFE7,  //  0018  JMP		#0001
+      0x80000000,  //  0019  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: save_fabrics
 ********************************************************************/
 be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
@@ -2875,65 +3406,9 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_redundant_fabric
+** Solidified function: find_session_source_id_unsecure
 ********************************************************************/
-be_local_closure(Matter_Session_Store_remove_redundant_fabric,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(fabrics),
-    /* K2   */  be_nested_str_weak(fabric_id),
-    /* K3   */  be_nested_str_weak(device_id),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_const_int(1),
-    }),
-    be_str_weak(remove_redundant_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[26]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0012,  //  0005  JMPF	R3	#0019
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x20100601,  //  0008  NE	R4	R3	R1
-      0x7812000C,  //  0009  JMPF	R4	#0017
-      0x88100702,  //  000A  GETMBR	R4	R3	K2
-      0x88140302,  //  000B  GETMBR	R5	R1	K2
-      0x1C100805,  //  000C  EQ	R4	R4	R5
-      0x78120008,  //  000D  JMPF	R4	#0017
-      0x88100703,  //  000E  GETMBR	R4	R3	K3
-      0x88140303,  //  000F  GETMBR	R5	R1	K3
-      0x1C100805,  //  0010  EQ	R4	R4	R5
-      0x78120004,  //  0011  JMPF	R4	#0017
-      0x88100101,  //  0012  GETMBR	R4	R0	K1
-      0x8C100904,  //  0013  GETMET	R4	R4	K4
-      0x5C180400,  //  0014  MOVE	R6	R2
-      0x7C100400,  //  0015  CALL	R4	2
-      0x70020000,  //  0016  JMP		#0018
-      0x00080505,  //  0017  ADD	R2	R2	K5
-      0x7001FFE7,  //  0018  JMP		#0001
-      0x80000000,  //  0019  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_create_session,   /* name */
+be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
@@ -2943,38 +3418,44 @@ be_local_closure(Matter_Session_Store_create_session,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K1   */  be_nested_str_weak(remove_session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Session),
-    /* K4   */  be_nested_str_weak(sessions),
-    /* K5   */  be_nested_str_weak(push),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(Session),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(source_node_id),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(push),
+    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K8   */  be_nested_str_weak(update),
     }),
-    be_str_weak(create_session),
+    be_str_weak(find_session_source_id_unsecure),
     &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
+    ( &(const binstruction[24]) {  /* code */
       0x8C0C0100,  //  0000  GETMET	R3	R0	K0
       0x5C140200,  //  0001  MOVE	R5	R1
       0x7C0C0400,  //  0002  CALL	R3	2
       0x4C100000,  //  0003  LDNIL	R4
-      0x20100604,  //  0004  NE	R4	R3	R4
-      0x78120002,  //  0005  JMPF	R4	#0009
-      0x8C100101,  //  0006  GETMET	R4	R0	K1
-      0x5C180600,  //  0007  MOVE	R6	R3
-      0x7C100400,  //  0008  CALL	R4	2
-      0xB8120400,  //  0009  GETNGBL	R4	K2
-      0x8C100903,  //  000A  GETMET	R4	R4	K3
-      0x5C180000,  //  000B  MOVE	R6	R0
-      0x5C1C0200,  //  000C  MOVE	R7	R1
-      0x5C200400,  //  000D  MOVE	R8	R2
-      0x7C100800,  //  000E  CALL	R4	4
-      0x5C0C0800,  //  000F  MOVE	R3	R4
-      0x88100104,  //  0010  GETMBR	R4	R0	K4
-      0x8C100905,  //  0011  GETMET	R4	R4	K5
-      0x5C180600,  //  0012  MOVE	R6	R3
-      0x7C100400,  //  0013  CALL	R4	2
-      0x80040600,  //  0014  RET	1	R3
+      0x1C100604,  //  0004  EQ	R4	R3	R4
+      0x7812000B,  //  0005  JMPF	R4	#0012
+      0xB8120200,  //  0006  GETNGBL	R4	K1
+      0x8C100902,  //  0007  GETMET	R4	R4	K2
+      0x5C180000,  //  0008  MOVE	R6	R0
+      0x581C0003,  //  0009  LDCONST	R7	K3
+      0x58200003,  //  000A  LDCONST	R8	K3
+      0x7C100800,  //  000B  CALL	R4	4
+      0x5C0C0800,  //  000C  MOVE	R3	R4
+      0x900E0801,  //  000D  SETMBR	R3	K4	R1
+      0x88100105,  //  000E  GETMBR	R4	R0	K5
+      0x8C100906,  //  000F  GETMET	R4	R4	K6
+      0x5C180600,  //  0010  MOVE	R6	R3
+      0x7C100400,  //  0011  CALL	R4	2
+      0x8C100707,  //  0012  GETMET	R4	R3	K7
+      0x5C180400,  //  0013  MOVE	R6	R2
+      0x7C100400,  //  0014  CALL	R4	2
+      0x8C100708,  //  0015  GETMET	R4	R3	K8
+      0x7C100200,  //  0016  CALL	R4	1
+      0x80040600,  //  0017  RET	1	R3
     })
   )
 );
@@ -2982,11 +3463,11 @@ be_local_closure(Matter_Session_Store_create_session,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_expired
+** Solidified function: gen_local_session_id
 ********************************************************************/
-be_local_closure(Matter_Session_Store_remove_expired,   /* name */
+be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
   be_nested_proto(
-    3,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2994,21 +3475,36 @@ be_local_closure(Matter_Session_Store_remove_expired,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(every_second),
-    /* K2   */  be_nested_str_weak(fabrics),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(random),
+    /* K2   */  be_const_int(2),
+    /* K3   */  be_nested_str_weak(get),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
     }),
-    be_str_weak(remove_expired),
+    be_str_weak(gen_local_session_id),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040102,  //  0003  GETMBR	R1	R0	K2
-      0x8C040301,  //  0004  GETMET	R1	R1	K1
-      0x7C040200,  //  0005  CALL	R1	1
-      0x80000000,  //  0006  RET	0
+    ( &(const binstruction[19]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x50080200,  //  0001  LDBOOL	R2	1	0
+      0x780A000E,  //  0002  JMPF	R2	#0012
+      0x8C080301,  //  0003  GETMET	R2	R1	K1
+      0x58100002,  //  0004  LDCONST	R4	K2
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x58100004,  //  0007  LDCONST	R4	K4
+      0x58140002,  //  0008  LDCONST	R5	K2
+      0x7C080600,  //  0009  CALL	R2	3
+      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
+      0x5C140400,  //  000B  MOVE	R5	R2
+      0x7C0C0400,  //  000C  CALL	R3	2
+      0x4C100000,  //  000D  LDNIL	R4
+      0x1C0C0604,  //  000E  EQ	R3	R3	R4
+      0x780E0000,  //  000F  JMPF	R3	#0011
+      0x80040400,  //  0010  RET	1	R2
+      0x7001FFEE,  //  0011  JMP		#0001
+      0x80000000,  //  0012  RET	0
     })
   )
 );
@@ -3187,11 +3683,11 @@ be_local_closure(Matter_Session_Store_load_fabrics,   /* name */
 
 
 /********************************************************************
-** Solidified function: remove_session
+** Solidified function: count_active_fabrics
 ********************************************************************/
-be_local_closure(Matter_Session_Store_remove_session,   /* name */
+be_local_closure(Matter_Session_Store_count_active_fabrics,   /* name */
   be_nested_proto(
-    7,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3199,98 +3695,20 @@ be_local_closure(Matter_Session_Store_remove_session,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(remove),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(remove_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x6010000C,  //  0002  GETGBL	R4	G12
-      0x88140101,  //  0003  GETMBR	R5	R0	K1
-      0x7C100200,  //  0004  CALL	R4	1
-      0x14100404,  //  0005  LT	R4	R2	R4
-      0x78120008,  //  0006  JMPF	R4	#0010
-      0x94100602,  //  0007  GETIDX	R4	R3	R2
-      0x1C100801,  //  0008  EQ	R4	R4	R1
-      0x78120003,  //  0009  JMPF	R4	#000E
-      0x8C100702,  //  000A  GETMET	R4	R3	K2
-      0x5C180400,  //  000B  MOVE	R6	R2
-      0x7C100400,  //  000C  CALL	R4	2
-      0x70020000,  //  000D  JMP		#000F
-      0x00080503,  //  000E  ADD	R2	R2	K3
-      0x7001FFF1,  //  000F  JMP		#0002
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_session,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x4C0C0000,  //  0000  LDNIL	R3
-      0x200C0403,  //  0001  NE	R3	R2	R3
-      0x780E0002,  //  0002  JMPF	R3	#0006
-      0x8C0C0300,  //  0003  GETMET	R3	R1	K0
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x8C0C0702,  //  0007  GETMET	R3	R3	K2
-      0x5C140200,  //  0008  MOVE	R5	R1
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x80000000,  //  000A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Session_Store_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(remove_expired),
+    /* K1   */  be_nested_str_weak(fabrics),
+    /* K2   */  be_nested_str_weak(count_persistables),
     }),
-    be_str_weak(every_second),
+    be_str_weak(count_active_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x7C080200,  //  0001  CALL	R2	1
+      0x88080101,  //  0002  GETMBR	R2	R0	K1
+      0x8C080502,  //  0003  GETMET	R2	R2	K2
+      0x7C080200,  //  0004  CALL	R2	1
+      0x80040400,  //  0005  RET	1	R2
     })
   )
 );
@@ -3350,418 +3768,34 @@ be_local_closure(Matter_Session_Store_sessions_active,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_add_fabric,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    /* K2   */  be_nested_str_weak(value_error),
-    /* K3   */  be_nested_str_weak(must_X20be_X20of_X20class_X20matter_X2EFabric),
-    /* K4   */  be_nested_str_weak(fabrics),
-    /* K5   */  be_nested_str_weak(find),
-    /* K6   */  be_nested_str_weak(remove_redundant_fabric),
-    /* K7   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x740A0000,  //  0005  JMPT	R2	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x88080104,  //  0007  GETMBR	R2	R0	K4
-      0x8C080505,  //  0008  GETMET	R2	R2	K5
-      0x5C100200,  //  0009  MOVE	R4	R1
-      0x7C080400,  //  000A  CALL	R2	2
-      0x4C0C0000,  //  000B  LDNIL	R3
-      0x1C080403,  //  000C  EQ	R2	R2	R3
-      0x780A0006,  //  000D  JMPF	R2	#0015
-      0x8C080106,  //  000E  GETMET	R2	R0	K6
-      0x5C100200,  //  000F  MOVE	R4	R1
-      0x7C080400,  //  0010  CALL	R2	2
-      0x88080104,  //  0011  GETMBR	R2	R0	K4
-      0x8C080507,  //  0012  GETMET	R2	R2	K7
-      0x5C100200,  //  0013  MOVE	R4	R1
-      0x7C080400,  //  0014  CALL	R2	2
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_local_session_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gen_local_session_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_gen_local_session_id,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(random),
-    /* K2   */  be_const_int(2),
-    /* K3   */  be_nested_str_weak(get),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(get_session_by_local_session_id),
-    }),
-    be_str_weak(gen_local_session_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080200,  //  0001  LDBOOL	R2	1	0
-      0x780A000E,  //  0002  JMPF	R2	#0012
-      0x8C080301,  //  0003  GETMET	R2	R1	K1
-      0x58100002,  //  0004  LDCONST	R4	K2
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x58100004,  //  0007  LDCONST	R4	K4
-      0x58140002,  //  0008  LDCONST	R5	K2
-      0x7C080600,  //  0009  CALL	R2	3
-      0x8C0C0105,  //  000A  GETMET	R3	R0	K5
-      0x5C140400,  //  000B  MOVE	R5	R2
-      0x7C0C0400,  //  000C  CALL	R3	2
-      0x4C100000,  //  000D  LDNIL	R4
-      0x1C0C0604,  //  000E  EQ	R3	R3	R4
-      0x780E0000,  //  000F  JMPF	R3	#0011
-      0x80040400,  //  0010  RET	1	R2
-      0x7001FFEE,  //  0011  JMP		#0001
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_Store_init,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Expirable_list),
-    /* K3   */  be_nested_str_weak(fabrics),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x90020001,  //  0003  SETMBR	R0	K0	R1
-      0xB8060200,  //  0004  GETNGBL	R1	K1
-      0x8C040302,  //  0005  GETMET	R1	R1	K2
-      0x7C040200,  //  0006  CALL	R1	1
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_session_source_id_unsecure
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_source_id_unsecure,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_session_by_source_node_id),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(Session),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(source_node_id),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(push),
-    /* K7   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K8   */  be_nested_str_weak(update),
-    }),
-    be_str_weak(find_session_source_id_unsecure),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x8C0C0100,  //  0000  GETMET	R3	R0	K0
-      0x5C140200,  //  0001  MOVE	R5	R1
-      0x7C0C0400,  //  0002  CALL	R3	2
-      0x4C100000,  //  0003  LDNIL	R4
-      0x1C100604,  //  0004  EQ	R4	R3	R4
-      0x7812000B,  //  0005  JMPF	R4	#0012
-      0xB8120200,  //  0006  GETNGBL	R4	K1
-      0x8C100902,  //  0007  GETMET	R4	R4	K2
-      0x5C180000,  //  0008  MOVE	R6	R0
-      0x581C0003,  //  0009  LDCONST	R7	K3
-      0x58200003,  //  000A  LDCONST	R8	K3
-      0x7C100800,  //  000B  CALL	R4	4
-      0x5C0C0800,  //  000C  MOVE	R3	R4
-      0x900E0801,  //  000D  SETMBR	R3	K4	R1
-      0x88100105,  //  000E  GETMBR	R4	R0	K5
-      0x8C100906,  //  000F  GETMET	R4	R4	K6
-      0x5C180600,  //  0010  MOVE	R6	R3
-      0x7C100400,  //  0011  CALL	R4	2
-      0x8C100707,  //  0012  GETMET	R4	R3	K7
-      0x5C180400,  //  0013  MOVE	R6	R2
-      0x7C100400,  //  0014  CALL	R4	2
-      0x8C100708,  //  0015  GETMET	R4	R3	K8
-      0x7C100200,  //  0016  CALL	R4	1
-      0x80040600,  //  0017  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_session_by_source_node_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_get_session_by_source_node_id,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(source_node_id),
-    /* K3   */  be_nested_str_weak(update),
-    /* K4   */  be_const_int(1),
-    }),
-    be_str_weak(get_session_by_source_node_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0001,  //  0002  JMPF	R2	#0005
-      0x4C080000,  //  0003  LDNIL	R2
-      0x80040400,  //  0004  RET	1	R2
-      0x6008000C,  //  0005  GETGBL	R2	G12
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C080200,  //  0007  CALL	R2	1
-      0x580C0001,  //  0008  LDCONST	R3	K1
-      0x88100100,  //  0009  GETMBR	R4	R0	K0
-      0x14140602,  //  000A  LT	R5	R3	R2
-      0x78160008,  //  000B  JMPF	R5	#0015
-      0x94140803,  //  000C  GETIDX	R5	R4	R3
-      0x88180B02,  //  000D  GETMBR	R6	R5	K2
-      0x1C180C01,  //  000E  EQ	R6	R6	R1
-      0x781A0002,  //  000F  JMPF	R6	#0013
-      0x8C180B03,  //  0010  GETMET	R6	R5	K3
-      0x7C180200,  //  0011  CALL	R6	1
-      0x80040A00,  //  0012  RET	1	R5
-      0x000C0704,  //  0013  ADD	R3	R3	K4
-      0x7001FFF4,  //  0014  JMP		#000A
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: find_session_by_resumption_id
-********************************************************************/
-be_local_closure(Matter_Session_Store_find_session_by_resumption_id,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(sessions),
-    /* K2   */  be_nested_str_weak(resumption_id),
-    /* K3   */  be_nested_str_weak(shared_secret),
-    /* K4   */  be_nested_str_weak(update),
-    /* K5   */  be_const_int(1),
-    }),
-    be_str_weak(find_session_by_resumption_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x5C080200,  //  0000  MOVE	R2	R1
-      0x740A0001,  //  0001  JMPT	R2	#0004
-      0x4C080000,  //  0002  LDNIL	R2
-      0x80040400,  //  0003  RET	1	R2
-      0x58080000,  //  0004  LDCONST	R2	K0
-      0x880C0101,  //  0005  GETMBR	R3	R0	K1
-      0x6010000C,  //  0006  GETGBL	R4	G12
-      0x5C140600,  //  0007  MOVE	R5	R3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x14100404,  //  0009  LT	R4	R2	R4
-      0x7812000C,  //  000A  JMPF	R4	#0018
-      0x94100602,  //  000B  GETIDX	R4	R3	R2
-      0x88140902,  //  000C  GETMBR	R5	R4	K2
-      0x1C140A01,  //  000D  EQ	R5	R5	R1
-      0x78160006,  //  000E  JMPF	R5	#0016
-      0x88140903,  //  000F  GETMBR	R5	R4	K3
-      0x4C180000,  //  0010  LDNIL	R6
-      0x20140A06,  //  0011  NE	R5	R5	R6
-      0x78160002,  //  0012  JMPF	R5	#0016
-      0x8C140904,  //  0013  GETMET	R5	R4	K4
-      0x7C140200,  //  0014  CALL	R5	1
-      0x80040800,  //  0015  RET	1	R4
-      0x00080505,  //  0016  ADD	R2	R2	K5
-      0x7001FFED,  //  0017  JMP		#0006
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: create_fabric
-********************************************************************/
-be_local_closure(Matter_Session_Store_create_fabric,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Fabric),
-    }),
-    be_str_weak(create_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0xB8060000,  //  0000  GETNGBL	R1	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80040200,  //  0004  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Session_Store
 ********************************************************************/
 be_local_class(Matter_Session_Store,
     2,
     NULL,
-    be_nested_map(20,
+    be_nested_map(21,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(fabrics, -1), be_const_var(1) },
-        { be_const_key_weak(remove_redundant_fabric, -1), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
-        { be_const_key_weak(create_session, 14), be_const_closure(Matter_Session_Store_create_session_closure) },
-        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Session_Store_remove_expired_closure) },
-        { be_const_key_weak(load_fabrics, -1), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
-        { be_const_key_weak(save_fabrics, 9), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
-        { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
-        { be_const_key_weak(add_session, 10), be_const_closure(Matter_Session_Store_add_session_closure) },
-        { be_const_key_weak(sessions, -1), be_const_var(0) },
-        { be_const_key_weak(every_second, 0), be_const_closure(Matter_Session_Store_every_second_closure) },
-        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
+        { be_const_key_weak(remove_expired, 20), be_const_closure(Matter_Session_Store_remove_expired_closure) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Session_Store_add_session_closure) },
         { be_const_key_weak(sessions_active, -1), be_const_closure(Matter_Session_Store_sessions_active_closure) },
-        { be_const_key_weak(find_session_source_id_unsecure, 17), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
-        { be_const_key_weak(get_session_by_local_session_id, -1), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
-        { be_const_key_weak(gen_local_session_id, -1), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_Session_Store_every_second_closure) },
+        { be_const_key_weak(create_fabric, 15), be_const_closure(Matter_Session_Store_create_fabric_closure) },
+        { be_const_key_weak(fabrics, 19), be_const_var(1) },
+        { be_const_key_weak(count_active_fabrics, -1), be_const_closure(Matter_Session_Store_count_active_fabrics_closure) },
+        { be_const_key_weak(sessions, 6), be_const_var(0) },
+        { be_const_key_weak(get_session_by_source_node_id, -1), be_const_closure(Matter_Session_Store_get_session_by_source_node_id_closure) },
+        { be_const_key_weak(remove_session, -1), be_const_closure(Matter_Session_Store_remove_session_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_Session_Store_init_closure) },
-        { be_const_key_weak(_FABRICS, 12), be_nested_str_weak(_matter_fabrics_X2Ejson) },
         { be_const_key_weak(add_fabric, -1), be_const_closure(Matter_Session_Store_add_fabric_closure) },
+        { be_const_key_weak(create_session, 10), be_const_closure(Matter_Session_Store_create_session_closure) },
+        { be_const_key_weak(remove_redundant_fabric, -1), be_const_closure(Matter_Session_Store_remove_redundant_fabric_closure) },
+        { be_const_key_weak(get_session_by_local_session_id, 13), be_const_closure(Matter_Session_Store_get_session_by_local_session_id_closure) },
+        { be_const_key_weak(save_fabrics, 11), be_const_closure(Matter_Session_Store_save_fabrics_closure) },
+        { be_const_key_weak(find_session_source_id_unsecure, -1), be_const_closure(Matter_Session_Store_find_session_source_id_unsecure_closure) },
+        { be_const_key_weak(gen_local_session_id, -1), be_const_closure(Matter_Session_Store_gen_local_session_id_closure) },
+        { be_const_key_weak(load_fabrics, 2), be_const_closure(Matter_Session_Store_load_fabrics_closure) },
+        { be_const_key_weak(_FABRICS, -1), be_nested_str_weak(_matter_fabrics_X2Ejson) },
         { be_const_key_weak(find_session_by_resumption_id, -1), be_const_closure(Matter_Session_Store_find_session_by_resumption_id_closure) },
-        { be_const_key_weak(create_fabric, -1), be_const_closure(Matter_Session_Store_create_fabric_closure) },
     })),
     be_str_weak(Matter_Session_Store)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -158,7 +158,7 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
 ********************************************************************/
 be_local_closure(Matter_UI_web_sensor,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    13,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -166,7 +166,7 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(tasmota),
@@ -176,18 +176,25 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
     /* K6   */  be_nested_str_weak(device),
     /* K7   */  be_nested_str_weak(commissioning_open),
     /* K8   */  be_nested_str_weak(show_commissioning_info),
-    /* K9   */  be_nested_str_weak(content_send),
-    /* K10  */  be_nested_str_weak(format),
-    /* K11  */  be_nested_str_weak(_X3Cbutton_X20onclick_X3D_X27la_X28_X22_X26mtc_X25i_X3D1_X22_X29_X3B_X27_X3E),
-    /* K12  */  be_const_int(1),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(_LOGO),
-    /* K15  */  be_nested_str_weak(_X20Open_X20Commissioning_X3C_X2Fbutton_X3E),
-    /* K16  */  be_nested_str_weak(_X20Close_X20Commissioning_X3C_X2Fbutton_X3E),
+    /* K9   */  be_nested_str_weak(sessions),
+    /* K10  */  be_nested_str_weak(count_active_fabrics),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_nested_str_weak(content_send),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(_X3Cdiv_X20style_X3D_X27text_X2Dalign_X3Aright_X3Bfont_X2Dsize_X3A11px_X3Bcolor_X3A_X23aaa_X3B_X27_X3E_X25s_X3C_X2Fdiv_X3E),
+    /* K15  */  be_nested_str_weak(No_X20active_X20associaition),
+    /* K16  */  be_const_int(1),
+    /* K17  */  be_nested_str_weak(_X20active_X20association),
+    /* K18  */  be_nested_str_weak(s),
+    /* K19  */  be_nested_str_weak(),
+    /* K20  */  be_nested_str_weak(_X3Cbutton_X20onclick_X3D_X27la_X28_X22_X26mtc_X25i_X3D1_X22_X29_X3B_X27_X3E),
+    /* K21  */  be_nested_str_weak(_LOGO),
+    /* K22  */  be_nested_str_weak(_X20Open_X20Commissioning_X3C_X2Fbutton_X3E),
+    /* K23  */  be_nested_str_weak(_X20Close_X20Commissioning_X3C_X2Fbutton_X3E),
     }),
     be_str_weak(web_sensor),
     &be_const_str_solidified,
-    ( &(const binstruction[43]) {  /* code */
+    ( &(const binstruction[71]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0xB80E0400,  //  0002  GETNGBL	R3	K2
@@ -195,42 +202,70 @@ be_local_closure(Matter_UI_web_sensor,   /* name */
       0xB8160800,  //  0004  GETNGBL	R5	K4
       0x88140B05,  //  0005  GETMBR	R5	R5	K5
       0x7C0C0400,  //  0006  CALL	R3	2
-      0x780E0021,  //  0007  JMPF	R3	#002A
+      0x780E003D,  //  0007  JMPF	R3	#0046
       0x88100106,  //  0008  GETMBR	R4	R0	K6
       0x88100907,  //  0009  GETMBR	R4	R4	K7
       0x78120001,  //  000A  JMPF	R4	#000D
       0x8C100108,  //  000B  GETMET	R4	R0	K8
       0x7C100200,  //  000C  CALL	R4	1
-      0x8C100309,  //  000D  GETMET	R4	R1	K9
-      0x8C18050A,  //  000E  GETMET	R6	R2	K10
-      0x5820000B,  //  000F  LDCONST	R8	K11
-      0x88240106,  //  0010  GETMBR	R9	R0	K6
-      0x88241307,  //  0011  GETMBR	R9	R9	K7
-      0x4C280000,  //  0012  LDNIL	R10
-      0x1C24120A,  //  0013  EQ	R9	R9	R10
-      0x78260001,  //  0014  JMPF	R9	#0017
-      0x5824000C,  //  0015  LDCONST	R9	K12
-      0x70020000,  //  0016  JMP		#0018
-      0x5824000D,  //  0017  LDCONST	R9	K13
-      0x7C180600,  //  0018  CALL	R6	3
-      0x7C100400,  //  0019  CALL	R4	2
-      0x8C100309,  //  001A  GETMET	R4	R1	K9
-      0xB81A0800,  //  001B  GETNGBL	R6	K4
-      0x88180D0E,  //  001C  GETMBR	R6	R6	K14
-      0x7C100400,  //  001D  CALL	R4	2
-      0x88100106,  //  001E  GETMBR	R4	R0	K6
-      0x88100907,  //  001F  GETMBR	R4	R4	K7
-      0x4C140000,  //  0020  LDNIL	R5
-      0x1C100805,  //  0021  EQ	R4	R4	R5
-      0x78120003,  //  0022  JMPF	R4	#0027
-      0x8C100309,  //  0023  GETMET	R4	R1	K9
-      0x5818000F,  //  0024  LDCONST	R6	K15
-      0x7C100400,  //  0025  CALL	R4	2
-      0x70020002,  //  0026  JMP		#002A
-      0x8C100309,  //  0027  GETMET	R4	R1	K9
-      0x58180010,  //  0028  LDCONST	R6	K16
-      0x7C100400,  //  0029  CALL	R4	2
-      0x80000000,  //  002A  RET	0
+      0x88100106,  //  000D  GETMBR	R4	R0	K6
+      0x88100909,  //  000E  GETMBR	R4	R4	K9
+      0x8C10090A,  //  000F  GETMET	R4	R4	K10
+      0x7C100200,  //  0010  CALL	R4	1
+      0x1C14090B,  //  0011  EQ	R5	R4	K11
+      0x78160006,  //  0012  JMPF	R5	#001A
+      0x8C14030C,  //  0013  GETMET	R5	R1	K12
+      0x8C1C050D,  //  0014  GETMET	R7	R2	K13
+      0x5824000E,  //  0015  LDCONST	R9	K14
+      0x5828000F,  //  0016  LDCONST	R10	K15
+      0x7C1C0600,  //  0017  CALL	R7	3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x7002000E,  //  0019  JMP		#0029
+      0x24140910,  //  001A  GT	R5	R4	K16
+      0x8C18030C,  //  001B  GETMET	R6	R1	K12
+      0x8C20050D,  //  001C  GETMET	R8	R2	K13
+      0x5828000E,  //  001D  LDCONST	R10	K14
+      0x602C0008,  //  001E  GETGBL	R11	G8
+      0x5C300800,  //  001F  MOVE	R12	R4
+      0x7C2C0200,  //  0020  CALL	R11	1
+      0x002C1711,  //  0021  ADD	R11	R11	K17
+      0x78160001,  //  0022  JMPF	R5	#0025
+      0x58300012,  //  0023  LDCONST	R12	K18
+      0x70020000,  //  0024  JMP		#0026
+      0x58300013,  //  0025  LDCONST	R12	K19
+      0x002C160C,  //  0026  ADD	R11	R11	R12
+      0x7C200600,  //  0027  CALL	R8	3
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C14030C,  //  0029  GETMET	R5	R1	K12
+      0x8C1C050D,  //  002A  GETMET	R7	R2	K13
+      0x58240014,  //  002B  LDCONST	R9	K20
+      0x88280106,  //  002C  GETMBR	R10	R0	K6
+      0x88281507,  //  002D  GETMBR	R10	R10	K7
+      0x4C2C0000,  //  002E  LDNIL	R11
+      0x1C28140B,  //  002F  EQ	R10	R10	R11
+      0x782A0001,  //  0030  JMPF	R10	#0033
+      0x58280010,  //  0031  LDCONST	R10	K16
+      0x70020000,  //  0032  JMP		#0034
+      0x5828000B,  //  0033  LDCONST	R10	K11
+      0x7C1C0600,  //  0034  CALL	R7	3
+      0x7C140400,  //  0035  CALL	R5	2
+      0x8C14030C,  //  0036  GETMET	R5	R1	K12
+      0xB81E0800,  //  0037  GETNGBL	R7	K4
+      0x881C0F15,  //  0038  GETMBR	R7	R7	K21
+      0x7C140400,  //  0039  CALL	R5	2
+      0x88140106,  //  003A  GETMBR	R5	R0	K6
+      0x88140B07,  //  003B  GETMBR	R5	R5	K7
+      0x4C180000,  //  003C  LDNIL	R6
+      0x1C140A06,  //  003D  EQ	R5	R5	R6
+      0x78160003,  //  003E  JMPF	R5	#0043
+      0x8C14030C,  //  003F  GETMET	R5	R1	K12
+      0x581C0016,  //  0040  LDCONST	R7	K22
+      0x7C140400,  //  0041  CALL	R5	2
+      0x70020002,  //  0042  JMP		#0046
+      0x8C14030C,  //  0043  GETMET	R5	R1	K12
+      0x581C0017,  //  0044  LDCONST	R7	K23
+      0x7C140400,  //  0045  CALL	R5	2
+      0x80000000,  //  0046  RET	0
     })
   )
 );
@@ -701,7 +736,7 @@ be_local_closure(Matter_UI_show_passcode_form,   /* name */
     /* K8   */  be_nested_str_weak(device),
     /* K9   */  be_nested_str_weak(passcode),
     /* K10  */  be_nested_str_weak(_X3Cp_X3EDistinguish_X20id_X3A_X3C_X2Fp_X3E),
-    /* K11  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X272047_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
+    /* K11  */  be_nested_str_weak(_X3Cinput_X20type_X3D_X27number_X27_X20min_X3D_X270_X27_X20max_X3D_X274095_X27_X20name_X3D_X27discriminator_X27_X20value_X3D_X27_X25i_X27_X3E),
     /* K12  */  be_nested_str_weak(discriminator),
     /* K13  */  be_nested_str_weak(_X3Cp_X3E_X3Cinput_X20type_X3D_X27checkbox_X27_X20name_X3D_X27ipv4_X27_X25s_X3EIPv4_X20only_X3C_X2Fp_X3E),
     /* K14  */  be_nested_str_weak(ipv4only),


### PR DESCRIPTION
## Description:

Matter fixes:
- Fix wrong feature map for network configuration (cluster 0x0031)

Changes:
- Matter UI in main screen now shows the number of active fabric associations
- Commissioning is automatically closed when the commissioning is complete

<img width="354" alt="image" src="https://user-images.githubusercontent.com/49731213/225455300-5b93e8cd-1ec3-4539-93f5-2bfa7c7cdbe6.png">


## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
