### PR TITLE
Add virtual Buttons & Switches in Digtian driver

### DIFF
--- a/tasmota/my_user_config.h
+++ b/tasmota/my_user_config.h
@@ -978,6 +978,11 @@
 //#define USE_HX711                                // Add support for HX711 load cell (+1k5 code)
 //  #define USE_HX711_GUI                          // Add optional web GUI to HX711 as scale (+1k8 code)
 
+//#define USE_DINGTIAN_RELAY                       // Add support for the Dingian board using 74'595 et 74'165 shift registers
+//  #define DINGTIAN_INPUTS_INVERTED               // Invert input states (Hi => OFF, Low => ON)
+//  #define DINGTIAN_USE_AS_BUTTON                 // Inputs as Tasmota's virtual Buttons
+//  #define DINGTIAN_USE_AS_SWITCH                 // Inputs as Tasmota's virtual Switches
+
 // Select none or only one of the below defines
 //#define USE_TX20_WIND_SENSOR                     // Add support for La Crosse TX20 anemometer (+2k6/0k8 code)
 //#define USE_TX23_WIND_SENSOR                     // Add support for La Crosse TX23 anemometer (+2k7/1k code)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** Followup on previous PR and the discussion with @jeroenst

Take advantage of recent support for virtual Buttons and Switches to implement that on the inputs of the DINGTIAN Relay board

3 new optional defines are supported:
```C++
#define DINGTIAN_INPUTS_INVERTED               // Invert input states (Hi => OFF, Low => ON)
#define DINGTIAN_USE_AS_BUTTON                 // Inputs as Tasmota's virtual Buttons
#define DINGTIAN_USE_AS_SWITCH                 // Inputs as Tasmota's virtual Switches
```
- Only one of DINGTIAN_USE_AS_BUTTON or DINGTIAN_USE_AS_SWITCH should be used
- DINGTIAN_INPUTS_INVERTED allows Buttons Inverted (and also invert values in Berry's `tasmota.get_switches()`). It also works with Switches although inversion can be handled by `SwitchMode`
- All Buttons or Switches features are supported (including Rules trigger, default attachement to power and options to detach, multipress buttons, all switchmodes, ....)
- :warning:  Warning: On the 32 I/O version of the board, Tasmota is limited to 28 switches. Buttons can be up to 32.
- Virtual buttons/switches are always enumerated after native GPIO. Use loglevel 3 to see which indexes are assigned to Dingtian I/O:
```haskell
00:00:00.123 DNGT: clk:14, sdi:13, q7:16, pl:32, rck:15, count:8
00:00:00.124 DNGT: Dingtian relays: POWER1 to POWER8
00:00:00.125 DNGT: Dingtian inputs: Switch1 to Switch8
```




## Checklist:
  - [X] The pull request is done against the latest development branch
  - [X] Only relevant files were touched
  - [X] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [X] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [X] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
