### PR TITLE
Update xnrg_01_hlw8012.ino

### DIFF
--- a/tasmota/tasmota_xnrg_energy/xnrg_01_hlw8012.ino
+++ b/tasmota/tasmota_xnrg_energy/xnrg_01_hlw8012.ino
@@ -153,7 +153,7 @@ void HlwEvery200ms(void) {
       DigitalWrite(GPIO_NRG_SEL, 0, Hlw.select_ui_flag);
 
       if (Hlw.cf1_pulse_counter) {
-        cf1_pulse_length = Hlw.cf1_summed_pulse_length / Hlw.cf1_pulse_counter;
+        cf1_pulse_length = Hlw.cf1_summed_pulse_length / Hlw.cf1_pulse_counter; //this creates a Voltage step precision of 0.3V at around 230V
       }
 
 #ifdef HLW_DEBUG
@@ -179,7 +179,7 @@ void HlwEvery200ms(void) {
         Hlw.cf1_voltage_pulse_length  = cf1_pulse_length;
 
         if (Hlw.cf1_voltage_pulse_length  && Energy->power_on) {     // If powered on always provide voltage
-          hlw_u = (Hlw.voltage_ratio * EnergyGetCalibration(ENERGY_VOLTAGE_CALIBRATION)) / Hlw.cf1_voltage_pulse_length ;  // V *10
+          hlw_u = (Hlw.voltage_ratio * EnergyGetCalibration(ENERGY_VOLTAGE_CALIBRATION)) * Hlw.cf1_pulse_counter / Hlw.cf1_summed_pulse_length ;  // V *10 // including line 156 into this formula makes measurements with 0.1V step rather than 0.3V steps
           Energy->voltage[0] = (float)hlw_u / 10;
         } else {
           Energy->voltage[0] = 0;


### PR DESCRIPTION
I am not shure if more changes are needed like changing the datatype to float? but i realised while researching the measurement capabilitys of smartplugs that there is some information loss through first averaging and then dividing. I got it running in my version with 0.1V steps, but there are a lot for the normal user unpleasant changes which would clutter this change proposal.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
