### PR TITLE
Matter partial fix for Apple Homekit

### DIFF
--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning.be
@@ -1,5 +1,5 @@
 #
-# Matter_Commissioning.be - suppport for Matter Commissioning process
+# Matter_Commissioning.be - suppport for Matter Commissioning process PASE and CASE
 #
 # Copyright (C) 2023  Stephan Hadinger & Theo Arends
 #
@@ -109,6 +109,7 @@ class Matter_Commisioning_Context
 
   def parse_PBKDFParamRequest(msg)
     import crypto
+    import string
     # sanity checks
     if msg.opcode != 0x20 || msg.local_session_id != 0 || msg.protocol_id != 0
       tasmota.log("MTR: invalid PBKDFParamRequest message", 2)
@@ -132,7 +133,7 @@ class Matter_Commisioning_Context
     # record the initiator_session_id
     self.future_initiator_session_id = pbkdfparamreq.initiator_session_id
     self.future_local_session_id = self.device.sessions.gen_local_session_id()
-    tasmota.log("MTR: Loc_session=" + str(self.future_local_session_id))
+    tasmota.log(string.format("MTR: +Session   (%6i) from '[%s]:%i'", self.future_local_session_id, msg.remote_ip, msg.remote_port), 2)
 
     # prepare response
     var pbkdfparamresp = matter.PBKDFParamResponse()
@@ -144,7 +145,7 @@ class Matter_Commisioning_Context
     pbkdfparamresp.pbkdf_parameters_salt = self.device.commissioning_salt
     pbkdfparamresp.pbkdf_parameters_iterations = self.device.commissioning_iterations
     tasmota.log("MTR: pbkdfparamresp: " + str(matter.inspect(pbkdfparamresp)), 4)
-    var pbkdfparamresp_raw = pbkdfparamresp.encode()
+    var pbkdfparamresp_raw = pbkdfparamresp.tlv2raw()
     tasmota.log("MTR: pbkdfparamresp_raw: " + pbkdfparamresp_raw.tohex(), 4)
 
     self.PBKDFParamResponse = pbkdfparamresp_raw
@@ -167,23 +168,23 @@ class Matter_Commisioning_Context
     var pake1 = matter.Pake1().parse(msg.raw, msg.app_payload_idx)
 
     self.pA = pake1.pA
-    tasmota.log("MTR: received pA=" + self.pA.tohex(), 4)
+    # tasmota.log("MTR: received pA=" + self.pA.tohex(), 4)
 
     
-    tasmota.log("MTR: spake: " + matter.inspect(self.spake), 4)
+    # tasmota.log("MTR: spake: " + matter.inspect(self.spake), 4)
     # instanciate SPAKE
     # for testing purpose, we don't send `w1` to make sure
     self.spake = crypto.SPAKE2P_Matter(self.device.commissioning_w0, nil, self.device.commissioning_L)
     # compute pB
     self.spake.compute_pB(self.y)
     self.pB = self.spake.pB
-    tasmota.log("MTR: y=" + self.y.tohex(), 4)
-    tasmota.log("MTR: pb=" + self.pB.tohex(), 4)
+    # tasmota.log("MTR: y=" + self.y.tohex(), 4)
+    # tasmota.log("MTR: pb=" + self.pB.tohex(), 4)
 
     # compute ZV
     self.spake.compute_ZV_verifier(self.pA)
-    tasmota.log("MTR: Z=" + self.spake.Z.tohex(), 4)
-    tasmota.log("MTR: V=" + self.spake.V.tohex(), 4)
+    # tasmota.log("MTR: Z=" + self.spake.Z.tohex(), 4)
+    # tasmota.log("MTR: V=" + self.spake.V.tohex(), 4)
 
     var context = crypto.SHA256()
     context.update(bytes().fromstring(self.Matter_Context_Prefix))
@@ -191,7 +192,7 @@ class Matter_Commisioning_Context
     context.update(self.PBKDFParamResponse)
     var context_hash = context.out()
 
-    tasmota.log("MTR: Context=" + context_hash.tohex(), 4)
+    # tasmota.log("MTR: Context=" + context_hash.tohex(), 4)
 
     # add pA
     self.spake.pA = self.pA
@@ -199,33 +200,33 @@ class Matter_Commisioning_Context
     self.spake.set_context(context_hash)
     self.spake.compute_TT_hash(true)      # `true` to indicate it's Matter variant to SPAKE2+
 
-    tasmota.log("MTR: ------------------------------", 4)
-    tasmota.log("MTR: Context = " + self.spake.Context.tohex(), 4)
-    tasmota.log("MTR: M       = " + self.spake.M.tohex(), 4)
-    tasmota.log("MTR: N       = " + self.spake.N.tohex(), 4)
-    tasmota.log("MTR: pA      = " + self.spake.pA.tohex(), 4)
-    tasmota.log("MTR: pB      = " + self.spake.pB.tohex(), 4)
-    tasmota.log("MTR: Z       = " + self.spake.Z.tohex(), 4)
-    tasmota.log("MTR: V       = " + self.spake.V.tohex(), 4)
-    tasmota.log("MTR: w0      = " + self.spake.w0.tohex(), 4)
-    tasmota.log("MTR: ------------------------------", 4)
+    # tasmota.log("MTR: ------------------------------", 4)
+    # tasmota.log("MTR: Context = " + self.spake.Context.tohex(), 4)
+    # tasmota.log("MTR: M       = " + self.spake.M.tohex(), 4)
+    # tasmota.log("MTR: N       = " + self.spake.N.tohex(), 4)
+    # tasmota.log("MTR: pA      = " + self.spake.pA.tohex(), 4)
+    # tasmota.log("MTR: pB      = " + self.spake.pB.tohex(), 4)
+    # tasmota.log("MTR: Z       = " + self.spake.Z.tohex(), 4)
+    # tasmota.log("MTR: V       = " + self.spake.V.tohex(), 4)
+    # tasmota.log("MTR: w0      = " + self.spake.w0.tohex(), 4)
+    # tasmota.log("MTR: ------------------------------", 4)
 
-    tasmota.log("MTR: Kmain   =" + self.spake.Kmain.tohex(), 4)
+    # tasmota.log("MTR: Kmain   =" + self.spake.Kmain.tohex(), 4)
 
-    tasmota.log("MTR: KcA     =" + self.spake.KcA.tohex(), 4)
-    tasmota.log("MTR: KcB     =" + self.spake.KcB.tohex(), 4)
-    tasmota.log("MTR: K_shared=" + self.spake.K_shared.tohex(), 4)
-    tasmota.log("MTR: Ke      =" + self.spake.Ke.tohex(), 4)
+    # tasmota.log("MTR: KcA     =" + self.spake.KcA.tohex(), 4)
+    # tasmota.log("MTR: KcB     =" + self.spake.KcB.tohex(), 4)
+    # tasmota.log("MTR: K_shared=" + self.spake.K_shared.tohex(), 4)
+    # tasmota.log("MTR: Ke      =" + self.spake.Ke.tohex(), 4)
     self.cB = self.spake.cB
     self.Ke = self.spake.Ke
-    tasmota.log("MTR: cB=" + self.cB.tohex(), 4)
+    # tasmota.log("MTR: cB=" + self.cB.tohex(), 4)
 
     var pake2 = matter.Pake2()
     pake2.pB = self.pB
     pake2.cB = self.cB
-    tasmota.log("MTR: pake2: " + matter.inspect(pake2), 4)
-    var pake2_raw = pake2.encode()
-    tasmota.log("MTR: pake2_raw: " + pake2_raw.tohex(), 4)
+    # tasmota.log("MTR: pake2: " + matter.inspect(pake2), 4)
+    var pake2_raw = pake2.tlv2raw()
+    # tasmota.log("MTR: pake2_raw: " + pake2_raw.tohex(), 4)
 
 
     # now package the response message
@@ -247,7 +248,7 @@ class Matter_Commisioning_Context
     var pake3 = matter.Pake3().parse(msg.raw, msg.app_payload_idx)
 
     self.cA = pake3.cA
-    tasmota.log("MTR: received cA=" + self.cA.tohex(), 4)
+    # tasmota.log("MTR: received cA=" + self.cA.tohex(), 4)
 
     # check the value against computed
     if self.cA != self.spake.cA
@@ -264,12 +265,12 @@ class Matter_Commisioning_Context
     self.R2IKey = session_keys[16..31]
     self.AttestationChallenge = session_keys[32..47]
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: session_keys=" + session_keys.tohex(), 4)
-    tasmota.log("MTR: I2RKey      =" + self.I2RKey.tohex(), 4)
-    tasmota.log("MTR: R2IKey      =" + self.R2IKey.tohex(), 4)
-    tasmota.log("MTR: AC          =" + self.AttestationChallenge.tohex(), 4)
-    tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: session_keys=" + session_keys.tohex(), 4)
+    # tasmota.log("MTR: I2RKey      =" + self.I2RKey.tohex(), 4)
+    # tasmota.log("MTR: R2IKey      =" + self.R2IKey.tohex(), 4)
+    # tasmota.log("MTR: AC          =" + self.AttestationChallenge.tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
 
     # StatusReport(GeneralCode: SUCCESS, ProtocolId: SECURE_CHANNEL, ProtocolCode: SESSION_ESTABLISHMENT_SUCCESS)
     var raw = self.send_status_report(msg, 0x00, 0x0000, 0x0000, false)
@@ -302,6 +303,7 @@ class Matter_Commisioning_Context
 
   def parse_Sigma1(msg)
     import crypto
+    import string
     # sanity checks
     if msg.opcode != 0x30 || msg.local_session_id != 0 || msg.protocol_id != 0
       tasmota.log("MTR: invalid Sigma1 message", 2)
@@ -340,7 +342,7 @@ class Matter_Commisioning_Context
     session.__future_initiator_session_id = sigma1.initiator_session_id    # update initiator_session_id
     session.__future_local_session_id = self.device.sessions.gen_local_session_id()
     self.future_local_session_id = session.__future_local_session_id
-    tasmota.log("MTR: Loc_session=" + str(self.future_local_session_id))
+    tasmota.log(string.format("MTR: +Session   (%6i) from '[%s]:%i'", self.future_local_session_id, msg.remote_ip, msg.remote_port), 2)
 
     # Check that it's a resumption
     if   is_resumption
@@ -356,12 +358,12 @@ class Matter_Commisioning_Context
       var Resume1MICPayload = ec.decrypt(encrypted)
       var decrypted_tag = ec.tag()
 
-      tasmota.log("****************************************", 4)
-      tasmota.log("MTR: * s1rk              = " + s1rk.tohex(), 4)
-      tasmota.log("MTR: * tag               = " + tag.tohex(), 4)
-      tasmota.log("MTR: * Resume1MICPayload = " + Resume1MICPayload.tohex(), 4)
-      tasmota.log("MTR: * decrypted_tag     = " + decrypted_tag.tohex(), 4)
-      tasmota.log("****************************************", 4)
+      # tasmota.log("****************************************", 4)
+      # tasmota.log("MTR: * s1rk              = " + s1rk.tohex(), 4)
+      # tasmota.log("MTR: * tag               = " + tag.tohex(), 4)
+      # tasmota.log("MTR: * Resume1MICPayload = " + Resume1MICPayload.tohex(), 4)
+      # tasmota.log("MTR: * decrypted_tag     = " + decrypted_tag.tohex(), 4)
+      # tasmota.log("****************************************", 4)
       if tag == decrypted_tag
         # Generate and Send Sigma2_Resume
         session.resumption_id = crypto.random(16)     # generate a new resumption id
@@ -390,15 +392,15 @@ class Matter_Commisioning_Context
         var ac = session_keys[32..47]
         var created = tasmota.rtc()['utc']
 
-        tasmota.log("MTR: ******************************", 4)
-        tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
-        tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
-        tasmota.log("MTR: AC          =" + ac.tohex(), 4)
-        tasmota.log("MTR: ******************************", 4)
+        # tasmota.log("MTR: ******************************", 4)
+        # tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
+        # tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
+        # tasmota.log("MTR: AC          =" + ac.tohex(), 4)
+        # tasmota.log("MTR: ******************************", 4)
 
-        var sigma2resume_raw = sigma2resume.encode()
+        var sigma2resume_raw = sigma2resume.tlv2raw()
         session.__Msg1 = nil
-        tasmota.log("MTR: sigma2resume_raw: " + sigma2resume_raw.tohex(), 4)
+        # tasmota.log("MTR: sigma2resume_raw: " + sigma2resume_raw.tohex(), 4)
 
         # now package the response message
         var resp = msg.build_response(0x33 #-sigma-2-resume-#, true)
@@ -437,7 +439,7 @@ class Matter_Commisioning_Context
       sigma2_tbsdata.add_TLV(3, matter.TLV.B2, self.ResponderEph_pub)
       sigma2_tbsdata.add_TLV(4, matter.TLV.B2, sigma1.initiatorEphPubKey)
 
-      var TBSData2Signature = crypto.EC_P256().ecdsa_sign_sha256(session.get_pk(), sigma2_tbsdata.encode())
+      var TBSData2Signature = crypto.EC_P256().ecdsa_sign_sha256(session.get_pk(), sigma2_tbsdata.tlv2raw())
 
       var sigma2_tbedata = matter.TLV.Matter_TLV_struct()
       sigma2_tbedata.add_TLV(1, matter.TLV.B2, session.get_noc())
@@ -446,9 +448,9 @@ class Matter_Commisioning_Context
       sigma2_tbedata.add_TLV(4, matter.TLV.B2, session.resumption_id)
 
       # compute TranscriptHash = Crypto_Hash(message = Msg1)
-      tasmota.log("****************************************", 4)
+      # tasmota.log("****************************************", 4)
       session.__Msg1 = sigma1.Msg1
-      tasmota.log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
+      # tasmota.log("MTR: * MSG1          = " + session.__Msg1.tohex(), 4)
       var TranscriptHash = crypto.SHA256().update(session.__Msg1).out()
       # tasmota.log("MTR: TranscriptHash =" + TranscriptHash.tohex(), 4)
 
@@ -457,27 +459,27 @@ class Matter_Commisioning_Context
       var s2k_salt = session.get_ipk_group_key() + responderRandom + self.ResponderEph_pub + TranscriptHash
 
       var s2k = crypto.HKDF_SHA256().derive(session.shared_secret, s2k_salt, s2k_info, 16)
-      tasmota.log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
-      tasmota.log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
-      tasmota.log("MTR: * s2k           = " + s2k.tohex(), 4)
+      # tasmota.log("MTR: * SharedSecret  = " + session.shared_secret.tohex(), 4)
+      # tasmota.log("MTR: * s2k_salt      = " + s2k_salt.tohex(), 4)
+      # tasmota.log("MTR: * s2k           = " + s2k.tohex(), 4)
 
-      var sigma2_tbedata_raw = sigma2_tbedata.encode()
+      var sigma2_tbedata_raw = sigma2_tbedata.tlv2raw()
       # // `AES_CCM.init(secret_key:bytes(16 or 32), iv:bytes(7..13), aad:bytes(), data_len:int, tag_len:int) -> instance`
 
       var aes = crypto.AES_CCM(s2k, bytes().fromstring(self.TBEData2_Nonce), bytes(), size(sigma2_tbedata_raw), 16)
       var TBEData2Encrypted = aes.encrypt(sigma2_tbedata_raw) + aes.tag()
-      tasmota.log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
-      tasmota.log("****************************************", 4)
+      # tasmota.log("MTR: * TBEData2Enc   = " + TBEData2Encrypted.tohex(), 4)
+      # tasmota.log("****************************************", 4)
 
       var sigma2 = matter.Sigma2()
       sigma2.responderRandom = responderRandom
       sigma2.responderSessionId = self.future_local_session_id
       sigma2.responderEphPubKey = self.ResponderEph_pub
       sigma2.encrypted2 = TBEData2Encrypted
-      tasmota.log("MTR: sigma2: " + matter.inspect(sigma2), 4)
-      var sigma2_raw = sigma2.encode()
+      # tasmota.log("MTR: sigma2: " + matter.inspect(sigma2), 4)
+      var sigma2_raw = sigma2.tlv2raw()
       session.__Msg2 = sigma2_raw
-      tasmota.log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
+      # tasmota.log("MTR: sigma2_raw: " + sigma2_raw.tohex(), 4)
   
       # now package the response message
       var resp = msg.build_response(0x31 #-sigma-2-#, true)  # no reliable flag
@@ -501,22 +503,22 @@ class Matter_Commisioning_Context
     var session = msg.session
     var sigma3 = matter.Sigma3().parse(msg.raw, msg.app_payload_idx)
 
-    tasmota.log("****************************************", 4)
+    # tasmota.log("****************************************", 4)
     # compute TranscriptHash = Crypto_Hash(message = Msg1 || Msg2)
     var TranscriptHash = crypto.SHA256().update(session.__Msg1).update(session.__Msg2).out()
-    tasmota.log("MTR: * session       = " + str(session), 4)
-    tasmota.log("MTR: session.ipk_epoch_key " + str(session.get_ipk_epoch_key()), 4)
-    tasmota.log("MTR: session.fabric_compressed " + str(session.get_fabric_compressed()), 4)
-    tasmota.log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
-    tasmota.log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
+    # tasmota.log("MTR: * session       = " + str(session), 4)
+    # tasmota.log("MTR: session.ipk_epoch_key " + str(session.get_ipk_epoch_key()), 4)
+    # tasmota.log("MTR: session.fabric_compressed " + str(session.get_fabric_compressed()), 4)
+    # tasmota.log("MTR: * ipk_group_key = " + session.get_ipk_group_key().tohex(), 4)
+    # tasmota.log("MTR: * TranscriptHash= " + TranscriptHash.tohex(), 4)
 
     var s3k_info = bytes().fromstring(self.S3K_Info)
     var s3k = crypto.HKDF_SHA256().derive(session.shared_secret, session.get_ipk_group_key() + TranscriptHash, s3k_info, 16)
 
-    tasmota.log("****************************************", 4)
-    tasmota.log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
-    tasmota.log("MTR: * s3k           = " + s3k.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * s3k_salt      = " + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # tasmota.log("MTR: * s3k           = " + s3k.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     # decrypt
     var encrypted = sigma3.TBEData3Encrypted[0..-17]
@@ -524,10 +526,10 @@ class Matter_Commisioning_Context
     var ec = crypto.AES_CCM(s3k, bytes().fromstring(self.TBEData3_Nonce), bytes(), size(encrypted), 16)
     var TBEData3 = ec.decrypt(encrypted)
     var TBETag3 = ec.tag()
-    tasmota.log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
-    tasmota.log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
-    tasmota.log("MTR: * tag_sent      = " + tag.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * TBEData3      = " + TBEData3.tohex(), 4)
+    # tasmota.log("MTR: * TBETag3       = " + TBETag3.tohex(), 4)
+    # tasmota.log("MTR: * tag_sent      = " + tag.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     if TBETag3 != tag
       tasmota.log("MTR: Tag don't match", 2)
@@ -543,24 +545,24 @@ class Matter_Commisioning_Context
     # Success = Crypto_VerifyChain(certificates = [TBEData3.initiatorNOC, TBEData3.initiatorICAC, TrustedRCAC]), when TBEData3.initiatorICAC is present
     # TODO
     var initiatorNOCTLV = matter.TLV.parse(initiatorNOC)
-    tasmota.log("MTR: initiatorNOCTLV = " + str(initiatorNOCTLV), 3)
+    # tasmota.log("MTR: initiatorNOCTLV = " + str(initiatorNOCTLV), 3)
     var initiatorNOCPubKey = initiatorNOCTLV.findsubval(9)
     var initiatorNOCListDN = initiatorNOCTLV.findsub(6)
     var initiatorFabricId = initiatorNOCListDN.findsubval(17)
     if type(initiatorFabricId) == 'int'   initiatorFabricId = int64(initiatorFabricId) end
     session.peer_node_id = initiatorFabricId.tobytes()
-    tasmota.log("MTR: initiatorFabricId="+str(session.peer_node_id), 3)
+    # tasmota.log("MTR: initiatorFabricId="+str(session.peer_node_id), 3)
 
     var sigma3_tbs = matter.TLV.Matter_TLV_struct()
     sigma3_tbs.add_TLV(1, matter.TLV.B1, initiatorNOC)
     sigma3_tbs.add_TLV(2, matter.TLV.B1, initiatorICAC)
     sigma3_tbs.add_TLV(3, matter.TLV.B1, self.initiatorEph_pub)
     sigma3_tbs.add_TLV(4, matter.TLV.B1, self.ResponderEph_pub) 
-    var sigma3_tbs_raw = sigma3_tbs.encode()
+    var sigma3_tbs_raw = sigma3_tbs.tlv2raw()
 
-    tasmota.log("MTR: * initiatorNOCPubKey      = " + initiatorNOCPubKey.tohex(), 4)
-    tasmota.log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
-    tasmota.log("****************************************", 4)
+    # tasmota.log("MTR: * initiatorNOCPubKey      = " + initiatorNOCPubKey.tohex(), 4)
+    # tasmota.log("MTR: * ec_signature      = " + ec_signature.tohex(), 4)
+    # tasmota.log("****************************************", 4)
 
     # `crypto.EC_P256().ecdsa_verify_sha256(public_key:bytes(65), message:bytes(), hash:bytes()) -> bool`
     var sigma3_tbs_valid = crypto.EC_P256().ecdsa_verify_sha256(initiatorNOCPubKey, sigma3_tbs_raw, ec_signature)
@@ -580,9 +582,9 @@ class Matter_Commisioning_Context
     session.__Msg1 = nil
     session.__Msg2 = nil
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
-    tasmota.log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: shared_secret =" + session.shared_secret.tohex(), 4)
+    # tasmota.log("MTR: ipk + hash    =" + (session.get_ipk_group_key() + TranscriptHash).tohex(), 4)
     # compute session key
     var session_keys = crypto.HKDF_SHA256().derive(session.shared_secret #- input key -#,
                                                    session.get_ipk_group_key() + TranscriptHash #- salt -#,
@@ -593,11 +595,11 @@ class Matter_Commisioning_Context
     var ac = session_keys[32..47]
     var created = tasmota.rtc()['utc']
 
-    tasmota.log("MTR: ******************************", 4)
-    tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
-    tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
-    tasmota.log("MTR: AC          =" + ac.tohex(), 4)
-    tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: ******************************", 4)
+    # tasmota.log("MTR: I2RKey      =" + i2r.tohex(), 4)
+    # tasmota.log("MTR: R2IKey      =" + r2i.tohex(), 4)
+    # tasmota.log("MTR: AC          =" + ac.tohex(), 4)
+    # tasmota.log("MTR: ******************************", 4)
 
     # StatusReport(GeneralCode: SUCCESS, ProtocolId: SECURE_CHANNEL, ProtocolCode: SESSION_ESTABLISHMENT_SUCCESS)
     var raw = self.send_status_report(msg, 0x00, 0x0000, 0x0000, true)
@@ -607,6 +609,7 @@ class Matter_Commisioning_Context
     
     # CASE Session completed, persist it
     session._breadcrumb = 0          # clear breadcrumb
+    session.counter_snd_next()    # force a first counter. It's important it's used before set_persist(true) to not have a double save
     session.set_persist(true)     # keep session on flash
     session.set_no_expiration()   # never expire
     session.persist_to_fabric()
@@ -617,7 +620,7 @@ class Matter_Commisioning_Context
 
   def parse_StatusReport(msg)
     var session = msg.session
-    tasmota.log("MTR: StatusReport = "+msg.raw[msg.app_payload_idx..].tohex())
+    tasmota.log("MTR: StatusReport = "+msg.raw[msg.app_payload_idx..].tohex(), 2)
     return true
   end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Commissioning_Data.be
@@ -70,7 +70,7 @@ class Matter_PBKDFParamResponse
   var SLEEPY_IDLE_INTERVAL
   var SLEEPY_ACTIVE_INTERVAL
 
-  def encode(b)
+  def tlv2raw(b)
     var s = matter.TLV.Matter_TLV_struct()
     # initiatorRandom
     s.add_TLV(1, matter.TLV.B1, self.initiatorRandom)
@@ -84,7 +84,7 @@ class Matter_PBKDFParamResponse
       s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
       s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
-    return s.encode(b)
+    return s.tlv2raw(b)
   end
 end
 matter.PBKDFParamResponse = Matter_PBKDFParamResponse
@@ -113,12 +113,12 @@ class Matter_Pake2
   var pB                # 65 bytes
   var cB                # 32 bytes
   
-  def encode(b)
+  def tlv2raw(b)
     var s = matter.TLV.Matter_TLV_struct()
     #
     s.add_TLV(1, matter.TLV.B1, self.pB)
     s.add_TLV(2, matter.TLV.B1, self.cB)
-    return s.encode(b)
+    return s.tlv2raw(b)
   end
 end
 matter.Pake2 = Matter_Pake2
@@ -186,7 +186,7 @@ class Matter_Sigma2
   var SLEEPY_IDLE_INTERVAL
   var SLEEPY_ACTIVE_INTERVAL
   
-  def encode(b)
+  def tlv2raw(b)
     var s = matter.TLV.Matter_TLV_struct()
     # initiatorRandom
     s.add_TLV(1, matter.TLV.B1, self.responderRandom)
@@ -198,7 +198,7 @@ class Matter_Sigma2
       s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
       s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
-    return s.encode(b)
+    return s.tlv2raw(b)
   end
 end
 matter.Sigma2 = Matter_Sigma2
@@ -213,7 +213,7 @@ class Matter_Sigma2Resume
   var SLEEPY_IDLE_INTERVAL
   var SLEEPY_ACTIVE_INTERVAL
   
-  def encode(b)
+  def tlv2raw(b)
     var s = matter.TLV.Matter_TLV_struct()
     # initiatorRandom
     s.add_TLV(1, matter.TLV.B1, self.resumptionID)
@@ -224,7 +224,7 @@ class Matter_Sigma2Resume
       s2.add_TLV(1, matter.TLV.U4, self.SLEEPY_IDLE_INTERVAL)
       s2.add_TLV(2, matter.TLV.U4, self.SLEEPY_ACTIVE_INTERVAL)
     end
-    return s.encode(b)
+    return s.tlv2raw(b)
   end
 end
 matter.Sigma2Resume = Matter_Sigma2Resume

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Expirable.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Expirable.be
@@ -74,6 +74,13 @@ class Matter_Expirable
   end
   
   #############################################################
+  # before_remove
+  #
+  # called right before the element is removed
+  def before_remove()
+  end
+
+  #############################################################
   # set absolute time for expiration
   def set_no_expiration()
     self._expiration = nil
@@ -131,6 +138,13 @@ class Matter_Expirable_list : list
     return super(self).setitem(i, o)
   end
 
+  #############################################################
+  # remove - override
+  #
+  def remove(i)
+    if i >= 0 && i < size(self)   self[i].before_remove()   end
+    return super(self).remove(i)
+  end
 
   #############################################################
   # remove_expired

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM.be
@@ -26,14 +26,14 @@ import matter
 #################################################################################
 class Matter_IM
   var device
-  var subs                        # subscriptions shop
+  var subs_shop                        # subscriptions shop
 
   var send_queue                  # list of IM_Message queued for sending as part of exchange-id
 
   def init(device)
     self.device = device
     self.send_queue = []
-    self.subs = matter.IM_Subscription_Shop(self)
+    self.subs_shop = matter.IM_Subscription_Shop(self)
   end
 
   def process_incoming(msg)
@@ -42,27 +42,31 @@ class Matter_IM
 
     var val = matter.TLV.parse(msg.raw, msg.app_payload_idx)
 
-    tasmota.log("MTR: IM TLV: " + str(val), 3)
+    # tasmota.log("MTR: IM TLV: " + str(val), 3)
 
     var InteractionModelRevision = val.findsubval(0xFF)
-    tasmota.log("MTR: InteractionModelRevision=" + (InteractionModelRevision != nil ? str(InteractionModelRevision) : "nil"), 4)
+    # tasmota.log("MTR: InteractionModelRevision=" + (InteractionModelRevision != nil ? str(InteractionModelRevision) : "nil"), 4)
 
     var opcode = msg.opcode
     if   opcode == 0x01   # Status Response
       return self.process_status_response(msg, val)
     elif opcode == 0x02   # Read Request
+      self.send_ack_now(msg)
       return self.process_read_request(msg, val)
     elif opcode == 0x03   # Subscribe Request
+      self.send_ack_now(msg)
       return self.subscribe_request(msg, val)
     elif opcode == 0x04   # Subscribe Response
       return self.subscribe_response(msg, val)
     elif opcode == 0x05   # Report Data
       return self.report_data(msg, val)
     elif opcode == 0x06   # Write Request
+      self.send_ack_now(msg)
       return self.process_write_request(msg, val)
     elif opcode == 0x07   # Write Response
       return self.process_write_response(msg, val)
     elif opcode == 0x08   # Invoke Request
+      self.send_ack_now(msg)
       return self.process_invoke_request(msg, val)
     elif opcode == 0x09   # Invoke Response
       return self.process_invoke_response(msg, val)
@@ -88,21 +92,38 @@ class Matter_IM
   end
 
   #############################################################
+  # send Ack response now and don't enqueue it
+  #
+  # returns `true` if packet could be sent
+  def send_ack_now(msg)
+    if msg.x_flag_r                   # send Ack only if requester asks for it
+      var resp = msg.build_standalone_ack(false #-not reliable-#)
+      resp.encode_frame()
+      resp.encrypt()
+      import string
+      tasmota.log(string.format("MTR: <Ack_now   (%6i) rack=%i id=%i [%s]:%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter, resp.remote_ip, resp.remote_port), 3)
+      msg.session._message_handler.send_response(resp.raw, resp.remote_ip, resp.remote_port, nil)
+      # self.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+      # return msg.send_im(msg.session._message_handler)         # send message now
+    else
+      return true
+    end
+  end
+
+  #############################################################
   # send enqueued responses
   #
+  # self.send_queue is a list of <Matter_IM_Message>
+  # 
   def send_enqueued(responder)
     var idx = 0
     while idx < size(self.send_queue)
       var message = self.send_queue[idx]
 
-      if message.ready
-        var finish = message.send(responder)         # send message
-        if finish
-          self.send_queue.remove(idx)
-          idx -= 1
-        else
-          message.ready = false             # needs more to proceed
-        end
+      var finish = message.send_im(responder)         # send message
+      if finish
+        self.send_queue.remove(idx)
+        idx -= 1
       end
       
       idx += 1
@@ -171,7 +192,7 @@ class Matter_IM
       if message
         return message.status_ok_received(msg)         # re-arm the sending of next packets for the same exchange
       else
-        tasmota.log("MTR: >Status_OK", 2)      # don't show 'SUCCESS' to not overflow logs with non-information
+        tasmota.log(string.format("MTR: >OK        (%6i) exch=%i not found", msg.session.local_session_id, msg.exchange_id), 3)      # don't show 'SUCCESS' to not overflow logs with non-information
       end
     else
       # error
@@ -188,7 +209,8 @@ class Matter_IM
   # Inner code shared between read_attributes and subscribe_request
   #
   # query: `ReadRequestMessage` or `SubscribeRequestMessage`
-  def _inner_process_read_request(session, query)
+  def _inner_process_read_request(session, query, no_log)
+    import string
 
     ### Inner function to be iterated upon
     # ret is the ReportDataMessage list to send back
@@ -216,7 +238,9 @@ class Matter_IM
         a1.attribute_data.data = res
 
         ret.attribute_reports.push(a1)
-        tasmota.log(string.format("MTR: Read_Attr  %s%s - %s", str(ctx), attr_name, str(res)), 2)
+        if !no_log
+          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - %s", session.local_session_id, str(ctx), attr_name, str(res)), 2)
+        end
         return true                         # stop expansion since we have a value
       elif ctx.status != nil
         if direct
@@ -230,11 +254,11 @@ class Matter_IM
           a1.attribute_status.status.status = ctx.status
 
           ret.attribute_reports.push(a1)
-          tasmota.log(string.format("MTR: Read_Attr  %s%s - STATUS: 0x%02X %s", str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 2)
+          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - STATUS: 0x%02X %s", session.local_session_id, str(ctx), attr_name, ctx.status, ctx.status == matter.UNSUPPORTED_ATTRIBUTE ? "UNSUPPORTED_ATTRIBUTE" : ""), 2)
           return true
         end
       else
-        tasmota.log(string.format("MTR: Read_Attr  %s%s - IGNORED", str(ctx), attr_name), 2)
+        tasmota.log(string.format("MTR: >Read_Attr (%6i) %s%s - IGNORED", session.local_session_id, str(ctx), attr_name), 2)
         # ignore if content is nil and status is undefined
         return false
       end
@@ -261,9 +285,9 @@ class Matter_IM
         # we need expansion, log first
         if ctx.cluster != nil && ctx.attribute != nil
           var attr_name = matter.get_attribute_name(ctx.cluster, ctx.attribute)
-          tasmota.log("MTR: Read_Attr  " + str(ctx) + (attr_name ? " (" + attr_name + ")" : ""), 2)
+          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx) + (attr_name ? " (" + attr_name + ")" : "")), 2)
         else
-          tasmota.log("MTR: Read_Attr  " + str(ctx), 2)
+          tasmota.log(string.format("MTR: >Read_Attr (%6i) %s", session.local_session_id, str(ctx)), 2)
         end
         
       end
@@ -304,12 +328,12 @@ class Matter_IM
     var query = matter.SubscribeRequestMessage().from_TLV(val)
 
     if !query.keep_subscriptions
-      self.subs.remove_by_session(msg.session)      # if `keep_subscriptions`, kill all subscriptions from current session
+      self.subs_shop.remove_by_session(msg.session)      # if `keep_subscriptions`, kill all subscriptions from current session
     end
 
     tasmota.log("MTR: received SubscribeRequestMessage=" + str(query), 3)
 
-    var sub = self.subs.new_subscription(msg.session, query)
+    var sub = self.subs_shop.new_subscription(msg.session, query)
 
     # expand a string with all attributes requested
     var attr_req = []
@@ -320,10 +344,10 @@ class Matter_IM
       ctx.attribute = q.attribute
       attr_req.push(str(ctx))
     end
-    tasmota.log(string.format("MTR: >Subscribe %s (min=%i, max=%i) sub_id=%i",
-                              attr_req.concat(" "), sub.min_interval, sub.max_interval, sub.subscription_id), 2)
+    tasmota.log(string.format("MTR: >Subscribe (%6i) %s (min=%i, max=%i, keep=%i) sub=%i",
+                              msg.session.local_session_id, attr_req.concat(" "), sub.min_interval, sub.max_interval, query.keep_subscriptions ? 1 : 0, sub.subscription_id), 2)
 
-    var ret = self._inner_process_read_request(msg.session, query)
+    var ret = self._inner_process_read_request(msg.session, query, true #-no_log-#)
     # ret is of type `Matter_ReportDataMessage`
     ret.subscription_id = sub.subscription_id     # enrich with subscription id TODO
     self.send_subscribe_response(msg, ret, sub)
@@ -356,7 +380,7 @@ class Matter_IM
         ctx.status = matter.UNSUPPORTED_COMMAND   #default error if returned `nil`
 
         var cmd_name = matter.get_command_name(ctx.cluster, ctx.command)
-        tasmota.log(string.format("MTR: >Received  %s %s from [%s]:%i", str(ctx), cmd_name ? cmd_name : "", msg.remote_ip, msg.remote_port), 2)
+        tasmota.log(string.format("MTR: >Command   (%6i) %s %s from [%s]:%i", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : "", msg.remote_ip, msg.remote_port), 2)
         var res = self.device.invoke_request(msg.session, q.command_fields, ctx)
         var a1 = matter.InvokeResponseIB()
         if res == true || ctx.status == matter.SUCCESS      # special case, just respond ok
@@ -368,7 +392,7 @@ class Matter_IM
           a1.status.status = matter.StatusIB()
           a1.status.status.status = matter.SUCCESS
           ret.invoke_responses.push(a1)
-          tasmota.log("MTR: <Replied   OK", 2)
+          tasmota.log(string.format("MTR: <Replied   (%6i) OK exch=%i", msg.session.local_session_id, msg.exchange_id), 2)
         elif res != nil
           a1.command = matter.CommandDataIB()
           a1.command.command_path = matter.CommandPathIB()
@@ -379,7 +403,7 @@ class Matter_IM
           ret.invoke_responses.push(a1)
 
           cmd_name = matter.get_command_name(ctx.cluster, ctx.command)
-          tasmota.log(string.format("MTR: <Replied   %s %s", str(ctx), cmd_name ? cmd_name : ""), 2)
+          tasmota.log(string.format("MTR: <Replied   (%6i) %s %s", msg.session.local_session_id, str(ctx), cmd_name ? cmd_name : ""), 2)
         elif ctx.status != nil
           a1.status = matter.CommandStatusIB()
           a1.status.command_path = matter.CommandPathIB()
@@ -389,9 +413,9 @@ class Matter_IM
           a1.status.status = matter.StatusIB()
           a1.status.status.status = ctx.status
           ret.invoke_responses.push(a1)
-          tasmota.log(string.format("MTR: <Replied   Status=0x%02X", ctx.status), 2)
+          tasmota.log(string.format("MTR: <Replied   (%6i) Status=0x%02X exch=%i", msg.session.local_session_id, ctx.status, msg.exchange_id), 2)
         else
-          tasmota.log("MTR: _Ignore", 2)
+          tasmota.log(string.format("MTR: _Ignore    (%6i) exch=%i", msg.session.local_session_id, msg.exchange_id), 2)
           # ignore if content is nil and status is undefined
         end
       end
@@ -560,7 +584,7 @@ class Matter_IM
     var query = matter.TimedRequestMessage().from_TLV(val)
     tasmota.log("MTR: received TimedRequestMessage=" + str(query), 3)
 
-    tasmota.log(string.format("MTR: >Received  TimedRequest=%i from [%s]:%i", query.timeout, msg.remote_ip, msg.remote_port), 2)
+    tasmota.log(string.format("MTR: >Command   (%6i) TimedRequest=%i from [%s]:%i", msg.session.local_session_id, query.timeout, msg.remote_ip, msg.remote_port), 2)
     
     # Send success status report
     self.send_status(msg, matter.SUCCESS)
@@ -589,16 +613,20 @@ class Matter_IM
     end
 
     if size(fake_read.attributes_requests) > 0
-      tasmota.log("MTR: <Sub_data  sub_id=" + str(sub.subscription_id), 2)
+      tasmota.log(string.format("MTR: <Sub_Data  (%6i) sub=%i", session.local_session_id, sub.subscription_id), 2)
+      sub.is_keep_alive = false             # sending an actual data update
     else
-      tasmota.log("MTR: <Sub_alive sub_id=" + str(sub.subscription_id), 2)
+      tasmota.log(string.format("MTR: <Sub_Alive (%6i) sub=%i", session.local_session_id, sub.subscription_id), 2)
+      sub.is_keep_alive = true              # sending keep-alive
     end
+
     var ret = self._inner_process_read_request(session, fake_read)
     ret.suppress_response = (size(fake_read.attributes_requests) == 0)        # ret is of class `ReportDataMessage`
     ret.subscription_id = sub.subscription_id
 
-    self.send_queue.push(matter.IM_ReportDataSubscribed(session._message_handler, session, ret, sub))
-    self.send_enqueued(session._message_handler)
+    var report_data_msg = matter.IM_ReportDataSubscribed(session._message_handler, session, ret, sub)
+    self.send_queue.push(report_data_msg)           # push message to queue
+    self.send_enqueued(session._message_handler)    # and send queued messages now
   end
   
   #############################################################
@@ -645,7 +673,7 @@ class Matter_IM
   #############################################################
   # dispatch every 250ms click to sub-objects that need it
   def every_250ms()
-    self.subs.every_250ms()
+    self.subs_shop.every_250ms()
   end
 
 end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Data.be
@@ -880,7 +880,7 @@ a = matter.AttributePathIB().from_TLV(m)
 assert(str(a) == "[00]0030/0000")
 m = a.to_TLV()
 assert(m.tostring() == "[[2 = 0U, 3 = 48U, 4 = 0U]]")
-assert(m.encode() == bytes("1724020024033024040018"))
+assert(m.tlv2raw() == bytes("1724020024033024040018"))
 
 
 # create DataVersionFilterIB from scratch
@@ -894,7 +894,7 @@ d = matter.DataVersionFilterIB()
 d.path = c
 d.data_version = 10
 assert(str(d.to_TLV()) == '{0 = [[1 = 1U, 2 = 32U]], 1 = 10U}')
-assert(d.to_TLV().encode() == bytes('1537002401012402201824010A18'))
+assert(d.to_TLV().tlv2raw() == bytes('1537002401012402201824010A18'))
 
 # decode DataVersionFilterIB from scratch
 m = matter.TLV.parse(bytes("1537002401012402201824010A18"))
@@ -932,7 +932,7 @@ a1.attribute_data.data = matter.TLV.create_TLV(matter.TLV.UTF1, "Tasmota")
 assert(str(a1.to_TLV()) == '{0 = {0 = [[2 = 0U, 3 = 48U, 4 = 0U]], 1 = [[0 = 0U, 1 = 0U]]}, 1 = {0 = 1U, 1 = [[2 = 0U, 3 = 48U, 4 = 0U]], 2 = "Tasmota"}}')
 r.attribute_reports.push(a1)
 #{0 = 1U, 1 = [{0 = {0 = [[2 = 0U, 3 = 48U, 4 = 0U]], 1 = [[0 = 0U, 1 = 0U]]}, 1 = {0 = 1U, 1 = [[2 = 0U, 3 = 48U, 4 = 0U]], 2 = "Tasmota"}}]}
-assert(r.to_TLV().encode() == bytes('1524000136011535003700240200240330240400183701240000240100181835012400013701240200240330240400182C02075461736D6F746118181818'))
+assert(r.to_TLV().tlv2raw() == bytes('1524000136011535003700240200240330240400183701240000240100181835012400013701240200240330240400182C02075461736D6F746118181818'))
 
 
 # <Matter_AttributeReportIB:{

--- a/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_IM_Message.be
@@ -69,12 +69,14 @@ class Matter_IM_Message
   var resp                            # response Frame object
   var ready                           # bool: ready to send (true) or wait (false)
   var data                            # TLV data of the response (if any)
+  var last_counter                    # counter value of last sent packet (to match ack)
 
   # build a response message stub
   def init(msg, opcode, reliable)
     self.resp = msg.build_response(opcode, reliable)
-    self.ready = true
+    self.ready = true                # by default send immediately
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT
+    self.last_counter = 0            # avoid `nil` value
   end
 
   # the message is being removed due to expiration
@@ -91,6 +93,8 @@ class Matter_IM_Message
   # Status Report OK received for previous message, proceed to next (if any)
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
+    import string
+    tasmota.log(string.format("MTR: IM_Message status_ok_received exch=%i", self.resp.exchange_id), 3)
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT     # give more time
     if msg
       self.resp = msg.build_response(self.resp.opcode, self.resp.x_flag_r, self.resp)   # update packet
@@ -110,11 +114,16 @@ class Matter_IM_Message
 
   # return true if transaction is complete (remove object from queue)
   # default responder for data
-  def send(responder)
+  def send_im(responder)
+    import string
+    tasmota.log(string.format("MTR: IM_Message send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    if !self.ready   return false  end
     var resp = self.resp
-    resp.encode_frame(self.data.to_TLV().encode())    # payload in cleartext
+    resp.encode_frame(self.data.to_TLV().tlv2raw())    # payload in cleartext
     resp.encrypt()
+    tasmota.log(string.format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter),3)
     responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+    self.last_counter = resp.message_counter
     return true
   end
 
@@ -133,7 +142,6 @@ class Matter_IM_Status : Matter_IM_Message
     var sr  = matter.StatusResponseMessage()
     sr.status = status
     self.data = sr
-    self.ready = true                # send immediately
   end
 end
 matter.IM_Status = Matter_IM_Status
@@ -148,7 +156,6 @@ class Matter_IM_InvokeResponse : Matter_IM_Message
   def init(msg, data)
     super(self).init(msg, 0x09 #-Invoke Response-#, true)
     self.data = data
-    self.ready = true                # send immediately
   end
 end
 matter.IM_InvokeResponse = Matter_IM_InvokeResponse
@@ -163,7 +170,6 @@ class Matter_IM_WriteResponse : Matter_IM_Message
   def init(msg, data)
     super(self).init(msg, 0x07 #-Write Response-#, true)
     self.data = data
-    self.ready = true                # send immediately
   end
 
 end
@@ -175,18 +181,19 @@ matter.IM_WriteResponse = Matter_IM_WriteResponse
 # Report Data for a Read Request
 #################################################################################
 class Matter_IM_ReportData : Matter_IM_Message
-  static var MAX_MESSAGE = 1200       # max bytes size for a single TLV worklaod
+  static var MAX_MESSAGE = 1000       # max bytes size for a single TLV worklaod
 
   def init(msg, data)
     super(self).init(msg, 0x05 #-Report Data-#, true)
     self.data = data
-    self.ready = true                # send immediately
   end
 
   # return true if transaction is complete (remove object from queue)
   # default responder for data
-  def send(responder)
+  def send_im(responder)
     import string
+    tasmota.log(string.format("MTR: IM_ReportData send_im exch=%i ready=%i", self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    if !self.ready   return false  end
     var resp = self.resp                          # response frame object
     var data = self.data                          # TLV data of the response (if any)
     var was_chunked = data.more_chunked_messages  # is this following a chunked packet?
@@ -209,17 +216,17 @@ class Matter_IM_ReportData : Matter_IM_Message
     end
 
 
-    tasmota.log(string.format("MTR: elements=%i msg_sz=%i total=%i", elements, msg_sz, size(data.attribute_reports)), 3)
+    tasmota.log(string.format("MTR: exch=%i elements=%i msg_sz=%i total=%i", self.get_exchangeid(), elements, msg_sz, size(data.attribute_reports)), 3)
     var next_elemnts = data.attribute_reports[elements .. ]
     data.attribute_reports = data.attribute_reports[0 .. elements - 1]
     data.more_chunked_messages = (size(next_elemnts) > 0)
 
     if was_chunked
-      tasmota.log(string.format("MTR: Read_Attr  next_chunk exch=%i", self.get_exchangeid()), 3)
+      tasmota.log(string.format("MTR: .Read_Attr next_chunk exch=%i", self.get_exchangeid()), 3)
     end
     if data.more_chunked_messages
       if !was_chunked
-        tasmota.log(string.format("MTR: Read_Attr  first_chunk exch=%i", self.get_exchangeid()), 3)
+        tasmota.log(string.format("MTR: .Read_Attr first_chunk exch=%i", self.get_exchangeid()), 3)
       end
       # tasmota.log("MTR: sending TLV" + str(data), 4)
     end
@@ -227,17 +234,20 @@ class Matter_IM_ReportData : Matter_IM_Message
     # print(">>>>> send elements before encode")
     var raw_tlv = self.data.to_TLV()
     # print(">>>>> send elements before encode 2")
-    var encoded_tlv = raw_tlv.encode(bytes(self.MAX_MESSAGE))    # takes time
+    var encoded_tlv = raw_tlv.tlv2raw(bytes(self.MAX_MESSAGE))    # takes time
     # print(">>>>> send elements before encode 3")
     resp.encode_frame(encoded_tlv)    # payload in cleartext, pre-allocate max buffer
     # print(">>>>> send elements after encode")
     resp.encrypt()
     # print(">>>>> send elements after encrypt")
+    tasmota.log(string.format("MTR: <snd       (%6i) id=%i exch=%i rack=%s", resp.session.local_session_id, resp.message_counter, resp.exchange_id, resp.ack_message_counter),3)
     responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+    self.last_counter = resp.message_counter
 
     if size(next_elemnts) > 0
       data.attribute_reports = next_elemnts
-      # tasmota.log("MTR: to_be_sent_later TLV" + str(data), 3)
+      tasmota.log(string.format("MTR: to_be_sent_later size=%i exch=%i", size(data.attribute_reports), resp.exchange_id), 3)
+      self.ready = false    # wait for Status Report before continuing sending
       return false          # keep alive
     else
       return true           # finished, remove
@@ -260,7 +270,7 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
   def init(message_handler, session, data, sub)
     self.resp = matter.Frame.initiate_response(message_handler, session, 0x05 #-Report Data-#, true)
     self.data = data
-    self.ready = true                # send immediately
+    self.ready = true                # by default send immediately
     self.expiration = tasmota.millis() + self.MSG_TIMEOUT
     #
     self.sub = sub
@@ -273,11 +283,14 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # ack received, confirm the heartbeat
   def ack_received(msg)
+    import string
+    tasmota.log(string.format("MTR: IM_ReportDataSubscribed ack_received sub=%i", self.sub.subscription_id), 3)
     super(self).ack_received(msg)
     if !self.report_data_phase
       # if ack is received while all data is sent, means that it finished without error
-      self.ready = true
-      self.sub.re_arm()           # signal that we can proceed to next sub report
+      if self.sub.is_keep_alive   # only if keep-alive, for normal reports, re_arm is called at last StatusReport
+        self.sub.re_arm()           # signal that we can proceed to next sub report
+      end
       return true                       # proceed to calling send() which removes the message
     else
       return false                      # do nothing
@@ -286,6 +299,8 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # we received an ACK error, remove subscription
   def status_error_received(msg)
+    import string
+    tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_error_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     self.sub.remove_self()
   end
 
@@ -293,10 +308,11 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
   # return true if we manage the ack ourselves, false if it needs to be done upper
   def status_ok_received(msg)
     import string
-    # tasmota.log(string.format("MTR: >Sub_OK    sub_id="+str(self.sub.subscription_id)), 2)
+    tasmota.log(string.format("MTR: IM_ReportDataSubscribed status_ok_received sub=%i exch=%i", self.sub.subscription_id, self.resp.exchange_id), 3)
     if self.report_data_phase
       return super(self).status_ok_received(msg)
     else
+      self.sub.re_arm()                       # always re_arm at last StatusReport. The only case where it does not happen is during keep-alive, hence we need to lookg for Ack (see above)
       super(self).status_ok_received(nil)
       return false                            # let the caller to the ack
     end
@@ -304,27 +320,32 @@ class Matter_IM_ReportDataSubscribed : Matter_IM_ReportData
 
   # returns true if transaction is complete (remove object from queue)
   # default responder for data
-  def send(responder)
+  def send_im(responder)
+    import string
+    tasmota.log(string.format("MTR: IM_ReportDataSubscribed send sub=%i exch=%i ready=%i", self.sub.subscription_id, self.resp.exchange_id, self.ready ? 1 : 0), 3)
+    if !self.ready   return false  end
     if size(self.data.attribute_reports) > 0
       if self.report_data_phase
-        var ret = super(self).send(responder)
+        var ret = super(self).send_im(responder)
         if !ret   return false end              # ReportData needs to continue
         # ReportData is finished
         self.report_data_phase = false
         return false
       else
         # send a simple ACK
-        var resp = self.resp.build_standalone_ack()
+        var resp = self.resp.build_standalone_ack(false)
         resp.encode_frame()
         resp.encrypt()
-        responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+        tasmota.log(string.format("MTR: <Ack       (%6i) ack=%i id=%i", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 3)
+        responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, nil #-not reliable-#)
+        self.last_counter = resp.message_counter
         return true                             # we received a ack(), just finish
       end
 
     else
       # simple heartbeat ReportData
       if self.report_data_phase
-        super(self).send(responder)
+        super(self).send_im(responder)
         self.report_data_phase = false
         return false                             # don't expect any response
       else
@@ -352,12 +373,17 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
 
   # return true if transaction is complete (remove object from queue)
   # default responder for data
-  def send(responder)
+  def send_im(responder)
+    import string
+    tasmota.log(string.format("MTR: Matter_IM_SubscribeResponse send sub=%i ready=%i", self.sub.subscription_id, self.ready ? 1 : 0), 3)
+    if !self.ready   return false  end
     if self.report_data_phase
-      var ret = super(self).send(responder)
-      if !ret   return false end              # ReportData needs to continue
-      # ReportData is finished
-      self.report_data_phase = false
+      var ret = super(self).send_im(responder)
+      if ret
+        # finished reporting of data, we still need to send SubscribeResponseMessage after next StatusReport
+        self.report_data_phase = false
+      end
+      self.ready = false    # wait for Status Report before continuing sending
       return false
 
     else
@@ -368,9 +394,11 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
       sr.max_interval = self.sub.max_interval
 
       self.resp.opcode = 0x04 #- Subscribe Response -#
-      resp.encode_frame(sr.to_TLV().encode())    # payload in cleartext
+      resp.encode_frame(sr.to_TLV().tlv2raw())    # payload in cleartext
       resp.encrypt()
       responder.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
+      self.last_counter = resp.message_counter
+      tasmota.log(string.format("MTR: Send SubscribeResponseMessage sub=%i id=%i", self.sub.subscription_id, resp.message_counter), 3)
       self.sub.re_arm()
       return true
     end
@@ -379,8 +407,9 @@ class Matter_IM_SubscribeResponse : Matter_IM_ReportData
   # Status ok received
   def status_ok_received(msg)
     import string
+    tasmota.log(string.format("MTR: IM_SubscribeResponse status_ok_received sub=%i exch=%i ack=%i last_counter=%i", self.sub.subscription_id, self.resp.exchange_id, msg.ack_message_counter ? msg.ack_message_counter : 0 , self.last_counter), 3)
     # once we receive ack, open flow for subscriptions
-    tasmota.log(string.format("MTR: >Sub_OK    sub_id="+str(self.sub.subscription_id)), 2)
+    tasmota.log(string.format("MTR: >Sub_OK    (%6i) sub=%i", msg.session.local_session_id, self.sub.subscription_id), 2)
     return super(self).status_ok_received(msg)
   end
     

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Message.be
@@ -228,7 +228,7 @@ class Matter_Frame
   #############################################################
   # Generate a Standalone Acknowledgment
   # Uses `PROTOCOL_ID_SECURE_CHANNEL` no ecnryption required
-  def build_standalone_ack()
+  def build_standalone_ack(reliable)
     import string
     # send back response
     var resp = classof(self)(self.message_handler)
@@ -253,9 +253,7 @@ class Matter_Frame
     resp.protocol_id = 0                # PROTOCOL_ID_SECURE_CHANNEL
     resp.x_flag_a = 1           # ACK of previous message
     resp.ack_message_counter = self.message_counter
-    resp.x_flag_r = 1
-
-    tasmota.log(string.format("MTR: <Replied   %s", matter.get_opcode_name(resp.opcode)), 3)
+    resp.x_flag_r = reliable ? 1 : 0
     return resp
   end
 
@@ -304,7 +302,7 @@ class Matter_Frame
     if resp.local_session_id == 0
       var op_name = matter.get_opcode_name(resp.opcode)
       if !op_name   op_name = string.format("0x%02X", resp.opcode) end
-      tasmota.log(string.format("MTR: <Replied   %s", op_name), 2)
+      tasmota.log(string.format("MTR: <Replied   (%6i) %s", resp.session.local_session_id, op_name), 2)
     end
     return resp
   end

--- a/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_MessageHandler.be
@@ -66,16 +66,18 @@ class Matter_MessageHandler
         
         # check if it's a duplicate
         if !session._counter_insecure_rcv.validate(frame.message_counter, false)
-          tasmota.log(string.format("MTR: rejected duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 3)
+          tasmota.log(string.format("MTR: .          Rejected duplicate unencrypted message = %i ref = %i", frame.message_counter, session._counter_insecure_rcv.val()), 3)
           return false
         end
 
         if !frame.decode_payload()    return false end
-        self.device.packet_ack(frame.ack_message_counter)       # acknowledge packet
+        self.device.received_ack(frame.ack_message_counter)     # remove acknowledge packet from sending list
         if frame.opcode != 0x10                                 # don't show `MRP_Standalone_Acknowledgement`
           var op_name = matter.get_opcode_name(frame.opcode)
           if !op_name   op_name = string.format("0x%02X", frame.opcode) end
-          tasmota.log(string.format("MTR: >Received  %s from [%s]:%i", op_name, addr, port), 2)
+          tasmota.log(string.format("MTR: >Received  (%6i) %s rid=%i exch=%i from [%s]:%i", session.local_session_id, op_name, frame.message_counter, frame.exchange_id, addr, port), 2)
+        else
+          tasmota.log(string.format("MTR: >rcv Ack   (%6i) rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.message_counter, frame.x_flag_r ? "{reliable} " : "", frame.exchange_id, str(frame.ack_message_counter), addr, port), 3)
         end
         self.commissioning.process_incoming(frame)
         return true
@@ -87,7 +89,7 @@ class Matter_MessageHandler
         var session = self.device.sessions.get_session_by_local_session_id(frame.local_session_id)
         if session == nil
           tasmota.log("MTR: unknown local_session_id="+str(frame.local_session_id), 2)
-          tasmota.log("MTR: frame="+matter.inspect(frame), 3)
+          # tasmota.log("MTR: frame="+matter.inspect(frame), 3)
           return false
         end
         if addr     session._ip = addr     end
@@ -97,7 +99,7 @@ class Matter_MessageHandler
        
         # check if it's a duplicate
         if !session.counter_rcv_validate(frame.message_counter, true)
-          tasmota.log("MTR: rejected duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
+          tasmota.log("MTR: .          Rejected duplicate encrypted message = " + str(frame.message_counter) + " counter=" + str(session.counter_rcv), 3)
           return false
         end
         
@@ -111,9 +113,11 @@ class Matter_MessageHandler
         # continue decoding
         tasmota.log(string.format("MTR: idx=%i clear=%s", frame.payload_idx, frame.raw.tohex()), 4)
         frame.decode_payload()
-        tasmota.log("MTR: decrypted message: protocol_id:"+str(frame.protocol_id)+" opcode="+str(frame.opcode)+" exchange_id="+str(frame.exchange_id & 0xFFFF), 3)
+        tasmota.log("MTR: >          Decrypted message: protocol_id:"+str(frame.protocol_id)+" opcode="+str(frame.opcode)+" exchange_id="+str(frame.exchange_id & 0xFFFF), 3)
 
-        self.device.packet_ack(frame.ack_message_counter)      # acknowledge packet
+        tasmota.log(string.format("MTR: >rcv       (%6i) [%02X/%02X] rid=%i exch=%i ack=%s %sfrom [%s]:%i", session.local_session_id, frame.protocol_id, frame.opcode, frame.message_counter, frame.exchange_id, str(frame.ack_message_counter), frame.x_flag_r ? "{reliable} " : "", addr, port), 3)
+
+        self.device.received_ack(frame.ack_message_counter)      # remove acknowledge packet from sending list
 
         # dispatch according to protocol_id
         var protocol_id = frame.protocol_id
@@ -135,9 +139,10 @@ class Matter_MessageHandler
             self.im.send_enqueued(self)
 
           elif frame.x_flag_r                   # nothing to respond, check if we need a standalone ack
-            var resp = frame.build_standalone_ack()
+            var resp = frame.build_standalone_ack(true)
             resp.encode_frame()
             resp.encrypt()
+            tasmota.log(string.format("MTR: <Ack       (%6i) ack=%i id=%i {reliable}", resp.session.local_session_id, resp.ack_message_counter, resp.message_counter), 3)
             self.send_response(resp.raw, resp.remote_ip, resp.remote_port, resp.message_counter)
           end
           ret = true

--- a/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_Plugin_Root.be
@@ -370,7 +370,7 @@ class Matter_Plugin_Root : Matter_Plugin
         ctx.command = 0x05              # CommissioningCompleteResponse
 
         self.device.start_commissioning_complete_deferred(session)
-        return ccr                      # trigger a standalone ack
+        return ccr
       end
 
     elif cluster == 0x003E              # ========== Node Operational Credentials Cluster 11.17 p.704 ==========
@@ -399,7 +399,7 @@ class Matter_Plugin_Root : Matter_Plugin
         att_elts.add_TLV(1, TLV.B2, matter.CD_FFF1_8000())    # certification_declaration
         att_elts.add_TLV(2, TLV.B1, AttestationNonce)         # attestation_nonce
         att_elts.add_TLV(3, TLV.U4, tasmota.rtc()['utc'])     # timestamp in epoch-s
-        var attestation_message = att_elts.encode()
+        var attestation_message = att_elts.tlv2raw()
 
         var ac = session.get_ac()
         var attestation_tbs = attestation_message + ac
@@ -426,7 +426,7 @@ class Matter_Plugin_Root : Matter_Plugin
         var nocsr_elements = TLV.Matter_TLV_struct()
         nocsr_elements.add_TLV(1, TLV.B2, csr)
         nocsr_elements.add_TLV(2, TLV.B1, CSRNonce)
-        var nocsr_elements_message = nocsr_elements.encode()
+        var nocsr_elements_message = nocsr_elements.tlv2raw()
         # sign with attestation challenge
         var nocsr_tbs = nocsr_elements_message + session.get_ac()
         tasmota.log("MTR: nocsr_tbs=" + nocsr_tbs.tohex(), 3)
@@ -497,6 +497,7 @@ class Matter_Plugin_Root : Matter_Plugin
         tasmota.log("MTR: ------------------------------------------", 3)
         tasmota.log("MTR: fabric=" + matter.inspect(session._fabric), 3)
         tasmota.log("MTR: ------------------------------------------", 3)
+        session._fabric.log_new_fabric()        # log that we registered a new fabric
         # create NOCResponse
         # 0=StatusCode
         # 1=FabricIndex (1-254) (opt)
@@ -510,6 +511,7 @@ class Matter_Plugin_Root : Matter_Plugin
       elif command == 0x0009            # ---------- UpdateFabricLabel ----------
         var label = val.findsubval(0)     # Label string max 32
         session.set_fabric_label(label)
+        tasmota.log(string.format("MTR: .          Update fabric '%s' label='%s'", session._fabric.get_fabric_id().copy().reverse().tohex(), str(label)), 2)
         ctx.status = matter.SUCCESS                  # OK
         return nil                      # trigger a standalone ack
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_TLV.be
@@ -46,6 +46,20 @@ class Matter_TLV
   ]
 
   # type values (enum like)
+  #
+  # Type|Description
+  # :----|:---
+  # I1 I2 I4|Signed integer of at most (1/2/4) bytes (as 32 bits signed Berry type)
+  # U1 U2 U4|Unsiged integer of at motst (1/2/4) bytes (as 32 bits signed Berry type, be careful when comparing. Use `matter.Counter.is_greater(a,b)`)
+  # I8 U8|Signed/insigned 8 bytes. You can pass `bytes(8)`, `int64()` or `int`. Type is collapsed to a lower type if possible when encoding.
+  # BOOL|boolean, takes `true` and `false`. Abstracts the internal `BTRUE` and `BFALSE` that you don't need to use
+  # FLOAT|32 bites float
+  # UTF1 UTF2|String as UTF, size is encoded as 1 or 2 bytes automatically
+  # B1 B2|raw `bytes()`, size is encoded as 1 or 2 bytes automatically
+  # NULL|takes only `nil` value
+  # STRUCT<BR>ARRAY<BR>LIST<BR>EOC|(internal) Use through abstractions
+  # DOUBLE<BR>UTF4 UTF8<BR>B4 B8|Unsuppored in Tasmota
+
   static var I1     = 0x00
   static var I2     = 0x01
   static var I4     = 0x02
@@ -206,7 +220,7 @@ class Matter_TLV
     # encode TLV
     #
     # appends to the bytes() object
-    def encode(b)
+    def tlv2raw(b)
       var TLV = self.TLV
       if b == nil   b = bytes() end     # start new buffer if none passed
 
@@ -605,7 +619,7 @@ class Matter_TLV
 
     #############################################################
     # encode to bytes
-    def encode(b)
+    def tlv2raw(b)
       if b == nil   b = bytes() end
       # encode tag and type
       self._encode_tag(b)
@@ -618,7 +632,7 @@ class Matter_TLV
 
       # output each one after the other
       for v : val_list
-        v.encode(b)
+        v.tlv2raw(b)
       end
 
       # add 'end of container'
@@ -885,7 +899,7 @@ import matter
 def test_TLV(b, s)
   var m =  matter.TLV.parse(b)
   assert(m.tostring() == s)
-  assert(m.encode() == b)
+  assert(m.tlv2raw() == b)
   assert(m.encode_len() == size(b))
 end
 

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UDPServer.be
@@ -46,9 +46,13 @@ class Matter_UDPPacket_sent
     self.port = port
     self.msg_id = id
     self.retries = 0
-    self.next_try = tasmota.millis() + self.backoff_time(self.retries)
+    self.next_try = tasmota.millis() + matter.UDPServer._backoff_time(self.retries)
   end
 
+  #############################################################
+  # Send packet now.
+  #
+  # Returns `true` if packet was successfully sent.
   def send(udp_socket)
     import string
     var ok = udp_socket.send(self.addr ? self.addr : udp_socket.remote_ip, self.port ? self.port : udp_socket.remote_port, self.raw)
@@ -57,27 +61,9 @@ class Matter_UDPPacket_sent
     else
       tasmota.log(string.format("MTR: error sending packet to '[%s]:%i'", self.addr, self.port), 3)
     end
+    return ok
   end
 
-  #############################################################
-  # Compute exponential backoff as per 4.11.2.1 p.137
-  def backoff_time(n)
-    def power_int(v, n)
-      var r = 1
-      while n > 0
-        r *= v
-        n -= 1
-      end
-      return r
-    end
-
-    import math
-    var i = 300                                   # SLEEPY_ACTIVE_INTERVAL
-    var rand = real(math.rand() & 0xFF) / 255     # 0..1 with reasonable granularity
-    var n_power = n > 0 ? n - 1 : 0
-    var mrpBackoffTime = i * power_int(1.6, n_power) * (1.0 + rand * 0.25 )
-    return int(mrpBackoffTime)
-  end
 end
 matter.UDPPacket_sent = Matter_UDPPacket_sent
 
@@ -88,30 +74,33 @@ matter.UDPPacket_sent = Matter_UDPPacket_sent
 class Matter_UDPServer
   static var RETRIES = 4            # 5 transmissions max (4 retries) `MRP_MAX_TRANSMISSIONS` 4.11.8 p.146
   static var MAX_PACKETS_READ = 4   # read at most 4 packets per tick
-  var address, port                 # local address and port
+  var addr, port                    # local addr and port
   var listening                     # true if active
   var udp_socket
   var dispatch_cb                   # callback to call when a message is received
   var packets_sent                  # list map of packets sent to be acknowledged
 
   #############################################################
-  def init(address, port)
-    self.address = address ? address : ""
+  # Init UDP Server listening to `addr` and `port` (opt).
+  #
+  # By default, the server listens to `""` (all addresses) and port `5540`
+  def init(addr, port)
+    self.addr = addr ? addr : ""
     self.port = port ? port : 5540
     self.listening = false
     self.packets_sent = []
   end
 
   #############################################################
-  # start the server
-  # raises an exception if something is wrong
-  # registers as device handle
+  # Starts the server.
+  # Registers as device handler to Tasmota
   #
-  # `cb`: callback to call when a message is received
+  # `cb(packet, from_addr, from_port)`: callback to call when a message is received.
+  # Raises an exception if something is wrong.
   def start(cb)
     if !self.listening
       self.udp_socket = udp()
-      var ok = self.udp_socket.begin(self.address, self.port)
+      var ok = self.udp_socket.begin(self.addr, self.port)
       if !ok    raise "network_error", "could not open UDP server" end
       self.listening = true
       self.dispatch_cb = cb
@@ -120,8 +109,7 @@ class Matter_UDPServer
   end
 
   #############################################################
-  # stop the server
-  # remove driver
+  # Stops the server and remove driver
   def stop()
     if self.listening
       self.udp_socket.stop()
@@ -131,6 +119,11 @@ class Matter_UDPServer
   end
 
   #############################################################
+  # At every tick:
+  # Check if a packet has arrived, and dispatch to `cb`.
+  # Read at most `MAX_PACKETS_READ (4) packets at each tick to
+  # avoid any starvation.
+  # Then resend queued outgoing packets.
   def every_50ms()
     import string
     var packet_read = 0
@@ -152,25 +145,33 @@ class Matter_UDPServer
         packet = nil
       end
     end
-    self.resend_packets()               # resend any packet
+    self._resend_packets()               # resend any packet
   end
 
   #############################################################
-  def resend_packets()
+  # Resend packets if they have not been acknowledged by receiver
+  # either with direct Ack packet or ack embedded in another packet.
+  # Packets with `id`=`nil` are not resent.
+  # <BR>
+  # Packets are re-sent at most `RETRIES` (4) times, i.e. sent maximum 5 times.
+  # Exponential backoff is added after each resending.
+  # <BR>
+  # If all retries expired, remove packet and log.
+  def _resend_packets()
     var idx = 0
     while idx < size(self.packets_sent)
       var packet = self.packets_sent[idx]
       if tasmota.time_reached(packet.next_try)
         if packet.retries <= self.RETRIES
-          tasmota.log("MTR: resending packet id=" + str(packet.msg_id), 3)
+          tasmota.log("MTR: .          Resending packet id=" + str(packet.msg_id), 3)
           packet.send(self.udp_socket)         # resend
-          packet.next_try = tasmota.millis() + packet.backoff_time(packet.retries)
+          packet.next_try = tasmota.millis() + self._backoff_time(packet.retries)
           packet.retries += 1
           idx += 1
         else
           import string
           self.packets_sent.remove(idx)
-          tasmota.log(string.format("MTR: target unreachable '[%s]:%i' msg_id=%i", packet.addr, packet.port, packet.msg_id), 2)
+          tasmota.log(string.format("MTR: .          Unacked packet '[%s]:%i' msg_id=%i", packet.addr, packet.port, packet.msg_id), 2)
         end
       else
         idx += 1
@@ -179,14 +180,15 @@ class Matter_UDPServer
   end
 
   #############################################################
-  # just received acknowledgment, remove packet from sender
-  def packet_ack(id)
+  # Just received acknowledgment, remove packet from sender
+  def received_ack(id)
     if id == nil   return end
+    tasmota.log("MTR: receveived ACK id="+str(id), 3)
     var idx = 0
     while idx < size(self.packets_sent)
       if self.packets_sent[idx].msg_id == id
         self.packets_sent.remove(idx)
-        tasmota.log("MTR: removed packet from sending list id=" + str(id), 4)
+        tasmota.log("MTR: .          Removed packet from sending list id=" + str(id), 3)
       else
         idx += 1
       end
@@ -194,10 +196,12 @@ class Matter_UDPServer
   end
 
   #############################################################
+  # Send a packet, enqueue it if `id` is not `nil`
   def send_response(raw, addr, port, id)
     var packet = matter.UDPPacket_sent(raw, addr, port, id)
     packet.send(self.udp_socket)    # send
     if id
+      # tasmota.log("MTR: <<< enqueue id="+str(id))
       self.packets_sent.push(packet)
     end
   end
@@ -206,13 +210,25 @@ class Matter_UDPServer
   # placeholder, nothing to run for now
   def every_second()
   end
+
+  #############################################################
+  # Compute exponential backoff as per 4.11.2.1 p.137
+  static def _backoff_time(n)
+    def power_int(v, n)
+      var r = 1
+      while n > 0
+        r *= v
+        n -= 1
+      end
+      return r
+    end
+
+    import math
+    var i = 300                                   # SLEEPY_ACTIVE_INTERVAL
+    var rand = real(math.rand() & 0xFF) / 255     # 0..1 with reasonable granularity
+    var n_power = n > 0 ? n - 1 : 0
+    var mrpBackoffTime = i * power_int(1.6, n_power) * (1.0 + rand * 0.25 )
+    return int(mrpBackoffTime)
+  end
 end
 matter.UDPServer = Matter_UDPServer
-
-#-
-
-import matter
-var udps = matter.UDPServer()
-udps.listen()
-
--#

--- a/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
+++ b/lib/libesp32/berry_matter/src/embedded/Matter_UI.be
@@ -185,7 +185,9 @@ class Matter_UI
         if !first     webserver.content_send("<hr>") end
         first = false
 
-        webserver.content_send(string.format("<fieldset><legend><b>&nbsp;#%i %s&nbsp;</b></legend><p></p>", f.get_fabric_index(), "&lt;No label&gt;"))
+        var label = f.fabric_label
+        if !label   label = "&lt;No label&gt;"    end
+        webserver.content_send(string.format("<fieldset><legend><b>&nbsp;#%i %s&nbsp;</b></legend><p></p>", f.get_fabric_index(), label))
 
         var fabric_rev = f.get_fabric_id().copy().reverse()
         var deviceid_rev = f.get_device_id().copy().reverse()

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning.h
@@ -57,7 +57,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[88]) {     /* constants */
+    ( &(const bvalue[65]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(opcode),
     /* K2   */  be_nested_str_weak(local_session_id),
@@ -75,81 +75,58 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
     /* K14  */  be_nested_str_weak(parse),
     /* K15  */  be_nested_str_weak(raw),
     /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K18  */  be_nested_str_weak(SHA256),
-    /* K19  */  be_nested_str_weak(update),
-    /* K20  */  be_nested_str_weak(__Msg1),
-    /* K21  */  be_nested_str_weak(__Msg2),
-    /* K22  */  be_nested_str_weak(out),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20session_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K24  */  be_nested_str_weak(MTR_X3A_X20session_X2Eipk_epoch_key_X20),
-    /* K25  */  be_nested_str_weak(get_ipk_epoch_key),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20session_X2Efabric_compressed_X20),
-    /* K27  */  be_nested_str_weak(get_fabric_compressed),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20ipk_group_key_X20_X3D_X20),
-    /* K29  */  be_nested_str_weak(get_ipk_group_key),
-    /* K30  */  be_nested_str_weak(tohex),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TranscriptHash_X3D_X20),
-    /* K32  */  be_nested_str_weak(fromstring),
-    /* K33  */  be_nested_str_weak(S3K_Info),
-    /* K34  */  be_nested_str_weak(HKDF_SHA256),
-    /* K35  */  be_nested_str_weak(derive),
-    /* K36  */  be_nested_str_weak(shared_secret),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s3k_salt_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s3k_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K39  */  be_nested_str_weak(TBEData3Encrypted),
-    /* K40  */  be_const_int(2147483647),
-    /* K41  */  be_nested_str_weak(AES_CCM),
-    /* K42  */  be_nested_str_weak(TBEData3_Nonce),
-    /* K43  */  be_nested_str_weak(decrypt),
-    /* K44  */  be_nested_str_weak(tag),
-    /* K45  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData3_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K46  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBETag3_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20tag_sent_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
-    /* K49  */  be_nested_str_weak(TLV),
-    /* K50  */  be_nested_str_weak(findsubval),
-    /* K51  */  be_const_int(3),
-    /* K52  */  be_nested_str_weak(MTR_X3A_X20initiatorNOCTLV_X20_X3D_X20),
-    /* K53  */  be_nested_str_weak(findsub),
-    /* K54  */  be_nested_str_weak(int),
-    /* K55  */  be_nested_str_weak(int64),
-    /* K56  */  be_nested_str_weak(peer_node_id),
-    /* K57  */  be_nested_str_weak(tobytes),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20initiatorFabricId_X3D),
-    /* K59  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K60  */  be_nested_str_weak(add_TLV),
-    /* K61  */  be_nested_str_weak(B1),
-    /* K62  */  be_nested_str_weak(initiatorEph_pub),
-    /* K63  */  be_nested_str_weak(ResponderEph_pub),
-    /* K64  */  be_nested_str_weak(encode),
-    /* K65  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20initiatorNOCPubKey_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20ec_signature_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K67  */  be_nested_str_weak(EC_P256),
-    /* K68  */  be_nested_str_weak(ecdsa_verify_sha256),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
-    /* K70  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
-    /* K71  */  be_nested_str_weak(Msg3),
-    /* K72  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20shared_secret_X20_X3D),
-    /* K74  */  be_nested_str_weak(MTR_X3A_X20ipk_X20_X2B_X20hash_X20_X20_X20_X20_X3D),
-    /* K75  */  be_nested_str_weak(SEKeys_Info),
-    /* K76  */  be_nested_str_weak(rtc),
-    /* K77  */  be_nested_str_weak(utc),
-    /* K78  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K79  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K80  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K81  */  be_nested_str_weak(close),
-    /* K82  */  be_nested_str_weak(set_keys),
-    /* K83  */  be_nested_str_weak(_breadcrumb),
-    /* K84  */  be_nested_str_weak(set_persist),
-    /* K85  */  be_nested_str_weak(set_no_expiration),
-    /* K86  */  be_nested_str_weak(persist_to_fabric),
-    /* K87  */  be_nested_str_weak(save),
+    /* K17  */  be_nested_str_weak(SHA256),
+    /* K18  */  be_nested_str_weak(update),
+    /* K19  */  be_nested_str_weak(__Msg1),
+    /* K20  */  be_nested_str_weak(__Msg2),
+    /* K21  */  be_nested_str_weak(out),
+    /* K22  */  be_nested_str_weak(fromstring),
+    /* K23  */  be_nested_str_weak(S3K_Info),
+    /* K24  */  be_nested_str_weak(HKDF_SHA256),
+    /* K25  */  be_nested_str_weak(derive),
+    /* K26  */  be_nested_str_weak(shared_secret),
+    /* K27  */  be_nested_str_weak(get_ipk_group_key),
+    /* K28  */  be_nested_str_weak(TBEData3Encrypted),
+    /* K29  */  be_const_int(2147483647),
+    /* K30  */  be_nested_str_weak(AES_CCM),
+    /* K31  */  be_nested_str_weak(TBEData3_Nonce),
+    /* K32  */  be_nested_str_weak(decrypt),
+    /* K33  */  be_nested_str_weak(tag),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20Tag_X20don_X27t_X20match),
+    /* K35  */  be_nested_str_weak(TLV),
+    /* K36  */  be_nested_str_weak(findsubval),
+    /* K37  */  be_const_int(3),
+    /* K38  */  be_nested_str_weak(findsub),
+    /* K39  */  be_nested_str_weak(int),
+    /* K40  */  be_nested_str_weak(int64),
+    /* K41  */  be_nested_str_weak(peer_node_id),
+    /* K42  */  be_nested_str_weak(tobytes),
+    /* K43  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K44  */  be_nested_str_weak(add_TLV),
+    /* K45  */  be_nested_str_weak(B1),
+    /* K46  */  be_nested_str_weak(initiatorEph_pub),
+    /* K47  */  be_nested_str_weak(ResponderEph_pub),
+    /* K48  */  be_nested_str_weak(tlv2raw),
+    /* K49  */  be_nested_str_weak(EC_P256),
+    /* K50  */  be_nested_str_weak(ecdsa_verify_sha256),
+    /* K51  */  be_nested_str_weak(MTR_X3A_X20sigma3_tbs_X20does_X20not_X20have_X20a_X20valid_X20signature),
+    /* K52  */  be_nested_str_weak(MTR_X3A_X20Sigma3_X20verified_X2C_X20computing_X20new_X20keys),
+    /* K53  */  be_nested_str_weak(Msg3),
+    /* K54  */  be_nested_str_weak(SEKeys_Info),
+    /* K55  */  be_nested_str_weak(rtc),
+    /* K56  */  be_nested_str_weak(utc),
+    /* K57  */  be_nested_str_weak(close),
+    /* K58  */  be_nested_str_weak(set_keys),
+    /* K59  */  be_nested_str_weak(_breadcrumb),
+    /* K60  */  be_nested_str_weak(counter_snd_next),
+    /* K61  */  be_nested_str_weak(set_persist),
+    /* K62  */  be_nested_str_weak(set_no_expiration),
+    /* K63  */  be_nested_str_weak(persist_to_fabric),
+    /* K64  */  be_nested_str_weak(save),
     }),
     be_str_weak(parse_Sigma3),
     &be_const_str_solidified,
-    ( &(const binstruction[478]) {  /* code */
+    ( &(const binstruction[291]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x54120031,  //  0002  LDINT	R4	50
@@ -183,451 +160,264 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma3,   /* name */
       0x8818030F,  //  001E  GETMBR	R6	R1	K15
       0x881C0310,  //  001F  GETMBR	R7	R1	K16
       0x7C100600,  //  0020  CALL	R4	3
-      0xB8160A00,  //  0021  GETNGBL	R5	K5
-      0x8C140B06,  //  0022  GETMET	R5	R5	K6
-      0x581C0011,  //  0023  LDCONST	R7	K17
-      0x54220003,  //  0024  LDINT	R8	4
-      0x7C140600,  //  0025  CALL	R5	3
-      0x8C140512,  //  0026  GETMET	R5	R2	K18
-      0x7C140200,  //  0027  CALL	R5	1
-      0x8C140B13,  //  0028  GETMET	R5	R5	K19
-      0x881C0714,  //  0029  GETMBR	R7	R3	K20
-      0x7C140400,  //  002A  CALL	R5	2
-      0x8C140B13,  //  002B  GETMET	R5	R5	K19
-      0x881C0715,  //  002C  GETMBR	R7	R3	K21
-      0x7C140400,  //  002D  CALL	R5	2
-      0x8C140B16,  //  002E  GETMET	R5	R5	K22
-      0x7C140200,  //  002F  CALL	R5	1
-      0xB81A0A00,  //  0030  GETNGBL	R6	K5
-      0x8C180D06,  //  0031  GETMET	R6	R6	K6
-      0x60200008,  //  0032  GETGBL	R8	G8
-      0x5C240600,  //  0033  MOVE	R9	R3
-      0x7C200200,  //  0034  CALL	R8	1
-      0x00222E08,  //  0035  ADD	R8	K23	R8
-      0x54260003,  //  0036  LDINT	R9	4
-      0x7C180600,  //  0037  CALL	R6	3
-      0xB81A0A00,  //  0038  GETNGBL	R6	K5
-      0x8C180D06,  //  0039  GETMET	R6	R6	K6
-      0x60200008,  //  003A  GETGBL	R8	G8
-      0x8C240719,  //  003B  GETMET	R9	R3	K25
-      0x7C240200,  //  003C  CALL	R9	1
-      0x7C200200,  //  003D  CALL	R8	1
-      0x00223008,  //  003E  ADD	R8	K24	R8
-      0x54260003,  //  003F  LDINT	R9	4
-      0x7C180600,  //  0040  CALL	R6	3
-      0xB81A0A00,  //  0041  GETNGBL	R6	K5
-      0x8C180D06,  //  0042  GETMET	R6	R6	K6
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x8C24071B,  //  0044  GETMET	R9	R3	K27
-      0x7C240200,  //  0045  CALL	R9	1
-      0x7C200200,  //  0046  CALL	R8	1
-      0x00223408,  //  0047  ADD	R8	K26	R8
-      0x54260003,  //  0048  LDINT	R9	4
-      0x7C180600,  //  0049  CALL	R6	3
-      0xB81A0A00,  //  004A  GETNGBL	R6	K5
-      0x8C180D06,  //  004B  GETMET	R6	R6	K6
-      0x8C20071D,  //  004C  GETMET	R8	R3	K29
-      0x7C200200,  //  004D  CALL	R8	1
-      0x8C20111E,  //  004E  GETMET	R8	R8	K30
-      0x7C200200,  //  004F  CALL	R8	1
-      0x00223808,  //  0050  ADD	R8	K28	R8
-      0x54260003,  //  0051  LDINT	R9	4
-      0x7C180600,  //  0052  CALL	R6	3
-      0xB81A0A00,  //  0053  GETNGBL	R6	K5
-      0x8C180D06,  //  0054  GETMET	R6	R6	K6
-      0x8C200B1E,  //  0055  GETMET	R8	R5	K30
-      0x7C200200,  //  0056  CALL	R8	1
-      0x00223E08,  //  0057  ADD	R8	K31	R8
-      0x54260003,  //  0058  LDINT	R9	4
-      0x7C180600,  //  0059  CALL	R6	3
-      0x60180015,  //  005A  GETGBL	R6	G21
-      0x7C180000,  //  005B  CALL	R6	0
-      0x8C180D20,  //  005C  GETMET	R6	R6	K32
-      0x88200121,  //  005D  GETMBR	R8	R0	K33
-      0x7C180400,  //  005E  CALL	R6	2
-      0x8C1C0522,  //  005F  GETMET	R7	R2	K34
-      0x7C1C0200,  //  0060  CALL	R7	1
-      0x8C1C0F23,  //  0061  GETMET	R7	R7	K35
-      0x88240724,  //  0062  GETMBR	R9	R3	K36
-      0x8C28071D,  //  0063  GETMET	R10	R3	K29
-      0x7C280200,  //  0064  CALL	R10	1
-      0x00281405,  //  0065  ADD	R10	R10	R5
-      0x5C2C0C00,  //  0066  MOVE	R11	R6
-      0x5432000F,  //  0067  LDINT	R12	16
-      0x7C1C0A00,  //  0068  CALL	R7	5
-      0xB8220A00,  //  0069  GETNGBL	R8	K5
-      0x8C201106,  //  006A  GETMET	R8	R8	K6
-      0x58280011,  //  006B  LDCONST	R10	K17
-      0x542E0003,  //  006C  LDINT	R11	4
-      0x7C200600,  //  006D  CALL	R8	3
-      0xB8220A00,  //  006E  GETNGBL	R8	K5
-      0x8C201106,  //  006F  GETMET	R8	R8	K6
-      0x8C28071D,  //  0070  GETMET	R10	R3	K29
-      0x7C280200,  //  0071  CALL	R10	1
-      0x00281405,  //  0072  ADD	R10	R10	R5
-      0x8C28151E,  //  0073  GETMET	R10	R10	K30
-      0x7C280200,  //  0074  CALL	R10	1
-      0x002A4A0A,  //  0075  ADD	R10	K37	R10
-      0x542E0003,  //  0076  LDINT	R11	4
-      0x7C200600,  //  0077  CALL	R8	3
-      0xB8220A00,  //  0078  GETNGBL	R8	K5
-      0x8C201106,  //  0079  GETMET	R8	R8	K6
-      0x8C280F1E,  //  007A  GETMET	R10	R7	K30
-      0x7C280200,  //  007B  CALL	R10	1
-      0x002A4C0A,  //  007C  ADD	R10	K38	R10
-      0x542E0003,  //  007D  LDINT	R11	4
-      0x7C200600,  //  007E  CALL	R8	3
-      0xB8220A00,  //  007F  GETNGBL	R8	K5
-      0x8C201106,  //  0080  GETMET	R8	R8	K6
-      0x58280011,  //  0081  LDCONST	R10	K17
-      0x542E0003,  //  0082  LDINT	R11	4
-      0x7C200600,  //  0083  CALL	R8	3
-      0x5421FFEE,  //  0084  LDINT	R8	-17
-      0x40220608,  //  0085  CONNECT	R8	K3	R8
-      0x88240927,  //  0086  GETMBR	R9	R4	K39
-      0x94201208,  //  0087  GETIDX	R8	R9	R8
-      0x5429FFEF,  //  0088  LDINT	R10	-16
-      0x40281528,  //  0089  CONNECT	R10	R10	K40
-      0x882C0927,  //  008A  GETMBR	R11	R4	K39
-      0x9424160A,  //  008B  GETIDX	R9	R11	R10
-      0x8C300529,  //  008C  GETMET	R12	R2	K41
-      0x5C380E00,  //  008D  MOVE	R14	R7
-      0x603C0015,  //  008E  GETGBL	R15	G21
-      0x7C3C0000,  //  008F  CALL	R15	0
-      0x8C3C1F20,  //  0090  GETMET	R15	R15	K32
-      0x8844012A,  //  0091  GETMBR	R17	R0	K42
-      0x7C3C0400,  //  0092  CALL	R15	2
-      0x60400015,  //  0093  GETGBL	R16	G21
-      0x7C400000,  //  0094  CALL	R16	0
-      0x6044000C,  //  0095  GETGBL	R17	G12
-      0x5C481000,  //  0096  MOVE	R18	R8
-      0x7C440200,  //  0097  CALL	R17	1
-      0x544A000F,  //  0098  LDINT	R18	16
-      0x7C300C00,  //  0099  CALL	R12	6
-      0x5C281800,  //  009A  MOVE	R10	R12
-      0x8C30152B,  //  009B  GETMET	R12	R10	K43
-      0x5C381000,  //  009C  MOVE	R14	R8
-      0x7C300400,  //  009D  CALL	R12	2
-      0x5C2C1800,  //  009E  MOVE	R11	R12
-      0x8C30152C,  //  009F  GETMET	R12	R10	K44
-      0x7C300200,  //  00A0  CALL	R12	1
-      0xB8360A00,  //  00A1  GETNGBL	R13	K5
-      0x8C341B06,  //  00A2  GETMET	R13	R13	K6
-      0x8C3C171E,  //  00A3  GETMET	R15	R11	K30
-      0x7C3C0200,  //  00A4  CALL	R15	1
-      0x003E5A0F,  //  00A5  ADD	R15	K45	R15
-      0x54420003,  //  00A6  LDINT	R16	4
-      0x7C340600,  //  00A7  CALL	R13	3
-      0xB8360A00,  //  00A8  GETNGBL	R13	K5
-      0x8C341B06,  //  00A9  GETMET	R13	R13	K6
-      0x8C3C191E,  //  00AA  GETMET	R15	R12	K30
-      0x7C3C0200,  //  00AB  CALL	R15	1
-      0x003E5C0F,  //  00AC  ADD	R15	K46	R15
-      0x54420003,  //  00AD  LDINT	R16	4
-      0x7C340600,  //  00AE  CALL	R13	3
-      0xB8360A00,  //  00AF  GETNGBL	R13	K5
-      0x8C341B06,  //  00B0  GETMET	R13	R13	K6
-      0x8C3C131E,  //  00B1  GETMET	R15	R9	K30
-      0x7C3C0200,  //  00B2  CALL	R15	1
-      0x003E5E0F,  //  00B3  ADD	R15	K47	R15
-      0x54420003,  //  00B4  LDINT	R16	4
-      0x7C340600,  //  00B5  CALL	R13	3
-      0xB8360A00,  //  00B6  GETNGBL	R13	K5
-      0x8C341B06,  //  00B7  GETMET	R13	R13	K6
-      0x583C0011,  //  00B8  LDCONST	R15	K17
-      0x54420003,  //  00B9  LDINT	R16	4
-      0x7C340600,  //  00BA  CALL	R13	3
-      0x20341809,  //  00BB  NE	R13	R12	R9
-      0x78360012,  //  00BC  JMPF	R13	#00D0
-      0xB8360A00,  //  00BD  GETNGBL	R13	K5
-      0x8C341B06,  //  00BE  GETMET	R13	R13	K6
-      0x583C0030,  //  00BF  LDCONST	R15	K48
-      0x58400008,  //  00C0  LDCONST	R16	K8
-      0x7C340600,  //  00C1  CALL	R13	3
-      0xB8360A00,  //  00C2  GETNGBL	R13	K5
-      0x8C341B06,  //  00C3  GETMET	R13	R13	K6
-      0x583C0007,  //  00C4  LDCONST	R15	K7
-      0x58400008,  //  00C5  LDCONST	R16	K8
-      0x7C340600,  //  00C6  CALL	R13	3
-      0x8C340109,  //  00C7  GETMET	R13	R0	K9
-      0x5C3C0200,  //  00C8  MOVE	R15	R1
-      0x5840000A,  //  00C9  LDCONST	R16	K10
-      0x58440003,  //  00CA  LDCONST	R17	K3
-      0x58480008,  //  00CB  LDCONST	R18	K8
-      0x504C0000,  //  00CC  LDBOOL	R19	0	0
-      0x7C340C00,  //  00CD  CALL	R13	6
-      0x50380000,  //  00CE  LDBOOL	R14	0	0
-      0x80041C00,  //  00CF  RET	1	R14
-      0xB8361800,  //  00D0  GETNGBL	R13	K12
-      0x88341B31,  //  00D1  GETMBR	R13	R13	K49
-      0x8C341B0E,  //  00D2  GETMET	R13	R13	K14
-      0x5C3C1600,  //  00D3  MOVE	R15	R11
-      0x7C340400,  //  00D4  CALL	R13	2
-      0x8C381B32,  //  00D5  GETMET	R14	R13	K50
-      0x5840000A,  //  00D6  LDCONST	R16	K10
-      0x7C380400,  //  00D7  CALL	R14	2
-      0x8C3C1B32,  //  00D8  GETMET	R15	R13	K50
-      0x58440008,  //  00D9  LDCONST	R17	K8
-      0x7C3C0400,  //  00DA  CALL	R15	2
-      0x8C401B32,  //  00DB  GETMET	R16	R13	K50
-      0x58480033,  //  00DC  LDCONST	R18	K51
-      0x7C400400,  //  00DD  CALL	R16	2
-      0xB8461800,  //  00DE  GETNGBL	R17	K12
-      0x88442331,  //  00DF  GETMBR	R17	R17	K49
-      0x8C44230E,  //  00E0  GETMET	R17	R17	K14
-      0x5C4C1C00,  //  00E1  MOVE	R19	R14
-      0x7C440400,  //  00E2  CALL	R17	2
-      0xB84A0A00,  //  00E3  GETNGBL	R18	K5
-      0x8C482506,  //  00E4  GETMET	R18	R18	K6
-      0x60500008,  //  00E5  GETGBL	R20	G8
-      0x5C542200,  //  00E6  MOVE	R21	R17
-      0x7C500200,  //  00E7  CALL	R20	1
-      0x00526814,  //  00E8  ADD	R20	K52	R20
-      0x58540033,  //  00E9  LDCONST	R21	K51
-      0x7C480600,  //  00EA  CALL	R18	3
-      0x8C482332,  //  00EB  GETMET	R18	R17	K50
-      0x54520008,  //  00EC  LDINT	R20	9
-      0x7C480400,  //  00ED  CALL	R18	2
-      0x8C4C2335,  //  00EE  GETMET	R19	R17	K53
-      0x54560005,  //  00EF  LDINT	R21	6
-      0x7C4C0400,  //  00F0  CALL	R19	2
-      0x8C502732,  //  00F1  GETMET	R20	R19	K50
-      0x545A0010,  //  00F2  LDINT	R22	17
-      0x7C500400,  //  00F3  CALL	R20	2
-      0x60540004,  //  00F4  GETGBL	R21	G4
-      0x5C582800,  //  00F5  MOVE	R22	R20
-      0x7C540200,  //  00F6  CALL	R21	1
-      0x1C542B36,  //  00F7  EQ	R21	R21	K54
-      0x78560003,  //  00F8  JMPF	R21	#00FD
-      0xB8566E00,  //  00F9  GETNGBL	R21	K55
-      0x5C582800,  //  00FA  MOVE	R22	R20
-      0x7C540200,  //  00FB  CALL	R21	1
-      0x5C502A00,  //  00FC  MOVE	R20	R21
-      0x8C542939,  //  00FD  GETMET	R21	R20	K57
-      0x7C540200,  //  00FE  CALL	R21	1
-      0x900E7015,  //  00FF  SETMBR	R3	K56	R21
-      0xB8560A00,  //  0100  GETNGBL	R21	K5
-      0x8C542B06,  //  0101  GETMET	R21	R21	K6
-      0x605C0008,  //  0102  GETGBL	R23	G8
-      0x88600738,  //  0103  GETMBR	R24	R3	K56
-      0x7C5C0200,  //  0104  CALL	R23	1
-      0x005E7417,  //  0105  ADD	R23	K58	R23
-      0x58600033,  //  0106  LDCONST	R24	K51
-      0x7C540600,  //  0107  CALL	R21	3
-      0xB8561800,  //  0108  GETNGBL	R21	K12
-      0x88542B31,  //  0109  GETMBR	R21	R21	K49
-      0x8C542B3B,  //  010A  GETMET	R21	R21	K59
-      0x7C540200,  //  010B  CALL	R21	1
-      0x8C582B3C,  //  010C  GETMET	R22	R21	K60
-      0x5860000A,  //  010D  LDCONST	R24	K10
-      0xB8661800,  //  010E  GETNGBL	R25	K12
-      0x88643331,  //  010F  GETMBR	R25	R25	K49
-      0x8864333D,  //  0110  GETMBR	R25	R25	K61
-      0x5C681C00,  //  0111  MOVE	R26	R14
-      0x7C580800,  //  0112  CALL	R22	4
-      0x8C582B3C,  //  0113  GETMET	R22	R21	K60
-      0x58600008,  //  0114  LDCONST	R24	K8
-      0xB8661800,  //  0115  GETNGBL	R25	K12
-      0x88643331,  //  0116  GETMBR	R25	R25	K49
-      0x8864333D,  //  0117  GETMBR	R25	R25	K61
-      0x5C681E00,  //  0118  MOVE	R26	R15
-      0x7C580800,  //  0119  CALL	R22	4
-      0x8C582B3C,  //  011A  GETMET	R22	R21	K60
-      0x58600033,  //  011B  LDCONST	R24	K51
-      0xB8661800,  //  011C  GETNGBL	R25	K12
-      0x88643331,  //  011D  GETMBR	R25	R25	K49
-      0x8864333D,  //  011E  GETMBR	R25	R25	K61
-      0x8868013E,  //  011F  GETMBR	R26	R0	K62
-      0x7C580800,  //  0120  CALL	R22	4
-      0x8C582B3C,  //  0121  GETMET	R22	R21	K60
-      0x54620003,  //  0122  LDINT	R24	4
-      0xB8661800,  //  0123  GETNGBL	R25	K12
-      0x88643331,  //  0124  GETMBR	R25	R25	K49
-      0x8864333D,  //  0125  GETMBR	R25	R25	K61
-      0x8868013F,  //  0126  GETMBR	R26	R0	K63
-      0x7C580800,  //  0127  CALL	R22	4
-      0x8C582B40,  //  0128  GETMET	R22	R21	K64
-      0x7C580200,  //  0129  CALL	R22	1
-      0xB85E0A00,  //  012A  GETNGBL	R23	K5
-      0x8C5C2F06,  //  012B  GETMET	R23	R23	K6
-      0x8C64251E,  //  012C  GETMET	R25	R18	K30
-      0x7C640200,  //  012D  CALL	R25	1
-      0x00668219,  //  012E  ADD	R25	K65	R25
-      0x546A0003,  //  012F  LDINT	R26	4
-      0x7C5C0600,  //  0130  CALL	R23	3
-      0xB85E0A00,  //  0131  GETNGBL	R23	K5
-      0x8C5C2F06,  //  0132  GETMET	R23	R23	K6
-      0x8C64211E,  //  0133  GETMET	R25	R16	K30
-      0x7C640200,  //  0134  CALL	R25	1
-      0x00668419,  //  0135  ADD	R25	K66	R25
-      0x546A0003,  //  0136  LDINT	R26	4
-      0x7C5C0600,  //  0137  CALL	R23	3
-      0xB85E0A00,  //  0138  GETNGBL	R23	K5
-      0x8C5C2F06,  //  0139  GETMET	R23	R23	K6
-      0x58640011,  //  013A  LDCONST	R25	K17
-      0x546A0003,  //  013B  LDINT	R26	4
-      0x7C5C0600,  //  013C  CALL	R23	3
-      0x8C5C0543,  //  013D  GETMET	R23	R2	K67
-      0x7C5C0200,  //  013E  CALL	R23	1
-      0x8C5C2F44,  //  013F  GETMET	R23	R23	K68
-      0x5C642400,  //  0140  MOVE	R25	R18
-      0x5C682C00,  //  0141  MOVE	R26	R22
-      0x5C6C2000,  //  0142  MOVE	R27	R16
-      0x7C5C0800,  //  0143  CALL	R23	4
-      0x5C602E00,  //  0144  MOVE	R24	R23
-      0x74620012,  //  0145  JMPT	R24	#0159
-      0xB8620A00,  //  0146  GETNGBL	R24	K5
-      0x8C603106,  //  0147  GETMET	R24	R24	K6
-      0x58680045,  //  0148  LDCONST	R26	K69
-      0x586C0008,  //  0149  LDCONST	R27	K8
-      0x7C600600,  //  014A  CALL	R24	3
-      0xB8620A00,  //  014B  GETNGBL	R24	K5
-      0x8C603106,  //  014C  GETMET	R24	R24	K6
-      0x58680007,  //  014D  LDCONST	R26	K7
-      0x586C0008,  //  014E  LDCONST	R27	K8
-      0x7C600600,  //  014F  CALL	R24	3
-      0x8C600109,  //  0150  GETMET	R24	R0	K9
-      0x5C680200,  //  0151  MOVE	R26	R1
-      0x586C000A,  //  0152  LDCONST	R27	K10
-      0x58700003,  //  0153  LDCONST	R28	K3
-      0x58740008,  //  0154  LDCONST	R29	K8
-      0x50780000,  //  0155  LDBOOL	R30	0	0
-      0x7C600C00,  //  0156  CALL	R24	6
-      0x50640000,  //  0157  LDBOOL	R25	0	0
-      0x80043200,  //  0158  RET	1	R25
-      0xB8620A00,  //  0159  GETNGBL	R24	K5
-      0x8C603106,  //  015A  GETMET	R24	R24	K6
-      0x58680046,  //  015B  LDCONST	R26	K70
-      0x586C0033,  //  015C  LDCONST	R27	K51
-      0x7C600600,  //  015D  CALL	R24	3
-      0x8C600512,  //  015E  GETMET	R24	R2	K18
-      0x7C600200,  //  015F  CALL	R24	1
-      0x8C603113,  //  0160  GETMET	R24	R24	K19
-      0x88680714,  //  0161  GETMBR	R26	R3	K20
-      0x7C600400,  //  0162  CALL	R24	2
-      0x8C603113,  //  0163  GETMET	R24	R24	K19
-      0x88680715,  //  0164  GETMBR	R26	R3	K21
-      0x7C600400,  //  0165  CALL	R24	2
-      0x8C603113,  //  0166  GETMET	R24	R24	K19
-      0x88680947,  //  0167  GETMBR	R26	R4	K71
-      0x7C600400,  //  0168  CALL	R24	2
-      0x8C603116,  //  0169  GETMET	R24	R24	K22
-      0x7C600200,  //  016A  CALL	R24	1
-      0x5C143000,  //  016B  MOVE	R5	R24
-      0x4C600000,  //  016C  LDNIL	R24
-      0x900E2818,  //  016D  SETMBR	R3	K20	R24
-      0x4C600000,  //  016E  LDNIL	R24
-      0x900E2A18,  //  016F  SETMBR	R3	K21	R24
-      0xB8620A00,  //  0170  GETNGBL	R24	K5
-      0x8C603106,  //  0171  GETMET	R24	R24	K6
-      0x58680048,  //  0172  LDCONST	R26	K72
-      0x546E0003,  //  0173  LDINT	R27	4
-      0x7C600600,  //  0174  CALL	R24	3
-      0xB8620A00,  //  0175  GETNGBL	R24	K5
-      0x8C603106,  //  0176  GETMET	R24	R24	K6
-      0x88680724,  //  0177  GETMBR	R26	R3	K36
-      0x8C68351E,  //  0178  GETMET	R26	R26	K30
-      0x7C680200,  //  0179  CALL	R26	1
-      0x006A921A,  //  017A  ADD	R26	K73	R26
-      0x546E0003,  //  017B  LDINT	R27	4
-      0x7C600600,  //  017C  CALL	R24	3
-      0xB8620A00,  //  017D  GETNGBL	R24	K5
-      0x8C603106,  //  017E  GETMET	R24	R24	K6
-      0x8C68071D,  //  017F  GETMET	R26	R3	K29
-      0x7C680200,  //  0180  CALL	R26	1
-      0x00683405,  //  0181  ADD	R26	R26	R5
-      0x8C68351E,  //  0182  GETMET	R26	R26	K30
-      0x7C680200,  //  0183  CALL	R26	1
-      0x006A941A,  //  0184  ADD	R26	K74	R26
-      0x546E0003,  //  0185  LDINT	R27	4
-      0x7C600600,  //  0186  CALL	R24	3
-      0x8C600522,  //  0187  GETMET	R24	R2	K34
-      0x7C600200,  //  0188  CALL	R24	1
-      0x8C603123,  //  0189  GETMET	R24	R24	K35
-      0x88680724,  //  018A  GETMBR	R26	R3	K36
-      0x8C6C071D,  //  018B  GETMET	R27	R3	K29
-      0x7C6C0200,  //  018C  CALL	R27	1
-      0x006C3605,  //  018D  ADD	R27	R27	R5
-      0x60700015,  //  018E  GETGBL	R28	G21
-      0x7C700000,  //  018F  CALL	R28	0
-      0x8C703920,  //  0190  GETMET	R28	R28	K32
-      0x8878014B,  //  0191  GETMBR	R30	R0	K75
-      0x7C700400,  //  0192  CALL	R28	2
-      0x5476002F,  //  0193  LDINT	R29	48
-      0x7C600A00,  //  0194  CALL	R24	5
-      0x5466000E,  //  0195  LDINT	R25	15
-      0x40660619,  //  0196  CONNECT	R25	K3	R25
-      0x94643019,  //  0197  GETIDX	R25	R24	R25
-      0x546A000F,  //  0198  LDINT	R26	16
-      0x546E001E,  //  0199  LDINT	R27	31
-      0x4068341B,  //  019A  CONNECT	R26	R26	R27
-      0x9468301A,  //  019B  GETIDX	R26	R24	R26
-      0x546E001F,  //  019C  LDINT	R27	32
-      0x5472002E,  //  019D  LDINT	R28	47
-      0x406C361C,  //  019E  CONNECT	R27	R27	R28
-      0x946C301B,  //  019F  GETIDX	R27	R24	R27
-      0xB8720A00,  //  01A0  GETNGBL	R28	K5
-      0x8C70394C,  //  01A1  GETMET	R28	R28	K76
-      0x7C700200,  //  01A2  CALL	R28	1
-      0x9470394D,  //  01A3  GETIDX	R28	R28	K77
-      0xB8760A00,  //  01A4  GETNGBL	R29	K5
-      0x8C743B06,  //  01A5  GETMET	R29	R29	K6
-      0x587C0048,  //  01A6  LDCONST	R31	K72
-      0x54820003,  //  01A7  LDINT	R32	4
-      0x7C740600,  //  01A8  CALL	R29	3
-      0xB8760A00,  //  01A9  GETNGBL	R29	K5
-      0x8C743B06,  //  01AA  GETMET	R29	R29	K6
-      0x8C7C331E,  //  01AB  GETMET	R31	R25	K30
-      0x7C7C0200,  //  01AC  CALL	R31	1
-      0x007E9C1F,  //  01AD  ADD	R31	K78	R31
-      0x54820003,  //  01AE  LDINT	R32	4
-      0x7C740600,  //  01AF  CALL	R29	3
-      0xB8760A00,  //  01B0  GETNGBL	R29	K5
-      0x8C743B06,  //  01B1  GETMET	R29	R29	K6
-      0x8C7C351E,  //  01B2  GETMET	R31	R26	K30
-      0x7C7C0200,  //  01B3  CALL	R31	1
-      0x007E9E1F,  //  01B4  ADD	R31	K79	R31
-      0x54820003,  //  01B5  LDINT	R32	4
-      0x7C740600,  //  01B6  CALL	R29	3
-      0xB8760A00,  //  01B7  GETNGBL	R29	K5
-      0x8C743B06,  //  01B8  GETMET	R29	R29	K6
-      0x8C7C371E,  //  01B9  GETMET	R31	R27	K30
-      0x7C7C0200,  //  01BA  CALL	R31	1
-      0x007EA01F,  //  01BB  ADD	R31	K80	R31
-      0x54820003,  //  01BC  LDINT	R32	4
-      0x7C740600,  //  01BD  CALL	R29	3
-      0xB8760A00,  //  01BE  GETNGBL	R29	K5
-      0x8C743B06,  //  01BF  GETMET	R29	R29	K6
-      0x587C0048,  //  01C0  LDCONST	R31	K72
-      0x54820003,  //  01C1  LDINT	R32	4
-      0x7C740600,  //  01C2  CALL	R29	3
-      0x8C740109,  //  01C3  GETMET	R29	R0	K9
-      0x5C7C0200,  //  01C4  MOVE	R31	R1
-      0x58800003,  //  01C5  LDCONST	R32	K3
-      0x58840003,  //  01C6  LDCONST	R33	K3
-      0x58880003,  //  01C7  LDCONST	R34	K3
-      0x508C0200,  //  01C8  LDBOOL	R35	1	0
-      0x7C740C00,  //  01C9  CALL	R29	6
-      0x8C780751,  //  01CA  GETMET	R30	R3	K81
-      0x7C780200,  //  01CB  CALL	R30	1
-      0x8C780752,  //  01CC  GETMET	R30	R3	K82
-      0x5C803200,  //  01CD  MOVE	R32	R25
-      0x5C843400,  //  01CE  MOVE	R33	R26
-      0x5C883600,  //  01CF  MOVE	R34	R27
-      0x5C8C3800,  //  01D0  MOVE	R35	R28
-      0x7C780A00,  //  01D1  CALL	R30	5
-      0x900EA703,  //  01D2  SETMBR	R3	K83	K3
-      0x8C780754,  //  01D3  GETMET	R30	R3	K84
-      0x50800200,  //  01D4  LDBOOL	R32	1	0
-      0x7C780400,  //  01D5  CALL	R30	2
-      0x8C780755,  //  01D6  GETMET	R30	R3	K85
-      0x7C780200,  //  01D7  CALL	R30	1
-      0x8C780756,  //  01D8  GETMET	R30	R3	K86
-      0x7C780200,  //  01D9  CALL	R30	1
-      0x8C780757,  //  01DA  GETMET	R30	R3	K87
-      0x7C780200,  //  01DB  CALL	R30	1
-      0x50780200,  //  01DC  LDBOOL	R30	1	0
-      0x80043C00,  //  01DD  RET	1	R30
+      0x8C140511,  //  0021  GETMET	R5	R2	K17
+      0x7C140200,  //  0022  CALL	R5	1
+      0x8C140B12,  //  0023  GETMET	R5	R5	K18
+      0x881C0713,  //  0024  GETMBR	R7	R3	K19
+      0x7C140400,  //  0025  CALL	R5	2
+      0x8C140B12,  //  0026  GETMET	R5	R5	K18
+      0x881C0714,  //  0027  GETMBR	R7	R3	K20
+      0x7C140400,  //  0028  CALL	R5	2
+      0x8C140B15,  //  0029  GETMET	R5	R5	K21
+      0x7C140200,  //  002A  CALL	R5	1
+      0x60180015,  //  002B  GETGBL	R6	G21
+      0x7C180000,  //  002C  CALL	R6	0
+      0x8C180D16,  //  002D  GETMET	R6	R6	K22
+      0x88200117,  //  002E  GETMBR	R8	R0	K23
+      0x7C180400,  //  002F  CALL	R6	2
+      0x8C1C0518,  //  0030  GETMET	R7	R2	K24
+      0x7C1C0200,  //  0031  CALL	R7	1
+      0x8C1C0F19,  //  0032  GETMET	R7	R7	K25
+      0x8824071A,  //  0033  GETMBR	R9	R3	K26
+      0x8C28071B,  //  0034  GETMET	R10	R3	K27
+      0x7C280200,  //  0035  CALL	R10	1
+      0x00281405,  //  0036  ADD	R10	R10	R5
+      0x5C2C0C00,  //  0037  MOVE	R11	R6
+      0x5432000F,  //  0038  LDINT	R12	16
+      0x7C1C0A00,  //  0039  CALL	R7	5
+      0x5421FFEE,  //  003A  LDINT	R8	-17
+      0x40220608,  //  003B  CONNECT	R8	K3	R8
+      0x8824091C,  //  003C  GETMBR	R9	R4	K28
+      0x94201208,  //  003D  GETIDX	R8	R9	R8
+      0x5429FFEF,  //  003E  LDINT	R10	-16
+      0x4028151D,  //  003F  CONNECT	R10	R10	K29
+      0x882C091C,  //  0040  GETMBR	R11	R4	K28
+      0x9424160A,  //  0041  GETIDX	R9	R11	R10
+      0x8C30051E,  //  0042  GETMET	R12	R2	K30
+      0x5C380E00,  //  0043  MOVE	R14	R7
+      0x603C0015,  //  0044  GETGBL	R15	G21
+      0x7C3C0000,  //  0045  CALL	R15	0
+      0x8C3C1F16,  //  0046  GETMET	R15	R15	K22
+      0x8844011F,  //  0047  GETMBR	R17	R0	K31
+      0x7C3C0400,  //  0048  CALL	R15	2
+      0x60400015,  //  0049  GETGBL	R16	G21
+      0x7C400000,  //  004A  CALL	R16	0
+      0x6044000C,  //  004B  GETGBL	R17	G12
+      0x5C481000,  //  004C  MOVE	R18	R8
+      0x7C440200,  //  004D  CALL	R17	1
+      0x544A000F,  //  004E  LDINT	R18	16
+      0x7C300C00,  //  004F  CALL	R12	6
+      0x5C281800,  //  0050  MOVE	R10	R12
+      0x8C301520,  //  0051  GETMET	R12	R10	K32
+      0x5C381000,  //  0052  MOVE	R14	R8
+      0x7C300400,  //  0053  CALL	R12	2
+      0x5C2C1800,  //  0054  MOVE	R11	R12
+      0x8C301521,  //  0055  GETMET	R12	R10	K33
+      0x7C300200,  //  0056  CALL	R12	1
+      0x20341809,  //  0057  NE	R13	R12	R9
+      0x78360012,  //  0058  JMPF	R13	#006C
+      0xB8360A00,  //  0059  GETNGBL	R13	K5
+      0x8C341B06,  //  005A  GETMET	R13	R13	K6
+      0x583C0022,  //  005B  LDCONST	R15	K34
+      0x58400008,  //  005C  LDCONST	R16	K8
+      0x7C340600,  //  005D  CALL	R13	3
+      0xB8360A00,  //  005E  GETNGBL	R13	K5
+      0x8C341B06,  //  005F  GETMET	R13	R13	K6
+      0x583C0007,  //  0060  LDCONST	R15	K7
+      0x58400008,  //  0061  LDCONST	R16	K8
+      0x7C340600,  //  0062  CALL	R13	3
+      0x8C340109,  //  0063  GETMET	R13	R0	K9
+      0x5C3C0200,  //  0064  MOVE	R15	R1
+      0x5840000A,  //  0065  LDCONST	R16	K10
+      0x58440003,  //  0066  LDCONST	R17	K3
+      0x58480008,  //  0067  LDCONST	R18	K8
+      0x504C0000,  //  0068  LDBOOL	R19	0	0
+      0x7C340C00,  //  0069  CALL	R13	6
+      0x50380000,  //  006A  LDBOOL	R14	0	0
+      0x80041C00,  //  006B  RET	1	R14
+      0xB8361800,  //  006C  GETNGBL	R13	K12
+      0x88341B23,  //  006D  GETMBR	R13	R13	K35
+      0x8C341B0E,  //  006E  GETMET	R13	R13	K14
+      0x5C3C1600,  //  006F  MOVE	R15	R11
+      0x7C340400,  //  0070  CALL	R13	2
+      0x8C381B24,  //  0071  GETMET	R14	R13	K36
+      0x5840000A,  //  0072  LDCONST	R16	K10
+      0x7C380400,  //  0073  CALL	R14	2
+      0x8C3C1B24,  //  0074  GETMET	R15	R13	K36
+      0x58440008,  //  0075  LDCONST	R17	K8
+      0x7C3C0400,  //  0076  CALL	R15	2
+      0x8C401B24,  //  0077  GETMET	R16	R13	K36
+      0x58480025,  //  0078  LDCONST	R18	K37
+      0x7C400400,  //  0079  CALL	R16	2
+      0xB8461800,  //  007A  GETNGBL	R17	K12
+      0x88442323,  //  007B  GETMBR	R17	R17	K35
+      0x8C44230E,  //  007C  GETMET	R17	R17	K14
+      0x5C4C1C00,  //  007D  MOVE	R19	R14
+      0x7C440400,  //  007E  CALL	R17	2
+      0x8C482324,  //  007F  GETMET	R18	R17	K36
+      0x54520008,  //  0080  LDINT	R20	9
+      0x7C480400,  //  0081  CALL	R18	2
+      0x8C4C2326,  //  0082  GETMET	R19	R17	K38
+      0x54560005,  //  0083  LDINT	R21	6
+      0x7C4C0400,  //  0084  CALL	R19	2
+      0x8C502724,  //  0085  GETMET	R20	R19	K36
+      0x545A0010,  //  0086  LDINT	R22	17
+      0x7C500400,  //  0087  CALL	R20	2
+      0x60540004,  //  0088  GETGBL	R21	G4
+      0x5C582800,  //  0089  MOVE	R22	R20
+      0x7C540200,  //  008A  CALL	R21	1
+      0x1C542B27,  //  008B  EQ	R21	R21	K39
+      0x78560003,  //  008C  JMPF	R21	#0091
+      0xB8565000,  //  008D  GETNGBL	R21	K40
+      0x5C582800,  //  008E  MOVE	R22	R20
+      0x7C540200,  //  008F  CALL	R21	1
+      0x5C502A00,  //  0090  MOVE	R20	R21
+      0x8C54292A,  //  0091  GETMET	R21	R20	K42
+      0x7C540200,  //  0092  CALL	R21	1
+      0x900E5215,  //  0093  SETMBR	R3	K41	R21
+      0xB8561800,  //  0094  GETNGBL	R21	K12
+      0x88542B23,  //  0095  GETMBR	R21	R21	K35
+      0x8C542B2B,  //  0096  GETMET	R21	R21	K43
+      0x7C540200,  //  0097  CALL	R21	1
+      0x8C582B2C,  //  0098  GETMET	R22	R21	K44
+      0x5860000A,  //  0099  LDCONST	R24	K10
+      0xB8661800,  //  009A  GETNGBL	R25	K12
+      0x88643323,  //  009B  GETMBR	R25	R25	K35
+      0x8864332D,  //  009C  GETMBR	R25	R25	K45
+      0x5C681C00,  //  009D  MOVE	R26	R14
+      0x7C580800,  //  009E  CALL	R22	4
+      0x8C582B2C,  //  009F  GETMET	R22	R21	K44
+      0x58600008,  //  00A0  LDCONST	R24	K8
+      0xB8661800,  //  00A1  GETNGBL	R25	K12
+      0x88643323,  //  00A2  GETMBR	R25	R25	K35
+      0x8864332D,  //  00A3  GETMBR	R25	R25	K45
+      0x5C681E00,  //  00A4  MOVE	R26	R15
+      0x7C580800,  //  00A5  CALL	R22	4
+      0x8C582B2C,  //  00A6  GETMET	R22	R21	K44
+      0x58600025,  //  00A7  LDCONST	R24	K37
+      0xB8661800,  //  00A8  GETNGBL	R25	K12
+      0x88643323,  //  00A9  GETMBR	R25	R25	K35
+      0x8864332D,  //  00AA  GETMBR	R25	R25	K45
+      0x8868012E,  //  00AB  GETMBR	R26	R0	K46
+      0x7C580800,  //  00AC  CALL	R22	4
+      0x8C582B2C,  //  00AD  GETMET	R22	R21	K44
+      0x54620003,  //  00AE  LDINT	R24	4
+      0xB8661800,  //  00AF  GETNGBL	R25	K12
+      0x88643323,  //  00B0  GETMBR	R25	R25	K35
+      0x8864332D,  //  00B1  GETMBR	R25	R25	K45
+      0x8868012F,  //  00B2  GETMBR	R26	R0	K47
+      0x7C580800,  //  00B3  CALL	R22	4
+      0x8C582B30,  //  00B4  GETMET	R22	R21	K48
+      0x7C580200,  //  00B5  CALL	R22	1
+      0x8C5C0531,  //  00B6  GETMET	R23	R2	K49
+      0x7C5C0200,  //  00B7  CALL	R23	1
+      0x8C5C2F32,  //  00B8  GETMET	R23	R23	K50
+      0x5C642400,  //  00B9  MOVE	R25	R18
+      0x5C682C00,  //  00BA  MOVE	R26	R22
+      0x5C6C2000,  //  00BB  MOVE	R27	R16
+      0x7C5C0800,  //  00BC  CALL	R23	4
+      0x5C602E00,  //  00BD  MOVE	R24	R23
+      0x74620012,  //  00BE  JMPT	R24	#00D2
+      0xB8620A00,  //  00BF  GETNGBL	R24	K5
+      0x8C603106,  //  00C0  GETMET	R24	R24	K6
+      0x58680033,  //  00C1  LDCONST	R26	K51
+      0x586C0008,  //  00C2  LDCONST	R27	K8
+      0x7C600600,  //  00C3  CALL	R24	3
+      0xB8620A00,  //  00C4  GETNGBL	R24	K5
+      0x8C603106,  //  00C5  GETMET	R24	R24	K6
+      0x58680007,  //  00C6  LDCONST	R26	K7
+      0x586C0008,  //  00C7  LDCONST	R27	K8
+      0x7C600600,  //  00C8  CALL	R24	3
+      0x8C600109,  //  00C9  GETMET	R24	R0	K9
+      0x5C680200,  //  00CA  MOVE	R26	R1
+      0x586C000A,  //  00CB  LDCONST	R27	K10
+      0x58700003,  //  00CC  LDCONST	R28	K3
+      0x58740008,  //  00CD  LDCONST	R29	K8
+      0x50780000,  //  00CE  LDBOOL	R30	0	0
+      0x7C600C00,  //  00CF  CALL	R24	6
+      0x50640000,  //  00D0  LDBOOL	R25	0	0
+      0x80043200,  //  00D1  RET	1	R25
+      0xB8620A00,  //  00D2  GETNGBL	R24	K5
+      0x8C603106,  //  00D3  GETMET	R24	R24	K6
+      0x58680034,  //  00D4  LDCONST	R26	K52
+      0x586C0025,  //  00D5  LDCONST	R27	K37
+      0x7C600600,  //  00D6  CALL	R24	3
+      0x8C600511,  //  00D7  GETMET	R24	R2	K17
+      0x7C600200,  //  00D8  CALL	R24	1
+      0x8C603112,  //  00D9  GETMET	R24	R24	K18
+      0x88680713,  //  00DA  GETMBR	R26	R3	K19
+      0x7C600400,  //  00DB  CALL	R24	2
+      0x8C603112,  //  00DC  GETMET	R24	R24	K18
+      0x88680714,  //  00DD  GETMBR	R26	R3	K20
+      0x7C600400,  //  00DE  CALL	R24	2
+      0x8C603112,  //  00DF  GETMET	R24	R24	K18
+      0x88680935,  //  00E0  GETMBR	R26	R4	K53
+      0x7C600400,  //  00E1  CALL	R24	2
+      0x8C603115,  //  00E2  GETMET	R24	R24	K21
+      0x7C600200,  //  00E3  CALL	R24	1
+      0x5C143000,  //  00E4  MOVE	R5	R24
+      0x4C600000,  //  00E5  LDNIL	R24
+      0x900E2618,  //  00E6  SETMBR	R3	K19	R24
+      0x4C600000,  //  00E7  LDNIL	R24
+      0x900E2818,  //  00E8  SETMBR	R3	K20	R24
+      0x8C600518,  //  00E9  GETMET	R24	R2	K24
+      0x7C600200,  //  00EA  CALL	R24	1
+      0x8C603119,  //  00EB  GETMET	R24	R24	K25
+      0x8868071A,  //  00EC  GETMBR	R26	R3	K26
+      0x8C6C071B,  //  00ED  GETMET	R27	R3	K27
+      0x7C6C0200,  //  00EE  CALL	R27	1
+      0x006C3605,  //  00EF  ADD	R27	R27	R5
+      0x60700015,  //  00F0  GETGBL	R28	G21
+      0x7C700000,  //  00F1  CALL	R28	0
+      0x8C703916,  //  00F2  GETMET	R28	R28	K22
+      0x88780136,  //  00F3  GETMBR	R30	R0	K54
+      0x7C700400,  //  00F4  CALL	R28	2
+      0x5476002F,  //  00F5  LDINT	R29	48
+      0x7C600A00,  //  00F6  CALL	R24	5
+      0x5466000E,  //  00F7  LDINT	R25	15
+      0x40660619,  //  00F8  CONNECT	R25	K3	R25
+      0x94643019,  //  00F9  GETIDX	R25	R24	R25
+      0x546A000F,  //  00FA  LDINT	R26	16
+      0x546E001E,  //  00FB  LDINT	R27	31
+      0x4068341B,  //  00FC  CONNECT	R26	R26	R27
+      0x9468301A,  //  00FD  GETIDX	R26	R24	R26
+      0x546E001F,  //  00FE  LDINT	R27	32
+      0x5472002E,  //  00FF  LDINT	R28	47
+      0x406C361C,  //  0100  CONNECT	R27	R27	R28
+      0x946C301B,  //  0101  GETIDX	R27	R24	R27
+      0xB8720A00,  //  0102  GETNGBL	R28	K5
+      0x8C703937,  //  0103  GETMET	R28	R28	K55
+      0x7C700200,  //  0104  CALL	R28	1
+      0x94703938,  //  0105  GETIDX	R28	R28	K56
+      0x8C740109,  //  0106  GETMET	R29	R0	K9
+      0x5C7C0200,  //  0107  MOVE	R31	R1
+      0x58800003,  //  0108  LDCONST	R32	K3
+      0x58840003,  //  0109  LDCONST	R33	K3
+      0x58880003,  //  010A  LDCONST	R34	K3
+      0x508C0200,  //  010B  LDBOOL	R35	1	0
+      0x7C740C00,  //  010C  CALL	R29	6
+      0x8C780739,  //  010D  GETMET	R30	R3	K57
+      0x7C780200,  //  010E  CALL	R30	1
+      0x8C78073A,  //  010F  GETMET	R30	R3	K58
+      0x5C803200,  //  0110  MOVE	R32	R25
+      0x5C843400,  //  0111  MOVE	R33	R26
+      0x5C883600,  //  0112  MOVE	R34	R27
+      0x5C8C3800,  //  0113  MOVE	R35	R28
+      0x7C780A00,  //  0114  CALL	R30	5
+      0x900E7703,  //  0115  SETMBR	R3	K59	K3
+      0x8C78073C,  //  0116  GETMET	R30	R3	K60
+      0x7C780200,  //  0117  CALL	R30	1
+      0x8C78073D,  //  0118  GETMET	R30	R3	K61
+      0x50800200,  //  0119  LDBOOL	R32	1	0
+      0x7C780400,  //  011A  CALL	R30	2
+      0x8C78073E,  //  011B  GETMET	R30	R3	K62
+      0x7C780200,  //  011C  CALL	R30	1
+      0x8C78073F,  //  011D  GETMET	R30	R3	K63
+      0x7C780200,  //  011E  CALL	R30	1
+      0x8C780740,  //  011F  GETMET	R30	R3	K64
+      0x7C780200,  //  0120  CALL	R30	1
+      0x50780200,  //  0121  LDBOOL	R30	1	0
+      0x80043C00,  //  0122  RET	1	R30
     })
   )
 );
@@ -893,7 +683,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake3,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[42]) {     /* constants */
+    ( &(const bvalue[35]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(opcode),
     /* K2   */  be_nested_str_weak(local_session_id),
@@ -912,34 +702,27 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake3,   /* name */
     /* K15  */  be_nested_str_weak(raw),
     /* K16  */  be_nested_str_weak(app_payload_idx),
     /* K17  */  be_nested_str_weak(cA),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20received_X20cA_X3D),
-    /* K19  */  be_nested_str_weak(tohex),
-    /* K20  */  be_nested_str_weak(spake),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
-    /* K22  */  be_nested_str_weak(created),
-    /* K23  */  be_nested_str_weak(rtc),
-    /* K24  */  be_nested_str_weak(utc),
-    /* K25  */  be_nested_str_weak(HKDF_SHA256),
-    /* K26  */  be_nested_str_weak(derive),
-    /* K27  */  be_nested_str_weak(Ke),
-    /* K28  */  be_nested_str_weak(fromstring),
-    /* K29  */  be_nested_str_weak(SEKeys_Info),
-    /* K30  */  be_nested_str_weak(I2RKey),
-    /* K31  */  be_nested_str_weak(R2IKey),
-    /* K32  */  be_nested_str_weak(AttestationChallenge),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K34  */  be_nested_str_weak(MTR_X3A_X20session_keys_X3D),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K36  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K38  */  be_nested_str_weak(responder),
-    /* K39  */  be_nested_str_weak(add_session),
-    /* K40  */  be_nested_str_weak(future_local_session_id),
-    /* K41  */  be_nested_str_weak(future_initiator_session_id),
+    /* K18  */  be_nested_str_weak(spake),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20invalid_X20cA_X20received),
+    /* K20  */  be_nested_str_weak(created),
+    /* K21  */  be_nested_str_weak(rtc),
+    /* K22  */  be_nested_str_weak(utc),
+    /* K23  */  be_nested_str_weak(HKDF_SHA256),
+    /* K24  */  be_nested_str_weak(derive),
+    /* K25  */  be_nested_str_weak(Ke),
+    /* K26  */  be_nested_str_weak(fromstring),
+    /* K27  */  be_nested_str_weak(SEKeys_Info),
+    /* K28  */  be_nested_str_weak(I2RKey),
+    /* K29  */  be_nested_str_weak(R2IKey),
+    /* K30  */  be_nested_str_weak(AttestationChallenge),
+    /* K31  */  be_nested_str_weak(responder),
+    /* K32  */  be_nested_str_weak(add_session),
+    /* K33  */  be_nested_str_weak(future_local_session_id),
+    /* K34  */  be_nested_str_weak(future_initiator_session_id),
     }),
     be_str_weak(parse_Pake3),
     &be_const_str_solidified,
-    ( &(const binstruction[161]) {  /* code */
+    ( &(const binstruction[112]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x54120023,  //  0002  LDINT	R4	36
@@ -979,128 +762,79 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake3,   /* name */
       0x7C0C0600,  //  0024  CALL	R3	3
       0x88100711,  //  0025  GETMBR	R4	R3	K17
       0x90022204,  //  0026  SETMBR	R0	K17	R4
-      0xB8120A00,  //  0027  GETNGBL	R4	K5
-      0x8C100906,  //  0028  GETMET	R4	R4	K6
-      0x88180111,  //  0029  GETMBR	R6	R0	K17
-      0x8C180D13,  //  002A  GETMET	R6	R6	K19
-      0x7C180200,  //  002B  CALL	R6	1
-      0x001A2406,  //  002C  ADD	R6	K18	R6
-      0x541E0003,  //  002D  LDINT	R7	4
-      0x7C100600,  //  002E  CALL	R4	3
-      0x88100111,  //  002F  GETMBR	R4	R0	K17
-      0x88140114,  //  0030  GETMBR	R5	R0	K20
-      0x88140B11,  //  0031  GETMBR	R5	R5	K17
-      0x20100805,  //  0032  NE	R4	R4	R5
-      0x78120012,  //  0033  JMPF	R4	#0047
-      0xB8120A00,  //  0034  GETNGBL	R4	K5
-      0x8C100906,  //  0035  GETMET	R4	R4	K6
-      0x58180015,  //  0036  LDCONST	R6	K21
-      0x581C0008,  //  0037  LDCONST	R7	K8
-      0x7C100600,  //  0038  CALL	R4	3
-      0xB8120A00,  //  0039  GETNGBL	R4	K5
-      0x8C100906,  //  003A  GETMET	R4	R4	K6
-      0x58180009,  //  003B  LDCONST	R6	K9
-      0x581C0008,  //  003C  LDCONST	R7	K8
-      0x7C100600,  //  003D  CALL	R4	3
-      0x8C10010A,  //  003E  GETMET	R4	R0	K10
-      0x5C180200,  //  003F  MOVE	R6	R1
-      0x581C000B,  //  0040  LDCONST	R7	K11
-      0x58200003,  //  0041  LDCONST	R8	K3
-      0x58240008,  //  0042  LDCONST	R9	K8
-      0x50280000,  //  0043  LDBOOL	R10	0	0
-      0x7C100C00,  //  0044  CALL	R4	6
-      0x50140000,  //  0045  LDBOOL	R5	0	0
-      0x80040A00,  //  0046  RET	1	R5
-      0xB8120A00,  //  0047  GETNGBL	R4	K5
-      0x8C100917,  //  0048  GETMET	R4	R4	K23
-      0x7C100200,  //  0049  CALL	R4	1
-      0x94100918,  //  004A  GETIDX	R4	R4	K24
-      0x90022C04,  //  004B  SETMBR	R0	K22	R4
-      0x8C100519,  //  004C  GETMET	R4	R2	K25
-      0x7C100200,  //  004D  CALL	R4	1
-      0x8C10091A,  //  004E  GETMET	R4	R4	K26
-      0x8818011B,  //  004F  GETMBR	R6	R0	K27
-      0x601C0015,  //  0050  GETGBL	R7	G21
-      0x7C1C0000,  //  0051  CALL	R7	0
-      0x60200015,  //  0052  GETGBL	R8	G21
-      0x7C200000,  //  0053  CALL	R8	0
-      0x8C20111C,  //  0054  GETMET	R8	R8	K28
-      0x8828011D,  //  0055  GETMBR	R10	R0	K29
-      0x7C200400,  //  0056  CALL	R8	2
-      0x5426002F,  //  0057  LDINT	R9	48
-      0x7C100A00,  //  0058  CALL	R4	5
-      0x5416000E,  //  0059  LDINT	R5	15
-      0x40160605,  //  005A  CONNECT	R5	K3	R5
-      0x94140805,  //  005B  GETIDX	R5	R4	R5
-      0x90023C05,  //  005C  SETMBR	R0	K30	R5
-      0x5416000F,  //  005D  LDINT	R5	16
-      0x541A001E,  //  005E  LDINT	R6	31
-      0x40140A06,  //  005F  CONNECT	R5	R5	R6
-      0x94140805,  //  0060  GETIDX	R5	R4	R5
-      0x90023E05,  //  0061  SETMBR	R0	K31	R5
-      0x5416001F,  //  0062  LDINT	R5	32
-      0x541A002E,  //  0063  LDINT	R6	47
-      0x40140A06,  //  0064  CONNECT	R5	R5	R6
-      0x94140805,  //  0065  GETIDX	R5	R4	R5
-      0x90024005,  //  0066  SETMBR	R0	K32	R5
-      0xB8160A00,  //  0067  GETNGBL	R5	K5
-      0x8C140B06,  //  0068  GETMET	R5	R5	K6
-      0x581C0021,  //  0069  LDCONST	R7	K33
-      0x54220003,  //  006A  LDINT	R8	4
-      0x7C140600,  //  006B  CALL	R5	3
-      0xB8160A00,  //  006C  GETNGBL	R5	K5
-      0x8C140B06,  //  006D  GETMET	R5	R5	K6
-      0x8C1C0913,  //  006E  GETMET	R7	R4	K19
-      0x7C1C0200,  //  006F  CALL	R7	1
-      0x001E4407,  //  0070  ADD	R7	K34	R7
-      0x54220003,  //  0071  LDINT	R8	4
-      0x7C140600,  //  0072  CALL	R5	3
-      0xB8160A00,  //  0073  GETNGBL	R5	K5
-      0x8C140B06,  //  0074  GETMET	R5	R5	K6
-      0x881C011E,  //  0075  GETMBR	R7	R0	K30
-      0x8C1C0F13,  //  0076  GETMET	R7	R7	K19
-      0x7C1C0200,  //  0077  CALL	R7	1
-      0x001E4607,  //  0078  ADD	R7	K35	R7
-      0x54220003,  //  0079  LDINT	R8	4
-      0x7C140600,  //  007A  CALL	R5	3
-      0xB8160A00,  //  007B  GETNGBL	R5	K5
-      0x8C140B06,  //  007C  GETMET	R5	R5	K6
-      0x881C011F,  //  007D  GETMBR	R7	R0	K31
-      0x8C1C0F13,  //  007E  GETMET	R7	R7	K19
-      0x7C1C0200,  //  007F  CALL	R7	1
-      0x001E4807,  //  0080  ADD	R7	K36	R7
-      0x54220003,  //  0081  LDINT	R8	4
-      0x7C140600,  //  0082  CALL	R5	3
-      0xB8160A00,  //  0083  GETNGBL	R5	K5
-      0x8C140B06,  //  0084  GETMET	R5	R5	K6
-      0x881C0120,  //  0085  GETMBR	R7	R0	K32
-      0x8C1C0F13,  //  0086  GETMET	R7	R7	K19
-      0x7C1C0200,  //  0087  CALL	R7	1
-      0x001E4A07,  //  0088  ADD	R7	K37	R7
-      0x54220003,  //  0089  LDINT	R8	4
-      0x7C140600,  //  008A  CALL	R5	3
-      0xB8160A00,  //  008B  GETNGBL	R5	K5
-      0x8C140B06,  //  008C  GETMET	R5	R5	K6
-      0x581C0021,  //  008D  LDCONST	R7	K33
-      0x54220003,  //  008E  LDINT	R8	4
-      0x7C140600,  //  008F  CALL	R5	3
-      0x8C14010A,  //  0090  GETMET	R5	R0	K10
-      0x5C1C0200,  //  0091  MOVE	R7	R1
-      0x58200003,  //  0092  LDCONST	R8	K3
-      0x58240003,  //  0093  LDCONST	R9	K3
-      0x58280003,  //  0094  LDCONST	R10	K3
-      0x502C0000,  //  0095  LDBOOL	R11	0	0
-      0x7C140C00,  //  0096  CALL	R5	6
-      0x88180126,  //  0097  GETMBR	R6	R0	K38
-      0x8C180D27,  //  0098  GETMET	R6	R6	K39
-      0x88200128,  //  0099  GETMBR	R8	R0	K40
-      0x88240129,  //  009A  GETMBR	R9	R0	K41
-      0x8828011E,  //  009B  GETMBR	R10	R0	K30
-      0x882C011F,  //  009C  GETMBR	R11	R0	K31
-      0x88300120,  //  009D  GETMBR	R12	R0	K32
-      0x88340116,  //  009E  GETMBR	R13	R0	K22
-      0x7C180E00,  //  009F  CALL	R6	7
-      0x80000000,  //  00A0  RET	0
+      0x88100111,  //  0027  GETMBR	R4	R0	K17
+      0x88140112,  //  0028  GETMBR	R5	R0	K18
+      0x88140B11,  //  0029  GETMBR	R5	R5	K17
+      0x20100805,  //  002A  NE	R4	R4	R5
+      0x78120012,  //  002B  JMPF	R4	#003F
+      0xB8120A00,  //  002C  GETNGBL	R4	K5
+      0x8C100906,  //  002D  GETMET	R4	R4	K6
+      0x58180013,  //  002E  LDCONST	R6	K19
+      0x581C0008,  //  002F  LDCONST	R7	K8
+      0x7C100600,  //  0030  CALL	R4	3
+      0xB8120A00,  //  0031  GETNGBL	R4	K5
+      0x8C100906,  //  0032  GETMET	R4	R4	K6
+      0x58180009,  //  0033  LDCONST	R6	K9
+      0x581C0008,  //  0034  LDCONST	R7	K8
+      0x7C100600,  //  0035  CALL	R4	3
+      0x8C10010A,  //  0036  GETMET	R4	R0	K10
+      0x5C180200,  //  0037  MOVE	R6	R1
+      0x581C000B,  //  0038  LDCONST	R7	K11
+      0x58200003,  //  0039  LDCONST	R8	K3
+      0x58240008,  //  003A  LDCONST	R9	K8
+      0x50280000,  //  003B  LDBOOL	R10	0	0
+      0x7C100C00,  //  003C  CALL	R4	6
+      0x50140000,  //  003D  LDBOOL	R5	0	0
+      0x80040A00,  //  003E  RET	1	R5
+      0xB8120A00,  //  003F  GETNGBL	R4	K5
+      0x8C100915,  //  0040  GETMET	R4	R4	K21
+      0x7C100200,  //  0041  CALL	R4	1
+      0x94100916,  //  0042  GETIDX	R4	R4	K22
+      0x90022804,  //  0043  SETMBR	R0	K20	R4
+      0x8C100517,  //  0044  GETMET	R4	R2	K23
+      0x7C100200,  //  0045  CALL	R4	1
+      0x8C100918,  //  0046  GETMET	R4	R4	K24
+      0x88180119,  //  0047  GETMBR	R6	R0	K25
+      0x601C0015,  //  0048  GETGBL	R7	G21
+      0x7C1C0000,  //  0049  CALL	R7	0
+      0x60200015,  //  004A  GETGBL	R8	G21
+      0x7C200000,  //  004B  CALL	R8	0
+      0x8C20111A,  //  004C  GETMET	R8	R8	K26
+      0x8828011B,  //  004D  GETMBR	R10	R0	K27
+      0x7C200400,  //  004E  CALL	R8	2
+      0x5426002F,  //  004F  LDINT	R9	48
+      0x7C100A00,  //  0050  CALL	R4	5
+      0x5416000E,  //  0051  LDINT	R5	15
+      0x40160605,  //  0052  CONNECT	R5	K3	R5
+      0x94140805,  //  0053  GETIDX	R5	R4	R5
+      0x90023805,  //  0054  SETMBR	R0	K28	R5
+      0x5416000F,  //  0055  LDINT	R5	16
+      0x541A001E,  //  0056  LDINT	R6	31
+      0x40140A06,  //  0057  CONNECT	R5	R5	R6
+      0x94140805,  //  0058  GETIDX	R5	R4	R5
+      0x90023A05,  //  0059  SETMBR	R0	K29	R5
+      0x5416001F,  //  005A  LDINT	R5	32
+      0x541A002E,  //  005B  LDINT	R6	47
+      0x40140A06,  //  005C  CONNECT	R5	R5	R6
+      0x94140805,  //  005D  GETIDX	R5	R4	R5
+      0x90023C05,  //  005E  SETMBR	R0	K30	R5
+      0x8C14010A,  //  005F  GETMET	R5	R0	K10
+      0x5C1C0200,  //  0060  MOVE	R7	R1
+      0x58200003,  //  0061  LDCONST	R8	K3
+      0x58240003,  //  0062  LDCONST	R9	K3
+      0x58280003,  //  0063  LDCONST	R10	K3
+      0x502C0000,  //  0064  LDBOOL	R11	0	0
+      0x7C140C00,  //  0065  CALL	R5	6
+      0x8818011F,  //  0066  GETMBR	R6	R0	K31
+      0x8C180D20,  //  0067  GETMET	R6	R6	K32
+      0x88200121,  //  0068  GETMBR	R8	R0	K33
+      0x88240122,  //  0069  GETMBR	R9	R0	K34
+      0x8828011C,  //  006A  GETMBR	R10	R0	K28
+      0x882C011D,  //  006B  GETMBR	R11	R0	K29
+      0x8830011E,  //  006C  GETMBR	R12	R0	K30
+      0x88340114,  //  006D  GETMBR	R13	R0	K20
+      0x7C180E00,  //  006E  CALL	R6	7
+      0x80000000,  //  006F  RET	0
     })
   )
 );
@@ -1112,7 +846,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake3,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name */
   be_nested_proto(
-    14,                          /* nstack */
+    15,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1120,195 +854,201 @@ be_local_closure(Matter_Commisioning_Context_parse_PBKDFParamRequest,   /* name 
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[50]) {     /* constants */
+    ( &(const bvalue[52]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(opcode),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(protocol_id),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_nested_str_weak(send_status_report),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(PBKDFParamRequest),
-    /* K14  */  be_nested_str_weak(parse),
-    /* K15  */  be_nested_str_weak(raw),
-    /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(session),
-    /* K18  */  be_nested_str_weak(set_mode_PASE),
-    /* K19  */  be_const_int(2147483647),
-    /* K20  */  be_nested_str_weak(passcodeId),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
-    /* K22  */  be_nested_str_weak(future_initiator_session_id),
-    /* K23  */  be_nested_str_weak(initiator_session_id),
-    /* K24  */  be_nested_str_weak(future_local_session_id),
-    /* K25  */  be_nested_str_weak(device),
-    /* K26  */  be_nested_str_weak(sessions),
-    /* K27  */  be_nested_str_weak(gen_local_session_id),
-    /* K28  */  be_nested_str_weak(MTR_X3A_X20Loc_session_X3D),
-    /* K29  */  be_nested_str_weak(PBKDFParamResponse),
-    /* K30  */  be_nested_str_weak(initiatorRandom),
-    /* K31  */  be_nested_str_weak(responderRandom),
-    /* K32  */  be_nested_str_weak(random),
-    /* K33  */  be_nested_str_weak(responderSessionId),
-    /* K34  */  be_nested_str_weak(pbkdf_parameters_salt),
-    /* K35  */  be_nested_str_weak(commissioning_salt),
-    /* K36  */  be_nested_str_weak(pbkdf_parameters_iterations),
-    /* K37  */  be_nested_str_weak(commissioning_iterations),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_X3A_X20),
-    /* K39  */  be_nested_str_weak(inspect),
-    /* K40  */  be_nested_str_weak(encode),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_raw_X3A_X20),
-    /* K42  */  be_nested_str_weak(tohex),
-    /* K43  */  be_nested_str_weak(build_response),
-    /* K44  */  be_nested_str_weak(encode_frame),
-    /* K45  */  be_nested_str_weak(responder),
-    /* K46  */  be_nested_str_weak(send_response),
-    /* K47  */  be_nested_str_weak(remote_ip),
-    /* K48  */  be_nested_str_weak(remote_port),
-    /* K49  */  be_nested_str_weak(message_counter),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(protocol_id),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20PBKDFParamRequest_X20message),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K11  */  be_nested_str_weak(send_status_report),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(PBKDFParamRequest),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(session),
+    /* K19  */  be_nested_str_weak(set_mode_PASE),
+    /* K20  */  be_const_int(2147483647),
+    /* K21  */  be_nested_str_weak(passcodeId),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20non_X2Dzero_X20passcode_X20id),
+    /* K23  */  be_nested_str_weak(future_initiator_session_id),
+    /* K24  */  be_nested_str_weak(initiator_session_id),
+    /* K25  */  be_nested_str_weak(future_local_session_id),
+    /* K26  */  be_nested_str_weak(device),
+    /* K27  */  be_nested_str_weak(sessions),
+    /* K28  */  be_nested_str_weak(gen_local_session_id),
+    /* K29  */  be_nested_str_weak(format),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K31  */  be_nested_str_weak(remote_ip),
+    /* K32  */  be_nested_str_weak(remote_port),
+    /* K33  */  be_nested_str_weak(PBKDFParamResponse),
+    /* K34  */  be_nested_str_weak(initiatorRandom),
+    /* K35  */  be_nested_str_weak(responderRandom),
+    /* K36  */  be_nested_str_weak(random),
+    /* K37  */  be_nested_str_weak(responderSessionId),
+    /* K38  */  be_nested_str_weak(pbkdf_parameters_salt),
+    /* K39  */  be_nested_str_weak(commissioning_salt),
+    /* K40  */  be_nested_str_weak(pbkdf_parameters_iterations),
+    /* K41  */  be_nested_str_weak(commissioning_iterations),
+    /* K42  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_X3A_X20),
+    /* K43  */  be_nested_str_weak(inspect),
+    /* K44  */  be_nested_str_weak(tlv2raw),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20pbkdfparamresp_raw_X3A_X20),
+    /* K46  */  be_nested_str_weak(tohex),
+    /* K47  */  be_nested_str_weak(build_response),
+    /* K48  */  be_nested_str_weak(encode_frame),
+    /* K49  */  be_nested_str_weak(responder),
+    /* K50  */  be_nested_str_weak(send_response),
+    /* K51  */  be_nested_str_weak(message_counter),
     }),
     be_str_weak(parse_PBKDFParamRequest),
     &be_const_str_solidified,
-    ( &(const binstruction[134]) {  /* code */
+    ( &(const binstruction[138]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x5412001F,  //  0002  LDINT	R4	32
-      0x200C0604,  //  0003  NE	R3	R3	R4
-      0x740E0005,  //  0004  JMPT	R3	#000B
-      0x880C0302,  //  0005  GETMBR	R3	R1	K2
-      0x200C0703,  //  0006  NE	R3	R3	K3
-      0x740E0002,  //  0007  JMPT	R3	#000B
-      0x880C0304,  //  0008  GETMBR	R3	R1	K4
-      0x200C0703,  //  0009  NE	R3	R3	K3
-      0x780E0012,  //  000A  JMPF	R3	#001E
-      0xB80E0A00,  //  000B  GETNGBL	R3	K5
-      0x8C0C0706,  //  000C  GETMET	R3	R3	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0x5416001F,  //  0003  LDINT	R5	32
+      0x20100805,  //  0004  NE	R4	R4	R5
+      0x74120005,  //  0005  JMPT	R4	#000C
+      0x88100303,  //  0006  GETMBR	R4	R1	K3
+      0x20100904,  //  0007  NE	R4	R4	K4
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x88100305,  //  0009  GETMBR	R4	R1	K5
+      0x20100904,  //  000A  NE	R4	R4	K4
+      0x78120012,  //  000B  JMPF	R4	#001F
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0A00,  //  0010  GETNGBL	R3	K5
-      0x8C0C0706,  //  0011  GETMET	R3	R3	K6
-      0x58140009,  //  0012  LDCONST	R5	K9
-      0x58180008,  //  0013  LDCONST	R6	K8
-      0x7C0C0600,  //  0014  CALL	R3	3
-      0x8C0C010A,  //  0015  GETMET	R3	R0	K10
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5818000B,  //  0017  LDCONST	R6	K11
-      0x581C0003,  //  0018  LDCONST	R7	K3
-      0x58200008,  //  0019  LDCONST	R8	K8
-      0x50240000,  //  001A  LDBOOL	R9	0	0
-      0x7C0C0C00,  //  001B  CALL	R3	6
-      0x50100000,  //  001C  LDBOOL	R4	0	0
-      0x80040800,  //  001D  RET	1	R4
-      0xB80E1800,  //  001E  GETNGBL	R3	K12
-      0x8C0C070D,  //  001F  GETMET	R3	R3	K13
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x8C0C070E,  //  0021  GETMET	R3	R3	K14
-      0x8814030F,  //  0022  GETMBR	R5	R1	K15
+      0x581C0009,  //  000F  LDCONST	R7	K9
+      0x7C100600,  //  0010  CALL	R4	3
+      0xB8120C00,  //  0011  GETNGBL	R4	K6
+      0x8C100907,  //  0012  GETMET	R4	R4	K7
+      0x5818000A,  //  0013  LDCONST	R6	K10
+      0x581C0009,  //  0014  LDCONST	R7	K9
+      0x7C100600,  //  0015  CALL	R4	3
+      0x8C10010B,  //  0016  GETMET	R4	R0	K11
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x581C000C,  //  0018  LDCONST	R7	K12
+      0x58200004,  //  0019  LDCONST	R8	K4
+      0x58240009,  //  001A  LDCONST	R9	K9
+      0x50280000,  //  001B  LDBOOL	R10	0	0
+      0x7C100C00,  //  001C  CALL	R4	6
+      0x50140000,  //  001D  LDBOOL	R5	0	0
+      0x80040A00,  //  001E  RET	1	R5
+      0xB8121A00,  //  001F  GETNGBL	R4	K13
+      0x8C10090E,  //  0020  GETMET	R4	R4	K14
+      0x7C100200,  //  0021  CALL	R4	1
+      0x8C10090F,  //  0022  GETMET	R4	R4	K15
       0x88180310,  //  0023  GETMBR	R6	R1	K16
-      0x7C0C0600,  //  0024  CALL	R3	3
-      0x88100311,  //  0025  GETMBR	R4	R1	K17
-      0x8C100912,  //  0026  GETMET	R4	R4	K18
-      0x7C100200,  //  0027  CALL	R4	1
-      0x88100310,  //  0028  GETMBR	R4	R1	K16
-      0x40100913,  //  0029  CONNECT	R4	R4	K19
-      0x8814030F,  //  002A  GETMBR	R5	R1	K15
-      0x94100A04,  //  002B  GETIDX	R4	R5	R4
-      0x90021A04,  //  002C  SETMBR	R0	K13	R4
-      0x88100714,  //  002D  GETMBR	R4	R3	K20
-      0x20100903,  //  002E  NE	R4	R4	K3
-      0x78120012,  //  002F  JMPF	R4	#0043
-      0xB8120A00,  //  0030  GETNGBL	R4	K5
-      0x8C100906,  //  0031  GETMET	R4	R4	K6
-      0x58180015,  //  0032  LDCONST	R6	K21
-      0x581C0008,  //  0033  LDCONST	R7	K8
-      0x7C100600,  //  0034  CALL	R4	3
-      0xB8120A00,  //  0035  GETNGBL	R4	K5
-      0x8C100906,  //  0036  GETMET	R4	R4	K6
-      0x58180009,  //  0037  LDCONST	R6	K9
-      0x581C0008,  //  0038  LDCONST	R7	K8
-      0x7C100600,  //  0039  CALL	R4	3
-      0x8C10010A,  //  003A  GETMET	R4	R0	K10
-      0x5C180200,  //  003B  MOVE	R6	R1
-      0x581C000B,  //  003C  LDCONST	R7	K11
-      0x58200003,  //  003D  LDCONST	R8	K3
-      0x58240008,  //  003E  LDCONST	R9	K8
-      0x50280000,  //  003F  LDBOOL	R10	0	0
-      0x7C100C00,  //  0040  CALL	R4	6
-      0x50140000,  //  0041  LDBOOL	R5	0	0
-      0x80040A00,  //  0042  RET	1	R5
-      0x88100717,  //  0043  GETMBR	R4	R3	K23
-      0x90022C04,  //  0044  SETMBR	R0	K22	R4
-      0x88100119,  //  0045  GETMBR	R4	R0	K25
-      0x8810091A,  //  0046  GETMBR	R4	R4	K26
-      0x8C10091B,  //  0047  GETMET	R4	R4	K27
-      0x7C100200,  //  0048  CALL	R4	1
-      0x90023004,  //  0049  SETMBR	R0	K24	R4
-      0xB8120A00,  //  004A  GETNGBL	R4	K5
-      0x8C100906,  //  004B  GETMET	R4	R4	K6
-      0x60180008,  //  004C  GETGBL	R6	G8
-      0x881C0118,  //  004D  GETMBR	R7	R0	K24
-      0x7C180200,  //  004E  CALL	R6	1
-      0x001A3806,  //  004F  ADD	R6	K28	R6
-      0x7C100400,  //  0050  CALL	R4	2
-      0xB8121800,  //  0051  GETNGBL	R4	K12
-      0x8C10091D,  //  0052  GETMET	R4	R4	K29
-      0x7C100200,  //  0053  CALL	R4	1
-      0x8814071E,  //  0054  GETMBR	R5	R3	K30
-      0x90123C05,  //  0055  SETMBR	R4	K30	R5
-      0x8C140520,  //  0056  GETMET	R5	R2	K32
-      0x541E001F,  //  0057  LDINT	R7	32
-      0x7C140400,  //  0058  CALL	R5	2
-      0x90123E05,  //  0059  SETMBR	R4	K31	R5
-      0x88140118,  //  005A  GETMBR	R5	R0	K24
-      0x90124205,  //  005B  SETMBR	R4	K33	R5
-      0x88140119,  //  005C  GETMBR	R5	R0	K25
-      0x88140B23,  //  005D  GETMBR	R5	R5	K35
-      0x90124405,  //  005E  SETMBR	R4	K34	R5
-      0x88140119,  //  005F  GETMBR	R5	R0	K25
-      0x88140B25,  //  0060  GETMBR	R5	R5	K37
-      0x90124805,  //  0061  SETMBR	R4	K36	R5
-      0xB8160A00,  //  0062  GETNGBL	R5	K5
-      0x8C140B06,  //  0063  GETMET	R5	R5	K6
-      0x601C0008,  //  0064  GETGBL	R7	G8
-      0xB8221800,  //  0065  GETNGBL	R8	K12
-      0x8C201127,  //  0066  GETMET	R8	R8	K39
-      0x5C280800,  //  0067  MOVE	R10	R4
-      0x7C200400,  //  0068  CALL	R8	2
-      0x7C1C0200,  //  0069  CALL	R7	1
-      0x001E4C07,  //  006A  ADD	R7	K38	R7
-      0x54220003,  //  006B  LDINT	R8	4
-      0x7C140600,  //  006C  CALL	R5	3
-      0x8C140928,  //  006D  GETMET	R5	R4	K40
-      0x7C140200,  //  006E  CALL	R5	1
-      0xB81A0A00,  //  006F  GETNGBL	R6	K5
-      0x8C180D06,  //  0070  GETMET	R6	R6	K6
-      0x8C200B2A,  //  0071  GETMET	R8	R5	K42
-      0x7C200200,  //  0072  CALL	R8	1
-      0x00225208,  //  0073  ADD	R8	K41	R8
-      0x54260003,  //  0074  LDINT	R9	4
-      0x7C180600,  //  0075  CALL	R6	3
-      0x90023A05,  //  0076  SETMBR	R0	K29	R5
-      0x8C18032B,  //  0077  GETMET	R6	R1	K43
-      0x54220020,  //  0078  LDINT	R8	33
-      0x50240200,  //  0079  LDBOOL	R9	1	0
-      0x7C180600,  //  007A  CALL	R6	3
-      0x8C1C0D2C,  //  007B  GETMET	R7	R6	K44
-      0x5C240A00,  //  007C  MOVE	R9	R5
-      0x7C1C0400,  //  007D  CALL	R7	2
-      0x8820012D,  //  007E  GETMBR	R8	R0	K45
-      0x8C20112E,  //  007F  GETMET	R8	R8	K46
-      0x5C280E00,  //  0080  MOVE	R10	R7
-      0x882C032F,  //  0081  GETMBR	R11	R1	K47
-      0x88300330,  //  0082  GETMBR	R12	R1	K48
-      0x88340D31,  //  0083  GETMBR	R13	R6	K49
-      0x7C200A00,  //  0084  CALL	R8	5
-      0x80000000,  //  0085  RET	0
+      0x881C0311,  //  0024  GETMBR	R7	R1	K17
+      0x7C100600,  //  0025  CALL	R4	3
+      0x88140312,  //  0026  GETMBR	R5	R1	K18
+      0x8C140B13,  //  0027  GETMET	R5	R5	K19
+      0x7C140200,  //  0028  CALL	R5	1
+      0x88140311,  //  0029  GETMBR	R5	R1	K17
+      0x40140B14,  //  002A  CONNECT	R5	R5	K20
+      0x88180310,  //  002B  GETMBR	R6	R1	K16
+      0x94140C05,  //  002C  GETIDX	R5	R6	R5
+      0x90021C05,  //  002D  SETMBR	R0	K14	R5
+      0x88140915,  //  002E  GETMBR	R5	R4	K21
+      0x20140B04,  //  002F  NE	R5	R5	K4
+      0x78160012,  //  0030  JMPF	R5	#0044
+      0xB8160C00,  //  0031  GETNGBL	R5	K6
+      0x8C140B07,  //  0032  GETMET	R5	R5	K7
+      0x581C0016,  //  0033  LDCONST	R7	K22
+      0x58200009,  //  0034  LDCONST	R8	K9
+      0x7C140600,  //  0035  CALL	R5	3
+      0xB8160C00,  //  0036  GETNGBL	R5	K6
+      0x8C140B07,  //  0037  GETMET	R5	R5	K7
+      0x581C000A,  //  0038  LDCONST	R7	K10
+      0x58200009,  //  0039  LDCONST	R8	K9
+      0x7C140600,  //  003A  CALL	R5	3
+      0x8C14010B,  //  003B  GETMET	R5	R0	K11
+      0x5C1C0200,  //  003C  MOVE	R7	R1
+      0x5820000C,  //  003D  LDCONST	R8	K12
+      0x58240004,  //  003E  LDCONST	R9	K4
+      0x58280009,  //  003F  LDCONST	R10	K9
+      0x502C0000,  //  0040  LDBOOL	R11	0	0
+      0x7C140C00,  //  0041  CALL	R5	6
+      0x50180000,  //  0042  LDBOOL	R6	0	0
+      0x80040C00,  //  0043  RET	1	R6
+      0x88140918,  //  0044  GETMBR	R5	R4	K24
+      0x90022E05,  //  0045  SETMBR	R0	K23	R5
+      0x8814011A,  //  0046  GETMBR	R5	R0	K26
+      0x88140B1B,  //  0047  GETMBR	R5	R5	K27
+      0x8C140B1C,  //  0048  GETMET	R5	R5	K28
+      0x7C140200,  //  0049  CALL	R5	1
+      0x90023205,  //  004A  SETMBR	R0	K25	R5
+      0xB8160C00,  //  004B  GETNGBL	R5	K6
+      0x8C140B07,  //  004C  GETMET	R5	R5	K7
+      0x8C1C071D,  //  004D  GETMET	R7	R3	K29
+      0x5824001E,  //  004E  LDCONST	R9	K30
+      0x88280119,  //  004F  GETMBR	R10	R0	K25
+      0x882C031F,  //  0050  GETMBR	R11	R1	K31
+      0x88300320,  //  0051  GETMBR	R12	R1	K32
+      0x7C1C0A00,  //  0052  CALL	R7	5
+      0x58200009,  //  0053  LDCONST	R8	K9
+      0x7C140600,  //  0054  CALL	R5	3
+      0xB8161A00,  //  0055  GETNGBL	R5	K13
+      0x8C140B21,  //  0056  GETMET	R5	R5	K33
+      0x7C140200,  //  0057  CALL	R5	1
+      0x88180922,  //  0058  GETMBR	R6	R4	K34
+      0x90164406,  //  0059  SETMBR	R5	K34	R6
+      0x8C180524,  //  005A  GETMET	R6	R2	K36
+      0x5422001F,  //  005B  LDINT	R8	32
+      0x7C180400,  //  005C  CALL	R6	2
+      0x90164606,  //  005D  SETMBR	R5	K35	R6
+      0x88180119,  //  005E  GETMBR	R6	R0	K25
+      0x90164A06,  //  005F  SETMBR	R5	K37	R6
+      0x8818011A,  //  0060  GETMBR	R6	R0	K26
+      0x88180D27,  //  0061  GETMBR	R6	R6	K39
+      0x90164C06,  //  0062  SETMBR	R5	K38	R6
+      0x8818011A,  //  0063  GETMBR	R6	R0	K26
+      0x88180D29,  //  0064  GETMBR	R6	R6	K41
+      0x90165006,  //  0065  SETMBR	R5	K40	R6
+      0xB81A0C00,  //  0066  GETNGBL	R6	K6
+      0x8C180D07,  //  0067  GETMET	R6	R6	K7
+      0x60200008,  //  0068  GETGBL	R8	G8
+      0xB8261A00,  //  0069  GETNGBL	R9	K13
+      0x8C24132B,  //  006A  GETMET	R9	R9	K43
+      0x5C2C0A00,  //  006B  MOVE	R11	R5
+      0x7C240400,  //  006C  CALL	R9	2
+      0x7C200200,  //  006D  CALL	R8	1
+      0x00225408,  //  006E  ADD	R8	K42	R8
+      0x54260003,  //  006F  LDINT	R9	4
+      0x7C180600,  //  0070  CALL	R6	3
+      0x8C180B2C,  //  0071  GETMET	R6	R5	K44
+      0x7C180200,  //  0072  CALL	R6	1
+      0xB81E0C00,  //  0073  GETNGBL	R7	K6
+      0x8C1C0F07,  //  0074  GETMET	R7	R7	K7
+      0x8C240D2E,  //  0075  GETMET	R9	R6	K46
+      0x7C240200,  //  0076  CALL	R9	1
+      0x00265A09,  //  0077  ADD	R9	K45	R9
+      0x542A0003,  //  0078  LDINT	R10	4
+      0x7C1C0600,  //  0079  CALL	R7	3
+      0x90024206,  //  007A  SETMBR	R0	K33	R6
+      0x8C1C032F,  //  007B  GETMET	R7	R1	K47
+      0x54260020,  //  007C  LDINT	R9	33
+      0x50280200,  //  007D  LDBOOL	R10	1	0
+      0x7C1C0600,  //  007E  CALL	R7	3
+      0x8C200F30,  //  007F  GETMET	R8	R7	K48
+      0x5C280C00,  //  0080  MOVE	R10	R6
+      0x7C200400,  //  0081  CALL	R8	2
+      0x88240131,  //  0082  GETMBR	R9	R0	K49
+      0x8C241332,  //  0083  GETMET	R9	R9	K50
+      0x5C2C1000,  //  0084  MOVE	R11	R8
+      0x8830031F,  //  0085  GETMBR	R12	R1	K31
+      0x88340320,  //  0086  GETMBR	R13	R1	K32
+      0x88380F33,  //  0087  GETMBR	R14	R7	K51
+      0x7C240A00,  //  0088  CALL	R9	5
+      0x80000000,  //  0089  RET	0
     })
   )
 );
@@ -1344,7 +1084,7 @@ be_local_closure(Matter_Commisioning_Context_every_second,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
   be_nested_proto(
-    35,                          /* nstack */
+    36,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1352,719 +1092,567 @@ be_local_closure(Matter_Commisioning_Context_parse_Sigma1,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[117]) {     /* constants */
+    ( &(const bvalue[100]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(opcode),
-    /* K2   */  be_nested_str_weak(local_session_id),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(protocol_id),
-    /* K5   */  be_nested_str_weak(tasmota),
-    /* K6   */  be_nested_str_weak(log),
-    /* K7   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Sigma1_X20message),
-    /* K8   */  be_const_int(2),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
-    /* K10  */  be_nested_str_weak(send_status_report),
-    /* K11  */  be_const_int(1),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(Sigma1),
-    /* K14  */  be_nested_str_weak(parse),
-    /* K15  */  be_nested_str_weak(raw),
-    /* K16  */  be_nested_str_weak(app_payload_idx),
-    /* K17  */  be_nested_str_weak(initiatorEph_pub),
-    /* K18  */  be_nested_str_weak(initiatorEphPubKey),
-    /* K19  */  be_nested_str_weak(resumptionID),
-    /* K20  */  be_nested_str_weak(initiatorResumeMIC),
-    /* K21  */  be_nested_str_weak(session),
-    /* K22  */  be_nested_str_weak(device),
-    /* K23  */  be_nested_str_weak(sessions),
-    /* K24  */  be_nested_str_weak(find_session_by_resumption_id),
-    /* K25  */  be_nested_str_weak(find_fabric_by_destination_id),
-    /* K26  */  be_nested_str_weak(destinationId),
-    /* K27  */  be_nested_str_weak(initiatorRandom),
-    /* K28  */  be_nested_str_weak(_fabric),
-    /* K29  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
-    /* K30  */  be_nested_str_weak(_source_node_id),
-    /* K31  */  be_nested_str_weak(source_node_id),
-    /* K32  */  be_nested_str_weak(set_mode_CASE),
-    /* K33  */  be_nested_str_weak(remove_session),
-    /* K34  */  be_nested_str_weak(__future_initiator_session_id),
-    /* K35  */  be_nested_str_weak(initiator_session_id),
-    /* K36  */  be_nested_str_weak(__future_local_session_id),
-    /* K37  */  be_nested_str_weak(gen_local_session_id),
-    /* K38  */  be_nested_str_weak(future_local_session_id),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20Loc_session_X3D),
-    /* K40  */  be_nested_str_weak(fromstring),
-    /* K41  */  be_nested_str_weak(Sigma1_Resume),
-    /* K42  */  be_nested_str_weak(HKDF_SHA256),
-    /* K43  */  be_nested_str_weak(derive),
-    /* K44  */  be_nested_str_weak(shared_secret),
-    /* K45  */  be_nested_str_weak(NCASE_SigmaR1),
-    /* K46  */  be_const_int(2147483647),
-    /* K47  */  be_nested_str_weak(AES_CCM),
-    /* K48  */  be_nested_str_weak(decrypt),
-    /* K49  */  be_nested_str_weak(tag),
-    /* K50  */  be_nested_str_weak(_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s1rk_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K52  */  be_nested_str_weak(tohex),
-    /* K53  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20tag_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20Resume1MICPayload_X20_X3D_X20),
-    /* K55  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20decrypted_tag_X20_X20_X20_X20_X20_X3D_X20),
-    /* K56  */  be_nested_str_weak(resumption_id),
-    /* K57  */  be_nested_str_weak(random),
-    /* K58  */  be_nested_str_weak(Sigma2_Resume),
-    /* K59  */  be_nested_str_weak(NCASE_SigmaR2),
-    /* K60  */  be_nested_str_weak(Sigma2Resume),
-    /* K61  */  be_nested_str_weak(responderSessionID),
-    /* K62  */  be_nested_str_weak(sigma2ResumeMIC),
-    /* K63  */  be_nested_str_weak(SessionResumptionKeys),
-    /* K64  */  be_nested_str_weak(rtc),
-    /* K65  */  be_nested_str_weak(utc),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K67  */  be_nested_str_weak(MTR_X3A_X20I2RKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20R2IKey_X20_X20_X20_X20_X20_X20_X3D),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20AC_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D),
-    /* K70  */  be_nested_str_weak(encode),
-    /* K71  */  be_nested_str_weak(__Msg1),
-    /* K72  */  be_nested_str_weak(MTR_X3A_X20sigma2resume_raw_X3A_X20),
-    /* K73  */  be_nested_str_weak(build_response),
-    /* K74  */  be_nested_str_weak(encode_frame),
-    /* K75  */  be_nested_str_weak(responder),
-    /* K76  */  be_nested_str_weak(send_response),
-    /* K77  */  be_nested_str_weak(remote_ip),
-    /* K78  */  be_nested_str_weak(remote_port),
-    /* K79  */  be_nested_str_weak(message_counter),
-    /* K80  */  be_nested_str_weak(set_keys),
-    /* K81  */  be_nested_str_weak(ResponderEph_priv),
-    /* K82  */  be_nested_str_weak(ResponderEph_pub),
-    /* K83  */  be_nested_str_weak(EC_P256),
-    /* K84  */  be_nested_str_weak(public_key),
-    /* K85  */  be_nested_str_weak(shared_key),
-    /* K86  */  be_nested_str_weak(TLV),
-    /* K87  */  be_nested_str_weak(Matter_TLV_struct),
-    /* K88  */  be_nested_str_weak(add_TLV),
-    /* K89  */  be_nested_str_weak(B2),
-    /* K90  */  be_nested_str_weak(get_noc),
-    /* K91  */  be_nested_str_weak(get_icac),
-    /* K92  */  be_const_int(3),
-    /* K93  */  be_nested_str_weak(ecdsa_sign_sha256),
-    /* K94  */  be_nested_str_weak(get_pk),
-    /* K95  */  be_nested_str_weak(Msg1),
-    /* K96  */  be_nested_str_weak(MTR_X3A_X20_X2A_X20MSG1_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K97  */  be_nested_str_weak(SHA256),
-    /* K98  */  be_nested_str_weak(update),
-    /* K99  */  be_nested_str_weak(out),
-    /* K100 */  be_nested_str_weak(S2K_Info),
-    /* K101 */  be_nested_str_weak(get_ipk_group_key),
-    /* K102 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20SharedSecret_X20_X20_X3D_X20),
-    /* K103 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2k_salt_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K104 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20s2k_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K105 */  be_nested_str_weak(TBEData2_Nonce),
-    /* K106 */  be_nested_str_weak(encrypt),
-    /* K107 */  be_nested_str_weak(MTR_X3A_X20_X2A_X20TBEData2Enc_X20_X20_X20_X3D_X20),
-    /* K108 */  be_nested_str_weak(Sigma2),
-    /* K109 */  be_nested_str_weak(responderRandom),
-    /* K110 */  be_nested_str_weak(responderSessionId),
-    /* K111 */  be_nested_str_weak(responderEphPubKey),
-    /* K112 */  be_nested_str_weak(encrypted2),
-    /* K113 */  be_nested_str_weak(MTR_X3A_X20sigma2_X3A_X20),
-    /* K114 */  be_nested_str_weak(inspect),
-    /* K115 */  be_nested_str_weak(__Msg2),
-    /* K116 */  be_nested_str_weak(MTR_X3A_X20sigma2_raw_X3A_X20),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(opcode),
+    /* K3   */  be_nested_str_weak(local_session_id),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(protocol_id),
+    /* K6   */  be_nested_str_weak(tasmota),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20invalid_X20Sigma1_X20message),
+    /* K9   */  be_const_int(2),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28General_X20Code_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20INVALID_PARAMETER_X29),
+    /* K11  */  be_nested_str_weak(send_status_report),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(matter),
+    /* K14  */  be_nested_str_weak(Sigma1),
+    /* K15  */  be_nested_str_weak(parse),
+    /* K16  */  be_nested_str_weak(raw),
+    /* K17  */  be_nested_str_weak(app_payload_idx),
+    /* K18  */  be_nested_str_weak(initiatorEph_pub),
+    /* K19  */  be_nested_str_weak(initiatorEphPubKey),
+    /* K20  */  be_nested_str_weak(resumptionID),
+    /* K21  */  be_nested_str_weak(initiatorResumeMIC),
+    /* K22  */  be_nested_str_weak(session),
+    /* K23  */  be_nested_str_weak(device),
+    /* K24  */  be_nested_str_weak(sessions),
+    /* K25  */  be_nested_str_weak(find_session_by_resumption_id),
+    /* K26  */  be_nested_str_weak(find_fabric_by_destination_id),
+    /* K27  */  be_nested_str_weak(destinationId),
+    /* K28  */  be_nested_str_weak(initiatorRandom),
+    /* K29  */  be_nested_str_weak(_fabric),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20StatusReport_X28GeneralCode_X3A_X20FAILURE_X2C_X20ProtocolId_X3A_X20SECURE_CHANNEL_X2C_X20ProtocolCode_X3A_X20NO_SHARED_TRUST_ROOTS_X29),
+    /* K31  */  be_nested_str_weak(_source_node_id),
+    /* K32  */  be_nested_str_weak(source_node_id),
+    /* K33  */  be_nested_str_weak(set_mode_CASE),
+    /* K34  */  be_nested_str_weak(remove_session),
+    /* K35  */  be_nested_str_weak(__future_initiator_session_id),
+    /* K36  */  be_nested_str_weak(initiator_session_id),
+    /* K37  */  be_nested_str_weak(__future_local_session_id),
+    /* K38  */  be_nested_str_weak(gen_local_session_id),
+    /* K39  */  be_nested_str_weak(future_local_session_id),
+    /* K40  */  be_nested_str_weak(format),
+    /* K41  */  be_nested_str_weak(MTR_X3A_X20_X2BSession_X20_X20_X20_X28_X256i_X29_X20from_X20_X27_X5B_X25s_X5D_X3A_X25i_X27),
+    /* K42  */  be_nested_str_weak(remote_ip),
+    /* K43  */  be_nested_str_weak(remote_port),
+    /* K44  */  be_nested_str_weak(fromstring),
+    /* K45  */  be_nested_str_weak(Sigma1_Resume),
+    /* K46  */  be_nested_str_weak(HKDF_SHA256),
+    /* K47  */  be_nested_str_weak(derive),
+    /* K48  */  be_nested_str_weak(shared_secret),
+    /* K49  */  be_nested_str_weak(NCASE_SigmaR1),
+    /* K50  */  be_const_int(2147483647),
+    /* K51  */  be_nested_str_weak(AES_CCM),
+    /* K52  */  be_nested_str_weak(decrypt),
+    /* K53  */  be_nested_str_weak(tag),
+    /* K54  */  be_nested_str_weak(resumption_id),
+    /* K55  */  be_nested_str_weak(random),
+    /* K56  */  be_nested_str_weak(Sigma2_Resume),
+    /* K57  */  be_nested_str_weak(NCASE_SigmaR2),
+    /* K58  */  be_nested_str_weak(Sigma2Resume),
+    /* K59  */  be_nested_str_weak(responderSessionID),
+    /* K60  */  be_nested_str_weak(sigma2ResumeMIC),
+    /* K61  */  be_nested_str_weak(SessionResumptionKeys),
+    /* K62  */  be_nested_str_weak(rtc),
+    /* K63  */  be_nested_str_weak(utc),
+    /* K64  */  be_nested_str_weak(tlv2raw),
+    /* K65  */  be_nested_str_weak(__Msg1),
+    /* K66  */  be_nested_str_weak(build_response),
+    /* K67  */  be_nested_str_weak(encode_frame),
+    /* K68  */  be_nested_str_weak(responder),
+    /* K69  */  be_nested_str_weak(send_response),
+    /* K70  */  be_nested_str_weak(message_counter),
+    /* K71  */  be_nested_str_weak(set_keys),
+    /* K72  */  be_nested_str_weak(ResponderEph_priv),
+    /* K73  */  be_nested_str_weak(ResponderEph_pub),
+    /* K74  */  be_nested_str_weak(EC_P256),
+    /* K75  */  be_nested_str_weak(public_key),
+    /* K76  */  be_nested_str_weak(shared_key),
+    /* K77  */  be_nested_str_weak(TLV),
+    /* K78  */  be_nested_str_weak(Matter_TLV_struct),
+    /* K79  */  be_nested_str_weak(add_TLV),
+    /* K80  */  be_nested_str_weak(B2),
+    /* K81  */  be_nested_str_weak(get_noc),
+    /* K82  */  be_nested_str_weak(get_icac),
+    /* K83  */  be_const_int(3),
+    /* K84  */  be_nested_str_weak(ecdsa_sign_sha256),
+    /* K85  */  be_nested_str_weak(get_pk),
+    /* K86  */  be_nested_str_weak(Msg1),
+    /* K87  */  be_nested_str_weak(SHA256),
+    /* K88  */  be_nested_str_weak(update),
+    /* K89  */  be_nested_str_weak(out),
+    /* K90  */  be_nested_str_weak(S2K_Info),
+    /* K91  */  be_nested_str_weak(get_ipk_group_key),
+    /* K92  */  be_nested_str_weak(TBEData2_Nonce),
+    /* K93  */  be_nested_str_weak(encrypt),
+    /* K94  */  be_nested_str_weak(Sigma2),
+    /* K95  */  be_nested_str_weak(responderRandom),
+    /* K96  */  be_nested_str_weak(responderSessionId),
+    /* K97  */  be_nested_str_weak(responderEphPubKey),
+    /* K98  */  be_nested_str_weak(encrypted2),
+    /* K99  */  be_nested_str_weak(__Msg2),
     }),
     be_str_weak(parse_Sigma1),
     &be_const_str_solidified,
-    ( &(const binstruction[591]) {  /* code */
+    ( &(const binstruction[456]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0x5412002F,  //  0002  LDINT	R4	48
-      0x200C0604,  //  0003  NE	R3	R3	R4
-      0x740E0005,  //  0004  JMPT	R3	#000B
-      0x880C0302,  //  0005  GETMBR	R3	R1	K2
-      0x200C0703,  //  0006  NE	R3	R3	K3
-      0x740E0002,  //  0007  JMPT	R3	#000B
-      0x880C0304,  //  0008  GETMBR	R3	R1	K4
-      0x200C0703,  //  0009  NE	R3	R3	K3
-      0x780E0012,  //  000A  JMPF	R3	#001E
-      0xB80E0A00,  //  000B  GETNGBL	R3	K5
-      0x8C0C0706,  //  000C  GETMET	R3	R3	K6
-      0x58140007,  //  000D  LDCONST	R5	K7
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x88100302,  //  0002  GETMBR	R4	R1	K2
+      0x5416002F,  //  0003  LDINT	R5	48
+      0x20100805,  //  0004  NE	R4	R4	R5
+      0x74120005,  //  0005  JMPT	R4	#000C
+      0x88100303,  //  0006  GETMBR	R4	R1	K3
+      0x20100904,  //  0007  NE	R4	R4	K4
+      0x74120002,  //  0008  JMPT	R4	#000C
+      0x88100305,  //  0009  GETMBR	R4	R1	K5
+      0x20100904,  //  000A  NE	R4	R4	K4
+      0x78120012,  //  000B  JMPF	R4	#001F
+      0xB8120C00,  //  000C  GETNGBL	R4	K6
+      0x8C100907,  //  000D  GETMET	R4	R4	K7
       0x58180008,  //  000E  LDCONST	R6	K8
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0A00,  //  0010  GETNGBL	R3	K5
-      0x8C0C0706,  //  0011  GETMET	R3	R3	K6
-      0x58140009,  //  0012  LDCONST	R5	K9
-      0x58180008,  //  0013  LDCONST	R6	K8
-      0x7C0C0600,  //  0014  CALL	R3	3
-      0x8C0C010A,  //  0015  GETMET	R3	R0	K10
-      0x5C140200,  //  0016  MOVE	R5	R1
-      0x5818000B,  //  0017  LDCONST	R6	K11
-      0x581C0003,  //  0018  LDCONST	R7	K3
-      0x58200008,  //  0019  LDCONST	R8	K8
-      0x50240000,  //  001A  LDBOOL	R9	0	0
-      0x7C0C0C00,  //  001B  CALL	R3	6
-      0x50100000,  //  001C  LDBOOL	R4	0	0
-      0x80040800,  //  001D  RET	1	R4
-      0xB80E1800,  //  001E  GETNGBL	R3	K12
-      0x8C0C070D,  //  001F  GETMET	R3	R3	K13
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x8C0C070E,  //  0021  GETMET	R3	R3	K14
-      0x8814030F,  //  0022  GETMBR	R5	R1	K15
+      0x581C0009,  //  000F  LDCONST	R7	K9
+      0x7C100600,  //  0010  CALL	R4	3
+      0xB8120C00,  //  0011  GETNGBL	R4	K6
+      0x8C100907,  //  0012  GETMET	R4	R4	K7
+      0x5818000A,  //  0013  LDCONST	R6	K10
+      0x581C0009,  //  0014  LDCONST	R7	K9
+      0x7C100600,  //  0015  CALL	R4	3
+      0x8C10010B,  //  0016  GETMET	R4	R0	K11
+      0x5C180200,  //  0017  MOVE	R6	R1
+      0x581C000C,  //  0018  LDCONST	R7	K12
+      0x58200004,  //  0019  LDCONST	R8	K4
+      0x58240009,  //  001A  LDCONST	R9	K9
+      0x50280000,  //  001B  LDBOOL	R10	0	0
+      0x7C100C00,  //  001C  CALL	R4	6
+      0x50140000,  //  001D  LDBOOL	R5	0	0
+      0x80040A00,  //  001E  RET	1	R5
+      0xB8121A00,  //  001F  GETNGBL	R4	K13
+      0x8C10090E,  //  0020  GETMET	R4	R4	K14
+      0x7C100200,  //  0021  CALL	R4	1
+      0x8C10090F,  //  0022  GETMET	R4	R4	K15
       0x88180310,  //  0023  GETMBR	R6	R1	K16
-      0x7C0C0600,  //  0024  CALL	R3	3
-      0x88100712,  //  0025  GETMBR	R4	R3	K18
-      0x90022204,  //  0026  SETMBR	R0	K17	R4
-      0x88100713,  //  0027  GETMBR	R4	R3	K19
-      0x4C140000,  //  0028  LDNIL	R5
-      0x20100805,  //  0029  NE	R4	R4	R5
-      0x78120003,  //  002A  JMPF	R4	#002F
-      0x88100714,  //  002B  GETMBR	R4	R3	K20
-      0x4C140000,  //  002C  LDNIL	R5
-      0x20100805,  //  002D  NE	R4	R4	R5
-      0x74120000,  //  002E  JMPT	R4	#0030
-      0x50100001,  //  002F  LDBOOL	R4	0	1
-      0x50100200,  //  0030  LDBOOL	R4	1	0
-      0x88140315,  //  0031  GETMBR	R5	R1	K21
-      0x78120006,  //  0032  JMPF	R4	#003A
-      0x88180116,  //  0033  GETMBR	R6	R0	K22
-      0x88180D17,  //  0034  GETMBR	R6	R6	K23
-      0x8C180D18,  //  0035  GETMET	R6	R6	K24
-      0x88200713,  //  0036  GETMBR	R8	R3	K19
-      0x7C180400,  //  0037  CALL	R6	2
-      0x5C140C00,  //  0038  MOVE	R5	R6
-      0x70020004,  //  0039  JMP		#003F
-      0x8C180119,  //  003A  GETMET	R6	R0	K25
-      0x8820071A,  //  003B  GETMBR	R8	R3	K26
-      0x8824071B,  //  003C  GETMBR	R9	R3	K27
-      0x7C180600,  //  003D  CALL	R6	3
-      0x90163806,  //  003E  SETMBR	R5	K28	R6
-      0x4C180000,  //  003F  LDNIL	R6
-      0x1C180A06,  //  0040  EQ	R6	R5	R6
-      0x741A0003,  //  0041  JMPT	R6	#0046
-      0x88180B1C,  //  0042  GETMBR	R6	R5	K28
-      0x4C1C0000,  //  0043  LDNIL	R7
-      0x1C180C07,  //  0044  EQ	R6	R6	R7
-      0x781A000D,  //  0045  JMPF	R6	#0054
-      0xB81A0A00,  //  0046  GETNGBL	R6	K5
-      0x8C180D06,  //  0047  GETMET	R6	R6	K6
-      0x5820001D,  //  0048  LDCONST	R8	K29
-      0x58240008,  //  0049  LDCONST	R9	K8
-      0x7C180600,  //  004A  CALL	R6	3
-      0x8C18010A,  //  004B  GETMET	R6	R0	K10
-      0x5C200200,  //  004C  MOVE	R8	R1
-      0x5824000B,  //  004D  LDCONST	R9	K11
-      0x58280003,  //  004E  LDCONST	R10	K3
-      0x582C000B,  //  004F  LDCONST	R11	K11
-      0x50300000,  //  0050  LDBOOL	R12	0	0
-      0x7C180C00,  //  0051  CALL	R6	6
-      0x501C0000,  //  0052  LDBOOL	R7	0	0
-      0x80040E00,  //  0053  RET	1	R7
-      0x8818031F,  //  0054  GETMBR	R6	R1	K31
-      0x90163C06,  //  0055  SETMBR	R5	K30	R6
-      0x8C180B20,  //  0056  GETMET	R6	R5	K32
-      0x7C180200,  //  0057  CALL	R6	1
-      0x88180315,  //  0058  GETMBR	R6	R1	K21
-      0x20180C05,  //  0059  NE	R6	R6	R5
-      0x781A0004,  //  005A  JMPF	R6	#0060
-      0x88180116,  //  005B  GETMBR	R6	R0	K22
-      0x88180D17,  //  005C  GETMBR	R6	R6	K23
-      0x8C180D21,  //  005D  GETMET	R6	R6	K33
-      0x88200315,  //  005E  GETMBR	R8	R1	K21
-      0x7C180400,  //  005F  CALL	R6	2
-      0x90062A05,  //  0060  SETMBR	R1	K21	R5
-      0x88180723,  //  0061  GETMBR	R6	R3	K35
-      0x90164406,  //  0062  SETMBR	R5	K34	R6
-      0x88180116,  //  0063  GETMBR	R6	R0	K22
-      0x88180D17,  //  0064  GETMBR	R6	R6	K23
-      0x8C180D25,  //  0065  GETMET	R6	R6	K37
-      0x7C180200,  //  0066  CALL	R6	1
-      0x90164806,  //  0067  SETMBR	R5	K36	R6
-      0x88180B24,  //  0068  GETMBR	R6	R5	K36
-      0x90024C06,  //  0069  SETMBR	R0	K38	R6
-      0xB81A0A00,  //  006A  GETNGBL	R6	K5
-      0x8C180D06,  //  006B  GETMET	R6	R6	K6
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x88240126,  //  006D  GETMBR	R9	R0	K38
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00224E08,  //  006F  ADD	R8	K39	R8
-      0x7C180400,  //  0070  CALL	R6	2
-      0x781200E1,  //  0071  JMPF	R4	#0154
-      0x8818071B,  //  0072  GETMBR	R6	R3	K27
-      0x881C0713,  //  0073  GETMBR	R7	R3	K19
-      0x00180C07,  //  0074  ADD	R6	R6	R7
-      0x601C0015,  //  0075  GETGBL	R7	G21
-      0x7C1C0000,  //  0076  CALL	R7	0
-      0x8C1C0F28,  //  0077  GETMET	R7	R7	K40
-      0x58240029,  //  0078  LDCONST	R9	K41
-      0x7C1C0400,  //  0079  CALL	R7	2
-      0x8C20052A,  //  007A  GETMET	R8	R2	K42
-      0x7C200200,  //  007B  CALL	R8	1
-      0x8C20112B,  //  007C  GETMET	R8	R8	K43
-      0x88280B2C,  //  007D  GETMBR	R10	R5	K44
-      0x5C2C0C00,  //  007E  MOVE	R11	R6
-      0x5C300E00,  //  007F  MOVE	R12	R7
-      0x5436000F,  //  0080  LDINT	R13	16
-      0x7C200A00,  //  0081  CALL	R8	5
-      0x60240015,  //  0082  GETGBL	R9	G21
-      0x7C240000,  //  0083  CALL	R9	0
-      0x8C241328,  //  0084  GETMET	R9	R9	K40
-      0x582C002D,  //  0085  LDCONST	R11	K45
-      0x7C240400,  //  0086  CALL	R9	2
-      0x5429FFEE,  //  0087  LDINT	R10	-17
-      0x402A060A,  //  0088  CONNECT	R10	K3	R10
-      0x882C0714,  //  0089  GETMBR	R11	R3	K20
-      0x9428160A,  //  008A  GETIDX	R10	R11	R10
-      0x5431FFEF,  //  008B  LDINT	R12	-16
-      0x4030192E,  //  008C  CONNECT	R12	R12	K46
-      0x88340714,  //  008D  GETMBR	R13	R3	K20
-      0x942C1A0C,  //  008E  GETIDX	R11	R13	R12
-      0x8C38052F,  //  008F  GETMET	R14	R2	K47
-      0x5C401000,  //  0090  MOVE	R16	R8
-      0x5C441200,  //  0091  MOVE	R17	R9
-      0x60480015,  //  0092  GETGBL	R18	G21
-      0x7C480000,  //  0093  CALL	R18	0
-      0x604C000C,  //  0094  GETGBL	R19	G12
-      0x5C501400,  //  0095  MOVE	R20	R10
-      0x7C4C0200,  //  0096  CALL	R19	1
-      0x5452000F,  //  0097  LDINT	R20	16
-      0x7C380C00,  //  0098  CALL	R14	6
-      0x5C301C00,  //  0099  MOVE	R12	R14
-      0x8C381930,  //  009A  GETMET	R14	R12	K48
-      0x5C401400,  //  009B  MOVE	R16	R10
-      0x7C380400,  //  009C  CALL	R14	2
-      0x5C341C00,  //  009D  MOVE	R13	R14
-      0x8C381931,  //  009E  GETMET	R14	R12	K49
-      0x7C380200,  //  009F  CALL	R14	1
-      0xB83E0A00,  //  00A0  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00A1  GETMET	R15	R15	K6
-      0x58440032,  //  00A2  LDCONST	R17	K50
-      0x544A0003,  //  00A3  LDINT	R18	4
-      0x7C3C0600,  //  00A4  CALL	R15	3
-      0xB83E0A00,  //  00A5  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00A6  GETMET	R15	R15	K6
-      0x8C441134,  //  00A7  GETMET	R17	R8	K52
-      0x7C440200,  //  00A8  CALL	R17	1
-      0x00466611,  //  00A9  ADD	R17	K51	R17
-      0x544A0003,  //  00AA  LDINT	R18	4
-      0x7C3C0600,  //  00AB  CALL	R15	3
-      0xB83E0A00,  //  00AC  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00AD  GETMET	R15	R15	K6
-      0x8C441734,  //  00AE  GETMET	R17	R11	K52
-      0x7C440200,  //  00AF  CALL	R17	1
-      0x00466A11,  //  00B0  ADD	R17	K53	R17
-      0x544A0003,  //  00B1  LDINT	R18	4
-      0x7C3C0600,  //  00B2  CALL	R15	3
-      0xB83E0A00,  //  00B3  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00B4  GETMET	R15	R15	K6
-      0x8C441B34,  //  00B5  GETMET	R17	R13	K52
-      0x7C440200,  //  00B6  CALL	R17	1
-      0x00466C11,  //  00B7  ADD	R17	K54	R17
-      0x544A0003,  //  00B8  LDINT	R18	4
-      0x7C3C0600,  //  00B9  CALL	R15	3
-      0xB83E0A00,  //  00BA  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00BB  GETMET	R15	R15	K6
-      0x8C441D34,  //  00BC  GETMET	R17	R14	K52
-      0x7C440200,  //  00BD  CALL	R17	1
-      0x00466E11,  //  00BE  ADD	R17	K55	R17
-      0x544A0003,  //  00BF  LDINT	R18	4
-      0x7C3C0600,  //  00C0  CALL	R15	3
-      0xB83E0A00,  //  00C1  GETNGBL	R15	K5
-      0x8C3C1F06,  //  00C2  GETMET	R15	R15	K6
-      0x58440032,  //  00C3  LDCONST	R17	K50
-      0x544A0003,  //  00C4  LDINT	R18	4
-      0x7C3C0600,  //  00C5  CALL	R15	3
-      0x1C3C160E,  //  00C6  EQ	R15	R11	R14
-      0x783E0089,  //  00C7  JMPF	R15	#0152
-      0x8C3C0539,  //  00C8  GETMET	R15	R2	K57
-      0x5446000F,  //  00C9  LDINT	R17	16
-      0x7C3C0400,  //  00CA  CALL	R15	2
-      0x9016700F,  //  00CB  SETMBR	R5	K56	R15
-      0x603C0015,  //  00CC  GETGBL	R15	G21
-      0x7C3C0000,  //  00CD  CALL	R15	0
-      0x8C3C1F28,  //  00CE  GETMET	R15	R15	K40
-      0x5844003A,  //  00CF  LDCONST	R17	K58
-      0x7C3C0400,  //  00D0  CALL	R15	2
-      0x88400B38,  //  00D1  GETMBR	R16	R5	K56
-      0x003C1E10,  //  00D2  ADD	R15	R15	R16
-      0x8840071B,  //  00D3  GETMBR	R16	R3	K27
-      0x88440713,  //  00D4  GETMBR	R17	R3	K19
-      0x00402011,  //  00D5  ADD	R16	R16	R17
-      0x8C44052A,  //  00D6  GETMET	R17	R2	K42
-      0x7C440200,  //  00D7  CALL	R17	1
-      0x8C44232B,  //  00D8  GETMET	R17	R17	K43
-      0x884C0B2C,  //  00D9  GETMBR	R19	R5	K44
-      0x5C502000,  //  00DA  MOVE	R20	R16
-      0x5C541E00,  //  00DB  MOVE	R21	R15
-      0x545A000F,  //  00DC  LDINT	R22	16
-      0x7C440A00,  //  00DD  CALL	R17	5
-      0x8C48052F,  //  00DE  GETMET	R18	R2	K47
-      0x5C502200,  //  00DF  MOVE	R20	R17
-      0x60540015,  //  00E0  GETGBL	R21	G21
-      0x7C540000,  //  00E1  CALL	R21	0
-      0x8C542B28,  //  00E2  GETMET	R21	R21	K40
-      0x585C003B,  //  00E3  LDCONST	R23	K59
-      0x7C540400,  //  00E4  CALL	R21	2
-      0x60580015,  //  00E5  GETGBL	R22	G21
-      0x7C580000,  //  00E6  CALL	R22	0
-      0x585C0003,  //  00E7  LDCONST	R23	K3
-      0x5462000F,  //  00E8  LDINT	R24	16
-      0x7C480C00,  //  00E9  CALL	R18	6
-      0x8C4C2531,  //  00EA  GETMET	R19	R18	K49
-      0x7C4C0200,  //  00EB  CALL	R19	1
-      0xB8521800,  //  00EC  GETNGBL	R20	K12
-      0x8C50293C,  //  00ED  GETMET	R20	R20	K60
-      0x7C500200,  //  00EE  CALL	R20	1
-      0x88540B38,  //  00EF  GETMBR	R21	R5	K56
-      0x90522615,  //  00F0  SETMBR	R20	K19	R21
-      0x88540B24,  //  00F1  GETMBR	R21	R5	K36
-      0x90527A15,  //  00F2  SETMBR	R20	K61	R21
-      0x90527C13,  //  00F3  SETMBR	R20	K62	R19
-      0x8C54052A,  //  00F4  GETMET	R21	R2	K42
-      0x7C540200,  //  00F5  CALL	R21	1
-      0x8C542B2B,  //  00F6  GETMET	R21	R21	K43
-      0x885C0B2C,  //  00F7  GETMBR	R23	R5	K44
-      0x8860071B,  //  00F8  GETMBR	R24	R3	K27
-      0x88640713,  //  00F9  GETMBR	R25	R3	K19
-      0x00603019,  //  00FA  ADD	R24	R24	R25
-      0x60640015,  //  00FB  GETGBL	R25	G21
-      0x7C640000,  //  00FC  CALL	R25	0
-      0x8C643328,  //  00FD  GETMET	R25	R25	K40
-      0x586C003F,  //  00FE  LDCONST	R27	K63
-      0x7C640400,  //  00FF  CALL	R25	2
-      0x546A002F,  //  0100  LDINT	R26	48
-      0x7C540A00,  //  0101  CALL	R21	5
-      0x545A000E,  //  0102  LDINT	R22	15
-      0x405A0616,  //  0103  CONNECT	R22	K3	R22
-      0x94582A16,  //  0104  GETIDX	R22	R21	R22
-      0x545E000F,  //  0105  LDINT	R23	16
-      0x5462001E,  //  0106  LDINT	R24	31
-      0x405C2E18,  //  0107  CONNECT	R23	R23	R24
-      0x945C2A17,  //  0108  GETIDX	R23	R21	R23
-      0x5462001F,  //  0109  LDINT	R24	32
-      0x5466002E,  //  010A  LDINT	R25	47
-      0x40603019,  //  010B  CONNECT	R24	R24	R25
-      0x94602A18,  //  010C  GETIDX	R24	R21	R24
-      0xB8660A00,  //  010D  GETNGBL	R25	K5
-      0x8C643340,  //  010E  GETMET	R25	R25	K64
-      0x7C640200,  //  010F  CALL	R25	1
-      0x94643341,  //  0110  GETIDX	R25	R25	K65
-      0xB86A0A00,  //  0111  GETNGBL	R26	K5
-      0x8C683506,  //  0112  GETMET	R26	R26	K6
-      0x58700042,  //  0113  LDCONST	R28	K66
-      0x54760003,  //  0114  LDINT	R29	4
-      0x7C680600,  //  0115  CALL	R26	3
-      0xB86A0A00,  //  0116  GETNGBL	R26	K5
-      0x8C683506,  //  0117  GETMET	R26	R26	K6
-      0x8C702D34,  //  0118  GETMET	R28	R22	K52
-      0x7C700200,  //  0119  CALL	R28	1
-      0x0072861C,  //  011A  ADD	R28	K67	R28
-      0x54760003,  //  011B  LDINT	R29	4
-      0x7C680600,  //  011C  CALL	R26	3
-      0xB86A0A00,  //  011D  GETNGBL	R26	K5
-      0x8C683506,  //  011E  GETMET	R26	R26	K6
-      0x8C702F34,  //  011F  GETMET	R28	R23	K52
-      0x7C700200,  //  0120  CALL	R28	1
-      0x0072881C,  //  0121  ADD	R28	K68	R28
-      0x54760003,  //  0122  LDINT	R29	4
-      0x7C680600,  //  0123  CALL	R26	3
-      0xB86A0A00,  //  0124  GETNGBL	R26	K5
-      0x8C683506,  //  0125  GETMET	R26	R26	K6
-      0x8C703134,  //  0126  GETMET	R28	R24	K52
-      0x7C700200,  //  0127  CALL	R28	1
-      0x00728A1C,  //  0128  ADD	R28	K69	R28
-      0x54760003,  //  0129  LDINT	R29	4
-      0x7C680600,  //  012A  CALL	R26	3
-      0xB86A0A00,  //  012B  GETNGBL	R26	K5
-      0x8C683506,  //  012C  GETMET	R26	R26	K6
-      0x58700042,  //  012D  LDCONST	R28	K66
-      0x54760003,  //  012E  LDINT	R29	4
-      0x7C680600,  //  012F  CALL	R26	3
-      0x8C682946,  //  0130  GETMET	R26	R20	K70
-      0x7C680200,  //  0131  CALL	R26	1
-      0x4C6C0000,  //  0132  LDNIL	R27
-      0x90168E1B,  //  0133  SETMBR	R5	K71	R27
-      0xB86E0A00,  //  0134  GETNGBL	R27	K5
-      0x8C6C3706,  //  0135  GETMET	R27	R27	K6
-      0x8C743534,  //  0136  GETMET	R29	R26	K52
-      0x7C740200,  //  0137  CALL	R29	1
-      0x0076901D,  //  0138  ADD	R29	K72	R29
-      0x547A0003,  //  0139  LDINT	R30	4
-      0x7C6C0600,  //  013A  CALL	R27	3
-      0x8C6C0349,  //  013B  GETMET	R27	R1	K73
-      0x54760032,  //  013C  LDINT	R29	51
-      0x50780200,  //  013D  LDBOOL	R30	1	0
-      0x7C6C0600,  //  013E  CALL	R27	3
-      0x8C70374A,  //  013F  GETMET	R28	R27	K74
-      0x5C783400,  //  0140  MOVE	R30	R26
-      0x7C700400,  //  0141  CALL	R28	2
-      0x8874014B,  //  0142  GETMBR	R29	R0	K75
-      0x8C743B4C,  //  0143  GETMET	R29	R29	K76
-      0x5C7C3800,  //  0144  MOVE	R31	R28
-      0x8880034D,  //  0145  GETMBR	R32	R1	K77
-      0x8884034E,  //  0146  GETMBR	R33	R1	K78
-      0x8888374F,  //  0147  GETMBR	R34	R27	K79
-      0x7C740A00,  //  0148  CALL	R29	5
-      0x8C740B50,  //  0149  GETMET	R29	R5	K80
-      0x5C7C2C00,  //  014A  MOVE	R31	R22
-      0x5C802E00,  //  014B  MOVE	R32	R23
-      0x5C843000,  //  014C  MOVE	R33	R24
-      0x5C883200,  //  014D  MOVE	R34	R25
-      0x7C740A00,  //  014E  CALL	R29	5
-      0x50740200,  //  014F  LDBOOL	R29	1	0
-      0x80043A00,  //  0150  RET	1	R29
-      0x70020001,  //  0151  JMP		#0154
-      0x4C3C0000,  //  0152  LDNIL	R15
-      0x900E260F,  //  0153  SETMBR	R3	K19	R15
-      0x88180713,  //  0154  GETMBR	R6	R3	K19
-      0x4C1C0000,  //  0155  LDNIL	R7
-      0x1C180C07,  //  0156  EQ	R6	R6	R7
-      0x741A0003,  //  0157  JMPT	R6	#015C
-      0x88180714,  //  0158  GETMBR	R6	R3	K20
-      0x4C1C0000,  //  0159  LDNIL	R7
-      0x1C180C07,  //  015A  EQ	R6	R6	R7
-      0x781A00F0,  //  015B  JMPF	R6	#024D
-      0x8C180539,  //  015C  GETMET	R6	R2	K57
-      0x5422000F,  //  015D  LDINT	R8	16
-      0x7C180400,  //  015E  CALL	R6	2
-      0x90167006,  //  015F  SETMBR	R5	K56	R6
-      0x8C180539,  //  0160  GETMET	R6	R2	K57
-      0x5422001F,  //  0161  LDINT	R8	32
-      0x7C180400,  //  0162  CALL	R6	2
-      0x9002A206,  //  0163  SETMBR	R0	K81	R6
-      0x8C180553,  //  0164  GETMET	R6	R2	K83
-      0x7C180200,  //  0165  CALL	R6	1
-      0x8C180D54,  //  0166  GETMET	R6	R6	K84
-      0x88200151,  //  0167  GETMBR	R8	R0	K81
-      0x7C180400,  //  0168  CALL	R6	2
-      0x9002A406,  //  0169  SETMBR	R0	K82	R6
-      0x8C180539,  //  016A  GETMET	R6	R2	K57
-      0x5422001F,  //  016B  LDINT	R8	32
-      0x7C180400,  //  016C  CALL	R6	2
-      0x8C1C0553,  //  016D  GETMET	R7	R2	K83
-      0x7C1C0200,  //  016E  CALL	R7	1
-      0x8C1C0F55,  //  016F  GETMET	R7	R7	K85
-      0x88240151,  //  0170  GETMBR	R9	R0	K81
-      0x88280712,  //  0171  GETMBR	R10	R3	K18
-      0x7C1C0600,  //  0172  CALL	R7	3
-      0x90165807,  //  0173  SETMBR	R5	K44	R7
-      0xB81E1800,  //  0174  GETNGBL	R7	K12
-      0x881C0F56,  //  0175  GETMBR	R7	R7	K86
-      0x8C1C0F57,  //  0176  GETMET	R7	R7	K87
-      0x7C1C0200,  //  0177  CALL	R7	1
-      0x8C200F58,  //  0178  GETMET	R8	R7	K88
-      0x5828000B,  //  0179  LDCONST	R10	K11
-      0xB82E1800,  //  017A  GETNGBL	R11	K12
-      0x882C1756,  //  017B  GETMBR	R11	R11	K86
-      0x882C1759,  //  017C  GETMBR	R11	R11	K89
-      0x8C300B5A,  //  017D  GETMET	R12	R5	K90
-      0x7C300200,  //  017E  CALL	R12	1
-      0x7C200800,  //  017F  CALL	R8	4
-      0x8C200F58,  //  0180  GETMET	R8	R7	K88
-      0x58280008,  //  0181  LDCONST	R10	K8
-      0xB82E1800,  //  0182  GETNGBL	R11	K12
-      0x882C1756,  //  0183  GETMBR	R11	R11	K86
-      0x882C1759,  //  0184  GETMBR	R11	R11	K89
-      0x8C300B5B,  //  0185  GETMET	R12	R5	K91
-      0x7C300200,  //  0186  CALL	R12	1
-      0x7C200800,  //  0187  CALL	R8	4
-      0x8C200F58,  //  0188  GETMET	R8	R7	K88
-      0x5828005C,  //  0189  LDCONST	R10	K92
-      0xB82E1800,  //  018A  GETNGBL	R11	K12
-      0x882C1756,  //  018B  GETMBR	R11	R11	K86
-      0x882C1759,  //  018C  GETMBR	R11	R11	K89
-      0x88300152,  //  018D  GETMBR	R12	R0	K82
-      0x7C200800,  //  018E  CALL	R8	4
-      0x8C200F58,  //  018F  GETMET	R8	R7	K88
-      0x542A0003,  //  0190  LDINT	R10	4
-      0xB82E1800,  //  0191  GETNGBL	R11	K12
-      0x882C1756,  //  0192  GETMBR	R11	R11	K86
-      0x882C1759,  //  0193  GETMBR	R11	R11	K89
-      0x88300712,  //  0194  GETMBR	R12	R3	K18
-      0x7C200800,  //  0195  CALL	R8	4
-      0x8C200553,  //  0196  GETMET	R8	R2	K83
-      0x7C200200,  //  0197  CALL	R8	1
-      0x8C20115D,  //  0198  GETMET	R8	R8	K93
-      0x8C280B5E,  //  0199  GETMET	R10	R5	K94
-      0x7C280200,  //  019A  CALL	R10	1
-      0x8C2C0F46,  //  019B  GETMET	R11	R7	K70
-      0x7C2C0200,  //  019C  CALL	R11	1
-      0x7C200600,  //  019D  CALL	R8	3
-      0xB8261800,  //  019E  GETNGBL	R9	K12
-      0x88241356,  //  019F  GETMBR	R9	R9	K86
-      0x8C241357,  //  01A0  GETMET	R9	R9	K87
-      0x7C240200,  //  01A1  CALL	R9	1
-      0x8C281358,  //  01A2  GETMET	R10	R9	K88
-      0x5830000B,  //  01A3  LDCONST	R12	K11
-      0xB8361800,  //  01A4  GETNGBL	R13	K12
-      0x88341B56,  //  01A5  GETMBR	R13	R13	K86
-      0x88341B59,  //  01A6  GETMBR	R13	R13	K89
-      0x8C380B5A,  //  01A7  GETMET	R14	R5	K90
-      0x7C380200,  //  01A8  CALL	R14	1
-      0x7C280800,  //  01A9  CALL	R10	4
-      0x8C281358,  //  01AA  GETMET	R10	R9	K88
-      0x58300008,  //  01AB  LDCONST	R12	K8
-      0xB8361800,  //  01AC  GETNGBL	R13	K12
-      0x88341B56,  //  01AD  GETMBR	R13	R13	K86
-      0x88341B59,  //  01AE  GETMBR	R13	R13	K89
-      0x8C380B5B,  //  01AF  GETMET	R14	R5	K91
-      0x7C380200,  //  01B0  CALL	R14	1
-      0x7C280800,  //  01B1  CALL	R10	4
-      0x8C281358,  //  01B2  GETMET	R10	R9	K88
-      0x5830005C,  //  01B3  LDCONST	R12	K92
-      0xB8361800,  //  01B4  GETNGBL	R13	K12
-      0x88341B56,  //  01B5  GETMBR	R13	R13	K86
-      0x88341B59,  //  01B6  GETMBR	R13	R13	K89
-      0x5C381000,  //  01B7  MOVE	R14	R8
-      0x7C280800,  //  01B8  CALL	R10	4
-      0x8C281358,  //  01B9  GETMET	R10	R9	K88
-      0x54320003,  //  01BA  LDINT	R12	4
-      0xB8361800,  //  01BB  GETNGBL	R13	K12
-      0x88341B56,  //  01BC  GETMBR	R13	R13	K86
-      0x88341B59,  //  01BD  GETMBR	R13	R13	K89
-      0x88380B38,  //  01BE  GETMBR	R14	R5	K56
-      0x7C280800,  //  01BF  CALL	R10	4
-      0xB82A0A00,  //  01C0  GETNGBL	R10	K5
-      0x8C281506,  //  01C1  GETMET	R10	R10	K6
-      0x58300032,  //  01C2  LDCONST	R12	K50
-      0x54360003,  //  01C3  LDINT	R13	4
-      0x7C280600,  //  01C4  CALL	R10	3
-      0x8828075F,  //  01C5  GETMBR	R10	R3	K95
-      0x90168E0A,  //  01C6  SETMBR	R5	K71	R10
-      0xB82A0A00,  //  01C7  GETNGBL	R10	K5
-      0x8C281506,  //  01C8  GETMET	R10	R10	K6
-      0x88300B47,  //  01C9  GETMBR	R12	R5	K71
-      0x8C301934,  //  01CA  GETMET	R12	R12	K52
-      0x7C300200,  //  01CB  CALL	R12	1
-      0x0032C00C,  //  01CC  ADD	R12	K96	R12
-      0x54360003,  //  01CD  LDINT	R13	4
-      0x7C280600,  //  01CE  CALL	R10	3
-      0x8C280561,  //  01CF  GETMET	R10	R2	K97
-      0x7C280200,  //  01D0  CALL	R10	1
-      0x8C281562,  //  01D1  GETMET	R10	R10	K98
-      0x88300B47,  //  01D2  GETMBR	R12	R5	K71
-      0x7C280400,  //  01D3  CALL	R10	2
-      0x8C281563,  //  01D4  GETMET	R10	R10	K99
-      0x7C280200,  //  01D5  CALL	R10	1
-      0x602C0015,  //  01D6  GETGBL	R11	G21
-      0x7C2C0000,  //  01D7  CALL	R11	0
-      0x8C2C1728,  //  01D8  GETMET	R11	R11	K40
-      0x88340164,  //  01D9  GETMBR	R13	R0	K100
-      0x7C2C0400,  //  01DA  CALL	R11	2
-      0x8C300B65,  //  01DB  GETMET	R12	R5	K101
-      0x7C300200,  //  01DC  CALL	R12	1
-      0x00301806,  //  01DD  ADD	R12	R12	R6
-      0x88340152,  //  01DE  GETMBR	R13	R0	K82
-      0x0030180D,  //  01DF  ADD	R12	R12	R13
-      0x0030180A,  //  01E0  ADD	R12	R12	R10
-      0x8C34052A,  //  01E1  GETMET	R13	R2	K42
-      0x7C340200,  //  01E2  CALL	R13	1
-      0x8C341B2B,  //  01E3  GETMET	R13	R13	K43
-      0x883C0B2C,  //  01E4  GETMBR	R15	R5	K44
-      0x5C401800,  //  01E5  MOVE	R16	R12
-      0x5C441600,  //  01E6  MOVE	R17	R11
-      0x544A000F,  //  01E7  LDINT	R18	16
-      0x7C340A00,  //  01E8  CALL	R13	5
-      0xB83A0A00,  //  01E9  GETNGBL	R14	K5
-      0x8C381D06,  //  01EA  GETMET	R14	R14	K6
-      0x88400B2C,  //  01EB  GETMBR	R16	R5	K44
-      0x8C402134,  //  01EC  GETMET	R16	R16	K52
-      0x7C400200,  //  01ED  CALL	R16	1
-      0x0042CC10,  //  01EE  ADD	R16	K102	R16
-      0x54460003,  //  01EF  LDINT	R17	4
-      0x7C380600,  //  01F0  CALL	R14	3
-      0xB83A0A00,  //  01F1  GETNGBL	R14	K5
-      0x8C381D06,  //  01F2  GETMET	R14	R14	K6
-      0x8C401934,  //  01F3  GETMET	R16	R12	K52
-      0x7C400200,  //  01F4  CALL	R16	1
-      0x0042CE10,  //  01F5  ADD	R16	K103	R16
-      0x54460003,  //  01F6  LDINT	R17	4
-      0x7C380600,  //  01F7  CALL	R14	3
-      0xB83A0A00,  //  01F8  GETNGBL	R14	K5
-      0x8C381D06,  //  01F9  GETMET	R14	R14	K6
-      0x8C401B34,  //  01FA  GETMET	R16	R13	K52
-      0x7C400200,  //  01FB  CALL	R16	1
-      0x0042D010,  //  01FC  ADD	R16	K104	R16
-      0x54460003,  //  01FD  LDINT	R17	4
-      0x7C380600,  //  01FE  CALL	R14	3
-      0x8C381346,  //  01FF  GETMET	R14	R9	K70
-      0x7C380200,  //  0200  CALL	R14	1
-      0x8C3C052F,  //  0201  GETMET	R15	R2	K47
-      0x5C441A00,  //  0202  MOVE	R17	R13
-      0x60480015,  //  0203  GETGBL	R18	G21
-      0x7C480000,  //  0204  CALL	R18	0
-      0x8C482528,  //  0205  GETMET	R18	R18	K40
-      0x88500169,  //  0206  GETMBR	R20	R0	K105
-      0x7C480400,  //  0207  CALL	R18	2
-      0x604C0015,  //  0208  GETGBL	R19	G21
-      0x7C4C0000,  //  0209  CALL	R19	0
-      0x6050000C,  //  020A  GETGBL	R20	G12
-      0x5C541C00,  //  020B  MOVE	R21	R14
-      0x7C500200,  //  020C  CALL	R20	1
-      0x5456000F,  //  020D  LDINT	R21	16
-      0x7C3C0C00,  //  020E  CALL	R15	6
-      0x8C401F6A,  //  020F  GETMET	R16	R15	K106
-      0x5C481C00,  //  0210  MOVE	R18	R14
-      0x7C400400,  //  0211  CALL	R16	2
-      0x8C441F31,  //  0212  GETMET	R17	R15	K49
-      0x7C440200,  //  0213  CALL	R17	1
-      0x00402011,  //  0214  ADD	R16	R16	R17
-      0xB8460A00,  //  0215  GETNGBL	R17	K5
-      0x8C442306,  //  0216  GETMET	R17	R17	K6
-      0x8C4C2134,  //  0217  GETMET	R19	R16	K52
-      0x7C4C0200,  //  0218  CALL	R19	1
-      0x004ED613,  //  0219  ADD	R19	K107	R19
-      0x54520003,  //  021A  LDINT	R20	4
-      0x7C440600,  //  021B  CALL	R17	3
-      0xB8460A00,  //  021C  GETNGBL	R17	K5
-      0x8C442306,  //  021D  GETMET	R17	R17	K6
-      0x584C0032,  //  021E  LDCONST	R19	K50
-      0x54520003,  //  021F  LDINT	R20	4
-      0x7C440600,  //  0220  CALL	R17	3
-      0xB8461800,  //  0221  GETNGBL	R17	K12
-      0x8C44236C,  //  0222  GETMET	R17	R17	K108
-      0x7C440200,  //  0223  CALL	R17	1
-      0x9046DA06,  //  0224  SETMBR	R17	K109	R6
-      0x88480126,  //  0225  GETMBR	R18	R0	K38
-      0x9046DC12,  //  0226  SETMBR	R17	K110	R18
-      0x88480152,  //  0227  GETMBR	R18	R0	K82
-      0x9046DE12,  //  0228  SETMBR	R17	K111	R18
-      0x9046E010,  //  0229  SETMBR	R17	K112	R16
-      0xB84A0A00,  //  022A  GETNGBL	R18	K5
-      0x8C482506,  //  022B  GETMET	R18	R18	K6
-      0xB8521800,  //  022C  GETNGBL	R20	K12
-      0x8C502972,  //  022D  GETMET	R20	R20	K114
-      0x5C582200,  //  022E  MOVE	R22	R17
-      0x7C500400,  //  022F  CALL	R20	2
-      0x0052E214,  //  0230  ADD	R20	K113	R20
-      0x54560003,  //  0231  LDINT	R21	4
-      0x7C480600,  //  0232  CALL	R18	3
-      0x8C482346,  //  0233  GETMET	R18	R17	K70
-      0x7C480200,  //  0234  CALL	R18	1
-      0x9016E612,  //  0235  SETMBR	R5	K115	R18
-      0xB84E0A00,  //  0236  GETNGBL	R19	K5
-      0x8C4C2706,  //  0237  GETMET	R19	R19	K6
-      0x8C542534,  //  0238  GETMET	R21	R18	K52
-      0x7C540200,  //  0239  CALL	R21	1
-      0x0056E815,  //  023A  ADD	R21	K116	R21
-      0x545A0003,  //  023B  LDINT	R22	4
-      0x7C4C0600,  //  023C  CALL	R19	3
-      0x8C4C0349,  //  023D  GETMET	R19	R1	K73
-      0x54560030,  //  023E  LDINT	R21	49
-      0x50580200,  //  023F  LDBOOL	R22	1	0
-      0x7C4C0600,  //  0240  CALL	R19	3
-      0x8C50274A,  //  0241  GETMET	R20	R19	K74
-      0x5C582400,  //  0242  MOVE	R22	R18
-      0x7C500400,  //  0243  CALL	R20	2
-      0x8854014B,  //  0244  GETMBR	R21	R0	K75
-      0x8C542B4C,  //  0245  GETMET	R21	R21	K76
-      0x5C5C2800,  //  0246  MOVE	R23	R20
-      0x8860034D,  //  0247  GETMBR	R24	R1	K77
-      0x8864034E,  //  0248  GETMBR	R25	R1	K78
-      0x8868274F,  //  0249  GETMBR	R26	R19	K79
-      0x7C540A00,  //  024A  CALL	R21	5
-      0x50540200,  //  024B  LDBOOL	R21	1	0
-      0x80042A00,  //  024C  RET	1	R21
-      0x50180200,  //  024D  LDBOOL	R6	1	0
-      0x80040C00,  //  024E  RET	1	R6
+      0x881C0311,  //  0024  GETMBR	R7	R1	K17
+      0x7C100600,  //  0025  CALL	R4	3
+      0x88140913,  //  0026  GETMBR	R5	R4	K19
+      0x90022405,  //  0027  SETMBR	R0	K18	R5
+      0x88140914,  //  0028  GETMBR	R5	R4	K20
+      0x4C180000,  //  0029  LDNIL	R6
+      0x20140A06,  //  002A  NE	R5	R5	R6
+      0x78160003,  //  002B  JMPF	R5	#0030
+      0x88140915,  //  002C  GETMBR	R5	R4	K21
+      0x4C180000,  //  002D  LDNIL	R6
+      0x20140A06,  //  002E  NE	R5	R5	R6
+      0x74160000,  //  002F  JMPT	R5	#0031
+      0x50140001,  //  0030  LDBOOL	R5	0	1
+      0x50140200,  //  0031  LDBOOL	R5	1	0
+      0x88180316,  //  0032  GETMBR	R6	R1	K22
+      0x78160006,  //  0033  JMPF	R5	#003B
+      0x881C0117,  //  0034  GETMBR	R7	R0	K23
+      0x881C0F18,  //  0035  GETMBR	R7	R7	K24
+      0x8C1C0F19,  //  0036  GETMET	R7	R7	K25
+      0x88240914,  //  0037  GETMBR	R9	R4	K20
+      0x7C1C0400,  //  0038  CALL	R7	2
+      0x5C180E00,  //  0039  MOVE	R6	R7
+      0x70020004,  //  003A  JMP		#0040
+      0x8C1C011A,  //  003B  GETMET	R7	R0	K26
+      0x8824091B,  //  003C  GETMBR	R9	R4	K27
+      0x8828091C,  //  003D  GETMBR	R10	R4	K28
+      0x7C1C0600,  //  003E  CALL	R7	3
+      0x901A3A07,  //  003F  SETMBR	R6	K29	R7
+      0x4C1C0000,  //  0040  LDNIL	R7
+      0x1C1C0C07,  //  0041  EQ	R7	R6	R7
+      0x741E0003,  //  0042  JMPT	R7	#0047
+      0x881C0D1D,  //  0043  GETMBR	R7	R6	K29
+      0x4C200000,  //  0044  LDNIL	R8
+      0x1C1C0E08,  //  0045  EQ	R7	R7	R8
+      0x781E000D,  //  0046  JMPF	R7	#0055
+      0xB81E0C00,  //  0047  GETNGBL	R7	K6
+      0x8C1C0F07,  //  0048  GETMET	R7	R7	K7
+      0x5824001E,  //  0049  LDCONST	R9	K30
+      0x58280009,  //  004A  LDCONST	R10	K9
+      0x7C1C0600,  //  004B  CALL	R7	3
+      0x8C1C010B,  //  004C  GETMET	R7	R0	K11
+      0x5C240200,  //  004D  MOVE	R9	R1
+      0x5828000C,  //  004E  LDCONST	R10	K12
+      0x582C0004,  //  004F  LDCONST	R11	K4
+      0x5830000C,  //  0050  LDCONST	R12	K12
+      0x50340000,  //  0051  LDBOOL	R13	0	0
+      0x7C1C0C00,  //  0052  CALL	R7	6
+      0x50200000,  //  0053  LDBOOL	R8	0	0
+      0x80041000,  //  0054  RET	1	R8
+      0x881C0320,  //  0055  GETMBR	R7	R1	K32
+      0x901A3E07,  //  0056  SETMBR	R6	K31	R7
+      0x8C1C0D21,  //  0057  GETMET	R7	R6	K33
+      0x7C1C0200,  //  0058  CALL	R7	1
+      0x881C0316,  //  0059  GETMBR	R7	R1	K22
+      0x201C0E06,  //  005A  NE	R7	R7	R6
+      0x781E0004,  //  005B  JMPF	R7	#0061
+      0x881C0117,  //  005C  GETMBR	R7	R0	K23
+      0x881C0F18,  //  005D  GETMBR	R7	R7	K24
+      0x8C1C0F22,  //  005E  GETMET	R7	R7	K34
+      0x88240316,  //  005F  GETMBR	R9	R1	K22
+      0x7C1C0400,  //  0060  CALL	R7	2
+      0x90062C06,  //  0061  SETMBR	R1	K22	R6
+      0x881C0924,  //  0062  GETMBR	R7	R4	K36
+      0x901A4607,  //  0063  SETMBR	R6	K35	R7
+      0x881C0117,  //  0064  GETMBR	R7	R0	K23
+      0x881C0F18,  //  0065  GETMBR	R7	R7	K24
+      0x8C1C0F26,  //  0066  GETMET	R7	R7	K38
+      0x7C1C0200,  //  0067  CALL	R7	1
+      0x901A4A07,  //  0068  SETMBR	R6	K37	R7
+      0x881C0D25,  //  0069  GETMBR	R7	R6	K37
+      0x90024E07,  //  006A  SETMBR	R0	K39	R7
+      0xB81E0C00,  //  006B  GETNGBL	R7	K6
+      0x8C1C0F07,  //  006C  GETMET	R7	R7	K7
+      0x8C240728,  //  006D  GETMET	R9	R3	K40
+      0x582C0029,  //  006E  LDCONST	R11	K41
+      0x88300127,  //  006F  GETMBR	R12	R0	K39
+      0x8834032A,  //  0070  GETMBR	R13	R1	K42
+      0x8838032B,  //  0071  GETMBR	R14	R1	K43
+      0x7C240A00,  //  0072  CALL	R9	5
+      0x58280009,  //  0073  LDCONST	R10	K9
+      0x7C1C0600,  //  0074  CALL	R7	3
+      0x78160095,  //  0075  JMPF	R5	#010C
+      0x881C091C,  //  0076  GETMBR	R7	R4	K28
+      0x88200914,  //  0077  GETMBR	R8	R4	K20
+      0x001C0E08,  //  0078  ADD	R7	R7	R8
+      0x60200015,  //  0079  GETGBL	R8	G21
+      0x7C200000,  //  007A  CALL	R8	0
+      0x8C20112C,  //  007B  GETMET	R8	R8	K44
+      0x5828002D,  //  007C  LDCONST	R10	K45
+      0x7C200400,  //  007D  CALL	R8	2
+      0x8C24052E,  //  007E  GETMET	R9	R2	K46
+      0x7C240200,  //  007F  CALL	R9	1
+      0x8C24132F,  //  0080  GETMET	R9	R9	K47
+      0x882C0D30,  //  0081  GETMBR	R11	R6	K48
+      0x5C300E00,  //  0082  MOVE	R12	R7
+      0x5C341000,  //  0083  MOVE	R13	R8
+      0x543A000F,  //  0084  LDINT	R14	16
+      0x7C240A00,  //  0085  CALL	R9	5
+      0x60280015,  //  0086  GETGBL	R10	G21
+      0x7C280000,  //  0087  CALL	R10	0
+      0x8C28152C,  //  0088  GETMET	R10	R10	K44
+      0x58300031,  //  0089  LDCONST	R12	K49
+      0x7C280400,  //  008A  CALL	R10	2
+      0x542DFFEE,  //  008B  LDINT	R11	-17
+      0x402E080B,  //  008C  CONNECT	R11	K4	R11
+      0x88300915,  //  008D  GETMBR	R12	R4	K21
+      0x942C180B,  //  008E  GETIDX	R11	R12	R11
+      0x5435FFEF,  //  008F  LDINT	R13	-16
+      0x40341B32,  //  0090  CONNECT	R13	R13	K50
+      0x88380915,  //  0091  GETMBR	R14	R4	K21
+      0x94301C0D,  //  0092  GETIDX	R12	R14	R13
+      0x8C3C0533,  //  0093  GETMET	R15	R2	K51
+      0x5C441200,  //  0094  MOVE	R17	R9
+      0x5C481400,  //  0095  MOVE	R18	R10
+      0x604C0015,  //  0096  GETGBL	R19	G21
+      0x7C4C0000,  //  0097  CALL	R19	0
+      0x6050000C,  //  0098  GETGBL	R20	G12
+      0x5C541600,  //  0099  MOVE	R21	R11
+      0x7C500200,  //  009A  CALL	R20	1
+      0x5456000F,  //  009B  LDINT	R21	16
+      0x7C3C0C00,  //  009C  CALL	R15	6
+      0x5C341E00,  //  009D  MOVE	R13	R15
+      0x8C3C1B34,  //  009E  GETMET	R15	R13	K52
+      0x5C441600,  //  009F  MOVE	R17	R11
+      0x7C3C0400,  //  00A0  CALL	R15	2
+      0x5C381E00,  //  00A1  MOVE	R14	R15
+      0x8C3C1B35,  //  00A2  GETMET	R15	R13	K53
+      0x7C3C0200,  //  00A3  CALL	R15	1
+      0x1C40180F,  //  00A4  EQ	R16	R12	R15
+      0x78420063,  //  00A5  JMPF	R16	#010A
+      0x8C400537,  //  00A6  GETMET	R16	R2	K55
+      0x544A000F,  //  00A7  LDINT	R18	16
+      0x7C400400,  //  00A8  CALL	R16	2
+      0x901A6C10,  //  00A9  SETMBR	R6	K54	R16
+      0x60400015,  //  00AA  GETGBL	R16	G21
+      0x7C400000,  //  00AB  CALL	R16	0
+      0x8C40212C,  //  00AC  GETMET	R16	R16	K44
+      0x58480038,  //  00AD  LDCONST	R18	K56
+      0x7C400400,  //  00AE  CALL	R16	2
+      0x88440D36,  //  00AF  GETMBR	R17	R6	K54
+      0x00402011,  //  00B0  ADD	R16	R16	R17
+      0x8844091C,  //  00B1  GETMBR	R17	R4	K28
+      0x88480914,  //  00B2  GETMBR	R18	R4	K20
+      0x00442212,  //  00B3  ADD	R17	R17	R18
+      0x8C48052E,  //  00B4  GETMET	R18	R2	K46
+      0x7C480200,  //  00B5  CALL	R18	1
+      0x8C48252F,  //  00B6  GETMET	R18	R18	K47
+      0x88500D30,  //  00B7  GETMBR	R20	R6	K48
+      0x5C542200,  //  00B8  MOVE	R21	R17
+      0x5C582000,  //  00B9  MOVE	R22	R16
+      0x545E000F,  //  00BA  LDINT	R23	16
+      0x7C480A00,  //  00BB  CALL	R18	5
+      0x8C4C0533,  //  00BC  GETMET	R19	R2	K51
+      0x5C542400,  //  00BD  MOVE	R21	R18
+      0x60580015,  //  00BE  GETGBL	R22	G21
+      0x7C580000,  //  00BF  CALL	R22	0
+      0x8C582D2C,  //  00C0  GETMET	R22	R22	K44
+      0x58600039,  //  00C1  LDCONST	R24	K57
+      0x7C580400,  //  00C2  CALL	R22	2
+      0x605C0015,  //  00C3  GETGBL	R23	G21
+      0x7C5C0000,  //  00C4  CALL	R23	0
+      0x58600004,  //  00C5  LDCONST	R24	K4
+      0x5466000F,  //  00C6  LDINT	R25	16
+      0x7C4C0C00,  //  00C7  CALL	R19	6
+      0x8C502735,  //  00C8  GETMET	R20	R19	K53
+      0x7C500200,  //  00C9  CALL	R20	1
+      0xB8561A00,  //  00CA  GETNGBL	R21	K13
+      0x8C542B3A,  //  00CB  GETMET	R21	R21	K58
+      0x7C540200,  //  00CC  CALL	R21	1
+      0x88580D36,  //  00CD  GETMBR	R22	R6	K54
+      0x90562816,  //  00CE  SETMBR	R21	K20	R22
+      0x88580D25,  //  00CF  GETMBR	R22	R6	K37
+      0x90567616,  //  00D0  SETMBR	R21	K59	R22
+      0x90567814,  //  00D1  SETMBR	R21	K60	R20
+      0x8C58052E,  //  00D2  GETMET	R22	R2	K46
+      0x7C580200,  //  00D3  CALL	R22	1
+      0x8C582D2F,  //  00D4  GETMET	R22	R22	K47
+      0x88600D30,  //  00D5  GETMBR	R24	R6	K48
+      0x8864091C,  //  00D6  GETMBR	R25	R4	K28
+      0x88680914,  //  00D7  GETMBR	R26	R4	K20
+      0x0064321A,  //  00D8  ADD	R25	R25	R26
+      0x60680015,  //  00D9  GETGBL	R26	G21
+      0x7C680000,  //  00DA  CALL	R26	0
+      0x8C68352C,  //  00DB  GETMET	R26	R26	K44
+      0x5870003D,  //  00DC  LDCONST	R28	K61
+      0x7C680400,  //  00DD  CALL	R26	2
+      0x546E002F,  //  00DE  LDINT	R27	48
+      0x7C580A00,  //  00DF  CALL	R22	5
+      0x545E000E,  //  00E0  LDINT	R23	15
+      0x405E0817,  //  00E1  CONNECT	R23	K4	R23
+      0x945C2C17,  //  00E2  GETIDX	R23	R22	R23
+      0x5462000F,  //  00E3  LDINT	R24	16
+      0x5466001E,  //  00E4  LDINT	R25	31
+      0x40603019,  //  00E5  CONNECT	R24	R24	R25
+      0x94602C18,  //  00E6  GETIDX	R24	R22	R24
+      0x5466001F,  //  00E7  LDINT	R25	32
+      0x546A002E,  //  00E8  LDINT	R26	47
+      0x4064321A,  //  00E9  CONNECT	R25	R25	R26
+      0x94642C19,  //  00EA  GETIDX	R25	R22	R25
+      0xB86A0C00,  //  00EB  GETNGBL	R26	K6
+      0x8C68353E,  //  00EC  GETMET	R26	R26	K62
+      0x7C680200,  //  00ED  CALL	R26	1
+      0x9468353F,  //  00EE  GETIDX	R26	R26	K63
+      0x8C6C2B40,  //  00EF  GETMET	R27	R21	K64
+      0x7C6C0200,  //  00F0  CALL	R27	1
+      0x4C700000,  //  00F1  LDNIL	R28
+      0x901A821C,  //  00F2  SETMBR	R6	K65	R28
+      0x8C700342,  //  00F3  GETMET	R28	R1	K66
+      0x547A0032,  //  00F4  LDINT	R30	51
+      0x507C0200,  //  00F5  LDBOOL	R31	1	0
+      0x7C700600,  //  00F6  CALL	R28	3
+      0x8C743943,  //  00F7  GETMET	R29	R28	K67
+      0x5C7C3600,  //  00F8  MOVE	R31	R27
+      0x7C740400,  //  00F9  CALL	R29	2
+      0x88780144,  //  00FA  GETMBR	R30	R0	K68
+      0x8C783D45,  //  00FB  GETMET	R30	R30	K69
+      0x5C803A00,  //  00FC  MOVE	R32	R29
+      0x8884032A,  //  00FD  GETMBR	R33	R1	K42
+      0x8888032B,  //  00FE  GETMBR	R34	R1	K43
+      0x888C3946,  //  00FF  GETMBR	R35	R28	K70
+      0x7C780A00,  //  0100  CALL	R30	5
+      0x8C780D47,  //  0101  GETMET	R30	R6	K71
+      0x5C802E00,  //  0102  MOVE	R32	R23
+      0x5C843000,  //  0103  MOVE	R33	R24
+      0x5C883200,  //  0104  MOVE	R34	R25
+      0x5C8C3400,  //  0105  MOVE	R35	R26
+      0x7C780A00,  //  0106  CALL	R30	5
+      0x50780200,  //  0107  LDBOOL	R30	1	0
+      0x80043C00,  //  0108  RET	1	R30
+      0x70020001,  //  0109  JMP		#010C
+      0x4C400000,  //  010A  LDNIL	R16
+      0x90122810,  //  010B  SETMBR	R4	K20	R16
+      0x881C0914,  //  010C  GETMBR	R7	R4	K20
+      0x4C200000,  //  010D  LDNIL	R8
+      0x1C1C0E08,  //  010E  EQ	R7	R7	R8
+      0x741E0003,  //  010F  JMPT	R7	#0114
+      0x881C0915,  //  0110  GETMBR	R7	R4	K21
+      0x4C200000,  //  0111  LDNIL	R8
+      0x1C1C0E08,  //  0112  EQ	R7	R7	R8
+      0x781E00B1,  //  0113  JMPF	R7	#01C6
+      0x8C1C0537,  //  0114  GETMET	R7	R2	K55
+      0x5426000F,  //  0115  LDINT	R9	16
+      0x7C1C0400,  //  0116  CALL	R7	2
+      0x901A6C07,  //  0117  SETMBR	R6	K54	R7
+      0x8C1C0537,  //  0118  GETMET	R7	R2	K55
+      0x5426001F,  //  0119  LDINT	R9	32
+      0x7C1C0400,  //  011A  CALL	R7	2
+      0x90029007,  //  011B  SETMBR	R0	K72	R7
+      0x8C1C054A,  //  011C  GETMET	R7	R2	K74
+      0x7C1C0200,  //  011D  CALL	R7	1
+      0x8C1C0F4B,  //  011E  GETMET	R7	R7	K75
+      0x88240148,  //  011F  GETMBR	R9	R0	K72
+      0x7C1C0400,  //  0120  CALL	R7	2
+      0x90029207,  //  0121  SETMBR	R0	K73	R7
+      0x8C1C0537,  //  0122  GETMET	R7	R2	K55
+      0x5426001F,  //  0123  LDINT	R9	32
+      0x7C1C0400,  //  0124  CALL	R7	2
+      0x8C20054A,  //  0125  GETMET	R8	R2	K74
+      0x7C200200,  //  0126  CALL	R8	1
+      0x8C20114C,  //  0127  GETMET	R8	R8	K76
+      0x88280148,  //  0128  GETMBR	R10	R0	K72
+      0x882C0913,  //  0129  GETMBR	R11	R4	K19
+      0x7C200600,  //  012A  CALL	R8	3
+      0x901A6008,  //  012B  SETMBR	R6	K48	R8
+      0xB8221A00,  //  012C  GETNGBL	R8	K13
+      0x8820114D,  //  012D  GETMBR	R8	R8	K77
+      0x8C20114E,  //  012E  GETMET	R8	R8	K78
+      0x7C200200,  //  012F  CALL	R8	1
+      0x8C24114F,  //  0130  GETMET	R9	R8	K79
+      0x582C000C,  //  0131  LDCONST	R11	K12
+      0xB8321A00,  //  0132  GETNGBL	R12	K13
+      0x8830194D,  //  0133  GETMBR	R12	R12	K77
+      0x88301950,  //  0134  GETMBR	R12	R12	K80
+      0x8C340D51,  //  0135  GETMET	R13	R6	K81
+      0x7C340200,  //  0136  CALL	R13	1
+      0x7C240800,  //  0137  CALL	R9	4
+      0x8C24114F,  //  0138  GETMET	R9	R8	K79
+      0x582C0009,  //  0139  LDCONST	R11	K9
+      0xB8321A00,  //  013A  GETNGBL	R12	K13
+      0x8830194D,  //  013B  GETMBR	R12	R12	K77
+      0x88301950,  //  013C  GETMBR	R12	R12	K80
+      0x8C340D52,  //  013D  GETMET	R13	R6	K82
+      0x7C340200,  //  013E  CALL	R13	1
+      0x7C240800,  //  013F  CALL	R9	4
+      0x8C24114F,  //  0140  GETMET	R9	R8	K79
+      0x582C0053,  //  0141  LDCONST	R11	K83
+      0xB8321A00,  //  0142  GETNGBL	R12	K13
+      0x8830194D,  //  0143  GETMBR	R12	R12	K77
+      0x88301950,  //  0144  GETMBR	R12	R12	K80
+      0x88340149,  //  0145  GETMBR	R13	R0	K73
+      0x7C240800,  //  0146  CALL	R9	4
+      0x8C24114F,  //  0147  GETMET	R9	R8	K79
+      0x542E0003,  //  0148  LDINT	R11	4
+      0xB8321A00,  //  0149  GETNGBL	R12	K13
+      0x8830194D,  //  014A  GETMBR	R12	R12	K77
+      0x88301950,  //  014B  GETMBR	R12	R12	K80
+      0x88340913,  //  014C  GETMBR	R13	R4	K19
+      0x7C240800,  //  014D  CALL	R9	4
+      0x8C24054A,  //  014E  GETMET	R9	R2	K74
+      0x7C240200,  //  014F  CALL	R9	1
+      0x8C241354,  //  0150  GETMET	R9	R9	K84
+      0x8C2C0D55,  //  0151  GETMET	R11	R6	K85
+      0x7C2C0200,  //  0152  CALL	R11	1
+      0x8C301140,  //  0153  GETMET	R12	R8	K64
+      0x7C300200,  //  0154  CALL	R12	1
+      0x7C240600,  //  0155  CALL	R9	3
+      0xB82A1A00,  //  0156  GETNGBL	R10	K13
+      0x8828154D,  //  0157  GETMBR	R10	R10	K77
+      0x8C28154E,  //  0158  GETMET	R10	R10	K78
+      0x7C280200,  //  0159  CALL	R10	1
+      0x8C2C154F,  //  015A  GETMET	R11	R10	K79
+      0x5834000C,  //  015B  LDCONST	R13	K12
+      0xB83A1A00,  //  015C  GETNGBL	R14	K13
+      0x88381D4D,  //  015D  GETMBR	R14	R14	K77
+      0x88381D50,  //  015E  GETMBR	R14	R14	K80
+      0x8C3C0D51,  //  015F  GETMET	R15	R6	K81
+      0x7C3C0200,  //  0160  CALL	R15	1
+      0x7C2C0800,  //  0161  CALL	R11	4
+      0x8C2C154F,  //  0162  GETMET	R11	R10	K79
+      0x58340009,  //  0163  LDCONST	R13	K9
+      0xB83A1A00,  //  0164  GETNGBL	R14	K13
+      0x88381D4D,  //  0165  GETMBR	R14	R14	K77
+      0x88381D50,  //  0166  GETMBR	R14	R14	K80
+      0x8C3C0D52,  //  0167  GETMET	R15	R6	K82
+      0x7C3C0200,  //  0168  CALL	R15	1
+      0x7C2C0800,  //  0169  CALL	R11	4
+      0x8C2C154F,  //  016A  GETMET	R11	R10	K79
+      0x58340053,  //  016B  LDCONST	R13	K83
+      0xB83A1A00,  //  016C  GETNGBL	R14	K13
+      0x88381D4D,  //  016D  GETMBR	R14	R14	K77
+      0x88381D50,  //  016E  GETMBR	R14	R14	K80
+      0x5C3C1200,  //  016F  MOVE	R15	R9
+      0x7C2C0800,  //  0170  CALL	R11	4
+      0x8C2C154F,  //  0171  GETMET	R11	R10	K79
+      0x54360003,  //  0172  LDINT	R13	4
+      0xB83A1A00,  //  0173  GETNGBL	R14	K13
+      0x88381D4D,  //  0174  GETMBR	R14	R14	K77
+      0x88381D50,  //  0175  GETMBR	R14	R14	K80
+      0x883C0D36,  //  0176  GETMBR	R15	R6	K54
+      0x7C2C0800,  //  0177  CALL	R11	4
+      0x882C0956,  //  0178  GETMBR	R11	R4	K86
+      0x901A820B,  //  0179  SETMBR	R6	K65	R11
+      0x8C2C0557,  //  017A  GETMET	R11	R2	K87
+      0x7C2C0200,  //  017B  CALL	R11	1
+      0x8C2C1758,  //  017C  GETMET	R11	R11	K88
+      0x88340D41,  //  017D  GETMBR	R13	R6	K65
+      0x7C2C0400,  //  017E  CALL	R11	2
+      0x8C2C1759,  //  017F  GETMET	R11	R11	K89
+      0x7C2C0200,  //  0180  CALL	R11	1
+      0x60300015,  //  0181  GETGBL	R12	G21
+      0x7C300000,  //  0182  CALL	R12	0
+      0x8C30192C,  //  0183  GETMET	R12	R12	K44
+      0x8838015A,  //  0184  GETMBR	R14	R0	K90
+      0x7C300400,  //  0185  CALL	R12	2
+      0x8C340D5B,  //  0186  GETMET	R13	R6	K91
+      0x7C340200,  //  0187  CALL	R13	1
+      0x00341A07,  //  0188  ADD	R13	R13	R7
+      0x88380149,  //  0189  GETMBR	R14	R0	K73
+      0x00341A0E,  //  018A  ADD	R13	R13	R14
+      0x00341A0B,  //  018B  ADD	R13	R13	R11
+      0x8C38052E,  //  018C  GETMET	R14	R2	K46
+      0x7C380200,  //  018D  CALL	R14	1
+      0x8C381D2F,  //  018E  GETMET	R14	R14	K47
+      0x88400D30,  //  018F  GETMBR	R16	R6	K48
+      0x5C441A00,  //  0190  MOVE	R17	R13
+      0x5C481800,  //  0191  MOVE	R18	R12
+      0x544E000F,  //  0192  LDINT	R19	16
+      0x7C380A00,  //  0193  CALL	R14	5
+      0x8C3C1540,  //  0194  GETMET	R15	R10	K64
+      0x7C3C0200,  //  0195  CALL	R15	1
+      0x8C400533,  //  0196  GETMET	R16	R2	K51
+      0x5C481C00,  //  0197  MOVE	R18	R14
+      0x604C0015,  //  0198  GETGBL	R19	G21
+      0x7C4C0000,  //  0199  CALL	R19	0
+      0x8C4C272C,  //  019A  GETMET	R19	R19	K44
+      0x8854015C,  //  019B  GETMBR	R21	R0	K92
+      0x7C4C0400,  //  019C  CALL	R19	2
+      0x60500015,  //  019D  GETGBL	R20	G21
+      0x7C500000,  //  019E  CALL	R20	0
+      0x6054000C,  //  019F  GETGBL	R21	G12
+      0x5C581E00,  //  01A0  MOVE	R22	R15
+      0x7C540200,  //  01A1  CALL	R21	1
+      0x545A000F,  //  01A2  LDINT	R22	16
+      0x7C400C00,  //  01A3  CALL	R16	6
+      0x8C44215D,  //  01A4  GETMET	R17	R16	K93
+      0x5C4C1E00,  //  01A5  MOVE	R19	R15
+      0x7C440400,  //  01A6  CALL	R17	2
+      0x8C482135,  //  01A7  GETMET	R18	R16	K53
+      0x7C480200,  //  01A8  CALL	R18	1
+      0x00442212,  //  01A9  ADD	R17	R17	R18
+      0xB84A1A00,  //  01AA  GETNGBL	R18	K13
+      0x8C48255E,  //  01AB  GETMET	R18	R18	K94
+      0x7C480200,  //  01AC  CALL	R18	1
+      0x904ABE07,  //  01AD  SETMBR	R18	K95	R7
+      0x884C0127,  //  01AE  GETMBR	R19	R0	K39
+      0x904AC013,  //  01AF  SETMBR	R18	K96	R19
+      0x884C0149,  //  01B0  GETMBR	R19	R0	K73
+      0x904AC213,  //  01B1  SETMBR	R18	K97	R19
+      0x904AC411,  //  01B2  SETMBR	R18	K98	R17
+      0x8C4C2540,  //  01B3  GETMET	R19	R18	K64
+      0x7C4C0200,  //  01B4  CALL	R19	1
+      0x901AC613,  //  01B5  SETMBR	R6	K99	R19
+      0x8C500342,  //  01B6  GETMET	R20	R1	K66
+      0x545A0030,  //  01B7  LDINT	R22	49
+      0x505C0200,  //  01B8  LDBOOL	R23	1	0
+      0x7C500600,  //  01B9  CALL	R20	3
+      0x8C542943,  //  01BA  GETMET	R21	R20	K67
+      0x5C5C2600,  //  01BB  MOVE	R23	R19
+      0x7C540400,  //  01BC  CALL	R21	2
+      0x88580144,  //  01BD  GETMBR	R22	R0	K68
+      0x8C582D45,  //  01BE  GETMET	R22	R22	K69
+      0x5C602A00,  //  01BF  MOVE	R24	R21
+      0x8864032A,  //  01C0  GETMBR	R25	R1	K42
+      0x8868032B,  //  01C1  GETMBR	R26	R1	K43
+      0x886C2946,  //  01C2  GETMBR	R27	R20	K70
+      0x7C580A00,  //  01C3  CALL	R22	5
+      0x50580200,  //  01C4  LDBOOL	R22	1	0
+      0x80042C00,  //  01C5  RET	1	R22
+      0x501C0200,  //  01C6  LDBOOL	R7	1	0
+      0x80040E00,  //  01C7  RET	1	R7
     })
   )
 );
@@ -2084,7 +1672,7 @@ be_local_closure(Matter_Commisioning_Context_parse_StatusReport,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
+    ( &(const bvalue[ 9]) {     /* constants */
     /* K0   */  be_nested_str_weak(session),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
@@ -2093,10 +1681,11 @@ be_local_closure(Matter_Commisioning_Context_parse_StatusReport,   /* name */
     /* K5   */  be_nested_str_weak(app_payload_idx),
     /* K6   */  be_const_int(2147483647),
     /* K7   */  be_nested_str_weak(tohex),
+    /* K8   */  be_const_int(2),
     }),
     be_str_weak(parse_StatusReport),
     &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x88080300,  //  0000  GETMBR	R2	R1	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
@@ -2107,9 +1696,10 @@ be_local_closure(Matter_Commisioning_Context_parse_StatusReport,   /* name */
       0x8C140B07,  //  0007  GETMET	R5	R5	K7
       0x7C140200,  //  0008  CALL	R5	1
       0x00160605,  //  0009  ADD	R5	K3	R5
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x500C0200,  //  000B  LDBOOL	R3	1	0
-      0x80040600,  //  000C  RET	1	R3
+      0x58180008,  //  000A  LDCONST	R6	K8
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0x500C0200,  //  000C  LDBOOL	R3	1	0
+      0x80040600,  //  000D  RET	1	R3
     })
   )
 );
@@ -2129,7 +1719,7 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake1,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[83]) {     /* constants */
+    ( &(const bvalue[47]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(opcode),
     /* K2   */  be_nested_str_weak(local_session_id),
@@ -2148,75 +1738,39 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake1,   /* name */
     /* K15  */  be_nested_str_weak(raw),
     /* K16  */  be_nested_str_weak(app_payload_idx),
     /* K17  */  be_nested_str_weak(pA),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20received_X20pA_X3D),
-    /* K19  */  be_nested_str_weak(tohex),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20spake_X3A_X20),
-    /* K21  */  be_nested_str_weak(inspect),
-    /* K22  */  be_nested_str_weak(spake),
-    /* K23  */  be_nested_str_weak(SPAKE2P_Matter),
-    /* K24  */  be_nested_str_weak(device),
-    /* K25  */  be_nested_str_weak(commissioning_w0),
-    /* K26  */  be_nested_str_weak(commissioning_L),
-    /* K27  */  be_nested_str_weak(compute_pB),
-    /* K28  */  be_nested_str_weak(y),
-    /* K29  */  be_nested_str_weak(pB),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20y_X3D),
-    /* K31  */  be_nested_str_weak(MTR_X3A_X20pb_X3D),
-    /* K32  */  be_nested_str_weak(compute_ZV_verifier),
-    /* K33  */  be_nested_str_weak(MTR_X3A_X20Z_X3D),
-    /* K34  */  be_nested_str_weak(Z),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20V_X3D),
-    /* K36  */  be_nested_str_weak(V),
-    /* K37  */  be_nested_str_weak(SHA256),
-    /* K38  */  be_nested_str_weak(update),
-    /* K39  */  be_nested_str_weak(fromstring),
-    /* K40  */  be_nested_str_weak(Matter_Context_Prefix),
-    /* K41  */  be_nested_str_weak(PBKDFParamRequest),
-    /* K42  */  be_nested_str_weak(PBKDFParamResponse),
-    /* K43  */  be_nested_str_weak(out),
-    /* K44  */  be_nested_str_weak(MTR_X3A_X20Context_X3D),
-    /* K45  */  be_nested_str_weak(set_context),
-    /* K46  */  be_nested_str_weak(compute_TT_hash),
-    /* K47  */  be_nested_str_weak(MTR_X3A_X20_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D_X2D),
-    /* K48  */  be_nested_str_weak(MTR_X3A_X20Context_X20_X3D_X20),
-    /* K49  */  be_nested_str_weak(Context),
-    /* K50  */  be_nested_str_weak(MTR_X3A_X20M_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K51  */  be_nested_str_weak(M),
-    /* K52  */  be_nested_str_weak(MTR_X3A_X20N_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K53  */  be_nested_str_weak(N),
-    /* K54  */  be_nested_str_weak(MTR_X3A_X20pA_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K55  */  be_nested_str_weak(MTR_X3A_X20pB_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K56  */  be_nested_str_weak(MTR_X3A_X20Z_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K57  */  be_nested_str_weak(MTR_X3A_X20V_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K58  */  be_nested_str_weak(MTR_X3A_X20w0_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K59  */  be_nested_str_weak(w0),
-    /* K60  */  be_nested_str_weak(MTR_X3A_X20Kmain_X20_X20_X20_X3D),
-    /* K61  */  be_nested_str_weak(Kmain),
-    /* K62  */  be_nested_str_weak(MTR_X3A_X20KcA_X20_X20_X20_X20_X20_X3D),
-    /* K63  */  be_nested_str_weak(KcA),
-    /* K64  */  be_nested_str_weak(MTR_X3A_X20KcB_X20_X20_X20_X20_X20_X3D),
-    /* K65  */  be_nested_str_weak(KcB),
-    /* K66  */  be_nested_str_weak(MTR_X3A_X20K_shared_X3D),
-    /* K67  */  be_nested_str_weak(K_shared),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20Ke_X20_X20_X20_X20_X20_X20_X3D),
-    /* K69  */  be_nested_str_weak(Ke),
-    /* K70  */  be_nested_str_weak(cB),
-    /* K71  */  be_nested_str_weak(MTR_X3A_X20cB_X3D),
-    /* K72  */  be_nested_str_weak(Pake2),
-    /* K73  */  be_nested_str_weak(MTR_X3A_X20pake2_X3A_X20),
-    /* K74  */  be_nested_str_weak(encode),
-    /* K75  */  be_nested_str_weak(MTR_X3A_X20pake2_raw_X3A_X20),
-    /* K76  */  be_nested_str_weak(build_response),
-    /* K77  */  be_nested_str_weak(encode_frame),
-    /* K78  */  be_nested_str_weak(responder),
-    /* K79  */  be_nested_str_weak(send_response),
-    /* K80  */  be_nested_str_weak(remote_ip),
-    /* K81  */  be_nested_str_weak(remote_port),
-    /* K82  */  be_nested_str_weak(message_counter),
+    /* K18  */  be_nested_str_weak(spake),
+    /* K19  */  be_nested_str_weak(SPAKE2P_Matter),
+    /* K20  */  be_nested_str_weak(device),
+    /* K21  */  be_nested_str_weak(commissioning_w0),
+    /* K22  */  be_nested_str_weak(commissioning_L),
+    /* K23  */  be_nested_str_weak(compute_pB),
+    /* K24  */  be_nested_str_weak(y),
+    /* K25  */  be_nested_str_weak(pB),
+    /* K26  */  be_nested_str_weak(compute_ZV_verifier),
+    /* K27  */  be_nested_str_weak(SHA256),
+    /* K28  */  be_nested_str_weak(update),
+    /* K29  */  be_nested_str_weak(fromstring),
+    /* K30  */  be_nested_str_weak(Matter_Context_Prefix),
+    /* K31  */  be_nested_str_weak(PBKDFParamRequest),
+    /* K32  */  be_nested_str_weak(PBKDFParamResponse),
+    /* K33  */  be_nested_str_weak(out),
+    /* K34  */  be_nested_str_weak(set_context),
+    /* K35  */  be_nested_str_weak(compute_TT_hash),
+    /* K36  */  be_nested_str_weak(cB),
+    /* K37  */  be_nested_str_weak(Ke),
+    /* K38  */  be_nested_str_weak(Pake2),
+    /* K39  */  be_nested_str_weak(tlv2raw),
+    /* K40  */  be_nested_str_weak(build_response),
+    /* K41  */  be_nested_str_weak(encode_frame),
+    /* K42  */  be_nested_str_weak(responder),
+    /* K43  */  be_nested_str_weak(send_response),
+    /* K44  */  be_nested_str_weak(remote_ip),
+    /* K45  */  be_nested_str_weak(remote_port),
+    /* K46  */  be_nested_str_weak(message_counter),
     }),
     be_str_weak(parse_Pake1),
     &be_const_str_solidified,
-    ( &(const binstruction[325]) {  /* code */
+    ( &(const binstruction[116]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0x880C0301,  //  0001  GETMBR	R3	R1	K1
       0x54120021,  //  0002  LDINT	R4	34
@@ -2256,292 +1810,83 @@ be_local_closure(Matter_Commisioning_Context_parse_Pake1,   /* name */
       0x7C0C0600,  //  0024  CALL	R3	3
       0x88100711,  //  0025  GETMBR	R4	R3	K17
       0x90022204,  //  0026  SETMBR	R0	K17	R4
-      0xB8120A00,  //  0027  GETNGBL	R4	K5
-      0x8C100906,  //  0028  GETMET	R4	R4	K6
-      0x88180111,  //  0029  GETMBR	R6	R0	K17
-      0x8C180D13,  //  002A  GETMET	R6	R6	K19
-      0x7C180200,  //  002B  CALL	R6	1
-      0x001A2406,  //  002C  ADD	R6	K18	R6
-      0x541E0003,  //  002D  LDINT	R7	4
-      0x7C100600,  //  002E  CALL	R4	3
-      0xB8120A00,  //  002F  GETNGBL	R4	K5
-      0x8C100906,  //  0030  GETMET	R4	R4	K6
-      0xB81A1800,  //  0031  GETNGBL	R6	K12
-      0x8C180D15,  //  0032  GETMET	R6	R6	K21
-      0x88200116,  //  0033  GETMBR	R8	R0	K22
-      0x7C180400,  //  0034  CALL	R6	2
-      0x001A2806,  //  0035  ADD	R6	K20	R6
-      0x541E0003,  //  0036  LDINT	R7	4
-      0x7C100600,  //  0037  CALL	R4	3
-      0x8C100517,  //  0038  GETMET	R4	R2	K23
-      0x88180118,  //  0039  GETMBR	R6	R0	K24
-      0x88180D19,  //  003A  GETMBR	R6	R6	K25
-      0x4C1C0000,  //  003B  LDNIL	R7
-      0x88200118,  //  003C  GETMBR	R8	R0	K24
-      0x8820111A,  //  003D  GETMBR	R8	R8	K26
-      0x7C100800,  //  003E  CALL	R4	4
-      0x90022C04,  //  003F  SETMBR	R0	K22	R4
-      0x88100116,  //  0040  GETMBR	R4	R0	K22
-      0x8C10091B,  //  0041  GETMET	R4	R4	K27
-      0x8818011C,  //  0042  GETMBR	R6	R0	K28
-      0x7C100400,  //  0043  CALL	R4	2
-      0x88100116,  //  0044  GETMBR	R4	R0	K22
-      0x8810091D,  //  0045  GETMBR	R4	R4	K29
-      0x90023A04,  //  0046  SETMBR	R0	K29	R4
-      0xB8120A00,  //  0047  GETNGBL	R4	K5
-      0x8C100906,  //  0048  GETMET	R4	R4	K6
-      0x8818011C,  //  0049  GETMBR	R6	R0	K28
-      0x8C180D13,  //  004A  GETMET	R6	R6	K19
-      0x7C180200,  //  004B  CALL	R6	1
-      0x001A3C06,  //  004C  ADD	R6	K30	R6
-      0x541E0003,  //  004D  LDINT	R7	4
-      0x7C100600,  //  004E  CALL	R4	3
-      0xB8120A00,  //  004F  GETNGBL	R4	K5
-      0x8C100906,  //  0050  GETMET	R4	R4	K6
-      0x8818011D,  //  0051  GETMBR	R6	R0	K29
-      0x8C180D13,  //  0052  GETMET	R6	R6	K19
-      0x7C180200,  //  0053  CALL	R6	1
-      0x001A3E06,  //  0054  ADD	R6	K31	R6
-      0x541E0003,  //  0055  LDINT	R7	4
-      0x7C100600,  //  0056  CALL	R4	3
-      0x88100116,  //  0057  GETMBR	R4	R0	K22
-      0x8C100920,  //  0058  GETMET	R4	R4	K32
-      0x88180111,  //  0059  GETMBR	R6	R0	K17
-      0x7C100400,  //  005A  CALL	R4	2
-      0xB8120A00,  //  005B  GETNGBL	R4	K5
-      0x8C100906,  //  005C  GETMET	R4	R4	K6
-      0x88180116,  //  005D  GETMBR	R6	R0	K22
-      0x88180D22,  //  005E  GETMBR	R6	R6	K34
-      0x8C180D13,  //  005F  GETMET	R6	R6	K19
-      0x7C180200,  //  0060  CALL	R6	1
-      0x001A4206,  //  0061  ADD	R6	K33	R6
-      0x541E0003,  //  0062  LDINT	R7	4
-      0x7C100600,  //  0063  CALL	R4	3
-      0xB8120A00,  //  0064  GETNGBL	R4	K5
-      0x8C100906,  //  0065  GETMET	R4	R4	K6
-      0x88180116,  //  0066  GETMBR	R6	R0	K22
-      0x88180D24,  //  0067  GETMBR	R6	R6	K36
-      0x8C180D13,  //  0068  GETMET	R6	R6	K19
-      0x7C180200,  //  0069  CALL	R6	1
-      0x001A4606,  //  006A  ADD	R6	K35	R6
-      0x541E0003,  //  006B  LDINT	R7	4
-      0x7C100600,  //  006C  CALL	R4	3
-      0x8C100525,  //  006D  GETMET	R4	R2	K37
-      0x7C100200,  //  006E  CALL	R4	1
-      0x8C140926,  //  006F  GETMET	R5	R4	K38
-      0x601C0015,  //  0070  GETGBL	R7	G21
-      0x7C1C0000,  //  0071  CALL	R7	0
-      0x8C1C0F27,  //  0072  GETMET	R7	R7	K39
-      0x88240128,  //  0073  GETMBR	R9	R0	K40
-      0x7C1C0400,  //  0074  CALL	R7	2
-      0x7C140400,  //  0075  CALL	R5	2
-      0x8C140926,  //  0076  GETMET	R5	R4	K38
-      0x881C0129,  //  0077  GETMBR	R7	R0	K41
-      0x7C140400,  //  0078  CALL	R5	2
-      0x8C140926,  //  0079  GETMET	R5	R4	K38
-      0x881C012A,  //  007A  GETMBR	R7	R0	K42
-      0x7C140400,  //  007B  CALL	R5	2
-      0x8C14092B,  //  007C  GETMET	R5	R4	K43
-      0x7C140200,  //  007D  CALL	R5	1
-      0xB81A0A00,  //  007E  GETNGBL	R6	K5
-      0x8C180D06,  //  007F  GETMET	R6	R6	K6
-      0x8C200B13,  //  0080  GETMET	R8	R5	K19
-      0x7C200200,  //  0081  CALL	R8	1
-      0x00225808,  //  0082  ADD	R8	K44	R8
-      0x54260003,  //  0083  LDINT	R9	4
-      0x7C180600,  //  0084  CALL	R6	3
-      0x88180116,  //  0085  GETMBR	R6	R0	K22
-      0x881C0111,  //  0086  GETMBR	R7	R0	K17
-      0x901A2207,  //  0087  SETMBR	R6	K17	R7
-      0x88180116,  //  0088  GETMBR	R6	R0	K22
-      0x8C180D2D,  //  0089  GETMET	R6	R6	K45
-      0x5C200A00,  //  008A  MOVE	R8	R5
-      0x7C180400,  //  008B  CALL	R6	2
-      0x88180116,  //  008C  GETMBR	R6	R0	K22
-      0x8C180D2E,  //  008D  GETMET	R6	R6	K46
-      0x50200200,  //  008E  LDBOOL	R8	1	0
-      0x7C180400,  //  008F  CALL	R6	2
-      0xB81A0A00,  //  0090  GETNGBL	R6	K5
-      0x8C180D06,  //  0091  GETMET	R6	R6	K6
-      0x5820002F,  //  0092  LDCONST	R8	K47
-      0x54260003,  //  0093  LDINT	R9	4
-      0x7C180600,  //  0094  CALL	R6	3
-      0xB81A0A00,  //  0095  GETNGBL	R6	K5
-      0x8C180D06,  //  0096  GETMET	R6	R6	K6
-      0x88200116,  //  0097  GETMBR	R8	R0	K22
-      0x88201131,  //  0098  GETMBR	R8	R8	K49
-      0x8C201113,  //  0099  GETMET	R8	R8	K19
-      0x7C200200,  //  009A  CALL	R8	1
-      0x00226008,  //  009B  ADD	R8	K48	R8
-      0x54260003,  //  009C  LDINT	R9	4
-      0x7C180600,  //  009D  CALL	R6	3
-      0xB81A0A00,  //  009E  GETNGBL	R6	K5
-      0x8C180D06,  //  009F  GETMET	R6	R6	K6
-      0x88200116,  //  00A0  GETMBR	R8	R0	K22
-      0x88201133,  //  00A1  GETMBR	R8	R8	K51
-      0x8C201113,  //  00A2  GETMET	R8	R8	K19
-      0x7C200200,  //  00A3  CALL	R8	1
-      0x00226408,  //  00A4  ADD	R8	K50	R8
-      0x54260003,  //  00A5  LDINT	R9	4
-      0x7C180600,  //  00A6  CALL	R6	3
-      0xB81A0A00,  //  00A7  GETNGBL	R6	K5
-      0x8C180D06,  //  00A8  GETMET	R6	R6	K6
-      0x88200116,  //  00A9  GETMBR	R8	R0	K22
-      0x88201135,  //  00AA  GETMBR	R8	R8	K53
-      0x8C201113,  //  00AB  GETMET	R8	R8	K19
-      0x7C200200,  //  00AC  CALL	R8	1
-      0x00226808,  //  00AD  ADD	R8	K52	R8
-      0x54260003,  //  00AE  LDINT	R9	4
-      0x7C180600,  //  00AF  CALL	R6	3
-      0xB81A0A00,  //  00B0  GETNGBL	R6	K5
-      0x8C180D06,  //  00B1  GETMET	R6	R6	K6
-      0x88200116,  //  00B2  GETMBR	R8	R0	K22
-      0x88201111,  //  00B3  GETMBR	R8	R8	K17
-      0x8C201113,  //  00B4  GETMET	R8	R8	K19
-      0x7C200200,  //  00B5  CALL	R8	1
-      0x00226C08,  //  00B6  ADD	R8	K54	R8
-      0x54260003,  //  00B7  LDINT	R9	4
-      0x7C180600,  //  00B8  CALL	R6	3
-      0xB81A0A00,  //  00B9  GETNGBL	R6	K5
-      0x8C180D06,  //  00BA  GETMET	R6	R6	K6
-      0x88200116,  //  00BB  GETMBR	R8	R0	K22
-      0x8820111D,  //  00BC  GETMBR	R8	R8	K29
-      0x8C201113,  //  00BD  GETMET	R8	R8	K19
-      0x7C200200,  //  00BE  CALL	R8	1
-      0x00226E08,  //  00BF  ADD	R8	K55	R8
-      0x54260003,  //  00C0  LDINT	R9	4
-      0x7C180600,  //  00C1  CALL	R6	3
-      0xB81A0A00,  //  00C2  GETNGBL	R6	K5
-      0x8C180D06,  //  00C3  GETMET	R6	R6	K6
-      0x88200116,  //  00C4  GETMBR	R8	R0	K22
-      0x88201122,  //  00C5  GETMBR	R8	R8	K34
-      0x8C201113,  //  00C6  GETMET	R8	R8	K19
-      0x7C200200,  //  00C7  CALL	R8	1
-      0x00227008,  //  00C8  ADD	R8	K56	R8
-      0x54260003,  //  00C9  LDINT	R9	4
-      0x7C180600,  //  00CA  CALL	R6	3
-      0xB81A0A00,  //  00CB  GETNGBL	R6	K5
-      0x8C180D06,  //  00CC  GETMET	R6	R6	K6
-      0x88200116,  //  00CD  GETMBR	R8	R0	K22
-      0x88201124,  //  00CE  GETMBR	R8	R8	K36
-      0x8C201113,  //  00CF  GETMET	R8	R8	K19
-      0x7C200200,  //  00D0  CALL	R8	1
-      0x00227208,  //  00D1  ADD	R8	K57	R8
-      0x54260003,  //  00D2  LDINT	R9	4
-      0x7C180600,  //  00D3  CALL	R6	3
-      0xB81A0A00,  //  00D4  GETNGBL	R6	K5
-      0x8C180D06,  //  00D5  GETMET	R6	R6	K6
-      0x88200116,  //  00D6  GETMBR	R8	R0	K22
-      0x8820113B,  //  00D7  GETMBR	R8	R8	K59
-      0x8C201113,  //  00D8  GETMET	R8	R8	K19
-      0x7C200200,  //  00D9  CALL	R8	1
-      0x00227408,  //  00DA  ADD	R8	K58	R8
-      0x54260003,  //  00DB  LDINT	R9	4
-      0x7C180600,  //  00DC  CALL	R6	3
-      0xB81A0A00,  //  00DD  GETNGBL	R6	K5
-      0x8C180D06,  //  00DE  GETMET	R6	R6	K6
-      0x5820002F,  //  00DF  LDCONST	R8	K47
-      0x54260003,  //  00E0  LDINT	R9	4
-      0x7C180600,  //  00E1  CALL	R6	3
-      0xB81A0A00,  //  00E2  GETNGBL	R6	K5
-      0x8C180D06,  //  00E3  GETMET	R6	R6	K6
-      0x88200116,  //  00E4  GETMBR	R8	R0	K22
-      0x8820113D,  //  00E5  GETMBR	R8	R8	K61
-      0x8C201113,  //  00E6  GETMET	R8	R8	K19
-      0x7C200200,  //  00E7  CALL	R8	1
-      0x00227808,  //  00E8  ADD	R8	K60	R8
-      0x54260003,  //  00E9  LDINT	R9	4
-      0x7C180600,  //  00EA  CALL	R6	3
-      0xB81A0A00,  //  00EB  GETNGBL	R6	K5
-      0x8C180D06,  //  00EC  GETMET	R6	R6	K6
-      0x88200116,  //  00ED  GETMBR	R8	R0	K22
-      0x8820113F,  //  00EE  GETMBR	R8	R8	K63
-      0x8C201113,  //  00EF  GETMET	R8	R8	K19
-      0x7C200200,  //  00F0  CALL	R8	1
-      0x00227C08,  //  00F1  ADD	R8	K62	R8
-      0x54260003,  //  00F2  LDINT	R9	4
-      0x7C180600,  //  00F3  CALL	R6	3
-      0xB81A0A00,  //  00F4  GETNGBL	R6	K5
-      0x8C180D06,  //  00F5  GETMET	R6	R6	K6
-      0x88200116,  //  00F6  GETMBR	R8	R0	K22
-      0x88201141,  //  00F7  GETMBR	R8	R8	K65
-      0x8C201113,  //  00F8  GETMET	R8	R8	K19
-      0x7C200200,  //  00F9  CALL	R8	1
-      0x00228008,  //  00FA  ADD	R8	K64	R8
-      0x54260003,  //  00FB  LDINT	R9	4
-      0x7C180600,  //  00FC  CALL	R6	3
-      0xB81A0A00,  //  00FD  GETNGBL	R6	K5
-      0x8C180D06,  //  00FE  GETMET	R6	R6	K6
-      0x88200116,  //  00FF  GETMBR	R8	R0	K22
-      0x88201143,  //  0100  GETMBR	R8	R8	K67
-      0x8C201113,  //  0101  GETMET	R8	R8	K19
-      0x7C200200,  //  0102  CALL	R8	1
-      0x00228408,  //  0103  ADD	R8	K66	R8
-      0x54260003,  //  0104  LDINT	R9	4
-      0x7C180600,  //  0105  CALL	R6	3
-      0xB81A0A00,  //  0106  GETNGBL	R6	K5
-      0x8C180D06,  //  0107  GETMET	R6	R6	K6
-      0x88200116,  //  0108  GETMBR	R8	R0	K22
-      0x88201145,  //  0109  GETMBR	R8	R8	K69
-      0x8C201113,  //  010A  GETMET	R8	R8	K19
-      0x7C200200,  //  010B  CALL	R8	1
-      0x00228808,  //  010C  ADD	R8	K68	R8
-      0x54260003,  //  010D  LDINT	R9	4
-      0x7C180600,  //  010E  CALL	R6	3
-      0x88180116,  //  010F  GETMBR	R6	R0	K22
-      0x88180D46,  //  0110  GETMBR	R6	R6	K70
-      0x90028C06,  //  0111  SETMBR	R0	K70	R6
-      0x88180116,  //  0112  GETMBR	R6	R0	K22
-      0x88180D45,  //  0113  GETMBR	R6	R6	K69
-      0x90028A06,  //  0114  SETMBR	R0	K69	R6
-      0xB81A0A00,  //  0115  GETNGBL	R6	K5
-      0x8C180D06,  //  0116  GETMET	R6	R6	K6
-      0x88200146,  //  0117  GETMBR	R8	R0	K70
-      0x8C201113,  //  0118  GETMET	R8	R8	K19
-      0x7C200200,  //  0119  CALL	R8	1
-      0x00228E08,  //  011A  ADD	R8	K71	R8
-      0x54260003,  //  011B  LDINT	R9	4
-      0x7C180600,  //  011C  CALL	R6	3
-      0xB81A1800,  //  011D  GETNGBL	R6	K12
-      0x8C180D48,  //  011E  GETMET	R6	R6	K72
-      0x7C180200,  //  011F  CALL	R6	1
-      0x881C011D,  //  0120  GETMBR	R7	R0	K29
-      0x901A3A07,  //  0121  SETMBR	R6	K29	R7
-      0x881C0146,  //  0122  GETMBR	R7	R0	K70
-      0x901A8C07,  //  0123  SETMBR	R6	K70	R7
-      0xB81E0A00,  //  0124  GETNGBL	R7	K5
-      0x8C1C0F06,  //  0125  GETMET	R7	R7	K6
-      0xB8261800,  //  0126  GETNGBL	R9	K12
-      0x8C241315,  //  0127  GETMET	R9	R9	K21
-      0x5C2C0C00,  //  0128  MOVE	R11	R6
-      0x7C240400,  //  0129  CALL	R9	2
-      0x00269209,  //  012A  ADD	R9	K73	R9
-      0x542A0003,  //  012B  LDINT	R10	4
-      0x7C1C0600,  //  012C  CALL	R7	3
-      0x8C1C0D4A,  //  012D  GETMET	R7	R6	K74
-      0x7C1C0200,  //  012E  CALL	R7	1
-      0xB8220A00,  //  012F  GETNGBL	R8	K5
-      0x8C201106,  //  0130  GETMET	R8	R8	K6
-      0x8C280F13,  //  0131  GETMET	R10	R7	K19
-      0x7C280200,  //  0132  CALL	R10	1
-      0x002A960A,  //  0133  ADD	R10	K75	R10
-      0x542E0003,  //  0134  LDINT	R11	4
-      0x7C200600,  //  0135  CALL	R8	3
-      0x8C20034C,  //  0136  GETMET	R8	R1	K76
-      0x542A0022,  //  0137  LDINT	R10	35
-      0x502C0200,  //  0138  LDBOOL	R11	1	0
-      0x7C200600,  //  0139  CALL	R8	3
-      0x8C24114D,  //  013A  GETMET	R9	R8	K77
-      0x5C2C0E00,  //  013B  MOVE	R11	R7
-      0x7C240400,  //  013C  CALL	R9	2
-      0x8828014E,  //  013D  GETMBR	R10	R0	K78
-      0x8C28154F,  //  013E  GETMET	R10	R10	K79
-      0x5C301200,  //  013F  MOVE	R12	R9
-      0x88340350,  //  0140  GETMBR	R13	R1	K80
-      0x88380351,  //  0141  GETMBR	R14	R1	K81
-      0x883C1152,  //  0142  GETMBR	R15	R8	K82
-      0x7C280A00,  //  0143  CALL	R10	5
-      0x80000000,  //  0144  RET	0
+      0x8C100513,  //  0027  GETMET	R4	R2	K19
+      0x88180114,  //  0028  GETMBR	R6	R0	K20
+      0x88180D15,  //  0029  GETMBR	R6	R6	K21
+      0x4C1C0000,  //  002A  LDNIL	R7
+      0x88200114,  //  002B  GETMBR	R8	R0	K20
+      0x88201116,  //  002C  GETMBR	R8	R8	K22
+      0x7C100800,  //  002D  CALL	R4	4
+      0x90022404,  //  002E  SETMBR	R0	K18	R4
+      0x88100112,  //  002F  GETMBR	R4	R0	K18
+      0x8C100917,  //  0030  GETMET	R4	R4	K23
+      0x88180118,  //  0031  GETMBR	R6	R0	K24
+      0x7C100400,  //  0032  CALL	R4	2
+      0x88100112,  //  0033  GETMBR	R4	R0	K18
+      0x88100919,  //  0034  GETMBR	R4	R4	K25
+      0x90023204,  //  0035  SETMBR	R0	K25	R4
+      0x88100112,  //  0036  GETMBR	R4	R0	K18
+      0x8C10091A,  //  0037  GETMET	R4	R4	K26
+      0x88180111,  //  0038  GETMBR	R6	R0	K17
+      0x7C100400,  //  0039  CALL	R4	2
+      0x8C10051B,  //  003A  GETMET	R4	R2	K27
+      0x7C100200,  //  003B  CALL	R4	1
+      0x8C14091C,  //  003C  GETMET	R5	R4	K28
+      0x601C0015,  //  003D  GETGBL	R7	G21
+      0x7C1C0000,  //  003E  CALL	R7	0
+      0x8C1C0F1D,  //  003F  GETMET	R7	R7	K29
+      0x8824011E,  //  0040  GETMBR	R9	R0	K30
+      0x7C1C0400,  //  0041  CALL	R7	2
+      0x7C140400,  //  0042  CALL	R5	2
+      0x8C14091C,  //  0043  GETMET	R5	R4	K28
+      0x881C011F,  //  0044  GETMBR	R7	R0	K31
+      0x7C140400,  //  0045  CALL	R5	2
+      0x8C14091C,  //  0046  GETMET	R5	R4	K28
+      0x881C0120,  //  0047  GETMBR	R7	R0	K32
+      0x7C140400,  //  0048  CALL	R5	2
+      0x8C140921,  //  0049  GETMET	R5	R4	K33
+      0x7C140200,  //  004A  CALL	R5	1
+      0x88180112,  //  004B  GETMBR	R6	R0	K18
+      0x881C0111,  //  004C  GETMBR	R7	R0	K17
+      0x901A2207,  //  004D  SETMBR	R6	K17	R7
+      0x88180112,  //  004E  GETMBR	R6	R0	K18
+      0x8C180D22,  //  004F  GETMET	R6	R6	K34
+      0x5C200A00,  //  0050  MOVE	R8	R5
+      0x7C180400,  //  0051  CALL	R6	2
+      0x88180112,  //  0052  GETMBR	R6	R0	K18
+      0x8C180D23,  //  0053  GETMET	R6	R6	K35
+      0x50200200,  //  0054  LDBOOL	R8	1	0
+      0x7C180400,  //  0055  CALL	R6	2
+      0x88180112,  //  0056  GETMBR	R6	R0	K18
+      0x88180D24,  //  0057  GETMBR	R6	R6	K36
+      0x90024806,  //  0058  SETMBR	R0	K36	R6
+      0x88180112,  //  0059  GETMBR	R6	R0	K18
+      0x88180D25,  //  005A  GETMBR	R6	R6	K37
+      0x90024A06,  //  005B  SETMBR	R0	K37	R6
+      0xB81A1800,  //  005C  GETNGBL	R6	K12
+      0x8C180D26,  //  005D  GETMET	R6	R6	K38
+      0x7C180200,  //  005E  CALL	R6	1
+      0x881C0119,  //  005F  GETMBR	R7	R0	K25
+      0x901A3207,  //  0060  SETMBR	R6	K25	R7
+      0x881C0124,  //  0061  GETMBR	R7	R0	K36
+      0x901A4807,  //  0062  SETMBR	R6	K36	R7
+      0x8C1C0D27,  //  0063  GETMET	R7	R6	K39
+      0x7C1C0200,  //  0064  CALL	R7	1
+      0x8C200328,  //  0065  GETMET	R8	R1	K40
+      0x542A0022,  //  0066  LDINT	R10	35
+      0x502C0200,  //  0067  LDBOOL	R11	1	0
+      0x7C200600,  //  0068  CALL	R8	3
+      0x8C241129,  //  0069  GETMET	R9	R8	K41
+      0x5C2C0E00,  //  006A  MOVE	R11	R7
+      0x7C240400,  //  006B  CALL	R9	2
+      0x8828012A,  //  006C  GETMBR	R10	R0	K42
+      0x8C28152B,  //  006D  GETMET	R10	R10	K43
+      0x5C301200,  //  006E  MOVE	R12	R9
+      0x8834032C,  //  006F  GETMBR	R13	R1	K44
+      0x8838032D,  //  0070  GETMBR	R14	R1	K45
+      0x883C112E,  //  0071  GETMBR	R15	R8	K46
+      0x7C280A00,  //  0072  CALL	R10	5
+      0x80000000,  //  0073  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Commissioning_Data.h
@@ -116,9 +116,9 @@ void be_load_Matter_PBKDFParamRequest_class(bvm *vm) {
 extern const bclass be_class_Matter_PBKDFParamResponse;
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_PBKDFParamResponse_encode,   /* name */
+be_local_closure(Matter_PBKDFParamResponse_tlv2raw,   /* name */
   be_nested_proto(
     10,                          /* nstack */
     2,                          /* argc */
@@ -147,9 +147,9 @@ be_local_closure(Matter_PBKDFParamResponse_encode,   /* name */
     /* K15  */  be_nested_str_weak(pbkdf_parameters_salt),
     /* K16  */  be_nested_str_weak(SLEEPY_IDLE_INTERVAL),
     /* K17  */  be_nested_str_weak(SLEEPY_ACTIVE_INTERVAL),
-    /* K18  */  be_nested_str_weak(encode),
+    /* K18  */  be_nested_str_weak(tlv2raw),
     }),
-    be_str_weak(encode),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[71]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -238,13 +238,13 @@ be_local_class(Matter_PBKDFParamResponse,
     be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(pbkdf_parameters_salt, -1), be_const_var(4) },
-        { be_const_key_weak(SLEEPY_IDLE_INTERVAL, -1), be_const_var(5) },
-        { be_const_key_weak(SLEEPY_ACTIVE_INTERVAL, 1), be_const_var(6) },
-        { be_const_key_weak(responderRandom, -1), be_const_var(1) },
+        { be_const_key_weak(SLEEPY_ACTIVE_INTERVAL, -1), be_const_var(6) },
+        { be_const_key_weak(SLEEPY_IDLE_INTERVAL, 1), be_const_var(5) },
+        { be_const_key_weak(responderSessionId, -1), be_const_var(2) },
         { be_const_key_weak(pbkdf_parameters_iterations, -1), be_const_var(3) },
-        { be_const_key_weak(initiatorRandom, -1), be_const_var(0) },
-        { be_const_key_weak(responderSessionId, 3), be_const_var(2) },
-        { be_const_key_weak(encode, -1), be_const_closure(Matter_PBKDFParamResponse_encode_closure) },
+        { be_const_key_weak(initiatorRandom, 7), be_const_var(0) },
+        { be_const_key_weak(responderRandom, 3), be_const_var(1) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_PBKDFParamResponse_tlv2raw_closure) },
     })),
     be_str_weak(Matter_PBKDFParamResponse)
 );
@@ -339,9 +339,9 @@ void be_load_Matter_Pake1_class(bvm *vm) {
 extern const bclass be_class_Matter_Pake2;
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_Pake2_encode,   /* name */
+be_local_closure(Matter_Pake2_tlv2raw,   /* name */
   be_nested_proto(
     8,                          /* nstack */
     2,                          /* argc */
@@ -361,9 +361,9 @@ be_local_closure(Matter_Pake2_encode,   /* name */
     /* K6   */  be_nested_str_weak(pB),
     /* K7   */  be_const_int(2),
     /* K8   */  be_nested_str_weak(cB),
-    /* K9   */  be_nested_str_weak(encode),
+    /* K9   */  be_nested_str_weak(tlv2raw),
     }),
-    be_str_weak(encode),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[22]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -402,7 +402,7 @@ be_local_class(Matter_Pake2,
     NULL,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(encode, -1), be_const_closure(Matter_Pake2_encode_closure) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_Pake2_tlv2raw_closure) },
         { be_const_key_weak(cB, -1), be_const_var(1) },
         { be_const_key_weak(pB, 0), be_const_var(0) },
     })),
@@ -633,9 +633,9 @@ void be_load_Matter_Sigma1_class(bvm *vm) {
 extern const bclass be_class_Matter_Sigma2;
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_Sigma2_encode,   /* name */
+be_local_closure(Matter_Sigma2_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -663,9 +663,9 @@ be_local_closure(Matter_Sigma2_encode,   /* name */
     /* K14  */  be_nested_str_weak(SLEEPY_ACTIVE_INTERVAL),
     /* K15  */  be_nested_str_weak(add_struct),
     /* K16  */  be_nested_str_weak(U4),
-    /* K17  */  be_nested_str_weak(encode),
+    /* K17  */  be_nested_str_weak(tlv2raw),
     }),
-    be_str_weak(encode),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[61]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -743,13 +743,13 @@ be_local_class(Matter_Sigma2,
     NULL,
     be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(encrypted2, -1), be_const_var(3) },
-        { be_const_key_weak(encode, -1), be_const_closure(Matter_Sigma2_encode_closure) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_Sigma2_tlv2raw_closure) },
+        { be_const_key_weak(responderEphPubKey, 3), be_const_var(2) },
         { be_const_key_weak(responderSessionId, -1), be_const_var(1) },
-        { be_const_key_weak(SLEEPY_IDLE_INTERVAL, 6), be_const_var(4) },
-        { be_const_key_weak(SLEEPY_ACTIVE_INTERVAL, 0), be_const_var(5) },
-        { be_const_key_weak(responderRandom, 3), be_const_var(0) },
-        { be_const_key_weak(responderEphPubKey, -1), be_const_var(2) },
+        { be_const_key_weak(SLEEPY_IDLE_INTERVAL, -1), be_const_var(4) },
+        { be_const_key_weak(SLEEPY_ACTIVE_INTERVAL, 6), be_const_var(5) },
+        { be_const_key_weak(responderRandom, 1), be_const_var(0) },
+        { be_const_key_weak(encrypted2, -1), be_const_var(3) },
     })),
     be_str_weak(Matter_Sigma2)
 );
@@ -764,9 +764,9 @@ void be_load_Matter_Sigma2_class(bvm *vm) {
 extern const bclass be_class_Matter_Sigma2Resume;
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_Sigma2Resume_encode,   /* name */
+be_local_closure(Matter_Sigma2Resume_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -792,9 +792,9 @@ be_local_closure(Matter_Sigma2Resume_encode,   /* name */
     /* K12  */  be_nested_str_weak(SLEEPY_ACTIVE_INTERVAL),
     /* K13  */  be_nested_str_weak(add_struct),
     /* K14  */  be_nested_str_weak(U4),
-    /* K15  */  be_nested_str_weak(encode),
+    /* K15  */  be_nested_str_weak(tlv2raw),
     }),
-    be_str_weak(encode),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[54]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
@@ -870,7 +870,7 @@ be_local_class(Matter_Sigma2Resume,
         { be_const_key_weak(sigma2ResumeMIC, -1), be_const_var(1) },
         { be_const_key_weak(responderSessionID, 1), be_const_var(2) },
         { be_const_key_weak(SLEEPY_ACTIVE_INTERVAL, -1), be_const_var(4) },
-        { be_const_key_weak(encode, -1), be_const_closure(Matter_Sigma2Resume_encode_closure) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_Sigma2Resume_tlv2raw_closure) },
     })),
     be_str_weak(Matter_Sigma2Resume)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Device.h
@@ -7,155 +7,9 @@
 extern const bclass be_class_Matter_Device;
 
 /********************************************************************
-** Solidified function: save_param
+** Solidified function: is_root_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_save_param,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[17]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(dump),
-    /* K2   */  be_nested_str_weak(distinguish),
-    /* K3   */  be_nested_str_weak(root_discriminator),
-    /* K4   */  be_nested_str_weak(passcode),
-    /* K5   */  be_nested_str_weak(root_passcode),
-    /* K6   */  be_nested_str_weak(ipv4only),
-    /* K7   */  be_nested_str_weak(string),
-    /* K8   */  be_nested_str_weak(FILENAME),
-    /* K9   */  be_nested_str_weak(w),
-    /* K10  */  be_nested_str_weak(write),
-    /* K11  */  be_nested_str_weak(close),
-    /* K12  */  be_nested_str_weak(tasmota),
-    /* K13  */  be_nested_str_weak(log),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
-    /* K15  */  be_nested_str_weak(_X7C),
-    /* K16  */  be_const_int(2),
-    }),
-    be_str_weak(save_param),
-    &be_const_str_solidified,
-    ( &(const binstruction[45]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x8C080301,  //  0001  GETMET	R2	R1	K1
-      0x60100013,  //  0002  GETGBL	R4	G19
-      0x7C100000,  //  0003  CALL	R4	0
-      0x88140103,  //  0004  GETMBR	R5	R0	K3
-      0x98120405,  //  0005  SETIDX	R4	K2	R5
-      0x88140105,  //  0006  GETMBR	R5	R0	K5
-      0x98120805,  //  0007  SETIDX	R4	K4	R5
-      0x88140106,  //  0008  GETMBR	R5	R0	K6
-      0x98120C05,  //  0009  SETIDX	R4	K6	R5
-      0x7C080400,  //  000A  CALL	R2	2
-      0xA802000D,  //  000B  EXBLK	0	#001A
-      0xA40E0E00,  //  000C  IMPORT	R3	K7
-      0x60100011,  //  000D  GETGBL	R4	G17
-      0x88140108,  //  000E  GETMBR	R5	R0	K8
-      0x58180009,  //  000F  LDCONST	R6	K9
-      0x7C100400,  //  0010  CALL	R4	2
-      0x8C14090A,  //  0011  GETMET	R5	R4	K10
-      0x5C1C0400,  //  0012  MOVE	R7	R2
-      0x7C140400,  //  0013  CALL	R5	2
-      0x8C14090B,  //  0014  GETMET	R5	R4	K11
-      0x7C140200,  //  0015  CALL	R5	1
-      0xA8040001,  //  0016  EXBLK	1	1
-      0x80040400,  //  0017  RET	1	R2
-      0xA8040001,  //  0018  EXBLK	1	1
-      0x70020011,  //  0019  JMP		#002C
-      0xAC0C0002,  //  001A  CATCH	R3	0	2
-      0x7002000E,  //  001B  JMP		#002B
-      0xB8161800,  //  001C  GETNGBL	R5	K12
-      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
-      0x601C0008,  //  001E  GETGBL	R7	G8
-      0x5C200600,  //  001F  MOVE	R8	R3
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0x001E1C07,  //  0021  ADD	R7	K14	R7
-      0x001C0F0F,  //  0022  ADD	R7	R7	K15
-      0x60200008,  //  0023  GETGBL	R8	G8
-      0x5C240800,  //  0024  MOVE	R9	R4
-      0x7C200200,  //  0025  CALL	R8	1
-      0x001C0E08,  //  0026  ADD	R7	R7	R8
-      0x58200010,  //  0027  LDCONST	R8	K16
-      0x7C140600,  //  0028  CALL	R5	3
-      0x80040400,  //  0029  RET	1	R2
-      0x70020000,  //  002A  JMP		#002C
-      0xB0080000,  //  002B  RAISE	2	R0	R0
-      0x80000000,  //  002C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        3,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_commissioning_complete),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
-    }),
-    be_str_weak(start_commissioning_complete_deferred),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_init_basic_commissioning,   /* name */
+be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -165,23 +19,199 @@ be_local_closure(Matter_Device_init_basic_commissioning,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(count_active_fabrics),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
     }),
-    be_str_weak(init_basic_commissioning),
+    be_str_weak(is_root_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[11]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x1C040302,  //  0003  EQ	R1	R1	K2
-      0x78060001,  //  0004  JMPF	R1	#0007
-      0x8C040103,  //  0005  GETMET	R1	R0	K3
-      0x7C040200,  //  0006  CALL	R1	1
-      0x80000000,  //  0007  RET	0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060003,  //  0003  JMPF	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x74060000,  //  0007  JMPT	R1	#0009
+      0x50040001,  //  0008  LDBOOL	R1	0	1
+      0x50040200,  //  0009  LDBOOL	R1	1	0
+      0x80040200,  //  000A  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
+    /* K11  */  be_const_int(2),
+    /* K12  */  be_nested_str_weak(eth),
+    /* K13  */  be_nested_str_weak(find),
+    /* K14  */  be_nested_str_weak(up),
+    /* K15  */  be_nested_str_weak(format),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
+    /* K17  */  be_nested_str_weak(hostname_eth),
+    /* K18  */  be_const_int(3),
+    /* K19  */  be_nested_str_weak(add_service),
+    /* K20  */  be_nested_str_weak(_matter),
+    /* K21  */  be_nested_str_weak(_tcp),
+    /* K22  */  be_nested_str_weak(_I),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
+    /* K24  */  be_nested_str_weak(add_subtype),
+    /* K25  */  be_nested_str_weak(wifi),
+    /* K26  */  be_nested_str_weak(hostname_wifi),
+    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K28  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_announce_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[122]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA8020064,  //  0002  EXBLK	0	#0068
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x00261406,  //  0013  ADD	R9	K10	R6
+      0x5828000B,  //  0014  LDCONST	R10	K11
+      0x7C1C0600,  //  0015  CALL	R7	3
+      0xB81E1000,  //  0016  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
+      0x7C1C0200,  //  0018  CALL	R7	1
+      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
+      0x5824000E,  //  001A  LDCONST	R9	K14
+      0x7C1C0400,  //  001B  CALL	R7	2
+      0x781E0020,  //  001C  JMPF	R7	#003E
+      0xB81E1000,  //  001D  GETNGBL	R7	K8
+      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
+      0x8C24070F,  //  001F  GETMET	R9	R3	K15
+      0x582C0010,  //  0020  LDCONST	R11	K16
+      0x5830000C,  //  0021  LDCONST	R12	K12
+      0x5C340C00,  //  0022  MOVE	R13	R6
+      0x88380111,  //  0023  GETMBR	R14	R0	K17
+      0x7C240A00,  //  0024  CALL	R9	5
+      0x58280012,  //  0025  LDCONST	R10	K18
+      0x7C1C0600,  //  0026  CALL	R7	3
+      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
+      0x58240014,  //  0028  LDCONST	R9	K20
+      0x58280015,  //  0029  LDCONST	R10	K21
+      0x542E15A3,  //  002A  LDINT	R11	5540
+      0x4C300000,  //  002B  LDNIL	R12
+      0x5C340C00,  //  002C  MOVE	R13	R6
+      0x88380111,  //  002D  GETMBR	R14	R0	K17
+      0x7C1C0E00,  //  002E  CALL	R7	7
+      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0030  CALL	R7	1
+      0x001E2C07,  //  0031  ADD	R7	K22	R7
+      0xB8221000,  //  0032  GETNGBL	R8	K8
+      0x8C201109,  //  0033  GETMET	R8	R8	K9
+      0x002A2E07,  //  0034  ADD	R10	K23	R7
+      0x582C0012,  //  0035  LDCONST	R11	K18
+      0x7C200600,  //  0036  CALL	R8	3
+      0x8C200518,  //  0037  GETMET	R8	R2	K24
+      0x58280014,  //  0038  LDCONST	R10	K20
+      0x582C0015,  //  0039  LDCONST	R11	K21
+      0x5C300C00,  //  003A  MOVE	R12	R6
+      0x88340111,  //  003B  GETMBR	R13	R0	K17
+      0x5C380E00,  //  003C  MOVE	R14	R7
+      0x7C200C00,  //  003D  CALL	R8	6
+      0xB81E1000,  //  003E  GETNGBL	R7	K8
+      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
+      0x7C1C0200,  //  0040  CALL	R7	1
+      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
+      0x5824000E,  //  0042  LDCONST	R9	K14
+      0x7C1C0400,  //  0043  CALL	R7	2
+      0x781E0020,  //  0044  JMPF	R7	#0066
+      0xB81E1000,  //  0045  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
+      0x8C24070F,  //  0047  GETMET	R9	R3	K15
+      0x582C0010,  //  0048  LDCONST	R11	K16
+      0x58300019,  //  0049  LDCONST	R12	K25
+      0x5C340C00,  //  004A  MOVE	R13	R6
+      0x8838011A,  //  004B  GETMBR	R14	R0	K26
+      0x7C240A00,  //  004C  CALL	R9	5
+      0x58280012,  //  004D  LDCONST	R10	K18
+      0x7C1C0600,  //  004E  CALL	R7	3
+      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
+      0x58240014,  //  0050  LDCONST	R9	K20
+      0x58280015,  //  0051  LDCONST	R10	K21
+      0x542E15A3,  //  0052  LDINT	R11	5540
+      0x4C300000,  //  0053  LDNIL	R12
+      0x5C340C00,  //  0054  MOVE	R13	R6
+      0x8838011A,  //  0055  GETMBR	R14	R0	K26
+      0x7C1C0E00,  //  0056  CALL	R7	7
+      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
+      0x7C1C0200,  //  0058  CALL	R7	1
+      0x001E2C07,  //  0059  ADD	R7	K22	R7
+      0xB8221000,  //  005A  GETNGBL	R8	K8
+      0x8C201109,  //  005B  GETMET	R8	R8	K9
+      0x002A2E07,  //  005C  ADD	R10	K23	R7
+      0x582C0012,  //  005D  LDCONST	R11	K18
+      0x7C200600,  //  005E  CALL	R8	3
+      0x8C200518,  //  005F  GETMET	R8	R2	K24
+      0x58280014,  //  0060  LDCONST	R10	K20
+      0x582C0015,  //  0061  LDCONST	R11	K21
+      0x5C300C00,  //  0062  MOVE	R12	R6
+      0x8834011A,  //  0063  GETMBR	R13	R0	K26
+      0x5C380E00,  //  0064  MOVE	R14	R7
+      0x7C200C00,  //  0065  CALL	R8	6
+      0xA8040001,  //  0066  EXBLK	1	1
+      0x70020010,  //  0067  JMP		#0079
+      0xAC100002,  //  0068  CATCH	R4	0	2
+      0x7002000D,  //  0069  JMP		#0078
+      0xB81A1000,  //  006A  GETNGBL	R6	K8
+      0x8C180D09,  //  006B  GETMET	R6	R6	K9
+      0x60200008,  //  006C  GETGBL	R8	G8
+      0x5C240800,  //  006D  MOVE	R9	R4
+      0x7C200200,  //  006E  CALL	R8	1
+      0x00223608,  //  006F  ADD	R8	K27	R8
+      0x0020111C,  //  0070  ADD	R8	R8	K28
+      0x60240008,  //  0071  GETGBL	R9	G8
+      0x5C280A00,  //  0072  MOVE	R10	R5
+      0x7C240200,  //  0073  CALL	R9	1
+      0x00201009,  //  0074  ADD	R8	R8	R9
+      0x5824000B,  //  0075  LDCONST	R9	K11
+      0x7C180600,  //  0076  CALL	R6	3
+      0x70020000,  //  0077  JMP		#0079
+      0xB0080000,  //  0078  RAISE	2	R0	R0
+      0x80000000,  //  0079  RET	0
     })
   )
 );
@@ -240,6 +270,383 @@ be_local_closure(Matter_Device_get_active_endpoints,   /* name */
       0xAC0C0200,  //  0019  CATCH	R3	1	0
       0xB0080000,  //  001A  RAISE	2	R0	R0
       0x80040400,  //  001B  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _init_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device__init_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(count_active_fabrics),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(start_root_basic_commissioning),
+    }),
+    be_str_weak(_init_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x1C040302,  //  0003  EQ	R1	R1	K2
+      0x78060001,  //  0004  JMPF	R1	#0007
+      0x8C040103,  //  0005  GETMET	R1	R0	K3
+      0x7C040200,  //  0006  CALL	R1	1
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_op_discovery
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(reverse),
+    /* K5   */  be_nested_str_weak(get_fabric_compressed),
+    /* K6   */  be_nested_str_weak(tohex),
+    /* K7   */  be_nested_str_weak(_X2D),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(eth),
+    /* K10  */  be_nested_str_weak(find),
+    /* K11  */  be_nested_str_weak(up),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(remove_service),
+    /* K17  */  be_nested_str_weak(_matter),
+    /* K18  */  be_nested_str_weak(_tcp),
+    /* K19  */  be_nested_str_weak(hostname_eth),
+    /* K20  */  be_nested_str_weak(wifi),
+    /* K21  */  be_nested_str_weak(hostname_wifi),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K23  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_remove_op_discovery),
+    &be_const_str_solidified,
+    ( &(const binstruction[81]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA802003B,  //  0002  EXBLK	0	#003F
+      0x8C100302,  //  0003  GETMET	R4	R1	K2
+      0x7C100200,  //  0004  CALL	R4	1
+      0x8C100903,  //  0005  GETMET	R4	R4	K3
+      0x7C100200,  //  0006  CALL	R4	1
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140305,  //  0009  GETMET	R5	R1	K5
+      0x7C140200,  //  000A  CALL	R5	1
+      0x8C180B06,  //  000B  GETMET	R6	R5	K6
+      0x7C180200,  //  000C  CALL	R6	1
+      0x00180D07,  //  000D  ADD	R6	R6	K7
+      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
+      0x7C1C0200,  //  000F  CALL	R7	1
+      0x00180C07,  //  0010  ADD	R6	R6	R7
+      0xB81E1000,  //  0011  GETNGBL	R7	K8
+      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
+      0x7C1C0200,  //  0013  CALL	R7	1
+      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
+      0x5824000B,  //  0015  LDCONST	R9	K11
+      0x7C1C0400,  //  0016  CALL	R7	2
+      0x781E000E,  //  0017  JMPF	R7	#0027
+      0xB81E1000,  //  0018  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
+      0x8C24070D,  //  001A  GETMET	R9	R3	K13
+      0x582C000E,  //  001B  LDCONST	R11	K14
+      0x58300009,  //  001C  LDCONST	R12	K9
+      0x5C340C00,  //  001D  MOVE	R13	R6
+      0x7C240800,  //  001E  CALL	R9	4
+      0x5828000F,  //  001F  LDCONST	R10	K15
+      0x7C1C0600,  //  0020  CALL	R7	3
+      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
+      0x58240011,  //  0022  LDCONST	R9	K17
+      0x58280012,  //  0023  LDCONST	R10	K18
+      0x5C2C0C00,  //  0024  MOVE	R11	R6
+      0x88300113,  //  0025  GETMBR	R12	R0	K19
+      0x7C1C0A00,  //  0026  CALL	R7	5
+      0xB81E1000,  //  0027  GETNGBL	R7	K8
+      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
+      0x7C1C0200,  //  0029  CALL	R7	1
+      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
+      0x5824000B,  //  002B  LDCONST	R9	K11
+      0x7C1C0400,  //  002C  CALL	R7	2
+      0x781E000E,  //  002D  JMPF	R7	#003D
+      0xB81E1000,  //  002E  GETNGBL	R7	K8
+      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
+      0x8C24070D,  //  0030  GETMET	R9	R3	K13
+      0x582C000E,  //  0031  LDCONST	R11	K14
+      0x58300014,  //  0032  LDCONST	R12	K20
+      0x5C340C00,  //  0033  MOVE	R13	R6
+      0x7C240800,  //  0034  CALL	R9	4
+      0x5828000F,  //  0035  LDCONST	R10	K15
+      0x7C1C0600,  //  0036  CALL	R7	3
+      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
+      0x58240011,  //  0038  LDCONST	R9	K17
+      0x58280012,  //  0039  LDCONST	R10	K18
+      0x5C2C0C00,  //  003A  MOVE	R11	R6
+      0x88300115,  //  003B  GETMBR	R12	R0	K21
+      0x7C1C0A00,  //  003C  CALL	R7	5
+      0xA8040001,  //  003D  EXBLK	1	1
+      0x70020010,  //  003E  JMP		#0050
+      0xAC100002,  //  003F  CATCH	R4	0	2
+      0x7002000D,  //  0040  JMP		#004F
+      0xB81A1000,  //  0041  GETNGBL	R6	K8
+      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
+      0x60200008,  //  0043  GETGBL	R8	G8
+      0x5C240800,  //  0044  MOVE	R9	R4
+      0x7C200200,  //  0045  CALL	R8	1
+      0x00222C08,  //  0046  ADD	R8	K22	R8
+      0x00201117,  //  0047  ADD	R8	R8	K23
+      0x60240008,  //  0048  GETGBL	R9	G8
+      0x5C280A00,  //  0049  MOVE	R10	R5
+      0x7C240200,  //  004A  CALL	R9	1
+      0x00201009,  //  004B  ADD	R8	R8	R9
+      0x5824000F,  //  004C  LDCONST	R9	K15
+      0x7C180600,  //  004D  CALL	R6	3
+      0x70020000,  //  004E  JMP		#0050
+      0xB0080000,  //  004F  RAISE	2	R0	R0
+      0x80000000,  //  0050  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_announce_op_discovery_all_fabrics
+********************************************************************/
+be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
+    /* K2   */  be_nested_str_weak(get_device_id),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(mdns_announce_op_discovery_all_fabrics),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: mdns_remove_PASE
+********************************************************************/
+be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(mdns_pase_eth),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K7   */  be_nested_str_weak(_matterc),
+    /* K8   */  be_nested_str_weak(_udp),
+    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
+    /* K10  */  be_nested_str_weak(hostname_eth),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
+    /* K13  */  be_nested_str_weak(eth),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(remove_service),
+    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
+    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
+    /* K18  */  be_nested_str_weak(hostname_wifi),
+    /* K19  */  be_nested_str_weak(wifi),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K21  */  be_nested_str_weak(_X7C),
+    }),
+    be_str_weak(mdns_remove_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[83]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xA802003D,  //  0002  EXBLK	0	#0041
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x780E001B,  //  0004  JMPF	R3	#0021
+      0xB80E0600,  //  0005  GETNGBL	R3	K3
+      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x8C140505,  //  0007  GETMET	R5	R2	K5
+      0x581C0006,  //  0008  LDCONST	R7	K6
+      0x58200007,  //  0009  LDCONST	R8	K7
+      0x58240008,  //  000A  LDCONST	R9	K8
+      0x88280109,  //  000B  GETMBR	R10	R0	K9
+      0x882C010A,  //  000C  GETMBR	R11	R0	K10
+      0x7C140C00,  //  000D  CALL	R5	6
+      0x5818000B,  //  000E  LDCONST	R6	K11
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0xB80E0600,  //  0010  GETNGBL	R3	K3
+      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
+      0x8C140505,  //  0012  GETMET	R5	R2	K5
+      0x581C000C,  //  0013  LDCONST	R7	K12
+      0x5820000D,  //  0014  LDCONST	R8	K13
+      0x88240109,  //  0015  GETMBR	R9	R0	K9
+      0x7C140800,  //  0016  CALL	R5	4
+      0x5818000E,  //  0017  LDCONST	R6	K14
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x500C0000,  //  0019  LDBOOL	R3	0	0
+      0x90020403,  //  001A  SETMBR	R0	K2	R3
+      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
+      0x58140007,  //  001C  LDCONST	R5	K7
+      0x58180008,  //  001D  LDCONST	R6	K8
+      0x881C0109,  //  001E  GETMBR	R7	R0	K9
+      0x8820010A,  //  001F  GETMBR	R8	R0	K10
+      0x7C0C0A00,  //  0020  CALL	R3	5
+      0x880C0110,  //  0021  GETMBR	R3	R0	K16
+      0x780E001B,  //  0022  JMPF	R3	#003F
+      0xB80E0600,  //  0023  GETNGBL	R3	K3
+      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
+      0x8C140505,  //  0025  GETMET	R5	R2	K5
+      0x581C0006,  //  0026  LDCONST	R7	K6
+      0x58200007,  //  0027  LDCONST	R8	K7
+      0x58240008,  //  0028  LDCONST	R9	K8
+      0x88280111,  //  0029  GETMBR	R10	R0	K17
+      0x882C0112,  //  002A  GETMBR	R11	R0	K18
+      0x7C140C00,  //  002B  CALL	R5	6
+      0x5818000B,  //  002C  LDCONST	R6	K11
+      0x7C0C0600,  //  002D  CALL	R3	3
+      0xB80E0600,  //  002E  GETNGBL	R3	K3
+      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
+      0x8C140505,  //  0030  GETMET	R5	R2	K5
+      0x581C000C,  //  0031  LDCONST	R7	K12
+      0x58200013,  //  0032  LDCONST	R8	K19
+      0x88240111,  //  0033  GETMBR	R9	R0	K17
+      0x7C140800,  //  0034  CALL	R5	4
+      0x5818000E,  //  0035  LDCONST	R6	K14
+      0x7C0C0600,  //  0036  CALL	R3	3
+      0x500C0000,  //  0037  LDBOOL	R3	0	0
+      0x90022003,  //  0038  SETMBR	R0	K16	R3
+      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
+      0x58140007,  //  003A  LDCONST	R5	K7
+      0x58180008,  //  003B  LDCONST	R6	K8
+      0x881C0111,  //  003C  GETMBR	R7	R0	K17
+      0x88200112,  //  003D  GETMBR	R8	R0	K18
+      0x7C0C0A00,  //  003E  CALL	R3	5
+      0xA8040001,  //  003F  EXBLK	1	1
+      0x70020010,  //  0040  JMP		#0052
+      0xAC0C0002,  //  0041  CATCH	R3	0	2
+      0x7002000D,  //  0042  JMP		#0051
+      0xB8160600,  //  0043  GETNGBL	R5	K3
+      0x8C140B04,  //  0044  GETMET	R5	R5	K4
+      0x601C0008,  //  0045  GETGBL	R7	G8
+      0x5C200600,  //  0046  MOVE	R8	R3
+      0x7C1C0200,  //  0047  CALL	R7	1
+      0x001E2807,  //  0048  ADD	R7	K20	R7
+      0x001C0F15,  //  0049  ADD	R7	R7	K21
+      0x60200008,  //  004A  GETGBL	R8	G8
+      0x5C240800,  //  004B  MOVE	R9	R4
+      0x7C200200,  //  004C  CALL	R8	1
+      0x001C0E08,  //  004D  ADD	R7	R7	R8
+      0x5820000E,  //  004E  LDCONST	R8	K14
+      0x7C140600,  //  004F  CALL	R5	3
+      0x70020000,  //  0050  JMP		#0052
+      0xB0080000,  //  0051  RAISE	2	R0	R0
+      0x80000000,  //  0052  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save_before_restart
+********************************************************************/
+be_local_closure(Matter_Device_save_before_restart,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
+    }),
+    be_str_weak(save_before_restart),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -372,6 +779,171 @@ be_local_closure(Matter_Device_start_mdns_announce_hostnames,   /* name */
       0x7C040800,  //  001D  CALL	R1	4
       0xA0000000,  //  001E  CLOSE	R0
       0x80000000,  //  001F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: invoke_request
+********************************************************************/
+be_local_closure(Matter_Device_invoke_request,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(endpoint),
+    /* K2   */  be_nested_str_weak(plugins),
+    /* K3   */  be_nested_str_weak(invoke_request),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_nested_str_weak(status),
+    /* K6   */  be_nested_str_weak(matter),
+    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
+    }),
+    be_str_weak(invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[24]) {  /* code */
+      0x58100000,  //  0000  LDCONST	R4	K0
+      0x88140701,  //  0001  GETMBR	R5	R3	K1
+      0x6018000C,  //  0002  GETGBL	R6	G12
+      0x881C0102,  //  0003  GETMBR	R7	R0	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0x14180806,  //  0005  LT	R6	R4	R6
+      0x781A000C,  //  0006  JMPF	R6	#0014
+      0x88180102,  //  0007  GETMBR	R6	R0	K2
+      0x94180C04,  //  0008  GETIDX	R6	R6	R4
+      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
+      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
+      0x781E0005,  //  000B  JMPF	R7	#0012
+      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
+      0x5C240200,  //  000D  MOVE	R9	R1
+      0x5C280400,  //  000E  MOVE	R10	R2
+      0x5C2C0600,  //  000F  MOVE	R11	R3
+      0x7C1C0800,  //  0010  CALL	R7	4
+      0x80040E00,  //  0011  RET	1	R7
+      0x00100904,  //  0012  ADD	R4	R4	K4
+      0x7001FFED,  //  0013  JMP		#0002
+      0xB81A0C00,  //  0014  GETNGBL	R6	K6
+      0x88180D07,  //  0015  GETMBR	R6	R6	K7
+      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
+      0x80000000,  //  0017  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: remove_fabric
+********************************************************************/
+be_local_closure(Matter_Device_remove_fabric,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(im),
+    /* K2   */  be_nested_str_weak(subs_shop),
+    /* K3   */  be_nested_str_weak(remove_by_fabric),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(sessions),
+    /* K6   */  be_nested_str_weak(remove_fabric),
+    /* K7   */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(remove_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x88080501,  //  0001  GETMBR	R2	R2	K1
+      0x88080502,  //  0002  GETMBR	R2	R2	K2
+      0x8C080503,  //  0003  GETMET	R2	R2	K3
+      0x5C100200,  //  0004  MOVE	R4	R1
+      0x7C080400,  //  0005  CALL	R2	2
+      0x8C080104,  //  0006  GETMET	R2	R0	K4
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x88080105,  //  0009  GETMBR	R2	R0	K5
+      0x8C080506,  //  000A  GETMET	R2	R2	K6
+      0x5C100200,  //  000B  MOVE	R4	R1
+      0x7C080400,  //  000C  CALL	R2	2
+      0x88080105,  //  000D  GETMBR	R2	R0	K5
+      0x8C080507,  //  000E  GETMET	R2	R2	K7
+      0x7C080200,  //  000F  CALL	R2	1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery_deferred
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_operational_discovery),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_operational_discovery_deferred),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x84140000,  //  0003  CLOSURE	R5	P0
+      0x7C080600,  //  0004  CALL	R2	3
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -537,11 +1109,83 @@ be_local_closure(Matter_Device_sort_distinct,   /* name */
 
 
 /********************************************************************
-** Solidified function: _mdns_announce_hostname
+** Solidified function: _trigger_read_sensors
 ********************************************************************/
-be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
+be_local_closure(Matter_Device__trigger_read_sensors,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(read_sensors),
+    /* K3   */  be_nested_str_weak(load),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(plugins),
+    /* K6   */  be_nested_str_weak(parse_sensors),
+    /* K7   */  be_const_int(1),
+    /* K8   */  be_nested_str_weak(log),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
+    /* K10  */  be_const_int(3),
+    }),
+    be_str_weak(_trigger_read_sensors),
+    &be_const_str_solidified,
+    ( &(const binstruction[37]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C0C0403,  //  0005  EQ	R3	R2	R3
+      0x780E0000,  //  0006  JMPF	R3	#0008
+      0x80000600,  //  0007  RET	0
+      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
+      0x5C140400,  //  0009  MOVE	R5	R2
+      0x7C0C0400,  //  000A  CALL	R3	2
+      0x4C100000,  //  000B  LDNIL	R4
+      0x20100604,  //  000C  NE	R4	R3	R4
+      0x7812000D,  //  000D  JMPF	R4	#001C
+      0x58100004,  //  000E  LDCONST	R4	K4
+      0x6014000C,  //  000F  GETGBL	R5	G12
+      0x88180105,  //  0010  GETMBR	R6	R0	K5
+      0x7C140200,  //  0011  CALL	R5	1
+      0x14140805,  //  0012  LT	R5	R4	R5
+      0x78160006,  //  0013  JMPF	R5	#001B
+      0x88140105,  //  0014  GETMBR	R5	R0	K5
+      0x94140A04,  //  0015  GETIDX	R5	R5	R4
+      0x8C140B06,  //  0016  GETMET	R5	R5	K6
+      0x5C1C0600,  //  0017  MOVE	R7	R3
+      0x7C140400,  //  0018  CALL	R5	2
+      0x00100907,  //  0019  ADD	R4	R4	K7
+      0x7001FFF3,  //  001A  JMP		#000F
+      0x70020007,  //  001B  JMP		#0024
+      0xB8120200,  //  001C  GETNGBL	R4	K1
+      0x8C100908,  //  001D  GETMET	R4	R4	K8
+      0x60180008,  //  001E  GETGBL	R6	G8
+      0x5C1C0400,  //  001F  MOVE	R7	R2
+      0x7C180200,  //  0020  CALL	R6	1
+      0x001A1206,  //  0021  ADD	R6	K9	R6
+      0x581C000A,  //  0022  LDCONST	R7	K10
+      0x7C100600,  //  0023  CALL	R4	3
+      0x80000000,  //  0024  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_operational_discovery
+********************************************************************/
+be_local_closure(Matter_Device_start_operational_discovery,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -549,211 +1193,250 @@ be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[28]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(start),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(eth),
-    /* K5   */  be_nested_str_weak(hostname_eth),
-    /* K6   */  be_nested_str_weak(replace),
-    /* K7   */  be_nested_str_weak(find),
-    /* K8   */  be_nested_str_weak(mac),
-    /* K9   */  be_nested_str_weak(_X3A),
-    /* K10  */  be_nested_str_weak(),
-    /* K11  */  be_nested_str_weak(ipv4only),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K15  */  be_nested_str_weak(ip6local),
-    /* K16  */  be_nested_str_weak(ip),
-    /* K17  */  be_const_int(3),
-    /* K18  */  be_nested_str_weak(add_hostname),
-    /* K19  */  be_nested_str_weak(ip6),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
-    /* K21  */  be_nested_str_weak(wifi),
-    /* K22  */  be_nested_str_weak(hostname_wifi),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
-    /* K24  */  be_const_int(2),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K26  */  be_nested_str_weak(_X7C),
-    /* K27  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(mdns),
+    /* K2   */  be_nested_str_weak(string),
+    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
+    /* K4   */  be_nested_str_weak(root_w0),
+    /* K5   */  be_nested_str_weak(root_L),
+    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
+    /* K8   */  be_nested_str_weak(get_fabric),
     }),
-    be_str_weak(_mdns_announce_hostname),
+    be_str_weak(start_operational_discovery),
     &be_const_str_solidified,
-    ( &(const binstruction[172]) {  /* code */
+    ( &(const binstruction[17]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
-      0x8C100502,  //  0002  GETMET	R4	R2	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0xA8020092,  //  0004  EXBLK	0	#0098
-      0x78060040,  //  0005  JMPF	R1	#0047
-      0xB8120600,  //  0006  GETNGBL	R4	K3
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140706,  //  0009  GETMET	R5	R3	K6
-      0x8C1C0907,  //  000A  GETMET	R7	R4	K7
-      0x58240008,  //  000B  LDCONST	R9	K8
-      0x7C1C0400,  //  000C  CALL	R7	2
-      0x58200009,  //  000D  LDCONST	R8	K9
-      0x5824000A,  //  000E  LDCONST	R9	K10
-      0x7C140800,  //  000F  CALL	R5	4
-      0x90020A05,  //  0010  SETMBR	R0	K5	R5
-      0x8814010B,  //  0011  GETMBR	R5	R0	K11
-      0x7416001F,  //  0012  JMPT	R5	#0033
-      0xB8160600,  //  0013  GETNGBL	R5	K3
-      0x8C140B0C,  //  0014  GETMET	R5	R5	K12
-      0x8C1C070D,  //  0015  GETMET	R7	R3	K13
-      0x5824000E,  //  0016  LDCONST	R9	K14
-      0x88280105,  //  0017  GETMBR	R10	R0	K5
-      0x8C2C0907,  //  0018  GETMET	R11	R4	K7
-      0x5834000F,  //  0019  LDCONST	R13	K15
-      0x5838000A,  //  001A  LDCONST	R14	K10
-      0x7C2C0600,  //  001B  CALL	R11	3
-      0x8C300907,  //  001C  GETMET	R12	R4	K7
-      0x58380010,  //  001D  LDCONST	R14	K16
-      0x583C000A,  //  001E  LDCONST	R15	K10
-      0x7C300600,  //  001F  CALL	R12	3
-      0x7C1C0A00,  //  0020  CALL	R7	5
-      0x58200011,  //  0021  LDCONST	R8	K17
-      0x7C140600,  //  0022  CALL	R5	3
-      0x8C140512,  //  0023  GETMET	R5	R2	K18
-      0x881C0105,  //  0024  GETMBR	R7	R0	K5
-      0x8C200907,  //  0025  GETMET	R8	R4	K7
-      0x5828000F,  //  0026  LDCONST	R10	K15
-      0x582C000A,  //  0027  LDCONST	R11	K10
-      0x7C200600,  //  0028  CALL	R8	3
-      0x8C240907,  //  0029  GETMET	R9	R4	K7
-      0x582C0010,  //  002A  LDCONST	R11	K16
-      0x5830000A,  //  002B  LDCONST	R12	K10
-      0x7C240600,  //  002C  CALL	R9	3
-      0x8C280907,  //  002D  GETMET	R10	R4	K7
-      0x58300013,  //  002E  LDCONST	R12	K19
-      0x5834000A,  //  002F  LDCONST	R13	K10
-      0x7C280600,  //  0030  CALL	R10	3
-      0x7C140A00,  //  0031  CALL	R5	5
-      0x70020012,  //  0032  JMP		#0046
-      0xB8160600,  //  0033  GETNGBL	R5	K3
-      0x8C140B0C,  //  0034  GETMET	R5	R5	K12
-      0x8C1C070D,  //  0035  GETMET	R7	R3	K13
-      0x58240014,  //  0036  LDCONST	R9	K20
-      0x88280105,  //  0037  GETMBR	R10	R0	K5
-      0x8C2C0907,  //  0038  GETMET	R11	R4	K7
-      0x58340010,  //  0039  LDCONST	R13	K16
-      0x5838000A,  //  003A  LDCONST	R14	K10
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0x8C140103,  //  0003  GETMET	R5	R0	K3
+      0x7C140200,  //  0004  CALL	R5	1
+      0x4C140000,  //  0005  LDNIL	R5
+      0x90020805,  //  0006  SETMBR	R0	K4	R5
+      0x4C140000,  //  0007  LDNIL	R5
+      0x90020A05,  //  0008  SETMBR	R0	K5	R5
+      0x8C140306,  //  0009  GETMET	R5	R1	K6
+      0x541E003B,  //  000A  LDINT	R7	60
+      0x7C140400,  //  000B  CALL	R5	2
+      0x8C140107,  //  000C  GETMET	R5	R0	K7
+      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
+      0x7C1C0200,  //  000E  CALL	R7	1
+      0x7C140400,  //  000F  CALL	R5	2
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: compute_manual_pairing_code
+********************************************************************/
+be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(root_discriminator),
+    /* K2   */  be_nested_str_weak(root_passcode),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(Verhoeff),
+    /* K7   */  be_nested_str_weak(checksum),
+    }),
+    be_str_weak(compute_manual_pairing_code),
+    &be_const_str_solidified,
+    ( &(const binstruction[31]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x540E0FFE,  //  0002  LDINT	R3	4095
+      0x2C080403,  //  0003  AND	R2	R2	R3
+      0x540E0009,  //  0004  LDINT	R3	10
+      0x3C080403,  //  0005  SHR	R2	R2	R3
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x541202FF,  //  0007  LDINT	R4	768
+      0x2C0C0604,  //  0008  AND	R3	R3	R4
+      0x54120005,  //  0009  LDINT	R4	6
+      0x380C0604,  //  000A  SHL	R3	R3	R4
+      0x88100102,  //  000B  GETMBR	R4	R0	K2
+      0x54163FFE,  //  000C  LDINT	R5	16383
+      0x2C100805,  //  000D  AND	R4	R4	R5
+      0x300C0604,  //  000E  OR	R3	R3	R4
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x5416000D,  //  0010  LDINT	R5	14
+      0x3C100805,  //  0011  SHR	R4	R4	R5
+      0x8C140303,  //  0012  GETMET	R5	R1	K3
+      0x581C0004,  //  0013  LDCONST	R7	K4
+      0x5C200400,  //  0014  MOVE	R8	R2
+      0x5C240600,  //  0015  MOVE	R9	R3
+      0x5C280800,  //  0016  MOVE	R10	R4
+      0x7C140A00,  //  0017  CALL	R5	5
+      0xB81A0A00,  //  0018  GETNGBL	R6	K5
+      0x88180D06,  //  0019  GETMBR	R6	R6	K6
+      0x8C180D07,  //  001A  GETMET	R6	R6	K7
+      0x5C200A00,  //  001B  MOVE	R8	R5
+      0x7C180400,  //  001C  CALL	R6	2
+      0x00140A06,  //  001D  ADD	R5	R5	R6
+      0x80040A00,  //  001E  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _compute_pbkdf
+********************************************************************/
+be_local_closure(Matter_Device__compute_pbkdf,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(add),
+    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
+    /* K4   */  be_nested_str_weak(derive),
+    /* K5   */  be_const_int(0),
+    /* K6   */  be_nested_str_weak(root_w0),
+    /* K7   */  be_nested_str_weak(EC_P256),
+    /* K8   */  be_nested_str_weak(mod),
+    /* K9   */  be_nested_str_weak(root_L),
+    /* K10  */  be_nested_str_weak(public_key),
+    /* K11  */  be_nested_str_weak(tasmota),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20salt_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K15  */  be_nested_str_weak(root_salt),
+    /* K16  */  be_nested_str_weak(tohex),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20passcode_hex_X20_X20_X3D_X20),
+    /* K18  */  be_nested_str_weak(MTR_X3A_X20w0_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20L_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
+    /* K20  */  be_nested_str_weak(compute_manual_pairing_code),
+    /* K21  */  be_nested_str_weak(format),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
+    /* K23  */  be_const_int(3),
+    /* K24  */  be_const_int(2147483647),
+    /* K25  */  be_const_int(2),
+    }),
+    be_str_weak(_compute_pbkdf),
+    &be_const_str_solidified,
+    ( &(const binstruction[100]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0xA4160200,  //  0001  IMPORT	R5	K1
+      0x60180015,  //  0002  GETGBL	R6	G21
+      0x7C180000,  //  0003  CALL	R6	0
+      0x8C180D02,  //  0004  GETMET	R6	R6	K2
+      0x5C200200,  //  0005  MOVE	R8	R1
+      0x54260003,  //  0006  LDINT	R9	4
+      0x7C180600,  //  0007  CALL	R6	3
+      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
+      0x5C240C00,  //  000B  MOVE	R9	R6
+      0x5C280600,  //  000C  MOVE	R10	R3
+      0x5C2C0400,  //  000D  MOVE	R11	R2
+      0x5432004F,  //  000E  LDINT	R12	80
+      0x7C1C0A00,  //  000F  CALL	R7	5
+      0x54220026,  //  0010  LDINT	R8	39
+      0x40220A08,  //  0011  CONNECT	R8	K5	R8
+      0x94200E08,  //  0012  GETIDX	R8	R7	R8
+      0x54260027,  //  0013  LDINT	R9	40
+      0x542A004E,  //  0014  LDINT	R10	79
+      0x4024120A,  //  0015  CONNECT	R9	R9	R10
+      0x94240E09,  //  0016  GETIDX	R9	R7	R9
+      0x8C280907,  //  0017  GETMET	R10	R4	K7
+      0x7C280200,  //  0018  CALL	R10	1
+      0x8C281508,  //  0019  GETMET	R10	R10	K8
+      0x5C301000,  //  001A  MOVE	R12	R8
+      0x7C280400,  //  001B  CALL	R10	2
+      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
+      0x8C280907,  //  001D  GETMET	R10	R4	K7
+      0x7C280200,  //  001E  CALL	R10	1
+      0x8C281508,  //  001F  GETMET	R10	R10	K8
+      0x5C301200,  //  0020  MOVE	R12	R9
+      0x7C280400,  //  0021  CALL	R10	2
+      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
+      0x7C2C0200,  //  0023  CALL	R11	1
+      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
+      0x5C341400,  //  0025  MOVE	R13	R10
+      0x7C2C0400,  //  0026  CALL	R11	2
+      0x9002120B,  //  0027  SETMBR	R0	K9	R11
+      0xB82E1600,  //  0028  GETNGBL	R11	K11
+      0x8C2C170C,  //  0029  GETMET	R11	R11	K12
+      0x5834000D,  //  002A  LDCONST	R13	K13
+      0x543A0003,  //  002B  LDINT	R14	4
+      0x7C2C0600,  //  002C  CALL	R11	3
+      0xB82E1600,  //  002D  GETNGBL	R11	K11
+      0x8C2C170C,  //  002E  GETMET	R11	R11	K12
+      0x8834010F,  //  002F  GETMBR	R13	R0	K15
+      0x8C341B10,  //  0030  GETMET	R13	R13	K16
+      0x7C340200,  //  0031  CALL	R13	1
+      0x00361C0D,  //  0032  ADD	R13	K14	R13
+      0x543A0003,  //  0033  LDINT	R14	4
+      0x7C2C0600,  //  0034  CALL	R11	3
+      0xB82E1600,  //  0035  GETNGBL	R11	K11
+      0x8C2C170C,  //  0036  GETMET	R11	R11	K12
+      0x8C340D10,  //  0037  GETMET	R13	R6	K16
+      0x7C340200,  //  0038  CALL	R13	1
+      0x0036220D,  //  0039  ADD	R13	K17	R13
+      0x543A0003,  //  003A  LDINT	R14	4
       0x7C2C0600,  //  003B  CALL	R11	3
-      0x7C1C0800,  //  003C  CALL	R7	4
-      0x58200011,  //  003D  LDCONST	R8	K17
-      0x7C140600,  //  003E  CALL	R5	3
-      0x8C140512,  //  003F  GETMET	R5	R2	K18
-      0x881C0105,  //  0040  GETMBR	R7	R0	K5
-      0x8C200907,  //  0041  GETMET	R8	R4	K7
-      0x58280010,  //  0042  LDCONST	R10	K16
-      0x582C000A,  //  0043  LDCONST	R11	K10
-      0x7C200600,  //  0044  CALL	R8	3
-      0x7C140600,  //  0045  CALL	R5	3
-      0x7002003F,  //  0046  JMP		#0087
-      0xB8120600,  //  0047  GETNGBL	R4	K3
-      0x8C100915,  //  0048  GETMET	R4	R4	K21
-      0x7C100200,  //  0049  CALL	R4	1
-      0x8C140706,  //  004A  GETMET	R5	R3	K6
-      0x8C1C0907,  //  004B  GETMET	R7	R4	K7
-      0x58240008,  //  004C  LDCONST	R9	K8
-      0x7C1C0400,  //  004D  CALL	R7	2
-      0x58200009,  //  004E  LDCONST	R8	K9
-      0x5824000A,  //  004F  LDCONST	R9	K10
-      0x7C140800,  //  0050  CALL	R5	4
-      0x90022C05,  //  0051  SETMBR	R0	K22	R5
-      0x8814010B,  //  0052  GETMBR	R5	R0	K11
-      0x7416001F,  //  0053  JMPT	R5	#0074
-      0xB8160600,  //  0054  GETNGBL	R5	K3
-      0x8C140B0C,  //  0055  GETMET	R5	R5	K12
-      0x8C1C070D,  //  0056  GETMET	R7	R3	K13
-      0x5824000E,  //  0057  LDCONST	R9	K14
-      0x88280116,  //  0058  GETMBR	R10	R0	K22
-      0x8C2C0907,  //  0059  GETMET	R11	R4	K7
-      0x5834000F,  //  005A  LDCONST	R13	K15
-      0x5838000A,  //  005B  LDCONST	R14	K10
-      0x7C2C0600,  //  005C  CALL	R11	3
-      0x8C300907,  //  005D  GETMET	R12	R4	K7
-      0x58380010,  //  005E  LDCONST	R14	K16
-      0x583C000A,  //  005F  LDCONST	R15	K10
-      0x7C300600,  //  0060  CALL	R12	3
-      0x7C1C0A00,  //  0061  CALL	R7	5
-      0x58200011,  //  0062  LDCONST	R8	K17
-      0x7C140600,  //  0063  CALL	R5	3
-      0x8C140512,  //  0064  GETMET	R5	R2	K18
-      0x881C0116,  //  0065  GETMBR	R7	R0	K22
-      0x8C200907,  //  0066  GETMET	R8	R4	K7
-      0x5828000F,  //  0067  LDCONST	R10	K15
-      0x582C000A,  //  0068  LDCONST	R11	K10
-      0x7C200600,  //  0069  CALL	R8	3
-      0x8C240907,  //  006A  GETMET	R9	R4	K7
-      0x582C0010,  //  006B  LDCONST	R11	K16
-      0x5830000A,  //  006C  LDCONST	R12	K10
-      0x7C240600,  //  006D  CALL	R9	3
-      0x8C280907,  //  006E  GETMET	R10	R4	K7
-      0x58300013,  //  006F  LDCONST	R12	K19
-      0x5834000A,  //  0070  LDCONST	R13	K10
-      0x7C280600,  //  0071  CALL	R10	3
-      0x7C140A00,  //  0072  CALL	R5	5
-      0x70020012,  //  0073  JMP		#0087
-      0xB8160600,  //  0074  GETNGBL	R5	K3
-      0x8C140B0C,  //  0075  GETMET	R5	R5	K12
-      0x8C1C070D,  //  0076  GETMET	R7	R3	K13
-      0x58240014,  //  0077  LDCONST	R9	K20
-      0x88280105,  //  0078  GETMBR	R10	R0	K5
-      0x8C2C0907,  //  0079  GETMET	R11	R4	K7
-      0x58340010,  //  007A  LDCONST	R13	K16
-      0x5838000A,  //  007B  LDCONST	R14	K10
-      0x7C2C0600,  //  007C  CALL	R11	3
-      0x7C1C0800,  //  007D  CALL	R7	4
-      0x58200011,  //  007E  LDCONST	R8	K17
-      0x7C140600,  //  007F  CALL	R5	3
-      0x8C140512,  //  0080  GETMET	R5	R2	K18
-      0x881C0116,  //  0081  GETMBR	R7	R0	K22
-      0x8C200907,  //  0082  GETMET	R8	R4	K7
-      0x58280010,  //  0083  LDCONST	R10	K16
-      0x582C000A,  //  0084  LDCONST	R11	K10
-      0x7C200600,  //  0085  CALL	R8	3
-      0x7C140600,  //  0086  CALL	R5	3
-      0xB8120600,  //  0087  GETNGBL	R4	K3
-      0x8C10090C,  //  0088  GETMET	R4	R4	K12
-      0x8C18070D,  //  0089  GETMET	R6	R3	K13
-      0x58200017,  //  008A  LDCONST	R8	K23
-      0x78060001,  //  008B  JMPF	R1	#008E
-      0x58240004,  //  008C  LDCONST	R9	K4
-      0x70020000,  //  008D  JMP		#008F
-      0x58240015,  //  008E  LDCONST	R9	K21
-      0x78060001,  //  008F  JMPF	R1	#0092
-      0x88280105,  //  0090  GETMBR	R10	R0	K5
-      0x70020000,  //  0091  JMP		#0093
-      0x88280116,  //  0092  GETMBR	R10	R0	K22
-      0x7C180800,  //  0093  CALL	R6	4
-      0x581C0018,  //  0094  LDCONST	R7	K24
-      0x7C100600,  //  0095  CALL	R4	3
-      0xA8040001,  //  0096  EXBLK	1	1
-      0x70020010,  //  0097  JMP		#00A9
-      0xAC100002,  //  0098  CATCH	R4	0	2
-      0x7002000D,  //  0099  JMP		#00A8
-      0xB81A0600,  //  009A  GETNGBL	R6	K3
-      0x8C180D0C,  //  009B  GETMET	R6	R6	K12
-      0x60200008,  //  009C  GETGBL	R8	G8
-      0x5C240800,  //  009D  MOVE	R9	R4
-      0x7C200200,  //  009E  CALL	R8	1
-      0x00223208,  //  009F  ADD	R8	K25	R8
-      0x0020111A,  //  00A0  ADD	R8	R8	K26
-      0x60240008,  //  00A1  GETGBL	R9	G8
-      0x5C280A00,  //  00A2  MOVE	R10	R5
-      0x7C240200,  //  00A3  CALL	R9	1
-      0x00201009,  //  00A4  ADD	R8	R8	R9
-      0x58240018,  //  00A5  LDCONST	R9	K24
-      0x7C180600,  //  00A6  CALL	R6	3
-      0x70020000,  //  00A7  JMP		#00A9
-      0xB0080000,  //  00A8  RAISE	2	R0	R0
-      0x8C10011B,  //  00A9  GETMET	R4	R0	K27
-      0x7C100200,  //  00AA  CALL	R4	1
-      0x80000000,  //  00AB  RET	0
+      0xB82E1600,  //  003C  GETNGBL	R11	K11
+      0x8C2C170C,  //  003D  GETMET	R11	R11	K12
+      0x88340106,  //  003E  GETMBR	R13	R0	K6
+      0x8C341B10,  //  003F  GETMET	R13	R13	K16
+      0x7C340200,  //  0040  CALL	R13	1
+      0x0036240D,  //  0041  ADD	R13	K18	R13
+      0x543A0003,  //  0042  LDINT	R14	4
+      0x7C2C0600,  //  0043  CALL	R11	3
+      0xB82E1600,  //  0044  GETNGBL	R11	K11
+      0x8C2C170C,  //  0045  GETMET	R11	R11	K12
+      0x88340109,  //  0046  GETMBR	R13	R0	K9
+      0x8C341B10,  //  0047  GETMET	R13	R13	K16
+      0x7C340200,  //  0048  CALL	R13	1
+      0x0036260D,  //  0049  ADD	R13	K19	R13
+      0x543A0003,  //  004A  LDINT	R14	4
+      0x7C2C0600,  //  004B  CALL	R11	3
+      0xB82E1600,  //  004C  GETNGBL	R11	K11
+      0x8C2C170C,  //  004D  GETMET	R11	R11	K12
+      0x5834000D,  //  004E  LDCONST	R13	K13
+      0x543A0003,  //  004F  LDINT	R14	4
+      0x7C2C0600,  //  0050  CALL	R11	3
+      0x8C2C0114,  //  0051  GETMET	R11	R0	K20
+      0x7C2C0200,  //  0052  CALL	R11	1
+      0xB8321600,  //  0053  GETNGBL	R12	K11
+      0x8C30190C,  //  0054  GETMET	R12	R12	K12
+      0x8C380B15,  //  0055  GETMET	R14	R5	K21
+      0x58400016,  //  0056  LDCONST	R16	K22
+      0x40460B17,  //  0057  CONNECT	R17	K5	K23
+      0x94441611,  //  0058  GETIDX	R17	R11	R17
+      0x544A0003,  //  0059  LDINT	R18	4
+      0x544E0005,  //  005A  LDINT	R19	6
+      0x40482413,  //  005B  CONNECT	R18	R18	R19
+      0x94481612,  //  005C  GETIDX	R18	R11	R18
+      0x544E0006,  //  005D  LDINT	R19	7
+      0x404C2718,  //  005E  CONNECT	R19	R19	K24
+      0x944C1613,  //  005F  GETIDX	R19	R11	R19
+      0x7C380A00,  //  0060  CALL	R14	5
+      0x583C0019,  //  0061  LDCONST	R15	K25
+      0x7C300600,  //  0062  CALL	R12	3
+      0x80000000,  //  0063  RET	0
     })
   )
 );
@@ -1096,154 +1779,11 @@ be_local_closure(Matter_Device_mdns_announce_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_basic_commissioning
+** Solidified function: save_param
 ********************************************************************/
-be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
+be_local_closure(Matter_Device_save_param,   /* name */
   be_nested_proto(
-    13,                          /* nstack */
-    8,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 4]) {     /* constants */
-        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
-        /* K1   */  be_nested_str_weak(tasmota),
-        /* K2   */  be_nested_str_weak(remove_rule),
-        /* K3   */  be_nested_str_weak(Eth_X23Connected),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 9]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0xB8020200,  //  0003  GETNGBL	R0	K1
-          0x8C000102,  //  0004  GETMET	R0	R0	K2
-          0x58080003,  //  0005  LDCONST	R2	K3
-          0x580C0000,  //  0006  LDCONST	R3	K0
-          0x7C000600,  //  0007  CALL	R0	3
-          0x80000000,  //  0008  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(commissioning_iterations),
-    /* K4   */  be_nested_str_weak(commissioning_discriminator),
-    /* K5   */  be_nested_str_weak(commissioning_salt),
-    /* K6   */  be_nested_str_weak(commissioning_w0),
-    /* K7   */  be_nested_str_weak(commissioning_L),
-    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
-    /* K9   */  be_nested_str_weak(wifi),
-    /* K10  */  be_nested_str_weak(up),
-    /* K11  */  be_nested_str_weak(eth),
-    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
-    /* K13  */  be_nested_str_weak(add_rule),
-    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K15  */  be_nested_str_weak(Eth_X23Connected),
-    }),
-    be_str_weak(start_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[40]) {  /* code */
-      0xB8220200,  //  0000  GETNGBL	R8	K1
-      0x8C201102,  //  0001  GETMET	R8	R8	K2
-      0x7C200200,  //  0002  CALL	R8	1
-      0x542603E7,  //  0003  LDINT	R9	1000
-      0x08240209,  //  0004  MUL	R9	R1	R9
-      0x00201009,  //  0005  ADD	R8	R8	R9
-      0x90020008,  //  0006  SETMBR	R0	K0	R8
-      0x90020602,  //  0007  SETMBR	R0	K3	R2
-      0x90020803,  //  0008  SETMBR	R0	K4	R3
-      0x90020A04,  //  0009  SETMBR	R0	K5	R4
-      0x90020C05,  //  000A  SETMBR	R0	K6	R5
-      0x90020E06,  //  000B  SETMBR	R0	K7	R6
-      0x90021007,  //  000C  SETMBR	R0	K8	R7
-      0xB8220200,  //  000D  GETNGBL	R8	K1
-      0x8C201109,  //  000E  GETMET	R8	R8	K9
-      0x7C200200,  //  000F  CALL	R8	1
-      0x9420110A,  //  0010  GETIDX	R8	R8	K10
-      0x74220004,  //  0011  JMPT	R8	#0017
-      0xB8220200,  //  0012  GETNGBL	R8	K1
-      0x8C20110B,  //  0013  GETMET	R8	R8	K11
-      0x7C200200,  //  0014  CALL	R8	1
-      0x9420110A,  //  0015  GETIDX	R8	R8	K10
-      0x78220002,  //  0016  JMPF	R8	#001A
-      0x8C20010C,  //  0017  GETMET	R8	R0	K12
-      0x7C200200,  //  0018  CALL	R8	1
-      0x7002000B,  //  0019  JMP		#0026
-      0xB8220200,  //  001A  GETNGBL	R8	K1
-      0x8C20110D,  //  001B  GETMET	R8	R8	K13
-      0x5828000E,  //  001C  LDCONST	R10	K14
-      0x842C0000,  //  001D  CLOSURE	R11	P0
-      0x5830000C,  //  001E  LDCONST	R12	K12
-      0x7C200800,  //  001F  CALL	R8	4
-      0xB8220200,  //  0020  GETNGBL	R8	K1
-      0x8C20110D,  //  0021  GETMET	R8	R8	K13
-      0x5828000F,  //  0022  LDCONST	R10	K15
-      0x842C0001,  //  0023  CLOSURE	R11	P1
-      0x5830000C,  //  0024  LDCONST	R12	K12
-      0x7C200800,  //  0025  CALL	R8	4
-      0xA0000000,  //  0026  CLOSE	R0
-      0x80000000,  //  0027  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery_all_fabrics
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1251,39 +1791,73 @@ be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name *
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    ( &(const bvalue[17]) {     /* constants */
+    /* K0   */  be_nested_str_weak(json),
+    /* K1   */  be_nested_str_weak(dump),
+    /* K2   */  be_nested_str_weak(distinguish),
+    /* K3   */  be_nested_str_weak(root_discriminator),
+    /* K4   */  be_nested_str_weak(passcode),
+    /* K5   */  be_nested_str_weak(root_passcode),
+    /* K6   */  be_nested_str_weak(ipv4only),
+    /* K7   */  be_nested_str_weak(string),
+    /* K8   */  be_nested_str_weak(FILENAME),
+    /* K9   */  be_nested_str_weak(w),
+    /* K10  */  be_nested_str_weak(write),
+    /* K11  */  be_nested_str_weak(close),
+    /* K12  */  be_nested_str_weak(tasmota),
+    /* K13  */  be_nested_str_weak(log),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
+    /* K15  */  be_nested_str_weak(_X7C),
+    /* K16  */  be_const_int(2),
     }),
-    be_str_weak(mdns_remove_op_discovery_all_fabrics),
+    be_str_weak(save_param),
     &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
+    ( &(const binstruction[45]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x8C080301,  //  0001  GETMET	R2	R1	K1
+      0x60100013,  //  0002  GETGBL	R4	G19
+      0x7C100000,  //  0003  CALL	R4	0
+      0x88140103,  //  0004  GETMBR	R5	R0	K3
+      0x98120405,  //  0005  SETIDX	R4	K2	R5
+      0x88140105,  //  0006  GETMBR	R5	R0	K5
+      0x98120805,  //  0007  SETIDX	R4	K4	R5
+      0x88140106,  //  0008  GETMBR	R5	R0	K6
+      0x98120C05,  //  0009  SETIDX	R4	K6	R5
+      0x7C080400,  //  000A  CALL	R2	2
+      0xA802000D,  //  000B  EXBLK	0	#001A
+      0xA40E0E00,  //  000C  IMPORT	R3	K7
+      0x60100011,  //  000D  GETGBL	R4	G17
+      0x88140108,  //  000E  GETMBR	R5	R0	K8
+      0x58180009,  //  000F  LDCONST	R6	K9
+      0x7C100400,  //  0010  CALL	R4	2
+      0x8C14090A,  //  0011  GETMET	R5	R4	K10
+      0x5C1C0400,  //  0012  MOVE	R7	R2
+      0x7C140400,  //  0013  CALL	R5	2
+      0x8C14090B,  //  0014  GETMET	R5	R4	K11
+      0x7C140200,  //  0015  CALL	R5	1
+      0xA8040001,  //  0016  EXBLK	1	1
+      0x80040400,  //  0017  RET	1	R2
+      0xA8040001,  //  0018  EXBLK	1	1
+      0x70020011,  //  0019  JMP		#002C
+      0xAC0C0002,  //  001A  CATCH	R3	0	2
+      0x7002000E,  //  001B  JMP		#002B
+      0xB8161800,  //  001C  GETNGBL	R5	K12
+      0x8C140B0D,  //  001D  GETMET	R5	R5	K13
+      0x601C0008,  //  001E  GETGBL	R7	G8
+      0x5C200600,  //  001F  MOVE	R8	R3
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0x001E1C07,  //  0021  ADD	R7	K14	R7
+      0x001C0F0F,  //  0022  ADD	R7	R7	K15
+      0x60200008,  //  0023  GETGBL	R8	G8
+      0x5C240800,  //  0024  MOVE	R9	R4
+      0x7C200200,  //  0025  CALL	R8	1
+      0x001C0E08,  //  0026  ADD	R7	R7	R8
+      0x58200010,  //  0027  LDCONST	R8	K16
+      0x7C140600,  //  0028  CALL	R5	3
+      0x80040400,  //  0029  RET	1	R2
+      0x70020000,  //  002A  JMP		#002C
+      0xB0080000,  //  002B  RAISE	2	R0	R0
+      0x80000000,  //  002C  RET	0
     })
   )
 );
@@ -1291,11 +1865,11 @@ be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name *
 
 
 /********************************************************************
-** Solidified function: attribute_updated
+** Solidified function: msg_send
 ********************************************************************/
-be_local_closure(Matter_Device_attribute_updated,   /* name */
+be_local_closure(Matter_Device_msg_send,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    11,                          /* nstack */
     5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1303,38 +1877,21 @@ be_local_closure(Matter_Device_attribute_updated,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Path),
-    /* K2   */  be_nested_str_weak(endpoint),
-    /* K3   */  be_nested_str_weak(cluster),
-    /* K4   */  be_nested_str_weak(attribute),
-    /* K5   */  be_nested_str_weak(message_handler),
-    /* K6   */  be_nested_str_weak(im),
-    /* K7   */  be_nested_str_weak(subs),
-    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(send_response),
     }),
-    be_str_weak(attribute_updated),
+    be_str_weak(msg_send),
     &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x4C140000,  //  0000  LDNIL	R5
-      0x1C140805,  //  0001  EQ	R5	R4	R5
-      0x78160000,  //  0002  JMPF	R5	#0004
-      0x50100000,  //  0003  LDBOOL	R4	0	0
-      0xB8160000,  //  0004  GETNGBL	R5	K0
-      0x8C140B01,  //  0005  GETMET	R5	R5	K1
-      0x7C140200,  //  0006  CALL	R5	1
-      0x90160401,  //  0007  SETMBR	R5	K2	R1
-      0x90160602,  //  0008  SETMBR	R5	K3	R2
-      0x90160803,  //  0009  SETMBR	R5	K4	R3
-      0x88180105,  //  000A  GETMBR	R6	R0	K5
-      0x88180D06,  //  000B  GETMBR	R6	R6	K6
-      0x88180D07,  //  000C  GETMBR	R6	R6	K7
-      0x8C180D08,  //  000D  GETMET	R6	R6	K8
-      0x5C200A00,  //  000E  MOVE	R8	R5
-      0x5C240800,  //  000F  MOVE	R9	R4
-      0x7C180600,  //  0010  CALL	R6	3
-      0x80000000,  //  0011  RET	0
+    ( &(const binstruction[ 8]) {  /* code */
+      0x88140100,  //  0000  GETMBR	R5	R0	K0
+      0x8C140B01,  //  0001  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0002  MOVE	R7	R1
+      0x5C200400,  //  0003  MOVE	R8	R2
+      0x5C240600,  //  0004  MOVE	R9	R3
+      0x5C280800,  //  0005  MOVE	R10	R4
+      0x7C140A00,  //  0006  CALL	R5	5
+      0x80040A00,  //  0007  RET	1	R5
     })
   )
 );
@@ -1342,101 +1899,271 @@ be_local_closure(Matter_Device_attribute_updated,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery_all_fabrics
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics,   /* name */
+be_local_closure(Matter_Device_init,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sessions),
-    /* K1   */  be_nested_str_weak(active_fabrics),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(get_fabric_id),
-    /* K4   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K5   */  be_nested_str_weak(stop_iteration),
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 3]) {
+      be_nested_proto(
+        2,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_trigger_read_sensors),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 4]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0x80000000,  //  0003  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 6]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_start_udp),
+        /* K1   */  be_nested_str_weak(UDP_PORT),
+        /* K2   */  be_nested_str_weak(tasmota),
+        /* K3   */  be_nested_str_weak(remove_rule),
+        /* K4   */  be_nested_str_weak(Wifi_X23Connected),
+        /* K5   */  be_nested_str_weak(matter_device_udp),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[11]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080000,  //  0002  GETUPV	R2	U0
+          0x88080501,  //  0003  GETMBR	R2	R2	K1
+          0x7C000400,  //  0004  CALL	R0	2
+          0xB8020400,  //  0005  GETNGBL	R0	K2
+          0x8C000103,  //  0006  GETMET	R0	R0	K3
+          0x58080004,  //  0007  LDCONST	R2	K4
+          0x580C0005,  //  0008  LDCONST	R3	K5
+          0x7C000600,  //  0009  CALL	R0	3
+          0x80000000,  //  000A  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 6]) {     /* constants */
+        /* K0   */  be_nested_str_weak(_start_udp),
+        /* K1   */  be_nested_str_weak(UDP_PORT),
+        /* K2   */  be_nested_str_weak(tasmota),
+        /* K3   */  be_nested_str_weak(remove_rule),
+        /* K4   */  be_nested_str_weak(Eth_X23Connected),
+        /* K5   */  be_nested_str_weak(matter_device_udp),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[11]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080000,  //  0002  GETUPV	R2	U0
+          0x88080501,  //  0003  GETMBR	R2	R2	K1
+          0x7C000400,  //  0004  CALL	R0	2
+          0xB8020400,  //  0005  GETNGBL	R0	K2
+          0x8C000103,  //  0006  GETMET	R0	R0	K3
+          0x58080004,  //  0007  LDCONST	R2	K4
+          0x580C0005,  //  0008  LDCONST	R3	K5
+          0x7C000600,  //  0009  CALL	R0	3
+          0x80000000,  //  000A  RET	0
+        })
+      ),
     }),
-    be_str_weak(mdns_announce_op_discovery_all_fabrics),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x60040010,  //  0000  GETGBL	R1	G16
-      0x88080100,  //  0001  GETMBR	R2	R0	K0
-      0x8C080501,  //  0002  GETMET	R2	R2	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x7C040200,  //  0004  CALL	R1	1
-      0xA802000B,  //  0005  EXBLK	0	#0012
-      0x5C080200,  //  0006  MOVE	R2	R1
-      0x7C080000,  //  0007  CALL	R2	0
-      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x780E0005,  //  000A  JMPF	R3	#0011
-      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x780E0002,  //  000D  JMPF	R3	#0011
-      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
-      0x5C140400,  //  000F  MOVE	R5	R2
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x7001FFF3,  //  0011  JMP		#0006
-      0x58040005,  //  0012  LDCONST	R1	K5
-      0xAC040200,  //  0013  CATCH	R1	1	0
-      0xB0080000,  //  0014  RAISE	2	R0	R0
-      0x80000000,  //  0015  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[44]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(mdns),
-    /* K2   */  be_nested_str_weak(string),
-    /* K3   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K4   */  be_nested_str_weak(root_w0),
-    /* K5   */  be_nested_str_weak(root_L),
-    /* K6   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K7   */  be_nested_str_weak(mdns_announce_op_discovery),
-    /* K8   */  be_nested_str_weak(get_fabric),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(get_option),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(MATTER_OPTION),
+    /* K6   */  be_nested_str_weak(UI),
+    /* K7   */  be_nested_str_weak(plugins),
+    /* K8   */  be_nested_str_weak(vendorid),
+    /* K9   */  be_nested_str_weak(VENDOR_ID),
+    /* K10  */  be_nested_str_weak(productid),
+    /* K11  */  be_nested_str_weak(PRODUCT_ID),
+    /* K12  */  be_nested_str_weak(root_iterations),
+    /* K13  */  be_nested_str_weak(PBKDF_ITERATIONS),
+    /* K14  */  be_nested_str_weak(root_salt),
+    /* K15  */  be_nested_str_weak(random),
+    /* K16  */  be_nested_str_weak(ipv4only),
+    /* K17  */  be_nested_str_weak(load_param),
+    /* K18  */  be_nested_str_weak(sessions),
+    /* K19  */  be_nested_str_weak(Session_Store),
+    /* K20  */  be_nested_str_weak(load_fabrics),
+    /* K21  */  be_nested_str_weak(message_handler),
+    /* K22  */  be_nested_str_weak(MessageHandler),
+    /* K23  */  be_nested_str_weak(ui),
+    /* K24  */  be_nested_str_weak(push),
+    /* K25  */  be_nested_str_weak(Plugin_Root),
+    /* K26  */  be_const_int(0),
+    /* K27  */  be_nested_str_weak(Plugin_OnOff),
+    /* K28  */  be_const_int(1),
+    /* K29  */  be_nested_str_weak(add_cron),
+    /* K30  */  be_nested_str_weak(_X2A_X2F5_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
+    /* K31  */  be_nested_str_weak(matter_sensors_5s),
+    /* K32  */  be_nested_str_weak(start_mdns_announce_hostnames),
+    /* K33  */  be_nested_str_weak(wifi),
+    /* K34  */  be_nested_str_weak(up),
+    /* K35  */  be_nested_str_weak(_start_udp),
+    /* K36  */  be_nested_str_weak(UDP_PORT),
+    /* K37  */  be_nested_str_weak(add_rule),
+    /* K38  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K39  */  be_nested_str_weak(matter_device_udp),
+    /* K40  */  be_nested_str_weak(eth),
+    /* K41  */  be_nested_str_weak(Eth_X23Connected),
+    /* K42  */  be_nested_str_weak(_init_basic_commissioning),
+    /* K43  */  be_nested_str_weak(add_driver),
     }),
-    be_str_weak(start_operational_discovery),
+    be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0x8C140103,  //  0003  GETMET	R5	R0	K3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x4C140000,  //  0005  LDNIL	R5
-      0x90020805,  //  0006  SETMBR	R0	K4	R5
-      0x4C140000,  //  0007  LDNIL	R5
-      0x90020A05,  //  0008  SETMBR	R0	K5	R5
-      0x8C140306,  //  0009  GETMET	R5	R1	K6
-      0x541E003B,  //  000A  LDINT	R7	60
-      0x7C140400,  //  000B  CALL	R5	2
-      0x8C140107,  //  000C  GETMET	R5	R0	K7
-      0x8C1C0308,  //  000D  GETMET	R7	R1	K8
-      0x7C1C0200,  //  000E  CALL	R7	1
-      0x7C140400,  //  000F  CALL	R5	2
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[110]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xA40A0200,  //  0001  IMPORT	R2	K1
+      0xB80E0400,  //  0002  GETNGBL	R3	K2
+      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
+      0xB8160800,  //  0004  GETNGBL	R5	K4
+      0x88140B05,  //  0005  GETMBR	R5	R5	K5
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x740E0004,  //  0007  JMPT	R3	#000D
+      0xB80E0800,  //  0008  GETNGBL	R3	K4
+      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
+      0x5C140000,  //  000A  MOVE	R5	R0
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x80000600,  //  000C  RET	0
+      0x600C0012,  //  000D  GETGBL	R3	G18
+      0x7C0C0000,  //  000E  CALL	R3	0
+      0x90020E03,  //  000F  SETMBR	R0	K7	R3
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
+      0x90021003,  //  0011  SETMBR	R0	K8	R3
+      0x880C010B,  //  0012  GETMBR	R3	R0	K11
+      0x90021403,  //  0013  SETMBR	R0	K10	R3
+      0x880C010D,  //  0014  GETMBR	R3	R0	K13
+      0x90021803,  //  0015  SETMBR	R0	K12	R3
+      0x8C0C030F,  //  0016  GETMET	R3	R1	K15
+      0x5416000F,  //  0017  LDINT	R5	16
+      0x7C0C0400,  //  0018  CALL	R3	2
+      0x90021C03,  //  0019  SETMBR	R0	K14	R3
+      0x500C0000,  //  001A  LDBOOL	R3	0	0
+      0x90022003,  //  001B  SETMBR	R0	K16	R3
+      0x8C0C0111,  //  001C  GETMET	R3	R0	K17
+      0x7C0C0200,  //  001D  CALL	R3	1
+      0xB80E0800,  //  001E  GETNGBL	R3	K4
+      0x8C0C0713,  //  001F  GETMET	R3	R3	K19
+      0x7C0C0200,  //  0020  CALL	R3	1
+      0x90022403,  //  0021  SETMBR	R0	K18	R3
+      0x880C0112,  //  0022  GETMBR	R3	R0	K18
+      0x8C0C0714,  //  0023  GETMET	R3	R3	K20
+      0x7C0C0200,  //  0024  CALL	R3	1
+      0xB80E0800,  //  0025  GETNGBL	R3	K4
+      0x8C0C0716,  //  0026  GETMET	R3	R3	K22
+      0x5C140000,  //  0027  MOVE	R5	R0
+      0x7C0C0400,  //  0028  CALL	R3	2
+      0x90022A03,  //  0029  SETMBR	R0	K21	R3
+      0xB80E0800,  //  002A  GETNGBL	R3	K4
+      0x8C0C0706,  //  002B  GETMET	R3	R3	K6
+      0x5C140000,  //  002C  MOVE	R5	R0
+      0x7C0C0400,  //  002D  CALL	R3	2
+      0x90022E03,  //  002E  SETMBR	R0	K23	R3
+      0x880C0107,  //  002F  GETMBR	R3	R0	K7
+      0x8C0C0718,  //  0030  GETMET	R3	R3	K24
+      0xB8160800,  //  0031  GETNGBL	R5	K4
+      0x8C140B19,  //  0032  GETMET	R5	R5	K25
+      0x5C1C0000,  //  0033  MOVE	R7	R0
+      0x5820001A,  //  0034  LDCONST	R8	K26
+      0x7C140600,  //  0035  CALL	R5	3
+      0x7C0C0400,  //  0036  CALL	R3	2
+      0x880C0107,  //  0037  GETMBR	R3	R0	K7
+      0x8C0C0718,  //  0038  GETMET	R3	R3	K24
+      0xB8160800,  //  0039  GETNGBL	R5	K4
+      0x8C140B1B,  //  003A  GETMET	R5	R5	K27
+      0x5C1C0000,  //  003B  MOVE	R7	R0
+      0x5820001C,  //  003C  LDCONST	R8	K28
+      0x5824001A,  //  003D  LDCONST	R9	K26
+      0x7C140800,  //  003E  CALL	R5	4
+      0x7C0C0400,  //  003F  CALL	R3	2
+      0xB80E0400,  //  0040  GETNGBL	R3	K2
+      0x8C0C071D,  //  0041  GETMET	R3	R3	K29
+      0x5814001E,  //  0042  LDCONST	R5	K30
+      0x84180000,  //  0043  CLOSURE	R6	P0
+      0x581C001F,  //  0044  LDCONST	R7	K31
+      0x7C0C0800,  //  0045  CALL	R3	4
+      0x8C0C0120,  //  0046  GETMET	R3	R0	K32
+      0x7C0C0200,  //  0047  CALL	R3	1
+      0xB80E0400,  //  0048  GETNGBL	R3	K2
+      0x8C0C0721,  //  0049  GETMET	R3	R3	K33
+      0x7C0C0200,  //  004A  CALL	R3	1
+      0x940C0722,  //  004B  GETIDX	R3	R3	K34
+      0x780E0003,  //  004C  JMPF	R3	#0051
+      0x8C0C0123,  //  004D  GETMET	R3	R0	K35
+      0x88140124,  //  004E  GETMBR	R5	R0	K36
+      0x7C0C0400,  //  004F  CALL	R3	2
+      0x70020005,  //  0050  JMP		#0057
+      0xB80E0400,  //  0051  GETNGBL	R3	K2
+      0x8C0C0725,  //  0052  GETMET	R3	R3	K37
+      0x58140026,  //  0053  LDCONST	R5	K38
+      0x84180001,  //  0054  CLOSURE	R6	P1
+      0x581C0027,  //  0055  LDCONST	R7	K39
+      0x7C0C0800,  //  0056  CALL	R3	4
+      0xB80E0400,  //  0057  GETNGBL	R3	K2
+      0x8C0C0728,  //  0058  GETMET	R3	R3	K40
+      0x7C0C0200,  //  0059  CALL	R3	1
+      0x940C0722,  //  005A  GETIDX	R3	R3	K34
+      0x780E0003,  //  005B  JMPF	R3	#0060
+      0x8C0C0123,  //  005C  GETMET	R3	R0	K35
+      0x88140124,  //  005D  GETMBR	R5	R0	K36
+      0x7C0C0400,  //  005E  CALL	R3	2
+      0x70020005,  //  005F  JMP		#0066
+      0xB80E0400,  //  0060  GETNGBL	R3	K2
+      0x8C0C0725,  //  0061  GETMET	R3	R3	K37
+      0x58140029,  //  0062  LDCONST	R5	K41
+      0x84180002,  //  0063  CLOSURE	R6	P2
+      0x581C0027,  //  0064  LDCONST	R7	K39
+      0x7C0C0800,  //  0065  CALL	R3	4
+      0x8C0C012A,  //  0066  GETMET	R3	R0	K42
+      0x7C0C0200,  //  0067  CALL	R3	1
+      0xB80E0400,  //  0068  GETNGBL	R3	K2
+      0x8C0C072B,  //  0069  GETMET	R3	R3	K43
+      0x5C140000,  //  006A  MOVE	R5	R0
+      0x7C0C0400,  //  006B  CALL	R3	2
+      0xA0000000,  //  006C  CLOSE	R0
+      0x80000000,  //  006D  RET	0
     })
   )
 );
@@ -1832,9 +2559,9 @@ be_local_closure(Matter_Device_process_attribute_expansion,   /* name */
 
 
 /********************************************************************
-** Solidified function: stop
+** Solidified function: is_commissioning_open
 ********************************************************************/
-be_local_closure(Matter_Device_stop,   /* name */
+be_local_closure(Matter_Device_is_commissioning_open,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -1844,19 +2571,16 @@ be_local_closure(Matter_Device_stop,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(stop),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
     }),
-    be_str_weak(stop),
+    be_str_weak(is_commissioning_open),
     &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x78060002,  //  0001  JMPF	R1	#0005
-      0x88040100,  //  0002  GETMBR	R1	R0	K0
-      0x8C040301,  //  0003  GETMET	R1	R1	K1
-      0x7C040200,  //  0004  CALL	R1	1
-      0x80000000,  //  0005  RET	0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
     })
   )
 );
@@ -1864,11 +2588,11 @@ be_local_closure(Matter_Device_stop,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_announce_op_discovery
+** Solidified function: received_ack
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
+be_local_closure(Matter_Device_received_ack,   /* name */
   be_nested_proto(
-    15,                          /* nstack */
+    5,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1876,162 +2600,294 @@ be_local_closure(Matter_Device_mdns_announce_op_discovery,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20Operational_X20Discovery_X20node_X20_X3D_X20),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(eth),
-    /* K13  */  be_nested_str_weak(find),
-    /* K14  */  be_nested_str_weak(up),
-    /* K15  */  be_nested_str_weak(format),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20adding_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27_X20ptr_X20to_X20_X60_X25s_X2Elocal_X60),
-    /* K17  */  be_nested_str_weak(hostname_eth),
-    /* K18  */  be_const_int(3),
-    /* K19  */  be_nested_str_weak(add_service),
-    /* K20  */  be_nested_str_weak(_matter),
-    /* K21  */  be_nested_str_weak(_tcp),
-    /* K22  */  be_nested_str_weak(_I),
-    /* K23  */  be_nested_str_weak(MTR_X3A_X20adding_X20subtype_X3A_X20),
-    /* K24  */  be_nested_str_weak(add_subtype),
-    /* K25  */  be_nested_str_weak(wifi),
-    /* K26  */  be_nested_str_weak(hostname_wifi),
-    /* K27  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K28  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(received_ack),
     }),
-    be_str_weak(mdns_announce_op_discovery),
+    be_str_weak(received_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[122]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA8020064,  //  0002  EXBLK	0	#0068
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x00261406,  //  0013  ADD	R9	K10	R6
-      0x5828000B,  //  0014  LDCONST	R10	K11
-      0x7C1C0600,  //  0015  CALL	R7	3
-      0xB81E1000,  //  0016  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0017  GETMET	R7	R7	K12
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x8C1C0F0D,  //  0019  GETMET	R7	R7	K13
-      0x5824000E,  //  001A  LDCONST	R9	K14
-      0x7C1C0400,  //  001B  CALL	R7	2
-      0x781E0020,  //  001C  JMPF	R7	#003E
-      0xB81E1000,  //  001D  GETNGBL	R7	K8
-      0x8C1C0F09,  //  001E  GETMET	R7	R7	K9
-      0x8C24070F,  //  001F  GETMET	R9	R3	K15
-      0x582C0010,  //  0020  LDCONST	R11	K16
-      0x5830000C,  //  0021  LDCONST	R12	K12
-      0x5C340C00,  //  0022  MOVE	R13	R6
-      0x88380111,  //  0023  GETMBR	R14	R0	K17
-      0x7C240A00,  //  0024  CALL	R9	5
-      0x58280012,  //  0025  LDCONST	R10	K18
-      0x7C1C0600,  //  0026  CALL	R7	3
-      0x8C1C0513,  //  0027  GETMET	R7	R2	K19
-      0x58240014,  //  0028  LDCONST	R9	K20
-      0x58280015,  //  0029  LDCONST	R10	K21
-      0x542E15A3,  //  002A  LDINT	R11	5540
-      0x4C300000,  //  002B  LDNIL	R12
-      0x5C340C00,  //  002C  MOVE	R13	R6
-      0x88380111,  //  002D  GETMBR	R14	R0	K17
-      0x7C1C0E00,  //  002E  CALL	R7	7
-      0x8C1C0B06,  //  002F  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0030  CALL	R7	1
-      0x001E2C07,  //  0031  ADD	R7	K22	R7
-      0xB8221000,  //  0032  GETNGBL	R8	K8
-      0x8C201109,  //  0033  GETMET	R8	R8	K9
-      0x002A2E07,  //  0034  ADD	R10	K23	R7
-      0x582C0012,  //  0035  LDCONST	R11	K18
-      0x7C200600,  //  0036  CALL	R8	3
-      0x8C200518,  //  0037  GETMET	R8	R2	K24
-      0x58280014,  //  0038  LDCONST	R10	K20
-      0x582C0015,  //  0039  LDCONST	R11	K21
-      0x5C300C00,  //  003A  MOVE	R12	R6
-      0x88340111,  //  003B  GETMBR	R13	R0	K17
-      0x5C380E00,  //  003C  MOVE	R14	R7
-      0x7C200C00,  //  003D  CALL	R8	6
-      0xB81E1000,  //  003E  GETNGBL	R7	K8
-      0x8C1C0F19,  //  003F  GETMET	R7	R7	K25
-      0x7C1C0200,  //  0040  CALL	R7	1
-      0x8C1C0F0D,  //  0041  GETMET	R7	R7	K13
-      0x5824000E,  //  0042  LDCONST	R9	K14
-      0x7C1C0400,  //  0043  CALL	R7	2
-      0x781E0020,  //  0044  JMPF	R7	#0066
-      0xB81E1000,  //  0045  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0046  GETMET	R7	R7	K9
-      0x8C24070F,  //  0047  GETMET	R9	R3	K15
-      0x582C0010,  //  0048  LDCONST	R11	K16
-      0x58300019,  //  0049  LDCONST	R12	K25
-      0x5C340C00,  //  004A  MOVE	R13	R6
-      0x8838011A,  //  004B  GETMBR	R14	R0	K26
-      0x7C240A00,  //  004C  CALL	R9	5
-      0x58280012,  //  004D  LDCONST	R10	K18
-      0x7C1C0600,  //  004E  CALL	R7	3
-      0x8C1C0513,  //  004F  GETMET	R7	R2	K19
-      0x58240014,  //  0050  LDCONST	R9	K20
-      0x58280015,  //  0051  LDCONST	R10	K21
-      0x542E15A3,  //  0052  LDINT	R11	5540
-      0x4C300000,  //  0053  LDNIL	R12
-      0x5C340C00,  //  0054  MOVE	R13	R6
-      0x8838011A,  //  0055  GETMBR	R14	R0	K26
-      0x7C1C0E00,  //  0056  CALL	R7	7
-      0x8C1C0B06,  //  0057  GETMET	R7	R5	K6
-      0x7C1C0200,  //  0058  CALL	R7	1
-      0x001E2C07,  //  0059  ADD	R7	K22	R7
-      0xB8221000,  //  005A  GETNGBL	R8	K8
-      0x8C201109,  //  005B  GETMET	R8	R8	K9
-      0x002A2E07,  //  005C  ADD	R10	K23	R7
-      0x582C0012,  //  005D  LDCONST	R11	K18
-      0x7C200600,  //  005E  CALL	R8	3
-      0x8C200518,  //  005F  GETMET	R8	R2	K24
-      0x58280014,  //  0060  LDCONST	R10	K20
-      0x582C0015,  //  0061  LDCONST	R11	K21
-      0x5C300C00,  //  0062  MOVE	R12	R6
-      0x8834011A,  //  0063  GETMBR	R13	R0	K26
-      0x5C380E00,  //  0064  MOVE	R14	R7
-      0x7C200C00,  //  0065  CALL	R8	6
-      0xA8040001,  //  0066  EXBLK	1	1
-      0x70020010,  //  0067  JMP		#0079
-      0xAC100002,  //  0068  CATCH	R4	0	2
-      0x7002000D,  //  0069  JMP		#0078
-      0xB81A1000,  //  006A  GETNGBL	R6	K8
-      0x8C180D09,  //  006B  GETMET	R6	R6	K9
-      0x60200008,  //  006C  GETGBL	R8	G8
-      0x5C240800,  //  006D  MOVE	R9	R4
-      0x7C200200,  //  006E  CALL	R8	1
-      0x00223608,  //  006F  ADD	R8	K27	R8
-      0x0020111C,  //  0070  ADD	R8	R8	K28
-      0x60240008,  //  0071  GETGBL	R9	G8
-      0x5C280A00,  //  0072  MOVE	R10	R5
-      0x7C240200,  //  0073  CALL	R9	1
-      0x00201009,  //  0074  ADD	R8	R8	R9
-      0x5824000B,  //  0075  LDCONST	R9	K11
-      0x7C180600,  //  0076  CALL	R6	3
-      0x70020000,  //  0077  JMP		#0079
-      0xB0080000,  //  0078  RAISE	2	R0	R0
-      0x80000000,  //  0079  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x80040400,  //  0004  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_commissioning_complete
+********************************************************************/
+be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
+    /* K3   */  be_const_int(2),
+    /* K4   */  be_nested_str_weak(stop_basic_commissioning),
+    }),
+    be_str_weak(start_commissioning_complete),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x58100002,  //  0002  LDCONST	R4	K2
+      0x58140003,  //  0003  LDCONST	R5	K3
+      0x7C080600,  //  0004  CALL	R2	3
+      0x8C080104,  //  0005  GETMET	R2	R0	K4
+      0x7C080200,  //  0006  CALL	R2	1
+      0x80000000,  //  0007  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _start_udp
+********************************************************************/
+be_local_closure(Matter_Device__start_udp,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(msg_received),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(udp_server),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(UDPServer),
+    /* K7   */  be_nested_str_weak(),
+    /* K8   */  be_nested_str_weak(start),
+    }),
+    be_str_weak(_start_udp),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x780A0000,  //  0001  JMPF	R2	#0003
+      0x80000400,  //  0002  RET	0
+      0x4C080000,  //  0003  LDNIL	R2
+      0x1C080202,  //  0004  EQ	R2	R1	R2
+      0x780A0000,  //  0005  JMPF	R2	#0007
+      0x540615A3,  //  0006  LDINT	R1	5540
+      0xB80A0200,  //  0007  GETNGBL	R2	K1
+      0x8C080502,  //  0008  GETMET	R2	R2	K2
+      0x60100008,  //  0009  GETGBL	R4	G8
+      0x5C140200,  //  000A  MOVE	R5	R1
+      0x7C100200,  //  000B  CALL	R4	1
+      0x00120604,  //  000C  ADD	R4	K3	R4
+      0x58140004,  //  000D  LDCONST	R5	K4
+      0x7C080600,  //  000E  CALL	R2	3
+      0xB80A0A00,  //  000F  GETNGBL	R2	K5
+      0x8C080506,  //  0010  GETMET	R2	R2	K6
+      0x58100007,  //  0011  LDCONST	R4	K7
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C080600,  //  0013  CALL	R2	3
+      0x90020002,  //  0014  SETMBR	R0	K0	R2
+      0x88080100,  //  0015  GETMBR	R2	R0	K0
+      0x8C080508,  //  0016  GETMET	R2	R2	K8
+      0x84100000,  //  0017  CLOSURE	R4	P0
+      0x7C080400,  //  0018  CALL	R2	2
+      0xA0000000,  //  0019  CLOSE	R0
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start_root_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
+    /* K1   */  be_nested_str_weak(_compute_pbkdf),
+    /* K2   */  be_nested_str_weak(root_passcode),
+    /* K3   */  be_nested_str_weak(root_iterations),
+    /* K4   */  be_nested_str_weak(root_salt),
+    /* K5   */  be_nested_str_weak(start_basic_commissioning),
+    /* K6   */  be_nested_str_weak(root_discriminator),
+    /* K7   */  be_nested_str_weak(root_w0),
+    /* K8   */  be_nested_str_weak(root_L),
+    }),
+    be_str_weak(start_root_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[19]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x88040100,  //  0003  GETMBR	R1	R0	K0
+      0x8C080101,  //  0004  GETMET	R2	R0	K1
+      0x88100102,  //  0005  GETMBR	R4	R0	K2
+      0x88140103,  //  0006  GETMBR	R5	R0	K3
+      0x88180104,  //  0007  GETMBR	R6	R0	K4
+      0x7C080800,  //  0008  CALL	R2	4
+      0x8C080105,  //  0009  GETMET	R2	R0	K5
+      0x5C100200,  //  000A  MOVE	R4	R1
+      0x88140103,  //  000B  GETMBR	R5	R0	K3
+      0x88180106,  //  000C  GETMBR	R6	R0	K6
+      0x881C0104,  //  000D  GETMBR	R7	R0	K4
+      0x88200107,  //  000E  GETMBR	R8	R0	K7
+      0x88240108,  //  000F  GETMBR	R9	R0	K8
+      0x4C280000,  //  0010  LDNIL	R10
+      0x7C081000,  //  0011  CALL	R2	8
+      0x80000000,  //  0012  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: stop_basic_commissioning
+********************************************************************/
+be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(mdns_remove_PASE),
+    /* K2   */  be_nested_str_weak(commissioning_iterations),
+    /* K3   */  be_nested_str_weak(commissioning_discriminator),
+    /* K4   */  be_nested_str_weak(commissioning_salt),
+    /* K5   */  be_nested_str_weak(commissioning_w0),
+    /* K6   */  be_nested_str_weak(commissioning_L),
+    /* K7   */  be_nested_str_weak(commissioning_admin_fabric),
+    }),
+    be_str_weak(stop_basic_commissioning),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x8C040101,  //  0002  GETMET	R1	R0	K1
+      0x7C040200,  //  0003  CALL	R1	1
+      0x4C040000,  //  0004  LDNIL	R1
+      0x90020401,  //  0005  SETMBR	R0	K2	R1
+      0x4C040000,  //  0006  LDNIL	R1
+      0x90020601,  //  0007  SETMBR	R0	K3	R1
+      0x4C040000,  //  0008  LDNIL	R1
+      0x90020801,  //  0009  SETMBR	R0	K4	R1
+      0x4C040000,  //  000A  LDNIL	R1
+      0x90020A01,  //  000B  SETMBR	R0	K5	R1
+      0x4C040000,  //  000C  LDNIL	R1
+      0x90020C01,  //  000D  SETMBR	R0	K6	R1
+      0x4C040000,  //  000E  LDNIL	R1
+      0x90020E01,  //  000F  SETMBR	R0	K7	R1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: attribute_updated
+********************************************************************/
+be_local_closure(Matter_Device_attribute_updated,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Path),
+    /* K2   */  be_nested_str_weak(endpoint),
+    /* K3   */  be_nested_str_weak(cluster),
+    /* K4   */  be_nested_str_weak(attribute),
+    /* K5   */  be_nested_str_weak(message_handler),
+    /* K6   */  be_nested_str_weak(im),
+    /* K7   */  be_nested_str_weak(subs_shop),
+    /* K8   */  be_nested_str_weak(attribute_updated_ctx),
+    }),
+    be_str_weak(attribute_updated),
+    &be_const_str_solidified,
+    ( &(const binstruction[18]) {  /* code */
+      0x4C140000,  //  0000  LDNIL	R5
+      0x1C140805,  //  0001  EQ	R5	R4	R5
+      0x78160000,  //  0002  JMPF	R5	#0004
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0xB8160000,  //  0004  GETNGBL	R5	K0
+      0x8C140B01,  //  0005  GETMET	R5	R5	K1
+      0x7C140200,  //  0006  CALL	R5	1
+      0x90160401,  //  0007  SETMBR	R5	K2	R1
+      0x90160602,  //  0008  SETMBR	R5	K3	R2
+      0x90160803,  //  0009  SETMBR	R5	K4	R3
+      0x88180105,  //  000A  GETMBR	R6	R0	K5
+      0x88180D06,  //  000B  GETMBR	R6	R6	K6
+      0x88180D07,  //  000C  GETMBR	R6	R6	K7
+      0x8C180D08,  //  000D  GETMET	R6	R6	K8
+      0x5C200A00,  //  000E  MOVE	R8	R5
+      0x5C240800,  //  000F  MOVE	R9	R4
+      0x7C180600,  //  0010  CALL	R6	3
+      0x80000000,  //  0011  RET	0
     })
   )
 );
@@ -2166,659 +3022,59 @@ be_local_closure(Matter_Device_load_param,   /* name */
 
 
 /********************************************************************
-** Solidified function: msg_send
+** Solidified function: start_commissioning_complete_deferred
 ********************************************************************/
-be_local_closure(Matter_Device_msg_send,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(send_response),
-    }),
-    be_str_weak(msg_send),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x88140100,  //  0000  GETMBR	R5	R0	K0
-      0x8C140B01,  //  0001  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0002  MOVE	R7	R1
-      0x5C200400,  //  0003  MOVE	R8	R2
-      0x5C240600,  //  0004  MOVE	R9	R3
-      0x5C280800,  //  0005  MOVE	R10	R4
-      0x7C140A00,  //  0006  CALL	R5	5
-      0x80040A00,  //  0007  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_root_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_start_root_basic_commissioning,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(PASE_TIMEOUT),
-    /* K1   */  be_nested_str_weak(compute_pbkdf),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(root_iterations),
-    /* K4   */  be_nested_str_weak(root_salt),
-    /* K5   */  be_nested_str_weak(start_basic_commissioning),
-    /* K6   */  be_nested_str_weak(root_discriminator),
-    /* K7   */  be_nested_str_weak(root_w0),
-    /* K8   */  be_nested_str_weak(root_L),
-    }),
-    be_str_weak(start_root_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x88040100,  //  0003  GETMBR	R1	R0	K0
-      0x8C080101,  //  0004  GETMET	R2	R0	K1
-      0x88100102,  //  0005  GETMBR	R4	R0	K2
-      0x88140103,  //  0006  GETMBR	R5	R0	K3
-      0x88180104,  //  0007  GETMBR	R6	R0	K4
-      0x7C080800,  //  0008  CALL	R2	4
-      0x8C080105,  //  0009  GETMET	R2	R0	K5
-      0x5C100200,  //  000A  MOVE	R4	R1
-      0x88140103,  //  000B  GETMBR	R5	R0	K3
-      0x88180106,  //  000C  GETMBR	R6	R0	K6
-      0x881C0104,  //  000D  GETMBR	R7	R0	K4
-      0x88200107,  //  000E  GETMBR	R8	R0	K7
-      0x88240108,  //  000F  GETMBR	R9	R0	K8
-      0x4C280000,  //  0010  LDNIL	R10
-      0x7C081000,  //  0011  CALL	R2	8
-      0x80000000,  //  0012  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Device_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 3]) {
-      be_nested_proto(
-        2,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(trigger_read_sensors),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 4]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x7C000200,  //  0002  CALL	R0	1
-          0x80000000,  //  0003  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 6]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_udp),
-        /* K1   */  be_nested_str_weak(UDP_PORT),
-        /* K2   */  be_nested_str_weak(tasmota),
-        /* K3   */  be_nested_str_weak(remove_rule),
-        /* K4   */  be_nested_str_weak(Wifi_X23Connected),
-        /* K5   */  be_nested_str_weak(matter_device_udp),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[11]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x88080501,  //  0003  GETMBR	R2	R2	K1
-          0x7C000400,  //  0004  CALL	R0	2
-          0xB8020400,  //  0005  GETNGBL	R0	K2
-          0x8C000103,  //  0006  GETMET	R0	R0	K3
-          0x58080004,  //  0007  LDCONST	R2	K4
-          0x580C0005,  //  0008  LDCONST	R3	K5
-          0x7C000600,  //  0009  CALL	R0	3
-          0x80000000,  //  000A  RET	0
-        })
-      ),
-      be_nested_proto(
-        4,                          /* nstack */
-        0,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 6]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_udp),
-        /* K1   */  be_nested_str_weak(UDP_PORT),
-        /* K2   */  be_nested_str_weak(tasmota),
-        /* K3   */  be_nested_str_weak(remove_rule),
-        /* K4   */  be_nested_str_weak(Eth_X23Connected),
-        /* K5   */  be_nested_str_weak(matter_device_udp),
-        }),
-        be_str_weak(_anonymous_),
-        &be_const_str_solidified,
-        ( &(const binstruction[11]) {  /* code */
-          0x68000000,  //  0000  GETUPV	R0	U0
-          0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080000,  //  0002  GETUPV	R2	U0
-          0x88080501,  //  0003  GETMBR	R2	R2	K1
-          0x7C000400,  //  0004  CALL	R0	2
-          0xB8020400,  //  0005  GETNGBL	R0	K2
-          0x8C000103,  //  0006  GETMET	R0	R0	K3
-          0x58080004,  //  0007  LDCONST	R2	K4
-          0x580C0005,  //  0008  LDCONST	R3	K5
-          0x7C000600,  //  0009  CALL	R0	3
-          0x80000000,  //  000A  RET	0
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[44]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(get_option),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(MATTER_OPTION),
-    /* K6   */  be_nested_str_weak(UI),
-    /* K7   */  be_nested_str_weak(plugins),
-    /* K8   */  be_nested_str_weak(vendorid),
-    /* K9   */  be_nested_str_weak(VENDOR_ID),
-    /* K10  */  be_nested_str_weak(productid),
-    /* K11  */  be_nested_str_weak(PRODUCT_ID),
-    /* K12  */  be_nested_str_weak(root_iterations),
-    /* K13  */  be_nested_str_weak(PBKDF_ITERATIONS),
-    /* K14  */  be_nested_str_weak(root_salt),
-    /* K15  */  be_nested_str_weak(random),
-    /* K16  */  be_nested_str_weak(ipv4only),
-    /* K17  */  be_nested_str_weak(load_param),
-    /* K18  */  be_nested_str_weak(sessions),
-    /* K19  */  be_nested_str_weak(Session_Store),
-    /* K20  */  be_nested_str_weak(load_fabrics),
-    /* K21  */  be_nested_str_weak(message_handler),
-    /* K22  */  be_nested_str_weak(MessageHandler),
-    /* K23  */  be_nested_str_weak(ui),
-    /* K24  */  be_nested_str_weak(push),
-    /* K25  */  be_nested_str_weak(Plugin_Root),
-    /* K26  */  be_const_int(0),
-    /* K27  */  be_nested_str_weak(Plugin_OnOff),
-    /* K28  */  be_const_int(1),
-    /* K29  */  be_nested_str_weak(add_cron),
-    /* K30  */  be_nested_str_weak(_X2A_X2F5_X20_X2A_X20_X2A_X20_X2A_X20_X2A_X20_X2A),
-    /* K31  */  be_nested_str_weak(matter_sensors_5s),
-    /* K32  */  be_nested_str_weak(start_mdns_announce_hostnames),
-    /* K33  */  be_nested_str_weak(wifi),
-    /* K34  */  be_nested_str_weak(up),
-    /* K35  */  be_nested_str_weak(start_udp),
-    /* K36  */  be_nested_str_weak(UDP_PORT),
-    /* K37  */  be_nested_str_weak(add_rule),
-    /* K38  */  be_nested_str_weak(Wifi_X23Connected),
-    /* K39  */  be_nested_str_weak(matter_device_udp),
-    /* K40  */  be_nested_str_weak(eth),
-    /* K41  */  be_nested_str_weak(Eth_X23Connected),
-    /* K42  */  be_nested_str_weak(init_basic_commissioning),
-    /* K43  */  be_nested_str_weak(add_driver),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[110]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xB80E0400,  //  0002  GETNGBL	R3	K2
-      0x8C0C0703,  //  0003  GETMET	R3	R3	K3
-      0xB8160800,  //  0004  GETNGBL	R5	K4
-      0x88140B05,  //  0005  GETMBR	R5	R5	K5
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x740E0004,  //  0007  JMPT	R3	#000D
-      0xB80E0800,  //  0008  GETNGBL	R3	K4
-      0x8C0C0706,  //  0009  GETMET	R3	R3	K6
-      0x5C140000,  //  000A  MOVE	R5	R0
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x80000600,  //  000C  RET	0
-      0x600C0012,  //  000D  GETGBL	R3	G18
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x90020E03,  //  000F  SETMBR	R0	K7	R3
-      0x880C0109,  //  0010  GETMBR	R3	R0	K9
-      0x90021003,  //  0011  SETMBR	R0	K8	R3
-      0x880C010B,  //  0012  GETMBR	R3	R0	K11
-      0x90021403,  //  0013  SETMBR	R0	K10	R3
-      0x880C010D,  //  0014  GETMBR	R3	R0	K13
-      0x90021803,  //  0015  SETMBR	R0	K12	R3
-      0x8C0C030F,  //  0016  GETMET	R3	R1	K15
-      0x5416000F,  //  0017  LDINT	R5	16
-      0x7C0C0400,  //  0018  CALL	R3	2
-      0x90021C03,  //  0019  SETMBR	R0	K14	R3
-      0x500C0000,  //  001A  LDBOOL	R3	0	0
-      0x90022003,  //  001B  SETMBR	R0	K16	R3
-      0x8C0C0111,  //  001C  GETMET	R3	R0	K17
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0xB80E0800,  //  001E  GETNGBL	R3	K4
-      0x8C0C0713,  //  001F  GETMET	R3	R3	K19
-      0x7C0C0200,  //  0020  CALL	R3	1
-      0x90022403,  //  0021  SETMBR	R0	K18	R3
-      0x880C0112,  //  0022  GETMBR	R3	R0	K18
-      0x8C0C0714,  //  0023  GETMET	R3	R3	K20
-      0x7C0C0200,  //  0024  CALL	R3	1
-      0xB80E0800,  //  0025  GETNGBL	R3	K4
-      0x8C0C0716,  //  0026  GETMET	R3	R3	K22
-      0x5C140000,  //  0027  MOVE	R5	R0
-      0x7C0C0400,  //  0028  CALL	R3	2
-      0x90022A03,  //  0029  SETMBR	R0	K21	R3
-      0xB80E0800,  //  002A  GETNGBL	R3	K4
-      0x8C0C0706,  //  002B  GETMET	R3	R3	K6
-      0x5C140000,  //  002C  MOVE	R5	R0
-      0x7C0C0400,  //  002D  CALL	R3	2
-      0x90022E03,  //  002E  SETMBR	R0	K23	R3
-      0x880C0107,  //  002F  GETMBR	R3	R0	K7
-      0x8C0C0718,  //  0030  GETMET	R3	R3	K24
-      0xB8160800,  //  0031  GETNGBL	R5	K4
-      0x8C140B19,  //  0032  GETMET	R5	R5	K25
-      0x5C1C0000,  //  0033  MOVE	R7	R0
-      0x5820001A,  //  0034  LDCONST	R8	K26
-      0x7C140600,  //  0035  CALL	R5	3
-      0x7C0C0400,  //  0036  CALL	R3	2
-      0x880C0107,  //  0037  GETMBR	R3	R0	K7
-      0x8C0C0718,  //  0038  GETMET	R3	R3	K24
-      0xB8160800,  //  0039  GETNGBL	R5	K4
-      0x8C140B1B,  //  003A  GETMET	R5	R5	K27
-      0x5C1C0000,  //  003B  MOVE	R7	R0
-      0x5820001C,  //  003C  LDCONST	R8	K28
-      0x5824001A,  //  003D  LDCONST	R9	K26
-      0x7C140800,  //  003E  CALL	R5	4
-      0x7C0C0400,  //  003F  CALL	R3	2
-      0xB80E0400,  //  0040  GETNGBL	R3	K2
-      0x8C0C071D,  //  0041  GETMET	R3	R3	K29
-      0x5814001E,  //  0042  LDCONST	R5	K30
-      0x84180000,  //  0043  CLOSURE	R6	P0
-      0x581C001F,  //  0044  LDCONST	R7	K31
-      0x7C0C0800,  //  0045  CALL	R3	4
-      0x8C0C0120,  //  0046  GETMET	R3	R0	K32
-      0x7C0C0200,  //  0047  CALL	R3	1
-      0xB80E0400,  //  0048  GETNGBL	R3	K2
-      0x8C0C0721,  //  0049  GETMET	R3	R3	K33
-      0x7C0C0200,  //  004A  CALL	R3	1
-      0x940C0722,  //  004B  GETIDX	R3	R3	K34
-      0x780E0003,  //  004C  JMPF	R3	#0051
-      0x8C0C0123,  //  004D  GETMET	R3	R0	K35
-      0x88140124,  //  004E  GETMBR	R5	R0	K36
-      0x7C0C0400,  //  004F  CALL	R3	2
-      0x70020005,  //  0050  JMP		#0057
-      0xB80E0400,  //  0051  GETNGBL	R3	K2
-      0x8C0C0725,  //  0052  GETMET	R3	R3	K37
-      0x58140026,  //  0053  LDCONST	R5	K38
-      0x84180001,  //  0054  CLOSURE	R6	P1
-      0x581C0027,  //  0055  LDCONST	R7	K39
-      0x7C0C0800,  //  0056  CALL	R3	4
-      0xB80E0400,  //  0057  GETNGBL	R3	K2
-      0x8C0C0728,  //  0058  GETMET	R3	R3	K40
-      0x7C0C0200,  //  0059  CALL	R3	1
-      0x940C0722,  //  005A  GETIDX	R3	R3	K34
-      0x780E0003,  //  005B  JMPF	R3	#0060
-      0x8C0C0123,  //  005C  GETMET	R3	R0	K35
-      0x88140124,  //  005D  GETMBR	R5	R0	K36
-      0x7C0C0400,  //  005E  CALL	R3	2
-      0x70020005,  //  005F  JMP		#0066
-      0xB80E0400,  //  0060  GETNGBL	R3	K2
-      0x8C0C0725,  //  0061  GETMET	R3	R3	K37
-      0x58140029,  //  0062  LDCONST	R5	K41
-      0x84180002,  //  0063  CLOSURE	R6	P2
-      0x581C0027,  //  0064  LDCONST	R7	K39
-      0x7C0C0800,  //  0065  CALL	R3	4
-      0x8C0C012A,  //  0066  GETMET	R3	R0	K42
-      0x7C0C0200,  //  0067  CALL	R3	1
-      0xB80E0400,  //  0068  GETNGBL	R3	K2
-      0x8C0C072B,  //  0069  GETMET	R3	R3	K43
-      0x5C140000,  //  006A  MOVE	R5	R0
-      0x7C0C0400,  //  006B  CALL	R3	2
-      0xA0000000,  //  006C  CLOSE	R0
-      0x80000000,  //  006D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_commissioning_open
-********************************************************************/
-be_local_closure(Matter_Device_is_commissioning_open,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    }),
-    be_str_weak(is_commissioning_open),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: compute_pbkdf
-********************************************************************/
-be_local_closure(Matter_Device_compute_pbkdf,   /* name */
-  be_nested_proto(
-    20,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(add),
-    /* K3   */  be_nested_str_weak(PBKDF2_HMAC_SHA256),
-    /* K4   */  be_nested_str_weak(derive),
-    /* K5   */  be_const_int(0),
-    /* K6   */  be_nested_str_weak(root_w0),
-    /* K7   */  be_nested_str_weak(EC_P256),
-    /* K8   */  be_nested_str_weak(mod),
-    /* K9   */  be_nested_str_weak(root_L),
-    /* K10  */  be_nested_str_weak(public_key),
-    /* K11  */  be_nested_str_weak(tasmota),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A_X2A),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20salt_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K15  */  be_nested_str_weak(root_salt),
-    /* K16  */  be_nested_str_weak(tohex),
-    /* K17  */  be_nested_str_weak(MTR_X3A_X20passcode_hex_X20_X20_X3D_X20),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20w0_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20L_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20_X3D_X20),
-    /* K20  */  be_nested_str_weak(compute_manual_pairing_code),
-    /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Manual_X20pairing_X20code_X3A_X20_X25s_X2D_X25s_X2D_X25s),
-    /* K23  */  be_const_int(3),
-    /* K24  */  be_const_int(2147483647),
-    /* K25  */  be_const_int(2),
-    }),
-    be_str_weak(compute_pbkdf),
-    &be_const_str_solidified,
-    ( &(const binstruction[100]) {  /* code */
-      0xA4120000,  //  0000  IMPORT	R4	K0
-      0xA4160200,  //  0001  IMPORT	R5	K1
-      0x60180015,  //  0002  GETGBL	R6	G21
-      0x7C180000,  //  0003  CALL	R6	0
-      0x8C180D02,  //  0004  GETMET	R6	R6	K2
-      0x5C200200,  //  0005  MOVE	R8	R1
-      0x54260003,  //  0006  LDINT	R9	4
-      0x7C180600,  //  0007  CALL	R6	3
-      0x8C1C0903,  //  0008  GETMET	R7	R4	K3
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x8C1C0F04,  //  000A  GETMET	R7	R7	K4
-      0x5C240C00,  //  000B  MOVE	R9	R6
-      0x5C280600,  //  000C  MOVE	R10	R3
-      0x5C2C0400,  //  000D  MOVE	R11	R2
-      0x5432004F,  //  000E  LDINT	R12	80
-      0x7C1C0A00,  //  000F  CALL	R7	5
-      0x54220026,  //  0010  LDINT	R8	39
-      0x40220A08,  //  0011  CONNECT	R8	K5	R8
-      0x94200E08,  //  0012  GETIDX	R8	R7	R8
-      0x54260027,  //  0013  LDINT	R9	40
-      0x542A004E,  //  0014  LDINT	R10	79
-      0x4024120A,  //  0015  CONNECT	R9	R9	R10
-      0x94240E09,  //  0016  GETIDX	R9	R7	R9
-      0x8C280907,  //  0017  GETMET	R10	R4	K7
-      0x7C280200,  //  0018  CALL	R10	1
-      0x8C281508,  //  0019  GETMET	R10	R10	K8
-      0x5C301000,  //  001A  MOVE	R12	R8
-      0x7C280400,  //  001B  CALL	R10	2
-      0x90020C0A,  //  001C  SETMBR	R0	K6	R10
-      0x8C280907,  //  001D  GETMET	R10	R4	K7
-      0x7C280200,  //  001E  CALL	R10	1
-      0x8C281508,  //  001F  GETMET	R10	R10	K8
-      0x5C301200,  //  0020  MOVE	R12	R9
-      0x7C280400,  //  0021  CALL	R10	2
-      0x8C2C0907,  //  0022  GETMET	R11	R4	K7
-      0x7C2C0200,  //  0023  CALL	R11	1
-      0x8C2C170A,  //  0024  GETMET	R11	R11	K10
-      0x5C341400,  //  0025  MOVE	R13	R10
-      0x7C2C0400,  //  0026  CALL	R11	2
-      0x9002120B,  //  0027  SETMBR	R0	K9	R11
-      0xB82E1600,  //  0028  GETNGBL	R11	K11
-      0x8C2C170C,  //  0029  GETMET	R11	R11	K12
-      0x5834000D,  //  002A  LDCONST	R13	K13
-      0x543A0003,  //  002B  LDINT	R14	4
-      0x7C2C0600,  //  002C  CALL	R11	3
-      0xB82E1600,  //  002D  GETNGBL	R11	K11
-      0x8C2C170C,  //  002E  GETMET	R11	R11	K12
-      0x8834010F,  //  002F  GETMBR	R13	R0	K15
-      0x8C341B10,  //  0030  GETMET	R13	R13	K16
-      0x7C340200,  //  0031  CALL	R13	1
-      0x00361C0D,  //  0032  ADD	R13	K14	R13
-      0x543A0003,  //  0033  LDINT	R14	4
-      0x7C2C0600,  //  0034  CALL	R11	3
-      0xB82E1600,  //  0035  GETNGBL	R11	K11
-      0x8C2C170C,  //  0036  GETMET	R11	R11	K12
-      0x8C340D10,  //  0037  GETMET	R13	R6	K16
-      0x7C340200,  //  0038  CALL	R13	1
-      0x0036220D,  //  0039  ADD	R13	K17	R13
-      0x543A0003,  //  003A  LDINT	R14	4
-      0x7C2C0600,  //  003B  CALL	R11	3
-      0xB82E1600,  //  003C  GETNGBL	R11	K11
-      0x8C2C170C,  //  003D  GETMET	R11	R11	K12
-      0x88340106,  //  003E  GETMBR	R13	R0	K6
-      0x8C341B10,  //  003F  GETMET	R13	R13	K16
-      0x7C340200,  //  0040  CALL	R13	1
-      0x0036240D,  //  0041  ADD	R13	K18	R13
-      0x543A0003,  //  0042  LDINT	R14	4
-      0x7C2C0600,  //  0043  CALL	R11	3
-      0xB82E1600,  //  0044  GETNGBL	R11	K11
-      0x8C2C170C,  //  0045  GETMET	R11	R11	K12
-      0x88340109,  //  0046  GETMBR	R13	R0	K9
-      0x8C341B10,  //  0047  GETMET	R13	R13	K16
-      0x7C340200,  //  0048  CALL	R13	1
-      0x0036260D,  //  0049  ADD	R13	K19	R13
-      0x543A0003,  //  004A  LDINT	R14	4
-      0x7C2C0600,  //  004B  CALL	R11	3
-      0xB82E1600,  //  004C  GETNGBL	R11	K11
-      0x8C2C170C,  //  004D  GETMET	R11	R11	K12
-      0x5834000D,  //  004E  LDCONST	R13	K13
-      0x543A0003,  //  004F  LDINT	R14	4
-      0x7C2C0600,  //  0050  CALL	R11	3
-      0x8C2C0114,  //  0051  GETMET	R11	R0	K20
-      0x7C2C0200,  //  0052  CALL	R11	1
-      0xB8321600,  //  0053  GETNGBL	R12	K11
-      0x8C30190C,  //  0054  GETMET	R12	R12	K12
-      0x8C380B15,  //  0055  GETMET	R14	R5	K21
-      0x58400016,  //  0056  LDCONST	R16	K22
-      0x40460B17,  //  0057  CONNECT	R17	K5	K23
-      0x94441611,  //  0058  GETIDX	R17	R11	R17
-      0x544A0003,  //  0059  LDINT	R18	4
-      0x544E0005,  //  005A  LDINT	R19	6
-      0x40482413,  //  005B  CONNECT	R18	R18	R19
-      0x94481612,  //  005C  GETIDX	R18	R11	R18
-      0x544E0006,  //  005D  LDINT	R19	7
-      0x404C2718,  //  005E  CONNECT	R19	R19	K24
-      0x944C1613,  //  005F  GETIDX	R19	R11	R19
-      0x7C380A00,  //  0060  CALL	R14	5
-      0x583C0019,  //  0061  LDCONST	R15	K25
-      0x7C300600,  //  0062  CALL	R12	3
-      0x80000000,  //  0063  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: invoke_request
-********************************************************************/
-be_local_closure(Matter_Device_invoke_request,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(endpoint),
-    /* K2   */  be_nested_str_weak(plugins),
-    /* K3   */  be_nested_str_weak(invoke_request),
-    /* K4   */  be_const_int(1),
-    /* K5   */  be_nested_str_weak(status),
-    /* K6   */  be_nested_str_weak(matter),
-    /* K7   */  be_nested_str_weak(UNSUPPORTED_ENDPOINT),
-    }),
-    be_str_weak(invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58100000,  //  0000  LDCONST	R4	K0
-      0x88140701,  //  0001  GETMBR	R5	R3	K1
-      0x6018000C,  //  0002  GETGBL	R6	G12
-      0x881C0102,  //  0003  GETMBR	R7	R0	K2
-      0x7C180200,  //  0004  CALL	R6	1
-      0x14180806,  //  0005  LT	R6	R4	R6
-      0x781A000C,  //  0006  JMPF	R6	#0014
-      0x88180102,  //  0007  GETMBR	R6	R0	K2
-      0x94180C04,  //  0008  GETIDX	R6	R6	R4
-      0x881C0D01,  //  0009  GETMBR	R7	R6	K1
-      0x1C1C0E05,  //  000A  EQ	R7	R7	R5
-      0x781E0005,  //  000B  JMPF	R7	#0012
-      0x8C1C0D03,  //  000C  GETMET	R7	R6	K3
-      0x5C240200,  //  000D  MOVE	R9	R1
-      0x5C280400,  //  000E  MOVE	R10	R2
-      0x5C2C0600,  //  000F  MOVE	R11	R3
-      0x7C1C0800,  //  0010  CALL	R7	4
-      0x80040E00,  //  0011  RET	1	R7
-      0x00100904,  //  0012  ADD	R4	R4	K4
-      0x7001FFED,  //  0013  JMP		#0002
-      0xB81A0C00,  //  0014  GETNGBL	R6	K6
-      0x88180D07,  //  0015  GETMBR	R6	R6	K7
-      0x900E0A06,  //  0016  SETMBR	R3	K5	R6
-      0x80000000,  //  0017  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_Device_every_250ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_commissioning_complete
-********************************************************************/
-be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
+be_local_closure(Matter_Device_start_commissioning_complete_deferred,   /* name */
   be_nested_proto(
     6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2A_X2A_X2A_X20Commissioning_X20complete_X20_X2A_X2A_X2A),
-    /* K3   */  be_const_int(2),
-    /* K4   */  be_nested_str_weak(stop_basic_commissioning),
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        3,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 0),
+          be_local_const_upval(1, 1),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 1]) {     /* constants */
+        /* K0   */  be_nested_str_weak(start_commissioning_complete),
+        }),
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 5]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x68080001,  //  0002  GETUPV	R2	U1
+          0x7C000400,  //  0003  CALL	R0	2
+          0x80040000,  //  0004  RET	1	R0
+        })
+      ),
     }),
-    be_str_weak(start_commissioning_complete),
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(set_timer),
+    /* K2   */  be_const_int(0),
+    }),
+    be_str_weak(start_commissioning_complete_deferred),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
+    ( &(const binstruction[ 7]) {  /* code */
       0xB80A0000,  //  0000  GETNGBL	R2	K0
       0x8C080501,  //  0001  GETMET	R2	R2	K1
       0x58100002,  //  0002  LDCONST	R4	K2
-      0x58140003,  //  0003  LDCONST	R5	K3
+      0x84140000,  //  0003  CLOSURE	R5	P0
       0x7C080600,  //  0004  CALL	R2	3
-      0x8C080104,  //  0005  GETMET	R2	R0	K4
-      0x7C080200,  //  0006  CALL	R2	1
-      0x80000000,  //  0007  RET	0
+      0xA0000000,  //  0005  CLOSE	R0
+      0x80000000,  //  0006  RET	0
     })
   )
 );
@@ -2826,11 +3082,11 @@ be_local_closure(Matter_Device_start_commissioning_complete,   /* name */
 
 
 /********************************************************************
-** Solidified function: compute_manual_pairing_code
+** Solidified function: mdns_remove_op_discovery_all_fabrics
 ********************************************************************/
-be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
+be_local_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
+    6,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2838,380 +3094,39 @@ be_local_closure(Matter_Device_compute_manual_pairing_code,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(root_discriminator),
-    /* K2   */  be_nested_str_weak(root_passcode),
-    /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(_X251i_X2505i_X2504i),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(Verhoeff),
-    /* K7   */  be_nested_str_weak(checksum),
-    }),
-    be_str_weak(compute_manual_pairing_code),
-    &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x540E0FFE,  //  0002  LDINT	R3	4095
-      0x2C080403,  //  0003  AND	R2	R2	R3
-      0x540E0009,  //  0004  LDINT	R3	10
-      0x3C080403,  //  0005  SHR	R2	R2	R3
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x541202FF,  //  0007  LDINT	R4	768
-      0x2C0C0604,  //  0008  AND	R3	R3	R4
-      0x54120005,  //  0009  LDINT	R4	6
-      0x380C0604,  //  000A  SHL	R3	R3	R4
-      0x88100102,  //  000B  GETMBR	R4	R0	K2
-      0x54163FFE,  //  000C  LDINT	R5	16383
-      0x2C100805,  //  000D  AND	R4	R4	R5
-      0x300C0604,  //  000E  OR	R3	R3	R4
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x5416000D,  //  0010  LDINT	R5	14
-      0x3C100805,  //  0011  SHR	R4	R4	R5
-      0x8C140303,  //  0012  GETMET	R5	R1	K3
-      0x581C0004,  //  0013  LDCONST	R7	K4
-      0x5C200400,  //  0014  MOVE	R8	R2
-      0x5C240600,  //  0015  MOVE	R9	R3
-      0x5C280800,  //  0016  MOVE	R10	R4
-      0x7C140A00,  //  0017  CALL	R5	5
-      0xB81A0A00,  //  0018  GETNGBL	R6	K5
-      0x88180D06,  //  0019  GETMBR	R6	R6	K6
-      0x8C180D07,  //  001A  GETMET	R6	R6	K7
-      0x5C200A00,  //  001B  MOVE	R8	R5
-      0x7C180400,  //  001C  CALL	R6	2
-      0x00140A06,  //  001D  ADD	R5	R5	R6
-      0x80040A00,  //  001E  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: remove_fabric
-********************************************************************/
-be_local_closure(Matter_Device_remove_fabric,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(message_handler),
-    /* K1   */  be_nested_str_weak(im),
-    /* K2   */  be_nested_str_weak(subs),
-    /* K3   */  be_nested_str_weak(remove_by_fabric),
-    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
-    /* K5   */  be_nested_str_weak(sessions),
-    /* K6   */  be_nested_str_weak(remove_fabric),
-    /* K7   */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(remove_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x88080501,  //  0001  GETMBR	R2	R2	K1
-      0x88080502,  //  0002  GETMBR	R2	R2	K2
-      0x8C080503,  //  0003  GETMET	R2	R2	K3
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x8C080104,  //  0006  GETMET	R2	R0	K4
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x88080105,  //  0009  GETMBR	R2	R0	K5
-      0x8C080506,  //  000A  GETMET	R2	R2	K6
-      0x5C100200,  //  000B  MOVE	R4	R1
-      0x7C080400,  //  000C  CALL	R2	2
-      0x88080105,  //  000D  GETMBR	R2	R0	K5
-      0x8C080507,  //  000E  GETMET	R2	R2	K7
-      0x7C080200,  //  000F  CALL	R2	1
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: trigger_read_sensors
-********************************************************************/
-be_local_closure(Matter_Device_trigger_read_sensors,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(json),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(read_sensors),
-    /* K3   */  be_nested_str_weak(load),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(plugins),
-    /* K6   */  be_nested_str_weak(parse_sensors),
-    /* K7   */  be_const_int(1),
-    /* K8   */  be_nested_str_weak(log),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20unable_X20to_X20parse_X20read_sensors_X3A_X20),
-    /* K10  */  be_const_int(3),
-    }),
-    be_str_weak(trigger_read_sensors),
-    &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xB80A0200,  //  0001  GETNGBL	R2	K1
-      0x8C080502,  //  0002  GETMET	R2	R2	K2
-      0x7C080200,  //  0003  CALL	R2	1
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C0C0403,  //  0005  EQ	R3	R2	R3
-      0x780E0000,  //  0006  JMPF	R3	#0008
-      0x80000600,  //  0007  RET	0
-      0x8C0C0303,  //  0008  GETMET	R3	R1	K3
-      0x5C140400,  //  0009  MOVE	R5	R2
-      0x7C0C0400,  //  000A  CALL	R3	2
-      0x4C100000,  //  000B  LDNIL	R4
-      0x20100604,  //  000C  NE	R4	R3	R4
-      0x7812000D,  //  000D  JMPF	R4	#001C
-      0x58100004,  //  000E  LDCONST	R4	K4
-      0x6014000C,  //  000F  GETGBL	R5	G12
-      0x88180105,  //  0010  GETMBR	R6	R0	K5
-      0x7C140200,  //  0011  CALL	R5	1
-      0x14140805,  //  0012  LT	R5	R4	R5
-      0x78160006,  //  0013  JMPF	R5	#001B
-      0x88140105,  //  0014  GETMBR	R5	R0	K5
-      0x94140A04,  //  0015  GETIDX	R5	R5	R4
-      0x8C140B06,  //  0016  GETMET	R5	R5	K6
-      0x5C1C0600,  //  0017  MOVE	R7	R3
-      0x7C140400,  //  0018  CALL	R5	2
-      0x00100907,  //  0019  ADD	R4	R4	K7
-      0x7001FFF3,  //  001A  JMP		#000F
-      0x70020007,  //  001B  JMP		#0024
-      0xB8120200,  //  001C  GETNGBL	R4	K1
-      0x8C100908,  //  001D  GETMET	R4	R4	K8
-      0x60180008,  //  001E  GETGBL	R6	G8
-      0x5C1C0400,  //  001F  MOVE	R7	R2
-      0x7C180200,  //  0020  CALL	R6	1
-      0x001A1206,  //  0021  ADD	R6	K9	R6
-      0x581C000A,  //  0022  LDCONST	R7	K10
-      0x7C100600,  //  0023  CALL	R4	3
-      0x80000000,  //  0024  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save_before_restart
-********************************************************************/
-be_local_closure(Matter_Device_save_before_restart,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(stop_basic_commissioning),
-    /* K1   */  be_nested_str_weak(mdns_remove_op_discovery_all_fabrics),
-    }),
-    be_str_weak(save_before_restart),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: mdns_remove_op_discovery
-********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_op_discovery,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(sessions),
+    /* K1   */  be_nested_str_weak(active_fabrics),
     /* K2   */  be_nested_str_weak(get_device_id),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(reverse),
-    /* K5   */  be_nested_str_weak(get_fabric_compressed),
-    /* K6   */  be_nested_str_weak(tohex),
-    /* K7   */  be_nested_str_weak(_X2D),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(eth),
-    /* K10  */  be_nested_str_weak(find),
-    /* K11  */  be_nested_str_weak(up),
-    /* K12  */  be_nested_str_weak(log),
-    /* K13  */  be_nested_str_weak(format),
-    /* K14  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K15  */  be_const_int(2),
-    /* K16  */  be_nested_str_weak(remove_service),
-    /* K17  */  be_nested_str_weak(_matter),
-    /* K18  */  be_nested_str_weak(_tcp),
-    /* K19  */  be_nested_str_weak(hostname_eth),
-    /* K20  */  be_nested_str_weak(wifi),
-    /* K21  */  be_nested_str_weak(hostname_wifi),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K23  */  be_nested_str_weak(_X7C),
+    /* K3   */  be_nested_str_weak(get_fabric_id),
+    /* K4   */  be_nested_str_weak(mdns_remove_op_discovery),
+    /* K5   */  be_nested_str_weak(stop_iteration),
     }),
-    be_str_weak(mdns_remove_op_discovery),
+    be_str_weak(mdns_remove_op_discovery_all_fabrics),
     &be_const_str_solidified,
-    ( &(const binstruction[81]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA802003B,  //  0002  EXBLK	0	#003F
-      0x8C100302,  //  0003  GETMET	R4	R1	K2
-      0x7C100200,  //  0004  CALL	R4	1
-      0x8C100903,  //  0005  GETMET	R4	R4	K3
-      0x7C100200,  //  0006  CALL	R4	1
-      0x8C100904,  //  0007  GETMET	R4	R4	K4
-      0x7C100200,  //  0008  CALL	R4	1
-      0x8C140305,  //  0009  GETMET	R5	R1	K5
-      0x7C140200,  //  000A  CALL	R5	1
-      0x8C180B06,  //  000B  GETMET	R6	R5	K6
-      0x7C180200,  //  000C  CALL	R6	1
-      0x00180D07,  //  000D  ADD	R6	R6	K7
-      0x8C1C0906,  //  000E  GETMET	R7	R4	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0x00180C07,  //  0010  ADD	R6	R6	R7
-      0xB81E1000,  //  0011  GETNGBL	R7	K8
-      0x8C1C0F09,  //  0012  GETMET	R7	R7	K9
-      0x7C1C0200,  //  0013  CALL	R7	1
-      0x8C1C0F0A,  //  0014  GETMET	R7	R7	K10
-      0x5824000B,  //  0015  LDCONST	R9	K11
-      0x7C1C0400,  //  0016  CALL	R7	2
-      0x781E000E,  //  0017  JMPF	R7	#0027
-      0xB81E1000,  //  0018  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  0019  GETMET	R7	R7	K12
-      0x8C24070D,  //  001A  GETMET	R9	R3	K13
-      0x582C000E,  //  001B  LDCONST	R11	K14
-      0x58300009,  //  001C  LDCONST	R12	K9
-      0x5C340C00,  //  001D  MOVE	R13	R6
-      0x7C240800,  //  001E  CALL	R9	4
-      0x5828000F,  //  001F  LDCONST	R10	K15
-      0x7C1C0600,  //  0020  CALL	R7	3
-      0x8C1C0510,  //  0021  GETMET	R7	R2	K16
-      0x58240011,  //  0022  LDCONST	R9	K17
-      0x58280012,  //  0023  LDCONST	R10	K18
-      0x5C2C0C00,  //  0024  MOVE	R11	R6
-      0x88300113,  //  0025  GETMBR	R12	R0	K19
-      0x7C1C0A00,  //  0026  CALL	R7	5
-      0xB81E1000,  //  0027  GETNGBL	R7	K8
-      0x8C1C0F14,  //  0028  GETMET	R7	R7	K20
-      0x7C1C0200,  //  0029  CALL	R7	1
-      0x8C1C0F0A,  //  002A  GETMET	R7	R7	K10
-      0x5824000B,  //  002B  LDCONST	R9	K11
-      0x7C1C0400,  //  002C  CALL	R7	2
-      0x781E000E,  //  002D  JMPF	R7	#003D
-      0xB81E1000,  //  002E  GETNGBL	R7	K8
-      0x8C1C0F0C,  //  002F  GETMET	R7	R7	K12
-      0x8C24070D,  //  0030  GETMET	R9	R3	K13
-      0x582C000E,  //  0031  LDCONST	R11	K14
-      0x58300014,  //  0032  LDCONST	R12	K20
-      0x5C340C00,  //  0033  MOVE	R13	R6
-      0x7C240800,  //  0034  CALL	R9	4
-      0x5828000F,  //  0035  LDCONST	R10	K15
-      0x7C1C0600,  //  0036  CALL	R7	3
-      0x8C1C0510,  //  0037  GETMET	R7	R2	K16
-      0x58240011,  //  0038  LDCONST	R9	K17
-      0x58280012,  //  0039  LDCONST	R10	K18
-      0x5C2C0C00,  //  003A  MOVE	R11	R6
-      0x88300115,  //  003B  GETMBR	R12	R0	K21
-      0x7C1C0A00,  //  003C  CALL	R7	5
-      0xA8040001,  //  003D  EXBLK	1	1
-      0x70020010,  //  003E  JMP		#0050
-      0xAC100002,  //  003F  CATCH	R4	0	2
-      0x7002000D,  //  0040  JMP		#004F
-      0xB81A1000,  //  0041  GETNGBL	R6	K8
-      0x8C180D0C,  //  0042  GETMET	R6	R6	K12
-      0x60200008,  //  0043  GETGBL	R8	G8
-      0x5C240800,  //  0044  MOVE	R9	R4
-      0x7C200200,  //  0045  CALL	R8	1
-      0x00222C08,  //  0046  ADD	R8	K22	R8
-      0x00201117,  //  0047  ADD	R8	R8	K23
-      0x60240008,  //  0048  GETGBL	R9	G8
-      0x5C280A00,  //  0049  MOVE	R10	R5
-      0x7C240200,  //  004A  CALL	R9	1
-      0x00201009,  //  004B  ADD	R8	R8	R9
-      0x5824000F,  //  004C  LDCONST	R9	K15
-      0x7C180600,  //  004D  CALL	R6	3
-      0x70020000,  //  004E  JMP		#0050
-      0xB0080000,  //  004F  RAISE	2	R0	R0
-      0x80000000,  //  0050  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: stop_basic_commissioning
-********************************************************************/
-be_local_closure(Matter_Device_stop_basic_commissioning,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(mdns_remove_PASE),
-    /* K2   */  be_nested_str_weak(commissioning_iterations),
-    /* K3   */  be_nested_str_weak(commissioning_discriminator),
-    /* K4   */  be_nested_str_weak(commissioning_salt),
-    /* K5   */  be_nested_str_weak(commissioning_w0),
-    /* K6   */  be_nested_str_weak(commissioning_L),
-    /* K7   */  be_nested_str_weak(commissioning_admin_fabric),
-    }),
-    be_str_weak(stop_basic_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x8C040101,  //  0002  GETMET	R1	R0	K1
-      0x7C040200,  //  0003  CALL	R1	1
-      0x4C040000,  //  0004  LDNIL	R1
-      0x90020401,  //  0005  SETMBR	R0	K2	R1
-      0x4C040000,  //  0006  LDNIL	R1
-      0x90020601,  //  0007  SETMBR	R0	K3	R1
-      0x4C040000,  //  0008  LDNIL	R1
-      0x90020801,  //  0009  SETMBR	R0	K4	R1
-      0x4C040000,  //  000A  LDNIL	R1
-      0x90020A01,  //  000B  SETMBR	R0	K5	R1
-      0x4C040000,  //  000C  LDNIL	R1
-      0x90020C01,  //  000D  SETMBR	R0	K6	R1
-      0x4C040000,  //  000E  LDNIL	R1
-      0x90020E01,  //  000F  SETMBR	R0	K7	R1
-      0x80000000,  //  0010  RET	0
+    ( &(const binstruction[22]) {  /* code */
+      0x60040010,  //  0000  GETGBL	R1	G16
+      0x88080100,  //  0001  GETMBR	R2	R0	K0
+      0x8C080501,  //  0002  GETMET	R2	R2	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x7C040200,  //  0004  CALL	R1	1
+      0xA802000B,  //  0005  EXBLK	0	#0012
+      0x5C080200,  //  0006  MOVE	R2	R1
+      0x7C080000,  //  0007  CALL	R2	0
+      0x8C0C0502,  //  0008  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x780E0005,  //  000A  JMPF	R3	#0011
+      0x8C0C0503,  //  000B  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x780E0002,  //  000D  JMPF	R3	#0011
+      0x8C0C0104,  //  000E  GETMET	R3	R0	K4
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x7C0C0400,  //  0010  CALL	R3	2
+      0x7001FFF3,  //  0011  JMP		#0006
+      0x58040005,  //  0012  LDCONST	R1	K5
+      0xAC040200,  //  0013  CATCH	R1	1	0
+      0xB0080000,  //  0014  RAISE	2	R0	R0
+      0x80000000,  //  0015  RET	0
     })
   )
 );
@@ -3252,86 +3167,223 @@ be_local_closure(Matter_Device_msg_received,   /* name */
 
 
 /********************************************************************
-** Solidified function: start_udp
+** Solidified function: _mdns_announce_hostname
 ********************************************************************/
-be_local_closure(Matter_Device_start_udp,   /* name */
+be_local_closure(Matter_Device__mdns_announce_hostname,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    16,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 0),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(msg_received),
-        }),
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x8C0C0700,  //  0001  GETMET	R3	R3	K0
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20starting_X20UDP_X20server_X20on_X20port_X3A_X20),
-    /* K4   */  be_const_int(2),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(UDPServer),
-    /* K7   */  be_nested_str_weak(),
-    /* K8   */  be_nested_str_weak(start),
+    ( &(const bvalue[28]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mdns),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(start),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(eth),
+    /* K5   */  be_nested_str_weak(hostname_eth),
+    /* K6   */  be_nested_str_weak(replace),
+    /* K7   */  be_nested_str_weak(find),
+    /* K8   */  be_nested_str_weak(mac),
+    /* K9   */  be_nested_str_weak(_X3A),
+    /* K10  */  be_nested_str_weak(),
+    /* K11  */  be_nested_str_weak(ipv4only),
+    /* K12  */  be_nested_str_weak(log),
+    /* K13  */  be_nested_str_weak(format),
+    /* K14  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
+    /* K15  */  be_nested_str_weak(ip6local),
+    /* K16  */  be_nested_str_weak(ip),
+    /* K17  */  be_const_int(3),
+    /* K18  */  be_nested_str_weak(add_hostname),
+    /* K19  */  be_nested_str_weak(ip6),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eadd_hostname_X28_X25s_X2C_X20_X25s_X29),
+    /* K21  */  be_nested_str_weak(wifi),
+    /* K22  */  be_nested_str_weak(hostname_wifi),
+    /* K23  */  be_nested_str_weak(MTR_X3A_X20start_X20mDNS_X20on_X20_X25s_X20host_X20_X27_X25s_X2Elocal_X27),
+    /* K24  */  be_const_int(2),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20Exception),
+    /* K26  */  be_nested_str_weak(_X7C),
+    /* K27  */  be_nested_str_weak(mdns_announce_op_discovery_all_fabrics),
     }),
-    be_str_weak(start_udp),
+    be_str_weak(_mdns_announce_hostname),
     &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A0000,  //  0001  JMPF	R2	#0003
-      0x80000400,  //  0002  RET	0
-      0x4C080000,  //  0003  LDNIL	R2
-      0x1C080202,  //  0004  EQ	R2	R1	R2
-      0x780A0000,  //  0005  JMPF	R2	#0007
-      0x540615A3,  //  0006  LDINT	R1	5540
-      0xB80A0200,  //  0007  GETNGBL	R2	K1
-      0x8C080502,  //  0008  GETMET	R2	R2	K2
-      0x60100008,  //  0009  GETGBL	R4	G8
-      0x5C140200,  //  000A  MOVE	R5	R1
-      0x7C100200,  //  000B  CALL	R4	1
-      0x00120604,  //  000C  ADD	R4	K3	R4
-      0x58140004,  //  000D  LDCONST	R5	K4
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80A0A00,  //  000F  GETNGBL	R2	K5
-      0x8C080506,  //  0010  GETMET	R2	R2	K6
-      0x58100007,  //  0011  LDCONST	R4	K7
-      0x5C140200,  //  0012  MOVE	R5	R1
-      0x7C080600,  //  0013  CALL	R2	3
-      0x90020002,  //  0014  SETMBR	R0	K0	R2
-      0x88080100,  //  0015  GETMBR	R2	R0	K0
-      0x8C080508,  //  0016  GETMET	R2	R2	K8
-      0x84100000,  //  0017  CLOSURE	R4	P0
-      0x7C080400,  //  0018  CALL	R2	2
-      0xA0000000,  //  0019  CLOSE	R0
-      0x80000000,  //  001A  RET	0
+    ( &(const binstruction[172]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0x8C100502,  //  0002  GETMET	R4	R2	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0xA8020092,  //  0004  EXBLK	0	#0098
+      0x78060040,  //  0005  JMPF	R1	#0047
+      0xB8120600,  //  0006  GETNGBL	R4	K3
+      0x8C100904,  //  0007  GETMET	R4	R4	K4
+      0x7C100200,  //  0008  CALL	R4	1
+      0x8C140706,  //  0009  GETMET	R5	R3	K6
+      0x8C1C0907,  //  000A  GETMET	R7	R4	K7
+      0x58240008,  //  000B  LDCONST	R9	K8
+      0x7C1C0400,  //  000C  CALL	R7	2
+      0x58200009,  //  000D  LDCONST	R8	K9
+      0x5824000A,  //  000E  LDCONST	R9	K10
+      0x7C140800,  //  000F  CALL	R5	4
+      0x90020A05,  //  0010  SETMBR	R0	K5	R5
+      0x8814010B,  //  0011  GETMBR	R5	R0	K11
+      0x7416001F,  //  0012  JMPT	R5	#0033
+      0xB8160600,  //  0013  GETNGBL	R5	K3
+      0x8C140B0C,  //  0014  GETMET	R5	R5	K12
+      0x8C1C070D,  //  0015  GETMET	R7	R3	K13
+      0x5824000E,  //  0016  LDCONST	R9	K14
+      0x88280105,  //  0017  GETMBR	R10	R0	K5
+      0x8C2C0907,  //  0018  GETMET	R11	R4	K7
+      0x5834000F,  //  0019  LDCONST	R13	K15
+      0x5838000A,  //  001A  LDCONST	R14	K10
+      0x7C2C0600,  //  001B  CALL	R11	3
+      0x8C300907,  //  001C  GETMET	R12	R4	K7
+      0x58380010,  //  001D  LDCONST	R14	K16
+      0x583C000A,  //  001E  LDCONST	R15	K10
+      0x7C300600,  //  001F  CALL	R12	3
+      0x7C1C0A00,  //  0020  CALL	R7	5
+      0x58200011,  //  0021  LDCONST	R8	K17
+      0x7C140600,  //  0022  CALL	R5	3
+      0x8C140512,  //  0023  GETMET	R5	R2	K18
+      0x881C0105,  //  0024  GETMBR	R7	R0	K5
+      0x8C200907,  //  0025  GETMET	R8	R4	K7
+      0x5828000F,  //  0026  LDCONST	R10	K15
+      0x582C000A,  //  0027  LDCONST	R11	K10
+      0x7C200600,  //  0028  CALL	R8	3
+      0x8C240907,  //  0029  GETMET	R9	R4	K7
+      0x582C0010,  //  002A  LDCONST	R11	K16
+      0x5830000A,  //  002B  LDCONST	R12	K10
+      0x7C240600,  //  002C  CALL	R9	3
+      0x8C280907,  //  002D  GETMET	R10	R4	K7
+      0x58300013,  //  002E  LDCONST	R12	K19
+      0x5834000A,  //  002F  LDCONST	R13	K10
+      0x7C280600,  //  0030  CALL	R10	3
+      0x7C140A00,  //  0031  CALL	R5	5
+      0x70020012,  //  0032  JMP		#0046
+      0xB8160600,  //  0033  GETNGBL	R5	K3
+      0x8C140B0C,  //  0034  GETMET	R5	R5	K12
+      0x8C1C070D,  //  0035  GETMET	R7	R3	K13
+      0x58240014,  //  0036  LDCONST	R9	K20
+      0x88280105,  //  0037  GETMBR	R10	R0	K5
+      0x8C2C0907,  //  0038  GETMET	R11	R4	K7
+      0x58340010,  //  0039  LDCONST	R13	K16
+      0x5838000A,  //  003A  LDCONST	R14	K10
+      0x7C2C0600,  //  003B  CALL	R11	3
+      0x7C1C0800,  //  003C  CALL	R7	4
+      0x58200011,  //  003D  LDCONST	R8	K17
+      0x7C140600,  //  003E  CALL	R5	3
+      0x8C140512,  //  003F  GETMET	R5	R2	K18
+      0x881C0105,  //  0040  GETMBR	R7	R0	K5
+      0x8C200907,  //  0041  GETMET	R8	R4	K7
+      0x58280010,  //  0042  LDCONST	R10	K16
+      0x582C000A,  //  0043  LDCONST	R11	K10
+      0x7C200600,  //  0044  CALL	R8	3
+      0x7C140600,  //  0045  CALL	R5	3
+      0x7002003F,  //  0046  JMP		#0087
+      0xB8120600,  //  0047  GETNGBL	R4	K3
+      0x8C100915,  //  0048  GETMET	R4	R4	K21
+      0x7C100200,  //  0049  CALL	R4	1
+      0x8C140706,  //  004A  GETMET	R5	R3	K6
+      0x8C1C0907,  //  004B  GETMET	R7	R4	K7
+      0x58240008,  //  004C  LDCONST	R9	K8
+      0x7C1C0400,  //  004D  CALL	R7	2
+      0x58200009,  //  004E  LDCONST	R8	K9
+      0x5824000A,  //  004F  LDCONST	R9	K10
+      0x7C140800,  //  0050  CALL	R5	4
+      0x90022C05,  //  0051  SETMBR	R0	K22	R5
+      0x8814010B,  //  0052  GETMBR	R5	R0	K11
+      0x7416001F,  //  0053  JMPT	R5	#0074
+      0xB8160600,  //  0054  GETNGBL	R5	K3
+      0x8C140B0C,  //  0055  GETMET	R5	R5	K12
+      0x8C1C070D,  //  0056  GETMET	R7	R3	K13
+      0x5824000E,  //  0057  LDCONST	R9	K14
+      0x88280116,  //  0058  GETMBR	R10	R0	K22
+      0x8C2C0907,  //  0059  GETMET	R11	R4	K7
+      0x5834000F,  //  005A  LDCONST	R13	K15
+      0x5838000A,  //  005B  LDCONST	R14	K10
+      0x7C2C0600,  //  005C  CALL	R11	3
+      0x8C300907,  //  005D  GETMET	R12	R4	K7
+      0x58380010,  //  005E  LDCONST	R14	K16
+      0x583C000A,  //  005F  LDCONST	R15	K10
+      0x7C300600,  //  0060  CALL	R12	3
+      0x7C1C0A00,  //  0061  CALL	R7	5
+      0x58200011,  //  0062  LDCONST	R8	K17
+      0x7C140600,  //  0063  CALL	R5	3
+      0x8C140512,  //  0064  GETMET	R5	R2	K18
+      0x881C0116,  //  0065  GETMBR	R7	R0	K22
+      0x8C200907,  //  0066  GETMET	R8	R4	K7
+      0x5828000F,  //  0067  LDCONST	R10	K15
+      0x582C000A,  //  0068  LDCONST	R11	K10
+      0x7C200600,  //  0069  CALL	R8	3
+      0x8C240907,  //  006A  GETMET	R9	R4	K7
+      0x582C0010,  //  006B  LDCONST	R11	K16
+      0x5830000A,  //  006C  LDCONST	R12	K10
+      0x7C240600,  //  006D  CALL	R9	3
+      0x8C280907,  //  006E  GETMET	R10	R4	K7
+      0x58300013,  //  006F  LDCONST	R12	K19
+      0x5834000A,  //  0070  LDCONST	R13	K10
+      0x7C280600,  //  0071  CALL	R10	3
+      0x7C140A00,  //  0072  CALL	R5	5
+      0x70020012,  //  0073  JMP		#0087
+      0xB8160600,  //  0074  GETNGBL	R5	K3
+      0x8C140B0C,  //  0075  GETMET	R5	R5	K12
+      0x8C1C070D,  //  0076  GETMET	R7	R3	K13
+      0x58240014,  //  0077  LDCONST	R9	K20
+      0x88280105,  //  0078  GETMBR	R10	R0	K5
+      0x8C2C0907,  //  0079  GETMET	R11	R4	K7
+      0x58340010,  //  007A  LDCONST	R13	K16
+      0x5838000A,  //  007B  LDCONST	R14	K10
+      0x7C2C0600,  //  007C  CALL	R11	3
+      0x7C1C0800,  //  007D  CALL	R7	4
+      0x58200011,  //  007E  LDCONST	R8	K17
+      0x7C140600,  //  007F  CALL	R5	3
+      0x8C140512,  //  0080  GETMET	R5	R2	K18
+      0x881C0116,  //  0081  GETMBR	R7	R0	K22
+      0x8C200907,  //  0082  GETMET	R8	R4	K7
+      0x58280010,  //  0083  LDCONST	R10	K16
+      0x582C000A,  //  0084  LDCONST	R11	K10
+      0x7C200600,  //  0085  CALL	R8	3
+      0x7C140600,  //  0086  CALL	R5	3
+      0xB8120600,  //  0087  GETNGBL	R4	K3
+      0x8C10090C,  //  0088  GETMET	R4	R4	K12
+      0x8C18070D,  //  0089  GETMET	R6	R3	K13
+      0x58200017,  //  008A  LDCONST	R8	K23
+      0x78060001,  //  008B  JMPF	R1	#008E
+      0x58240004,  //  008C  LDCONST	R9	K4
+      0x70020000,  //  008D  JMP		#008F
+      0x58240015,  //  008E  LDCONST	R9	K21
+      0x78060001,  //  008F  JMPF	R1	#0092
+      0x88280105,  //  0090  GETMBR	R10	R0	K5
+      0x70020000,  //  0091  JMP		#0093
+      0x88280116,  //  0092  GETMBR	R10	R0	K22
+      0x7C180800,  //  0093  CALL	R6	4
+      0x581C0018,  //  0094  LDCONST	R7	K24
+      0x7C100600,  //  0095  CALL	R4	3
+      0xA8040001,  //  0096  EXBLK	1	1
+      0x70020010,  //  0097  JMP		#00A9
+      0xAC100002,  //  0098  CATCH	R4	0	2
+      0x7002000D,  //  0099  JMP		#00A8
+      0xB81A0600,  //  009A  GETNGBL	R6	K3
+      0x8C180D0C,  //  009B  GETMET	R6	R6	K12
+      0x60200008,  //  009C  GETGBL	R8	G8
+      0x5C240800,  //  009D  MOVE	R9	R4
+      0x7C200200,  //  009E  CALL	R8	1
+      0x00223208,  //  009F  ADD	R8	K25	R8
+      0x0020111A,  //  00A0  ADD	R8	R8	K26
+      0x60240008,  //  00A1  GETGBL	R9	G8
+      0x5C280A00,  //  00A2  MOVE	R10	R5
+      0x7C240200,  //  00A3  CALL	R9	1
+      0x00201009,  //  00A4  ADD	R8	R8	R9
+      0x58240018,  //  00A5  LDCONST	R9	K24
+      0x7C180600,  //  00A6  CALL	R6	3
+      0x70020000,  //  00A7  JMP		#00A9
+      0xB0080000,  //  00A8  RAISE	2	R0	R0
+      0x8C10011B,  //  00A9  GETMET	R4	R0	K27
+      0x7C100200,  //  00AA  CALL	R4	1
+      0x80000000,  //  00AB  RET	0
     })
   )
 );
@@ -3339,11 +3391,11 @@ be_local_closure(Matter_Device_start_udp,   /* name */
 
 
 /********************************************************************
-** Solidified function: mdns_remove_PASE
+** Solidified function: stop
 ********************************************************************/
-be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
+be_local_closure(Matter_Device_stop,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    4,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -3351,116 +3403,25 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mdns),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(mdns_pase_eth),
-    /* K3   */  be_nested_str_weak(tasmota),
-    /* K4   */  be_nested_str_weak(log),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20calling_X20mdns_X2Eremove_service_X28_X25s_X2C_X20_X25s_X2C_X20_X25s_X2C_X20_X25s_X29),
-    /* K7   */  be_nested_str_weak(_matterc),
-    /* K8   */  be_nested_str_weak(_udp),
-    /* K9   */  be_nested_str_weak(commissioning_instance_eth),
-    /* K10  */  be_nested_str_weak(hostname_eth),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20remove_X20mDNS_X20on_X20_X25s_X20_X27_X25s_X27),
-    /* K13  */  be_nested_str_weak(eth),
-    /* K14  */  be_const_int(2),
-    /* K15  */  be_nested_str_weak(remove_service),
-    /* K16  */  be_nested_str_weak(mdns_pase_wifi),
-    /* K17  */  be_nested_str_weak(commissioning_instance_wifi),
-    /* K18  */  be_nested_str_weak(hostname_wifi),
-    /* K19  */  be_nested_str_weak(wifi),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20Exception),
-    /* K21  */  be_nested_str_weak(_X7C),
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(remove_driver),
+    /* K2   */  be_nested_str_weak(udp_server),
+    /* K3   */  be_nested_str_weak(stop),
     }),
-    be_str_weak(mdns_remove_PASE),
+    be_str_weak(stop),
     &be_const_str_solidified,
-    ( &(const binstruction[83]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0xA40A0200,  //  0001  IMPORT	R2	K1
-      0xA802003D,  //  0002  EXBLK	0	#0041
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x780E001B,  //  0004  JMPF	R3	#0021
-      0xB80E0600,  //  0005  GETNGBL	R3	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x8C140505,  //  0007  GETMET	R5	R2	K5
-      0x581C0006,  //  0008  LDCONST	R7	K6
-      0x58200007,  //  0009  LDCONST	R8	K7
-      0x58240008,  //  000A  LDCONST	R9	K8
-      0x88280109,  //  000B  GETMBR	R10	R0	K9
-      0x882C010A,  //  000C  GETMBR	R11	R0	K10
-      0x7C140C00,  //  000D  CALL	R5	6
-      0x5818000B,  //  000E  LDCONST	R6	K11
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0xB80E0600,  //  0010  GETNGBL	R3	K3
-      0x8C0C0704,  //  0011  GETMET	R3	R3	K4
-      0x8C140505,  //  0012  GETMET	R5	R2	K5
-      0x581C000C,  //  0013  LDCONST	R7	K12
-      0x5820000D,  //  0014  LDCONST	R8	K13
-      0x88240109,  //  0015  GETMBR	R9	R0	K9
-      0x7C140800,  //  0016  CALL	R5	4
-      0x5818000E,  //  0017  LDCONST	R6	K14
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x500C0000,  //  0019  LDBOOL	R3	0	0
-      0x90020403,  //  001A  SETMBR	R0	K2	R3
-      0x8C0C030F,  //  001B  GETMET	R3	R1	K15
-      0x58140007,  //  001C  LDCONST	R5	K7
-      0x58180008,  //  001D  LDCONST	R6	K8
-      0x881C0109,  //  001E  GETMBR	R7	R0	K9
-      0x8820010A,  //  001F  GETMBR	R8	R0	K10
-      0x7C0C0A00,  //  0020  CALL	R3	5
-      0x880C0110,  //  0021  GETMBR	R3	R0	K16
-      0x780E001B,  //  0022  JMPF	R3	#003F
-      0xB80E0600,  //  0023  GETNGBL	R3	K3
-      0x8C0C0704,  //  0024  GETMET	R3	R3	K4
-      0x8C140505,  //  0025  GETMET	R5	R2	K5
-      0x581C0006,  //  0026  LDCONST	R7	K6
-      0x58200007,  //  0027  LDCONST	R8	K7
-      0x58240008,  //  0028  LDCONST	R9	K8
-      0x88280111,  //  0029  GETMBR	R10	R0	K17
-      0x882C0112,  //  002A  GETMBR	R11	R0	K18
-      0x7C140C00,  //  002B  CALL	R5	6
-      0x5818000B,  //  002C  LDCONST	R6	K11
-      0x7C0C0600,  //  002D  CALL	R3	3
-      0xB80E0600,  //  002E  GETNGBL	R3	K3
-      0x8C0C0704,  //  002F  GETMET	R3	R3	K4
-      0x8C140505,  //  0030  GETMET	R5	R2	K5
-      0x581C000C,  //  0031  LDCONST	R7	K12
-      0x58200013,  //  0032  LDCONST	R8	K19
-      0x88240111,  //  0033  GETMBR	R9	R0	K17
-      0x7C140800,  //  0034  CALL	R5	4
-      0x5818000E,  //  0035  LDCONST	R6	K14
-      0x7C0C0600,  //  0036  CALL	R3	3
-      0x500C0000,  //  0037  LDBOOL	R3	0	0
-      0x90022003,  //  0038  SETMBR	R0	K16	R3
-      0x8C0C030F,  //  0039  GETMET	R3	R1	K15
-      0x58140007,  //  003A  LDCONST	R5	K7
-      0x58180008,  //  003B  LDCONST	R6	K8
-      0x881C0111,  //  003C  GETMBR	R7	R0	K17
-      0x88200112,  //  003D  GETMBR	R8	R0	K18
-      0x7C0C0A00,  //  003E  CALL	R3	5
-      0xA8040001,  //  003F  EXBLK	1	1
-      0x70020010,  //  0040  JMP		#0052
-      0xAC0C0002,  //  0041  CATCH	R3	0	2
-      0x7002000D,  //  0042  JMP		#0051
-      0xB8160600,  //  0043  GETNGBL	R5	K3
-      0x8C140B04,  //  0044  GETMET	R5	R5	K4
-      0x601C0008,  //  0045  GETGBL	R7	G8
-      0x5C200600,  //  0046  MOVE	R8	R3
-      0x7C1C0200,  //  0047  CALL	R7	1
-      0x001E2807,  //  0048  ADD	R7	K20	R7
-      0x001C0F15,  //  0049  ADD	R7	R7	K21
-      0x60200008,  //  004A  GETGBL	R8	G8
-      0x5C240800,  //  004B  MOVE	R9	R4
-      0x7C200200,  //  004C  CALL	R8	1
-      0x001C0E08,  //  004D  ADD	R7	R7	R8
-      0x5820000E,  //  004E  LDCONST	R8	K14
-      0x7C140600,  //  004F  CALL	R5	3
-      0x70020000,  //  0050  JMP		#0052
-      0xB0080000,  //  0051  RAISE	2	R0	R0
-      0x80000000,  //  0052  RET	0
+    ( &(const binstruction[10]) {  /* code */
+      0xB8060000,  //  0000  GETNGBL	R1	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x78060002,  //  0005  JMPF	R1	#0009
+      0x88040102,  //  0006  GETMBR	R1	R0	K2
+      0x8C040303,  //  0007  GETMET	R1	R1	K3
+      0x7C040200,  //  0008  CALL	R1	1
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -3468,9 +3429,9 @@ be_local_closure(Matter_Device_mdns_remove_PASE,   /* name */
 
 
 /********************************************************************
-** Solidified function: is_root_commissioning_open
+** Solidified function: every_250ms
 ********************************************************************/
-be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
+be_local_closure(Matter_Device_every_250ms,   /* name */
   be_nested_proto(
     3,                          /* nstack */
     1,                          /* argc */
@@ -3481,23 +3442,16 @@ be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(commissioning_open),
-    /* K1   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K0   */  be_nested_str_weak(message_handler),
+    /* K1   */  be_nested_str_weak(every_250ms),
     }),
-    be_str_weak(is_root_commissioning_open),
+    be_str_weak(every_250ms),
     &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
+    ( &(const binstruction[ 4]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060003,  //  0003  JMPF	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x74060000,  //  0007  JMPT	R1	#0009
-      0x50040001,  //  0008  LDBOOL	R1	0	1
-      0x50040200,  //  0009  LDBOOL	R1	1	0
-      0x80040200,  //  000A  RET	1	R1
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -3505,114 +3459,142 @@ be_local_closure(Matter_Device_is_root_commissioning_open,   /* name */
 
 
 /********************************************************************
-** Solidified function: finish_commissioning
+** Solidified function: start_basic_commissioning
 ********************************************************************/
-be_local_closure(Matter_Device_finish_commissioning,   /* name */
+be_local_closure(Matter_Device_start_basic_commissioning,   /* name */
   be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(finish_commissioning),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: start_operational_discovery_deferred
-********************************************************************/
-be_local_closure(Matter_Device_start_operational_discovery_deferred,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    13,                          /* nstack */
+    8,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
+    ( &(const struct bproto*[ 2]) {
       be_nested_proto(
-        3,                          /* nstack */
+        4,                          /* nstack */
         0,                          /* argc */
         0,                          /* varg */
         1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
           be_local_const_upval(1, 0),
-          be_local_const_upval(1, 1),
         }),
         0,                          /* has sup protos */
         NULL,                       /* no sub protos */
         1,                          /* has constants */
-        ( &(const bvalue[ 1]) {     /* constants */
-        /* K0   */  be_nested_str_weak(start_operational_discovery),
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Wifi_X23Connected),
         }),
-        be_str_weak(_X3Clambda_X3E),
+        be_str_weak(_anonymous_),
         &be_const_str_solidified,
-        ( &(const binstruction[ 5]) {  /* code */
+        ( &(const binstruction[ 9]) {  /* code */
           0x68000000,  //  0000  GETUPV	R0	U0
           0x8C000100,  //  0001  GETMET	R0	R0	K0
-          0x68080001,  //  0002  GETUPV	R2	U1
-          0x7C000400,  //  0003  CALL	R0	2
-          0x80040000,  //  0004  RET	1	R0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
+        })
+      ),
+      be_nested_proto(
+        4,                          /* nstack */
+        0,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 1]) {  /* upvals */
+          be_local_const_upval(1, 0),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 4]) {     /* constants */
+        /* K0   */  be_nested_str_weak(mdns_announce_PASE),
+        /* K1   */  be_nested_str_weak(tasmota),
+        /* K2   */  be_nested_str_weak(remove_rule),
+        /* K3   */  be_nested_str_weak(Eth_X23Connected),
+        }),
+        be_str_weak(_anonymous_),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 9]) {  /* code */
+          0x68000000,  //  0000  GETUPV	R0	U0
+          0x8C000100,  //  0001  GETMET	R0	R0	K0
+          0x7C000200,  //  0002  CALL	R0	1
+          0xB8020200,  //  0003  GETNGBL	R0	K1
+          0x8C000102,  //  0004  GETMET	R0	R0	K2
+          0x58080003,  //  0005  LDCONST	R2	K3
+          0x580C0000,  //  0006  LDCONST	R3	K0
+          0x7C000600,  //  0007  CALL	R0	3
+          0x80000000,  //  0008  RET	0
         })
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(set_timer),
-    /* K2   */  be_const_int(0),
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(commissioning_open),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(commissioning_iterations),
+    /* K4   */  be_nested_str_weak(commissioning_discriminator),
+    /* K5   */  be_nested_str_weak(commissioning_salt),
+    /* K6   */  be_nested_str_weak(commissioning_w0),
+    /* K7   */  be_nested_str_weak(commissioning_L),
+    /* K8   */  be_nested_str_weak(commissioning_admin_fabric),
+    /* K9   */  be_nested_str_weak(wifi),
+    /* K10  */  be_nested_str_weak(up),
+    /* K11  */  be_nested_str_weak(eth),
+    /* K12  */  be_nested_str_weak(mdns_announce_PASE),
+    /* K13  */  be_nested_str_weak(add_rule),
+    /* K14  */  be_nested_str_weak(Wifi_X23Connected),
+    /* K15  */  be_nested_str_weak(Eth_X23Connected),
     }),
-    be_str_weak(start_operational_discovery_deferred),
+    be_str_weak(start_basic_commissioning),
     &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x58100002,  //  0002  LDCONST	R4	K2
-      0x84140000,  //  0003  CLOSURE	R5	P0
-      0x7C080600,  //  0004  CALL	R2	3
-      0xA0000000,  //  0005  CLOSE	R0
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: packet_ack
-********************************************************************/
-be_local_closure(Matter_Device_packet_ack,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(udp_server),
-    /* K1   */  be_nested_str_weak(packet_ack),
-    }),
-    be_str_weak(packet_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x80040400,  //  0004  RET	1	R2
+    ( &(const binstruction[40]) {  /* code */
+      0xB8220200,  //  0000  GETNGBL	R8	K1
+      0x8C201102,  //  0001  GETMET	R8	R8	K2
+      0x7C200200,  //  0002  CALL	R8	1
+      0x542603E7,  //  0003  LDINT	R9	1000
+      0x08240209,  //  0004  MUL	R9	R1	R9
+      0x00201009,  //  0005  ADD	R8	R8	R9
+      0x90020008,  //  0006  SETMBR	R0	K0	R8
+      0x90020602,  //  0007  SETMBR	R0	K3	R2
+      0x90020803,  //  0008  SETMBR	R0	K4	R3
+      0x90020A04,  //  0009  SETMBR	R0	K5	R4
+      0x90020C05,  //  000A  SETMBR	R0	K6	R5
+      0x90020E06,  //  000B  SETMBR	R0	K7	R6
+      0x90021007,  //  000C  SETMBR	R0	K8	R7
+      0xB8220200,  //  000D  GETNGBL	R8	K1
+      0x8C201109,  //  000E  GETMET	R8	R8	K9
+      0x7C200200,  //  000F  CALL	R8	1
+      0x9420110A,  //  0010  GETIDX	R8	R8	K10
+      0x74220004,  //  0011  JMPT	R8	#0017
+      0xB8220200,  //  0012  GETNGBL	R8	K1
+      0x8C20110B,  //  0013  GETMET	R8	R8	K11
+      0x7C200200,  //  0014  CALL	R8	1
+      0x9420110A,  //  0015  GETIDX	R8	R8	K10
+      0x78220002,  //  0016  JMPF	R8	#001A
+      0x8C20010C,  //  0017  GETMET	R8	R0	K12
+      0x7C200200,  //  0018  CALL	R8	1
+      0x7002000B,  //  0019  JMP		#0026
+      0xB8220200,  //  001A  GETNGBL	R8	K1
+      0x8C20110D,  //  001B  GETMET	R8	R8	K13
+      0x5828000E,  //  001C  LDCONST	R10	K14
+      0x842C0000,  //  001D  CLOSURE	R11	P0
+      0x5830000C,  //  001E  LDCONST	R12	K12
+      0x7C200800,  //  001F  CALL	R8	4
+      0xB8220200,  //  0020  GETNGBL	R8	K1
+      0x8C20110D,  //  0021  GETMET	R8	R8	K13
+      0x5828000F,  //  0022  LDCONST	R10	K15
+      0x842C0001,  //  0023  CLOSURE	R11	P1
+      0x5830000C,  //  0024  LDCONST	R12	K12
+      0x7C200800,  //  0025  CALL	R8	4
+      0xA0000000,  //  0026  CLOSE	R0
+      0x80000000,  //  0027  RET	0
     })
   )
 );
@@ -3688,82 +3670,81 @@ be_local_closure(Matter_Device_every_second,   /* name */
 be_local_class(Matter_Device,
     27,
     NULL,
-    be_nested_map(74,
+    be_nested_map(73,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(save_param, 36), be_const_closure(Matter_Device_save_param_closure) },
-        { be_const_key_weak(commissioning_L, 63), be_const_var(10) },
-        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
-        { be_const_key_weak(every_second, 13), be_const_closure(Matter_Device_every_second_closure) },
-        { be_const_key_weak(udp_server, -1), be_const_var(1) },
-        { be_const_key_weak(commissioning_open, -1), be_const_var(5) },
-        { be_const_key_weak(packet_ack, -1), be_const_closure(Matter_Device_packet_ack_closure) },
-        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
-        { be_const_key_weak(commissioning_admin_fabric, -1), be_const_var(11) },
-        { be_const_key_weak(get_active_endpoints, 26), be_const_closure(Matter_Device_get_active_endpoints_closure) },
-        { be_const_key_weak(init_basic_commissioning, 73), be_const_closure(Matter_Device_init_basic_commissioning_closure) },
-        { be_const_key_weak(finish_commissioning, 41), be_const_closure(Matter_Device_finish_commissioning_closure) },
-        { be_const_key_weak(ipv4only, -1), be_const_var(22) },
-        { be_const_key_weak(mdns_pase_wifi, 30), be_const_var(19) },
-        { be_const_key_weak(load_param, -1), be_const_closure(Matter_Device_load_param_closure) },
-        { be_const_key_weak(productid, -1), be_const_var(17) },
-        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
-        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
-        { be_const_key_weak(start_basic_commissioning, 12), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
-        { be_const_key_weak(message_handler, -1), be_const_var(2) },
-        { be_const_key_weak(sessions, 61), be_const_var(3) },
-        { be_const_key_weak(plugins, -1), be_const_var(0) },
-        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
-        { be_const_key_weak(sort_distinct, 34), be_const_static_closure(Matter_Device_sort_distinct_closure) },
-        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
-        { be_const_key_weak(msg_send, -1), be_const_closure(Matter_Device_msg_send_closure) },
-        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
-        { be_const_key_weak(hostname_wifi, 11), be_const_var(14) },
-        { be_const_key_weak(PBKDF_ITERATIONS, 68), be_const_int(1000) },
-        { be_const_key_weak(commissioning_iterations, -1), be_const_var(6) },
-        { be_const_key_weak(stop, 3), be_const_closure(Matter_Device_stop_closure) },
-        { be_const_key_weak(hostname_eth, 66), be_const_var(15) },
-        { be_const_key_weak(start_commissioning_complete_deferred, 14), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
-        { be_const_key_weak(commissioning_instance_eth, 72), be_const_var(13) },
-        { be_const_key_weak(commissioning_w0, -1), be_const_var(9) },
-        { be_const_key_weak(mdns_remove_PASE, -1), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
-        { be_const_key_weak(is_commissioning_open, -1), be_const_closure(Matter_Device_is_commissioning_open_closure) },
-        { be_const_key_weak(start_udp, -1), be_const_closure(Matter_Device_start_udp_closure) },
-        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
-        { be_const_key_weak(stop_basic_commissioning, 56), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
-        { be_const_key_weak(root_salt, -1), be_const_var(24) },
-        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
-        { be_const_key_weak(commissioning_instance_wifi, 60), be_const_var(12) },
-        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
-        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
-        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
-        { be_const_key_weak(compute_manual_pairing_code, 35), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
-        { be_const_key_weak(start_mdns_announce_hostnames, 40), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
-        { be_const_key_weak(compute_pbkdf, 57), be_const_closure(Matter_Device_compute_pbkdf_closure) },
-        { be_const_key_weak(commissioning_salt, -1), be_const_var(8) },
-        { be_const_key_weak(mdns_pase_eth, -1), be_const_var(18) },
-        { be_const_key_weak(ui, 52), be_const_var(4) },
-        { be_const_key_weak(save_before_restart, -1), be_const_closure(Matter_Device_save_before_restart_closure) },
-        { be_const_key_weak(mdns_remove_op_discovery, -1), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
-        { be_const_key_weak(PRODUCT_ID, 8), be_const_int(32768) },
-        { be_const_key_weak(trigger_read_sensors, -1), be_const_closure(Matter_Device_trigger_read_sensors_closure) },
-        { be_const_key_weak(msg_received, -1), be_const_closure(Matter_Device_msg_received_closure) },
-        { be_const_key_weak(root_w0, 39), be_const_var(25) },
-        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
-        { be_const_key_weak(root_discriminator, -1), be_const_var(20) },
-        { be_const_key_weak(PASE_TIMEOUT, -1), be_const_int(600) },
-        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
-        { be_const_key_weak(root_passcode, -1), be_const_var(21) },
-        { be_const_key_weak(is_root_commissioning_open, -1), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(every_second, 44), be_const_closure(Matter_Device_every_second_closure) },
+        { be_const_key_weak(plugins, 71), be_const_var(0) },
+        { be_const_key_weak(commissioning_open, 46), be_const_var(5) },
+        { be_const_key_weak(start_basic_commissioning, 21), be_const_closure(Matter_Device_start_basic_commissioning_closure) },
         { be_const_key_weak(mdns_announce_op_discovery, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_closure) },
-        { be_const_key_weak(commissioning_discriminator, -1), be_const_var(7) },
-        { be_const_key_weak(process_attribute_expansion, 7), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(get_active_endpoints, 3), be_const_closure(Matter_Device_get_active_endpoints_closure) },
+        { be_const_key_weak(_init_basic_commissioning, 47), be_const_closure(Matter_Device__init_basic_commissioning_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery, 50), be_const_closure(Matter_Device_mdns_remove_op_discovery_closure) },
+        { be_const_key_weak(mdns_announce_op_discovery_all_fabrics, -1), be_const_closure(Matter_Device_mdns_announce_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(mdns_remove_PASE, 22), be_const_closure(Matter_Device_mdns_remove_PASE_closure) },
         { be_const_key_weak(start_operational_discovery_deferred, -1), be_const_closure(Matter_Device_start_operational_discovery_deferred_closure) },
-        { be_const_key_weak(root_L, 2), be_const_var(26) },
-        { be_const_key_weak(compute_qrcode_content, 6), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_Device_every_250ms_closure) },
+        { be_const_key_weak(save_before_restart, 41), be_const_closure(Matter_Device_save_before_restart_closure) },
+        { be_const_key_weak(start_mdns_announce_hostnames, -1), be_const_closure(Matter_Device_start_mdns_announce_hostnames_closure) },
+        { be_const_key_weak(mdns_pase_wifi, -1), be_const_var(19) },
+        { be_const_key_weak(commissioning_w0, -1), be_const_var(9) },
+        { be_const_key_weak(_mdns_announce_hostname, -1), be_const_closure(Matter_Device__mdns_announce_hostname_closure) },
+        { be_const_key_weak(commissioning_discriminator, 39), be_const_var(7) },
+        { be_const_key_weak(invoke_request, -1), be_const_closure(Matter_Device_invoke_request_closure) },
+        { be_const_key_weak(remove_fabric, -1), be_const_closure(Matter_Device_remove_fabric_closure) },
+        { be_const_key_weak(msg_received, 25), be_const_closure(Matter_Device_msg_received_closure) },
+        { be_const_key_weak(mdns_remove_op_discovery_all_fabrics, 59), be_const_closure(Matter_Device_mdns_remove_op_discovery_all_fabrics_closure) },
+        { be_const_key_weak(_compute_pbkdf, -1), be_const_closure(Matter_Device__compute_pbkdf_closure) },
+        { be_const_key_weak(load_param, 38), be_const_closure(Matter_Device_load_param_closure) },
+        { be_const_key_weak(root_salt, 51), be_const_var(24) },
+        { be_const_key_weak(save_param, -1), be_const_closure(Matter_Device_save_param_closure) },
+        { be_const_key_weak(sessions, -1), be_const_var(3) },
+        { be_const_key_weak(start_operational_discovery, -1), be_const_closure(Matter_Device_start_operational_discovery_closure) },
+        { be_const_key_weak(commissioning_L, -1), be_const_var(10) },
+        { be_const_key_weak(udp_server, 14), be_const_var(1) },
+        { be_const_key_weak(PASE_TIMEOUT, 55), be_const_int(600) },
+        { be_const_key_weak(PRODUCT_ID, -1), be_const_int(32768) },
+        { be_const_key_weak(sort_distinct, 65), be_const_static_closure(Matter_Device_sort_distinct_closure) },
+        { be_const_key_weak(UDP_PORT, -1), be_const_int(5540) },
+        { be_const_key_weak(mdns_announce_PASE, -1), be_const_closure(Matter_Device_mdns_announce_PASE_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Device_init_closure) },
+        { be_const_key_weak(hostname_wifi, 20), be_const_var(14) },
+        { be_const_key_weak(compute_qrcode_content, 26), be_const_closure(Matter_Device_compute_qrcode_content_closure) },
+        { be_const_key_weak(stop_basic_commissioning, 42), be_const_closure(Matter_Device_stop_basic_commissioning_closure) },
+        { be_const_key_weak(root_w0, -1), be_const_var(25) },
+        { be_const_key_weak(is_root_commissioning_open, 57), be_const_closure(Matter_Device_is_root_commissioning_open_closure) },
+        { be_const_key_weak(ui, 35), be_const_var(4) },
+        { be_const_key_weak(PASSCODE_DEFAULT, -1), be_const_int(20202021) },
+        { be_const_key_weak(productid, 54), be_const_var(17) },
+        { be_const_key_weak(VENDOR_ID, -1), be_const_int(65521) },
+        { be_const_key_weak(commissioning_admin_fabric, 33), be_const_var(11) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_Device_received_ack_closure) },
+        { be_const_key_weak(_start_udp, 10), be_const_closure(Matter_Device__start_udp_closure) },
+        { be_const_key_weak(message_handler, -1), be_const_var(2) },
+        { be_const_key_weak(commissioning_iterations, -1), be_const_var(6) },
+        { be_const_key_weak(commissioning_instance_eth, -1), be_const_var(13) },
+        { be_const_key_weak(start_commissioning_complete, -1), be_const_closure(Matter_Device_start_commissioning_complete_closure) },
+        { be_const_key_weak(root_passcode, -1), be_const_var(21) },
         { be_const_key_weak(vendorid, -1), be_const_var(16) },
-        { be_const_key_weak(root_iterations, -1), be_const_var(23) },
+        { be_const_key_weak(mdns_pase_eth, 66), be_const_var(18) },
+        { be_const_key_weak(compute_manual_pairing_code, -1), be_const_closure(Matter_Device_compute_manual_pairing_code_closure) },
+        { be_const_key_weak(start_root_basic_commissioning, -1), be_const_closure(Matter_Device_start_root_basic_commissioning_closure) },
+        { be_const_key_weak(process_attribute_expansion, -1), be_const_closure(Matter_Device_process_attribute_expansion_closure) },
+        { be_const_key_weak(root_L, 11), be_const_var(26) },
+        { be_const_key_weak(PBKDF_ITERATIONS, -1), be_const_int(1000) },
+        { be_const_key_weak(root_iterations, 31), be_const_var(23) },
+        { be_const_key_weak(commissioning_salt, -1), be_const_var(8) },
+        { be_const_key_weak(attribute_updated, -1), be_const_closure(Matter_Device_attribute_updated_closure) },
+        { be_const_key_weak(root_discriminator, 23), be_const_var(20) },
+        { be_const_key_weak(start_commissioning_complete_deferred, -1), be_const_closure(Matter_Device_start_commissioning_complete_deferred_closure) },
+        { be_const_key_weak(hostname_eth, 69), be_const_var(15) },
+        { be_const_key_weak(commissioning_instance_wifi, -1), be_const_var(12) },
+        { be_const_key_weak(is_commissioning_open, 16), be_const_closure(Matter_Device_is_commissioning_open_closure) },
+        { be_const_key_weak(stop, -1), be_const_closure(Matter_Device_stop_closure) },
+        { be_const_key_weak(_trigger_read_sensors, -1), be_const_closure(Matter_Device__trigger_read_sensors_closure) },
+        { be_const_key_weak(FILENAME, -1), be_nested_str_weak(_matter_device_X2Ejson) },
+        { be_const_key_weak(ipv4only, -1), be_const_var(22) },
+        { be_const_key_weak(msg_send, 0), be_const_closure(Matter_Device_msg_send_closure) },
     })),
     be_str_weak(Matter_Device)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Expirable.h
@@ -7,6 +7,58 @@
 extern const bclass be_class_Matter_Expirable;
 
 /********************************************************************
+** Solidified function: before_remove
+********************************************************************/
+be_local_closure(Matter_Expirable_before_remove,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(before_remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_no_expiration
+********************************************************************/
+be_local_closure(Matter_Expirable_set_no_expiration,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_expiration),
+    }),
+    be_str_weak(set_no_expiration),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x4C040000,  //  0000  LDNIL	R1
+      0x90020001,  //  0001  SETMBR	R0	K0	R1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: init
 ********************************************************************/
 be_local_closure(Matter_Expirable_init,   /* name */
@@ -35,9 +87,9 @@ be_local_closure(Matter_Expirable_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_persist
+** Solidified function: set_expire_time
 ********************************************************************/
-be_local_closure(Matter_Expirable_set_persist,   /* name */
+be_local_closure(Matter_Expirable_set_expire_time,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     2,                          /* argc */
@@ -48,12 +100,12 @@ be_local_closure(Matter_Expirable_set_persist,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
+    /* K0   */  be_nested_str_weak(_expiration),
     }),
-    be_str_weak(set_persist),
+    be_str_weak(set_expire_time),
     &be_const_str_solidified,
     ( &(const binstruction[ 5]) {  /* code */
-      0x60080017,  //  0000  GETGBL	R2	G23
+      0x60080009,  //  0000  GETGBL	R2	G9
       0x5C0C0200,  //  0001  MOVE	R3	R1
       0x7C080200,  //  0002  CALL	R2	1
       0x90020002,  //  0003  SETMBR	R0	K0	R2
@@ -109,12 +161,12 @@ be_local_closure(Matter_Expirable_has_expired,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_parent_list
+** Solidified function: set_parent_list
 ********************************************************************/
-be_local_closure(Matter_Expirable_get_parent_list,   /* name */
+be_local_closure(Matter_Expirable_set_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
-    1,                          /* argc */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -124,89 +176,11 @@ be_local_closure(Matter_Expirable_get_parent_list,   /* name */
     ( &(const bvalue[ 1]) {     /* constants */
     /* K0   */  be_nested_str_weak(_list),
     }),
-    be_str_weak(get_parent_list),
+    be_str_weak(set_parent_list),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: persist_post
-********************************************************************/
-be_local_closure(Matter_Expirable_persist_post,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(persist_post),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_expire_time
-********************************************************************/
-be_local_closure(Matter_Expirable_set_expire_time,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_expiration),
-    }),
-    be_str_weak(set_expire_time),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x60080009,  //  0000  GETGBL	R2	G9
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x90020002,  //  0003  SETMBR	R0	K0	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: persist_pre
-********************************************************************/
-be_local_closure(Matter_Expirable_persist_pre,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(persist_pre),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80000000,  //  0000  RET	0
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
     })
   )
 );
@@ -231,33 +205,6 @@ be_local_closure(Matter_Expirable_hydrate_post,   /* name */
     &be_const_str_solidified,
     ( &(const binstruction[ 1]) {  /* code */
       0x80000000,  //  0000  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: does_persist
-********************************************************************/
-be_local_closure(Matter_Expirable_does_persist,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_persist),
-    }),
-    be_str_weak(does_persist),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
     })
   )
 );
@@ -308,36 +255,9 @@ be_local_closure(Matter_Expirable_set_expire_in_seconds,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_parent_list
+** Solidified function: get_parent_list
 ********************************************************************/
-be_local_closure(Matter_Expirable_set_parent_list,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_list),
-    }),
-    be_str_weak(set_parent_list),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_no_expiration
-********************************************************************/
-be_local_closure(Matter_Expirable_set_no_expiration,   /* name */
+be_local_closure(Matter_Expirable_get_parent_list,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -348,14 +268,118 @@ be_local_closure(Matter_Expirable_set_no_expiration,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_expiration),
+    /* K0   */  be_nested_str_weak(_list),
     }),
-    be_str_weak(set_no_expiration),
+    be_str_weak(get_parent_list),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x4C040000,  //  0000  LDNIL	R1
-      0x90020001,  //  0001  SETMBR	R0	K0	R1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: does_persist
+********************************************************************/
+be_local_closure(Matter_Expirable_does_persist,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_persist),
+    }),
+    be_str_weak(does_persist),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_persist
+********************************************************************/
+be_local_closure(Matter_Expirable_set_persist,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_persist),
+    }),
+    be_str_weak(set_persist),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x60080017,  //  0000  GETGBL	R2	G23
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x90020002,  //  0003  SETMBR	R0	K0	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: persist_pre
+********************************************************************/
+be_local_closure(Matter_Expirable_persist_pre,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(persist_pre),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: persist_post
+********************************************************************/
+be_local_closure(Matter_Expirable_persist_post,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(persist_post),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80000000,  //  0000  RET	0
     })
   )
 );
@@ -368,23 +392,24 @@ be_local_closure(Matter_Expirable_set_no_expiration,   /* name */
 be_local_class(Matter_Expirable,
     3,
     NULL,
-    be_nested_map(15,
+    be_nested_map(16,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Expirable_init_closure) },
-        { be_const_key_weak(set_persist, -1), be_const_closure(Matter_Expirable_set_persist_closure) },
-        { be_const_key_weak(has_expired, 7), be_const_closure(Matter_Expirable_has_expired_closure) },
-        { be_const_key_weak(_persist, -1), be_const_var(1) },
-        { be_const_key_weak(get_parent_list, 13), be_const_closure(Matter_Expirable_get_parent_list_closure) },
+        { be_const_key_weak(_expiration, -1), be_const_var(2) },
+        { be_const_key_weak(set_no_expiration, 9), be_const_closure(Matter_Expirable_set_no_expiration_closure) },
         { be_const_key_weak(persist_post, -1), be_const_closure(Matter_Expirable_persist_post_closure) },
-        { be_const_key_weak(set_expire_time, -1), be_const_closure(Matter_Expirable_set_expire_time_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Expirable_init_closure) },
+        { be_const_key_weak(has_expired, -1), be_const_closure(Matter_Expirable_has_expired_closure) },
+        { be_const_key_weak(set_expire_time, 6), be_const_closure(Matter_Expirable_set_expire_time_closure) },
+        { be_const_key_weak(set_parent_list, 4), be_const_closure(Matter_Expirable_set_parent_list_closure) },
+        { be_const_key_weak(hydrate_post, -1), be_const_closure(Matter_Expirable_hydrate_post_closure) },
+        { be_const_key_weak(set_expire_in_seconds, -1), be_const_closure(Matter_Expirable_set_expire_in_seconds_closure) },
+        { be_const_key_weak(get_parent_list, 8), be_const_closure(Matter_Expirable_get_parent_list_closure) },
         { be_const_key_weak(_list, -1), be_const_var(0) },
         { be_const_key_weak(does_persist, -1), be_const_closure(Matter_Expirable_does_persist_closure) },
-        { be_const_key_weak(hydrate_post, 8), be_const_closure(Matter_Expirable_hydrate_post_closure) },
-        { be_const_key_weak(set_expire_in_seconds, 3), be_const_closure(Matter_Expirable_set_expire_in_seconds_closure) },
-        { be_const_key_weak(_expiration, 10), be_const_var(2) },
-        { be_const_key_weak(set_parent_list, -1), be_const_closure(Matter_Expirable_set_parent_list_closure) },
+        { be_const_key_weak(set_persist, -1), be_const_closure(Matter_Expirable_set_persist_closure) },
         { be_const_key_weak(persist_pre, -1), be_const_closure(Matter_Expirable_persist_pre_closure) },
-        { be_const_key_weak(set_no_expiration, -1), be_const_closure(Matter_Expirable_set_no_expiration_closure) },
+        { be_const_key_weak(_persist, 2), be_const_var(1) },
+        { be_const_key_weak(before_remove, 0), be_const_closure(Matter_Expirable_before_remove_closure) },
     })),
     be_str_weak(Matter_Expirable)
 );
@@ -440,6 +465,125 @@ be_local_closure(Matter_Expirable_list_count_persistables,   /* name */
 
 
 /********************************************************************
+** Solidified function: remove
+********************************************************************/
+be_local_closure(Matter_Expirable_list_remove,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(before_remove),
+    /* K2   */  be_nested_str_weak(remove),
+    }),
+    be_str_weak(remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x28080300,  //  0000  GE	R2	R1	K0
+      0x780A0007,  //  0001  JMPF	R2	#000A
+      0x6008000C,  //  0002  GETGBL	R2	G12
+      0x5C0C0000,  //  0003  MOVE	R3	R0
+      0x7C080200,  //  0004  CALL	R2	1
+      0x14080202,  //  0005  LT	R2	R1	R2
+      0x780A0002,  //  0006  JMPF	R2	#000A
+      0x94080001,  //  0007  GETIDX	R2	R0	R1
+      0x8C080501,  //  0008  GETMET	R2	R2	K1
+      0x7C080200,  //  0009  CALL	R2	1
+      0x60080003,  //  000A  GETGBL	R2	G3
+      0x5C0C0000,  //  000B  MOVE	R3	R0
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C080502,  //  000D  GETMET	R2	R2	K2
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x7C080400,  //  000F  CALL	R2	2
+      0x80040400,  //  0010  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: push
+********************************************************************/
+be_local_closure(Matter_Expirable_list_push,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(Expirable),
+    /* K2   */  be_nested_str_weak(type_error),
+    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
+    /* K4   */  be_nested_str_weak(set_parent_list),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(push),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x6008000F,  //  0000  GETGBL	R2	G15
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0xB8120000,  //  0002  GETNGBL	R4	K0
+      0x88100901,  //  0003  GETMBR	R4	R4	K1
+      0x7C080400,  //  0004  CALL	R2	2
+      0x740A0000,  //  0005  JMPT	R2	#0007
+      0xB0060503,  //  0006  RAISE	1	K2	K3
+      0x8C080304,  //  0007  GETMET	R2	R1	K4
+      0x5C100000,  //  0008  MOVE	R4	R0
+      0x7C080400,  //  0009  CALL	R2	2
+      0x60080003,  //  000A  GETGBL	R2	G3
+      0x5C0C0000,  //  000B  MOVE	R3	R0
+      0x7C080200,  //  000C  CALL	R2	1
+      0x8C080505,  //  000D  GETMET	R2	R2	K5
+      0x5C100200,  //  000E  MOVE	R4	R1
+      0x7C080400,  //  000F  CALL	R2	2
+      0x80040400,  //  0010  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_Expirable_list_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(remove_expired),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: remove_expired
 ********************************************************************/
 be_local_closure(Matter_Expirable_list_remove_expired,   /* name */
@@ -484,82 +628,6 @@ be_local_closure(Matter_Expirable_list_remove_expired,   /* name */
       0x00080504,  //  0013  ADD	R2	R2	K4
       0x7001FFEC,  //  0014  JMP		#0002
       0x80040200,  //  0015  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: setitem
-********************************************************************/
-be_local_closure(Matter_Expirable_list_setitem,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(Expirable),
-    /* K2   */  be_nested_str_weak(type_error),
-    /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
-    /* K4   */  be_nested_str_weak(set_parent_list),
-    /* K5   */  be_nested_str_weak(setitem),
-    }),
-    be_str_weak(setitem),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x600C000F,  //  0000  GETGBL	R3	G15
-      0x5C100400,  //  0001  MOVE	R4	R2
-      0xB8160000,  //  0002  GETNGBL	R5	K0
-      0x88140B01,  //  0003  GETMBR	R5	R5	K1
-      0x7C0C0400,  //  0004  CALL	R3	2
-      0x740E0000,  //  0005  JMPT	R3	#0007
-      0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
-      0x5C140000,  //  0008  MOVE	R5	R0
-      0x7C0C0400,  //  0009  CALL	R3	2
-      0x600C0003,  //  000A  GETGBL	R3	G3
-      0x5C100000,  //  000B  MOVE	R4	R0
-      0x7C0C0200,  //  000C  CALL	R3	1
-      0x8C0C0705,  //  000D  GETMET	R3	R3	K5
-      0x5C140200,  //  000E  MOVE	R5	R1
-      0x5C180400,  //  000F  MOVE	R6	R2
-      0x7C0C0600,  //  0010  CALL	R3	3
-      0x80040600,  //  0011  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_Expirable_list_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(remove_expired),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -626,12 +694,12 @@ be_local_closure(Matter_Expirable_list_persistables,   /* name */
 
 
 /********************************************************************
-** Solidified function: push
+** Solidified function: setitem
 ********************************************************************/
-be_local_closure(Matter_Expirable_list_push,   /* name */
+be_local_closure(Matter_Expirable_list_setitem,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
+    7,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -644,28 +712,29 @@ be_local_closure(Matter_Expirable_list_push,   /* name */
     /* K2   */  be_nested_str_weak(type_error),
     /* K3   */  be_nested_str_weak(argument_X20must_X20be_X20of_X20class_X20_X27Expirable_X27),
     /* K4   */  be_nested_str_weak(set_parent_list),
-    /* K5   */  be_nested_str_weak(push),
+    /* K5   */  be_nested_str_weak(setitem),
     }),
-    be_str_weak(push),
+    be_str_weak(setitem),
     &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x6008000F,  //  0000  GETGBL	R2	G15
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0xB8120000,  //  0002  GETNGBL	R4	K0
-      0x88100901,  //  0003  GETMBR	R4	R4	K1
-      0x7C080400,  //  0004  CALL	R2	2
-      0x740A0000,  //  0005  JMPT	R2	#0007
+    ( &(const binstruction[18]) {  /* code */
+      0x600C000F,  //  0000  GETGBL	R3	G15
+      0x5C100400,  //  0001  MOVE	R4	R2
+      0xB8160000,  //  0002  GETNGBL	R5	K0
+      0x88140B01,  //  0003  GETMBR	R5	R5	K1
+      0x7C0C0400,  //  0004  CALL	R3	2
+      0x740E0000,  //  0005  JMPT	R3	#0007
       0xB0060503,  //  0006  RAISE	1	K2	K3
-      0x8C080304,  //  0007  GETMET	R2	R1	K4
-      0x5C100000,  //  0008  MOVE	R4	R0
-      0x7C080400,  //  0009  CALL	R2	2
-      0x60080003,  //  000A  GETGBL	R2	G3
-      0x5C0C0000,  //  000B  MOVE	R3	R0
-      0x7C080200,  //  000C  CALL	R2	1
-      0x8C080505,  //  000D  GETMET	R2	R2	K5
-      0x5C100200,  //  000E  MOVE	R4	R1
-      0x7C080400,  //  000F  CALL	R2	2
-      0x80040400,  //  0010  RET	1	R2
+      0x8C0C0504,  //  0007  GETMET	R3	R2	K4
+      0x5C140000,  //  0008  MOVE	R5	R0
+      0x7C0C0400,  //  0009  CALL	R3	2
+      0x600C0003,  //  000A  GETGBL	R3	G3
+      0x5C100000,  //  000B  MOVE	R4	R0
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x8C0C0705,  //  000D  GETMET	R3	R3	K5
+      0x5C140200,  //  000E  MOVE	R5	R1
+      0x5C180400,  //  000F  MOVE	R6	R2
+      0x7C0C0600,  //  0010  CALL	R3	3
+      0x80040600,  //  0011  RET	1	R3
     })
   )
 );
@@ -679,14 +748,15 @@ extern const bclass be_class_list;
 be_local_class(Matter_Expirable_list,
     0,
     &be_class_list,
-    be_nested_map(6,
+    be_nested_map(7,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(count_persistables, -1), be_const_closure(Matter_Expirable_list_count_persistables_closure) },
+        { be_const_key_weak(count_persistables, 4), be_const_closure(Matter_Expirable_list_count_persistables_closure) },
+        { be_const_key_weak(remove, -1), be_const_closure(Matter_Expirable_list_remove_closure) },
+        { be_const_key_weak(push, 5), be_const_closure(Matter_Expirable_list_push_closure) },
         { be_const_key_weak(every_second, -1), be_const_closure(Matter_Expirable_list_every_second_closure) },
-        { be_const_key_weak(setitem, -1), be_const_closure(Matter_Expirable_list_setitem_closure) },
-        { be_const_key_weak(remove_expired, 1), be_const_closure(Matter_Expirable_list_remove_expired_closure) },
+        { be_const_key_weak(setitem, 6), be_const_closure(Matter_Expirable_list_setitem_closure) },
         { be_const_key_weak(persistables, -1), be_const_closure(Matter_Expirable_list_persistables_closure) },
-        { be_const_key_weak(push, -1), be_const_closure(Matter_Expirable_list_push_closure) },
+        { be_const_key_weak(remove_expired, -1), be_const_closure(Matter_Expirable_list_remove_expired_closure) },
     })),
     be_str_weak(Matter_Expirable_list)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM.h
@@ -7,55 +7,142 @@
 extern const bclass be_class_Matter_IM;
 
 /********************************************************************
-** Solidified function: expire_sendqueue
+** Solidified function: subscribe_request
 ********************************************************************/
-be_local_closure(Matter_IM_expire_sendqueue,   /* name */
+be_local_closure(Matter_IM_subscribe_request,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
+    19,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(reached_timeout),
-    /* K6   */  be_nested_str_weak(remove),
-    /* K7   */  be_const_int(1),
+    ( &(const bvalue[33]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(keep_subscriptions),
+    /* K5   */  be_nested_str_weak(subs_shop),
+    /* K6   */  be_nested_str_weak(remove_by_session),
+    /* K7   */  be_nested_str_weak(session),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeRequestMessage_X3D),
+    /* K11  */  be_const_int(3),
+    /* K12  */  be_nested_str_weak(new_subscription),
+    /* K13  */  be_nested_str_weak(Path),
+    /* K14  */  be_nested_str_weak(attributes_requests),
+    /* K15  */  be_nested_str_weak(endpoint),
+    /* K16  */  be_nested_str_weak(cluster),
+    /* K17  */  be_nested_str_weak(attribute),
+    /* K18  */  be_nested_str_weak(push),
+    /* K19  */  be_nested_str_weak(stop_iteration),
+    /* K20  */  be_nested_str_weak(format),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X28_X256i_X29_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X2C_X20keep_X3D_X25i_X29_X20sub_X3D_X25i),
+    /* K22  */  be_nested_str_weak(local_session_id),
+    /* K23  */  be_nested_str_weak(concat),
+    /* K24  */  be_nested_str_weak(_X20),
+    /* K25  */  be_nested_str_weak(min_interval),
+    /* K26  */  be_nested_str_weak(max_interval),
+    /* K27  */  be_const_int(1),
+    /* K28  */  be_const_int(0),
+    /* K29  */  be_nested_str_weak(subscription_id),
+    /* K30  */  be_const_int(2),
+    /* K31  */  be_nested_str_weak(_inner_process_read_request),
+    /* K32  */  be_nested_str_weak(send_subscribe_response),
     }),
-    be_str_weak(expire_sendqueue),
+    be_str_weak(subscribe_request),
     &be_const_str_solidified,
-    ( &(const binstruction[24]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A000F,  //  0005  JMPF	R2	#0016
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E0006,  //  000C  JMPF	R3	#0014
-      0x8C0C0505,  //  000D  GETMET	R3	R2	K5
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
-      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
-      0x5C140200,  //  0011  MOVE	R5	R1
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0x70020000,  //  0013  JMP		#0015
-      0x00040307,  //  0014  ADD	R1	R1	K7
-      0x7001FFEA,  //  0015  JMP		#0001
-      0x4C080000,  //  0016  LDNIL	R2
-      0x80040400,  //  0017  RET	1	R2
+    ( &(const binstruction[86]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0x88140904,  //  0007  GETMBR	R5	R4	K4
+      0x74160003,  //  0008  JMPT	R5	#000D
+      0x88140105,  //  0009  GETMBR	R5	R0	K5
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x881C0307,  //  000B  GETMBR	R7	R1	K7
+      0x7C140400,  //  000C  CALL	R5	2
+      0xB8161000,  //  000D  GETNGBL	R5	K8
+      0x8C140B09,  //  000E  GETMET	R5	R5	K9
+      0x601C0008,  //  000F  GETGBL	R7	G8
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C1C0200,  //  0011  CALL	R7	1
+      0x001E1407,  //  0012  ADD	R7	K10	R7
+      0x5820000B,  //  0013  LDCONST	R8	K11
+      0x7C140600,  //  0014  CALL	R5	3
+      0x88140105,  //  0015  GETMBR	R5	R0	K5
+      0x8C140B0C,  //  0016  GETMET	R5	R5	K12
+      0x881C0307,  //  0017  GETMBR	R7	R1	K7
+      0x5C200800,  //  0018  MOVE	R8	R4
+      0x7C140600,  //  0019  CALL	R5	3
+      0x60180012,  //  001A  GETGBL	R6	G18
+      0x7C180000,  //  001B  CALL	R6	0
+      0xB81E0200,  //  001C  GETNGBL	R7	K1
+      0x8C1C0F0D,  //  001D  GETMET	R7	R7	K13
+      0x7C1C0200,  //  001E  CALL	R7	1
+      0x60200010,  //  001F  GETGBL	R8	G16
+      0x8824090E,  //  0020  GETMBR	R9	R4	K14
+      0x7C200200,  //  0021  CALL	R8	1
+      0xA802000D,  //  0022  EXBLK	0	#0031
+      0x5C241000,  //  0023  MOVE	R9	R8
+      0x7C240000,  //  0024  CALL	R9	0
+      0x8828130F,  //  0025  GETMBR	R10	R9	K15
+      0x901E1E0A,  //  0026  SETMBR	R7	K15	R10
+      0x88281310,  //  0027  GETMBR	R10	R9	K16
+      0x901E200A,  //  0028  SETMBR	R7	K16	R10
+      0x88281311,  //  0029  GETMBR	R10	R9	K17
+      0x901E220A,  //  002A  SETMBR	R7	K17	R10
+      0x8C280D12,  //  002B  GETMET	R10	R6	K18
+      0x60300008,  //  002C  GETGBL	R12	G8
+      0x5C340E00,  //  002D  MOVE	R13	R7
+      0x7C300200,  //  002E  CALL	R12	1
+      0x7C280400,  //  002F  CALL	R10	2
+      0x7001FFF1,  //  0030  JMP		#0023
+      0x58200013,  //  0031  LDCONST	R8	K19
+      0xAC200200,  //  0032  CATCH	R8	1	0
+      0xB0080000,  //  0033  RAISE	2	R0	R0
+      0xB8221000,  //  0034  GETNGBL	R8	K8
+      0x8C201109,  //  0035  GETMET	R8	R8	K9
+      0x8C280714,  //  0036  GETMET	R10	R3	K20
+      0x58300015,  //  0037  LDCONST	R12	K21
+      0x88340307,  //  0038  GETMBR	R13	R1	K7
+      0x88341B16,  //  0039  GETMBR	R13	R13	K22
+      0x8C380D17,  //  003A  GETMET	R14	R6	K23
+      0x58400018,  //  003B  LDCONST	R16	K24
+      0x7C380400,  //  003C  CALL	R14	2
+      0x883C0B19,  //  003D  GETMBR	R15	R5	K25
+      0x88400B1A,  //  003E  GETMBR	R16	R5	K26
+      0x88440904,  //  003F  GETMBR	R17	R4	K4
+      0x78460001,  //  0040  JMPF	R17	#0043
+      0x5844001B,  //  0041  LDCONST	R17	K27
+      0x70020000,  //  0042  JMP		#0044
+      0x5844001C,  //  0043  LDCONST	R17	K28
+      0x88480B1D,  //  0044  GETMBR	R18	R5	K29
+      0x7C281000,  //  0045  CALL	R10	8
+      0x582C001E,  //  0046  LDCONST	R11	K30
+      0x7C200600,  //  0047  CALL	R8	3
+      0x8C20011F,  //  0048  GETMET	R8	R0	K31
+      0x88280307,  //  0049  GETMBR	R10	R1	K7
+      0x5C2C0800,  //  004A  MOVE	R11	R4
+      0x50300200,  //  004B  LDBOOL	R12	1	0
+      0x7C200800,  //  004C  CALL	R8	4
+      0x88240B1D,  //  004D  GETMBR	R9	R5	K29
+      0x90223A09,  //  004E  SETMBR	R8	K29	R9
+      0x8C240120,  //  004F  GETMET	R9	R0	K32
+      0x5C2C0200,  //  0050  MOVE	R11	R1
+      0x5C301000,  //  0051  MOVE	R12	R8
+      0x5C340A00,  //  0052  MOVE	R13	R5
+      0x7C240800,  //  0053  CALL	R9	4
+      0x50240200,  //  0054  LDBOOL	R9	1	0
+      0x80041200,  //  0055  RET	1	R9
     })
   )
 );
@@ -63,9 +150,135 @@ be_local_closure(Matter_IM_expire_sendqueue,   /* name */
 
 
 /********************************************************************
-** Solidified function: report_data
+** Solidified function: send_subscribe_response
 ********************************************************************/
-be_local_closure(Matter_IM_report_data,   /* name */
+be_local_closure(Matter_IM_send_subscribe_response,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_SubscribeResponse),
+    }),
+    be_str_weak(send_subscribe_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x8C100901,  //  0001  GETMET	R4	R4	K1
+      0xB81A0400,  //  0002  GETNGBL	R6	K2
+      0x8C180D03,  //  0003  GETMET	R6	R6	K3
+      0x5C200200,  //  0004  MOVE	R8	R1
+      0x5C240400,  //  0005  MOVE	R9	R2
+      0x5C280600,  //  0006  MOVE	R10	R3
+      0x7C180800,  //  0007  CALL	R6	4
+      0x7C100400,  //  0008  CALL	R4	2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_write_response
+********************************************************************/
+be_local_closure(Matter_IM_send_write_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_WriteResponse),
+    }),
+    be_str_weak(send_write_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_read_request
+********************************************************************/
+be_local_closure(Matter_IM_process_read_request,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(ReadRequestMessage),
+    /* K2   */  be_nested_str_weak(from_TLV),
+    /* K3   */  be_nested_str_weak(attributes_requests),
+    /* K4   */  be_nested_str_weak(_inner_process_read_request),
+    /* K5   */  be_nested_str_weak(session),
+    /* K6   */  be_nested_str_weak(send_report_data),
+    }),
+    be_str_weak(process_read_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0xB80E0000,  //  0000  GETNGBL	R3	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x7C0C0200,  //  0002  CALL	R3	1
+      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
+      0x5C140400,  //  0004  MOVE	R5	R2
+      0x7C0C0400,  //  0005  CALL	R3	2
+      0x88100703,  //  0006  GETMBR	R4	R3	K3
+      0x4C140000,  //  0007  LDNIL	R5
+      0x20100805,  //  0008  NE	R4	R4	R5
+      0x78120007,  //  0009  JMPF	R4	#0012
+      0x8C100104,  //  000A  GETMET	R4	R0	K4
+      0x88180305,  //  000B  GETMBR	R6	R1	K5
+      0x5C1C0600,  //  000C  MOVE	R7	R3
+      0x7C100600,  //  000D  CALL	R4	3
+      0x8C140106,  //  000E  GETMET	R5	R0	K6
+      0x5C1C0200,  //  000F  MOVE	R7	R1
+      0x5C200800,  //  0010  MOVE	R8	R4
+      0x7C140600,  //  0011  CALL	R5	3
+      0x50100200,  //  0012  LDBOOL	R4	1	0
+      0x80040800,  //  0013  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_write_response
+********************************************************************/
+be_local_closure(Matter_IM_process_write_response,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     3,                          /* argc */
@@ -78,14 +291,14 @@ be_local_closure(Matter_IM_report_data,   /* name */
     ( &(const bvalue[ 8]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(ReportDataMessage),
+    /* K2   */  be_nested_str_weak(WriteResponseMessage),
     /* K3   */  be_nested_str_weak(from_TLV),
     /* K4   */  be_nested_str_weak(tasmota),
     /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20ReportDataMessage_X3D),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteResponseMessage_X3D),
     /* K7   */  be_const_int(2),
     }),
-    be_str_weak(report_data),
+    be_str_weak(process_write_response),
     &be_const_str_solidified,
     ( &(const binstruction[17]) {  /* code */
       0xA40E0000,  //  0000  IMPORT	R3	K0
@@ -105,6 +318,95 @@ be_local_closure(Matter_IM_report_data,   /* name */
       0x7C140600,  //  000E  CALL	R5	3
       0x50140000,  //  000F  LDBOOL	R5	0	0
       0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_status_response
+********************************************************************/
+be_local_closure(Matter_IM_process_status_response,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(findsubval),
+    /* K2   */  be_const_int(0),
+    /* K3   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K4   */  be_nested_str_weak(exchange_id),
+    /* K5   */  be_nested_str_weak(matter),
+    /* K6   */  be_nested_str_weak(SUCCESS),
+    /* K7   */  be_nested_str_weak(status_ok_received),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(log),
+    /* K10  */  be_nested_str_weak(format),
+    /* K11  */  be_nested_str_weak(MTR_X3A_X20_X3EOK_X20_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i_X20not_X20found),
+    /* K12  */  be_nested_str_weak(session),
+    /* K13  */  be_nested_str_weak(local_session_id),
+    /* K14  */  be_const_int(3),
+    /* K15  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
+    /* K16  */  be_const_int(2),
+    /* K17  */  be_nested_str_weak(status_error_received),
+    /* K18  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
+    }),
+    be_str_weak(process_status_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[46]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0x8C100501,  //  0001  GETMET	R4	R2	K1
+      0x58180002,  //  0002  LDCONST	R6	K2
+      0x541E00FE,  //  0003  LDINT	R7	255
+      0x7C100600,  //  0004  CALL	R4	3
+      0x8C140103,  //  0005  GETMET	R5	R0	K3
+      0x881C0304,  //  0006  GETMBR	R7	R1	K4
+      0x7C140400,  //  0007  CALL	R5	2
+      0xB81A0A00,  //  0008  GETNGBL	R6	K5
+      0x88180D06,  //  0009  GETMBR	R6	R6	K6
+      0x1C180806,  //  000A  EQ	R6	R4	R6
+      0x781A0010,  //  000B  JMPF	R6	#001D
+      0x78160004,  //  000C  JMPF	R5	#0012
+      0x8C180B07,  //  000D  GETMET	R6	R5	K7
+      0x5C200200,  //  000E  MOVE	R8	R1
+      0x7C180400,  //  000F  CALL	R6	2
+      0x80040C00,  //  0010  RET	1	R6
+      0x70020009,  //  0011  JMP		#001C
+      0xB81A1000,  //  0012  GETNGBL	R6	K8
+      0x8C180D09,  //  0013  GETMET	R6	R6	K9
+      0x8C20070A,  //  0014  GETMET	R8	R3	K10
+      0x5828000B,  //  0015  LDCONST	R10	K11
+      0x882C030C,  //  0016  GETMBR	R11	R1	K12
+      0x882C170D,  //  0017  GETMBR	R11	R11	K13
+      0x88300304,  //  0018  GETMBR	R12	R1	K4
+      0x7C200800,  //  0019  CALL	R8	4
+      0x5824000E,  //  001A  LDCONST	R9	K14
+      0x7C180600,  //  001B  CALL	R6	3
+      0x7002000E,  //  001C  JMP		#002C
+      0xB81A1000,  //  001D  GETNGBL	R6	K8
+      0x8C180D09,  //  001E  GETMET	R6	R6	K9
+      0x8C20070A,  //  001F  GETMET	R8	R3	K10
+      0x5828000F,  //  0020  LDCONST	R10	K15
+      0x5C2C0800,  //  0021  MOVE	R11	R4
+      0x7C200600,  //  0022  CALL	R8	3
+      0x58240010,  //  0023  LDCONST	R9	K16
+      0x7C180600,  //  0024  CALL	R6	3
+      0x78160005,  //  0025  JMPF	R5	#002C
+      0x8C180B11,  //  0026  GETMET	R6	R5	K17
+      0x5C200200,  //  0027  MOVE	R8	R1
+      0x7C180400,  //  0028  CALL	R6	2
+      0x8C180112,  //  0029  GETMET	R6	R0	K18
+      0x88200304,  //  002A  GETMBR	R8	R1	K4
+      0x7C180400,  //  002B  CALL	R6	2
+      0x50180000,  //  002C  LDBOOL	R6	0	0
+      0x80040C00,  //  002D  RET	1	R6
     })
   )
 );
@@ -475,131 +777,55 @@ be_local_closure(Matter_IM_process_write_request,   /* name */
 
 
 /********************************************************************
-** Solidified function: subscribe_request
+** Solidified function: expire_sendqueue
 ********************************************************************/
-be_local_closure(Matter_IM_subscribe_request,   /* name */
+be_local_closure(Matter_IM_expire_sendqueue,   /* name */
   be_nested_proto(
-    17,                          /* nstack */
-    3,                          /* argc */
+    6,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[30]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(keep_subscriptions),
-    /* K5   */  be_nested_str_weak(subs),
-    /* K6   */  be_nested_str_weak(remove_by_session),
-    /* K7   */  be_nested_str_weak(session),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeRequestMessage_X3D),
-    /* K11  */  be_const_int(3),
-    /* K12  */  be_nested_str_weak(new_subscription),
-    /* K13  */  be_nested_str_weak(Path),
-    /* K14  */  be_nested_str_weak(attributes_requests),
-    /* K15  */  be_nested_str_weak(endpoint),
-    /* K16  */  be_nested_str_weak(cluster),
-    /* K17  */  be_nested_str_weak(attribute),
-    /* K18  */  be_nested_str_weak(push),
-    /* K19  */  be_nested_str_weak(stop_iteration),
-    /* K20  */  be_nested_str_weak(format),
-    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X3ESubscribe_X20_X25s_X20_X28min_X3D_X25i_X2C_X20max_X3D_X25i_X29_X20sub_id_X3D_X25i),
-    /* K22  */  be_nested_str_weak(concat),
-    /* K23  */  be_nested_str_weak(_X20),
-    /* K24  */  be_nested_str_weak(min_interval),
-    /* K25  */  be_nested_str_weak(max_interval),
-    /* K26  */  be_nested_str_weak(subscription_id),
-    /* K27  */  be_const_int(2),
-    /* K28  */  be_nested_str_weak(_inner_process_read_request),
-    /* K29  */  be_nested_str_weak(send_subscribe_response),
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(time_reached),
+    /* K4   */  be_nested_str_weak(expiration),
+    /* K5   */  be_nested_str_weak(reached_timeout),
+    /* K6   */  be_nested_str_weak(remove),
+    /* K7   */  be_const_int(1),
     }),
-    be_str_weak(subscribe_request),
+    be_str_weak(expire_sendqueue),
     &be_const_str_solidified,
-    ( &(const binstruction[78]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0x88140904,  //  0007  GETMBR	R5	R4	K4
-      0x74160003,  //  0008  JMPT	R5	#000D
-      0x88140105,  //  0009  GETMBR	R5	R0	K5
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x881C0307,  //  000B  GETMBR	R7	R1	K7
-      0x7C140400,  //  000C  CALL	R5	2
-      0xB8161000,  //  000D  GETNGBL	R5	K8
-      0x8C140B09,  //  000E  GETMET	R5	R5	K9
-      0x601C0008,  //  000F  GETGBL	R7	G8
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C1C0200,  //  0011  CALL	R7	1
-      0x001E1407,  //  0012  ADD	R7	K10	R7
-      0x5820000B,  //  0013  LDCONST	R8	K11
-      0x7C140600,  //  0014  CALL	R5	3
-      0x88140105,  //  0015  GETMBR	R5	R0	K5
-      0x8C140B0C,  //  0016  GETMET	R5	R5	K12
-      0x881C0307,  //  0017  GETMBR	R7	R1	K7
-      0x5C200800,  //  0018  MOVE	R8	R4
-      0x7C140600,  //  0019  CALL	R5	3
-      0x60180012,  //  001A  GETGBL	R6	G18
-      0x7C180000,  //  001B  CALL	R6	0
-      0xB81E0200,  //  001C  GETNGBL	R7	K1
-      0x8C1C0F0D,  //  001D  GETMET	R7	R7	K13
-      0x7C1C0200,  //  001E  CALL	R7	1
-      0x60200010,  //  001F  GETGBL	R8	G16
-      0x8824090E,  //  0020  GETMBR	R9	R4	K14
-      0x7C200200,  //  0021  CALL	R8	1
-      0xA802000D,  //  0022  EXBLK	0	#0031
-      0x5C241000,  //  0023  MOVE	R9	R8
-      0x7C240000,  //  0024  CALL	R9	0
-      0x8828130F,  //  0025  GETMBR	R10	R9	K15
-      0x901E1E0A,  //  0026  SETMBR	R7	K15	R10
-      0x88281310,  //  0027  GETMBR	R10	R9	K16
-      0x901E200A,  //  0028  SETMBR	R7	K16	R10
-      0x88281311,  //  0029  GETMBR	R10	R9	K17
-      0x901E220A,  //  002A  SETMBR	R7	K17	R10
-      0x8C280D12,  //  002B  GETMET	R10	R6	K18
-      0x60300008,  //  002C  GETGBL	R12	G8
-      0x5C340E00,  //  002D  MOVE	R13	R7
-      0x7C300200,  //  002E  CALL	R12	1
-      0x7C280400,  //  002F  CALL	R10	2
-      0x7001FFF1,  //  0030  JMP		#0023
-      0x58200013,  //  0031  LDCONST	R8	K19
-      0xAC200200,  //  0032  CATCH	R8	1	0
-      0xB0080000,  //  0033  RAISE	2	R0	R0
-      0xB8221000,  //  0034  GETNGBL	R8	K8
-      0x8C201109,  //  0035  GETMET	R8	R8	K9
-      0x8C280714,  //  0036  GETMET	R10	R3	K20
-      0x58300015,  //  0037  LDCONST	R12	K21
-      0x8C340D16,  //  0038  GETMET	R13	R6	K22
-      0x583C0017,  //  0039  LDCONST	R15	K23
-      0x7C340400,  //  003A  CALL	R13	2
-      0x88380B18,  //  003B  GETMBR	R14	R5	K24
-      0x883C0B19,  //  003C  GETMBR	R15	R5	K25
-      0x88400B1A,  //  003D  GETMBR	R16	R5	K26
-      0x7C280C00,  //  003E  CALL	R10	6
-      0x582C001B,  //  003F  LDCONST	R11	K27
-      0x7C200600,  //  0040  CALL	R8	3
-      0x8C20011C,  //  0041  GETMET	R8	R0	K28
-      0x88280307,  //  0042  GETMBR	R10	R1	K7
-      0x5C2C0800,  //  0043  MOVE	R11	R4
-      0x7C200600,  //  0044  CALL	R8	3
-      0x88240B1A,  //  0045  GETMBR	R9	R5	K26
-      0x90223409,  //  0046  SETMBR	R8	K26	R9
-      0x8C24011D,  //  0047  GETMET	R9	R0	K29
-      0x5C2C0200,  //  0048  MOVE	R11	R1
-      0x5C301000,  //  0049  MOVE	R12	R8
-      0x5C340A00,  //  004A  MOVE	R13	R5
-      0x7C240800,  //  004B  CALL	R9	4
-      0x50240200,  //  004C  LDBOOL	R9	1	0
-      0x80041200,  //  004D  RET	1	R9
+    ( &(const binstruction[24]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x14080202,  //  0004  LT	R2	R1	R2
+      0x780A000F,  //  0005  JMPF	R2	#0016
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x94080401,  //  0007  GETIDX	R2	R2	R1
+      0xB80E0400,  //  0008  GETNGBL	R3	K2
+      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
+      0x88140504,  //  000A  GETMBR	R5	R2	K4
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x780E0006,  //  000C  JMPF	R3	#0014
+      0x8C0C0505,  //  000D  GETMET	R3	R2	K5
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x880C0101,  //  000F  GETMBR	R3	R0	K1
+      0x8C0C0706,  //  0010  GETMET	R3	R3	K6
+      0x5C140200,  //  0011  MOVE	R5	R1
+      0x7C0C0400,  //  0012  CALL	R3	2
+      0x70020000,  //  0013  JMP		#0015
+      0x00040307,  //  0014  ADD	R1	R1	K7
+      0x7001FFEA,  //  0015  JMP		#0001
+      0x4C080000,  //  0016  LDNIL	R2
+      0x80040400,  //  0017  RET	1	R2
     })
   )
 );
@@ -637,1504 +863,6 @@ be_local_closure(Matter_IM_send_invoke_response,   /* name */
       0x7C140600,  //  0006  CALL	R5	3
       0x7C0C0400,  //  0007  CALL	R3	2
       0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_status_response
-********************************************************************/
-be_local_closure(Matter_IM_process_status_response,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(findsubval),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K4   */  be_nested_str_weak(exchange_id),
-    /* K5   */  be_nested_str_weak(matter),
-    /* K6   */  be_nested_str_weak(SUCCESS),
-    /* K7   */  be_nested_str_weak(status_ok_received),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(log),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_OK),
-    /* K11  */  be_const_int(2),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3EStatus_X20_X20_X20_X20ERROR_X20_X3D_X200x_X2502X),
-    /* K14  */  be_nested_str_weak(status_error_received),
-    /* K15  */  be_nested_str_weak(remove_sendqueue_by_exchangeid),
-    }),
-    be_str_weak(process_status_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[41]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0x8C100501,  //  0001  GETMET	R4	R2	K1
-      0x58180002,  //  0002  LDCONST	R6	K2
-      0x541E00FE,  //  0003  LDINT	R7	255
-      0x7C100600,  //  0004  CALL	R4	3
-      0x8C140103,  //  0005  GETMET	R5	R0	K3
-      0x881C0304,  //  0006  GETMBR	R7	R1	K4
-      0x7C140400,  //  0007  CALL	R5	2
-      0xB81A0A00,  //  0008  GETNGBL	R6	K5
-      0x88180D06,  //  0009  GETMBR	R6	R6	K6
-      0x1C180806,  //  000A  EQ	R6	R4	R6
-      0x781A000B,  //  000B  JMPF	R6	#0018
-      0x78160004,  //  000C  JMPF	R5	#0012
-      0x8C180B07,  //  000D  GETMET	R6	R5	K7
-      0x5C200200,  //  000E  MOVE	R8	R1
-      0x7C180400,  //  000F  CALL	R6	2
-      0x80040C00,  //  0010  RET	1	R6
-      0x70020004,  //  0011  JMP		#0017
-      0xB81A1000,  //  0012  GETNGBL	R6	K8
-      0x8C180D09,  //  0013  GETMET	R6	R6	K9
-      0x5820000A,  //  0014  LDCONST	R8	K10
-      0x5824000B,  //  0015  LDCONST	R9	K11
-      0x7C180600,  //  0016  CALL	R6	3
-      0x7002000E,  //  0017  JMP		#0027
-      0xB81A1000,  //  0018  GETNGBL	R6	K8
-      0x8C180D09,  //  0019  GETMET	R6	R6	K9
-      0x8C20070C,  //  001A  GETMET	R8	R3	K12
-      0x5828000D,  //  001B  LDCONST	R10	K13
-      0x5C2C0800,  //  001C  MOVE	R11	R4
-      0x7C200600,  //  001D  CALL	R8	3
-      0x5824000B,  //  001E  LDCONST	R9	K11
-      0x7C180600,  //  001F  CALL	R6	3
-      0x78160005,  //  0020  JMPF	R5	#0027
-      0x8C180B0E,  //  0021  GETMET	R6	R5	K14
-      0x5C200200,  //  0022  MOVE	R8	R1
-      0x7C180400,  //  0023  CALL	R6	2
-      0x8C18010F,  //  0024  GETMET	R6	R0	K15
-      0x88200304,  //  0025  GETMBR	R8	R1	K4
-      0x7C180400,  //  0026  CALL	R6	2
-      0x50180000,  //  0027  LDBOOL	R6	0	0
-      0x80040C00,  //  0028  RET	1	R6
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_read_request
-********************************************************************/
-be_local_closure(Matter_IM_process_read_request,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(ReadRequestMessage),
-    /* K2   */  be_nested_str_weak(from_TLV),
-    /* K3   */  be_nested_str_weak(attributes_requests),
-    /* K4   */  be_nested_str_weak(_inner_process_read_request),
-    /* K5   */  be_nested_str_weak(session),
-    /* K6   */  be_nested_str_weak(send_report_data),
-    }),
-    be_str_weak(process_read_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
-      0xB80E0000,  //  0000  GETNGBL	R3	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x7C0C0200,  //  0002  CALL	R3	1
-      0x8C0C0702,  //  0003  GETMET	R3	R3	K2
-      0x5C140400,  //  0004  MOVE	R5	R2
-      0x7C0C0400,  //  0005  CALL	R3	2
-      0x88100703,  //  0006  GETMBR	R4	R3	K3
-      0x4C140000,  //  0007  LDNIL	R5
-      0x20100805,  //  0008  NE	R4	R4	R5
-      0x78120007,  //  0009  JMPF	R4	#0012
-      0x8C100104,  //  000A  GETMET	R4	R0	K4
-      0x88180305,  //  000B  GETMBR	R6	R1	K5
-      0x5C1C0600,  //  000C  MOVE	R7	R3
-      0x7C100600,  //  000D  CALL	R4	3
-      0x8C140106,  //  000E  GETMET	R5	R0	K6
-      0x5C1C0200,  //  000F  MOVE	R7	R1
-      0x5C200800,  //  0010  MOVE	R8	R4
-      0x7C140600,  //  0011  CALL	R5	3
-      0x50100200,  //  0012  LDBOOL	R4	1	0
-      0x80040800,  //  0013  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_write_response
-********************************************************************/
-be_local_closure(Matter_IM_send_write_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_WriteResponse),
-    }),
-    be_str_weak(send_write_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_250ms
-********************************************************************/
-be_local_closure(Matter_IM_every_250ms,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs),
-    /* K1   */  be_nested_str_weak(every_250ms),
-    }),
-    be_str_weak(every_250ms),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_incoming
-********************************************************************/
-be_local_closure(Matter_IM_process_incoming,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tasmota),
-    /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20IM_X20message_X20),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(inspect),
-    /* K5   */  be_const_int(3),
-    /* K6   */  be_nested_str_weak(TLV),
-    /* K7   */  be_nested_str_weak(parse),
-    /* K8   */  be_nested_str_weak(raw),
-    /* K9   */  be_nested_str_weak(app_payload_idx),
-    /* K10  */  be_nested_str_weak(MTR_X3A_X20IM_X20TLV_X3A_X20),
-    /* K11  */  be_nested_str_weak(findsubval),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20InteractionModelRevision_X3D),
-    /* K13  */  be_nested_str_weak(nil),
-    /* K14  */  be_nested_str_weak(opcode),
-    /* K15  */  be_const_int(1),
-    /* K16  */  be_nested_str_weak(process_status_response),
-    /* K17  */  be_const_int(2),
-    /* K18  */  be_nested_str_weak(process_read_request),
-    /* K19  */  be_nested_str_weak(subscribe_request),
-    /* K20  */  be_nested_str_weak(subscribe_response),
-    /* K21  */  be_nested_str_weak(report_data),
-    /* K22  */  be_nested_str_weak(process_write_request),
-    /* K23  */  be_nested_str_weak(process_write_response),
-    /* K24  */  be_nested_str_weak(process_invoke_request),
-    /* K25  */  be_nested_str_weak(process_invoke_response),
-    /* K26  */  be_nested_str_weak(process_timed_request),
-    }),
-    be_str_weak(process_incoming),
-    &be_const_str_solidified,
-    ( &(const binstruction[128]) {  /* code */
-      0xB80A0000,  //  0000  GETNGBL	R2	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0xB8120600,  //  0002  GETNGBL	R4	K3
-      0x8C100904,  //  0003  GETMET	R4	R4	K4
-      0x5C180200,  //  0004  MOVE	R6	R1
-      0x7C100400,  //  0005  CALL	R4	2
-      0x00120404,  //  0006  ADD	R4	K2	R4
-      0x58140005,  //  0007  LDCONST	R5	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0xB80A0600,  //  0009  GETNGBL	R2	K3
-      0x88080506,  //  000A  GETMBR	R2	R2	K6
-      0x8C080507,  //  000B  GETMET	R2	R2	K7
-      0x88100308,  //  000C  GETMBR	R4	R1	K8
-      0x88140309,  //  000D  GETMBR	R5	R1	K9
-      0x7C080600,  //  000E  CALL	R2	3
-      0xB80E0000,  //  000F  GETNGBL	R3	K0
-      0x8C0C0701,  //  0010  GETMET	R3	R3	K1
-      0x60140008,  //  0011  GETGBL	R5	G8
-      0x5C180400,  //  0012  MOVE	R6	R2
-      0x7C140200,  //  0013  CALL	R5	1
-      0x00161405,  //  0014  ADD	R5	K10	R5
-      0x58180005,  //  0015  LDCONST	R6	K5
-      0x7C0C0600,  //  0016  CALL	R3	3
-      0x8C0C050B,  //  0017  GETMET	R3	R2	K11
-      0x541600FE,  //  0018  LDINT	R5	255
-      0x7C0C0400,  //  0019  CALL	R3	2
-      0xB8120000,  //  001A  GETNGBL	R4	K0
-      0x8C100901,  //  001B  GETMET	R4	R4	K1
-      0x4C180000,  //  001C  LDNIL	R6
-      0x20180606,  //  001D  NE	R6	R3	R6
-      0x781A0003,  //  001E  JMPF	R6	#0023
-      0x60180008,  //  001F  GETGBL	R6	G8
-      0x5C1C0600,  //  0020  MOVE	R7	R3
-      0x7C180200,  //  0021  CALL	R6	1
-      0x70020000,  //  0022  JMP		#0024
-      0x5818000D,  //  0023  LDCONST	R6	K13
-      0x001A1806,  //  0024  ADD	R6	K12	R6
-      0x541E0003,  //  0025  LDINT	R7	4
-      0x7C100600,  //  0026  CALL	R4	3
-      0x8810030E,  //  0027  GETMBR	R4	R1	K14
-      0x1C14090F,  //  0028  EQ	R5	R4	K15
-      0x78160005,  //  0029  JMPF	R5	#0030
-      0x8C140110,  //  002A  GETMET	R5	R0	K16
-      0x5C1C0200,  //  002B  MOVE	R7	R1
-      0x5C200400,  //  002C  MOVE	R8	R2
-      0x7C140600,  //  002D  CALL	R5	3
-      0x80040A00,  //  002E  RET	1	R5
-      0x7002004D,  //  002F  JMP		#007E
-      0x1C140911,  //  0030  EQ	R5	R4	K17
-      0x78160005,  //  0031  JMPF	R5	#0038
-      0x8C140112,  //  0032  GETMET	R5	R0	K18
-      0x5C1C0200,  //  0033  MOVE	R7	R1
-      0x5C200400,  //  0034  MOVE	R8	R2
-      0x7C140600,  //  0035  CALL	R5	3
-      0x80040A00,  //  0036  RET	1	R5
-      0x70020045,  //  0037  JMP		#007E
-      0x1C140905,  //  0038  EQ	R5	R4	K5
-      0x78160005,  //  0039  JMPF	R5	#0040
-      0x8C140113,  //  003A  GETMET	R5	R0	K19
-      0x5C1C0200,  //  003B  MOVE	R7	R1
-      0x5C200400,  //  003C  MOVE	R8	R2
-      0x7C140600,  //  003D  CALL	R5	3
-      0x80040A00,  //  003E  RET	1	R5
-      0x7002003D,  //  003F  JMP		#007E
-      0x54160003,  //  0040  LDINT	R5	4
-      0x1C140805,  //  0041  EQ	R5	R4	R5
-      0x78160005,  //  0042  JMPF	R5	#0049
-      0x8C140114,  //  0043  GETMET	R5	R0	K20
-      0x5C1C0200,  //  0044  MOVE	R7	R1
-      0x5C200400,  //  0045  MOVE	R8	R2
-      0x7C140600,  //  0046  CALL	R5	3
-      0x80040A00,  //  0047  RET	1	R5
-      0x70020034,  //  0048  JMP		#007E
-      0x54160004,  //  0049  LDINT	R5	5
-      0x1C140805,  //  004A  EQ	R5	R4	R5
-      0x78160005,  //  004B  JMPF	R5	#0052
-      0x8C140115,  //  004C  GETMET	R5	R0	K21
-      0x5C1C0200,  //  004D  MOVE	R7	R1
-      0x5C200400,  //  004E  MOVE	R8	R2
-      0x7C140600,  //  004F  CALL	R5	3
-      0x80040A00,  //  0050  RET	1	R5
-      0x7002002B,  //  0051  JMP		#007E
-      0x54160005,  //  0052  LDINT	R5	6
-      0x1C140805,  //  0053  EQ	R5	R4	R5
-      0x78160005,  //  0054  JMPF	R5	#005B
-      0x8C140116,  //  0055  GETMET	R5	R0	K22
-      0x5C1C0200,  //  0056  MOVE	R7	R1
-      0x5C200400,  //  0057  MOVE	R8	R2
-      0x7C140600,  //  0058  CALL	R5	3
-      0x80040A00,  //  0059  RET	1	R5
-      0x70020022,  //  005A  JMP		#007E
-      0x54160006,  //  005B  LDINT	R5	7
-      0x1C140805,  //  005C  EQ	R5	R4	R5
-      0x78160005,  //  005D  JMPF	R5	#0064
-      0x8C140117,  //  005E  GETMET	R5	R0	K23
-      0x5C1C0200,  //  005F  MOVE	R7	R1
-      0x5C200400,  //  0060  MOVE	R8	R2
-      0x7C140600,  //  0061  CALL	R5	3
-      0x80040A00,  //  0062  RET	1	R5
-      0x70020019,  //  0063  JMP		#007E
-      0x54160007,  //  0064  LDINT	R5	8
-      0x1C140805,  //  0065  EQ	R5	R4	R5
-      0x78160005,  //  0066  JMPF	R5	#006D
-      0x8C140118,  //  0067  GETMET	R5	R0	K24
-      0x5C1C0200,  //  0068  MOVE	R7	R1
-      0x5C200400,  //  0069  MOVE	R8	R2
-      0x7C140600,  //  006A  CALL	R5	3
-      0x80040A00,  //  006B  RET	1	R5
-      0x70020010,  //  006C  JMP		#007E
-      0x54160008,  //  006D  LDINT	R5	9
-      0x1C140805,  //  006E  EQ	R5	R4	R5
-      0x78160005,  //  006F  JMPF	R5	#0076
-      0x8C140119,  //  0070  GETMET	R5	R0	K25
-      0x5C1C0200,  //  0071  MOVE	R7	R1
-      0x5C200400,  //  0072  MOVE	R8	R2
-      0x7C140600,  //  0073  CALL	R5	3
-      0x80040A00,  //  0074  RET	1	R5
-      0x70020007,  //  0075  JMP		#007E
-      0x54160009,  //  0076  LDINT	R5	10
-      0x1C140805,  //  0077  EQ	R5	R4	R5
-      0x78160004,  //  0078  JMPF	R5	#007E
-      0x8C14011A,  //  0079  GETMET	R5	R0	K26
-      0x5C1C0200,  //  007A  MOVE	R7	R1
-      0x5C200400,  //  007B  MOVE	R8	R2
-      0x7C140600,  //  007C  CALL	R5	3
-      0x80040A00,  //  007D  RET	1	R5
-      0x50140000,  //  007E  LDBOOL	R5	0	0
-      0x80040A00,  //  007F  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_subscribe_update
-********************************************************************/
-be_local_closure(Matter_IM_send_subscribe_update,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[26]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(session),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(ReadRequestMessage),
-    /* K4   */  be_nested_str_weak(fabric_filtered),
-    /* K5   */  be_nested_str_weak(attributes_requests),
-    /* K6   */  be_nested_str_weak(updates),
-    /* K7   */  be_nested_str_weak(AttributePathIB),
-    /* K8   */  be_nested_str_weak(endpoint),
-    /* K9   */  be_nested_str_weak(cluster),
-    /* K10  */  be_nested_str_weak(attribute),
-    /* K11  */  be_nested_str_weak(push),
-    /* K12  */  be_nested_str_weak(stop_iteration),
-    /* K13  */  be_const_int(0),
-    /* K14  */  be_nested_str_weak(tasmota),
-    /* K15  */  be_nested_str_weak(log),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_data_X20_X20sub_id_X3D),
-    /* K17  */  be_nested_str_weak(subscription_id),
-    /* K18  */  be_const_int(2),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_alive_X20sub_id_X3D),
-    /* K20  */  be_nested_str_weak(_inner_process_read_request),
-    /* K21  */  be_nested_str_weak(suppress_response),
-    /* K22  */  be_nested_str_weak(send_queue),
-    /* K23  */  be_nested_str_weak(IM_ReportDataSubscribed),
-    /* K24  */  be_nested_str_weak(_message_handler),
-    /* K25  */  be_nested_str_weak(send_enqueued),
-    }),
-    be_str_weak(send_subscribe_update),
-    &be_const_str_solidified,
-    ( &(const binstruction[80]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0301,  //  0001  GETMBR	R3	R1	K1
-      0xB8120400,  //  0002  GETNGBL	R4	K2
-      0x8C100903,  //  0003  GETMET	R4	R4	K3
-      0x7C100200,  //  0004  CALL	R4	1
-      0x50140000,  //  0005  LDBOOL	R5	0	0
-      0x90120805,  //  0006  SETMBR	R4	K4	R5
-      0x60140012,  //  0007  GETGBL	R5	G18
-      0x7C140000,  //  0008  CALL	R5	0
-      0x90120A05,  //  0009  SETMBR	R4	K5	R5
-      0x60140010,  //  000A  GETGBL	R5	G16
-      0x88180306,  //  000B  GETMBR	R6	R1	K6
-      0x7C140200,  //  000C  CALL	R5	1
-      0xA802000F,  //  000D  EXBLK	0	#001E
-      0x5C180A00,  //  000E  MOVE	R6	R5
-      0x7C180000,  //  000F  CALL	R6	0
-      0xB81E0400,  //  0010  GETNGBL	R7	K2
-      0x8C1C0F07,  //  0011  GETMET	R7	R7	K7
-      0x7C1C0200,  //  0012  CALL	R7	1
-      0x88200D08,  //  0013  GETMBR	R8	R6	K8
-      0x901E1008,  //  0014  SETMBR	R7	K8	R8
-      0x88200D09,  //  0015  GETMBR	R8	R6	K9
-      0x901E1208,  //  0016  SETMBR	R7	K9	R8
-      0x88200D0A,  //  0017  GETMBR	R8	R6	K10
-      0x901E1408,  //  0018  SETMBR	R7	K10	R8
-      0x88200905,  //  0019  GETMBR	R8	R4	K5
-      0x8C20110B,  //  001A  GETMET	R8	R8	K11
-      0x5C280E00,  //  001B  MOVE	R10	R7
-      0x7C200400,  //  001C  CALL	R8	2
-      0x7001FFEF,  //  001D  JMP		#000E
-      0x5814000C,  //  001E  LDCONST	R5	K12
-      0xAC140200,  //  001F  CATCH	R5	1	0
-      0xB0080000,  //  0020  RAISE	2	R0	R0
-      0x6014000C,  //  0021  GETGBL	R5	G12
-      0x88180905,  //  0022  GETMBR	R6	R4	K5
-      0x7C140200,  //  0023  CALL	R5	1
-      0x24140B0D,  //  0024  GT	R5	R5	K13
-      0x78160008,  //  0025  JMPF	R5	#002F
-      0xB8161C00,  //  0026  GETNGBL	R5	K14
-      0x8C140B0F,  //  0027  GETMET	R5	R5	K15
-      0x601C0008,  //  0028  GETGBL	R7	G8
-      0x88200311,  //  0029  GETMBR	R8	R1	K17
-      0x7C1C0200,  //  002A  CALL	R7	1
-      0x001E2007,  //  002B  ADD	R7	K16	R7
-      0x58200012,  //  002C  LDCONST	R8	K18
-      0x7C140600,  //  002D  CALL	R5	3
-      0x70020007,  //  002E  JMP		#0037
-      0xB8161C00,  //  002F  GETNGBL	R5	K14
-      0x8C140B0F,  //  0030  GETMET	R5	R5	K15
-      0x601C0008,  //  0031  GETGBL	R7	G8
-      0x88200311,  //  0032  GETMBR	R8	R1	K17
-      0x7C1C0200,  //  0033  CALL	R7	1
-      0x001E2607,  //  0034  ADD	R7	K19	R7
-      0x58200012,  //  0035  LDCONST	R8	K18
-      0x7C140600,  //  0036  CALL	R5	3
-      0x8C140114,  //  0037  GETMET	R5	R0	K20
-      0x5C1C0600,  //  0038  MOVE	R7	R3
-      0x5C200800,  //  0039  MOVE	R8	R4
-      0x7C140600,  //  003A  CALL	R5	3
-      0x6018000C,  //  003B  GETGBL	R6	G12
-      0x881C0905,  //  003C  GETMBR	R7	R4	K5
-      0x7C180200,  //  003D  CALL	R6	1
-      0x1C180D0D,  //  003E  EQ	R6	R6	K13
-      0x90162A06,  //  003F  SETMBR	R5	K21	R6
-      0x88180311,  //  0040  GETMBR	R6	R1	K17
-      0x90162206,  //  0041  SETMBR	R5	K17	R6
-      0x88180116,  //  0042  GETMBR	R6	R0	K22
-      0x8C180D0B,  //  0043  GETMET	R6	R6	K11
-      0xB8220400,  //  0044  GETNGBL	R8	K2
-      0x8C201117,  //  0045  GETMET	R8	R8	K23
-      0x88280718,  //  0046  GETMBR	R10	R3	K24
-      0x5C2C0600,  //  0047  MOVE	R11	R3
-      0x5C300A00,  //  0048  MOVE	R12	R5
-      0x5C340200,  //  0049  MOVE	R13	R1
-      0x7C200A00,  //  004A  CALL	R8	5
-      0x7C180400,  //  004B  CALL	R6	2
-      0x8C180119,  //  004C  GETMET	R6	R0	K25
-      0x88200718,  //  004D  GETMBR	R8	R3	K24
-      0x7C180400,  //  004E  CALL	R6	2
-      0x80000000,  //  004F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_incoming_ack
-********************************************************************/
-be_local_closure(Matter_IM_process_incoming_ack,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    /* K2   */  be_nested_str_weak(ack_received),
-    }),
-    be_str_weak(process_incoming_ack),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x8C080100,  //  0000  GETMET	R2	R0	K0
-      0x88100301,  //  0001  GETMBR	R4	R1	K1
-      0x7C080400,  //  0002  CALL	R2	2
-      0x780A0003,  //  0003  JMPF	R2	#0008
-      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
-      0x5C140200,  //  0005  MOVE	R5	R1
-      0x7C0C0400,  //  0006  CALL	R3	2
-      0x80040600,  //  0007  RET	1	R3
-      0x500C0000,  //  0008  LDBOOL	R3	0	0
-      0x80040600,  //  0009  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_subscribe_response
-********************************************************************/
-be_local_closure(Matter_IM_send_subscribe_response,   /* name */
-  be_nested_proto(
-    11,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_SubscribeResponse),
-    }),
-    be_str_weak(send_subscribe_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x8C100901,  //  0001  GETMET	R4	R4	K1
-      0xB81A0400,  //  0002  GETNGBL	R6	K2
-      0x8C180D03,  //  0003  GETMET	R6	R6	K3
-      0x5C200200,  //  0004  MOVE	R8	R1
-      0x5C240400,  //  0005  MOVE	R9	R2
-      0x5C280600,  //  0006  MOVE	R10	R3
-      0x7C180800,  //  0007  CALL	R6	4
-      0x7C100400,  //  0008  CALL	R4	2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_status
-********************************************************************/
-be_local_closure(Matter_IM_send_status,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_Status),
-    }),
-    be_str_weak(send_status),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_invoke_request
-********************************************************************/
-be_local_closure(Matter_IM_process_invoke_request,   /* name */
-  be_nested_proto(
-    19,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[48]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(log),
-    /* K3   */  be_nested_str_weak(MTR_X3A_X20IM_X3Ainvoke_request_X20processing_X20start),
-    /* K4   */  be_nested_str_weak(matter),
-    /* K5   */  be_nested_str_weak(Path),
-    /* K6   */  be_nested_str_weak(InvokeRequestMessage),
-    /* K7   */  be_nested_str_weak(from_TLV),
-    /* K8   */  be_nested_str_weak(invoke_requests),
-    /* K9   */  be_nested_str_weak(InvokeResponseMessage),
-    /* K10  */  be_nested_str_weak(suppress_response),
-    /* K11  */  be_nested_str_weak(invoke_responses),
-    /* K12  */  be_nested_str_weak(endpoint),
-    /* K13  */  be_nested_str_weak(command_path),
-    /* K14  */  be_nested_str_weak(cluster),
-    /* K15  */  be_nested_str_weak(command),
-    /* K16  */  be_nested_str_weak(status),
-    /* K17  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
-    /* K18  */  be_nested_str_weak(get_command_name),
-    /* K19  */  be_nested_str_weak(format),
-    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X25s_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K21  */  be_nested_str_weak(),
-    /* K22  */  be_nested_str_weak(remote_ip),
-    /* K23  */  be_nested_str_weak(remote_port),
-    /* K24  */  be_const_int(2),
-    /* K25  */  be_nested_str_weak(device),
-    /* K26  */  be_nested_str_weak(invoke_request),
-    /* K27  */  be_nested_str_weak(session),
-    /* K28  */  be_nested_str_weak(command_fields),
-    /* K29  */  be_nested_str_weak(InvokeResponseIB),
-    /* K30  */  be_nested_str_weak(SUCCESS),
-    /* K31  */  be_nested_str_weak(CommandStatusIB),
-    /* K32  */  be_nested_str_weak(CommandPathIB),
-    /* K33  */  be_nested_str_weak(StatusIB),
-    /* K34  */  be_nested_str_weak(push),
-    /* K35  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20OK),
-    /* K36  */  be_nested_str_weak(CommandDataIB),
-    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s_X20_X25s),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20Status_X3D0x_X2502X),
-    /* K39  */  be_nested_str_weak(MTR_X3A_X20_Ignore),
-    /* K40  */  be_nested_str_weak(stop_iteration),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20invoke_responses_X3D),
-    /* K42  */  be_const_int(0),
-    /* K43  */  be_nested_str_weak(MTR_X3A_X20InvokeResponse_X3D),
-    /* K44  */  be_nested_str_weak(MTR_X3A_X20InvokeResponseTLV_X3D),
-    /* K45  */  be_nested_str_weak(to_TLV),
-    /* K46  */  be_const_int(3),
-    /* K47  */  be_nested_str_weak(send_invoke_response),
-    }),
-    be_str_weak(process_invoke_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[271]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x58180003,  //  0003  LDCONST	R6	K3
-      0x541E0003,  //  0004  LDINT	R7	4
-      0x7C100600,  //  0005  CALL	R4	3
-      0xB8120800,  //  0006  GETNGBL	R4	K4
-      0x8C100905,  //  0007  GETMET	R4	R4	K5
-      0x7C100200,  //  0008  CALL	R4	1
-      0xB8160800,  //  0009  GETNGBL	R5	K4
-      0x8C140B06,  //  000A  GETMET	R5	R5	K6
-      0x7C140200,  //  000B  CALL	R5	1
-      0x8C140B07,  //  000C  GETMET	R5	R5	K7
-      0x5C1C0400,  //  000D  MOVE	R7	R2
-      0x7C140400,  //  000E  CALL	R5	2
-      0x88180B08,  //  000F  GETMBR	R6	R5	K8
-      0x4C1C0000,  //  0010  LDNIL	R7
-      0x20180C07,  //  0011  NE	R6	R6	R7
-      0x781A00FA,  //  0012  JMPF	R6	#010E
-      0xB81A0800,  //  0013  GETNGBL	R6	K4
-      0x8C180D09,  //  0014  GETMET	R6	R6	K9
-      0x7C180200,  //  0015  CALL	R6	1
-      0x501C0000,  //  0016  LDBOOL	R7	0	0
-      0x901A1407,  //  0017  SETMBR	R6	K10	R7
-      0x601C0012,  //  0018  GETGBL	R7	G18
-      0x7C1C0000,  //  0019  CALL	R7	0
-      0x901A1607,  //  001A  SETMBR	R6	K11	R7
-      0x601C0010,  //  001B  GETGBL	R7	G16
-      0x88200B08,  //  001C  GETMBR	R8	R5	K8
-      0x7C1C0200,  //  001D  CALL	R7	1
-      0xA80200C4,  //  001E  EXBLK	0	#00E4
-      0x5C200E00,  //  001F  MOVE	R8	R7
-      0x7C200000,  //  0020  CALL	R8	0
-      0x8824110D,  //  0021  GETMBR	R9	R8	K13
-      0x8824130C,  //  0022  GETMBR	R9	R9	K12
-      0x90121809,  //  0023  SETMBR	R4	K12	R9
-      0x8824110D,  //  0024  GETMBR	R9	R8	K13
-      0x8824130E,  //  0025  GETMBR	R9	R9	K14
-      0x90121C09,  //  0026  SETMBR	R4	K14	R9
-      0x8824110D,  //  0027  GETMBR	R9	R8	K13
-      0x8824130F,  //  0028  GETMBR	R9	R9	K15
-      0x90121E09,  //  0029  SETMBR	R4	K15	R9
-      0xB8260800,  //  002A  GETNGBL	R9	K4
-      0x88241311,  //  002B  GETMBR	R9	R9	K17
-      0x90122009,  //  002C  SETMBR	R4	K16	R9
-      0xB8260800,  //  002D  GETNGBL	R9	K4
-      0x8C241312,  //  002E  GETMET	R9	R9	K18
-      0x882C090E,  //  002F  GETMBR	R11	R4	K14
-      0x8830090F,  //  0030  GETMBR	R12	R4	K15
-      0x7C240600,  //  0031  CALL	R9	3
-      0xB82A0200,  //  0032  GETNGBL	R10	K1
-      0x8C281502,  //  0033  GETMET	R10	R10	K2
-      0x8C300713,  //  0034  GETMET	R12	R3	K19
-      0x58380014,  //  0035  LDCONST	R14	K20
-      0x603C0008,  //  0036  GETGBL	R15	G8
-      0x5C400800,  //  0037  MOVE	R16	R4
-      0x7C3C0200,  //  0038  CALL	R15	1
-      0x78260001,  //  0039  JMPF	R9	#003C
-      0x5C401200,  //  003A  MOVE	R16	R9
-      0x70020000,  //  003B  JMP		#003D
-      0x58400015,  //  003C  LDCONST	R16	K21
-      0x88440316,  //  003D  GETMBR	R17	R1	K22
-      0x88480317,  //  003E  GETMBR	R18	R1	K23
-      0x7C300C00,  //  003F  CALL	R12	6
-      0x58340018,  //  0040  LDCONST	R13	K24
-      0x7C280600,  //  0041  CALL	R10	3
-      0x88280119,  //  0042  GETMBR	R10	R0	K25
-      0x8C28151A,  //  0043  GETMET	R10	R10	K26
-      0x8830031B,  //  0044  GETMBR	R12	R1	K27
-      0x8834111C,  //  0045  GETMBR	R13	R8	K28
-      0x5C380800,  //  0046  MOVE	R14	R4
-      0x7C280800,  //  0047  CALL	R10	4
-      0xB82E0800,  //  0048  GETNGBL	R11	K4
-      0x8C2C171D,  //  0049  GETMET	R11	R11	K29
-      0x7C2C0200,  //  004A  CALL	R11	1
-      0x50300200,  //  004B  LDBOOL	R12	1	0
-      0x1C30140C,  //  004C  EQ	R12	R10	R12
-      0x74320004,  //  004D  JMPT	R12	#0053
-      0x88300910,  //  004E  GETMBR	R12	R4	K16
-      0xB8360800,  //  004F  GETNGBL	R13	K4
-      0x88341B1E,  //  0050  GETMBR	R13	R13	K30
-      0x1C30180D,  //  0051  EQ	R12	R12	R13
-      0x78320028,  //  0052  JMPF	R12	#007C
-      0xB8320800,  //  0053  GETNGBL	R12	K4
-      0x8C30191F,  //  0054  GETMET	R12	R12	K31
-      0x7C300200,  //  0055  CALL	R12	1
-      0x902E200C,  //  0056  SETMBR	R11	K16	R12
-      0x88301710,  //  0057  GETMBR	R12	R11	K16
-      0xB8360800,  //  0058  GETNGBL	R13	K4
-      0x8C341B20,  //  0059  GETMET	R13	R13	K32
-      0x7C340200,  //  005A  CALL	R13	1
-      0x90321A0D,  //  005B  SETMBR	R12	K13	R13
-      0x88301710,  //  005C  GETMBR	R12	R11	K16
-      0x8830190D,  //  005D  GETMBR	R12	R12	K13
-      0x8834090C,  //  005E  GETMBR	R13	R4	K12
-      0x9032180D,  //  005F  SETMBR	R12	K12	R13
-      0x88301710,  //  0060  GETMBR	R12	R11	K16
-      0x8830190D,  //  0061  GETMBR	R12	R12	K13
-      0x8834090E,  //  0062  GETMBR	R13	R4	K14
-      0x90321C0D,  //  0063  SETMBR	R12	K14	R13
-      0x88301710,  //  0064  GETMBR	R12	R11	K16
-      0x8830190D,  //  0065  GETMBR	R12	R12	K13
-      0x8834090F,  //  0066  GETMBR	R13	R4	K15
-      0x90321E0D,  //  0067  SETMBR	R12	K15	R13
-      0x88301710,  //  0068  GETMBR	R12	R11	K16
-      0xB8360800,  //  0069  GETNGBL	R13	K4
-      0x8C341B21,  //  006A  GETMET	R13	R13	K33
-      0x7C340200,  //  006B  CALL	R13	1
-      0x9032200D,  //  006C  SETMBR	R12	K16	R13
-      0x88301710,  //  006D  GETMBR	R12	R11	K16
-      0x88301910,  //  006E  GETMBR	R12	R12	K16
-      0xB8360800,  //  006F  GETNGBL	R13	K4
-      0x88341B1E,  //  0070  GETMBR	R13	R13	K30
-      0x9032200D,  //  0071  SETMBR	R12	K16	R13
-      0x88300D0B,  //  0072  GETMBR	R12	R6	K11
-      0x8C301922,  //  0073  GETMET	R12	R12	K34
-      0x5C381600,  //  0074  MOVE	R14	R11
-      0x7C300400,  //  0075  CALL	R12	2
-      0xB8320200,  //  0076  GETNGBL	R12	K1
-      0x8C301902,  //  0077  GETMET	R12	R12	K2
-      0x58380023,  //  0078  LDCONST	R14	K35
-      0x583C0018,  //  0079  LDCONST	R15	K24
-      0x7C300600,  //  007A  CALL	R12	3
-      0x70020066,  //  007B  JMP		#00E3
-      0x4C300000,  //  007C  LDNIL	R12
-      0x2030140C,  //  007D  NE	R12	R10	R12
-      0x7832002F,  //  007E  JMPF	R12	#00AF
-      0xB8320800,  //  007F  GETNGBL	R12	K4
-      0x8C301924,  //  0080  GETMET	R12	R12	K36
-      0x7C300200,  //  0081  CALL	R12	1
-      0x902E1E0C,  //  0082  SETMBR	R11	K15	R12
-      0x8830170F,  //  0083  GETMBR	R12	R11	K15
-      0xB8360800,  //  0084  GETNGBL	R13	K4
-      0x8C341B20,  //  0085  GETMET	R13	R13	K32
-      0x7C340200,  //  0086  CALL	R13	1
-      0x90321A0D,  //  0087  SETMBR	R12	K13	R13
-      0x8830170F,  //  0088  GETMBR	R12	R11	K15
-      0x8830190D,  //  0089  GETMBR	R12	R12	K13
-      0x8834090C,  //  008A  GETMBR	R13	R4	K12
-      0x9032180D,  //  008B  SETMBR	R12	K12	R13
-      0x8830170F,  //  008C  GETMBR	R12	R11	K15
-      0x8830190D,  //  008D  GETMBR	R12	R12	K13
-      0x8834090E,  //  008E  GETMBR	R13	R4	K14
-      0x90321C0D,  //  008F  SETMBR	R12	K14	R13
-      0x8830170F,  //  0090  GETMBR	R12	R11	K15
-      0x8830190D,  //  0091  GETMBR	R12	R12	K13
-      0x8834090F,  //  0092  GETMBR	R13	R4	K15
-      0x90321E0D,  //  0093  SETMBR	R12	K15	R13
-      0x8830170F,  //  0094  GETMBR	R12	R11	K15
-      0x9032380A,  //  0095  SETMBR	R12	K28	R10
-      0x88300D0B,  //  0096  GETMBR	R12	R6	K11
-      0x8C301922,  //  0097  GETMET	R12	R12	K34
-      0x5C381600,  //  0098  MOVE	R14	R11
-      0x7C300400,  //  0099  CALL	R12	2
-      0xB8320800,  //  009A  GETNGBL	R12	K4
-      0x8C301912,  //  009B  GETMET	R12	R12	K18
-      0x8838090E,  //  009C  GETMBR	R14	R4	K14
-      0x883C090F,  //  009D  GETMBR	R15	R4	K15
-      0x7C300600,  //  009E  CALL	R12	3
-      0x5C241800,  //  009F  MOVE	R9	R12
-      0xB8320200,  //  00A0  GETNGBL	R12	K1
-      0x8C301902,  //  00A1  GETMET	R12	R12	K2
-      0x8C380713,  //  00A2  GETMET	R14	R3	K19
-      0x58400025,  //  00A3  LDCONST	R16	K37
-      0x60440008,  //  00A4  GETGBL	R17	G8
-      0x5C480800,  //  00A5  MOVE	R18	R4
-      0x7C440200,  //  00A6  CALL	R17	1
-      0x78260001,  //  00A7  JMPF	R9	#00AA
-      0x5C481200,  //  00A8  MOVE	R18	R9
-      0x70020000,  //  00A9  JMP		#00AB
-      0x58480015,  //  00AA  LDCONST	R18	K21
-      0x7C380800,  //  00AB  CALL	R14	4
-      0x583C0018,  //  00AC  LDCONST	R15	K24
-      0x7C300600,  //  00AD  CALL	R12	3
-      0x70020033,  //  00AE  JMP		#00E3
-      0x88300910,  //  00AF  GETMBR	R12	R4	K16
-      0x4C340000,  //  00B0  LDNIL	R13
-      0x2030180D,  //  00B1  NE	R12	R12	R13
-      0x7832002A,  //  00B2  JMPF	R12	#00DE
-      0xB8320800,  //  00B3  GETNGBL	R12	K4
-      0x8C30191F,  //  00B4  GETMET	R12	R12	K31
-      0x7C300200,  //  00B5  CALL	R12	1
-      0x902E200C,  //  00B6  SETMBR	R11	K16	R12
-      0x88301710,  //  00B7  GETMBR	R12	R11	K16
-      0xB8360800,  //  00B8  GETNGBL	R13	K4
-      0x8C341B20,  //  00B9  GETMET	R13	R13	K32
-      0x7C340200,  //  00BA  CALL	R13	1
-      0x90321A0D,  //  00BB  SETMBR	R12	K13	R13
-      0x88301710,  //  00BC  GETMBR	R12	R11	K16
-      0x8830190D,  //  00BD  GETMBR	R12	R12	K13
-      0x8834090C,  //  00BE  GETMBR	R13	R4	K12
-      0x9032180D,  //  00BF  SETMBR	R12	K12	R13
-      0x88301710,  //  00C0  GETMBR	R12	R11	K16
-      0x8830190D,  //  00C1  GETMBR	R12	R12	K13
-      0x8834090E,  //  00C2  GETMBR	R13	R4	K14
-      0x90321C0D,  //  00C3  SETMBR	R12	K14	R13
-      0x88301710,  //  00C4  GETMBR	R12	R11	K16
-      0x8830190D,  //  00C5  GETMBR	R12	R12	K13
-      0x8834090F,  //  00C6  GETMBR	R13	R4	K15
-      0x90321E0D,  //  00C7  SETMBR	R12	K15	R13
-      0x88301710,  //  00C8  GETMBR	R12	R11	K16
-      0xB8360800,  //  00C9  GETNGBL	R13	K4
-      0x8C341B21,  //  00CA  GETMET	R13	R13	K33
-      0x7C340200,  //  00CB  CALL	R13	1
-      0x9032200D,  //  00CC  SETMBR	R12	K16	R13
-      0x88301710,  //  00CD  GETMBR	R12	R11	K16
-      0x88301910,  //  00CE  GETMBR	R12	R12	K16
-      0x88340910,  //  00CF  GETMBR	R13	R4	K16
-      0x9032200D,  //  00D0  SETMBR	R12	K16	R13
-      0x88300D0B,  //  00D1  GETMBR	R12	R6	K11
-      0x8C301922,  //  00D2  GETMET	R12	R12	K34
-      0x5C381600,  //  00D3  MOVE	R14	R11
-      0x7C300400,  //  00D4  CALL	R12	2
-      0xB8320200,  //  00D5  GETNGBL	R12	K1
-      0x8C301902,  //  00D6  GETMET	R12	R12	K2
-      0x8C380713,  //  00D7  GETMET	R14	R3	K19
-      0x58400026,  //  00D8  LDCONST	R16	K38
-      0x88440910,  //  00D9  GETMBR	R17	R4	K16
-      0x7C380600,  //  00DA  CALL	R14	3
-      0x583C0018,  //  00DB  LDCONST	R15	K24
-      0x7C300600,  //  00DC  CALL	R12	3
-      0x70020004,  //  00DD  JMP		#00E3
-      0xB8320200,  //  00DE  GETNGBL	R12	K1
-      0x8C301902,  //  00DF  GETMET	R12	R12	K2
-      0x58380027,  //  00E0  LDCONST	R14	K39
-      0x583C0018,  //  00E1  LDCONST	R15	K24
-      0x7C300600,  //  00E2  CALL	R12	3
-      0x7001FF3A,  //  00E3  JMP		#001F
-      0x581C0028,  //  00E4  LDCONST	R7	K40
-      0xAC1C0200,  //  00E5  CATCH	R7	1	0
-      0xB0080000,  //  00E6  RAISE	2	R0	R0
-      0xB81E0200,  //  00E7  GETNGBL	R7	K1
-      0x8C1C0F02,  //  00E8  GETMET	R7	R7	K2
-      0x60240008,  //  00E9  GETGBL	R9	G8
-      0x88280D0B,  //  00EA  GETMBR	R10	R6	K11
-      0x7C240200,  //  00EB  CALL	R9	1
-      0x00265209,  //  00EC  ADD	R9	K41	R9
-      0x542A0003,  //  00ED  LDINT	R10	4
-      0x7C1C0600,  //  00EE  CALL	R7	3
-      0x601C000C,  //  00EF  GETGBL	R7	G12
-      0x88200D0B,  //  00F0  GETMBR	R8	R6	K11
-      0x7C1C0200,  //  00F1  CALL	R7	1
-      0x241C0F2A,  //  00F2  GT	R7	R7	K42
-      0x781E0015,  //  00F3  JMPF	R7	#010A
-      0xB81E0200,  //  00F4  GETNGBL	R7	K1
-      0x8C1C0F02,  //  00F5  GETMET	R7	R7	K2
-      0x60240008,  //  00F6  GETGBL	R9	G8
-      0x5C280C00,  //  00F7  MOVE	R10	R6
-      0x7C240200,  //  00F8  CALL	R9	1
-      0x00265609,  //  00F9  ADD	R9	K43	R9
-      0x542A0003,  //  00FA  LDINT	R10	4
-      0x7C1C0600,  //  00FB  CALL	R7	3
-      0xB81E0200,  //  00FC  GETNGBL	R7	K1
-      0x8C1C0F02,  //  00FD  GETMET	R7	R7	K2
-      0x60240008,  //  00FE  GETGBL	R9	G8
-      0x8C280D2D,  //  00FF  GETMET	R10	R6	K45
-      0x7C280200,  //  0100  CALL	R10	1
-      0x7C240200,  //  0101  CALL	R9	1
-      0x00265809,  //  0102  ADD	R9	K44	R9
-      0x5828002E,  //  0103  LDCONST	R10	K46
-      0x7C1C0600,  //  0104  CALL	R7	3
-      0x8C1C012F,  //  0105  GETMET	R7	R0	K47
-      0x5C240200,  //  0106  MOVE	R9	R1
-      0x5C280C00,  //  0107  MOVE	R10	R6
-      0x7C1C0600,  //  0108  CALL	R7	3
-      0x70020001,  //  0109  JMP		#010C
-      0x501C0000,  //  010A  LDBOOL	R7	0	0
-      0x80040E00,  //  010B  RET	1	R7
-      0x501C0200,  //  010C  LDBOOL	R7	1	0
-      0x80040E00,  //  010D  RET	1	R7
-      0x80000000,  //  010E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_report_data
-********************************************************************/
-be_local_closure(Matter_IM_send_report_data,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(send_queue),
-    /* K1   */  be_nested_str_weak(push),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(IM_ReportData),
-    }),
-    be_str_weak(send_report_data),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0xB8160400,  //  0002  GETNGBL	R5	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x5C1C0200,  //  0004  MOVE	R7	R1
-      0x5C200400,  //  0005  MOVE	R8	R2
-      0x7C140600,  //  0006  CALL	R5	3
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_IM_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(subs),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x60080012,  //  0001  GETGBL	R2	G18
-      0x7C080000,  //  0002  CALL	R2	0
-      0x90020202,  //  0003  SETMBR	R0	K1	R2
-      0xB80A0600,  //  0004  GETNGBL	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
-      0x5C100000,  //  0006  MOVE	R4	R0
-      0x7C080400,  //  0007  CALL	R2	2
-      0x90020402,  //  0008  SETMBR	R0	K2	R2
-      0x80000000,  //  0009  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_write_response
-********************************************************************/
-be_local_closure(Matter_IM_process_write_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(WriteResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20WriteResponseMessage_X3D),
-    /* K7   */  be_const_int(2),
-    }),
-    be_str_weak(process_write_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: subscribe_response
-********************************************************************/
-be_local_closure(Matter_IM_subscribe_response,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeResponsetMessage_X3D),
-    /* K7   */  be_const_int(2),
-    }),
-    be_str_weak(subscribe_response),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0x50140000,  //  000F  LDBOOL	R5	0	0
-      0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _inner_process_read_request
-********************************************************************/
-be_local_closure(Matter_IM__inner_process_read_request,   /* name */
-  be_nested_proto(
-    14,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 2]) {
-      be_nested_proto(
-        18,                          /* nstack */
-        4,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 1]) {  /* upvals */
-          be_local_const_upval(1, 1),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[32]) {     /* constants */
-        /* K0   */  be_nested_str_weak(string),
-        /* K1   */  be_nested_str_weak(matter),
-        /* K2   */  be_nested_str_weak(get_attribute_name),
-        /* K3   */  be_nested_str_weak(cluster),
-        /* K4   */  be_nested_str_weak(attribute),
-        /* K5   */  be_nested_str_weak(_X20_X28),
-        /* K6   */  be_nested_str_weak(_X29),
-        /* K7   */  be_nested_str_weak(),
-        /* K8   */  be_nested_str_weak(read_attribute),
-        /* K9   */  be_nested_str_weak(AttributeReportIB),
-        /* K10  */  be_nested_str_weak(attribute_data),
-        /* K11  */  be_nested_str_weak(AttributeDataIB),
-        /* K12  */  be_nested_str_weak(data_version),
-        /* K13  */  be_const_int(1),
-        /* K14  */  be_nested_str_weak(path),
-        /* K15  */  be_nested_str_weak(AttributePathIB),
-        /* K16  */  be_nested_str_weak(endpoint),
-        /* K17  */  be_nested_str_weak(data),
-        /* K18  */  be_nested_str_weak(attribute_reports),
-        /* K19  */  be_nested_str_weak(push),
-        /* K20  */  be_nested_str_weak(tasmota),
-        /* K21  */  be_nested_str_weak(log),
-        /* K22  */  be_nested_str_weak(format),
-        /* K23  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20_X25s_X25s_X20_X2D_X20_X25s),
-        /* K24  */  be_const_int(2),
-        /* K25  */  be_nested_str_weak(status),
-        /* K26  */  be_nested_str_weak(attribute_status),
-        /* K27  */  be_nested_str_weak(AttributeStatusIB),
-        /* K28  */  be_nested_str_weak(StatusIB),
-        /* K29  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
-        /* K30  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-        /* K31  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20_X25s_X25s_X20_X2D_X20IGNORED),
-        }),
-        be_str_weak(read_single_attribute),
-        &be_const_str_solidified,
-        ( &(const binstruction[152]) {  /* code */
-          0xA4120000,  //  0000  IMPORT	R4	K0
-          0xB8160200,  //  0001  GETNGBL	R5	K1
-          0x8C140B02,  //  0002  GETMET	R5	R5	K2
-          0x881C0503,  //  0003  GETMBR	R7	R2	K3
-          0x88200504,  //  0004  GETMBR	R8	R2	K4
-          0x7C140600,  //  0005  CALL	R5	3
-          0x78160002,  //  0006  JMPF	R5	#000A
-          0x001A0A05,  //  0007  ADD	R6	K5	R5
-          0x00180D06,  //  0008  ADD	R6	R6	K6
-          0x70020000,  //  0009  JMP		#000B
-          0x58180007,  //  000A  LDCONST	R6	K7
-          0x5C140C00,  //  000B  MOVE	R5	R6
-          0x4C180000,  //  000C  LDNIL	R6
-          0x20180206,  //  000D  NE	R6	R1	R6
-          0x781A0004,  //  000E  JMPF	R6	#0014
-          0x8C180308,  //  000F  GETMET	R6	R1	K8
-          0x68200000,  //  0010  GETUPV	R8	U0
-          0x5C240400,  //  0011  MOVE	R9	R2
-          0x7C180600,  //  0012  CALL	R6	3
-          0x70020000,  //  0013  JMP		#0015
-          0x4C180000,  //  0014  LDNIL	R6
-          0x4C1C0000,  //  0015  LDNIL	R7
-          0x201C0C07,  //  0016  NE	R7	R6	R7
-          0x781E0030,  //  0017  JMPF	R7	#0049
-          0xB81E0200,  //  0018  GETNGBL	R7	K1
-          0x8C1C0F09,  //  0019  GETMET	R7	R7	K9
-          0x7C1C0200,  //  001A  CALL	R7	1
-          0xB8220200,  //  001B  GETNGBL	R8	K1
-          0x8C20110B,  //  001C  GETMET	R8	R8	K11
-          0x7C200200,  //  001D  CALL	R8	1
-          0x901E1408,  //  001E  SETMBR	R7	K10	R8
-          0x88200F0A,  //  001F  GETMBR	R8	R7	K10
-          0x9022190D,  //  0020  SETMBR	R8	K12	K13
-          0x88200F0A,  //  0021  GETMBR	R8	R7	K10
-          0xB8260200,  //  0022  GETNGBL	R9	K1
-          0x8C24130F,  //  0023  GETMET	R9	R9	K15
-          0x7C240200,  //  0024  CALL	R9	1
-          0x90221C09,  //  0025  SETMBR	R8	K14	R9
-          0x88200F0A,  //  0026  GETMBR	R8	R7	K10
-          0x8820110E,  //  0027  GETMBR	R8	R8	K14
-          0x88240510,  //  0028  GETMBR	R9	R2	K16
-          0x90222009,  //  0029  SETMBR	R8	K16	R9
-          0x88200F0A,  //  002A  GETMBR	R8	R7	K10
-          0x8820110E,  //  002B  GETMBR	R8	R8	K14
-          0x88240503,  //  002C  GETMBR	R9	R2	K3
-          0x90220609,  //  002D  SETMBR	R8	K3	R9
-          0x88200F0A,  //  002E  GETMBR	R8	R7	K10
-          0x8820110E,  //  002F  GETMBR	R8	R8	K14
-          0x88240504,  //  0030  GETMBR	R9	R2	K4
-          0x90220809,  //  0031  SETMBR	R8	K4	R9
-          0x88200F0A,  //  0032  GETMBR	R8	R7	K10
-          0x90222206,  //  0033  SETMBR	R8	K17	R6
-          0x88200112,  //  0034  GETMBR	R8	R0	K18
-          0x8C201113,  //  0035  GETMET	R8	R8	K19
-          0x5C280E00,  //  0036  MOVE	R10	R7
-          0x7C200400,  //  0037  CALL	R8	2
-          0xB8222800,  //  0038  GETNGBL	R8	K20
-          0x8C201115,  //  0039  GETMET	R8	R8	K21
-          0x8C280916,  //  003A  GETMET	R10	R4	K22
-          0x58300017,  //  003B  LDCONST	R12	K23
-          0x60340008,  //  003C  GETGBL	R13	G8
-          0x5C380400,  //  003D  MOVE	R14	R2
-          0x7C340200,  //  003E  CALL	R13	1
-          0x5C380A00,  //  003F  MOVE	R14	R5
-          0x603C0008,  //  0040  GETGBL	R15	G8
-          0x5C400C00,  //  0041  MOVE	R16	R6
-          0x7C3C0200,  //  0042  CALL	R15	1
-          0x7C280A00,  //  0043  CALL	R10	5
-          0x582C0018,  //  0044  LDCONST	R11	K24
-          0x7C200600,  //  0045  CALL	R8	3
-          0x50200200,  //  0046  LDBOOL	R8	1	0
-          0x80041000,  //  0047  RET	1	R8
-          0x7002004D,  //  0048  JMP		#0097
-          0x881C0519,  //  0049  GETMBR	R7	R2	K25
-          0x4C200000,  //  004A  LDNIL	R8
-          0x201C0E08,  //  004B  NE	R7	R7	R8
-          0x781E003C,  //  004C  JMPF	R7	#008A
-          0x780E003A,  //  004D  JMPF	R3	#0089
-          0xB81E0200,  //  004E  GETNGBL	R7	K1
-          0x8C1C0F09,  //  004F  GETMET	R7	R7	K9
-          0x7C1C0200,  //  0050  CALL	R7	1
-          0xB8220200,  //  0051  GETNGBL	R8	K1
-          0x8C20111B,  //  0052  GETMET	R8	R8	K27
-          0x7C200200,  //  0053  CALL	R8	1
-          0x901E3408,  //  0054  SETMBR	R7	K26	R8
-          0x88200F1A,  //  0055  GETMBR	R8	R7	K26
-          0xB8260200,  //  0056  GETNGBL	R9	K1
-          0x8C24130F,  //  0057  GETMET	R9	R9	K15
-          0x7C240200,  //  0058  CALL	R9	1
-          0x90221C09,  //  0059  SETMBR	R8	K14	R9
-          0x88200F1A,  //  005A  GETMBR	R8	R7	K26
-          0xB8260200,  //  005B  GETNGBL	R9	K1
-          0x8C24131C,  //  005C  GETMET	R9	R9	K28
-          0x7C240200,  //  005D  CALL	R9	1
-          0x90223209,  //  005E  SETMBR	R8	K25	R9
-          0x88200F1A,  //  005F  GETMBR	R8	R7	K26
-          0x8820110E,  //  0060  GETMBR	R8	R8	K14
-          0x88240510,  //  0061  GETMBR	R9	R2	K16
-          0x90222009,  //  0062  SETMBR	R8	K16	R9
-          0x88200F1A,  //  0063  GETMBR	R8	R7	K26
-          0x8820110E,  //  0064  GETMBR	R8	R8	K14
-          0x88240503,  //  0065  GETMBR	R9	R2	K3
-          0x90220609,  //  0066  SETMBR	R8	K3	R9
-          0x88200F1A,  //  0067  GETMBR	R8	R7	K26
-          0x8820110E,  //  0068  GETMBR	R8	R8	K14
-          0x88240504,  //  0069  GETMBR	R9	R2	K4
-          0x90220809,  //  006A  SETMBR	R8	K4	R9
-          0x88200F1A,  //  006B  GETMBR	R8	R7	K26
-          0x88201119,  //  006C  GETMBR	R8	R8	K25
-          0x88240519,  //  006D  GETMBR	R9	R2	K25
-          0x90223209,  //  006E  SETMBR	R8	K25	R9
-          0x88200112,  //  006F  GETMBR	R8	R0	K18
-          0x8C201113,  //  0070  GETMET	R8	R8	K19
-          0x5C280E00,  //  0071  MOVE	R10	R7
-          0x7C200400,  //  0072  CALL	R8	2
-          0xB8222800,  //  0073  GETNGBL	R8	K20
-          0x8C201115,  //  0074  GETMET	R8	R8	K21
-          0x8C280916,  //  0075  GETMET	R10	R4	K22
-          0x5830001D,  //  0076  LDCONST	R12	K29
-          0x60340008,  //  0077  GETGBL	R13	G8
-          0x5C380400,  //  0078  MOVE	R14	R2
-          0x7C340200,  //  0079  CALL	R13	1
-          0x5C380A00,  //  007A  MOVE	R14	R5
-          0x883C0519,  //  007B  GETMBR	R15	R2	K25
-          0x88400519,  //  007C  GETMBR	R16	R2	K25
-          0xB8460200,  //  007D  GETNGBL	R17	K1
-          0x8844231E,  //  007E  GETMBR	R17	R17	K30
-          0x1C402011,  //  007F  EQ	R16	R16	R17
-          0x78420001,  //  0080  JMPF	R16	#0083
-          0x5840001E,  //  0081  LDCONST	R16	K30
-          0x70020000,  //  0082  JMP		#0084
-          0x58400007,  //  0083  LDCONST	R16	K7
-          0x7C280C00,  //  0084  CALL	R10	6
-          0x582C0018,  //  0085  LDCONST	R11	K24
-          0x7C200600,  //  0086  CALL	R8	3
-          0x50200200,  //  0087  LDBOOL	R8	1	0
-          0x80041000,  //  0088  RET	1	R8
-          0x7002000C,  //  0089  JMP		#0097
-          0xB81E2800,  //  008A  GETNGBL	R7	K20
-          0x8C1C0F15,  //  008B  GETMET	R7	R7	K21
-          0x8C240916,  //  008C  GETMET	R9	R4	K22
-          0x582C001F,  //  008D  LDCONST	R11	K31
-          0x60300008,  //  008E  GETGBL	R12	G8
-          0x5C340400,  //  008F  MOVE	R13	R2
-          0x7C300200,  //  0090  CALL	R12	1
-          0x5C340A00,  //  0091  MOVE	R13	R5
-          0x7C240800,  //  0092  CALL	R9	4
-          0x58280018,  //  0093  LDCONST	R10	K24
-          0x7C1C0600,  //  0094  CALL	R7	3
-          0x501C0000,  //  0095  LDBOOL	R7	0	0
-          0x80040E00,  //  0096  RET	1	R7
-          0x80000000,  //  0097  RET	0
-        })
-      ),
-      be_nested_proto(
-        8,                          /* nstack */
-        3,                          /* argc */
-        0,                          /* varg */
-        1,                          /* has upvals */
-        ( &(const bupvaldesc[ 2]) {  /* upvals */
-          be_local_const_upval(1, 3),
-          be_local_const_upval(1, 6),
-        }),
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        0,                          /* has constants */
-        NULL,                       /* no const */
-        be_str_weak(_X3Clambda_X3E),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x680C0000,  //  0000  GETUPV	R3	U0
-          0x68100001,  //  0001  GETUPV	R4	U1
-          0x5C140000,  //  0002  MOVE	R5	R0
-          0x5C180200,  //  0003  MOVE	R6	R1
-          0x5C1C0400,  //  0004  MOVE	R7	R2
-          0x7C0C0800,  //  0005  CALL	R3	4
-          0x80040600,  //  0006  RET	1	R3
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[22]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device),
-    /* K1   */  be_nested_str_weak(get_active_endpoints),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Path),
-    /* K4   */  be_nested_str_weak(ReportDataMessage),
-    /* K5   */  be_nested_str_weak(attribute_reports),
-    /* K6   */  be_nested_str_weak(attributes_requests),
-    /* K7   */  be_nested_str_weak(endpoint),
-    /* K8   */  be_nested_str_weak(cluster),
-    /* K9   */  be_nested_str_weak(attribute),
-    /* K10  */  be_nested_str_weak(status),
-    /* K11  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
-    /* K12  */  be_nested_str_weak(get_attribute_name),
-    /* K13  */  be_nested_str_weak(tasmota),
-    /* K14  */  be_nested_str_weak(log),
-    /* K15  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20),
-    /* K16  */  be_nested_str_weak(_X20_X28),
-    /* K17  */  be_nested_str_weak(_X29),
-    /* K18  */  be_nested_str_weak(),
-    /* K19  */  be_const_int(2),
-    /* K20  */  be_nested_str_weak(process_attribute_expansion),
-    /* K21  */  be_nested_str_weak(stop_iteration),
-    }),
-    be_str_weak(_inner_process_read_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[87]) {  /* code */
-      0x840C0000,  //  0000  CLOSURE	R3	P0
-      0x88100100,  //  0001  GETMBR	R4	R0	K0
-      0x8C100901,  //  0002  GETMET	R4	R4	K1
-      0x7C100200,  //  0003  CALL	R4	1
-      0xB8160400,  //  0004  GETNGBL	R5	K2
-      0x8C140B03,  //  0005  GETMET	R5	R5	K3
-      0x7C140200,  //  0006  CALL	R5	1
-      0xB81A0400,  //  0007  GETNGBL	R6	K2
-      0x8C180D04,  //  0008  GETMET	R6	R6	K4
-      0x7C180200,  //  0009  CALL	R6	1
-      0x601C0012,  //  000A  GETGBL	R7	G18
-      0x7C1C0000,  //  000B  CALL	R7	0
-      0x901A0A07,  //  000C  SETMBR	R6	K5	R7
-      0x601C0010,  //  000D  GETGBL	R7	G16
-      0x88200506,  //  000E  GETMBR	R8	R2	K6
-      0x7C1C0200,  //  000F  CALL	R7	1
-      0xA8020040,  //  0010  EXBLK	0	#0052
-      0x5C200E00,  //  0011  MOVE	R8	R7
-      0x7C200000,  //  0012  CALL	R8	0
-      0x88241107,  //  0013  GETMBR	R9	R8	K7
-      0x90160E09,  //  0014  SETMBR	R5	K7	R9
-      0x88241108,  //  0015  GETMBR	R9	R8	K8
-      0x90161009,  //  0016  SETMBR	R5	K8	R9
-      0x88241109,  //  0017  GETMBR	R9	R8	K9
-      0x90161209,  //  0018  SETMBR	R5	K9	R9
-      0xB8260400,  //  0019  GETNGBL	R9	K2
-      0x8824130B,  //  001A  GETMBR	R9	R9	K11
-      0x90161409,  //  001B  SETMBR	R5	K10	R9
-      0x88240B07,  //  001C  GETMBR	R9	R5	K7
-      0x4C280000,  //  001D  LDNIL	R10
-      0x1C24120A,  //  001E  EQ	R9	R9	R10
-      0x74260007,  //  001F  JMPT	R9	#0028
-      0x88240B08,  //  0020  GETMBR	R9	R5	K8
-      0x4C280000,  //  0021  LDNIL	R10
-      0x1C24120A,  //  0022  EQ	R9	R9	R10
-      0x74260003,  //  0023  JMPT	R9	#0028
-      0x88240B09,  //  0024  GETMBR	R9	R5	K9
-      0x4C280000,  //  0025  LDNIL	R10
-      0x1C24120A,  //  0026  EQ	R9	R9	R10
-      0x78260023,  //  0027  JMPF	R9	#004C
-      0x88240B08,  //  0028  GETMBR	R9	R5	K8
-      0x4C280000,  //  0029  LDNIL	R10
-      0x2024120A,  //  002A  NE	R9	R9	R10
-      0x78260017,  //  002B  JMPF	R9	#0044
-      0x88240B09,  //  002C  GETMBR	R9	R5	K9
-      0x4C280000,  //  002D  LDNIL	R10
-      0x2024120A,  //  002E  NE	R9	R9	R10
-      0x78260013,  //  002F  JMPF	R9	#0044
-      0xB8260400,  //  0030  GETNGBL	R9	K2
-      0x8C24130C,  //  0031  GETMET	R9	R9	K12
-      0x882C0B08,  //  0032  GETMBR	R11	R5	K8
-      0x88300B09,  //  0033  GETMBR	R12	R5	K9
-      0x7C240600,  //  0034  CALL	R9	3
-      0xB82A1A00,  //  0035  GETNGBL	R10	K13
-      0x8C28150E,  //  0036  GETMET	R10	R10	K14
-      0x60300008,  //  0037  GETGBL	R12	G8
-      0x5C340A00,  //  0038  MOVE	R13	R5
-      0x7C300200,  //  0039  CALL	R12	1
-      0x00321E0C,  //  003A  ADD	R12	K15	R12
-      0x78260002,  //  003B  JMPF	R9	#003F
-      0x00362009,  //  003C  ADD	R13	K16	R9
-      0x00341B11,  //  003D  ADD	R13	R13	K17
-      0x70020000,  //  003E  JMP		#0040
-      0x58340012,  //  003F  LDCONST	R13	K18
-      0x0030180D,  //  0040  ADD	R12	R12	R13
-      0x58340013,  //  0041  LDCONST	R13	K19
-      0x7C280600,  //  0042  CALL	R10	3
-      0x70020007,  //  0043  JMP		#004C
-      0xB8261A00,  //  0044  GETNGBL	R9	K13
-      0x8C24130E,  //  0045  GETMET	R9	R9	K14
-      0x602C0008,  //  0046  GETGBL	R11	G8
-      0x5C300A00,  //  0047  MOVE	R12	R5
-      0x7C2C0200,  //  0048  CALL	R11	1
-      0x002E1E0B,  //  0049  ADD	R11	K15	R11
-      0x58300013,  //  004A  LDCONST	R12	K19
-      0x7C240600,  //  004B  CALL	R9	3
-      0x88240100,  //  004C  GETMBR	R9	R0	K0
-      0x8C241314,  //  004D  GETMET	R9	R9	K20
-      0x5C2C0A00,  //  004E  MOVE	R11	R5
-      0x84300001,  //  004F  CLOSURE	R12	P1
-      0x7C240600,  //  0050  CALL	R9	3
-      0x7001FFBE,  //  0051  JMP		#0011
-      0x581C0015,  //  0052  LDCONST	R7	K21
-      0xAC1C0200,  //  0053  CATCH	R7	1	0
-      0xB0080000,  //  0054  RAISE	2	R0	R0
-      0xA0000000,  //  0055  CLOSE	R0
-      0x80040C00,  //  0056  RET	1	R6
     })
   )
 );
@@ -2192,6 +920,43 @@ be_local_closure(Matter_IM_find_sendqueue_by_exchangeid,   /* name */
 
 
 /********************************************************************
+** Solidified function: process_incoming_ack
+********************************************************************/
+be_local_closure(Matter_IM_process_incoming_ack,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(find_sendqueue_by_exchangeid),
+    /* K1   */  be_nested_str_weak(exchange_id),
+    /* K2   */  be_nested_str_weak(ack_received),
+    }),
+    be_str_weak(process_incoming_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x8C080100,  //  0000  GETMET	R2	R0	K0
+      0x88100301,  //  0001  GETMBR	R4	R1	K1
+      0x7C080400,  //  0002  CALL	R2	2
+      0x780A0003,  //  0003  JMPF	R2	#0008
+      0x8C0C0502,  //  0004  GETMET	R3	R2	K2
+      0x5C140200,  //  0005  MOVE	R5	R1
+      0x7C0C0400,  //  0006  CALL	R3	2
+      0x80040600,  //  0007  RET	1	R3
+      0x500C0000,  //  0008  LDBOOL	R3	0	0
+      0x80040600,  //  0009  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: process_invoke_response
 ********************************************************************/
 be_local_closure(Matter_IM_process_invoke_response,   /* name */
@@ -2234,161 +999,6 @@ be_local_closure(Matter_IM_process_invoke_response,   /* name */
       0x7C140600,  //  000E  CALL	R5	3
       0x50140000,  //  000F  LDBOOL	R5	0	0
       0x80040A00,  //  0010  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send_enqueued
-********************************************************************/
-be_local_closure(Matter_IM_send_enqueued,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(send_queue),
-    /* K2   */  be_nested_str_weak(ready),
-    /* K3   */  be_nested_str_weak(send),
-    /* K4   */  be_nested_str_weak(remove),
-    /* K5   */  be_const_int(1),
-    }),
-    be_str_weak(send_enqueued),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0x600C000C,  //  0001  GETGBL	R3	G12
-      0x88100101,  //  0002  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0003  CALL	R3	1
-      0x140C0403,  //  0004  LT	R3	R2	R3
-      0x780E0011,  //  0005  JMPF	R3	#0018
-      0x880C0101,  //  0006  GETMBR	R3	R0	K1
-      0x940C0602,  //  0007  GETIDX	R3	R3	R2
-      0x88100702,  //  0008  GETMBR	R4	R3	K2
-      0x7812000B,  //  0009  JMPF	R4	#0016
-      0x8C100703,  //  000A  GETMET	R4	R3	K3
-      0x5C180200,  //  000B  MOVE	R6	R1
-      0x7C100400,  //  000C  CALL	R4	2
-      0x78120005,  //  000D  JMPF	R4	#0014
-      0x88140101,  //  000E  GETMBR	R5	R0	K1
-      0x8C140B04,  //  000F  GETMET	R5	R5	K4
-      0x5C1C0400,  //  0010  MOVE	R7	R2
-      0x7C140400,  //  0011  CALL	R5	2
-      0x04080505,  //  0012  SUB	R2	R2	K5
-      0x70020001,  //  0013  JMP		#0016
-      0x50140000,  //  0014  LDBOOL	R5	0	0
-      0x900E0405,  //  0015  SETMBR	R3	K2	R5
-      0x00080505,  //  0016  ADD	R2	R2	K5
-      0x7001FFE8,  //  0017  JMP		#0001
-      0x80000000,  //  0018  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: process_timed_request
-********************************************************************/
-be_local_closure(Matter_IM_process_timed_request,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[16]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(matter),
-    /* K2   */  be_nested_str_weak(TimedRequestMessage),
-    /* K3   */  be_nested_str_weak(from_TLV),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
-    /* K7   */  be_const_int(3),
-    /* K8   */  be_nested_str_weak(format),
-    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20TimedRequest_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K10  */  be_nested_str_weak(timeout),
-    /* K11  */  be_nested_str_weak(remote_ip),
-    /* K12  */  be_nested_str_weak(remote_port),
-    /* K13  */  be_const_int(2),
-    /* K14  */  be_nested_str_weak(send_status),
-    /* K15  */  be_nested_str_weak(SUCCESS),
-    }),
-    be_str_weak(process_timed_request),
-    &be_const_str_solidified,
-    ( &(const binstruction[32]) {  /* code */
-      0xA40E0000,  //  0000  IMPORT	R3	K0
-      0xB8120200,  //  0001  GETNGBL	R4	K1
-      0x8C100902,  //  0002  GETMET	R4	R4	K2
-      0x7C100200,  //  0003  CALL	R4	1
-      0x8C100903,  //  0004  GETMET	R4	R4	K3
-      0x5C180400,  //  0005  MOVE	R6	R2
-      0x7C100400,  //  0006  CALL	R4	2
-      0xB8160800,  //  0007  GETNGBL	R5	K4
-      0x8C140B05,  //  0008  GETMET	R5	R5	K5
-      0x601C0008,  //  0009  GETGBL	R7	G8
-      0x5C200800,  //  000A  MOVE	R8	R4
-      0x7C1C0200,  //  000B  CALL	R7	1
-      0x001E0C07,  //  000C  ADD	R7	K6	R7
-      0x58200007,  //  000D  LDCONST	R8	K7
-      0x7C140600,  //  000E  CALL	R5	3
-      0xB8160800,  //  000F  GETNGBL	R5	K4
-      0x8C140B05,  //  0010  GETMET	R5	R5	K5
-      0x8C1C0708,  //  0011  GETMET	R7	R3	K8
-      0x58240009,  //  0012  LDCONST	R9	K9
-      0x8828090A,  //  0013  GETMBR	R10	R4	K10
-      0x882C030B,  //  0014  GETMBR	R11	R1	K11
-      0x8830030C,  //  0015  GETMBR	R12	R1	K12
-      0x7C1C0A00,  //  0016  CALL	R7	5
-      0x5820000D,  //  0017  LDCONST	R8	K13
-      0x7C140600,  //  0018  CALL	R5	3
-      0x8C14010E,  //  0019  GETMET	R5	R0	K14
-      0x5C1C0200,  //  001A  MOVE	R7	R1
-      0xB8220200,  //  001B  GETNGBL	R8	K1
-      0x8820110F,  //  001C  GETMBR	R8	R8	K15
-      0x7C140600,  //  001D  CALL	R5	3
-      0x50140200,  //  001E  LDBOOL	R5	1	0
-      0x80040A00,  //  001F  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: every_second
-********************************************************************/
-be_local_closure(Matter_IM_every_second,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expire_sendqueue),
-    }),
-    be_str_weak(every_second),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -2449,42 +1059,1566 @@ be_local_closure(Matter_IM_remove_sendqueue_by_exchangeid,   /* name */
 
 
 /********************************************************************
+** Solidified function: subscribe_response
+********************************************************************/
+be_local_closure(Matter_IM_subscribe_response,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(SubscribeResponseMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20SubscribeResponsetMessage_X3D),
+    /* K7   */  be_const_int(2),
+    }),
+    be_str_weak(subscribe_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x50140000,  //  000F  LDBOOL	R5	0	0
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_enqueued
+********************************************************************/
+be_local_closure(Matter_IM_send_enqueued,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(send_im),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_const_int(1),
+    }),
+    be_str_weak(send_enqueued),
+    &be_const_str_solidified,
+    ( &(const binstruction[20]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0x600C000C,  //  0001  GETGBL	R3	G12
+      0x88100101,  //  0002  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x140C0403,  //  0004  LT	R3	R2	R3
+      0x780E000C,  //  0005  JMPF	R3	#0013
+      0x880C0101,  //  0006  GETMBR	R3	R0	K1
+      0x940C0602,  //  0007  GETIDX	R3	R3	R2
+      0x8C100702,  //  0008  GETMET	R4	R3	K2
+      0x5C180200,  //  0009  MOVE	R6	R1
+      0x7C100400,  //  000A  CALL	R4	2
+      0x78120004,  //  000B  JMPF	R4	#0011
+      0x88140101,  //  000C  GETMBR	R5	R0	K1
+      0x8C140B03,  //  000D  GETMET	R5	R5	K3
+      0x5C1C0400,  //  000E  MOVE	R7	R2
+      0x7C140400,  //  000F  CALL	R5	2
+      0x04080504,  //  0010  SUB	R2	R2	K4
+      0x00080504,  //  0011  ADD	R2	R2	K4
+      0x7001FFED,  //  0012  JMP		#0001
+      0x80000000,  //  0013  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_IM_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device),
+    /* K1   */  be_nested_str_weak(send_queue),
+    /* K2   */  be_nested_str_weak(subs_shop),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(IM_Subscription_Shop),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x60080012,  //  0001  GETGBL	R2	G18
+      0x7C080000,  //  0002  CALL	R2	0
+      0x90020202,  //  0003  SETMBR	R0	K1	R2
+      0xB80A0600,  //  0004  GETNGBL	R2	K3
+      0x8C080504,  //  0005  GETMET	R2	R2	K4
+      0x5C100000,  //  0006  MOVE	R4	R0
+      0x7C080400,  //  0007  CALL	R2	2
+      0x90020402,  //  0008  SETMBR	R0	K2	R2
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_status
+********************************************************************/
+be_local_closure(Matter_IM_send_status,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_Status),
+    }),
+    be_str_weak(send_status),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_incoming
+********************************************************************/
+be_local_closure(Matter_IM_process_incoming,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20received_X20IM_X20message_X20),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(inspect),
+    /* K5   */  be_const_int(3),
+    /* K6   */  be_nested_str_weak(TLV),
+    /* K7   */  be_nested_str_weak(parse),
+    /* K8   */  be_nested_str_weak(raw),
+    /* K9   */  be_nested_str_weak(app_payload_idx),
+    /* K10  */  be_nested_str_weak(findsubval),
+    /* K11  */  be_nested_str_weak(opcode),
+    /* K12  */  be_const_int(1),
+    /* K13  */  be_nested_str_weak(process_status_response),
+    /* K14  */  be_const_int(2),
+    /* K15  */  be_nested_str_weak(send_ack_now),
+    /* K16  */  be_nested_str_weak(process_read_request),
+    /* K17  */  be_nested_str_weak(subscribe_request),
+    /* K18  */  be_nested_str_weak(subscribe_response),
+    /* K19  */  be_nested_str_weak(report_data),
+    /* K20  */  be_nested_str_weak(process_write_request),
+    /* K21  */  be_nested_str_weak(process_write_response),
+    /* K22  */  be_nested_str_weak(process_invoke_request),
+    /* K23  */  be_nested_str_weak(process_invoke_response),
+    /* K24  */  be_nested_str_weak(process_timed_request),
+    }),
+    be_str_weak(process_incoming),
+    &be_const_str_solidified,
+    ( &(const binstruction[119]) {  /* code */
+      0xB80A0000,  //  0000  GETNGBL	R2	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0xB8120600,  //  0002  GETNGBL	R4	K3
+      0x8C100904,  //  0003  GETMET	R4	R4	K4
+      0x5C180200,  //  0004  MOVE	R6	R1
+      0x7C100400,  //  0005  CALL	R4	2
+      0x00120404,  //  0006  ADD	R4	K2	R4
+      0x58140005,  //  0007  LDCONST	R5	K5
+      0x7C080600,  //  0008  CALL	R2	3
+      0xB80A0600,  //  0009  GETNGBL	R2	K3
+      0x88080506,  //  000A  GETMBR	R2	R2	K6
+      0x8C080507,  //  000B  GETMET	R2	R2	K7
+      0x88100308,  //  000C  GETMBR	R4	R1	K8
+      0x88140309,  //  000D  GETMBR	R5	R1	K9
+      0x7C080600,  //  000E  CALL	R2	3
+      0x8C0C050A,  //  000F  GETMET	R3	R2	K10
+      0x541600FE,  //  0010  LDINT	R5	255
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8810030B,  //  0012  GETMBR	R4	R1	K11
+      0x1C14090C,  //  0013  EQ	R5	R4	K12
+      0x78160005,  //  0014  JMPF	R5	#001B
+      0x8C14010D,  //  0015  GETMET	R5	R0	K13
+      0x5C1C0200,  //  0016  MOVE	R7	R1
+      0x5C200400,  //  0017  MOVE	R8	R2
+      0x7C140600,  //  0018  CALL	R5	3
+      0x80040A00,  //  0019  RET	1	R5
+      0x70020059,  //  001A  JMP		#0075
+      0x1C14090E,  //  001B  EQ	R5	R4	K14
+      0x78160008,  //  001C  JMPF	R5	#0026
+      0x8C14010F,  //  001D  GETMET	R5	R0	K15
+      0x5C1C0200,  //  001E  MOVE	R7	R1
+      0x7C140400,  //  001F  CALL	R5	2
+      0x8C140110,  //  0020  GETMET	R5	R0	K16
+      0x5C1C0200,  //  0021  MOVE	R7	R1
+      0x5C200400,  //  0022  MOVE	R8	R2
+      0x7C140600,  //  0023  CALL	R5	3
+      0x80040A00,  //  0024  RET	1	R5
+      0x7002004E,  //  0025  JMP		#0075
+      0x1C140905,  //  0026  EQ	R5	R4	K5
+      0x78160008,  //  0027  JMPF	R5	#0031
+      0x8C14010F,  //  0028  GETMET	R5	R0	K15
+      0x5C1C0200,  //  0029  MOVE	R7	R1
+      0x7C140400,  //  002A  CALL	R5	2
+      0x8C140111,  //  002B  GETMET	R5	R0	K17
+      0x5C1C0200,  //  002C  MOVE	R7	R1
+      0x5C200400,  //  002D  MOVE	R8	R2
+      0x7C140600,  //  002E  CALL	R5	3
+      0x80040A00,  //  002F  RET	1	R5
+      0x70020043,  //  0030  JMP		#0075
+      0x54160003,  //  0031  LDINT	R5	4
+      0x1C140805,  //  0032  EQ	R5	R4	R5
+      0x78160005,  //  0033  JMPF	R5	#003A
+      0x8C140112,  //  0034  GETMET	R5	R0	K18
+      0x5C1C0200,  //  0035  MOVE	R7	R1
+      0x5C200400,  //  0036  MOVE	R8	R2
+      0x7C140600,  //  0037  CALL	R5	3
+      0x80040A00,  //  0038  RET	1	R5
+      0x7002003A,  //  0039  JMP		#0075
+      0x54160004,  //  003A  LDINT	R5	5
+      0x1C140805,  //  003B  EQ	R5	R4	R5
+      0x78160005,  //  003C  JMPF	R5	#0043
+      0x8C140113,  //  003D  GETMET	R5	R0	K19
+      0x5C1C0200,  //  003E  MOVE	R7	R1
+      0x5C200400,  //  003F  MOVE	R8	R2
+      0x7C140600,  //  0040  CALL	R5	3
+      0x80040A00,  //  0041  RET	1	R5
+      0x70020031,  //  0042  JMP		#0075
+      0x54160005,  //  0043  LDINT	R5	6
+      0x1C140805,  //  0044  EQ	R5	R4	R5
+      0x78160008,  //  0045  JMPF	R5	#004F
+      0x8C14010F,  //  0046  GETMET	R5	R0	K15
+      0x5C1C0200,  //  0047  MOVE	R7	R1
+      0x7C140400,  //  0048  CALL	R5	2
+      0x8C140114,  //  0049  GETMET	R5	R0	K20
+      0x5C1C0200,  //  004A  MOVE	R7	R1
+      0x5C200400,  //  004B  MOVE	R8	R2
+      0x7C140600,  //  004C  CALL	R5	3
+      0x80040A00,  //  004D  RET	1	R5
+      0x70020025,  //  004E  JMP		#0075
+      0x54160006,  //  004F  LDINT	R5	7
+      0x1C140805,  //  0050  EQ	R5	R4	R5
+      0x78160005,  //  0051  JMPF	R5	#0058
+      0x8C140115,  //  0052  GETMET	R5	R0	K21
+      0x5C1C0200,  //  0053  MOVE	R7	R1
+      0x5C200400,  //  0054  MOVE	R8	R2
+      0x7C140600,  //  0055  CALL	R5	3
+      0x80040A00,  //  0056  RET	1	R5
+      0x7002001C,  //  0057  JMP		#0075
+      0x54160007,  //  0058  LDINT	R5	8
+      0x1C140805,  //  0059  EQ	R5	R4	R5
+      0x78160008,  //  005A  JMPF	R5	#0064
+      0x8C14010F,  //  005B  GETMET	R5	R0	K15
+      0x5C1C0200,  //  005C  MOVE	R7	R1
+      0x7C140400,  //  005D  CALL	R5	2
+      0x8C140116,  //  005E  GETMET	R5	R0	K22
+      0x5C1C0200,  //  005F  MOVE	R7	R1
+      0x5C200400,  //  0060  MOVE	R8	R2
+      0x7C140600,  //  0061  CALL	R5	3
+      0x80040A00,  //  0062  RET	1	R5
+      0x70020010,  //  0063  JMP		#0075
+      0x54160008,  //  0064  LDINT	R5	9
+      0x1C140805,  //  0065  EQ	R5	R4	R5
+      0x78160005,  //  0066  JMPF	R5	#006D
+      0x8C140117,  //  0067  GETMET	R5	R0	K23
+      0x5C1C0200,  //  0068  MOVE	R7	R1
+      0x5C200400,  //  0069  MOVE	R8	R2
+      0x7C140600,  //  006A  CALL	R5	3
+      0x80040A00,  //  006B  RET	1	R5
+      0x70020007,  //  006C  JMP		#0075
+      0x54160009,  //  006D  LDINT	R5	10
+      0x1C140805,  //  006E  EQ	R5	R4	R5
+      0x78160004,  //  006F  JMPF	R5	#0075
+      0x8C140118,  //  0070  GETMET	R5	R0	K24
+      0x5C1C0200,  //  0071  MOVE	R7	R1
+      0x5C200400,  //  0072  MOVE	R8	R2
+      0x7C140600,  //  0073  CALL	R5	3
+      0x80040A00,  //  0074  RET	1	R5
+      0x50140000,  //  0075  LDBOOL	R5	0	0
+      0x80040A00,  //  0076  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_timed_request
+********************************************************************/
+be_local_closure(Matter_IM_process_timed_request,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(TimedRequestMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20TimedRequestMessage_X3D),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(format),
+    /* K9   */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20TimedRequest_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K10  */  be_nested_str_weak(session),
+    /* K11  */  be_nested_str_weak(local_session_id),
+    /* K12  */  be_nested_str_weak(timeout),
+    /* K13  */  be_nested_str_weak(remote_ip),
+    /* K14  */  be_nested_str_weak(remote_port),
+    /* K15  */  be_const_int(2),
+    /* K16  */  be_nested_str_weak(send_status),
+    /* K17  */  be_nested_str_weak(SUCCESS),
+    }),
+    be_str_weak(process_timed_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[34]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0xB8160800,  //  000F  GETNGBL	R5	K4
+      0x8C140B05,  //  0010  GETMET	R5	R5	K5
+      0x8C1C0708,  //  0011  GETMET	R7	R3	K8
+      0x58240009,  //  0012  LDCONST	R9	K9
+      0x8828030A,  //  0013  GETMBR	R10	R1	K10
+      0x8828150B,  //  0014  GETMBR	R10	R10	K11
+      0x882C090C,  //  0015  GETMBR	R11	R4	K12
+      0x8830030D,  //  0016  GETMBR	R12	R1	K13
+      0x8834030E,  //  0017  GETMBR	R13	R1	K14
+      0x7C1C0C00,  //  0018  CALL	R7	6
+      0x5820000F,  //  0019  LDCONST	R8	K15
+      0x7C140600,  //  001A  CALL	R5	3
+      0x8C140110,  //  001B  GETMET	R5	R0	K16
+      0x5C1C0200,  //  001C  MOVE	R7	R1
+      0xB8220200,  //  001D  GETNGBL	R8	K1
+      0x88201111,  //  001E  GETMBR	R8	R8	K17
+      0x7C140600,  //  001F  CALL	R5	3
+      0x50140200,  //  0020  LDBOOL	R5	1	0
+      0x80040A00,  //  0021  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_report_data
+********************************************************************/
+be_local_closure(Matter_IM_send_report_data,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(send_queue),
+    /* K1   */  be_nested_str_weak(push),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(IM_ReportData),
+    }),
+    be_str_weak(send_report_data),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 9]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0xB8160400,  //  0002  GETNGBL	R5	K2
+      0x8C140B03,  //  0003  GETMET	R5	R5	K3
+      0x5C1C0200,  //  0004  MOVE	R7	R1
+      0x5C200400,  //  0005  MOVE	R8	R2
+      0x7C140600,  //  0006  CALL	R5	3
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x80000000,  //  0008  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_250ms
+********************************************************************/
+be_local_closure(Matter_IM_every_250ms,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs_shop),
+    /* K1   */  be_nested_str_weak(every_250ms),
+    }),
+    be_str_weak(every_250ms),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: process_invoke_request
+********************************************************************/
+be_local_closure(Matter_IM_process_invoke_request,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[50]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(MTR_X3A_X20IM_X3Ainvoke_request_X20processing_X20start),
+    /* K4   */  be_nested_str_weak(matter),
+    /* K5   */  be_nested_str_weak(Path),
+    /* K6   */  be_nested_str_weak(InvokeRequestMessage),
+    /* K7   */  be_nested_str_weak(from_TLV),
+    /* K8   */  be_nested_str_weak(invoke_requests),
+    /* K9   */  be_nested_str_weak(InvokeResponseMessage),
+    /* K10  */  be_nested_str_weak(suppress_response),
+    /* K11  */  be_nested_str_weak(invoke_responses),
+    /* K12  */  be_nested_str_weak(endpoint),
+    /* K13  */  be_nested_str_weak(command_path),
+    /* K14  */  be_nested_str_weak(cluster),
+    /* K15  */  be_nested_str_weak(command),
+    /* K16  */  be_nested_str_weak(status),
+    /* K17  */  be_nested_str_weak(UNSUPPORTED_COMMAND),
+    /* K18  */  be_nested_str_weak(get_command_name),
+    /* K19  */  be_nested_str_weak(format),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3ECommand_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K21  */  be_nested_str_weak(session),
+    /* K22  */  be_nested_str_weak(local_session_id),
+    /* K23  */  be_nested_str_weak(),
+    /* K24  */  be_nested_str_weak(remote_ip),
+    /* K25  */  be_nested_str_weak(remote_port),
+    /* K26  */  be_const_int(2),
+    /* K27  */  be_nested_str_weak(device),
+    /* K28  */  be_nested_str_weak(invoke_request),
+    /* K29  */  be_nested_str_weak(command_fields),
+    /* K30  */  be_nested_str_weak(InvokeResponseIB),
+    /* K31  */  be_nested_str_weak(SUCCESS),
+    /* K32  */  be_nested_str_weak(CommandStatusIB),
+    /* K33  */  be_nested_str_weak(CommandPathIB),
+    /* K34  */  be_nested_str_weak(StatusIB),
+    /* K35  */  be_nested_str_weak(push),
+    /* K36  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20OK_X20exch_X3D_X25i),
+    /* K37  */  be_nested_str_weak(exchange_id),
+    /* K38  */  be_nested_str_weak(CommandDataIB),
+    /* K39  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s_X20_X25s),
+    /* K40  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20Status_X3D0x_X2502X_X20exch_X3D_X25i),
+    /* K41  */  be_nested_str_weak(MTR_X3A_X20_Ignore_X20_X20_X20_X20_X28_X256i_X29_X20exch_X3D_X25i),
+    /* K42  */  be_nested_str_weak(stop_iteration),
+    /* K43  */  be_nested_str_weak(MTR_X3A_X20invoke_responses_X3D),
+    /* K44  */  be_const_int(0),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20InvokeResponse_X3D),
+    /* K46  */  be_nested_str_weak(MTR_X3A_X20InvokeResponseTLV_X3D),
+    /* K47  */  be_nested_str_weak(to_TLV),
+    /* K48  */  be_const_int(3),
+    /* K49  */  be_nested_str_weak(send_invoke_response),
+    }),
+    be_str_weak(process_invoke_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[288]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x58180003,  //  0003  LDCONST	R6	K3
+      0x541E0003,  //  0004  LDINT	R7	4
+      0x7C100600,  //  0005  CALL	R4	3
+      0xB8120800,  //  0006  GETNGBL	R4	K4
+      0x8C100905,  //  0007  GETMET	R4	R4	K5
+      0x7C100200,  //  0008  CALL	R4	1
+      0xB8160800,  //  0009  GETNGBL	R5	K4
+      0x8C140B06,  //  000A  GETMET	R5	R5	K6
+      0x7C140200,  //  000B  CALL	R5	1
+      0x8C140B07,  //  000C  GETMET	R5	R5	K7
+      0x5C1C0400,  //  000D  MOVE	R7	R2
+      0x7C140400,  //  000E  CALL	R5	2
+      0x88180B08,  //  000F  GETMBR	R6	R5	K8
+      0x4C1C0000,  //  0010  LDNIL	R7
+      0x20180C07,  //  0011  NE	R6	R6	R7
+      0x781A010B,  //  0012  JMPF	R6	#011F
+      0xB81A0800,  //  0013  GETNGBL	R6	K4
+      0x8C180D09,  //  0014  GETMET	R6	R6	K9
+      0x7C180200,  //  0015  CALL	R6	1
+      0x501C0000,  //  0016  LDBOOL	R7	0	0
+      0x901A1407,  //  0017  SETMBR	R6	K10	R7
+      0x601C0012,  //  0018  GETGBL	R7	G18
+      0x7C1C0000,  //  0019  CALL	R7	0
+      0x901A1607,  //  001A  SETMBR	R6	K11	R7
+      0x601C0010,  //  001B  GETGBL	R7	G16
+      0x88200B08,  //  001C  GETMBR	R8	R5	K8
+      0x7C1C0200,  //  001D  CALL	R7	1
+      0xA80200D5,  //  001E  EXBLK	0	#00F5
+      0x5C200E00,  //  001F  MOVE	R8	R7
+      0x7C200000,  //  0020  CALL	R8	0
+      0x8824110D,  //  0021  GETMBR	R9	R8	K13
+      0x8824130C,  //  0022  GETMBR	R9	R9	K12
+      0x90121809,  //  0023  SETMBR	R4	K12	R9
+      0x8824110D,  //  0024  GETMBR	R9	R8	K13
+      0x8824130E,  //  0025  GETMBR	R9	R9	K14
+      0x90121C09,  //  0026  SETMBR	R4	K14	R9
+      0x8824110D,  //  0027  GETMBR	R9	R8	K13
+      0x8824130F,  //  0028  GETMBR	R9	R9	K15
+      0x90121E09,  //  0029  SETMBR	R4	K15	R9
+      0xB8260800,  //  002A  GETNGBL	R9	K4
+      0x88241311,  //  002B  GETMBR	R9	R9	K17
+      0x90122009,  //  002C  SETMBR	R4	K16	R9
+      0xB8260800,  //  002D  GETNGBL	R9	K4
+      0x8C241312,  //  002E  GETMET	R9	R9	K18
+      0x882C090E,  //  002F  GETMBR	R11	R4	K14
+      0x8830090F,  //  0030  GETMBR	R12	R4	K15
+      0x7C240600,  //  0031  CALL	R9	3
+      0xB82A0200,  //  0032  GETNGBL	R10	K1
+      0x8C281502,  //  0033  GETMET	R10	R10	K2
+      0x8C300713,  //  0034  GETMET	R12	R3	K19
+      0x58380014,  //  0035  LDCONST	R14	K20
+      0x883C0315,  //  0036  GETMBR	R15	R1	K21
+      0x883C1F16,  //  0037  GETMBR	R15	R15	K22
+      0x60400008,  //  0038  GETGBL	R16	G8
+      0x5C440800,  //  0039  MOVE	R17	R4
+      0x7C400200,  //  003A  CALL	R16	1
+      0x78260001,  //  003B  JMPF	R9	#003E
+      0x5C441200,  //  003C  MOVE	R17	R9
+      0x70020000,  //  003D  JMP		#003F
+      0x58440017,  //  003E  LDCONST	R17	K23
+      0x88480318,  //  003F  GETMBR	R18	R1	K24
+      0x884C0319,  //  0040  GETMBR	R19	R1	K25
+      0x7C300E00,  //  0041  CALL	R12	7
+      0x5834001A,  //  0042  LDCONST	R13	K26
+      0x7C280600,  //  0043  CALL	R10	3
+      0x8828011B,  //  0044  GETMBR	R10	R0	K27
+      0x8C28151C,  //  0045  GETMET	R10	R10	K28
+      0x88300315,  //  0046  GETMBR	R12	R1	K21
+      0x8834111D,  //  0047  GETMBR	R13	R8	K29
+      0x5C380800,  //  0048  MOVE	R14	R4
+      0x7C280800,  //  0049  CALL	R10	4
+      0xB82E0800,  //  004A  GETNGBL	R11	K4
+      0x8C2C171E,  //  004B  GETMET	R11	R11	K30
+      0x7C2C0200,  //  004C  CALL	R11	1
+      0x50300200,  //  004D  LDBOOL	R12	1	0
+      0x1C30140C,  //  004E  EQ	R12	R10	R12
+      0x74320004,  //  004F  JMPT	R12	#0055
+      0x88300910,  //  0050  GETMBR	R12	R4	K16
+      0xB8360800,  //  0051  GETNGBL	R13	K4
+      0x88341B1F,  //  0052  GETMBR	R13	R13	K31
+      0x1C30180D,  //  0053  EQ	R12	R12	R13
+      0x7832002D,  //  0054  JMPF	R12	#0083
+      0xB8320800,  //  0055  GETNGBL	R12	K4
+      0x8C301920,  //  0056  GETMET	R12	R12	K32
+      0x7C300200,  //  0057  CALL	R12	1
+      0x902E200C,  //  0058  SETMBR	R11	K16	R12
+      0x88301710,  //  0059  GETMBR	R12	R11	K16
+      0xB8360800,  //  005A  GETNGBL	R13	K4
+      0x8C341B21,  //  005B  GETMET	R13	R13	K33
+      0x7C340200,  //  005C  CALL	R13	1
+      0x90321A0D,  //  005D  SETMBR	R12	K13	R13
+      0x88301710,  //  005E  GETMBR	R12	R11	K16
+      0x8830190D,  //  005F  GETMBR	R12	R12	K13
+      0x8834090C,  //  0060  GETMBR	R13	R4	K12
+      0x9032180D,  //  0061  SETMBR	R12	K12	R13
+      0x88301710,  //  0062  GETMBR	R12	R11	K16
+      0x8830190D,  //  0063  GETMBR	R12	R12	K13
+      0x8834090E,  //  0064  GETMBR	R13	R4	K14
+      0x90321C0D,  //  0065  SETMBR	R12	K14	R13
+      0x88301710,  //  0066  GETMBR	R12	R11	K16
+      0x8830190D,  //  0067  GETMBR	R12	R12	K13
+      0x8834090F,  //  0068  GETMBR	R13	R4	K15
+      0x90321E0D,  //  0069  SETMBR	R12	K15	R13
+      0x88301710,  //  006A  GETMBR	R12	R11	K16
+      0xB8360800,  //  006B  GETNGBL	R13	K4
+      0x8C341B22,  //  006C  GETMET	R13	R13	K34
+      0x7C340200,  //  006D  CALL	R13	1
+      0x9032200D,  //  006E  SETMBR	R12	K16	R13
+      0x88301710,  //  006F  GETMBR	R12	R11	K16
+      0x88301910,  //  0070  GETMBR	R12	R12	K16
+      0xB8360800,  //  0071  GETNGBL	R13	K4
+      0x88341B1F,  //  0072  GETMBR	R13	R13	K31
+      0x9032200D,  //  0073  SETMBR	R12	K16	R13
+      0x88300D0B,  //  0074  GETMBR	R12	R6	K11
+      0x8C301923,  //  0075  GETMET	R12	R12	K35
+      0x5C381600,  //  0076  MOVE	R14	R11
+      0x7C300400,  //  0077  CALL	R12	2
+      0xB8320200,  //  0078  GETNGBL	R12	K1
+      0x8C301902,  //  0079  GETMET	R12	R12	K2
+      0x8C380713,  //  007A  GETMET	R14	R3	K19
+      0x58400024,  //  007B  LDCONST	R16	K36
+      0x88440315,  //  007C  GETMBR	R17	R1	K21
+      0x88442316,  //  007D  GETMBR	R17	R17	K22
+      0x88480325,  //  007E  GETMBR	R18	R1	K37
+      0x7C380800,  //  007F  CALL	R14	4
+      0x583C001A,  //  0080  LDCONST	R15	K26
+      0x7C300600,  //  0081  CALL	R12	3
+      0x70020070,  //  0082  JMP		#00F4
+      0x4C300000,  //  0083  LDNIL	R12
+      0x2030140C,  //  0084  NE	R12	R10	R12
+      0x78320031,  //  0085  JMPF	R12	#00B8
+      0xB8320800,  //  0086  GETNGBL	R12	K4
+      0x8C301926,  //  0087  GETMET	R12	R12	K38
+      0x7C300200,  //  0088  CALL	R12	1
+      0x902E1E0C,  //  0089  SETMBR	R11	K15	R12
+      0x8830170F,  //  008A  GETMBR	R12	R11	K15
+      0xB8360800,  //  008B  GETNGBL	R13	K4
+      0x8C341B21,  //  008C  GETMET	R13	R13	K33
+      0x7C340200,  //  008D  CALL	R13	1
+      0x90321A0D,  //  008E  SETMBR	R12	K13	R13
+      0x8830170F,  //  008F  GETMBR	R12	R11	K15
+      0x8830190D,  //  0090  GETMBR	R12	R12	K13
+      0x8834090C,  //  0091  GETMBR	R13	R4	K12
+      0x9032180D,  //  0092  SETMBR	R12	K12	R13
+      0x8830170F,  //  0093  GETMBR	R12	R11	K15
+      0x8830190D,  //  0094  GETMBR	R12	R12	K13
+      0x8834090E,  //  0095  GETMBR	R13	R4	K14
+      0x90321C0D,  //  0096  SETMBR	R12	K14	R13
+      0x8830170F,  //  0097  GETMBR	R12	R11	K15
+      0x8830190D,  //  0098  GETMBR	R12	R12	K13
+      0x8834090F,  //  0099  GETMBR	R13	R4	K15
+      0x90321E0D,  //  009A  SETMBR	R12	K15	R13
+      0x8830170F,  //  009B  GETMBR	R12	R11	K15
+      0x90323A0A,  //  009C  SETMBR	R12	K29	R10
+      0x88300D0B,  //  009D  GETMBR	R12	R6	K11
+      0x8C301923,  //  009E  GETMET	R12	R12	K35
+      0x5C381600,  //  009F  MOVE	R14	R11
+      0x7C300400,  //  00A0  CALL	R12	2
+      0xB8320800,  //  00A1  GETNGBL	R12	K4
+      0x8C301912,  //  00A2  GETMET	R12	R12	K18
+      0x8838090E,  //  00A3  GETMBR	R14	R4	K14
+      0x883C090F,  //  00A4  GETMBR	R15	R4	K15
+      0x7C300600,  //  00A5  CALL	R12	3
+      0x5C241800,  //  00A6  MOVE	R9	R12
+      0xB8320200,  //  00A7  GETNGBL	R12	K1
+      0x8C301902,  //  00A8  GETMET	R12	R12	K2
+      0x8C380713,  //  00A9  GETMET	R14	R3	K19
+      0x58400027,  //  00AA  LDCONST	R16	K39
+      0x88440315,  //  00AB  GETMBR	R17	R1	K21
+      0x88442316,  //  00AC  GETMBR	R17	R17	K22
+      0x60480008,  //  00AD  GETGBL	R18	G8
+      0x5C4C0800,  //  00AE  MOVE	R19	R4
+      0x7C480200,  //  00AF  CALL	R18	1
+      0x78260001,  //  00B0  JMPF	R9	#00B3
+      0x5C4C1200,  //  00B1  MOVE	R19	R9
+      0x70020000,  //  00B2  JMP		#00B4
+      0x584C0017,  //  00B3  LDCONST	R19	K23
+      0x7C380A00,  //  00B4  CALL	R14	5
+      0x583C001A,  //  00B5  LDCONST	R15	K26
+      0x7C300600,  //  00B6  CALL	R12	3
+      0x7002003B,  //  00B7  JMP		#00F4
+      0x88300910,  //  00B8  GETMBR	R12	R4	K16
+      0x4C340000,  //  00B9  LDNIL	R13
+      0x2030180D,  //  00BA  NE	R12	R12	R13
+      0x7832002D,  //  00BB  JMPF	R12	#00EA
+      0xB8320800,  //  00BC  GETNGBL	R12	K4
+      0x8C301920,  //  00BD  GETMET	R12	R12	K32
+      0x7C300200,  //  00BE  CALL	R12	1
+      0x902E200C,  //  00BF  SETMBR	R11	K16	R12
+      0x88301710,  //  00C0  GETMBR	R12	R11	K16
+      0xB8360800,  //  00C1  GETNGBL	R13	K4
+      0x8C341B21,  //  00C2  GETMET	R13	R13	K33
+      0x7C340200,  //  00C3  CALL	R13	1
+      0x90321A0D,  //  00C4  SETMBR	R12	K13	R13
+      0x88301710,  //  00C5  GETMBR	R12	R11	K16
+      0x8830190D,  //  00C6  GETMBR	R12	R12	K13
+      0x8834090C,  //  00C7  GETMBR	R13	R4	K12
+      0x9032180D,  //  00C8  SETMBR	R12	K12	R13
+      0x88301710,  //  00C9  GETMBR	R12	R11	K16
+      0x8830190D,  //  00CA  GETMBR	R12	R12	K13
+      0x8834090E,  //  00CB  GETMBR	R13	R4	K14
+      0x90321C0D,  //  00CC  SETMBR	R12	K14	R13
+      0x88301710,  //  00CD  GETMBR	R12	R11	K16
+      0x8830190D,  //  00CE  GETMBR	R12	R12	K13
+      0x8834090F,  //  00CF  GETMBR	R13	R4	K15
+      0x90321E0D,  //  00D0  SETMBR	R12	K15	R13
+      0x88301710,  //  00D1  GETMBR	R12	R11	K16
+      0xB8360800,  //  00D2  GETNGBL	R13	K4
+      0x8C341B22,  //  00D3  GETMET	R13	R13	K34
+      0x7C340200,  //  00D4  CALL	R13	1
+      0x9032200D,  //  00D5  SETMBR	R12	K16	R13
+      0x88301710,  //  00D6  GETMBR	R12	R11	K16
+      0x88301910,  //  00D7  GETMBR	R12	R12	K16
+      0x88340910,  //  00D8  GETMBR	R13	R4	K16
+      0x9032200D,  //  00D9  SETMBR	R12	K16	R13
+      0x88300D0B,  //  00DA  GETMBR	R12	R6	K11
+      0x8C301923,  //  00DB  GETMET	R12	R12	K35
+      0x5C381600,  //  00DC  MOVE	R14	R11
+      0x7C300400,  //  00DD  CALL	R12	2
+      0xB8320200,  //  00DE  GETNGBL	R12	K1
+      0x8C301902,  //  00DF  GETMET	R12	R12	K2
+      0x8C380713,  //  00E0  GETMET	R14	R3	K19
+      0x58400028,  //  00E1  LDCONST	R16	K40
+      0x88440315,  //  00E2  GETMBR	R17	R1	K21
+      0x88442316,  //  00E3  GETMBR	R17	R17	K22
+      0x88480910,  //  00E4  GETMBR	R18	R4	K16
+      0x884C0325,  //  00E5  GETMBR	R19	R1	K37
+      0x7C380A00,  //  00E6  CALL	R14	5
+      0x583C001A,  //  00E7  LDCONST	R15	K26
+      0x7C300600,  //  00E8  CALL	R12	3
+      0x70020009,  //  00E9  JMP		#00F4
+      0xB8320200,  //  00EA  GETNGBL	R12	K1
+      0x8C301902,  //  00EB  GETMET	R12	R12	K2
+      0x8C380713,  //  00EC  GETMET	R14	R3	K19
+      0x58400029,  //  00ED  LDCONST	R16	K41
+      0x88440315,  //  00EE  GETMBR	R17	R1	K21
+      0x88442316,  //  00EF  GETMBR	R17	R17	K22
+      0x88480325,  //  00F0  GETMBR	R18	R1	K37
+      0x7C380800,  //  00F1  CALL	R14	4
+      0x583C001A,  //  00F2  LDCONST	R15	K26
+      0x7C300600,  //  00F3  CALL	R12	3
+      0x7001FF29,  //  00F4  JMP		#001F
+      0x581C002A,  //  00F5  LDCONST	R7	K42
+      0xAC1C0200,  //  00F6  CATCH	R7	1	0
+      0xB0080000,  //  00F7  RAISE	2	R0	R0
+      0xB81E0200,  //  00F8  GETNGBL	R7	K1
+      0x8C1C0F02,  //  00F9  GETMET	R7	R7	K2
+      0x60240008,  //  00FA  GETGBL	R9	G8
+      0x88280D0B,  //  00FB  GETMBR	R10	R6	K11
+      0x7C240200,  //  00FC  CALL	R9	1
+      0x00265609,  //  00FD  ADD	R9	K43	R9
+      0x542A0003,  //  00FE  LDINT	R10	4
+      0x7C1C0600,  //  00FF  CALL	R7	3
+      0x601C000C,  //  0100  GETGBL	R7	G12
+      0x88200D0B,  //  0101  GETMBR	R8	R6	K11
+      0x7C1C0200,  //  0102  CALL	R7	1
+      0x241C0F2C,  //  0103  GT	R7	R7	K44
+      0x781E0015,  //  0104  JMPF	R7	#011B
+      0xB81E0200,  //  0105  GETNGBL	R7	K1
+      0x8C1C0F02,  //  0106  GETMET	R7	R7	K2
+      0x60240008,  //  0107  GETGBL	R9	G8
+      0x5C280C00,  //  0108  MOVE	R10	R6
+      0x7C240200,  //  0109  CALL	R9	1
+      0x00265A09,  //  010A  ADD	R9	K45	R9
+      0x542A0003,  //  010B  LDINT	R10	4
+      0x7C1C0600,  //  010C  CALL	R7	3
+      0xB81E0200,  //  010D  GETNGBL	R7	K1
+      0x8C1C0F02,  //  010E  GETMET	R7	R7	K2
+      0x60240008,  //  010F  GETGBL	R9	G8
+      0x8C280D2F,  //  0110  GETMET	R10	R6	K47
+      0x7C280200,  //  0111  CALL	R10	1
+      0x7C240200,  //  0112  CALL	R9	1
+      0x00265C09,  //  0113  ADD	R9	K46	R9
+      0x58280030,  //  0114  LDCONST	R10	K48
+      0x7C1C0600,  //  0115  CALL	R7	3
+      0x8C1C0131,  //  0116  GETMET	R7	R0	K49
+      0x5C240200,  //  0117  MOVE	R9	R1
+      0x5C280C00,  //  0118  MOVE	R10	R6
+      0x7C1C0600,  //  0119  CALL	R7	3
+      0x70020001,  //  011A  JMP		#011D
+      0x501C0000,  //  011B  LDBOOL	R7	0	0
+      0x80040E00,  //  011C  RET	1	R7
+      0x501C0200,  //  011D  LDBOOL	R7	1	0
+      0x80040E00,  //  011E  RET	1	R7
+      0x80000000,  //  011F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_subscribe_update
+********************************************************************/
+be_local_closure(Matter_IM_send_subscribe_update,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[29]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(session),
+    /* K2   */  be_nested_str_weak(matter),
+    /* K3   */  be_nested_str_weak(ReadRequestMessage),
+    /* K4   */  be_nested_str_weak(fabric_filtered),
+    /* K5   */  be_nested_str_weak(attributes_requests),
+    /* K6   */  be_nested_str_weak(updates),
+    /* K7   */  be_nested_str_weak(AttributePathIB),
+    /* K8   */  be_nested_str_weak(endpoint),
+    /* K9   */  be_nested_str_weak(cluster),
+    /* K10  */  be_nested_str_weak(attribute),
+    /* K11  */  be_nested_str_weak(push),
+    /* K12  */  be_nested_str_weak(stop_iteration),
+    /* K13  */  be_const_int(0),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(format),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Data_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(subscription_id),
+    /* K20  */  be_const_int(2),
+    /* K21  */  be_nested_str_weak(is_keep_alive),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3CSub_Alive_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K23  */  be_nested_str_weak(_inner_process_read_request),
+    /* K24  */  be_nested_str_weak(suppress_response),
+    /* K25  */  be_nested_str_weak(IM_ReportDataSubscribed),
+    /* K26  */  be_nested_str_weak(_message_handler),
+    /* K27  */  be_nested_str_weak(send_queue),
+    /* K28  */  be_nested_str_weak(send_enqueued),
+    }),
+    be_str_weak(send_subscribe_update),
+    &be_const_str_solidified,
+    ( &(const binstruction[87]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x880C0301,  //  0001  GETMBR	R3	R1	K1
+      0xB8120400,  //  0002  GETNGBL	R4	K2
+      0x8C100903,  //  0003  GETMET	R4	R4	K3
+      0x7C100200,  //  0004  CALL	R4	1
+      0x50140000,  //  0005  LDBOOL	R5	0	0
+      0x90120805,  //  0006  SETMBR	R4	K4	R5
+      0x60140012,  //  0007  GETGBL	R5	G18
+      0x7C140000,  //  0008  CALL	R5	0
+      0x90120A05,  //  0009  SETMBR	R4	K5	R5
+      0x60140010,  //  000A  GETGBL	R5	G16
+      0x88180306,  //  000B  GETMBR	R6	R1	K6
+      0x7C140200,  //  000C  CALL	R5	1
+      0xA802000F,  //  000D  EXBLK	0	#001E
+      0x5C180A00,  //  000E  MOVE	R6	R5
+      0x7C180000,  //  000F  CALL	R6	0
+      0xB81E0400,  //  0010  GETNGBL	R7	K2
+      0x8C1C0F07,  //  0011  GETMET	R7	R7	K7
+      0x7C1C0200,  //  0012  CALL	R7	1
+      0x88200D08,  //  0013  GETMBR	R8	R6	K8
+      0x901E1008,  //  0014  SETMBR	R7	K8	R8
+      0x88200D09,  //  0015  GETMBR	R8	R6	K9
+      0x901E1208,  //  0016  SETMBR	R7	K9	R8
+      0x88200D0A,  //  0017  GETMBR	R8	R6	K10
+      0x901E1408,  //  0018  SETMBR	R7	K10	R8
+      0x88200905,  //  0019  GETMBR	R8	R4	K5
+      0x8C20110B,  //  001A  GETMET	R8	R8	K11
+      0x5C280E00,  //  001B  MOVE	R10	R7
+      0x7C200400,  //  001C  CALL	R8	2
+      0x7001FFEF,  //  001D  JMP		#000E
+      0x5814000C,  //  001E  LDCONST	R5	K12
+      0xAC140200,  //  001F  CATCH	R5	1	0
+      0xB0080000,  //  0020  RAISE	2	R0	R0
+      0x6014000C,  //  0021  GETGBL	R5	G12
+      0x88180905,  //  0022  GETMBR	R6	R4	K5
+      0x7C140200,  //  0023  CALL	R5	1
+      0x24140B0D,  //  0024  GT	R5	R5	K13
+      0x7816000B,  //  0025  JMPF	R5	#0032
+      0xB8161C00,  //  0026  GETNGBL	R5	K14
+      0x8C140B0F,  //  0027  GETMET	R5	R5	K15
+      0x8C1C0510,  //  0028  GETMET	R7	R2	K16
+      0x58240011,  //  0029  LDCONST	R9	K17
+      0x88280712,  //  002A  GETMBR	R10	R3	K18
+      0x882C0313,  //  002B  GETMBR	R11	R1	K19
+      0x7C1C0800,  //  002C  CALL	R7	4
+      0x58200014,  //  002D  LDCONST	R8	K20
+      0x7C140600,  //  002E  CALL	R5	3
+      0x50140000,  //  002F  LDBOOL	R5	0	0
+      0x90062A05,  //  0030  SETMBR	R1	K21	R5
+      0x7002000A,  //  0031  JMP		#003D
+      0xB8161C00,  //  0032  GETNGBL	R5	K14
+      0x8C140B0F,  //  0033  GETMET	R5	R5	K15
+      0x8C1C0510,  //  0034  GETMET	R7	R2	K16
+      0x58240016,  //  0035  LDCONST	R9	K22
+      0x88280712,  //  0036  GETMBR	R10	R3	K18
+      0x882C0313,  //  0037  GETMBR	R11	R1	K19
+      0x7C1C0800,  //  0038  CALL	R7	4
+      0x58200014,  //  0039  LDCONST	R8	K20
+      0x7C140600,  //  003A  CALL	R5	3
+      0x50140200,  //  003B  LDBOOL	R5	1	0
+      0x90062A05,  //  003C  SETMBR	R1	K21	R5
+      0x8C140117,  //  003D  GETMET	R5	R0	K23
+      0x5C1C0600,  //  003E  MOVE	R7	R3
+      0x5C200800,  //  003F  MOVE	R8	R4
+      0x7C140600,  //  0040  CALL	R5	3
+      0x6018000C,  //  0041  GETGBL	R6	G12
+      0x881C0905,  //  0042  GETMBR	R7	R4	K5
+      0x7C180200,  //  0043  CALL	R6	1
+      0x1C180D0D,  //  0044  EQ	R6	R6	K13
+      0x90163006,  //  0045  SETMBR	R5	K24	R6
+      0x88180313,  //  0046  GETMBR	R6	R1	K19
+      0x90162606,  //  0047  SETMBR	R5	K19	R6
+      0xB81A0400,  //  0048  GETNGBL	R6	K2
+      0x8C180D19,  //  0049  GETMET	R6	R6	K25
+      0x8820071A,  //  004A  GETMBR	R8	R3	K26
+      0x5C240600,  //  004B  MOVE	R9	R3
+      0x5C280A00,  //  004C  MOVE	R10	R5
+      0x5C2C0200,  //  004D  MOVE	R11	R1
+      0x7C180A00,  //  004E  CALL	R6	5
+      0x881C011B,  //  004F  GETMBR	R7	R0	K27
+      0x8C1C0F0B,  //  0050  GETMET	R7	R7	K11
+      0x5C240C00,  //  0051  MOVE	R9	R6
+      0x7C1C0400,  //  0052  CALL	R7	2
+      0x8C1C011C,  //  0053  GETMET	R7	R0	K28
+      0x8824071A,  //  0054  GETMBR	R9	R3	K26
+      0x7C1C0400,  //  0055  CALL	R7	2
+      0x80000000,  //  0056  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_ack_now
+********************************************************************/
+be_local_closure(Matter_IM_send_ack_now,   /* name */
+  be_nested_proto(
+    14,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[19]) {     /* constants */
+    /* K0   */  be_nested_str_weak(x_flag_r),
+    /* K1   */  be_nested_str_weak(build_standalone_ack),
+    /* K2   */  be_nested_str_weak(encode_frame),
+    /* K3   */  be_nested_str_weak(encrypt),
+    /* K4   */  be_nested_str_weak(string),
+    /* K5   */  be_nested_str_weak(tasmota),
+    /* K6   */  be_nested_str_weak(log),
+    /* K7   */  be_nested_str_weak(format),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X3CAck_now_X20_X20_X20_X28_X256i_X29_X20rack_X3D_X25i_X20id_X3D_X25i_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K9   */  be_nested_str_weak(session),
+    /* K10  */  be_nested_str_weak(local_session_id),
+    /* K11  */  be_nested_str_weak(ack_message_counter),
+    /* K12  */  be_nested_str_weak(message_counter),
+    /* K13  */  be_nested_str_weak(remote_ip),
+    /* K14  */  be_nested_str_weak(remote_port),
+    /* K15  */  be_const_int(3),
+    /* K16  */  be_nested_str_weak(_message_handler),
+    /* K17  */  be_nested_str_weak(send_response),
+    /* K18  */  be_nested_str_weak(raw),
+    }),
+    be_str_weak(send_ack_now),
+    &be_const_str_solidified,
+    ( &(const binstruction[35]) {  /* code */
+      0x88080300,  //  0000  GETMBR	R2	R1	K0
+      0x780A001D,  //  0001  JMPF	R2	#0020
+      0x8C080301,  //  0002  GETMET	R2	R1	K1
+      0x50100000,  //  0003  LDBOOL	R4	0	0
+      0x7C080400,  //  0004  CALL	R2	2
+      0x8C0C0502,  //  0005  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0006  CALL	R3	1
+      0x8C0C0503,  //  0007  GETMET	R3	R2	K3
+      0x7C0C0200,  //  0008  CALL	R3	1
+      0xA40E0800,  //  0009  IMPORT	R3	K4
+      0xB8120A00,  //  000A  GETNGBL	R4	K5
+      0x8C100906,  //  000B  GETMET	R4	R4	K6
+      0x8C180707,  //  000C  GETMET	R6	R3	K7
+      0x58200008,  //  000D  LDCONST	R8	K8
+      0x88240509,  //  000E  GETMBR	R9	R2	K9
+      0x8824130A,  //  000F  GETMBR	R9	R9	K10
+      0x8828050B,  //  0010  GETMBR	R10	R2	K11
+      0x882C050C,  //  0011  GETMBR	R11	R2	K12
+      0x8830050D,  //  0012  GETMBR	R12	R2	K13
+      0x8834050E,  //  0013  GETMBR	R13	R2	K14
+      0x7C180E00,  //  0014  CALL	R6	7
+      0x581C000F,  //  0015  LDCONST	R7	K15
+      0x7C100600,  //  0016  CALL	R4	3
+      0x88100309,  //  0017  GETMBR	R4	R1	K9
+      0x88100910,  //  0018  GETMBR	R4	R4	K16
+      0x8C100911,  //  0019  GETMET	R4	R4	K17
+      0x88180512,  //  001A  GETMBR	R6	R2	K18
+      0x881C050D,  //  001B  GETMBR	R7	R2	K13
+      0x8820050E,  //  001C  GETMBR	R8	R2	K14
+      0x4C240000,  //  001D  LDNIL	R9
+      0x7C100A00,  //  001E  CALL	R4	5
+      0x70020001,  //  001F  JMP		#0022
+      0x50080200,  //  0020  LDBOOL	R2	1	0
+      0x80040400,  //  0021  RET	1	R2
+      0x80000000,  //  0022  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: every_second
+********************************************************************/
+be_local_closure(Matter_IM_every_second,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expire_sendqueue),
+    }),
+    be_str_weak(every_second),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _inner_process_read_request
+********************************************************************/
+be_local_closure(Matter_IM__inner_process_read_request,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 2]) {
+      be_nested_proto(
+        19,                          /* nstack */
+        4,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 1),
+          be_local_const_upval(1, 3),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[33]) {     /* constants */
+        /* K0   */  be_nested_str_weak(string),
+        /* K1   */  be_nested_str_weak(matter),
+        /* K2   */  be_nested_str_weak(get_attribute_name),
+        /* K3   */  be_nested_str_weak(cluster),
+        /* K4   */  be_nested_str_weak(attribute),
+        /* K5   */  be_nested_str_weak(_X20_X28),
+        /* K6   */  be_nested_str_weak(_X29),
+        /* K7   */  be_nested_str_weak(),
+        /* K8   */  be_nested_str_weak(read_attribute),
+        /* K9   */  be_nested_str_weak(AttributeReportIB),
+        /* K10  */  be_nested_str_weak(attribute_data),
+        /* K11  */  be_nested_str_weak(AttributeDataIB),
+        /* K12  */  be_nested_str_weak(data_version),
+        /* K13  */  be_const_int(1),
+        /* K14  */  be_nested_str_weak(path),
+        /* K15  */  be_nested_str_weak(AttributePathIB),
+        /* K16  */  be_nested_str_weak(endpoint),
+        /* K17  */  be_nested_str_weak(data),
+        /* K18  */  be_nested_str_weak(attribute_reports),
+        /* K19  */  be_nested_str_weak(push),
+        /* K20  */  be_nested_str_weak(tasmota),
+        /* K21  */  be_nested_str_weak(log),
+        /* K22  */  be_nested_str_weak(format),
+        /* K23  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20_X25s),
+        /* K24  */  be_nested_str_weak(local_session_id),
+        /* K25  */  be_const_int(2),
+        /* K26  */  be_nested_str_weak(status),
+        /* K27  */  be_nested_str_weak(attribute_status),
+        /* K28  */  be_nested_str_weak(AttributeStatusIB),
+        /* K29  */  be_nested_str_weak(StatusIB),
+        /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20STATUS_X3A_X200x_X2502X_X20_X25s),
+        /* K31  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+        /* K32  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s_X25s_X20_X2D_X20IGNORED),
+        }),
+        be_str_weak(read_single_attribute),
+        &be_const_str_solidified,
+        ( &(const binstruction[160]) {  /* code */
+          0xA4120000,  //  0000  IMPORT	R4	K0
+          0xB8160200,  //  0001  GETNGBL	R5	K1
+          0x8C140B02,  //  0002  GETMET	R5	R5	K2
+          0x881C0503,  //  0003  GETMBR	R7	R2	K3
+          0x88200504,  //  0004  GETMBR	R8	R2	K4
+          0x7C140600,  //  0005  CALL	R5	3
+          0x78160002,  //  0006  JMPF	R5	#000A
+          0x001A0A05,  //  0007  ADD	R6	K5	R5
+          0x00180D06,  //  0008  ADD	R6	R6	K6
+          0x70020000,  //  0009  JMP		#000B
+          0x58180007,  //  000A  LDCONST	R6	K7
+          0x5C140C00,  //  000B  MOVE	R5	R6
+          0x4C180000,  //  000C  LDNIL	R6
+          0x20180206,  //  000D  NE	R6	R1	R6
+          0x781A0004,  //  000E  JMPF	R6	#0014
+          0x8C180308,  //  000F  GETMET	R6	R1	K8
+          0x68200000,  //  0010  GETUPV	R8	U0
+          0x5C240400,  //  0011  MOVE	R9	R2
+          0x7C180600,  //  0012  CALL	R6	3
+          0x70020000,  //  0013  JMP		#0015
+          0x4C180000,  //  0014  LDNIL	R6
+          0x4C1C0000,  //  0015  LDNIL	R7
+          0x201C0C07,  //  0016  NE	R7	R6	R7
+          0x781E0034,  //  0017  JMPF	R7	#004D
+          0xB81E0200,  //  0018  GETNGBL	R7	K1
+          0x8C1C0F09,  //  0019  GETMET	R7	R7	K9
+          0x7C1C0200,  //  001A  CALL	R7	1
+          0xB8220200,  //  001B  GETNGBL	R8	K1
+          0x8C20110B,  //  001C  GETMET	R8	R8	K11
+          0x7C200200,  //  001D  CALL	R8	1
+          0x901E1408,  //  001E  SETMBR	R7	K10	R8
+          0x88200F0A,  //  001F  GETMBR	R8	R7	K10
+          0x9022190D,  //  0020  SETMBR	R8	K12	K13
+          0x88200F0A,  //  0021  GETMBR	R8	R7	K10
+          0xB8260200,  //  0022  GETNGBL	R9	K1
+          0x8C24130F,  //  0023  GETMET	R9	R9	K15
+          0x7C240200,  //  0024  CALL	R9	1
+          0x90221C09,  //  0025  SETMBR	R8	K14	R9
+          0x88200F0A,  //  0026  GETMBR	R8	R7	K10
+          0x8820110E,  //  0027  GETMBR	R8	R8	K14
+          0x88240510,  //  0028  GETMBR	R9	R2	K16
+          0x90222009,  //  0029  SETMBR	R8	K16	R9
+          0x88200F0A,  //  002A  GETMBR	R8	R7	K10
+          0x8820110E,  //  002B  GETMBR	R8	R8	K14
+          0x88240503,  //  002C  GETMBR	R9	R2	K3
+          0x90220609,  //  002D  SETMBR	R8	K3	R9
+          0x88200F0A,  //  002E  GETMBR	R8	R7	K10
+          0x8820110E,  //  002F  GETMBR	R8	R8	K14
+          0x88240504,  //  0030  GETMBR	R9	R2	K4
+          0x90220809,  //  0031  SETMBR	R8	K4	R9
+          0x88200F0A,  //  0032  GETMBR	R8	R7	K10
+          0x90222206,  //  0033  SETMBR	R8	K17	R6
+          0x88200112,  //  0034  GETMBR	R8	R0	K18
+          0x8C201113,  //  0035  GETMET	R8	R8	K19
+          0x5C280E00,  //  0036  MOVE	R10	R7
+          0x7C200400,  //  0037  CALL	R8	2
+          0x68200001,  //  0038  GETUPV	R8	U1
+          0x7422000F,  //  0039  JMPT	R8	#004A
+          0xB8222800,  //  003A  GETNGBL	R8	K20
+          0x8C201115,  //  003B  GETMET	R8	R8	K21
+          0x8C280916,  //  003C  GETMET	R10	R4	K22
+          0x58300017,  //  003D  LDCONST	R12	K23
+          0x68340000,  //  003E  GETUPV	R13	U0
+          0x88341B18,  //  003F  GETMBR	R13	R13	K24
+          0x60380008,  //  0040  GETGBL	R14	G8
+          0x5C3C0400,  //  0041  MOVE	R15	R2
+          0x7C380200,  //  0042  CALL	R14	1
+          0x5C3C0A00,  //  0043  MOVE	R15	R5
+          0x60400008,  //  0044  GETGBL	R16	G8
+          0x5C440C00,  //  0045  MOVE	R17	R6
+          0x7C400200,  //  0046  CALL	R16	1
+          0x7C280C00,  //  0047  CALL	R10	6
+          0x582C0019,  //  0048  LDCONST	R11	K25
+          0x7C200600,  //  0049  CALL	R8	3
+          0x50200200,  //  004A  LDBOOL	R8	1	0
+          0x80041000,  //  004B  RET	1	R8
+          0x70020051,  //  004C  JMP		#009F
+          0x881C051A,  //  004D  GETMBR	R7	R2	K26
+          0x4C200000,  //  004E  LDNIL	R8
+          0x201C0E08,  //  004F  NE	R7	R7	R8
+          0x781E003E,  //  0050  JMPF	R7	#0090
+          0x780E003C,  //  0051  JMPF	R3	#008F
+          0xB81E0200,  //  0052  GETNGBL	R7	K1
+          0x8C1C0F09,  //  0053  GETMET	R7	R7	K9
+          0x7C1C0200,  //  0054  CALL	R7	1
+          0xB8220200,  //  0055  GETNGBL	R8	K1
+          0x8C20111C,  //  0056  GETMET	R8	R8	K28
+          0x7C200200,  //  0057  CALL	R8	1
+          0x901E3608,  //  0058  SETMBR	R7	K27	R8
+          0x88200F1B,  //  0059  GETMBR	R8	R7	K27
+          0xB8260200,  //  005A  GETNGBL	R9	K1
+          0x8C24130F,  //  005B  GETMET	R9	R9	K15
+          0x7C240200,  //  005C  CALL	R9	1
+          0x90221C09,  //  005D  SETMBR	R8	K14	R9
+          0x88200F1B,  //  005E  GETMBR	R8	R7	K27
+          0xB8260200,  //  005F  GETNGBL	R9	K1
+          0x8C24131D,  //  0060  GETMET	R9	R9	K29
+          0x7C240200,  //  0061  CALL	R9	1
+          0x90223409,  //  0062  SETMBR	R8	K26	R9
+          0x88200F1B,  //  0063  GETMBR	R8	R7	K27
+          0x8820110E,  //  0064  GETMBR	R8	R8	K14
+          0x88240510,  //  0065  GETMBR	R9	R2	K16
+          0x90222009,  //  0066  SETMBR	R8	K16	R9
+          0x88200F1B,  //  0067  GETMBR	R8	R7	K27
+          0x8820110E,  //  0068  GETMBR	R8	R8	K14
+          0x88240503,  //  0069  GETMBR	R9	R2	K3
+          0x90220609,  //  006A  SETMBR	R8	K3	R9
+          0x88200F1B,  //  006B  GETMBR	R8	R7	K27
+          0x8820110E,  //  006C  GETMBR	R8	R8	K14
+          0x88240504,  //  006D  GETMBR	R9	R2	K4
+          0x90220809,  //  006E  SETMBR	R8	K4	R9
+          0x88200F1B,  //  006F  GETMBR	R8	R7	K27
+          0x8820111A,  //  0070  GETMBR	R8	R8	K26
+          0x8824051A,  //  0071  GETMBR	R9	R2	K26
+          0x90223409,  //  0072  SETMBR	R8	K26	R9
+          0x88200112,  //  0073  GETMBR	R8	R0	K18
+          0x8C201113,  //  0074  GETMET	R8	R8	K19
+          0x5C280E00,  //  0075  MOVE	R10	R7
+          0x7C200400,  //  0076  CALL	R8	2
+          0xB8222800,  //  0077  GETNGBL	R8	K20
+          0x8C201115,  //  0078  GETMET	R8	R8	K21
+          0x8C280916,  //  0079  GETMET	R10	R4	K22
+          0x5830001E,  //  007A  LDCONST	R12	K30
+          0x68340000,  //  007B  GETUPV	R13	U0
+          0x88341B18,  //  007C  GETMBR	R13	R13	K24
+          0x60380008,  //  007D  GETGBL	R14	G8
+          0x5C3C0400,  //  007E  MOVE	R15	R2
+          0x7C380200,  //  007F  CALL	R14	1
+          0x5C3C0A00,  //  0080  MOVE	R15	R5
+          0x8840051A,  //  0081  GETMBR	R16	R2	K26
+          0x8844051A,  //  0082  GETMBR	R17	R2	K26
+          0xB84A0200,  //  0083  GETNGBL	R18	K1
+          0x8848251F,  //  0084  GETMBR	R18	R18	K31
+          0x1C442212,  //  0085  EQ	R17	R17	R18
+          0x78460001,  //  0086  JMPF	R17	#0089
+          0x5844001F,  //  0087  LDCONST	R17	K31
+          0x70020000,  //  0088  JMP		#008A
+          0x58440007,  //  0089  LDCONST	R17	K7
+          0x7C280E00,  //  008A  CALL	R10	7
+          0x582C0019,  //  008B  LDCONST	R11	K25
+          0x7C200600,  //  008C  CALL	R8	3
+          0x50200200,  //  008D  LDBOOL	R8	1	0
+          0x80041000,  //  008E  RET	1	R8
+          0x7002000E,  //  008F  JMP		#009F
+          0xB81E2800,  //  0090  GETNGBL	R7	K20
+          0x8C1C0F15,  //  0091  GETMET	R7	R7	K21
+          0x8C240916,  //  0092  GETMET	R9	R4	K22
+          0x582C0020,  //  0093  LDCONST	R11	K32
+          0x68300000,  //  0094  GETUPV	R12	U0
+          0x88301918,  //  0095  GETMBR	R12	R12	K24
+          0x60340008,  //  0096  GETGBL	R13	G8
+          0x5C380400,  //  0097  MOVE	R14	R2
+          0x7C340200,  //  0098  CALL	R13	1
+          0x5C380A00,  //  0099  MOVE	R14	R5
+          0x7C240A00,  //  009A  CALL	R9	5
+          0x58280019,  //  009B  LDCONST	R10	K25
+          0x7C1C0600,  //  009C  CALL	R7	3
+          0x501C0000,  //  009D  LDBOOL	R7	0	0
+          0x80040E00,  //  009E  RET	1	R7
+          0x80000000,  //  009F  RET	0
+        })
+      ),
+      be_nested_proto(
+        8,                          /* nstack */
+        3,                          /* argc */
+        0,                          /* varg */
+        1,                          /* has upvals */
+        ( &(const bupvaldesc[ 2]) {  /* upvals */
+          be_local_const_upval(1, 5),
+          be_local_const_upval(1, 8),
+        }),
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        0,                          /* has constants */
+        NULL,                       /* no const */
+        be_str_weak(_X3Clambda_X3E),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x680C0000,  //  0000  GETUPV	R3	U0
+          0x68100001,  //  0001  GETUPV	R4	U1
+          0x5C140000,  //  0002  MOVE	R5	R0
+          0x5C180200,  //  0003  MOVE	R6	R1
+          0x5C1C0400,  //  0004  MOVE	R7	R2
+          0x7C0C0800,  //  0005  CALL	R3	4
+          0x80040600,  //  0006  RET	1	R3
+        })
+      ),
+    }),
+    1,                          /* has constants */
+    ( &(const bvalue[25]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(device),
+    /* K2   */  be_nested_str_weak(get_active_endpoints),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Path),
+    /* K5   */  be_nested_str_weak(ReportDataMessage),
+    /* K6   */  be_nested_str_weak(attribute_reports),
+    /* K7   */  be_nested_str_weak(attributes_requests),
+    /* K8   */  be_nested_str_weak(endpoint),
+    /* K9   */  be_nested_str_weak(cluster),
+    /* K10  */  be_nested_str_weak(attribute),
+    /* K11  */  be_nested_str_weak(status),
+    /* K12  */  be_nested_str_weak(UNSUPPORTED_ATTRIBUTE),
+    /* K13  */  be_nested_str_weak(get_attribute_name),
+    /* K14  */  be_nested_str_weak(tasmota),
+    /* K15  */  be_nested_str_weak(log),
+    /* K16  */  be_nested_str_weak(format),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20_X3ERead_Attr_X20_X28_X256i_X29_X20_X25s),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(_X20_X28),
+    /* K20  */  be_nested_str_weak(_X29),
+    /* K21  */  be_nested_str_weak(),
+    /* K22  */  be_const_int(2),
+    /* K23  */  be_nested_str_weak(process_attribute_expansion),
+    /* K24  */  be_nested_str_weak(stop_iteration),
+    }),
+    be_str_weak(_inner_process_read_request),
+    &be_const_str_solidified,
+    ( &(const binstruction[94]) {  /* code */
+      0xA4120000,  //  0000  IMPORT	R4	K0
+      0x84140000,  //  0001  CLOSURE	R5	P0
+      0x88180101,  //  0002  GETMBR	R6	R0	K1
+      0x8C180D02,  //  0003  GETMET	R6	R6	K2
+      0x7C180200,  //  0004  CALL	R6	1
+      0xB81E0600,  //  0005  GETNGBL	R7	K3
+      0x8C1C0F04,  //  0006  GETMET	R7	R7	K4
+      0x7C1C0200,  //  0007  CALL	R7	1
+      0xB8220600,  //  0008  GETNGBL	R8	K3
+      0x8C201105,  //  0009  GETMET	R8	R8	K5
+      0x7C200200,  //  000A  CALL	R8	1
+      0x60240012,  //  000B  GETGBL	R9	G18
+      0x7C240000,  //  000C  CALL	R9	0
+      0x90220C09,  //  000D  SETMBR	R8	K6	R9
+      0x60240010,  //  000E  GETGBL	R9	G16
+      0x88280507,  //  000F  GETMBR	R10	R2	K7
+      0x7C240200,  //  0010  CALL	R9	1
+      0xA8020046,  //  0011  EXBLK	0	#0059
+      0x5C281200,  //  0012  MOVE	R10	R9
+      0x7C280000,  //  0013  CALL	R10	0
+      0x882C1508,  //  0014  GETMBR	R11	R10	K8
+      0x901E100B,  //  0015  SETMBR	R7	K8	R11
+      0x882C1509,  //  0016  GETMBR	R11	R10	K9
+      0x901E120B,  //  0017  SETMBR	R7	K9	R11
+      0x882C150A,  //  0018  GETMBR	R11	R10	K10
+      0x901E140B,  //  0019  SETMBR	R7	K10	R11
+      0xB82E0600,  //  001A  GETNGBL	R11	K3
+      0x882C170C,  //  001B  GETMBR	R11	R11	K12
+      0x901E160B,  //  001C  SETMBR	R7	K11	R11
+      0x882C0F08,  //  001D  GETMBR	R11	R7	K8
+      0x4C300000,  //  001E  LDNIL	R12
+      0x1C2C160C,  //  001F  EQ	R11	R11	R12
+      0x742E0007,  //  0020  JMPT	R11	#0029
+      0x882C0F09,  //  0021  GETMBR	R11	R7	K9
+      0x4C300000,  //  0022  LDNIL	R12
+      0x1C2C160C,  //  0023  EQ	R11	R11	R12
+      0x742E0003,  //  0024  JMPT	R11	#0029
+      0x882C0F0A,  //  0025  GETMBR	R11	R7	K10
+      0x4C300000,  //  0026  LDNIL	R12
+      0x1C2C160C,  //  0027  EQ	R11	R11	R12
+      0x782E0029,  //  0028  JMPF	R11	#0053
+      0x882C0F09,  //  0029  GETMBR	R11	R7	K9
+      0x4C300000,  //  002A  LDNIL	R12
+      0x202C160C,  //  002B  NE	R11	R11	R12
+      0x782E001A,  //  002C  JMPF	R11	#0048
+      0x882C0F0A,  //  002D  GETMBR	R11	R7	K10
+      0x4C300000,  //  002E  LDNIL	R12
+      0x202C160C,  //  002F  NE	R11	R11	R12
+      0x782E0016,  //  0030  JMPF	R11	#0048
+      0xB82E0600,  //  0031  GETNGBL	R11	K3
+      0x8C2C170D,  //  0032  GETMET	R11	R11	K13
+      0x88340F09,  //  0033  GETMBR	R13	R7	K9
+      0x88380F0A,  //  0034  GETMBR	R14	R7	K10
+      0x7C2C0600,  //  0035  CALL	R11	3
+      0xB8321C00,  //  0036  GETNGBL	R12	K14
+      0x8C30190F,  //  0037  GETMET	R12	R12	K15
+      0x8C380910,  //  0038  GETMET	R14	R4	K16
+      0x58400011,  //  0039  LDCONST	R16	K17
+      0x88440312,  //  003A  GETMBR	R17	R1	K18
+      0x60480008,  //  003B  GETGBL	R18	G8
+      0x5C4C0E00,  //  003C  MOVE	R19	R7
+      0x7C480200,  //  003D  CALL	R18	1
+      0x782E0002,  //  003E  JMPF	R11	#0042
+      0x004E260B,  //  003F  ADD	R19	K19	R11
+      0x004C2714,  //  0040  ADD	R19	R19	K20
+      0x70020000,  //  0041  JMP		#0043
+      0x584C0015,  //  0042  LDCONST	R19	K21
+      0x00482413,  //  0043  ADD	R18	R18	R19
+      0x7C380800,  //  0044  CALL	R14	4
+      0x583C0016,  //  0045  LDCONST	R15	K22
+      0x7C300600,  //  0046  CALL	R12	3
+      0x7002000A,  //  0047  JMP		#0053
+      0xB82E1C00,  //  0048  GETNGBL	R11	K14
+      0x8C2C170F,  //  0049  GETMET	R11	R11	K15
+      0x8C340910,  //  004A  GETMET	R13	R4	K16
+      0x583C0011,  //  004B  LDCONST	R15	K17
+      0x88400312,  //  004C  GETMBR	R16	R1	K18
+      0x60440008,  //  004D  GETGBL	R17	G8
+      0x5C480E00,  //  004E  MOVE	R18	R7
+      0x7C440200,  //  004F  CALL	R17	1
+      0x7C340800,  //  0050  CALL	R13	4
+      0x58380016,  //  0051  LDCONST	R14	K22
+      0x7C2C0600,  //  0052  CALL	R11	3
+      0x882C0101,  //  0053  GETMBR	R11	R0	K1
+      0x8C2C1717,  //  0054  GETMET	R11	R11	K23
+      0x5C340E00,  //  0055  MOVE	R13	R7
+      0x84380001,  //  0056  CLOSURE	R14	P1
+      0x7C2C0600,  //  0057  CALL	R11	3
+      0x7001FFB8,  //  0058  JMP		#0012
+      0x58240018,  //  0059  LDCONST	R9	K24
+      0xAC240200,  //  005A  CATCH	R9	1	0
+      0xB0080000,  //  005B  RAISE	2	R0	R0
+      0xA0000000,  //  005C  CLOSE	R0
+      0x80041000,  //  005D  RET	1	R8
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: report_data
+********************************************************************/
+be_local_closure(Matter_IM_report_data,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(matter),
+    /* K2   */  be_nested_str_weak(ReportDataMessage),
+    /* K3   */  be_nested_str_weak(from_TLV),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(log),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20received_X20ReportDataMessage_X3D),
+    /* K7   */  be_const_int(2),
+    }),
+    be_str_weak(report_data),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA40E0000,  //  0000  IMPORT	R3	K0
+      0xB8120200,  //  0001  GETNGBL	R4	K1
+      0x8C100902,  //  0002  GETMET	R4	R4	K2
+      0x7C100200,  //  0003  CALL	R4	1
+      0x8C100903,  //  0004  GETMET	R4	R4	K3
+      0x5C180400,  //  0005  MOVE	R6	R2
+      0x7C100400,  //  0006  CALL	R4	2
+      0xB8160800,  //  0007  GETNGBL	R5	K4
+      0x8C140B05,  //  0008  GETMET	R5	R5	K5
+      0x601C0008,  //  0009  GETGBL	R7	G8
+      0x5C200800,  //  000A  MOVE	R8	R4
+      0x7C1C0200,  //  000B  CALL	R7	1
+      0x001E0C07,  //  000C  ADD	R7	K6	R7
+      0x58200007,  //  000D  LDCONST	R8	K7
+      0x7C140600,  //  000E  CALL	R5	3
+      0x50140000,  //  000F  LDBOOL	R5	0	0
+      0x80040A00,  //  0010  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_IM
 ********************************************************************/
 be_local_class(Matter_IM,
     3,
     NULL,
-    be_nested_map(29,
+    be_nested_map(30,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(expire_sendqueue, -1), be_const_closure(Matter_IM_expire_sendqueue_closure) },
-        { be_const_key_weak(device, -1), be_const_var(0) },
-        { be_const_key_weak(send_queue, -1), be_const_var(2) },
-        { be_const_key_weak(report_data, -1), be_const_closure(Matter_IM_report_data_closure) },
-        { be_const_key_weak(send_status, -1), be_const_closure(Matter_IM_send_status_closure) },
-        { be_const_key_weak(subscribe_request, 23), be_const_closure(Matter_IM_subscribe_request_closure) },
-        { be_const_key_weak(send_invoke_response, -1), be_const_closure(Matter_IM_send_invoke_response_closure) },
         { be_const_key_weak(process_status_response, -1), be_const_closure(Matter_IM_process_status_response_closure) },
+        { be_const_key_weak(report_data, -1), be_const_closure(Matter_IM_report_data_closure) },
+        { be_const_key_weak(_inner_process_read_request, -1), be_const_closure(Matter_IM__inner_process_read_request_closure) },
         { be_const_key_weak(process_read_request, -1), be_const_closure(Matter_IM_process_read_request_closure) },
-        { be_const_key_weak(subs, -1), be_const_var(1) },
-        { be_const_key_weak(every_250ms, 25), be_const_closure(Matter_IM_every_250ms_closure) },
-        { be_const_key_weak(process_incoming, -1), be_const_closure(Matter_IM_process_incoming_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_IM_every_second_closure) },
-        { be_const_key_weak(process_invoke_request, -1), be_const_closure(Matter_IM_process_invoke_request_closure) },
-        { be_const_key_weak(send_subscribe_response, -1), be_const_closure(Matter_IM_send_subscribe_response_closure) },
-        { be_const_key_weak(process_incoming_ack, 4), be_const_closure(Matter_IM_process_incoming_ack_closure) },
-        { be_const_key_weak(send_write_response, 13), be_const_closure(Matter_IM_send_write_response_closure) },
-        { be_const_key_weak(send_enqueued, 18), be_const_closure(Matter_IM_send_enqueued_closure) },
-        { be_const_key_weak(process_invoke_response, -1), be_const_closure(Matter_IM_process_invoke_response_closure) },
-        { be_const_key_weak(find_sendqueue_by_exchangeid, 22), be_const_closure(Matter_IM_find_sendqueue_by_exchangeid_closure) },
-        { be_const_key_weak(send_subscribe_update, 19), be_const_closure(Matter_IM_send_subscribe_update_closure) },
-        { be_const_key_weak(send_report_data, -1), be_const_closure(Matter_IM_send_report_data_closure) },
-        { be_const_key_weak(subscribe_response, 21), be_const_closure(Matter_IM_subscribe_response_closure) },
         { be_const_key_weak(process_write_response, -1), be_const_closure(Matter_IM_process_write_response_closure) },
-        { be_const_key_weak(process_write_request, 17), be_const_closure(Matter_IM_process_write_request_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_init_closure) },
-        { be_const_key_weak(_inner_process_read_request, 12), be_const_closure(Matter_IM__inner_process_read_request_closure) },
-        { be_const_key_weak(process_timed_request, 9), be_const_closure(Matter_IM_process_timed_request_closure) },
+        { be_const_key_weak(send_write_response, 0), be_const_closure(Matter_IM_send_write_response_closure) },
+        { be_const_key_weak(process_write_request, -1), be_const_closure(Matter_IM_process_write_request_closure) },
+        { be_const_key_weak(every_second, 22), be_const_closure(Matter_IM_every_second_closure) },
+        { be_const_key_weak(send_ack_now, 23), be_const_closure(Matter_IM_send_ack_now_closure) },
+        { be_const_key_weak(find_sendqueue_by_exchangeid, -1), be_const_closure(Matter_IM_find_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(subscribe_response, -1), be_const_closure(Matter_IM_subscribe_response_closure) },
+        { be_const_key_weak(process_incoming_ack, 24), be_const_closure(Matter_IM_process_incoming_ack_closure) },
         { be_const_key_weak(remove_sendqueue_by_exchangeid, -1), be_const_closure(Matter_IM_remove_sendqueue_by_exchangeid_closure) },
+        { be_const_key_weak(subscribe_request, 10), be_const_closure(Matter_IM_subscribe_request_closure) },
+        { be_const_key_weak(send_invoke_response, 26), be_const_closure(Matter_IM_send_invoke_response_closure) },
+        { be_const_key_weak(init, 7), be_const_closure(Matter_IM_init_closure) },
+        { be_const_key_weak(expire_sendqueue, 25), be_const_closure(Matter_IM_expire_sendqueue_closure) },
+        { be_const_key_weak(process_incoming, -1), be_const_closure(Matter_IM_process_incoming_closure) },
+        { be_const_key_weak(process_timed_request, -1), be_const_closure(Matter_IM_process_timed_request_closure) },
+        { be_const_key_weak(process_invoke_response, -1), be_const_closure(Matter_IM_process_invoke_response_closure) },
+        { be_const_key_weak(send_subscribe_response, 8), be_const_closure(Matter_IM_send_subscribe_response_closure) },
+        { be_const_key_weak(device, -1), be_const_var(0) },
+        { be_const_key_weak(process_invoke_request, -1), be_const_closure(Matter_IM_process_invoke_request_closure) },
+        { be_const_key_weak(every_250ms, -1), be_const_closure(Matter_IM_every_250ms_closure) },
+        { be_const_key_weak(send_report_data, 19), be_const_closure(Matter_IM_send_report_data_closure) },
+        { be_const_key_weak(send_status, -1), be_const_closure(Matter_IM_send_status_closure) },
+        { be_const_key_weak(send_enqueued, -1), be_const_closure(Matter_IM_send_enqueued_closure) },
+        { be_const_key_weak(subs_shop, 2), be_const_var(1) },
+        { be_const_key_weak(send_subscribe_update, 1), be_const_closure(Matter_IM_send_subscribe_update_closure) },
+        { be_const_key_weak(send_queue, -1), be_const_var(2) },
     })),
     be_str_weak(Matter_IM)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Message.h
@@ -148,6 +148,220 @@ void be_load_Matter_Path_class(bvm *vm) {
 extern const bclass be_class_Matter_IM_Message;
 
 /********************************************************************
+** Solidified function: ack_received
+********************************************************************/
+be_local_closure(Matter_IM_Message_ack_received,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(expiration),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(millis),
+    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
+    }),
+    be_str_weak(ack_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 8]) {  /* code */
+      0xB80A0200,  //  0000  GETNGBL	R2	K1
+      0x8C080502,  //  0001  GETMET	R2	R2	K2
+      0x7C080200,  //  0002  CALL	R2	1
+      0x880C0103,  //  0003  GETMBR	R3	R0	K3
+      0x00080403,  //  0004  ADD	R2	R2	R3
+      0x90020002,  //  0005  SETMBR	R0	K0	R2
+      0x50080000,  //  0006  LDBOOL	R2	0	0
+      0x80040400,  //  0007  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_exchangeid
+********************************************************************/
+be_local_closure(Matter_IM_Message_get_exchangeid,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resp),
+    /* K1   */  be_nested_str_weak(exchange_id),
+    }),
+    be_str_weak(get_exchangeid),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_IM_Message_init,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 9]) {     /* constants */
+    /* K0   */  be_nested_str_weak(resp),
+    /* K1   */  be_nested_str_weak(build_response),
+    /* K2   */  be_nested_str_weak(ready),
+    /* K3   */  be_nested_str_weak(expiration),
+    /* K4   */  be_nested_str_weak(tasmota),
+    /* K5   */  be_nested_str_weak(millis),
+    /* K6   */  be_nested_str_weak(MSG_TIMEOUT),
+    /* K7   */  be_nested_str_weak(last_counter),
+    /* K8   */  be_const_int(0),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[15]) {  /* code */
+      0x8C100301,  //  0000  GETMET	R4	R1	K1
+      0x5C180400,  //  0001  MOVE	R6	R2
+      0x5C1C0600,  //  0002  MOVE	R7	R3
+      0x7C100600,  //  0003  CALL	R4	3
+      0x90020004,  //  0004  SETMBR	R0	K0	R4
+      0x50100200,  //  0005  LDBOOL	R4	1	0
+      0x90020404,  //  0006  SETMBR	R0	K2	R4
+      0xB8120800,  //  0007  GETNGBL	R4	K4
+      0x8C100905,  //  0008  GETMET	R4	R4	K5
+      0x7C100200,  //  0009  CALL	R4	1
+      0x88140106,  //  000A  GETMBR	R5	R0	K6
+      0x00100805,  //  000B  ADD	R4	R4	R5
+      0x90020604,  //  000C  SETMBR	R0	K3	R4
+      0x90020F08,  //  000D  SETMBR	R0	K7	K8
+      0x80000000,  //  000E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_im
+********************************************************************/
+be_local_closure(Matter_IM_Message_send_im,   /* name */
+  be_nested_proto(
+    13,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[26]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_Message_X20send_im_X20exch_X3D_X25i_X20ready_X3D_X25i),
+    /* K5   */  be_nested_str_weak(resp),
+    /* K6   */  be_nested_str_weak(exchange_id),
+    /* K7   */  be_nested_str_weak(ready),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(encode_frame),
+    /* K12  */  be_nested_str_weak(data),
+    /* K13  */  be_nested_str_weak(to_TLV),
+    /* K14  */  be_nested_str_weak(tlv2raw),
+    /* K15  */  be_nested_str_weak(encrypt),
+    /* K16  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K17  */  be_nested_str_weak(session),
+    /* K18  */  be_nested_str_weak(local_session_id),
+    /* K19  */  be_nested_str_weak(message_counter),
+    /* K20  */  be_nested_str_weak(ack_message_counter),
+    /* K21  */  be_nested_str_weak(send_response),
+    /* K22  */  be_nested_str_weak(raw),
+    /* K23  */  be_nested_str_weak(remote_ip),
+    /* K24  */  be_nested_str_weak(remote_port),
+    /* K25  */  be_nested_str_weak(last_counter),
+    }),
+    be_str_weak(send_im),
+    &be_const_str_solidified,
+    ( &(const binstruction[51]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x78260001,  //  0008  JMPF	R9	#000B
+      0x58240008,  //  0009  LDCONST	R9	K8
+      0x70020000,  //  000A  JMP		#000C
+      0x58240009,  //  000B  LDCONST	R9	K9
+      0x7C140800,  //  000C  CALL	R5	4
+      0x5818000A,  //  000D  LDCONST	R6	K10
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x880C0107,  //  000F  GETMBR	R3	R0	K7
+      0x740E0001,  //  0010  JMPT	R3	#0013
+      0x500C0000,  //  0011  LDBOOL	R3	0	0
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0105,  //  0013  GETMBR	R3	R0	K5
+      0x8C10070B,  //  0014  GETMET	R4	R3	K11
+      0x8818010C,  //  0015  GETMBR	R6	R0	K12
+      0x8C180D0D,  //  0016  GETMET	R6	R6	K13
+      0x7C180200,  //  0017  CALL	R6	1
+      0x8C180D0E,  //  0018  GETMET	R6	R6	K14
+      0x7C180200,  //  0019  CALL	R6	1
+      0x7C100400,  //  001A  CALL	R4	2
+      0x8C10070F,  //  001B  GETMET	R4	R3	K15
+      0x7C100200,  //  001C  CALL	R4	1
+      0xB8120200,  //  001D  GETNGBL	R4	K1
+      0x8C100902,  //  001E  GETMET	R4	R4	K2
+      0x8C180503,  //  001F  GETMET	R6	R2	K3
+      0x58200010,  //  0020  LDCONST	R8	K16
+      0x88240711,  //  0021  GETMBR	R9	R3	K17
+      0x88241312,  //  0022  GETMBR	R9	R9	K18
+      0x88280713,  //  0023  GETMBR	R10	R3	K19
+      0x882C0706,  //  0024  GETMBR	R11	R3	K6
+      0x88300714,  //  0025  GETMBR	R12	R3	K20
+      0x7C180C00,  //  0026  CALL	R6	6
+      0x581C000A,  //  0027  LDCONST	R7	K10
+      0x7C100600,  //  0028  CALL	R4	3
+      0x8C100315,  //  0029  GETMET	R4	R1	K21
+      0x88180716,  //  002A  GETMBR	R6	R3	K22
+      0x881C0717,  //  002B  GETMBR	R7	R3	K23
+      0x88200718,  //  002C  GETMBR	R8	R3	K24
+      0x88240713,  //  002D  GETMBR	R9	R3	K19
+      0x7C100A00,  //  002E  CALL	R4	5
+      0x88100713,  //  002F  GETMBR	R4	R3	K19
+      0x90023204,  //  0030  SETMBR	R0	K25	R4
+      0x50100200,  //  0031  LDBOOL	R4	1	0
+      0x80040800,  //  0032  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: status_error_received
 ********************************************************************/
 be_local_closure(Matter_IM_Message_status_error_received,   /* name */
@@ -196,38 +410,9 @@ be_local_closure(Matter_IM_Message_reached_timeout,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_exchangeid
+** Solidified function: status_ok_received
 ********************************************************************/
-be_local_closure(Matter_IM_Message_get_exchangeid,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(exchange_id),
-    }),
-    be_str_weak(get_exchangeid),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send
-********************************************************************/
-be_local_closure(Matter_IM_Message_send,   /* name */
+be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -237,173 +422,55 @@ be_local_closure(Matter_IM_Message_send,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(encode_frame),
-    /* K2   */  be_nested_str_weak(data),
-    /* K3   */  be_nested_str_weak(to_TLV),
-    /* K4   */  be_nested_str_weak(encode),
-    /* K5   */  be_nested_str_weak(encrypt),
-    /* K6   */  be_nested_str_weak(send_response),
-    /* K7   */  be_nested_str_weak(raw),
-    /* K8   */  be_nested_str_weak(remote_ip),
-    /* K9   */  be_nested_str_weak(remote_port),
-    /* K10  */  be_nested_str_weak(message_counter),
-    }),
-    be_str_weak(send),
-    &be_const_str_solidified,
-    ( &(const binstruction[18]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C0C0501,  //  0001  GETMET	R3	R2	K1
-      0x88140102,  //  0002  GETMBR	R5	R0	K2
-      0x8C140B03,  //  0003  GETMET	R5	R5	K3
-      0x7C140200,  //  0004  CALL	R5	1
-      0x8C140B04,  //  0005  GETMET	R5	R5	K4
-      0x7C140200,  //  0006  CALL	R5	1
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x8C0C0505,  //  0008  GETMET	R3	R2	K5
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x8C0C0306,  //  000A  GETMET	R3	R1	K6
-      0x88140507,  //  000B  GETMBR	R5	R2	K7
-      0x88180508,  //  000C  GETMBR	R6	R2	K8
-      0x881C0509,  //  000D  GETMBR	R7	R2	K9
-      0x8820050A,  //  000E  GETMBR	R8	R2	K10
-      0x7C0C0A00,  //  000F  CALL	R3	5
-      0x500C0200,  //  0010  LDBOOL	R3	1	0
-      0x80040600,  //  0011  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: ack_received
-********************************************************************/
-be_local_closure(Matter_IM_Message_ack_received,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expiration),
+    ( &(const bvalue[15]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
-    }),
-    be_str_weak(ack_received),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0xB80A0200,  //  0000  GETNGBL	R2	K1
-      0x8C080502,  //  0001  GETMET	R2	R2	K2
-      0x7C080200,  //  0002  CALL	R2	1
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x00080403,  //  0004  ADD	R2	R2	R3
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
-      0x50080000,  //  0006  LDBOOL	R2	0	0
-      0x80040400,  //  0007  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: status_ok_received
-********************************************************************/
-be_local_closure(Matter_IM_Message_status_ok_received,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(expiration),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(millis),
-    /* K3   */  be_nested_str_weak(MSG_TIMEOUT),
-    /* K4   */  be_nested_str_weak(resp),
-    /* K5   */  be_nested_str_weak(build_response),
-    /* K6   */  be_nested_str_weak(opcode),
-    /* K7   */  be_nested_str_weak(x_flag_r),
-    /* K8   */  be_nested_str_weak(ready),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_Message_X20status_ok_received_X20exch_X3D_X25i),
+    /* K5   */  be_nested_str_weak(resp),
+    /* K6   */  be_nested_str_weak(exchange_id),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(expiration),
+    /* K9   */  be_nested_str_weak(millis),
+    /* K10  */  be_nested_str_weak(MSG_TIMEOUT),
+    /* K11  */  be_nested_str_weak(build_response),
+    /* K12  */  be_nested_str_weak(opcode),
+    /* K13  */  be_nested_str_weak(x_flag_r),
+    /* K14  */  be_nested_str_weak(ready),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0xB80A0200,  //  0000  GETNGBL	R2	K1
-      0x8C080502,  //  0001  GETMET	R2	R2	K2
-      0x7C080200,  //  0002  CALL	R2	1
-      0x880C0103,  //  0003  GETMBR	R3	R0	K3
-      0x00080403,  //  0004  ADD	R2	R2	R3
-      0x90020002,  //  0005  SETMBR	R0	K0	R2
-      0x78060007,  //  0006  JMPF	R1	#000F
-      0x8C080305,  //  0007  GETMET	R2	R1	K5
-      0x88100104,  //  0008  GETMBR	R4	R0	K4
-      0x88100906,  //  0009  GETMBR	R4	R4	K6
-      0x88140104,  //  000A  GETMBR	R5	R0	K4
-      0x88140B07,  //  000B  GETMBR	R5	R5	K7
-      0x88180104,  //  000C  GETMBR	R6	R0	K4
-      0x7C080800,  //  000D  CALL	R2	4
-      0x90020802,  //  000E  SETMBR	R0	K4	R2
-      0x50080200,  //  000F  LDBOOL	R2	1	0
-      0x90021002,  //  0010  SETMBR	R0	K8	R2
-      0x50080200,  //  0011  LDBOOL	R2	1	0
-      0x80040400,  //  0012  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_IM_Message_init,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(resp),
-    /* K1   */  be_nested_str_weak(build_response),
-    /* K2   */  be_nested_str_weak(ready),
-    /* K3   */  be_nested_str_weak(expiration),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(millis),
-    /* K6   */  be_nested_str_weak(MSG_TIMEOUT),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
-      0x8C100301,  //  0000  GETMET	R4	R1	K1
-      0x5C180400,  //  0001  MOVE	R6	R2
-      0x5C1C0600,  //  0002  MOVE	R7	R3
-      0x7C100600,  //  0003  CALL	R4	3
-      0x90020004,  //  0004  SETMBR	R0	K0	R4
-      0x50100200,  //  0005  LDBOOL	R4	1	0
-      0x90020404,  //  0006  SETMBR	R0	K2	R4
-      0xB8120800,  //  0007  GETNGBL	R4	K4
-      0x8C100905,  //  0008  GETMET	R4	R4	K5
-      0x7C100200,  //  0009  CALL	R4	1
-      0x88140106,  //  000A  GETMBR	R5	R0	K6
-      0x00100805,  //  000B  ADD	R4	R4	R5
-      0x90020604,  //  000C  SETMBR	R0	K3	R4
-      0x80000000,  //  000D  RET	0
+    ( &(const binstruction[29]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x7C140600,  //  0007  CALL	R5	3
+      0x58180007,  //  0008  LDCONST	R6	K7
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0xB80E0200,  //  000A  GETNGBL	R3	K1
+      0x8C0C0709,  //  000B  GETMET	R3	R3	K9
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x8810010A,  //  000D  GETMBR	R4	R0	K10
+      0x000C0604,  //  000E  ADD	R3	R3	R4
+      0x90021003,  //  000F  SETMBR	R0	K8	R3
+      0x78060007,  //  0010  JMPF	R1	#0019
+      0x8C0C030B,  //  0011  GETMET	R3	R1	K11
+      0x88140105,  //  0012  GETMBR	R5	R0	K5
+      0x88140B0C,  //  0013  GETMBR	R5	R5	K12
+      0x88180105,  //  0014  GETMBR	R6	R0	K5
+      0x88180D0D,  //  0015  GETMBR	R6	R6	K13
+      0x881C0105,  //  0016  GETMBR	R7	R0	K5
+      0x7C0C0800,  //  0017  CALL	R3	4
+      0x90020A03,  //  0018  SETMBR	R0	K5	R3
+      0x500C0200,  //  0019  LDBOOL	R3	1	0
+      0x90021C03,  //  001A  SETMBR	R0	K14	R3
+      0x500C0200,  //  001B  LDBOOL	R3	1	0
+      0x80040600,  //  001C  RET	1	R3
     })
   )
 );
@@ -414,22 +481,23 @@ be_local_closure(Matter_IM_Message_init,   /* name */
 ** Solidified class: Matter_IM_Message
 ********************************************************************/
 be_local_class(Matter_IM_Message,
-    4,
+    5,
     NULL,
-    be_nested_map(12,
+    be_nested_map(13,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(expiration, 9), be_const_var(0) },
-        { be_const_key_weak(data, -1), be_const_var(3) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Message_init_closure) },
-        { be_const_key_weak(resp, 2), be_const_var(1) },
-        { be_const_key_weak(status_error_received, 6), be_const_closure(Matter_IM_Message_status_error_received_closure) },
-        { be_const_key_weak(reached_timeout, -1), be_const_closure(Matter_IM_Message_reached_timeout_closure) },
+        { be_const_key_weak(status_ok_received, -1), be_const_closure(Matter_IM_Message_status_ok_received_closure) },
+        { be_const_key_weak(data, 0), be_const_var(3) },
+        { be_const_key_weak(resp, 11), be_const_var(1) },
+        { be_const_key_weak(ack_received, 9), be_const_closure(Matter_IM_Message_ack_received_closure) },
+        { be_const_key_weak(MSG_TIMEOUT, 12), be_const_int(5000) },
         { be_const_key_weak(get_exchangeid, -1), be_const_closure(Matter_IM_Message_get_exchangeid_closure) },
-        { be_const_key_weak(send, -1), be_const_closure(Matter_IM_Message_send_closure) },
-        { be_const_key_weak(ack_received, -1), be_const_closure(Matter_IM_Message_ack_received_closure) },
-        { be_const_key_weak(status_ok_received, 11), be_const_closure(Matter_IM_Message_status_ok_received_closure) },
-        { be_const_key_weak(MSG_TIMEOUT, -1), be_const_int(5000) },
+        { be_const_key_weak(init, 8), be_const_closure(Matter_IM_Message_init_closure) },
+        { be_const_key_weak(send_im, -1), be_const_closure(Matter_IM_Message_send_im_closure) },
+        { be_const_key_weak(expiration, -1), be_const_var(0) },
+        { be_const_key_weak(reached_timeout, -1), be_const_closure(Matter_IM_Message_reached_timeout_closure) },
         { be_const_key_weak(ready, -1), be_const_var(2) },
+        { be_const_key_weak(status_error_received, -1), be_const_closure(Matter_IM_Message_status_error_received_closure) },
+        { be_const_key_weak(last_counter, -1), be_const_var(4) },
     })),
     be_str_weak(Matter_IM_Message)
 );
@@ -456,18 +524,17 @@ be_local_closure(Matter_IM_Status_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
+    ( &(const bvalue[ 6]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
     /* K1   */  be_const_int(1),
     /* K2   */  be_nested_str_weak(matter),
     /* K3   */  be_nested_str_weak(StatusResponseMessage),
     /* K4   */  be_nested_str_weak(status),
     /* K5   */  be_nested_str_weak(data),
-    /* K6   */  be_nested_str_weak(ready),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
+    ( &(const binstruction[14]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -481,9 +548,7 @@ be_local_closure(Matter_IM_Status_init,   /* name */
       0x7C0C0200,  //  000A  CALL	R3	1
       0x900E0802,  //  000B  SETMBR	R3	K4	R2
       0x90020A03,  //  000C  SETMBR	R0	K5	R3
-      0x50100200,  //  000D  LDBOOL	R4	1	0
-      0x90020C04,  //  000E  SETMBR	R0	K6	R4
-      0x80000000,  //  000F  RET	0
+      0x80000000,  //  000D  RET	0
     })
   )
 );
@@ -526,14 +591,13 @@ be_local_closure(Matter_IM_InvokeResponse_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
     /* K1   */  be_nested_str_weak(data),
-    /* K2   */  be_nested_str_weak(ready),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -543,9 +607,7 @@ be_local_closure(Matter_IM_InvokeResponse_init,   /* name */
       0x501C0200,  //  0006  LDBOOL	R7	1	0
       0x7C0C0800,  //  0007  CALL	R3	4
       0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x500C0200,  //  0009  LDBOOL	R3	1	0
-      0x90020403,  //  000A  SETMBR	R0	K2	R3
-      0x80000000,  //  000B  RET	0
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -588,14 +650,13 @@ be_local_closure(Matter_IM_WriteResponse_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
     /* K1   */  be_nested_str_weak(data),
-    /* K2   */  be_nested_str_weak(ready),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -605,9 +666,7 @@ be_local_closure(Matter_IM_WriteResponse_init,   /* name */
       0x501C0200,  //  0006  LDBOOL	R7	1	0
       0x7C0C0800,  //  0007  CALL	R3	4
       0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x500C0200,  //  0009  LDBOOL	R3	1	0
-      0x90020403,  //  000A  SETMBR	R0	K2	R3
-      0x80000000,  //  000B  RET	0
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -638,6 +697,234 @@ void be_load_Matter_IM_WriteResponse_class(bvm *vm) {
 extern const bclass be_class_Matter_IM_ReportData;
 
 /********************************************************************
+** Solidified function: send_im
+********************************************************************/
+be_local_closure(Matter_IM_ReportData_send_im,   /* name */
+  be_nested_proto(
+    20,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[36]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportData_X20send_im_X20exch_X3D_X25i_X20ready_X3D_X25i),
+    /* K5   */  be_nested_str_weak(resp),
+    /* K6   */  be_nested_str_weak(exchange_id),
+    /* K7   */  be_nested_str_weak(ready),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(data),
+    /* K12  */  be_nested_str_weak(more_chunked_messages),
+    /* K13  */  be_nested_str_weak(attribute_reports),
+    /* K14  */  be_nested_str_weak(to_TLV),
+    /* K15  */  be_nested_str_weak(encode_len),
+    /* K16  */  be_nested_str_weak(MAX_MESSAGE),
+    /* K17  */  be_nested_str_weak(MTR_X3A_X20exch_X3D_X25i_X20elements_X3D_X25i_X20msg_sz_X3D_X25i_X20total_X3D_X25i),
+    /* K18  */  be_nested_str_weak(get_exchangeid),
+    /* K19  */  be_const_int(2147483647),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20next_chunk_X20exch_X3D_X25i),
+    /* K21  */  be_nested_str_weak(MTR_X3A_X20_X2ERead_Attr_X20first_chunk_X20exch_X3D_X25i),
+    /* K22  */  be_nested_str_weak(tlv2raw),
+    /* K23  */  be_nested_str_weak(encode_frame),
+    /* K24  */  be_nested_str_weak(encrypt),
+    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3Csnd_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20id_X3D_X25i_X20exch_X3D_X25i_X20rack_X3D_X25s),
+    /* K26  */  be_nested_str_weak(session),
+    /* K27  */  be_nested_str_weak(local_session_id),
+    /* K28  */  be_nested_str_weak(message_counter),
+    /* K29  */  be_nested_str_weak(ack_message_counter),
+    /* K30  */  be_nested_str_weak(send_response),
+    /* K31  */  be_nested_str_weak(raw),
+    /* K32  */  be_nested_str_weak(remote_ip),
+    /* K33  */  be_nested_str_weak(remote_port),
+    /* K34  */  be_nested_str_weak(last_counter),
+    /* K35  */  be_nested_str_weak(MTR_X3A_X20to_be_sent_later_X20size_X3D_X25i_X20exch_X3D_X25i),
+    }),
+    be_str_weak(send_im),
+    &be_const_str_solidified,
+    ( &(const binstruction[168]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x78260001,  //  0008  JMPF	R9	#000B
+      0x58240008,  //  0009  LDCONST	R9	K8
+      0x70020000,  //  000A  JMP		#000C
+      0x58240009,  //  000B  LDCONST	R9	K9
+      0x7C140800,  //  000C  CALL	R5	4
+      0x5818000A,  //  000D  LDCONST	R6	K10
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x880C0107,  //  000F  GETMBR	R3	R0	K7
+      0x740E0001,  //  0010  JMPT	R3	#0013
+      0x500C0000,  //  0011  LDBOOL	R3	0	0
+      0x80040600,  //  0012  RET	1	R3
+      0x880C0105,  //  0013  GETMBR	R3	R0	K5
+      0x8810010B,  //  0014  GETMBR	R4	R0	K11
+      0x8814090C,  //  0015  GETMBR	R5	R4	K12
+      0x58180009,  //  0016  LDCONST	R6	K9
+      0x581C0009,  //  0017  LDCONST	R7	K9
+      0x6020000C,  //  0018  GETGBL	R8	G12
+      0x8824090D,  //  0019  GETMBR	R9	R4	K13
+      0x7C200200,  //  001A  CALL	R8	1
+      0x24201109,  //  001B  GT	R8	R8	K9
+      0x78220007,  //  001C  JMPF	R8	#0025
+      0x8820090D,  //  001D  GETMBR	R8	R4	K13
+      0x94201109,  //  001E  GETIDX	R8	R8	K9
+      0x8C20110E,  //  001F  GETMET	R8	R8	K14
+      0x7C200200,  //  0020  CALL	R8	1
+      0x8C20110F,  //  0021  GETMET	R8	R8	K15
+      0x7C200200,  //  0022  CALL	R8	1
+      0x5C181000,  //  0023  MOVE	R6	R8
+      0x581C0008,  //  0024  LDCONST	R7	K8
+      0x88200110,  //  0025  GETMBR	R8	R0	K16
+      0x14200C08,  //  0026  LT	R8	R6	R8
+      0x78220013,  //  0027  JMPF	R8	#003C
+      0x6020000C,  //  0028  GETGBL	R8	G12
+      0x8824090D,  //  0029  GETMBR	R9	R4	K13
+      0x7C200200,  //  002A  CALL	R8	1
+      0x14200E08,  //  002B  LT	R8	R7	R8
+      0x7822000E,  //  002C  JMPF	R8	#003C
+      0x8820090D,  //  002D  GETMBR	R8	R4	K13
+      0x94201007,  //  002E  GETIDX	R8	R8	R7
+      0x8C20110E,  //  002F  GETMET	R8	R8	K14
+      0x7C200200,  //  0030  CALL	R8	1
+      0x8C20110F,  //  0031  GETMET	R8	R8	K15
+      0x7C200200,  //  0032  CALL	R8	1
+      0x00240C08,  //  0033  ADD	R9	R6	R8
+      0x88280110,  //  0034  GETMBR	R10	R0	K16
+      0x1424120A,  //  0035  LT	R9	R9	R10
+      0x78260002,  //  0036  JMPF	R9	#003A
+      0x00180C08,  //  0037  ADD	R6	R6	R8
+      0x001C0F08,  //  0038  ADD	R7	R7	K8
+      0x70020000,  //  0039  JMP		#003B
+      0x70020000,  //  003A  JMP		#003C
+      0x7001FFE8,  //  003B  JMP		#0025
+      0xB8220200,  //  003C  GETNGBL	R8	K1
+      0x8C201102,  //  003D  GETMET	R8	R8	K2
+      0x8C280503,  //  003E  GETMET	R10	R2	K3
+      0x58300011,  //  003F  LDCONST	R12	K17
+      0x8C340112,  //  0040  GETMET	R13	R0	K18
+      0x7C340200,  //  0041  CALL	R13	1
+      0x5C380E00,  //  0042  MOVE	R14	R7
+      0x5C3C0C00,  //  0043  MOVE	R15	R6
+      0x6040000C,  //  0044  GETGBL	R16	G12
+      0x8844090D,  //  0045  GETMBR	R17	R4	K13
+      0x7C400200,  //  0046  CALL	R16	1
+      0x7C280C00,  //  0047  CALL	R10	6
+      0x582C000A,  //  0048  LDCONST	R11	K10
+      0x7C200600,  //  0049  CALL	R8	3
+      0x40200F13,  //  004A  CONNECT	R8	R7	K19
+      0x8824090D,  //  004B  GETMBR	R9	R4	K13
+      0x94201208,  //  004C  GETIDX	R8	R9	R8
+      0x04280F08,  //  004D  SUB	R10	R7	K8
+      0x402A120A,  //  004E  CONNECT	R10	K9	R10
+      0x882C090D,  //  004F  GETMBR	R11	R4	K13
+      0x9428160A,  //  0050  GETIDX	R10	R11	R10
+      0x90121A0A,  //  0051  SETMBR	R4	K13	R10
+      0x6028000C,  //  0052  GETGBL	R10	G12
+      0x5C2C1000,  //  0053  MOVE	R11	R8
+      0x7C280200,  //  0054  CALL	R10	1
+      0x24281509,  //  0055  GT	R10	R10	K9
+      0x9012180A,  //  0056  SETMBR	R4	K12	R10
+      0x78160008,  //  0057  JMPF	R5	#0061
+      0xB82A0200,  //  0058  GETNGBL	R10	K1
+      0x8C281502,  //  0059  GETMET	R10	R10	K2
+      0x8C300503,  //  005A  GETMET	R12	R2	K3
+      0x58380014,  //  005B  LDCONST	R14	K20
+      0x8C3C0112,  //  005C  GETMET	R15	R0	K18
+      0x7C3C0200,  //  005D  CALL	R15	1
+      0x7C300600,  //  005E  CALL	R12	3
+      0x5834000A,  //  005F  LDCONST	R13	K10
+      0x7C280600,  //  0060  CALL	R10	3
+      0x8824090C,  //  0061  GETMBR	R9	R4	K12
+      0x7826000A,  //  0062  JMPF	R9	#006E
+      0x5C240A00,  //  0063  MOVE	R9	R5
+      0x74260008,  //  0064  JMPT	R9	#006E
+      0xB8260200,  //  0065  GETNGBL	R9	K1
+      0x8C241302,  //  0066  GETMET	R9	R9	K2
+      0x8C2C0503,  //  0067  GETMET	R11	R2	K3
+      0x58340015,  //  0068  LDCONST	R13	K21
+      0x8C380112,  //  0069  GETMET	R14	R0	K18
+      0x7C380200,  //  006A  CALL	R14	1
+      0x7C2C0600,  //  006B  CALL	R11	3
+      0x5830000A,  //  006C  LDCONST	R12	K10
+      0x7C240600,  //  006D  CALL	R9	3
+      0x8824010B,  //  006E  GETMBR	R9	R0	K11
+      0x8C24130E,  //  006F  GETMET	R9	R9	K14
+      0x7C240200,  //  0070  CALL	R9	1
+      0x8C281316,  //  0071  GETMET	R10	R9	K22
+      0x60300015,  //  0072  GETGBL	R12	G21
+      0x88340110,  //  0073  GETMBR	R13	R0	K16
+      0x7C300200,  //  0074  CALL	R12	1
+      0x7C280400,  //  0075  CALL	R10	2
+      0x8C2C0717,  //  0076  GETMET	R11	R3	K23
+      0x5C341400,  //  0077  MOVE	R13	R10
+      0x7C2C0400,  //  0078  CALL	R11	2
+      0x8C2C0718,  //  0079  GETMET	R11	R3	K24
+      0x7C2C0200,  //  007A  CALL	R11	1
+      0xB82E0200,  //  007B  GETNGBL	R11	K1
+      0x8C2C1702,  //  007C  GETMET	R11	R11	K2
+      0x8C340503,  //  007D  GETMET	R13	R2	K3
+      0x583C0019,  //  007E  LDCONST	R15	K25
+      0x8840071A,  //  007F  GETMBR	R16	R3	K26
+      0x8840211B,  //  0080  GETMBR	R16	R16	K27
+      0x8844071C,  //  0081  GETMBR	R17	R3	K28
+      0x88480706,  //  0082  GETMBR	R18	R3	K6
+      0x884C071D,  //  0083  GETMBR	R19	R3	K29
+      0x7C340C00,  //  0084  CALL	R13	6
+      0x5838000A,  //  0085  LDCONST	R14	K10
+      0x7C2C0600,  //  0086  CALL	R11	3
+      0x8C2C031E,  //  0087  GETMET	R11	R1	K30
+      0x8834071F,  //  0088  GETMBR	R13	R3	K31
+      0x88380720,  //  0089  GETMBR	R14	R3	K32
+      0x883C0721,  //  008A  GETMBR	R15	R3	K33
+      0x8840071C,  //  008B  GETMBR	R16	R3	K28
+      0x7C2C0A00,  //  008C  CALL	R11	5
+      0x882C071C,  //  008D  GETMBR	R11	R3	K28
+      0x9002440B,  //  008E  SETMBR	R0	K34	R11
+      0x602C000C,  //  008F  GETGBL	R11	G12
+      0x5C301000,  //  0090  MOVE	R12	R8
+      0x7C2C0200,  //  0091  CALL	R11	1
+      0x242C1709,  //  0092  GT	R11	R11	K9
+      0x782E0010,  //  0093  JMPF	R11	#00A5
+      0x90121A08,  //  0094  SETMBR	R4	K13	R8
+      0xB82E0200,  //  0095  GETNGBL	R11	K1
+      0x8C2C1702,  //  0096  GETMET	R11	R11	K2
+      0x8C340503,  //  0097  GETMET	R13	R2	K3
+      0x583C0023,  //  0098  LDCONST	R15	K35
+      0x6040000C,  //  0099  GETGBL	R16	G12
+      0x8844090D,  //  009A  GETMBR	R17	R4	K13
+      0x7C400200,  //  009B  CALL	R16	1
+      0x88440706,  //  009C  GETMBR	R17	R3	K6
+      0x7C340800,  //  009D  CALL	R13	4
+      0x5838000A,  //  009E  LDCONST	R14	K10
+      0x7C2C0600,  //  009F  CALL	R11	3
+      0x502C0000,  //  00A0  LDBOOL	R11	0	0
+      0x90020E0B,  //  00A1  SETMBR	R0	K7	R11
+      0x502C0000,  //  00A2  LDBOOL	R11	0	0
+      0x80041600,  //  00A3  RET	1	R11
+      0x70020001,  //  00A4  JMP		#00A7
+      0x502C0200,  //  00A5  LDBOOL	R11	1	0
+      0x80041600,  //  00A6  RET	1	R11
+      0x80000000,  //  00A7  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: init
 ********************************************************************/
 be_local_closure(Matter_IM_ReportData_init,   /* name */
@@ -650,14 +937,13 @@ be_local_closure(Matter_IM_ReportData_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(init),
     /* K1   */  be_nested_str_weak(data),
-    /* K2   */  be_nested_str_weak(ready),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[10]) {  /* code */
       0x600C0003,  //  0000  GETGBL	R3	G3
       0x5C100000,  //  0001  MOVE	R4	R0
       0x7C0C0200,  //  0002  CALL	R3	1
@@ -667,181 +953,7 @@ be_local_closure(Matter_IM_ReportData_init,   /* name */
       0x501C0200,  //  0006  LDBOOL	R7	1	0
       0x7C0C0800,  //  0007  CALL	R3	4
       0x90020202,  //  0008  SETMBR	R0	K1	R2
-      0x500C0200,  //  0009  LDBOOL	R3	1	0
-      0x90020403,  //  000A  SETMBR	R0	K2	R3
-      0x80000000,  //  000B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: send
-********************************************************************/
-be_local_closure(Matter_IM_ReportData_send,   /* name */
-  be_nested_proto(
-    17,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[27]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(resp),
-    /* K2   */  be_nested_str_weak(data),
-    /* K3   */  be_nested_str_weak(more_chunked_messages),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(attribute_reports),
-    /* K6   */  be_nested_str_weak(to_TLV),
-    /* K7   */  be_nested_str_weak(encode_len),
-    /* K8   */  be_const_int(1),
-    /* K9   */  be_nested_str_weak(MAX_MESSAGE),
-    /* K10  */  be_nested_str_weak(tasmota),
-    /* K11  */  be_nested_str_weak(log),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(MTR_X3A_X20elements_X3D_X25i_X20msg_sz_X3D_X25i_X20total_X3D_X25i),
-    /* K14  */  be_const_int(3),
-    /* K15  */  be_const_int(2147483647),
-    /* K16  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20next_chunk_X20exch_X3D_X25i),
-    /* K17  */  be_nested_str_weak(get_exchangeid),
-    /* K18  */  be_nested_str_weak(MTR_X3A_X20Read_Attr_X20_X20first_chunk_X20exch_X3D_X25i),
-    /* K19  */  be_nested_str_weak(encode),
-    /* K20  */  be_nested_str_weak(encode_frame),
-    /* K21  */  be_nested_str_weak(encrypt),
-    /* K22  */  be_nested_str_weak(send_response),
-    /* K23  */  be_nested_str_weak(raw),
-    /* K24  */  be_nested_str_weak(remote_ip),
-    /* K25  */  be_nested_str_weak(remote_port),
-    /* K26  */  be_nested_str_weak(message_counter),
-    }),
-    be_str_weak(send),
-    &be_const_str_solidified,
-    ( &(const binstruction[121]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x88100102,  //  0002  GETMBR	R4	R0	K2
-      0x88140903,  //  0003  GETMBR	R5	R4	K3
-      0x58180004,  //  0004  LDCONST	R6	K4
-      0x581C0004,  //  0005  LDCONST	R7	K4
-      0x6020000C,  //  0006  GETGBL	R8	G12
-      0x88240905,  //  0007  GETMBR	R9	R4	K5
-      0x7C200200,  //  0008  CALL	R8	1
-      0x24201104,  //  0009  GT	R8	R8	K4
-      0x78220007,  //  000A  JMPF	R8	#0013
-      0x88200905,  //  000B  GETMBR	R8	R4	K5
-      0x94201104,  //  000C  GETIDX	R8	R8	K4
-      0x8C201106,  //  000D  GETMET	R8	R8	K6
-      0x7C200200,  //  000E  CALL	R8	1
-      0x8C201107,  //  000F  GETMET	R8	R8	K7
-      0x7C200200,  //  0010  CALL	R8	1
-      0x5C181000,  //  0011  MOVE	R6	R8
-      0x581C0008,  //  0012  LDCONST	R7	K8
-      0x88200109,  //  0013  GETMBR	R8	R0	K9
-      0x14200C08,  //  0014  LT	R8	R6	R8
-      0x78220013,  //  0015  JMPF	R8	#002A
-      0x6020000C,  //  0016  GETGBL	R8	G12
-      0x88240905,  //  0017  GETMBR	R9	R4	K5
-      0x7C200200,  //  0018  CALL	R8	1
-      0x14200E08,  //  0019  LT	R8	R7	R8
-      0x7822000E,  //  001A  JMPF	R8	#002A
-      0x88200905,  //  001B  GETMBR	R8	R4	K5
-      0x94201007,  //  001C  GETIDX	R8	R8	R7
-      0x8C201106,  //  001D  GETMET	R8	R8	K6
-      0x7C200200,  //  001E  CALL	R8	1
-      0x8C201107,  //  001F  GETMET	R8	R8	K7
-      0x7C200200,  //  0020  CALL	R8	1
-      0x00240C08,  //  0021  ADD	R9	R6	R8
-      0x88280109,  //  0022  GETMBR	R10	R0	K9
-      0x1424120A,  //  0023  LT	R9	R9	R10
-      0x78260002,  //  0024  JMPF	R9	#0028
-      0x00180C08,  //  0025  ADD	R6	R6	R8
-      0x001C0F08,  //  0026  ADD	R7	R7	K8
-      0x70020000,  //  0027  JMP		#0029
-      0x70020000,  //  0028  JMP		#002A
-      0x7001FFE8,  //  0029  JMP		#0013
-      0xB8221400,  //  002A  GETNGBL	R8	K10
-      0x8C20110B,  //  002B  GETMET	R8	R8	K11
-      0x8C28050C,  //  002C  GETMET	R10	R2	K12
-      0x5830000D,  //  002D  LDCONST	R12	K13
-      0x5C340E00,  //  002E  MOVE	R13	R7
-      0x5C380C00,  //  002F  MOVE	R14	R6
-      0x603C000C,  //  0030  GETGBL	R15	G12
-      0x88400905,  //  0031  GETMBR	R16	R4	K5
-      0x7C3C0200,  //  0032  CALL	R15	1
-      0x7C280A00,  //  0033  CALL	R10	5
-      0x582C000E,  //  0034  LDCONST	R11	K14
-      0x7C200600,  //  0035  CALL	R8	3
-      0x40200F0F,  //  0036  CONNECT	R8	R7	K15
-      0x88240905,  //  0037  GETMBR	R9	R4	K5
-      0x94201208,  //  0038  GETIDX	R8	R9	R8
-      0x04280F08,  //  0039  SUB	R10	R7	K8
-      0x402A080A,  //  003A  CONNECT	R10	K4	R10
-      0x882C0905,  //  003B  GETMBR	R11	R4	K5
-      0x9428160A,  //  003C  GETIDX	R10	R11	R10
-      0x90120A0A,  //  003D  SETMBR	R4	K5	R10
-      0x6028000C,  //  003E  GETGBL	R10	G12
-      0x5C2C1000,  //  003F  MOVE	R11	R8
-      0x7C280200,  //  0040  CALL	R10	1
-      0x24281504,  //  0041  GT	R10	R10	K4
-      0x9012060A,  //  0042  SETMBR	R4	K3	R10
-      0x78160008,  //  0043  JMPF	R5	#004D
-      0xB82A1400,  //  0044  GETNGBL	R10	K10
-      0x8C28150B,  //  0045  GETMET	R10	R10	K11
-      0x8C30050C,  //  0046  GETMET	R12	R2	K12
-      0x58380010,  //  0047  LDCONST	R14	K16
-      0x8C3C0111,  //  0048  GETMET	R15	R0	K17
-      0x7C3C0200,  //  0049  CALL	R15	1
-      0x7C300600,  //  004A  CALL	R12	3
-      0x5834000E,  //  004B  LDCONST	R13	K14
-      0x7C280600,  //  004C  CALL	R10	3
-      0x88240903,  //  004D  GETMBR	R9	R4	K3
-      0x7826000A,  //  004E  JMPF	R9	#005A
-      0x5C240A00,  //  004F  MOVE	R9	R5
-      0x74260008,  //  0050  JMPT	R9	#005A
-      0xB8261400,  //  0051  GETNGBL	R9	K10
-      0x8C24130B,  //  0052  GETMET	R9	R9	K11
-      0x8C2C050C,  //  0053  GETMET	R11	R2	K12
-      0x58340012,  //  0054  LDCONST	R13	K18
-      0x8C380111,  //  0055  GETMET	R14	R0	K17
-      0x7C380200,  //  0056  CALL	R14	1
-      0x7C2C0600,  //  0057  CALL	R11	3
-      0x5830000E,  //  0058  LDCONST	R12	K14
-      0x7C240600,  //  0059  CALL	R9	3
-      0x88240102,  //  005A  GETMBR	R9	R0	K2
-      0x8C241306,  //  005B  GETMET	R9	R9	K6
-      0x7C240200,  //  005C  CALL	R9	1
-      0x8C281313,  //  005D  GETMET	R10	R9	K19
-      0x60300015,  //  005E  GETGBL	R12	G21
-      0x88340109,  //  005F  GETMBR	R13	R0	K9
-      0x7C300200,  //  0060  CALL	R12	1
-      0x7C280400,  //  0061  CALL	R10	2
-      0x8C2C0714,  //  0062  GETMET	R11	R3	K20
-      0x5C341400,  //  0063  MOVE	R13	R10
-      0x7C2C0400,  //  0064  CALL	R11	2
-      0x8C2C0715,  //  0065  GETMET	R11	R3	K21
-      0x7C2C0200,  //  0066  CALL	R11	1
-      0x8C2C0316,  //  0067  GETMET	R11	R1	K22
-      0x88340717,  //  0068  GETMBR	R13	R3	K23
-      0x88380718,  //  0069  GETMBR	R14	R3	K24
-      0x883C0719,  //  006A  GETMBR	R15	R3	K25
-      0x8840071A,  //  006B  GETMBR	R16	R3	K26
-      0x7C2C0A00,  //  006C  CALL	R11	5
-      0x602C000C,  //  006D  GETGBL	R11	G12
-      0x5C301000,  //  006E  MOVE	R12	R8
-      0x7C2C0200,  //  006F  CALL	R11	1
-      0x242C1704,  //  0070  GT	R11	R11	K4
-      0x782E0003,  //  0071  JMPF	R11	#0076
-      0x90120A08,  //  0072  SETMBR	R4	K5	R8
-      0x502C0000,  //  0073  LDBOOL	R11	0	0
-      0x80041600,  //  0074  RET	1	R11
-      0x70020001,  //  0075  JMP		#0078
-      0x502C0200,  //  0076  LDBOOL	R11	1	0
-      0x80041600,  //  0077  RET	1	R11
-      0x80000000,  //  0078  RET	0
+      0x80000000,  //  0009  RET	0
     })
   )
 );
@@ -857,9 +969,9 @@ be_local_class(Matter_IM_ReportData,
     &be_class_Matter_IM_Message,
     be_nested_map(3,
     ( (struct bmapnode*) &(const bmapnode[]) {
+        { be_const_key_weak(send_im, 1), be_const_closure(Matter_IM_ReportData_send_im_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_IM_ReportData_init_closure) },
-        { be_const_key_weak(send, -1), be_const_closure(Matter_IM_ReportData_send_closure) },
-        { be_const_key_weak(MAX_MESSAGE, -1), be_const_int(1200) },
+        { be_const_key_weak(MAX_MESSAGE, -1), be_const_int(1000) },
     })),
     be_str_weak(Matter_IM_ReportData)
 );
@@ -878,7 +990,7 @@ extern const bclass be_class_Matter_IM_ReportDataSubscribed;
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
   be_nested_proto(
-    5,                          /* nstack */
+    9,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -886,35 +998,53 @@ be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ack_received),
-    /* K1   */  be_nested_str_weak(report_data_phase),
-    /* K2   */  be_nested_str_weak(ready),
-    /* K3   */  be_nested_str_weak(sub),
-    /* K4   */  be_nested_str_weak(re_arm),
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20ack_received_X20sub_X3D_X25i),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(ack_received),
+    /* K9   */  be_nested_str_weak(report_data_phase),
+    /* K10  */  be_nested_str_weak(is_keep_alive),
+    /* K11  */  be_nested_str_weak(re_arm),
     }),
     be_str_weak(ack_received),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
-      0x60080003,  //  0000  GETGBL	R2	G3
-      0x5C0C0000,  //  0001  MOVE	R3	R0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x8C080500,  //  0003  GETMET	R2	R2	K0
-      0x5C100200,  //  0004  MOVE	R4	R1
-      0x7C080400,  //  0005  CALL	R2	2
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x740A0007,  //  0007  JMPT	R2	#0010
-      0x50080200,  //  0008  LDBOOL	R2	1	0
-      0x90020402,  //  0009  SETMBR	R0	K2	R2
-      0x88080103,  //  000A  GETMBR	R2	R0	K3
-      0x8C080504,  //  000B  GETMET	R2	R2	K4
-      0x7C080200,  //  000C  CALL	R2	1
-      0x50080200,  //  000D  LDBOOL	R2	1	0
-      0x80040400,  //  000E  RET	1	R2
-      0x70020001,  //  000F  JMP		#0012
-      0x50080000,  //  0010  LDBOOL	R2	0	0
-      0x80040400,  //  0011  RET	1	R2
-      0x80000000,  //  0012  RET	0
+    ( &(const binstruction[30]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x7C140600,  //  0007  CALL	R5	3
+      0x58180007,  //  0008  LDCONST	R6	K7
+      0x7C0C0600,  //  0009  CALL	R3	3
+      0x600C0003,  //  000A  GETGBL	R3	G3
+      0x5C100000,  //  000B  MOVE	R4	R0
+      0x7C0C0200,  //  000C  CALL	R3	1
+      0x8C0C0708,  //  000D  GETMET	R3	R3	K8
+      0x5C140200,  //  000E  MOVE	R5	R1
+      0x7C0C0400,  //  000F  CALL	R3	2
+      0x880C0109,  //  0010  GETMBR	R3	R0	K9
+      0x740E0008,  //  0011  JMPT	R3	#001B
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x880C070A,  //  0013  GETMBR	R3	R3	K10
+      0x780E0002,  //  0014  JMPF	R3	#0018
+      0x880C0105,  //  0015  GETMBR	R3	R0	K5
+      0x8C0C070B,  //  0016  GETMET	R3	R3	K11
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x500C0200,  //  0018  LDBOOL	R3	1	0
+      0x80040600,  //  0019  RET	1	R3
+      0x70020001,  //  001A  JMP		#001D
+      0x500C0000,  //  001B  LDBOOL	R3	0	0
+      0x80040600,  //  001C  RET	1	R3
+      0x80000000,  //  001D  RET	0
     })
   )
 );
@@ -922,11 +1052,11 @@ be_local_closure(Matter_IM_ReportDataSubscribed_ack_received,   /* name */
 
 
 /********************************************************************
-** Solidified function: status_ok_received
+** Solidified function: send_im
 ********************************************************************/
-be_local_closure(Matter_IM_ReportDataSubscribed_status_ok_received,   /* name */
+be_local_closure(Matter_IM_ReportDataSubscribed_send_im,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -934,64 +1064,131 @@ be_local_closure(Matter_IM_ReportDataSubscribed_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(report_data_phase),
-    /* K2   */  be_nested_str_weak(status_ok_received),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20send_X20sub_X3D_X25i_X20exch_X3D_X25i_X20ready_X3D_X25i),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(exchange_id),
+    /* K9   */  be_nested_str_weak(ready),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_const_int(0),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(data),
+    /* K14  */  be_nested_str_weak(attribute_reports),
+    /* K15  */  be_nested_str_weak(report_data_phase),
+    /* K16  */  be_nested_str_weak(send_im),
+    /* K17  */  be_nested_str_weak(build_standalone_ack),
+    /* K18  */  be_nested_str_weak(encode_frame),
+    /* K19  */  be_nested_str_weak(encrypt),
+    /* K20  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i),
+    /* K21  */  be_nested_str_weak(session),
+    /* K22  */  be_nested_str_weak(local_session_id),
+    /* K23  */  be_nested_str_weak(ack_message_counter),
+    /* K24  */  be_nested_str_weak(message_counter),
+    /* K25  */  be_nested_str_weak(send_response),
+    /* K26  */  be_nested_str_weak(raw),
+    /* K27  */  be_nested_str_weak(remote_ip),
+    /* K28  */  be_nested_str_weak(remote_port),
+    /* K29  */  be_nested_str_weak(last_counter),
     }),
-    be_str_weak(status_ok_received),
+    be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[20]) {  /* code */
+    ( &(const binstruction[90]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x780E0007,  //  0002  JMPF	R3	#000B
-      0x600C0003,  //  0003  GETGBL	R3	G3
-      0x5C100000,  //  0004  MOVE	R4	R0
-      0x7C0C0200,  //  0005  CALL	R3	1
-      0x8C0C0702,  //  0006  GETMET	R3	R3	K2
-      0x5C140200,  //  0007  MOVE	R5	R1
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x80040600,  //  0009  RET	1	R3
-      0x70020007,  //  000A  JMP		#0013
-      0x600C0003,  //  000B  GETGBL	R3	G3
-      0x5C100000,  //  000C  MOVE	R4	R0
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x8C0C0702,  //  000E  GETMET	R3	R3	K2
-      0x4C140000,  //  000F  LDNIL	R5
-      0x7C0C0400,  //  0010  CALL	R3	2
-      0x500C0000,  //  0011  LDBOOL	R3	0	0
-      0x80040600,  //  0012  RET	1	R3
-      0x80000000,  //  0013  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: reached_timeout
-********************************************************************/
-be_local_closure(Matter_IM_ReportDataSubscribed_reached_timeout,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(sub),
-    /* K1   */  be_nested_str_weak(remove_self),
-    }),
-    be_str_weak(reached_timeout),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x88241308,  //  0008  GETMBR	R9	R9	K8
+      0x88280109,  //  0009  GETMBR	R10	R0	K9
+      0x782A0001,  //  000A  JMPF	R10	#000D
+      0x5828000A,  //  000B  LDCONST	R10	K10
+      0x70020000,  //  000C  JMP		#000E
+      0x5828000B,  //  000D  LDCONST	R10	K11
+      0x7C140A00,  //  000E  CALL	R5	5
+      0x5818000C,  //  000F  LDCONST	R6	K12
+      0x7C0C0600,  //  0010  CALL	R3	3
+      0x880C0109,  //  0011  GETMBR	R3	R0	K9
+      0x740E0001,  //  0012  JMPT	R3	#0015
+      0x500C0000,  //  0013  LDBOOL	R3	0	0
+      0x80040600,  //  0014  RET	1	R3
+      0x600C000C,  //  0015  GETGBL	R3	G12
+      0x8810010D,  //  0016  GETMBR	R4	R0	K13
+      0x8810090E,  //  0017  GETMBR	R4	R4	K14
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x240C070B,  //  0019  GT	R3	R3	K11
+      0x780E002E,  //  001A  JMPF	R3	#004A
+      0x880C010F,  //  001B  GETMBR	R3	R0	K15
+      0x780E000E,  //  001C  JMPF	R3	#002C
+      0x600C0003,  //  001D  GETGBL	R3	G3
+      0x5C100000,  //  001E  MOVE	R4	R0
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x8C0C0710,  //  0020  GETMET	R3	R3	K16
+      0x5C140200,  //  0021  MOVE	R5	R1
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x5C100600,  //  0023  MOVE	R4	R3
+      0x74120001,  //  0024  JMPT	R4	#0027
+      0x50100000,  //  0025  LDBOOL	R4	0	0
+      0x80040800,  //  0026  RET	1	R4
+      0x50100000,  //  0027  LDBOOL	R4	0	0
+      0x90021E04,  //  0028  SETMBR	R0	K15	R4
+      0x50100000,  //  0029  LDBOOL	R4	0	0
+      0x80040800,  //  002A  RET	1	R4
+      0x7002001C,  //  002B  JMP		#0049
+      0x880C0107,  //  002C  GETMBR	R3	R0	K7
+      0x8C0C0711,  //  002D  GETMET	R3	R3	K17
+      0x50140000,  //  002E  LDBOOL	R5	0	0
+      0x7C0C0400,  //  002F  CALL	R3	2
+      0x8C100712,  //  0030  GETMET	R4	R3	K18
+      0x7C100200,  //  0031  CALL	R4	1
+      0x8C100713,  //  0032  GETMET	R4	R3	K19
+      0x7C100200,  //  0033  CALL	R4	1
+      0xB8120200,  //  0034  GETNGBL	R4	K1
+      0x8C100902,  //  0035  GETMET	R4	R4	K2
+      0x8C180503,  //  0036  GETMET	R6	R2	K3
+      0x58200014,  //  0037  LDCONST	R8	K20
+      0x88240715,  //  0038  GETMBR	R9	R3	K21
+      0x88241316,  //  0039  GETMBR	R9	R9	K22
+      0x88280717,  //  003A  GETMBR	R10	R3	K23
+      0x882C0718,  //  003B  GETMBR	R11	R3	K24
+      0x7C180A00,  //  003C  CALL	R6	5
+      0x581C000C,  //  003D  LDCONST	R7	K12
+      0x7C100600,  //  003E  CALL	R4	3
+      0x8C100319,  //  003F  GETMET	R4	R1	K25
+      0x8818071A,  //  0040  GETMBR	R6	R3	K26
+      0x881C071B,  //  0041  GETMBR	R7	R3	K27
+      0x8820071C,  //  0042  GETMBR	R8	R3	K28
+      0x4C240000,  //  0043  LDNIL	R9
+      0x7C100A00,  //  0044  CALL	R4	5
+      0x88100718,  //  0045  GETMBR	R4	R3	K24
+      0x90023A04,  //  0046  SETMBR	R0	K29	R4
+      0x50100200,  //  0047  LDBOOL	R4	1	0
+      0x80040800,  //  0048  RET	1	R4
+      0x7002000E,  //  0049  JMP		#0059
+      0x880C010F,  //  004A  GETMBR	R3	R0	K15
+      0x780E000A,  //  004B  JMPF	R3	#0057
+      0x600C0003,  //  004C  GETGBL	R3	G3
+      0x5C100000,  //  004D  MOVE	R4	R0
+      0x7C0C0200,  //  004E  CALL	R3	1
+      0x8C0C0710,  //  004F  GETMET	R3	R3	K16
+      0x5C140200,  //  0050  MOVE	R5	R1
+      0x7C0C0400,  //  0051  CALL	R3	2
+      0x500C0000,  //  0052  LDBOOL	R3	0	0
+      0x90021E03,  //  0053  SETMBR	R0	K15	R3
+      0x500C0000,  //  0054  LDBOOL	R3	0	0
+      0x80040600,  //  0055  RET	1	R3
+      0x70020001,  //  0056  JMP		#0059
+      0x500C0200,  //  0057  LDBOOL	R3	1	0
+      0x80040600,  //  0058  RET	1	R3
+      0x80000000,  //  0059  RET	0
     })
   )
 );
@@ -1061,8 +1258,59 @@ be_local_closure(Matter_IM_ReportDataSubscribed_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_ReportDataSubscribed_status_error_received,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20status_error_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(exchange_id),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(remove_self),
+    }),
+    be_str_weak(status_error_received),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x88241308,  //  0008  GETMBR	R9	R9	K8
+      0x7C140800,  //  0009  CALL	R5	4
+      0x58180009,  //  000A  LDCONST	R6	K9
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0x880C0105,  //  000C  GETMBR	R3	R0	K5
+      0x8C0C070A,  //  000D  GETMET	R3	R3	K10
+      0x7C0C0200,  //  000E  CALL	R3	1
+      0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: reached_timeout
+********************************************************************/
+be_local_closure(Matter_IM_ReportDataSubscribed_reached_timeout,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
@@ -1073,12 +1321,12 @@ be_local_closure(Matter_IM_ReportDataSubscribed_status_error_received,   /* name
     /* K0   */  be_nested_str_weak(sub),
     /* K1   */  be_nested_str_weak(remove_self),
     }),
-    be_str_weak(status_error_received),
+    be_str_weak(reached_timeout),
     &be_const_str_solidified,
     ( &(const binstruction[ 4]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x7C080200,  //  0002  CALL	R2	1
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
       0x80000000,  //  0003  RET	0
     })
   )
@@ -1087,11 +1335,11 @@ be_local_closure(Matter_IM_ReportDataSubscribed_status_error_received,   /* name
 
 
 /********************************************************************
-** Solidified function: send
+** Solidified function: status_ok_received
 ********************************************************************/
-be_local_closure(Matter_IM_ReportDataSubscribed_send,   /* name */
+be_local_closure(Matter_IM_ReportDataSubscribed_status_ok_received,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    10,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1099,80 +1347,58 @@ be_local_closure(Matter_IM_ReportDataSubscribed_send,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[14]) {     /* constants */
-    /* K0   */  be_nested_str_weak(data),
-    /* K1   */  be_nested_str_weak(attribute_reports),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_nested_str_weak(report_data_phase),
-    /* K4   */  be_nested_str_weak(send),
-    /* K5   */  be_nested_str_weak(resp),
-    /* K6   */  be_nested_str_weak(build_standalone_ack),
-    /* K7   */  be_nested_str_weak(encode_frame),
-    /* K8   */  be_nested_str_weak(encrypt),
-    /* K9   */  be_nested_str_weak(send_response),
-    /* K10  */  be_nested_str_weak(raw),
-    /* K11  */  be_nested_str_weak(remote_ip),
-    /* K12  */  be_nested_str_weak(remote_port),
-    /* K13  */  be_nested_str_weak(message_counter),
+    ( &(const bvalue[13]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_ReportDataSubscribed_X20status_ok_received_X20sub_X3D_X25i_X20exch_X3D_X25i),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(exchange_id),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_nested_str_weak(report_data_phase),
+    /* K11  */  be_nested_str_weak(status_ok_received),
+    /* K12  */  be_nested_str_weak(re_arm),
     }),
-    be_str_weak(send),
+    be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[55]) {  /* code */
-      0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x880C0701,  //  0002  GETMBR	R3	R3	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x24080502,  //  0004  GT	R2	R2	K2
-      0x780A0020,  //  0005  JMPF	R2	#0027
-      0x88080103,  //  0006  GETMBR	R2	R0	K3
-      0x780A000E,  //  0007  JMPF	R2	#0017
-      0x60080003,  //  0008  GETGBL	R2	G3
-      0x5C0C0000,  //  0009  MOVE	R3	R0
-      0x7C080200,  //  000A  CALL	R2	1
-      0x8C080504,  //  000B  GETMET	R2	R2	K4
-      0x5C100200,  //  000C  MOVE	R4	R1
-      0x7C080400,  //  000D  CALL	R2	2
-      0x5C0C0400,  //  000E  MOVE	R3	R2
-      0x740E0001,  //  000F  JMPT	R3	#0012
-      0x500C0000,  //  0010  LDBOOL	R3	0	0
-      0x80040600,  //  0011  RET	1	R3
-      0x500C0000,  //  0012  LDBOOL	R3	0	0
-      0x90020603,  //  0013  SETMBR	R0	K3	R3
-      0x500C0000,  //  0014  LDBOOL	R3	0	0
-      0x80040600,  //  0015  RET	1	R3
-      0x7002000E,  //  0016  JMP		#0026
-      0x88080105,  //  0017  GETMBR	R2	R0	K5
-      0x8C080506,  //  0018  GETMET	R2	R2	K6
-      0x7C080200,  //  0019  CALL	R2	1
-      0x8C0C0507,  //  001A  GETMET	R3	R2	K7
+    ( &(const binstruction[34]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x88241308,  //  0008  GETMBR	R9	R9	K8
+      0x7C140800,  //  0009  CALL	R5	4
+      0x58180009,  //  000A  LDCONST	R6	K9
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0x880C010A,  //  000C  GETMBR	R3	R0	K10
+      0x780E0007,  //  000D  JMPF	R3	#0016
+      0x600C0003,  //  000E  GETGBL	R3	G3
+      0x5C100000,  //  000F  MOVE	R4	R0
+      0x7C0C0200,  //  0010  CALL	R3	1
+      0x8C0C070B,  //  0011  GETMET	R3	R3	K11
+      0x5C140200,  //  0012  MOVE	R5	R1
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x80040600,  //  0014  RET	1	R3
+      0x7002000A,  //  0015  JMP		#0021
+      0x880C0105,  //  0016  GETMBR	R3	R0	K5
+      0x8C0C070C,  //  0017  GETMET	R3	R3	K12
+      0x7C0C0200,  //  0018  CALL	R3	1
+      0x600C0003,  //  0019  GETGBL	R3	G3
+      0x5C100000,  //  001A  MOVE	R4	R0
       0x7C0C0200,  //  001B  CALL	R3	1
-      0x8C0C0508,  //  001C  GETMET	R3	R2	K8
-      0x7C0C0200,  //  001D  CALL	R3	1
-      0x8C0C0309,  //  001E  GETMET	R3	R1	K9
-      0x8814050A,  //  001F  GETMBR	R5	R2	K10
-      0x8818050B,  //  0020  GETMBR	R6	R2	K11
-      0x881C050C,  //  0021  GETMBR	R7	R2	K12
-      0x8820050D,  //  0022  GETMBR	R8	R2	K13
-      0x7C0C0A00,  //  0023  CALL	R3	5
-      0x500C0200,  //  0024  LDBOOL	R3	1	0
-      0x80040600,  //  0025  RET	1	R3
-      0x7002000E,  //  0026  JMP		#0036
-      0x88080103,  //  0027  GETMBR	R2	R0	K3
-      0x780A000A,  //  0028  JMPF	R2	#0034
-      0x60080003,  //  0029  GETGBL	R2	G3
-      0x5C0C0000,  //  002A  MOVE	R3	R0
-      0x7C080200,  //  002B  CALL	R2	1
-      0x8C080504,  //  002C  GETMET	R2	R2	K4
-      0x5C100200,  //  002D  MOVE	R4	R1
-      0x7C080400,  //  002E  CALL	R2	2
-      0x50080000,  //  002F  LDBOOL	R2	0	0
-      0x90020602,  //  0030  SETMBR	R0	K3	R2
-      0x50080000,  //  0031  LDBOOL	R2	0	0
-      0x80040400,  //  0032  RET	1	R2
-      0x70020001,  //  0033  JMP		#0036
-      0x50080200,  //  0034  LDBOOL	R2	1	0
-      0x80040400,  //  0035  RET	1	R2
-      0x80000000,  //  0036  RET	0
+      0x8C0C070B,  //  001C  GETMET	R3	R3	K11
+      0x4C140000,  //  001D  LDNIL	R5
+      0x7C0C0400,  //  001E  CALL	R3	2
+      0x500C0000,  //  001F  LDBOOL	R3	0	0
+      0x80040600,  //  0020  RET	1	R3
+      0x80000000,  //  0021  RET	0
     })
   )
 );
@@ -1190,12 +1416,12 @@ be_local_class(Matter_IM_ReportDataSubscribed,
     ( (struct bmapnode*) &(const bmapnode[]) {
         { be_const_key_weak(ack_received, 1), be_const_closure(Matter_IM_ReportDataSubscribed_ack_received_closure) },
         { be_const_key_weak(status_ok_received, -1), be_const_closure(Matter_IM_ReportDataSubscribed_status_ok_received_closure) },
-        { be_const_key_weak(status_error_received, -1), be_const_closure(Matter_IM_ReportDataSubscribed_status_error_received_closure) },
+        { be_const_key_weak(send_im, -1), be_const_closure(Matter_IM_ReportDataSubscribed_send_im_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_IM_ReportDataSubscribed_init_closure) },
-        { be_const_key_weak(report_data_phase, 2), be_const_var(1) },
-        { be_const_key_weak(reached_timeout, 6), be_const_closure(Matter_IM_ReportDataSubscribed_reached_timeout_closure) },
-        { be_const_key_weak(sub, -1), be_const_var(0) },
-        { be_const_key_weak(send, -1), be_const_closure(Matter_IM_ReportDataSubscribed_send_closure) },
+        { be_const_key_weak(report_data_phase, 7), be_const_var(1) },
+        { be_const_key_weak(sub, 6), be_const_var(0) },
+        { be_const_key_weak(reached_timeout, -1), be_const_closure(Matter_IM_ReportDataSubscribed_reached_timeout_closure) },
+        { be_const_key_weak(status_error_received, -1), be_const_closure(Matter_IM_ReportDataSubscribed_status_error_received_closure) },
     })),
     be_str_weak(Matter_IM_ReportDataSubscribed)
 );
@@ -1252,7 +1478,7 @@ be_local_closure(Matter_IM_SubscribeResponse_init,   /* name */
 ********************************************************************/
 be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1260,39 +1486,65 @@ be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
+    ( &(const bvalue[18]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
     /* K3   */  be_nested_str_weak(format),
-    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20sub_id_X3D),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20IM_SubscribeResponse_X20status_ok_received_X20sub_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25i_X20last_counter_X3D_X25i),
     /* K5   */  be_nested_str_weak(sub),
     /* K6   */  be_nested_str_weak(subscription_id),
-    /* K7   */  be_const_int(2),
-    /* K8   */  be_nested_str_weak(status_ok_received),
+    /* K7   */  be_nested_str_weak(resp),
+    /* K8   */  be_nested_str_weak(exchange_id),
+    /* K9   */  be_nested_str_weak(ack_message_counter),
+    /* K10  */  be_const_int(0),
+    /* K11  */  be_nested_str_weak(last_counter),
+    /* K12  */  be_const_int(3),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X3ESub_OK_X20_X20_X20_X20_X28_X256i_X29_X20sub_X3D_X25i),
+    /* K14  */  be_nested_str_weak(session),
+    /* K15  */  be_nested_str_weak(local_session_id),
+    /* K16  */  be_const_int(2),
+    /* K17  */  be_nested_str_weak(status_ok_received),
     }),
     be_str_weak(status_ok_received),
     &be_const_str_solidified,
-    ( &(const binstruction[19]) {  /* code */
+    ( &(const binstruction[36]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xB80E0200,  //  0001  GETNGBL	R3	K1
       0x8C0C0702,  //  0002  GETMET	R3	R3	K2
       0x8C140503,  //  0003  GETMET	R5	R2	K3
-      0x601C0008,  //  0004  GETGBL	R7	G8
+      0x581C0004,  //  0004  LDCONST	R7	K4
       0x88200105,  //  0005  GETMBR	R8	R0	K5
       0x88201106,  //  0006  GETMBR	R8	R8	K6
-      0x7C1C0200,  //  0007  CALL	R7	1
-      0x001E0807,  //  0008  ADD	R7	K4	R7
-      0x7C140400,  //  0009  CALL	R5	2
-      0x58180007,  //  000A  LDCONST	R6	K7
-      0x7C0C0600,  //  000B  CALL	R3	3
-      0x600C0003,  //  000C  GETGBL	R3	G3
-      0x5C100000,  //  000D  MOVE	R4	R0
-      0x7C0C0200,  //  000E  CALL	R3	1
-      0x8C0C0708,  //  000F  GETMET	R3	R3	K8
-      0x5C140200,  //  0010  MOVE	R5	R1
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x80040600,  //  0012  RET	1	R3
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x88241308,  //  0008  GETMBR	R9	R9	K8
+      0x88280309,  //  0009  GETMBR	R10	R1	K9
+      0x782A0001,  //  000A  JMPF	R10	#000D
+      0x88280309,  //  000B  GETMBR	R10	R1	K9
+      0x70020000,  //  000C  JMP		#000E
+      0x5828000A,  //  000D  LDCONST	R10	K10
+      0x882C010B,  //  000E  GETMBR	R11	R0	K11
+      0x7C140C00,  //  000F  CALL	R5	6
+      0x5818000C,  //  0010  LDCONST	R6	K12
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0xB80E0200,  //  0012  GETNGBL	R3	K1
+      0x8C0C0702,  //  0013  GETMET	R3	R3	K2
+      0x8C140503,  //  0014  GETMET	R5	R2	K3
+      0x581C000D,  //  0015  LDCONST	R7	K13
+      0x8820030E,  //  0016  GETMBR	R8	R1	K14
+      0x8820110F,  //  0017  GETMBR	R8	R8	K15
+      0x88240105,  //  0018  GETMBR	R9	R0	K5
+      0x88241306,  //  0019  GETMBR	R9	R9	K6
+      0x7C140800,  //  001A  CALL	R5	4
+      0x58180010,  //  001B  LDCONST	R6	K16
+      0x7C0C0600,  //  001C  CALL	R3	3
+      0x600C0003,  //  001D  GETGBL	R3	G3
+      0x5C100000,  //  001E  MOVE	R4	R0
+      0x7C0C0200,  //  001F  CALL	R3	1
+      0x8C0C0711,  //  0020  GETMET	R3	R3	K17
+      0x5C140200,  //  0021  MOVE	R5	R1
+      0x7C0C0400,  //  0022  CALL	R3	2
+      0x80040600,  //  0023  RET	1	R3
     })
   )
 );
@@ -1300,11 +1552,11 @@ be_local_closure(Matter_IM_SubscribeResponse_status_ok_received,   /* name */
 
 
 /********************************************************************
-** Solidified function: send
+** Solidified function: send_im
 ********************************************************************/
-be_local_closure(Matter_IM_SubscribeResponse_send,   /* name */
+be_local_closure(Matter_IM_SubscribeResponse_send_im,   /* name */
   be_nested_proto(
-    10,                          /* nstack */
+    12,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1312,80 +1564,121 @@ be_local_closure(Matter_IM_SubscribeResponse_send,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[19]) {     /* constants */
-    /* K0   */  be_nested_str_weak(report_data_phase),
-    /* K1   */  be_nested_str_weak(send),
-    /* K2   */  be_nested_str_weak(resp),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(SubscribeResponseMessage),
-    /* K5   */  be_nested_str_weak(subscription_id),
-    /* K6   */  be_nested_str_weak(sub),
-    /* K7   */  be_nested_str_weak(max_interval),
-    /* K8   */  be_nested_str_weak(opcode),
-    /* K9   */  be_nested_str_weak(encode_frame),
-    /* K10  */  be_nested_str_weak(to_TLV),
-    /* K11  */  be_nested_str_weak(encode),
-    /* K12  */  be_nested_str_weak(encrypt),
-    /* K13  */  be_nested_str_weak(send_response),
-    /* K14  */  be_nested_str_weak(raw),
-    /* K15  */  be_nested_str_weak(remote_ip),
-    /* K16  */  be_nested_str_weak(remote_port),
-    /* K17  */  be_nested_str_weak(message_counter),
-    /* K18  */  be_nested_str_weak(re_arm),
+    ( &(const bvalue[30]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20Matter_IM_SubscribeResponse_X20send_X20sub_X3D_X25i_X20ready_X3D_X25i),
+    /* K5   */  be_nested_str_weak(sub),
+    /* K6   */  be_nested_str_weak(subscription_id),
+    /* K7   */  be_nested_str_weak(ready),
+    /* K8   */  be_const_int(1),
+    /* K9   */  be_const_int(0),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(report_data_phase),
+    /* K12  */  be_nested_str_weak(send_im),
+    /* K13  */  be_nested_str_weak(resp),
+    /* K14  */  be_nested_str_weak(matter),
+    /* K15  */  be_nested_str_weak(SubscribeResponseMessage),
+    /* K16  */  be_nested_str_weak(max_interval),
+    /* K17  */  be_nested_str_weak(opcode),
+    /* K18  */  be_nested_str_weak(encode_frame),
+    /* K19  */  be_nested_str_weak(to_TLV),
+    /* K20  */  be_nested_str_weak(tlv2raw),
+    /* K21  */  be_nested_str_weak(encrypt),
+    /* K22  */  be_nested_str_weak(send_response),
+    /* K23  */  be_nested_str_weak(raw),
+    /* K24  */  be_nested_str_weak(remote_ip),
+    /* K25  */  be_nested_str_weak(remote_port),
+    /* K26  */  be_nested_str_weak(message_counter),
+    /* K27  */  be_nested_str_weak(last_counter),
+    /* K28  */  be_nested_str_weak(MTR_X3A_X20Send_X20SubscribeResponseMessage_X20sub_X3D_X25i_X20id_X3D_X25i),
+    /* K29  */  be_nested_str_weak(re_arm),
     }),
-    be_str_weak(send),
+    be_str_weak(send_im),
     &be_const_str_solidified,
-    ( &(const binstruction[50]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x780A000E,  //  0001  JMPF	R2	#0011
-      0x60080003,  //  0002  GETGBL	R2	G3
-      0x5C0C0000,  //  0003  MOVE	R3	R0
-      0x7C080200,  //  0004  CALL	R2	1
-      0x8C080501,  //  0005  GETMET	R2	R2	K1
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x7C080400,  //  0007  CALL	R2	2
-      0x5C0C0400,  //  0008  MOVE	R3	R2
-      0x740E0001,  //  0009  JMPT	R3	#000C
-      0x500C0000,  //  000A  LDBOOL	R3	0	0
-      0x80040600,  //  000B  RET	1	R3
-      0x500C0000,  //  000C  LDBOOL	R3	0	0
-      0x90020003,  //  000D  SETMBR	R0	K0	R3
-      0x500C0000,  //  000E  LDBOOL	R3	0	0
-      0x80040600,  //  000F  RET	1	R3
-      0x7002001F,  //  0010  JMP		#0031
-      0x88080102,  //  0011  GETMBR	R2	R0	K2
-      0xB80E0600,  //  0012  GETNGBL	R3	K3
-      0x8C0C0704,  //  0013  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0014  CALL	R3	1
-      0x88100106,  //  0015  GETMBR	R4	R0	K6
-      0x88100905,  //  0016  GETMBR	R4	R4	K5
-      0x900E0A04,  //  0017  SETMBR	R3	K5	R4
-      0x88100106,  //  0018  GETMBR	R4	R0	K6
-      0x88100907,  //  0019  GETMBR	R4	R4	K7
-      0x900E0E04,  //  001A  SETMBR	R3	K7	R4
-      0x88100102,  //  001B  GETMBR	R4	R0	K2
-      0x54160003,  //  001C  LDINT	R5	4
-      0x90121005,  //  001D  SETMBR	R4	K8	R5
-      0x8C100509,  //  001E  GETMET	R4	R2	K9
-      0x8C18070A,  //  001F  GETMET	R6	R3	K10
-      0x7C180200,  //  0020  CALL	R6	1
-      0x8C180D0B,  //  0021  GETMET	R6	R6	K11
-      0x7C180200,  //  0022  CALL	R6	1
-      0x7C100400,  //  0023  CALL	R4	2
-      0x8C10050C,  //  0024  GETMET	R4	R2	K12
-      0x7C100200,  //  0025  CALL	R4	1
-      0x8C10030D,  //  0026  GETMET	R4	R1	K13
-      0x8818050E,  //  0027  GETMBR	R6	R2	K14
-      0x881C050F,  //  0028  GETMBR	R7	R2	K15
-      0x88200510,  //  0029  GETMBR	R8	R2	K16
-      0x88240511,  //  002A  GETMBR	R9	R2	K17
-      0x7C100A00,  //  002B  CALL	R4	5
-      0x88100106,  //  002C  GETMBR	R4	R0	K6
-      0x8C100912,  //  002D  GETMET	R4	R4	K18
-      0x7C100200,  //  002E  CALL	R4	1
-      0x50100200,  //  002F  LDBOOL	R4	1	0
-      0x80040800,  //  0030  RET	1	R4
-      0x80000000,  //  0031  RET	0
+    ( &(const binstruction[80]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0xB80E0200,  //  0001  GETNGBL	R3	K1
+      0x8C0C0702,  //  0002  GETMET	R3	R3	K2
+      0x8C140503,  //  0003  GETMET	R5	R2	K3
+      0x581C0004,  //  0004  LDCONST	R7	K4
+      0x88200105,  //  0005  GETMBR	R8	R0	K5
+      0x88201106,  //  0006  GETMBR	R8	R8	K6
+      0x88240107,  //  0007  GETMBR	R9	R0	K7
+      0x78260001,  //  0008  JMPF	R9	#000B
+      0x58240008,  //  0009  LDCONST	R9	K8
+      0x70020000,  //  000A  JMP		#000C
+      0x58240009,  //  000B  LDCONST	R9	K9
+      0x7C140800,  //  000C  CALL	R5	4
+      0x5818000A,  //  000D  LDCONST	R6	K10
+      0x7C0C0600,  //  000E  CALL	R3	3
+      0x880C0107,  //  000F  GETMBR	R3	R0	K7
+      0x740E0001,  //  0010  JMPT	R3	#0013
+      0x500C0000,  //  0011  LDBOOL	R3	0	0
+      0x80040600,  //  0012  RET	1	R3
+      0x880C010B,  //  0013  GETMBR	R3	R0	K11
+      0x780E000D,  //  0014  JMPF	R3	#0023
+      0x600C0003,  //  0015  GETGBL	R3	G3
+      0x5C100000,  //  0016  MOVE	R4	R0
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x8C0C070C,  //  0018  GETMET	R3	R3	K12
+      0x5C140200,  //  0019  MOVE	R5	R1
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0x780E0001,  //  001B  JMPF	R3	#001E
+      0x50100000,  //  001C  LDBOOL	R4	0	0
+      0x90021604,  //  001D  SETMBR	R0	K11	R4
+      0x50100000,  //  001E  LDBOOL	R4	0	0
+      0x90020E04,  //  001F  SETMBR	R0	K7	R4
+      0x50100000,  //  0020  LDBOOL	R4	0	0
+      0x80040800,  //  0021  RET	1	R4
+      0x7002002B,  //  0022  JMP		#004F
+      0x880C010D,  //  0023  GETMBR	R3	R0	K13
+      0xB8121C00,  //  0024  GETNGBL	R4	K14
+      0x8C10090F,  //  0025  GETMET	R4	R4	K15
+      0x7C100200,  //  0026  CALL	R4	1
+      0x88140105,  //  0027  GETMBR	R5	R0	K5
+      0x88140B06,  //  0028  GETMBR	R5	R5	K6
+      0x90120C05,  //  0029  SETMBR	R4	K6	R5
+      0x88140105,  //  002A  GETMBR	R5	R0	K5
+      0x88140B10,  //  002B  GETMBR	R5	R5	K16
+      0x90122005,  //  002C  SETMBR	R4	K16	R5
+      0x8814010D,  //  002D  GETMBR	R5	R0	K13
+      0x541A0003,  //  002E  LDINT	R6	4
+      0x90162206,  //  002F  SETMBR	R5	K17	R6
+      0x8C140712,  //  0030  GETMET	R5	R3	K18
+      0x8C1C0913,  //  0031  GETMET	R7	R4	K19
+      0x7C1C0200,  //  0032  CALL	R7	1
+      0x8C1C0F14,  //  0033  GETMET	R7	R7	K20
+      0x7C1C0200,  //  0034  CALL	R7	1
+      0x7C140400,  //  0035  CALL	R5	2
+      0x8C140715,  //  0036  GETMET	R5	R3	K21
+      0x7C140200,  //  0037  CALL	R5	1
+      0x8C140316,  //  0038  GETMET	R5	R1	K22
+      0x881C0717,  //  0039  GETMBR	R7	R3	K23
+      0x88200718,  //  003A  GETMBR	R8	R3	K24
+      0x88240719,  //  003B  GETMBR	R9	R3	K25
+      0x8828071A,  //  003C  GETMBR	R10	R3	K26
+      0x7C140A00,  //  003D  CALL	R5	5
+      0x8814071A,  //  003E  GETMBR	R5	R3	K26
+      0x90023605,  //  003F  SETMBR	R0	K27	R5
+      0xB8160200,  //  0040  GETNGBL	R5	K1
+      0x8C140B02,  //  0041  GETMET	R5	R5	K2
+      0x8C1C0503,  //  0042  GETMET	R7	R2	K3
+      0x5824001C,  //  0043  LDCONST	R9	K28
+      0x88280105,  //  0044  GETMBR	R10	R0	K5
+      0x88281506,  //  0045  GETMBR	R10	R10	K6
+      0x882C071A,  //  0046  GETMBR	R11	R3	K26
+      0x7C1C0800,  //  0047  CALL	R7	4
+      0x5820000A,  //  0048  LDCONST	R8	K10
+      0x7C140600,  //  0049  CALL	R5	3
+      0x88140105,  //  004A  GETMBR	R5	R0	K5
+      0x8C140B1D,  //  004B  GETMET	R5	R5	K29
+      0x7C140200,  //  004C  CALL	R5	1
+      0x50140200,  //  004D  LDBOOL	R5	1	0
+      0x80040A00,  //  004E  RET	1	R5
+      0x80000000,  //  004F  RET	0
     })
   )
 );
@@ -1401,11 +1694,11 @@ be_local_class(Matter_IM_SubscribeResponse,
     &be_class_Matter_IM_ReportData,
     be_nested_map(5,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(init, 3), be_const_closure(Matter_IM_SubscribeResponse_init_closure) },
-        { be_const_key_weak(sub, 4), be_const_var(0) },
+        { be_const_key_weak(init, 4), be_const_closure(Matter_IM_SubscribeResponse_init_closure) },
+        { be_const_key_weak(sub, -1), be_const_var(0) },
         { be_const_key_weak(status_ok_received, -1), be_const_closure(Matter_IM_SubscribeResponse_status_ok_received_closure) },
+        { be_const_key_weak(send_im, -1), be_const_closure(Matter_IM_SubscribeResponse_send_im_closure) },
         { be_const_key_weak(report_data_phase, -1), be_const_var(1) },
-        { be_const_key_weak(send, -1), be_const_closure(Matter_IM_SubscribeResponse_send_closure) },
     })),
     be_str_weak(Matter_IM_SubscribeResponse)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_IM_Subscription.h
@@ -7,68 +7,106 @@
 extern const bclass be_class_Matter_IM_Subscription;
 
 /********************************************************************
-** Solidified function: re_arm
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_IM_Subscription_re_arm,   /* name */
+be_local_closure(Matter_IM_Subscription_init,   /* name */
   be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
+    13,                          /* nstack */
+    5,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[15]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(wait_status),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(millis),
-    /* K4   */  be_nested_str_weak(expiration),
-    /* K5   */  be_nested_str_weak(max_interval),
-    /* K6   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
-    /* K7   */  be_nested_str_weak(not_before),
-    /* K8   */  be_nested_str_weak(min_interval),
-    /* K9   */  be_const_int(1),
-    /* K10  */  be_nested_str_weak(log),
-    /* K11  */  be_nested_str_weak(format),
-    /* K12  */  be_nested_str_weak(MTR_X3A_X20_X3ESub_Done_X20_X20sub_id_X3D),
-    /* K13  */  be_nested_str_weak(subscription_id),
-    /* K14  */  be_const_int(2),
+    ( &(const bvalue[22]) {     /* constants */
+    /* K0   */  be_nested_str_weak(subs_shop),
+    /* K1   */  be_nested_str_weak(subscription_id),
+    /* K2   */  be_nested_str_weak(session),
+    /* K3   */  be_nested_str_weak(min_interval_floor),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(min_interval),
+    /* K6   */  be_nested_str_weak(max_interval_ceiling),
+    /* K7   */  be_nested_str_weak(max_interval),
+    /* K8   */  be_nested_str_weak(wait_status),
+    /* K9   */  be_nested_str_weak(fabric_filtered),
+    /* K10  */  be_nested_str_weak(path_list),
+    /* K11  */  be_nested_str_weak(attributes_requests),
+    /* K12  */  be_nested_str_weak(matter),
+    /* K13  */  be_nested_str_weak(Path),
+    /* K14  */  be_nested_str_weak(endpoint),
+    /* K15  */  be_nested_str_weak(cluster),
+    /* K16  */  be_nested_str_weak(attribute),
+    /* K17  */  be_nested_str_weak(push),
+    /* K18  */  be_nested_str_weak(stop_iteration),
+    /* K19  */  be_nested_str_weak(updates),
+    /* K20  */  be_nested_str_weak(clear_before_arm),
+    /* K21  */  be_nested_str_weak(is_keep_alive),
     }),
-    be_str_weak(re_arm),
+    be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x50080000,  //  0001  LDBOOL	R2	0	0
-      0x90020202,  //  0002  SETMBR	R0	K1	R2
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x8C080503,  //  0004  GETMET	R2	R2	K3
-      0x7C080200,  //  0005  CALL	R2	1
-      0x880C0105,  //  0006  GETMBR	R3	R0	K5
-      0x88100106,  //  0007  GETMBR	R4	R0	K6
-      0x040C0604,  //  0008  SUB	R3	R3	R4
-      0x541203E7,  //  0009  LDINT	R4	1000
-      0x080C0604,  //  000A  MUL	R3	R3	R4
-      0x000C0403,  //  000B  ADD	R3	R2	R3
-      0x90020803,  //  000C  SETMBR	R0	K4	R3
-      0x880C0108,  //  000D  GETMBR	R3	R0	K8
-      0x541203E7,  //  000E  LDINT	R4	1000
-      0x080C0604,  //  000F  MUL	R3	R3	R4
-      0x000C0403,  //  0010  ADD	R3	R2	R3
-      0x040C0709,  //  0011  SUB	R3	R3	K9
-      0x90020E03,  //  0012  SETMBR	R0	K7	R3
-      0xB80E0400,  //  0013  GETNGBL	R3	K2
-      0x8C0C070A,  //  0014  GETMET	R3	R3	K10
-      0x8C14030B,  //  0015  GETMET	R5	R1	K11
-      0x601C0008,  //  0016  GETGBL	R7	G8
-      0x8820010D,  //  0017  GETMBR	R8	R0	K13
-      0x7C1C0200,  //  0018  CALL	R7	1
-      0x001E1807,  //  0019  ADD	R7	K12	R7
-      0x7C140400,  //  001A  CALL	R5	2
-      0x5818000E,  //  001B  LDCONST	R6	K14
-      0x7C0C0600,  //  001C  CALL	R3	3
-      0x80000000,  //  001D  RET	0
+    ( &(const binstruction[61]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x90020202,  //  0001  SETMBR	R0	K1	R2
+      0x90020403,  //  0002  SETMBR	R0	K2	R3
+      0x88140903,  //  0003  GETMBR	R5	R4	K3
+      0x14180B04,  //  0004  LT	R6	R5	K4
+      0x781A0000,  //  0005  JMPF	R6	#0007
+      0x58140004,  //  0006  LDCONST	R5	K4
+      0x541A003B,  //  0007  LDINT	R6	60
+      0x24180A06,  //  0008  GT	R6	R5	R6
+      0x781A0000,  //  0009  JMPF	R6	#000B
+      0x5416003B,  //  000A  LDINT	R5	60
+      0x90020A05,  //  000B  SETMBR	R0	K5	R5
+      0x88180906,  //  000C  GETMBR	R6	R4	K6
+      0x541E003B,  //  000D  LDINT	R7	60
+      0x141C0C07,  //  000E  LT	R7	R6	R7
+      0x781E0000,  //  000F  JMPF	R7	#0011
+      0x541A003B,  //  0010  LDINT	R6	60
+      0x541E0E0F,  //  0011  LDINT	R7	3600
+      0x241C0C07,  //  0012  GT	R7	R6	R7
+      0x781E0000,  //  0013  JMPF	R7	#0015
+      0x541A0E0F,  //  0014  LDINT	R6	3600
+      0x541A003B,  //  0015  LDINT	R6	60
+      0x90020E06,  //  0016  SETMBR	R0	K7	R6
+      0x501C0000,  //  0017  LDBOOL	R7	0	0
+      0x90021007,  //  0018  SETMBR	R0	K8	R7
+      0x881C0909,  //  0019  GETMBR	R7	R4	K9
+      0x90021207,  //  001A  SETMBR	R0	K9	R7
+      0x601C0012,  //  001B  GETGBL	R7	G18
+      0x7C1C0000,  //  001C  CALL	R7	0
+      0x90021407,  //  001D  SETMBR	R0	K10	R7
+      0x601C0010,  //  001E  GETGBL	R7	G16
+      0x8820090B,  //  001F  GETMBR	R8	R4	K11
+      0x7C1C0200,  //  0020  CALL	R7	1
+      0xA802000F,  //  0021  EXBLK	0	#0032
+      0x5C200E00,  //  0022  MOVE	R8	R7
+      0x7C200000,  //  0023  CALL	R8	0
+      0xB8261800,  //  0024  GETNGBL	R9	K12
+      0x8C24130D,  //  0025  GETMET	R9	R9	K13
+      0x7C240200,  //  0026  CALL	R9	1
+      0x8828110E,  //  0027  GETMBR	R10	R8	K14
+      0x90261C0A,  //  0028  SETMBR	R9	K14	R10
+      0x8828110F,  //  0029  GETMBR	R10	R8	K15
+      0x90261E0A,  //  002A  SETMBR	R9	K15	R10
+      0x88281110,  //  002B  GETMBR	R10	R8	K16
+      0x9026200A,  //  002C  SETMBR	R9	K16	R10
+      0x8828010A,  //  002D  GETMBR	R10	R0	K10
+      0x8C281511,  //  002E  GETMET	R10	R10	K17
+      0x5C301200,  //  002F  MOVE	R12	R9
+      0x7C280400,  //  0030  CALL	R10	2
+      0x7001FFEF,  //  0031  JMP		#0022
+      0x581C0012,  //  0032  LDCONST	R7	K18
+      0xAC1C0200,  //  0033  CATCH	R7	1	0
+      0xB0080000,  //  0034  RAISE	2	R0	R0
+      0x601C0012,  //  0035  GETGBL	R7	G18
+      0x7C1C0000,  //  0036  CALL	R7	0
+      0x90022607,  //  0037  SETMBR	R0	K19	R7
+      0x8C1C0114,  //  0038  GETMET	R7	R0	K20
+      0x7C1C0200,  //  0039  CALL	R7	1
+      0x501C0000,  //  003A  LDBOOL	R7	0	0
+      0x90022A07,  //  003B  SETMBR	R0	K21	R7
+      0x80000000,  //  003C  RET	0
     })
   )
 );
@@ -147,29 +185,31 @@ be_local_closure(Matter_IM_Subscription_remove_self,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
+    ( &(const bvalue[ 7]) {     /* constants */
     /* K0   */  be_nested_str_weak(tasmota),
     /* K1   */  be_nested_str_weak(log),
-    /* K2   */  be_nested_str_weak(MTR_X3A_X20Remove_Sub_X20sub_id_X3D),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20_X2DSub_Del_X20_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D),
     /* K3   */  be_nested_str_weak(subscription_id),
-    /* K4   */  be_nested_str_weak(subs),
-    /* K5   */  be_nested_str_weak(remove_sub),
+    /* K4   */  be_const_int(2),
+    /* K5   */  be_nested_str_weak(subs_shop),
+    /* K6   */  be_nested_str_weak(remove_sub),
     }),
     be_str_weak(remove_self),
     &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
+    ( &(const binstruction[13]) {  /* code */
       0xB8060000,  //  0000  GETNGBL	R1	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
       0x600C0008,  //  0002  GETGBL	R3	G8
       0x88100103,  //  0003  GETMBR	R4	R0	K3
       0x7C0C0200,  //  0004  CALL	R3	1
       0x000E0403,  //  0005  ADD	R3	K2	R3
-      0x7C040400,  //  0006  CALL	R1	2
-      0x88040104,  //  0007  GETMBR	R1	R0	K4
-      0x8C040305,  //  0008  GETMET	R1	R1	K5
-      0x5C0C0000,  //  0009  MOVE	R3	R0
-      0x7C040400,  //  000A  CALL	R1	2
-      0x80000000,  //  000B  RET	0
+      0x58100004,  //  0006  LDCONST	R4	K4
+      0x7C040600,  //  0007  CALL	R1	3
+      0x88040105,  //  0008  GETMBR	R1	R0	K5
+      0x8C040306,  //  0009  GETMET	R1	R1	K6
+      0x5C0C0000,  //  000A  MOVE	R3	R0
+      0x7C040400,  //  000B  CALL	R1	2
+      0x80000000,  //  000C  RET	0
     })
   )
 );
@@ -203,110 +243,6 @@ be_local_closure(Matter_IM_Subscription_clear_before_arm,   /* name */
       0x50040200,  //  0003  LDBOOL	R1	1	0
       0x90020401,  //  0004  SETMBR	R0	K2	R1
       0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_IM_Subscription_init,   /* name */
-  be_nested_proto(
-    13,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[21]) {     /* constants */
-    /* K0   */  be_nested_str_weak(subs),
-    /* K1   */  be_nested_str_weak(subscription_id),
-    /* K2   */  be_nested_str_weak(session),
-    /* K3   */  be_nested_str_weak(min_interval_floor),
-    /* K4   */  be_const_int(0),
-    /* K5   */  be_nested_str_weak(min_interval),
-    /* K6   */  be_nested_str_weak(max_interval_ceiling),
-    /* K7   */  be_nested_str_weak(max_interval),
-    /* K8   */  be_nested_str_weak(wait_status),
-    /* K9   */  be_nested_str_weak(fabric_filtered),
-    /* K10  */  be_nested_str_weak(path_list),
-    /* K11  */  be_nested_str_weak(attributes_requests),
-    /* K12  */  be_nested_str_weak(matter),
-    /* K13  */  be_nested_str_weak(Path),
-    /* K14  */  be_nested_str_weak(endpoint),
-    /* K15  */  be_nested_str_weak(cluster),
-    /* K16  */  be_nested_str_weak(attribute),
-    /* K17  */  be_nested_str_weak(push),
-    /* K18  */  be_nested_str_weak(stop_iteration),
-    /* K19  */  be_nested_str_weak(updates),
-    /* K20  */  be_nested_str_weak(clear_before_arm),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[59]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x90020202,  //  0001  SETMBR	R0	K1	R2
-      0x90020403,  //  0002  SETMBR	R0	K2	R3
-      0x88140903,  //  0003  GETMBR	R5	R4	K3
-      0x14180B04,  //  0004  LT	R6	R5	K4
-      0x781A0000,  //  0005  JMPF	R6	#0007
-      0x58140004,  //  0006  LDCONST	R5	K4
-      0x541A003B,  //  0007  LDINT	R6	60
-      0x24180A06,  //  0008  GT	R6	R5	R6
-      0x781A0000,  //  0009  JMPF	R6	#000B
-      0x5416003B,  //  000A  LDINT	R5	60
-      0x90020A05,  //  000B  SETMBR	R0	K5	R5
-      0x88180906,  //  000C  GETMBR	R6	R4	K6
-      0x541E003B,  //  000D  LDINT	R7	60
-      0x141C0C07,  //  000E  LT	R7	R6	R7
-      0x781E0000,  //  000F  JMPF	R7	#0011
-      0x541A003B,  //  0010  LDINT	R6	60
-      0x541E0E0F,  //  0011  LDINT	R7	3600
-      0x241C0C07,  //  0012  GT	R7	R6	R7
-      0x781E0000,  //  0013  JMPF	R7	#0015
-      0x541A0E0F,  //  0014  LDINT	R6	3600
-      0x541A003B,  //  0015  LDINT	R6	60
-      0x90020E06,  //  0016  SETMBR	R0	K7	R6
-      0x501C0000,  //  0017  LDBOOL	R7	0	0
-      0x90021007,  //  0018  SETMBR	R0	K8	R7
-      0x881C0909,  //  0019  GETMBR	R7	R4	K9
-      0x90021207,  //  001A  SETMBR	R0	K9	R7
-      0x601C0012,  //  001B  GETGBL	R7	G18
-      0x7C1C0000,  //  001C  CALL	R7	0
-      0x90021407,  //  001D  SETMBR	R0	K10	R7
-      0x601C0010,  //  001E  GETGBL	R7	G16
-      0x8820090B,  //  001F  GETMBR	R8	R4	K11
-      0x7C1C0200,  //  0020  CALL	R7	1
-      0xA802000F,  //  0021  EXBLK	0	#0032
-      0x5C200E00,  //  0022  MOVE	R8	R7
-      0x7C200000,  //  0023  CALL	R8	0
-      0xB8261800,  //  0024  GETNGBL	R9	K12
-      0x8C24130D,  //  0025  GETMET	R9	R9	K13
-      0x7C240200,  //  0026  CALL	R9	1
-      0x8828110E,  //  0027  GETMBR	R10	R8	K14
-      0x90261C0A,  //  0028  SETMBR	R9	K14	R10
-      0x8828110F,  //  0029  GETMBR	R10	R8	K15
-      0x90261E0A,  //  002A  SETMBR	R9	K15	R10
-      0x88281110,  //  002B  GETMBR	R10	R8	K16
-      0x9026200A,  //  002C  SETMBR	R9	K16	R10
-      0x8828010A,  //  002D  GETMBR	R10	R0	K10
-      0x8C281511,  //  002E  GETMET	R10	R10	K17
-      0x5C301200,  //  002F  MOVE	R12	R9
-      0x7C280400,  //  0030  CALL	R10	2
-      0x7001FFEF,  //  0031  JMP		#0022
-      0x581C0012,  //  0032  LDCONST	R7	K18
-      0xAC1C0200,  //  0033  CATCH	R7	1	0
-      0xB0080000,  //  0034  RAISE	2	R0	R0
-      0x601C0012,  //  0035  GETGBL	R7	G18
-      0x7C1C0000,  //  0036  CALL	R7	0
-      0x90022607,  //  0037  SETMBR	R0	K19	R7
-      0x8C1C0114,  //  0038  GETMET	R7	R0	K20
-      0x7C1C0200,  //  0039  CALL	R7	1
-      0x80000000,  //  003A  RET	0
     })
   )
 );
@@ -383,31 +319,102 @@ be_local_closure(Matter_IM_Subscription_attribute_updated_ctx,   /* name */
 
 
 /********************************************************************
+** Solidified function: re_arm
+********************************************************************/
+be_local_closure(Matter_IM_Subscription_re_arm,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[16]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(wait_status),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(millis),
+    /* K4   */  be_nested_str_weak(expiration),
+    /* K5   */  be_nested_str_weak(max_interval),
+    /* K6   */  be_nested_str_weak(MAX_INTERVAL_MARGIN),
+    /* K7   */  be_nested_str_weak(not_before),
+    /* K8   */  be_nested_str_weak(min_interval),
+    /* K9   */  be_const_int(1),
+    /* K10  */  be_nested_str_weak(is_keep_alive),
+    /* K11  */  be_nested_str_weak(log),
+    /* K12  */  be_nested_str_weak(format),
+    /* K13  */  be_nested_str_weak(MTR_X3A_X20_X2ESub_Done_X20_X20_X28_X20_X20_X20_X20_X20_X20_X29_X20sub_X3D_X25i),
+    /* K14  */  be_nested_str_weak(subscription_id),
+    /* K15  */  be_const_int(2),
+    }),
+    be_str_weak(re_arm),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x50080000,  //  0001  LDBOOL	R2	0	0
+      0x90020202,  //  0002  SETMBR	R0	K1	R2
+      0xB80A0400,  //  0003  GETNGBL	R2	K2
+      0x8C080503,  //  0004  GETMET	R2	R2	K3
+      0x7C080200,  //  0005  CALL	R2	1
+      0x880C0105,  //  0006  GETMBR	R3	R0	K5
+      0x88100106,  //  0007  GETMBR	R4	R0	K6
+      0x040C0604,  //  0008  SUB	R3	R3	R4
+      0x541203E7,  //  0009  LDINT	R4	1000
+      0x080C0604,  //  000A  MUL	R3	R3	R4
+      0x000C0403,  //  000B  ADD	R3	R2	R3
+      0x90020803,  //  000C  SETMBR	R0	K4	R3
+      0x880C0108,  //  000D  GETMBR	R3	R0	K8
+      0x541203E7,  //  000E  LDINT	R4	1000
+      0x080C0604,  //  000F  MUL	R3	R3	R4
+      0x000C0403,  //  0010  ADD	R3	R2	R3
+      0x040C0709,  //  0011  SUB	R3	R3	K9
+      0x90020E03,  //  0012  SETMBR	R0	K7	R3
+      0x880C010A,  //  0013  GETMBR	R3	R0	K10
+      0x740E0007,  //  0014  JMPT	R3	#001D
+      0xB80E0400,  //  0015  GETNGBL	R3	K2
+      0x8C0C070B,  //  0016  GETMET	R3	R3	K11
+      0x8C14030C,  //  0017  GETMET	R5	R1	K12
+      0x581C000D,  //  0018  LDCONST	R7	K13
+      0x8820010E,  //  0019  GETMBR	R8	R0	K14
+      0x7C140600,  //  001A  CALL	R5	3
+      0x5818000F,  //  001B  LDCONST	R6	K15
+      0x7C0C0600,  //  001C  CALL	R3	3
+      0x80000000,  //  001D  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_IM_Subscription
 ********************************************************************/
 be_local_class(Matter_IM_Subscription,
-    11,
+    12,
     NULL,
-    be_nested_map(18,
+    be_nested_map(19,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(subscription_id, 4), be_const_var(1) },
-        { be_const_key_weak(wait_status, -1), be_const_var(9) },
-        { be_const_key_weak(attribute_updated_ctx, 5), be_const_closure(Matter_IM_Subscription_attribute_updated_ctx_closure) },
+        { be_const_key_weak(not_before, -1), be_const_var(7) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_IM_Subscription_init_closure) },
-        { be_const_key_weak(fabric_filtered, 17), be_const_var(6) },
-        { be_const_key_weak(clear_before_arm, -1), be_const_closure(Matter_IM_Subscription_clear_before_arm_closure) },
-        { be_const_key_weak(_add_attribute_unique_path, -1), be_const_closure(Matter_IM_Subscription__add_attribute_unique_path_closure) },
-        { be_const_key_weak(session, -1), be_const_var(2) },
-        { be_const_key_weak(expiration, 16), be_const_var(8) },
-        { be_const_key_weak(re_arm, 10), be_const_closure(Matter_IM_Subscription_re_arm_closure) },
-        { be_const_key_weak(max_interval, -1), be_const_var(5) },
+        { be_const_key_weak(attribute_updated_ctx, -1), be_const_closure(Matter_IM_Subscription_attribute_updated_ctx_closure) },
+        { be_const_key_weak(updates, -1), be_const_var(11) },
         { be_const_key_weak(min_interval, -1), be_const_var(4) },
-        { be_const_key_weak(MAX_INTERVAL_MARGIN, 8), be_const_int(5) },
-        { be_const_key_weak(updates, 2), be_const_var(10) },
-        { be_const_key_weak(not_before, 0), be_const_var(7) },
-        { be_const_key_weak(path_list, 3), be_const_var(3) },
-        { be_const_key_weak(remove_self, -1), be_const_closure(Matter_IM_Subscription_remove_self_closure) },
-        { be_const_key_weak(subs, -1), be_const_var(0) },
+        { be_const_key_weak(expiration, -1), be_const_var(8) },
+        { be_const_key_weak(subscription_id, 3), be_const_var(1) },
+        { be_const_key_weak(subs_shop, -1), be_const_var(0) },
+        { be_const_key_weak(max_interval, -1), be_const_var(5) },
+        { be_const_key_weak(remove_self, 1), be_const_closure(Matter_IM_Subscription_remove_self_closure) },
+        { be_const_key_weak(MAX_INTERVAL_MARGIN, -1), be_const_int(5) },
+        { be_const_key_weak(fabric_filtered, 7), be_const_var(6) },
+        { be_const_key_weak(_add_attribute_unique_path, 11), be_const_closure(Matter_IM_Subscription__add_attribute_unique_path_closure) },
+        { be_const_key_weak(path_list, 9), be_const_var(3) },
+        { be_const_key_weak(is_keep_alive, -1), be_const_var(10) },
+        { be_const_key_weak(clear_before_arm, -1), be_const_closure(Matter_IM_Subscription_clear_before_arm_closure) },
+        { be_const_key_weak(session, 2), be_const_var(2) },
+        { be_const_key_weak(re_arm, -1), be_const_closure(Matter_IM_Subscription_re_arm_closure) },
+        { be_const_key_weak(wait_status, 0), be_const_var(9) },
     })),
     be_str_weak(Matter_IM_Subscription)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Message.h
@@ -438,15 +438,15 @@ be_local_closure(Matter_Frame_debug,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
-    1,                          /* argc */
+    6,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[22]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(message_handler),
     /* K2   */  be_nested_str_weak(remote_ip),
@@ -469,70 +469,56 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
     /* K19  */  be_nested_str_weak(x_flag_a),
     /* K20  */  be_nested_str_weak(ack_message_counter),
     /* K21  */  be_nested_str_weak(x_flag_r),
-    /* K22  */  be_nested_str_weak(tasmota),
-    /* K23  */  be_nested_str_weak(log),
-    /* K24  */  be_nested_str_weak(format),
-    /* K25  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s),
-    /* K26  */  be_nested_str_weak(matter),
-    /* K27  */  be_nested_str_weak(get_opcode_name),
-    /* K28  */  be_const_int(3),
     }),
     be_str_weak(build_standalone_ack),
     &be_const_str_solidified,
-    ( &(const binstruction[53]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x60080006,  //  0001  GETGBL	R2	G6
-      0x5C0C0000,  //  0002  MOVE	R3	R0
-      0x7C080200,  //  0003  CALL	R2	1
-      0x880C0101,  //  0004  GETMBR	R3	R0	K1
-      0x7C080200,  //  0005  CALL	R2	1
-      0x880C0102,  //  0006  GETMBR	R3	R0	K2
-      0x900A0403,  //  0007  SETMBR	R2	K2	R3
-      0x880C0103,  //  0008  GETMBR	R3	R0	K3
-      0x900A0603,  //  0009  SETMBR	R2	K3	R3
-      0x880C0104,  //  000A  GETMBR	R3	R0	K4
-      0x780E0003,  //  000B  JMPF	R3	#0010
-      0x900A0B06,  //  000C  SETMBR	R2	K5	K6
-      0x880C0108,  //  000D  GETMBR	R3	R0	K8
-      0x900A0E03,  //  000E  SETMBR	R2	K7	R3
+    ( &(const binstruction[46]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x600C0006,  //  0001  GETGBL	R3	G6
+      0x5C100000,  //  0002  MOVE	R4	R0
+      0x7C0C0200,  //  0003  CALL	R3	1
+      0x88100101,  //  0004  GETMBR	R4	R0	K1
+      0x7C0C0200,  //  0005  CALL	R3	1
+      0x88100102,  //  0006  GETMBR	R4	R0	K2
+      0x900E0404,  //  0007  SETMBR	R3	K2	R4
+      0x88100103,  //  0008  GETMBR	R4	R0	K3
+      0x900E0604,  //  0009  SETMBR	R3	K3	R4
+      0x88100104,  //  000A  GETMBR	R4	R0	K4
+      0x78120003,  //  000B  JMPF	R4	#0010
+      0x900E0B06,  //  000C  SETMBR	R3	K5	K6
+      0x88100108,  //  000D  GETMBR	R4	R0	K8
+      0x900E0E04,  //  000E  SETMBR	R3	K7	R4
       0x70020000,  //  000F  JMP		#0011
-      0x900A0B09,  //  0010  SETMBR	R2	K5	K9
-      0x880C010A,  //  0011  GETMBR	R3	R0	K10
-      0x900A1403,  //  0012  SETMBR	R2	K10	R3
-      0x880C010A,  //  0013  GETMBR	R3	R0	K10
-      0x8C0C070C,  //  0014  GETMET	R3	R3	K12
-      0x7C0C0200,  //  0015  CALL	R3	1
-      0x900A1603,  //  0016  SETMBR	R2	K11	R3
-      0x880C010A,  //  0017  GETMBR	R3	R0	K10
-      0x880C070E,  //  0018  GETMBR	R3	R3	K14
-      0x900A1A03,  //  0019  SETMBR	R2	K13	R3
-      0x880C010F,  //  001A  GETMBR	R3	R0	K15
-      0x780E0001,  //  001B  JMPF	R3	#001E
-      0x580C0009,  //  001C  LDCONST	R3	K9
+      0x900E0B09,  //  0010  SETMBR	R3	K5	K9
+      0x8810010A,  //  0011  GETMBR	R4	R0	K10
+      0x900E1404,  //  0012  SETMBR	R3	K10	R4
+      0x8810010A,  //  0013  GETMBR	R4	R0	K10
+      0x8C10090C,  //  0014  GETMET	R4	R4	K12
+      0x7C100200,  //  0015  CALL	R4	1
+      0x900E1604,  //  0016  SETMBR	R3	K11	R4
+      0x8810010A,  //  0017  GETMBR	R4	R0	K10
+      0x8810090E,  //  0018  GETMBR	R4	R4	K14
+      0x900E1A04,  //  0019  SETMBR	R3	K13	R4
+      0x8810010F,  //  001A  GETMBR	R4	R0	K15
+      0x78120001,  //  001B  JMPF	R4	#001E
+      0x58100009,  //  001C  LDCONST	R4	K9
       0x70020000,  //  001D  JMP		#001F
-      0x580C0006,  //  001E  LDCONST	R3	K6
-      0x900A1E03,  //  001F  SETMBR	R2	K15	R3
-      0x540E000F,  //  0020  LDINT	R3	16
-      0x900A2003,  //  0021  SETMBR	R2	K16	R3
-      0x880C0111,  //  0022  GETMBR	R3	R0	K17
-      0x900A2203,  //  0023  SETMBR	R2	K17	R3
-      0x900A2509,  //  0024  SETMBR	R2	K18	K9
-      0x900A2706,  //  0025  SETMBR	R2	K19	K6
-      0x880C010B,  //  0026  GETMBR	R3	R0	K11
-      0x900A2803,  //  0027  SETMBR	R2	K20	R3
-      0x900A2B06,  //  0028  SETMBR	R2	K21	K6
-      0xB80E2C00,  //  0029  GETNGBL	R3	K22
-      0x8C0C0717,  //  002A  GETMET	R3	R3	K23
-      0x8C140318,  //  002B  GETMET	R5	R1	K24
-      0x581C0019,  //  002C  LDCONST	R7	K25
-      0xB8223400,  //  002D  GETNGBL	R8	K26
-      0x8C20111B,  //  002E  GETMET	R8	R8	K27
-      0x88280510,  //  002F  GETMBR	R10	R2	K16
-      0x7C200400,  //  0030  CALL	R8	2
-      0x7C140600,  //  0031  CALL	R5	3
-      0x5818001C,  //  0032  LDCONST	R6	K28
-      0x7C0C0600,  //  0033  CALL	R3	3
-      0x80040400,  //  0034  RET	1	R2
+      0x58100006,  //  001E  LDCONST	R4	K6
+      0x900E1E04,  //  001F  SETMBR	R3	K15	R4
+      0x5412000F,  //  0020  LDINT	R4	16
+      0x900E2004,  //  0021  SETMBR	R3	K16	R4
+      0x88100111,  //  0022  GETMBR	R4	R0	K17
+      0x900E2204,  //  0023  SETMBR	R3	K17	R4
+      0x900E2509,  //  0024  SETMBR	R3	K18	K9
+      0x900E2706,  //  0025  SETMBR	R3	K19	K6
+      0x8810010B,  //  0026  GETMBR	R4	R0	K11
+      0x900E2804,  //  0027  SETMBR	R3	K20	R4
+      0x78060001,  //  0028  JMPF	R1	#002B
+      0x58100006,  //  0029  LDCONST	R4	K6
+      0x70020000,  //  002A  JMP		#002C
+      0x58100009,  //  002B  LDCONST	R4	K9
+      0x900E2A04,  //  002C  SETMBR	R3	K21	R4
+      0x80040600,  //  002D  RET	1	R3
     })
   )
 );
@@ -544,7 +530,7 @@ be_local_closure(Matter_Frame_build_standalone_ack,   /* name */
 ********************************************************************/
 be_local_closure(Matter_Frame_build_response,   /* name */
   be_nested_proto(
-    12,                          /* nstack */
+    13,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -583,12 +569,12 @@ be_local_closure(Matter_Frame_build_response,   /* name */
     /* K27  */  be_nested_str_weak(0x_X2502X),
     /* K28  */  be_nested_str_weak(tasmota),
     /* K29  */  be_nested_str_weak(log),
-    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X25s),
+    /* K30  */  be_nested_str_weak(MTR_X3A_X20_X3CReplied_X20_X20_X20_X28_X256i_X29_X20_X25s),
     /* K31  */  be_const_int(2),
     }),
     be_str_weak(build_response),
     &be_const_str_solidified,
-    ( &(const binstruction[90]) {  /* code */
+    ( &(const binstruction[92]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x4C140000,  //  0001  LDNIL	R5
       0x1C140605,  //  0002  EQ	R5	R3	R5
@@ -658,7 +644,7 @@ be_local_closure(Matter_Frame_build_response,   /* name */
       0x900E2A05,  //  0042  SETMBR	R3	K21	R5
       0x8814070B,  //  0043  GETMBR	R5	R3	K11
       0x1C140B09,  //  0044  EQ	R5	R5	K9
-      0x78160012,  //  0045  JMPF	R5	#0059
+      0x78160014,  //  0045  JMPF	R5	#005B
       0xB8163000,  //  0046  GETNGBL	R5	K24
       0x8C140B19,  //  0047  GETMET	R5	R5	K25
       0x881C0712,  //  0048  GETMBR	R7	R3	K18
@@ -674,11 +660,13 @@ be_local_closure(Matter_Frame_build_response,   /* name */
       0x8C180D1D,  //  0052  GETMET	R6	R6	K29
       0x8C20091A,  //  0053  GETMET	R8	R4	K26
       0x5828001E,  //  0054  LDCONST	R10	K30
-      0x5C2C0A00,  //  0055  MOVE	R11	R5
-      0x7C200600,  //  0056  CALL	R8	3
-      0x5824001F,  //  0057  LDCONST	R9	K31
-      0x7C180600,  //  0058  CALL	R6	3
-      0x80040600,  //  0059  RET	1	R3
+      0x882C070A,  //  0055  GETMBR	R11	R3	K10
+      0x882C170B,  //  0056  GETMBR	R11	R11	K11
+      0x5C300A00,  //  0057  MOVE	R12	R5
+      0x7C200800,  //  0058  CALL	R8	4
+      0x5824001F,  //  0059  LDCONST	R9	K31
+      0x7C180600,  //  005A  CALL	R6	3
+      0x80040600,  //  005B  RET	1	R3
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_MessageHandler.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_MessageHandler;
 ********************************************************************/
 be_local_closure(Matter_MessageHandler_msg_received,   /* name */
   be_nested_proto(
-    18,                          /* nstack */
+    24,                          /* nstack */
     4,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,7 +19,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[73]) {     /* constants */
+    ( &(const bvalue[77]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
     /* K1   */  be_nested_str_weak(tasmota),
     /* K2   */  be_nested_str_weak(log),
@@ -46,60 +46,64 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
     /* K23  */  be_nested_str_weak(validate),
     /* K24  */  be_nested_str_weak(message_counter),
     /* K25  */  be_nested_str_weak(format),
-    /* K26  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
+    /* K26  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Rejected_X20duplicate_X20unencrypted_X20message_X20_X3D_X20_X25i_X20ref_X20_X3D_X20_X25i),
     /* K27  */  be_nested_str_weak(val),
     /* K28  */  be_nested_str_weak(decode_payload),
-    /* K29  */  be_nested_str_weak(packet_ack),
+    /* K29  */  be_nested_str_weak(received_ack),
     /* K30  */  be_nested_str_weak(ack_message_counter),
     /* K31  */  be_nested_str_weak(opcode),
     /* K32  */  be_nested_str_weak(get_opcode_name),
     /* K33  */  be_nested_str_weak(0x_X2502X),
-    /* K34  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X25s_X20from_X20_X5B_X25s_X5D_X3A_X25i),
-    /* K35  */  be_const_int(2),
-    /* K36  */  be_nested_str_weak(commissioning),
-    /* K37  */  be_nested_str_weak(process_incoming),
-    /* K38  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
-    /* K39  */  be_nested_str_weak(get_session_by_local_session_id),
-    /* K40  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
-    /* K41  */  be_nested_str_weak(MTR_X3A_X20frame_X3D),
-    /* K42  */  be_nested_str_weak(inspect),
-    /* K43  */  be_nested_str_weak(counter_rcv_validate),
-    /* K44  */  be_nested_str_weak(MTR_X3A_X20rejected_X20duplicate_X20encrypted_X20message_X20_X3D_X20),
-    /* K45  */  be_nested_str_weak(_X20counter_X3D),
-    /* K46  */  be_nested_str_weak(counter_rcv),
-    /* K47  */  be_nested_str_weak(decrypt),
-    /* K48  */  be_nested_str_weak(raw),
-    /* K49  */  be_nested_str_weak(payload_idx),
-    /* K50  */  be_const_int(1),
-    /* K51  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
-    /* K52  */  be_nested_str_weak(MTR_X3A_X20decrypted_X20message_X3A_X20protocol_id_X3A),
-    /* K53  */  be_nested_str_weak(protocol_id),
-    /* K54  */  be_nested_str_weak(_X20opcode_X3D),
-    /* K55  */  be_nested_str_weak(_X20exchange_id_X3D),
-    /* K56  */  be_nested_str_weak(exchange_id),
-    /* K57  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
-    /* K58  */  be_nested_str_weak(im),
-    /* K59  */  be_nested_str_weak(process_incoming_ack),
-    /* K60  */  be_nested_str_weak(send_enqueued),
-    /* K61  */  be_nested_str_weak(x_flag_r),
-    /* K62  */  be_nested_str_weak(build_standalone_ack),
-    /* K63  */  be_nested_str_weak(encode_frame),
-    /* K64  */  be_nested_str_weak(encrypt),
-    /* K65  */  be_nested_str_weak(send_response),
-    /* K66  */  be_nested_str_weak(remote_ip),
-    /* K67  */  be_nested_str_weak(remote_port),
-    /* K68  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
-    /* K69  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
-    /* K70  */  be_nested_str_weak(_X3B),
-    /* K71  */  be_nested_str_weak(debug),
-    /* K72  */  be_nested_str_weak(traceback),
+    /* K34  */  be_nested_str_weak(MTR_X3A_X20_X3EReceived_X20_X20_X28_X256i_X29_X20_X25s_X20rid_X3D_X25i_X20exch_X3D_X25i_X20from_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K35  */  be_nested_str_weak(exchange_id),
+    /* K36  */  be_const_int(2),
+    /* K37  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20Ack_X20_X20_X20_X28_X256i_X29_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K38  */  be_nested_str_weak(x_flag_r),
+    /* K39  */  be_nested_str_weak(_X7Breliable_X7D_X20),
+    /* K40  */  be_nested_str_weak(),
+    /* K41  */  be_nested_str_weak(commissioning),
+    /* K42  */  be_nested_str_weak(process_incoming),
+    /* K43  */  be_nested_str_weak(MTR_X3A_X20decode_X20header_X3A_X20local_session_id_X3D_X25i_X20message_counter_X3D_X25i),
+    /* K44  */  be_nested_str_weak(get_session_by_local_session_id),
+    /* K45  */  be_nested_str_weak(MTR_X3A_X20unknown_X20local_session_id_X3D),
+    /* K46  */  be_nested_str_weak(counter_rcv_validate),
+    /* K47  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Rejected_X20duplicate_X20encrypted_X20message_X20_X3D_X20),
+    /* K48  */  be_nested_str_weak(_X20counter_X3D),
+    /* K49  */  be_nested_str_weak(counter_rcv),
+    /* K50  */  be_nested_str_weak(decrypt),
+    /* K51  */  be_nested_str_weak(raw),
+    /* K52  */  be_nested_str_weak(payload_idx),
+    /* K53  */  be_const_int(1),
+    /* K54  */  be_nested_str_weak(MTR_X3A_X20idx_X3D_X25i_X20clear_X3D_X25s),
+    /* K55  */  be_nested_str_weak(MTR_X3A_X20_X3E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Decrypted_X20message_X3A_X20protocol_id_X3A),
+    /* K56  */  be_nested_str_weak(protocol_id),
+    /* K57  */  be_nested_str_weak(_X20opcode_X3D),
+    /* K58  */  be_nested_str_weak(_X20exchange_id_X3D),
+    /* K59  */  be_nested_str_weak(MTR_X3A_X20_X3Ercv_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20_X5B_X2502X_X2F_X2502X_X5D_X20rid_X3D_X25i_X20exch_X3D_X25i_X20ack_X3D_X25s_X20_X25sfrom_X20_X5B_X25s_X5D_X3A_X25i),
+    /* K60  */  be_nested_str_weak(MTR_X3A_X20PROTOCOL_ID_SECURE_CHANNEL_X20),
+    /* K61  */  be_nested_str_weak(inspect),
+    /* K62  */  be_nested_str_weak(im),
+    /* K63  */  be_nested_str_weak(process_incoming_ack),
+    /* K64  */  be_nested_str_weak(send_enqueued),
+    /* K65  */  be_nested_str_weak(build_standalone_ack),
+    /* K66  */  be_nested_str_weak(encode_frame),
+    /* K67  */  be_nested_str_weak(encrypt),
+    /* K68  */  be_nested_str_weak(MTR_X3A_X20_X3CAck_X20_X20_X20_X20_X20_X20_X20_X28_X256i_X29_X20ack_X3D_X25i_X20id_X3D_X25i_X20_X7Breliable_X7D),
+    /* K69  */  be_nested_str_weak(send_response),
+    /* K70  */  be_nested_str_weak(remote_ip),
+    /* K71  */  be_nested_str_weak(remote_port),
+    /* K72  */  be_nested_str_weak(MTR_X3A_X20ignoring_X20unhandled_X20protocol_id_X3A),
+    /* K73  */  be_nested_str_weak(MTR_X3A_X20MessageHandler_X3A_X3Amsg_received_X20exception_X3A_X20),
+    /* K74  */  be_nested_str_weak(_X3B),
+    /* K75  */  be_nested_str_weak(debug),
+    /* K76  */  be_nested_str_weak(traceback),
     }),
     be_str_weak(msg_received),
     &be_const_str_solidified,
-    ( &(const binstruction[325]) {  /* code */
+    ( &(const binstruction[374]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0x50140000,  //  0001  LDBOOL	R5	0	0
-      0xA802012B,  //  0002  EXBLK	0	#012F
+      0xA802015C,  //  0002  EXBLK	0	#0160
       0xB81A0200,  //  0003  GETNGBL	R6	K1
       0x8C180D02,  //  0004  GETMET	R6	R6	K2
       0x8C200304,  //  0005  GETMET	R8	R1	K4
@@ -123,10 +127,10 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x80041000,  //  0017  RET	1	R8
       0x88200D08,  //  0018  GETMBR	R8	R6	K8
       0x1C201109,  //  0019  EQ	R8	R8	K9
-      0x7822005A,  //  001A  JMPF	R8	#0076
+      0x78220072,  //  001A  JMPF	R8	#008E
       0x88200D0A,  //  001B  GETMBR	R8	R6	K10
       0x1C201109,  //  001C  EQ	R8	R8	K9
-      0x78220057,  //  001D  JMPF	R8	#0076
+      0x7822006F,  //  001D  JMPF	R8	#008E
       0x8820010B,  //  001E  GETMBR	R8	R0	K11
       0x8820110C,  //  001F  GETMBR	R8	R8	K12
       0x8C20110D,  //  0020  GETMET	R8	R8	K13
@@ -185,7 +189,7 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x88240D1F,  //  0055  GETMBR	R9	R6	K31
       0x542A000F,  //  0056  LDINT	R10	16
       0x2024120A,  //  0057  NE	R9	R9	R10
-      0x78260014,  //  0058  JMPF	R9	#006E
+      0x78260018,  //  0058  JMPF	R9	#0072
       0xB8260A00,  //  0059  GETNGBL	R9	K5
       0x8C241320,  //  005A  GETMET	R9	R9	K32
       0x882C0D1F,  //  005B  GETMBR	R11	R6	K31
@@ -201,227 +205,276 @@ be_local_closure(Matter_MessageHandler_msg_received,   /* name */
       0x8C281502,  //  0065  GETMET	R10	R10	K2
       0x8C300919,  //  0066  GETMET	R12	R4	K25
       0x58380022,  //  0067  LDCONST	R14	K34
-      0x5C3C1200,  //  0068  MOVE	R15	R9
-      0x5C400400,  //  0069  MOVE	R16	R2
-      0x5C440600,  //  006A  MOVE	R17	R3
-      0x7C300A00,  //  006B  CALL	R12	5
-      0x58340023,  //  006C  LDCONST	R13	K35
-      0x7C280600,  //  006D  CALL	R10	3
-      0x88240124,  //  006E  GETMBR	R9	R0	K36
-      0x8C241325,  //  006F  GETMET	R9	R9	K37
-      0x5C2C0C00,  //  0070  MOVE	R11	R6
-      0x7C240400,  //  0071  CALL	R9	2
-      0x50240200,  //  0072  LDBOOL	R9	1	0
-      0xA8040001,  //  0073  EXBLK	1	1
-      0x80041200,  //  0074  RET	1	R9
-      0x700200B4,  //  0075  JMP		#012B
-      0xB8220200,  //  0076  GETNGBL	R8	K1
-      0x8C201102,  //  0077  GETMET	R8	R8	K2
-      0x8C280919,  //  0078  GETMET	R10	R4	K25
-      0x58300026,  //  0079  LDCONST	R12	K38
-      0x88340D08,  //  007A  GETMBR	R13	R6	K8
-      0x88380D18,  //  007B  GETMBR	R14	R6	K24
-      0x7C280800,  //  007C  CALL	R10	4
-      0x582C0011,  //  007D  LDCONST	R11	K17
-      0x7C200600,  //  007E  CALL	R8	3
-      0x8820010B,  //  007F  GETMBR	R8	R0	K11
-      0x8820110C,  //  0080  GETMBR	R8	R8	K12
-      0x8C201127,  //  0081  GETMET	R8	R8	K39
-      0x88280D08,  //  0082  GETMBR	R10	R6	K8
-      0x7C200400,  //  0083  CALL	R8	2
-      0x4C240000,  //  0084  LDNIL	R9
-      0x1C241009,  //  0085  EQ	R9	R8	R9
-      0x78260013,  //  0086  JMPF	R9	#009B
-      0xB8260200,  //  0087  GETNGBL	R9	K1
-      0x8C241302,  //  0088  GETMET	R9	R9	K2
-      0x602C0008,  //  0089  GETGBL	R11	G8
-      0x88300D08,  //  008A  GETMBR	R12	R6	K8
-      0x7C2C0200,  //  008B  CALL	R11	1
-      0x002E500B,  //  008C  ADD	R11	K40	R11
-      0x58300023,  //  008D  LDCONST	R12	K35
-      0x7C240600,  //  008E  CALL	R9	3
-      0xB8260200,  //  008F  GETNGBL	R9	K1
-      0x8C241302,  //  0090  GETMET	R9	R9	K2
-      0xB82E0A00,  //  0091  GETNGBL	R11	K5
-      0x8C2C172A,  //  0092  GETMET	R11	R11	K42
-      0x5C340C00,  //  0093  MOVE	R13	R6
-      0x7C2C0400,  //  0094  CALL	R11	2
-      0x002E520B,  //  0095  ADD	R11	K41	R11
-      0x58300011,  //  0096  LDCONST	R12	K17
-      0x7C240600,  //  0097  CALL	R9	3
-      0x50240000,  //  0098  LDBOOL	R9	0	0
-      0xA8040001,  //  0099  EXBLK	1	1
-      0x80041200,  //  009A  RET	1	R9
-      0x780A0000,  //  009B  JMPF	R2	#009D
-      0x90222402,  //  009C  SETMBR	R8	K18	R2
-      0x780E0000,  //  009D  JMPF	R3	#009F
-      0x90222603,  //  009E  SETMBR	R8	K19	R3
-      0x90222800,  //  009F  SETMBR	R8	K20	R0
-      0x901A2A08,  //  00A0  SETMBR	R6	K21	R8
-      0x8C24112B,  //  00A1  GETMET	R9	R8	K43
-      0x882C0D18,  //  00A2  GETMBR	R11	R6	K24
-      0x50300200,  //  00A3  LDBOOL	R12	1	0
-      0x7C240600,  //  00A4  CALL	R9	3
-      0x7426000F,  //  00A5  JMPT	R9	#00B6
-      0xB8260200,  //  00A6  GETNGBL	R9	K1
-      0x8C241302,  //  00A7  GETMET	R9	R9	K2
-      0x602C0008,  //  00A8  GETGBL	R11	G8
-      0x88300D18,  //  00A9  GETMBR	R12	R6	K24
-      0x7C2C0200,  //  00AA  CALL	R11	1
-      0x002E580B,  //  00AB  ADD	R11	K44	R11
-      0x002C172D,  //  00AC  ADD	R11	R11	K45
-      0x60300008,  //  00AD  GETGBL	R12	G8
-      0x8834112E,  //  00AE  GETMBR	R13	R8	K46
-      0x7C300200,  //  00AF  CALL	R12	1
-      0x002C160C,  //  00B0  ADD	R11	R11	R12
-      0x58300011,  //  00B1  LDCONST	R12	K17
-      0x7C240600,  //  00B2  CALL	R9	3
-      0x50240000,  //  00B3  LDBOOL	R9	0	0
-      0xA8040001,  //  00B4  EXBLK	1	1
-      0x80041200,  //  00B5  RET	1	R9
-      0x8C240D2F,  //  00B6  GETMET	R9	R6	K47
-      0x7C240200,  //  00B7  CALL	R9	1
-      0x5C281200,  //  00B8  MOVE	R10	R9
-      0x742A0002,  //  00B9  JMPT	R10	#00BD
-      0x50280000,  //  00BA  LDBOOL	R10	0	0
-      0xA8040001,  //  00BB  EXBLK	1	1
-      0x80041400,  //  00BC  RET	1	R10
-      0x88280D31,  //  00BD  GETMBR	R10	R6	K49
-      0x04281532,  //  00BE  SUB	R10	R10	K50
-      0x402A120A,  //  00BF  CONNECT	R10	K9	R10
-      0x882C0D30,  //  00C0  GETMBR	R11	R6	K48
-      0x9428160A,  //  00C1  GETIDX	R10	R11	R10
-      0x901A600A,  //  00C2  SETMBR	R6	K48	R10
-      0x88280D30,  //  00C3  GETMBR	R10	R6	K48
-      0x40281409,  //  00C4  CONNECT	R10	R10	R9
-      0xB82A0200,  //  00C5  GETNGBL	R10	K1
-      0x8C281502,  //  00C6  GETMET	R10	R10	K2
-      0x8C300919,  //  00C7  GETMET	R12	R4	K25
-      0x58380033,  //  00C8  LDCONST	R14	K51
-      0x883C0D31,  //  00C9  GETMBR	R15	R6	K49
-      0x88400D30,  //  00CA  GETMBR	R16	R6	K48
-      0x8C402104,  //  00CB  GETMET	R16	R16	K4
-      0x7C400200,  //  00CC  CALL	R16	1
-      0x7C300800,  //  00CD  CALL	R12	4
-      0x54360003,  //  00CE  LDINT	R13	4
-      0x7C280600,  //  00CF  CALL	R10	3
-      0x8C280D1C,  //  00D0  GETMET	R10	R6	K28
-      0x7C280200,  //  00D1  CALL	R10	1
-      0xB82A0200,  //  00D2  GETNGBL	R10	K1
-      0x8C281502,  //  00D3  GETMET	R10	R10	K2
-      0x60300008,  //  00D4  GETGBL	R12	G8
-      0x88340D35,  //  00D5  GETMBR	R13	R6	K53
-      0x7C300200,  //  00D6  CALL	R12	1
-      0x0032680C,  //  00D7  ADD	R12	K52	R12
-      0x00301936,  //  00D8  ADD	R12	R12	K54
-      0x60340008,  //  00D9  GETGBL	R13	G8
-      0x88380D1F,  //  00DA  GETMBR	R14	R6	K31
-      0x7C340200,  //  00DB  CALL	R13	1
-      0x0030180D,  //  00DC  ADD	R12	R12	R13
-      0x00301937,  //  00DD  ADD	R12	R12	K55
-      0x60340008,  //  00DE  GETGBL	R13	G8
-      0x88380D38,  //  00DF  GETMBR	R14	R6	K56
-      0x543EFFFE,  //  00E0  LDINT	R15	65535
-      0x2C381C0F,  //  00E1  AND	R14	R14	R15
-      0x7C340200,  //  00E2  CALL	R13	1
-      0x0030180D,  //  00E3  ADD	R12	R12	R13
-      0x58340011,  //  00E4  LDCONST	R13	K17
-      0x7C280600,  //  00E5  CALL	R10	3
-      0x8828010B,  //  00E6  GETMBR	R10	R0	K11
-      0x8C28151D,  //  00E7  GETMET	R10	R10	K29
-      0x88300D1E,  //  00E8  GETMBR	R12	R6	K30
-      0x7C280400,  //  00E9  CALL	R10	2
-      0x88280D35,  //  00EA  GETMBR	R10	R6	K53
-      0x1C2C1509,  //  00EB  EQ	R11	R10	K9
-      0x782E0018,  //  00EC  JMPF	R11	#0106
-      0xB82E0200,  //  00ED  GETNGBL	R11	K1
-      0x8C2C1702,  //  00EE  GETMET	R11	R11	K2
-      0xB8360A00,  //  00EF  GETNGBL	R13	K5
-      0x8C341B2A,  //  00F0  GETMET	R13	R13	K42
-      0x5C3C0C00,  //  00F1  MOVE	R15	R6
-      0x7C340400,  //  00F2  CALL	R13	2
-      0x0036720D,  //  00F3  ADD	R13	K57	R13
-      0x58380011,  //  00F4  LDCONST	R14	K17
-      0x7C2C0600,  //  00F5  CALL	R11	3
-      0x882C0D1F,  //  00F6  GETMBR	R11	R6	K31
-      0x5432000F,  //  00F7  LDINT	R12	16
-      0x1C2C160C,  //  00F8  EQ	R11	R11	R12
-      0x782E0009,  //  00F9  JMPF	R11	#0104
-      0x882C013A,  //  00FA  GETMBR	R11	R0	K58
-      0x8C2C173B,  //  00FB  GETMET	R11	R11	K59
-      0x5C340C00,  //  00FC  MOVE	R13	R6
-      0x7C2C0400,  //  00FD  CALL	R11	2
-      0x5C141600,  //  00FE  MOVE	R5	R11
-      0x78160003,  //  00FF  JMPF	R5	#0104
-      0x882C013A,  //  0100  GETMBR	R11	R0	K58
-      0x8C2C173C,  //  0101  GETMET	R11	R11	K60
-      0x5C340000,  //  0102  MOVE	R13	R0
-      0x7C2C0400,  //  0103  CALL	R11	2
-      0x50140200,  //  0104  LDBOOL	R5	1	0
-      0x70020024,  //  0105  JMP		#012B
-      0x1C2C1532,  //  0106  EQ	R11	R10	K50
-      0x782E001A,  //  0107  JMPF	R11	#0123
-      0x882C013A,  //  0108  GETMBR	R11	R0	K58
-      0x8C2C1725,  //  0109  GETMET	R11	R11	K37
-      0x5C340C00,  //  010A  MOVE	R13	R6
-      0x7C2C0400,  //  010B  CALL	R11	2
-      0x5C141600,  //  010C  MOVE	R5	R11
-      0x78160004,  //  010D  JMPF	R5	#0113
-      0x882C013A,  //  010E  GETMBR	R11	R0	K58
-      0x8C2C173C,  //  010F  GETMET	R11	R11	K60
-      0x5C340000,  //  0110  MOVE	R13	R0
-      0x7C2C0400,  //  0111  CALL	R11	2
-      0x7002000D,  //  0112  JMP		#0121
-      0x882C0D3D,  //  0113  GETMBR	R11	R6	K61
-      0x782E000B,  //  0114  JMPF	R11	#0121
-      0x8C2C0D3E,  //  0115  GETMET	R11	R6	K62
-      0x7C2C0200,  //  0116  CALL	R11	1
-      0x8C30173F,  //  0117  GETMET	R12	R11	K63
-      0x7C300200,  //  0118  CALL	R12	1
-      0x8C301740,  //  0119  GETMET	R12	R11	K64
-      0x7C300200,  //  011A  CALL	R12	1
-      0x8C300141,  //  011B  GETMET	R12	R0	K65
-      0x88381730,  //  011C  GETMBR	R14	R11	K48
-      0x883C1742,  //  011D  GETMBR	R15	R11	K66
-      0x88401743,  //  011E  GETMBR	R16	R11	K67
-      0x88441718,  //  011F  GETMBR	R17	R11	K24
-      0x7C300A00,  //  0120  CALL	R12	5
-      0x50140200,  //  0121  LDBOOL	R5	1	0
-      0x70020007,  //  0122  JMP		#012B
-      0xB82E0200,  //  0123  GETNGBL	R11	K1
-      0x8C2C1702,  //  0124  GETMET	R11	R11	K2
-      0x60340008,  //  0125  GETGBL	R13	G8
-      0x5C381400,  //  0126  MOVE	R14	R10
-      0x7C340200,  //  0127  CALL	R13	1
-      0x0036880D,  //  0128  ADD	R13	K68	R13
-      0x58380011,  //  0129  LDCONST	R14	K17
-      0x7C2C0600,  //  012A  CALL	R11	3
-      0xA8040001,  //  012B  EXBLK	1	1
-      0x80040A00,  //  012C  RET	1	R5
-      0xA8040001,  //  012D  EXBLK	1	1
-      0x70020014,  //  012E  JMP		#0144
-      0xAC180002,  //  012F  CATCH	R6	0	2
-      0x70020011,  //  0130  JMP		#0143
-      0xB8220200,  //  0131  GETNGBL	R8	K1
-      0x8C201102,  //  0132  GETMET	R8	R8	K2
-      0x60280008,  //  0133  GETGBL	R10	G8
-      0x5C2C0C00,  //  0134  MOVE	R11	R6
-      0x7C280200,  //  0135  CALL	R10	1
-      0x002A8A0A,  //  0136  ADD	R10	K69	R10
-      0x00281546,  //  0137  ADD	R10	R10	K70
-      0x602C0008,  //  0138  GETGBL	R11	G8
-      0x5C300E00,  //  0139  MOVE	R12	R7
-      0x7C2C0200,  //  013A  CALL	R11	1
-      0x0028140B,  //  013B  ADD	R10	R10	R11
-      0x7C200400,  //  013C  CALL	R8	2
-      0xA4228E00,  //  013D  IMPORT	R8	K71
-      0x8C241148,  //  013E  GETMET	R9	R8	K72
-      0x7C240200,  //  013F  CALL	R9	1
-      0x50240000,  //  0140  LDBOOL	R9	0	0
-      0x80041200,  //  0141  RET	1	R9
-      0x70020000,  //  0142  JMP		#0144
-      0xB0080000,  //  0143  RAISE	2	R0	R0
-      0x80000000,  //  0144  RET	0
+      0x883C1108,  //  0068  GETMBR	R15	R8	K8
+      0x5C401200,  //  0069  MOVE	R16	R9
+      0x88440D18,  //  006A  GETMBR	R17	R6	K24
+      0x88480D23,  //  006B  GETMBR	R18	R6	K35
+      0x5C4C0400,  //  006C  MOVE	R19	R2
+      0x5C500600,  //  006D  MOVE	R20	R3
+      0x7C301000,  //  006E  CALL	R12	8
+      0x58340024,  //  006F  LDCONST	R13	K36
+      0x7C280600,  //  0070  CALL	R10	3
+      0x70020013,  //  0071  JMP		#0086
+      0xB8260200,  //  0072  GETNGBL	R9	K1
+      0x8C241302,  //  0073  GETMET	R9	R9	K2
+      0x8C2C0919,  //  0074  GETMET	R11	R4	K25
+      0x58340025,  //  0075  LDCONST	R13	K37
+      0x88381108,  //  0076  GETMBR	R14	R8	K8
+      0x883C0D18,  //  0077  GETMBR	R15	R6	K24
+      0x88400D26,  //  0078  GETMBR	R16	R6	K38
+      0x78420001,  //  0079  JMPF	R16	#007C
+      0x58400027,  //  007A  LDCONST	R16	K39
+      0x70020000,  //  007B  JMP		#007D
+      0x58400028,  //  007C  LDCONST	R16	K40
+      0x88440D23,  //  007D  GETMBR	R17	R6	K35
+      0x60480008,  //  007E  GETGBL	R18	G8
+      0x884C0D1E,  //  007F  GETMBR	R19	R6	K30
+      0x7C480200,  //  0080  CALL	R18	1
+      0x5C4C0400,  //  0081  MOVE	R19	R2
+      0x5C500600,  //  0082  MOVE	R20	R3
+      0x7C2C1200,  //  0083  CALL	R11	9
+      0x58300011,  //  0084  LDCONST	R12	K17
+      0x7C240600,  //  0085  CALL	R9	3
+      0x88240129,  //  0086  GETMBR	R9	R0	K41
+      0x8C24132A,  //  0087  GETMET	R9	R9	K42
+      0x5C2C0C00,  //  0088  MOVE	R11	R6
+      0x7C240400,  //  0089  CALL	R9	2
+      0x50240200,  //  008A  LDBOOL	R9	1	0
+      0xA8040001,  //  008B  EXBLK	1	1
+      0x80041200,  //  008C  RET	1	R9
+      0x700200CD,  //  008D  JMP		#015C
+      0xB8220200,  //  008E  GETNGBL	R8	K1
+      0x8C201102,  //  008F  GETMET	R8	R8	K2
+      0x8C280919,  //  0090  GETMET	R10	R4	K25
+      0x5830002B,  //  0091  LDCONST	R12	K43
+      0x88340D08,  //  0092  GETMBR	R13	R6	K8
+      0x88380D18,  //  0093  GETMBR	R14	R6	K24
+      0x7C280800,  //  0094  CALL	R10	4
+      0x582C0011,  //  0095  LDCONST	R11	K17
+      0x7C200600,  //  0096  CALL	R8	3
+      0x8820010B,  //  0097  GETMBR	R8	R0	K11
+      0x8820110C,  //  0098  GETMBR	R8	R8	K12
+      0x8C20112C,  //  0099  GETMET	R8	R8	K44
+      0x88280D08,  //  009A  GETMBR	R10	R6	K8
+      0x7C200400,  //  009B  CALL	R8	2
+      0x4C240000,  //  009C  LDNIL	R9
+      0x1C241009,  //  009D  EQ	R9	R8	R9
+      0x7826000A,  //  009E  JMPF	R9	#00AA
+      0xB8260200,  //  009F  GETNGBL	R9	K1
+      0x8C241302,  //  00A0  GETMET	R9	R9	K2
+      0x602C0008,  //  00A1  GETGBL	R11	G8
+      0x88300D08,  //  00A2  GETMBR	R12	R6	K8
+      0x7C2C0200,  //  00A3  CALL	R11	1
+      0x002E5A0B,  //  00A4  ADD	R11	K45	R11
+      0x58300024,  //  00A5  LDCONST	R12	K36
+      0x7C240600,  //  00A6  CALL	R9	3
+      0x50240000,  //  00A7  LDBOOL	R9	0	0
+      0xA8040001,  //  00A8  EXBLK	1	1
+      0x80041200,  //  00A9  RET	1	R9
+      0x780A0000,  //  00AA  JMPF	R2	#00AC
+      0x90222402,  //  00AB  SETMBR	R8	K18	R2
+      0x780E0000,  //  00AC  JMPF	R3	#00AE
+      0x90222603,  //  00AD  SETMBR	R8	K19	R3
+      0x90222800,  //  00AE  SETMBR	R8	K20	R0
+      0x901A2A08,  //  00AF  SETMBR	R6	K21	R8
+      0x8C24112E,  //  00B0  GETMET	R9	R8	K46
+      0x882C0D18,  //  00B1  GETMBR	R11	R6	K24
+      0x50300200,  //  00B2  LDBOOL	R12	1	0
+      0x7C240600,  //  00B3  CALL	R9	3
+      0x7426000F,  //  00B4  JMPT	R9	#00C5
+      0xB8260200,  //  00B5  GETNGBL	R9	K1
+      0x8C241302,  //  00B6  GETMET	R9	R9	K2
+      0x602C0008,  //  00B7  GETGBL	R11	G8
+      0x88300D18,  //  00B8  GETMBR	R12	R6	K24
+      0x7C2C0200,  //  00B9  CALL	R11	1
+      0x002E5E0B,  //  00BA  ADD	R11	K47	R11
+      0x002C1730,  //  00BB  ADD	R11	R11	K48
+      0x60300008,  //  00BC  GETGBL	R12	G8
+      0x88341131,  //  00BD  GETMBR	R13	R8	K49
+      0x7C300200,  //  00BE  CALL	R12	1
+      0x002C160C,  //  00BF  ADD	R11	R11	R12
+      0x58300011,  //  00C0  LDCONST	R12	K17
+      0x7C240600,  //  00C1  CALL	R9	3
+      0x50240000,  //  00C2  LDBOOL	R9	0	0
+      0xA8040001,  //  00C3  EXBLK	1	1
+      0x80041200,  //  00C4  RET	1	R9
+      0x8C240D32,  //  00C5  GETMET	R9	R6	K50
+      0x7C240200,  //  00C6  CALL	R9	1
+      0x5C281200,  //  00C7  MOVE	R10	R9
+      0x742A0002,  //  00C8  JMPT	R10	#00CC
+      0x50280000,  //  00C9  LDBOOL	R10	0	0
+      0xA8040001,  //  00CA  EXBLK	1	1
+      0x80041400,  //  00CB  RET	1	R10
+      0x88280D34,  //  00CC  GETMBR	R10	R6	K52
+      0x04281535,  //  00CD  SUB	R10	R10	K53
+      0x402A120A,  //  00CE  CONNECT	R10	K9	R10
+      0x882C0D33,  //  00CF  GETMBR	R11	R6	K51
+      0x9428160A,  //  00D0  GETIDX	R10	R11	R10
+      0x901A660A,  //  00D1  SETMBR	R6	K51	R10
+      0x88280D33,  //  00D2  GETMBR	R10	R6	K51
+      0x40281409,  //  00D3  CONNECT	R10	R10	R9
+      0xB82A0200,  //  00D4  GETNGBL	R10	K1
+      0x8C281502,  //  00D5  GETMET	R10	R10	K2
+      0x8C300919,  //  00D6  GETMET	R12	R4	K25
+      0x58380036,  //  00D7  LDCONST	R14	K54
+      0x883C0D34,  //  00D8  GETMBR	R15	R6	K52
+      0x88400D33,  //  00D9  GETMBR	R16	R6	K51
+      0x8C402104,  //  00DA  GETMET	R16	R16	K4
+      0x7C400200,  //  00DB  CALL	R16	1
+      0x7C300800,  //  00DC  CALL	R12	4
+      0x54360003,  //  00DD  LDINT	R13	4
+      0x7C280600,  //  00DE  CALL	R10	3
+      0x8C280D1C,  //  00DF  GETMET	R10	R6	K28
+      0x7C280200,  //  00E0  CALL	R10	1
+      0xB82A0200,  //  00E1  GETNGBL	R10	K1
+      0x8C281502,  //  00E2  GETMET	R10	R10	K2
+      0x60300008,  //  00E3  GETGBL	R12	G8
+      0x88340D38,  //  00E4  GETMBR	R13	R6	K56
+      0x7C300200,  //  00E5  CALL	R12	1
+      0x00326E0C,  //  00E6  ADD	R12	K55	R12
+      0x00301939,  //  00E7  ADD	R12	R12	K57
+      0x60340008,  //  00E8  GETGBL	R13	G8
+      0x88380D1F,  //  00E9  GETMBR	R14	R6	K31
+      0x7C340200,  //  00EA  CALL	R13	1
+      0x0030180D,  //  00EB  ADD	R12	R12	R13
+      0x0030193A,  //  00EC  ADD	R12	R12	K58
+      0x60340008,  //  00ED  GETGBL	R13	G8
+      0x88380D23,  //  00EE  GETMBR	R14	R6	K35
+      0x543EFFFE,  //  00EF  LDINT	R15	65535
+      0x2C381C0F,  //  00F0  AND	R14	R14	R15
+      0x7C340200,  //  00F1  CALL	R13	1
+      0x0030180D,  //  00F2  ADD	R12	R12	R13
+      0x58340011,  //  00F3  LDCONST	R13	K17
+      0x7C280600,  //  00F4  CALL	R10	3
+      0xB82A0200,  //  00F5  GETNGBL	R10	K1
+      0x8C281502,  //  00F6  GETMET	R10	R10	K2
+      0x8C300919,  //  00F7  GETMET	R12	R4	K25
+      0x5838003B,  //  00F8  LDCONST	R14	K59
+      0x883C1108,  //  00F9  GETMBR	R15	R8	K8
+      0x88400D38,  //  00FA  GETMBR	R16	R6	K56
+      0x88440D1F,  //  00FB  GETMBR	R17	R6	K31
+      0x88480D18,  //  00FC  GETMBR	R18	R6	K24
+      0x884C0D23,  //  00FD  GETMBR	R19	R6	K35
+      0x60500008,  //  00FE  GETGBL	R20	G8
+      0x88540D1E,  //  00FF  GETMBR	R21	R6	K30
+      0x7C500200,  //  0100  CALL	R20	1
+      0x88540D26,  //  0101  GETMBR	R21	R6	K38
+      0x78560001,  //  0102  JMPF	R21	#0105
+      0x58540027,  //  0103  LDCONST	R21	K39
+      0x70020000,  //  0104  JMP		#0106
+      0x58540028,  //  0105  LDCONST	R21	K40
+      0x5C580400,  //  0106  MOVE	R22	R2
+      0x5C5C0600,  //  0107  MOVE	R23	R3
+      0x7C301600,  //  0108  CALL	R12	11
+      0x58340011,  //  0109  LDCONST	R13	K17
+      0x7C280600,  //  010A  CALL	R10	3
+      0x8828010B,  //  010B  GETMBR	R10	R0	K11
+      0x8C28151D,  //  010C  GETMET	R10	R10	K29
+      0x88300D1E,  //  010D  GETMBR	R12	R6	K30
+      0x7C280400,  //  010E  CALL	R10	2
+      0x88280D38,  //  010F  GETMBR	R10	R6	K56
+      0x1C2C1509,  //  0110  EQ	R11	R10	K9
+      0x782E0018,  //  0111  JMPF	R11	#012B
+      0xB82E0200,  //  0112  GETNGBL	R11	K1
+      0x8C2C1702,  //  0113  GETMET	R11	R11	K2
+      0xB8360A00,  //  0114  GETNGBL	R13	K5
+      0x8C341B3D,  //  0115  GETMET	R13	R13	K61
+      0x5C3C0C00,  //  0116  MOVE	R15	R6
+      0x7C340400,  //  0117  CALL	R13	2
+      0x0036780D,  //  0118  ADD	R13	K60	R13
+      0x58380011,  //  0119  LDCONST	R14	K17
+      0x7C2C0600,  //  011A  CALL	R11	3
+      0x882C0D1F,  //  011B  GETMBR	R11	R6	K31
+      0x5432000F,  //  011C  LDINT	R12	16
+      0x1C2C160C,  //  011D  EQ	R11	R11	R12
+      0x782E0009,  //  011E  JMPF	R11	#0129
+      0x882C013E,  //  011F  GETMBR	R11	R0	K62
+      0x8C2C173F,  //  0120  GETMET	R11	R11	K63
+      0x5C340C00,  //  0121  MOVE	R13	R6
+      0x7C2C0400,  //  0122  CALL	R11	2
+      0x5C141600,  //  0123  MOVE	R5	R11
+      0x78160003,  //  0124  JMPF	R5	#0129
+      0x882C013E,  //  0125  GETMBR	R11	R0	K62
+      0x8C2C1740,  //  0126  GETMET	R11	R11	K64
+      0x5C340000,  //  0127  MOVE	R13	R0
+      0x7C2C0400,  //  0128  CALL	R11	2
+      0x50140200,  //  0129  LDBOOL	R5	1	0
+      0x70020030,  //  012A  JMP		#015C
+      0x1C2C1535,  //  012B  EQ	R11	R10	K53
+      0x782E0026,  //  012C  JMPF	R11	#0154
+      0x882C013E,  //  012D  GETMBR	R11	R0	K62
+      0x8C2C172A,  //  012E  GETMET	R11	R11	K42
+      0x5C340C00,  //  012F  MOVE	R13	R6
+      0x7C2C0400,  //  0130  CALL	R11	2
+      0x5C141600,  //  0131  MOVE	R5	R11
+      0x78160004,  //  0132  JMPF	R5	#0138
+      0x882C013E,  //  0133  GETMBR	R11	R0	K62
+      0x8C2C1740,  //  0134  GETMET	R11	R11	K64
+      0x5C340000,  //  0135  MOVE	R13	R0
+      0x7C2C0400,  //  0136  CALL	R11	2
+      0x70020019,  //  0137  JMP		#0152
+      0x882C0D26,  //  0138  GETMBR	R11	R6	K38
+      0x782E0017,  //  0139  JMPF	R11	#0152
+      0x8C2C0D41,  //  013A  GETMET	R11	R6	K65
+      0x50340200,  //  013B  LDBOOL	R13	1	0
+      0x7C2C0400,  //  013C  CALL	R11	2
+      0x8C301742,  //  013D  GETMET	R12	R11	K66
+      0x7C300200,  //  013E  CALL	R12	1
+      0x8C301743,  //  013F  GETMET	R12	R11	K67
+      0x7C300200,  //  0140  CALL	R12	1
+      0xB8320200,  //  0141  GETNGBL	R12	K1
+      0x8C301902,  //  0142  GETMET	R12	R12	K2
+      0x8C380919,  //  0143  GETMET	R14	R4	K25
+      0x58400044,  //  0144  LDCONST	R16	K68
+      0x88441715,  //  0145  GETMBR	R17	R11	K21
+      0x88442308,  //  0146  GETMBR	R17	R17	K8
+      0x8848171E,  //  0147  GETMBR	R18	R11	K30
+      0x884C1718,  //  0148  GETMBR	R19	R11	K24
+      0x7C380A00,  //  0149  CALL	R14	5
+      0x583C0011,  //  014A  LDCONST	R15	K17
+      0x7C300600,  //  014B  CALL	R12	3
+      0x8C300145,  //  014C  GETMET	R12	R0	K69
+      0x88381733,  //  014D  GETMBR	R14	R11	K51
+      0x883C1746,  //  014E  GETMBR	R15	R11	K70
+      0x88401747,  //  014F  GETMBR	R16	R11	K71
+      0x88441718,  //  0150  GETMBR	R17	R11	K24
+      0x7C300A00,  //  0151  CALL	R12	5
+      0x50140200,  //  0152  LDBOOL	R5	1	0
+      0x70020007,  //  0153  JMP		#015C
+      0xB82E0200,  //  0154  GETNGBL	R11	K1
+      0x8C2C1702,  //  0155  GETMET	R11	R11	K2
+      0x60340008,  //  0156  GETGBL	R13	G8
+      0x5C381400,  //  0157  MOVE	R14	R10
+      0x7C340200,  //  0158  CALL	R13	1
+      0x0036900D,  //  0159  ADD	R13	K72	R13
+      0x58380011,  //  015A  LDCONST	R14	K17
+      0x7C2C0600,  //  015B  CALL	R11	3
+      0xA8040001,  //  015C  EXBLK	1	1
+      0x80040A00,  //  015D  RET	1	R5
+      0xA8040001,  //  015E  EXBLK	1	1
+      0x70020014,  //  015F  JMP		#0175
+      0xAC180002,  //  0160  CATCH	R6	0	2
+      0x70020011,  //  0161  JMP		#0174
+      0xB8220200,  //  0162  GETNGBL	R8	K1
+      0x8C201102,  //  0163  GETMET	R8	R8	K2
+      0x60280008,  //  0164  GETGBL	R10	G8
+      0x5C2C0C00,  //  0165  MOVE	R11	R6
+      0x7C280200,  //  0166  CALL	R10	1
+      0x002A920A,  //  0167  ADD	R10	K73	R10
+      0x0028154A,  //  0168  ADD	R10	R10	K74
+      0x602C0008,  //  0169  GETGBL	R11	G8
+      0x5C300E00,  //  016A  MOVE	R12	R7
+      0x7C2C0200,  //  016B  CALL	R11	1
+      0x0028140B,  //  016C  ADD	R10	R10	R11
+      0x7C200400,  //  016D  CALL	R8	2
+      0xA4229600,  //  016E  IMPORT	R8	K75
+      0x8C24114C,  //  016F  GETMET	R9	R8	K76
+      0x7C240200,  //  0170  CALL	R9	1
+      0x50240000,  //  0171  LDBOOL	R9	0	0
+      0x80041200,  //  0172  RET	1	R9
+      0x70020000,  //  0173  JMP		#0175
+      0xB0080000,  //  0174  RAISE	2	R0	R0
+      0x80000000,  //  0175  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Plugin_Root.h
@@ -1204,7 +1204,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       ),
     }),
     1,                          /* has constants */
-    ( &(const bvalue[96]) {     /* constants */
+    ( &(const bvalue[98]) {     /* constants */
     /* K0   */  be_nested_str_weak(crypto),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(matter),
@@ -1239,7 +1239,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K31  */  be_nested_str_weak(tasmota),
     /* K32  */  be_nested_str_weak(rtc),
     /* K33  */  be_nested_str_weak(utc),
-    /* K34  */  be_nested_str_weak(encode),
+    /* K34  */  be_nested_str_weak(tlv2raw),
     /* K35  */  be_nested_str_weak(get_ac),
     /* K36  */  be_nested_str_weak(log),
     /* K37  */  be_nested_str_weak(MTR_X3A_X20attestation_tbs_X3D),
@@ -1279,32 +1279,34 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
     /* K71  */  be_nested_str_weak(MTR_X3A_X20fabric_X3D),
     /* K72  */  be_nested_str_weak(inspect),
     /* K73  */  be_nested_str_weak(_fabric),
-    /* K74  */  be_nested_str_weak(set_fabric_label),
-    /* K75  */  be_nested_str_weak(sessions),
-    /* K76  */  be_nested_str_weak(active_fabrics),
-    /* K77  */  be_nested_str_weak(get_fabric_index),
-    /* K78  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
-    /* K79  */  be_nested_str_weak(get_fabric_id),
-    /* K80  */  be_nested_str_weak(set_timer),
-    /* K81  */  be_nested_str_weak(stop_iteration),
-    /* K82  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
-    /* K83  */  be_nested_str_weak(_X29_X20not_X20found),
-    /* K84  */  be_nested_str_weak(INVALID_ACTION),
-    /* K85  */  be_nested_str_weak(format),
-    /* K86  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
-    /* K87  */  be_nested_str_weak(INVALID_DATA_TYPE),
-    /* K88  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
-    /* K89  */  be_nested_str_weak(CONSTRAINT_ERROR),
-    /* K90  */  be_nested_str_weak(start_basic_commissioning),
-    /* K91  */  be_nested_str_weak(get_fabric),
-    /* K92  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
-    /* K93  */  be_nested_str_weak(start_root_basic_commissioning),
-    /* K94  */  be_nested_str_weak(stop_basic_commissioning),
-    /* K95  */  be_nested_str_weak(invoke_request),
+    /* K74  */  be_nested_str_weak(log_new_fabric),
+    /* K75  */  be_nested_str_weak(set_fabric_label),
+    /* K76  */  be_nested_str_weak(format),
+    /* K77  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Update_X20fabric_X20_X27_X25s_X27_X20label_X3D_X27_X25s_X27),
+    /* K78  */  be_nested_str_weak(get_fabric_id),
+    /* K79  */  be_nested_str_weak(sessions),
+    /* K80  */  be_nested_str_weak(active_fabrics),
+    /* K81  */  be_nested_str_weak(get_fabric_index),
+    /* K82  */  be_nested_str_weak(MTR_X3A_X20removing_X20fabric_X20),
+    /* K83  */  be_nested_str_weak(set_timer),
+    /* K84  */  be_nested_str_weak(stop_iteration),
+    /* K85  */  be_nested_str_weak(MTR_X3A_X20RemoveFabric_X20fabric_X28),
+    /* K86  */  be_nested_str_weak(_X29_X20not_X20found),
+    /* K87  */  be_nested_str_weak(INVALID_ACTION),
+    /* K88  */  be_nested_str_weak(MTR_X3A_X20OpenCommissioningWindow_X28timeout_X3D_X25i_X2C_X20passcode_X3D_X25s_X2C_X20discriminator_X3D_X25i_X2C_X20iterations_X3D_X25i_X2C_X20salt_X3D_X25s_X29),
+    /* K89  */  be_nested_str_weak(INVALID_DATA_TYPE),
+    /* K90  */  be_nested_str_weak(MTR_X3A_X20wrong_X20size_X20for_X20PAKE_X20parameters),
+    /* K91  */  be_nested_str_weak(CONSTRAINT_ERROR),
+    /* K92  */  be_nested_str_weak(start_basic_commissioning),
+    /* K93  */  be_nested_str_weak(get_fabric),
+    /* K94  */  be_nested_str_weak(MTR_X3A_X20OpenBasicCommissioningWindow_X20commissioning_timeout_X3D),
+    /* K95  */  be_nested_str_weak(start_root_basic_commissioning),
+    /* K96  */  be_nested_str_weak(stop_basic_commissioning),
+    /* K97  */  be_nested_str_weak(invoke_request),
     }),
     be_str_weak(invoke_request),
     &be_const_str_solidified,
-    ( &(const binstruction[706]) {  /* code */
+    ( &(const binstruction[728]) {  /* code */
       0xA4120000,  //  0000  IMPORT	R4	K0
       0xA4160200,  //  0001  IMPORT	R5	K1
       0xB81A0400,  //  0002  GETNGBL	R6	K2
@@ -1398,10 +1400,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x5C300200,  //  005A  MOVE	R12	R1
       0x7C280400,  //  005B  CALL	R10	2
       0x80041200,  //  005C  RET	1	R9
-      0x70020261,  //  005D  JMP		#02C0
+      0x70020277,  //  005D  JMP		#02D6
       0x5426003D,  //  005E  LDINT	R9	62
       0x1C240E09,  //  005F  EQ	R9	R7	R9
-      0x782601C3,  //  0060  JMPF	R9	#0225
+      0x782601D9,  //  0060  JMPF	R9	#023B
       0x1C24110F,  //  0061  EQ	R9	R8	K15
       0x7826001D,  //  0062  JMPF	R9	#0081
       0x8C240507,  //  0063  GETMET	R9	R2	K7
@@ -1433,7 +1435,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C2C0800,  //  007D  CALL	R11	4
       0x900E0B11,  //  007E  SETMBR	R3	K5	K17
       0x80041400,  //  007F  RET	1	R10
-      0x700201A2,  //  0080  JMP		#0224
+      0x700201B8,  //  0080  JMP		#023A
       0x1C241106,  //  0081  EQ	R9	R8	K6
       0x78260044,  //  0082  JMPF	R9	#00C8
       0x8C240507,  //  0083  GETMET	R9	R2	K7
@@ -1504,7 +1506,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x7C400800,  //  00C4  CALL	R16	4
       0x900E0B08,  //  00C5  SETMBR	R3	K5	K8
       0x80041E00,  //  00C6  RET	1	R15
-      0x7002015B,  //  00C7  JMP		#0224
+      0x70020171,  //  00C7  JMP		#023A
       0x54260003,  //  00C8  LDINT	R9	4
       0x1C241009,  //  00C9  EQ	R9	R8	R9
       0x78260040,  //  00CA  JMPF	R9	#010C
@@ -1572,7 +1574,7 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x54460004,  //  0108  LDINT	R17	5
       0x900E0A11,  //  0109  SETMBR	R3	K5	R17
       0x80042000,  //  010A  RET	1	R16
-      0x70020117,  //  010B  JMP		#0224
+      0x7002012D,  //  010B  JMP		#023A
       0x5426000A,  //  010C  LDINT	R9	11
       0x1C241009,  //  010D  EQ	R9	R8	R9
       0x78260012,  //  010E  JMPF	R9	#0122
@@ -1594,10 +1596,10 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x900E2E0A,  //  011E  SETMBR	R3	K23	R10
       0x4C280000,  //  011F  LDNIL	R10
       0x80041400,  //  0120  RET	1	R10
-      0x70020101,  //  0121  JMP		#0224
+      0x70020117,  //  0121  JMP		#023A
       0x54260005,  //  0122  LDINT	R9	6
       0x1C241009,  //  0123  EQ	R9	R8	R9
-      0x782600B2,  //  0124  JMPF	R9	#01D8
+      0x782600B5,  //  0124  JMPF	R9	#01DB
       0x8C240507,  //  0125  GETMET	R9	R2	K7
       0x582C0006,  //  0126  LDCONST	R11	K6
       0x7C240400,  //  0127  CALL	R9	2
@@ -1760,257 +1762,279 @@ be_local_closure(Matter_Plugin_Root_invoke_request,   /* name */
       0x58640046,  //  01C4  LDCONST	R25	K70
       0x58680011,  //  01C5  LDCONST	R26	K17
       0x7C5C0600,  //  01C6  CALL	R23	3
-      0x8C5C0D0A,  //  01C7  GETMET	R23	R6	K10
-      0x7C5C0200,  //  01C8  CALL	R23	1
-      0x8C602F0B,  //  01C9  GETMET	R24	R23	K11
-      0x58680006,  //  01CA  LDCONST	R26	K6
-      0x886C0D0C,  //  01CB  GETMBR	R27	R6	K12
-      0xB8720400,  //  01CC  GETNGBL	R28	K2
-      0x8870392E,  //  01CD  GETMBR	R28	R28	K46
-      0x7C600800,  //  01CE  CALL	R24	4
-      0x8C602F0B,  //  01CF  GETMET	R24	R23	K11
-      0x58680008,  //  01D0  LDCONST	R26	K8
-      0x886C0D0C,  //  01D1  GETMBR	R27	R6	K12
-      0x58700008,  //  01D2  LDCONST	R28	K8
-      0x7C600800,  //  01D3  CALL	R24	4
-      0x54620007,  //  01D4  LDINT	R24	8
-      0x900E0A18,  //  01D5  SETMBR	R3	K5	R24
-      0x80042E00,  //  01D6  RET	1	R23
-      0x7002004B,  //  01D7  JMP		#0224
-      0x54260008,  //  01D8  LDINT	R9	9
-      0x1C241009,  //  01D9  EQ	R9	R8	R9
-      0x7826000B,  //  01DA  JMPF	R9	#01E7
-      0x8C240507,  //  01DB  GETMET	R9	R2	K7
-      0x582C0006,  //  01DC  LDCONST	R11	K6
-      0x7C240400,  //  01DD  CALL	R9	2
-      0x8C28034A,  //  01DE  GETMET	R10	R1	K74
-      0x5C301200,  //  01DF  MOVE	R12	R9
-      0x7C280400,  //  01E0  CALL	R10	2
-      0xB82A0400,  //  01E1  GETNGBL	R10	K2
-      0x8828152E,  //  01E2  GETMBR	R10	R10	K46
-      0x900E2E0A,  //  01E3  SETMBR	R3	K23	R10
-      0x4C280000,  //  01E4  LDNIL	R10
-      0x80041400,  //  01E5  RET	1	R10
-      0x7002003C,  //  01E6  JMP		#0224
-      0x54260009,  //  01E7  LDINT	R9	10
-      0x1C241009,  //  01E8  EQ	R9	R8	R9
-      0x78260039,  //  01E9  JMPF	R9	#0224
-      0x8C240507,  //  01EA  GETMET	R9	R2	K7
-      0x582C0006,  //  01EB  LDCONST	R11	K6
-      0x7C240400,  //  01EC  CALL	R9	2
-      0x60280010,  //  01ED  GETGBL	R10	G16
-      0x882C0115,  //  01EE  GETMBR	R11	R0	K21
-      0x882C174B,  //  01EF  GETMBR	R11	R11	K75
-      0x8C2C174C,  //  01F0  GETMET	R11	R11	K76
-      0x7C2C0200,  //  01F1  CALL	R11	1
-      0x7C280200,  //  01F2  CALL	R10	1
-      0xA802001D,  //  01F3  EXBLK	0	#0212
-      0x5C2C1400,  //  01F4  MOVE	R11	R10
-      0x7C2C0000,  //  01F5  CALL	R11	0
-      0x8C30174D,  //  01F6  GETMET	R12	R11	K77
-      0x7C300200,  //  01F7  CALL	R12	1
-      0x1C301809,  //  01F8  EQ	R12	R12	R9
-      0x78320015,  //  01F9  JMPF	R12	#0210
-      0xB8323E00,  //  01FA  GETNGBL	R12	K31
-      0x8C301924,  //  01FB  GETMET	R12	R12	K36
-      0x8C38174F,  //  01FC  GETMET	R14	R11	K79
-      0x7C380200,  //  01FD  CALL	R14	1
-      0x8C381D3F,  //  01FE  GETMET	R14	R14	K63
-      0x7C380200,  //  01FF  CALL	R14	1
-      0x8C381D40,  //  0200  GETMET	R14	R14	K64
-      0x7C380200,  //  0201  CALL	R14	1
-      0x8C381D26,  //  0202  GETMET	R14	R14	K38
-      0x7C380200,  //  0203  CALL	R14	1
-      0x003A9C0E,  //  0204  ADD	R14	K78	R14
-      0x583C000F,  //  0205  LDCONST	R15	K15
-      0x7C300600,  //  0206  CALL	R12	3
-      0xB8323E00,  //  0207  GETNGBL	R12	K31
-      0x8C301950,  //  0208  GETMET	R12	R12	K80
-      0x543A07CF,  //  0209  LDINT	R14	2000
-      0x843C0000,  //  020A  CLOSURE	R15	P0
-      0x7C300600,  //  020B  CALL	R12	3
-      0x50300200,  //  020C  LDBOOL	R12	1	0
-      0xA0000000,  //  020D  CLOSE	R0
-      0xA8040001,  //  020E  EXBLK	1	1
-      0x80041800,  //  020F  RET	1	R12
-      0xA0280000,  //  0210  CLOSE	R10
-      0x7001FFE1,  //  0211  JMP		#01F4
-      0x58280051,  //  0212  LDCONST	R10	K81
-      0xAC280200,  //  0213  CATCH	R10	1	0
-      0xB0080000,  //  0214  RAISE	2	R0	R0
-      0xB82A3E00,  //  0215  GETNGBL	R10	K31
-      0x8C281524,  //  0216  GETMET	R10	R10	K36
-      0x60300008,  //  0217  GETGBL	R12	G8
-      0x5C341200,  //  0218  MOVE	R13	R9
-      0x7C300200,  //  0219  CALL	R12	1
-      0x0032A40C,  //  021A  ADD	R12	K82	R12
-      0x00301953,  //  021B  ADD	R12	R12	K83
-      0x5834000F,  //  021C  LDCONST	R13	K15
-      0x7C280600,  //  021D  CALL	R10	3
-      0xB82A0400,  //  021E  GETNGBL	R10	K2
-      0x88281554,  //  021F  GETMBR	R10	R10	K84
-      0x900E2E0A,  //  0220  SETMBR	R3	K23	R10
-      0x4C280000,  //  0221  LDNIL	R10
-      0xA0000000,  //  0222  CLOSE	R0
-      0x80041400,  //  0223  RET	1	R10
-      0x7002009A,  //  0224  JMP		#02C0
-      0x5426003B,  //  0225  LDINT	R9	60
-      0x1C240E09,  //  0226  EQ	R9	R7	R9
-      0x78260084,  //  0227  JMPF	R9	#02AD
-      0x1C241106,  //  0228  EQ	R9	R8	K6
-      0x78260064,  //  0229  JMPF	R9	#028F
-      0x8C240507,  //  022A  GETMET	R9	R2	K7
-      0x582C0006,  //  022B  LDCONST	R11	K6
-      0x7C240400,  //  022C  CALL	R9	2
-      0x8C280507,  //  022D  GETMET	R10	R2	K7
-      0x58300008,  //  022E  LDCONST	R12	K8
-      0x7C280400,  //  022F  CALL	R10	2
-      0x8C2C0507,  //  0230  GETMET	R11	R2	K7
-      0x5834000F,  //  0231  LDCONST	R13	K15
-      0x7C2C0400,  //  0232  CALL	R11	2
-      0x8C300507,  //  0233  GETMET	R12	R2	K7
-      0x58380011,  //  0234  LDCONST	R14	K17
-      0x7C300400,  //  0235  CALL	R12	2
-      0x8C340507,  //  0236  GETMET	R13	R2	K7
-      0x543E0003,  //  0237  LDINT	R15	4
-      0x7C340400,  //  0238  CALL	R13	2
-      0xB83A3E00,  //  0239  GETNGBL	R14	K31
-      0x8C381D24,  //  023A  GETMET	R14	R14	K36
-      0x8C400B55,  //  023B  GETMET	R16	R5	K85
-      0x58480056,  //  023C  LDCONST	R18	K86
-      0x5C4C1200,  //  023D  MOVE	R19	R9
-      0x8C501526,  //  023E  GETMET	R20	R10	K38
-      0x7C500200,  //  023F  CALL	R20	1
-      0x5C541600,  //  0240  MOVE	R21	R11
-      0x5C581800,  //  0241  MOVE	R22	R12
-      0x8C5C1B26,  //  0242  GETMET	R23	R13	K38
-      0x7C5C0200,  //  0243  CALL	R23	1
-      0x7C400E00,  //  0244  CALL	R16	7
-      0x5844000F,  //  0245  LDCONST	R17	K15
-      0x7C380600,  //  0246  CALL	R14	3
-      0x4C380000,  //  0247  LDNIL	R14
-      0x1C38120E,  //  0248  EQ	R14	R9	R14
-      0x743A000B,  //  0249  JMPT	R14	#0256
-      0x4C380000,  //  024A  LDNIL	R14
-      0x1C38140E,  //  024B  EQ	R14	R10	R14
-      0x743A0008,  //  024C  JMPT	R14	#0256
-      0x4C380000,  //  024D  LDNIL	R14
-      0x1C38160E,  //  024E  EQ	R14	R11	R14
-      0x743A0005,  //  024F  JMPT	R14	#0256
-      0x4C380000,  //  0250  LDNIL	R14
-      0x1C38180E,  //  0251  EQ	R14	R12	R14
-      0x743A0002,  //  0252  JMPT	R14	#0256
-      0x4C380000,  //  0253  LDNIL	R14
-      0x1C381A0E,  //  0254  EQ	R14	R13	R14
-      0x783A0005,  //  0255  JMPF	R14	#025C
-      0xB83A0400,  //  0256  GETNGBL	R14	K2
-      0x88381D57,  //  0257  GETMBR	R14	R14	K87
-      0x900E2E0E,  //  0258  SETMBR	R3	K23	R14
-      0x4C380000,  //  0259  LDNIL	R14
-      0xA0000000,  //  025A  CLOSE	R0
-      0x80041C00,  //  025B  RET	1	R14
-      0x6038000C,  //  025C  GETGBL	R14	G12
-      0x5C3C1400,  //  025D  MOVE	R15	R10
-      0x7C380200,  //  025E  CALL	R14	1
-      0x543E001F,  //  025F  LDINT	R15	32
-      0x54420040,  //  0260  LDINT	R16	65
-      0x003C1E10,  //  0261  ADD	R15	R15	R16
-      0x20381C0F,  //  0262  NE	R14	R14	R15
-      0x743A000B,  //  0263  JMPT	R14	#0270
-      0x6038000C,  //  0264  GETGBL	R14	G12
-      0x5C3C1A00,  //  0265  MOVE	R15	R13
-      0x7C380200,  //  0266  CALL	R14	1
-      0x543E000F,  //  0267  LDINT	R15	16
-      0x14381C0F,  //  0268  LT	R14	R14	R15
-      0x743A0005,  //  0269  JMPT	R14	#0270
-      0x6038000C,  //  026A  GETGBL	R14	G12
-      0x5C3C1A00,  //  026B  MOVE	R15	R13
-      0x7C380200,  //  026C  CALL	R14	1
-      0x543E001F,  //  026D  LDINT	R15	32
-      0x24381C0F,  //  026E  GT	R14	R14	R15
-      0x783A0009,  //  026F  JMPF	R14	#027A
-      0xB83A3E00,  //  0270  GETNGBL	R14	K31
-      0x8C381D24,  //  0271  GETMET	R14	R14	K36
-      0x58400058,  //  0272  LDCONST	R16	K88
-      0x7C380400,  //  0273  CALL	R14	2
-      0xB83A0400,  //  0274  GETNGBL	R14	K2
-      0x88381D59,  //  0275  GETMBR	R14	R14	K89
-      0x900E2E0E,  //  0276  SETMBR	R3	K23	R14
-      0x4C380000,  //  0277  LDNIL	R14
-      0xA0000000,  //  0278  CLOSE	R0
-      0x80041C00,  //  0279  RET	1	R14
-      0x543A001E,  //  027A  LDINT	R14	31
-      0x403A0C0E,  //  027B  CONNECT	R14	K6	R14
-      0x9438140E,  //  027C  GETIDX	R14	R10	R14
-      0x543E001F,  //  027D  LDINT	R15	32
-      0x403C1F3B,  //  027E  CONNECT	R15	R15	K59
-      0x943C140F,  //  027F  GETIDX	R15	R10	R15
-      0x88400115,  //  0280  GETMBR	R16	R0	K21
-      0x8C40215A,  //  0281  GETMET	R16	R16	K90
-      0x5C481200,  //  0282  MOVE	R18	R9
-      0x5C4C1800,  //  0283  MOVE	R19	R12
-      0x5C501600,  //  0284  MOVE	R20	R11
-      0x5C541A00,  //  0285  MOVE	R21	R13
-      0x5C581C00,  //  0286  MOVE	R22	R14
-      0x5C5C1E00,  //  0287  MOVE	R23	R15
-      0x8C60035B,  //  0288  GETMET	R24	R1	K91
-      0x7C600200,  //  0289  CALL	R24	1
-      0x7C401000,  //  028A  CALL	R16	8
-      0x50400200,  //  028B  LDBOOL	R16	1	0
-      0xA0000000,  //  028C  CLOSE	R0
-      0x80042000,  //  028D  RET	1	R16
-      0x7002001C,  //  028E  JMP		#02AC
-      0x1C241108,  //  028F  EQ	R9	R8	K8
-      0x78260012,  //  0290  JMPF	R9	#02A4
-      0x8C240507,  //  0291  GETMET	R9	R2	K7
-      0x582C0006,  //  0292  LDCONST	R11	K6
-      0x7C240400,  //  0293  CALL	R9	2
-      0xB82A3E00,  //  0294  GETNGBL	R10	K31
-      0x8C281524,  //  0295  GETMET	R10	R10	K36
-      0x60300008,  //  0296  GETGBL	R12	G8
-      0x5C341200,  //  0297  MOVE	R13	R9
-      0x7C300200,  //  0298  CALL	R12	1
-      0x0032B80C,  //  0299  ADD	R12	K92	R12
-      0x5834000F,  //  029A  LDCONST	R13	K15
-      0x7C280600,  //  029B  CALL	R10	3
-      0x88280115,  //  029C  GETMBR	R10	R0	K21
-      0x8C28155D,  //  029D  GETMET	R10	R10	K93
-      0x5C301200,  //  029E  MOVE	R12	R9
-      0x7C280400,  //  029F  CALL	R10	2
-      0x50280200,  //  02A0  LDBOOL	R10	1	0
-      0xA0000000,  //  02A1  CLOSE	R0
-      0x80041400,  //  02A2  RET	1	R10
-      0x70020007,  //  02A3  JMP		#02AC
-      0x1C24110F,  //  02A4  EQ	R9	R8	K15
-      0x78260005,  //  02A5  JMPF	R9	#02AC
-      0x88240115,  //  02A6  GETMBR	R9	R0	K21
-      0x8C24135E,  //  02A7  GETMET	R9	R9	K94
-      0x7C240200,  //  02A8  CALL	R9	1
-      0x50240200,  //  02A9  LDBOOL	R9	1	0
-      0xA0000000,  //  02AA  CLOSE	R0
-      0x80041200,  //  02AB  RET	1	R9
-      0x70020012,  //  02AC  JMP		#02C0
-      0x54260029,  //  02AD  LDINT	R9	42
-      0x1C240E09,  //  02AE  EQ	R9	R7	R9
-      0x78260005,  //  02AF  JMPF	R9	#02B6
-      0x1C241106,  //  02B0  EQ	R9	R8	K6
-      0x78260002,  //  02B1  JMPF	R9	#02B5
-      0x50240200,  //  02B2  LDBOOL	R9	1	0
-      0xA0000000,  //  02B3  CLOSE	R0
-      0x80041200,  //  02B4  RET	1	R9
-      0x70020009,  //  02B5  JMP		#02C0
-      0x60240003,  //  02B6  GETGBL	R9	G3
-      0x5C280000,  //  02B7  MOVE	R10	R0
-      0x7C240200,  //  02B8  CALL	R9	1
-      0x8C24135F,  //  02B9  GETMET	R9	R9	K95
-      0x5C2C0200,  //  02BA  MOVE	R11	R1
-      0x5C300400,  //  02BB  MOVE	R12	R2
-      0x5C340600,  //  02BC  MOVE	R13	R3
-      0x7C240800,  //  02BD  CALL	R9	4
-      0xA0000000,  //  02BE  CLOSE	R0
-      0x80041200,  //  02BF  RET	1	R9
+      0x885C0349,  //  01C7  GETMBR	R23	R1	K73
+      0x8C5C2F4A,  //  01C8  GETMET	R23	R23	K74
+      0x7C5C0200,  //  01C9  CALL	R23	1
+      0x8C5C0D0A,  //  01CA  GETMET	R23	R6	K10
+      0x7C5C0200,  //  01CB  CALL	R23	1
+      0x8C602F0B,  //  01CC  GETMET	R24	R23	K11
+      0x58680006,  //  01CD  LDCONST	R26	K6
+      0x886C0D0C,  //  01CE  GETMBR	R27	R6	K12
+      0xB8720400,  //  01CF  GETNGBL	R28	K2
+      0x8870392E,  //  01D0  GETMBR	R28	R28	K46
+      0x7C600800,  //  01D1  CALL	R24	4
+      0x8C602F0B,  //  01D2  GETMET	R24	R23	K11
+      0x58680008,  //  01D3  LDCONST	R26	K8
+      0x886C0D0C,  //  01D4  GETMBR	R27	R6	K12
+      0x58700008,  //  01D5  LDCONST	R28	K8
+      0x7C600800,  //  01D6  CALL	R24	4
+      0x54620007,  //  01D7  LDINT	R24	8
+      0x900E0A18,  //  01D8  SETMBR	R3	K5	R24
+      0x80042E00,  //  01D9  RET	1	R23
+      0x7002005E,  //  01DA  JMP		#023A
+      0x54260008,  //  01DB  LDINT	R9	9
+      0x1C241009,  //  01DC  EQ	R9	R8	R9
+      0x7826001E,  //  01DD  JMPF	R9	#01FD
+      0x8C240507,  //  01DE  GETMET	R9	R2	K7
+      0x582C0006,  //  01DF  LDCONST	R11	K6
+      0x7C240400,  //  01E0  CALL	R9	2
+      0x8C28034B,  //  01E1  GETMET	R10	R1	K75
+      0x5C301200,  //  01E2  MOVE	R12	R9
+      0x7C280400,  //  01E3  CALL	R10	2
+      0xB82A3E00,  //  01E4  GETNGBL	R10	K31
+      0x8C281524,  //  01E5  GETMET	R10	R10	K36
+      0x8C300B4C,  //  01E6  GETMET	R12	R5	K76
+      0x5838004D,  //  01E7  LDCONST	R14	K77
+      0x883C0349,  //  01E8  GETMBR	R15	R1	K73
+      0x8C3C1F4E,  //  01E9  GETMET	R15	R15	K78
+      0x7C3C0200,  //  01EA  CALL	R15	1
+      0x8C3C1F3F,  //  01EB  GETMET	R15	R15	K63
+      0x7C3C0200,  //  01EC  CALL	R15	1
+      0x8C3C1F40,  //  01ED  GETMET	R15	R15	K64
+      0x7C3C0200,  //  01EE  CALL	R15	1
+      0x8C3C1F26,  //  01EF  GETMET	R15	R15	K38
+      0x7C3C0200,  //  01F0  CALL	R15	1
+      0x60400008,  //  01F1  GETGBL	R16	G8
+      0x5C441200,  //  01F2  MOVE	R17	R9
+      0x7C400200,  //  01F3  CALL	R16	1
+      0x7C300800,  //  01F4  CALL	R12	4
+      0x5834000F,  //  01F5  LDCONST	R13	K15
+      0x7C280600,  //  01F6  CALL	R10	3
+      0xB82A0400,  //  01F7  GETNGBL	R10	K2
+      0x8828152E,  //  01F8  GETMBR	R10	R10	K46
+      0x900E2E0A,  //  01F9  SETMBR	R3	K23	R10
+      0x4C280000,  //  01FA  LDNIL	R10
+      0x80041400,  //  01FB  RET	1	R10
+      0x7002003C,  //  01FC  JMP		#023A
+      0x54260009,  //  01FD  LDINT	R9	10
+      0x1C241009,  //  01FE  EQ	R9	R8	R9
+      0x78260039,  //  01FF  JMPF	R9	#023A
+      0x8C240507,  //  0200  GETMET	R9	R2	K7
+      0x582C0006,  //  0201  LDCONST	R11	K6
+      0x7C240400,  //  0202  CALL	R9	2
+      0x60280010,  //  0203  GETGBL	R10	G16
+      0x882C0115,  //  0204  GETMBR	R11	R0	K21
+      0x882C174F,  //  0205  GETMBR	R11	R11	K79
+      0x8C2C1750,  //  0206  GETMET	R11	R11	K80
+      0x7C2C0200,  //  0207  CALL	R11	1
+      0x7C280200,  //  0208  CALL	R10	1
+      0xA802001D,  //  0209  EXBLK	0	#0228
+      0x5C2C1400,  //  020A  MOVE	R11	R10
+      0x7C2C0000,  //  020B  CALL	R11	0
+      0x8C301751,  //  020C  GETMET	R12	R11	K81
+      0x7C300200,  //  020D  CALL	R12	1
+      0x1C301809,  //  020E  EQ	R12	R12	R9
+      0x78320015,  //  020F  JMPF	R12	#0226
+      0xB8323E00,  //  0210  GETNGBL	R12	K31
+      0x8C301924,  //  0211  GETMET	R12	R12	K36
+      0x8C38174E,  //  0212  GETMET	R14	R11	K78
+      0x7C380200,  //  0213  CALL	R14	1
+      0x8C381D3F,  //  0214  GETMET	R14	R14	K63
+      0x7C380200,  //  0215  CALL	R14	1
+      0x8C381D40,  //  0216  GETMET	R14	R14	K64
+      0x7C380200,  //  0217  CALL	R14	1
+      0x8C381D26,  //  0218  GETMET	R14	R14	K38
+      0x7C380200,  //  0219  CALL	R14	1
+      0x003AA40E,  //  021A  ADD	R14	K82	R14
+      0x583C000F,  //  021B  LDCONST	R15	K15
+      0x7C300600,  //  021C  CALL	R12	3
+      0xB8323E00,  //  021D  GETNGBL	R12	K31
+      0x8C301953,  //  021E  GETMET	R12	R12	K83
+      0x543A07CF,  //  021F  LDINT	R14	2000
+      0x843C0000,  //  0220  CLOSURE	R15	P0
+      0x7C300600,  //  0221  CALL	R12	3
+      0x50300200,  //  0222  LDBOOL	R12	1	0
+      0xA0000000,  //  0223  CLOSE	R0
+      0xA8040001,  //  0224  EXBLK	1	1
+      0x80041800,  //  0225  RET	1	R12
+      0xA0280000,  //  0226  CLOSE	R10
+      0x7001FFE1,  //  0227  JMP		#020A
+      0x58280054,  //  0228  LDCONST	R10	K84
+      0xAC280200,  //  0229  CATCH	R10	1	0
+      0xB0080000,  //  022A  RAISE	2	R0	R0
+      0xB82A3E00,  //  022B  GETNGBL	R10	K31
+      0x8C281524,  //  022C  GETMET	R10	R10	K36
+      0x60300008,  //  022D  GETGBL	R12	G8
+      0x5C341200,  //  022E  MOVE	R13	R9
+      0x7C300200,  //  022F  CALL	R12	1
+      0x0032AA0C,  //  0230  ADD	R12	K85	R12
+      0x00301956,  //  0231  ADD	R12	R12	K86
+      0x5834000F,  //  0232  LDCONST	R13	K15
+      0x7C280600,  //  0233  CALL	R10	3
+      0xB82A0400,  //  0234  GETNGBL	R10	K2
+      0x88281557,  //  0235  GETMBR	R10	R10	K87
+      0x900E2E0A,  //  0236  SETMBR	R3	K23	R10
+      0x4C280000,  //  0237  LDNIL	R10
+      0xA0000000,  //  0238  CLOSE	R0
+      0x80041400,  //  0239  RET	1	R10
+      0x7002009A,  //  023A  JMP		#02D6
+      0x5426003B,  //  023B  LDINT	R9	60
+      0x1C240E09,  //  023C  EQ	R9	R7	R9
+      0x78260084,  //  023D  JMPF	R9	#02C3
+      0x1C241106,  //  023E  EQ	R9	R8	K6
+      0x78260064,  //  023F  JMPF	R9	#02A5
+      0x8C240507,  //  0240  GETMET	R9	R2	K7
+      0x582C0006,  //  0241  LDCONST	R11	K6
+      0x7C240400,  //  0242  CALL	R9	2
+      0x8C280507,  //  0243  GETMET	R10	R2	K7
+      0x58300008,  //  0244  LDCONST	R12	K8
+      0x7C280400,  //  0245  CALL	R10	2
+      0x8C2C0507,  //  0246  GETMET	R11	R2	K7
+      0x5834000F,  //  0247  LDCONST	R13	K15
+      0x7C2C0400,  //  0248  CALL	R11	2
+      0x8C300507,  //  0249  GETMET	R12	R2	K7
+      0x58380011,  //  024A  LDCONST	R14	K17
+      0x7C300400,  //  024B  CALL	R12	2
+      0x8C340507,  //  024C  GETMET	R13	R2	K7
+      0x543E0003,  //  024D  LDINT	R15	4
+      0x7C340400,  //  024E  CALL	R13	2
+      0xB83A3E00,  //  024F  GETNGBL	R14	K31
+      0x8C381D24,  //  0250  GETMET	R14	R14	K36
+      0x8C400B4C,  //  0251  GETMET	R16	R5	K76
+      0x58480058,  //  0252  LDCONST	R18	K88
+      0x5C4C1200,  //  0253  MOVE	R19	R9
+      0x8C501526,  //  0254  GETMET	R20	R10	K38
+      0x7C500200,  //  0255  CALL	R20	1
+      0x5C541600,  //  0256  MOVE	R21	R11
+      0x5C581800,  //  0257  MOVE	R22	R12
+      0x8C5C1B26,  //  0258  GETMET	R23	R13	K38
+      0x7C5C0200,  //  0259  CALL	R23	1
+      0x7C400E00,  //  025A  CALL	R16	7
+      0x5844000F,  //  025B  LDCONST	R17	K15
+      0x7C380600,  //  025C  CALL	R14	3
+      0x4C380000,  //  025D  LDNIL	R14
+      0x1C38120E,  //  025E  EQ	R14	R9	R14
+      0x743A000B,  //  025F  JMPT	R14	#026C
+      0x4C380000,  //  0260  LDNIL	R14
+      0x1C38140E,  //  0261  EQ	R14	R10	R14
+      0x743A0008,  //  0262  JMPT	R14	#026C
+      0x4C380000,  //  0263  LDNIL	R14
+      0x1C38160E,  //  0264  EQ	R14	R11	R14
+      0x743A0005,  //  0265  JMPT	R14	#026C
+      0x4C380000,  //  0266  LDNIL	R14
+      0x1C38180E,  //  0267  EQ	R14	R12	R14
+      0x743A0002,  //  0268  JMPT	R14	#026C
+      0x4C380000,  //  0269  LDNIL	R14
+      0x1C381A0E,  //  026A  EQ	R14	R13	R14
+      0x783A0005,  //  026B  JMPF	R14	#0272
+      0xB83A0400,  //  026C  GETNGBL	R14	K2
+      0x88381D59,  //  026D  GETMBR	R14	R14	K89
+      0x900E2E0E,  //  026E  SETMBR	R3	K23	R14
+      0x4C380000,  //  026F  LDNIL	R14
+      0xA0000000,  //  0270  CLOSE	R0
+      0x80041C00,  //  0271  RET	1	R14
+      0x6038000C,  //  0272  GETGBL	R14	G12
+      0x5C3C1400,  //  0273  MOVE	R15	R10
+      0x7C380200,  //  0274  CALL	R14	1
+      0x543E001F,  //  0275  LDINT	R15	32
+      0x54420040,  //  0276  LDINT	R16	65
+      0x003C1E10,  //  0277  ADD	R15	R15	R16
+      0x20381C0F,  //  0278  NE	R14	R14	R15
+      0x743A000B,  //  0279  JMPT	R14	#0286
+      0x6038000C,  //  027A  GETGBL	R14	G12
+      0x5C3C1A00,  //  027B  MOVE	R15	R13
+      0x7C380200,  //  027C  CALL	R14	1
+      0x543E000F,  //  027D  LDINT	R15	16
+      0x14381C0F,  //  027E  LT	R14	R14	R15
+      0x743A0005,  //  027F  JMPT	R14	#0286
+      0x6038000C,  //  0280  GETGBL	R14	G12
+      0x5C3C1A00,  //  0281  MOVE	R15	R13
+      0x7C380200,  //  0282  CALL	R14	1
+      0x543E001F,  //  0283  LDINT	R15	32
+      0x24381C0F,  //  0284  GT	R14	R14	R15
+      0x783A0009,  //  0285  JMPF	R14	#0290
+      0xB83A3E00,  //  0286  GETNGBL	R14	K31
+      0x8C381D24,  //  0287  GETMET	R14	R14	K36
+      0x5840005A,  //  0288  LDCONST	R16	K90
+      0x7C380400,  //  0289  CALL	R14	2
+      0xB83A0400,  //  028A  GETNGBL	R14	K2
+      0x88381D5B,  //  028B  GETMBR	R14	R14	K91
+      0x900E2E0E,  //  028C  SETMBR	R3	K23	R14
+      0x4C380000,  //  028D  LDNIL	R14
+      0xA0000000,  //  028E  CLOSE	R0
+      0x80041C00,  //  028F  RET	1	R14
+      0x543A001E,  //  0290  LDINT	R14	31
+      0x403A0C0E,  //  0291  CONNECT	R14	K6	R14
+      0x9438140E,  //  0292  GETIDX	R14	R10	R14
+      0x543E001F,  //  0293  LDINT	R15	32
+      0x403C1F3B,  //  0294  CONNECT	R15	R15	K59
+      0x943C140F,  //  0295  GETIDX	R15	R10	R15
+      0x88400115,  //  0296  GETMBR	R16	R0	K21
+      0x8C40215C,  //  0297  GETMET	R16	R16	K92
+      0x5C481200,  //  0298  MOVE	R18	R9
+      0x5C4C1800,  //  0299  MOVE	R19	R12
+      0x5C501600,  //  029A  MOVE	R20	R11
+      0x5C541A00,  //  029B  MOVE	R21	R13
+      0x5C581C00,  //  029C  MOVE	R22	R14
+      0x5C5C1E00,  //  029D  MOVE	R23	R15
+      0x8C60035D,  //  029E  GETMET	R24	R1	K93
+      0x7C600200,  //  029F  CALL	R24	1
+      0x7C401000,  //  02A0  CALL	R16	8
+      0x50400200,  //  02A1  LDBOOL	R16	1	0
+      0xA0000000,  //  02A2  CLOSE	R0
+      0x80042000,  //  02A3  RET	1	R16
+      0x7002001C,  //  02A4  JMP		#02C2
+      0x1C241108,  //  02A5  EQ	R9	R8	K8
+      0x78260012,  //  02A6  JMPF	R9	#02BA
+      0x8C240507,  //  02A7  GETMET	R9	R2	K7
+      0x582C0006,  //  02A8  LDCONST	R11	K6
+      0x7C240400,  //  02A9  CALL	R9	2
+      0xB82A3E00,  //  02AA  GETNGBL	R10	K31
+      0x8C281524,  //  02AB  GETMET	R10	R10	K36
+      0x60300008,  //  02AC  GETGBL	R12	G8
+      0x5C341200,  //  02AD  MOVE	R13	R9
+      0x7C300200,  //  02AE  CALL	R12	1
+      0x0032BC0C,  //  02AF  ADD	R12	K94	R12
+      0x5834000F,  //  02B0  LDCONST	R13	K15
+      0x7C280600,  //  02B1  CALL	R10	3
+      0x88280115,  //  02B2  GETMBR	R10	R0	K21
+      0x8C28155F,  //  02B3  GETMET	R10	R10	K95
+      0x5C301200,  //  02B4  MOVE	R12	R9
+      0x7C280400,  //  02B5  CALL	R10	2
+      0x50280200,  //  02B6  LDBOOL	R10	1	0
+      0xA0000000,  //  02B7  CLOSE	R0
+      0x80041400,  //  02B8  RET	1	R10
+      0x70020007,  //  02B9  JMP		#02C2
+      0x1C24110F,  //  02BA  EQ	R9	R8	K15
+      0x78260005,  //  02BB  JMPF	R9	#02C2
+      0x88240115,  //  02BC  GETMBR	R9	R0	K21
+      0x8C241360,  //  02BD  GETMET	R9	R9	K96
+      0x7C240200,  //  02BE  CALL	R9	1
+      0x50240200,  //  02BF  LDBOOL	R9	1	0
       0xA0000000,  //  02C0  CLOSE	R0
-      0x80000000,  //  02C1  RET	0
+      0x80041200,  //  02C1  RET	1	R9
+      0x70020012,  //  02C2  JMP		#02D6
+      0x54260029,  //  02C3  LDINT	R9	42
+      0x1C240E09,  //  02C4  EQ	R9	R7	R9
+      0x78260005,  //  02C5  JMPF	R9	#02CC
+      0x1C241106,  //  02C6  EQ	R9	R8	K6
+      0x78260002,  //  02C7  JMPF	R9	#02CB
+      0x50240200,  //  02C8  LDBOOL	R9	1	0
+      0xA0000000,  //  02C9  CLOSE	R0
+      0x80041200,  //  02CA  RET	1	R9
+      0x70020009,  //  02CB  JMP		#02D6
+      0x60240003,  //  02CC  GETGBL	R9	G3
+      0x5C280000,  //  02CD  MOVE	R10	R0
+      0x7C240200,  //  02CE  CALL	R9	1
+      0x8C241361,  //  02CF  GETMET	R9	R9	K97
+      0x5C2C0200,  //  02D0  MOVE	R11	R1
+      0x5C300400,  //  02D1  MOVE	R12	R2
+      0x5C340600,  //  02D2  MOVE	R13	R3
+      0x7C240800,  //  02D3  CALL	R9	4
+      0xA0000000,  //  02D4  CLOSE	R0
+      0x80041200,  //  02D5  RET	1	R9
+      0xA0000000,  //  02D6  CLOSE	R0
+      0x80000000,  //  02D7  RET	0
     })
   )
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_Session.h
@@ -7,62 +7,6 @@
 extern const bclass be_class_Matter_Fabric;
 
 /********************************************************************
-** Solidified function: get_newest_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_newest_session,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
-    be_str_weak(get_newest_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0000,  //  0001  LDBOOL	R3	0	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_label
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_label),
-    }),
-    be_str_weak(get_fabric_label),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_ca_pub
 ********************************************************************/
 be_local_closure(Matter_Fabric_get_ca_pub,   /* name */
@@ -104,534 +48,6 @@ be_local_closure(Matter_Fabric_get_ca_pub,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(get_fabric_compressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_noc
-********************************************************************/
-be_local_closure(Matter_Fabric_get_noc,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(noc),
-    }),
-    be_str_weak(get_noc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_subject
-********************************************************************/
-be_local_closure(Matter_Fabric_get_admin_subject,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(admin_subject),
-    }),
-    be_str_weak(get_admin_subject),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Fabric_init,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(_sessions),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Expirable_list),
-    /* K5   */  be_nested_str_weak(fabric_label),
-    /* K6   */  be_nested_str_weak(),
-    /* K7   */  be_nested_str_weak(created),
-    /* K8   */  be_nested_str_weak(tasmota),
-    /* K9   */  be_nested_str_weak(rtc),
-    /* K10  */  be_nested_str_weak(utc),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[13]) {  /* code */
-      0xA40A0000,  //  0000  IMPORT	R2	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0xB80E0600,  //  0002  GETNGBL	R3	K3
-      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x90020403,  //  0005  SETMBR	R0	K2	R3
-      0x90020B06,  //  0006  SETMBR	R0	K5	K6
-      0xB80E1000,  //  0007  GETNGBL	R3	K8
-      0x8C0C0709,  //  0008  GETMET	R3	R3	K9
-      0x7C0C0200,  //  0009  CALL	R3	1
-      0x940C070A,  //  000A  GETIDX	R3	R3	K10
-      0x90020E03,  //  000B  SETMBR	R0	K7	R3
-      0x80000000,  //  000C  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_oldest_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_old_recent_session),
-    }),
-    be_str_weak(get_oldest_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x500C0200,  //  0001  LDBOOL	R3	1	0
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_index
-********************************************************************/
-be_local_closure(Matter_Fabric_set_fabric_index,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
-    be_str_weak(set_fabric_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x80000000,  //  0001  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_group_key
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(HKDF_SHA256),
-    /* K4   */  be_nested_str_weak(fromstring),
-    /* K5   */  be_nested_str_weak(_GROUP_KEY),
-    /* K6   */  be_nested_str_weak(derive),
-    }),
-    be_str_weak(get_ipk_group_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[25]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x74060003,  //  0003  JMPT	R1	#0008
-      0x88040101,  //  0004  GETMBR	R1	R0	K1
-      0x4C080000,  //  0005  LDNIL	R2
-      0x1C040202,  //  0006  EQ	R1	R1	R2
-      0x78060001,  //  0007  JMPF	R1	#000A
-      0x4C040000,  //  0008  LDNIL	R1
-      0x80040200,  //  0009  RET	1	R1
-      0xA4060400,  //  000A  IMPORT	R1	K2
-      0x8C080303,  //  000B  GETMET	R2	R1	K3
-      0x7C080200,  //  000C  CALL	R2	1
-      0x600C0015,  //  000D  GETGBL	R3	G21
-      0x7C0C0000,  //  000E  CALL	R3	0
-      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
-      0x88140105,  //  0010  GETMBR	R5	R0	K5
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x8C100506,  //  0012  GETMET	R4	R2	K6
-      0x88180100,  //  0013  GETMBR	R6	R0	K0
-      0x881C0101,  //  0014  GETMBR	R7	R0	K1
-      0x5C200600,  //  0015  MOVE	R8	R3
-      0x5426000F,  //  0016  LDINT	R9	16
-      0x7C100A00,  //  0017  CALL	R4	5
-      0x80040800,  //  0018  RET	1	R4
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: fromjson
-********************************************************************/
-be_local_closure(Matter_Fabric_fromjson,   /* name */
-  be_nested_proto(
-    16,                          /* nstack */
-    2,                          /* argc */
-    4,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[18]) {     /* constants */
-    /* K0   */  be_const_class(be_class_Matter_Fabric),
-    /* K1   */  be_nested_str_weak(string),
-    /* K2   */  be_nested_str_weak(introspect),
-    /* K3   */  be_nested_str_weak(matter),
-    /* K4   */  be_nested_str_weak(Fabric),
-    /* K5   */  be_nested_str_weak(keys),
-    /* K6   */  be_const_int(0),
-    /* K7   */  be_nested_str_weak(_),
-    /* K8   */  be_nested_str_weak(find),
-    /* K9   */  be_nested_str_weak(0x),
-    /* K10  */  be_nested_str_weak(set),
-    /* K11  */  be_nested_str_weak(fromhex),
-    /* K12  */  be_const_int(2),
-    /* K13  */  be_const_int(2147483647),
-    /* K14  */  be_nested_str_weak(_X24_X24),
-    /* K15  */  be_nested_str_weak(fromb64),
-    /* K16  */  be_nested_str_weak(stop_iteration),
-    /* K17  */  be_nested_str_weak(hydrate_post),
-    }),
-    be_str_weak(fromjson),
-    &be_const_str_solidified,
-    ( &(const binstruction[76]) {  /* code */
-      0x58080000,  //  0000  LDCONST	R2	K0
-      0xA40E0200,  //  0001  IMPORT	R3	K1
-      0xA4120400,  //  0002  IMPORT	R4	K2
-      0xB8160600,  //  0003  GETNGBL	R5	K3
-      0x8C140B04,  //  0004  GETMET	R5	R5	K4
-      0x5C1C0000,  //  0005  MOVE	R7	R0
-      0x7C140400,  //  0006  CALL	R5	2
-      0x60180010,  //  0007  GETGBL	R6	G16
-      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
-      0x7C1C0200,  //  0009  CALL	R7	1
-      0x7C180200,  //  000A  CALL	R6	1
-      0xA8020039,  //  000B  EXBLK	0	#0046
-      0x5C1C0C00,  //  000C  MOVE	R7	R6
-      0x7C1C0000,  //  000D  CALL	R7	0
-      0x94200F06,  //  000E  GETIDX	R8	R7	K6
-      0x1C201107,  //  000F  EQ	R8	R8	K7
-      0x78220000,  //  0010  JMPF	R8	#0012
-      0x7001FFF9,  //  0011  JMP		#000C
-      0x94200207,  //  0012  GETIDX	R8	R1	R7
-      0x60240004,  //  0013  GETGBL	R9	G4
-      0x5C281000,  //  0014  MOVE	R10	R8
-      0x7C240200,  //  0015  CALL	R9	1
-      0x1C241301,  //  0016  EQ	R9	R9	K1
-      0x78260027,  //  0017  JMPF	R9	#0040
-      0x8C240708,  //  0018  GETMET	R9	R3	K8
-      0x5C2C1000,  //  0019  MOVE	R11	R8
-      0x58300009,  //  001A  LDCONST	R12	K9
-      0x7C240600,  //  001B  CALL	R9	3
-      0x1C241306,  //  001C  EQ	R9	R9	K6
-      0x7826000A,  //  001D  JMPF	R9	#0029
-      0x8C24090A,  //  001E  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  001F  MOVE	R11	R5
-      0x5C300E00,  //  0020  MOVE	R12	R7
-      0x60340015,  //  0021  GETGBL	R13	G21
-      0x7C340000,  //  0022  CALL	R13	0
-      0x8C341B0B,  //  0023  GETMET	R13	R13	K11
-      0x403E190D,  //  0024  CONNECT	R15	K12	K13
-      0x943C100F,  //  0025  GETIDX	R15	R8	R15
-      0x7C340400,  //  0026  CALL	R13	2
-      0x7C240800,  //  0027  CALL	R9	4
-      0x70020015,  //  0028  JMP		#003F
-      0x8C240708,  //  0029  GETMET	R9	R3	K8
-      0x5C2C1000,  //  002A  MOVE	R11	R8
-      0x5830000E,  //  002B  LDCONST	R12	K14
-      0x7C240600,  //  002C  CALL	R9	3
-      0x1C241306,  //  002D  EQ	R9	R9	K6
-      0x7826000A,  //  002E  JMPF	R9	#003A
-      0x8C24090A,  //  002F  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  0030  MOVE	R11	R5
-      0x5C300E00,  //  0031  MOVE	R12	R7
-      0x60340015,  //  0032  GETGBL	R13	G21
-      0x7C340000,  //  0033  CALL	R13	0
-      0x8C341B0F,  //  0034  GETMET	R13	R13	K15
-      0x403E190D,  //  0035  CONNECT	R15	K12	K13
-      0x943C100F,  //  0036  GETIDX	R15	R8	R15
-      0x7C340400,  //  0037  CALL	R13	2
-      0x7C240800,  //  0038  CALL	R9	4
-      0x70020004,  //  0039  JMP		#003F
-      0x8C24090A,  //  003A  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  003B  MOVE	R11	R5
-      0x5C300E00,  //  003C  MOVE	R12	R7
-      0x5C341000,  //  003D  MOVE	R13	R8
-      0x7C240800,  //  003E  CALL	R9	4
-      0x70020004,  //  003F  JMP		#0045
-      0x8C24090A,  //  0040  GETMET	R9	R4	K10
-      0x5C2C0A00,  //  0041  MOVE	R11	R5
-      0x5C300E00,  //  0042  MOVE	R12	R7
-      0x5C341000,  //  0043  MOVE	R13	R8
-      0x7C240800,  //  0044  CALL	R9	4
-      0x7001FFC5,  //  0045  JMP		#000C
-      0x58180010,  //  0046  LDCONST	R6	K16
-      0xAC180200,  //  0047  CATCH	R6	1	0
-      0xB0080000,  //  0048  RAISE	2	R0	R0
-      0x8C180B11,  //  0049  GETMET	R6	R5	K17
-      0x7C180200,  //  004A  CALL	R6	1
-      0x80040A00,  //  004B  RET	1	R5
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_index
-********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_index,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_index),
-    }),
-    be_str_weak(get_fabric_index),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_old_recent_session
-********************************************************************/
-be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(last_used),
-    /* K3   */  be_const_int(1),
-    }),
-    be_str_weak(get_old_recent_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[30]) {  /* code */
-      0x6008000C,  //  0000  GETGBL	R2	G12
-      0x880C0100,  //  0001  GETMBR	R3	R0	K0
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080501,  //  0003  EQ	R2	R2	K1
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x4C080000,  //  0005  LDNIL	R2
-      0x80040400,  //  0006  RET	1	R2
-      0x88080100,  //  0007  GETMBR	R2	R0	K0
-      0x94080501,  //  0008  GETIDX	R2	R2	K1
-      0x880C0502,  //  0009  GETMBR	R3	R2	K2
-      0x58100003,  //  000A  LDCONST	R4	K3
-      0x6014000C,  //  000B  GETGBL	R5	G12
-      0x88180100,  //  000C  GETMBR	R6	R0	K0
-      0x7C140200,  //  000D  CALL	R5	1
-      0x14140805,  //  000E  LT	R5	R4	R5
-      0x7816000C,  //  000F  JMPF	R5	#001D
-      0x88140100,  //  0010  GETMBR	R5	R0	K0
-      0x94140A04,  //  0011  GETIDX	R5	R5	R4
-      0x88140B02,  //  0012  GETMBR	R5	R5	K2
-      0x78060001,  //  0013  JMPF	R1	#0016
-      0x14180A03,  //  0014  LT	R6	R5	R3
-      0x70020000,  //  0015  JMP		#0017
-      0x24180A03,  //  0016  GT	R6	R5	R3
-      0x781A0002,  //  0017  JMPF	R6	#001B
-      0x88180100,  //  0018  GETMBR	R6	R0	K0
-      0x94080C04,  //  0019  GETIDX	R2	R6	R4
-      0x5C0C0A00,  //  001A  MOVE	R3	R5
-      0x00100903,  //  001B  ADD	R4	R4	K3
-      0x7001FFED,  //  001C  JMP		#000B
-      0x80040400,  //  001D  RET	1	R2
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(get_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: add_session
-********************************************************************/
-be_local_closure(Matter_Fabric_add_session,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_sessions),
-    /* K1   */  be_nested_str_weak(find),
-    /* K2   */  be_nested_str_weak(_MAX_CASE),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_nested_str_weak(get_oldest_session),
-    /* K5   */  be_nested_str_weak(push),
-    }),
-    be_str_weak(add_session),
-    &be_const_str_solidified,
-    ( &(const binstruction[27]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100200,  //  0002  MOVE	R4	R1
-      0x7C080400,  //  0003  CALL	R2	2
-      0x4C0C0000,  //  0004  LDNIL	R3
-      0x1C080403,  //  0005  EQ	R2	R2	R3
-      0x780A0012,  //  0006  JMPF	R2	#001A
-      0x6008000C,  //  0007  GETGBL	R2	G12
-      0x880C0100,  //  0008  GETMBR	R3	R0	K0
-      0x7C080200,  //  0009  CALL	R2	1
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x28080403,  //  000B  GE	R2	R2	R3
-      0x780A0008,  //  000C  JMPF	R2	#0016
-      0x88080100,  //  000D  GETMBR	R2	R0	K0
-      0x8C080503,  //  000E  GETMET	R2	R2	K3
-      0x88100100,  //  000F  GETMBR	R4	R0	K0
-      0x8C100901,  //  0010  GETMET	R4	R4	K1
-      0x8C180104,  //  0011  GETMET	R6	R0	K4
-      0x7C180200,  //  0012  CALL	R6	1
-      0x7C100400,  //  0013  CALL	R4	2
-      0x7C080400,  //  0014  CALL	R2	2
-      0x7001FFF0,  //  0015  JMP		#0007
-      0x88080100,  //  0016  GETMBR	R2	R0	K0
-      0x8C080505,  //  0017  GETMET	R2	R2	K5
-      0x5C100200,  //  0018  MOVE	R4	R1
-      0x7C080400,  //  0019  CALL	R2	2
-      0x80000000,  //  001A  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: get_admin_vendor
 ********************************************************************/
 be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
@@ -659,9 +75,9 @@ be_local_closure(Matter_Fabric_get_admin_vendor,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric_id
+** Solidified function: get_fabric_compressed
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
+be_local_closure(Matter_Fabric_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -672,9 +88,9 @@ be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(fabric_id),
+    /* K0   */  be_nested_str_weak(fabric_compressed),
     }),
-    be_str_weak(get_fabric_id),
+    be_str_weak(get_fabric_compressed),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -686,9 +102,9 @@ be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_icac
+** Solidified function: get_ipk_epoch_key
 ********************************************************************/
-be_local_closure(Matter_Fabric_get_icac,   /* name */
+be_local_closure(Matter_Fabric_get_ipk_epoch_key,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -699,63 +115,9 @@ be_local_closure(Matter_Fabric_get_icac,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(icac),
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
     }),
-    be_str_weak(get_icac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_device_id
-********************************************************************/
-be_local_closure(Matter_Fabric_get_device_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(device_id),
-    }),
-    be_str_weak(get_device_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca
-********************************************************************/
-be_local_closure(Matter_Fabric_get_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(get_ca),
+    be_str_weak(get_ipk_epoch_key),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -940,52 +302,794 @@ be_local_closure(Matter_Fabric_tojson,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_fabric_id
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_id),
+    }),
+    be_str_weak(get_fabric_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_icac
+********************************************************************/
+be_local_closure(Matter_Fabric_get_icac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_subject
+********************************************************************/
+be_local_closure(Matter_Fabric_get_admin_subject,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(admin_subject),
+    }),
+    be_str_weak(get_admin_subject),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: fromjson
+********************************************************************/
+be_local_closure(Matter_Fabric_fromjson,   /* name */
+  be_nested_proto(
+    16,                          /* nstack */
+    2,                          /* argc */
+    4,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[18]) {     /* constants */
+    /* K0   */  be_const_class(be_class_Matter_Fabric),
+    /* K1   */  be_nested_str_weak(string),
+    /* K2   */  be_nested_str_weak(introspect),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Fabric),
+    /* K5   */  be_nested_str_weak(keys),
+    /* K6   */  be_const_int(0),
+    /* K7   */  be_nested_str_weak(_),
+    /* K8   */  be_nested_str_weak(find),
+    /* K9   */  be_nested_str_weak(0x),
+    /* K10  */  be_nested_str_weak(set),
+    /* K11  */  be_nested_str_weak(fromhex),
+    /* K12  */  be_const_int(2),
+    /* K13  */  be_const_int(2147483647),
+    /* K14  */  be_nested_str_weak(_X24_X24),
+    /* K15  */  be_nested_str_weak(fromb64),
+    /* K16  */  be_nested_str_weak(stop_iteration),
+    /* K17  */  be_nested_str_weak(hydrate_post),
+    }),
+    be_str_weak(fromjson),
+    &be_const_str_solidified,
+    ( &(const binstruction[76]) {  /* code */
+      0x58080000,  //  0000  LDCONST	R2	K0
+      0xA40E0200,  //  0001  IMPORT	R3	K1
+      0xA4120400,  //  0002  IMPORT	R4	K2
+      0xB8160600,  //  0003  GETNGBL	R5	K3
+      0x8C140B04,  //  0004  GETMET	R5	R5	K4
+      0x5C1C0000,  //  0005  MOVE	R7	R0
+      0x7C140400,  //  0006  CALL	R5	2
+      0x60180010,  //  0007  GETGBL	R6	G16
+      0x8C1C0305,  //  0008  GETMET	R7	R1	K5
+      0x7C1C0200,  //  0009  CALL	R7	1
+      0x7C180200,  //  000A  CALL	R6	1
+      0xA8020039,  //  000B  EXBLK	0	#0046
+      0x5C1C0C00,  //  000C  MOVE	R7	R6
+      0x7C1C0000,  //  000D  CALL	R7	0
+      0x94200F06,  //  000E  GETIDX	R8	R7	K6
+      0x1C201107,  //  000F  EQ	R8	R8	K7
+      0x78220000,  //  0010  JMPF	R8	#0012
+      0x7001FFF9,  //  0011  JMP		#000C
+      0x94200207,  //  0012  GETIDX	R8	R1	R7
+      0x60240004,  //  0013  GETGBL	R9	G4
+      0x5C281000,  //  0014  MOVE	R10	R8
+      0x7C240200,  //  0015  CALL	R9	1
+      0x1C241301,  //  0016  EQ	R9	R9	K1
+      0x78260027,  //  0017  JMPF	R9	#0040
+      0x8C240708,  //  0018  GETMET	R9	R3	K8
+      0x5C2C1000,  //  0019  MOVE	R11	R8
+      0x58300009,  //  001A  LDCONST	R12	K9
+      0x7C240600,  //  001B  CALL	R9	3
+      0x1C241306,  //  001C  EQ	R9	R9	K6
+      0x7826000A,  //  001D  JMPF	R9	#0029
+      0x8C24090A,  //  001E  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  001F  MOVE	R11	R5
+      0x5C300E00,  //  0020  MOVE	R12	R7
+      0x60340015,  //  0021  GETGBL	R13	G21
+      0x7C340000,  //  0022  CALL	R13	0
+      0x8C341B0B,  //  0023  GETMET	R13	R13	K11
+      0x403E190D,  //  0024  CONNECT	R15	K12	K13
+      0x943C100F,  //  0025  GETIDX	R15	R8	R15
+      0x7C340400,  //  0026  CALL	R13	2
+      0x7C240800,  //  0027  CALL	R9	4
+      0x70020015,  //  0028  JMP		#003F
+      0x8C240708,  //  0029  GETMET	R9	R3	K8
+      0x5C2C1000,  //  002A  MOVE	R11	R8
+      0x5830000E,  //  002B  LDCONST	R12	K14
+      0x7C240600,  //  002C  CALL	R9	3
+      0x1C241306,  //  002D  EQ	R9	R9	K6
+      0x7826000A,  //  002E  JMPF	R9	#003A
+      0x8C24090A,  //  002F  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  0030  MOVE	R11	R5
+      0x5C300E00,  //  0031  MOVE	R12	R7
+      0x60340015,  //  0032  GETGBL	R13	G21
+      0x7C340000,  //  0033  CALL	R13	0
+      0x8C341B0F,  //  0034  GETMET	R13	R13	K15
+      0x403E190D,  //  0035  CONNECT	R15	K12	K13
+      0x943C100F,  //  0036  GETIDX	R15	R8	R15
+      0x7C340400,  //  0037  CALL	R13	2
+      0x7C240800,  //  0038  CALL	R9	4
+      0x70020004,  //  0039  JMP		#003F
+      0x8C24090A,  //  003A  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  003B  MOVE	R11	R5
+      0x5C300E00,  //  003C  MOVE	R12	R7
+      0x5C341000,  //  003D  MOVE	R13	R8
+      0x7C240800,  //  003E  CALL	R9	4
+      0x70020004,  //  003F  JMP		#0045
+      0x8C24090A,  //  0040  GETMET	R9	R4	K10
+      0x5C2C0A00,  //  0041  MOVE	R11	R5
+      0x5C300E00,  //  0042  MOVE	R12	R7
+      0x5C341000,  //  0043  MOVE	R13	R8
+      0x7C240800,  //  0044  CALL	R9	4
+      0x7001FFC5,  //  0045  JMP		#000C
+      0x58180010,  //  0046  LDCONST	R6	K16
+      0xAC180200,  //  0047  CATCH	R6	1	0
+      0xB0080000,  //  0048  RAISE	2	R0	R0
+      0x8C180B11,  //  0049  GETMET	R6	R5	K17
+      0x7C180200,  //  004A  CALL	R6	1
+      0x80040A00,  //  004B  RET	1	R5
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_newest_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_newest_session,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    }),
+    be_str_weak(get_newest_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x500C0000,  //  0001  LDBOOL	R3	0	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_index
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_index,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_index),
+    }),
+    be_str_weak(get_fabric_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: before_remove
+********************************************************************/
+be_local_closure(Matter_Fabric_before_remove,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27_X20_X28removed_X29),
+    /* K5   */  be_nested_str_weak(get_fabric_id),
+    /* K6   */  be_nested_str_weak(copy),
+    /* K7   */  be_nested_str_weak(reverse),
+    /* K8   */  be_nested_str_weak(tohex),
+    /* K9   */  be_const_int(2),
+    }),
+    be_str_weak(before_remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x8C100303,  //  0003  GETMET	R4	R1	K3
+      0x58180004,  //  0004  LDCONST	R6	K4
+      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x7C100600,  //  000D  CALL	R4	3
+      0x58140009,  //  000E  LDCONST	R5	K9
+      0x7C080600,  //  000F  CALL	R2	3
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(get_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_old_recent_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_old_recent_session,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_sessions),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(last_used),
+    /* K3   */  be_const_int(1),
+    }),
+    be_str_weak(get_old_recent_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[30]) {  /* code */
+      0x6008000C,  //  0000  GETGBL	R2	G12
+      0x880C0100,  //  0001  GETMBR	R3	R0	K0
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080501,  //  0003  EQ	R2	R2	K1
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x4C080000,  //  0005  LDNIL	R2
+      0x80040400,  //  0006  RET	1	R2
+      0x88080100,  //  0007  GETMBR	R2	R0	K0
+      0x94080501,  //  0008  GETIDX	R2	R2	K1
+      0x880C0502,  //  0009  GETMBR	R3	R2	K2
+      0x58100003,  //  000A  LDCONST	R4	K3
+      0x6014000C,  //  000B  GETGBL	R5	G12
+      0x88180100,  //  000C  GETMBR	R6	R0	K0
+      0x7C140200,  //  000D  CALL	R5	1
+      0x14140805,  //  000E  LT	R5	R4	R5
+      0x7816000C,  //  000F  JMPF	R5	#001D
+      0x88140100,  //  0010  GETMBR	R5	R0	K0
+      0x94140A04,  //  0011  GETIDX	R5	R5	R4
+      0x88140B02,  //  0012  GETMBR	R5	R5	K2
+      0x78060001,  //  0013  JMPF	R1	#0016
+      0x14180A03,  //  0014  LT	R6	R5	R3
+      0x70020000,  //  0015  JMP		#0017
+      0x24180A03,  //  0016  GT	R6	R5	R3
+      0x781A0002,  //  0017  JMPF	R6	#001B
+      0x88180100,  //  0018  GETMBR	R6	R0	K0
+      0x94080C04,  //  0019  GETIDX	R2	R6	R4
+      0x5C0C0A00,  //  001A  MOVE	R3	R5
+      0x00100903,  //  001B  ADD	R4	R4	K3
+      0x7001FFED,  //  001C  JMP		#000B
+      0x80040400,  //  001D  RET	1	R2
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: log_new_fabric
+********************************************************************/
+be_local_closure(Matter_Fabric_log_new_fabric,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2BFabric_X20_X20_X20_X20fab_X3D_X27_X25s_X27),
+    /* K5   */  be_nested_str_weak(get_fabric_id),
+    /* K6   */  be_nested_str_weak(copy),
+    /* K7   */  be_nested_str_weak(reverse),
+    /* K8   */  be_nested_str_weak(tohex),
+    /* K9   */  be_const_int(2),
+    }),
+    be_str_weak(log_new_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x8C100303,  //  0003  GETMET	R4	R1	K3
+      0x58180004,  //  0004  LDCONST	R6	K4
+      0x8C1C0105,  //  0005  GETMET	R7	R0	K5
+      0x7C1C0200,  //  0006  CALL	R7	1
+      0x8C1C0F06,  //  0007  GETMET	R7	R7	K6
+      0x7C1C0200,  //  0008  CALL	R7	1
+      0x8C1C0F07,  //  0009  GETMET	R7	R7	K7
+      0x7C1C0200,  //  000A  CALL	R7	1
+      0x8C1C0F08,  //  000B  GETMET	R7	R7	K8
+      0x7C1C0200,  //  000C  CALL	R7	1
+      0x7C100600,  //  000D  CALL	R4	3
+      0x58140009,  //  000E  LDCONST	R5	K9
+      0x7C080600,  //  000F  CALL	R2	3
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_device_id
+********************************************************************/
+be_local_closure(Matter_Fabric_get_device_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(device_id),
+    }),
+    be_str_weak(get_device_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: add_session
+********************************************************************/
+be_local_closure(Matter_Fabric_add_session,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_sessions),
+    /* K1   */  be_nested_str_weak(find),
+    /* K2   */  be_nested_str_weak(_MAX_CASE),
+    /* K3   */  be_nested_str_weak(remove),
+    /* K4   */  be_nested_str_weak(get_oldest_session),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(add_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[27]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100200,  //  0002  MOVE	R4	R1
+      0x7C080400,  //  0003  CALL	R2	2
+      0x4C0C0000,  //  0004  LDNIL	R3
+      0x1C080403,  //  0005  EQ	R2	R2	R3
+      0x780A0012,  //  0006  JMPF	R2	#001A
+      0x6008000C,  //  0007  GETGBL	R2	G12
+      0x880C0100,  //  0008  GETMBR	R3	R0	K0
+      0x7C080200,  //  0009  CALL	R2	1
+      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x28080403,  //  000B  GE	R2	R2	R3
+      0x780A0008,  //  000C  JMPF	R2	#0016
+      0x88080100,  //  000D  GETMBR	R2	R0	K0
+      0x8C080503,  //  000E  GETMET	R2	R2	K3
+      0x88100100,  //  000F  GETMBR	R4	R0	K0
+      0x8C100901,  //  0010  GETMET	R4	R4	K1
+      0x8C180104,  //  0011  GETMET	R6	R0	K4
+      0x7C180200,  //  0012  CALL	R6	1
+      0x7C100400,  //  0013  CALL	R4	2
+      0x7C080400,  //  0014  CALL	R2	2
+      0x7001FFF0,  //  0015  JMP		#0007
+      0x88080100,  //  0016  GETMBR	R2	R0	K0
+      0x8C080505,  //  0017  GETMET	R2	R2	K5
+      0x5C100200,  //  0018  MOVE	R4	R1
+      0x7C080400,  //  0019  CALL	R2	2
+      0x80000000,  //  001A  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_oldest_session
+********************************************************************/
+be_local_closure(Matter_Fabric_get_oldest_session,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_old_recent_session),
+    }),
+    be_str_weak(get_oldest_session),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x500C0200,  //  0001  LDBOOL	R3	1	0
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_label
+********************************************************************/
+be_local_closure(Matter_Fabric_get_fabric_label,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_label),
+    }),
+    be_str_weak(get_fabric_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_index
+********************************************************************/
+be_local_closure(Matter_Fabric_set_fabric_index,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(fabric_index),
+    }),
+    be_str_weak(set_fabric_index),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x80000000,  //  0001  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Fabric_init,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(_store),
+    /* K2   */  be_nested_str_weak(_sessions),
+    /* K3   */  be_nested_str_weak(matter),
+    /* K4   */  be_nested_str_weak(Expirable_list),
+    /* K5   */  be_nested_str_weak(fabric_label),
+    /* K6   */  be_nested_str_weak(),
+    /* K7   */  be_nested_str_weak(created),
+    /* K8   */  be_nested_str_weak(tasmota),
+    /* K9   */  be_nested_str_weak(rtc),
+    /* K10  */  be_nested_str_weak(utc),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[13]) {  /* code */
+      0xA40A0000,  //  0000  IMPORT	R2	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0xB80E0600,  //  0002  GETNGBL	R3	K3
+      0x8C0C0704,  //  0003  GETMET	R3	R3	K4
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x90020403,  //  0005  SETMBR	R0	K2	R3
+      0x90020B06,  //  0006  SETMBR	R0	K5	K6
+      0xB80E1000,  //  0007  GETNGBL	R3	K8
+      0x8C0C0709,  //  0008  GETMET	R3	R3	K9
+      0x7C0C0200,  //  0009  CALL	R3	1
+      0x940C070A,  //  000A  GETIDX	R3	R3	K10
+      0x90020E03,  //  000B  SETMBR	R0	K7	R3
+      0x80000000,  //  000C  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_noc
+********************************************************************/
+be_local_closure(Matter_Fabric_get_noc,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(noc),
+    }),
+    be_str_weak(get_noc),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_group_key
+********************************************************************/
+be_local_closure(Matter_Fabric_get_ipk_group_key,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(ipk_epoch_key),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(HKDF_SHA256),
+    /* K4   */  be_nested_str_weak(fromstring),
+    /* K5   */  be_nested_str_weak(_GROUP_KEY),
+    /* K6   */  be_nested_str_weak(derive),
+    }),
+    be_str_weak(get_ipk_group_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[25]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x74060003,  //  0003  JMPT	R1	#0008
+      0x88040101,  //  0004  GETMBR	R1	R0	K1
+      0x4C080000,  //  0005  LDNIL	R2
+      0x1C040202,  //  0006  EQ	R1	R1	R2
+      0x78060001,  //  0007  JMPF	R1	#000A
+      0x4C040000,  //  0008  LDNIL	R1
+      0x80040200,  //  0009  RET	1	R1
+      0xA4060400,  //  000A  IMPORT	R1	K2
+      0x8C080303,  //  000B  GETMET	R2	R1	K3
+      0x7C080200,  //  000C  CALL	R2	1
+      0x600C0015,  //  000D  GETGBL	R3	G21
+      0x7C0C0000,  //  000E  CALL	R3	0
+      0x8C0C0704,  //  000F  GETMET	R3	R3	K4
+      0x88140105,  //  0010  GETMBR	R5	R0	K5
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x8C100506,  //  0012  GETMET	R4	R2	K6
+      0x88180100,  //  0013  GETMBR	R6	R0	K0
+      0x881C0101,  //  0014  GETMBR	R7	R0	K1
+      0x5C200600,  //  0015  MOVE	R8	R3
+      0x5426000F,  //  0016  LDINT	R9	16
+      0x7C100A00,  //  0017  CALL	R4	5
+      0x80040800,  //  0018  RET	1	R4
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_Fabric
 ********************************************************************/
 extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Fabric,
     15,
     &be_class_Matter_Expirable,
-    be_nested_map(38,
+    be_nested_map(40,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(no_private_key, 27), be_const_var(4) },
-        { be_const_key_weak(get_newest_session, -1), be_const_closure(Matter_Fabric_get_newest_session_closure) },
-        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
-        { be_const_key_weak(_MAX_CASE, -1), be_const_int(5) },
-        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
-        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
         { be_const_key_weak(fabric_compressed, -1), be_const_var(10) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Fabric_init_closure) },
-        { be_const_key_weak(root_ca_certificate, -1), be_const_var(5) },
-        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(_store, -1), be_const_var(0) },
-        { be_const_key_weak(admin_vendor, -1), be_const_var(14) },
-        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
-        { be_const_key_weak(device_id, 7), be_const_var(11) },
+        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
         { be_const_key_weak(tojson, -1), be_const_closure(Matter_Fabric_tojson_closure) },
-        { be_const_key_weak(admin_subject, 10), be_const_var(13) },
-        { be_const_key_weak(get_oldest_session, -1), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
-        { be_const_key_weak(icac, 24), be_const_var(7) },
-        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Fabric_get_ipk_group_key_closure) },
-        { be_const_key_weak(fabric_index, 32), be_const_var(2) },
-        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
-        { be_const_key_weak(_sessions, -1), be_const_var(3) },
-        { be_const_key_weak(get_old_recent_session, -1), be_const_closure(Matter_Fabric_get_old_recent_session_closure) },
-        { be_const_key_weak(created, 17), be_const_var(1) },
-        { be_const_key_weak(noc, -1), be_const_var(6) },
-        { be_const_key_weak(ipk_epoch_key, -1), be_const_var(8) },
-        { be_const_key_weak(get_ipk_epoch_key, 33), be_const_closure(Matter_Fabric_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(set_fabric_index, -1), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
-        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
+        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Fabric_get_fabric_compressed_closure) },
+        { be_const_key_weak(get_ca_pub, 1), be_const_closure(Matter_Fabric_get_ca_pub_closure) },
+        { be_const_key_weak(noc, 9), be_const_var(6) },
+        { be_const_key_weak(get_admin_vendor, 2), be_const_closure(Matter_Fabric_get_admin_vendor_closure) },
         { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Fabric_get_fabric_id_closure) },
-        { be_const_key_weak(get_noc, 31), be_const_closure(Matter_Fabric_get_noc_closure) },
-        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Fabric_get_icac_closure) },
-        { be_const_key_weak(add_session, 35), be_const_closure(Matter_Fabric_add_session_closure) },
-        { be_const_key_weak(fabric_id, -1), be_const_var(9) },
-        { be_const_key_weak(get_ca, 14), be_const_closure(Matter_Fabric_get_ca_closure) },
+        { be_const_key_weak(get_icac, 37), be_const_closure(Matter_Fabric_get_icac_closure) },
         { be_const_key_weak(fromjson, -1), be_const_static_closure(Matter_Fabric_fromjson_closure) },
-        { be_const_key_weak(get_device_id, 8), be_const_closure(Matter_Fabric_get_device_id_closure) },
+        { be_const_key_weak(_store, -1), be_const_var(0) },
+        { be_const_key_weak(admin_subject, 5), be_const_var(13) },
+        { be_const_key_weak(fabric_id, -1), be_const_var(9) },
+        { be_const_key_weak(get_newest_session, -1), be_const_closure(Matter_Fabric_get_newest_session_closure) },
+        { be_const_key_weak(get_fabric_index, -1), be_const_closure(Matter_Fabric_get_fabric_index_closure) },
+        { be_const_key_weak(before_remove, -1), be_const_closure(Matter_Fabric_before_remove_closure) },
+        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Fabric_get_ca_closure) },
         { be_const_key_weak(fabric_label, -1), be_const_var(12) },
+        { be_const_key_weak(get_old_recent_session, -1), be_const_closure(Matter_Fabric_get_old_recent_session_closure) },
+        { be_const_key_weak(_sessions, 20), be_const_var(3) },
+        { be_const_key_weak(created, -1), be_const_var(1) },
+        { be_const_key_weak(icac, -1), be_const_var(7) },
+        { be_const_key_weak(root_ca_certificate, -1), be_const_var(5) },
+        { be_const_key_weak(ipk_epoch_key, 10), be_const_var(8) },
+        { be_const_key_weak(log_new_fabric, 32), be_const_closure(Matter_Fabric_log_new_fabric_closure) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Fabric_get_device_id_closure) },
+        { be_const_key_weak(add_session, -1), be_const_closure(Matter_Fabric_add_session_closure) },
+        { be_const_key_weak(get_oldest_session, -1), be_const_closure(Matter_Fabric_get_oldest_session_closure) },
+        { be_const_key_weak(_MAX_CASE, -1), be_const_int(5) },
+        { be_const_key_weak(no_private_key, -1), be_const_var(4) },
+        { be_const_key_weak(admin_vendor, -1), be_const_var(14) },
+        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Fabric_get_fabric_label_closure) },
+        { be_const_key_weak(device_id, 29), be_const_var(11) },
+        { be_const_key_weak(set_fabric_index, -1), be_const_closure(Matter_Fabric_set_fabric_index_closure) },
+        { be_const_key_weak(init, -1), be_const_closure(Matter_Fabric_init_closure) },
+        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Fabric_get_noc_closure) },
+        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Fabric_get_admin_subject_closure) },
+        { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Fabric_get_ipk_group_key_closure) },
+        { be_const_key_weak(fabric_index, -1), be_const_var(2) },
     })),
     be_str_weak(Matter_Fabric)
 );
@@ -1000,9 +1104,210 @@ void be_load_Matter_Fabric_class(bvm *vm) {
 extern const bclass be_class_Matter_Session;
 
 /********************************************************************
-** Solidified function: get_fabric_label
+** Solidified function: before_remove
 ********************************************************************/
-be_local_closure(Matter_Session_get_fabric_label,   /* name */
+be_local_closure(Matter_Session_before_remove,   /* name */
+  be_nested_proto(
+    8,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(log),
+    /* K3   */  be_nested_str_weak(format),
+    /* K4   */  be_nested_str_weak(MTR_X3A_X20_X2DSession_X20_X20_X20_X28_X256i_X29_X20_X28removed_X29),
+    /* K5   */  be_nested_str_weak(local_session_id),
+    /* K6   */  be_const_int(3),
+    }),
+    be_str_weak(before_remove),
+    &be_const_str_solidified,
+    ( &(const binstruction[10]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0xB80A0200,  //  0001  GETNGBL	R2	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x8C100303,  //  0003  GETMET	R4	R1	K3
+      0x58180004,  //  0004  LDCONST	R6	K4
+      0x881C0105,  //  0005  GETMBR	R7	R0	K5
+      0x7C100600,  //  0006  CALL	R4	3
+      0x58140006,  //  0007  LDCONST	R5	K6
+      0x7C080600,  //  0008  CALL	R2	3
+      0x80000000,  //  0009  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_fabric_device
+********************************************************************/
+be_local_closure(Matter_Session_set_fabric_device,   /* name */
+  be_nested_proto(
+    5,                          /* nstack */
+    4,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_id),
+    /* K2   */  be_nested_str_weak(device_id),
+    /* K3   */  be_nested_str_weak(fabric_compressed),
+    }),
+    be_str_weak(set_fabric_device),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x88100100,  //  0000  GETMBR	R4	R0	K0
+      0x90120201,  //  0001  SETMBR	R4	K1	R1
+      0x88100100,  //  0002  GETMBR	R4	R0	K0
+      0x90120402,  //  0003  SETMBR	R4	K2	R2
+      0x88100100,  //  0004  GETMBR	R4	R0	K0
+      0x90120603,  //  0005  SETMBR	R4	K3	R3
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: init
+********************************************************************/
+be_local_closure(Matter_Session_init,   /* name */
+  be_nested_proto(
+    10,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[24]) {     /* constants */
+    /* K0   */  be_nested_str_weak(crypto),
+    /* K1   */  be_nested_str_weak(_store),
+    /* K2   */  be_nested_str_weak(mode),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(local_session_id),
+    /* K5   */  be_nested_str_weak(initiator_session_id),
+    /* K6   */  be_nested_str_weak(_counter_snd_impl),
+    /* K7   */  be_nested_str_weak(matter),
+    /* K8   */  be_nested_str_weak(Counter),
+    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K10  */  be_nested_str_weak(counter_rcv),
+    /* K11  */  be_nested_str_weak(counter_snd),
+    /* K12  */  be_nested_str_weak(next),
+    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
+    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
+    /* K16  */  be_nested_str_weak(_breadcrumb),
+    /* K17  */  be_nested_str_weak(_exchange_id),
+    /* K18  */  be_nested_str_weak(random),
+    /* K19  */  be_const_int(2),
+    /* K20  */  be_nested_str_weak(get),
+    /* K21  */  be_nested_str_weak(_fabric),
+    /* K22  */  be_nested_str_weak(create_fabric),
+    /* K23  */  be_nested_str_weak(update),
+    }),
+    be_str_weak(init),
+    &be_const_str_solidified,
+    ( &(const binstruction[47]) {  /* code */
+      0xA4160000,  //  0000  IMPORT	R5	K0
+      0x90020201,  //  0001  SETMBR	R0	K1	R1
+      0x90020503,  //  0002  SETMBR	R0	K2	K3
+      0x90020802,  //  0003  SETMBR	R0	K4	R2
+      0x90020A03,  //  0004  SETMBR	R0	K5	R3
+      0xB81A0E00,  //  0005  GETNGBL	R6	K7
+      0x8C180D08,  //  0006  GETMET	R6	R6	K8
+      0x7C180200,  //  0007  CALL	R6	1
+      0x90020C06,  //  0008  SETMBR	R0	K6	R6
+      0xB81A0E00,  //  0009  GETNGBL	R6	K7
+      0x8C180D08,  //  000A  GETMET	R6	R6	K8
+      0x7C180200,  //  000B  CALL	R6	1
+      0x90021206,  //  000C  SETMBR	R0	K9	R6
+      0x90021503,  //  000D  SETMBR	R0	K10	K3
+      0x88180106,  //  000E  GETMBR	R6	R0	K6
+      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
+      0x7C180200,  //  0010  CALL	R6	1
+      0x881C010D,  //  0011  GETMBR	R7	R0	K13
+      0x00180C07,  //  0012  ADD	R6	R6	R7
+      0x90021606,  //  0013  SETMBR	R0	K11	R6
+      0xB81A0E00,  //  0014  GETNGBL	R6	K7
+      0x8C180D08,  //  0015  GETMET	R6	R6	K8
+      0x7C180200,  //  0016  CALL	R6	1
+      0x90021C06,  //  0017  SETMBR	R0	K14	R6
+      0xB81A0E00,  //  0018  GETNGBL	R6	K7
+      0x8C180D08,  //  0019  GETMET	R6	R6	K8
+      0x7C180200,  //  001A  CALL	R6	1
+      0x90021E06,  //  001B  SETMBR	R0	K15	R6
+      0x90022103,  //  001C  SETMBR	R0	K16	K3
+      0x8C180B12,  //  001D  GETMET	R6	R5	K18
+      0x58200013,  //  001E  LDCONST	R8	K19
+      0x7C180400,  //  001F  CALL	R6	2
+      0x8C180D14,  //  0020  GETMET	R6	R6	K20
+      0x58200003,  //  0021  LDCONST	R8	K3
+      0x58240013,  //  0022  LDCONST	R9	K19
+      0x7C180600,  //  0023  CALL	R6	3
+      0x90022206,  //  0024  SETMBR	R0	K17	R6
+      0x78120001,  //  0025  JMPF	R4	#0028
+      0x5C180800,  //  0026  MOVE	R6	R4
+      0x70020002,  //  0027  JMP		#002B
+      0x88180101,  //  0028  GETMBR	R6	R0	K1
+      0x8C180D16,  //  0029  GETMET	R6	R6	K22
+      0x7C180200,  //  002A  CALL	R6	1
+      0x90022A06,  //  002B  SETMBR	R0	K21	R6
+      0x8C180117,  //  002C  GETMET	R6	R0	K23
+      0x7C180200,  //  002D  CALL	R6	1
+      0x80000000,  //  002E  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_CASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_CASE,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(set_mode_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_admin_vendor
+********************************************************************/
+be_local_closure(Matter_Session_get_admin_vendor,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -1014,14 +1319,457 @@ be_local_closure(Matter_Session_get_fabric_label,   /* name */
     1,                          /* has constants */
     ( &(const bvalue[ 2]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_label),
+    /* K1   */  be_nested_str_weak(admin_vendor),
     }),
-    be_str_weak(get_fabric_label),
+    be_str_weak(get_admin_vendor),
     &be_const_str_solidified,
     ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x88040301,  //  0001  GETMBR	R1	R1	K1
       0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_id
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_id),
+    }),
+    be_str_weak(get_fabric_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ac
+********************************************************************/
+be_local_closure(Matter_Session_get_ac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(attestation_challenge),
+    }),
+    be_str_weak(get_ac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca
+********************************************************************/
+be_local_closure(Matter_Session_get_ca,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(get_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_device_id
+********************************************************************/
+be_local_closure(Matter_Session_get_device_id,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(device_id),
+    }),
+    be_str_weak(get_device_id),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_keys
+********************************************************************/
+be_local_closure(Matter_Session_set_keys,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    /* K1   */  be_nested_str_weak(_i2r_privacy),
+    /* K2   */  be_nested_str_weak(r2ikey),
+    /* K3   */  be_nested_str_weak(attestation_challenge),
+    /* K4   */  be_nested_str_weak(created),
+    }),
+    be_str_weak(set_keys),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 7]) {  /* code */
+      0x90020001,  //  0000  SETMBR	R0	K0	R1
+      0x4C140000,  //  0001  LDNIL	R5
+      0x90020205,  //  0002  SETMBR	R0	K1	R5
+      0x90020402,  //  0003  SETMBR	R0	K2	R2
+      0x90020603,  //  0004  SETMBR	R0	K3	R3
+      0x90020804,  //  0005  SETMBR	R0	K4	R4
+      0x80000000,  //  0006  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_i2r_privacy
+********************************************************************/
+be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
+  be_nested_proto(
+    9,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 7]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_i2r_privacy),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(HKDF_SHA256),
+    /* K3   */  be_nested_str_weak(derive),
+    /* K4   */  be_nested_str_weak(get_i2r),
+    /* K5   */  be_nested_str_weak(fromstring),
+    /* K6   */  be_nested_str_weak(PrivacyKey),
+    }),
+    be_str_weak(get_i2r_privacy),
+    &be_const_str_solidified,
+    ( &(const binstruction[22]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x7806000F,  //  0003  JMPF	R1	#0014
+      0xA4060200,  //  0004  IMPORT	R1	K1
+      0x8C080302,  //  0005  GETMET	R2	R1	K2
+      0x7C080200,  //  0006  CALL	R2	1
+      0x8C080503,  //  0007  GETMET	R2	R2	K3
+      0x8C100104,  //  0008  GETMET	R4	R0	K4
+      0x7C100200,  //  0009  CALL	R4	1
+      0x60140015,  //  000A  GETGBL	R5	G21
+      0x7C140000,  //  000B  CALL	R5	0
+      0x60180015,  //  000C  GETGBL	R6	G21
+      0x7C180000,  //  000D  CALL	R6	0
+      0x8C180D05,  //  000E  GETMET	R6	R6	K5
+      0x58200006,  //  000F  LDCONST	R8	K6
+      0x7C180400,  //  0010  CALL	R6	2
+      0x541E000F,  //  0011  LDINT	R7	16
+      0x7C080A00,  //  0012  CALL	R2	5
+      0x90020002,  //  0013  SETMBR	R0	K0	R2
+      0x88040100,  //  0014  GETMBR	R1	R0	K0
+      0x80040200,  //  0015  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ca_pub
+********************************************************************/
+be_local_closure(Matter_Session_get_ca_pub,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(get_ca_pub),
+    }),
+    be_str_weak(get_ca_pub),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_admin_subject_vendor
+********************************************************************/
+be_local_closure(Matter_Session_set_admin_subject_vendor,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(admin_subject),
+    /* K2   */  be_nested_str_weak(admin_vendor),
+    }),
+    be_str_weak(set_admin_subject_vendor),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x900E0201,  //  0001  SETMBR	R3	K1	R1
+      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x900E0402,  //  0003  SETMBR	R3	K2	R2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_pk
+********************************************************************/
+be_local_closure(Matter_Session_get_pk,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(no_private_key),
+    /* K2   */  be_nested_str_weak(crypto),
+    /* K3   */  be_nested_str_weak(random),
+    }),
+    be_str_weak(get_pk),
+    &be_const_str_solidified,
+    ( &(const binstruction[12]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x74060005,  //  0002  JMPT	R1	#0009
+      0xA4060400,  //  0003  IMPORT	R1	K2
+      0x88080100,  //  0004  GETMBR	R2	R0	K0
+      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
+      0x5416001F,  //  0006  LDINT	R5	32
+      0x7C0C0400,  //  0007  CALL	R3	2
+      0x900A0203,  //  0008  SETMBR	R2	K1	R3
+      0x88040100,  //  0009  GETMBR	R1	R0	K0
+      0x88040301,  //  000A  GETMBR	R1	R1	K1
+      0x80040200,  //  000B  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: gen_CSR
+********************************************************************/
+be_local_closure(Matter_Session_gen_CSR,   /* name */
+  be_nested_proto(
+    15,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[12]) {     /* constants */
+    /* K0   */  be_nested_str_weak(get_pk),
+    /* K1   */  be_nested_str_weak(crypto),
+    /* K2   */  be_nested_str_weak(EC_P256),
+    /* K3   */  be_nested_str_weak(public_key),
+    /* K4   */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
+    /* K5   */  be_nested_str_weak(A000),
+    /* K6   */  be_nested_str_weak(300C06082A8648CE3D0403020500),
+    /* K7   */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
+    /* K8   */  be_nested_str_weak(add),
+    /* K9   */  be_const_int(3),
+    /* K10  */  be_const_int(1),
+    /* K11  */  be_const_int(0),
+    }),
+    be_str_weak(gen_CSR),
+    &be_const_str_solidified,
+    ( &(const binstruction[73]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x7C040200,  //  0001  CALL	R1	1
+      0xA40A0200,  //  0002  IMPORT	R2	K1
+      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
+      0x7C0C0200,  //  0004  CALL	R3	1
+      0x8C100703,  //  0005  GETMET	R4	R3	K3
+      0x5C180200,  //  0006  MOVE	R6	R1
+      0x7C100400,  //  0007  CALL	R4	2
+      0x60140015,  //  0008  GETGBL	R5	G21
+      0x58180004,  //  0009  LDCONST	R6	K4
+      0x7C140200,  //  000A  CALL	R5	1
+      0x40180A04,  //  000B  CONNECT	R6	R5	R4
+      0x60180015,  //  000C  GETGBL	R6	G21
+      0x581C0005,  //  000D  LDCONST	R7	K5
+      0x7C180200,  //  000E  CALL	R6	1
+      0x40180A06,  //  000F  CONNECT	R6	R5	R6
+      0x60180015,  //  0010  GETGBL	R6	G21
+      0x581C0006,  //  0011  LDCONST	R7	K6
+      0x7C180200,  //  0012  CALL	R6	1
+      0x8C1C0707,  //  0013  GETMET	R7	R3	K7
+      0x5C240200,  //  0014  MOVE	R9	R1
+      0x5C280A00,  //  0015  MOVE	R10	R5
+      0x7C1C0600,  //  0016  CALL	R7	3
+      0x60200015,  //  0017  GETGBL	R8	G21
+      0x5426007F,  //  0018  LDINT	R9	128
+      0x7C200200,  //  0019  CALL	R8	1
+      0x8C241108,  //  001A  GETMET	R9	R8	K8
+      0x582C0009,  //  001B  LDCONST	R11	K9
+      0x5830000A,  //  001C  LDCONST	R12	K10
+      0x7C240600,  //  001D  CALL	R9	3
+      0x8C241108,  //  001E  GETMET	R9	R8	K8
+      0x602C000C,  //  001F  GETGBL	R11	G12
+      0x5C300E00,  //  0020  MOVE	R12	R7
+      0x7C2C0200,  //  0021  CALL	R11	1
+      0x002C170A,  //  0022  ADD	R11	R11	K10
+      0x5830000A,  //  0023  LDCONST	R12	K10
+      0x7C240600,  //  0024  CALL	R9	3
+      0x8C241108,  //  0025  GETMET	R9	R8	K8
+      0x582C000B,  //  0026  LDCONST	R11	K11
+      0x5830000A,  //  0027  LDCONST	R12	K10
+      0x7C240600,  //  0028  CALL	R9	3
+      0x40241007,  //  0029  CONNECT	R9	R8	R7
+      0x6024000C,  //  002A  GETGBL	R9	G12
+      0x5C280A00,  //  002B  MOVE	R10	R5
+      0x7C240200,  //  002C  CALL	R9	1
+      0x6028000C,  //  002D  GETGBL	R10	G12
+      0x5C2C0C00,  //  002E  MOVE	R11	R6
+      0x7C280200,  //  002F  CALL	R10	1
+      0x0024120A,  //  0030  ADD	R9	R9	R10
+      0x6028000C,  //  0031  GETGBL	R10	G12
+      0x5C2C1000,  //  0032  MOVE	R11	R8
+      0x7C280200,  //  0033  CALL	R10	1
+      0x0024120A,  //  0034  ADD	R9	R9	R10
+      0x60280015,  //  0035  GETGBL	R10	G21
+      0x542E00CF,  //  0036  LDINT	R11	208
+      0x7C280200,  //  0037  CALL	R10	1
+      0x8C2C1508,  //  0038  GETMET	R11	R10	K8
+      0x5436002F,  //  0039  LDINT	R13	48
+      0x5838000A,  //  003A  LDCONST	R14	K10
+      0x7C2C0600,  //  003B  CALL	R11	3
+      0x8C2C1508,  //  003C  GETMET	R11	R10	K8
+      0x54360080,  //  003D  LDINT	R13	129
+      0x5838000A,  //  003E  LDCONST	R14	K10
+      0x7C2C0600,  //  003F  CALL	R11	3
+      0x8C2C1508,  //  0040  GETMET	R11	R10	K8
+      0x543600FE,  //  0041  LDINT	R13	255
+      0x2C34120D,  //  0042  AND	R13	R9	R13
+      0x5838000A,  //  0043  LDCONST	R14	K10
+      0x7C2C0600,  //  0044  CALL	R11	3
+      0x402C1405,  //  0045  CONNECT	R11	R10	R5
+      0x402C1406,  //  0046  CONNECT	R11	R10	R6
+      0x402C1408,  //  0047  CONNECT	R11	R10	R8
+      0x80041400,  //  0048  RET	1	R10
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ca
+********************************************************************/
+be_local_closure(Matter_Session_set_ca,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    }),
+    be_str_weak(set_ca),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x900A0201,  //  0001  SETMBR	R2	K1	R1
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -1173,174 +1921,9 @@ be_local_closure(Matter_Session_tojson,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_noc
+** Solidified function: fabric_candidate
 ********************************************************************/
-be_local_closure(Matter_Session_set_noc,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(noc),
-    /* K2   */  be_nested_str_weak(icac),
-    }),
-    be_str_weak(set_noc),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x900E0201,  //  0001  SETMBR	R3	K1	R1
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
-      0x900E0402,  //  0003  SETMBR	R3	K2	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ipk_epoch_key
-********************************************************************/
-be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(set_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x900A0201,  //  0001  SETMBR	R2	K1	R1
-      0x80000000,  //  0002  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_pk
-********************************************************************/
-be_local_closure(Matter_Session_get_pk,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(no_private_key),
-    /* K2   */  be_nested_str_weak(crypto),
-    /* K3   */  be_nested_str_weak(random),
-    }),
-    be_str_weak(get_pk),
-    &be_const_str_solidified,
-    ( &(const binstruction[12]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x74060005,  //  0002  JMPT	R1	#0009
-      0xA4060400,  //  0003  IMPORT	R1	K2
-      0x88080100,  //  0004  GETMBR	R2	R0	K0
-      0x8C0C0303,  //  0005  GETMET	R3	R1	K3
-      0x5416001F,  //  0006  LDINT	R5	32
-      0x7C0C0400,  //  0007  CALL	R3	2
-      0x900A0203,  //  0008  SETMBR	R2	K1	R3
-      0x88040100,  //  0009  GETMBR	R1	R0	K0
-      0x88040301,  //  000A  GETMBR	R1	R1	K1
-      0x80040200,  //  000B  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_device
-********************************************************************/
-be_local_closure(Matter_Session_set_fabric_device,   /* name */
-  be_nested_proto(
-    5,                          /* nstack */
-    4,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_id),
-    /* K2   */  be_nested_str_weak(device_id),
-    /* K3   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(set_fabric_device),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x88100100,  //  0000  GETMBR	R4	R0	K0
-      0x90120201,  //  0001  SETMBR	R4	K1	R1
-      0x88100100,  //  0002  GETMBR	R4	R0	K0
-      0x90120402,  //  0003  SETMBR	R4	K2	R2
-      0x88100100,  //  0004  GETMBR	R4	R0	K0
-      0x90120603,  //  0005  SETMBR	R4	K3	R3
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_icac
-********************************************************************/
-be_local_closure(Matter_Session_get_icac,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(icac),
-    }),
-    be_str_weak(get_icac),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: persist_to_fabric
-********************************************************************/
-be_local_closure(Matter_Session_persist_to_fabric,   /* name */
+be_local_closure(Matter_Session_fabric_candidate,   /* name */
   be_nested_proto(
     4,                          /* nstack */
     1,                          /* argc */
@@ -1350,18 +1933,24 @@ be_local_closure(Matter_Session_persist_to_fabric,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
+    ( &(const bvalue[ 4]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(add_session),
+    /* K1   */  be_nested_str_weak(set_expire_in_seconds),
+    /* K2   */  be_nested_str_weak(_store),
+    /* K3   */  be_nested_str_weak(add_fabric),
     }),
-    be_str_weak(persist_to_fabric),
+    be_str_weak(fabric_candidate),
     &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
+    ( &(const binstruction[ 9]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x540E0077,  //  0002  LDINT	R3	120
       0x7C040400,  //  0003  CALL	R1	2
-      0x80000000,  //  0004  RET	0
+      0x88040102,  //  0004  GETMBR	R1	R0	K2
+      0x8C040303,  //  0005  GETMET	R1	R1	K3
+      0x880C0100,  //  0006  GETMBR	R3	R0	K0
+      0x7C040400,  //  0007  CALL	R1	2
+      0x80000000,  //  0008  RET	0
     })
   )
 );
@@ -1369,66 +1958,66 @@ be_local_closure(Matter_Session_persist_to_fabric,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_admin_subject_vendor
+** Solidified function: counter_snd_next
 ********************************************************************/
-be_local_closure(Matter_Session_set_admin_subject_vendor,   /* name */
+be_local_closure(Matter_Session_counter_snd_next,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
+    9,                          /* nstack */
+    1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_subject),
-    /* K2   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(set_admin_subject_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 5]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x900E0201,  //  0001  SETMBR	R3	K1	R1
-      0x880C0100,  //  0002  GETMBR	R3	R0	K0
-      0x900E0402,  //  0003  SETMBR	R3	K2	R2
-      0x80000000,  //  0004  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_fabric_label
-********************************************************************/
-be_local_closure(Matter_Session_set_fabric_label,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 3]) {     /* constants */
+    ( &(const bvalue[15]) {     /* constants */
     /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(_fabric),
-    /* K2   */  be_nested_str_weak(fabric_label),
+    /* K1   */  be_nested_str_weak(_counter_snd_impl),
+    /* K2   */  be_nested_str_weak(next),
+    /* K3   */  be_nested_str_weak(tasmota),
+    /* K4   */  be_nested_str_weak(log),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Counter_snd_X3D_X25i),
+    /* K7   */  be_const_int(3),
+    /* K8   */  be_nested_str_weak(matter),
+    /* K9   */  be_nested_str_weak(Counter),
+    /* K10  */  be_nested_str_weak(is_greater),
+    /* K11  */  be_nested_str_weak(counter_snd),
+    /* K12  */  be_nested_str_weak(_COUNTER_SND_INCR),
+    /* K13  */  be_nested_str_weak(does_persist),
+    /* K14  */  be_nested_str_weak(save),
     }),
-    be_str_weak(set_fabric_label),
+    be_str_weak(counter_snd_next),
     &be_const_str_solidified,
-    ( &(const binstruction[ 8]) {  /* code */
-      0x60080004,  //  0000  GETGBL	R2	G4
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x7C080200,  //  0002  CALL	R2	1
-      0x1C080500,  //  0003  EQ	R2	R2	K0
-      0x780A0001,  //  0004  JMPF	R2	#0007
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x900A0401,  //  0006  SETMBR	R2	K2	R1
-      0x80000000,  //  0007  RET	0
+    ( &(const binstruction[28]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x8C080502,  //  0002  GETMET	R2	R2	K2
+      0x7C080200,  //  0003  CALL	R2	1
+      0xB80E0600,  //  0004  GETNGBL	R3	K3
+      0x8C0C0704,  //  0005  GETMET	R3	R3	K4
+      0x8C140305,  //  0006  GETMET	R5	R1	K5
+      0x581C0006,  //  0007  LDCONST	R7	K6
+      0x5C200400,  //  0008  MOVE	R8	R2
+      0x7C140600,  //  0009  CALL	R5	3
+      0x58180007,  //  000A  LDCONST	R6	K7
+      0x7C0C0600,  //  000B  CALL	R3	3
+      0xB80E1000,  //  000C  GETNGBL	R3	K8
+      0x880C0709,  //  000D  GETMBR	R3	R3	K9
+      0x8C0C070A,  //  000E  GETMET	R3	R3	K10
+      0x5C140400,  //  000F  MOVE	R5	R2
+      0x8818010B,  //  0010  GETMBR	R6	R0	K11
+      0x7C0C0600,  //  0011  CALL	R3	3
+      0x780E0007,  //  0012  JMPF	R3	#001B
+      0x880C010C,  //  0013  GETMBR	R3	R0	K12
+      0x000C0403,  //  0014  ADD	R3	R2	R3
+      0x90021603,  //  0015  SETMBR	R0	K11	R3
+      0x8C0C010D,  //  0016  GETMET	R3	R0	K13
+      0x7C0C0200,  //  0017  CALL	R3	1
+      0x780E0001,  //  0018  JMPF	R3	#001B
+      0x8C0C010E,  //  0019  GETMET	R3	R0	K14
+      0x7C0C0200,  //  001A  CALL	R3	1
+      0x80040400,  //  001B  RET	1	R2
     })
   )
 );
@@ -1552,698 +2141,6 @@ be_local_closure(Matter_Session_fromjson,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_fabric
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    }),
-    be_str_weak(get_fabric),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: gen_CSR
-********************************************************************/
-be_local_closure(Matter_Session_gen_CSR,   /* name */
-  be_nested_proto(
-    15,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[12]) {     /* constants */
-    /* K0   */  be_nested_str_weak(get_pk),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(EC_P256),
-    /* K3   */  be_nested_str_weak(public_key),
-    /* K4   */  be_nested_str_weak(3070020100300E310C300A060355040A0C034353523059301306072A8648CE3D020106082A8648CE3D030107034200),
-    /* K5   */  be_nested_str_weak(A000),
-    /* K6   */  be_nested_str_weak(300C06082A8648CE3D0403020500),
-    /* K7   */  be_nested_str_weak(ecdsa_sign_sha256_asn1),
-    /* K8   */  be_nested_str_weak(add),
-    /* K9   */  be_const_int(3),
-    /* K10  */  be_const_int(1),
-    /* K11  */  be_const_int(0),
-    }),
-    be_str_weak(gen_CSR),
-    &be_const_str_solidified,
-    ( &(const binstruction[73]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x7C040200,  //  0001  CALL	R1	1
-      0xA40A0200,  //  0002  IMPORT	R2	K1
-      0x8C0C0502,  //  0003  GETMET	R3	R2	K2
-      0x7C0C0200,  //  0004  CALL	R3	1
-      0x8C100703,  //  0005  GETMET	R4	R3	K3
-      0x5C180200,  //  0006  MOVE	R6	R1
-      0x7C100400,  //  0007  CALL	R4	2
-      0x60140015,  //  0008  GETGBL	R5	G21
-      0x58180004,  //  0009  LDCONST	R6	K4
-      0x7C140200,  //  000A  CALL	R5	1
-      0x40180A04,  //  000B  CONNECT	R6	R5	R4
-      0x60180015,  //  000C  GETGBL	R6	G21
-      0x581C0005,  //  000D  LDCONST	R7	K5
-      0x7C180200,  //  000E  CALL	R6	1
-      0x40180A06,  //  000F  CONNECT	R6	R5	R6
-      0x60180015,  //  0010  GETGBL	R6	G21
-      0x581C0006,  //  0011  LDCONST	R7	K6
-      0x7C180200,  //  0012  CALL	R6	1
-      0x8C1C0707,  //  0013  GETMET	R7	R3	K7
-      0x5C240200,  //  0014  MOVE	R9	R1
-      0x5C280A00,  //  0015  MOVE	R10	R5
-      0x7C1C0600,  //  0016  CALL	R7	3
-      0x60200015,  //  0017  GETGBL	R8	G21
-      0x5426007F,  //  0018  LDINT	R9	128
-      0x7C200200,  //  0019  CALL	R8	1
-      0x8C241108,  //  001A  GETMET	R9	R8	K8
-      0x582C0009,  //  001B  LDCONST	R11	K9
-      0x5830000A,  //  001C  LDCONST	R12	K10
-      0x7C240600,  //  001D  CALL	R9	3
-      0x8C241108,  //  001E  GETMET	R9	R8	K8
-      0x602C000C,  //  001F  GETGBL	R11	G12
-      0x5C300E00,  //  0020  MOVE	R12	R7
-      0x7C2C0200,  //  0021  CALL	R11	1
-      0x002C170A,  //  0022  ADD	R11	R11	K10
-      0x5830000A,  //  0023  LDCONST	R12	K10
-      0x7C240600,  //  0024  CALL	R9	3
-      0x8C241108,  //  0025  GETMET	R9	R8	K8
-      0x582C000B,  //  0026  LDCONST	R11	K11
-      0x5830000A,  //  0027  LDCONST	R12	K10
-      0x7C240600,  //  0028  CALL	R9	3
-      0x40241007,  //  0029  CONNECT	R9	R8	R7
-      0x6024000C,  //  002A  GETGBL	R9	G12
-      0x5C280A00,  //  002B  MOVE	R10	R5
-      0x7C240200,  //  002C  CALL	R9	1
-      0x6028000C,  //  002D  GETGBL	R10	G12
-      0x5C2C0C00,  //  002E  MOVE	R11	R6
-      0x7C280200,  //  002F  CALL	R10	1
-      0x0024120A,  //  0030  ADD	R9	R9	R10
-      0x6028000C,  //  0031  GETGBL	R10	G12
-      0x5C2C1000,  //  0032  MOVE	R11	R8
-      0x7C280200,  //  0033  CALL	R10	1
-      0x0024120A,  //  0034  ADD	R9	R9	R10
-      0x60280015,  //  0035  GETGBL	R10	G21
-      0x542E00CF,  //  0036  LDINT	R11	208
-      0x7C280200,  //  0037  CALL	R10	1
-      0x8C2C1508,  //  0038  GETMET	R11	R10	K8
-      0x5436002F,  //  0039  LDINT	R13	48
-      0x5838000A,  //  003A  LDCONST	R14	K10
-      0x7C2C0600,  //  003B  CALL	R11	3
-      0x8C2C1508,  //  003C  GETMET	R11	R10	K8
-      0x54360080,  //  003D  LDINT	R13	129
-      0x5838000A,  //  003E  LDCONST	R14	K10
-      0x7C2C0600,  //  003F  CALL	R11	3
-      0x8C2C1508,  //  0040  GETMET	R11	R10	K8
-      0x543600FE,  //  0041  LDINT	R13	255
-      0x2C34120D,  //  0042  AND	R13	R9	R13
-      0x5838000A,  //  0043  LDCONST	R14	K10
-      0x7C2C0600,  //  0044  CALL	R11	3
-      0x402C1405,  //  0045  CONNECT	R11	R10	R5
-      0x402C1406,  //  0046  CONNECT	R11	R10	R6
-      0x402C1408,  //  0047  CONNECT	R11	R10	R8
-      0x80041400,  //  0048  RET	1	R10
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_i2r_privacy
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r_privacy,   /* name */
-  be_nested_proto(
-    9,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_i2r_privacy),
-    /* K1   */  be_nested_str_weak(crypto),
-    /* K2   */  be_nested_str_weak(HKDF_SHA256),
-    /* K3   */  be_nested_str_weak(derive),
-    /* K4   */  be_nested_str_weak(get_i2r),
-    /* K5   */  be_nested_str_weak(fromstring),
-    /* K6   */  be_nested_str_weak(PrivacyKey),
-    }),
-    be_str_weak(get_i2r_privacy),
-    &be_const_str_solidified,
-    ( &(const binstruction[22]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x7806000F,  //  0003  JMPF	R1	#0014
-      0xA4060200,  //  0004  IMPORT	R1	K1
-      0x8C080302,  //  0005  GETMET	R2	R1	K2
-      0x7C080200,  //  0006  CALL	R2	1
-      0x8C080503,  //  0007  GETMET	R2	R2	K3
-      0x8C100104,  //  0008  GETMET	R4	R0	K4
-      0x7C100200,  //  0009  CALL	R4	1
-      0x60140015,  //  000A  GETGBL	R5	G21
-      0x7C140000,  //  000B  CALL	R5	0
-      0x60180015,  //  000C  GETGBL	R6	G21
-      0x7C180000,  //  000D  CALL	R6	0
-      0x8C180D05,  //  000E  GETMET	R6	R6	K5
-      0x58200006,  //  000F  LDCONST	R8	K6
-      0x7C180400,  //  0010  CALL	R6	2
-      0x541E000F,  //  0011  LDINT	R7	16
-      0x7C080A00,  //  0012  CALL	R2	5
-      0x90020002,  //  0013  SETMBR	R0	K0	R2
-      0x88040100,  //  0014  GETMBR	R1	R0	K0
-      0x80040200,  //  0015  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: counter_rcv_validate
-********************************************************************/
-be_local_closure(Matter_Session_counter_rcv_validate,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K1   */  be_nested_str_weak(validate),
-    /* K2   */  be_nested_str_weak(counter_rcv),
-    /* K3   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(counter_rcv_validate),
-    &be_const_str_solidified,
-    ( &(const binstruction[11]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
-      0x5C140200,  //  0002  MOVE	R5	R1
-      0x5C180400,  //  0003  MOVE	R6	R2
-      0x7C0C0600,  //  0004  CALL	R3	3
-      0x780E0003,  //  0005  JMPF	R3	#000A
-      0x88100100,  //  0006  GETMBR	R4	R0	K0
-      0x8C100903,  //  0007  GETMET	R4	R4	K3
-      0x7C100200,  //  0008  CALL	R4	1
-      0x90020404,  //  0009  SETMBR	R0	K2	R4
-      0x80040600,  //  000A  RET	1	R3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_device_id
-********************************************************************/
-be_local_closure(Matter_Session_get_device_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(device_id),
-    }),
-    be_str_weak(get_device_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: counter_snd_next
-********************************************************************/
-be_local_closure(Matter_Session_counter_snd_next,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 9]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(next),
-    /* K2   */  be_nested_str_weak(matter),
-    /* K3   */  be_nested_str_weak(Counter),
-    /* K4   */  be_nested_str_weak(is_greater),
-    /* K5   */  be_nested_str_weak(counter_snd),
-    /* K6   */  be_nested_str_weak(does_persist),
-    /* K7   */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K8   */  be_nested_str_weak(save),
-    }),
-    be_str_weak(counter_snd_next),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0xB80A0400,  //  0003  GETNGBL	R2	K2
-      0x88080503,  //  0004  GETMBR	R2	R2	K3
-      0x8C080504,  //  0005  GETMET	R2	R2	K4
-      0x5C100200,  //  0006  MOVE	R4	R1
-      0x88140105,  //  0007  GETMBR	R5	R0	K5
-      0x7C080600,  //  0008  CALL	R2	3
-      0x780A0009,  //  0009  JMPF	R2	#0014
-      0x8C080106,  //  000A  GETMET	R2	R0	K6
-      0x7C080200,  //  000B  CALL	R2	1
-      0x780A0005,  //  000C  JMPF	R2	#0013
-      0x88080107,  //  000D  GETMBR	R2	R0	K7
-      0x00080202,  //  000E  ADD	R2	R1	R2
-      0x90020A02,  //  000F  SETMBR	R0	K5	R2
-      0x8C080108,  //  0010  GETMET	R2	R0	K8
-      0x7C080200,  //  0011  CALL	R2	1
-      0x70020000,  //  0012  JMP		#0014
-      0x90020A01,  //  0013  SETMBR	R0	K5	R1
-      0x80040200,  //  0014  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_CASE
-********************************************************************/
-be_local_closure(Matter_Session_is_CASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
-    be_str_weak(is_CASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_Session_init,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[24]) {     /* constants */
-    /* K0   */  be_nested_str_weak(crypto),
-    /* K1   */  be_nested_str_weak(_store),
-    /* K2   */  be_nested_str_weak(mode),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(local_session_id),
-    /* K5   */  be_nested_str_weak(initiator_session_id),
-    /* K6   */  be_nested_str_weak(_counter_snd_impl),
-    /* K7   */  be_nested_str_weak(matter),
-    /* K8   */  be_nested_str_weak(Counter),
-    /* K9   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K10  */  be_nested_str_weak(counter_rcv),
-    /* K11  */  be_nested_str_weak(counter_snd),
-    /* K12  */  be_nested_str_weak(next),
-    /* K13  */  be_nested_str_weak(_COUNTER_SND_INCR),
-    /* K14  */  be_nested_str_weak(_counter_insecure_rcv),
-    /* K15  */  be_nested_str_weak(_counter_insecure_snd),
-    /* K16  */  be_nested_str_weak(_breadcrumb),
-    /* K17  */  be_nested_str_weak(_exchange_id),
-    /* K18  */  be_nested_str_weak(random),
-    /* K19  */  be_const_int(2),
-    /* K20  */  be_nested_str_weak(get),
-    /* K21  */  be_nested_str_weak(_fabric),
-    /* K22  */  be_nested_str_weak(create_fabric),
-    /* K23  */  be_nested_str_weak(update),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[47]) {  /* code */
-      0xA4160000,  //  0000  IMPORT	R5	K0
-      0x90020201,  //  0001  SETMBR	R0	K1	R1
-      0x90020503,  //  0002  SETMBR	R0	K2	K3
-      0x90020802,  //  0003  SETMBR	R0	K4	R2
-      0x90020A03,  //  0004  SETMBR	R0	K5	R3
-      0xB81A0E00,  //  0005  GETNGBL	R6	K7
-      0x8C180D08,  //  0006  GETMET	R6	R6	K8
-      0x7C180200,  //  0007  CALL	R6	1
-      0x90020C06,  //  0008  SETMBR	R0	K6	R6
-      0xB81A0E00,  //  0009  GETNGBL	R6	K7
-      0x8C180D08,  //  000A  GETMET	R6	R6	K8
-      0x7C180200,  //  000B  CALL	R6	1
-      0x90021206,  //  000C  SETMBR	R0	K9	R6
-      0x90021503,  //  000D  SETMBR	R0	K10	K3
-      0x88180106,  //  000E  GETMBR	R6	R0	K6
-      0x8C180D0C,  //  000F  GETMET	R6	R6	K12
-      0x7C180200,  //  0010  CALL	R6	1
-      0x881C010D,  //  0011  GETMBR	R7	R0	K13
-      0x00180C07,  //  0012  ADD	R6	R6	R7
-      0x90021606,  //  0013  SETMBR	R0	K11	R6
-      0xB81A0E00,  //  0014  GETNGBL	R6	K7
-      0x8C180D08,  //  0015  GETMET	R6	R6	K8
-      0x7C180200,  //  0016  CALL	R6	1
-      0x90021C06,  //  0017  SETMBR	R0	K14	R6
-      0xB81A0E00,  //  0018  GETNGBL	R6	K7
-      0x8C180D08,  //  0019  GETMET	R6	R6	K8
-      0x7C180200,  //  001A  CALL	R6	1
-      0x90021E06,  //  001B  SETMBR	R0	K15	R6
-      0x90022103,  //  001C  SETMBR	R0	K16	K3
-      0x8C180B12,  //  001D  GETMET	R6	R5	K18
-      0x58200013,  //  001E  LDCONST	R8	K19
-      0x7C180400,  //  001F  CALL	R6	2
-      0x8C180D14,  //  0020  GETMET	R6	R6	K20
-      0x58200003,  //  0021  LDCONST	R8	K3
-      0x58240013,  //  0022  LDCONST	R9	K19
-      0x7C180600,  //  0023  CALL	R6	3
-      0x90022206,  //  0024  SETMBR	R0	K17	R6
-      0x78120001,  //  0025  JMPF	R4	#0028
-      0x5C180800,  //  0026  MOVE	R6	R4
-      0x70020002,  //  0027  JMP		#002B
-      0x88180101,  //  0028  GETMBR	R6	R0	K1
-      0x8C180D16,  //  0029  GETMET	R6	R6	K22
-      0x7C180200,  //  002A  CALL	R6	1
-      0x90022A06,  //  002B  SETMBR	R0	K21	R6
-      0x8C180117,  //  002C  GETMET	R6	R0	K23
-      0x7C180200,  //  002D  CALL	R6	1
-      0x80000000,  //  002E  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: update
-********************************************************************/
-be_local_closure(Matter_Session_update,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
-    /* K0   */  be_nested_str_weak(last_used),
-    /* K1   */  be_nested_str_weak(tasmota),
-    /* K2   */  be_nested_str_weak(rtc),
-    /* K3   */  be_nested_str_weak(utc),
-    }),
-    be_str_weak(update),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0xB8060200,  //  0000  GETNGBL	R1	K1
-      0x8C040302,  //  0001  GETMET	R1	R1	K2
-      0x7C040200,  //  0002  CALL	R1	1
-      0x94040303,  //  0003  GETIDX	R1	R1	K3
-      0x90020001,  //  0004  SETMBR	R0	K0	R1
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: is_PASE
-********************************************************************/
-be_local_closure(Matter_Session_is_PASE,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(is_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88080101,  //  0001  GETMBR	R2	R0	K1
-      0x1C040202,  //  0002  EQ	R1	R1	R2
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_id
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_id,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_id),
-    }),
-    be_str_weak(get_fabric_id),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca
-********************************************************************/
-be_local_closure(Matter_Session_get_ca,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
-    }),
-    be_str_weak(get_ca),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: hydrate_post
-********************************************************************/
-be_local_closure(Matter_Session_hydrate_post,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_counter_snd_impl),
-    /* K1   */  be_nested_str_weak(reset),
-    /* K2   */  be_nested_str_weak(counter_snd),
-    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
-    /* K4   */  be_nested_str_weak(counter_rcv),
-    /* K5   */  be_nested_str_weak(val),
-    }),
-    be_str_weak(hydrate_post),
-    &be_const_str_solidified,
-    ( &(const binstruction[17]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x880C0102,  //  0002  GETMBR	R3	R0	K2
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040103,  //  0004  GETMBR	R1	R0	K3
-      0x8C040301,  //  0005  GETMET	R1	R1	K1
-      0x880C0104,  //  0006  GETMBR	R3	R0	K4
-      0x7C040400,  //  0007  CALL	R1	2
-      0x88040100,  //  0008  GETMBR	R1	R0	K0
-      0x8C040305,  //  0009  GETMET	R1	R1	K5
-      0x7C040200,  //  000A  CALL	R1	1
-      0x90020401,  //  000B  SETMBR	R0	K2	R1
-      0x88040103,  //  000C  GETMBR	R1	R0	K3
-      0x8C040305,  //  000D  GETMET	R1	R1	K5
-      0x7C040200,  //  000E  CALL	R1	1
-      0x90020801,  //  000F  SETMBR	R0	K4	R1
-      0x80000000,  //  0010  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: save
-********************************************************************/
-be_local_closure(Matter_Session_save,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_store),
-    /* K1   */  be_nested_str_weak(save_fabrics),
-    }),
-    be_str_weak(save),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ca_pub
-********************************************************************/
-be_local_closure(Matter_Session_get_ca_pub,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(get_ca_pub),
-    }),
-    be_str_weak(get_ca_pub),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x7C040200,  //  0002  CALL	R1	1
-      0x80040200,  //  0003  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_mode
-********************************************************************/
-be_local_closure(Matter_Session_get_mode,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(mode),
-    }),
-    be_str_weak(get_mode),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified function: fabric_completed
 ********************************************************************/
 be_local_closure(Matter_Session_fabric_completed,   /* name */
@@ -2300,9 +2197,119 @@ be_local_closure(Matter_Session_fabric_completed,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_r2i
+** Solidified function: hydrate_post
 ********************************************************************/
-be_local_closure(Matter_Session_get_r2i,   /* name */
+be_local_closure(Matter_Session_hydrate_post,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_snd_impl),
+    /* K1   */  be_nested_str_weak(reset),
+    /* K2   */  be_nested_str_weak(counter_snd),
+    /* K3   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K4   */  be_nested_str_weak(counter_rcv),
+    /* K5   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(hydrate_post),
+    &be_const_str_solidified,
+    ( &(const binstruction[17]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x880C0102,  //  0002  GETMBR	R3	R0	K2
+      0x7C040400,  //  0003  CALL	R1	2
+      0x88040103,  //  0004  GETMBR	R1	R0	K3
+      0x8C040301,  //  0005  GETMET	R1	R1	K1
+      0x880C0104,  //  0006  GETMBR	R3	R0	K4
+      0x7C040400,  //  0007  CALL	R1	2
+      0x88040100,  //  0008  GETMBR	R1	R0	K0
+      0x8C040305,  //  0009  GETMET	R1	R1	K5
+      0x7C040200,  //  000A  CALL	R1	1
+      0x90020401,  //  000B  SETMBR	R0	K2	R1
+      0x88040103,  //  000C  GETMBR	R1	R0	K3
+      0x8C040305,  //  000D  GETMET	R1	R1	K5
+      0x7C040200,  //  000E  CALL	R1	1
+      0x90020801,  //  000F  SETMBR	R0	K4	R1
+      0x80000000,  //  0010  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_set_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(set_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x900A0201,  //  0001  SETMBR	R2	K1	R1
+      0x80000000,  //  0002  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: update
+********************************************************************/
+be_local_closure(Matter_Session_update,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(last_used),
+    /* K1   */  be_nested_str_weak(tasmota),
+    /* K2   */  be_nested_str_weak(rtc),
+    /* K3   */  be_nested_str_weak(utc),
+    }),
+    be_str_weak(update),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0xB8060200,  //  0000  GETNGBL	R1	K1
+      0x8C040302,  //  0001  GETMET	R1	R1	K2
+      0x7C040200,  //  0002  CALL	R1	1
+      0x94040303,  //  0003  GETIDX	R1	R1	K3
+      0x90020001,  //  0004  SETMBR	R0	K0	R1
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_compressed
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -2312,14 +2319,104 @@ be_local_closure(Matter_Session_get_r2i,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(r2ikey),
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_compressed),
     }),
-    be_str_weak(get_r2i),
+    be_str_weak(get_fabric_compressed),
     &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
+    ( &(const binstruction[ 3]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_ipk_epoch_key
+********************************************************************/
+be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(ipk_epoch_key),
+    }),
+    be_str_weak(get_ipk_epoch_key),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_PASE
+********************************************************************/
+be_local_closure(Matter_Session_is_PASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_PASE),
+    }),
+    be_str_weak(is_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_icac
+********************************************************************/
+be_local_closure(Matter_Session_get_icac,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(icac),
+    }),
+    be_str_weak(get_icac),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
     })
   )
 );
@@ -2433,76 +2530,11 @@ be_local_closure(Matter_Session_close,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_ipk_epoch_key
+** Solidified function: set_fabric_label
 ********************************************************************/
-be_local_closure(Matter_Session_get_ipk_epoch_key,   /* name */
+be_local_closure(Matter_Session_set_fabric_label,   /* name */
   be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(ipk_epoch_key),
-    }),
-    be_str_weak(get_ipk_epoch_key),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_keys
-********************************************************************/
-be_local_closure(Matter_Session_set_keys,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    5,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    /* K1   */  be_nested_str_weak(_i2r_privacy),
-    /* K2   */  be_nested_str_weak(r2ikey),
-    /* K3   */  be_nested_str_weak(attestation_challenge),
-    /* K4   */  be_nested_str_weak(created),
-    }),
-    be_str_weak(set_keys),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 7]) {  /* code */
-      0x90020001,  //  0000  SETMBR	R0	K0	R1
-      0x4C140000,  //  0001  LDNIL	R5
-      0x90020205,  //  0002  SETMBR	R0	K1	R5
-      0x90020402,  //  0003  SETMBR	R0	K2	R2
-      0x90020603,  //  0004  SETMBR	R0	K3	R3
-      0x90020804,  //  0005  SETMBR	R0	K4	R4
-      0x80000000,  //  0006  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_ca
-********************************************************************/
-be_local_closure(Matter_Session_set_ca,   /* name */
-  be_nested_proto(
-    3,                          /* nstack */
+    4,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2510,16 +2542,22 @@ be_local_closure(Matter_Session_set_ca,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(root_ca_certificate),
+    ( &(const bvalue[ 3]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(_fabric),
+    /* K2   */  be_nested_str_weak(fabric_label),
     }),
-    be_str_weak(set_ca),
+    be_str_weak(set_fabric_label),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x900A0201,  //  0001  SETMBR	R2	K1	R1
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[ 8]) {  /* code */
+      0x60080004,  //  0000  GETGBL	R2	G4
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x7C080200,  //  0002  CALL	R2	1
+      0x1C080500,  //  0003  EQ	R2	R2	K0
+      0x780A0001,  //  0004  JMPF	R2	#0007
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x900A0401,  //  0006  SETMBR	R2	K2	R1
+      0x80000000,  //  0007  RET	0
     })
   )
 );
@@ -2527,68 +2565,9 @@ be_local_closure(Matter_Session_set_ca,   /* name */
 
 
 /********************************************************************
-** Solidified function: set_mode_PASE
+** Solidified function: get_mode
 ********************************************************************/
-be_local_closure(Matter_Session_set_mode_PASE,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_PASE),
-    }),
-    be_str_weak(set_mode_PASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_fabric_compressed
-********************************************************************/
-be_local_closure(Matter_Session_get_fabric_compressed,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(fabric_compressed),
-    }),
-    be_str_weak(get_fabric_compressed),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_ac
-********************************************************************/
-be_local_closure(Matter_Session_get_ac,   /* name */
+be_local_closure(Matter_Session_get_mode,   /* name */
   be_nested_proto(
     2,                          /* nstack */
     1,                          /* argc */
@@ -2599,9 +2578,9 @@ be_local_closure(Matter_Session_get_ac,   /* name */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(attestation_challenge),
+    /* K0   */  be_nested_str_weak(mode),
     }),
-    be_str_weak(get_ac),
+    be_str_weak(get_mode),
     &be_const_str_solidified,
     ( &(const binstruction[ 2]) {  /* code */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
@@ -2640,6 +2619,150 @@ be_local_closure(Matter_Session_set_mode,   /* name */
 
 
 /********************************************************************
+** Solidified function: get_i2r
+********************************************************************/
+be_local_closure(Matter_Session_get_i2r,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(i2rkey),
+    }),
+    be_str_weak(get_i2r),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    }),
+    be_str_weak(get_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: persist_to_fabric
+********************************************************************/
+be_local_closure(Matter_Session_persist_to_fabric,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(add_session),
+    }),
+    be_str_weak(persist_to_fabric),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 5]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x5C0C0000,  //  0002  MOVE	R3	R0
+      0x7C040400,  //  0003  CALL	R1	2
+      0x80000000,  //  0004  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_fabric_label
+********************************************************************/
+be_local_closure(Matter_Session_get_fabric_label,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_fabric),
+    /* K1   */  be_nested_str_weak(fabric_label),
+    }),
+    be_str_weak(get_fabric_label),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 3]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88040301,  //  0001  GETMBR	R1	R1	K1
+      0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: is_CASE
+********************************************************************/
+be_local_closure(Matter_Session_is_CASE,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(mode),
+    /* K1   */  be_nested_str_weak(_CASE),
+    }),
+    be_str_weak(is_CASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x88080101,  //  0001  GETMBR	R2	R0	K1
+      0x1C040202,  //  0002  EQ	R1	R1	R2
+      0x80040200,  //  0003  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: get_admin_subject
 ********************************************************************/
 be_local_closure(Matter_Session_get_admin_subject,   /* name */
@@ -2662,6 +2785,132 @@ be_local_closure(Matter_Session_get_admin_subject,   /* name */
       0x88040100,  //  0000  GETMBR	R1	R0	K0
       0x88040301,  //  0001  GETMBR	R1	R1	K1
       0x80040200,  //  0002  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: counter_rcv_validate
+********************************************************************/
+be_local_closure(Matter_Session_counter_rcv_validate,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    3,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 4]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_counter_rcv_impl),
+    /* K1   */  be_nested_str_weak(validate),
+    /* K2   */  be_nested_str_weak(counter_rcv),
+    /* K3   */  be_nested_str_weak(val),
+    }),
+    be_str_weak(counter_rcv_validate),
+    &be_const_str_solidified,
+    ( &(const binstruction[11]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x8C0C0701,  //  0001  GETMET	R3	R3	K1
+      0x5C140200,  //  0002  MOVE	R5	R1
+      0x5C180400,  //  0003  MOVE	R6	R2
+      0x7C0C0600,  //  0004  CALL	R3	3
+      0x780E0003,  //  0005  JMPF	R3	#000A
+      0x88100100,  //  0006  GETMBR	R4	R0	K0
+      0x8C100903,  //  0007  GETMET	R4	R4	K3
+      0x7C100200,  //  0008  CALL	R4	1
+      0x90020404,  //  0009  SETMBR	R0	K2	R4
+      0x80040600,  //  000A  RET	1	R3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: get_r2i
+********************************************************************/
+be_local_closure(Matter_Session_get_r2i,   /* name */
+  be_nested_proto(
+    2,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(r2ikey),
+    }),
+    be_str_weak(get_r2i),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 2]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x80040200,  //  0001  RET	1	R1
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: save
+********************************************************************/
+be_local_closure(Matter_Session_save,   /* name */
+  be_nested_proto(
+    3,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_store),
+    /* K1   */  be_nested_str_weak(save_fabrics),
+    }),
+    be_str_weak(save),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x8C040301,  //  0001  GETMET	R1	R1	K1
+      0x7C040200,  //  0002  CALL	R1	1
+      0x80000000,  //  0003  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: set_mode_PASE
+********************************************************************/
+be_local_closure(Matter_Session_set_mode_PASE,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 2]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_mode),
+    /* K1   */  be_nested_str_weak(_PASE),
+    }),
+    be_str_weak(set_mode_PASE),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 4]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x880C0101,  //  0001  GETMBR	R3	R0	K1
+      0x7C040400,  //  0002  CALL	R1	2
+      0x80000000,  //  0003  RET	0
     })
   )
 );
@@ -2698,66 +2947,31 @@ be_local_closure(Matter_Session_get_noc,   /* name */
 
 
 /********************************************************************
-** Solidified function: fabric_candidate
+** Solidified function: set_noc
 ********************************************************************/
-be_local_closure(Matter_Session_fabric_candidate,   /* name */
+be_local_closure(Matter_Session_set_noc,   /* name */
   be_nested_proto(
     4,                          /* nstack */
-    1,                          /* argc */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 4]) {     /* constants */
+    ( &(const bvalue[ 3]) {     /* constants */
     /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(set_expire_in_seconds),
-    /* K2   */  be_nested_str_weak(_store),
-    /* K3   */  be_nested_str_weak(add_fabric),
+    /* K1   */  be_nested_str_weak(noc),
+    /* K2   */  be_nested_str_weak(icac),
     }),
-    be_str_weak(fabric_candidate),
+    be_str_weak(set_noc),
     &be_const_str_solidified,
-    ( &(const binstruction[ 9]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x8C040301,  //  0001  GETMET	R1	R1	K1
-      0x540E0077,  //  0002  LDINT	R3	120
-      0x7C040400,  //  0003  CALL	R1	2
-      0x88040102,  //  0004  GETMBR	R1	R0	K2
-      0x8C040303,  //  0005  GETMET	R1	R1	K3
-      0x880C0100,  //  0006  GETMBR	R3	R0	K0
-      0x7C040400,  //  0007  CALL	R1	2
-      0x80000000,  //  0008  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_mode_CASE
-********************************************************************/
-be_local_closure(Matter_Session_set_mode_CASE,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_mode),
-    /* K1   */  be_nested_str_weak(_CASE),
-    }),
-    be_str_weak(set_mode_CASE),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 4]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x880C0101,  //  0001  GETMBR	R3	R0	K1
-      0x7C040400,  //  0002  CALL	R1	2
-      0x80000000,  //  0003  RET	0
+    ( &(const binstruction[ 5]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x900E0201,  //  0001  SETMBR	R3	K1	R1
+      0x880C0100,  //  0002  GETMBR	R3	R0	K0
+      0x900E0402,  //  0003  SETMBR	R3	K2	R2
+      0x80000000,  //  0004  RET	0
     })
   )
 );
@@ -2825,149 +3039,94 @@ be_local_closure(Matter_Session_get_ipk_group_key,   /* name */
 
 
 /********************************************************************
-** Solidified function: get_i2r
-********************************************************************/
-be_local_closure(Matter_Session_get_i2r,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(i2rkey),
-    }),
-    be_str_weak(get_i2r),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 2]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x80040200,  //  0001  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: get_admin_vendor
-********************************************************************/
-be_local_closure(Matter_Session_get_admin_vendor,   /* name */
-  be_nested_proto(
-    2,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 2]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_fabric),
-    /* K1   */  be_nested_str_weak(admin_vendor),
-    }),
-    be_str_weak(get_admin_vendor),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x88040301,  //  0001  GETMBR	R1	R1	K1
-      0x80040200,  //  0002  RET	1	R1
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
 ** Solidified class: Matter_Session
 ********************************************************************/
 extern const bclass be_class_Matter_Expirable;
 be_local_class(Matter_Session,
     31,
     &be_class_Matter_Expirable,
-    be_nested_map(79,
+    be_nested_map(80,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Session_get_fabric_label_closure) },
-        { be_const_key_weak(_counter_insecure_rcv, -1), be_const_var(18) },
-        { be_const_key_weak(set_noc, 1), be_const_closure(Matter_Session_set_noc_closure) },
-        { be_const_key_weak(_exchange_id, -1), be_const_var(14) },
-        { be_const_key_weak(set_fabric_label, -1), be_const_closure(Matter_Session_set_fabric_label_closure) },
-        { be_const_key_weak(_i2r_privacy, -1), be_const_var(22) },
-        { be_const_key_weak(get_fabric, -1), be_const_closure(Matter_Session_get_fabric_closure) },
-        { be_const_key_weak(mode, -1), be_const_var(1) },
-        { be_const_key_weak(counter_rcv, 3), be_const_var(10) },
-        { be_const_key_weak(get_device_id, -1), be_const_closure(Matter_Session_get_device_id_closure) },
-        { be_const_key_weak(get_icac, 35), be_const_closure(Matter_Session_get_icac_closure) },
-        { be_const_key_weak(is_CASE, -1), be_const_closure(Matter_Session_is_CASE_closure) },
-        { be_const_key_weak(init, -1), be_const_closure(Matter_Session_init_closure) },
-        { be_const_key_weak(_store, -1), be_const_var(0) },
-        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Session_get_admin_subject_closure) },
-        { be_const_key_weak(set_admin_subject_vendor, -1), be_const_closure(Matter_Session_set_admin_subject_vendor_closure) },
-        { be_const_key_weak(tojson, 8), be_const_closure(Matter_Session_tojson_closure) },
-        { be_const_key_weak(set_mode, 37), be_const_closure(Matter_Session_set_mode_closure) },
-        { be_const_key_weak(get_ac, -1), be_const_closure(Matter_Session_get_ac_closure) },
-        { be_const_key_weak(_breadcrumb, 23), be_const_var(25) },
-        { be_const_key_weak(get_pk, 6), be_const_closure(Matter_Session_get_pk_closure) },
-        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
-        { be_const_key_weak(__Msg2, -1), be_const_var(29) },
-        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
-        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
-        { be_const_key_weak(get_i2r_privacy, 62), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
-        { be_const_key_weak(counter_rcv_validate, 34), be_const_closure(Matter_Session_counter_rcv_validate_closure) },
-        { be_const_key_weak(last_used, -1), be_const_var(6) },
-        { be_const_key_weak(_source_node_id, 45), be_const_var(7) },
-        { be_const_key_weak(set_ipk_epoch_key, 9), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
-        { be_const_key_weak(counter_snd_next, -1), be_const_closure(Matter_Session_counter_snd_next_closure) },
-        { be_const_key_weak(set_mode_PASE, -1), be_const_closure(Matter_Session_set_mode_PASE_closure) },
-        { be_const_key_weak(_counter_snd_impl, 11), be_const_var(13) },
-        { be_const_key_weak(__future_initiator_session_id, 24), be_const_var(8) },
-        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
-        { be_const_key_weak(_fabric, 12), be_const_var(2) },
-        { be_const_key_weak(_port, 54), be_const_var(16) },
-        { be_const_key_weak(set_keys, -1), be_const_closure(Matter_Session_set_keys_closure) },
-        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Session_get_fabric_id_closure) },
-        { be_const_key_weak(_counter_insecure_snd, 68), be_const_var(19) },
-        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(30) },
-        { be_const_key_weak(counter_snd, 63), be_const_var(11) },
-        { be_const_key_weak(is_PASE, 33), be_const_closure(Matter_Session_is_PASE_closure) },
-        { be_const_key_weak(attestation_challenge, -1), be_const_var(23) },
-        { be_const_key_weak(get_ipk_epoch_key, 4), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
-        { be_const_key_weak(close, 53), be_const_closure(Matter_Session_close_closure) },
-        { be_const_key_weak(created, -1), be_const_var(5) },
-        { be_const_key_weak(get_ca_pub, -1), be_const_closure(Matter_Session_get_ca_pub_closure) },
-        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
-        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
-        { be_const_key_weak(resumption_id, -1), be_const_var(26) },
-        { be_const_key_weak(fromjson, 55), be_const_static_closure(Matter_Session_fromjson_closure) },
-        { be_const_key_weak(_CASE, 57), be_const_int(2) },
-        { be_const_key_weak(__Msg1, -1), be_const_var(28) },
-        { be_const_key_weak(i2rkey, -1), be_const_var(20) },
-        { be_const_key_weak(_COUNTER_SND_INCR, -1), be_const_int(1024) },
-        { be_const_key_weak(persist_to_fabric, 48), be_const_closure(Matter_Session_persist_to_fabric_closure) },
-        { be_const_key_weak(fabric_completed, -1), be_const_closure(Matter_Session_fabric_completed_closure) },
-        { be_const_key_weak(set_fabric_device, 44), be_const_closure(Matter_Session_set_fabric_device_closure) },
-        { be_const_key_weak(_PASE, 43), be_const_int(1) },
-        { be_const_key_weak(local_session_id, 17), be_const_var(3) },
-        { be_const_key_weak(r2ikey, 14), be_const_var(21) },
-        { be_const_key_weak(save, -1), be_const_closure(Matter_Session_save_closure) },
-        { be_const_key_weak(shared_secret, 66), be_const_var(27) },
-        { be_const_key_weak(peer_node_id, 31), be_const_var(24) },
         { be_const_key_weak(initiator_session_id, -1), be_const_var(4) },
-        { be_const_key_weak(hydrate_post, 69), be_const_closure(Matter_Session_hydrate_post_closure) },
-        { be_const_key_weak(_message_handler, 18), be_const_var(17) },
-        { be_const_key_weak(get_ca, -1), be_const_closure(Matter_Session_get_ca_closure) },
-        { be_const_key_weak(update, -1), be_const_closure(Matter_Session_update_closure) },
-        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Session_get_noc_closure) },
-        { be_const_key_weak(_ip, -1), be_const_var(15) },
+        { be_const_key_weak(set_keys, -1), be_const_closure(Matter_Session_set_keys_closure) },
+        { be_const_key_weak(set_noc, 1), be_const_closure(Matter_Session_set_noc_closure) },
+        { be_const_key_weak(attestation_challenge, -1), be_const_var(23) },
+        { be_const_key_weak(set_mode_CASE, 31), be_const_closure(Matter_Session_set_mode_CASE_closure) },
+        { be_const_key_weak(local_session_id, 11), be_const_var(3) },
+        { be_const_key_weak(get_admin_vendor, 62), be_const_closure(Matter_Session_get_admin_vendor_closure) },
+        { be_const_key_weak(get_fabric_id, -1), be_const_closure(Matter_Session_get_fabric_id_closure) },
+        { be_const_key_weak(get_ac, 36), be_const_closure(Matter_Session_get_ac_closure) },
+        { be_const_key_weak(_port, 68), be_const_var(16) },
+        { be_const_key_weak(tojson, -1), be_const_closure(Matter_Session_tojson_closure) },
+        { be_const_key_weak(_COUNTER_SND_INCR, 56), be_const_int(1024) },
+        { be_const_key_weak(set_mode_PASE, -1), be_const_closure(Matter_Session_set_mode_PASE_closure) },
+        { be_const_key_weak(_exchange_id, -1), be_const_var(14) },
+        { be_const_key_weak(peer_node_id, -1), be_const_var(24) },
+        { be_const_key_weak(before_remove, 58), be_const_closure(Matter_Session_before_remove_closure) },
+        { be_const_key_weak(get_ca, 2), be_const_closure(Matter_Session_get_ca_closure) },
+        { be_const_key_weak(resumption_id, 75), be_const_var(26) },
+        { be_const_key_weak(mode, 21), be_const_var(1) },
+        { be_const_key_weak(_PASE, 32), be_const_int(1) },
+        { be_const_key_weak(get_i2r_privacy, -1), be_const_closure(Matter_Session_get_i2r_privacy_closure) },
+        { be_const_key_weak(__Msg2, -1), be_const_var(29) },
+        { be_const_key_weak(_message_handler, -1), be_const_var(17) },
+        { be_const_key_weak(set_admin_subject_vendor, 54), be_const_closure(Matter_Session_set_admin_subject_vendor_closure) },
+        { be_const_key_weak(_source_node_id, -1), be_const_var(7) },
+        { be_const_key_weak(get_pk, -1), be_const_closure(Matter_Session_get_pk_closure) },
+        { be_const_key_weak(get_device_id, 77), be_const_closure(Matter_Session_get_device_id_closure) },
+        { be_const_key_weak(__future_initiator_session_id, -1), be_const_var(8) },
+        { be_const_key_weak(set_ca, -1), be_const_closure(Matter_Session_set_ca_closure) },
+        { be_const_key_weak(counter_rcv, -1), be_const_var(10) },
         { be_const_key_weak(fabric_candidate, -1), be_const_closure(Matter_Session_fabric_candidate_closure) },
+        { be_const_key_weak(update, -1), be_const_closure(Matter_Session_update_closure) },
+        { be_const_key_weak(_counter_rcv_impl, 53), be_const_var(12) },
+        { be_const_key_weak(counter_snd_next, -1), be_const_closure(Matter_Session_counter_snd_next_closure) },
+        { be_const_key_weak(_CASE, -1), be_const_int(2) },
+        { be_const_key_weak(init, 74), be_const_closure(Matter_Session_init_closure) },
+        { be_const_key_weak(get_admin_subject, -1), be_const_closure(Matter_Session_get_admin_subject_closure) },
+        { be_const_key_weak(r2ikey, -1), be_const_var(21) },
+        { be_const_key_weak(fabric_completed, -1), be_const_closure(Matter_Session_fabric_completed_closure) },
+        { be_const_key_weak(hydrate_post, -1), be_const_closure(Matter_Session_hydrate_post_closure) },
+        { be_const_key_weak(set_ipk_epoch_key, -1), be_const_closure(Matter_Session_set_ipk_epoch_key_closure) },
+        { be_const_key_weak(i2rkey, 29), be_const_var(20) },
+        { be_const_key_weak(_GROUP_KEY, -1), be_nested_str_weak(GroupKey_X20v1_X2E0) },
+        { be_const_key_weak(get_fabric_compressed, -1), be_const_closure(Matter_Session_get_fabric_compressed_closure) },
+        { be_const_key_weak(get_ca_pub, 69), be_const_closure(Matter_Session_get_ca_pub_closure) },
+        { be_const_key_weak(_counter_insecure_rcv, -1), be_const_var(18) },
+        { be_const_key_weak(get_mode, -1), be_const_closure(Matter_Session_get_mode_closure) },
+        { be_const_key_weak(counter_snd, -1), be_const_var(11) },
+        { be_const_key_weak(set_fabric_device, 61), be_const_closure(Matter_Session_set_fabric_device_closure) },
+        { be_const_key_weak(__chunked_attr_reports, -1), be_const_var(30) },
+        { be_const_key_weak(_store, 41), be_const_var(0) },
+        { be_const_key_weak(fromjson, 60), be_const_static_closure(Matter_Session_fromjson_closure) },
+        { be_const_key_weak(set_fabric_label, -1), be_const_closure(Matter_Session_set_fabric_label_closure) },
         { be_const_key_weak(__future_local_session_id, -1), be_const_var(9) },
-        { be_const_key_weak(_counter_rcv_impl, 7), be_const_var(12) },
-        { be_const_key_weak(set_mode_CASE, -1), be_const_closure(Matter_Session_set_mode_CASE_closure) },
+        { be_const_key_weak(persist_to_fabric, -1), be_const_closure(Matter_Session_persist_to_fabric_closure) },
+        { be_const_key_weak(set_mode, 12), be_const_closure(Matter_Session_set_mode_closure) },
+        { be_const_key_weak(shared_secret, -1), be_const_var(27) },
+        { be_const_key_weak(_breadcrumb, 46), be_const_var(25) },
+        { be_const_key_weak(_ip, -1), be_const_var(15) },
+        { be_const_key_weak(created, 57), be_const_var(5) },
+        { be_const_key_weak(close, -1), be_const_closure(Matter_Session_close_closure) },
+        { be_const_key_weak(get_icac, -1), be_const_closure(Matter_Session_get_icac_closure) },
+        { be_const_key_weak(_i2r_privacy, 10), be_const_var(22) },
+        { be_const_key_weak(_fabric, 50), be_const_var(2) },
+        { be_const_key_weak(get_fabric_label, -1), be_const_closure(Matter_Session_get_fabric_label_closure) },
+        { be_const_key_weak(get_fabric, 42), be_const_closure(Matter_Session_get_fabric_closure) },
+        { be_const_key_weak(is_CASE, -1), be_const_closure(Matter_Session_is_CASE_closure) },
+        { be_const_key_weak(get_i2r, 37), be_const_closure(Matter_Session_get_i2r_closure) },
+        { be_const_key_weak(is_PASE, -1), be_const_closure(Matter_Session_is_PASE_closure) },
+        { be_const_key_weak(get_ipk_epoch_key, -1), be_const_closure(Matter_Session_get_ipk_epoch_key_closure) },
+        { be_const_key_weak(counter_rcv_validate, -1), be_const_closure(Matter_Session_counter_rcv_validate_closure) },
+        { be_const_key_weak(get_r2i, -1), be_const_closure(Matter_Session_get_r2i_closure) },
+        { be_const_key_weak(save, -1), be_const_closure(Matter_Session_save_closure) },
+        { be_const_key_weak(_counter_insecure_snd, 19), be_const_var(19) },
+        { be_const_key_weak(last_used, -1), be_const_var(6) },
+        { be_const_key_weak(_counter_snd_impl, -1), be_const_var(13) },
+        { be_const_key_weak(get_noc, -1), be_const_closure(Matter_Session_get_noc_closure) },
+        { be_const_key_weak(gen_CSR, -1), be_const_closure(Matter_Session_gen_CSR_closure) },
         { be_const_key_weak(get_ipk_group_key, -1), be_const_closure(Matter_Session_get_ipk_group_key_closure) },
-        { be_const_key_weak(get_i2r, -1), be_const_closure(Matter_Session_get_i2r_closure) },
-        { be_const_key_weak(get_admin_vendor, -1), be_const_closure(Matter_Session_get_admin_vendor_closure) },
+        { be_const_key_weak(__Msg1, 0), be_const_var(28) },
     })),
     be_str_weak(Matter_Session)
 );
@@ -3682,7 +3841,7 @@ be_local_closure(Matter_Session_Store_save_fabrics,   /* name */
     /* K19  */  be_nested_str_weak(tasmota),
     /* K20  */  be_nested_str_weak(log),
     /* K21  */  be_nested_str_weak(format),
-    /* K22  */  be_nested_str_weak(MTR_X3A_X20Saved_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
+    /* K22  */  be_nested_str_weak(MTR_X3A_X20_X3DSaved_X20_X20_X20_X20_X20_X25i_X20fabric_X28s_X29_X20and_X20_X25i_X20session_X28s_X29),
     /* K23  */  be_const_int(2),
     /* K24  */  be_nested_str_weak(MTR_X3A_X20Session_Store_X3A_X3Asave_X20Exception_X3A),
     /* K25  */  be_nested_str_weak(_X7C),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_TLV.h
@@ -102,6 +102,139 @@ be_local_closure(Matter_TLV_item_set_anonymoustag,   /* name */
 
 
 /********************************************************************
+** Solidified function: set_commonprofile
+********************************************************************/
+be_local_closure(Matter_TLV_item_set_commonprofile,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(set_fulltag),
+    }),
+    be_str_weak(set_commonprofile),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 6]) {  /* code */
+      0x8C040100,  //  0000  GETMET	R1	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x5411FFFE,  //  0002  LDINT	R4	-1
+      0x4C140000,  //  0003  LDNIL	R5
+      0x7C040800,  //  0004  CALL	R1	4
+      0x80000000,  //  0005  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _cmp_gt
+********************************************************************/
+be_local_closure(Matter_TLV_item__cmp_gt,   /* name */
+  be_nested_proto(
+    4,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tag_vendor),
+    /* K1   */  be_const_int(1),
+    /* K2   */  be_nested_str_weak(tag_profile),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_nested_str_weak(tag_number),
+    /* K5   */  be_nested_str_weak(tag_sub),
+    }),
+    be_str_weak(_cmp_gt),
+    &be_const_str_solidified,
+    ( &(const binstruction[72]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x4C0C0000,  //  0001  LDNIL	R3
+      0x20080403,  //  0002  NE	R2	R2	R3
+      0x780A0012,  //  0003  JMPF	R2	#0017
+      0x88080300,  //  0004  GETMBR	R2	R1	K0
+      0x4C0C0000,  //  0005  LDNIL	R3
+      0x1C080403,  //  0006  EQ	R2	R2	R3
+      0x780A0000,  //  0007  JMPF	R2	#0009
+      0x80060200,  //  0008  RET	1	K1
+      0x88080100,  //  0009  GETMBR	R2	R0	K0
+      0x880C0300,  //  000A  GETMBR	R3	R1	K0
+      0x24080403,  //  000B  GT	R2	R2	R3
+      0x780A0000,  //  000C  JMPF	R2	#000E
+      0x80060200,  //  000D  RET	1	K1
+      0x88080100,  //  000E  GETMBR	R2	R0	K0
+      0x880C0300,  //  000F  GETMBR	R3	R1	K0
+      0x1C080403,  //  0010  EQ	R2	R2	R3
+      0x780A0004,  //  0011  JMPF	R2	#0017
+      0x88080102,  //  0012  GETMBR	R2	R0	K2
+      0x880C0302,  //  0013  GETMBR	R3	R1	K2
+      0x24080403,  //  0014  GT	R2	R2	R3
+      0x780A0000,  //  0015  JMPF	R2	#0017
+      0x80060200,  //  0016  RET	1	K1
+      0x88080102,  //  0017  GETMBR	R2	R0	K2
+      0x540DFFFE,  //  0018  LDINT	R3	-1
+      0x1C080403,  //  0019  EQ	R2	R2	R3
+      0x780A0005,  //  001A  JMPF	R2	#0021
+      0x88080302,  //  001B  GETMBR	R2	R1	K2
+      0x4C0C0000,  //  001C  LDNIL	R3
+      0x1C080403,  //  001D  EQ	R2	R2	R3
+      0x780A0000,  //  001E  JMPF	R2	#0020
+      0x80060200,  //  001F  RET	1	K1
+      0x70020008,  //  0020  JMP		#002A
+      0x88080102,  //  0021  GETMBR	R2	R0	K2
+      0x4C0C0000,  //  0022  LDNIL	R3
+      0x1C080403,  //  0023  EQ	R2	R2	R3
+      0x780A0004,  //  0024  JMPF	R2	#002A
+      0x88080302,  //  0025  GETMBR	R2	R1	K2
+      0x540DFFFE,  //  0026  LDINT	R3	-1
+      0x1C080403,  //  0027  EQ	R2	R2	R3
+      0x780A0000,  //  0028  JMPF	R2	#002A
+      0x80060600,  //  0029  RET	1	K3
+      0x88080104,  //  002A  GETMBR	R2	R0	K4
+      0x4C0C0000,  //  002B  LDNIL	R3
+      0x20080403,  //  002C  NE	R2	R2	R3
+      0x780A000A,  //  002D  JMPF	R2	#0039
+      0x88080304,  //  002E  GETMBR	R2	R1	K4
+      0x4C0C0000,  //  002F  LDNIL	R3
+      0x1C080403,  //  0030  EQ	R2	R2	R3
+      0x780A0000,  //  0031  JMPF	R2	#0033
+      0x80060200,  //  0032  RET	1	K1
+      0x88080104,  //  0033  GETMBR	R2	R0	K4
+      0x880C0304,  //  0034  GETMBR	R3	R1	K4
+      0x24080403,  //  0035  GT	R2	R2	R3
+      0x780A0000,  //  0036  JMPF	R2	#0038
+      0x80060200,  //  0037  RET	1	K1
+      0x80060600,  //  0038  RET	1	K3
+      0x88080105,  //  0039  GETMBR	R2	R0	K5
+      0x4C0C0000,  //  003A  LDNIL	R3
+      0x20080403,  //  003B  NE	R2	R2	R3
+      0x780A0009,  //  003C  JMPF	R2	#0047
+      0x88080305,  //  003D  GETMBR	R2	R1	K5
+      0x4C0C0000,  //  003E  LDNIL	R3
+      0x1C080403,  //  003F  EQ	R2	R2	R3
+      0x780A0000,  //  0040  JMPF	R2	#0042
+      0x80060200,  //  0041  RET	1	K1
+      0x88080105,  //  0042  GETMBR	R2	R0	K5
+      0x880C0305,  //  0043  GETMBR	R3	R1	K5
+      0x24080403,  //  0044  GT	R2	R2	R3
+      0x780A0000,  //  0045  JMPF	R2	#0047
+      0x80060200,  //  0046  RET	1	K1
+      0x80060600,  //  0047  RET	1	K3
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: _encode_tag
 ********************************************************************/
 be_local_closure(Matter_TLV_item__encode_tag,   /* name */
@@ -261,363 +394,6 @@ be_local_closure(Matter_TLV_item__encode_tag,   /* name */
       0x58200005,  //  0082  LDCONST	R8	K5
       0x7C140600,  //  0083  CALL	R5	3
       0x80000000,  //  0084  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: set_commonprofile
-********************************************************************/
-be_local_closure(Matter_TLV_item_set_commonprofile,   /* name */
-  be_nested_proto(
-    6,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(set_fulltag),
-    }),
-    be_str_weak(set_commonprofile),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 6]) {  /* code */
-      0x8C040100,  //  0000  GETMET	R1	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x5411FFFE,  //  0002  LDINT	R4	-1
-      0x4C140000,  //  0003  LDNIL	R5
-      0x7C040800,  //  0004  CALL	R1	4
-      0x80000000,  //  0005  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: _cmp_gt
-********************************************************************/
-be_local_closure(Matter_TLV_item__cmp_gt,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_vendor),
-    /* K1   */  be_const_int(1),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_const_int(0),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    }),
-    be_str_weak(_cmp_gt),
-    &be_const_str_solidified,
-    ( &(const binstruction[72]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x4C0C0000,  //  0001  LDNIL	R3
-      0x20080403,  //  0002  NE	R2	R2	R3
-      0x780A0012,  //  0003  JMPF	R2	#0017
-      0x88080300,  //  0004  GETMBR	R2	R1	K0
-      0x4C0C0000,  //  0005  LDNIL	R3
-      0x1C080403,  //  0006  EQ	R2	R2	R3
-      0x780A0000,  //  0007  JMPF	R2	#0009
-      0x80060200,  //  0008  RET	1	K1
-      0x88080100,  //  0009  GETMBR	R2	R0	K0
-      0x880C0300,  //  000A  GETMBR	R3	R1	K0
-      0x24080403,  //  000B  GT	R2	R2	R3
-      0x780A0000,  //  000C  JMPF	R2	#000E
-      0x80060200,  //  000D  RET	1	K1
-      0x88080100,  //  000E  GETMBR	R2	R0	K0
-      0x880C0300,  //  000F  GETMBR	R3	R1	K0
-      0x1C080403,  //  0010  EQ	R2	R2	R3
-      0x780A0004,  //  0011  JMPF	R2	#0017
-      0x88080102,  //  0012  GETMBR	R2	R0	K2
-      0x880C0302,  //  0013  GETMBR	R3	R1	K2
-      0x24080403,  //  0014  GT	R2	R2	R3
-      0x780A0000,  //  0015  JMPF	R2	#0017
-      0x80060200,  //  0016  RET	1	K1
-      0x88080102,  //  0017  GETMBR	R2	R0	K2
-      0x540DFFFE,  //  0018  LDINT	R3	-1
-      0x1C080403,  //  0019  EQ	R2	R2	R3
-      0x780A0005,  //  001A  JMPF	R2	#0021
-      0x88080302,  //  001B  GETMBR	R2	R1	K2
-      0x4C0C0000,  //  001C  LDNIL	R3
-      0x1C080403,  //  001D  EQ	R2	R2	R3
-      0x780A0000,  //  001E  JMPF	R2	#0020
-      0x80060200,  //  001F  RET	1	K1
-      0x70020008,  //  0020  JMP		#002A
-      0x88080102,  //  0021  GETMBR	R2	R0	K2
-      0x4C0C0000,  //  0022  LDNIL	R3
-      0x1C080403,  //  0023  EQ	R2	R2	R3
-      0x780A0004,  //  0024  JMPF	R2	#002A
-      0x88080302,  //  0025  GETMBR	R2	R1	K2
-      0x540DFFFE,  //  0026  LDINT	R3	-1
-      0x1C080403,  //  0027  EQ	R2	R2	R3
-      0x780A0000,  //  0028  JMPF	R2	#002A
-      0x80060600,  //  0029  RET	1	K3
-      0x88080104,  //  002A  GETMBR	R2	R0	K4
-      0x4C0C0000,  //  002B  LDNIL	R3
-      0x20080403,  //  002C  NE	R2	R2	R3
-      0x780A000A,  //  002D  JMPF	R2	#0039
-      0x88080304,  //  002E  GETMBR	R2	R1	K4
-      0x4C0C0000,  //  002F  LDNIL	R3
-      0x1C080403,  //  0030  EQ	R2	R2	R3
-      0x780A0000,  //  0031  JMPF	R2	#0033
-      0x80060200,  //  0032  RET	1	K1
-      0x88080104,  //  0033  GETMBR	R2	R0	K4
-      0x880C0304,  //  0034  GETMBR	R3	R1	K4
-      0x24080403,  //  0035  GT	R2	R2	R3
-      0x780A0000,  //  0036  JMPF	R2	#0038
-      0x80060200,  //  0037  RET	1	K1
-      0x80060600,  //  0038  RET	1	K3
-      0x88080105,  //  0039  GETMBR	R2	R0	K5
-      0x4C0C0000,  //  003A  LDNIL	R3
-      0x20080403,  //  003B  NE	R2	R2	R3
-      0x780A0009,  //  003C  JMPF	R2	#0047
-      0x88080305,  //  003D  GETMBR	R2	R1	K5
-      0x4C0C0000,  //  003E  LDNIL	R3
-      0x1C080403,  //  003F  EQ	R2	R2	R3
-      0x780A0000,  //  0040  JMPF	R2	#0042
-      0x80060200,  //  0041  RET	1	K1
-      0x88080105,  //  0042  GETMBR	R2	R0	K5
-      0x880C0305,  //  0043  GETMBR	R3	R1	K5
-      0x24080403,  //  0044  GT	R2	R2	R3
-      0x780A0000,  //  0045  JMPF	R2	#0047
-      0x80060200,  //  0046  RET	1	K1
-      0x80060600,  //  0047  RET	1	K3
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: tostring
-********************************************************************/
-be_local_closure(Matter_TLV_item_tostring,   /* name */
-  be_nested_proto(
-    8,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[35]) {     /* constants */
-    /* K0   */  be_nested_str_weak(string),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(tag_profile),
-    /* K3   */  be_nested_str_weak(Matter_X3A_X3A),
-    /* K4   */  be_nested_str_weak(tag_number),
-    /* K5   */  be_nested_str_weak(format),
-    /* K6   */  be_nested_str_weak(0x_X2508X_X20),
-    /* K7   */  be_nested_str_weak(tag_vendor),
-    /* K8   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
-    /* K9   */  be_nested_str_weak(0x_X2504X_X3A),
-    /* K10  */  be_nested_str_weak(tag_sub),
-    /* K11  */  be_nested_str_weak(_X25i_X20),
-    /* K12  */  be_const_int(0),
-    /* K13  */  be_nested_str_weak(_X3D_X20),
-    /* K14  */  be_nested_str_weak(val),
-    /* K15  */  be_nested_str_weak(int),
-    /* K16  */  be_nested_str_weak(_X25i),
-    /* K17  */  be_nested_str_weak(typ),
-    /* K18  */  be_nested_str_weak(TLV),
-    /* K19  */  be_nested_str_weak(U1),
-    /* K20  */  be_nested_str_weak(U8),
-    /* K21  */  be_nested_str_weak(U),
-    /* K22  */  be_nested_str_weak(bool),
-    /* K23  */  be_nested_str_weak(true),
-    /* K24  */  be_nested_str_weak(false),
-    /* K25  */  be_nested_str_weak(null),
-    /* K26  */  be_nested_str_weak(real),
-    /* K27  */  be_nested_str_weak(_X25g),
-    /* K28  */  be_nested_str_weak(_X22_X25s_X22),
-    /* K29  */  be_nested_str_weak(int64),
-    /* K30  */  be_nested_str_weak(tostring),
-    /* K31  */  be_nested_str_weak(instance),
-    /* K32  */  be_nested_str_weak(_X25s),
-    /* K33  */  be_nested_str_weak(tohex),
-    /* K34  */  be_nested_str_weak(_X20),
-    }),
-    be_str_weak(tostring),
-    &be_const_str_solidified,
-    ( &(const binstruction[165]) {  /* code */
-      0xA4060000,  //  0000  IMPORT	R1	K0
-      0x58080001,  //  0001  LDCONST	R2	K1
-      0xA8020099,  //  0002  EXBLK	0	#009D
-      0x880C0102,  //  0003  GETMBR	R3	R0	K2
-      0x5411FFFE,  //  0004  LDINT	R4	-1
-      0x1C0C0604,  //  0005  EQ	R3	R3	R4
-      0x780E000A,  //  0006  JMPF	R3	#0012
-      0x00080503,  //  0007  ADD	R2	R2	K3
-      0x880C0104,  //  0008  GETMBR	R3	R0	K4
-      0x4C100000,  //  0009  LDNIL	R4
-      0x200C0604,  //  000A  NE	R3	R3	R4
-      0x780E0004,  //  000B  JMPF	R3	#0011
-      0x8C0C0305,  //  000C  GETMET	R3	R1	K5
-      0x58140006,  //  000D  LDCONST	R5	K6
-      0x88180104,  //  000E  GETMBR	R6	R0	K4
-      0x7C0C0600,  //  000F  CALL	R3	3
-      0x00080403,  //  0010  ADD	R2	R2	R3
-      0x70020023,  //  0011  JMP		#0036
-      0x880C0107,  //  0012  GETMBR	R3	R0	K7
-      0x4C100000,  //  0013  LDNIL	R4
-      0x200C0604,  //  0014  NE	R3	R3	R4
-      0x780E0004,  //  0015  JMPF	R3	#001B
-      0x8C0C0305,  //  0016  GETMET	R3	R1	K5
-      0x58140008,  //  0017  LDCONST	R5	K8
-      0x88180107,  //  0018  GETMBR	R6	R0	K7
-      0x7C0C0600,  //  0019  CALL	R3	3
-      0x00080403,  //  001A  ADD	R2	R2	R3
-      0x880C0102,  //  001B  GETMBR	R3	R0	K2
-      0x4C100000,  //  001C  LDNIL	R4
-      0x200C0604,  //  001D  NE	R3	R3	R4
-      0x780E0004,  //  001E  JMPF	R3	#0024
-      0x8C0C0305,  //  001F  GETMET	R3	R1	K5
-      0x58140009,  //  0020  LDCONST	R5	K9
-      0x88180102,  //  0021  GETMBR	R6	R0	K2
-      0x7C0C0600,  //  0022  CALL	R3	3
-      0x00080403,  //  0023  ADD	R2	R2	R3
-      0x880C0104,  //  0024  GETMBR	R3	R0	K4
-      0x4C100000,  //  0025  LDNIL	R4
-      0x200C0604,  //  0026  NE	R3	R3	R4
-      0x780E0004,  //  0027  JMPF	R3	#002D
-      0x8C0C0305,  //  0028  GETMET	R3	R1	K5
-      0x58140006,  //  0029  LDCONST	R5	K6
-      0x88180104,  //  002A  GETMBR	R6	R0	K4
-      0x7C0C0600,  //  002B  CALL	R3	3
-      0x00080403,  //  002C  ADD	R2	R2	R3
-      0x880C010A,  //  002D  GETMBR	R3	R0	K10
-      0x4C100000,  //  002E  LDNIL	R4
-      0x200C0604,  //  002F  NE	R3	R3	R4
-      0x780E0004,  //  0030  JMPF	R3	#0036
-      0x8C0C0305,  //  0031  GETMET	R3	R1	K5
-      0x5814000B,  //  0032  LDCONST	R5	K11
-      0x8818010A,  //  0033  GETMBR	R6	R0	K10
-      0x7C0C0600,  //  0034  CALL	R3	3
-      0x00080403,  //  0035  ADD	R2	R2	R3
-      0x600C000C,  //  0036  GETGBL	R3	G12
-      0x5C100400,  //  0037  MOVE	R4	R2
-      0x7C0C0200,  //  0038  CALL	R3	1
-      0x240C070C,  //  0039  GT	R3	R3	K12
-      0x780E0000,  //  003A  JMPF	R3	#003C
-      0x0008050D,  //  003B  ADD	R2	R2	K13
-      0x600C0004,  //  003C  GETGBL	R3	G4
-      0x8810010E,  //  003D  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  003E  CALL	R3	1
-      0x1C0C070F,  //  003F  EQ	R3	R3	K15
-      0x780E0010,  //  0040  JMPF	R3	#0052
-      0x8C0C0305,  //  0041  GETMET	R3	R1	K5
-      0x58140010,  //  0042  LDCONST	R5	K16
-      0x8818010E,  //  0043  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  0044  CALL	R3	3
-      0x00080403,  //  0045  ADD	R2	R2	R3
-      0x880C0111,  //  0046  GETMBR	R3	R0	K17
-      0x88100112,  //  0047  GETMBR	R4	R0	K18
-      0x88100913,  //  0048  GETMBR	R4	R4	K19
-      0x280C0604,  //  0049  GE	R3	R3	R4
-      0x780E0005,  //  004A  JMPF	R3	#0051
-      0x880C0111,  //  004B  GETMBR	R3	R0	K17
-      0x88100112,  //  004C  GETMBR	R4	R0	K18
-      0x88100914,  //  004D  GETMBR	R4	R4	K20
-      0x180C0604,  //  004E  LE	R3	R3	R4
-      0x780E0000,  //  004F  JMPF	R3	#0051
-      0x00080515,  //  0050  ADD	R2	R2	K21
-      0x70020048,  //  0051  JMP		#009B
-      0x600C0004,  //  0052  GETGBL	R3	G4
-      0x8810010E,  //  0053  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0054  CALL	R3	1
-      0x1C0C0716,  //  0055  EQ	R3	R3	K22
-      0x780E0006,  //  0056  JMPF	R3	#005E
-      0x880C010E,  //  0057  GETMBR	R3	R0	K14
-      0x780E0001,  //  0058  JMPF	R3	#005B
-      0x580C0017,  //  0059  LDCONST	R3	K23
-      0x70020000,  //  005A  JMP		#005C
-      0x580C0018,  //  005B  LDCONST	R3	K24
-      0x00080403,  //  005C  ADD	R2	R2	R3
-      0x7002003C,  //  005D  JMP		#009B
-      0x880C010E,  //  005E  GETMBR	R3	R0	K14
-      0x4C100000,  //  005F  LDNIL	R4
-      0x1C0C0604,  //  0060  EQ	R3	R3	R4
-      0x780E0001,  //  0061  JMPF	R3	#0064
-      0x00080519,  //  0062  ADD	R2	R2	K25
-      0x70020036,  //  0063  JMP		#009B
-      0x600C0004,  //  0064  GETGBL	R3	G4
-      0x8810010E,  //  0065  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0066  CALL	R3	1
-      0x1C0C071A,  //  0067  EQ	R3	R3	K26
-      0x780E0005,  //  0068  JMPF	R3	#006F
-      0x8C0C0305,  //  0069  GETMET	R3	R1	K5
-      0x5814001B,  //  006A  LDCONST	R5	K27
-      0x8818010E,  //  006B  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  006C  CALL	R3	3
-      0x00080403,  //  006D  ADD	R2	R2	R3
-      0x7002002B,  //  006E  JMP		#009B
-      0x600C0004,  //  006F  GETGBL	R3	G4
-      0x8810010E,  //  0070  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0071  CALL	R3	1
-      0x1C0C0700,  //  0072  EQ	R3	R3	K0
-      0x780E0005,  //  0073  JMPF	R3	#007A
-      0x8C0C0305,  //  0074  GETMET	R3	R1	K5
-      0x5814001C,  //  0075  LDCONST	R5	K28
-      0x8818010E,  //  0076  GETMBR	R6	R0	K14
-      0x7C0C0600,  //  0077  CALL	R3	3
-      0x00080403,  //  0078  ADD	R2	R2	R3
-      0x70020020,  //  0079  JMP		#009B
-      0x600C000F,  //  007A  GETGBL	R3	G15
-      0x8810010E,  //  007B  GETMBR	R4	R0	K14
-      0xB8163A00,  //  007C  GETNGBL	R5	K29
-      0x7C0C0400,  //  007D  CALL	R3	2
-      0x780E000F,  //  007E  JMPF	R3	#008F
-      0x880C010E,  //  007F  GETMBR	R3	R0	K14
-      0x8C0C071E,  //  0080  GETMET	R3	R3	K30
-      0x7C0C0200,  //  0081  CALL	R3	1
-      0x00080403,  //  0082  ADD	R2	R2	R3
-      0x880C0111,  //  0083  GETMBR	R3	R0	K17
-      0x88100112,  //  0084  GETMBR	R4	R0	K18
-      0x88100913,  //  0085  GETMBR	R4	R4	K19
-      0x280C0604,  //  0086  GE	R3	R3	R4
-      0x780E0005,  //  0087  JMPF	R3	#008E
-      0x880C0111,  //  0088  GETMBR	R3	R0	K17
-      0x88100112,  //  0089  GETMBR	R4	R0	K18
-      0x88100914,  //  008A  GETMBR	R4	R4	K20
-      0x180C0604,  //  008B  LE	R3	R3	R4
-      0x780E0000,  //  008C  JMPF	R3	#008E
-      0x00080515,  //  008D  ADD	R2	R2	K21
-      0x7002000B,  //  008E  JMP		#009B
-      0x600C0004,  //  008F  GETGBL	R3	G4
-      0x8810010E,  //  0090  GETMBR	R4	R0	K14
-      0x7C0C0200,  //  0091  CALL	R3	1
-      0x1C0C071F,  //  0092  EQ	R3	R3	K31
-      0x780E0006,  //  0093  JMPF	R3	#009B
-      0x8C0C0305,  //  0094  GETMET	R3	R1	K5
-      0x58140020,  //  0095  LDCONST	R5	K32
-      0x8818010E,  //  0096  GETMBR	R6	R0	K14
-      0x8C180D21,  //  0097  GETMET	R6	R6	K33
-      0x7C180200,  //  0098  CALL	R6	1
-      0x7C0C0600,  //  0099  CALL	R3	3
-      0x00080403,  //  009A  ADD	R2	R2	R3
-      0xA8040001,  //  009B  EXBLK	1	1
-      0x70020006,  //  009C  JMP		#00A4
-      0xAC0C0002,  //  009D  CATCH	R3	0	2
-      0x70020003,  //  009E  JMP		#00A3
-      0x00140722,  //  009F  ADD	R5	R3	K34
-      0x00140A04,  //  00A0  ADD	R5	R5	R4
-      0x80040A00,  //  00A1  RET	1	R5
-      0x70020000,  //  00A2  JMP		#00A4
-      0xB0080000,  //  00A3  RAISE	2	R0	R0
-      0x80040400,  //  00A4  RET	1	R2
     })
   )
 );
@@ -1006,11 +782,11 @@ be_local_closure(Matter_TLV_item_set_fulltag,   /* name */
 
 
 /********************************************************************
-** Solidified function: _encode_tag_len
+** Solidified function: tostring
 ********************************************************************/
-be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
+be_local_closure(Matter_TLV_item_tostring,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
+    8,                          /* nstack */
     1,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -1018,73 +794,211 @@ be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_nested_str_weak(tag_number),
-    /* K1   */  be_const_int(0),
-    /* K2   */  be_nested_str_weak(tag_vendor),
-    /* K3   */  be_nested_str_weak(tag_profile),
-    /* K4   */  be_const_int(3),
-    /* K5   */  be_nested_str_weak(tag_sub),
-    /* K6   */  be_const_int(2),
-    /* K7   */  be_const_int(1),
+    ( &(const bvalue[35]) {     /* constants */
+    /* K0   */  be_nested_str_weak(string),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(tag_profile),
+    /* K3   */  be_nested_str_weak(Matter_X3A_X3A),
+    /* K4   */  be_nested_str_weak(tag_number),
+    /* K5   */  be_nested_str_weak(format),
+    /* K6   */  be_nested_str_weak(0x_X2508X_X20),
+    /* K7   */  be_nested_str_weak(tag_vendor),
+    /* K8   */  be_nested_str_weak(0x_X2504X_X3A_X3A),
+    /* K9   */  be_nested_str_weak(0x_X2504X_X3A),
+    /* K10  */  be_nested_str_weak(tag_sub),
+    /* K11  */  be_nested_str_weak(_X25i_X20),
+    /* K12  */  be_const_int(0),
+    /* K13  */  be_nested_str_weak(_X3D_X20),
+    /* K14  */  be_nested_str_weak(val),
+    /* K15  */  be_nested_str_weak(int),
+    /* K16  */  be_nested_str_weak(_X25i),
+    /* K17  */  be_nested_str_weak(typ),
+    /* K18  */  be_nested_str_weak(TLV),
+    /* K19  */  be_nested_str_weak(U1),
+    /* K20  */  be_nested_str_weak(U8),
+    /* K21  */  be_nested_str_weak(U),
+    /* K22  */  be_nested_str_weak(bool),
+    /* K23  */  be_nested_str_weak(true),
+    /* K24  */  be_nested_str_weak(false),
+    /* K25  */  be_nested_str_weak(null),
+    /* K26  */  be_nested_str_weak(real),
+    /* K27  */  be_nested_str_weak(_X25g),
+    /* K28  */  be_nested_str_weak(_X22_X25s_X22),
+    /* K29  */  be_nested_str_weak(int64),
+    /* K30  */  be_nested_str_weak(tostring),
+    /* K31  */  be_nested_str_weak(instance),
+    /* K32  */  be_nested_str_weak(_X25s),
+    /* K33  */  be_nested_str_weak(tohex),
+    /* K34  */  be_nested_str_weak(_X20),
     }),
-    be_str_weak(_encode_tag_len),
+    be_str_weak(tostring),
     &be_const_str_solidified,
-    ( &(const binstruction[54]) {  /* code */
-      0x88040100,  //  0000  GETMBR	R1	R0	K0
-      0x4C080000,  //  0001  LDNIL	R2
-      0x20040202,  //  0002  NE	R1	R1	R2
-      0x78060001,  //  0003  JMPF	R1	#0006
-      0x88040100,  //  0004  GETMBR	R1	R0	K0
-      0x70020000,  //  0005  JMP		#0007
-      0x58040001,  //  0006  LDCONST	R1	K1
-      0x540AFFFF,  //  0007  LDINT	R2	65536
-      0x28080202,  //  0008  GE	R2	R1	R2
-      0x740A0002,  //  0009  JMPT	R2	#000D
-      0x14080301,  //  000A  LT	R2	R1	K1
-      0x740A0000,  //  000B  JMPT	R2	#000D
-      0x50080001,  //  000C  LDBOOL	R2	0	1
-      0x50080200,  //  000D  LDBOOL	R2	1	0
-      0x580C0001,  //  000E  LDCONST	R3	K1
-      0x88100102,  //  000F  GETMBR	R4	R0	K2
-      0x4C140000,  //  0010  LDNIL	R5
-      0x20100805,  //  0011  NE	R4	R4	R5
-      0x78120006,  //  0012  JMPF	R4	#001A
-      0x780A0002,  //  0013  JMPF	R2	#0017
-      0x54120008,  //  0014  LDINT	R4	9
-      0x80040800,  //  0015  RET	1	R4
-      0x70020001,  //  0016  JMP		#0019
-      0x54120006,  //  0017  LDINT	R4	7
-      0x80040800,  //  0018  RET	1	R4
-      0x7002001A,  //  0019  JMP		#0035
-      0x88100103,  //  001A  GETMBR	R4	R0	K3
-      0x5415FFFE,  //  001B  LDINT	R5	-1
-      0x1C100805,  //  001C  EQ	R4	R4	R5
-      0x78120005,  //  001D  JMPF	R4	#0024
-      0x780A0002,  //  001E  JMPF	R2	#0022
-      0x54120004,  //  001F  LDINT	R4	5
-      0x80040800,  //  0020  RET	1	R4
-      0x70020000,  //  0021  JMP		#0023
-      0x80060800,  //  0022  RET	1	K4
-      0x70020010,  //  0023  JMP		#0035
-      0x88100103,  //  0024  GETMBR	R4	R0	K3
-      0x4C140000,  //  0025  LDNIL	R5
-      0x20100805,  //  0026  NE	R4	R4	R5
-      0x78120005,  //  0027  JMPF	R4	#002E
-      0x780A0002,  //  0028  JMPF	R2	#002C
-      0x54120004,  //  0029  LDINT	R4	5
-      0x80040800,  //  002A  RET	1	R4
-      0x70020000,  //  002B  JMP		#002D
-      0x80060800,  //  002C  RET	1	K4
-      0x70020006,  //  002D  JMP		#0035
-      0x88100105,  //  002E  GETMBR	R4	R0	K5
-      0x4C140000,  //  002F  LDNIL	R5
-      0x20100805,  //  0030  NE	R4	R4	R5
-      0x78120001,  //  0031  JMPF	R4	#0034
-      0x80060C00,  //  0032  RET	1	K6
-      0x70020000,  //  0033  JMP		#0035
-      0x80060E00,  //  0034  RET	1	K7
-      0x80000000,  //  0035  RET	0
+    ( &(const binstruction[165]) {  /* code */
+      0xA4060000,  //  0000  IMPORT	R1	K0
+      0x58080001,  //  0001  LDCONST	R2	K1
+      0xA8020099,  //  0002  EXBLK	0	#009D
+      0x880C0102,  //  0003  GETMBR	R3	R0	K2
+      0x5411FFFE,  //  0004  LDINT	R4	-1
+      0x1C0C0604,  //  0005  EQ	R3	R3	R4
+      0x780E000A,  //  0006  JMPF	R3	#0012
+      0x00080503,  //  0007  ADD	R2	R2	K3
+      0x880C0104,  //  0008  GETMBR	R3	R0	K4
+      0x4C100000,  //  0009  LDNIL	R4
+      0x200C0604,  //  000A  NE	R3	R3	R4
+      0x780E0004,  //  000B  JMPF	R3	#0011
+      0x8C0C0305,  //  000C  GETMET	R3	R1	K5
+      0x58140006,  //  000D  LDCONST	R5	K6
+      0x88180104,  //  000E  GETMBR	R6	R0	K4
+      0x7C0C0600,  //  000F  CALL	R3	3
+      0x00080403,  //  0010  ADD	R2	R2	R3
+      0x70020023,  //  0011  JMP		#0036
+      0x880C0107,  //  0012  GETMBR	R3	R0	K7
+      0x4C100000,  //  0013  LDNIL	R4
+      0x200C0604,  //  0014  NE	R3	R3	R4
+      0x780E0004,  //  0015  JMPF	R3	#001B
+      0x8C0C0305,  //  0016  GETMET	R3	R1	K5
+      0x58140008,  //  0017  LDCONST	R5	K8
+      0x88180107,  //  0018  GETMBR	R6	R0	K7
+      0x7C0C0600,  //  0019  CALL	R3	3
+      0x00080403,  //  001A  ADD	R2	R2	R3
+      0x880C0102,  //  001B  GETMBR	R3	R0	K2
+      0x4C100000,  //  001C  LDNIL	R4
+      0x200C0604,  //  001D  NE	R3	R3	R4
+      0x780E0004,  //  001E  JMPF	R3	#0024
+      0x8C0C0305,  //  001F  GETMET	R3	R1	K5
+      0x58140009,  //  0020  LDCONST	R5	K9
+      0x88180102,  //  0021  GETMBR	R6	R0	K2
+      0x7C0C0600,  //  0022  CALL	R3	3
+      0x00080403,  //  0023  ADD	R2	R2	R3
+      0x880C0104,  //  0024  GETMBR	R3	R0	K4
+      0x4C100000,  //  0025  LDNIL	R4
+      0x200C0604,  //  0026  NE	R3	R3	R4
+      0x780E0004,  //  0027  JMPF	R3	#002D
+      0x8C0C0305,  //  0028  GETMET	R3	R1	K5
+      0x58140006,  //  0029  LDCONST	R5	K6
+      0x88180104,  //  002A  GETMBR	R6	R0	K4
+      0x7C0C0600,  //  002B  CALL	R3	3
+      0x00080403,  //  002C  ADD	R2	R2	R3
+      0x880C010A,  //  002D  GETMBR	R3	R0	K10
+      0x4C100000,  //  002E  LDNIL	R4
+      0x200C0604,  //  002F  NE	R3	R3	R4
+      0x780E0004,  //  0030  JMPF	R3	#0036
+      0x8C0C0305,  //  0031  GETMET	R3	R1	K5
+      0x5814000B,  //  0032  LDCONST	R5	K11
+      0x8818010A,  //  0033  GETMBR	R6	R0	K10
+      0x7C0C0600,  //  0034  CALL	R3	3
+      0x00080403,  //  0035  ADD	R2	R2	R3
+      0x600C000C,  //  0036  GETGBL	R3	G12
+      0x5C100400,  //  0037  MOVE	R4	R2
+      0x7C0C0200,  //  0038  CALL	R3	1
+      0x240C070C,  //  0039  GT	R3	R3	K12
+      0x780E0000,  //  003A  JMPF	R3	#003C
+      0x0008050D,  //  003B  ADD	R2	R2	K13
+      0x600C0004,  //  003C  GETGBL	R3	G4
+      0x8810010E,  //  003D  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  003E  CALL	R3	1
+      0x1C0C070F,  //  003F  EQ	R3	R3	K15
+      0x780E0010,  //  0040  JMPF	R3	#0052
+      0x8C0C0305,  //  0041  GETMET	R3	R1	K5
+      0x58140010,  //  0042  LDCONST	R5	K16
+      0x8818010E,  //  0043  GETMBR	R6	R0	K14
+      0x7C0C0600,  //  0044  CALL	R3	3
+      0x00080403,  //  0045  ADD	R2	R2	R3
+      0x880C0111,  //  0046  GETMBR	R3	R0	K17
+      0x88100112,  //  0047  GETMBR	R4	R0	K18
+      0x88100913,  //  0048  GETMBR	R4	R4	K19
+      0x280C0604,  //  0049  GE	R3	R3	R4
+      0x780E0005,  //  004A  JMPF	R3	#0051
+      0x880C0111,  //  004B  GETMBR	R3	R0	K17
+      0x88100112,  //  004C  GETMBR	R4	R0	K18
+      0x88100914,  //  004D  GETMBR	R4	R4	K20
+      0x180C0604,  //  004E  LE	R3	R3	R4
+      0x780E0000,  //  004F  JMPF	R3	#0051
+      0x00080515,  //  0050  ADD	R2	R2	K21
+      0x70020048,  //  0051  JMP		#009B
+      0x600C0004,  //  0052  GETGBL	R3	G4
+      0x8810010E,  //  0053  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  0054  CALL	R3	1
+      0x1C0C0716,  //  0055  EQ	R3	R3	K22
+      0x780E0006,  //  0056  JMPF	R3	#005E
+      0x880C010E,  //  0057  GETMBR	R3	R0	K14
+      0x780E0001,  //  0058  JMPF	R3	#005B
+      0x580C0017,  //  0059  LDCONST	R3	K23
+      0x70020000,  //  005A  JMP		#005C
+      0x580C0018,  //  005B  LDCONST	R3	K24
+      0x00080403,  //  005C  ADD	R2	R2	R3
+      0x7002003C,  //  005D  JMP		#009B
+      0x880C010E,  //  005E  GETMBR	R3	R0	K14
+      0x4C100000,  //  005F  LDNIL	R4
+      0x1C0C0604,  //  0060  EQ	R3	R3	R4
+      0x780E0001,  //  0061  JMPF	R3	#0064
+      0x00080519,  //  0062  ADD	R2	R2	K25
+      0x70020036,  //  0063  JMP		#009B
+      0x600C0004,  //  0064  GETGBL	R3	G4
+      0x8810010E,  //  0065  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  0066  CALL	R3	1
+      0x1C0C071A,  //  0067  EQ	R3	R3	K26
+      0x780E0005,  //  0068  JMPF	R3	#006F
+      0x8C0C0305,  //  0069  GETMET	R3	R1	K5
+      0x5814001B,  //  006A  LDCONST	R5	K27
+      0x8818010E,  //  006B  GETMBR	R6	R0	K14
+      0x7C0C0600,  //  006C  CALL	R3	3
+      0x00080403,  //  006D  ADD	R2	R2	R3
+      0x7002002B,  //  006E  JMP		#009B
+      0x600C0004,  //  006F  GETGBL	R3	G4
+      0x8810010E,  //  0070  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  0071  CALL	R3	1
+      0x1C0C0700,  //  0072  EQ	R3	R3	K0
+      0x780E0005,  //  0073  JMPF	R3	#007A
+      0x8C0C0305,  //  0074  GETMET	R3	R1	K5
+      0x5814001C,  //  0075  LDCONST	R5	K28
+      0x8818010E,  //  0076  GETMBR	R6	R0	K14
+      0x7C0C0600,  //  0077  CALL	R3	3
+      0x00080403,  //  0078  ADD	R2	R2	R3
+      0x70020020,  //  0079  JMP		#009B
+      0x600C000F,  //  007A  GETGBL	R3	G15
+      0x8810010E,  //  007B  GETMBR	R4	R0	K14
+      0xB8163A00,  //  007C  GETNGBL	R5	K29
+      0x7C0C0400,  //  007D  CALL	R3	2
+      0x780E000F,  //  007E  JMPF	R3	#008F
+      0x880C010E,  //  007F  GETMBR	R3	R0	K14
+      0x8C0C071E,  //  0080  GETMET	R3	R3	K30
+      0x7C0C0200,  //  0081  CALL	R3	1
+      0x00080403,  //  0082  ADD	R2	R2	R3
+      0x880C0111,  //  0083  GETMBR	R3	R0	K17
+      0x88100112,  //  0084  GETMBR	R4	R0	K18
+      0x88100913,  //  0085  GETMBR	R4	R4	K19
+      0x280C0604,  //  0086  GE	R3	R3	R4
+      0x780E0005,  //  0087  JMPF	R3	#008E
+      0x880C0111,  //  0088  GETMBR	R3	R0	K17
+      0x88100112,  //  0089  GETMBR	R4	R0	K18
+      0x88100914,  //  008A  GETMBR	R4	R4	K20
+      0x180C0604,  //  008B  LE	R3	R3	R4
+      0x780E0000,  //  008C  JMPF	R3	#008E
+      0x00080515,  //  008D  ADD	R2	R2	K21
+      0x7002000B,  //  008E  JMP		#009B
+      0x600C0004,  //  008F  GETGBL	R3	G4
+      0x8810010E,  //  0090  GETMBR	R4	R0	K14
+      0x7C0C0200,  //  0091  CALL	R3	1
+      0x1C0C071F,  //  0092  EQ	R3	R3	K31
+      0x780E0006,  //  0093  JMPF	R3	#009B
+      0x8C0C0305,  //  0094  GETMET	R3	R1	K5
+      0x58140020,  //  0095  LDCONST	R5	K32
+      0x8818010E,  //  0096  GETMBR	R6	R0	K14
+      0x8C180D21,  //  0097  GETMET	R6	R6	K33
+      0x7C180200,  //  0098  CALL	R6	1
+      0x7C0C0600,  //  0099  CALL	R3	3
+      0x00080403,  //  009A  ADD	R2	R2	R3
+      0xA8040001,  //  009B  EXBLK	1	1
+      0x70020006,  //  009C  JMP		#00A4
+      0xAC0C0002,  //  009D  CATCH	R3	0	2
+      0x70020003,  //  009E  JMP		#00A3
+      0x00140722,  //  009F  ADD	R5	R3	K34
+      0x00140A04,  //  00A0  ADD	R5	R5	R4
+      0x80040A00,  //  00A1  RET	1	R5
+      0x70020000,  //  00A2  JMP		#00A4
+      0xB0080000,  //  00A3  RAISE	2	R0	R0
+      0x80040400,  //  00A4  RET	1	R2
     })
   )
 );
@@ -1119,9 +1033,9 @@ be_local_closure(Matter_TLV_item_init,   /* name */
 
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_TLV_item_encode,   /* name */
+be_local_closure(Matter_TLV_item_tlv2raw,   /* name */
   be_nested_proto(
     9,                          /* nstack */
     2,                          /* argc */
@@ -1174,7 +1088,7 @@ be_local_closure(Matter_TLV_item_encode,   /* name */
     /* K39  */  be_nested_str_weak(NULL),
     /* K40  */  be_nested_str_weak(unsupported_X20type_X20),
     }),
-    be_str_weak(encode),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
     ( &(const binstruction[361]) {  /* code */
       0x88080100,  //  0000  GETMBR	R2	R0	K0
@@ -1545,6 +1459,92 @@ be_local_closure(Matter_TLV_item_encode,   /* name */
 
 
 /********************************************************************
+** Solidified function: _encode_tag_len
+********************************************************************/
+be_local_closure(Matter_TLV_item__encode_tag_len,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 8]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tag_number),
+    /* K1   */  be_const_int(0),
+    /* K2   */  be_nested_str_weak(tag_vendor),
+    /* K3   */  be_nested_str_weak(tag_profile),
+    /* K4   */  be_const_int(3),
+    /* K5   */  be_nested_str_weak(tag_sub),
+    /* K6   */  be_const_int(2),
+    /* K7   */  be_const_int(1),
+    }),
+    be_str_weak(_encode_tag_len),
+    &be_const_str_solidified,
+    ( &(const binstruction[54]) {  /* code */
+      0x88040100,  //  0000  GETMBR	R1	R0	K0
+      0x4C080000,  //  0001  LDNIL	R2
+      0x20040202,  //  0002  NE	R1	R1	R2
+      0x78060001,  //  0003  JMPF	R1	#0006
+      0x88040100,  //  0004  GETMBR	R1	R0	K0
+      0x70020000,  //  0005  JMP		#0007
+      0x58040001,  //  0006  LDCONST	R1	K1
+      0x540AFFFF,  //  0007  LDINT	R2	65536
+      0x28080202,  //  0008  GE	R2	R1	R2
+      0x740A0002,  //  0009  JMPT	R2	#000D
+      0x14080301,  //  000A  LT	R2	R1	K1
+      0x740A0000,  //  000B  JMPT	R2	#000D
+      0x50080001,  //  000C  LDBOOL	R2	0	1
+      0x50080200,  //  000D  LDBOOL	R2	1	0
+      0x580C0001,  //  000E  LDCONST	R3	K1
+      0x88100102,  //  000F  GETMBR	R4	R0	K2
+      0x4C140000,  //  0010  LDNIL	R5
+      0x20100805,  //  0011  NE	R4	R4	R5
+      0x78120006,  //  0012  JMPF	R4	#001A
+      0x780A0002,  //  0013  JMPF	R2	#0017
+      0x54120008,  //  0014  LDINT	R4	9
+      0x80040800,  //  0015  RET	1	R4
+      0x70020001,  //  0016  JMP		#0019
+      0x54120006,  //  0017  LDINT	R4	7
+      0x80040800,  //  0018  RET	1	R4
+      0x7002001A,  //  0019  JMP		#0035
+      0x88100103,  //  001A  GETMBR	R4	R0	K3
+      0x5415FFFE,  //  001B  LDINT	R5	-1
+      0x1C100805,  //  001C  EQ	R4	R4	R5
+      0x78120005,  //  001D  JMPF	R4	#0024
+      0x780A0002,  //  001E  JMPF	R2	#0022
+      0x54120004,  //  001F  LDINT	R4	5
+      0x80040800,  //  0020  RET	1	R4
+      0x70020000,  //  0021  JMP		#0023
+      0x80060800,  //  0022  RET	1	K4
+      0x70020010,  //  0023  JMP		#0035
+      0x88100103,  //  0024  GETMBR	R4	R0	K3
+      0x4C140000,  //  0025  LDNIL	R5
+      0x20100805,  //  0026  NE	R4	R4	R5
+      0x78120005,  //  0027  JMPF	R4	#002E
+      0x780A0002,  //  0028  JMPF	R2	#002C
+      0x54120004,  //  0029  LDINT	R4	5
+      0x80040800,  //  002A  RET	1	R4
+      0x70020000,  //  002B  JMP		#002D
+      0x80060800,  //  002C  RET	1	K4
+      0x70020006,  //  002D  JMP		#0035
+      0x88100105,  //  002E  GETMBR	R4	R0	K5
+      0x4C140000,  //  002F  LDNIL	R5
+      0x20100805,  //  0030  NE	R4	R4	R5
+      0x78120001,  //  0031  JMPF	R4	#0034
+      0x80060C00,  //  0032  RET	1	K6
+      0x70020000,  //  0033  JMP		#0035
+      0x80060E00,  //  0034  RET	1	K7
+      0x80000000,  //  0035  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified function: sort
 ********************************************************************/
 be_local_closure(Matter_TLV_item_sort,   /* name */
@@ -1600,30 +1600,6 @@ be_local_closure(Matter_TLV_item_sort,   /* name */
       0xAC080200,  //  001E  CATCH	R2	1	0
       0xB0080000,  //  001F  RAISE	2	R0	R0
       0x80040000,  //  0020  RET	1	R0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: to_TLV
-********************************************************************/
-be_local_closure(Matter_TLV_item_to_TLV,   /* name */
-  be_nested_proto(
-    1,                          /* nstack */
-    1,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    0,                          /* has constants */
-    NULL,                       /* no const */
-    be_str_weak(to_TLV),
-    &be_const_str_solidified,
-    ( &(const binstruction[ 1]) {  /* code */
-      0x80040000,  //  0000  RET	1	R0
     })
   )
 );
@@ -1785,6 +1761,30 @@ be_local_closure(Matter_TLV_item_parse,   /* name */
 
 
 /********************************************************************
+** Solidified function: to_TLV
+********************************************************************/
+be_local_closure(Matter_TLV_item_to_TLV,   /* name */
+  be_nested_proto(
+    1,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    0,                          /* has constants */
+    NULL,                       /* no const */
+    be_str_weak(to_TLV),
+    &be_const_str_solidified,
+    ( &(const binstruction[ 1]) {  /* code */
+      0x80040000,  //  0000  RET	1	R0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
 ** Solidified class: Matter_TLV_item
 ********************************************************************/
 be_local_class(Matter_TLV_item,
@@ -1796,25 +1796,25 @@ be_local_class(Matter_TLV_item,
         { be_const_key_weak(create_TLV, -1), be_const_static_closure(Matter_TLV_item_create_TLV_closure) },
         { be_const_key_weak(next_idx, -1), be_const_var(1) },
         { be_const_key_weak(TLV, -1), be_const_class(be_class_Matter_TLV) },
-        { be_const_key_weak(_encode_tag, 10), be_const_closure(Matter_TLV_item__encode_tag_closure) },
+        { be_const_key_weak(tag_vendor, 22), be_const_var(2) },
         { be_const_key_weak(set_anonymoustag, 17), be_const_closure(Matter_TLV_item_set_anonymoustag_closure) },
         { be_const_key_weak(val, -1), be_const_var(7) },
-        { be_const_key_weak(parse, -1), be_const_closure(Matter_TLV_item_parse_closure) },
         { be_const_key_weak(to_TLV, -1), be_const_closure(Matter_TLV_item_to_TLV_closure) },
-        { be_const_key_weak(_cmp_gt, 8), be_const_closure(Matter_TLV_item__cmp_gt_closure) },
-        { be_const_key_weak(tag_vendor, -1), be_const_var(2) },
-        { be_const_key_weak(encode_len, 19), be_const_closure(Matter_TLV_item_encode_len_closure) },
-        { be_const_key_weak(set_contextspecific, 7), be_const_closure(Matter_TLV_item_set_contextspecific_closure) },
+        { be_const_key_weak(parse, -1), be_const_closure(Matter_TLV_item_parse_closure) },
+        { be_const_key_weak(_cmp_gt, 7), be_const_closure(Matter_TLV_item__cmp_gt_closure) },
+        { be_const_key_weak(tag_profile, -1), be_const_var(3) },
+        { be_const_key_weak(encode_len, 10), be_const_closure(Matter_TLV_item_encode_len_closure) },
+        { be_const_key_weak(set_contextspecific, 8), be_const_closure(Matter_TLV_item_set_contextspecific_closure) },
         { be_const_key_weak(set_fulltag, -1), be_const_closure(Matter_TLV_item_set_fulltag_closure) },
         { be_const_key_weak(parent, -1), be_const_var(0) },
-        { be_const_key_weak(encode, 18), be_const_closure(Matter_TLV_item_encode_closure) },
+        { be_const_key_weak(_encode_tag_len, 19), be_const_closure(Matter_TLV_item__encode_tag_len_closure) },
         { be_const_key_weak(tag_sub, -1), be_const_var(5) },
         { be_const_key_weak(init, 23), be_const_closure(Matter_TLV_item_init_closure) },
-        { be_const_key_weak(_encode_tag_len, 22), be_const_closure(Matter_TLV_item__encode_tag_len_closure) },
-        { be_const_key_weak(tag_profile, -1), be_const_var(3) },
+        { be_const_key_weak(tlv2raw, -1), be_const_closure(Matter_TLV_item_tlv2raw_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_item_tostring_closure) },
         { be_const_key_weak(set_commonprofile, 15), be_const_closure(Matter_TLV_item_set_commonprofile_closure) },
         { be_const_key_weak(sort, -1), be_const_static_closure(Matter_TLV_item_sort_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_item_tostring_closure) },
+        { be_const_key_weak(_encode_tag, -1), be_const_closure(Matter_TLV_item__encode_tag_closure) },
         { be_const_key_weak(tag_number, 16), be_const_var(4) },
         { be_const_key_weak(typ, 3), be_const_var(6) },
     })),
@@ -1971,38 +1971,27 @@ be_local_closure(Matter_TLV_list_getsubval,   /* name */
 
 
 /********************************************************************
-** Solidified function: add_list
+** Solidified function: setitem
 ********************************************************************/
-be_local_closure(Matter_TLV_list_add_list,   /* name */
+be_local_closure(Matter_TLV_list_setitem,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
+    4,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(TLV),
-    /* K1   */  be_nested_str_weak(Matter_TLV_list),
-    /* K2   */  be_nested_str_weak(tag_sub),
-    /* K3   */  be_nested_str_weak(val),
-    /* K4   */  be_nested_str_weak(push),
+    ( &(const bvalue[ 1]) {     /* constants */
+    /* K0   */  be_nested_str_weak(val),
     }),
-    be_str_weak(add_list),
+    be_str_weak(setitem),
     &be_const_str_solidified,
-    ( &(const binstruction[10]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x8C080501,  //  0001  GETMET	R2	R2	K1
-      0x5C100000,  //  0002  MOVE	R4	R0
-      0x7C080400,  //  0003  CALL	R2	2
-      0x900A0401,  //  0004  SETMBR	R2	K2	R1
-      0x880C0103,  //  0005  GETMBR	R3	R0	K3
-      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
-      0x5C140400,  //  0007  MOVE	R5	R2
-      0x7C0C0400,  //  0008  CALL	R3	2
-      0x80040400,  //  0009  RET	1	R2
+    ( &(const binstruction[ 3]) {  /* code */
+      0x880C0100,  //  0000  GETMBR	R3	R0	K0
+      0x980C0202,  //  0001  SETIDX	R3	R1	R2
+      0x80000000,  //  0002  RET	0
     })
   )
 );
@@ -2103,11 +2092,11 @@ be_local_closure(Matter_TLV_list_findsubtyp,   /* name */
 
 
 /********************************************************************
-** Solidified function: encode
+** Solidified function: add_list
 ********************************************************************/
-be_local_closure(Matter_TLV_list_encode,   /* name */
+be_local_closure(Matter_TLV_list_add_list,   /* name */
   be_nested_proto(
-    8,                          /* nstack */
+    6,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -2115,59 +2104,26 @@ be_local_closure(Matter_TLV_list_encode,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(_encode_tag),
-    /* K1   */  be_nested_str_weak(val),
-    /* K2   */  be_nested_str_weak(is_struct),
-    /* K3   */  be_nested_str_weak(copy),
-    /* K4   */  be_nested_str_weak(sort),
-    /* K5   */  be_nested_str_weak(encode),
-    /* K6   */  be_nested_str_weak(stop_iteration),
-    /* K7   */  be_nested_str_weak(add),
-    /* K8   */  be_nested_str_weak(TLV),
-    /* K9   */  be_nested_str_weak(EOC),
-    /* K10  */  be_const_int(1),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(TLV),
+    /* K1   */  be_nested_str_weak(Matter_TLV_list),
+    /* K2   */  be_nested_str_weak(tag_sub),
+    /* K3   */  be_nested_str_weak(val),
+    /* K4   */  be_nested_str_weak(push),
     }),
-    be_str_weak(encode),
+    be_str_weak(add_list),
     &be_const_str_solidified,
-    ( &(const binstruction[37]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0002,  //  0002  JMPF	R2	#0006
-      0x60080015,  //  0003  GETGBL	R2	G21
-      0x7C080000,  //  0004  CALL	R2	0
-      0x5C040400,  //  0005  MOVE	R1	R2
-      0x8C080100,  //  0006  GETMET	R2	R0	K0
-      0x5C100200,  //  0007  MOVE	R4	R1
-      0x7C080400,  //  0008  CALL	R2	2
-      0x88080101,  //  0009  GETMBR	R2	R0	K1
-      0x880C0102,  //  000A  GETMBR	R3	R0	K2
-      0x780E0005,  //  000B  JMPF	R3	#0012
-      0x8C0C0503,  //  000C  GETMET	R3	R2	K3
-      0x7C0C0200,  //  000D  CALL	R3	1
-      0x5C080600,  //  000E  MOVE	R2	R3
-      0x8C0C0104,  //  000F  GETMET	R3	R0	K4
-      0x5C140400,  //  0010  MOVE	R5	R2
-      0x7C0C0400,  //  0011  CALL	R3	2
-      0x600C0010,  //  0012  GETGBL	R3	G16
-      0x5C100400,  //  0013  MOVE	R4	R2
-      0x7C0C0200,  //  0014  CALL	R3	1
-      0xA8020005,  //  0015  EXBLK	0	#001C
-      0x5C100600,  //  0016  MOVE	R4	R3
-      0x7C100000,  //  0017  CALL	R4	0
-      0x8C140905,  //  0018  GETMET	R5	R4	K5
-      0x5C1C0200,  //  0019  MOVE	R7	R1
-      0x7C140400,  //  001A  CALL	R5	2
-      0x7001FFF9,  //  001B  JMP		#0016
-      0x580C0006,  //  001C  LDCONST	R3	K6
-      0xAC0C0200,  //  001D  CATCH	R3	1	0
-      0xB0080000,  //  001E  RAISE	2	R0	R0
-      0x8C0C0307,  //  001F  GETMET	R3	R1	K7
-      0x88140108,  //  0020  GETMBR	R5	R0	K8
-      0x88140B09,  //  0021  GETMBR	R5	R5	K9
-      0x5818000A,  //  0022  LDCONST	R6	K10
-      0x7C0C0600,  //  0023  CALL	R3	3
-      0x80040200,  //  0024  RET	1	R1
+    ( &(const binstruction[10]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x8C080501,  //  0001  GETMET	R2	R2	K1
+      0x5C100000,  //  0002  MOVE	R4	R0
+      0x7C080400,  //  0003  CALL	R2	2
+      0x900A0401,  //  0004  SETMBR	R2	K2	R1
+      0x880C0103,  //  0005  GETMBR	R3	R0	K3
+      0x8C0C0704,  //  0006  GETMET	R3	R3	K4
+      0x5C140400,  //  0007  MOVE	R5	R2
+      0x7C0C0400,  //  0008  CALL	R3	2
+      0x80040400,  //  0009  RET	1	R2
     })
   )
 );
@@ -2516,27 +2472,71 @@ be_local_closure(Matter_TLV_list_add_TLV,   /* name */
 
 
 /********************************************************************
-** Solidified function: setitem
+** Solidified function: tlv2raw
 ********************************************************************/
-be_local_closure(Matter_TLV_list_setitem,   /* name */
+be_local_closure(Matter_TLV_list_tlv2raw,   /* name */
   be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
+    8,                          /* nstack */
+    2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 1]) {     /* constants */
-    /* K0   */  be_nested_str_weak(val),
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(_encode_tag),
+    /* K1   */  be_nested_str_weak(val),
+    /* K2   */  be_nested_str_weak(is_struct),
+    /* K3   */  be_nested_str_weak(copy),
+    /* K4   */  be_nested_str_weak(sort),
+    /* K5   */  be_nested_str_weak(tlv2raw),
+    /* K6   */  be_nested_str_weak(stop_iteration),
+    /* K7   */  be_nested_str_weak(add),
+    /* K8   */  be_nested_str_weak(TLV),
+    /* K9   */  be_nested_str_weak(EOC),
+    /* K10  */  be_const_int(1),
     }),
-    be_str_weak(setitem),
+    be_str_weak(tlv2raw),
     &be_const_str_solidified,
-    ( &(const binstruction[ 3]) {  /* code */
-      0x880C0100,  //  0000  GETMBR	R3	R0	K0
-      0x980C0202,  //  0001  SETIDX	R3	R1	R2
-      0x80000000,  //  0002  RET	0
+    ( &(const binstruction[37]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0002,  //  0002  JMPF	R2	#0006
+      0x60080015,  //  0003  GETGBL	R2	G21
+      0x7C080000,  //  0004  CALL	R2	0
+      0x5C040400,  //  0005  MOVE	R1	R2
+      0x8C080100,  //  0006  GETMET	R2	R0	K0
+      0x5C100200,  //  0007  MOVE	R4	R1
+      0x7C080400,  //  0008  CALL	R2	2
+      0x88080101,  //  0009  GETMBR	R2	R0	K1
+      0x880C0102,  //  000A  GETMBR	R3	R0	K2
+      0x780E0005,  //  000B  JMPF	R3	#0012
+      0x8C0C0503,  //  000C  GETMET	R3	R2	K3
+      0x7C0C0200,  //  000D  CALL	R3	1
+      0x5C080600,  //  000E  MOVE	R2	R3
+      0x8C0C0104,  //  000F  GETMET	R3	R0	K4
+      0x5C140400,  //  0010  MOVE	R5	R2
+      0x7C0C0400,  //  0011  CALL	R3	2
+      0x600C0010,  //  0012  GETGBL	R3	G16
+      0x5C100400,  //  0013  MOVE	R4	R2
+      0x7C0C0200,  //  0014  CALL	R3	1
+      0xA8020005,  //  0015  EXBLK	0	#001C
+      0x5C100600,  //  0016  MOVE	R4	R3
+      0x7C100000,  //  0017  CALL	R4	0
+      0x8C140905,  //  0018  GETMET	R5	R4	K5
+      0x5C1C0200,  //  0019  MOVE	R7	R1
+      0x7C140400,  //  001A  CALL	R5	2
+      0x7001FFF9,  //  001B  JMP		#0016
+      0x580C0006,  //  001C  LDCONST	R3	K6
+      0xAC0C0200,  //  001D  CATCH	R3	1	0
+      0xB0080000,  //  001E  RAISE	2	R0	R0
+      0x8C0C0307,  //  001F  GETMET	R3	R1	K7
+      0x88140108,  //  0020  GETMBR	R5	R0	K8
+      0x88140B09,  //  0021  GETMBR	R5	R5	K9
+      0x5818000A,  //  0022  LDCONST	R6	K10
+      0x7C0C0600,  //  0023  CALL	R3	3
+      0x80040200,  //  0024  RET	1	R1
     })
   )
 );
@@ -2722,17 +2722,17 @@ be_local_class(Matter_TLV_list,
         { be_const_key_weak(parse, -1), be_const_closure(Matter_TLV_list_parse_closure) },
         { be_const_key_weak(size, -1), be_const_closure(Matter_TLV_list_size_closure) },
         { be_const_key_weak(findsubtyp, -1), be_const_closure(Matter_TLV_list_findsubtyp_closure) },
-        { be_const_key_weak(encode, -1), be_const_closure(Matter_TLV_list_encode_closure) },
+        { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_list_tostring_closure) },
         { be_const_key_weak(tostring_inner, 4), be_const_closure(Matter_TLV_list_tostring_inner_closure) },
-        { be_const_key_weak(encode_len, 15), be_const_closure(Matter_TLV_list_encode_len_closure) },
+        { be_const_key_weak(encode_len, 8), be_const_closure(Matter_TLV_list_encode_len_closure) },
         { be_const_key_weak(findsubval, -1), be_const_closure(Matter_TLV_list_findsubval_closure) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_TLV_list_init_closure) },
         { be_const_key_weak(add_array, 16), be_const_closure(Matter_TLV_list_add_array_closure) },
-        { be_const_key_weak(add_TLV, 18), be_const_closure(Matter_TLV_list_add_TLV_closure) },
-        { be_const_key_weak(tostring, -1), be_const_closure(Matter_TLV_list_tostring_closure) },
+        { be_const_key_weak(setitem, 15), be_const_closure(Matter_TLV_list_setitem_closure) },
+        { be_const_key_weak(tlv2raw, 18), be_const_closure(Matter_TLV_list_tlv2raw_closure) },
         { be_const_key_weak(findsub, -1), be_const_closure(Matter_TLV_list_findsub_closure) },
         { be_const_key_weak(is_struct, -1), be_const_bool(0) },
-        { be_const_key_weak(setitem, -1), be_const_closure(Matter_TLV_list_setitem_closure) },
+        { be_const_key_weak(add_TLV, -1), be_const_closure(Matter_TLV_list_add_TLV_closure) },
         { be_const_key_weak(item, 5), be_const_closure(Matter_TLV_list_item_closure) },
         { be_const_key_weak(add_list, -1), be_const_closure(Matter_TLV_list_add_list_closure) },
     })),

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UDPServer.h
@@ -19,7 +19,7 @@ be_local_closure(Matter_UDPPacket_sent_init,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[10]) {     /* constants */
+    ( &(const bvalue[12]) {     /* constants */
     /* K0   */  be_nested_str_weak(raw),
     /* K1   */  be_nested_str_weak(addr),
     /* K2   */  be_nested_str_weak(port),
@@ -29,11 +29,13 @@ be_local_closure(Matter_UDPPacket_sent_init,   /* name */
     /* K6   */  be_nested_str_weak(next_try),
     /* K7   */  be_nested_str_weak(tasmota),
     /* K8   */  be_nested_str_weak(millis),
-    /* K9   */  be_nested_str_weak(backoff_time),
+    /* K9   */  be_nested_str_weak(matter),
+    /* K10  */  be_nested_str_weak(UDPServer),
+    /* K11  */  be_nested_str_weak(_backoff_time),
     }),
     be_str_weak(init),
     &be_const_str_solidified,
-    ( &(const binstruction[14]) {  /* code */
+    ( &(const binstruction[16]) {  /* code */
       0x90020001,  //  0000  SETMBR	R0	K0	R1
       0x90020202,  //  0001  SETMBR	R0	K1	R2
       0x90020403,  //  0002  SETMBR	R0	K2	R3
@@ -42,97 +44,14 @@ be_local_closure(Matter_UDPPacket_sent_init,   /* name */
       0xB8160E00,  //  0005  GETNGBL	R5	K7
       0x8C140B08,  //  0006  GETMET	R5	R5	K8
       0x7C140200,  //  0007  CALL	R5	1
-      0x8C180109,  //  0008  GETMET	R6	R0	K9
-      0x88200104,  //  0009  GETMBR	R8	R0	K4
-      0x7C180400,  //  000A  CALL	R6	2
-      0x00140A06,  //  000B  ADD	R5	R5	R6
-      0x90020C05,  //  000C  SETMBR	R0	K6	R5
-      0x80000000,  //  000D  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: backoff_time
-********************************************************************/
-be_local_closure(Matter_UDPPacket_sent_backoff_time,   /* name */
-  be_nested_proto(
-    10,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    1,                          /* has sup protos */
-    ( &(const struct bproto*[ 1]) {
-      be_nested_proto(
-        4,                          /* nstack */
-        2,                          /* argc */
-        0,                          /* varg */
-        0,                          /* has upvals */
-        NULL,                       /* no upvals */
-        0,                          /* has sup protos */
-        NULL,                       /* no sub protos */
-        1,                          /* has constants */
-        ( &(const bvalue[ 2]) {     /* constants */
-        /* K0   */  be_const_int(1),
-        /* K1   */  be_const_int(0),
-        }),
-        be_str_weak(power_int),
-        &be_const_str_solidified,
-        ( &(const binstruction[ 7]) {  /* code */
-          0x58080000,  //  0000  LDCONST	R2	K0
-          0x240C0301,  //  0001  GT	R3	R1	K1
-          0x780E0002,  //  0002  JMPF	R3	#0006
-          0x08080400,  //  0003  MUL	R2	R2	R0
-          0x04040300,  //  0004  SUB	R1	R1	K0
-          0x7001FFFA,  //  0005  JMP		#0001
-          0x80040400,  //  0006  RET	1	R2
-        })
-      ),
-    }),
-    1,                          /* has constants */
-    ( &(const bvalue[ 7]) {     /* constants */
-    /* K0   */  be_nested_str_weak(math),
-    /* K1   */  be_nested_str_weak(rand),
-    /* K2   */  be_const_int(0),
-    /* K3   */  be_const_int(1),
-    /* K4   */  be_const_real_hex(0x3FCCCCCD),
-    /* K5   */  be_const_real_hex(0x3F800000),
-    /* K6   */  be_const_real_hex(0x3E800000),
-    }),
-    be_str_weak(backoff_time),
-    &be_const_str_solidified,
-    ( &(const binstruction[28]) {  /* code */
-      0x84080000,  //  0000  CLOSURE	R2	P0
-      0xA40E0000,  //  0001  IMPORT	R3	K0
-      0x5412012B,  //  0002  LDINT	R4	300
-      0x6014000A,  //  0003  GETGBL	R5	G10
-      0x8C180701,  //  0004  GETMET	R6	R3	K1
-      0x7C180200,  //  0005  CALL	R6	1
-      0x541E00FE,  //  0006  LDINT	R7	255
-      0x2C180C07,  //  0007  AND	R6	R6	R7
-      0x7C140200,  //  0008  CALL	R5	1
-      0x541A00FE,  //  0009  LDINT	R6	255
-      0x0C140A06,  //  000A  DIV	R5	R5	R6
-      0x24180302,  //  000B  GT	R6	R1	K2
-      0x781A0001,  //  000C  JMPF	R6	#000F
-      0x04180303,  //  000D  SUB	R6	R1	K3
-      0x70020000,  //  000E  JMP		#0010
-      0x58180002,  //  000F  LDCONST	R6	K2
-      0x5C1C0400,  //  0010  MOVE	R7	R2
-      0x58200004,  //  0011  LDCONST	R8	K4
-      0x5C240C00,  //  0012  MOVE	R9	R6
-      0x7C1C0400,  //  0013  CALL	R7	2
-      0x081C0807,  //  0014  MUL	R7	R4	R7
-      0x08200B06,  //  0015  MUL	R8	R5	K6
-      0x00220A08,  //  0016  ADD	R8	K5	R8
-      0x081C0E08,  //  0017  MUL	R7	R7	R8
-      0x60200009,  //  0018  GETGBL	R8	G9
-      0x5C240E00,  //  0019  MOVE	R9	R7
-      0x7C200200,  //  001A  CALL	R8	1
-      0x80041000,  //  001B  RET	1	R8
+      0xB81A1200,  //  0008  GETNGBL	R6	K9
+      0x88180D0A,  //  0009  GETMBR	R6	R6	K10
+      0x8C180D0B,  //  000A  GETMET	R6	R6	K11
+      0x88200104,  //  000B  GETMBR	R8	R0	K4
+      0x7C180400,  //  000C  CALL	R6	2
+      0x00140A06,  //  000D  ADD	R5	R5	R6
+      0x90020C05,  //  000E  SETMBR	R0	K6	R5
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -204,7 +123,7 @@ be_local_closure(Matter_UDPPacket_sent_send,   /* name */
       0x7C180800,  //  001F  CALL	R6	4
       0x581C000C,  //  0020  LDCONST	R7	K12
       0x7C100600,  //  0021  CALL	R4	3
-      0x80000000,  //  0022  RET	0
+      0x80040600,  //  0022  RET	1	R3
     })
   )
 );
@@ -217,17 +136,16 @@ be_local_closure(Matter_UDPPacket_sent_send,   /* name */
 be_local_class(Matter_UDPPacket_sent,
     6,
     NULL,
-    be_nested_map(9,
+    be_nested_map(8,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(send, 7), be_const_closure(Matter_UDPPacket_sent_send_closure) },
-        { be_const_key_weak(msg_id, -1), be_const_var(3) },
-        { be_const_key_weak(retries, 8), be_const_var(4) },
-        { be_const_key_weak(backoff_time, -1), be_const_closure(Matter_UDPPacket_sent_backoff_time_closure) },
-        { be_const_key_weak(next_try, 0), be_const_var(5) },
-        { be_const_key_weak(raw, 3), be_const_var(0) },
+        { be_const_key_weak(addr, -1), be_const_var(1) },
+        { be_const_key_weak(raw, -1), be_const_var(0) },
+        { be_const_key_weak(msg_id, 0), be_const_var(3) },
         { be_const_key_weak(init, -1), be_const_closure(Matter_UDPPacket_sent_init_closure) },
         { be_const_key_weak(port, -1), be_const_var(2) },
-        { be_const_key_weak(addr, -1), be_const_var(1) },
+        { be_const_key_weak(retries, -1), be_const_var(4) },
+        { be_const_key_weak(next_try, 4), be_const_var(5) },
+        { be_const_key_weak(send, -1), be_const_closure(Matter_UDPPacket_sent_send_closure) },
     })),
     be_str_weak(Matter_UDPPacket_sent)
 );
@@ -242,270 +160,132 @@ void be_load_Matter_UDPPacket_sent_class(bvm *vm) {
 extern const bclass be_class_Matter_UDPServer;
 
 /********************************************************************
-** Solidified function: start
+** Solidified function: _backoff_time
 ********************************************************************/
-be_local_closure(Matter_UDPServer_start,   /* name */
+be_local_closure(Matter_UDPServer__backoff_time,   /* name */
   be_nested_proto(
-    6,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[11]) {     /* constants */
-    /* K0   */  be_nested_str_weak(listening),
-    /* K1   */  be_nested_str_weak(udp_socket),
-    /* K2   */  be_nested_str_weak(udp),
-    /* K3   */  be_nested_str_weak(begin),
-    /* K4   */  be_nested_str_weak(address),
-    /* K5   */  be_nested_str_weak(port),
-    /* K6   */  be_nested_str_weak(network_error),
-    /* K7   */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
-    /* K8   */  be_nested_str_weak(dispatch_cb),
-    /* K9   */  be_nested_str_weak(tasmota),
-    /* K10  */  be_nested_str_weak(add_driver),
-    }),
-    be_str_weak(start),
-    &be_const_str_solidified,
-    ( &(const binstruction[21]) {  /* code */
-      0x88080100,  //  0000  GETMBR	R2	R0	K0
-      0x740A0011,  //  0001  JMPT	R2	#0014
-      0xB80A0400,  //  0002  GETNGBL	R2	K2
-      0x7C080000,  //  0003  CALL	R2	0
-      0x90020202,  //  0004  SETMBR	R0	K1	R2
-      0x88080101,  //  0005  GETMBR	R2	R0	K1
-      0x8C080503,  //  0006  GETMET	R2	R2	K3
-      0x88100104,  //  0007  GETMBR	R4	R0	K4
-      0x88140105,  //  0008  GETMBR	R5	R0	K5
-      0x7C080600,  //  0009  CALL	R2	3
-      0x5C0C0400,  //  000A  MOVE	R3	R2
-      0x740E0000,  //  000B  JMPT	R3	#000D
-      0xB0060D07,  //  000C  RAISE	1	K6	K7
-      0x500C0200,  //  000D  LDBOOL	R3	1	0
-      0x90020003,  //  000E  SETMBR	R0	K0	R3
-      0x90021001,  //  000F  SETMBR	R0	K8	R1
-      0xB80E1200,  //  0010  GETNGBL	R3	K9
-      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
-      0x5C140000,  //  0012  MOVE	R5	R0
-      0x7C0C0400,  //  0013  CALL	R3	2
-      0x80000000,  //  0014  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: init
-********************************************************************/
-be_local_closure(Matter_UDPServer_init,   /* name */
-  be_nested_proto(
-    4,                          /* nstack */
-    3,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[ 5]) {     /* constants */
-    /* K0   */  be_nested_str_weak(address),
-    /* K1   */  be_nested_str_weak(),
-    /* K2   */  be_nested_str_weak(port),
-    /* K3   */  be_nested_str_weak(listening),
-    /* K4   */  be_nested_str_weak(packets_sent),
-    }),
-    be_str_weak(init),
-    &be_const_str_solidified,
-    ( &(const binstruction[16]) {  /* code */
-      0x78060001,  //  0000  JMPF	R1	#0003
-      0x5C0C0200,  //  0001  MOVE	R3	R1
-      0x70020000,  //  0002  JMP		#0004
-      0x580C0001,  //  0003  LDCONST	R3	K1
-      0x90020003,  //  0004  SETMBR	R0	K0	R3
-      0x780A0001,  //  0005  JMPF	R2	#0008
-      0x5C0C0400,  //  0006  MOVE	R3	R2
-      0x70020000,  //  0007  JMP		#0009
-      0x540E15A3,  //  0008  LDINT	R3	5540
-      0x90020403,  //  0009  SETMBR	R0	K2	R3
-      0x500C0000,  //  000A  LDBOOL	R3	0	0
-      0x90020603,  //  000B  SETMBR	R0	K3	R3
-      0x600C0012,  //  000C  GETGBL	R3	G18
-      0x7C0C0000,  //  000D  CALL	R3	0
-      0x90020803,  //  000E  SETMBR	R0	K4	R3
-      0x80000000,  //  000F  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: resend_packets
-********************************************************************/
-be_local_closure(Matter_UDPServer_resend_packets,   /* name */
-  be_nested_proto(
-    12,                          /* nstack */
+    10,                          /* nstack */
     1,                          /* argc */
-    2,                          /* varg */
+    4,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
-    1,                          /* has constants */
-    ( &(const bvalue[23]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(packets_sent),
-    /* K2   */  be_nested_str_weak(tasmota),
-    /* K3   */  be_nested_str_weak(time_reached),
-    /* K4   */  be_nested_str_weak(next_try),
-    /* K5   */  be_nested_str_weak(retries),
-    /* K6   */  be_nested_str_weak(RETRIES),
-    /* K7   */  be_nested_str_weak(log),
-    /* K8   */  be_nested_str_weak(MTR_X3A_X20resending_X20packet_X20id_X3D),
-    /* K9   */  be_nested_str_weak(msg_id),
-    /* K10  */  be_const_int(3),
-    /* K11  */  be_nested_str_weak(send),
-    /* K12  */  be_nested_str_weak(udp_socket),
-    /* K13  */  be_nested_str_weak(millis),
-    /* K14  */  be_nested_str_weak(backoff_time),
-    /* K15  */  be_const_int(1),
-    /* K16  */  be_nested_str_weak(string),
-    /* K17  */  be_nested_str_weak(remove),
-    /* K18  */  be_nested_str_weak(format),
-    /* K19  */  be_nested_str_weak(MTR_X3A_X20target_X20unreachable_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
-    /* K20  */  be_nested_str_weak(addr),
-    /* K21  */  be_nested_str_weak(port),
-    /* K22  */  be_const_int(2),
+    1,                          /* has sup protos */
+    ( &(const struct bproto*[ 1]) {
+      be_nested_proto(
+        4,                          /* nstack */
+        2,                          /* argc */
+        0,                          /* varg */
+        0,                          /* has upvals */
+        NULL,                       /* no upvals */
+        0,                          /* has sup protos */
+        NULL,                       /* no sub protos */
+        1,                          /* has constants */
+        ( &(const bvalue[ 2]) {     /* constants */
+        /* K0   */  be_const_int(1),
+        /* K1   */  be_const_int(0),
+        }),
+        be_str_weak(power_int),
+        &be_const_str_solidified,
+        ( &(const binstruction[ 7]) {  /* code */
+          0x58080000,  //  0000  LDCONST	R2	K0
+          0x240C0301,  //  0001  GT	R3	R1	K1
+          0x780E0002,  //  0002  JMPF	R3	#0006
+          0x08080400,  //  0003  MUL	R2	R2	R0
+          0x04040300,  //  0004  SUB	R1	R1	K0
+          0x7001FFFA,  //  0005  JMP		#0001
+          0x80040400,  //  0006  RET	1	R2
+        })
+      ),
     }),
-    be_str_weak(resend_packets),
-    &be_const_str_solidified,
-    ( &(const binstruction[60]) {  /* code */
-      0x58040000,  //  0000  LDCONST	R1	K0
-      0x6008000C,  //  0001  GETGBL	R2	G12
-      0x880C0101,  //  0002  GETMBR	R3	R0	K1
-      0x7C080200,  //  0003  CALL	R2	1
-      0x14080202,  //  0004  LT	R2	R1	R2
-      0x780A0034,  //  0005  JMPF	R2	#003B
-      0x88080101,  //  0006  GETMBR	R2	R0	K1
-      0x94080401,  //  0007  GETIDX	R2	R2	R1
-      0xB80E0400,  //  0008  GETNGBL	R3	K2
-      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
-      0x88140504,  //  000A  GETMBR	R5	R2	K4
-      0x7C0C0400,  //  000B  CALL	R3	2
-      0x780E002B,  //  000C  JMPF	R3	#0039
-      0x880C0505,  //  000D  GETMBR	R3	R2	K5
-      0x88100106,  //  000E  GETMBR	R4	R0	K6
-      0x180C0604,  //  000F  LE	R3	R3	R4
-      0x780E0017,  //  0010  JMPF	R3	#0029
-      0xB80E0400,  //  0011  GETNGBL	R3	K2
-      0x8C0C0707,  //  0012  GETMET	R3	R3	K7
-      0x60140008,  //  0013  GETGBL	R5	G8
-      0x88180509,  //  0014  GETMBR	R6	R2	K9
-      0x7C140200,  //  0015  CALL	R5	1
-      0x00161005,  //  0016  ADD	R5	K8	R5
-      0x5818000A,  //  0017  LDCONST	R6	K10
-      0x7C0C0600,  //  0018  CALL	R3	3
-      0x8C0C050B,  //  0019  GETMET	R3	R2	K11
-      0x8814010C,  //  001A  GETMBR	R5	R0	K12
-      0x7C0C0400,  //  001B  CALL	R3	2
-      0xB80E0400,  //  001C  GETNGBL	R3	K2
-      0x8C0C070D,  //  001D  GETMET	R3	R3	K13
-      0x7C0C0200,  //  001E  CALL	R3	1
-      0x8C10050E,  //  001F  GETMET	R4	R2	K14
-      0x88180505,  //  0020  GETMBR	R6	R2	K5
-      0x7C100400,  //  0021  CALL	R4	2
-      0x000C0604,  //  0022  ADD	R3	R3	R4
-      0x900A0803,  //  0023  SETMBR	R2	K4	R3
-      0x880C0505,  //  0024  GETMBR	R3	R2	K5
-      0x000C070F,  //  0025  ADD	R3	R3	K15
-      0x900A0A03,  //  0026  SETMBR	R2	K5	R3
-      0x0004030F,  //  0027  ADD	R1	R1	K15
-      0x7002000E,  //  0028  JMP		#0038
-      0xA40E2000,  //  0029  IMPORT	R3	K16
-      0x88100101,  //  002A  GETMBR	R4	R0	K1
-      0x8C100911,  //  002B  GETMET	R4	R4	K17
-      0x5C180200,  //  002C  MOVE	R6	R1
-      0x7C100400,  //  002D  CALL	R4	2
-      0xB8120400,  //  002E  GETNGBL	R4	K2
-      0x8C100907,  //  002F  GETMET	R4	R4	K7
-      0x8C180712,  //  0030  GETMET	R6	R3	K18
-      0x58200013,  //  0031  LDCONST	R8	K19
-      0x88240514,  //  0032  GETMBR	R9	R2	K20
-      0x88280515,  //  0033  GETMBR	R10	R2	K21
-      0x882C0509,  //  0034  GETMBR	R11	R2	K9
-      0x7C180A00,  //  0035  CALL	R6	5
-      0x581C0016,  //  0036  LDCONST	R7	K22
-      0x7C100600,  //  0037  CALL	R4	3
-      0x70020000,  //  0038  JMP		#003A
-      0x0004030F,  //  0039  ADD	R1	R1	K15
-      0x7001FFC5,  //  003A  JMP		#0001
-      0x80000000,  //  003B  RET	0
-    })
-  )
-);
-/*******************************************************************/
-
-
-/********************************************************************
-** Solidified function: packet_ack
-********************************************************************/
-be_local_closure(Matter_UDPServer_packet_ack,   /* name */
-  be_nested_proto(
-    7,                          /* nstack */
-    2,                          /* argc */
-    2,                          /* varg */
-    0,                          /* has upvals */
-    NULL,                       /* no upvals */
-    0,                          /* has sup protos */
-    NULL,                       /* no sub protos */
     1,                          /* has constants */
     ( &(const bvalue[ 8]) {     /* constants */
-    /* K0   */  be_const_int(0),
-    /* K1   */  be_nested_str_weak(packets_sent),
-    /* K2   */  be_nested_str_weak(msg_id),
-    /* K3   */  be_nested_str_weak(remove),
-    /* K4   */  be_nested_str_weak(tasmota),
-    /* K5   */  be_nested_str_weak(log),
-    /* K6   */  be_nested_str_weak(MTR_X3A_X20removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
-    /* K7   */  be_const_int(1),
+    /* K0   */  be_const_class(be_class_Matter_UDPServer),
+    /* K1   */  be_nested_str_weak(math),
+    /* K2   */  be_nested_str_weak(rand),
+    /* K3   */  be_const_int(0),
+    /* K4   */  be_const_int(1),
+    /* K5   */  be_const_real_hex(0x3FCCCCCD),
+    /* K6   */  be_const_real_hex(0x3F800000),
+    /* K7   */  be_const_real_hex(0x3E800000),
     }),
-    be_str_weak(packet_ack),
+    be_str_weak(_backoff_time),
     &be_const_str_solidified,
-    ( &(const binstruction[31]) {  /* code */
-      0x4C080000,  //  0000  LDNIL	R2
-      0x1C080202,  //  0001  EQ	R2	R1	R2
-      0x780A0000,  //  0002  JMPF	R2	#0004
-      0x80000400,  //  0003  RET	0
-      0x58080000,  //  0004  LDCONST	R2	K0
-      0x600C000C,  //  0005  GETGBL	R3	G12
-      0x88100101,  //  0006  GETMBR	R4	R0	K1
-      0x7C0C0200,  //  0007  CALL	R3	1
-      0x140C0403,  //  0008  LT	R3	R2	R3
-      0x780E0013,  //  0009  JMPF	R3	#001E
-      0x880C0101,  //  000A  GETMBR	R3	R0	K1
-      0x940C0602,  //  000B  GETIDX	R3	R3	R2
-      0x880C0702,  //  000C  GETMBR	R3	R3	K2
-      0x1C0C0601,  //  000D  EQ	R3	R3	R1
-      0x780E000C,  //  000E  JMPF	R3	#001C
-      0x880C0101,  //  000F  GETMBR	R3	R0	K1
-      0x8C0C0703,  //  0010  GETMET	R3	R3	K3
-      0x5C140400,  //  0011  MOVE	R5	R2
-      0x7C0C0400,  //  0012  CALL	R3	2
-      0xB80E0800,  //  0013  GETNGBL	R3	K4
-      0x8C0C0705,  //  0014  GETMET	R3	R3	K5
-      0x60140008,  //  0015  GETGBL	R5	G8
-      0x5C180200,  //  0016  MOVE	R6	R1
-      0x7C140200,  //  0017  CALL	R5	1
-      0x00160C05,  //  0018  ADD	R5	K6	R5
-      0x541A0003,  //  0019  LDINT	R6	4
-      0x7C0C0600,  //  001A  CALL	R3	3
-      0x70020000,  //  001B  JMP		#001D
-      0x00080507,  //  001C  ADD	R2	R2	K7
-      0x7001FFE6,  //  001D  JMP		#0005
-      0x80000000,  //  001E  RET	0
+    ( &(const binstruction[29]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x84080000,  //  0001  CLOSURE	R2	P0
+      0xA40E0200,  //  0002  IMPORT	R3	K1
+      0x5412012B,  //  0003  LDINT	R4	300
+      0x6014000A,  //  0004  GETGBL	R5	G10
+      0x8C180702,  //  0005  GETMET	R6	R3	K2
+      0x7C180200,  //  0006  CALL	R6	1
+      0x541E00FE,  //  0007  LDINT	R7	255
+      0x2C180C07,  //  0008  AND	R6	R6	R7
+      0x7C140200,  //  0009  CALL	R5	1
+      0x541A00FE,  //  000A  LDINT	R6	255
+      0x0C140A06,  //  000B  DIV	R5	R5	R6
+      0x24180103,  //  000C  GT	R6	R0	K3
+      0x781A0001,  //  000D  JMPF	R6	#0010
+      0x04180104,  //  000E  SUB	R6	R0	K4
+      0x70020000,  //  000F  JMP		#0011
+      0x58180003,  //  0010  LDCONST	R6	K3
+      0x5C1C0400,  //  0011  MOVE	R7	R2
+      0x58200005,  //  0012  LDCONST	R8	K5
+      0x5C240C00,  //  0013  MOVE	R9	R6
+      0x7C1C0400,  //  0014  CALL	R7	2
+      0x081C0807,  //  0015  MUL	R7	R4	R7
+      0x08200B07,  //  0016  MUL	R8	R5	K7
+      0x00220C08,  //  0017  ADD	R8	K6	R8
+      0x081C0E08,  //  0018  MUL	R7	R7	R8
+      0x60200009,  //  0019  GETGBL	R8	G9
+      0x5C240E00,  //  001A  MOVE	R9	R7
+      0x7C200200,  //  001B  CALL	R8	1
+      0x80041000,  //  001C  RET	1	R8
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: send_response
+********************************************************************/
+be_local_closure(Matter_UDPServer_send_response,   /* name */
+  be_nested_proto(
+    11,                          /* nstack */
+    5,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[ 6]) {     /* constants */
+    /* K0   */  be_nested_str_weak(matter),
+    /* K1   */  be_nested_str_weak(UDPPacket_sent),
+    /* K2   */  be_nested_str_weak(send),
+    /* K3   */  be_nested_str_weak(udp_socket),
+    /* K4   */  be_nested_str_weak(packets_sent),
+    /* K5   */  be_nested_str_weak(push),
+    }),
+    be_str_weak(send_response),
+    &be_const_str_solidified,
+    ( &(const binstruction[16]) {  /* code */
+      0xB8160000,  //  0000  GETNGBL	R5	K0
+      0x8C140B01,  //  0001  GETMET	R5	R5	K1
+      0x5C1C0200,  //  0002  MOVE	R7	R1
+      0x5C200400,  //  0003  MOVE	R8	R2
+      0x5C240600,  //  0004  MOVE	R9	R3
+      0x5C280800,  //  0005  MOVE	R10	R4
+      0x7C140A00,  //  0006  CALL	R5	5
+      0x8C180B02,  //  0007  GETMET	R6	R5	K2
+      0x88200103,  //  0008  GETMBR	R8	R0	K3
+      0x7C180400,  //  0009  CALL	R6	2
+      0x78120003,  //  000A  JMPF	R4	#000F
+      0x88180104,  //  000B  GETMBR	R6	R0	K4
+      0x8C180D05,  //  000C  GETMET	R6	R6	K5
+      0x5C200A00,  //  000D  MOVE	R8	R5
+      0x7C180400,  //  000E  CALL	R6	2
+      0x80000000,  //  000F  RET	0
     })
   )
 );
@@ -540,7 +320,7 @@ be_local_closure(Matter_UDPServer_every_50ms,   /* name */
     /* K11  */  be_const_int(3),
     /* K12  */  be_nested_str_weak(dispatch_cb),
     /* K13  */  be_nested_str_weak(MAX_PACKETS_READ),
-    /* K14  */  be_nested_str_weak(resend_packets),
+    /* K14  */  be_nested_str_weak(_resend_packets),
     }),
     be_str_weak(every_50ms),
     &be_const_str_solidified,
@@ -664,45 +444,280 @@ be_local_closure(Matter_UDPServer_stop,   /* name */
 
 
 /********************************************************************
-** Solidified function: send_response
+** Solidified function: init
 ********************************************************************/
-be_local_closure(Matter_UDPServer_send_response,   /* name */
+be_local_closure(Matter_UDPServer_init,   /* name */
   be_nested_proto(
-    11,                          /* nstack */
-    5,                          /* argc */
+    4,                          /* nstack */
+    3,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
     NULL,                       /* no upvals */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[ 6]) {     /* constants */
-    /* K0   */  be_nested_str_weak(matter),
-    /* K1   */  be_nested_str_weak(UDPPacket_sent),
-    /* K2   */  be_nested_str_weak(send),
-    /* K3   */  be_nested_str_weak(udp_socket),
+    ( &(const bvalue[ 5]) {     /* constants */
+    /* K0   */  be_nested_str_weak(addr),
+    /* K1   */  be_nested_str_weak(),
+    /* K2   */  be_nested_str_weak(port),
+    /* K3   */  be_nested_str_weak(listening),
     /* K4   */  be_nested_str_weak(packets_sent),
-    /* K5   */  be_nested_str_weak(push),
     }),
-    be_str_weak(send_response),
+    be_str_weak(init),
     &be_const_str_solidified,
     ( &(const binstruction[16]) {  /* code */
-      0xB8160000,  //  0000  GETNGBL	R5	K0
-      0x8C140B01,  //  0001  GETMET	R5	R5	K1
-      0x5C1C0200,  //  0002  MOVE	R7	R1
-      0x5C200400,  //  0003  MOVE	R8	R2
-      0x5C240600,  //  0004  MOVE	R9	R3
-      0x5C280800,  //  0005  MOVE	R10	R4
-      0x7C140A00,  //  0006  CALL	R5	5
-      0x8C180B02,  //  0007  GETMET	R6	R5	K2
-      0x88200103,  //  0008  GETMBR	R8	R0	K3
-      0x7C180400,  //  0009  CALL	R6	2
-      0x78120003,  //  000A  JMPF	R4	#000F
-      0x88180104,  //  000B  GETMBR	R6	R0	K4
-      0x8C180D05,  //  000C  GETMET	R6	R6	K5
-      0x5C200A00,  //  000D  MOVE	R8	R5
-      0x7C180400,  //  000E  CALL	R6	2
+      0x78060001,  //  0000  JMPF	R1	#0003
+      0x5C0C0200,  //  0001  MOVE	R3	R1
+      0x70020000,  //  0002  JMP		#0004
+      0x580C0001,  //  0003  LDCONST	R3	K1
+      0x90020003,  //  0004  SETMBR	R0	K0	R3
+      0x780A0001,  //  0005  JMPF	R2	#0008
+      0x5C0C0400,  //  0006  MOVE	R3	R2
+      0x70020000,  //  0007  JMP		#0009
+      0x540E15A3,  //  0008  LDINT	R3	5540
+      0x90020403,  //  0009  SETMBR	R0	K2	R3
+      0x500C0000,  //  000A  LDBOOL	R3	0	0
+      0x90020603,  //  000B  SETMBR	R0	K3	R3
+      0x600C0012,  //  000C  GETGBL	R3	G18
+      0x7C0C0000,  //  000D  CALL	R3	0
+      0x90020803,  //  000E  SETMBR	R0	K4	R3
       0x80000000,  //  000F  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: _resend_packets
+********************************************************************/
+be_local_closure(Matter_UDPServer__resend_packets,   /* name */
+  be_nested_proto(
+    12,                          /* nstack */
+    1,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[23]) {     /* constants */
+    /* K0   */  be_const_int(0),
+    /* K1   */  be_nested_str_weak(packets_sent),
+    /* K2   */  be_nested_str_weak(tasmota),
+    /* K3   */  be_nested_str_weak(time_reached),
+    /* K4   */  be_nested_str_weak(next_try),
+    /* K5   */  be_nested_str_weak(retries),
+    /* K6   */  be_nested_str_weak(RETRIES),
+    /* K7   */  be_nested_str_weak(log),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Resending_X20packet_X20id_X3D),
+    /* K9   */  be_nested_str_weak(msg_id),
+    /* K10  */  be_const_int(3),
+    /* K11  */  be_nested_str_weak(send),
+    /* K12  */  be_nested_str_weak(udp_socket),
+    /* K13  */  be_nested_str_weak(millis),
+    /* K14  */  be_nested_str_weak(_backoff_time),
+    /* K15  */  be_const_int(1),
+    /* K16  */  be_nested_str_weak(string),
+    /* K17  */  be_nested_str_weak(remove),
+    /* K18  */  be_nested_str_weak(format),
+    /* K19  */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Unacked_X20packet_X20_X27_X5B_X25s_X5D_X3A_X25i_X27_X20msg_id_X3D_X25i),
+    /* K20  */  be_nested_str_weak(addr),
+    /* K21  */  be_nested_str_weak(port),
+    /* K22  */  be_const_int(2),
+    }),
+    be_str_weak(_resend_packets),
+    &be_const_str_solidified,
+    ( &(const binstruction[60]) {  /* code */
+      0x58040000,  //  0000  LDCONST	R1	K0
+      0x6008000C,  //  0001  GETGBL	R2	G12
+      0x880C0101,  //  0002  GETMBR	R3	R0	K1
+      0x7C080200,  //  0003  CALL	R2	1
+      0x14080202,  //  0004  LT	R2	R1	R2
+      0x780A0034,  //  0005  JMPF	R2	#003B
+      0x88080101,  //  0006  GETMBR	R2	R0	K1
+      0x94080401,  //  0007  GETIDX	R2	R2	R1
+      0xB80E0400,  //  0008  GETNGBL	R3	K2
+      0x8C0C0703,  //  0009  GETMET	R3	R3	K3
+      0x88140504,  //  000A  GETMBR	R5	R2	K4
+      0x7C0C0400,  //  000B  CALL	R3	2
+      0x780E002B,  //  000C  JMPF	R3	#0039
+      0x880C0505,  //  000D  GETMBR	R3	R2	K5
+      0x88100106,  //  000E  GETMBR	R4	R0	K6
+      0x180C0604,  //  000F  LE	R3	R3	R4
+      0x780E0017,  //  0010  JMPF	R3	#0029
+      0xB80E0400,  //  0011  GETNGBL	R3	K2
+      0x8C0C0707,  //  0012  GETMET	R3	R3	K7
+      0x60140008,  //  0013  GETGBL	R5	G8
+      0x88180509,  //  0014  GETMBR	R6	R2	K9
+      0x7C140200,  //  0015  CALL	R5	1
+      0x00161005,  //  0016  ADD	R5	K8	R5
+      0x5818000A,  //  0017  LDCONST	R6	K10
+      0x7C0C0600,  //  0018  CALL	R3	3
+      0x8C0C050B,  //  0019  GETMET	R3	R2	K11
+      0x8814010C,  //  001A  GETMBR	R5	R0	K12
+      0x7C0C0400,  //  001B  CALL	R3	2
+      0xB80E0400,  //  001C  GETNGBL	R3	K2
+      0x8C0C070D,  //  001D  GETMET	R3	R3	K13
+      0x7C0C0200,  //  001E  CALL	R3	1
+      0x8C10010E,  //  001F  GETMET	R4	R0	K14
+      0x88180505,  //  0020  GETMBR	R6	R2	K5
+      0x7C100400,  //  0021  CALL	R4	2
+      0x000C0604,  //  0022  ADD	R3	R3	R4
+      0x900A0803,  //  0023  SETMBR	R2	K4	R3
+      0x880C0505,  //  0024  GETMBR	R3	R2	K5
+      0x000C070F,  //  0025  ADD	R3	R3	K15
+      0x900A0A03,  //  0026  SETMBR	R2	K5	R3
+      0x0004030F,  //  0027  ADD	R1	R1	K15
+      0x7002000E,  //  0028  JMP		#0038
+      0xA40E2000,  //  0029  IMPORT	R3	K16
+      0x88100101,  //  002A  GETMBR	R4	R0	K1
+      0x8C100911,  //  002B  GETMET	R4	R4	K17
+      0x5C180200,  //  002C  MOVE	R6	R1
+      0x7C100400,  //  002D  CALL	R4	2
+      0xB8120400,  //  002E  GETNGBL	R4	K2
+      0x8C100907,  //  002F  GETMET	R4	R4	K7
+      0x8C180712,  //  0030  GETMET	R6	R3	K18
+      0x58200013,  //  0031  LDCONST	R8	K19
+      0x88240514,  //  0032  GETMBR	R9	R2	K20
+      0x88280515,  //  0033  GETMBR	R10	R2	K21
+      0x882C0509,  //  0034  GETMBR	R11	R2	K9
+      0x7C180A00,  //  0035  CALL	R6	5
+      0x581C0016,  //  0036  LDCONST	R7	K22
+      0x7C100600,  //  0037  CALL	R4	3
+      0x70020000,  //  0038  JMP		#003A
+      0x0004030F,  //  0039  ADD	R1	R1	K15
+      0x7001FFC5,  //  003A  JMP		#0001
+      0x80000000,  //  003B  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: start
+********************************************************************/
+be_local_closure(Matter_UDPServer_start,   /* name */
+  be_nested_proto(
+    6,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[11]) {     /* constants */
+    /* K0   */  be_nested_str_weak(listening),
+    /* K1   */  be_nested_str_weak(udp_socket),
+    /* K2   */  be_nested_str_weak(udp),
+    /* K3   */  be_nested_str_weak(begin),
+    /* K4   */  be_nested_str_weak(addr),
+    /* K5   */  be_nested_str_weak(port),
+    /* K6   */  be_nested_str_weak(network_error),
+    /* K7   */  be_nested_str_weak(could_X20not_X20open_X20UDP_X20server),
+    /* K8   */  be_nested_str_weak(dispatch_cb),
+    /* K9   */  be_nested_str_weak(tasmota),
+    /* K10  */  be_nested_str_weak(add_driver),
+    }),
+    be_str_weak(start),
+    &be_const_str_solidified,
+    ( &(const binstruction[21]) {  /* code */
+      0x88080100,  //  0000  GETMBR	R2	R0	K0
+      0x740A0011,  //  0001  JMPT	R2	#0014
+      0xB80A0400,  //  0002  GETNGBL	R2	K2
+      0x7C080000,  //  0003  CALL	R2	0
+      0x90020202,  //  0004  SETMBR	R0	K1	R2
+      0x88080101,  //  0005  GETMBR	R2	R0	K1
+      0x8C080503,  //  0006  GETMET	R2	R2	K3
+      0x88100104,  //  0007  GETMBR	R4	R0	K4
+      0x88140105,  //  0008  GETMBR	R5	R0	K5
+      0x7C080600,  //  0009  CALL	R2	3
+      0x5C0C0400,  //  000A  MOVE	R3	R2
+      0x740E0000,  //  000B  JMPT	R3	#000D
+      0xB0060D07,  //  000C  RAISE	1	K6	K7
+      0x500C0200,  //  000D  LDBOOL	R3	1	0
+      0x90020003,  //  000E  SETMBR	R0	K0	R3
+      0x90021001,  //  000F  SETMBR	R0	K8	R1
+      0xB80E1200,  //  0010  GETNGBL	R3	K9
+      0x8C0C070A,  //  0011  GETMET	R3	R3	K10
+      0x5C140000,  //  0012  MOVE	R5	R0
+      0x7C0C0400,  //  0013  CALL	R3	2
+      0x80000000,  //  0014  RET	0
+    })
+  )
+);
+/*******************************************************************/
+
+
+/********************************************************************
+** Solidified function: received_ack
+********************************************************************/
+be_local_closure(Matter_UDPServer_received_ack,   /* name */
+  be_nested_proto(
+    7,                          /* nstack */
+    2,                          /* argc */
+    2,                          /* varg */
+    0,                          /* has upvals */
+    NULL,                       /* no upvals */
+    0,                          /* has sup protos */
+    NULL,                       /* no sub protos */
+    1,                          /* has constants */
+    ( &(const bvalue[10]) {     /* constants */
+    /* K0   */  be_nested_str_weak(tasmota),
+    /* K1   */  be_nested_str_weak(log),
+    /* K2   */  be_nested_str_weak(MTR_X3A_X20receveived_X20ACK_X20id_X3D),
+    /* K3   */  be_const_int(3),
+    /* K4   */  be_const_int(0),
+    /* K5   */  be_nested_str_weak(packets_sent),
+    /* K6   */  be_nested_str_weak(msg_id),
+    /* K7   */  be_nested_str_weak(remove),
+    /* K8   */  be_nested_str_weak(MTR_X3A_X20_X2E_X20_X20_X20_X20_X20_X20_X20_X20_X20_X20Removed_X20packet_X20from_X20sending_X20list_X20id_X3D),
+    /* K9   */  be_const_int(1),
+    }),
+    be_str_weak(received_ack),
+    &be_const_str_solidified,
+    ( &(const binstruction[39]) {  /* code */
+      0x4C080000,  //  0000  LDNIL	R2
+      0x1C080202,  //  0001  EQ	R2	R1	R2
+      0x780A0000,  //  0002  JMPF	R2	#0004
+      0x80000400,  //  0003  RET	0
+      0xB80A0000,  //  0004  GETNGBL	R2	K0
+      0x8C080501,  //  0005  GETMET	R2	R2	K1
+      0x60100008,  //  0006  GETGBL	R4	G8
+      0x5C140200,  //  0007  MOVE	R5	R1
+      0x7C100200,  //  0008  CALL	R4	1
+      0x00120404,  //  0009  ADD	R4	K2	R4
+      0x58140003,  //  000A  LDCONST	R5	K3
+      0x7C080600,  //  000B  CALL	R2	3
+      0x58080004,  //  000C  LDCONST	R2	K4
+      0x600C000C,  //  000D  GETGBL	R3	G12
+      0x88100105,  //  000E  GETMBR	R4	R0	K5
+      0x7C0C0200,  //  000F  CALL	R3	1
+      0x140C0403,  //  0010  LT	R3	R2	R3
+      0x780E0013,  //  0011  JMPF	R3	#0026
+      0x880C0105,  //  0012  GETMBR	R3	R0	K5
+      0x940C0602,  //  0013  GETIDX	R3	R3	R2
+      0x880C0706,  //  0014  GETMBR	R3	R3	K6
+      0x1C0C0601,  //  0015  EQ	R3	R3	R1
+      0x780E000C,  //  0016  JMPF	R3	#0024
+      0x880C0105,  //  0017  GETMBR	R3	R0	K5
+      0x8C0C0707,  //  0018  GETMET	R3	R3	K7
+      0x5C140400,  //  0019  MOVE	R5	R2
+      0x7C0C0400,  //  001A  CALL	R3	2
+      0xB80E0000,  //  001B  GETNGBL	R3	K0
+      0x8C0C0701,  //  001C  GETMET	R3	R3	K1
+      0x60140008,  //  001D  GETGBL	R5	G8
+      0x5C180200,  //  001E  MOVE	R6	R1
+      0x7C140200,  //  001F  CALL	R5	1
+      0x00161005,  //  0020  ADD	R5	K8	R5
+      0x58180003,  //  0021  LDCONST	R6	K3
+      0x7C0C0600,  //  0022  CALL	R3	3
+      0x70020000,  //  0023  JMP		#0025
+      0x00080509,  //  0024  ADD	R2	R2	K9
+      0x7001FFE6,  //  0025  JMP		#000D
+      0x80000000,  //  0026  RET	0
     })
   )
 );
@@ -715,24 +730,25 @@ be_local_closure(Matter_UDPServer_send_response,   /* name */
 be_local_class(Matter_UDPServer,
     6,
     NULL,
-    be_nested_map(16,
+    be_nested_map(17,
     ( (struct bmapnode*) &(const bmapnode[]) {
-        { be_const_key_weak(MAX_PACKETS_READ, 14), be_const_int(4) },
-        { be_const_key_weak(send_response, -1), be_const_closure(Matter_UDPServer_send_response_closure) },
-        { be_const_key_weak(stop, -1), be_const_closure(Matter_UDPServer_stop_closure) },
-        { be_const_key_weak(init, 12), be_const_closure(Matter_UDPServer_init_closure) },
-        { be_const_key_weak(resend_packets, -1), be_const_closure(Matter_UDPServer_resend_packets_closure) },
-        { be_const_key_weak(RETRIES, 2), be_const_int(4) },
-        { be_const_key_weak(port, -1), be_const_var(1) },
-        { be_const_key_weak(packet_ack, -1), be_const_closure(Matter_UDPServer_packet_ack_closure) },
-        { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_UDPServer_every_50ms_closure) },
-        { be_const_key_weak(every_second, -1), be_const_closure(Matter_UDPServer_every_second_closure) },
+        { be_const_key_weak(RETRIES, -1), be_const_int(4) },
+        { be_const_key_weak(_backoff_time, 6), be_const_static_closure(Matter_UDPServer__backoff_time_closure) },
         { be_const_key_weak(listening, -1), be_const_var(2) },
-        { be_const_key_weak(dispatch_cb, -1), be_const_var(4) },
-        { be_const_key_weak(address, -1), be_const_var(0) },
-        { be_const_key_weak(packets_sent, 11), be_const_var(5) },
+        { be_const_key_weak(send_response, -1), be_const_closure(Matter_UDPServer_send_response_closure) },
+        { be_const_key_weak(received_ack, -1), be_const_closure(Matter_UDPServer_received_ack_closure) },
+        { be_const_key_weak(every_second, -1), be_const_closure(Matter_UDPServer_every_second_closure) },
+        { be_const_key_weak(every_50ms, -1), be_const_closure(Matter_UDPServer_every_50ms_closure) },
+        { be_const_key_weak(packets_sent, -1), be_const_var(5) },
+        { be_const_key_weak(port, -1), be_const_var(1) },
         { be_const_key_weak(udp_socket, -1), be_const_var(3) },
-        { be_const_key_weak(start, 1), be_const_closure(Matter_UDPServer_start_closure) },
+        { be_const_key_weak(_resend_packets, 11), be_const_closure(Matter_UDPServer__resend_packets_closure) },
+        { be_const_key_weak(stop, -1), be_const_closure(Matter_UDPServer_stop_closure) },
+        { be_const_key_weak(addr, -1), be_const_var(0) },
+        { be_const_key_weak(MAX_PACKETS_READ, 10), be_const_int(4) },
+        { be_const_key_weak(start, -1), be_const_closure(Matter_UDPServer_start_closure) },
+        { be_const_key_weak(init, 4), be_const_closure(Matter_UDPServer_init_closure) },
+        { be_const_key_weak(dispatch_cb, 0), be_const_var(4) },
     })),
     be_str_weak(Matter_UDPServer)
 );

--- a/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
+++ b/lib/libesp32/berry_matter/src/solidify/solidified_Matter_UI.h
@@ -11,7 +11,7 @@ extern const bclass be_class_Matter_UI;
 ********************************************************************/
 be_local_closure(Matter_UI_show_fabric_info,   /* name */
   be_nested_proto(
-    16,                          /* nstack */
+    17,                          /* nstack */
     2,                          /* argc */
     2,                          /* varg */
     0,                          /* has upvals */
@@ -19,7 +19,7 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
     0,                          /* has sup protos */
     NULL,                       /* no sub protos */
     1,                          /* has constants */
-    ( &(const bvalue[29]) {     /* constants */
+    ( &(const bvalue[30]) {     /* constants */
     /* K0   */  be_nested_str_weak(webserver),
     /* K1   */  be_nested_str_weak(string),
     /* K2   */  be_nested_str_weak(content_send),
@@ -32,27 +32,28 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
     /* K9   */  be_nested_str_weak(fabrics),
     /* K10  */  be_nested_str_weak(persistables),
     /* K11  */  be_nested_str_weak(_X3Chr_X3E),
-    /* K12  */  be_nested_str_weak(format),
-    /* K13  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K14  */  be_nested_str_weak(get_fabric_index),
-    /* K15  */  be_nested_str_weak(_X26lt_X3BNo_X20label_X26gt_X3B),
-    /* K16  */  be_nested_str_weak(get_fabric_id),
-    /* K17  */  be_nested_str_weak(copy),
-    /* K18  */  be_nested_str_weak(reverse),
-    /* K19  */  be_nested_str_weak(get_device_id),
-    /* K20  */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
-    /* K21  */  be_nested_str_weak(tohex),
-    /* K22  */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
-    /* K23  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20),
-    /* K24  */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
-    /* K25  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
-    /* K26  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
-    /* K27  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
-    /* K28  */  be_nested_str_weak(stop_iteration),
+    /* K12  */  be_nested_str_weak(fabric_label),
+    /* K13  */  be_nested_str_weak(_X26lt_X3BNo_X20label_X26gt_X3B),
+    /* K14  */  be_nested_str_weak(format),
+    /* K15  */  be_nested_str_weak(_X3Cfieldset_X3E_X3Clegend_X3E_X3Cb_X3E_X26nbsp_X3B_X23_X25i_X20_X25s_X26nbsp_X3B_X3C_X2Fb_X3E_X3C_X2Flegend_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K16  */  be_nested_str_weak(get_fabric_index),
+    /* K17  */  be_nested_str_weak(get_fabric_id),
+    /* K18  */  be_nested_str_weak(copy),
+    /* K19  */  be_nested_str_weak(reverse),
+    /* K20  */  be_nested_str_weak(get_device_id),
+    /* K21  */  be_nested_str_weak(Fabric_X3A_X20_X25s_X3Cbr_X3E),
+    /* K22  */  be_nested_str_weak(tohex),
+    /* K23  */  be_nested_str_weak(Device_X3A_X20_X25s_X3Cbr_X3E_X26nbsp_X3B),
+    /* K24  */  be_nested_str_weak(_X3Cform_X20action_X3D_X27_X2Fmatterc_X27_X20method_X3D_X27post_X27_X20),
+    /* K25  */  be_nested_str_weak(onsubmit_X3D_X27return_X20confirm_X28_X22This_X20will_X20cause_X20a_X20restart_X2E_X22_X29_X3B_X27_X3E),
+    /* K26  */  be_nested_str_weak(_X3Cinput_X20name_X3D_X27del_fabric_X27_X20type_X3D_X27hidden_X27_X20value_X3D_X27_X25s_X27_X3E),
+    /* K27  */  be_nested_str_weak(_X3Cbutton_X20name_X3D_X27del_X27_X20class_X3D_X27button_X20bgrn_X27_X3EDelete_X20Fabric_X3C_X2Fbutton_X3E_X3C_X2Fform_X3E_X3C_X2Fp_X3E),
+    /* K28  */  be_nested_str_weak(_X3Cp_X3E_X3C_X2Fp_X3E_X3C_X2Ffieldset_X3E_X3Cp_X3E_X3C_X2Fp_X3E),
+    /* K29  */  be_nested_str_weak(stop_iteration),
     }),
     be_str_weak(show_fabric_info),
     &be_const_str_solidified,
-    ( &(const binstruction[97]) {  /* code */
+    ( &(const binstruction[101]) {  /* code */
       0xA40A0000,  //  0000  IMPORT	R2	K0
       0xA40E0200,  //  0001  IMPORT	R3	K1
       0x8C100502,  //  0002  GETMET	R4	R2	K2
@@ -71,7 +72,7 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
       0x8C100502,  //  000F  GETMET	R4	R2	K2
       0x58180008,  //  0010  LDCONST	R6	K8
       0x7C100400,  //  0011  CALL	R4	2
-      0x70020049,  //  0012  JMP		#005D
+      0x7002004D,  //  0012  JMP		#0061
       0x50100200,  //  0013  LDBOOL	R4	1	0
       0x60140010,  //  0014  GETGBL	R5	G16
       0x88180105,  //  0015  GETMBR	R6	R0	K5
@@ -80,7 +81,7 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
       0x8C180D0A,  //  0018  GETMET	R6	R6	K10
       0x7C180200,  //  0019  CALL	R6	1
       0x7C140200,  //  001A  CALL	R5	1
-      0xA802003D,  //  001B  EXBLK	0	#005A
+      0xA8020041,  //  001B  EXBLK	0	#005E
       0x5C180A00,  //  001C  MOVE	R6	R5
       0x7C180000,  //  001D  CALL	R6	0
       0x5C1C0800,  //  001E  MOVE	R7	R4
@@ -89,67 +90,71 @@ be_local_closure(Matter_UI_show_fabric_info,   /* name */
       0x5824000B,  //  0021  LDCONST	R9	K11
       0x7C1C0400,  //  0022  CALL	R7	2
       0x50100000,  //  0023  LDBOOL	R4	0	0
-      0x8C1C0502,  //  0024  GETMET	R7	R2	K2
-      0x8C24070C,  //  0025  GETMET	R9	R3	K12
-      0x582C000D,  //  0026  LDCONST	R11	K13
-      0x8C300D0E,  //  0027  GETMET	R12	R6	K14
-      0x7C300200,  //  0028  CALL	R12	1
-      0x5834000F,  //  0029  LDCONST	R13	K15
-      0x7C240800,  //  002A  CALL	R9	4
-      0x7C1C0400,  //  002B  CALL	R7	2
-      0x8C1C0D10,  //  002C  GETMET	R7	R6	K16
-      0x7C1C0200,  //  002D  CALL	R7	1
-      0x8C1C0F11,  //  002E  GETMET	R7	R7	K17
-      0x7C1C0200,  //  002F  CALL	R7	1
-      0x8C1C0F12,  //  0030  GETMET	R7	R7	K18
-      0x7C1C0200,  //  0031  CALL	R7	1
-      0x8C200D13,  //  0032  GETMET	R8	R6	K19
+      0x881C0D0C,  //  0024  GETMBR	R7	R6	K12
+      0x5C200E00,  //  0025  MOVE	R8	R7
+      0x74220000,  //  0026  JMPT	R8	#0028
+      0x581C000D,  //  0027  LDCONST	R7	K13
+      0x8C200502,  //  0028  GETMET	R8	R2	K2
+      0x8C28070E,  //  0029  GETMET	R10	R3	K14
+      0x5830000F,  //  002A  LDCONST	R12	K15
+      0x8C340D10,  //  002B  GETMET	R13	R6	K16
+      0x7C340200,  //  002C  CALL	R13	1
+      0x5C380E00,  //  002D  MOVE	R14	R7
+      0x7C280800,  //  002E  CALL	R10	4
+      0x7C200400,  //  002F  CALL	R8	2
+      0x8C200D11,  //  0030  GETMET	R8	R6	K17
+      0x7C200200,  //  0031  CALL	R8	1
+      0x8C201112,  //  0032  GETMET	R8	R8	K18
       0x7C200200,  //  0033  CALL	R8	1
-      0x8C201111,  //  0034  GETMET	R8	R8	K17
+      0x8C201113,  //  0034  GETMET	R8	R8	K19
       0x7C200200,  //  0035  CALL	R8	1
-      0x8C201112,  //  0036  GETMET	R8	R8	K18
-      0x7C200200,  //  0037  CALL	R8	1
-      0x8C240502,  //  0038  GETMET	R9	R2	K2
-      0x8C2C070C,  //  0039  GETMET	R11	R3	K12
-      0x58340014,  //  003A  LDCONST	R13	K20
-      0x8C380F15,  //  003B  GETMET	R14	R7	K21
-      0x7C380200,  //  003C  CALL	R14	1
-      0x7C2C0600,  //  003D  CALL	R11	3
-      0x7C240400,  //  003E  CALL	R9	2
-      0x8C240502,  //  003F  GETMET	R9	R2	K2
-      0x8C2C070C,  //  0040  GETMET	R11	R3	K12
-      0x58340016,  //  0041  LDCONST	R13	K22
-      0x8C381115,  //  0042  GETMET	R14	R8	K21
-      0x7C380200,  //  0043  CALL	R14	1
-      0x7C2C0600,  //  0044  CALL	R11	3
-      0x7C240400,  //  0045  CALL	R9	2
-      0x8C240502,  //  0046  GETMET	R9	R2	K2
-      0x582C0017,  //  0047  LDCONST	R11	K23
-      0x7C240400,  //  0048  CALL	R9	2
-      0x8C240502,  //  0049  GETMET	R9	R2	K2
-      0x582C0018,  //  004A  LDCONST	R11	K24
-      0x7C240400,  //  004B  CALL	R9	2
-      0x8C240502,  //  004C  GETMET	R9	R2	K2
-      0x8C2C070C,  //  004D  GETMET	R11	R3	K12
-      0x58340019,  //  004E  LDCONST	R13	K25
-      0x8C380F15,  //  004F  GETMET	R14	R7	K21
-      0x7C380200,  //  0050  CALL	R14	1
-      0x7C2C0600,  //  0051  CALL	R11	3
-      0x7C240400,  //  0052  CALL	R9	2
-      0x8C240502,  //  0053  GETMET	R9	R2	K2
-      0x582C001A,  //  0054  LDCONST	R11	K26
-      0x7C240400,  //  0055  CALL	R9	2
-      0x8C240502,  //  0056  GETMET	R9	R2	K2
-      0x582C001B,  //  0057  LDCONST	R11	K27
-      0x7C240400,  //  0058  CALL	R9	2
-      0x7001FFC1,  //  0059  JMP		#001C
-      0x5814001C,  //  005A  LDCONST	R5	K28
-      0xAC140200,  //  005B  CATCH	R5	1	0
-      0xB0080000,  //  005C  RAISE	2	R0	R0
-      0x8C100502,  //  005D  GETMET	R4	R2	K2
-      0x5818001B,  //  005E  LDCONST	R6	K27
-      0x7C100400,  //  005F  CALL	R4	2
-      0x80000000,  //  0060  RET	0
+      0x8C240D14,  //  0036  GETMET	R9	R6	K20
+      0x7C240200,  //  0037  CALL	R9	1
+      0x8C241312,  //  0038  GETMET	R9	R9	K18
+      0x7C240200,  //  0039  CALL	R9	1
+      0x8C241313,  //  003A  GETMET	R9	R9	K19
+      0x7C240200,  //  003B  CALL	R9	1
+      0x8C280502,  //  003C  GETMET	R10	R2	K2
+      0x8C30070E,  //  003D  GETMET	R12	R3	K14
+      0x58380015,  //  003E  LDCONST	R14	K21
+      0x8C3C1116,  //  003F  GETMET	R15	R8	K22
+      0x7C3C0200,  //  0040  CALL	R15	1
+      0x7C300600,  //  0041  CALL	R12	3
+      0x7C280400,  //  0042  CALL	R10	2
+      0x8C280502,  //  0043  GETMET	R10	R2	K2
+      0x8C30070E,  //  0044  GETMET	R12	R3	K14
+      0x58380017,  //  0045  LDCONST	R14	K23
+      0x8C3C1316,  //  0046  GETMET	R15	R9	K22
+      0x7C3C0200,  //  0047  CALL	R15	1
+      0x7C300600,  //  0048  CALL	R12	3
+      0x7C280400,  //  0049  CALL	R10	2
+      0x8C280502,  //  004A  GETMET	R10	R2	K2
+      0x58300018,  //  004B  LDCONST	R12	K24
+      0x7C280400,  //  004C  CALL	R10	2
+      0x8C280502,  //  004D  GETMET	R10	R2	K2
+      0x58300019,  //  004E  LDCONST	R12	K25
+      0x7C280400,  //  004F  CALL	R10	2
+      0x8C280502,  //  0050  GETMET	R10	R2	K2
+      0x8C30070E,  //  0051  GETMET	R12	R3	K14
+      0x5838001A,  //  0052  LDCONST	R14	K26
+      0x8C3C1116,  //  0053  GETMET	R15	R8	K22
+      0x7C3C0200,  //  0054  CALL	R15	1
+      0x7C300600,  //  0055  CALL	R12	3
+      0x7C280400,  //  0056  CALL	R10	2
+      0x8C280502,  //  0057  GETMET	R10	R2	K2
+      0x5830001B,  //  0058  LDCONST	R12	K27
+      0x7C280400,  //  0059  CALL	R10	2
+      0x8C280502,  //  005A  GETMET	R10	R2	K2
+      0x5830001C,  //  005B  LDCONST	R12	K28
+      0x7C280400,  //  005C  CALL	R10	2
+      0x7001FFBD,  //  005D  JMP		#001C
+      0x5814001D,  //  005E  LDCONST	R5	K29
+      0xAC140200,  //  005F  CATCH	R5	1	0
+      0xB0080000,  //  0060  RAISE	2	R0	R0
+      0x8C100502,  //  0061  GETMET	R4	R2	K2
+      0x5818001C,  //  0062  LDCONST	R6	K28
+      0x7C100400,  //  0063  CALL	R4	2
+      0x80000000,  //  0064  RET	0
     })
   )
 );


### PR DESCRIPTION
## Description:

Matter:
- Fix when several ReadAttribute and SubscribeRequests are sent in parallel
- Extended log format
- Many minor improvements

I've been fighting this week with subtle bugs in AppleTV. Currently it works, but for still unknown reason the initial subscribe from AppleTV does not get updates. After 1 minute time-out, AppleTV sends a new subscription and from that moment everything works fine. So not yet flawless, but closer.

See #17872 for more details

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.7
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
