### PR TITLE
Matter implement counter_snd persistance

### DIFF
--- a/lib/libesp32/berry_matter/src/be_matter_counter.cpp
+++ b/lib/libesp32/berry_matter/src/be_matter_counter.cpp
@@ -69,6 +69,12 @@ static void mc_deinit(bvm *vm, matter_counter_t *c) {
 }
 BE_FUNC_CTYPE_DECLARE(mc_deinit, "", "@.")
 
+// do a unisgned int32 comparison
+bbool mc_is_greater(uint32_t a, uint32_t b) {
+  return a > b;
+}
+BE_FUNC_CTYPE_DECLARE(mc_is_greater, "b", "ii")
+
 static void mc_reset(matter_counter_t *c, int32_t val) {
   c->counter = val;
   c->window.reset();
@@ -185,6 +191,8 @@ class be_class_Matter_Counter (scope: global, name: Matter_Counter, strings: wea
   val, ctype_func(mc_val)
   next, ctype_func(mc_next)
   validate, ctype_func(mc_validate)
+
+  is_greater, static_ctype_func(mc_is_greater)    // compare two numbers as unsigned 32 bits
 }
 @const_object_info_end */
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Device.be
@@ -275,6 +275,7 @@ class Matter_Device
   def trigger_read_sensors()
     import json
     var rs_json = tasmota.read_sensors()
+    if rs_json == nil   return  end
     var rs = json.load(rs_json)
     if rs != nil
 
@@ -286,7 +287,7 @@ class Matter_Device
       end
 
     else
-      tasmota.log("MTR: unable to parse read_sensors: "+rs_json, 3)
+      tasmota.log("MTR: unable to parse read_sensors: "+str(rs_json), 3)
     end
 
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
@@ -244,7 +244,7 @@ class Matter_Frame
     end
     resp.session = self.session         # also copy the session object
     # message counter
-    resp.message_counter = self.session.counter_snd.next()
+    resp.message_counter = self.session.counter_snd_next()
     resp.local_session_id = self.session.initiator_session_id
       
     resp.x_flag_i = (self.x_flag_i ? 0 : 1)     # invert the initiator flag
@@ -284,7 +284,7 @@ class Matter_Frame
     # message counter
     # if self.session && self.session.initiator_session_id != 0
     if self.local_session_id != 0 && self.session && self.session.initiator_session_id != 0
-      resp.message_counter = self.session.counter_snd.next()
+      resp.message_counter = self.session.counter_snd_next()
       resp.local_session_id = self.session.initiator_session_id
     else
       resp.message_counter = self.session._counter_insecure_snd.next()
@@ -327,7 +327,7 @@ class Matter_Frame
     resp.session = session         # also copy the session object
     # message counter
     if session && session.initiator_session_id != 0
-      resp.message_counter = session.counter_snd.next()
+      resp.message_counter = session.counter_snd_next()
       resp.local_session_id = session.initiator_session_id
     else
       resp.message_counter = session._counter_insecure_snd.next()

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -96,8 +96,8 @@ class Matter_MessageHandler
         frame.session = session   # keep a pointer of the session in the message
        
         # check if it's a duplicate
-        if !session.counter_rcv.validate(frame.message_counter, true)
-          tasmota.log("MTR: rejected duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv.val()), 3)
+        if !session.counter_rcv_validate(frame.message_counter, true)
+          tasmota.log("MTR: rejected duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
           return false
         end
         

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -2961,37 +2961,44 @@ be_local_closure(Matter_Device_trigger_read_sensors,   /* name */
     }),
     be_str_weak(trigger_read_sensors),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
+    ( &(const binstruction[37]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xB80A0200,  //  0001  GETNGBL	R2	K1
       0x8C080502,  //  0002  GETMET	R2	R2	K2
       0x7C080200,  //  0003  CALL	R2	1
-      0x8C0C0303,  //  0004  GETMET	R3	R1	K3
-      0x5C140400,  //  0005  MOVE	R5	R2
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x4C100000,  //  0007  LDNIL	R4
-      0x20100604,  //  0008  NE	R4	R3	R4
-      0x7812000D,  //  0009  JMPF	R4	#0018
-      0x58100004,  //  000A  LDCONST	R4	K4
-      0x6014000C,  //  000B  GETGBL	R5	G12
-      0x88180105,  //  000C  GETMBR	R6	R0	K5
-      0x7C140200,  //  000D  CALL	R5	1
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x78160006,  //  000F  JMPF	R5	#0017
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
-      0x94140A04,  //  0011  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0012  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0013  MOVE	R7	R3
-      0x7C140400,  //  0014  CALL	R5	2
-      0x00100907,  //  0015  ADD	R4	R4	K7
-      0x7001FFF3,  //  0016  JMP		#000B
-      0x70020004,  //  0017  JMP		#001D
-      0xB8120200,  //  0018  GETNGBL	R4	K1
-      0x8C100908,  //  0019  GETMET	R4	R4	K8
-      0x001A1202,  //  001A  ADD	R6	K9	R2
-      0x581C000A,  //  001B  LDCONST	R7	K10
-      0x7C100600,  //  001C  CALL	R4	3
-      0x80000000,  //  001D  RET	0
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -446,7 +446,7 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
+    ( &(const bvalue[29]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(message_handler),
     /* K2   */  be_nested_str_weak(remote_ip),
@@ -459,28 +459,27 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
     /* K9   */  be_const_int(0),
     /* K10  */  be_nested_str_weak(session),
     /* K11  */  be_nested_str_weak(message_counter),
-    /* K12  */  be_nested_str_weak(counter_snd),
-    /* K13  */  be_nested_str_weak(next),
-    /* K14  */  be_nested_str_weak(local_session_id),
-    /* K15  */  be_nested_str_weak(initiator_session_id),
-    /* K16  */  be_nested_str_weak(x_flag_i),
-    /* K17  */  be_nested_str_weak(opcode),
-    /* K18  */  be_nested_str_weak(exchange_id),
-    /* K19  */  be_nested_str_weak(protocol_id),
-    /* K20  */  be_nested_str_weak(x_flag_a),
-    /* K21  */  be_nested_str_weak(ack_message_counter),
-    /* K22  */  be_nested_str_weak(x_flag_r),
-    /* K23  */  be_nested_str_weak(tasmota),
-    /* K24  */  be_nested_str_weak(log),
-    /* K25  */  be_nested_str_weak(format),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s),
-    /* K27  */  be_nested_str_weak(matter),
-    /* K28  */  be_nested_str_weak(get_opcode_name),
-    /* K29  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(counter_snd_next),
+    /* K13  */  be_nested_str_weak(local_session_id),
+    /* K14  */  be_nested_str_weak(initiator_session_id),
+    /* K15  */  be_nested_str_weak(x_flag_i),
+    /* K16  */  be_nested_str_weak(opcode),
+    /* K17  */  be_nested_str_weak(exchange_id),
+    /* K18  */  be_nested_str_weak(protocol_id),
+    /* K19  */  be_nested_str_weak(x_flag_a),
+    /* K20  */  be_nested_str_weak(ack_message_counter),
+    /* K21  */  be_nested_str_weak(x_flag_r),
+    /* K22  */  be_nested_str_weak(tasmota),
+    /* K23  */  be_nested_str_weak(log),
+    /* K24  */  be_nested_str_weak(format),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s),
+    /* K26  */  be_nested_str_weak(matter),
+    /* K27  */  be_nested_str_weak(get_opcode_name),
+    /* K28  */  be_const_int(3),
     }),
     be_str_weak(build_standalone_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
+    ( &(const binstruction[53]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0x60080006,  //  0001  GETGBL	R2	G6
       0x5C0C0000,  //  0002  MOVE	R3	R0
@@ -501,40 +500,39 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
       0x880C010A,  //  0011  GETMBR	R3	R0	K10
       0x900A1403,  //  0012  SETMBR	R2	K10	R3
       0x880C010A,  //  0013  GETMBR	R3	R0	K10
-      0x880C070C,  //  0014  GETMBR	R3	R3	K12
-      0x8C0C070D,  //  0015  GETMET	R3	R3	K13
-      0x7C0C0200,  //  0016  CALL	R3	1
-      0x900A1603,  //  0017  SETMBR	R2	K11	R3
-      0x880C010A,  //  0018  GETMBR	R3	R0	K10
-      0x880C070F,  //  0019  GETMBR	R3	R3	K15
-      0x900A1C03,  //  001A  SETMBR	R2	K14	R3
-      0x880C0110,  //  001B  GETMBR	R3	R0	K16
-      0x780E0001,  //  001C  JMPF	R3	#001F
-      0x580C0009,  //  001D  LDCONST	R3	K9
-      0x70020000,  //  001E  JMP		#0020
-      0x580C0006,  //  001F  LDCONST	R3	K6
-      0x900A2003,  //  0020  SETMBR	R2	K16	R3
-      0x540E000F,  //  0021  LDINT	R3	16
-      0x900A2203,  //  0022  SETMBR	R2	K17	R3
-      0x880C0112,  //  0023  GETMBR	R3	R0	K18
-      0x900A2403,  //  0024  SETMBR	R2	K18	R3
-      0x900A2709,  //  0025  SETMBR	R2	K19	K9
-      0x900A2906,  //  0026  SETMBR	R2	K20	K6
-      0x880C010B,  //  0027  GETMBR	R3	R0	K11
-      0x900A2A03,  //  0028  SETMBR	R2	K21	R3
-      0x900A2D06,  //  0029  SETMBR	R2	K22	K6
-      0xB80E2E00,  //  002A  GETNGBL	R3	K23
-      0x8C0C0718,  //  002B  GETMET	R3	R3	K24
-      0x8C140319,  //  002C  GETMET	R5	R1	K25
-      0x581C001A,  //  002D  LDCONST	R7	K26
-      0xB8223600,  //  002E  GETNGBL	R8	K27
-      0x8C20111C,  //  002F  GETMET	R8	R8	K28
-      0x88280511,  //  0030  GETMBR	R10	R2	K17
-      0x7C200400,  //  0031  CALL	R8	2
-      0x7C140600,  //  0032  CALL	R5	3
-      0x5818001D,  //  0033  LDCONST	R6	K29
-      0x7C0C0600,  //  0034  CALL	R3	3
-      0x80040400,  //  0035  RET	1	R2
+      0x8C0C070C,  //  0014  GETMET	R3	R3	K12
+      0x7C0C0200,  //  0015  CALL	R3	1
+      0x900A1603,  //  0016  SETMBR	R2	K11	R3
+      0x880C010A,  //  0017  GETMBR	R3	R0	K10
+      0x880C070E,  //  0018  GETMBR	R3	R3	K14
+      0x900A1A03,  //  0019  SETMBR	R2	K13	R3
+      0x880C010F,  //  001A  GETMBR	R3	R0	K15
+      0x780E0001,  //  001B  JMPF	R3	#001E
+      0x580C0009,  //  001C  LDCONST	R3	K9
+      0x70020000,  //  001D  JMP		#001F
+      0x580C0006,  //  001E  LDCONST	R3	K6
+      0x900A1E03,  //  001F  SETMBR	R2	K15	R3
+      0x540E000F,  //  0020  LDINT	R3	16
+      0x900A2003,  //  0021  SETMBR	R2	K16	R3
+      0x880C0111,  //  0022  GETMBR	R3	R0	K17
+      0x900A2203,  //  0023  SETMBR	R2	K17	R3
+      0x900A2509,  //  0024  SETMBR	R2	K18	K9
+      0x900A2706,  //  0025  SETMBR	R2	K19	K6
+      0x880C010B,  //  0026  GETMBR	R3	R0	K11
+      0x900A2803,  //  0027  SETMBR	R2	K20	R3
+      0x900A2B06,  //  0028  SETMBR	R2	K21	K6
+      0xB80E2C00,  //  0029  GETNGBL	R3	K22
+      0x8C0C0717,  //  002A  GETMET	R3	R3	K23
+      0x8C140318,  //  002B  GETMET	R5	R1	K24
+      0x581C0019,  //  002C  LDCONST	R7	K25
+      0xB8223400,  //  002D  GETNGBL	R8	K26
+      0x8C20111B,  //  002E  GETMET	R8	R8	K27
+      0x88280510,  //  002F  GETMBR	R10	R2	K16
+      0x7C200400,  //  0030  CALL	R8	2
+      0x7C140600,  //  0031  CALL	R5	3
+      0x5818001C,  //  0032  LDCONST	R6	K28
+      0x7C0C0600,  //  0033  CALL	R3	3
+      0x80040400,  //  0034  RET	1	R2
     })
   )
 );
@@ -569,9 +567,9 @@ be_local_closure(Matter_Frame_build_response,   /* name */
     /* K11  */  be_nested_str_weak(local_session_id),
     /* K12  */  be_nested_str_weak(initiator_session_id),
     /* K13  */  be_nested_str_weak(message_counter),
-    /* K14  */  be_nested_str_weak(counter_snd),
-    /* K15  */  be_nested_str_weak(next),
-    /* K16  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K14  */  be_nested_str_weak(counter_snd_next),
+    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K16  */  be_nested_str_weak(next),
     /* K17  */  be_nested_str_weak(x_flag_i),
     /* K18  */  be_nested_str_weak(opcode),
     /* K19  */  be_nested_str_weak(exchange_id),
@@ -590,7 +588,7 @@ be_local_closure(Matter_Frame_build_response,   /* name */
     }),
     be_str_weak(build_response),
     &be_const_str_solidified,
-    ( &(const binstruction[91]) {  /* code */
+    ( &(const binstruction[90]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x4C140000,  //  0001  LDNIL	R5
       0x1C140605,  //  0002  EQ	R5	R3	R5
@@ -616,72 +614,71 @@ be_local_closure(Matter_Frame_build_response,   /* name */
       0x900E1405,  //  0016  SETMBR	R3	K10	R5
       0x8814010B,  //  0017  GETMBR	R5	R0	K11
       0x20140B09,  //  0018  NE	R5	R5	K9
-      0x7816000E,  //  0019  JMPF	R5	#0029
+      0x7816000D,  //  0019  JMPF	R5	#0028
       0x8814010A,  //  001A  GETMBR	R5	R0	K10
-      0x7816000C,  //  001B  JMPF	R5	#0029
+      0x7816000B,  //  001B  JMPF	R5	#0028
       0x8814010A,  //  001C  GETMBR	R5	R0	K10
       0x88140B0C,  //  001D  GETMBR	R5	R5	K12
       0x20140B09,  //  001E  NE	R5	R5	K9
-      0x78160008,  //  001F  JMPF	R5	#0029
+      0x78160007,  //  001F  JMPF	R5	#0028
       0x8814010A,  //  0020  GETMBR	R5	R0	K10
-      0x88140B0E,  //  0021  GETMBR	R5	R5	K14
-      0x8C140B0F,  //  0022  GETMET	R5	R5	K15
-      0x7C140200,  //  0023  CALL	R5	1
-      0x900E1A05,  //  0024  SETMBR	R3	K13	R5
-      0x8814010A,  //  0025  GETMBR	R5	R0	K10
-      0x88140B0C,  //  0026  GETMBR	R5	R5	K12
-      0x900E1605,  //  0027  SETMBR	R3	K11	R5
-      0x70020005,  //  0028  JMP		#002F
-      0x8814010A,  //  0029  GETMBR	R5	R0	K10
-      0x88140B10,  //  002A  GETMBR	R5	R5	K16
-      0x8C140B0F,  //  002B  GETMET	R5	R5	K15
-      0x7C140200,  //  002C  CALL	R5	1
-      0x900E1A05,  //  002D  SETMBR	R3	K13	R5
-      0x900E1709,  //  002E  SETMBR	R3	K11	K9
-      0x88140111,  //  002F  GETMBR	R5	R0	K17
-      0x78160001,  //  0030  JMPF	R5	#0033
-      0x58140009,  //  0031  LDCONST	R5	K9
-      0x70020000,  //  0032  JMP		#0034
-      0x58140006,  //  0033  LDCONST	R5	K6
-      0x900E2205,  //  0034  SETMBR	R3	K17	R5
-      0x900E2401,  //  0035  SETMBR	R3	K18	R1
-      0x88140113,  //  0036  GETMBR	R5	R0	K19
-      0x900E2605,  //  0037  SETMBR	R3	K19	R5
-      0x88140114,  //  0038  GETMBR	R5	R0	K20
-      0x900E2805,  //  0039  SETMBR	R3	K20	R5
-      0x88140115,  //  003A  GETMBR	R5	R0	K21
-      0x78160002,  //  003B  JMPF	R5	#003F
-      0x900E2D06,  //  003C  SETMBR	R3	K22	K6
-      0x8814010D,  //  003D  GETMBR	R5	R0	K13
-      0x900E2E05,  //  003E  SETMBR	R3	K23	R5
-      0x780A0001,  //  003F  JMPF	R2	#0042
-      0x58140006,  //  0040  LDCONST	R5	K6
-      0x70020000,  //  0041  JMP		#0043
-      0x58140009,  //  0042  LDCONST	R5	K9
-      0x900E2A05,  //  0043  SETMBR	R3	K21	R5
-      0x8814070B,  //  0044  GETMBR	R5	R3	K11
-      0x1C140B09,  //  0045  EQ	R5	R5	K9
-      0x78160012,  //  0046  JMPF	R5	#005A
-      0xB8163000,  //  0047  GETNGBL	R5	K24
-      0x8C140B19,  //  0048  GETMET	R5	R5	K25
-      0x881C0712,  //  0049  GETMBR	R7	R3	K18
-      0x7C140400,  //  004A  CALL	R5	2
-      0x5C180A00,  //  004B  MOVE	R6	R5
-      0x741A0004,  //  004C  JMPT	R6	#0052
-      0x8C18091A,  //  004D  GETMET	R6	R4	K26
-      0x5820001B,  //  004E  LDCONST	R8	K27
-      0x88240712,  //  004F  GETMBR	R9	R3	K18
-      0x7C180600,  //  0050  CALL	R6	3
-      0x5C140C00,  //  0051  MOVE	R5	R6
-      0xB81A3800,  //  0052  GETNGBL	R6	K28
-      0x8C180D1D,  //  0053  GETMET	R6	R6	K29
-      0x8C20091A,  //  0054  GETMET	R8	R4	K26
-      0x5828001E,  //  0055  LDCONST	R10	K30
-      0x5C2C0A00,  //  0056  MOVE	R11	R5
-      0x7C200600,  //  0057  CALL	R8	3
-      0x5824001F,  //  0058  LDCONST	R9	K31
-      0x7C180600,  //  0059  CALL	R6	3
-      0x80040600,  //  005A  RET	1	R3
+      0x8C140B0E,  //  0021  GETMET	R5	R5	K14
+      0x7C140200,  //  0022  CALL	R5	1
+      0x900E1A05,  //  0023  SETMBR	R3	K13	R5
+      0x8814010A,  //  0024  GETMBR	R5	R0	K10
+      0x88140B0C,  //  0025  GETMBR	R5	R5	K12
+      0x900E1605,  //  0026  SETMBR	R3	K11	R5
+      0x70020005,  //  0027  JMP		#002E
+      0x8814010A,  //  0028  GETMBR	R5	R0	K10
+      0x88140B0F,  //  0029  GETMBR	R5	R5	K15
+      0x8C140B10,  //  002A  GETMET	R5	R5	K16
+      0x7C140200,  //  002B  CALL	R5	1
+      0x900E1A05,  //  002C  SETMBR	R3	K13	R5
+      0x900E1709,  //  002D  SETMBR	R3	K11	K9
+      0x88140111,  //  002E  GETMBR	R5	R0	K17
+      0x78160001,  //  002F  JMPF	R5	#0032
+      0x58140009,  //  0030  LDCONST	R5	K9
+      0x70020000,  //  0031  JMP		#0033
+      0x58140006,  //  0032  LDCONST	R5	K6
+      0x900E2205,  //  0033  SETMBR	R3	K17	R5
+      0x900E2401,  //  0034  SETMBR	R3	K18	R1
+      0x88140113,  //  0035  GETMBR	R5	R0	K19
+      0x900E2605,  //  0036  SETMBR	R3	K19	R5
+      0x88140114,  //  0037  GETMBR	R5	R0	K20
+      0x900E2805,  //  0038  SETMBR	R3	K20	R5
+      0x88140115,  //  0039  GETMBR	R5	R0	K21
+      0x78160002,  //  003A  JMPF	R5	#003E
+      0x900E2D06,  //  003B  SETMBR	R3	K22	K6
+      0x8814010D,  //  003C  GETMBR	R5	R0	K13
+      0x900E2E05,  //  003D  SETMBR	R3	K23	R5
+      0x780A0001,  //  003E  JMPF	R2	#0041
+      0x58140006,  //  003F  LDCONST	R5	K6
+      0x70020000,  //  0040  JMP		#0042
+      0x58140009,  //  0041  LDCONST	R5	K9
+      0x900E2A05,  //  0042  SETMBR	R3	K21	R5
+      0x8814070B,  //  0043  GETMBR	R5	R3	K11
+      0x1C140B09,  //  0044  EQ	R5	R5	K9
+      0x78160012,  //  0045  JMPF	R5	#0059
+      0xB8163000,  //  0046  GETNGBL	R5	K24
+      0x8C140B19,  //  0047  GETMET	R5	R5	K25
+      0x881C0712,  //  0048  GETMBR	R7	R3	K18
+      0x7C140400,  //  0049  CALL	R5	2
+      0x5C180A00,  //  004A  MOVE	R6	R5
+      0x741A0004,  //  004B  JMPT	R6	#0051
+      0x8C18091A,  //  004C  GETMET	R6	R4	K26
+      0x5820001B,  //  004D  LDCONST	R8	K27
+      0x88240712,  //  004E  GETMBR	R9	R3	K18
+      0x7C180600,  //  004F  CALL	R6	3
+      0x5C140C00,  //  0050  MOVE	R5	R6
+      0xB81A3800,  //  0051  GETNGBL	R6	K28
+      0x8C180D1D,  //  0052  GETMET	R6	R6	K29
+      0x8C20091A,  //  0053  GETMET	R8	R4	K26
+      0x5828001E,  //  0054  LDCONST	R10	K30
+      0x5C2C0A00,  //  0055  MOVE	R11	R5
+      0x7C200600,  //  0056  CALL	R8	3
+      0x5824001F,  //  0057  LDCONST	R9	K31
+      0x7C180600,  //  0058  CALL	R6	3
+      0x80040600,  //  0059  RET	1	R3
     })
   )
 );
@@ -715,10 +712,10 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
     /* K10  */  be_nested_str_weak(session),
     /* K11  */  be_nested_str_weak(initiator_session_id),
     /* K12  */  be_nested_str_weak(message_counter),
-    /* K13  */  be_nested_str_weak(counter_snd),
-    /* K14  */  be_nested_str_weak(next),
-    /* K15  */  be_nested_str_weak(local_session_id),
-    /* K16  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K13  */  be_nested_str_weak(counter_snd_next),
+    /* K14  */  be_nested_str_weak(local_session_id),
+    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K16  */  be_nested_str_weak(next),
     /* K17  */  be_nested_str_weak(x_flag_i),
     /* K18  */  be_const_int(1),
     /* K19  */  be_nested_str_weak(opcode),
@@ -729,7 +726,7 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
     }),
     be_str_weak(initiate_response),
     &be_const_str_solidified,
