### PR TITLE
Platformio `lib_archive = no`

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,7 @@ monitor_speed               = 115200
 ; *** Upload Serial reset method for Wemos and NodeMCU
 upload_resetmethod          = nodemcu
 extra_scripts               = ${esp_defaults.extra_scripts}
+lib_archive                 = no
 lib_ldf_mode                = chain
 lib_compat_mode             = strict
 shared_libdeps_dir          = lib


### PR DESCRIPTION
## Description:

change behaviour for making `weak` symbols usage (either in the framework or libraries) possible.

By default, PlatformIO instructs the linker to link libraries as static archives, so the first encountered symbol is used even when it has the weak annotation (that's why the order of libraries is important). The `lib_archive = no` option instructs PlatformIO build system to link extra libraries as object files instead of static archives (similarly to the Arduino IDE) so that the linker will scan through all symbols and will use the proper strong symbol.

Description [lib_archive](https://docs.platformio.org/en/latest/projectconf/sections/env/options/library/lib_archive.html)

[Details of an issue](https://github.com/espressif/arduino-esp32/issues/8001)

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
