### PR TITLE
Berry fix `tasmota.get_power(index)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Refactor energy monitoring reducing stack usage and solve inherent exceptions and watchdogs (#18164)
+- Berry fix `tasmota.get_power(index)`
 
 ### Removed
 

--- a/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_52_3_berry_tasmota.ino
@@ -708,17 +708,25 @@ extern "C" {
   int32_t l_getpower(bvm *vm) {
     power_t pow = TasmotaGlobal.power;
     int32_t top = be_top(vm); // Get the number of arguments
-    if (top == 2 && be_isint(vm, 2)) {
-      pow = be_toint(vm, 2);
-    }
-    be_newobject(vm, "list");
-    for (uint32_t i = 0; i < TasmotaGlobal.devices_present; i++) {
-      be_pushbool(vm, bitRead(pow, i));
-      be_data_push(vm, -2);
+    if (top >= 2 && be_isint(vm, 2)) {
+      int32_t idx = be_toint(vm, 2);
+      if (idx >= 0 && idx < TasmotaGlobal.devices_present) {
+        be_pushbool(vm, bitRead(pow, idx));
+        be_return(vm);
+      } else {
+        be_return_nil(vm);
+      }
+    } else {
+      // no parameter, return an array of all values
+      be_newobject(vm, "list");
+      for (uint32_t i = 0; i < TasmotaGlobal.devices_present; i++) {
+        be_pushbool(vm, bitRead(pow, i));
+        be_data_push(vm, -2);
+        be_pop(vm, 1);
+      }
       be_pop(vm, 1);
+      be_return(vm); // Return
     }
-    be_pop(vm, 1);
-    be_return(vm); // Return
   }
 
   int32_t l_setpower(bvm *vm);


### PR DESCRIPTION
## Description:

Fix `tasmota.get_power()` to allow retrieving a single value and avoid allocating a list. When called with no parameters, it keeps it previous behavior of returning a list.

``` berry
> tasmota.get_power()
[true, false]

> tasmota.get_power(0)
true

> tasmota.get_power(1)
false

> tasmota.get_power(2)
(nil)
```

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
