### PR TITLE
Fix webpage, when ESP32 driver used

### DIFF
--- a/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_01_9_webserver.ino
@@ -1232,7 +1232,7 @@ void HandleRoot(void)
 #ifdef USE_SHUTTER
     if (Settings->flag3.shutter_mode) {  // SetOption80 - Enable shutter support
       for (uint32_t i = 0; i < TasmotaGlobal.shutters_present; i++) {
-        WSContentSend_P(HTTP_MSG_SLIDER_SHUTTER, Settings->shutter_position[i], i+1);
+        WSContentSend_P(HTTP_MSG_SLIDER_SHUTTER,  ShutterRealToPercentPosition(-9999, i), i+1);
       }
     }
 #endif  // USE_SHUTTER
@@ -1482,9 +1482,9 @@ int32_t IsShutterWebButton(uint32_t idx) {
   /* 0: Not a shutter, 1..4: shutter up idx, -1..-4: shutter down idx */
   int32_t ShutterWebButton = 0;
   if (Settings->flag3.shutter_mode) {  // SetOption80 - Enable shutter support
-    for (uint32_t i = 0; i < MAX_SHUTTERS; i++) {
-      if (Settings->shutter_startrelay[i] && ((Settings->shutter_startrelay[i] == idx) || (Settings->shutter_startrelay[i] == (idx-1)))) {
-        ShutterWebButton = (Settings->shutter_startrelay[i] == idx) ? (i+1): (-1-i);
+    for (uint32_t i = 0; i < TasmotaGlobal.shutters_present ; i++) {
+      if (ShutterGetStartRelay(i) && ((ShutterGetStartRelay(i) == idx) || (ShutterGetStartRelay(i) == (idx-1)))) {
+        ShutterWebButton = (ShutterGetStartRelay(i) == idx) ? (i+1): (-1-i);
         break;
       }
     }

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_esp32_shutter.ino
@@ -336,6 +336,10 @@ void ShutterLogPos(uint32_t i)
     Shutter[i].pwm_velocity, Shutter[i].pwm_value,Shutter[i].tilt_real_pos);
 }
 
+uint8_t ShutterGetStartRelay(uint8_t index) {
+  return ShutterSettings.shutter_startrelay[index];
+}
+
 void ExecuteCommandPowerShutter(uint32_t device, uint32_t state, uint32_t source)
 {
   // first implementation for virtual relays. Avoid switching relay numbers that do not exist.
@@ -438,6 +442,9 @@ int32_t ShutterPercentToRealPosition(int16_t percent, uint32_t index)
 
 uint8_t ShutterRealToPercentPosition(int32_t realpos, uint32_t index)
 {
+  if (realpos == -9999) {
+    realpos = Shutter[index].real_position;
+  }
 	if (ShutterSettings.shutter_set50percent[index] != 50) {
 		return (ShutterSettings.shuttercoeff[2][index] * 5 > realpos/10) ? SHT_DIV_ROUND(realpos/10, ShutterSettings.shuttercoeff[2][index]) : SHT_DIV_ROUND(realpos/10-ShutterSettings.shuttercoeff[0][index]*10, ShutterSettings.shuttercoeff[1][index]);
 	} else {
@@ -1120,6 +1127,7 @@ bool ShutterButtonHandlerMulti(void)
       
     CmndShutterPosition();
   }
+
   if (ShutterSettings.shutter_button[button_index].position[pos_press_index].mqtt_broadcast) {
     // MQTT broadcast to grouptopic
     char scommand[CMDSZ];

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -280,6 +280,9 @@ int32_t ShutterPercentToRealPosition(int16_t percent, uint32_t index)
 
 uint8_t ShutterRealToPercentPosition(int32_t realpos, uint32_t index)
 {
+  if (realpos == -9999) {
+    realpos = Shutter[index].real_position;
+  }
 	if (Settings->shutter_set50percent[index] != 50) {
 		return (Settings->shuttercoeff[2][index] * 5 > realpos/10) ? SHT_DIV_ROUND(realpos/10, Settings->shuttercoeff[2][index]) : SHT_DIV_ROUND(realpos/10-Settings->shuttercoeff[0][index]*10, Settings->shuttercoeff[1][index]);
 	} else {

--- a/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
+++ b/tasmota/tasmota_xdrv_driver/xdrv_27_shutter.ino
@@ -174,6 +174,10 @@ void ShutterLogPos(uint32_t i)
     Shutter[i].pwm_velocity, Shutter[i].pwm_value,Shutter[i].tilt_real_pos);
 }
 
+uint8_t ShutterGetStartRelay(uint8_t index) {
+  return Settings->shutter_startrelay[index];
+}
+
 void ExecuteCommandPowerShutter(uint32_t device, uint32_t state, uint32_t source)
 {
   // first implementation for virtual relays. Avoid switching relay numbers that do not exist.


### PR DESCRIPTION
## Description:
webserver pages still referenced old settings. changed into general approach. Both do work in parallel.

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>
#17380 

## Checklist:
  - [ ] The pull request is done against the latest development branch
  - [ ] Only relevant files were touched
  - [ ] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [ ] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
