### PR TITLE
make IRHVAC send incremental changes.

### DIFF
--- a/tasmota/include/i18n.h
+++ b/tasmota/include/i18n.h
@@ -561,6 +561,7 @@
     #define D_JSON_IRHVAC_STATE_MODE_SEND_ONLY "SendOnly"
     #define D_JSON_IRHVAC_STATE_MODE_STORE_ONLY "StoreOnly"
     #define D_JSON_IRHVAC_STATE_MODE_SEND_STORE "SendStore"
+  #define D_JSON_IRHVAC_INCREMENTAL "Incremental"
 #define D_JSON_IRRECEIVED "IrReceived"
 
 // Commands xdrv_06_snfbridge.ino


### PR DESCRIPTION
## Description:

This change will allow mqtt messages simpler by allowing something like `publish cmnd/ir-bridge/IRHVAC {"Power": "On", "Incremental": true}`.
The simpler format is required for working with mqtt clients like iotMQTTPanel or similar on android.

Limitations:
- Requires full message be sent at-least once. I work around this with a `system#boot` rule
- Gets messy with multiple devices. I have only one AC per room, and this doesn't doesn't interfere with other IR devices.

TODO:
- [ ] Persist `irac_prev_state` across reboots.
- [ ] Support multiple devices.

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