-    ( &(const binstruction[48]) {  /* code */
+    ( &(const binstruction[47]) {  /* code */
       0x58140000,  //  0000  LDCONST	R5	K0
       0xA41A0200,  //  0001  IMPORT	R6	K1
       0x4C1C0000,  //  0002  LDNIL	R7
@@ -746,38 +743,37 @@ be_local_closure(Matter_Frame_initiate_response,   /* name */
       0x90120C07,  //  000D  SETMBR	R4	K6	R7
       0x90121109,  //  000E  SETMBR	R4	K8	K9
       0x90121401,  //  000F  SETMBR	R4	K10	R1
-      0x78060009,  //  0010  JMPF	R1	#001B
+      0x78060008,  //  0010  JMPF	R1	#001A
       0x881C030B,  //  0011  GETMBR	R7	R1	K11
       0x201C0F09,  //  0012  NE	R7	R7	K9
-      0x781E0006,  //  0013  JMPF	R7	#001B
-      0x881C030D,  //  0014  GETMBR	R7	R1	K13
-      0x8C1C0F0E,  //  0015  GETMET	R7	R7	K14
-      0x7C1C0200,  //  0016  CALL	R7	1
-      0x90121807,  //  0017  SETMBR	R4	K12	R7
-      0x881C030B,  //  0018  GETMBR	R7	R1	K11
-      0x90121E07,  //  0019  SETMBR	R4	K15	R7
-      0x70020004,  //  001A  JMP		#0020
-      0x881C0310,  //  001B  GETMBR	R7	R1	K16
-      0x8C1C0F0E,  //  001C  GETMET	R7	R7	K14
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0x90121807,  //  001E  SETMBR	R4	K12	R7
-      0x90121F09,  //  001F  SETMBR	R4	K15	K9
-      0x90122312,  //  0020  SETMBR	R4	K17	K18
-      0x90122602,  //  0021  SETMBR	R4	K19	R2
-      0x881C0314,  //  0022  GETMBR	R7	R1	K20
-      0x001C0F12,  //  0023  ADD	R7	R7	K18
-      0x90062807,  //  0024  SETMBR	R1	K20	R7
-      0x881C0314,  //  0025  GETMBR	R7	R1	K20
-      0x5422FFFF,  //  0026  LDINT	R8	65536
-      0x301C0E08,  //  0027  OR	R7	R7	R8
-      0x90122A07,  //  0028  SETMBR	R4	K21	R7
-      0x90122D12,  //  0029  SETMBR	R4	K22	K18
-      0x780E0001,  //  002A  JMPF	R3	#002D
-      0x581C0012,  //  002B  LDCONST	R7	K18
-      0x70020000,  //  002C  JMP		#002E
-      0x581C0009,  //  002D  LDCONST	R7	K9
-      0x90122E07,  //  002E  SETMBR	R4	K23	R7
-      0x80040800,  //  002F  RET	1	R4
+      0x781E0005,  //  0013  JMPF	R7	#001A
+      0x8C1C030D,  //  0014  GETMET	R7	R1	K13
+      0x7C1C0200,  //  0015  CALL	R7	1
+      0x90121807,  //  0016  SETMBR	R4	K12	R7
+      0x881C030B,  //  0017  GETMBR	R7	R1	K11
+      0x90121C07,  //  0018  SETMBR	R4	K14	R7
+      0x70020004,  //  0019  JMP		#001F
+      0x881C030F,  //  001A  GETMBR	R7	R1	K15
+      0x8C1C0F10,  //  001B  GETMET	R7	R7	K16
+      0x7C1C0200,  //  001C  CALL	R7	1
+      0x90121807,  //  001D  SETMBR	R4	K12	R7
+      0x90121D09,  //  001E  SETMBR	R4	K14	K9
+      0x90122312,  //  001F  SETMBR	R4	K17	K18
+      0x90122602,  //  0020  SETMBR	R4	K19	R2
+      0x881C0314,  //  0021  GETMBR	R7	R1	K20
+      0x001C0F12,  //  0022  ADD	R7	R7	K18
+      0x90062807,  //  0023  SETMBR	R1	K20	R7
+      0x881C0314,  //  0024  GETMBR	R7	R1	K20
+      0x5422FFFF,  //  0025  LDINT	R8	65536
+      0x301C0E08,  //  0026  OR	R7	R7	R8
+      0x90122A07,  //  0027  SETMBR	R4	K21	R7
+      0x90122D12,  //  0028  SETMBR	R4	K22	K18
+      0x780E0001,  //  0029  JMPF	R3	#002C
+      0x581C0012,  //  002A  LDCONST	R7	K18
+      0x70020000,  //  002B  JMP		#002D
+      0x581C0009,  //  002C  LDCONST	R7	K9
+      0x90122E07,  //  002D  SETMBR	R4	K23	R7
+      0x80040800,  //  002E  RET	1	R4
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[72]) {     /* constants */
+    ( &(const bvalue[73]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
@@ -63,42 +63,43 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     /* K40  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
     /* K41  */  be_nested_str_weak(MTR_X3A_X20frame_X3D),
     /* K42  */  be_nested_str_weak(inspect),
-    /* K43  */  be_nested_str_weak(counter_rcv),
+    /* K43  */  be_nested_str_weak(counter_rcv_validate),
     /* K44  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20encrypted_X20message_X20_X3D_X20),
     /* K45  */  be_nested_str_weak(_X20counter_X3D),
-    /* K46  */  be_nested_str_weak(decrypt),
-    /* K47  */  be_nested_str_weak(raw),
-    /* K48  */  be_nested_str_weak(payload_idx),
-    /* K49  */  be_const_int(1),
-    /* K50  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20decrypted_X20message_X3A_X20protocol_id_X3A),
-    /* K52  */  be_nested_str_weak(protocol_id),
-    /* K53  */  be_nested_str_weak(_X20opcode_X3D),
-    /* K54  */  be_nested_str_weak(_X20exchange_id_X3D),
-    /* K55  */  be_nested_str_weak(exchange_id),
-    /* K56  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
-    /* K57  */  be_nested_str_weak(im),
-    /* K58  */  be_nested_str_weak(process_incoming_ack),
-    /* K59  */  be_nested_str_weak(send_enqueued),
-    /* K60  */  be_nested_str_weak(x_flag_r),
-    /* K61  */  be_nested_str_weak(build_standalone_ack),
-    /* K62  */  be_nested_str_weak(encode_frame),
-    /* K63  */  be_nested_str_weak(encrypt),
-    /* K64  */  be_nested_str_weak(send_response),
-    /* K65  */  be_nested_str_weak(remote_ip),
-    /* K66  */  be_nested_str_weak(remote_port),
-    /* K67  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K69  */  be_nested_str_weak(_X3B),
-    /* K70  */  be_nested_str_weak(debug),
-    /* K71  */  be_nested_str_weak(traceback),
+    /* K46  */  be_nested_str_weak(counter_rcv),
+    /* K47  */  be_nested_str_weak(decrypt),
+    /* K48  */  be_nested_str_weak(raw),
+    /* K49  */  be_nested_str_weak(payload_idx),
+    /* K50  */  be_const_int(1),
+    /* K51  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20decrypted_X20message_X3A_X20protocol_id_X3A),
+    /* K53  */  be_nested_str_weak(protocol_id),
+    /* K54  */  be_nested_str_weak(_X20opcode_X3D),
+    /* K55  */  be_nested_str_weak(_X20exchange_id_X3D),
+    /* K56  */  be_nested_str_weak(exchange_id),
+    /* K57  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
+    /* K58  */  be_nested_str_weak(im),
+    /* K59  */  be_nested_str_weak(process_incoming_ack),
+    /* K60  */  be_nested_str_weak(send_enqueued),
+    /* K61  */  be_nested_str_weak(x_flag_r),
+    /* K62  */  be_nested_str_weak(build_standalone_ack),
+    /* K63  */  be_nested_str_weak(encode_frame),
+    /* K64  */  be_nested_str_weak(encrypt),
+    /* K65  */  be_nested_str_weak(send_response),
+    /* K66  */  be_nested_str_weak(remote_ip),
+    /* K67  */  be_nested_str_weak(remote_port),
+    /* K68  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+    /* K69  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+    /* K70  */  be_nested_str_weak(_X3B),
+    /* K71  */  be_nested_str_weak(debug),
+    /* K72  */  be_nested_str_weak(traceback),
     }),
     be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[328]) {  /* code */
+    ( &(const binstruction[325]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x50140000,  //  0001  LDBOOL	R5	0	0
-      0xA802012E,  //  0002  EXBLK	0	#0132
+      0xA802012B,  //  0002  EXBLK	0	#012F
       0xB81A0200,  //  0003  GETNGBL	R6	K1
       0x8C180D02,  //  0004  GETMET	R6	R6	K2
       0x8C200304,  //  0005  GETMET	R8	R1	K4
@@ -213,7 +214,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x50240200,  //  0072  LDBOOL	R9	1	0
       0xA8040001,  //  0073  EXBLK	1	1
       0x80041200,  //  0074  RET	1	R9
-      0x700200B7,  //  0075  JMP		#012E
+      0x700200B4,  //  0075  JMP		#012B
       0xB8220200,  //  0076  GETNGBL	R8	K1
       0x8C201102,  //  0077  GETMET	R8	R8	K2
       0x8C280919,  //  0078  GETMET	R10	R4	K25
@@ -257,173 +258,170 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x90222603,  //  009E  SETMBR	R8	K19	R3
       0x90222800,  //  009F  SETMBR	R8	K20	R0
       0x901A2A08,  //  00A0  SETMBR	R6	K21	R8
-      0x8824112B,  //  00A1  GETMBR	R9	R8	K43
-      0x8C241317,  //  00A2  GETMET	R9	R9	K23
-      0x882C0D18,  //  00A3  GETMBR	R11	R6	K24
-      0x50300200,  //  00A4  LDBOOL	R12	1	0
-      0x7C240600,  //  00A5  CALL	R9	3
-      0x74260011,  //  00A6  JMPT	R9	#00B9
-      0xB8260200,  //  00A7  GETNGBL	R9	K1
-      0x8C241302,  //  00A8  GETMET	R9	R9	K2
-      0x602C0008,  //  00A9  GETGBL	R11	G8
-      0x88300D18,  //  00AA  GETMBR	R12	R6	K24
-      0x7C2C0200,  //  00AB  CALL	R11	1
-      0x002E580B,  //  00AC  ADD	R11	K44	R11
-      0x002C172D,  //  00AD  ADD	R11	R11	K45
-      0x60300008,  //  00AE  GETGBL	R12	G8
-      0x8834112B,  //  00AF  GETMBR	R13	R8	K43
-      0x8C341B1B,  //  00B0  GETMET	R13	R13	K27
-      0x7C340200,  //  00B1  CALL	R13	1
-      0x7C300200,  //  00B2  CALL	R12	1
-      0x002C160C,  //  00B3  ADD	R11	R11	R12
-      0x58300011,  //  00B4  LDCONST	R12	K17
-      0x7C240600,  //  00B5  CALL	R9	3
-      0x50240000,  //  00B6  LDBOOL	R9	0	0
-      0xA8040001,  //  00B7  EXBLK	1	1
-      0x80041200,  //  00B8  RET	1	R9
-      0x8C240D2E,  //  00B9  GETMET	R9	R6	K46
-      0x7C240200,  //  00BA  CALL	R9	1
-      0x5C281200,  //  00BB  MOVE	R10	R9
-      0x742A0002,  //  00BC  JMPT	R10	#00C0
-      0x50280000,  //  00BD  LDBOOL	R10	0	0
-      0xA8040001,  //  00BE  EXBLK	1	1
-      0x80041400,  //  00BF  RET	1	R10
-      0x88280D30,  //  00C0  GETMBR	R10	R6	K48
-      0x04281531,  //  00C1  SUB	R10	R10	K49
-      0x402A120A,  //  00C2  CONNECT	R10	K9	R10
-      0x882C0D2F,  //  00C3  GETMBR	R11	R6	K47
-      0x9428160A,  //  00C4  GETIDX	R10	R11	R10
-      0x901A5E0A,  //  00C5  SETMBR	R6	K47	R10
-      0x88280D2F,  //  00C6  GETMBR	R10	R6	K47
-      0x40281409,  //  00C7  CONNECT	R10	R10	R9
-      0xB82A0200,  //  00C8  GETNGBL	R10	K1
-      0x8C281502,  //  00C9  GETMET	R10	R10	K2
-      0x8C300919,  //  00CA  GETMET	R12	R4	K25
-      0x58380032,  //  00CB  LDCONST	R14	K50
-      0x883C0D30,  //  00CC  GETMBR	R15	R6	K48
-      0x88400D2F,  //  00CD  GETMBR	R16	R6	K47
-      0x8C402104,  //  00CE  GETMET	R16	R16	K4
-      0x7C400200,  //  00CF  CALL	R16	1
-      0x7C300800,  //  00D0  CALL	R12	4
-      0x54360003,  //  00D1  LDINT	R13	4
-      0x7C280600,  //  00D2  CALL	R10	3
-      0x8C280D1C,  //  00D3  GETMET	R10	R6	K28
-      0x7C280200,  //  00D4  CALL	R10	1
-      0xB82A0200,  //  00D5  GETNGBL	R10	K1
-      0x8C281502,  //  00D6  GETMET	R10	R10	K2
-      0x60300008,  //  00D7  GETGBL	R12	G8
-      0x88340D34,  //  00D8  GETMBR	R13	R6	K52
-      0x7C300200,  //  00D9  CALL	R12	1
-      0x0032660C,  //  00DA  ADD	R12	K51	R12
-      0x00301935,  //  00DB  ADD	R12	R12	K53
-      0x60340008,  //  00DC  GETGBL	R13	G8
-      0x88380D1F,  //  00DD  GETMBR	R14	R6	K31
-      0x7C340200,  //  00DE  CALL	R13	1
-      0x0030180D,  //  00DF  ADD	R12	R12	R13
-      0x00301936,  //  00E0  ADD	R12	R12	K54
-      0x60340008,  //  00E1  GETGBL	R13	G8
-      0x88380D37,  //  00E2  GETMBR	R14	R6	K55
-      0x543EFFFE,  //  00E3  LDINT	R15	65535
-      0x2C381C0F,  //  00E4  AND	R14	R14	R15
-      0x7C340200,  //  00E5  CALL	R13	1
-      0x0030180D,  //  00E6  ADD	R12	R12	R13
-      0x58340011,  //  00E7  LDCONST	R13	K17
-      0x7C280600,  //  00E8  CALL	R10	3
-      0x8828010B,  //  00E9  GETMBR	R10	R0	K11
-      0x8C28151D,  //  00EA  GETMET	R10	R10	K29
-      0x88300D1E,  //  00EB  GETMBR	R12	R6	K30
-      0x7C280400,  //  00EC  CALL	R10	2
-      0x88280D34,  //  00ED  GETMBR	R10	R6	K52
-      0x1C2C1509,  //  00EE  EQ	R11	R10	K9
-      0x782E0018,  //  00EF  JMPF	R11	#0109
-      0xB82E0200,  //  00F0  GETNGBL	R11	K1
-      0x8C2C1702,  //  00F1  GETMET	R11	R11	K2
-      0xB8360A00,  //  00F2  GETNGBL	R13	K5
-      0x8C341B2A,  //  00F3  GETMET	R13	R13	K42
-      0x5C3C0C00,  //  00F4  MOVE	R15	R6
-      0x7C340400,  //  00F5  CALL	R13	2
-      0x0036700D,  //  00F6  ADD	R13	K56	R13
-      0x58380011,  //  00F7  LDCONST	R14	K17
-      0x7C2C0600,  //  00F8  CALL	R11	3
-      0x882C0D1F,  //  00F9  GETMBR	R11	R6	K31
-      0x5432000F,  //  00FA  LDINT	R12	16
-      0x1C2C160C,  //  00FB  EQ	R11	R11	R12
-      0x782E0009,  //  00FC  JMPF	R11	#0107
-      0x882C0139,  //  00FD  GETMBR	R11	R0	K57
-      0x8C2C173A,  //  00FE  GETMET	R11	R11	K58
-      0x5C340C00,  //  00FF  MOVE	R13	R6
-      0x7C2C0400,  //  0100  CALL	R11	2
-      0x5C141600,  //  0101  MOVE	R5	R11
-      0x78160003,  //  0102  JMPF	R5	#0107
-      0x882C0139,  //  0103  GETMBR	R11	R0	K57
-      0x8C2C173B,  //  0104  GETMET	R11	R11	K59
-      0x5C340000,  //  0105  MOVE	R13	R0
-      0x7C2C0400,  //  0106  CALL	R11	2
-      0x50140200,  //  0107  LDBOOL	R5	1	0
-      0x70020024,  //  0108  JMP		#012E
-      0x1C2C1531,  //  0109  EQ	R11	R10	K49
-      0x782E001A,  //  010A  JMPF	R11	#0126
-      0x882C0139,  //  010B  GETMBR	R11	R0	K57
-      0x8C2C1725,  //  010C  GETMET	R11	R11	K37
-      0x5C340C00,  //  010D  MOVE	R13	R6
-      0x7C2C0400,  //  010E  CALL	R11	2
-      0x5C141600,  //  010F  MOVE	R5	R11
-      0x78160004,  //  0110  JMPF	R5	#0116
-      0x882C0139,  //  0111  GETMBR	R11	R0	K57
-      0x8C2C173B,  //  0112  GETMET	R11	R11	K59
-      0x5C340000,  //  0113  MOVE	R13	R0
-      0x7C2C0400,  //  0114  CALL	R11	2
-      0x7002000D,  //  0115  JMP		#0124
-      0x882C0D3C,  //  0116  GETMBR	R11	R6	K60
-      0x782E000B,  //  0117  JMPF	R11	#0124
-      0x8C2C0D3D,  //  0118  GETMET	R11	R6	K61
-      0x7C2C0200,  //  0119  CALL	R11	1
-      0x8C30173E,  //  011A  GETMET	R12	R11	K62
-      0x7C300200,  //  011B  CALL	R12	1
-      0x8C30173F,  //  011C  GETMET	R12	R11	K63
-      0x7C300200,  //  011D  CALL	R12	1
-      0x8C300140,  //  011E  GETMET	R12	R0	K64
-      0x8838172F,  //  011F  GETMBR	R14	R11	K47
-      0x883C1741,  //  0120  GETMBR	R15	R11	K65
-      0x88401742,  //  0121  GETMBR	R16	R11	K66
-      0x88441718,  //  0122  GETMBR	R17	R11	K24
-      0x7C300A00,  //  0123  CALL	R12	5
-      0x50140200,  //  0124  LDBOOL	R5	1	0
-      0x70020007,  //  0125  JMP		#012E
-      0xB82E0200,  //  0126  GETNGBL	R11	K1
-      0x8C2C1702,  //  0127  GETMET	R11	R11	K2
-      0x60340008,  //  0128  GETGBL	R13	G8
-      0x5C381400,  //  0129  MOVE	R14	R10
-      0x7C340200,  //  012A  CALL	R13	1
-      0x0036860D,  //  012B  ADD	R13	K67	R13
-      0x58380011,  //  012C  LDCONST	R14	K17
-      0x7C2C0600,  //  012D  CALL	R11	3
-      0xA8040001,  //  012E  EXBLK	1	1
-      0x80040A00,  //  012F  RET	1	R5
-      0xA8040001,  //  0130  EXBLK	1	1
-      0x70020014,  //  0131  JMP		#0147
-      0xAC180002,  //  0132  CATCH	R6	0	2
-      0x70020011,  //  0133  JMP		#0146
-      0xB8220200,  //  0134  GETNGBL	R8	K1
-      0x8C201102,  //  0135  GETMET	R8	R8	K2
-      0x60280008,  //  0136  GETGBL	R10	G8
-      0x5C2C0C00,  //  0137  MOVE	R11	R6
-      0x7C280200,  //  0138  CALL	R10	1
-      0x002A880A,  //  0139  ADD	R10	K68	R10
-      0x00281545,  //  013A  ADD	R10	R10	K69
-      0x602C0008,  //  013B  GETGBL	R11	G8
-      0x5C300E00,  //  013C  MOVE	R12	R7
-      0x7C2C0200,  //  013D  CALL	R11	1
-      0x0028140B,  //  013E  ADD	R10	R10	R11
-      0x7C200400,  //  013F  CALL	R8	2
-      0xA4228C00,  //  0140  IMPORT	R8	K70
-      0x8C241147,  //  0141  GETMET	R9	R8	K71
-      0x7C240200,  //  0142  CALL	R9	1
-      0x50240000,  //  0143  LDBOOL	R9	0	0
-      0x80041200,  //  0144  RET	1	R9
-      0x70020000,  //  0145  JMP		#0147
-      0xB0080000,  //  0146  RAISE	2	R0	R0
-      0x80000000,  //  0147  RET	0
+      0x8C24112B,  //  00A1  GETMET	R9	R8	K43
+      0x882C0D18,  //  00A2  GETMBR	R11	R6	K24
+      0x50300200,  //  00A3  LDBOOL	R12	1	0
+      0x7C240600,  //  00A4  CALL	R9	3
+      0x7426000F,  //  00A5  JMPT	R9	#00B6
+      0xB8260200,  //  00A6  GETNGBL	R9	K1
+      0x8C241302,  //  00A7  GETMET	R9	R9	K2
+      0x602C0008,  //  00A8  GETGBL	R11	G8
+      0x88300D18,  //  00A9  GETMBR	R12	R6	K24
+      0x7C2C0200,  //  00AA  CALL	R11	1
+      0x002E580B,  //  00AB  ADD	R11	K44	R11
+      0x002C172D,  //  00AC  ADD	R11	R11	K45
+      0x60300008,  //  00AD  GETGBL	R12	G8
+      0x8834112E,  //  00AE  GETMBR	R13	R8	K46
+      0x7C300200,  //  00AF  CALL	R12	1
+      0x002C160C,  //  00B0  ADD	R11	R11	R12
+      0x58300011,  //  00B1  LDCONST	R12	K17
+      0x7C240600,  //  00B2  CALL	R9	3
+      0x50240000,  //  00B3  LDBOOL	R9	0	0
+      0xA8040001,  //  00B4  EXBLK	1	1
+      0x80041200,  //  00B5  RET	1	R9
+      0x8C240D2F,  //  00B6  GETMET	R9	R6	K47
+      0x7C240200,  //  00B7  CALL	R9	1
+      0x5C281200,  //  00B8  MOVE	R10	R9
+      0x742A0002,  //  00B9  JMPT	R10	#00BD
+      0x50280000,  //  00BA  LDBOOL	R10	0	0
+      0xA8040001,  //  00BB  EXBLK	1	1
+      0x80041400,  //  00BC  RET	1	R10
+      0x88280D31,  //  00BD  GETMBR	R10	R6	K49
+      0x04281532,  //  00BE  SUB	R10	R10	K50
+      0x402A120A,  //  00BF  CONNECT	R10	K9	R10
+      0x882C0D30,  //  00C0  GETMBR	R11	R6	K48
+      0x9428160A,  //  00C1  GETIDX	R10	R11	R10
+      0x901A600A,  //  00C2  SETMBR	R6	K48	R10
+      0x88280D30,  //  00C3  GETMBR	R10	R6	K48
+      0x40281409,  //  00C4  CONNECT	R10	R10	R9
+      0xB82A0200,  //  00C5  GETNGBL	R10	K1
+      0x8C281502,  //  00C6  GETMET	R10	R10	K2
+      0x8C300919,  //  00C7  GETMET	R12	R4	K25
+      0x58380033,  //  00C8  LDCONST	R14	K51
+      0x883C0D31,  //  00C9  GETMBR	R15	R6	K49
+      0x88400D30,  //  00CA  GETMBR	R16	R6	K48
+      0x8C402104,  //  00CB  GETMET	R16	R16	K4
+      0x7C400200,  //  00CC  CALL	R16	1
+      0x7C300800,  //  00CD  CALL	R12	4
+      0x54360003,  //  00CE  LDINT	R13	4
+      0x7C280600,  //  00CF  CALL	R10	3
+      0x8C280D1C,  //  00D0  GETMET	R10	R6	K28
+      0x7C280200,  //  00D1  CALL	R10	1
+      0xB82A0200,  //  00D2  GETNGBL	R10	K1
+      0x8C281502,  //  00D3  GETMET	R10	R10	K2
+      0x60300008,  //  00D4  GETGBL	R12	G8
+      0x88340D35,  //  00D5  GETMBR	R13	R6	K53
+      0x7C300200,  //  00D6  CALL	R12	1
+      0x0032680C,  //  00D7  ADD	R12	K52	R12
+      0x00301936,  //  00D8  ADD	R12	R12	K54
+      0x60340008,  //  00D9  GETGBL	R13	G8
+      0x88380D1F,  //  00DA  GETMBR	R14	R6	K31
+      0x7C340200,  //  00DB  CALL	R13	1
+      0x0030180D,  //  00DC  ADD	R12	R12	R13
+      0x00301937,  //  00DD  ADD	R12	R12	K55
+      0x60340008,  //  00DE  GETGBL	R13	G8
+      0x88380D38,  //  00DF  GETMBR	R14	R6	K56
+      0x543EFFFE,  //  00E0  LDINT	R15	65535
+      0x2C381C0F,  //  00E1  AND	R14	R14	R15
+      0x7C340200,  //  00E2  CALL	R13	1
+      0x0030180D,  //  00E3  ADD	R12	R12	R13
+      0x58340011,  //  00E4  LDCONST	R13	K17
+      0x7C280600,  //  00E5  CALL	R10	3
+      0x8828010B,  //  00E6  GETMBR	R10	R0	K11
+      0x8C28151D,  //  00E7  GETMET	R10	R10	K29
+      0x88300D1E,  //  00E8  GETMBR	R12	R6	K30
+      0x7C280400,  //  00E9  CALL	R10	2
+      0x88280D35,  //  00EA  GETMBR	R10	R6	K53
+      0x1C2C1509,  //  00EB  EQ	R11	R10	K9
+      0x782E0018,  //  00EC  JMPF	R11	#0106
+      0xB82E0200,  //  00ED  GETNGBL	R11	K1
+      0x8C2C1702,  //  00EE  GETMET	R11	R11	K2
+      0xB8360A00,  //  00EF  GETNGBL	R13	K5
+      0x8C341B2A,  //  00F0  GETMET	R13	R13	K42
+      0x5C3C0C00,  //  00F1  MOVE	R15	R6
+      0x7C340400,  //  00F2  CALL	R13	2
+      0x0036720D,  //  00F3  ADD	R13	K57	R13
+      0x58380011,  //  00F4  LDCONST	R14	K17
+      0x7C2C0600,  //  00F5  CALL	R11	3
+      0x882C0D1F,  //  00F6  GETMBR	R11	R6	K31
+      0x5432000F,  //  00F7  LDINT	R12	16
+      0x1C2C160C,  //  00F8  EQ	R11	R11	R12
+      0x782E0009,  //  00F9  JMPF	R11	#0104
+      0x882C013A,  //  00FA  GETMBR	R11	R0	K58
+      0x8C2C173B,  //  00FB  GETMET	R11	R11	K59
+      0x5C340C00,  //  00FC  MOVE	R13	R6
+      0x7C2C0400,  //  00FD  CALL	R11	2
+      0x5C141600,  //  00FE  MOVE	R5	R11
+      0x78160003,  //  00FF  JMPF	R5	#0104
+      0x882C013A,  //  0100  GETMBR	R11	R0	K58
+      0x8C2C173C,  //  0101  GETMET	R11	R11	K60
+      0x5C340000,  //  0102  MOVE	R13	R0
+      0x7C2C0400,  //  0103  CALL	R11	2
+      0x50140200,  //  0104  LDBOOL	R5	1	0
+      0x70020024,  //  0105  JMP		#012B
+      0x1C2C1532,  //  0106  EQ	R11	R10	K50
+      0x782E001A,  //  0107  JMPF	R11	#0123
+      0x882C013A,  //  0108  GETMBR	R11	R0	K58
+      0x8C2C1725,  //  0109  GETMET	R11	R11	K37
+      0x5C340C00,  //  010A  MOVE	R13	R6
+      0x7C2C0400,  //  010B  CALL	R11	2
+      0x5C141600,  //  010C  MOVE	R5	R11
+      0x78160004,  //  010D  JMPF	R5	#0113
+      0x882C013A,  //  010E  GETMBR	R11	R0	K58
+      0x8C2C173C,  //  010F  GETMET	R11	R11	K60
+      0x5C340000,  //  0110  MOVE	R13	R0
+      0x7C2C0400,  //  0111  CALL	R11	2
+      0x7002000D,  //  0112  JMP		#0121
+      0x882C0D3D,  //  0113  GETMBR	R11	R6	K61
+      0x782E000B,  //  0114  JMPF	R11	#0121
+      0x8C2C0D3E,  //  0115  GETMET	R11	R6	K62
+      0x7C2C0200,  //  0116  CALL	R11	1
+      0x8C30173F,  //  0117  GETMET	R12	R11	K63
+      0x7C300200,  //  0118  CALL	R12	1
+      0x8C301740,  //  0119  GETMET	R12	R11	K64
+      0x7C300200,  //  011A  CALL	R12	1
+      0x8C300141,  //  011B  GETMET	R12	R0	K65
+      0x88381730,  //  011C  GETMBR	R14	R11	K48
+      0x883C1742,  //  011D  GETMBR	R15	R11	K66
+      0x88401743,  //  011E  GETMBR	R16	R11	K67
+      0x88441718,  //  011F  GETMBR	R17	R11	K24
+      0x7C300A00,  //  0120  CALL	R12	5
+      0x50140200,  //  0121  LDBOOL	R5	1	0
+      0x70020007,  //  0122  JMP		#012B
+      0xB82E0200,  //  0123  GETNGBL	R11	K1
+      0x8C2C1702,  //  0124  GETMET	R11	R11	K2
+      0x60340008,  //  0125  GETGBL	R13	G8
+      0x5C381400,  //  0126  MOVE	R14	R10
+      0x7C340200,  //  0127  CALL	R13	1
+      0x0036880D,  //  0128  ADD	R13	K68	R13
+      0x58380011,  //  0129  LDCONST	R14	K17
+      0x7C2C0600,  //  012A  CALL	R11	3
+      0xA8040001,  //  012B  EXBLK	1	1
+      0x80040A00,  //  012C  RET	1	R5
+      0xA8040001,  //  012D  EXBLK	1	1
+      0x70020014,  //  012E  JMP		#0144
+      0xAC180002,  //  012F  CATCH	R6	0	2
+      0x70020011,  //  0130  JMP		#0143
+      0xB8220200,  //  0131  GETNGBL	R8	K1
+      0x8C201102,  //  0132  GETMET	R8	R8	K2
+      0x60280008,  //  0133  GETGBL	R10	G8
+      0x5C2C0C00,  //  0134  MOVE	R11	R6
+      0x7C280200,  //  0135  CALL	R10	1
+      0x002A8A0A,  //  0136  ADD	R10	K69	R10
+      0x00281546,  //  0137  ADD	R10	R10	K70
+      0x602C0008,  //  0138  GETGBL	R11	G8
+      0x5C300E00,  //  0139  MOVE	R12	R7
+      0x7C2C0200,  //  013A  CALL	R11	1
+      0x0028140B,  //  013B  ADD	R10	R10	R11
+      0x7C200400,  //  013C  CALL	R8	2
+      0xA4228E00,  //  013D  IMPORT	R8	K71
+      0x8C241148,  //  013E  GETMET	R9	R8	K72
+      0x7C240200,  //  013F  CALL	R9	1
+      0x50240000,  //  0140  LDBOOL	R9	0	0
+      0x80041200,  //  0141  RET	1	R9
+      0x70020000,  //  0142  JMP		#0144
+      0xB0080000,  //  0143  RAISE	2	R0	R0
+      0x80000000,  //  0144  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -1000,9 +1000,9 @@ void be_load_Matter_Fabric_class(bvm *vm) {
 extern const bclass be_class_Matter_Session;
 
 /********************************************************************
-** Solidified function: get_ipk_epoch_key
+** Solidified function: get_fabric_label
 ********************************************************************/
-be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+be_local_closure(Matter_Session_get_fabric_label,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1014,304 +1014,14 @@ be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(get_ipk_epoch_key),
+    be_str_weak(get_fabric_label),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x88040301,  //  0001  GETMBR	R1	R1	K1
       0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_mode_CASE
-********************************************************************/
-be_local_closure(Matter_Session_set_mode_CASE,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
-    be_str_weak(set_mode_CASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_admin_subject_vendor
-********************************************************************/
-be_local_closure(Matter_Session_set_admin_subject_vendor,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_subject),
-    /* K2   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(set_admin_subject_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x900E0201,  //  0001  SETMBR	R3	K1	R1
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
-      0x900E0402,  //  0003  SETMBR	R3	K2	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_device_id
-********************************************************************/
-be_local_closure(Matter_Session_get_device_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(device_id),
-    }),
-    be_str_weak(get_device_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(mode),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_nested_str_weak(initiator_session_id),
-    /* K6   */  be_nested_str_weak(counter_rcv),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Counter),
-    /* K9   */  be_nested_str_weak(counter_snd),
-    /* K10  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K11  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K12  */  be_nested_str_weak(_breadcrumb),
-    /* K13  */  be_nested_str_weak(_exchange_id),
-    /* K14  */  be_nested_str_weak(random),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(get),
-    /* K17  */  be_nested_str_weak(_fabric),
-    /* K18  */  be_nested_str_weak(create_fabric),
-    /* K19  */  be_nested_str_weak(update),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x90020503,  //  0002  SETMBR	R0	K2	K3
-      0x90020802,  //  0003  SETMBR	R0	K4	R2
-      0x90020A03,  //  0004  SETMBR	R0	K5	R3
-      0xB81A0E00,  //  0005  GETNGBL	R6	K7
-      0x8C180D08,  //  0006  GETMET	R6	R6	K8
-      0x7C180200,  //  0007  CALL	R6	1
-      0x90020C06,  //  0008  SETMBR	R0	K6	R6
-      0xB81A0E00,  //  0009  GETNGBL	R6	K7
-      0x8C180D08,  //  000A  GETMET	R6	R6	K8
-      0x7C180200,  //  000B  CALL	R6	1
-      0x90021206,  //  000C  SETMBR	R0	K9	R6
-      0xB81A0E00,  //  000D  GETNGBL	R6	K7
-      0x8C180D08,  //  000E  GETMET	R6	R6	K8
-      0x7C180200,  //  000F  CALL	R6	1
-      0x90021406,  //  0010  SETMBR	R0	K10	R6
-      0xB81A0E00,  //  0011  GETNGBL	R6	K7
-      0x8C180D08,  //  0012  GETMET	R6	R6	K8
-      0x7C180200,  //  0013  CALL	R6	1
-      0x90021606,  //  0014  SETMBR	R0	K11	R6
-      0x90021903,  //  0015  SETMBR	R0	K12	K3
-      0x8C180B0E,  //  0016  GETMET	R6	R5	K14
-      0x5820000F,  //  0017  LDCONST	R8	K15
-      0x7C180400,  //  0018  CALL	R6	2
-      0x8C180D10,  //  0019  GETMET	R6	R6	K16
-      0x58200003,  //  001A  LDCONST	R8	K3
-      0x5824000F,  //  001B  LDCONST	R9	K15
-      0x7C180600,  //  001C  CALL	R6	3
-      0x90021A06,  //  001D  SETMBR	R0	K13	R6
-      0x78120001,  //  001E  JMPF	R4	#0021
-      0x5C180800,  //  001F  MOVE	R6	R4
-      0x70020002,  //  0020  JMP		#0024
-      0x88180101,  //  0021  GETMBR	R6	R0	K1
-      0x8C180D12,  //  0022  GETMET	R6	R6	K18
-      0x7C180200,  //  0023  CALL	R6	1
-      0x90022206,  //  0024  SETMBR	R0	K17	R6
-      0x8C180113,  //  0025  GETMET	R6	R0	K19
-      0x7C180200,  //  0026  CALL	R6	1
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_mode_PASE
-********************************************************************/
-be_local_closure(Matter_Session_set_mode_PASE,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(set_mode_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ca
-********************************************************************/
-be_local_closure(Matter_Session_set_ca,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(set_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x900A0201,  //  0001  SETMBR	R2	K1	R1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(set_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x900A0201,  //  0001  SETMBR	R2	K1	R1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_r2i
-********************************************************************/
-be_local_closure(Matter_Session_get_r2i,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(r2ikey),
-    }),
-    be_str_weak(get_r2i),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -1331,7 +1041,7 @@ be_local_closure(Matter_Session_tojson,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
+    ( &(const bvalue[24]) {     /* constants */
     /* K0   */  be_nested_str_weak(json),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(introspect),
@@ -1345,25 +1055,21 @@ be_local_closure(Matter_Session_tojson,   /* name */
     /* K10  */  be_nested_str_weak(stop_iteration),
     /* K11  */  be_nested_str_weak(matter),
     /* K12  */  be_nested_str_weak(sort),
-    /* K13  */  be_nested_str_weak(counter_rcv),
-    /* K14  */  be_nested_str_weak(val),
-    /* K15  */  be_nested_str_weak(counter_snd),
-    /* K16  */  be_nested_str_weak(next),
-    /* K17  */  be_nested_str_weak(_X24_X24),
-    /* K18  */  be_nested_str_weak(tob64),
-    /* K19  */  be_nested_str_weak(instance),
-    /* K20  */  be_nested_str_weak(format),
-    /* K21  */  be_nested_str_weak(_X25s_X3A_X25s),
-    /* K22  */  be_nested_str_weak(dump),
-    /* K23  */  be_nested_str_weak(persist_post),
-    /* K24  */  be_nested_str_weak(_X7B),
-    /* K25  */  be_nested_str_weak(concat),
-    /* K26  */  be_nested_str_weak(_X2C),
-    /* K27  */  be_nested_str_weak(_X7D),
+    /* K13  */  be_nested_str_weak(_X24_X24),
+    /* K14  */  be_nested_str_weak(tob64),
+    /* K15  */  be_nested_str_weak(instance),
+    /* K16  */  be_nested_str_weak(format),
+    /* K17  */  be_nested_str_weak(_X25s_X3A_X25s),
+    /* K18  */  be_nested_str_weak(dump),
+    /* K19  */  be_nested_str_weak(persist_post),
+    /* K20  */  be_nested_str_weak(_X7B),
+    /* K21  */  be_nested_str_weak(concat),
+    /* K22  */  be_nested_str_weak(_X2C),
+    /* K23  */  be_nested_str_weak(_X7D),
     }),
     be_str_weak(tojson),
     &be_const_str_solidified,
-    ( &(const binstruction[110]) {  /* code */
+    ( &(const binstruction[96]) {  /* code */
       0xA4060000,  //  0000  IMPORT	R1	K0
       0xA40A0200,  //  0001  IMPORT	R2	K1
       0xA40E0400,  //  0002  IMPORT	R3	K2
@@ -1408,7 +1114,7 @@ be_local_closure(Matter_Session_tojson,   /* name */
       0x60180010,  //  0029  GETGBL	R6	G16
       0x5C1C0800,  //  002A  MOVE	R7	R4
       0x7C180200,  //  002B  CALL	R6	1
-      0xA8020035,  //  002C  EXBLK	0	#0063
+      0xA8020027,  //  002C  EXBLK	0	#0055
       0x5C1C0C00,  //  002D  MOVE	R7	R6
       0x7C1C0000,  //  002E  CALL	R7	0
       0x8C200705,  //  002F  GETMET	R8	R3	K5
@@ -1419,61 +1125,47 @@ be_local_closure(Matter_Session_tojson,   /* name */
       0x1C241009,  //  0034  EQ	R9	R8	R9
       0x78260000,  //  0035  JMPF	R9	#0037
       0x7001FFF5,  //  0036  JMP		#002D
-      0x1C240F0D,  //  0037  EQ	R9	R7	K13
-      0x78260003,  //  0038  JMPF	R9	#003D
-      0x8C24110E,  //  0039  GETMET	R9	R8	K14
-      0x7C240200,  //  003A  CALL	R9	1
-      0x5C201200,  //  003B  MOVE	R8	R9
-      0x70020017,  //  003C  JMP		#0055
-      0x1C240F0F,  //  003D  EQ	R9	R7	K15
-      0x78260005,  //  003E  JMPF	R9	#0045
-      0x8C241110,  //  003F  GETMET	R9	R8	K16
-      0x7C240200,  //  0040  CALL	R9	1
-      0x542A00FF,  //  0041  LDINT	R10	256
-      0x0024120A,  //  0042  ADD	R9	R9	R10
-      0x5C201200,  //  0043  MOVE	R8	R9
-      0x7002000F,  //  0044  JMP		#0055
-      0x6024000F,  //  0045  GETGBL	R9	G15
-      0x5C281000,  //  0046  MOVE	R10	R8
-      0x602C0015,  //  0047  GETGBL	R11	G21
-      0x7C240400,  //  0048  CALL	R9	2
-      0x78260004,  //  0049  JMPF	R9	#004F
-      0x8C241112,  //  004A  GETMET	R9	R8	K18
-      0x7C240200,  //  004B  CALL	R9	1
-      0x00262209,  //  004C  ADD	R9	K17	R9
-      0x5C201200,  //  004D  MOVE	R8	R9
-      0x70020005,  //  004E  JMP		#0055
-      0x60240004,  //  004F  GETGBL	R9	G4
-      0x5C281000,  //  0050  MOVE	R10	R8
-      0x7C240200,  //  0051  CALL	R9	1
-      0x1C241313,  //  0052  EQ	R9	R9	K19
-      0x78260000,  //  0053  JMPF	R9	#0055
+      0x6024000F,  //  0037  GETGBL	R9	G15
+      0x5C281000,  //  0038  MOVE	R10	R8
+      0x602C0015,  //  0039  GETGBL	R11	G21
+      0x7C240400,  //  003A  CALL	R9	2
+      0x78260004,  //  003B  JMPF	R9	#0041
+      0x8C24110E,  //  003C  GETMET	R9	R8	K14
+      0x7C240200,  //  003D  CALL	R9	1
+      0x00261A09,  //  003E  ADD	R9	K13	R9
+      0x5C201200,  //  003F  MOVE	R8	R9
+      0x70020005,  //  0040  JMP		#0047
+      0x60240004,  //  0041  GETGBL	R9	G4
+      0x5C281000,  //  0042  MOVE	R10	R8
+      0x7C240200,  //  0043  CALL	R9	1
+      0x1C24130F,  //  0044  EQ	R9	R9	K15
+      0x78260000,  //  0045  JMPF	R9	#0047
+      0x7001FFE5,  //  0046  JMP		#002D
+      0x8C240B09,  //  0047  GETMET	R9	R5	K9
+      0x8C2C0510,  //  0048  GETMET	R11	R2	K16
+      0x58340011,  //  0049  LDCONST	R13	K17
+      0x8C380312,  //  004A  GETMET	R14	R1	K18
+      0x60400008,  //  004B  GETGBL	R16	G8
+      0x5C440E00,  //  004C  MOVE	R17	R7
+      0x7C400200,  //  004D  CALL	R16	1
+      0x7C380400,  //  004E  CALL	R14	2
+      0x8C3C0312,  //  004F  GETMET	R15	R1	K18
+      0x5C441000,  //  0050  MOVE	R17	R8
+      0x7C3C0400,  //  0051  CALL	R15	2
+      0x7C2C0800,  //  0052  CALL	R11	4
+      0x7C240400,  //  0053  CALL	R9	2
       0x7001FFD7,  //  0054  JMP		#002D
-      0x8C240B09,  //  0055  GETMET	R9	R5	K9
-      0x8C2C0514,  //  0056  GETMET	R11	R2	K20
-      0x58340015,  //  0057  LDCONST	R13	K21
-      0x8C380316,  //  0058  GETMET	R14	R1	K22
-      0x60400008,  //  0059  GETGBL	R16	G8
-      0x5C440E00,  //  005A  MOVE	R17	R7
-      0x7C400200,  //  005B  CALL	R16	1
-      0x7C380400,  //  005C  CALL	R14	2
-      0x8C3C0316,  //  005D  GETMET	R15	R1	K22
-      0x5C441000,  //  005E  MOVE	R17	R8
-      0x7C3C0400,  //  005F  CALL	R15	2
-      0x7C2C0800,  //  0060  CALL	R11	4
-      0x7C240400,  //  0061  CALL	R9	2
-      0x7001FFC9,  //  0062  JMP		#002D
-      0x5818000A,  //  0063  LDCONST	R6	K10
-      0xAC180200,  //  0064  CATCH	R6	1	0
-      0xB0080000,  //  0065  RAISE	2	R0	R0
-      0x8C180117,  //  0066  GETMET	R6	R0	K23
-      0x7C180200,  //  0067  CALL	R6	1
-      0x8C180B19,  //  0068  GETMET	R6	R5	K25
-      0x5820001A,  //  0069  LDCONST	R8	K26
-      0x7C180400,  //  006A  CALL	R6	2
-      0x001A3006,  //  006B  ADD	R6	K24	R6
-      0x00180D1B,  //  006C  ADD	R6	R6	K27
-      0x80040C00,  //  006D  RET	1	R6
+      0x5818000A,  //  0055  LDCONST	R6	K10
+      0xAC180200,  //  0056  CATCH	R6	1	0
+      0xB0080000,  //  0057  RAISE	2	R0	R0
+      0x8C180113,  //  0058  GETMET	R6	R0	K19
+      0x7C180200,  //  0059  CALL	R6	1
+      0x8C180B15,  //  005A  GETMET	R6	R5	K21
+      0x58200016,  //  005B  LDCONST	R8	K22
+      0x7C180400,  //  005C  CALL	R6	2
+      0x001A2806,  //  005D  ADD	R6	K20	R6
+      0x00180D17,  //  005E  ADD	R6	R6	K23
+      0x80040C00,  //  005F  RET	1	R6
     })
   )
 );
@@ -1481,803 +1173,60 @@ be_local_closure(Matter_Session_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric_compressed
+** Solidified function: set_noc
 ********************************************************************/
-be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+be_local_closure(Matter_Session_set_noc,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(get_fabric_compressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_i2r
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    }),
-    be_str_weak(get_i2r),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(get_fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(_GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[29]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x4C080000,  //  0002  LDNIL	R2
-      0x1C040202,  //  0003  EQ	R1	R1	R2
-      0x74060004,  //  0004  JMPT	R1	#000A
-      0x8C040101,  //  0005  GETMET	R1	R0	K1
-      0x7C040200,  //  0006  CALL	R1	1
-      0x4C080000,  //  0007  LDNIL	R2
-      0x1C040202,  //  0008  EQ	R1	R1	R2
-      0x78060001,  //  0009  JMPF	R1	#000C
-      0x4C040000,  //  000A  LDNIL	R1
-      0x80040200,  //  000B  RET	1	R1
-      0xA4060400,  //  000C  IMPORT	R1	K2
-      0x8C080303,  //  000D  GETMET	R2	R1	K3
-      0x7C080200,  //  000E  CALL	R2	1
-      0x600C0015,  //  000F  GETGBL	R3	G21
-      0x7C0C0000,  //  0010  CALL	R3	0
-      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
-      0x88140105,  //  0012  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x8C100506,  //  0014  GETMET	R4	R2	K6
-      0x8C180100,  //  0015  GETMET	R6	R0	K0
-      0x7C180200,  //  0016  CALL	R6	1
-      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x5C200600,  //  0019  MOVE	R8	R3
-      0x5426000F,  //  001A  LDINT	R9	16
-      0x7C100A00,  //  001B  CALL	R4	5
-      0x80040800,  //  001C  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fromjson
-********************************************************************/
-be_local_closure(Matter_Session_fromjson,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
+    4,                          /* nstack */
     3,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Session),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Session),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_nested_str_weak(counter_rcv),
-    /* K7   */  be_nested_str_weak(reset),
-    /* K8   */  be_nested_str_weak(counter_snd),
-    /* K9   */  be_nested_str_weak(find),
-    /* K10  */  be_nested_str_weak(0x),
-    /* K11  */  be_const_int(0),
-    /* K12  */  be_nested_str_weak(set),
-    /* K13  */  be_nested_str_weak(fromhex),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_const_int(2147483647),
-    /* K16  */  be_nested_str_weak(_X24_X24),
-    /* K17  */  be_nested_str_weak(fromb64),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(hydrate_post),
-    }),
-    be_str_weak(fromjson),
-    &be_const_str_solidified,
-    ( &(const binstruction[93]) {  /* code */
-      0x580C0000,  //  0000  LDCONST	R3	K0
-      0xA4120200,  //  0001  IMPORT	R4	K1
-      0xA4160400,  //  0002  IMPORT	R5	K2
-      0xB81A0600,  //  0003  GETNGBL	R6	K3
-      0x8C180D04,  //  0004  GETMET	R6	R6	K4
-      0x5C200000,  //  0005  MOVE	R8	R0
-      0x4C240000,  //  0006  LDNIL	R9
-      0x4C280000,  //  0007  LDNIL	R10
-      0x5C2C0400,  //  0008  MOVE	R11	R2
-      0x7C180A00,  //  0009  CALL	R6	5
-      0x601C0010,  //  000A  GETGBL	R7	G16
-      0x8C200305,  //  000B  GETMET	R8	R1	K5
-      0x7C200200,  //  000C  CALL	R8	1
-      0x7C1C0200,  //  000D  CALL	R7	1
-      0xA8020047,  //  000E  EXBLK	0	#0057
-      0x5C200E00,  //  000F  MOVE	R8	R7
-      0x7C200000,  //  0010  CALL	R8	0
-      0x94240208,  //  0011  GETIDX	R9	R1	R8
-      0x1C281106,  //  0012  EQ	R10	R8	K6
-      0x782A0006,  //  0013  JMPF	R10	#001B
-      0x88280D06,  //  0014  GETMBR	R10	R6	K6
-      0x8C281507,  //  0015  GETMET	R10	R10	K7
-      0x60300009,  //  0016  GETGBL	R12	G9
-      0x5C341200,  //  0017  MOVE	R13	R9
-      0x7C300200,  //  0018  CALL	R12	1
-      0x7C280400,  //  0019  CALL	R10	2
-      0x7002003A,  //  001A  JMP		#0056
-      0x1C281108,  //  001B  EQ	R10	R8	K8
-      0x782A0006,  //  001C  JMPF	R10	#0024
-      0x88280D08,  //  001D  GETMBR	R10	R6	K8
-      0x8C281507,  //  001E  GETMET	R10	R10	K7
-      0x60300009,  //  001F  GETGBL	R12	G9
-      0x5C341200,  //  0020  MOVE	R13	R9
-      0x7C300200,  //  0021  CALL	R12	1
-      0x7C280400,  //  0022  CALL	R10	2
-      0x70020031,  //  0023  JMP		#0056
-      0x60280004,  //  0024  GETGBL	R10	G4
-      0x5C2C1200,  //  0025  MOVE	R11	R9
-      0x7C280200,  //  0026  CALL	R10	1
-      0x1C281501,  //  0027  EQ	R10	R10	K1
-      0x782A0027,  //  0028  JMPF	R10	#0051
-      0x8C280909,  //  0029  GETMET	R10	R4	K9
-      0x5C301200,  //  002A  MOVE	R12	R9
-      0x5834000A,  //  002B  LDCONST	R13	K10
-      0x7C280600,  //  002C  CALL	R10	3
-      0x1C28150B,  //  002D  EQ	R10	R10	K11
-      0x782A000A,  //  002E  JMPF	R10	#003A
-      0x8C280B0C,  //  002F  GETMET	R10	R5	K12
-      0x5C300C00,  //  0030  MOVE	R12	R6
-      0x5C341000,  //  0031  MOVE	R13	R8
-      0x60380015,  //  0032  GETGBL	R14	G21
-      0x7C380000,  //  0033  CALL	R14	0
-      0x8C381D0D,  //  0034  GETMET	R14	R14	K13
-      0x40421D0F,  //  0035  CONNECT	R16	K14	K15
-      0x94401210,  //  0036  GETIDX	R16	R9	R16
-      0x7C380400,  //  0037  CALL	R14	2
-      0x7C280800,  //  0038  CALL	R10	4
-      0x70020015,  //  0039  JMP		#0050
-      0x8C280909,  //  003A  GETMET	R10	R4	K9
-      0x5C301200,  //  003B  MOVE	R12	R9
-      0x58340010,  //  003C  LDCONST	R13	K16
-      0x7C280600,  //  003D  CALL	R10	3
-      0x1C28150B,  //  003E  EQ	R10	R10	K11
-      0x782A000A,  //  003F  JMPF	R10	#004B
-      0x8C280B0C,  //  0040  GETMET	R10	R5	K12
-      0x5C300C00,  //  0041  MOVE	R12	R6
-      0x5C341000,  //  0042  MOVE	R13	R8
-      0x60380015,  //  0043  GETGBL	R14	G21
-      0x7C380000,  //  0044  CALL	R14	0
-      0x8C381D11,  //  0045  GETMET	R14	R14	K17
-      0x40421D0F,  //  0046  CONNECT	R16	K14	K15
-      0x94401210,  //  0047  GETIDX	R16	R9	R16
-      0x7C380400,  //  0048  CALL	R14	2
-      0x7C280800,  //  0049  CALL	R10	4
-      0x70020004,  //  004A  JMP		#0050
-      0x8C280B0C,  //  004B  GETMET	R10	R5	K12
-      0x5C300C00,  //  004C  MOVE	R12	R6
-      0x5C341000,  //  004D  MOVE	R13	R8
-      0x5C381200,  //  004E  MOVE	R14	R9
-      0x7C280800,  //  004F  CALL	R10	4
-      0x70020004,  //  0050  JMP		#0056
-      0x8C280B0C,  //  0051  GETMET	R10	R5	K12
-      0x5C300C00,  //  0052  MOVE	R12	R6
-      0x5C341000,  //  0053  MOVE	R13	R8
-      0x5C381200,  //  0054  MOVE	R14	R9
-      0x7C280800,  //  0055  CALL	R10	4
-      0x7001FFB7,  //  0056  JMP		#000F
-      0x581C0012,  //  0057  LDCONST	R7	K18
-      0xAC1C0200,  //  0058  CATCH	R7	1	0
-      0xB0080000,  //  0059  RAISE	2	R0	R0
-      0x8C1C0D13,  //  005A  GETMET	R7	R6	K19
-      0x7C1C0200,  //  005B  CALL	R7	1
-      0x80040C00,  //  005C  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ac
-********************************************************************/
-be_local_closure(Matter_Session_get_ac,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attestation_challenge),
-    }),
-    be_str_weak(get_ac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_label
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_label,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_label),
-    }),
-    be_str_weak(get_fabric_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_noc
-********************************************************************/
-be_local_closure(Matter_Session_get_noc,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
     /* K1   */  be_nested_str_weak(noc),
+    /* K2   */  be_nested_str_weak(icac),
     }),
-    be_str_weak(get_noc),
+    be_str_weak(set_noc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x900E0201,  //  0001  SETMBR	R3	K1	R1
+      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x900E0402,  //  0003  SETMBR	R3	K2	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(set_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_device
-********************************************************************/
-be_local_closure(Matter_Session_set_fabric_device,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_id),
-    /* K2   */  be_nested_str_weak(device_id),
-    /* K3   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(set_fabric_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x90120201,  //  0001  SETMBR	R4	K1	R1
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x90120402,  //  0003  SETMBR	R4	K2	R2
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x90120603,  //  0005  SETMBR	R4	K3	R3
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(Matter_Session_update,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(last_used),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(rtc),
-    /* K3   */  be_nested_str_weak(utc),
-    }),
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040303,  //  0003  GETIDX	R1	R1	K3
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_PASE
-********************************************************************/
-be_local_closure(Matter_Session_is_PASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(is_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_vendor
-********************************************************************/
-be_local_closure(Matter_Session_get_admin_vendor,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(get_admin_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: close
-********************************************************************/
-be_local_closure(Matter_Session_close,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[20]) {     /* constants */
-    /* K0   */  be_nested_str_weak(local_session_id),
-    /* K1   */  be_nested_str_weak(__future_local_session_id),
-    /* K2   */  be_nested_str_weak(initiator_session_id),
-    /* K3   */  be_nested_str_weak(__future_initiator_session_id),
-    /* K4   */  be_nested_str_weak(counter_rcv),
-    /* K5   */  be_nested_str_weak(reset),
-    /* K6   */  be_nested_str_weak(counter_snd),
-    /* K7   */  be_nested_str_weak(i2rkey),
-    /* K8   */  be_nested_str_weak(_i2r_privacy),
-    /* K9   */  be_nested_str_weak(r2ikey),
-    /* K10  */  be_nested_str_weak(attestation_challenge),
-    /* K11  */  be_nested_str_weak(introspect),
-    /* K12  */  be_nested_str_weak(members),
-    /* K13  */  be_nested_str_weak(get),
-    /* K14  */  be_nested_str_weak(function),
-    /* K15  */  be_nested_str_weak(instance),
-    /* K16  */  be_const_int(0),
-    /* K17  */  be_nested_str_weak(_),
-    /* K18  */  be_const_int(1),
-    /* K19  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(close),
-    &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x88040101,  //  0000  GETMBR	R1	R0	K1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x88040103,  //  0002  GETMBR	R1	R0	K3
-      0x90020401,  //  0003  SETMBR	R0	K2	R1
-      0x88040104,  //  0004  GETMBR	R1	R0	K4
-      0x8C040305,  //  0005  GETMET	R1	R1	K5
-      0x7C040200,  //  0006  CALL	R1	1
-      0x88040106,  //  0007  GETMBR	R1	R0	K6
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
-      0x7C040200,  //  0009  CALL	R1	1
-      0x4C040000,  //  000A  LDNIL	R1
-      0x90020E01,  //  000B  SETMBR	R0	K7	R1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90021001,  //  000D  SETMBR	R0	K8	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90021201,  //  000F  SETMBR	R0	K9	R1
-      0x4C040000,  //  0010  LDNIL	R1
-      0x90021401,  //  0011  SETMBR	R0	K10	R1
-      0xA4061600,  //  0012  IMPORT	R1	K11
-      0x60080010,  //  0013  GETGBL	R2	G16
-      0x8C0C030C,  //  0014  GETMET	R3	R1	K12
-      0x5C140000,  //  0015  MOVE	R5	R0
-      0x7C0C0400,  //  0016  CALL	R3	2
-      0x7C080200,  //  0017  CALL	R2	1
-      0xA8020018,  //  0018  EXBLK	0	#0032
-      0x5C0C0400,  //  0019  MOVE	R3	R2
-      0x7C0C0000,  //  001A  CALL	R3	0
-      0x8C10030D,  //  001B  GETMET	R4	R1	K13
-      0x5C180000,  //  001C  MOVE	R6	R0
-      0x5C1C0600,  //  001D  MOVE	R7	R3
-      0x7C100600,  //  001E  CALL	R4	3
-      0x60140004,  //  001F  GETGBL	R5	G4
-      0x5C180800,  //  0020  MOVE	R6	R4
-      0x7C140200,  //  0021  CALL	R5	1
-      0x20140B0E,  //  0022  NE	R5	R5	K14
-      0x7816000C,  //  0023  JMPF	R5	#0031
-      0x60140004,  //  0024  GETGBL	R5	G4
-      0x5C180800,  //  0025  MOVE	R6	R4
-      0x7C140200,  //  0026  CALL	R5	1
-      0x20140B0F,  //  0027  NE	R5	R5	K15
-      0x78160007,  //  0028  JMPF	R5	#0031
-      0x94140710,  //  0029  GETIDX	R5	R3	K16
-      0x1C140B11,  //  002A  EQ	R5	R5	K17
-      0x78160004,  //  002B  JMPF	R5	#0031
-      0x94140712,  //  002C  GETIDX	R5	R3	K18
-      0x1C140B11,  //  002D  EQ	R5	R5	K17
-      0x78160001,  //  002E  JMPF	R5	#0031
-      0x4C140000,  //  002F  LDNIL	R5
-      0x90000605,  //  0030  SETMBR	R0	R3	R5
-      0x7001FFE6,  //  0031  JMP		#0019
-      0x58080013,  //  0032  LDCONST	R2	K19
-      0xAC080200,  //  0033  CATCH	R2	1	0
-      0xB0080000,  //  0034  RAISE	2	R0	R0
-      0x80000000,  //  0035  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_icac
-********************************************************************/
-be_local_closure(Matter_Session_get_icac,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(icac),
-    }),
-    be_str_weak(get_icac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fabric_completed
-********************************************************************/
-be_local_closure(Matter_Session_fabric_completed,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(set_no_expiration),
-    /* K2   */  be_nested_str_weak(set_persist),
-    /* K3   */  be_nested_str_weak(get_fabric_index),
-    /* K4   */  be_nested_str_weak(set_fabric_index),
-    /* K5   */  be_nested_str_weak(_store),
-    /* K6   */  be_nested_str_weak(next_fabric_idx),
-    /* K7   */  be_nested_str_weak(add_fabric),
-    }),
-    be_str_weak(fabric_completed),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C040302,  //  0004  GETMET	R1	R1	K2
-      0x500C0200,  //  0005  LDBOOL	R3	1	0
-      0x7C040400,  //  0006  CALL	R1	2
-      0x88040100,  //  0007  GETMBR	R1	R0	K0
-      0x8C040303,  //  0008  GETMET	R1	R1	K3
-      0x7C040200,  //  0009  CALL	R1	1
-      0x4C080000,  //  000A  LDNIL	R2
-      0x1C040202,  //  000B  EQ	R1	R1	R2
-      0x78060005,  //  000C  JMPF	R1	#0013
-      0x88040100,  //  000D  GETMBR	R1	R0	K0
-      0x8C040304,  //  000E  GETMET	R1	R1	K4
-      0x880C0105,  //  000F  GETMBR	R3	R0	K5
-      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
-      0x7C0C0200,  //  0011  CALL	R3	1
-      0x7C040400,  //  0012  CALL	R1	2
-      0x88040105,  //  0013  GETMBR	R1	R0	K5
-      0x8C040307,  //  0014  GETMET	R1	R1	K7
-      0x880C0100,  //  0015  GETMBR	R3	R0	K0
-      0x7C040400,  //  0016  CALL	R1	2
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca_pub
-********************************************************************/
-be_local_closure(Matter_Session_get_ca_pub,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ca_pub),
-    }),
-    be_str_weak(get_ca_pub),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save
-********************************************************************/
-be_local_closure(Matter_Session_save,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_store),
-    /* K1   */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(save),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_keys
-********************************************************************/
-be_local_closure(Matter_Session_set_keys,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    /* K1   */  be_nested_str_weak(_i2r_privacy),
-    /* K2   */  be_nested_str_weak(r2ikey),
-    /* K3   */  be_nested_str_weak(attestation_challenge),
-    /* K4   */  be_nested_str_weak(created),
-    }),
-    be_str_weak(set_keys),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x4C140000,  //  0001  LDNIL	R5
-      0x90020205,  //  0002  SETMBR	R0	K1	R5
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020603,  //  0004  SETMBR	R0	K3	R3
-      0x90020804,  //  0005  SETMBR	R0	K4	R4
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_CASE
-********************************************************************/
-be_local_closure(Matter_Session_is_CASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
-    be_str_weak(is_CASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_id
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_id),
-    }),
-    be_str_weak(get_fabric_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x900A0201,  //  0001  SETMBR	R2	K1	R1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -2325,9 +1274,73 @@ be_local_closure(Matter_Session_get_pk,   /* name */
 
 
 /********************************************************************
-** Solidified function: fabric_candidate
+** Solidified function: set_fabric_device
 ********************************************************************/
-be_local_closure(Matter_Session_fabric_candidate,   /* name */
+be_local_closure(Matter_Session_set_fabric_device,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_id),
+    /* K2   */  be_nested_str_weak(device_id),
+    /* K3   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(set_fabric_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x90120201,  //  0001  SETMBR	R4	K1	R1
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x90120402,  //  0003  SETMBR	R4	K2	R2
+      0x88100100,  //  0004  GETMBR	R4	R0	K0
+      0x90120603,  //  0005  SETMBR	R4	K3	R3
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_icac
+********************************************************************/
+be_local_closure(Matter_Session_get_icac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: persist_to_fabric
+********************************************************************/
+be_local_closure(Matter_Session_persist_to_fabric,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -2337,24 +1350,18 @@ be_local_closure(Matter_Session_fabric_candidate,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(add_fabric),
+    /* K1   */  be_nested_str_weak(add_session),
     }),
-    be_str_weak(fabric_candidate),
+    be_str_weak(persist_to_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
+    ( &(const binstruction[ 5]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x540E0077,  //  0002  LDINT	R3	120
+      0x5C0C0000,  //  0002  MOVE	R3	R0
       0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x8C040303,  //  0005  GETMET	R1	R1	K3
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x80000000,  //  0008  RET	0
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -2362,9 +1369,9 @@ be_local_closure(Matter_Session_fabric_candidate,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_noc
+** Solidified function: set_admin_subject_vendor
 ********************************************************************/
-be_local_closure(Matter_Session_set_noc,   /* name */
+be_local_closure(Matter_Session_set_admin_subject_vendor,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     3,                          /* argc */
@@ -2376,10 +1383,10 @@ be_local_closure(Matter_Session_set_noc,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(noc),
-    /* K2   */  be_nested_str_weak(icac),
+    /* K1   */  be_nested_str_weak(admin_subject),
+    /* K2   */  be_nested_str_weak(admin_vendor),
     }),
-    be_str_weak(set_noc),
+    be_str_weak(set_admin_subject_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
       0x880C0100,  //  0000  GETMBR	R3	R0	K0
@@ -2429,28 +1436,115 @@ be_local_closure(Matter_Session_set_fabric_label,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ca
+** Solidified function: fromjson
 ********************************************************************/
-be_local_closure(Matter_Session_get_ca,   /* name */
+be_local_closure(Matter_Session_fromjson,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
+    17,                          /* nstack */
+    3,                          /* argc */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Session),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(introspect),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Session),
+    /* K5   */  be_nested_str_weak(keys),
+    /* K6   */  be_nested_str_weak(find),
+    /* K7   */  be_nested_str_weak(0x),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(set),
+    /* K10  */  be_nested_str_weak(fromhex),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_const_int(2147483647),
+    /* K13  */  be_nested_str_weak(_X24_X24),
+    /* K14  */  be_nested_str_weak(fromb64),
+    /* K15  */  be_nested_str_weak(stop_iteration),
+    /* K16  */  be_nested_str_weak(hydrate_post),
     }),
-    be_str_weak(get_ca),
+    be_str_weak(fromjson),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+    ( &(const binstruction[75]) {  /* code */
+      0x580C0000,  //  0000  LDCONST	R3	K0
+      0xA4120200,  //  0001  IMPORT	R4	K1
+      0xA4160400,  //  0002  IMPORT	R5	K2
+      0xB81A0600,  //  0003  GETNGBL	R6	K3
+      0x8C180D04,  //  0004  GETMET	R6	R6	K4
+      0x5C200000,  //  0005  MOVE	R8	R0
+      0x4C240000,  //  0006  LDNIL	R9
+      0x4C280000,  //  0007  LDNIL	R10
+      0x5C2C0400,  //  0008  MOVE	R11	R2
+      0x7C180A00,  //  0009  CALL	R6	5
+      0x601C0010,  //  000A  GETGBL	R7	G16
+      0x8C200305,  //  000B  GETMET	R8	R1	K5
+      0x7C200200,  //  000C  CALL	R8	1
+      0x7C1C0200,  //  000D  CALL	R7	1
+      0xA8020035,  //  000E  EXBLK	0	#0045
+      0x5C200E00,  //  000F  MOVE	R8	R7
+      0x7C200000,  //  0010  CALL	R8	0
+      0x94240208,  //  0011  GETIDX	R9	R1	R8
+      0x60280004,  //  0012  GETGBL	R10	G4
+      0x5C2C1200,  //  0013  MOVE	R11	R9
+      0x7C280200,  //  0014  CALL	R10	1
+      0x1C281501,  //  0015  EQ	R10	R10	K1
+      0x782A0027,  //  0016  JMPF	R10	#003F
+      0x8C280906,  //  0017  GETMET	R10	R4	K6
+      0x5C301200,  //  0018  MOVE	R12	R9
+      0x58340007,  //  0019  LDCONST	R13	K7
+      0x7C280600,  //  001A  CALL	R10	3
+      0x1C281508,  //  001B  EQ	R10	R10	K8
+      0x782A000A,  //  001C  JMPF	R10	#0028
+      0x8C280B09,  //  001D  GETMET	R10	R5	K9
+      0x5C300C00,  //  001E  MOVE	R12	R6
+      0x5C341000,  //  001F  MOVE	R13	R8
+      0x60380015,  //  0020  GETGBL	R14	G21
+      0x7C380000,  //  0021  CALL	R14	0
+      0x8C381D0A,  //  0022  GETMET	R14	R14	K10
+      0x4042170C,  //  0023  CONNECT	R16	K11	K12
+      0x94401210,  //  0024  GETIDX	R16	R9	R16
+      0x7C380400,  //  0025  CALL	R14	2
+      0x7C280800,  //  0026  CALL	R10	4
+      0x70020015,  //  0027  JMP		#003E
+      0x8C280906,  //  0028  GETMET	R10	R4	K6
+      0x5C301200,  //  0029  MOVE	R12	R9
+      0x5834000D,  //  002A  LDCONST	R13	K13
+      0x7C280600,  //  002B  CALL	R10	3
+      0x1C281508,  //  002C  EQ	R10	R10	K8
+      0x782A000A,  //  002D  JMPF	R10	#0039
+      0x8C280B09,  //  002E  GETMET	R10	R5	K9
+      0x5C300C00,  //  002F  MOVE	R12	R6
+      0x5C341000,  //  0030  MOVE	R13	R8
+      0x60380015,  //  0031  GETGBL	R14	G21
+      0x7C380000,  //  0032  CALL	R14	0
+      0x8C381D0E,  //  0033  GETMET	R14	R14	K14
+      0x4042170C,  //  0034  CONNECT	R16	K11	K12
+      0x94401210,  //  0035  GETIDX	R16	R9	R16
+      0x7C380400,  //  0036  CALL	R14	2
+      0x7C280800,  //  0037  CALL	R10	4
+      0x70020004,  //  0038  JMP		#003E
+      0x8C280B09,  //  0039  GETMET	R10	R5	K9
+      0x5C300C00,  //  003A  MOVE	R12	R6
+      0x5C341000,  //  003B  MOVE	R13	R8
+      0x5C381200,  //  003C  MOVE	R14	R9
+      0x7C280800,  //  003D  CALL	R10	4
+      0x70020004,  //  003E  JMP		#0044
+      0x8C280B09,  //  003F  GETMET	R10	R5	K9
+      0x5C300C00,  //  0040  MOVE	R12	R6
+      0x5C341000,  //  0041  MOVE	R13	R8
+      0x5C381200,  //  0042  MOVE	R14	R9
+      0x7C280800,  //  0043  CALL	R10	4
+      0x7001FFC9,  //  0044  JMP		#000F
+      0x581C000F,  //  0045  LDCONST	R7	K15
+      0xAC1C0200,  //  0046  CATCH	R7	1	0
+      0xB0080000,  //  0047  RAISE	2	R0	R0
+      0x8C1C0D10,  //  0048  GETMET	R7	R6	K16
+      0x7C1C0200,  //  0049  CALL	R7	1
+      0x80040C00,  //  004A  RET	1	R6
     })
   )
 );
@@ -2458,9 +1552,9 @@ be_local_closure(Matter_Session_get_ca,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_admin_subject
+** Solidified function: get_fabric
 ********************************************************************/
-be_local_closure(Matter_Session_get_admin_subject,   /* name */
+be_local_closure(Matter_Session_get_fabric,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -2470,16 +1564,14 @@ be_local_closure(Matter_Session_get_admin_subject,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_subject),
     }),
-    be_str_weak(get_admin_subject),
+    be_str_weak(get_fabric),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
+    ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
+      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -2596,64 +1688,6 @@ be_local_closure(Matter_Session_gen_CSR,   /* name */
 
 
 /********************************************************************
-** Solidified function: persist_to_fabric
-********************************************************************/
-be_local_closure(Matter_Session_persist_to_fabric,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(add_session),
-    }),
-    be_str_weak(persist_to_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C040400,  //  0003  CALL	R1	2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    }),
-    be_str_weak(get_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_i2r_privacy
 ********************************************************************/
 be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
@@ -2707,6 +1741,482 @@ be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
 
 
 /********************************************************************
+** Solidified function: counter_rcv_validate
+********************************************************************/
+be_local_closure(Matter_Session_counter_rcv_validate,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K1   */  be_nested_str_weak(validate),
+    /* K2   */  be_nested_str_weak(counter_rcv),
+    /* K3   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(counter_rcv_validate),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x780E0003,  //  0005  JMPF	R3	#000A
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x90020404,  //  0009  SETMBR	R0	K2	R4
+      0x80040600,  //  000A  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_device_id
+********************************************************************/
+be_local_closure(Matter_Session_get_device_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(device_id),
+    }),
+    be_str_weak(get_device_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: counter_snd_next
+********************************************************************/
+be_local_closure(Matter_Session_counter_snd_next,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(next),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(Counter),
+    /* K4   */  be_nested_str_weak(is_greater),
+    /* K5   */  be_nested_str_weak(counter_snd),
+    /* K6   */  be_nested_str_weak(does_persist),
+    /* K7   */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K8   */  be_nested_str_weak(save),
+    }),
+    be_str_weak(counter_snd_next),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x88080503,  //  0004  GETMBR	R2	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100200,  //  0006  MOVE	R4	R1
+      0x88140105,  //  0007  GETMBR	R5	R0	K5
+      0x7C080600,  //  0008  CALL	R2	3
+      0x780A0009,  //  0009  JMPF	R2	#0014
+      0x8C080106,  //  000A  GETMET	R2	R0	K6
+      0x7C080200,  //  000B  CALL	R2	1
+      0x780A0005,  //  000C  JMPF	R2	#0013
+      0x88080107,  //  000D  GETMBR	R2	R0	K7
+      0x00080202,  //  000E  ADD	R2	R1	R2
+      0x90020A02,  //  000F  SETMBR	R0	K5	R2
+      0x8C080108,  //  0010  GETMET	R2	R0	K8
+      0x7C080200,  //  0011  CALL	R2	1
+      0x70020000,  //  0012  JMP		#0014
+      0x90020A01,  //  0013  SETMBR	R0	K5	R1
+      0x80040200,  //  0014  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_CASE
+********************************************************************/
+be_local_closure(Matter_Session_is_CASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(is_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_init,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(_store),
+    /* K2   */  be_nested_str_weak(mode),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(local_session_id),
+    /* K5   */  be_nested_str_weak(initiator_session_id),
+    /* K6   */  be_nested_str_weak(_counter_snd_impl),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Counter),
+    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K10  */  be_nested_str_weak(counter_rcv),
+    /* K11  */  be_nested_str_weak(counter_snd),
+    /* K12  */  be_nested_str_weak(next),
+    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
+    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K16  */  be_nested_str_weak(_breadcrumb),
+    /* K17  */  be_nested_str_weak(_exchange_id),
+    /* K18  */  be_nested_str_weak(random),
+    /* K19  */  be_const_int(2),
+    /* K20  */  be_nested_str_weak(get),
+    /* K21  */  be_nested_str_weak(_fabric),
+    /* K22  */  be_nested_str_weak(create_fabric),
+    /* K23  */  be_nested_str_weak(update),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0x90020503,  //  0002  SETMBR	R0	K2	K3
+      0x90020802,  //  0003  SETMBR	R0	K4	R2
+      0x90020A03,  //  0004  SETMBR	R0	K5	R3
+      0xB81A0E00,  //  0005  GETNGBL	R6	K7
+      0x8C180D08,  //  0006  GETMET	R6	R6	K8
+      0x7C180200,  //  0007  CALL	R6	1
+      0x90020C06,  //  0008  SETMBR	R0	K6	R6
+      0xB81A0E00,  //  0009  GETNGBL	R6	K7
+      0x8C180D08,  //  000A  GETMET	R6	R6	K8
+      0x7C180200,  //  000B  CALL	R6	1
+      0x90021206,  //  000C  SETMBR	R0	K9	R6
+      0x90021503,  //  000D  SETMBR	R0	K10	K3
+      0x88180106,  //  000E  GETMBR	R6	R0	K6
+      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
+      0x7C180200,  //  0010  CALL	R6	1
+      0x881C010D,  //  0011  GETMBR	R7	R0	K13
+      0x00180C07,  //  0012  ADD	R6	R6	R7
+      0x90021606,  //  0013  SETMBR	R0	K11	R6
+      0xB81A0E00,  //  0014  GETNGBL	R6	K7
+      0x8C180D08,  //  0015  GETMET	R6	R6	K8
+      0x7C180200,  //  0016  CALL	R6	1
+      0x90021C06,  //  0017  SETMBR	R0	K14	R6
+      0xB81A0E00,  //  0018  GETNGBL	R6	K7
+      0x8C180D08,  //  0019  GETMET	R6	R6	K8
+      0x7C180200,  //  001A  CALL	R6	1
+      0x90021E06,  //  001B  SETMBR	R0	K15	R6
+      0x90022103,  //  001C  SETMBR	R0	K16	K3
+      0x8C180B12,  //  001D  GETMET	R6	R5	K18
+      0x58200013,  //  001E  LDCONST	R8	K19
+      0x7C180400,  //  001F  CALL	R6	2
+      0x8C180D14,  //  0020  GETMET	R6	R6	K20
+      0x58200003,  //  0021  LDCONST	R8	K3
+      0x58240013,  //  0022  LDCONST	R9	K19
+      0x7C180600,  //  0023  CALL	R6	3
+      0x90022206,  //  0024  SETMBR	R0	K17	R6
+      0x78120001,  //  0025  JMPF	R4	#0028
+      0x5C180800,  //  0026  MOVE	R6	R4
+      0x70020002,  //  0027  JMP		#002B
+      0x88180101,  //  0028  GETMBR	R6	R0	K1
+      0x8C180D16,  //  0029  GETMET	R6	R6	K22
+      0x7C180200,  //  002A  CALL	R6	1
+      0x90022A06,  //  002B  SETMBR	R0	K21	R6
+      0x8C180117,  //  002C  GETMET	R6	R0	K23
+      0x7C180200,  //  002D  CALL	R6	1
+      0x80000000,  //  002E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(Matter_Session_update,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(last_used),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(rtc),
+    /* K3   */  be_nested_str_weak(utc),
+    }),
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040303,  //  0003  GETIDX	R1	R1	K3
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_PASE
+********************************************************************/
+be_local_closure(Matter_Session_is_PASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_PASE),
+    }),
+    be_str_weak(is_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_id
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_id),
+    }),
+    be_str_weak(get_fabric_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca
+********************************************************************/
+be_local_closure(Matter_Session_get_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(get_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: hydrate_post
+********************************************************************/
+be_local_closure(Matter_Session_hydrate_post,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(reset),
+    /* K2   */  be_nested_str_weak(counter_snd),
+    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K4   */  be_nested_str_weak(counter_rcv),
+    /* K5   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(hydrate_post),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040103,  //  0004  GETMBR	R1	R0	K3
+      0x8C040301,  //  0005  GETMET	R1	R1	K1
+      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x7C040400,  //  0007  CALL	R1	2
+      0x88040100,  //  0008  GETMBR	R1	R0	K0
+      0x8C040305,  //  0009  GETMET	R1	R1	K5
+      0x7C040200,  //  000A  CALL	R1	1
+      0x90020401,  //  000B  SETMBR	R0	K2	R1
+      0x88040103,  //  000C  GETMBR	R1	R0	K3
+      0x8C040305,  //  000D  GETMET	R1	R1	K5
+      0x7C040200,  //  000E  CALL	R1	1
+      0x90020801,  //  000F  SETMBR	R0	K4	R1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save
+********************************************************************/
+be_local_closure(Matter_Session_save,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_store),
+    /* K1   */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(save),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca_pub
+********************************************************************/
+be_local_closure(Matter_Session_get_ca_pub,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(get_ca_pub),
+    }),
+    be_str_weak(get_ca_pub),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_mode
 ********************************************************************/
 be_local_closure(Matter_Session_get_mode,   /* name */
@@ -2723,6 +2233,375 @@ be_local_closure(Matter_Session_get_mode,   /* name */
     /* K0   */  be_nested_str_weak(mode),
     }),
     be_str_weak(get_mode),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fabric_completed
+********************************************************************/
+be_local_closure(Matter_Session_fabric_completed,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(set_no_expiration),
+    /* K2   */  be_nested_str_weak(set_persist),
+    /* K3   */  be_nested_str_weak(get_fabric_index),
+    /* K4   */  be_nested_str_weak(set_fabric_index),
+    /* K5   */  be_nested_str_weak(_store),
+    /* K6   */  be_nested_str_weak(next_fabric_idx),
+    /* K7   */  be_nested_str_weak(add_fabric),
+    }),
+    be_str_weak(fabric_completed),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C040302,  //  0004  GETMET	R1	R1	K2
+      0x500C0200,  //  0005  LDBOOL	R3	1	0
+      0x7C040400,  //  0006  CALL	R1	2
+      0x88040100,  //  0007  GETMBR	R1	R0	K0
+      0x8C040303,  //  0008  GETMET	R1	R1	K3
+      0x7C040200,  //  0009  CALL	R1	1
+      0x4C080000,  //  000A  LDNIL	R2
+      0x1C040202,  //  000B  EQ	R1	R1	R2
+      0x78060005,  //  000C  JMPF	R1	#0013
+      0x88040100,  //  000D  GETMBR	R1	R0	K0
+      0x8C040304,  //  000E  GETMET	R1	R1	K4
+      0x880C0105,  //  000F  GETMBR	R3	R0	K5
+      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x7C0C0200,  //  0011  CALL	R3	1
+      0x7C040400,  //  0012  CALL	R1	2
+      0x88040105,  //  0013  GETMBR	R1	R0	K5
+      0x8C040307,  //  0014  GETMET	R1	R1	K7
+      0x880C0100,  //  0015  GETMBR	R3	R0	K0
+      0x7C040400,  //  0016  CALL	R1	2
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_r2i
+********************************************************************/
+be_local_closure(Matter_Session_get_r2i,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(r2ikey),
+    }),
+    be_str_weak(get_r2i),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: close
+********************************************************************/
+be_local_closure(Matter_Session_close,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_nested_str_weak(local_session_id),
+    /* K1   */  be_nested_str_weak(__future_local_session_id),
+    /* K2   */  be_nested_str_weak(initiator_session_id),
+    /* K3   */  be_nested_str_weak(__future_initiator_session_id),
+    /* K4   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K5   */  be_nested_str_weak(reset),
+    /* K6   */  be_nested_str_weak(_counter_snd_impl),
+    /* K7   */  be_nested_str_weak(counter_rcv),
+    /* K8   */  be_const_int(0),
+    /* K9   */  be_nested_str_weak(counter_snd),
+    /* K10  */  be_nested_str_weak(next),
+    /* K11  */  be_nested_str_weak(i2rkey),
+    /* K12  */  be_nested_str_weak(_i2r_privacy),
+    /* K13  */  be_nested_str_weak(r2ikey),
+    /* K14  */  be_nested_str_weak(attestation_challenge),
+    /* K15  */  be_nested_str_weak(introspect),
+    /* K16  */  be_nested_str_weak(members),
+    /* K17  */  be_nested_str_weak(get),
+    /* K18  */  be_nested_str_weak(function),
+    /* K19  */  be_nested_str_weak(instance),
+    /* K20  */  be_nested_str_weak(_),
+    /* K21  */  be_const_int(1),
+    /* K22  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(close),
+    &be_const_str_solidified,
+    ( &(const binstruction[59]) {  /* code */
+      0x88040101,  //  0000  GETMBR	R1	R0	K1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x88040103,  //  0002  GETMBR	R1	R0	K3
+      0x90020401,  //  0003  SETMBR	R0	K2	R1
+      0x88040104,  //  0004  GETMBR	R1	R0	K4
+      0x8C040305,  //  0005  GETMET	R1	R1	K5
+      0x7C040200,  //  0006  CALL	R1	1
+      0x88040106,  //  0007  GETMBR	R1	R0	K6
+      0x8C040305,  //  0008  GETMET	R1	R1	K5
+      0x7C040200,  //  0009  CALL	R1	1
+      0x90020F08,  //  000A  SETMBR	R0	K7	K8
+      0x88040106,  //  000B  GETMBR	R1	R0	K6
+      0x8C04030A,  //  000C  GETMET	R1	R1	K10
+      0x7C040200,  //  000D  CALL	R1	1
+      0x90021201,  //  000E  SETMBR	R0	K9	R1
+      0x4C040000,  //  000F  LDNIL	R1
+      0x90021601,  //  0010  SETMBR	R0	K11	R1
+      0x4C040000,  //  0011  LDNIL	R1
+      0x90021801,  //  0012  SETMBR	R0	K12	R1
+      0x4C040000,  //  0013  LDNIL	R1
+      0x90021A01,  //  0014  SETMBR	R0	K13	R1
+      0x4C040000,  //  0015  LDNIL	R1
+      0x90021C01,  //  0016  SETMBR	R0	K14	R1
+      0xA4061E00,  //  0017  IMPORT	R1	K15
+      0x60080010,  //  0018  GETGBL	R2	G16
+      0x8C0C0310,  //  0019  GETMET	R3	R1	K16
+      0x5C140000,  //  001A  MOVE	R5	R0
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0x7C080200,  //  001C  CALL	R2	1
+      0xA8020018,  //  001D  EXBLK	0	#0037
+      0x5C0C0400,  //  001E  MOVE	R3	R2
+      0x7C0C0000,  //  001F  CALL	R3	0
+      0x8C100311,  //  0020  GETMET	R4	R1	K17
+      0x5C180000,  //  0021  MOVE	R6	R0
+      0x5C1C0600,  //  0022  MOVE	R7	R3
+      0x7C100600,  //  0023  CALL	R4	3
+      0x60140004,  //  0024  GETGBL	R5	G4
+      0x5C180800,  //  0025  MOVE	R6	R4
+      0x7C140200,  //  0026  CALL	R5	1
+      0x20140B12,  //  0027  NE	R5	R5	K18
+      0x7816000C,  //  0028  JMPF	R5	#0036
+      0x60140004,  //  0029  GETGBL	R5	G4
+      0x5C180800,  //  002A  MOVE	R6	R4
+      0x7C140200,  //  002B  CALL	R5	1
+      0x20140B13,  //  002C  NE	R5	R5	K19
+      0x78160007,  //  002D  JMPF	R5	#0036
+      0x94140708,  //  002E  GETIDX	R5	R3	K8
+      0x1C140B14,  //  002F  EQ	R5	R5	K20
+      0x78160004,  //  0030  JMPF	R5	#0036
+      0x94140715,  //  0031  GETIDX	R5	R3	K21
+      0x1C140B14,  //  0032  EQ	R5	R5	K20
+      0x78160001,  //  0033  JMPF	R5	#0036
+      0x4C140000,  //  0034  LDNIL	R5
+      0x90000605,  //  0035  SETMBR	R0	R3	R5
+      0x7001FFE6,  //  0036  JMP		#001E
+      0x58080016,  //  0037  LDCONST	R2	K22
+      0xAC080200,  //  0038  CATCH	R2	1	0
+      0xB0080000,  //  0039  RAISE	2	R0	R0
+      0x80000000,  //  003A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(get_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_keys
+********************************************************************/
+be_local_closure(Matter_Session_set_keys,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    /* K1   */  be_nested_str_weak(_i2r_privacy),
+    /* K2   */  be_nested_str_weak(r2ikey),
+    /* K3   */  be_nested_str_weak(attestation_challenge),
+    /* K4   */  be_nested_str_weak(created),
+    }),
+    be_str_weak(set_keys),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x4C140000,  //  0001  LDNIL	R5
+      0x90020205,  //  0002  SETMBR	R0	K1	R5
+      0x90020402,  //  0003  SETMBR	R0	K2	R2
+      0x90020603,  //  0004  SETMBR	R0	K3	R3
+      0x90020804,  //  0005  SETMBR	R0	K4	R4
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ca
+********************************************************************/
+be_local_closure(Matter_Session_set_ca,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(set_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x900A0201,  //  0001  SETMBR	R2	K1	R1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_PASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_PASE,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_PASE),
+    }),
+    be_str_weak(set_mode_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(get_fabric_compressed),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ac
+********************************************************************/
+be_local_closure(Matter_Session_get_ac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attestation_challenge),
+    }),
+    be_str_weak(get_ac),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -2761,87 +2640,334 @@ be_local_closure(Matter_Session_set_mode,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_admin_subject
+********************************************************************/
+be_local_closure(Matter_Session_get_admin_subject,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(admin_subject),
+    }),
+    be_str_weak(get_admin_subject),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_noc
+********************************************************************/
+be_local_closure(Matter_Session_get_noc,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(noc),
+    }),
+    be_str_weak(get_noc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fabric_candidate
+********************************************************************/
+be_local_closure(Matter_Session_fabric_candidate,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K2   */  be_nested_str_weak(_store),
+    /* K3   */  be_nested_str_weak(add_fabric),
+    }),
+    be_str_weak(fabric_candidate),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x540E0077,  //  0002  LDINT	R3	120
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x8C040303,  //  0005  GETMET	R1	R1	K3
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_CASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_CASE,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(set_mode_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_group_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(get_fabric_compressed),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(HKDF_SHA256),
+    /* K4   */  be_nested_str_weak(fromstring),
+    /* K5   */  be_nested_str_weak(_GROUP_KEY),
+    /* K6   */  be_nested_str_weak(derive),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[29]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x4C080000,  //  0002  LDNIL	R2
+      0x1C040202,  //  0003  EQ	R1	R1	R2
+      0x74060004,  //  0004  JMPT	R1	#000A
+      0x8C040101,  //  0005  GETMET	R1	R0	K1
+      0x7C040200,  //  0006  CALL	R1	1
+      0x4C080000,  //  0007  LDNIL	R2
+      0x1C040202,  //  0008  EQ	R1	R1	R2
+      0x78060001,  //  0009  JMPF	R1	#000C
+      0x4C040000,  //  000A  LDNIL	R1
+      0x80040200,  //  000B  RET	1	R1
+      0xA4060400,  //  000C  IMPORT	R1	K2
+      0x8C080303,  //  000D  GETMET	R2	R1	K3
+      0x7C080200,  //  000E  CALL	R2	1
+      0x600C0015,  //  000F  GETGBL	R3	G21
+      0x7C0C0000,  //  0010  CALL	R3	0
+      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
+      0x88140105,  //  0012  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x8C100506,  //  0014  GETMET	R4	R2	K6
+      0x8C180100,  //  0015  GETMET	R6	R0	K0
+      0x7C180200,  //  0016  CALL	R6	1
+      0x8C1C0101,  //  0017  GETMET	R7	R0	K1
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x5C200600,  //  0019  MOVE	R8	R3
+      0x5426000F,  //  001A  LDINT	R9	16
+      0x7C100A00,  //  001B  CALL	R4	5
+      0x80040800,  //  001C  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_i2r
+********************************************************************/
+be_local_closure(Matter_Session_get_i2r,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    }),
+    be_str_weak(get_i2r),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_vendor
+********************************************************************/
+be_local_closure(Matter_Session_get_admin_vendor,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(admin_vendor),
+    }),
+    be_str_weak(get_admin_vendor),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Session
 ********************************************************************/
 extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Session,
-    29,
+    31,
     &be_class_Matter_Expirable,
-    be_nested_map(73,
+    be_nested_map(79,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(set_mode, 61), be_const_closure(Matter_Session_set_mode_closure) },
-        { be_const_key_weak(get_ipk_epoch_key, 72), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(last_used, -1), be_const_var(6) },
-        { be_const_key_weak(attestation_challenge, 26), be_const_var(21) },
-        { be_const_key_weak(resumption_id, -1), be_const_var(24) },
-        { be_const_key_weak(set_mode_CASE, 50), be_const_closure(Matter_Session_set_mode_CASE_closure) },
-        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(set_admin_subject_vendor, 6), be_const_closure(Matter_Session_set_admin_subject_vendor_closure) },
-        { be_const_key_weak(_ip, -1), be_const_var(13) },
-        { be_const_key_weak(shared_secret, -1), be_const_var(25) },
-        { be_const_key_weak(get_mode, 43), be_const_closure(Matter_Session_get_mode_closure) },
-        { be_const_key_weak(_port, 33), be_const_var(14) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_init_closure) },
-        { be_const_key_weak(get_i2r_privacy, -1), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
-        { be_const_key_weak(set_mode_PASE, -1), be_const_closure(Matter_Session_set_mode_PASE_closure) },
-        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
-        { be_const_key_weak(_breadcrumb, -1), be_const_var(23) },
-        { be_const_key_weak(is_PASE, -1), be_const_closure(Matter_Session_is_PASE_closure) },
-        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
-        { be_const_key_weak(r2ikey, -1), be_const_var(19) },
-        { be_const_key_weak(_PASE, -1), be_const_int(1) },
-        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
-        { be_const_key_weak(_CASE, 13), be_const_int(2) },
-        { be_const_key_weak(get_r2i, 68), be_const_closure(Matter_Session_get_r2i_closure) },
-        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
-        { be_const_key_weak(peer_node_id, -1), be_const_var(22) },
-        { be_const_key_weak(__future_local_session_id, -1), be_const_var(9) },
-        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
-        { be_const_key_weak(tojson, 66), be_const_closure(Matter_Session_tojson_closure) },
-        { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
         { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Session_get_fabric_label_closure) },
-        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Session_get_noc_closure) },
-        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
-        { be_const_key_weak(get_admin_subject, 36), be_const_closure(Matter_Session_get_admin_subject_closure) },
-        { be_const_key_weak(counter_snd, 28), be_const_var(11) },
-        { be_const_key_weak(_store, -1), be_const_var(0) },
+        { be_const_key_weak(_counter_insecure_rcv, -1), be_const_var(18) },
+        { be_const_key_weak(set_noc, 1), be_const_closure(Matter_Session_set_noc_closure) },
+        { be_const_key_weak(_exchange_id, -1), be_const_var(14) },
         { be_const_key_weak(set_fabric_label, -1), be_const_closure(Matter_Session_set_fabric_label_closure) },
-        { be_const_key_weak(local_session_id, 34), be_const_var(3) },
-        { be_const_key_weak(i2rkey, 0), be_const_var(18) },
-        { be_const_key_weak(_fabric, 55), be_const_var(2) },
-        { be_const_key_weak(_message_handler, -1), be_const_var(15) },
+        { be_const_key_weak(_i2r_privacy, -1), be_const_var(22) },
+        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
         { be_const_key_weak(mode, -1), be_const_var(1) },
-        { be_const_key_weak(set_ipk_epoch_key, 59), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
-        { be_const_key_weak(set_noc, -1), be_const_closure(Matter_Session_set_noc_closure) },
-        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(28) },
-        { be_const_key_weak(counter_rcv, 57), be_const_var(10) },
-        { be_const_key_weak(fabric_candidate, -1), be_const_closure(Matter_Session_fabric_candidate_closure) },
-        { be_const_key_weak(set_keys, -1), be_const_closure(Matter_Session_set_keys_closure) },
-        { be_const_key_weak(set_fabric_device, 39), be_const_closure(Matter_Session_set_fabric_device_closure) },
+        { be_const_key_weak(counter_rcv, 3), be_const_var(10) },
+        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Session_get_device_id_closure) },
+        { be_const_key_weak(get_icac, 35), be_const_closure(Matter_Session_get_icac_closure) },
         { be_const_key_weak(is_CASE, -1), be_const_closure(Matter_Session_is_CASE_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_init_closure) },
+        { be_const_key_weak(_store, -1), be_const_var(0) },
+        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Session_get_admin_subject_closure) },
+        { be_const_key_weak(set_admin_subject_vendor, -1), be_const_closure(Matter_Session_set_admin_subject_vendor_closure) },
+        { be_const_key_weak(tojson, 8), be_const_closure(Matter_Session_tojson_closure) },
+        { be_const_key_weak(set_mode, 37), be_const_closure(Matter_Session_set_mode_closure) },
+        { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
+        { be_const_key_weak(_breadcrumb, 23), be_const_var(25) },
+        { be_const_key_weak(get_pk, 6), be_const_closure(Matter_Session_get_pk_closure) },
+        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
+        { be_const_key_weak(__Msg2, -1), be_const_var(29) },
+        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(get_i2r_privacy, 62), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
+        { be_const_key_weak(counter_rcv_validate, 34), be_const_closure(Matter_Session_counter_rcv_validate_closure) },
+        { be_const_key_weak(last_used, -1), be_const_var(6) },
+        { be_const_key_weak(_source_node_id, 45), be_const_var(7) },
+        { be_const_key_weak(set_ipk_epoch_key, 9), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
+        { be_const_key_weak(counter_snd_next, -1), be_const_closure(Matter_Session_counter_snd_next_closure) },
+        { be_const_key_weak(set_mode_PASE, -1), be_const_closure(Matter_Session_set_mode_PASE_closure) },
+        { be_const_key_weak(_counter_snd_impl, 11), be_const_var(13) },
+        { be_const_key_weak(__future_initiator_session_id, 24), be_const_var(8) },
+        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
+        { be_const_key_weak(_fabric, 12), be_const_var(2) },
+        { be_const_key_weak(_port, 54), be_const_var(16) },
+        { be_const_key_weak(set_keys, -1), be_const_closure(Matter_Session_set_keys_closure) },
         { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Session_get_fabric_id_closure) },
-        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
-        { be_const_key_weak(__future_initiator_session_id, 40), be_const_var(8) },
-        { be_const_key_weak(_counter_insecure_rcv, 46), be_const_var(16) },
-        { be_const_key_weak(_counter_insecure_snd, 10), be_const_var(17) },
-        { be_const_key_weak(_exchange_id, 56), be_const_var(12) },
-        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Session_get_icac_closure) },
-        { be_const_key_weak(__Msg1, -1), be_const_var(26) },
-        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Session_get_ca_closure) },
-        { be_const_key_weak(fabric_completed, 17), be_const_closure(Matter_Session_fabric_completed_closure) },
-        { be_const_key_weak(save, 32), be_const_closure(Matter_Session_save_closure) },
-        { be_const_key_weak(close, 62), be_const_closure(Matter_Session_close_closure) },
-        { be_const_key_weak(get_admin_vendor, 67), be_const_closure(Matter_Session_get_admin_vendor_closure) },
-        { be_const_key_weak(get_ca_pub, 18), be_const_closure(Matter_Session_get_ca_pub_closure) },
+        { be_const_key_weak(_counter_insecure_snd, 68), be_const_var(19) },
+        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(30) },
+        { be_const_key_weak(counter_snd, 63), be_const_var(11) },
+        { be_const_key_weak(is_PASE, 33), be_const_closure(Matter_Session_is_PASE_closure) },
+        { be_const_key_weak(attestation_challenge, -1), be_const_var(23) },
+        { be_const_key_weak(get_ipk_epoch_key, 4), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(close, 53), be_const_closure(Matter_Session_close_closure) },
         { be_const_key_weak(created, -1), be_const_var(5) },
-        { be_const_key_weak(initiator_session_id, 16), be_const_var(4) },
-        { be_const_key_weak(_source_node_id, -1), be_const_var(7) },
-        { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Session_fromjson_closure) },
-        { be_const_key_weak(_i2r_privacy, -1), be_const_var(20) },
-        { be_const_key_weak(get_device_id, 4), be_const_closure(Matter_Session_get_device_id_closure) },
-        { be_const_key_weak(persist_to_fabric, 3), be_const_closure(Matter_Session_persist_to_fabric_closure) },
-        { be_const_key_weak(update, 2), be_const_closure(Matter_Session_update_closure) },
-        { be_const_key_weak(__Msg2, -1), be_const_var(27) },
+        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Session_get_ca_pub_closure) },
+        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
+        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
+        { be_const_key_weak(resumption_id, -1), be_const_var(26) },
+        { be_const_key_weak(fromjson, 55), be_const_static_closure(Matter_Session_fromjson_closure) },
+        { be_const_key_weak(_CASE, 57), be_const_int(2) },
+        { be_const_key_weak(__Msg1, -1), be_const_var(28) },
+        { be_const_key_weak(i2rkey, -1), be_const_var(20) },
+        { be_const_key_weak(_COUNTER_SND_INCR, -1), be_const_int(1024) },
+        { be_const_key_weak(persist_to_fabric, 48), be_const_closure(Matter_Session_persist_to_fabric_closure) },
+        { be_const_key_weak(fabric_completed, -1), be_const_closure(Matter_Session_fabric_completed_closure) },
+        { be_const_key_weak(set_fabric_device, 44), be_const_closure(Matter_Session_set_fabric_device_closure) },
+        { be_const_key_weak(_PASE, 43), be_const_int(1) },
+        { be_const_key_weak(local_session_id, 17), be_const_var(3) },
+        { be_const_key_weak(r2ikey, 14), be_const_var(21) },
+        { be_const_key_weak(save, -1), be_const_closure(Matter_Session_save_closure) },
+        { be_const_key_weak(shared_secret, 66), be_const_var(27) },
+        { be_const_key_weak(peer_node_id, 31), be_const_var(24) },
+        { be_const_key_weak(initiator_session_id, -1), be_const_var(4) },
+        { be_const_key_weak(hydrate_post, 69), be_const_closure(Matter_Session_hydrate_post_closure) },
+        { be_const_key_weak(_message_handler, 18), be_const_var(17) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Session_get_ca_closure) },
+        { be_const_key_weak(update, -1), be_const_closure(Matter_Session_update_closure) },
+        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Session_get_noc_closure) },
+        { be_const_key_weak(_ip, -1), be_const_var(15) },
+        { be_const_key_weak(fabric_candidate, -1), be_const_closure(Matter_Session_fabric_candidate_closure) },
+        { be_const_key_weak(__future_local_session_id, -1), be_const_var(9) },
+        { be_const_key_weak(_counter_rcv_impl, 7), be_const_var(12) },
+        { be_const_key_weak(set_mode_CASE, -1), be_const_closure(Matter_Session_set_mode_CASE_closure) },
+        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
+        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
+        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Session_get_admin_vendor_closure) },
     })),
     be_str_weak(Matter_Session)
 );


### PR DESCRIPTION
## Description:

Matter, ensure that counter_send is persisted with a high enough value, and update if needed. Each time a session is restored from flash and used, we increase the persisted value by 1024. This means that we can send up to 1024 messages before requiring to write to flash again.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
